### PR TITLE
Fix a nasty traceback when invoking salt incorrectly

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -141,6 +141,12 @@ class SaltCMD(object):
                 opts['tgt'] = args[0].split(',')
             else:
                 opts['tgt'] = args[0]
+
+            # Catch invalid invocations of salt such as: salt run
+            if len(args) <= 1:
+                parser.print_help()
+                parser.exit()
+
             if args[1].count(','):
                 opts['fun'] = args[1].split(',')
                 opts['arg'] = []


### PR DESCRIPTION
To trigger the traceback, try: salt run
