### PR TITLE
RFE: Add a --text-out option to salt for "pretty printing" cmd.run output

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -100,6 +100,12 @@ class SaltCMD(object):
                 help='Print the output from the salt command in raw python'\
                    + ' form, this is suitable for re-reading the output into'\
                    + ' an executing python script with eval.')
+        parser.add_option('--text-out',
+                default=False,
+                action='store_true',
+                dest='txt_out',
+                help='Print the output from the salt command in the same form '\
+                   + 'the shell would.')
         if JSON:
             parser.add_option('--json-out',
                     default=False,
@@ -119,6 +125,7 @@ class SaltCMD(object):
         opts['return'] = options.return_
         opts['conf_file'] = options.conf_file
         opts['raw_out'] = options.raw_out
+        opts['txt_out'] = options.txt_out
         if JSON:
             opts['json_out'] = options.json_out
         else:
@@ -200,6 +207,13 @@ class SaltCMD(object):
                         print ret
                     elif self.opts['json_out']:
                         print json.dumps(ret)
+                    elif self.opts['txt_out']:
+                        for i in ret.keys():
+                            data = ret[i]
+                            if not data: continue
+                            for line in ret[i].split('\n'):
+                                if line:
+                                    print "{0}: {1}".format(i, line)
                     else:
                         print yaml.dump(ret)
 

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -211,7 +211,7 @@ class SaltCMD(object):
                         for i in ret.keys():
                             data = ret[i]
                             if not data: continue
-                            for line in ret[i].split('\n'):
+                            for line in data.split('\n'):
                                 if line:
                                     print "{0}: {1}".format(i, line)
                     else:


### PR DESCRIPTION
This is _heavily_ inspired from onall:
https://code.ticketmaster.com/trac/browser/onall/trunk/onall?format=txt

Example onall output:
$ echo ops{1,2}.els{0,2}2.int | onall -qy hostname
ops1.els2.int: ops1.els2.int
ops1.els0.int: ops1.els0.int
ops2.els2.int: ops2.els2.int
ops2.els0.int: ops2.els0.int

$ echo ops{1,2}.els{0,2}2.int | onall -qy date
ops1.els2.int: Thu Jul  7 01:08:04 EDT 2011
ops1.els0.int: Thu Jul  7 01:08:04 EDT 2011
ops2.els2.int: Thu Jul  7 01:08:04 EDT 2011
ops2.els0.int: Thu Jul  7 01:08:04 EDT 2011

$ salt 'localhost6.localdomain6' cmd.run --text-out 'tracepath localhost'
localhost6.localdomain6:  1:  localhost.localdomain                                 0.072ms pmtu 16436
localhost6.localdomain6:  1:  localhost.localdomain                                 0.032ms reached
localhost6.localdomain6:  1:  localhost.localdomain                                 0.031ms reached
localhost6.localdomain6:      Resume: pmtu 16436 hops 1 back 64

I would also like to lobby to make this the default output format at very least for cmd.run.
