### PR TITLE
Bump the Salt version number

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -1,7 +1,7 @@
 '''
 Make me some salt!
 '''
-__version_info__ = (0, 9, 2)
+__version_info__ = (0, 9, 3, 'pre')
 __version__ = '.'.join(map(str, __version_info__))
 
 # Import python libs


### PR DESCRIPTION
The Sphinx guys just add a 'pre' to the end of the version number for pre-release versions. I dig the minimalism - do you like it?
