### PR TITLE
Leading dot interpreted as troff macro; fixes #147

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -31,7 +31,7 @@ def custom():
 
     status.cpustats.custom: [ 'cpu', 'ctxt', 'btime', 'processes' ]
 
-    ...where status refers to status.py, cpustats is the function
+    where status refers to status.py, cpustats is the function
     where we get our data, and custom is this function It is followed
     by a list of keys that we want returned.
 


### PR DESCRIPTION
I'm not too familiar with troff to work around this, so this just removes the problem formatting.
