### PR TITLE
Updated manpages for 0.9.3 release

### DIFF
--- a/doc/man/salt-call.1
+++ b/doc/man/salt-call.1
@@ -1,4 +1,4 @@
-.TH "SALT-CALL" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-CALL" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-call \- salt-call Documentation
 .

--- a/doc/man/salt-cp.1
+++ b/doc/man/salt-cp.1
@@ -1,4 +1,4 @@
-.TH "SALT-CP" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-CP" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-cp \- salt-cp Documentation
 .

--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -1,4 +1,4 @@
-.TH "SALT-KEY" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-KEY" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-key \- salt-key Documentation
 .

--- a/doc/man/salt-master.1
+++ b/doc/man/salt-master.1
@@ -1,4 +1,4 @@
-.TH "SALT-MASTER" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-MASTER" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-master \- salt-master Documentation
 .

--- a/doc/man/salt-minion.1
+++ b/doc/man/salt-minion.1
@@ -1,4 +1,4 @@
-.TH "SALT-MINION" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-MINION" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-minion \- salt-minion Documentation
 .

--- a/doc/man/salt-run.1
+++ b/doc/man/salt-run.1
@@ -1,4 +1,4 @@
-.TH "SALT-RUN" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-RUN" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-run \- salt-run Documentation
 .

--- a/doc/man/salt-syndic.1
+++ b/doc/man/salt-syndic.1
@@ -1,4 +1,4 @@
-.TH "SALT-SYNDIC" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT-SYNDIC" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt-syndic \- salt-syndic Documentation
 .

--- a/doc/man/salt.1
+++ b/doc/man/salt.1
@@ -1,4 +1,4 @@
-.TH "SALT" "1" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT" "1" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt \- salt
 .

--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -1,4 +1,4 @@
-.TH "SALT" "7" "August 27, 2011" "0.9.0" "Salt"
+.TH "SALT" "7" "November 06, 2011" "0.9.3" "Salt"
 .SH NAME
 salt \- Salt Documentation
 .
@@ -30,863 +30,5440 @@ level margin: \\n[rst2man-indent\\n[rst2man-indent-level]]
 ..
 .\" Man page generated from reStructeredText.
 .
-Salt is a powerful remote execution manager that can be used to administer
-servers in a fast and efficient way.
+.SH SALT AT A GLANCE
 .sp
-Salt allows commands to be executed across large groups of servers. This means
-systems can be easily managed, but data can also be easily gathered. Quick
-introspection into running systems becomes a reality.
-.sp
-Remote execution is usually used to set up a certain state on a remote system.
-Salt addresses this problem as well, the salt state system uses salt state
-files to define the state a server needs to be in.
-.sp
-Between the remote execution system, and state management Salt addresses the
-backbone of cloud and data center management.
-.sp
-0.8.9 released!
-.sp
-Release announcement:
-.SH SALT 0.8.9 RELEASE NOTES
-.sp
-Salt 0.8.9 has finally arrived! Unfortunately this is much later than I had
-hoped to release 0.8.9, life has been very crazy over the last month. But
-despite challenges, Salt has moved forward!
-.sp
-This release, as expected, adds few new features and many refinements. One
-of the most exciting aspect of this release is that the development community
-for salt has grown a great deal and much of the code is from contributors.
-.sp
-Also, I have filled out the documentation a great deal. So information on
-States is properly documented, and much of the documentation that was out of
-date has been filled in.
-.SS Download!
-.sp
-The Salt source can be downloaded from the salt github site:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/salt-0.8.9.tar.gz\fP
-.sp
-Or from PiPy:
-.sp
-\fI\%http://pypi.python.org/packages/source/s/salt/salt-0.8.9.tar.gz\fP
-.sp
-Here s the md5sum:
-.sp
-7d5aca4633bc22f59045f59e82f43b56
-.sp
-For instructions on how to set up Salt please see the tutorial
-.SS Tutorial
-.sp
-The Salt system setup is amazingly simple, as this is one of the central design
-goals of Salt. Setting up Salt only requires that the Salt \fImaster\fP be
-running and the Salt \fIminions\fP point to the master.
-.INDENT 0.0
-.TP
-.B master
-The Salt master is the central server that all minions connect to. You
-run commands on the minions through the master and minions send data
-back to the master (unless otherwise redirected with a \fBreturner\fP). It is started with the
-\fBsalt\-master\fP program.
-.TP
-.B minion
-Salt minions are the potentially hundreds or thousands of servers that
-you query and control from the master.
-.UNINDENT
-.SS Installing Salt
-.sp
-As of this writing packages for Salt only exist for Arch Linux, but rpms and
-debs will be available in the future (contributions welcome).
-.SS Instructions by operating system
+Learn about the various parts of Salt in five minute increments (or less).
 .INDENT 0.0
 .IP \(bu 2
-\fI\%Installing on Arch Linux\fP
+\fBWhat is Salt?:\fP
+\fBOverview\fP
+| \fBCommunity\fP
 .IP \(bu 2
-\fI\%Installing on Debian or Ubuntu\fP
+\fBThe basics:\fP
+\fBInstallation\fP
+| \fBConfiguration\fP
+| [image: vid]
+[image]
+ \fI\%Watch the screencast\fP
 .IP \(bu 2
-\fI\%Installing from the source tarball\fP
+\fBRemote execution:\fP
+\fBModules\fP
+.IP \(bu 2
+\fBState management:\fP
+\fBPart 1\fP
+| \fBPart 2\fP
+| \fBPart 3\fP
 .UNINDENT
-.SS Installing on Arch Linux
-.sp
-The Arch Linux Salt package is available in the Arch Linux AUR (if you like
-Salt vote for it on the Arch Linux AUR):
-.sp
-\fI\%https://aur.archlinux.org/packages.php?ID=47512\fP
-.sp
-For help using packages in the Arch Linux AUR:
-.sp
-\fI\%https://wiki.archlinux.org/index.php/AUR\fP
-.SS Installing on Debian or Ubuntu
-.sp
-Providing a .deb installer is on our short\-list of things to do; until then
-this is the best way to install Salt on Debian and Ubuntu systems:
-.INDENT 0.0
-.IP 1. 3
-Install the prerequisite packages:
-.sp
-.nf
-.ft C
-aptitude install python\-setuptools python\-yaml python\-crypto python\-m2crypto cython libzmq\-dev
-.ft P
-.fi
-.IP Note
-Installing on Ubuntu Lucid (10.04 LTS)
-.sp
-The ZeroMQ package is available starting with Maverick but it is not
-yet available in Lucid backports. Fortunately, Chris Lea has made a
-\fI\%ZeroMQ PPA\fP available. Install it before installing Salt:
-.sp
-.nf
-.ft C
-aptitude install python\-software\-properties
-add\-apt\-repository ppa:chris\-lea/zeromq
-aptitude update
-aptitude install libzmq\-dev
-.ft P
-.fi
-.RE
-.IP 2. 3
-Grab the latest Python ZeroMQ bindings:
-.sp
-.nf
-.ft C
-easy_install pyzmq
-.ft P
-.fi
-.IP 3. 3
-Install Salt:
-.sp
-.nf
-.ft C
-easy_install \-\-install\-layout=deb https://github.com/downloads/thatch45/salt/salt\-0.9.0\&.tar.gz
-.ft P
-.fi
-.sp
-Please take note of the \fB\-\-install\-layout=deb\fP flag. This is important
-for a functioning installation of Salt.
-.UNINDENT
-.SS Installing from the source tarball
-.INDENT 0.0
-.IP 1. 3
-Download the latest source tarball from the GitHub downloads directory for
-the Salt project: \fI\%https://github.com/thatch45/salt/downloads\fP
-.IP 2. 3
-Untar the tarball and run the \fBsetup.py\fP as root:
-.UNINDENT
-.sp
-.nf
-.ft C
-tar xvf salt\-0.9.0\&.tar.gz
-cd salt\-0.9.0
-python2 setup.py install
-.ft P
-.fi
-.SS Salt dependencies
-.sp
-This is a basic Python setup, nothing fancy. Salt does require a number of
-dependencies though, all of which should be available in your distribution\(aqs
-packages.
-.INDENT 0.0
-.IP \(bu 2
-\fI\%Python 2.6\fP
-.IP \(bu 2
-\fI\%pyzmq\fP \- ZeroMQ Python bindings
-.IP \(bu 2
-\fI\%M2Crypto\fP \- Python OpenSSL wrapper
-.IP \(bu 2
-\fI\%YAML\fP \- Python YAML bindings
-.IP \(bu 2
-\fI\%PyCrypto\fP \- The Python cryptography toolkit
-.UNINDENT
-.sp
-Optional Dependencies:
-.INDENT 0.0
-.IP \(bu 2
-gcc \- dynamic \fI\%Cython\fP module compiling
-.UNINDENT
-.SS Configuring Salt
-.sp
-Salt configuration is very simple. The default configuration for the
-\fImaster\fP will work for most installations and the only requirement for
-setting up a \fIminion\fP is to set the location of the master in the minion
-configuration file. The configuration files will be installed to
-\fB/etc/salt\fP and are named after the respective components,
-\fB/etc/salt/master\fP and \fB/etc/salt/minion\fP.
-.sp
-To make a minion check into the correct master simply edit the
-\fBmaster\fP variable in the minion configuration file to reference
-the master DNS name or IPv4 address.
-.IP "See also"
-.sp
-For further information consult the \fBconfiguration guide\fP.
-.RE
-.SS Running Salt
-.INDENT 0.0
-.IP 1. 3
-Start the \fImaster\fP in the foreground (to daemonize the process, pass
-the \fI\-d flag\fP):
-.sp
-.nf
-.ft C
-salt\-master
-.ft P
-.fi
-.IP 2. 3
-Start the \fIminion\fP in the foreground (to daemonize the process, pass
-the \fI\-d flag\fP):
-.sp
-.nf
-.ft C
-salt\-minion
-.ft P
-.fi
-.UNINDENT
-.IP "See also"
-.sp
-\fBsalt\-master manpage\fP and
-\fBsalt\-minion manpage\fP
-.RE
-.SS Arch Linux init scripts
-.sp
-.nf
-.ft C
-/etc/rc.d/salt\-master start
-/etc/rc.d/salt\-minion start
-.ft P
-.fi
-.SS Manage Salt public keys
-.sp
-Salt manages authentication with RSA public keys. The keys are managed on the
-\fImaster\fP via the \fBsalt\-key\fP command. Once a \fIminion\fP
-checks into the master the master will save a copy of the minion key. Before
-the master can send commands to the minion the key needs to be "accepted".
-.INDENT 0.0
-.IP 1. 3
-List the accepted and unaccepted salt keys:
-.sp
-.nf
-.ft C
-salt\-key \-L
-.ft P
-.fi
-.IP 2. 3
-Accept a minion key:
-.sp
-.nf
-.ft C
-salt\-key \-a <minion id>
-.ft P
-.fi
-.sp
-or accept all unaccepted minion keys:
-.sp
-.nf
-.ft C
-salt\-key \-A
-.ft P
-.fi
-.UNINDENT
-.IP "See also"
-.sp
-\fBsalt\-key manpage\fP
-.RE
-.SS Order your minions around
-.sp
-Now that you have a \fImaster\fP and at least one \fIminion\fP
-communicating with each other you can perform commands on the minion via the
-\fBsalt\fP command. Salt calls are comprised of three main components:
-.sp
-.nf
-.ft C
-salt \(aq<target>\(aq <function> [arguments]
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBsalt manpage\fP
-.RE
-.SS target
-.sp
-The target component allows you to filter which minions should run the
-following function. The default filter is a glob on the minion id. E.g.:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq test.ping
-salt \(aq*.example.org\(aq test.ping
-.ft P
-.fi
-.sp
-Targets can be based on minion system information using the grains system:
-.sp
-.nf
-.ft C
-salt \-G \(aqos:Ubuntu\(aq test.ping
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBGrains system\fP
-.RE
-.sp
-Targets can be filtered by regular expression:
-.sp
-.nf
-.ft C
-salt \-E \(aqvirtmach[0\-9]\(aq test.ping
-.ft P
-.fi
-.sp
-Finally, targets can be explicitly specified in a list:
-.sp
-.nf
-.ft C
-salt \-L foo,bar,baz,quo test.ping
-.ft P
-.fi
-.SS function
-.sp
-A function is some functionality provided by a module. Salt ships with a large
-collection of available functions. List all available functions on your
-minions:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq sys.doc
-.ft P
-.fi
-.sp
-Here are some examples:
-.sp
-Show all currently available minions:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq test.ping
-.ft P
-.fi
-.sp
-Run an arbitrary shell command:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq cmd.run \(aquname \-a\(aq
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBthe full list of modules\fP
-.RE
-.SS arguments
-.sp
-Space\-delimited arguments to the function:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq cmd.exec_code python \(aqimport sys; print sys.version\(aq
-.ft P
-.fi
-.SS New Features
-.SS Salt Run
-.sp
-A big feature is the addition of Salt run, the \fBsalt\-run\fP command allows for
-master side execution modules to be made that gather specific information or
-execute custom routines from the master.
-.sp
-Documentation for salt\-run can be found here:
-.sp
-\fI\%http://saltstack.org/ref/runners.html\fP
-.SS Refined Outputters
-.sp
-One problem often complained about in salt was the fact that the output was
-so messy. Thanks to help from Jeff Schroeder a cleaner interface for the
-command output for the Salt cli has been made. This new interface makes
-adding new printout formats easy and additions to the capabilities of minion
-modules makes it possible to set the printout mode or \fBoutputter\fP for
-functions in minion modules.
-.SS Cross Calling Salt Modules
-.sp
-Salt modules can now call each other, the \fB__salt__\fP dict has been added to
-the predefined references in minion modules. This new feature is documented in
-the modules documentation:
-.sp
-\fI\%http://saltstack.org/ref/modules/index.html\fP
-.SS Watch Option Added to Salt State System
-.sp
-Now in Salt states you can set the watch option, this will allow watch enabled
-states to change based on a change in the other defined states. This is similar
-to subscribe and notify statements in puppet.
-.SS Root Dir Option
-.sp
-Travis Cline has added the ability to define the option \fBroot_dir\fP which
-allows the salt minion to operate in a subdir. This is a strong move in
-supporting the minion running as an unprivileged user
-.SS Config Files Defined in Variables
-.sp
-Thanks again to Travis Cline, the master and minion configuration file locations
-can be defined in environment variables now.
-.SS New Modules
-.sp
-Quite a few new modules, states, returners and runners have been made.
-.SS New Minion Modules
-.SS apt
-.sp
-Support for apt\-get has been added, this adds greatly improved Debian and
-Ubuntu support to Salt!
-.SS useradd and groupadd
-.sp
-Support for manipulating users and groups on Unix\-like systems.
-.SS moosefs
-.sp
-Initial support for reporting on aspects of the distributed file system,
-MooseFS. For more information on MooseFS please see: \fI\%http://moosefs.org\fP
-.sp
-Thanks to Joseph Hall for his work on MooseFS support.
-.SS mount
-.sp
-Manage mounts and the fstab.
-.SS puppet
-.sp
-Execute puppet on remote systems.
-.SS shadow
-.sp
-Manipulate and manage the user password file.
-.SS ssh
-.sp
-Interact with ssh keys.
-.SS New States
-.SS user and group
-.sp
-Support for managing users and groups in Salt States.
-.SS mount
-.sp
-Enforce mounts and the fstab.
-.SS New Returners
-.SS mongo_return
-.sp
-Send the return information to a mongodb server.
-.SS New Runners
-.SS manage
-.sp
-Display minions that are up or down.
-.sp
-The latest Salt is 0.8.9:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/salt-0.8.9.tar.gz\fP
-.sp
-Additional packages can be downloaded from the download page:
-.SH DOWNLOAD SALT
-.sp
-Packages and dependencies for Salt can be downloaded here for specific
-operating systems. Please follow and specific instructions for your system.
-.SS Salt From Source
-.sp
-The Salt source can be downloaded and installed directly from git:
-.sp
-.nf
-.ft C
-# git clone git://github.com/thatch45/salt.git
-.ft P
-.fi
-.sp
-The latest source tarball can be downloaded as well:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/salt-0.8.9.tar.gz\fP
-.sp
-Salt should run on any Unix like platform so long as the dependencies are met.
-.SS Salt for Red Hat
-.sp
-Salt rpms have been prepared for Red Hat Enterprise Linux 6 and Fedora 15.
-While Fedora 15 only requires the Salt rpm Red Hat Enterprise Linux 6 requires
-that a newer version of ZeroMQ be installed than what is available in the EPEL
-repositories.
-.SS Fedora rpms
-.sp
-Salt noarch rpm for Fedora 15:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/salt-0.8.9-1.fc15.noarch.rpm\fP
-.SS Red Hat Enterprise Linux 6 rpms
-.sp
-The EPEL repository is required for Salt as well as updated ZeroMQ packages.
-.sp
-The Salt rpm can be downloaded here:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/salt-0.8.9-1.el6.noarch.rpm\fP
-.sp
-ZeroMQ backport:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/zeromq-2.1.7-1.el6.x86_64.rpm\fP
-.sp
-PyZMQ bindings backport:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/python-zmq-2.1.7-1.el6.src.rpm\fP
-.sp
-Package to set up EPEL repository (provided by the EPEL project):
-.sp
-\fI\%http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-5.noarch.rpm\fP
-.SS Red Hat Enterprise Linux 5 rpms
-.sp
-Red Hat Enterprise Linux 5 requires more backports and the use of the
-python 2.6 stack provided in the EPEL repository. All of the listed packages
-need to be installed and the EPEL repository enabled to bring in the needed
-dependencies:
-.sp
-Salt rpm:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/salt-0.8.9-1.el5.noarch.rpm\fP
-.sp
-YAML bindings for python 2.6:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/python26-PyYAML-3.08-4.el5.x86_64.rpm\fP
-.sp
-ZeroMQ backport:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/zeromq-2.1.7-1.el5.x86_64.rpm\fP
-.sp
-PyZMQ bindings backport:
-.sp
-\fI\%https://github.com/downloads/thatch45/salt/python26-zmq-2.1.7-1.el5.x86_64.rpm\fP
-.SS Salt for Arch Linux
-.sp
-Salt can be easily installed on Arch Linux, install the package from the Arch
-Linux AUR:
-.sp
-\fI\%https://aur.archlinux.org/packages.php?ID=47512\fP
-.sp
-Or install directly from git on Arch Linux:
-.sp
-\fI\%https://aur.archlinux.org/packages.php?ID=47513\fP
-.SH GETTING STARTED
-.sp
-A number of resources are available to get going with Salt.
-.sp
-If you want to get set up quickly and try out Salt, follow the tutorial.
-.SH TUTORIAL
-.sp
-The Salt system setup is amazingly simple, as this is one of the central design
-goals of Salt. Setting up Salt only requires that the Salt \fImaster\fP be
-running and the Salt \fIminions\fP point to the master.
-.INDENT 0.0
-.TP
-.B master
-The Salt master is the central server that all minions connect to. You
-run commands on the minions through the master and minions send data
-back to the master (unless otherwise redirected with a \fBreturner\fP). It is started with the
-\fBsalt\-master\fP program.
-.TP
-.B minion
-Salt minions are the potentially hundreds or thousands of servers that
-you query and control from the master.
-.UNINDENT
-.SS Installing Salt
-.sp
-As of this writing packages for Salt only exist for Arch Linux, but rpms and
-debs will be available in the future (contributions welcome).
-.SS Instructions by operating system
-.INDENT 0.0
-.IP \(bu 2
-\fI\%Installing on Arch Linux\fP
-.IP \(bu 2
-\fI\%Installing on Debian or Ubuntu\fP
-.IP \(bu 2
-\fI\%Installing from the source tarball\fP
-.UNINDENT
-.SS Installing on Arch Linux
-.sp
-The Arch Linux Salt package is available in the Arch Linux AUR (if you like
-Salt vote for it on the Arch Linux AUR):
-.sp
-\fI\%https://aur.archlinux.org/packages.php?ID=47512\fP
-.sp
-For help using packages in the Arch Linux AUR:
-.sp
-\fI\%https://wiki.archlinux.org/index.php/AUR\fP
-.SS Installing on Debian or Ubuntu
-.sp
-Providing a .deb installer is on our short\-list of things to do; until then
-this is the best way to install Salt on Debian and Ubuntu systems:
-.INDENT 0.0
-.IP 1. 3
-Install the prerequisite packages:
-.sp
-.nf
-.ft C
-aptitude install python\-setuptools python\-yaml python\-crypto python\-m2crypto cython libzmq\-dev
-.ft P
-.fi
-.IP Note
-Installing on Ubuntu Lucid (10.04 LTS)
-.sp
-The ZeroMQ package is available starting with Maverick but it is not
-yet available in Lucid backports. Fortunately, Chris Lea has made a
-\fI\%ZeroMQ PPA\fP available. Install it before installing Salt:
-.sp
-.nf
-.ft C
-aptitude install python\-software\-properties
-add\-apt\-repository ppa:chris\-lea/zeromq
-aptitude update
-aptitude install libzmq\-dev
-.ft P
-.fi
-.RE
-.IP 2. 3
-Grab the latest Python ZeroMQ bindings:
-.sp
-.nf
-.ft C
-easy_install pyzmq
-.ft P
-.fi
-.IP 3. 3
-Install Salt:
-.sp
-.nf
-.ft C
-easy_install \-\-install\-layout=deb https://github.com/downloads/thatch45/salt/salt\-0.9.0\&.tar.gz
-.ft P
-.fi
-.sp
-Please take note of the \fB\-\-install\-layout=deb\fP flag. This is important
-for a functioning installation of Salt.
-.UNINDENT
-.SS Installing from the source tarball
-.INDENT 0.0
-.IP 1. 3
-Download the latest source tarball from the GitHub downloads directory for
-the Salt project: \fI\%https://github.com/thatch45/salt/downloads\fP
-.IP 2. 3
-Untar the tarball and run the \fBsetup.py\fP as root:
-.UNINDENT
-.sp
-.nf
-.ft C
-tar xvf salt\-0.9.0\&.tar.gz
-cd salt\-0.9.0
-python2 setup.py install
-.ft P
-.fi
-.SS Salt dependencies
-.sp
-This is a basic Python setup, nothing fancy. Salt does require a number of
-dependencies though, all of which should be available in your distribution\(aqs
-packages.
-.INDENT 0.0
-.IP \(bu 2
-\fI\%Python 2.6\fP
-.IP \(bu 2
-\fI\%pyzmq\fP \- ZeroMQ Python bindings
-.IP \(bu 2
-\fI\%M2Crypto\fP \- Python OpenSSL wrapper
-.IP \(bu 2
-\fI\%YAML\fP \- Python YAML bindings
-.IP \(bu 2
-\fI\%PyCrypto\fP \- The Python cryptography toolkit
-.UNINDENT
-.sp
-Optional Dependencies:
-.INDENT 0.0
-.IP \(bu 2
-gcc \- dynamic \fI\%Cython\fP module compiling
-.UNINDENT
-.SS Configuring Salt
-.sp
-Salt configuration is very simple. The default configuration for the
-\fImaster\fP will work for most installations and the only requirement for
-setting up a \fIminion\fP is to set the location of the master in the minion
-configuration file. The configuration files will be installed to
-\fB/etc/salt\fP and are named after the respective components,
-\fB/etc/salt/master\fP and \fB/etc/salt/minion\fP.
-.sp
-To make a minion check into the correct master simply edit the
-\fBmaster\fP variable in the minion configuration file to reference
-the master DNS name or IPv4 address.
-.IP "See also"
-.sp
-For further information consult the \fBconfiguration guide\fP.
-.RE
-.SS Running Salt
-.INDENT 0.0
-.IP 1. 3
-Start the \fImaster\fP in the foreground (to daemonize the process, pass
-the \fI\-d flag\fP):
-.sp
-.nf
-.ft C
-salt\-master
-.ft P
-.fi
-.IP 2. 3
-Start the \fIminion\fP in the foreground (to daemonize the process, pass
-the \fI\-d flag\fP):
-.sp
-.nf
-.ft C
-salt\-minion
-.ft P
-.fi
-.UNINDENT
-.IP "See also"
-.sp
-\fBsalt\-master manpage\fP and
-\fBsalt\-minion manpage\fP
-.RE
-.SS Arch Linux init scripts
-.sp
-.nf
-.ft C
-/etc/rc.d/salt\-master start
-/etc/rc.d/salt\-minion start
-.ft P
-.fi
-.SS Manage Salt public keys
-.sp
-Salt manages authentication with RSA public keys. The keys are managed on the
-\fImaster\fP via the \fBsalt\-key\fP command. Once a \fIminion\fP
-checks into the master the master will save a copy of the minion key. Before
-the master can send commands to the minion the key needs to be "accepted".
-.INDENT 0.0
-.IP 1. 3
-List the accepted and unaccepted salt keys:
-.sp
-.nf
-.ft C
-salt\-key \-L
-.ft P
-.fi
-.IP 2. 3
-Accept a minion key:
-.sp
-.nf
-.ft C
-salt\-key \-a <minion id>
-.ft P
-.fi
-.sp
-or accept all unaccepted minion keys:
-.sp
-.nf
-.ft C
-salt\-key \-A
-.ft P
-.fi
-.UNINDENT
-.IP "See also"
-.sp
-\fBsalt\-key manpage\fP
-.RE
-.SS Order your minions around
-.sp
-Now that you have a \fImaster\fP and at least one \fIminion\fP
-communicating with each other you can perform commands on the minion via the
-\fBsalt\fP command. Salt calls are comprised of three main components:
-.sp
-.nf
-.ft C
-salt \(aq<target>\(aq <function> [arguments]
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBsalt manpage\fP
-.RE
-.SS target
-.sp
-The target component allows you to filter which minions should run the
-following function. The default filter is a glob on the minion id. E.g.:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq test.ping
-salt \(aq*.example.org\(aq test.ping
-.ft P
-.fi
-.sp
-Targets can be based on minion system information using the grains system:
-.sp
-.nf
-.ft C
-salt \-G \(aqos:Ubuntu\(aq test.ping
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBGrains system\fP
-.RE
-.sp
-Targets can be filtered by regular expression:
-.sp
-.nf
-.ft C
-salt \-E \(aqvirtmach[0\-9]\(aq test.ping
-.ft P
-.fi
-.sp
-Finally, targets can be explicitly specified in a list:
-.sp
-.nf
-.ft C
-salt \-L foo,bar,baz,quo test.ping
-.ft P
-.fi
-.SS function
-.sp
-A function is some functionality provided by a module. Salt ships with a large
-collection of available functions. List all available functions on your
-minions:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq sys.doc
-.ft P
-.fi
-.sp
-Here are some examples:
-.sp
-Show all currently available minions:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq test.ping
-.ft P
-.fi
-.sp
-Run an arbitrary shell command:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq cmd.run \(aquname \-a\(aq
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBthe full list of modules\fP
-.RE
-.SS arguments
-.sp
-Space\-delimited arguments to the function:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq cmd.exec_code python \(aqimport sys; print sys.version\(aq
-.ft P
-.fi
 .SH SALT IN DEPTH
 .sp
-While using and setting up Salt is a simple task, the capabilities of Salt
-run much deeper.
-.sp
-Gaining a better understanding of how Salt works will allow you to get much
-more out of Salt.
-.sp
-Presentation at SLLUG in May 2011
+While using and setting up Salt is a simple task, the capabilities of Salt run
+much deeper. Gaining a better understanding of how Salt works will allow you to
+get much more out of Salt.
+.INDENT 0.0
+.IP \(bu 2
+\fBRemote execution:\fP
+\fBWriting modules\fP
+| \fBfull list of modules\fP
+.IP \(bu 2
+\fBSystem info & detection:\fP
+\fBGrains\fP
+.IP \(bu 2
+\fBDisplaying or storing responses:\fP
+\fBWriting returners\fP
+| \fBfull list of returners\fP
+.IP \(bu 2
+\fBState enforcement:\fP
+\fBStates\fP
+| \fBRenderers\fP
+| \fBHighstate data structure\fP
+.IP \(bu 2
+\fBTransferring & syncing files:\fP
+\fBFile Server\fP
+.IP \(bu 2
+\fBNetwork topology:\fP
+\fBref/syndic\fP
+| \fBref/peer\fP
+.IP \(bu 2
+\fBConfiguration:\fP
+\fBFull list of minion settings\fP
+| \fBFull list of master settings\fP
+.IP \(bu 2
+\fBUsing Salt:\fP
+\fBFrom the command\-line\fP
+| \fBThrough the Python API\fP
+.UNINDENT
+.IP "Screencasts and presentations"
+.INDENT 0.0
+.IP \(bu 2
+Presentation at the Salt Lake Linux User Group (SLLUG) in May 2011
 \fI\%video\fP | \fI\%slides\fP (PDF)
-.SH CONFIGURATION GUIDE
+.UNINDENT
+.RE
+.SH SALT QUICK REFERENCE
+.INDENT 0.0
+.IP \(bu 2
+\fBRelease notes\fP
+| \fBRoadmap\fP
+.IP \(bu 2
+\fImodindex\fP
+| \fIgenindex\fP
+| \fBFull table of contents\fP
+.IP \(bu 2
+\fIsearch\fP
+.UNINDENT
+.SH INTRODUCTION TO SALT
+We’re not just talking about NaCl..SS Distributed remote execution
 .sp
-The Salt system is amazingly simple and easy to configure, the two components
-of the Salt system each have a respective configuration file. The
-\fBsalt\-master\fP is configured via the master configuration file, and the
-\fBsalt\-minion\fP is configured via the minion configuration file.
-.SS Configuration file examples
+Salt is a distributed remote execution system used to execute commands and
+query data. It was developed in order to bring the best solutions found in the
+world of remote execution together and make them better, faster and more
+malleable. Salt accomplishes this via its ability to handle larger loads of
+information, and not just dozens, but hundreds or even thousands of individual
+servers, handle them quickly and through a simple and manageable interface.
+.SS Simplicity
+.sp
+Versatility between massive scale deployments and smaller systems may seem
+daunting, but Salt is very simple to set up and maintain, regardless of the
+size of the project. The architecture of Salt is designed to work with any
+number of servers, from a handful of local network systems to international
+deployments across disparate datacenters. The topology is a simple
+server/client model with the needed functionality built into a single set of
+daemons. While the default configuration will work with little to no
+modification, Salt can be fine tuned to meet specific needs.
+.SS Parallel execution
+.sp
+The core function of Salt is to enable remote commands to be called in parallel
+rather than in serial, to use a secure and encrypted protocol, the smallest and
+fastest network payloads possible, and with a simple programmer interface. Salt
+also introduces more granular controls to the realm of remote execution,
+allowing for commands to be executed in parallel and for systems to be targeted
+based on more than just hostname, but by system properties.
+.SS Building on proven technology
+.sp
+Salt takes advantage of a number of technologies and techniques. The networking
+layer is built with the excellent \fI\%ZeroMQ\fP networking library, so Salt itself
+contains a viable, and transparent, AMQ broker inside the daemon. Salt uses
+public keys for authentication with the master daemon, then uses faster AES
+encryption for payload communication, this means that authentication and
+encryption are also built into Salt. Salt takes advantage of communication via
+Python pickles, enabling fast and light network traffic.
+.SS Python client interface
+.sp
+In order to allow for simple expansion, Salt execution routines can be written
+as plain Python modules and the data collected from Salt executions can be sent
+back to the master server, or to any arbitrary program. Salt can be called from
+a simple Python API, or from the command line, so that Salt can be used to
+execute one\-off commands as well as operate as an integral part of a larger
+application.
+.SS Fast, flexible, scalable
+.sp
+The result is a system that can execute commands across groups of varying size,
+from very few to very many servers at considerably high speed. A system that is
+very fast, easy to set up and amazingly malleable, able to suit the needs of
+any number of servers working within the same system. Salt’s unique
+architecture brings together the best of the remote execution world, amplifies
+its capabilities and expands its range, resulting in this system that is as
+versatile as it is practical, able to suit any network.
+.SS Open
+.sp
+Salt is developed under the \fI\%Apache 2.0 licence\fP, and can be used for open and
+proprietary projects. Please submit your expansions back to the Salt project so
+that we can all benefit together as Salt grows.  So, please feel free to
+sprinkle some of this around your systems and let the deliciousness come forth.
+.SH INSTALLING SALT
+.sp
+The Salt system setup is amazingly simple, as this is one of the central design
+goals of Salt. Setting up Salt only requires that the Salt \fImaster\fP be
+running and the Salt \fIminions\fP point to the master.
+.SS Instructions by operating system
+.INDENT 0.0
+.IP \(bu 2
+\fI\%Red Hat\fP
+.IP \(bu 2
+\fI\%Arch Linux\fP
+.IP \(bu 2
+\fI\%Debian / Ubuntu\fP
+.IP \(bu 2
+\fI\%Installing from source\fP
+.UNINDENT
+.SS Red Hat
+.SS Fedora
+.sp
+Salt is currently being built for Fedora. The latest koji build pages can be
+found here:
+.INDENT 0.0
+.IP \(bu 2
+\fI\%Fedora 14\fP
+.IP \(bu 2
+\fI\%Fedora 15\fP
+.IP \(bu 2
+\fI\%Fedora Rawhide\fP
+.UNINDENT
+.SS Red Hat Enterprise Linux 6
+.sp
+Salt is being built for EPEL6. \fI\%Browse the latest builds.\fP
+.sp
+The ZeroMQ packages in EPEL6 have been tested with this package, but if you
+still have issues these backports may help:
+.INDENT 0.0
+.IP \(bu 2
+\fI\%ZeroMQ backport\fP
+.IP \(bu 2
+\fI\%pyzmq bindings backport\fP
+.IP \(bu 2
+\fI\%Package to set up EPEL repository\fP
+(provided by the EPEL project)
+.UNINDENT
+.SS Red Hat Enterprise Linux 5
+.sp
+Salt is being built for RHEL5, updates will be available soon!
+.sp
+Red Hat Enterprise Linux 5 requires more backports and the use of the Python
+2.6 stack provided in the EPEL repository. All of the listed packages need to
+be installed and the EPEL repository enabled to bring in the needed
+dependencies:
+.INDENT 0.0
+.IP \(bu 2
+\fI\%Salt rpm\fP
+.IP \(bu 2
+\fI\%YAML bindings for Python 2.6\fP
+.IP \(bu 2
+\fI\%ZeroMQ backport\fP
+.IP \(bu 2
+\fI\%pyzmq bindings backport\fP
+.UNINDENT
+.SS Arch Linux
+.sp
+Salt can be easily installed from the Arch Linux AUR in one of two flavors:
+.INDENT 0.0
+.IP \(bu 2
+\fI\%Install a Salt release\fP
+.IP \(bu 2
+\fI\%Install the latest Salt from Git\fP
+.UNINDENT
+.SS Debian / Ubuntu
+.sp
+A deb package is \fI\%currently in testing\fP. Until it is accepted the best way to
+install Salt on Debian and Ubuntu systems is as follows:
+.INDENT 0.0
+.IP 1. 3
+Install the prerequisite packages:
+.sp
+.nf
+.ft C
+aptitude install python\-dev python\-setuptools \e
+    python\-yaml python\-jinja2 \e
+    python\-crypto python\-m2crypto libzmq\-dev
+.ft P
+.fi
+.IP "Installing on Ubuntu Lucid (10.04 LTS)"
+.sp
+The ZeroMQ package is available starting with Maverick but it is not
+yet available in Lucid backports. Fortunately, Chris Lea has made a
+\fI\%ZeroMQ PPA\fP available. Install it before installing Salt:
+.sp
+.nf
+.ft C
+aptitude install python\-software\-properties
+add\-apt\-repository ppa:chris\-lea/zeromq
+add\-apt\-repository ppa:chris\-lea/libpgm
+aptitude update
+aptitude install libzmq\-dev
+.ft P
+.fi
+.sp
+If you have an older version of ZeroMQ installed (perhaps from a
+previous installation of Salt) you may need to purge it: \fBaptitude
+purge libzmq0\fP.
+.RE
+.IP 2. 3
+Grab the latest Python ZeroMQ bindings:
+.sp
+.nf
+.ft C
+easy_install \-U pyzmq
+.ft P
+.fi
+.IP 3. 3
+Install Salt:
+.sp
+.nf
+.ft C
+easy_install \-U \-\-install\-layout=deb \fI\%https://github.com/downloads/thatch45/salt/salt-0.9.3.tar.gz\fP
+.ft P
+.fi
+.sp
+Please take note of the \fB\-\-install\-layout=deb\fP flag. This is important
+for a functioning installation of Salt.
+.UNINDENT
+.SS Installing from source
+.INDENT 0.0
+.IP 1. 3
+Download the latest source tarball from the GitHub downloads directory for
+the Salt project: \fI\%https://github.com/downloads/thatch45/salt/salt-0.9.3.tar.gz\fP
+.IP 2. 3
+Untar the tarball and run the \fBsetup.py\fP as root:
+.UNINDENT
+.sp
+.nf
+.ft C
+tar xvf salt\-0.9.3\&.tar.gz
+cd salt\-0.9.3
+python2 setup.py install
+.ft P
+.fi
+.SS Salt dependencies
+.sp
+This is a basic Python setup, nothing fancy. Salt should run on any Unix\-like
+platform so long as the dependencies are met:
+.INDENT 0.0
+.IP \(bu 2
+\fI\%Python 2.6\fP
+.IP \(bu 2
+\fI\%pyzmq\fP \- ZeroMQ Python bindings
+.IP \(bu 2
+\fI\%M2Crypto\fP \- Python OpenSSL wrapper
+.IP \(bu 2
+\fI\%YAML\fP \- Python YAML bindings
+.IP \(bu 2
+\fI\%PyCrypto\fP \- The Python cryptography toolkit
+.UNINDENT
+.sp
+Optional Dependencies:
+.INDENT 0.0
+.IP \(bu 2
+gcc \- dynamic \fI\%Cython\fP module compiling
+.UNINDENT
+.SH CONFIGURING SALT
+.sp
+Salt configuration is very simple. The default configuration for the
+\fImaster\fP will work for most installations and the only requirement for
+setting up a \fIminion\fP is to set the location of the master in the minion
+configuration file.
+.INDENT 0.0
+.TP
+.B master
+The Salt master is the central server that all minions connect to. You
+run commands on the minions through the master and minions send data
+back to the master (unless otherwise redirected with a \fBreturner\fP). It is started with the
+\fBsalt\-master\fP program.
+.TP
+.B minion
+Salt minions are the potentially hundreds or thousands of servers that
+you query and control from the master.
+.UNINDENT
+.sp
+The configuration files will be installed to \fB/etc/salt\fP and are named
+after the respective components, \fB/etc/salt/master\fP and
+\fB/etc/salt/minion\fP.
+.sp
+To make a minion check into the correct master simply edit the
+\fBmaster\fP variable in the minion configuration file to reference
+the master DNS name or IPv4 address.
+.SS Running Salt
+.INDENT 0.0
+.IP 1. 3
+Start the master in the foreground (to daemonize the process, pass the
+\fI\-d flag\fP):
+.sp
+.nf
+.ft C
+salt\-master
+.ft P
+.fi
+.IP 2. 3
+Start the minion in the foreground (to daemonize the process, pass the
+\fI\-d flag\fP):
+.sp
+.nf
+.ft C
+salt\-minion
+.ft P
+.fi
+.UNINDENT
+.IP "Having trouble?"
+.sp
+The simplest way to troubleshoot Salt is to run the master and minion in
+the foreground with \fIlog level\fP set to \fBdebug\fP:
+.sp
+.nf
+.ft C
+salt\-master \-\-log\-level=debug
+.ft P
+.fi
+.RE
+.SS Manage Salt public keys
+.sp
+Salt manages authentication with RSA public keys. The keys are managed on the
+\fImaster\fP via the \fBsalt\-key\fP command. Once a \fIminion\fP
+checks into the master the master will save a copy of the minion key. Before
+the master can send commands to the minion the key needs to be "accepted".
+.INDENT 0.0
+.IP 1. 3
+List the accepted and unaccepted salt keys:
+.sp
+.nf
+.ft C
+salt\-key \-L
+.ft P
+.fi
+.IP 2. 3
+Accept a minion key:
+.sp
+.nf
+.ft C
+salt\-key \-a <minion id>
+.ft P
+.fi
+.sp
+or accept all unaccepted minion keys:
+.sp
+.nf
+.ft C
+salt\-key \-A
+.ft P
+.fi
+.UNINDENT
+.IP "See also"
+.sp
+\fBsalt\-key manpage\fP
+.RE
+.SH REMOTE EXECUTION TUTORIAL
+.sp
+\fBBefore continuing\fP make sure you have a working Salt installation by
+following the \fBinstallation\fP and the
+\fBconfiguration\fP instructions.
+.IP "Stuck?"
+.sp
+If you get stuck at any point, there are many ways to \fBget help from
+the Salt community\fP including our mailing list and our
+IRC channel.
+.RE
+.SS Order your minions around
+.sp
+Now that you have a \fImaster\fP and at least one \fIminion\fP
+communicating with each other you can perform commands on the minion via the
+\fBsalt\fP command. Salt calls are comprised of three main components:
+.sp
+.nf
+.ft C
+salt \(aq<target>\(aq <function> [arguments]
+.ft P
+.fi
+.IP "See also"
+.sp
+\fBsalt manpage\fP
+.RE
+.SS target
+.sp
+The target component allows you to filter which minions should run the
+following function. The default filter is a glob on the minion id. E.g.:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq test.ping
+salt \(aq*.example.org\(aq test.ping
+.ft P
+.fi
+.sp
+Targets can be based on minion system information using the grains system:
+.sp
+.nf
+.ft C
+salt \-G \(aqos:Ubuntu\(aq test.ping
+.ft P
+.fi
+.IP "See also"
+.sp
+\fBGrains system\fP
+.RE
+.sp
+Targets can be filtered by regular expression:
+.sp
+.nf
+.ft C
+salt \-E \(aqvirtmach[0\-9]\(aq test.ping
+.ft P
+.fi
+.sp
+Finally, targets can be explicitly specified in a list:
+.sp
+.nf
+.ft C
+salt \-L foo,bar,baz,quo test.ping
+.ft P
+.fi
+.SS function
+.sp
+A function is some functionality provided by a module. Salt ships with a large
+collection of available functions. List all available functions on your
+minions:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq sys.doc
+.ft P
+.fi
+.sp
+Here are some examples:
+.sp
+Show all currently available minions:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq test.ping
+.ft P
+.fi
+.sp
+Run an arbitrary shell command:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq cmd.run \(aquname \-a\(aq
+.ft P
+.fi
+.IP "See also"
+.sp
+\fBthe full list of modules\fP
+.RE
+.SS arguments
+.sp
+Space\-delimited arguments to the function:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq cmd.exec_code python \(aqimport sys; print sys.version\(aq
+.ft P
+.fi
+.SH STATES TUTORIAL, PART 1
+.sp
+The purpose of this tutorial is to demonstrate how quickly you can configure a
+system to be managed by Salt States. For detailed information about the state
+system please refer to the full \fBstates reference\fP.
+.sp
+This tutorial will walk you through using Salt to configure a single system to
+run the Apache HTTP server and to ensure the server is running.
+.sp
+\fBBefore continuing\fP make sure you have a working Salt installation by
+following the \fBinstallation\fP and the
+\fBconfiguration\fP instructions.
+.IP "Stuck?"
+.sp
+If you get stuck at any point, there are many ways to \fBget help from
+the Salt community\fP including our mailing list and our
+IRC channel.
+.RE
+.SS Create an \fBsls\fP file
+.sp
+Start by creating an empty \fIsls file\fP named \fBwebserver.sls\fP. Type the
+following and save the file:
+.sp
+.nf
+.ft C
+apache2:                # ID declaration
+  pkg:                  # state declaration
+    \- installed         # function
+.ft P
+.fi
+.sp
+The first line, called the \fIID declaration\fP, is an arbitrary identifier.
+In this case it defines the name of the package to be installed. (The exact
+package name for the Apache httpd web server may differ on your OS or distro.)
+.sp
+The second line, called the \fIstate declaration\fP, defines which of the
+Salt States we are using. In this example, we are using the \fBpkg state\fP to ensure that a given package is installed.
+.sp
+The third line, called the \fIfunction\fP defines which function in the
+\fBpkg state\fP module to call.
+.IP "Renderers"
+.sp
+States \fIsls\fP files can be written in many formats. Salt requires only
+a simple data structure and is not concerned with how that data structure
+is built. Building the expected structure is the job of Salt
+\fBrenderers\fP.
+.sp
+In this tutorial we will be using yaml in Jinja2 templates which is the
+default format. You can change the default by changing
+\fBrenderer\fP in the master configuration file.
+.RE
+.SS Install the package
+.sp
+Next, let\(aqs run that state. Open a terminal and run:
+.sp
+.nf
+.ft C
+% salt \(aq*\(aq state.template /path/to/your/helloworld.sls
+.ft P
+.fi
+.sp
+\fBstate.template\fP is the simplest way to use
+Salt states. It takes the path to a template as an argument and executes it on
+the minion.
+.sp
+You should see a bunch of output as Salt installs Apache.
+.SS Ensure a service is running
+.sp
+Let\(aqs make a quick modification to also start Apache if it is not running:
+.sp
+.nf
+.ft C
+apache2:
+    pkg:
+        \- installed
+    service:
+        \- running
+.ft P
+.fi
+.sp
+Run \fBstate.template\fP once again and observe the output.
+.SS Next steps
+.sp
+This tutorial focused on using Salt States only on the local system. \fBPart
+2\fP of the will build on this example to cover using Salt States on
+a remote host.
+.SH STATES TUTORIAL, PART 2
+.sp
+This tutorial builds on the topic covered in \fBpart 1\fP. It is
+recommended that you begin there.
+.sp
+In the last Salt States tutorial we ran everything locally and did not take
+advantage of Salt\(aqs tremendous ability to run on multiple hosts. In this
+tutorial, we will modify \fBwebserver.sls\fP to run from the \fISalt master\fP and transfer configuration and files to the \fISalt minions\fP.
+.SS Setting up the Salt State Tree
+.sp
+Groups of states are defined on the Salt master inside of the master\(aqs file
+server and are expressed in a \fIState Tree\fP. To start using a central
+state system in Salt you must first set up the Salt File Server. Edit your
+master config file (\fB/etc/salt/master\fP) and uncomment the following lines:
+.sp
+.nf
+.ft C
+file_roots:
+  base:
+    \- /srv/salt
+.ft P
+.fi
+.sp
+Restart the Salt master in order to pick up this change:
+.sp
+.nf
+.ft C
+% pkill salt\-master
+% salt\-master \-d
+.ft P
+.fi
+.SS Preparing the Top File
+.sp
+On the master in the directory you specified in the previous step, create a new
+file called \fBtop.sls\fP and add the following:
+.sp
+.nf
+.ft C
+base:
+  \(aq*\(aq:
+    \- webserver
+.ft P
+.fi
+.sp
+The \fItop file\fP is separated into environments (discussed later). The
+default environment is \fBbase\fP. Under the \fBbase\fP environment a collection of
+minion matches is defined; for now simply specify all hosts (\fB*\fP).
+.IP "Matching minions"
+.sp
+The expressions can use any or the matching mechanisms used by Salt, so
+minions can be matched by glob, pcre regular expression, or by grains. When
+a minion executes a state call it will download the \fItop file\fP and
+attempt to match the expressions, when it does match an expression the
+modules listed for it will be downloaded, compiled, and executed.
+.RE
+.SS Define an SLS module
+.sp
+Move your \fBwebserver.sls\fP file into the same directory as \fBtop.sls\fP. This
+defines the "webserver sls module".
+.sp
+SLS modules are appended with the file extension \fB.sls\fP and are referenced by
+name starting at the root of the state tree.
+.IP "Directories and SLS modules"
+.sp
+An SLS module can be also defined as a directory. If the directory
+\fBpython\fP exists, and a module named \fBpython\fP is desired, than a file
+called \fBinit.sls\fP in the \fBpython\fP directory can be used to define the
+\fBpython\fP module. For example:
+.sp
+.nf
+.ft C
+|\- top.sls
+|\- python
+|  |\- init.sls
+|  \(ga\- django.sls
+|\- haproxy
+|  \(ga\- init.sls
+\(ga\- core.sls
+.ft P
+.fi
+.sp
+In the example above the \fBdjango.sls\fP module would be referenced as
+\fBpython.django\fP.
+.RE
+.SS Add a dependency
+.sp
+We now have a working installation of Apache so let\(aqs add an HTML file to
+customize our website. Include the following at the bottom of your
+\fBwebserver.sls\fP file:
+.sp
+.nf
+.ft C
+/var/www/index.html:                # ID declaration
+  file:                             # state declaration
+    \- managed                       # function
+    \- source: salt://index.html     # function arg
+    \- require:                      # requisite declaration
+      \- pkg: apache2                # requisite reference
+.ft P
+.fi
+.sp
+Again in \fBline 1\fP is the \fIID declaration\fP. In this example it is the
+location we want to install our custom HTML file. (The default location that
+Apache serves may differ from the above on your OS or distro. \fB/srv/www\fP
+could also be a likely place to look.)
+.sp
+\fBLine 2\fP the \fIstate declaration\fP. This example uses the Salt \fBfile
+state\fP.
+.sp
+\fBLine 3\fP is the \fIfunction declaration\fP. The \fBmanaged function\fP will download a file from the master and install it
+in the location specified.
+.sp
+\fBLine 4\fP is a \fIfunction arg declaration\fP which, in this example, passes
+the \fBsource\fP argument to the \fBmanaged function\fP.
+.sp
+\fBLine 5\fP is a \fIrequisite declaration\fP.
+.sp
+\fBLine 6\fP is a \fIrequisite reference\fP which refers to a state and an ID.
+In this example, it is referring to the \fBID declaration\fP from our example in
+\fBpart 1\fP. This declaration tells Salt not to install the HTML
+file until Apache is installed.
+.SS Call the highstate
+.sp
+Create the \fBindex.html\fP file and save it in the same directory as \fBtop.sls\fP
+and \fBwebserver.sls\fP:
+.sp
+.nf
+.ft C
+<html>
+    <head><title>Salt rocks</title></head>
+    <body>
+        <h1>This file brought to you by Salt</h1>
+    </body>
+</html>
+.ft P
+.fi
+.sp
+Last, call \fBstate.highstate\fP which
+instructs the minion to fetch and execute the highstate from the Salt master:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq salt.highstate
+.ft P
+.fi
+.sp
+Verify that Apache is now serving your custom HTML.
+.sp
+In \fBpart 3\fP we will discuss how to use templating in the
+\fBsls\fP files.
+.SH STATES TUTORIAL, PART 3
+.sp
+This tutorial builds on the topic covered in \fBpart 2\fP. It is
+recommended that you begin there.
+.sp
+This tutorial will cover more advanced templating and configuration techniques
+for \fBsls\fP files.
+.SS Templating SLS modules
+.sp
+SLS modules may require programming logic or inline executions. This is
+accomplished with module templating. The default module templating system used
+is \fI\%Jinja2\fP  and may be configured by changing the \fBrenderer\fP
+value in the master config.
+.sp
+All states are passed through a templating system when they are initially read,
+so all that is required to make use of the templating system is to add some
+templating code. An example of an sls module with templating may look like
+this:
+.sp
+.nf
+.ft C
+{% for usr in \(aqmoe\(aq,\(aqlarry\(aq,\(aqcurly\(aq %}
+{{ usr }}:
+  user:
+    \- present
+{% endfor %}
+.ft P
+.fi
+.sp
+This templated sls file once generated will look like this:
+.sp
+.nf
+.ft C
+moe:
+  user:
+    \- present
+larry:
+  user:
+    \- present
+currly:
+  user:
+    \- present
+.ft P
+.fi
+.SS Using Grains in SLS modules
+.sp
+Often times a state will need to behave differently on different systems.
+\fBSalt grains\fP can be used from within sls modules. An object
+called \fBgrains\fP is made available in the template context:
+.sp
+.nf
+.ft C
+apache:
+  pkg:
+    {% if grains[\(aqos\(aq] == \(aqRedHat\(aq %}
+    \- name: httpd
+    {% elif grains[\(aqos\(aq] == \(aqUbuntu\(aq %}
+    \- name: apache2
+    {% endif %}
+    \- installed
+.ft P
+.fi
+.SS Calling Salt modules from templates
+.sp
+All of the Salt modules loaded by the minion ave available within the
+templating system. This allows data to be gathered in real time, on the target
+system. It also allows for shell commands to be run easily from within the sls
+modules.
+.sp
+The Salt module functions are also made available in the template context as
+\fBsalt\fP:
+.sp
+.nf
+.ft C
+{% for usr in \(aqmoe\(aq,\(aqlarry\(aq,\(aqcurly\(aq %}
+{{ usr }}:
+  group:
+    \- present
+  user:
+    \- present
+    \- gid: {{ salt[\(aqfile.group_to_gid\(aq](usr) }}
+    \- require:
+      \- group: {{ usr }}
+{% endfor %}
+.ft P
+.fi
+.sp
+Below is another example that calls an arbitrary command in order to grab the
+mac addr for eth0:
+.sp
+.nf
+.ft C
+salt[\(aqcmd.run\(aq](\(aqifconfig eth0 | grep HWaddr | cut \-d" " \-f10\(aq)
+.ft P
+.fi
+.SS Advanced SLS module syntax
+.sp
+Last we will cover some incredibly useful techniques for more complex State
+trees.
+.SS \fIInclude declaration\fP
+.sp
+You have seen an example of how to spread a Salt tree across several files but
+in order to be able to have \fIrequisite references\fP
+span multiple files you must use a \fIinclude declaration\fP. For example:
+.sp
+\fBpython\-libs.sls\fP:
+.sp
+.nf
+.ft C
+python\-dateutil:
+  pkg:
+    \- installed
+.ft P
+.fi
+.sp
+\fBdjango.sls\fP:
+.sp
+.nf
+.ft C
+include:
+  \- python\-libs
+
+django:
+  pkg:
+    \- installed
+    \- require:
+      \- pkg: python\-dateutil
+.ft P
+.fi
+.SS \fIExtend declaration\fP
+.sp
+You can modify previous declarations by using a \fIextend declaration\fP. For
+example the following modifies the Apache tree to also restart Apache when the
+vhosts file is changed:
+.sp
+\fBapache.sls\fP:
+.sp
+.nf
+.ft C
+apache:
+  pkg:
+    \- installed
+.ft P
+.fi
+.sp
+\fBmywebsite.sls\fP:
+.sp
+.nf
+.ft C
+include:
+  \- apache
+
+extend:
+  apache
+    service:
+      \- watch:
+        \- file: /etc/httpd/extra/httpd\-vhosts.conf
+
+/etc/httpd/extra/httpd\-vhosts.conf:
+  file:
+    \- managed
+    \- source: salt://httpd\-vhosts.conf
+.ft P
+.fi
+.SS \fIName declaration\fP
+.sp
+You can override the \fIID declaration\fP by using a \fIname
+declaration\fP. For example the previous example is a bit more maintainable if
+rewritten as the following:
+.sp
+\fBmywebsite.sls\fP:
+.sp
+.nf
+.ft C
+include:
+  \- apache
+
+extend:
+  apache
+    service:
+      \- watch:
+        \- file: mywebsite
+
+mywebsite:
+  file:
+    \- managed
+    \- name: /etc/httpd/extra/httpd\-vhosts.conf
+    \- source: salt://httpd\-vhosts.conf
+.ft P
+.fi
+.SS \fINames declaration\fP
+.sp
+Even more powerful is using a \fInames declaration\fP to override the
+\fIID declaration\fP for multiple states at once. This often can remove the
+need for looping in a template. For example, the first example in this tutorial
+can be rewritten without the loop:
+.sp
+.nf
+.ft C
+stooges:
+  user:
+    \- present
+    \- names:
+      \- moe
+      \- larry
+      \- curly
+.ft P
+.fi
+.SS Continue reading
+.sp
+The best way to continue learing about Salt States is to read through the
+\fBreference documentation\fP. If you have any questions,
+suggestions, or just want to chat with other people who are using Salt we have
+an \fBactive community\fP.
+.SH COMMUNITY
+.sp
+Join the Salt!
+.sp
+There are many ways to participate in and communicate with the Salt community.
+.sp
+Salt has an active IRC channel and a mailing list.
+.SS Mailing List
+.sp
+Join the \fI\%salt-users mailing list\fP. It is the best place to ask questions
+about Salt and see whats going on with Salt development! The Salt mailing list
+is hosted by Google Groups. It is open to new members.
+.sp
+\fI\%http://groups.google.com/group/salt-users\fP
+.SS IRC
+.sp
+The Salt IRC channel is hosted on the \fI\%OFTC\fP network. Connect to the OFTC
+server:
+.sp
+\fI\%irc://irc.oftc.net:6667\fP
+.sp
+and join us in \fB#salt\fP.
+.SS Follow on Github
+.sp
+The Salt code is developed via Github. Follow Salt for constant updates on what
+is happening in Salt development:
+.sp
+\fI\%https://github.com/thatch45/salt\fP
+.SS The Red45 Blog
+.sp
+News and thoughts on Salt and related projects is often posted on Thomas\(aq blog
+\fI\%The Red45\fP:
+.sp
+\fI\%http://red45.wordpress.com/\fP
+.SS Follow on ohloh
+.sp
+\fI\%https://www.ohloh.net/p/salt\fP
+.SS Developing Salt
+.sp
+If you want to help develop Salt there is a great need and your patches are
+welcome!
+.sp
+To assist in Salt development, you can help in a number of ways.
+.SS Posting patches to the mailing list
+.sp
+If you have a patch for Salt, please format it via \fBgit format\-patch\fP and
+send it to the Salt users mailing list. This allows the patch to give you the
+contributor the credit for your patch, and gives the Salt community an archive
+of the patch and a place for discussion.
+.SS Setting a Github pull request
+.sp
+This is probably the preferred method for contributions, simply create a Github
+fork, commit your changes to the fork, and then open up a pull request.
+.SS Contributions Welcome!
+.sp
+The goal here it to make contributions clear, make sure there is a trail for
+where the code has come from, but most importantly, to give credit where credit
+is due!
+.SH INTRODUCTION TO EXTENDING SALT
+.sp
+Salt is made to be used, and made to be extended. The primary goal of Salt is
+to provide a foundation which can be used to solve problems. And the goal of
+Salt is to not assume what those problems might be.
+.sp
+One of the greatest benefit of developing Salt has been the vast array of ways
+in which people have wanted to use it, while the original intention was as a
+communication layer for a cloud controller Salt has been extended to facilitate
+so much more.
+.SS Client API
+.sp
+The primary interface used to extend salt, is to simply use it. Salt executions
+can be called via the Salt client api, making programming master side solutions
+with Salt is easy.
+.SS Adding Loadable Plugins
+.sp
+Salt is comprised of a core platform that loads many types of easy to write
+plugins. The idea is to enable all of the breaking points in the salt processes
+to have a point of pluggable interaction. This means that all of the main
+features of Salt can be extended, modified or used.
+.sp
+The breaking points and helping interfaces span from convenience master side
+executions to manipulating the flow of how data is handled by Salt.
+.SS Minion Execution Modules
+.sp
+The minion execution modules or just \fBmodules\fP are the core to what salt is
+and does. These modules are found in:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/modules\fP
+.sp
+These modules are what is called by the salt command line and the salt client
+api. Adding modules is done by simply adding additional python modules to the
+modules directory and restarting the minion.
+.SS Grains
+.sp
+Salt grains, or "grains of truth" are bits of static information that are
+generated when the minion starts. This information is useful when determining
+what package manager to default to, or where certain configuration files are
+stored on the minion.
+.sp
+The Salt grains are the interface used for auto detection and dynamic assignment
+of execution modules and types to specific salt minions.
+.sp
+The code used to generate the Salt grains can be found here:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/grains\fP
+.SS States
+.sp
+Salt supports state enforcement, this makes Salt a high speed and very efficient
+solution for system configuration management.
+.sp
+States can be easily added to Salt by dropping a new state module in:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/states\fP
+.SS Renderers
+.sp
+Salt states are controlled by simple data structures, these structures can be
+abstracted in a number of ways. While the default is to be in a yaml file
+wrapped in a jinja template, any abstraction can be used. This means that any
+format that can be dreamed is possible, so long as a renderer is written for
+it.
+.sp
+The existing renderers can be found here:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/renderers\fP
+.SS Returners
+.sp
+The salt commands all produce a return value, that return value is sent to the
+salt master by default, but it can be sent anywhere. The returner interface
+makes it programmatically possible for the information to be sent to anything
+from an SQL or NOSQL database, to a custom application made to use Salt.
+.sp
+The existing returners can be found here:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/returners\fP
+.SS Runners
+.sp
+Sometimes a certain application can be made to execute and run from the
+existing salt command line. This is where the salt runners come into play.
+The Salt Runners what is called by the salt\-run command and are meant to
+act as a generic interface for encapsulating master side executions.
+.sp
+Existing Salt runners are located here:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/runners\fP
+.SH MODULES
+.sp
+Salt modules are the functions called by the \fBsalt\fP command.
+.IP "See also"
+.sp
+\fBFull list of builtin modules\fP
+.sp
+Salt ships with many modules that cover a wide variety of tasks.
+.RE
+.SS Easy Modules to write
+.sp
+Salt modules are amazingly simple to write, just write a regular Python module
+or a regular Cython module and place it in the \fBsalt/modules\fP directory.
+.sp
+Since Salt modules are just Python/Cython modules there are no restraints as to
+what you can put inside of a salt module, and if a Salt module has errors and
+cannot import the Salt minion will continue to load without issue, the module
+with errors will simply be omitted.
+.sp
+If adding a Cython module the file must be named \fB<modulename>.pyx\fP so that
+the loader knows that the module needs to be imported as a Cython module. The
+compilation of the Cython module is automatic and happens when the minion
+starts, so only the \fB*.pyx\fP file is required.
+.SS Cross Calling Modules
+.sp
+All of the salt modules are available to each other, and can be "cross called".
+This means that when creating a module functions in modules which already exist
+can be called.
+.sp
+The variable \fB__salt__\fP is packed into the modules after they are loaded into
+the salt minion. This variable is a python dictionary of all of the salt
+functions, laid out in the same way that they are made available to the salt
+command.
+.sp
+Salt modules can be cross called by accessing the value in the \fB__salt__\fP
+dict:
+.sp
+.nf
+.ft C
+def foo(bar):
+    return __salt__[\(aqcmd.run\(aq](bar)
+.ft P
+.fi
+.sp
+This code will call the Salt cmd module\(aqs run function and pass the argument
+\fBbar\fP.
+.SS Preloaded Modules Data
+.sp
+When interacting with modules often it is nice to be able to read information
+dynamically about the minion, or load in configuration parameters for a module.
+Salt allows for different types of data to be loaded into the modules by the
+minion, as of this writing Salt loads information gathered from the Salt Grains
+system and from the minion configuration file.
+.SS Grains Data
+.sp
+The Salt minion detects information about the system when started. This allows
+for modules to be written dynamically with respect to the underlying hardware
+and OS. This information is referred to as Salt Grains, or "grains of salt".
+The Grains system was introduced to replace Facter, since relying on a Ruby
+application from a Python application was both slow and inefficient. Grains
+support replaces Facter in all releases after 0.8
+.sp
+The values detected by the Salt Grains on the minion are available in a dict by
+the name of \fB__grains__\fP and can be accessed from within callable objects in
+the Python modules.
+.sp
+To see the contents of the grains dict for a given system in your deployment
+run the \fBgrains.items()\fP function:
+.sp
+.nf
+.ft C
+salt \(aqhostname\(aq grains.items
+.ft P
+.fi
+.sp
+To use the \fB__grains__\fP dict simply call it as a Python dict from within your
+code, an excellent example is available in the Grains module:
+\fBsalt.modules.grains\fP.
+.SS Module Configuration
+.sp
+Since parameters for configuring a module may be desired, Salt allows for
+configuration information stored in the main minion config file to be passed to
+the modules.
+.sp
+Since the minion configuration file is a yaml document, arbitrary configuration
+data can be passed in the minion config that is read by the modules. It is
+\fBstrongly\fP recommended that the values passed in the configuration file match
+the module. This means that a value intended for the \fBtest\fP module should be
+named \fBtest.<value>\fP.
+.sp
+Configuration also requires that default configuration parameters need to be
+loaded as well. This can be done simply by adding the \fB__opts__\fP dict to the
+top level of the module.
+.sp
+The test module contains usage of the module configuration, and the default
+configuration file for the minion contains the information and format used to
+pass data to the modules. \fBsalt.modules.test\fP, \fBconf/minion\fP.
+.SS Printout Configuration
+.sp
+Since module functions can return different data, and the way the data is
+printed can greatly change the presentation, Salt has a printout
+configuration.
+.sp
+When writing a module the \fB__outputter__\fP dict can be declared in the module.
+The \fB__outputter__\fP dict contains a mapping of function name to Salt
+Outputter.
+.sp
+.nf
+.ft C
+__outputter__ = {
+                \(aqrun\(aq: \(aqtxt\(aq
+                }
+.ft P
+.fi
+.sp
+This will ensure that the text outputter is used.
+.SS Virtual Modules
+.sp
+Sometimes a module should be presented in a generic way. A good example of this
+can be found in the package manager modules. The package manager changes from
+one operating system to another, but the salt module that interfaces with the
+package manager can be presented in a generic way.
+.sp
+The salt modules for package managers all contain a \fB__virtual__\fP function
+which is called to define what systems the module should be loaded on.
+.sp
+The \fB__virtual__\fP function is used to return either a string or False. If
+False is returned then the module is not loaded, if a string is returned then
+the module is loaded with the name of the string.
+.sp
+This means that the package manager modules can be presented as the pkg module
+regardless of what the actual module is named.
+.sp
+The package manager modules are the best example of using the \fB__virtual__\fP
+function:
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/modules/pacman.py\fP
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/modules/yum.py\fP
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/modules/apt.py\fP
+.SS Documentation
+.sp
+Salt modules are self documenting, the \fBsys.doc()\fP function will return the
+documentation for all available Facter modules:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq sys.doc
+.ft P
+.fi
+.sp
+This function simple prints out the docstrings found in the modules, when
+writing salt modules, please follow the formating conventions for docstrings as
+they appear in the other modules.
+.SS Adding Documentation to Salt Modules
+.sp
+Since life is much better with documentation, it is strongly suggested that
+all Salt modules have documentation added. Any Salt modules submitted for
+inclusion in the main distribution of Salt will be required to have
+documentation.
+.sp
+Documenting Salt modules is easy! Just add a python docstring to the function.
+.sp
+.nf
+.ft C
+def spam(eggs):
+    \(aq\(aq\(aq
+    A function to make some spam with eggs!
+
+    CLI Example:
+    salt \(aq*\(aq test.spam eggs
+    \(aq\(aq\(aq
+    return eggs
+.ft P
+.fi
+.sp
+Now when the sys.doc call is executed the docstring will be cleanly returned
+to the calling terminal.
+.SS How Functions are Read
+.sp
+In Salt Python callable objects contained within a module are made available to
+the Salt minion for use. The only exception to this rule is a callable object
+with a name starting with an underscore \fB_\fP.
+.SS Objects Loaded Into the Salt Minion
+.sp
+.nf
+.ft C
+def foo(bar):
+    return bar
+
+class baz:
+    def __init__(self, quo):
+        return quo
+.ft P
+.fi
+.SS Objects NOT Loaded into the Salt Minion
+.sp
+.nf
+.ft C
+def _foobar(baz): # Preceded with an _
+    return baz
+
+cheese = {} # Not a callable python object
+.ft P
+.fi
+.SS Examples of Salt Modules
+.sp
+The existing Salt modules should be fairly easy to read and understand, the
+goal of the main distribution\(aqs Salt modules is not only to build a set of
+functions for salt, but to stand as examples for building out more Salt
+modules.
+.sp
+The existing modules can be found here:
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/modules\fP
+.sp
+The most simple module is the test module, it contains the simplest salt
+function, test.ping:
+.sp
+.nf
+.ft C
+def ping():
+    \(aq\(aq\(aq
+    Just used to make sure the minion is up and responding
+    Return True
+
+    CLI Example:
+    salt \(aq*\(aq test.ping
+    \(aq\(aq\(aq
+    return True
+.ft P
+.fi
+.SH FULL LIST OF BUILTIN MODULES
+.SS Contents
+.INDENT 0.0
+.IP \(bu 2
+\fI\%salt.modules.apache\fP
+.IP \(bu 2
+\fI\%salt.modules.apt\fP
+.IP \(bu 2
+\fI\%salt.modules.butterkvm\fP
+.IP \(bu 2
+\fI\%salt.modules.cluster\fP
+.IP \(bu 2
+\fI\%salt.modules.cmd\fP
+.IP \(bu 2
+\fI\%salt.modules.cp\fP
+.IP \(bu 2
+\fI\%salt.modules.cron\fP
+.IP \(bu 2
+\fI\%salt.modules.disk\fP
+.IP \(bu 2
+\fI\%salt.modules.file\fP
+.IP \(bu 2
+\fI\%salt.modules.freebsdpkg\fP
+.IP \(bu 2
+\fI\%salt.modules.grains\fP
+.IP \(bu 2
+\fI\%salt.modules.groupadd\fP
+.IP \(bu 2
+\fI\%salt.modules.hosts\fP
+.IP \(bu 2
+\fI\%salt.modules.kmod\fP
+.IP \(bu 2
+\fI\%salt.modules.mdadm\fP
+.IP \(bu 2
+\fI\%salt.modules.moosefs\fP
+.IP \(bu 2
+\fI\%salt.modules.mount\fP
+.IP \(bu 2
+\fI\%salt.modules.mysql\fP
+.IP \(bu 2
+\fI\%salt.modules.network\fP
+.IP \(bu 2
+\fI\%salt.modules.pacman\fP
+.IP \(bu 2
+\fI\%salt.modules.ps\fP
+.IP \(bu 2
+\fI\%salt.modules.publish\fP
+.IP \(bu 2
+\fI\%salt.modules.puppet\fP
+.IP \(bu 2
+\fI\%salt.modules.pw_group\fP
+.IP \(bu 2
+\fI\%salt.modules.pw_user\fP
+.IP \(bu 2
+\fI\%salt.modules.selinux\fP
+.IP \(bu 2
+\fI\%salt.modules.service\fP
+.IP \(bu 2
+\fI\%salt.modules.shadow\fP
+.IP \(bu 2
+\fI\%salt.modules.solr\fP
+.IP \(bu 2
+\fI\%salt.modules.ssh\fP
+.IP \(bu 2
+\fI\%salt.modules.state\fP
+.IP \(bu 2
+\fI\%salt.modules.status\fP
+.IP \(bu 2
+\fI\%salt.modules.test\fP
+.IP \(bu 2
+\fI\%salt.modules.useradd\fP
+.IP \(bu 2
+\fI\%salt.modules.virt\fP
+.IP \(bu 2
+\fI\%salt.modules.yum\fP
+.UNINDENT
+.SS \fBsalt.modules.apache\fP
+.sp
+Support for Apache
+.INDENT 0.0
+.TP
+.B salt.modules.apache.directives()
+Return list of directives together with expected arguments
+and places where the directive is valid (apachectl \-L)
+.sp
+CLI Example:
+salt \(aq*\(aq apache.directives
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apache.fullversion()
+Return server version from apachectl \-V
+.sp
+CLI Example:
+salt \(aq*\(aq apache.fullversion
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apache.modules()
+Return list of static and shared modules from apachectl \-M
+.sp
+CLI Example:
+salt \(aq*\(aq apache.modules
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apache.servermods()
+Return list of modules compiled into the server (apachectl \-l)
+.sp
+CLI Example:
+salt \(aq*\(aq apache.servermods
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apache.signal(signal=None)
+Signals httpd to start, restart, or stop.
+.sp
+CLI Example:
+salt \(aq*\(aq apache.signal restart
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apache.version()
+Return server version from apachectl \-v
+.sp
+CLI Example:
+salt \(aq*\(aq apache.version
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apache.vhosts()
+Show the settings as parsed from the config file (currently
+only shows the virtualhost settings). (apachectl \-S)
+Because each additional virtual host adds to the execution
+time, this command may require a long timeout be specified.
+.sp
+CLI Example:
+salt \-t 10 \(aq*\(aq apache.vhosts
+.UNINDENT
+.SS \fBsalt.modules.apt\fP
+.sp
+Support for apt
+.INDENT 0.0
+.TP
+.B salt.modules.apt.available_version(name)
+The available version of the package in the repository
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.available_version <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.install(pkg, refresh=False)
+Install the passed package
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+        \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq pkg.install <package name>
+.ft P
+.fi
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.list_pkgs(regex_string=\(aq\(aq)
+List the packages currently installed in a dict:
+{\(aq<package_name>\(aq: \(aq<version>\(aq}
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.list_pkgs
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.purge(pkg)
+Remove a package via apt\-get along with all configuration files and
+unused dependencies as determined by apt\-get autoremove
+.sp
+Returns a list containing the names of the removed packages
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.purge <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.refresh_db()
+Updates the apt database to latest packages based upon repositories
+.sp
+Returns a dict: {\(aq<database name>\(aq: Bool}
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.refresh_db
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.remove(pkg)
+Remove a single package via apt\-get remove
+.sp
+Return a list containing the names of the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.remove <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.upgrade(refresh=True)
+Upgrades all packages via apt\-get dist\-upgrade
+.sp
+Returns a list of dicts containing the package names, and the new and old
+versions:
+.sp
+.nf
+.ft C
+[
+    {\(aq<package>\(aq:  {\(aqold\(aq: \(aq<old\-version>\(aq,
+                \(aqnew\(aq: \(aq<new\-version>\(aq]
+    }\(aq,
+    ...
+]
+.ft P
+.fi
+.sp
+CLI Example:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq pkg.upgrade
+.ft P
+.fi
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.apt.version(name)
+Returns a string representing the package version or an empty string if not
+installed
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.version <package name>
+.UNINDENT
+.SS \fBsalt.modules.butterkvm\fP
+.sp
+Specialized routines used by the butter cloud component
+.INDENT 0.0
+.TP
+.B salt.modules.butterkvm.create(instance, vda, image, pin)
+Create a virtual machine, this is part of the butter vm system and assumes
+that the files prepared by butter are available via shared storage.
+AKA \- don\(aqt call this from the command line!
+.sp
+Arguments:
+instance \- string, The path to the instance directory for the given vm on
+shared storage
+vda \- The location where the virtual machine image needs to be placed
+image \- The image to move into place
+pin \- a "pin" data structure defining the myriad of possible vdb\-vbz disk
+images to generate.
+.sp
+CLI Example:
+salt \(aq*\(aq butterkvm.create <instance dir> <root image location>            <Destination> <pin data>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.butterkvm.full_butter_data(local_path)
+Return the full virt info, but add butter data!
+.sp
+CLI Example:
+salt \(aq*\(aq buttervm.full_butter_data <image_path>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.butterkvm.libvirt_creds()
+Returns the user and group that the disk images should be owned by
+.sp
+CLI Example:
+salt \(aq*\(aq butterkvm.libvirt_creds
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.butterkvm.local_images(local_path)
+return the virtual machine names for all of the images located in the
+butter cloud\(aqs local_path in a list:
+.sp
+[\(aqvm1.boo.com\(aq, \(aqvm2.foo.com\(aq]
+.sp
+CLI Example:
+salt \(aq*\(aq buttervm.local_images <image_path>
+.UNINDENT
+.SS \fBsalt.modules.cluster\fP
+.sp
+The cluster module is used to distribute and activate salt HA cluster
+components
+.INDENT 0.0
+.TP
+.B salt.modules.cluster.distrib(minions, master_conf, master_pem, conf_file)
+Set up this minion as a failover master \- only intended for use by the
+cluster interface
+.UNINDENT
+.SS \fBsalt.modules.cmd\fP
+.sp
+A module for shelling out
+.sp
+Keep in mind that this module is insecure, in that it can give whomever has
+access to the master root execution access to all salt minions
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.exec_code(lang, code, cwd=\(aq/home/sendout\(aq)
+Pass in two strings, the first naming the executable language, aka \-
+python2, python3, ruby, perl, lua, etc. the second string containing
+the code you wish to execute. The stdout and stderr will be returned
+.sp
+CLI Example:
+salt \(aq*\(aq cmd.exec_code ruby \(aqputs "cheese"\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.has_exec(cmd)
+Returns true if the executable is available on the minion, false otherwise
+.sp
+CLI Example:
+salt \(aq*\(aq cat
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.retcode(cmd, cwd=\(aq/home/sendout\(aq)
+Execute a shell command and return the command\(aqs return code.
+.sp
+CLI Example:
+salt \(aq*\(aq cmd.retcode "file /bin/bash"
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.run(cmd, cwd=\(aq/home/sendout\(aq)
+Execute the passed command and return the output as a string
+.sp
+CLI Example:
+salt \(aq*\(aq cmd.run "ls \-l | grep foo | awk \(aq{print $2}\(aq"
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.run_all(cmd, cwd=\(aq/home/sendout\(aq)
+Execute the passed command and return a dict of return data
+.sp
+CLI Example:
+salt \(aq*\(aq cmd.run_all "ls \-l | grep foo | awk \(aq{print $2}\(aq"
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.run_stderr(cmd, cwd=\(aq/home/sendout\(aq)
+Execute a command and only return the standard error
+.sp
+CLI Example:
+salt \(aq*\(aq cmd.run "ls \-l | grep foo | awk \(aq{print $2}\(aq"
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cmd.run_stdout(cmd, cwd=\(aq/home/sendout\(aq)
+Execute a command, and only return the standard out
+.sp
+CLI Example:
+salt \(aq*\(aq cmd.run "ls \-l | grep foo | awk \(aq{print $2}\(aq"
+.UNINDENT
+.SS \fBsalt.modules.cp\fP
+.sp
+Minion side functions for salt\-cp
+.INDENT 0.0
+.TP
+.B salt.modules.cp.cache_dir(path, env=\(aqbase\(aq)
+Download and cache everything under a directory from the master
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.cache_file(path, env=\(aqbase\(aq)
+Used to cache a single file in the local salt\-master file cache.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.cache_files(paths, env=\(aqbase\(aq)
+Used to gather many files from the master, the gathered files will be
+saved in the minion cachedir reflective to the paths retrieved from the
+master.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.cache_master(env=\(aqbase\(aq)
+Retrieve all of the files on the master and cache them locally
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.get_file(path, dest, env=\(aqbase\(aq)
+Used to get a single file from the salt master
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.hash_file(path, env=\(aqbase\(aq)
+Return the hash of a file, to get the hash of a file on the
+salt master file server prepend the path with salt://<file on server>
+otherwise, prepend the file with / for a local file.
+.sp
+CLI Example:
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.list_master(env=\(aqbase\(aq)
+Retrieve all of the files on the master and cache them locally
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cp.recv(files, dest)
+Used with salt\-cp, pass the files dict, and the destination.
+.sp
+This function receives small fast copy files from the master via salt\-cp
+.UNINDENT
+.SS \fBsalt.modules.cron\fP
+.sp
+Work with cron
+.INDENT 0.0
+.TP
+.B salt.modules.cron.list_tab(user)
+Return the contents of the specified user\(aqs crontab
+.sp
+CLI Example:
+salt \(aq*\(aq cron.list_tab root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cron.raw_cron(user)
+Return the contents of the user\(aqs crontab
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cron.rm_job(user, minute, hour, dom, month, dow, cmd)
+Remove a cron job up for a specified user.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cron.set_job(user, minute, hour, dom, month, dow, cmd)
+Sets a cron job up for a specified user.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.cron.set_special(user, special, cmd)
+Set up a special command in the crontab.
+.sp
+CLI Example:
+salt \(aq*\(aq cron.set_special @hourly \(aqecho foobar\(aq
+.UNINDENT
+.SS \fBsalt.modules.disk\fP
+.sp
+Module for gathering disk information
+.INDENT 0.0
+.TP
+.B salt.modules.disk.usage()
+Return usage information for volumes mounted on this minion
+.sp
+CLI Example:
+salt \(aq*\(aq disk.usage
+.UNINDENT
+.SS \fBsalt.modules.file\fP
+.sp
+Manage information about files on the minion, set/read user, group, and mode
+data
+.INDENT 0.0
+.TP
+.B salt.modules.file.chgrp(path, group)
+Change the group of a file
+.sp
+CLI Example:
+salt \(aq*\(aq file.chgrp /etc/passwd root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.chown(path, user, group)
+Chown a file, pass the file the desired user and group
+.sp
+CLI Example:
+salt \(aq*\(aq file.chown /etc/passwd root root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.find(path, *opts)
+Approximate the Unix find(1) command and return a list of paths that
+meet the specified critera.
+.sp
+The options include match criteria:
+.sp
+.nf
+.ft C
+name    = path\-glob                 # case sensitive
+iname   = path\-glob                 # case insensitive
+regex   = path\-regex                # case sensitive
+iregex  = path\-regex                # case insensitive
+type    = file\-types                # match any listed type
+user    = users                     # match any listed user
+group   = groups                    # match any listed group
+size    = [+\-]number[size\-unit]     # default unit = byte
+mtime   = interval                  # modified since date
+grep    = regex                     # search file contents
+.ft P
+.fi
+.sp
+and/or actions:
+.sp
+.nf
+.ft C
+delete [= file\-types]               # default type = \(aqf\(aq
+exec    = command [arg ...]         # where {} is replaced by pathname
+print  [= print\-opts]
+.ft P
+.fi
+.sp
+The default action is \(aqprint=path\(aq.
+.sp
+file\-glob:
+.sp
+.nf
+.ft C
+*                = match zero or more chars
+?                = match any char
+[abc]            = match a, b, or c
+[!abc] or [^abc] = match anything except a, b, and c
+[x\-y]            = match chars x through y
+[!x\-y] or [^x\-y] = match anything except chars x through y
+{a,b,c}          = match a or b or c
+.ft P
+.fi
+.INDENT 7.0
+.TP
+.B path\-regex:
+a Python re (regular expression) pattern to match pathnames
+.UNINDENT
+.sp
+file\-types: a string of one or more of the following:
+.sp
+.nf
+.ft C
+a: all file types
+b: block device
+c: character device
+d: directory
+p: FIFO (named pipe)
+f: plain file
+l: symlink
+s: socket
+.ft P
+.fi
+.INDENT 7.0
+.TP
+.B users:
+a space and/or comma separated list of user names and/or uids
+.TP
+.B groups:
+a space and/or comma separated list of group names and/or gids
+.UNINDENT
+.sp
+size\-unit:
+.sp
+.nf
+.ft C
+b: bytes
+k: kilobytes
+m: megabytes
+g: gigabytes
+t: terabytes
+.ft P
+.fi
+.sp
+interval:
+.sp
+.nf
+.ft C
+[<num>w] [<num>[d]] [<num>h] [<num>m] [<num>s]
+
+where:
+    w: week
+    d: day
+    h: hour
+    m: minute
+    s: second
+.ft P
+.fi
+.sp
+print\-opts: a comma and/or space separated list of one or more of the
+following:
+.sp
+.nf
+.ft C
+group: group name
+md5:   MD5 digest of file contents
+mode:  file permissions (as integer)
+mtime: last modification time (as time_t)
+name:  file basename
+path:  file absolute path
+size:  file size in bytes
+type:  file type
+user:  user name
+.ft P
+.fi
+.sp
+CLI Examples:
+.sp
+.nf
+.ft C
+salt \(aq*\(aq / type=f name=\e*.bak size=+10m
+salt \(aq*\(aq /var mtime=+30d size=+10m print=path,size,mtime
+salt \(aq*\(aq /var/log name=\e*.[0\-9] mtime=+30d size=+10m delete
+.ft P
+.fi
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.get_gid(path)
+Return the user that owns a given file
+.sp
+CLI Example:
+salt \(aq*\(aq file.get_gid /etc/passwd
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.get_group(path)
+Return the user that owns a given file
+.sp
+CLI Example:
+salt \(aq*\(aq file.get_group /etc/passwd
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.get_mode(path)
+Return the mode of a file
+.sp
+CLI Example:
+salt \(aq*\(aq file.get_mode /etc/passwd
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.get_sum(path, form=\(aqmd5\(aq)
+Return the sum for the given file, default is md5, sha1, sha224, sha256,
+sha384, sha512 are supported
+.sp
+CLI Example:
+salt \(aq*\(aq /etc/passwd sha512
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.get_uid(path)
+Return the user that owns a given file
+.sp
+CLI Example:
+salt \(aq*\(aq file.get_uid /etc/passwd
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.get_user(path)
+Return the user that owns a given file
+.sp
+CLI Example:
+salt \(aq*\(aq file.get_user /etc/passwd
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.gid_to_group(gid)
+Convert the group id to the group name on this system
+.sp
+CLI Example:
+salt \(aq*\(aq file.gid_to_group 0
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.group_to_gid(group)
+Convert the group to the gid on this system
+.sp
+CLI Example:
+salt \(aq*\(aq file.group_to_gid root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.set_mode(path, mode)
+Set the more of a file
+.sp
+CLI Example:
+salt \(aq*\(aq file.set_mode /etc/passwd 0644
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.uid_to_user(uid)
+Convert a uid to a user name
+.sp
+CLI Example:
+salt \(aq*\(aq file.uid_to_user 0
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.file.user_to_uid(user)
+Convert user name to a gid
+.sp
+CLI Example:
+salt \(aq*\(aq file.user_to_uid root
+.UNINDENT
+.SS \fBsalt.modules.freebsdpkg\fP
+.sp
+Package support for FreeBSD
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.available_version(name)
+The available version of the package in the repository
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.available_version <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.install(name, refresh=False)
+Install the passed package
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+           \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.install <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.list_pkgs()
+List the packages currently installed in a dict:
+{\(aq<package_name>\(aq: \(aq<version>\(aq}
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.list_pkgs
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.purge(name)
+Remove a single package with pkg_delete
+.sp
+Return a list containing the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.purge <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.refresh_db()
+Update the ports tree with portsnap. If the ports tre does not exist it
+will be downloaded and set up.
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.refresh_db
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.remove(name)
+Remove a single package with pkg_delete
+.sp
+Return a list containing the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.remove <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.upgrade()
+Run a full system upgrade, a "freebsd\-update fetch install"
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+           \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.upgrade
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.freebsdpkg.version(name)
+Returns a version if the package is installed, else returns an empty string
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.version <package name>
+.UNINDENT
+.SS \fBsalt.modules.grains\fP
+.sp
+Control aspects of the grains data
+.INDENT 0.0
+.TP
+.B salt.modules.grains.item(key)
+Return a singe component of the grains data
+.sp
+CLI Example:
+salt \(aq*\(aq grains.item os
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.grains.items()
+Return the grains data
+.sp
+CLI Example:
+salt \(aq*\(aq grains.items
+.UNINDENT
+.SS \fBsalt.modules.groupadd\fP
+.sp
+Manage groups on Linux
+.INDENT 0.0
+.TP
+.B salt.modules.groupadd.add(name, gid=None)
+Add the specified group
+.sp
+CLI Example:
+salt \(aq*\(aq group.add foo 3456
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.groupadd.chgid(name, gid)
+Change the default shell of the user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chshell foo /bin/zsh
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.groupadd.delete(name)
+Remove the named group
+.sp
+CLI Example:
+salt \(aq*\(aq group.delete foo
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.groupadd.getent()
+Return info on all groups
+.sp
+CLI Example:
+salt \(aq*\(aq group.getent
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.groupadd.info(name)
+Return information about a group
+.sp
+CLI Example:
+salt \(aq*\(aq group.info foo
+.UNINDENT
+.SS \fBsalt.modules.hosts\fP
+.sp
+Manage the information in the hosts file
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.add_host(ip, alias)
+Add a host to an existing entry, if the entry is not in place then create
+it with the given host
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.add_host <ip> <alias>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.get_alias(ip)
+Return the list of aliases associated with an ip
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.get_alias <ip addr>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.get_ip(host)
+Return the ip associated with the named host
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.get_ip <hostname>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.has_pair(ip, alias)
+Return true if the alias is set
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.has_pair <ip> <alias>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.list_hosts()
+Return the hosts found in the hosts file in this format:
+.sp
+{\(aq<ip addr>\(aq: [\(aqalias1\(aq, \(aqalias2\(aq, ...]}
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.list_hosts
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.rm_host(ip, alias)
+Remove a host entry from the hosts file
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.rm_host <ip> <alias>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.hosts.set_host(ip, alias)
+Set the host entry in th hosts file for the given ip, this will overwrite
+any previous entry for the given ip
+.sp
+CLI Example:
+salt \(aq*\(aq hosts.set_host <ip> <alias>
+.UNINDENT
+.SS \fBsalt.modules.kmod\fP
+.sp
+Module to manage Linux kernel modules
+.INDENT 0.0
+.TP
+.B salt.modules.kmod.available()
+Return a list of all available kernel modules
+.sp
+CLI Example:
+salt \(aq*\(aq kmod.available
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.kmod.check_available(mod)
+Check to see if the speciified kernel module is available
+.sp
+CLI Example:
+salt \(aq*\(aq kmod.check_available kvm
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.kmod.load(mod)
+Load the specified kernel module
+.sp
+CLI Example:
+salt \(aq*\(aq kmod.load kvm
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.kmod.lsmod()
+Return a dict containing information about currently loaded modules
+.sp
+CLI Example:
+salt \(aq*\(aq kmod.lsmod
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.kmod.remove(mod)
+Remove the specified kernel module
+.sp
+CLI Example:
+salt \(aq*\(aq kmod.remove kvm
+.UNINDENT
+.SS \fBsalt.modules.mdadm\fP
+.sp
+Salt module to manage RAID arrays with mdadm
+.INDENT 0.0
+.TP
+.B salt.modules.mdadm.detail(device=\(aq/dev/md0\(aq)
+Show detail for a specified RAID device
+.sp
+CLI Example:
+salt \(aq*\(aq mdadm.detail \(aq/dev/md0\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mdadm.list()
+List the RAID devices.
+.sp
+CLI Example:
+salt \(aq*\(aq mdadm.list
+.UNINDENT
+.SS \fBsalt.modules.moosefs\fP
+.sp
+Module for gathering and managing information about MooseFS
+.INDENT 0.0
+.TP
+.B salt.modules.moosefs.dirinfo(path, opts=None)
+Return information on a directory located on the Moose
+.sp
+CLI Example:
+salt \(aq*\(aq moosefs.dirinfo /path/to/dir/ [\-[n][h|H]]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.moosefs.fileinfo(path)
+Return information on a file located on the Moose
+.sp
+CLI Example:
+salt \(aq*\(aq moosefs.fileinfo /path/to/dir/
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.moosefs.getgoal(path, opts=None)
+Return goal(s) for a file or directory
+.sp
+CLI Example:
+salt \(aq*\(aq moosefs.getgoal /path/to/file [\-[n][h|H]]
+salt \(aq*\(aq moosefs.getgoal /path/to/dir/ [\-[n][h|H][r]]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.moosefs.mounts()
+Return a list of current MooseFS mounts
+.sp
+CLI Example:
+salt \(aq*\(aq moosefs.mounts
+.UNINDENT
+.SS \fBsalt.modules.mount\fP
+.sp
+Salt module to manage unix mounts and the fstab file
+.INDENT 0.0
+.TP
+.B salt.modules.mount.active()
+List the active mounts.
+.sp
+CLI Example:
+salt \(aq*\(aq mount.active
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mount.fstab(config=\(aq/etc/fstab\(aq)
+List the contents of the fstab
+.sp
+CLI Example:
+salt \(aq*\(aq mount.fstab
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mount.is_fuse_exec(cmd)
+Returns true if the command passed is a fuse mountable application.
+.sp
+CLI Example:
+salt \(aq*\(aq mount.is_fuse_exec sshfs
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mount.mount(name, device, mkmnt=False, fstype=\(aq\(aq, opts=\(aqdefaults\(aq)
+Mount a device
+.sp
+CLI Example:
+salt \(aq*\(aq mount.mount /mnt/foo /dev/sdz1 True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mount.remount(name, device, mkmnt=False, fstype=\(aq\(aq, opts=\(aqdefaults\(aq)
+Attempt to remount a device, if the device is not already mounted, mount
+is called
+.sp
+CLI Example:
+salt \(aq*\(aq mount.remount /mnt/foo /dev/sdz1 True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mount.rm_fstab(name, config=\(aq/etc/fstab\(aq)
+Remove the mount point from the fstab
+.sp
+CLI Example:
+salt \(aq*\(aq /mnt/foo
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mount.set_fstab(name, device, fstype, opts=\(aqdefaults\(aq, dump=0, pass_num=0, config=\(aq/etc/fstab\(aq)
+Verify that this mount is represented in the fstab, chage the mount point
+to match the data passed, or add the mount if it is not present.
+.sp
+CLI Example:
+salt \(aq*\(aq mount.set_fstab /mnt/foo /dev/sdz1 ext4
+.UNINDENT
+.SS \fBsalt.modules.mysql\fP
+.sp
+Module to provide MySQL compatibility to salt.
+.sp
+In order to connect to MySQL, certain configuration is required 
+in /etc/salt/minion on the relevant minions. Some sample configs
+might look like:
+.sp
+mysql.host: \(aqlocalhost\(aq
+mysql.port: 3306
+mysql.user: \(aqroot\(aq
+mysql.pass: \(aq\(aq
+mysql.db: \(aqmysql\(aq
+.INDENT 0.0
+.TP
+.B salt.modules.mysql.connect()
+wrap authentication credentials here
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mysql.status()
+Return the status of a MySQL server using the output
+from the SHOW STATUS query.
+.sp
+CLI Example:
+salt \(aq*\(aq mysql.status
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.mysql.version()
+Return the version of a MySQL server using the output
+from the SELECT VERSION() query.
+.sp
+CLI Example:
+salt \(aq*\(aq mysql.version
+.UNINDENT
+.SS \fBsalt.modules.network\fP
+.sp
+Module for gathering and managing network information
+.INDENT 0.0
+.TP
+.B salt.modules.network.dig(host)
+Performs a DNS lookup with dig
+.sp
+CLI Example:
+salt \(aq*\(aq network.dig archlinux.org
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.network.isportopen(host, port)
+Return status of a port
+.sp
+CLI Example:
+salt \(aq*\(aq network.isportopen 127.0.0.1 22
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.network.netstat()
+Return information on open ports and states
+.sp
+CLI Example:
+salt \(aq*\(aq network.netstat
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.network.ping(host)
+Performs a ping to a host
+.sp
+CLI Example:
+salt \(aq*\(aq network.ping archlinux.org \-c 4
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.network.traceroute(host)
+Performs a traceroute to a 3rd party host
+.sp
+CLI Example:
+salt \(aq*\(aq network.traceroute archlinux.org
+.UNINDENT
+.SS \fBsalt.modules.pacman\fP
+.sp
+A module to wrap pacman calls, since Arch is the best
+(\fI\%https://wiki.archlinux.org/index.php/Arch_is_the_best\fP)
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.available_version(name)
+The available version of the package in the repository
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.available_version <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.install(name, refresh=False)
+Install the passed package, add refresh=True to install with an \-Sy
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+           \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.install <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.list_pkgs()
+List the packages currently installed in a dict:
+{\(aq<package_name>\(aq: \(aq<version>\(aq}
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.list_pkgs
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.purge(name)
+Recursively remove a package and all dependencies which were installed
+with it, this will call a pacman \-Rsc
+.sp
+Return a list containing the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.purge <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.refresh_db()
+Just run a pacman \-Sy, return a dict:
+{\(aq<database name>\(aq: Bool}
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.refresh_db
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.remove(name)
+Remove a single package with pacman \-R
+.sp
+Return a list containing the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.remove <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.upgrade()
+Run a full system upgrade, a pacman \-Syu
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+           \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.upgrade
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pacman.version(name)
+Returns a version if the package is installed, else returns an empty string
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.version <package name>
+.UNINDENT
+.SS \fBsalt.modules.ps\fP
+.sp
+A salt interface to psutil, a system and process library.
+See \fI\%http://code.google.com/p/psutil\fP.
+.INDENT 0.0
+.TP
+.B salt.modules.ps.BOOT_TIME()
+Return the boot time in number of seconds since the epoch began.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.NUM_CPUS()
+Return the number of CPUs.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.TOTAL_PHYMEM()
+Return the total number of bytes of physical memory.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.cached_phymem()
+Return the amount cached memory.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.cpu_percent(interval=0.10000000000000001, per_cpu=False)
+Return the percent of time the CPU is busy.
+.INDENT 7.0
+.TP
+.B interval
+the number of seconds to sample CPU usage over
+.TP
+.B per_cpu
+if True return an array of CPU percent busy for each CPU, otherwise
+aggregate all precents into one number
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.cpu_times(per_cpu=False)
+Return the percent of time the CPU spends in each state,
+e.g. user, system, idle, nice, iowait, irq, softirq.
+.INDENT 7.0
+.TP
+.B per_cpu
+if True return an array of percents for each CPU, otherwise aggregate
+all precents into one number
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.disk_partition_usage(all=False)
+Return a list of disk partitions plus the mount point, filesystem and usage
+statistics.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.disk_partitions(all=False)
+Return a list of disk partitions and their device, mount point, and filesystem type.
+.INDENT 7.0
+.TP
+.B all
+if set to False, only return local, physical partitions (hard disk,
+USB, CD/DVD partitions).  If True, return all filesystems.
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.disk_usage(path)
+Given a path, return a dict listing the total available space as well as
+the free space, and used space.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.get_pid_list()
+Return a list of process ids (PIDs) for all running processes.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.phymem_buffers()
+Return the amount of physical memory buffers.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.phymem_usage()
+Return a dict that describes free and available physical memory.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.top(num_processes=5, interval=3)
+Return a list of top CPU consuming processes during the interval.
+num_processes = return the top N CPU consuming processes
+interval = the number of seconds to sample CPU usage over
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ps.virtmem_usage()
+Return a dict that describes free and available memory, both physical
+and virtual.
+.UNINDENT
+.SS \fBsalt.modules.publish\fP
+.sp
+Publish a command from a minion to a target
+.INDENT 0.0
+.TP
+.B salt.modules.publish.publish(tgt, fun, arg, expr_form=\(aqglob\(aq, returner=\(aq\(aq)
+Publish a command from the minion out to other minions, publications need
+to be enabled on the Salt master and the minion needs to have permission
+to publish the command. The Salt master will also prevent a recursive
+publication loop, this means that a minion cannot command another minion
+to command another minion as that would create an infinate command loop.
+.sp
+The arguments sent to the minion publish function are seperated with
+commas. This means that a minion who is executing a command with multiple
+args it will look like this:
+.sp
+salt system.example.com publish.publish \(aq*\(aq user.add \(aqfoo,1020,1020\(aq
+.sp
+CLI Example:
+salt system.example.com publish.publish \(aq*\(aq cmd.run \(aqls \-la /tmp\(aq
+.UNINDENT
+.SS \fBsalt.modules.puppet\fP
+.sp
+Execute puppet routines
+.INDENT 0.0
+.TP
+.B salt.modules.puppet.run()
+Execute a puppet run and return a dict with the stderr,stdout,return code
+etc.
+.sp
+CLI Example:
+salt \(aq*\(aq puppet.run
+.UNINDENT
+.SS \fBsalt.modules.pw_group\fP
+.sp
+Manage groups on Linux
+.INDENT 0.0
+.TP
+.B salt.modules.pw_group.add(name, gid=None)
+Add the specified group
+.sp
+CLI Example:
+salt \(aq*\(aq group.add foo 3456
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_group.chgid(name, gid)
+Change the default shell of the user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chshell foo /bin/zsh
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_group.delete(name)
+Remove the named group
+.sp
+CLI Example:
+salt \(aq*\(aq group.delete foo
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_group.getent()
+Return info on all groups
+.sp
+CLI Example:
+salt \(aq*\(aq group.getent
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_group.info(name)
+Return information about a group
+.sp
+CLI Example:
+salt \(aq*\(aq group.info foo
+.UNINDENT
+.SS \fBsalt.modules.pw_user\fP
+.sp
+Manage users with the useradd command
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.add(name, uid=None, gid=None, groups=None, home=False, shell=\(aq/bin/false\(aq)
+Add a user to the minion
+.sp
+CLI Example:
+salt \(aq*\(aq user.add name <uid> <gid> <groups> <home> <shell>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.chgid(name, gid)
+Change the default group of the user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chgid foo 4376
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.chgroups(name, groups, append=False)
+Change the groups this user belongs to, add append to append the specified
+groups
+.sp
+CLI Example:
+salt \(aq*\(aq user.chgroups foo wheel,root True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.chhome(name, home, persist=False)
+Change the home directory of the user, pass true for persist to copy files
+to the new home dir
+.sp
+CLI Example:
+salt \(aq*\(aq user.chhome foo /home/users/foo True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.chshell(name, shell)
+Change the default shell of the user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chshell foo /bin/zsh
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.chuid(name, uid)
+Change the uid for a named user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chuid foo 4376
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.delete(name, remove=False, force=False)
+Remove a user from the minion
+.sp
+CLI Example:
+salt \(aq*\(aq user.delete name True True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.getent()
+Return the list of all info for all users
+.sp
+CLI Example:
+salt \(aq*\(aq user.getent
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.info(name)
+Return user information
+.sp
+CLI Example:
+salt \(aq*\(aq user.info root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.pw_user.list_groups(name)
+Return a list of groups the named user belings to
+.sp
+CLI Example:
+salt \(aq*\(aq user.groups foo
+.UNINDENT
+.SS \fBsalt.modules.selinux\fP
+.sp
+Execute calls on selinux
+.INDENT 0.0
+.TP
+.B salt.modules.selinux.getenforce()
+Return the mode selinux is running in
+.sp
+CLE Example:
+salt \(aq*\(aq selinux.getenforce
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.selinux.setenforce(mode)
+Set the enforcing mode
+.UNINDENT
+.SS \fBsalt.modules.service\fP
+.sp
+Top level package command wrapper, used to translate the os detected by the
+grains to the correct service manager
+.INDENT 0.0
+.TP
+.B salt.modules.service.restart(name)
+Restart the named service
+.sp
+CLI Example:
+salt \(aq*\(aq service.restart <service name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.service.start(name)
+Start the specified service
+.sp
+CLI Example:
+salt \(aq*\(aq service.start <service name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.service.status(name, sig=None)
+Return the status for a service, returns the PID or an empty string if the
+service is running or not, pass a signature to use to find the service via
+ps
+.sp
+CLI Example:
+salt \(aq*\(aq service.status <service name> [service signature]
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.service.stop(name)
+Stop the specified service
+.sp
+CLI Example:
+salt \(aq*\(aq service.stop <service name>
+.UNINDENT
+.SS \fBsalt.modules.shadow\fP
+.sp
+Manage the shadow file
+.INDENT 0.0
+.TP
+.B salt.modules.shadow.info(name)
+Return the information for the specified user
+.sp
+CLI Example:
+salt \(aq*\(aq shadow.user root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.shadow.set_password(name, password)
+Set the password for a named user, the password must be a properly defined
+hash, the password hash can be generated with this command:
+openssl passwd \-1 <plaintext password>
+.sp
+CLI Example:
+salt \(aq*\(aq root $1$UYCIxa628.9qXjpQCjM4a..
+.UNINDENT
+.SS \fBsalt.modules.solr\fP
+.INDENT 0.0
+.TP
+.B salt.modules.solr.backup_master(core_name=None, path=None)
+Tell the master to make a backup. If you don\(aqt pass a core name and you are
+using cores it will backup all cores and append the name of the core to the
+backup path.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.TP
+.B Param: str path (/srv/media/solr/backup): The base backup path. 
+DO NOT INCLUDE THE CORE NAME!
+if the core name is specified or
+if you are using cores and leave
+core_name blank the name of the
+core will be appened to it.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.backup_master music
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.is_replication_enabled(core_name=None)
+USED ONLY BY SLAVES
+Check for errors, and determine if a slave is replicating or not.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.is_replication_enabled music
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.lucene_version(core_name=None)
+Gets the lucene version that solr is using. If you are running a multi\-core
+setup you should specify a core name since all the cores run under the same
+servlet container, they will all have the same version.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example: 
+salt \(aq*\(aq solr.lucene_version
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.match_index_versions(core_name=None)
+SLAVE ONLY
+Verifies that the master and the slave versions are in sync by 
+comparing the index version.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.match_index_versions music
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.optimize(core_name=None)
+RUN ON THE MASTER ONLY
+Optimize the solr index.  This should be done on a daily basis and only on
+solr masters. It may take a LONG time to run and depending on timeout 
+settings may time out the http request.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return:  dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.optimize music
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.ping(core_name=None)
+Does a health check on solr, makes sure solr can talk to the indexes.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.ping music
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.replication_details(core_name=None)
+Get the full replication details.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.replication_details music
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.set_is_polling(polling, core_name=None)
+SLAVE ONLY
+Prevent the slaves from polling the master for updates.
+.sp
+Param: bool polling: True will enable polling. False will disable it.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+salt \(aq*\(aq solr.set_is_polling False
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.signal(signal=None)
+Signals Apache Solr to start, stop, or restart. Obvioulsy this is only
+going to work if the minion resides on the solr host. Additionally 
+Solr doesn\(aqt ship with an init script so one must be created.
+.INDENT 7.0
+.TP
+.B Param: str signal (None): The command to pass to the apache solr init
+valid values are \(aqstart\(aq, \(aqstop\(aq, and \(aqrestart\(aq
+.UNINDENT
+.sp
+CLI Example:
+salt \(aq*\(aq solr.signal restart
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.solr.version(core_name=None)
+Gets the solr version for the core specified.  You should specify a core 
+here as all the cores will run under the same servelet container and so 
+will all have the same version.
+.INDENT 7.0
+.TP
+.B Param: str core_name (None): The name of the solr core if using cores. 
+Leave this blank if you are not using cores or
+if you want to check all cores.
+.UNINDENT
+.sp
+Return: dict {\(aqsuccess\(aq:bool, \(aqdata\(aq:dict, \(aqerrors\(aq:list, \(aqwarnings\(aq:list}
+.sp
+CLI Example:
+alt \(aq*\(aq solr.version
+.UNINDENT
+.SS \fBsalt.modules.ssh\fP
+.sp
+Manage client ssh components
+.INDENT 0.0
+.TP
+.B salt.modules.ssh.auth_keys(user, config=\(aq.ssh/authorized_keys\(aq)
+Return the authorized keys for the specified user
+.sp
+CLI Example:
+salt \(aq*\(aq ssh.auth_keys root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ssh.host_keys(keydir=None)
+Return the minion\(aqs host keys
+.sp
+CLI Example:
+salt \(aq*\(aq ssh.host_keys
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ssh.rm_auth_key(user, key, config=\(aq.ssh/authorized_keys\(aq)
+Remove an authorized key from the specified user\(aqs authorized key file
+.sp
+CLI Example:
+salt \(aq*\(aq ssh.rm_auth_key <user> <key>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.ssh.set_auth_key(user, key, enc=\(aqssh\-rsa\(aq, comment=\(aq\(aq, options=[], config=\(aq.ssh/authorized_keys\(aq)
+Add a key to the authorized_keys file
+.sp
+CLI Example:
+salt \(aq*\(aq ssh.set_auth_key <user> <key> dsa \(aq[]\(aq .ssh/authorized_keys
+.UNINDENT
+.SS \fBsalt.modules.state\fP
+.sp
+Control the state system on the minion
+.INDENT 0.0
+.TP
+.B salt.modules.state.high(data)
+Execute the compound calls stored in a single set of high data
+This function is mostly intended for testing the state system
+.sp
+CLI Example:
+salt \(aq*\(aq state.high \(aq{"vim": {"pkg": ["installed"]}}\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.state.highstate()
+Retrive the state data from the salt master for this minion and execute it
+.sp
+CLI Example:
+salt \(aq*\(aq state.highstate
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.state.low(data)
+Execute a single low data call
+This function is mostly intended for testing the state system
+.sp
+CLI Example:
+salt \(aq*\(aq state.low \(aq{"state": "pkg", "fun": "installed", "name": "vim"}\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.state.show_lowstate()
+List out the low data that will be applied to this minion
+.sp
+CLI Example:
+salt \(aq*\(aq show_lowstate
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.state.template(tem)
+Execute the information stored in a template file on the minion
+.sp
+CLI Example:
+salt \(aq*\(aq state.template \(aq<Path to template on the minion>\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.state.template_str(tem)
+Execute the information stored in a template file on the minion
+.sp
+CLI Example:
+salt \(aq*\(aq state.template_str \(aq<Template String>\(aq
+.UNINDENT
+.SS \fBsalt.modules.status\fP
+.sp
+Module for returning various status data about a minion.
+These data can be useful for compiling into stats later.
+.INDENT 0.0
+.TP
+.B salt.modules.status.all_status()
+Return a composite of all status data and info for this minoon.
+Warning: There is a LOT here!
+.sp
+CLI Example:
+salt \(aq*\(aq status.all_status
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.cpuinfo()
+Return the CPU info for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.cpuinfo
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.cpustats()
+Return the CPU stats for this minon
+.sp
+CLI Example:
+salt \(aq*\(aq status.cpustats
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.custom()
+Return a custom composite of status data and info for this minon,
+based on the minion config file. An example config like might be:
+.sp
+status.cpustats.custom: [ \(aqcpu\(aq, \(aqctxt\(aq, \(aqbtime\(aq, \(aqprocesses\(aq ]
+.sp
+where status refers to status.py, cpustats is the function
+where we get our data, and custom is this function It is followed
+by a list of keys that we want returned.
+.sp
+This function is meant to replace all_status(), which returns
+anything and everything, which we probably don\(aqt want.
+.sp
+By default, nothing is returned. Warning: Depending on what you
+include, there can be a LOT here!
+.sp
+CLI Example:
+salt \(aq*\(aq status.custom
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.diskstats()
+Return the disk stats for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.diskstats
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.diskusage(*args)
+Return the disk usage for this minion
+.sp
+Usage:
+salt \(aq*\(aq status.diskusage [paths and/or filesystem types]
+.sp
+CLI Example:
+salt \(aq*\(aq status.diskusage         # usage for all filesystems
+salt \(aq*\(aq status.diskusage / /tmp  # usage for / and /tmp
+salt \(aq*\(aq status.diskusage ext?    # usage for ext2, ext3, & ext4 filesystems
+salt \(aq*\(aq status.diskusage / ext?  # usage for / and all ext filesystems
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.loadavg()
+Return the load averages for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.loadavg
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.meminfo()
+Return the CPU stats for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.meminfo
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.netdev()
+Return the network device stats for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.netdev
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.netstats()
+Return the network stats for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.netstats
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.uptime()
+Return the uptime for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.uptime
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.vmstats()
+Return the virtual memory stats for this minion
+.sp
+CLI Example:
+salt \(aq*\(aq status.vmstats
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.status.w()
+Return a list of logged in users for this minion, using the w command
+.sp
+CLI Example:
+salt \(aq*\(aq status.w
+.UNINDENT
+.SS \fBsalt.modules.test\fP
+.sp
+Module for running arbitrary tests
+.INDENT 0.0
+.TP
+.B salt.modules.test.collatz(start)
+Execute the collatz conjecture from the passed starting number, returns
+the sequence and the time it took to compute. Used for performance tests.
+.sp
+CLI Example:
+salt \(aq*\(aq test.collatz 3
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.conf_test()
+Return the value for test.foo in the minion configuration file, or return
+the default value
+.sp
+CLI Example:
+salt \(aq*\(aq test.conf_test
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.cross_test(func, args=[])
+Execute a minion function via the __salt__ object in the test module, used
+to verify that the minion functions can be called via the __salt__module
+.sp
+CLI Example:
+salt \(aq*\(aq test.cross_test file.gid_to_group 0
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.echo(text)
+Return a string \- used for testing the connection
+.sp
+CLI Example:
+salt \(aq*\(aq test.echo \(aqfoo bar baz quo qux\(aq
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.fib(num)
+Return a Fibonacci sequence up to the passed number, and the time it took
+to compute in seconds. Used for performance tests
+.sp
+CLI Example:
+salt \(aq*\(aq test.fib 3
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.get_opts()
+Return the configuration options passed to this minion
+.sp
+CLI Example:
+salt \(aq*\(aq test.get_opts
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.outputter(data)
+Test the outputter, pass in data to return
+.sp
+CLI Example:
+salt \(aq*\(aq test.outputter foobar
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.test.ping()
+Just used to make sure the minion is up and responding
+Return True
+.sp
+CLI Example:
+salt \(aq*\(aq test.ping
+.UNINDENT
+.SS \fBsalt.modules.useradd\fP
+.sp
+Manage users with the useradd command
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.add(name, uid=None, gid=None, groups=None, home=False, shell=\(aq/bin/false\(aq)
+Add a user to the minion
+.sp
+CLI Example:
+salt \(aq*\(aq user.add name <uid> <gid> <groups> <home> <shell>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.chgid(name, gid)
+Change the default group of the user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chgid foo 4376
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.chgroups(name, groups, append=False)
+Change the groups this user belongs to, add append to append the specified
+groups
+.sp
+CLI Example:
+salt \(aq*\(aq user.chgroups foo wheel,root True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.chhome(name, home, persist=False)
+Change the home directory of the user, pass true for persist to copy files
+to the new home dir
+.sp
+CLI Example:
+salt \(aq*\(aq user.chhome foo /home/users/foo True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.chshell(name, shell)
+Change the default shell of the user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chshell foo /bin/zsh
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.chuid(name, uid)
+Change the uid for a named user
+.sp
+CLI Example:
+salt \(aq*\(aq user.chuid foo 4376
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.delete(name, remove=False, force=False)
+Remove a user from the minion
+.sp
+CLI Example:
+salt \(aq*\(aq user.delete name True True
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.getent()
+Return the list of all info for all users
+.sp
+CLI Example:
+salt \(aq*\(aq user.getent
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.info(name)
+Return user information
+.sp
+CLI Example:
+salt \(aq*\(aq user.info root
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.useradd.list_groups(name)
+Return a list of groups the named user belings to
+.sp
+CLI Example:
+salt \(aq*\(aq user.groups foo
+.UNINDENT
+.SS \fBsalt.modules.virt\fP
+.sp
+Work with virtual machines managed by libvirt
+.INDENT 0.0
+.TP
+.B salt.modules.virt.create(vm_)
+Start a defined domain
+.sp
+CLI Example:
+salt \(aq*\(aq virt.create <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.create_xml_path(path)
+Start a defined domain
+.sp
+CLI Example:
+salt \(aq*\(aq virt.create_xml_path <path to xml file on the node>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.create_xml_str(xml)
+Start a domain based on the xml passed to the function
+.sp
+CLI Example:
+salt \(aq*\(aq virt.create_xml_str <xml in string format>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.destroy(vm_)
+Hard power down the virtual machine, this is equivalent to pulling the
+power
+.sp
+CLI Example:
+salt \(aq*\(aq virt.destroy <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.freecpu()
+Return an int representing the number of unallocated cpus on this
+hypervisor
+.sp
+CLI Example:
+salt \(aq*\(aq virt.freemem
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.freemem()
+Return an int representing the amount of memory that has not been given
+to virtual machines on this node
+.sp
+CLI Example:
+salt \(aq*\(aq virt.freemem
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.full_info()
+Return the node_info, vm_info and freemem
+.sp
+CLI Example:
+salt \(aq*\(aq virt.full_info
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.get_disks(vm_)
+Return the disks of a named vm
+.sp
+CLI Example:
+salt \(aq*\(aq virt.get_disks <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.get_graphics(vm_)
+Returns the information on vnc for a given vm
+.sp
+CLI Example:
+salt \(aq*\(aq virt.get_graphics <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.get_xml(vm_)
+Returns the xml for a given vm
+.sp
+CLI Example:
+salt \(aq*\(aq virt.get_xml <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.is_kvm_hyper()
+Returns a bool whether or not this node is a hypervisor
+.sp
+CLI Example:
+salt \(aq*\(aq virt.is_kvm_hyper
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.list_vms()
+Return a list of virtual machine names on the minion
+.sp
+CLI Example:
+salt \(aq*\(aq virt.list_vms
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.migrate(vm_, target)
+Shared storage migration
+.sp
+CLI Example:
+salt \(aq*\(aq virt.migrate <vm name> <target hypervisor>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.migrate_non_shared(vm_, target)
+Attempt to execute non\-shared storage "all" migration
+.sp
+CLI Example:
+salt \(aq*\(aq virt.migrate_non_shared <vm name> <target hypervisor>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.migrate_non_shared_inc(vm_, target)
+Attempt to execute non\-shared storage "all" migration
+.sp
+CLI Example:
+salt \(aq*\(aq virt.migrate_non_shared_inc <vm name> <target hypervisor>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.node_info()
+Return a dict with information about this node
+.sp
+CLI Example:
+salt \(aq*\(aq virt.node_info
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.pause(vm_)
+Pause the named vm
+.sp
+CLI Example:
+salt \(aq*\(aq virt.pause <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.purge(vm_, dirs=False)
+Recursively destroy and delete a virtual machine, pass True for dir\(aqs to
+also delete the directories containing the virtual machine disk images \-
+USE WITH EXTREAME CAUTION!
+.sp
+CLI Example:
+salt \(aq*\(aq virt.purge <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.resume(vm_)
+Resume the named vm
+.sp
+CLI Example:
+salt \(aq*\(aq virt.resume <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.seed_non_shared_migrate(disks, force=False)
+Non shared migration requires that the disks be present on the migration
+destination, pass the disks information via this function, to the
+migration destination before executing the migration.
+.sp
+CLI Example:
+salt \(aq*\(aq virt.seed_non_shared_migrate <disks>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.shutdown(vm_)
+Send a soft shutdown signal to the named vm
+.sp
+CLI Example:
+salt \(aq*\(aq virt.shutdown <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.undefine(vm_)
+Remove a defined vm, this does not purge the virtual machine image, and
+this only works if the vm is powered down
+.sp
+CLI Example:
+salt \(aq*\(aq virt.undefine <vm name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.virt_type()
+Returns the virtual machine type as a string
+.sp
+CLI Example:
+salt \(aq*\(aq virt.virt_type
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.virt.vm_info()
+Return detailed information about the vms on this hyper in a dict:
+.INDENT 7.0
+.TP
+.B {\(aqcpu\(aq: <int>,
+\(aqmaxMem\(aq: <int>,
+\(aqmem\(aq: <int>,
+\(aqstate\(aq: \(aq<state>\(aq,
+\(aqcputime\(aq <int>}
+.UNINDENT
+.sp
+CLI Example:
+salt \(aq*\(aq virt.vm_info
+.UNINDENT
+.SS \fBsalt.modules.yum\fP
+.sp
+Support for YUM
+.INDENT 0.0
+.TP
+.B salt.modules.yum.available_version(name)
+The available version of the package in the repository
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.available_version <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.install(pkg, refresh=False)
+Install the passed package, add refresh=True to clean out the yum database
+before executing
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+           \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.install <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.list_pkgs()
+List the packages currently installed in a dict:
+{\(aq<package_name>\(aq: \(aq<version>\(aq}
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.list_pkgs
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.purge(pkg)
+Yum does not have a purge, this function calls remove
+.sp
+Return a list containing the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.purge <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.refresh_db()
+Since yum refreshes the database automatically, this runs a yum clean,
+so that the next yum operation will have a clean database
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.refresh_db
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.remove(pkg)
+Remove a single package with yum remove
+.sp
+Return a list containing the removed packages:
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.remove <package name>
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.upgrade()
+Run a full system upgrade, a yum upgrade
+.sp
+Return a dict containing the new package names and versions:
+.sp
+.nf
+.ft C
+{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
+           \(aqnew\(aq: \(aq<new\-version>\(aq]}
+.ft P
+.fi
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.upgrade
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.modules.yum.version(name)
+Returns a version if the package is installed, else returns an empty string
+.sp
+CLI Example:
+salt \(aq*\(aq pkg.version <package name>
+.UNINDENT
+.SH GRAINS
+.sp
+Salt comes with an interface to derive information about the underlying system.
+This is called the grains interface, because it presents salt with grains of
+information.
+.sp
+The grains interface is made available to Salt modules and components so that
+the right salt minion commands are automatically available on the right
+systems.
+.sp
+It is important to remember that grains are bits of information loaded when
+the salt minion starts, so this information is static. This means that the
+information in grains is unchanging, therefore the nature of the data is
+static. So grains information are things like the running kernel, or the
+operating system.
+.SS Writing Grains
+.sp
+Grains are easy to write, the grains interface is derived my executing all of
+the "public" functions found in the modules located in the grains package.
+The functions in the modules of the grains must return a python dict, the keys
+in the dict are the names of the grains, the values are the values.
+.sp
+This means that the actual grains interface is simply a python dict.
+.sp
+Before adding a grain to salt, consider what the grain is and remember that
+grains need to be static data.
+.SS Examples of Grains
+.sp
+The core module in the grains package is where the main grains are loaded by
+the salt minion and the principal example of how to write grains:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/grains/core.py\fP
+.SH RETURNERS
+.sp
+By default the return values of the commands sent to the salt minions are
+returned to the salt\-master. But since the commands executed on the salt
+minions are detatched from the call on the salt master, there is no need for
+the minion to return the data to the salt master.
+.sp
+This is where the returner interface comes in. Returners are modules called
+in place of returning the data to the salt master.
+.sp
+The returner interface allows the return data to be sent to any system that
+can receive data. This means that return data can be sent to a Redis server,
+a MongoDB server, a MySQL server, or any system!
+.IP "See also"
+.sp
+\fBFull list of builtin returners\fP
+.RE
+.SS Writing a Returner
+.sp
+A returner is a module which contains a returner function, the returner
+function must accept a single argument. this argument is the return data from
+the called minion function. So if the minion function \fBtest.ping\fP is called
+the value of the argument will be \fBTrue\fP.
+.sp
+A simple returner is implimented here:
+.sp
+.nf
+.ft C
+import redis
+import json
+
+def returner(ret):
+    \(aq\(aq\(aq
+    Return information to a redis server
+    \(aq\(aq\(aq
+    # Get a redis commection
+    serv = redis.Redis(
+                host=\(aqredis\-serv.example.com\(aq,
+                port=6379,
+                db=\(aq0\(aq)
+    serv.sadd("%(id)s:jobs" % ret, ret[\(aqjid\(aq])
+    serv.set("%(jid)s:%(id)s" % ret, json.dumps(ret[\(aqreturn\(aq]))
+    serv.sadd(\(aqjobs\(aq, ret[\(aqjid\(aq])
+    serv.sadd(ret[\(aqjid\(aq], ret[\(aqid\(aq])
+.ft P
+.fi
+.sp
+This simple example of a returner set to send the data to a redis server
+serializes the data as json and sets it in redis.
+.SS Examples
+.sp
+The collection of builtin salt returners can be found here:
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/returners\fP
+.SH FULL LIST OF BUILTIN RETURNERS
+.SS Contents
+.INDENT 0.0
+.IP \(bu 2
+\fI\%salt.returners.local\fP
+.IP \(bu 2
+\fI\%salt.returners.redis_return\fP
+.IP \(bu 2
+\fI\%salt.returners.mongo_return\fP
+.UNINDENT
+.SS \fBsalt.returners.local\fP
+.sp
+The local returner is used to test the returner interface, it just prints the
+return data to the console to verify that it is being passed properly
+.INDENT 0.0
+.TP
+.B salt.returners.local.returner(ret)
+Print the return data to the terminal to verify functionality
+.UNINDENT
+.SS \fBsalt.returners.redis_return\fP
+.sp
+Return data to a redis server
+This is a VERY simple example for pushing data to a redis server and is not
+necessarily intended as a usable interface.
+.INDENT 0.0
+.TP
+.B salt.returners.redis_return.returner(ret)
+Return data to a redis data store
+.UNINDENT
+.SS \fBsalt.returners.mongo_return\fP
+.sp
+Return data to a mongodb server
+.sp
+This is the default interface for returning data for the butter statd subsytem
+.INDENT 0.0
+.TP
+.B salt.returners.mongo_return.returner(ret)
+Return data to a mongodb server
+.UNINDENT
+.SH HIGHSTATE DATA STRUCTURE DEFINITIONS
+.SS The Salt State Tree
+.SS Include declaration
+.INDENT 0.0
+.TP
+.B Include declaration
+Defines a list of \fImodule reference\fP strings to include in this
+\fIsls\fP.
+.sp
+Occurs only in the top level of the highstate structure.
+.sp
+Example:
+.sp
+.nf
+.ft C
+include:
+  \- edit.vim
+  \- http.server
+.ft P
+.fi
+.UNINDENT
+.SS Module reference
+.INDENT 0.0
+.TP
+.B Module reference
+The name of a SLS module defined by a separate SLS file and residing on
+the Salt Master. A module named \fBedit.vim\fP is a reference to the sls
+file \fBsalt://edit/vim.sls\fP.
+.UNINDENT
+.SS ID declaration
+.INDENT 0.0
+.TP
+.B ID declaration
+Defines an individual highstate component. Always references a value of
+a dictionary containing keys referencing \fIstate declarations\fP and \fIrequisite declarations\fP. Can be overridden by \fIname\fP and \fInames\fP.
+.sp
+Occurs on the top level or under the \fIextend declaration\fP.
+.UNINDENT
+.SS Extend declaration
+.INDENT 0.0
+.TP
+.B Extend declaration
+Used to extend a \fIname\fP declaration from an included \fBsls
+module\fP. The keys of the extend declaration always define existing
+\fIID declarations\fP which have been defined in
+included \fBsls modules\fP.
+.sp
+Occurs only in the top level and defines a dictionary.
+.UNINDENT
+.SS State declaration
+.INDENT 0.0
+.TP
+.B State declaration
+A list which contains one string defining the \fIfunction\fP and any
+number of \fIfunction arg\fP dictionaries.
+.sp
+Can, optionally, contain a number of additional components like the
+name override components — \fIname\fP and \fInames\fP. Can
+also contain \fIrequisite declarations\fP.
+.sp
+Occurs under an \fIID declaration\fP.
+.UNINDENT
+.SS Requisite declaration
+.INDENT 0.0
+.TP
+.B Requisite declaration
+A list containing \fIrequisite references\fP.
+.sp
+Used to build the action dependency tree. While Salt states are made to
+execute in a deterministic order, this order is managed by requiring
+and watching other Salt states.
+.sp
+Occurs as a list component under a \fIstate declaration\fP or as a
+key under an \fIID declaration\fP.
+.UNINDENT
+.SS Requisite reference
+.INDENT 0.0
+.TP
+.B Requisite reference
+A single key dictionary. The key is the name of the referenced
+\fIstate declaration\fP and the value is the ID of the referenced
+\fIID declaration\fP.
+.sp
+Occurs as a single index in a \fIrequisite declaration\fP list.
+.UNINDENT
+.SS Function declaration
+.INDENT 0.0
+.TP
+.B Function declaration
+The name of the function to call within the state. Any given state
+declaration can only have a single function.
+.sp
+Occurs as the only index in the \fIstate declaration\fP list.
+.UNINDENT
+.SS Function arg declaration
+.INDENT 0.0
+.TP
+.B Function arg declaration
+A single key dictionary referencing a Python type which is to be passed
+to the named \fIfunction\fP as a parameter. The type must be the data
+type expected by the function.
+.sp
+Occurs under a \fIfunction\fP.
+.UNINDENT
+.SS Name declaration
+.INDENT 0.0
+.TP
+.B Name declaration
+Used to override the name argument relative the \fIstate
+declaration\fP. If the name is not specified then the \fIID
+declaration\fP satisfies the name argument. The name is always a single
+key dictionary referencing a string.
+.UNINDENT
+.SS Names declaration
+.INDENT 0.0
+.TP
+.B Names declaration
+Used to apply the contents of the \fIstate declaration\fP to multiple
+states, each with its own name.
+.sp
+Example:
+.sp
+.nf
+.ft C
+python\-pkgs:
+  pkg:
+    \- installed
+    \- names:
+      \- python\-django
+      \- python\-crypto
+      \- python\-yaml
+.ft P
+.fi
+.UNINDENT
+.SS Large example
+.sp
+Here is the layout in yaml using the names of the highdata structure
+components.
+.sp
+.nf
+.ft C
+<Include Declaration>:
+  \- <Module Reference>
+  \- <Module Reference>
+<Extend Declaration>:
+  <ID Declaration>:
+    <State Declaration>:
+      \- <Function>
+      \- <Function Arg>
+      \- <Function Arg>
+      \- <Function Arg>
+      \- <Name>: <name>
+      \- <Requisite Declaration>:
+        \- <Requisite Reference>
+        \- <Requisite Reference>
+  <ID Declaration>:
+    <State Declaration>:
+      \- <Function>
+      \- <Function Arg>
+      \- <Function Arg>
+      \- <Function Arg>
+      \- <Names>:
+        \- <name>
+        \- <name>
+        \- <name>
+      \- <Requisite Declaration>:
+        \- <Requisite Reference>
+        \- <Requisite Reference>
+<ID Declaration>:
+  <State Declaration>:
+    \- <Function>
+    \- <Function Arg>
+    \- <Function Arg>
+    \- <Function Arg>
+    \- <Name>
+    \- <Requisite Declaration>:
+      \- <Requisite Reference>
+      \- <Requisite Reference>
+<ID Declaration>:
+  <State Declaration>:
+    \- <Function>
+    \- <Function Arg>
+    \- <Function Arg>
+    \- <Function Arg>
+    \- <Names>:
+      \- <name>
+      \- <name>
+      \- <name>
+    \- <Requisite Declaration>:
+      \- <Requisite Reference>
+      \- <Requisite Reference>
+.ft P
+.fi
+.SH STATE ENFORCEMENT
+.sp
+Salt offers an optional interface to manage the configuration or "state" of the
+salt minions. This interface is a fully capable mechanism used to enforce the
+state of systems from a central manager.
+.sp
+The Salt state system is made to be accurate, simple, and fast. And like the
+rest of the Salt system, Salt states are highly modular.
+.SS State management
+.sp
+State management, also frequently called software configuration management
+(SCM), is a program that puts and keeps a system into a predetermined state. It
+installs software packages, starts or restarts services, or puts configuration
+files in place and watches them for changes.
+.sp
+Having a state management system in place allows you to easily and reliably
+configure and manage a few servers or a few thousand servers. It allows you to
+keep that configuration under version control.
+.sp
+Salt States is an extension of the Salt Modules that we discussed in the
+previous \fBremote execution\fP tutorial. Instead
+of calling one\-off executions the state of a system can be easily defined and
+then enforced.
+.SS Understanding the Salt State System Components
+.sp
+The Salt state system is comprised of a number of components, as a user, an
+understanding of the sls and renderer systems are needed. But as a developer,
+an understanding of salt states, as well as understanding salt states and how
+to write the states used by salt.
+.SS Salt SLS System
+.INDENT 0.0
+.TP
+.B sls
+The primary system used by the Salt state system is the SLS system. SLS
+stands for \fBS\fPa\fBL\fPt \fBS\fPtate.
+.sp
+The Salt States are files which contain the information about how to
+configure salt minions. The states are laid out in a directory tree and
+can be written in many different formats.
+.sp
+The contents of the files and they way they are laid out is intended to
+be as simple as possible while allowing for maximum flexibility. The
+files are laid out in states and contains information about how the
+minion needs to be configured.
+.UNINDENT
+.SS SLS File Layout
+.sp
+SLS files are laid out in the Salt file server. A simple layout can look like
+this:
+.sp
+.nf
+.ft C
+top.sls
+ssh.sls
+sshd_config
+users/init.sls
+users/admin.sls
+salt/init.sls
+salt/master.sls
+.ft P
+.fi
+.sp
+This example shows the core concepts of file layout. The top file is a key
+component and is used with salt matchers to match SLS states with minions.
+The \fB.sls\fP files are states. The rest of the files are seen by the salt
+master as just files that can be downloaded.
+.sp
+The states are translated into dot notation, so the \fBssh.sls\fP file is
+seen as the ssh state, the \fBusers/admin.sls\fP file is seen as the
+users.admin states.
+.sp
+The init.sls files are translated to be the state name of the parent
+directory, so the \fBsalt/init.sls\fP file translates to the salt state.
+.sp
+The plain files are visible to the minions, as well as the state files, in
+salt, everything is a file, there is not "magic translation" of files and file
+types. This means that a state file can be distributed to minions just like a
+plain text or binary file.
+.SS SLS Files
+.sp
+The Salt state files are simple sets of data. Since the SLS files are just data
+they can be represented in a number of different ways. The default format is
+yaml generated from a jinja template. This allows for the states files to have
+all the language constructs of Python, and the simplicity of yaml. State files
+can then be complicated jinja templates the translate down to yaml, or just
+plain and simple yaml files!
+.sp
+The State files are constructed data structures in a simple format. The format
+allows for many real activates to be expressed in very little text, while
+maintaining the utmost in readability and usability.
+.sp
+Here is an example of a Salt State:
+.sp
+.nf
+.ft C
+vim:
+    pkg:
+        \- installed
+
+salt:
+    pkg:
+        \- latest
+    service:
+        \- running
+        \- require:
+            \- file: /etc/salt/minion
+            \- pkg: salt
+        \- names:
+            \- salt\-master
+            \- salt\-minion
+        \- watch:
+            \- file: /etc/salt/minion
+
+/etc/salt/minion:
+    file:
+        \- managed
+        \- source: salt://salt/minion
+        \- user: root
+        \- group: root
+        \- mode: 644
+        \- require:
+            \- pkg: salt
+.ft P
+.fi
+.sp
+This short stanza will ensure that vim is installed, salt is installed and up
+to date, the salt\-master and salt\-minion daemons are running and the Salt
+minion configuration file is in place. It will also ensure everything is
+deployed in the right order and that the Salt services are restarted when the
+watched file updated.
+.SS The Top File
+.sp
+The top file is the mapping for the state system. The top file specifies which
+minions should have which modules applied and which environments they should
+draw the states from.
+.sp
+The top file works by specifying the environment, containing matchers with
+lists of Salt states sent to the matching minions:
+.sp
+.nf
+.ft C
+base:
+    \(aq*\(aq:
+        \- salt
+        \- users
+        \- users.admin
+    \(aqsaltmaster.*\(aq:
+        \- match: pcre
+        \- salt.master
+.ft P
+.fi
+.sp
+This simple example uses the base environment, which is built into the default
+salt setup, and then all minions will have the modules salt, users and
+users.admin since \(aq*\(aq will match all minions. Then the regular expression
+matcher will match all minions\(aq with an id matching saltmaster.* and add the
+salt.master state.
+.SS Renderer System
+.sp
+The Renderer system is a key component to the state system. SLS files are
+representations of Salt "high data" structures. All Salt cares about when
+reading an sls file is the data structure that is produced from file.
+.sp
+This allows Salt states to be represented by multiple types of files. The
+Renderer system can be used to allow different formats to be used for sls
+files.
+.sp
+The available renderers can be found in the renderers directory in the Salt
+source code:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/renderers\fP
+.sp
+By default sls files are rendered using jinja as a templating engine, and yaml
+as the serialization format. Since the rendering system can be extended simply
+by adding a new renderer to the renderers directory, it is possible that any
+structured file could be used to represent the SLS files.
+.sp
+In the future xml and raw python will be added, as well as many other formats.
+.SH FULL LIST OF BUILTIN STATES
+.SS \fBsalt.states.cmd\fP
+.SS Command Executions
+.sp
+The cmd state module manages the enforcement of executed commands, this
+state can tell a command to run under certian circumstances.
+.SS Available Functions
+.sp
+The cmd state only has a single function, the \fBrun\fP function
+.SS run
+.sp
+Execute a command given certian conditions
+.sp
+A simple exampe:
+.sp
+.nf
+.ft C
+date > /tmp/salt\-run:
+  cmd:
+    \- run
+.ft P
+.fi
+.sp
+Only run if another execution returns sucessfully, in this case truncate
+syslog if there is no disk space:
+.sp
+.nf
+.ft C
+> /var/log/messages:
+  cmd:
+    \- run
+    \- unless: echo \(aqfoo\(aq > /tmp/.test
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.cmd.run(name, onlyif=None, unless=None, cwd=\(aq/root\(aq, user=None, group=None)
+Run a command if certian circumstances are met
+.INDENT 7.0
+.TP
+.B name
+The command to execute, remember that the command will execute with the
+path and permissions of the salt\-minion.
+.TP
+.B onlyif
+A command to run as a check, run the named command only if the command
+passed to the \fBonlyif\fP option returns true
+.TP
+.B unless
+A command to run as a check, only run the named command if the command
+passed to the \fBunless\fP option returns false
+.TP
+.B cwd
+The current working directory to execute the command in, defaults to
+/root
+.TP
+.B user
+The user name to run the command as
+.TP
+.B group
+The group context to run the command as
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.cron\fP
+.SS Cron Management
+.sp
+The cron state module allows for user crontabs to be cleanly managed.
+.sp
+Cron declarations require a number of paramaters. The timing paramaters, need
+to be declared, minute, hour, daymonth, month and dayweek. The  user who\(aqs
+crontab is to be edited also needs to be defined.
+.sp
+By default the timing arguments are all \fB*\fP and the user is root. When making
+changes to an existing cron job the name declaraion is the uniqe factor, so if
+and existing cron that looks like this:
+.sp
+.nf
+.ft C
+date > /tmp/crontest:
+  cron:
+    \- present
+    \- user: root
+    \- minute: 5
+.ft P
+.fi
+.sp
+Is changed to this:
+.sp
+.nf
+.ft C
+date > /tmp/crontest:
+  cron:
+    \- present
+    \- user: root
+    \- minute: 7
+    \- hour: 2
+.ft P
+.fi
+.sp
+Then the existing cron will be updated, but if the cron command is changed,
+then a new cron job will be added to the user\(aqs crontab.
+.INDENT 0.0
+.TP
+.B salt.states.cron.absent(name, user=\(aqroot\(aq, minute=\(aq*\(aq, hour=\(aq*\(aq, daymonth=\(aq*\(aq, month=\(aq*\(aq, dayweek=\(aq*\(aq)
+Verifies that the specified cron job is absent for the specified user, only
+the name is matched when removing a cron job.
+.INDENT 7.0
+.TP
+.B name
+The command that should be absent in the user crontab.
+.TP
+.B user
+The name of the user who\(aqs crontab needs to be modified, defaults to
+the root user
+.TP
+.B minute
+The information to be set into the minute section, this can be any
+string supported by your cron system\(aqs the minute field. Default is
+\fB*\fP
+.TP
+.B hour
+The information to be set in the hour section. Default is \fB*\fP
+.TP
+.B daymonth
+The information to be set in the day of month section. Default is \fB*\fP
+.TP
+.B month
+The information to be set in the month section. Default is \fB*\fP
+.TP
+.B dayweek
+The information to be set in the day of day of week section. Default is
+\fB*\fP
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.cron.present(name, user=\(aqroot\(aq, minute=\(aq*\(aq, hour=\(aq*\(aq, daymonth=\(aq*\(aq, month=\(aq*\(aq, dayweek=\(aq*\(aq)
+Verifies that the specified cron job is present for the specified user.
+For more advanced information about what exactly can be set in the cron
+timing paramaters check your cron system\(aqs documentation. Most Unix\-like
+systems\(aq cron documentation can be found via the crontab man page:
+\fBman 5 crontab\fP.
+.INDENT 7.0
+.TP
+.B name
+The command that should be executed by the cron job.
+.TP
+.B user
+The name of the user who\(aqs crontab needs to be modified, defaults to
+the root user
+.TP
+.B minute
+The information to be set into the minute section, this can be any
+string supported by your cron system\(aqs the minute field. Default is
+\fB*\fP
+.TP
+.B hour
+The information to be set in the hour section. Default is \fB*\fP
+.TP
+.B daymonth
+The information to be set in the day of month section. Default is \fB*\fP
+.TP
+.B month
+The information to be set in the month section. Default is \fB*\fP
+.TP
+.B dayweek
+The information to be set in the day of day of week section. Default is
+\fB*\fP
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.file\fP
+.SS File Management
+.sp
+Salt States can agresively manipulate files on a system. There are a number of
+ways in which files can be managed.
+.sp
+Regular files can be enforced with the \fBmanaged\fP function. This function
+downloads files from the salt master and places them on the target system.
+The downloaded files can be rendered as a jinja or mako template adding
+a dynamic component to file management. An example of \fBfile.managed\fP which
+makes use of the jinja templating system would look like this:
+.sp
+.nf
+.ft C
+/etc/http/conf/http.conf:
+  file:
+    \- managed
+    \- source: salt://apache/http.conf
+    \- user: root
+    \- group: root
+    \- mode: 644
+    \- template: jinja
+.ft P
+.fi
+.sp
+Directories can be managed via the \fBdirectory\fP function. This function can
+create and enforce the premissions on a directory. A directory statement will
+look like this:
+.sp
+.nf
+.ft C
+/srv/stuff/substuf:
+  file:
+    \- directory
+    \- user: fred
+    \- group: users
+    \- mode: 755
+    \- makedirs: True
+.ft P
+.fi
+.sp
+Symlinks can be easily created, the symlink function is very simple and only
+takes a few arguments
+.sp
+.nf
+.ft C
+/etc/grub.conf:
+  file:
+    \- symlink
+    \- target: /boot/grub/grub.conf
+.ft P
+.fi
+.sp
+Recursive directory management can also be set via the \fBrecurse\fP
+function. Recursive directory management allows for a directory on the salt
+master to be recursively coppied down to the minion. This is a great tool for
+deploying large code and configuration systems. A recuse state would look
+something like this:
+.sp
+.nf
+.ft C
+/opt/code/flask:
+  file:
+    \- recurse
+    \- source: salt://code/flask
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.file.absent(name)
+Verify that the named file or directory is absent, this will work to
+reverse any of the functions in the file state module.
+.INDENT 7.0
+.TP
+.B name
+The path which should be deleted
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.file.directory(name, user=None, group=None, mode=None, makedirs=False)
+Ensure that a named directory is present and has the right perms
+.INDENT 7.0
+.TP
+.B name
+The location to create or manage a directory
+.TP
+.B user
+The user to own the directory, this defaults to the user salt is
+running as on the minion
+.TP
+.B group
+The group ownership set for the directory, this defaults to the group
+salt is running as on the minion
+.TP
+.B mode
+The permissions to set on this directory, aka 755
+.TP
+.B makedirs
+If the directory is located in a path without a parent directory, then
+the the state will fail. If makedirs is set to True, then the parent
+directories will be created to facilitate the creation of the named
+file.
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.file.managed(name, source, user=None, group=None, mode=None, template=None, makedirs=False, __env__=\(aqbase\(aq)
+Manage a given file, this function allows for a file to be downloaded from
+the salt master and potentially run through a templating system.
+.INDENT 7.0
+.TP
+.B name
+The location of the file to manage
+.TP
+.B source
+The source file, this file is located on the salt master file server
+and is specified with the salt:// protocol. If the file is located on
+the master in the directory named spam, and is called eggs, the source
+string is salt://spam/eggs
+.TP
+.B user
+The user to own the file, this defaults to the user salt is running as
+on the minion
+.TP
+.B group
+The group ownership set for the file, this defaults to the group salt
+is running as on the minion
+.TP
+.B mode
+The permissions to set on this file, aka 644, 0775, 4664
+.TP
+.B template
+If this setting is applied then the named templating engine will be
+used to render the downloaded file, currently jinja and mako are
+supported
+.TP
+.B makedirs
+If the file is located in a path without a parent directory, then the
+the state will fail. If makedirs is set to True, then the parent
+directories will be created to facilitate the creation of the named
+file.
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.file.recurse(name, source, __env__=\(aqbase\(aq)
+Recurse through a subdirectory on the master and copy said subdirecory
+over to the specified path.
+.INDENT 7.0
+.TP
+.B name
+The directory to set the recursion in
+.TP
+.B source
+The source directory, this directory is located on the salt master file
+server and is specified with the salt:// protocol. If the directory is
+located on the master in the directory named spam, and is called eggs,
+the source string is salt://spam/eggs
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.file.symlink(name, target, force=False, makedirs=False)
+Create a symlink
+.INDENT 7.0
+.TP
+.B name
+The location of the symlink to create
+.TP
+.B target
+The location that the symlink points to
+.TP
+.B force
+If the location of the symlink exists and is not a symlink then the
+state will fail, set force to True and any file or directory in the way
+of the symlink file will be deleted to make room for the symlink
+.TP
+.B makedirs
+If the location of the symlink does not already have a parent directory
+then the state will fail, setting makedirs to True will allow Salt to
+create the parent directory
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.group\fP
+.SS Group Management
+.sp
+The group module is used to create and manage unix group settings, groups
+can be either present or absent:
+.sp
+.nf
+.ft C
+cheese:
+  group:
+    \- present
+    \- gid: 7648
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.group.absent(name)
+Ensure that the named group is absent
+.INDENT 7.0
+.TP
+.B name
+The name of the group to remove
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.group.present(name, gid=None)
+Ensure that a group is present
+.INDENT 7.0
+.TP
+.B name
+The name of the group to manage
+.TP
+.B gid
+The group id to assign to the named group, if left empty then the next
+available group id will be assigned
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.host\fP
+.SS Hosts File Management
+.sp
+The hosts file can be managed to contain definitions for specific hosts:
+.sp
+.nf
+.ft C
+salt\-master:
+  host:
+    \- present
+    \- ip: 192.168.0.42
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.host.absent(name, ip)
+Ensure that the the named host is absent
+.INDENT 7.0
+.TP
+.B name
+The host to remove
+.TP
+.B ip
+The ip addr of the host to remove
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.host.present(name, ip)
+Ensures that the named host is present with the given ip
+.INDENT 7.0
+.TP
+.B name
+The host to assign an ip to
+.TP
+.B ip
+The ip addr to apply to the host
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.mount\fP
+.SS Mount Managment
+.sp
+Mount any type of mountable filesystem with the mounted function:
+.sp
+.nf
+.ft C
+/mnt/sdb:
+  mount:
+    \- mounted
+    \- device: /dev/sdb1
+    \- fstype: ext4
+    \- mkmnt: True
+    \- opts:
+      \- defaults
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.mount.mounted(name, device, fstype, mkmnt=False, opts=[\(aqdefaults\(aq], dump=0, pass_num=0, config=\(aq/etc/fstab\(aq, remount=True, persist=True)
+Verify that a device is mounted
+.INDENT 7.0
+.TP
+.B name
+The path to the location where the device is to be mounted
+.TP
+.B device
+The device name, typically the device node, such as /dev/sdb1
+.TP
+.B fstype
+The filesystem type, this will be xfs, ext2/3/4 in the case of classic
+filesystems, and fuse in the case of fuse mounts
+.TP
+.B mkmnt
+If the mount point is not present then the state will fail, set mkmnt
+to True to create the mount point if it is otherwise not present
+.TP
+.B opts
+A list object of options or a comma delimited list
+.TP
+.B dump
+The dump value to be passed into the fstab, default to 0
+.TP
+.B pass_num
+The pass value to be passed into the fstab, default to 0
+.TP
+.B config
+Set an alternative location for the fstab, default to /etc/fstab
+.TP
+.B remount
+Set if the file system can be remounted with the remount option,
+default to True
+.TP
+.B persist
+Set if the mount should be saved in the fstab, default to True
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.pkg\fP
+.SS Package Management
+.sp
+Salt can manage software packages via the pkg state module, packages can be
+set up to be installed, latest, removed and purged. Package management
+declarations are typically rather simple:
+.sp
+.nf
+.ft C
+vim:
+  pkg:
+    \- installed
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.pkg.installed(name)
+Verify that the package is installed, and only that it is installed. This
+state will not upgrade an existing package and only verify that it is
+installed
+.INDENT 7.0
+.TP
+.B name
+The name of the package to install
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.pkg.latest(name)
+Verify that the named package is installed and the latest available
+package. If the package can be updated this state function will update
+the package. Generally it is better for the installed function to be
+used, as \fBlatest\fP will update the package the package whenever a new
+package is available
+.INDENT 7.0
+.TP
+.B name
+The name of the package to maintain at the latest available version
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.pkg.purged(name)
+Verify that the package is purged, this will call the purge function in the
+salt pkg module for the platform.
+.INDENT 7.0
+.TP
+.B name
+The name of the package to be purged
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.pkg.removed(name)
+Verify that the package is removed, this will remove the package via
+the remove function in the salt pkg module for the platform.
+.INDENT 7.0
+.TP
+.B name
+The name of the package to be removed
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.service\fP
+.SS Service Management
+.sp
+Services are defined as system daemons typically started with system init or
+rc scripts, services can be defined as running or dead.
+.sp
+.nf
+.ft C
+httpd:
+  service:
+    \- running
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.service.dead(name, sig=None)
+Ensure that the named service is dead
+.INDENT 7.0
+.TP
+.B name
+The name of the init or rc script used to manage the service
+.TP
+.B sig
+The string to search for when looking for the service process with ps
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.service.running(name, sig=None)
+Verify that the service is running
+.INDENT 7.0
+.TP
+.B name
+The name of the init or rc script used to manage the service
+.TP
+.B sig
+The string to search for when looking for the service process with ps
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.service.watcher(name, sig=None)
+The service watcher, called to invoke the watch command.
+.INDENT 7.0
+.TP
+.B name
+The name of the init or rc script used to manage the service
+.TP
+.B sig
+The string to search for when looking for the service process with ps
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.ssh_auth\fP
+.SS SSH Authorized Key Management
+.sp
+The information stored in a user\(aqs ssh authorized key file can be easily
+controlled via the ssh_auth state:
+.sp
+.nf
+.ft C
+AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyYvlRBsJdDOfhlWHWXQRqul6rwL4KIuPrhY7hBw0tV7UNC7J9IZRNO4iGod9C+OYutuWGJ2x5YNf7P4uGhH9AhBQGQ4LKOLxhDyT1OrDKXVFw3wgY3rHiJYAbd1PXNuclJHOKL27QZCRFjWSEaSrUOoczvAAAAFQD9d4jp2dCJSIseSkk4Lez3LqFcqQAAAIAmovHIVSrbLbXAXQE8eyPoL9x5C+x2GRpEcA7AeMH6bGx/xw6NtnQZVMcmZIre5Elrw3OKgxcDNomjYFNHuOYaQLBBMosyO++tJe1KTAr3A2zGj2xbWO9JhEzu8xvSdF8jRu0N5SRXPpzSyU4o1WGIPLVZSeSq1VFTHRT4lXB7PQAAAIBXUz6ZO0bregF5xtJRuxUN583HlfQkXvxLqHAGY8WSEVlTnuG/x75wolBDbVzeTlxWxgxhafj7P6Ncdv25Wz9wvc6ko/puww0b3rcLNqK+XCNJlsM/7lB8Q26iK5mRZzNsGeGwGTyzNIMBjhgjhYQ5MRdIcPv5t7IP/1M6fQDEsAXQ==:
+  ssh_auth:
+    \- present
+    \- user: root
+    \- enc: ssh\-dss
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.ssh_auth.absent(name, user, config=\(aq.ssh/authorized_keys\(aq)
+Verifies that the specified ssh key is absent
+.INDENT 7.0
+.TP
+.B name
+The ssh key to manage
+.TP
+.B user
+The user who owns the ssh authorixed keys file to modify
+.TP
+.B config
+The location of the authorized keys file relative to the user\(aqs home
+direcotory, defaults to ".ssh/authorized_keys"
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.ssh_auth.present(name, user, enc=\(aqssh\-rsa\(aq, comment=\(aq\(aq, options=[], config=\(aq.ssh/authorized_keys\(aq)
+Verifies that the specified ssh key is present for the specified user
+.INDENT 7.0
+.TP
+.B name
+The ssh key to manage
+.TP
+.B user
+The user who owns the ssh authorixed keys file to modify
+.TP
+.B enc
+Defines what type of key is being used, can be ssh\-rsa or ssh\-dss
+.TP
+.B comment
+The comment to be placed with the ssh public key
+.TP
+.B options
+The options passed to the key, pass a list object
+.TP
+.B config
+The location of the authorized keys file relative to the user\(aqs home
+direcotory, defaults to ".ssh/authorized_keys"
+.UNINDENT
+.UNINDENT
+.SS \fBsalt.states.user\fP
+.SS User Management
+.sp
+The user module is used to create and manage user settings, users can be set
+as either absent or present
+.sp
+.nf
+.ft C
+fred:
+  user:
+    \- present
+    \- shell: /bin/zsh
+    \- home: /home/fred
+    \- uid: 4000
+    \- gid: 4000
+    \- groups:
+      \- wheel
+      \- storage
+      \- games
+.ft P
+.fi
+.INDENT 0.0
+.TP
+.B salt.states.user.absent(name, purge=False, force=False)
+Ensure that the named user is absent
+.INDENT 7.0
+.TP
+.B name
+The name of the user to remove
+.TP
+.B purge
+Set purge to delete all of the user\(aqs file as well as the user
+.TP
+.B force
+If the user is logged in the absent state will fail, set the force
+option to True to remove the user even if they are logged in
+.UNINDENT
+.UNINDENT
+.INDENT 0.0
+.TP
+.B salt.states.user.present(name, uid=None, gid=None, groups=None, home=False, shell=\(aq/bin/bash\(aq)
+Ensure that the named user is present with the specified properties
+.INDENT 7.0
+.TP
+.B name
+The name of the user to manage
+.TP
+.B uid
+The user id to assign, if left empty then the next available user id
+will be assigned
+.TP
+.B gid
+The default group id
+.TP
+.B groups
+A list of groups to assign the user to, pass a list object
+.TP
+.B home
+The location of the home directory to manage
+.TP
+.B shell
+The login shell, defaults to /bin/bash
+.UNINDENT
+.UNINDENT
+.SH RENDERERS
+.sp
+The Salt state system operates by gathering information from simple data
+structures. The state system was designed in this way to make interacting with
+it generic and simple. This also means that state files (sls files) can be one
+of many formats.
+.sp
+By default sls files are rendered as jinja templates and then parsed as yaml
+documents. But since the only thing the state system cares about is raw data,
+the sls files can be any structured format that can be dreamed up.
+.sp
+Currently there is support for \fBjinja + yaml\fP, \fBmako + yaml\fP,
+\fBjinja + json\fP and \fBmako + json\fP. But renderers can be written to support
+anything. This means that the Salt states could be managed by xml files, html
+files, puppet files, or any format that can be translated into the data
+structure used by the state system.
+.SS Writing Renderers
+.sp
+Writing a renderer is easy, all that is required is that a python module
+is placed in the rendered directory and that the module implements the
+render function. The render function will be passed the path of the sls file.
+In the render function, parse the passed file and return the data structure
+derived from the file.
+.SS Examples
+.sp
+The best place to find examples of renderers is in the Salt source code. The
+renderers included with Salt can be found here:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/renderers\fP
+.sp
+Here is a simple jinja + yaml example:
+.sp
+.nf
+.ft C
+# Import python libs
+import os
+
+# Import Third Party libs
+import yaml
+from jinja2 import Template
+
+def render(template):
+    \(aq\(aq\(aq
+    Render the data passing the functions and grains into the rendering system
+    \(aq\(aq\(aq
+    if not os.path.isfile(template):
+        return {}
+    passthrough = {}
+    passthrough.update(__salt__)
+    passthrough.update(__grains__)
+    template = Template(open(template, \(aqr\(aq).read())
+    yaml_data = template.render(**passthrough)
+    return yaml.load(yaml_data)
+.ft P
+.fi
+.SH FULL LIST OF BUILTIN RENDERERS
+.sp
+The default rendering engine, yaml_jinja, this renderer will take a yaml file
+with the jinja template and render it to a high data format for salt states.
+.INDENT 0.0
+.TP
+.B salt.renderers.json_jinja.render(template, env=\(aq\(aq, sls=\(aq\(aq)
+Render the data passing the functions and grains into the rendering system
+.UNINDENT
+.sp
+The default rendering engine, yaml_jinja, this renderer will take a yaml file
+with the jinja template and render it to a high data format for salt states.
+.INDENT 0.0
+.TP
+.B salt.renderers.json_mako.render(template)
+Render the data passing the functions and grains into the rendering system
+.UNINDENT
+.sp
+Pure python state renderer, the sls file should contain a function called sls
+which returns high state data
+.INDENT 0.0
+.TP
+.B salt.renderers.py.render(template, env=\(aq\(aq, sls=\(aq\(aq)
+Render the python module\(aqs components
+.UNINDENT
+.sp
+The default rendering engine, yaml_jinja, this renderer will take a yaml file
+with the jinja template and render it to a high data format for salt states.
+.INDENT 0.0
+.TP
+.B salt.renderers.yaml_jinja.render(template, env=\(aq\(aq, sls=\(aq\(aq)
+Render the data passing the functions and grains into the rendering system
+.UNINDENT
+.sp
+yaml_mako, this renderer will take a yaml file
+within a mako template and render it to a high data format for salt states.
+.INDENT 0.0
+.TP
+.B salt.renderers.yaml_mako.render(template, env=\(aq\(aq, sls=\(aq\(aq)
+Render the data passing the functions and grains into the rendering system
+.UNINDENT
+.SH SALT RUNNERS
+.sp
+Salt runners are convenience applications executed with the salt\-run command.
+.sp
+A Salt runner can be a simple client call, or a complex application.
+.sp
+The use for a salt running is to build a frontend hook for running sets of
+commands via salt of creating special formatted output.
+.SS Writing Salt Runners
+.sp
+Salt runners can be easily written, the work in a similar way to Salt modules
+except they run on the server side.
+.sp
+A runner is a python module that contains functions, each public function is
+a runner that can be executed via the salt\-run command.
+.sp
+If a python module named test.py is created in the runners directory and
+contains a function called \fBfoo\fP then the function could be called with:
+.sp
+.nf
+.ft C
+# salt \(aq*\(aq test.foo
+.ft P
+.fi
+.SS Examples
+.sp
+The best examples of runners can be found in the Salt source:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/v0.9.3/salt/runners\fP
+.sp
+A simple runner that returns a well formated list of the minons that are
+responding to salt calls would look like this:
+.sp
+.nf
+.ft C
+# Import salt modules
+import salt.client
+
+def up():
+    \(aq\(aq\(aq
+    Print a list of all of the minions that are up
+    \(aq\(aq\(aq
+    client = salt.client.LocalClient(__opts__[\(aqconfig\(aq])
+    minions = client.cmd(\(aq*\(aq, \(aqtest.ping\(aq, timeout=1)
+    for minion in sorted(minions):
+        print minion
+.ft P
+.fi
+.SH PEER COMMUNICATION
+.sp
+Salt 0.9.0 introduced the capability for salt minions to publish commands. The
+intent of this feature is not for salt minions to act as independent brokers
+one with another, but to allow salt minions to pass commands to each other.
+.sp
+The peer interface allows a minion to call out publications on the salt master
+and receive the return data.
+.sp
+Since this presents a viable security risk by allowing minions access to the
+master publisher the capability is turned off by default. The minions can be
+allowed access to the master publisher on a per minion basis based on regular
+expressions. Minions with specific ids can be allowed access to certain salt
+modules and functions.
+.SS Configuration
+.sp
+The configuration is done under the peer setting in the salt master
+configuration file, here are a number of configuration possibilities.
+.sp
+The simplest approach is to enable all communication for all minions, this is
+only recommended for very secure environments.
+.sp
+.nf
+.ft C
+peer:
+  .*:
+    \- .*
+.ft P
+.fi
+.sp
+This configuration will allow minions with ids ending in example.com access
+to the test, ps, and pkg module functions.
+.sp
+.nf
+.ft C
+peer:
+  .*example.com:
+    \- test.*
+    \- ps.*
+    \- pkg.*
+.ft P
+.fi
+.sp
+The configuration logic is simple, a regular expression is passed for matching
+minion ids, and then a list of expressions matching minion functions is
+associated with the named minion. For instance, this configuration will also
+allow minions ending with foo.org access to the publisher.
+.sp
+.nf
+.ft C
+peer:
+  .*example.com:
+    \- test.*
+    \- ps.*
+    \- pkg.*
+  .*foo.org:
+    \- test.*
+    \- ps.*
+    \- pkg.*
+.ft P
+.fi
+.SH SALT SYNDIC
+.sp
+The Salt Syndic interface is a powerful tool which allows for the construction
+of Salt command topologies. A basic Salt setup has a Salt Master commanding a
+group of Salt Minions. The Syndic interface is a special passthrough
+minion, it is run on a master and connects to another master, then the master
+that the Syndic minion is listening to can control the minions attatched to
+the master running the syndic.
+.sp
+The intent for supporting many layouts is not presented with the intent of
+supposing the use of any single topology, but to allow a more flexible method
+of controlling many systems.
+.SS Configuring the Syndic
+.sp
+Since the Syndic only needs to be attatched to a higher level master the
+configuration is very simple. On a master that is running a syndic to connect
+to a higher level master the syndic_master option needs to be set in the
+master config file. The syndic_master option contains the hostname or ip
+address of the master server that can control the master that the syndic is
+running on.
+.sp
+The master that the syndic connects to sees the syndic as an ordinary minion,
+and treats it as such. the higher level master will need to accept the syndic\(aqs
+minion key like any other minion. This master will also need to set the
+order_masters value in the configuration to True. The order_masters option in
+the config on the higher level master is very important, to control a syndic
+extra information needs to be sent with the publications, the order_masters
+option makes sure that the extra data is sent out.
+.SS Running the Syndic
+.sp
+The Syndic is a seperate daemon that needs to be started on the master that is
+controlled by a higher master. Starting the Syndic daemon is the same as
+starting the other Salt daemons.
+.sp
+.nf
+.ft C
+# salt\-syndic
+.ft P
+.fi
+.SH PYTHON CLIENT API
+.sp
+Salt is written to be completely API centric, Salt minions and master can be
+built directly into third party applications as a communication layer. The Salt
+client API is very straightforward.
+.SS Using the LocalClient API
+.sp
+Sending information through the client is simple:
+.sp
+.nf
+.ft C
+# Import the salt client library
+import salt.client
+# create a local client object
+client = salt.client.LocalClient()
+# make calls with the cmd method
+ret = client.cmd(\(aq*\(aq, \(aqcmd.run\(aq, [\(aqls \-l\(aq])
+.ft P
+.fi
+.sp
+The cmd call is the only one needed for the local client, the arguments are as
+follows:
+.INDENT 0.0
+.TP
+.B LocalClient.cmd(tgt, fun, arg=[], timeout=5, expr_form=\(aqglob\(aq)
+.UNINDENT
+.sp
+The LocalClient object only works running as root on the salt\-master, it is the
+same interface used by the salt command line tool. The arguments are as
+follows.
+.INDENT 0.0
+.TP
+.B tgt
+The tgt option is the target specification, by default a target is passed
+in as a bash shell glob. The expr_form option allows the tgt to be passed
+as either a pcre regular expression or as a python list.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B fun
+The name of the function to call on the specified minions. The
+documentation for these functions can be seen by running on the
+salt\-master: salt \(aq*\(aq sys.doc
+.UNINDENT
+.INDENT 0.0
+.TP
+.B arg
+The optional arg parameter is used to pass a list of options on to the
+remote function
+.UNINDENT
+.INDENT 0.0
+.TP
+.B timeout
+The number of seconds to wait after the last minion returns but before all
+minions return.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B expr_form
+The type of tgt that is passed in, the allowed values are:
+.INDENT 7.0
+.IP \(bu 2
+\(aqglob\(aq \- Bash glob completion \- Default
+.IP \(bu 2
+\(aqpcre\(aq \- Perl style regular expression
+.IP \(bu 2
+\(aqlist\(aq \- Python list of hosts
+.UNINDENT
+.UNINDENT
+.SS Compound Command Execution With the Salt API
+.sp
+The Salt client API can also send what is called a compound command. Often
+a collection of commands need to be executed on the targeted minions, rather
+than send the commands one after another, they can be send in a single publish
+containing a series of commands. This can dramatically lower overhead and
+speed up the application communicating with Salt.
+.sp
+When commands are executed with compound execution the minion functions called
+are executed in serial on the minion and the return value is sent back in a
+different fashion. The return value is a dict, with the function names as keys
+to the function returns as values.
+.sp
+Using the compound command execution system via the API requires that the fun
+value and the arg value are lists matching by index. This ensures that the
+order of the executions can be controlled. Any function that has no arguments
+MUST have an empty array in the corresponding arg index.
+.sp
+.nf
+.ft C
+# Import the salt client library
+import salt.client
+# create a local client object
+client = salt.client.LocalClient()
+# make compound execution calls with the cmd method
+ret = client.cmd(\(aq*\(aq, [\(aqcmd.run\(aq, \(aqtest.ping\(aq, \(aqtest.echo\(aq], [[\(aqls \-l\(aq], [], [\(aqfoo\(aq]])
+.ft P
+.fi
+.sp
+This will execute \fBcmd.run ls \-l\fP then \fBtest.ping\fP and finally
+\fBtest.echo foo\fP.
+The return data from the minion will look like this:
+.sp
+.nf
+.ft C
+{\(aqcmd.run\(aq: \(aq<output from ls \-l>\(aq,
+ \(aqtest.ping\(aq: True,
+ \(aqtest.echo\(aq: \(aqfoo\(aq}
+.ft P
+.fi
+.SH SALT FILE SERVER
+.sp
+Salt comes with a simple file server suitable for distributing files to the
+salt minions. The file server is a stateless ZeroMQ server that is built into
+the salt master.
+.sp
+The main intent of the Salt File server is the present files for use in the
+Salt state system. With this said, the Salt file server can be used for any
+general file transfer from the master to the minions.
+.SS The cp Module
+.sp
+The cp module is the home of minion side file server operations. The cp module
+is used by the Salt state system, salt\-cp and can be used to distribute files
+presented by the Salt file server.
+.SS Environments
+.sp
+Since the file server is made to work with the Salt state system, it supports
+environments. The environments are defined in the master config file and
+when referencing an environment the file specified will be based on the root
+directory of the environment.
+.SS get_file
+.sp
+The cp.get_file function can be used on the minion to download a file from
+the master, the syntax looks like this:
+.sp
+.nf
+.ft C
+# salt \(aq*\(aq cp.get_file salt://vimrc /etc/vimrc
+.ft P
+.fi
+.sp
+This will instruct all salt minions to download the vimrc file and copy it
+to /etc/vimrc
+.SS File Server Client API
+.sp
+A client API is available which allows for modules and applications to be
+written which make use of the Salt file server.
+.sp
+The file server uses the same authentication and encryption used by the rest
+of the Salt system for network communication.
+.SS FileClient Class
+.sp
+The FileClient class is used to set up the communication from the minion to
+the master. When creating a FileClient object the minion configuration needs
+to be passed in. When using the FileClient from within a minion module the
+built in \fB__opts__\fP data can be passed:
+.sp
+.nf
+.ft C
+import salt.minion
+
+def get_file(path, dest, env=\(aqbase\(aq):
+\(aq\(aq\(aq
+Used to get a single file from the salt master
+
+CLI Example:
+salt \(aq*\(aq cp.get_file salt://vimrc /etc/vimrc
+\(aq\(aq\(aq
+# Create the FileClient object
+client = salt.minion.FileClient(__opts__)
+# Call get_file
+return client.get_file(path, dest, False, env)
+.ft P
+.fi
+.sp
+Using the FileClient class outside of a minion module where the \fB__opts__\fP
+data is not available, it needs to be generated:
+.sp
+.nf
+.ft C
+import salt.minion
+import salt.config
+
+def get_file(path, dest, env=\(aqbase\(aq):
+\(aq\(aq\(aq
+Used to get a single file from the salt master
+\(aq\(aq\(aq
+# Get the configuration data
+opts = salt.config.minion_config(\(aq/etc/salt/minion\(aq)
+# Create the FileClient object
+client = salt.minion.FileClient(opts)
+# Call get_file
+return client.get_file(path, dest, False, env)
+.ft P
+.fi
+.SH CONFIGURATION FILE EXAMPLES
 .INDENT 0.0
 .IP \(bu 2
 \fI\%Example master configuration file\fP
@@ -1092,9 +5669,13 @@ of the Salt system each have a respective configuration file. The
 # clusters.
 #id:
 
+# The minion connection to the master may be inturupted, the minion will
+# verify the connection every so many seconds, to disable connection
+# verification set this value to 0
+#sub_timeout: 60
+
 # Where cache data goes
 #cachedir: /var/cache/salt
-
 
 #####   Minion module management     #####
 ##########################################
@@ -1110,8 +5691,8 @@ of the Salt system each have a respective configuration file. The
 #returner_dirs: []
 #states_dirs: []
 #render_dirs: []
-# Enable Cython modules searching and loading. (Default: True)
-#cython_enable: true
+# Enable Cython modules searching and loading. (Default: False)
+#cython_enable: False
 
 #####    State Management Settings    #####
 ###########################################
@@ -1184,13 +5765,16 @@ of the Salt system each have a respective configuration file. The
 
 .ft P
 .fi
+.SH CONFIGURING THE SALT MASTER
+.sp
+The Salt system is amazingly simple and easy to configure, the two components
+of the Salt system each have a respective configuration file. The
+\fBsalt\-master\fP is configured via the master configuration file, and the
+\fBsalt\-minion\fP is configured via the minion configuration file.
 .IP "See also"
 .sp
 \fIexample master configuration file\fP
-|
-\fIexample minion configuration file\fP
 .RE
-.SS Configuring the Salt Master
 .sp
 The configuration file for the salt\-master is located at
 \fB/etc/salt/master\fP. The available options are as follows:
@@ -1446,7 +6030,16 @@ log_granular_levels: {
 }
 .ft P
 .fi
-.SS Configuring the Salt Minion
+.SH CONFIGURING THE SALT MINION
+.sp
+The Salt system is amazingly simple and easy to configure, the two components
+of the Salt system each have a respective configuration file. The
+\fBsalt\-master\fP is configured via the master configuration file, and the
+\fBsalt\-minion\fP is configured via the minion configuration file.
+.IP "See also"
+.sp
+\fIexample minion configuration file\fP
+.RE
 .sp
 The Salt Minion configuration is very simple, typically the only value that
 needs to be set is the master value so the minion can find its master.
@@ -1539,257 +6132,6 @@ open_mode: False
 .ft P
 .fi
 .SH COMMAND LINE REFERENCE
-.SS \fBsalt\fP
-.SS Synopsis
-.INDENT 0.0
-.INDENT 3.5
-salt \(aq*\(aq [ options ] sys.doc
-.sp
-salt \-E \(aq.*\(aq [ options ] sys.doc cmd
-.sp
-salt \-F \(aqoperatingsystem:Arch.*\(aq [ options ] test.ping
-.sp
-salt \-Q test.ping
-.UNINDENT
-.UNINDENT
-.SS Description
-.sp
-Salt allows for commands to be executed across a swath of remote systems in
-parallel. This means that remote systems can be both controlled and queried
-with ease.
-.SS Options
-.INDENT 0.0
-.TP
-.B \-h, \-\-help
-Print a usage message briefly summarizing these command\-line options
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-t TIMEOUT, \-\-timeout=TIMEOUT
-The timeout in seconds to wait for replies from the salt minions.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-E, \-\-pcre
-The target expression will be interpreted as a pcre regular expression
-rather than a shell glob.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-L, \-\-list
-The target expression will be interpreted as a comma delimited list,
-example: server1.foo.bar,server2.foo.bar,example7.quo.qux
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-G, \-\-grain
-The target expression matches values returned by the salt grains system on
-the minions. The target expression is in the format of \(aq<grain value>:<pcre
-regular expression>\(aq; example: \(aqos:Arch.*\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-Q, \-\-query
-Execute a salt command query, this can be used to find the results os a
-previous function call: \-Q test.echo\(aq)
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-c CONFIG, \-\-config=CONFIG
-The location of the salt master configuration file, the salt master
-settings are required to know where the connections are;
-default=/etc/salt/master
-.UNINDENT
-.SS See also
-.sp
-\fIsalt(7)\fP
-\fIsalt\-master(1)\fP
-\fIsalt\-minion(1)\fP
-.SS \fBsalt\-master\fP
-.sp
-The salt master daemon, used to control the salt minions
-.SS Synopsis
-.sp
-salt\-master [ options ]
-.SS Description
-.sp
-The master daemon controls the salt minions
-.SS Options
-.INDENT 0.0
-.TP
-.B \-h, \-\-help
-Print a usage message briefly summarizing these command\-line options.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-d, \-\-daemon
-Run the salt master as a daemon
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-c CONFIG, \-\-config=CONFIG
-The master configuration file to use, the default is /etc/salt/master
-.UNINDENT
-.SS \fBsalt\-minion\fP
-.sp
-The salt minion daemon, receives commands from a remote salt master.
-.SS Synopsis
-.sp
-salt\-minion [ options ]
-.SS Description
-.sp
-The salt minion receives commands from the central salt master and replies with
-the results of said commands.
-.SS Options
-.INDENT 0.0
-.TP
-.B \-h, \-\-help
-Print a usage message briefly summarizing these command\-line options.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-d, \-\-daemon
-Run the salt minion as a daemon
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-c CONFIG, \-\-config=CONFIG
-The minion configuration file to use, the default is /etc/salt/minion
-.UNINDENT
-.SS \fBsalt\-key\fP
-.SS Synopsis
-.sp
-salt\-key [ options ]
-.SS Description
-.sp
-Salt\-key executes simple management of salt server public keys used for
-authentication.
-.SS Options
-.INDENT 0.0
-.TP
-.B \-h, \-\-help
-Print a usage message briefly summarizing these command\-line options.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-l, \-\-list
-List the unaccepted minion public keys.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-L, \-\-list\-all
-List all public keys on this salt master, both accepted and pending
-acceptance.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-a ACCEPT, \-\-accept=ACCEPT
-Accept the named minion public key for command execution.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-A, \-\-accept\-all
-Accepts all pending public keys.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-c CONFIG, \-\-config=CONFIG
-The master configuration file needs to be read to determine where the salt
-keys are stored via the pki_dir configuration value;
-default=/etc/salt/master
-.UNINDENT
-.SS \fBsalt\-cp\fP
-.sp
-Copy a file to a set of systems
-.SS Synopsis
-.sp
-.nf
-.ft C
-salt\-cp \(aq*\(aq [ options ] SOURCE DEST
-
-salt\-cp \-E \(aq.*\(aq [ options ] SOURCE DEST
-
-salt\-cp \-G \(aqos:Arch.*\(aq [ options ] SOURCE DEST
-.ft P
-.fi
-.SS Description
-.sp
-Salt copy copies a local file out to all of the salt minions matched by the
-given target.
-.SS Options
-.INDENT 0.0
-.TP
-.B \-h, \-\-help
-Print a usage message briefly summarizing these command\-line options
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-t TIMEOUT, \-\-timeout=TIMEOUT
-The timeout in seconds to wait for replies from the salt minions.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-E, \-\-pcre
-The target expresion will be interpereted as a pcre regular expression
-rather than a shell glob.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-L, \-\-list
-The target expression will be interpereted as a comma delimited list,
-example: server1.foo.bar,server2.foo.bar,example7.quo.qux
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-G, \-\-grain
-The target expression matches values returned by the salt grains system on
-the minions. The target expresion is in the format of \(aq<grain value>:<pcre
-regular expresion>\(aq; example: \(aqos:Arch.*\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-Q, \-\-query
-Execute a salt command query, this can be used to find the results os a
-previous function call: \-Q test.echo\(aq)
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-c CONFIG, \-\-config=CONFIG
-The location of the salt master configuration file, the salt master
-settings are required to know where the connections are;
-default=/etc/salt/master
-.UNINDENT
-.SS \fBsalt\-call\fP
-.SS Synopsis
-.sp
-.nf
-.ft C
-salt\-call [options]
-.ft P
-.fi
-.SS Options
-.INDENT 0.0
-.TP
-.B \-h, \-\-help
-Print a usage message briefly summarizing these command\-line options
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-g, \-\-grains
-Return the information generated by the salt grains
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-m MODULE_DIRS, \-\-module\-dirs=MODULE_DIRS
-Specify an additional directories to pull modules from, multiple
-directories can be delimited by commas
-.UNINDENT
-.INDENT 0.0
-.TP
-.B \-d, \-\-doc
-Return the documentation for the specified module of for all modules if
-none are specified
-.UNINDENT
 .sp
 Salt can be controlled by a command line client by the root user on the Salt
 master. The Salt command line client uses the Salt client API to communicate
@@ -1804,7 +6146,7 @@ the default configuration file does not exist then Salt falls back to use the
 environment variables \fBSALT_MASTER_CONFIG\fP and \fBSALT_MINION_CONFIG\fP.
 .IP "See also"
 .sp
-\fB../configuration/index\fP
+\fB/topics/configuration\fP
 .RE
 .SS Using the Salt Command
 .sp
@@ -1920,2040 +6262,334 @@ arguments, then there needs to be a placeholder for the absent arguments. This
 is why in the above example, there are two commas right next to each other.
 \fBtest.ping\fP takes no arguments, so we need to add another comma, otherwise
 Salt would attempt to pass "foo" to \fBtest.ping\fP.
-.SH EXTENDING SALT
-.sp
-Writing your own customizations on top of Salt
-.SS Introduction to Extending Salt
-.sp
-Salt is made to be used, and made to be extended. The primary goal of Salt is
-to provide a foundation which can be used to solve problems. And the goal of
-Salt is to not assume what those problems might be.
-.sp
-One of the greatest benefit of developing Salt has been the vast array of ways
-in which people have wanted to use it, while the original intention was as a
-communication layer for a cloud controller Salt has been extended to facilitate
-so much more.
-.SS Client API
-.sp
-The primary interface used to extend salt, is to simply use it. Salt executions
-can be called via the Salt client api, making programming master side solutions
-with Salt is easy.
-.SS Adding Loadable Plugins
-.sp
-Salt is comprised of a core platform that loads many types of easy to write
-plugins. The idea is to enable all of the breaking points in the salt processes
-to have a point of pluggable interaction. This means that all of the main
-features of Salt can be extended, modified or used.
-.sp
-The breaking points and helping interfaces span from convenience master side
-executions to manipulating the flow of how data is handled by Salt.
-.SS Minion Execution Modules
-.sp
-The minion execution modules or just \fBmodules\fP are the core to what salt is
-and does. These modules are found in:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/modules\fP
-.sp
-These modules are what is called by the salt command line and the salt client
-api. Adding modules is done by simply adding additional python modules to the
-modules directory and restarting the minion.
-.SS Grains
-.sp
-Salt grains, or "grains of truth" are bits of static information that are
-generated when the minion starts. This information is useful when determining
-what package manager to default to, or where certain configuration files are
-stored on the minion.
-.sp
-The Salt grains are the interface used for auto detection and dynamic assignment
-of execution modules and types to specific salt minions.
-.sp
-The code used to generate the Salt grains can be found here:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/grains\fP
-.SS States
-.sp
-Salt supports state enforcement, this makes Salt a high speed and very efficient
-solution for system configuration management.
-.sp
-States can be easily added to Salt by dropping a new state module in:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/states\fP
-.SS Renderers
-.sp
-Salt states are controlled by simple data structures, these structures can be
-abstracted in a number of ways. While the default is to be in a yaml file
-wrapped in a jinja template, any abstraction can be used. This means that any
-format that can be dreamed is possible, so long as a renderer is written for
-it.
-.sp
-The existing renderers can be found here:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/renderers\fP
-.SS Returners
-.sp
-The salt commands all produce a return value, that return value is sent to the
-salt master by default, but it can be sent anywhere. The returner interface
-makes it programmatically possible for the information to be sent to anything
-from an SQL or NOSQL database, to a custom application made to use Salt.
-.sp
-The existing returners can be found here:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/returners\fP
-.SS Runners
-.sp
-Sometimes a certain application can be made to execute and run from the
-existing salt command line. This is where the salt runners come into play.
-The Salt Runners what is called by the salt\-run command and are meant to
-act as a generic interface for encapsulating master side executions.
-.sp
-Existing Salt runners are located here:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/runners\fP
-.SS Modules
-.sp
-Salt modules are the functions called by the \fBsalt\fP command.
-.SS Full list of builtin modules
-.SS Contents
+.SH SALT
+.SS Synopsis
 .INDENT 0.0
-.IP \(bu 2
-\fI\%salt.modules.butterkvm\fP
-.IP \(bu 2
-\fI\%salt.modules.cluster\fP
-.IP \(bu 2
-\fI\%salt.modules.cmd\fP
-.IP \(bu 2
-\fI\%salt.modules.cp\fP
-.IP \(bu 2
-\fI\%salt.modules.disk\fP
-.IP \(bu 2
-\fI\%salt.modules.grains\fP
-.IP \(bu 2
-\fI\%salt.modules.network\fP
-.IP \(bu 2
-\fI\%salt.modules.pacman\fP
-.IP \(bu 2
-\fI\%salt.modules.service\fP
-.IP \(bu 2
-\fI\%salt.modules.state\fP
-.IP \(bu 2
-\fI\%salt.modules.status\fP
-.IP \(bu 2
-\fI\%salt.modules.sysctl\fP
-.IP \(bu 2
-\fI\%salt.modules.test\fP
-.IP \(bu 2
-\fI\%salt.modules.virt\fP
-.IP \(bu 2
-\fI\%salt.modules.yum\fP
-.UNINDENT
-.SS \fBsalt.modules.butterkvm\fP
-.sp
-Specialized routines used by the butter cloud component
-.INDENT 0.0
-.TP
-.B salt.modules.butterkvm.create(instance, vda, image, pin)
-Create a virtual machine, this is part of the butter vm system and assumes
-that the files prepared by butter are available via shared storage.
-AKA \- don\(aqt call this from the command line!
-.sp
-Arguments:
-instance \- string, The path to the instance directory for the given vm on
-shared storage
-vda \- The location where the virtual machine image needs to be placed
-image \- The image to move into place
-pin \- a "pin" data structure defining the myriad of possible vdb\-vbz disk
-images to generate.
-.sp
-CLI Example:
-salt \(aq*\(aq butterkvm.create <instance dir> <root image location>            <Destination> <pin data>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.butterkvm.full_butter_data(local_path)
-Return the full virt info, but add butter data!
-.sp
-CLI Example:
-salt \(aq*\(aq buttervm.full_butter_data <image_path>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.butterkvm.libvirt_creds()
-Returns the user and group that the disk images should be owned by
-.sp
-CLI Example:
-salt \(aq*\(aq butterkvm.libvirt_creds
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.butterkvm.local_images(local_path)
-return the virtual machine names for all of the images located in the
-butter cloud\(aqs local_path in a list:
-.sp
-[\(aqvm1.boo.com\(aq, \(aqvm2.foo.com\(aq]
-.sp
-CLI Example:
-salt \(aq*\(aq buttervm.local_images <image_path>
-.UNINDENT
-.SS \fBsalt.modules.cluster\fP
-.sp
-The cluster module is used to distribute and activate salt HA cluster
-components
-.INDENT 0.0
-.TP
-.B salt.modules.cluster.distrib(minions, master_conf, master_pem, conf_file)
-Set up this minion as a failover master \- only intended for use by the
-cluster interface
-.UNINDENT
-.SS \fBsalt.modules.cmd\fP
-.sp
-A module for shelling out
-.sp
-Keep in mind that this module is insecure, in that it can give whomever has
-access to the master root execution access to all salt minions
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.exec_code(lang, code)
-Pass in two strings, the first naming the executable language, aka \-
-python2, python3, ruby, perl, lua, etc. the second string containing
-the code you wish to execute. The stdout and stderr will be returned
-.sp
-CLI Example:
-salt \(aq*\(aq cmd.exec_code ruby \(aqputs "cheese"\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.has_exec(cmd)
-Returns true if the executable is available on the minion, false otherwise
-.sp
-CLI Example:
-salt \(aq*\(aq cat
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.retcode(cmd, cwd=\(aq/home/thatch\(aq)
-Execute a shell command and return the command\(aqs return code.
-.sp
-CLI Example:
-salt \(aq*\(aq cmd.retcode "file /bin/bash"
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.run(cmd, cwd=\(aq/home/thatch\(aq)
-Execute the passed command and return the output as a string
-.sp
-CLI Example:
-salt \(aq*\(aq cmd.run "ls \-l | grep foo | awk \(aq{print $2}\(aq"
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.run_all(cmd, cwd=\(aq/home/thatch\(aq)
-Execute the passed command and return a dict of return data
-.sp
-CLI Example:
-salt \(aq*\(aq cmd.run_all "ls \-l | grep foo | awk \(aq{print $2}\(aq"
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.run_stderr(cmd, cwd=\(aq/home/thatch\(aq)
-Execute a command and only return the standard error
-.sp
-CLI Example:
-salt \(aq*\(aq cmd.run "ls \-l | grep foo | awk \(aq{print $2}\(aq"
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cmd.run_stdout(cmd, cwd=\(aq/home/thatch\(aq)
-Execute a command, and only return the standard out
-.sp
-CLI Example:
-salt \(aq*\(aq cmd.run "ls \-l | grep foo | awk \(aq{print $2}\(aq"
-.UNINDENT
-.SS \fBsalt.modules.cp\fP
-.sp
-Minion side functions for salt\-cp
-.INDENT 0.0
-.TP
-.B salt.modules.cp.cache_file(path, env=\(aqbase\(aq)
-Used to cache a single file in the local salt\-master file cache.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cp.cache_files(paths, env=\(aqbase\(aq)
-Used to gather many files from the master, the gathered files will be
-saved in the minion cachedir reflective to the paths retrieved from the
-master.
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cp.get_file(path, dest, env=\(aqbase\(aq)
-Used to get a single file from the salt master
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cp.hash_file(path, env=\(aqbase\(aq)
-Return the hash of a file, to get the hash of a file on the
-salt master file server prepend the path with salt://<file on server>
-otherwise, prepend the file with / for a local file.
-.sp
-CLI Example:
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.cp.recv(files, dest)
-Used with salt\-cp, pass the files dict, and the destination.
-.sp
-This function receives small fast copy files from the master via salt\-cp
-.UNINDENT
-.SS \fBsalt.modules.disk\fP
-.sp
-Module for gathering disk information
-.INDENT 0.0
-.TP
-.B salt.modules.disk.usage()
-Return usage information for volumes mounted on this minion
-.sp
-CLI Example:
-salt \(aq*\(aq disk.usage
-.UNINDENT
-.SS \fBsalt.modules.grains\fP
-.sp
-Control aspects of the grains data
-.INDENT 0.0
-.TP
-.B salt.modules.grains.item(key)
-Return a singe component of the grains data
-.sp
-CLI Example:
-salt \(aq*\(aq grains.item os
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.grains.items()
-Return the grains data
-.sp
-CLI Example:
-salt \(aq*\(aq grains.items
-.UNINDENT
-.SS \fBsalt.modules.network\fP
-.sp
-Module for gathering and managing network information
-.INDENT 0.0
-.TP
-.B salt.modules.network.dig(host)
-Performs a DNS lookup with dig
-.sp
-CLI Example:
-salt \(aq*\(aq network.dig archlinux.org
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.network.isportopen(host, port)
-Return status of a port
-.sp
-CLI Example:
-salt \(aq*\(aq network.isportopen 127.0.0.1 22
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.network.netstat()
-Return information on open ports and states
-.sp
-CLI Example:
-salt \(aq*\(aq network.netstat
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.network.ping(host)
-Performs a ping to a host
-.sp
-CLI Example:
-salt \(aq*\(aq network.ping archlinux.org \-c 4
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.network.traceroute(host)
-Performs a traceroute to a 3rd party host
-.sp
-CLI Example:
-salt \(aq*\(aq network.traceroute archlinux.org
-.UNINDENT
-.SS \fBsalt.modules.pacman\fP
-.sp
-A module to wrap pacman calls, since Arch is the best
-(\fI\%https://wiki.archlinux.org/index.php/Arch_is_the_best\fP)
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.available_version(name)
-The available version of the package in the repository
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.available_version <package name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.install(name, refresh=False)
-Install the passed package, add refresh=True to install with an \-Sy
-.sp
-Return a dict containing the new package names and versions:
-{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
-.INDENT 7.0
 .INDENT 3.5
-\(aqnew\(aq: \(aq<new\-version>\(aq]}
-.UNINDENT
-.UNINDENT
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.install <package name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.list_pkgs()
-List the packages currently installed in a dict:
-{\(aq<package_name>\(aq: \(aq<version>\(aq}
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.list_pkgs
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.purge(name)
-Recursively remove a package and all dependencies which were installed
-with it, this will call a pacman \-Rsc
-.sp
-Return a list containing the removed packages:
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.purge <package name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.refresh_db()
-Just run a pacman \-Sy, return a dict:
-{\(aq<database name>\(aq: Bool}
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.refresh_db
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.remove(name)
-Remove a single package with pacman \-R
-.sp
-Return a list containing the removed packages:
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.remove <package name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.upgrade()
-Run a full system upgrade, a pacman \-Syu
-.sp
-Return a dict containing the new package names and versions:
-{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
-.INDENT 7.0
-.INDENT 3.5
-\(aqnew\(aq: \(aq<new\-version>\(aq]}
-.UNINDENT
-.UNINDENT
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.upgrade
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.pacman.version(name)
-Returns a version if the package is installed, else returns an empty string
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.version <package name>
-.UNINDENT
-.SS \fBsalt.modules.service\fP
-.sp
-Top level package command wrapper, used to translate the os detected by the
-grains to the correct service manager
-.INDENT 0.0
-.TP
-.B salt.modules.service.restart(name)
-Restart the named service
-.sp
-CLI Example:
-salt \(aq*\(aq service.restart <service name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.service.start(name)
-Start the specified service
-.sp
-CLI Example:
-salt \(aq*\(aq service.start <service name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.service.status(name, sig=None)
-Return the status for a service, returns the PID or an empty string if the
-service is running or not, pass a signature to use to find the service via
-ps
-.sp
-CLI Example:
-salt \(aq*\(aq service.status <service name> [service signature]
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.service.stop(name)
-Stop the specified service
-.sp
-CLI Example:
-salt \(aq*\(aq service.stop <service name>
-.UNINDENT
-.SS \fBsalt.modules.state\fP
-.sp
-Control the state system on the minion
-.INDENT 0.0
-.TP
-.B salt.modules.state.high(data)
-Execute the compound calls stored in a single set of high data
-This function is mostly intended for testing the state system
-.sp
-CLI Example:
-salt \(aq*\(aq state.high \(aq{"vim": {"pkg": ["installed"]}}\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.state.highstate()
-Retrive the state data from the salt master for this minion and execute it
-.sp
-CLI Example:
-salt \(aq*\(aq state.highstate
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.state.low(data)
-Execute a single low data call
-This function is mostly intended for testing the state system
-.sp
-CLI Example:
-salt \(aq*\(aq state.low \(aq{"state": "pkg", "fun": "installed", "name": "vim"}\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.state.template(tem)
-Execute the information stored in a template file on the minion
-.sp
-CLI Example:
-salt \(aq*\(aq state.template \(aq<Path to template on the minion>\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.state.template_str(tem)
-Execute the information stored in a template file on the minion
-.sp
-CLI Example:
-salt \(aq*\(aq state.template_str \(aq<Template String>\(aq
-.UNINDENT
-.SS \fBsalt.modules.status\fP
-.sp
-Module for returning various status data about a minion.
-These data can be useful for compiling into stats later.
-.INDENT 0.0
-.TP
-.B salt.modules.status.all_status()
-Return a composite of all status data and info for this minoon.
-Warning: There is a LOT here!
-.sp
-CLI Example:
-salt \(aq*\(aq status.all_status
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.cpuinfo()
-Return the CPU info for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.cpuinfo
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.cpustats()
-Return the CPU stats for this minon
-.sp
-CLI Example:
-salt \(aq*\(aq status.cpustats
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.custom()
-Return a custom composite of status data and info for this minon,
-based on the minion config file. An example config like might be:
-.sp
-status.cpustats.custom: [ \(aqcpu\(aq, \(aqctxt\(aq, \(aqbtime\(aq, \(aqprocesses\(aq ]
-.sp
-...where status refers to status.py, cpustats is the function
-where we get our data, and custom is this function It is followed
-by a list of keys that we want returned.
-.sp
-This function is meant to replace all_status(), which returns
-anything and everything, which we probably don\(aqt want.
-.sp
-By default, nothing is returned. Warning: Depending on what you
-include, there can be a LOT here!
-.sp
-CLI Example:
-salt \(aq*\(aq status.custom
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.diskstats()
-Return the disk stats for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.diskstats
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.diskusage(*args)
-Return the disk usage for this minion
-.sp
-Usage:
-salt \(aq*\(aq status.diskusage [paths and/or filesystem types]
-.sp
-CLI Example:
-salt \(aq*\(aq status.diskusage         # usage for all filesystems
-salt \(aq*\(aq status.diskusage / /tmp  # usage for / and /tmp
-salt \(aq*\(aq status.diskusage ext?    # usage for ext2, ext3, & ext4 filesystems
-salt \(aq*\(aq status.diskusage / ext?  # usage for / and all ext filesystems
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.loadavg()
-Return the load averages for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.loadavg
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.meminfo()
-Return the CPU stats for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.meminfo
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.netdev()
-Return the network device stats for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.netdev
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.netstats()
-Return the network stats for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.netstats
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.uptime()
-Return the uptime for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.uptime
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.vmstats()
-Return the virtual memory stats for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq status.vmstats
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.status.w()
-Return a list of logged in users for this minion, using the w command
-.sp
-CLI Example:
-salt \(aq*\(aq status.w
-.UNINDENT
-.SS \fBsalt.modules.sysctl\fP
-.sp
-Module for viewing and modifying sysctl parameters
-.INDENT 0.0
-.TP
-.B salt.modules.sysctl.assign(name, value)
-Assign a single sysctl parameter for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq sysctl.assign net.ipv4.ip_forward 1
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.sysctl.get(name)
-Return a single sysctl parameter for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq sysctl.get net.ipv4.ip_forward
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.sysctl.show()
-Return a list of sysctl parameters for this minion
-.sp
-CLI Example:
-salt \(aq*\(aq sysctl.show
-.UNINDENT
-.SS \fBsalt.modules.test\fP
-.sp
-Module for running arbitrary tests
-.INDENT 0.0
-.TP
-.B salt.modules.test.collatz(start)
-Execute the collatz conjecture from the passed starting number, returns
-the sequence and the time it took to compute. Used for performance tests.
-.sp
-CLI Example:
-salt \(aq*\(aq test.collatz 3
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.conf_test()
-Return the value for test.foo in the minion configuration file, or return
-the default value
-.sp
-CLI Example:
-salt \(aq*\(aq test.conf_test
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.cross_test(func, args=[])
-Execute a minion function via the __salt__ object in the test module, used
-to verify that the minion functions can be called via the __salt__module
-.sp
-CLI Example:
-salt \(aq*\(aq test.cross_test file.gid_to_group 0
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.echo(text)
-Return a string \- used for testing the connection
-.sp
-CLI Example:
-salt \(aq*\(aq test.echo \(aqfoo bar baz quo qux\(aq
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.fib(num)
-Return a Fibonacci sequence up to the passed number, and the time it took
-to compute in seconds. Used for performance tests
-.sp
-CLI Example:
-salt \(aq*\(aq test.fib 3
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.get_opts()
-Return the configuration options passed to this minion
-.sp
-CLI Example:
-salt \(aq*\(aq test.get_opts
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.outputter(data)
-Test the outputter, pass in data to return
-.sp
-CLI Example:
-salt \(aq*\(aq test.outputter foobar
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.test.ping()
-Just used to make sure the minion is up and responding
-Return True
-.sp
-CLI Example:
-salt \(aq*\(aq test.ping
-.UNINDENT
-.SS \fBsalt.modules.virt\fP
+salt \(aq*\(aq [ options ] sys.doc
 .sp
-Work with virtual machines managed by libvirt
-.INDENT 0.0
-.TP
-.B salt.modules.virt.create(vm_)
-Start a defined domain
-.sp
-CLI Example:
-salt \(aq*\(aq virt.create <vm name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.create_xml_path(path)
-Start a defined domain
+salt \-E \(aq.*\(aq [ options ] sys.doc cmd
 .sp
-CLI Example:
-salt \(aq*\(aq virt.create_xml_path <path to xml file on the node>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.create_xml_str(xml)
-Start a domain based on the xml passed to the function
+salt \-F \(aqoperatingsystem:Arch.*\(aq [ options ] test.ping
 .sp
-CLI Example:
-salt \(aq*\(aq virt.create_xml_str <xml in string format>
+salt \-Q test.ping
 .UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.destroy(vm_)
-Hard power down the virtual machine, this is equivalent to pulling the
-power
-.sp
-CLI Example:
-salt \(aq*\(aq virt.destroy <vm name>
 .UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.freecpu()
-Return an int representing the number of unallocated cpus on this
-hypervisor
+.SS Description
 .sp
-CLI Example:
-salt \(aq*\(aq virt.freemem
-.UNINDENT
+Salt allows for commands to be executed across a swath of remote systems in
+parallel. This means that remote systems can be both controlled and queried
+with ease.
+.SS Options
 .INDENT 0.0
 .TP
-.B salt.modules.virt.freemem()
-Return an int representing the amount of memory that has not been given
-to virtual machines on this node
-.sp
-CLI Example:
-salt \(aq*\(aq virt.freemem
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.full_info()
-Return the node_info, vm_info and freemem
-.sp
-CLI Example:
-salt \(aq*\(aq virt.full_info
+.B \-t TIMEOUT, \-\-timeout=TIMEOUT
+The timeout in seconds to wait for replies from the salt minions.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.get_disks(vm_)
-Return the disks of a named vm
-.sp
-CLI Example:
-salt \(aq*\(aq virt.get_disks <vm name>
+.B \-E, \-\-pcre
+The target expression will be interpreted as a pcre regular expression
+rather than a shell glob.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.get_graphics(vm_)
-Returns the information on vnc for a given vm
-.sp
-CLI Example:
-salt \(aq*\(aq virt.get_graphics <vm name>
+.B \-L, \-\-list
+The target expression will be interpreted as a comma delimited list,
+example: server1.foo.bar,server2.foo.bar,example7.quo.qux
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.get_xml(vm_)
-Returns the xml for a given vm
-.sp
-CLI Example:
-salt \(aq*\(aq virt.get_xml <vm name>
+.B \-G, \-\-grain
+The target expression matches values returned by the salt grains system on
+the minions. The target expression is in the format of \(aq<grain value>:<pcre
+regular expression>\(aq; example: \(aqos:Arch.*\(aq
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.is_kvm_hyper()
-Returns a bool whether or not this node is a hypervisor
-.sp
-CLI Example:
-salt \(aq*\(aq virt.is_kvm_hyper
+.B \-Q, \-\-query
+Execute a salt command query, this can be used to find the results os a
+previous function call: \-Q test.echo\(aq)
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.list_vms()
-Return a list of virtual machine names on the minion
-.sp
-CLI Example:
-salt \(aq*\(aq virt.list_vms
+.B \-c CONFIG, \-\-config=CONFIG
+The location of the salt master configuration file, the salt master
+settings are required to know where the connections are;
+default=/etc/salt/master
 .UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.migrate(vm_, target)
-Shared storage migration
+.SS See also
 .sp
-CLI Example:
-salt \(aq*\(aq virt.migrate <vm name> <target hypervisor>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.migrate_non_shared(vm_, target)
-Attempt to execute non\-shared storage "all" migration
+\fIsalt(7)\fP
+\fIsalt\-master(1)\fP
+\fIsalt\-minion(1)\fP
+.SH SALT-MASTER
 .sp
-CLI Example:
-salt \(aq*\(aq virt.migrate_non_shared <vm name> <target hypervisor>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.migrate_non_shared_inc(vm_, target)
-Attempt to execute non\-shared storage "all" migration
+The salt master daemon, used to control the salt minions
+.SS Synopsis
 .sp
-CLI Example:
-salt \(aq*\(aq virt.migrate_non_shared_inc <vm name> <target hypervisor>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.node_info()
-Return a dict with information about this node
+salt\-master [ options ]
+.SS Description
 .sp
-CLI Example:
-salt \(aq*\(aq virt.node_info
-.UNINDENT
+The master daemon controls the salt minions
+.SS Options
 .INDENT 0.0
 .TP
-.B salt.modules.virt.pause(vm_)
-Pause the named vm
-.sp
-CLI Example:
-salt \(aq*\(aq virt.pause <vm name>
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.purge(vm_, dirs=False)
-Recursively destroy and delete a virtual machine, pass True for dir\(aqs to
-also delete the directories containing the virtual machine disk images \-
-USE WITH EXTREAME CAUTION!
-.sp
-CLI Example:
-salt \(aq*\(aq virt.purge <vm name>
+.B \-d, \-\-daemon
+Run the salt master as a daemon
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.resume(vm_)
-Resume the named vm
-.sp
-CLI Example:
-salt \(aq*\(aq virt.resume <vm name>
+.B \-c CONFIG, \-\-config=CONFIG
+The master configuration file to use, the default is /etc/salt/master
 .UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.seed_non_shared_migrate(disks, force=False)
-Non shared migration requires that the disks be present on the migration
-destination, pass the disks information via this function, to the
-migration destination before executing the migration.
+.SH SALT-MINION
 .sp
-CLI Example:
-salt \(aq*\(aq virt.seed_non_shared_migrate <disks>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.shutdown(vm_)
-Send a soft shutdown signal to the named vm
+The salt minion daemon, receives commands from a remote salt master.
+.SS Synopsis
 .sp
-CLI Example:
-salt \(aq*\(aq virt.shutdown <vm name>
-.UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.virt.undefine(vm_)
-Remove a defined vm, this does not purge the virtual machine image, and
-this only works if the vm is powered down
+salt\-minion [ options ]
+.SS Description
 .sp
-CLI Example:
-salt \(aq*\(aq virt.undefine <vm name>
-.UNINDENT
+The salt minion receives commands from the central salt master and replies with
+the results of said commands.
+.SS Options
 .INDENT 0.0
 .TP
-.B salt.modules.virt.virt_type()
-Returns the virtual machine type as a string
-.sp
-CLI Example:
-salt \(aq*\(aq virt.virt_type
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.virt.vm_info()
-Return detailed information about the vms on this hyper in a dict:
-.INDENT 7.0
-.TP
-.B {\(aqcpu\(aq: <int>,
-\(aqmaxMem\(aq: <int>,
-\(aqmem\(aq: <int>,
-\(aqstate\(aq: \(aq<state>\(aq,
-\(aqcputime\(aq <int>}
-.UNINDENT
-.sp
-CLI Example:
-salt \(aq*\(aq virt.vm_info
+.B \-d, \-\-daemon
+Run the salt minion as a daemon
 .UNINDENT
-.SS \fBsalt.modules.yum\fP
-.sp
-Support for YUM
 .INDENT 0.0
 .TP
-.B salt.modules.yum.available_version(name)
-The available version of the package in the repository
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.available_version <package name>
+.B \-c CONFIG, \-\-config=CONFIG
+The minion configuration file to use, the default is /etc/salt/minion
 .UNINDENT
-.INDENT 0.0
-.TP
-.B salt.modules.yum.install(pkg, refresh=False)
-Install the passed package, add refresh=True to clean out the yum database
-before executing
+.SH SALT-KEY
+.SS Synopsis
 .sp
-Return a dict containing the new package names and versions:
-{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
-.INDENT 7.0
-.INDENT 3.5
-\(aqnew\(aq: \(aq<new\-version>\(aq]}
-.UNINDENT
-.UNINDENT
+salt\-key [ options ]
+.SS Description
 .sp
-CLI Example:
-salt \(aq*\(aq pkg.install <package name>
-.UNINDENT
+Salt\-key executes simple management of salt server public keys used for
+authentication.
+.SS Options
 .INDENT 0.0
 .TP
-.B salt.modules.yum.list_pkgs()
-List the packages currently installed in a dict:
-{\(aq<package_name>\(aq: \(aq<version>\(aq}
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.list_pkgs
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.yum.purge(pkg)
-Yum does not have a purge, this function calls remove
-.sp
-Return a list containing the removed packages:
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.purge <package name>
+.B \-l, \-\-list
+List the unaccepted minion public keys.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.yum.refresh_db()
-Since yum refreshes the database automatically, this runs a yum clean,
-so that the next yum operation will have a clean database
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.refresh_db
+.B \-L, \-\-list\-all
+List all public keys on this salt master, both accepted and pending
+acceptance.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.yum.remove(pkg)
-Remove a single package with yum remove
-.sp
-Return a list containing the removed packages:
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.remove <package name>
+.B \-a ACCEPT, \-\-accept=ACCEPT
+Accept the named minion public key for command execution.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.yum.upgrade()
-Run a full system upgrade, a yum upgrade
-.sp
-Return a dict containing the new package names and versions:
-{\(aq<package>\(aq: {\(aqold\(aq: \(aq<old\-version>\(aq,
-.INDENT 7.0
-.INDENT 3.5
-\(aqnew\(aq: \(aq<new\-version>\(aq]}
-.UNINDENT
-.UNINDENT
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.upgrade
+.B \-A, \-\-accept\-all
+Accepts all pending public keys.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.yum.version(name)
-Returns a version if the package is installed, else returns an empty string
-.sp
-CLI Example:
-salt \(aq*\(aq pkg.version <package name>
+.B \-c CONFIG, \-\-config=CONFIG
+The master configuration file needs to be read to determine where the salt
+keys are stored via the pki_dir configuration value;
+default=/etc/salt/master
 .UNINDENT
-.IP "See also"
-.sp
-\fBFull list of builtin modules\fP
-.sp
-Salt ships with many modules that cover a wide variety of tasks.
-.RE
-.SS Easy Modules to write
-.sp
-Salt modules are amazingly simple to write, just write a regular Python module
-or a regular Cython module and place it in the \fBsalt/modules\fP directory.
-.sp
-Since Salt modules are just Python/Cython modules there are no restraints as to
-what you can put inside of a salt module, and if a Salt module has errors and
-cannot import the Salt minion will continue to load without issue, the module
-with errors will simply be omitted.
-.sp
-If adding a Cython module the file must be named \fB<modulename>.pyx\fP so that
-the loader knows that the module needs to be imported as a Cython module. The
-compilation of the Cython module is automatic and happens when the minion
-starts, so only the \fB*.pyx\fP file is required.
-.SS Cross Calling Modules
-.sp
-All of the salt modules are available to each other, and can be "cross called".
-This means that when creating a module functions in modules which already exist
-can be called.
-.sp
-The variable \fB__salt__\fP is packed into the modules after they are loaded into
-the salt minion. This variable is a python dictionary of all of the salt
-functions, laid out in the same way that they are made available to the salt
-command.
+.SH SALT-CP
 .sp
-Salt modules can be cross called by accessing the value in the \fB__salt__\fP
-dict:
+Copy a file to a set of systems
+.SS Synopsis
 .sp
 .nf
 .ft C
-def foo(bar):
-    return __salt__[\(aqcmd.run\(aq](bar)
-.ft P
-.fi
-.sp
-This code will call the Salt cmd module\(aqs run function and pass the argument
-\fBbar\fP.
-.SS Preloaded Modules Data
-.sp
-When interacting with modules often it is nice to be able to read information
-dynamically about the minion, or load in configuration parameters for a module.
-Salt allows for different types of data to be loaded into the modules by the
-minion, as of this writing Salt loads information gathered from the Salt Grains
-system and from the minion configuration file.
-.SS Grains Data
-.sp
-The Salt minion detects information about the system when started. This allows
-for modules to be written dynamically with respect to the underlying hardware
-and OS. This information is referred to as Salt Grains, or "grains of salt".
-The Grains system was introduced to replace Facter, since relying on a Ruby
-application from a Python application was both slow and inefficient. Grains
-support replaces Facter in all releases after 0.8
-.sp
-The values detected by the Salt Grains on the minion are available in a dict by
-the name of \fB__grains__\fP and can be accessed from within callable objects in
-the Python modules.
-.sp
-To see the contents of the grains dict for a given system in your deployment
-run the \fBgrains.items()\fP function:
-.sp
-.nf
-.ft C
-salt \(aqhostname\(aq grains.items
-.ft P
-.fi
-.sp
-To use the \fB__grains__\fP dict simply call it as a Python dict from within your
-code, an excellent example is available in the Grains module:
-\fBsalt.modules.grains\fP.
-.SS Module Configuration
-.sp
-Since parameters for configuring a module may be desired, Salt allows for
-configuration information stored in the main minion config file to be passed to
-the modules.
-.sp
-Since the minion configuration file is a yaml document, arbitrary configuration
-data can be passed in the minion config that is read by the modules. It is
-\fBstrongly\fP recommended that the values passed in the configuration file match
-the module. This means that a value intended for the \fBtest\fP module should be
-named \fBtest.<value>\fP.
-.sp
-Configuration also requires that default configuration parameters need to be
-loaded as well. This can be done simply by adding the \fB__opts__\fP dict to the
-top level of the module.
-.sp
-The test module contains usage of the module configuration, and the default
-configuration file for the minion contains the information and format used to
-pass data to the modules. \fBsalt.modules.test\fP, \fBconf/minion\fP.
-.SS Printout Configuration
-.sp
-Since module functions can return different data, and the way the data is
-printed can greatly change the presentation, Salt has a printout
-configuration.
-.sp
-When writing a module the \fB__outputter__\fP dict can be declared in the module.
-The \fB__outputter__\fP dict contains a mapping of function name to Salt
-Outputter.
-.sp
-.nf
-.ft C
-__outputter__ = {
-                \(aqrun\(aq: \(aqtxt\(aq
-                }
-.ft P
-.fi
-.sp
-This will ensure that the text outputter is used.
-.SS Virtual Modules
-.sp
-Sometimes a module should be presented in a generic way. A good example of this
-can be found in the package manager modules. The package manager changes from
-one operating system to another, but the salt module that interfaces with the
-package manager can be presented in a generic way.
-.sp
-The salt modules for package managers all contain a \fB__virtual__\fP function
-which is called to define what systems the module should be loaded on.
-.sp
-The \fB__virtual__\fP function is used to return either a string or False. If
-False is returned then the module is not loaded, if a string is returned then
-the module is loaded with the name of the string.
-.sp
-This means that the package manager modules can be presented as the pkg module
-regardless of what the actual module is named.
-.sp
-The package manager modules are the best example of using the \fB__virtual__\fP
-function:
-\fI\%https://github.com/thatch45/salt/blob/master/salt/modules/pacman.py\fP
-\fI\%https://github.com/thatch45/salt/blob/master/salt/modules/yum.py\fP
-\fI\%https://github.com/thatch45/salt/blob/master/salt/modules/apt.py\fP
-.SS Documentation
-.sp
-Salt modules are self documenting, the \fBsys.doc()\fP function will return the
-documentation for all available Facter modules:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq sys.doc
-.ft P
-.fi
-.sp
-This function simple prints out the docstrings found in the modules, when
-writing salt modules, please follow the formating conventions for docstrings as
-they appear in the other modules.
-.SS Adding Documentation to Salt Modules
-.sp
-Since life is much better with documentation, it is strongly suggested that
-all Salt modules have documentation added. Any Salt modules submitted for
-inclusion in the main distribution of Salt will be required to have
-documentation.
-.sp
-Documenting Salt modules is easy! Just add a python docstring to the function.
-.sp
-.nf
-.ft C
-def spam(eggs):
-    \(aq\(aq\(aq
-    A function to make some spam with eggs!
+salt\-cp \(aq*\(aq [ options ] SOURCE DEST
 
-    CLI Example:
-    salt \(aq*\(aq test.spam eggs
-    \(aq\(aq\(aq
-    return eggs
-.ft P
-.fi
-.sp
-Now when the sys.doc call is executed the docstring will be cleanly returned
-to the calling terminal.
-.SS How Functions are Read
-.sp
-In Salt Python callable objects contained within a module are made available to
-the Salt minion for use. The only exception to this rule is a callable object
-with a name starting with an underscore \fB_\fP.
-.SS Objects Loaded Into the Salt Minion
-.sp
-.nf
-.ft C
-def foo(bar):
-    return bar
+salt\-cp \-E \(aq.*\(aq [ options ] SOURCE DEST
 
-class baz:
-    def __init__(self, quo):
-        return quo
+salt\-cp \-G \(aqos:Arch.*\(aq [ options ] SOURCE DEST
 .ft P
 .fi
-.SS Objects NOT Loaded into the Salt Minion
+.SS Description
 .sp
-.nf
-.ft C
-def _foobar(baz): # Preceded with an _
-    return baz
-
-cheese = {} # Not a callable python object
-.ft P
-.fi
-.SS Examples of Salt Modules
-.sp
-The existing Salt modules should be fairly easy to read and understand, the
-goal of the main distribution\(aqs Salt modules is not only to build a set of
-functions for salt, but to stand as examples for building out more Salt
-modules.
-.sp
-The existing modules can be found here:
-\fI\%https://github.com/thatch45/salt/tree/master/salt/modules\fP
-.sp
-The most simple module is the test module, it contains the simplest salt
-function, test.ping:
-.sp
-.nf
-.ft C
-def ping():
-    \(aq\(aq\(aq
-    Just used to make sure the minion is up and responding
-    Return True
-
-    CLI Example:
-    salt \(aq*\(aq test.ping
-    \(aq\(aq\(aq
-    return True
-.ft P
-.fi
-.SS Grains
-.sp
-Salt comes with an interface to derive information about the underlying system.
-This is called the grains interface, because it presents salt with grains of
-information.
-.sp
-The grains interface is made available to Salt modules and components so that
-the right salt minion commands are automatically available on the right
-systems.
-.sp
-It is important to remember that grains are bits of information loaded when
-the salt minion starts, so this information is static. This means that the
-information in grains is unchanging, therefore the nature of the data is
-static. So grains information are things like the running kernel, or the
-operating system.
-.SS Writing Grains
-.sp
-Grains are easy to write, the grains interface is derived my executing all of
-the "public" functions found in the modules located in the grains package.
-The functions in the modules of the grains must return a python dict, the keys
-in the dict are the names of the grains, the values are the values.
-.sp
-This means that the actual grains interface is simply a python dict.
-.sp
-Before adding a grain to salt, consider what the grain is and remember that
-grains need to be static data.
-.SS Examples of Grains
-.sp
-The core module in the grains package is where the main grains are loaded by
-the salt minion and the principal example of how to write grains:
-.sp
-\fI\%https://github.com/thatch45/salt/blob/master/salt/grains/core.py\fP
-.SS Returners
-.SS Full list of builtin returners
-.SS Contents
-.INDENT 0.0
-.IP \(bu 2
-\fI\%salt.returners.local\fP
-.IP \(bu 2
-\fI\%salt.returners.redis\fP
-.UNINDENT
-.SS \fBsalt.returners.local\fP
-.sp
-The local returner is used to test the returner interface, it just prints the
-return data to the console to verify that it is being passed properly
+Salt copy copies a local file out to all of the salt minions matched by the
+given target.
+.SS Options
 .INDENT 0.0
 .TP
-.B salt.returners.local.returner(ret)
-Print the return data to the terminal to verify functionality
-.UNINDENT
-.SS \fBsalt.returners.redis\fP
-.sp
-By default the return values of the commands sent to the salt minions are
-returned to the salt\-master. But since the commands executed on the salt
-minions are detatched from the call on the salt master, there is no need for
-the minion to return the data to the salt master.
-.sp
-This is where the returner interface comes in. Returners are modules called
-in place of returning the data to the salt master.
-.sp
-The returner interface allows the return data to be sent to any system that
-can receive data. This means that return data can be sent to a Redis server,
-a MongoDB server, a MySQL server, or any system!
-.IP "See also"
-.sp
-\fBFull list of builtin returners\fP
-.RE
-.SS Writing a Returner
-.sp
-A returner is a module which contains a returner function, the returner
-function must accept a single argument. this argument is the return data from
-the called minion function. So if the minion function \fBtest.ping\fP is called
-the value of the argument will be \fBTrue\fP.
-.sp
-A simple returner is implimented here:
-.sp
-.nf
-.ft C
-import redis
-import json
-
-def returner(ret):
-    \(aq\(aq\(aq
-    Return information to a redis server
-    \(aq\(aq\(aq
-    # Get a redis commection
-    serv = redis.Redis(
-                host=\(aqredis\-serv.example.com\(aq,
-                port=6379,
-                db=\(aq0\(aq)
-    serv.sadd("%(id)s:jobs" % ret, ret[\(aqjid\(aq])
-    serv.set("%(jid)s:%(id)s" % ret, json.dumps(ret[\(aqreturn\(aq]))
-    serv.sadd(\(aqjobs\(aq, ret[\(aqjid\(aq])
-    serv.sadd(ret[\(aqjid\(aq], ret[\(aqid\(aq])
-.ft P
-.fi
-.sp
-This simple example of a returner set to send the data to a redis server
-serializes the data as json and sets it in redis.
-.SS Examples
-.sp
-The collection of builtin salt returners can be found here:
-\fI\%https://github.com/thatch45/salt/tree/master/salt/returners\fP
-.SS State Enforcement
-.sp
-Salt offers an optional interface to manage the configuration or "state" of the
-salt minions. This interface is a fully capable mechanism used to enforce the
-state of systems from a central manager.
-.sp
-The Salt state system is made to be accurate, simple, and fast. And like the
-rest of the Salt system, Salt states are highly modular.
-.SS Understanding the Salt State System Components
-.sp
-The Salt state system is comprised of a number of components, as a user, an
-understanding of the sls and renderer systems are needed. But as a developer,
-an understanding of salt states, as well as understanding salt states and how
-to write the states used by salt.
-.SS Salt SLS System
-.sp
-The primary system used by the Salt state system is the SLS system. SLS stands
-for SaLt State.
-.sp
-The Salt States are files which contain the information about how to configure
-salt minions. The states are laid out in a directory tree and can be written in
-many different formats.
-.sp
-The contents of the files and they way they are laid out is intended to be as
-simple as possible while allowing for maximum flexibility. The files are laid
-out in states and contains information about how the minion needs to be
-configured.
-.SS SLS File Layout
-.sp
-SLS files are laid out in the Salt file server. A simple layout can look like
-this:
-.sp
-.nf
-.ft C
-top.sls
-ssh.sls
-sshd_config
-users/init.sls
-users/admin.sls
-salt/init.sls
-salt/master.sls
-.ft P
-.fi
-.sp
-This example shows the core concepts of file layout. The top file is a key
-component and is used with salt matchers to match SLS states with minions.
-The \fB.sls\fP files are states. The rest of the files are seen by the salt
-master as just files that can be downloaded.
-.sp
-The states are translated into dot notation, so the \fBssh.sls\fP file is
-seen as the ssh state, the \fBusers/admin.sls\fP file is seen as the
-users.admin states.
-.sp
-The init.sls files are translated to be the state name of the parent
-directory, so the \fBsalt/init.sls\fP file translates to the salt state.
-.sp
-The plain files are visible to the minions, as well as the state files, in
-salt, everything is a file, there is not "magic translation" of files and file
-types. This means that a state file can be distributed to minions just like a
-plain text or binary file.
-.SS SLS Files
-.sp
-The Salt state files are simple sets of data. Since the SLS files are just data
-they can be represented in a number of different ways. The default format is
-yaml generated from a jinja template. This allows for the states files to have
-all the language constructs of Python, and the simplicity of yaml. State files
-can then be complicated jinja templates the translate down to yaml, or just
-plain and simple yaml files!
-.sp
-The State files are constructed data structures in a simple format. The format
-allows for many real activates to be expressed in very little text, while
-maintaining the utmost in readability and usability.
-.sp
-Here is an example of a Salt State:
-.sp
-.nf
-.ft C
-vim:
-    pkg:
-        \- installed
-
-salt:
-    pkg:
-        \- latest
-    service:
-        \- running
-        \- require:
-            \- file: /etc/salt/minion
-            \- pkg: salt
-        \- names:
-            \- salt\-master
-            \- salt\-minion
-        \- watch:
-            \- file: /etc/salt/minion
-
-/etc/salt/minion:
-    file:
-        \- managed
-        \- source: salt://salt/minion
-        \- user: root
-        \- group: root
-        \- mode: 644
-        \- require:
-            \- pkg: salt
-.ft P
-.fi
-.sp
-This short stanza will ensure that vim is installed, salt is installed and up
-to date, the salt\-master and salt\-minion daemons are running and the Salt
-minion configuration file is in place. It will also ensure everything is
-deployed in the right order and that the Salt services are restarted when the
-watched file updated.
-.SS The Top File
-.sp
-The top file is the mapping for the state system. The top file specifies which
-minions should have which modules applied and which environments they should
-draw the states from.
-.sp
-The top file works by specifying the environment, containing matchers with
-lists of Salt states sent to the matching minions:
-.sp
-.nf
-.ft C
-base:
-    \(aq*\(aq:
-        \- salt
-        \- users
-        \- users.admin
-    \(aqsaltmaster.*\(aq:
-        \- match: pcre
-        \- salt.master
-.ft P
-.fi
-.sp
-This simple example uses the base environment, which is built into the default
-salt setup, and then all minions will have the modules salt, users and
-users.admin since \(aq*\(aq will match all minions. Then the regular expression
-matcher will match all minions\(aq with an id matching saltmaster.* and add the
-salt.master state.
-.SS Renderer System
-.sp
-The Renderer system is a key component to the state system. SLS files are
-representations of Salt "high data" structures. All Salt cares about when
-reading an sls file is the data structure that is produced from file.
-.sp
-This allows Salt states to be represented by multiple types of files. The
-Renderer system can be used to allow different formats to be used for sls
-files.
-.sp
-The available renderers can be found in the renderers directory in the Salt
-source code:
-.sp
-\fI\%https://github.com/thatch45/salt/tree/master/salt/renderers\fP
-.sp
-By default sls files are rendered using jinja as a templating engine, and yaml
-as the serialization format. Since the rendering system can be extended simply
-by adding a new renderer to the renderers directory, it is possible that any
-structured file could be used to represent the SLS files.
-.sp
-In the future xml and raw python will be added, as well as many other formats.
-.SS Salt Runners
-.sp
-Salt runners are convenience applications executed with the salt\-run command.
-.sp
-A Salt runner can be a simple client call, or a complex application.
-.sp
-The use for a salt running is to build a frontend hook for running sets of
-commands via salt of creating special formatted output.
-.SS Writing Salt Runners
-.sp
-Salt runners can be easily written, the work in a similar way to Salt modules
-except they run on the server side.
-.sp
-A runner is a python module that contains functions, each public function is
-a runner that can be executed via the salt\-run command.
-.sp
-If a python module named test.py is created in the runners directory and
-contains a function called \fBfoo\fP then the function could be called with:
-.sp
-.nf
-.ft C
-# salt \(aq*\(aq test.foo
-.ft P
-.fi
-.SS Examples
-.sp
-The best examples of runners can be found in the Salt source:
-.sp
-\fI\%https://github.com/thatch45/salt/blob/master/salt/runners\fP
-.sp
-A simple runner that returns a well formated list of the minons that are
-responding to salt calls would look like this:
-.sp
-.nf
-.ft C
-# Import salt modules
-import salt.client
-
-def up():
-    \(aq\(aq\(aq
-    Print a list of all of the minions that are up
-    \(aq\(aq\(aq
-    client = salt.client.LocalClient(__opts__[\(aqconfig\(aq])
-    minions = client.cmd(\(aq*\(aq, \(aqtest.ping\(aq, timeout=1)
-    for minion in sorted(minions):
-        print minion
-.ft P
-.fi
-.SS Renderers
-.sp
-The Salt state system operates by gathering information from simple data
-structures. The state system was designed in this way to make interacting with
-it generic and simple. This also means that state files (sls files) can be one
-of many formats.
-.sp
-By default sls files are rendered as jinja templates and then parsed as yaml
-documents. But since the only thing the state system cares about is raw data,
-the sls files can be any structured format that can be dreamed up.
-.sp
-Currently there is support for \fBjinja + yaml\fP, \fBmako + yaml\fP,
-\fBjinja + json\fP and \fBmako + json\fP. But renderers can be written to support
-anything. This means that the Salt states could be managed by xml files, html
-files, puppet files, or any format that can be translated into the data
-structure used by the state system.
-.SS Writing Renderers
-.sp
-Writing a renderer is easy, all that is required is that a python module
-is placed in the rendered directory and that the module implements the
-render function. The render function will be passed the path of the sls file.
-In the render function, parse the passed file and return the data structure
-derived from the file.
-.SS Examples
-.sp
-The best place to find examples of renderers is in the Salt source code. The
-renderers included with Salt can be found here:
-.sp
-\fI\%https://github.com/thatch45/salt/blob/master/salt/renderers\fP
-.sp
-Here is a simple jinja + yaml example:
-.sp
-.nf
-.ft C
-# Import python libs
-import os
-
-# Import Third Party libs
-import yaml
-from jinja2 import Template
-
-def render(template):
-    \(aq\(aq\(aq
-    Render the data passing the functions and grains into the rendering system
-    \(aq\(aq\(aq
-    if not os.path.isfile(template):
-        return {}
-    passthrough = {}
-    passthrough.update(__salt__)
-    passthrough.update(__grains__)
-    template = Template(open(template, \(aqr\(aq).read())
-    yaml_data = template.render(**passthrough)
-    return yaml.load(yaml_data)
-.ft P
-.fi
-.SS Python client API
-.sp
-Salt is written to be completely API centric, Salt minions and master can be
-built directly into third party applications as a communication layer. The Salt
-client API is very straightforward.
-.SS Using the LocalClient API
-.sp
-Sending information through the client is simple:
-.sp
-.nf
-.ft C
-# Import the salt client library
-import salt.client
-# create a local client object
-client = salt.client.LocalClient()
-# make calls with the cmd method
-ret = client.cmd(\(aq*\(aq, \(aqcmd.run\(aq, [\(aqls \-l\(aq])
-.ft P
-.fi
-.sp
-The cmd call is the only one needed for the local client, the arguments are as
-follows:
-.INDENT 0.0
-.TP
-.B LocalClient.cmd(tgt, fun, arg=[], timeout=5, expr_form=\(aqglob\(aq)
-.UNINDENT
-.sp
-The LocalClient object only works running as root on the salt\-master, it is the
-same interface used by the salt command line tool. The arguments are as
-follows.
-.INDENT 0.0
-.TP
-.B tgt
-The tgt option is the target specification, by default a target is passed
-in as a bash shell glob. The expr_form option allows the tgt to be passed
-as either a pcre regular expression or as a python list.
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options
 .UNINDENT
 .INDENT 0.0
 .TP
-.B fun
-The name of the function to call on the specified minions. The
-documentation for these functions can be seen by running on the
-salt\-master: salt \(aq*\(aq sys.doc
+.B \-t TIMEOUT, \-\-timeout=TIMEOUT
+The timeout in seconds to wait for replies from the salt minions.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B arg
-The optional arg parameter is used to pass a list of options on to the
-remote function
+.B \-E, \-\-pcre
+The target expresion will be interpereted as a pcre regular expression
+rather than a shell glob.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B timeout
-The number of seconds to wait after the last minion returns but before all
-minions return.
+.B \-L, \-\-list
+The target expression will be interpereted as a comma delimited list,
+example: server1.foo.bar,server2.foo.bar,example7.quo.qux
 .UNINDENT
 .INDENT 0.0
 .TP
-.B expr_form
-The type of tgt that is passed in, the allowed values are:
-.INDENT 7.0
-.IP \(bu 2
-\(aqglob\(aq \- Bash glob completion \- Default
-.IP \(bu 2
-\(aqpcre\(aq \- Perl style regular expression
-.IP \(bu 2
-\(aqlist\(aq \- Python list of hosts
+.B \-G, \-\-grain
+The target expression matches values returned by the salt grains system on
+the minions. The target expresion is in the format of \(aq<grain value>:<pcre
+regular expresion>\(aq; example: \(aqos:Arch.*\(aq
 .UNINDENT
-.UNINDENT
-.SS Compound Command Execution With the Salt API
-.sp
-The Salt client API can also send what is called a compound command. Often
-a collection of commands need to be executed on the targeted minions, rather
-than send the commands one after another, they can be send in a single publish
-containing a series of commands. This can dramatically lower overhead and
-speed up the application communicating with Salt.
-.sp
-When commands are executed with compound execution the minion functions called
-are executed in serial on the minion and the return value is sent back in a
-different fashion. The return value is a dict, with the function names as keys
-to the function returns as values.
-.sp
-Using the compound command execution system via the API requires that the fun
-value and the arg value are lists matching by index. This ensures that the
-order of the executions can be controlled. Any function that has no arguments
-MUST have an empty array in the corresponding arg index.
-.sp
-.nf
-.ft C
-# Import the salt client library
-import salt.client
-# create a local client object
-client = salt.client.LocalClient()
-# make compound execution calls with the cmd method
-ret = client.cmd(\(aq*\(aq, [\(aqcmd.run\(aq, \(aqtest.ping\(aq, \(aqtest.echo\(aq], [[\(aqls \-l\(aq], [], [\(aqfoo\(aq]])
-.ft P
-.fi
-.sp
-This will execute \fBcmd.run ls \-l\fP then \fBtest.ping\fP and finally
-\fBtest.echo foo\fP.
-The return data from the minion will look like this:
-.sp
-.nf
-.ft C
-{\(aqcmd.run\(aq: \(aq<output from ls \-l>\(aq,
- \(aqtest.ping\(aq: True,
- \(aqtest.echo\(aq: \(aqfoo\(aq}
-.ft P
-.fi
-.SS Salt File Server
-.sp
-Salt comes with a simple file server suitable for distributing files to the
-salt minions. The file server is a stateless ZeroMQ server that is built into
-the salt master.
-.sp
-The main intent of the Salt File server is the present files for use in the
-Salt state system. With this said, the Salt file server can be used for any
-general file transfer from the master to the minions.
-.SS The cp Module
-.sp
-The cp module is the home of minion side file server operations. The cp module
-is used by the Salt state system, salt\-cp and can be used to distribute files
-presented by the Salt file server.
-.SS Environments
-.sp
-Since the file server is made to work with the Salt state system, it supports
-environments. The environments are defined in the master config file and
-when referencing an environment the file specified will be based on the root
-directory of the environment.
-.SS get_file
-.sp
-The cp.get_file function can be used on the minion to download a file from
-the master, the syntax looks like this:
-.sp
-.nf
-.ft C
-# salt \(aq*\(aq cp.get_file salt://vimrc /etc/vimrc
-.ft P
-.fi
-.sp
-This will instruct all salt minions to download the vimrc file and copy it
-to /etc/vimrc
-.SS File Server Client API
-.sp
-A client API is available which allows for modules and applications to be
-written which make use of the Salt file server.
-.sp
-The file server uses the same authentication and encryption used by the rest
-of the Salt system for network communication.
-.SS FileClient Class
-.sp
-The FileClient class is used to set up the communication from the minion to
-the master. When creating a FileClient object the minion configuration needs
-to be passed in. When using the FileClient from within a minion module the
-built in \fB__opts__\fP data can be passed:
-.sp
-.nf
-.ft C
-import salt.minion
-
-def get_file(path, dest, env=\(aqbase\(aq):
-\(aq\(aq\(aq
-Used to get a single file from the salt master
-
-CLI Example:
-salt \(aq*\(aq cp.get_file salt://vimrc /etc/vimrc
-\(aq\(aq\(aq
-# Create the FileClient object
-client = salt.minion.FileClient(__opts__)
-# Call get_file
-return client.get_file(path, dest, False, env)
-.ft P
-.fi
-.sp
-Using the FileClient class outside of a minion module where the \fB__opts__\fP
-data is not available, it needs to be generated:
-.sp
-.nf
-.ft C
-import salt.minion
-import salt.config
-
-def get_file(path, dest, env=\(aqbase\(aq):
-\(aq\(aq\(aq
-Used to get a single file from the salt master
-\(aq\(aq\(aq
-# Get the configuration data
-opts = salt.config.minion_config(\(aq/etc/salt/minion\(aq)
-# Create the FileClient object
-client = salt.minion.FileClient(opts)
-# Call get_file
-return client.get_file(path, dest, False, env)
-.ft P
-.fi
 .INDENT 0.0
-.IP \(bu 2
-\fBModules:\fP
-\fBWriting modules\fP
-| \fBfull list of modules\fP
-.IP \(bu 2
-\fBGrains:\fP
-\fBGrains\fP
-.IP \(bu 2
-\fBReturners:\fP
-\fBWriting returners\fP
-| \fBfull list of returners\fP
-.IP \(bu 2
-\fBState enforcement:\fP
-\fBStates\fP
-| \fBRenderers\fP
-.IP \(bu 2
-\fBPython API:\fP
-\fBPython API\fP
-.IP \(bu 2
-\fBFile Server:\fP
-\fBFile Server\fP
+.TP
+.B \-Q, \-\-query
+Execute a salt command query, this can be used to find the results os a
+previous function call: \-Q test.echo\(aq)
 .UNINDENT
-.SH SALT NETWORK TOPOLOGY
-.sp
-Salt can be extended beyond a simple master commanding minions, for more
-information read up on the peer and syndic interfaces.
-.SS Salt Syndic
-.sp
-The Salt Syndic interface is a powerful tool which allows for the construction
-of Salt command topologies. A basic Salt setup has a Salt Master commanding a
-group of Salt Minions. The Syndic interface is a special passthrough
-minion, it is run on a master and connects to another master, then the master
-that the Syndic minion is listening to can control the minions attatched to
-the master running the syndic.
-.sp
-The intent for supporting many layouts is not presented with the intent of
-supposing the use of any single topology, but to allow a more flexible method
-of controlling many systems.
-.SS Configuring the Syndic
-.sp
-Since the Syndic only needs to be attatched to a higher level master the
-configuration is very simple. On a master that is running a syndic to connect
-to a higher level master the syndic_master option needs to be set in the
-master config file. The syndic_master option contains the hostname or ip
-address of the master server that can control the master that the syndic is
-running on.
-.sp
-The master that the syndic connects to sees the syndic as an ordinary minion,
-and treats it as such. the higher level master will need to accept the syndic\(aqs
-minion key like any other minion. This master will also need to set the
-order_masters value in the configuration to True. The order_masters option in
-the config on the higher level master is very important, to control a syndic
-extra information needs to be sent with the publications, the order_masters
-option makes sure that the extra data is sent out.
-.SS Running the Syndic
-.sp
-The Syndic is a seperate daemon that needs to be started on the master that is
-controlled by a higher master. Starting the Syndic daemon is the same as
-starting the other Salt daemons.
+.INDENT 0.0
+.TP
+.B \-c CONFIG, \-\-config=CONFIG
+The location of the salt master configuration file, the salt master
+settings are required to know where the connections are;
+default=/etc/salt/master
+.UNINDENT
+.SH SALT-CALL
+.SS Synopsis
 .sp
 .nf
 .ft C
-# salt\-syndic
+salt\-call [options]
 .ft P
 .fi
-.SS Peer Communication
+.SS Options
+.INDENT 0.0
+.TP
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-g, \-\-grains
+Return the information generated by the salt grains
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-m MODULE_DIRS, \-\-module\-dirs=MODULE_DIRS
+Specify an additional directories to pull modules from, multiple
+directories can be delimited by commas
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-d, \-\-doc
+Return the documentation for the specified module of for all modules if
+none are specified
+.UNINDENT
+.SH SALT-RUN
 .sp
-Salt 0.9.0 introduced the capability for salt minions to publish commands. The
-intent of this feature is not for salt minions to act as independent brokers
-one with another, but to allow salt minions to pass commands to each other.
-.sp
-The peer interface allows a minion to call out publications on the salt master
-and receive the return data.
-.sp
-Since this presents a viable security risk by allowing minions access to the
-master publisher the capability is turned off by default. The minions can be
-allowed access to the master publisher on a per minion basis based on regular
-expressions. Minions with specific ids can be allowed access to certain salt
-modules and functions.
-.SS Configuration
-.sp
-The configuration is done under the peer setting in the salt master
-configuration file, here are a number of configuration possibilities.
-.sp
-The simplest approach is to enable all communication for all minions, this is
-only recommended for very secure environments.
+Execute a Salt runner
+.SS Synopsis
 .sp
 .nf
 .ft C
-peer:
-  .*:
-    \- .*
+salt\-run RUNNER
 .ft P
 .fi
+.SS Description
 .sp
-This configuration will allow minions with ids ending in example.com access
-to the test, ps, and pkg module functions.
+Salt run is the frontend command for executing \fBSalt Runners\fP.
+Salt runners are simple modules used to execute convenience functions on the
+master
+.SS Options
+.INDENT 0.0
+.TP
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-c CONFIG, \-\-config=CONFIG
+The location of the salt master configuration file, the salt master
+settings are required to know where the connections are;
+default=/etc/salt/master
+.UNINDENT
+.SH SALT-SYNDIC
 .sp
-.nf
-.ft C
-peer:
-  .*example.com:
-    \- test.*
-    \- ps.*
-    \- pkg.*
-.ft P
-.fi
+The salt syndic daemon, a special minion that passes through commands from a
+higher master
+.SS Synopsis
 .sp
-The configuration logic is simple, a regular expression is passed for matching
-minion ids, and then a list of expressions matching minion functions is
-associated with the named minion. For instance, this configuration will also
-allow minions ending with foo.org access to the publisher.
+salt\-syndic [ options ]
+.SS Description
 .sp
-.nf
-.ft C
-peer:
-  .*example.com:
-    \- test.*
-    \- ps.*
-    \- pkg.*
-  .*foo.org:
-    \- test.*
-    \- ps.*
-    \- pkg.*
-.ft P
-.fi
-.SH GETTING INVOLVED
+The salt syndic daemon, a special minion that passes through commands from a
+higher master.
+.SS Options
+.INDENT 0.0
+.TP
+.B \-h, \-\-help
+Print a usage message briefly summarizing these command\-line options.
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-d, \-\-daemon
+Run the salt syndic as a daemon
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-master\-config=MASTER_CONFIG
+The master configuration file to use, the default is /etc/salt/master
+.UNINDENT
+.INDENT 0.0
+.TP
+.B \-\-minion\-config=MINION_CONFIG
+The minion configuration file to use, the default is /etc/salt/minion
+.UNINDENT
+.SH SALT STACK ROADMAP
 .sp
-There are many ways to interact with the Salt community.
-.SS Community
+Salt is the core of a more complete goal, the Salt Stack. The Salt Stack is a
+complete infrastructure management system which is comprised of many
+components all functioning on top of Salt.
 .sp
-Join the Salt!
+The majority of the functionality of the Salt Stack happens directly inside
+Salt, but the information derived from Salt needs to be used to create a
+transparent view of the infrastructure as a whole.
 .sp
-There are many ways to participate in and communicate with the Salt community.
+The information used in Salt States will be matched via a higher interface
+and the low salt data will be visualized. This will allow the state data to
+appear in the web interface.
 .sp
-Salt has an active IRC channel and a mailing list.
-.SS Mailing List
-.sp
-Join the \fI\%salt-users mailing list\fP. It is the best place to ask questions
-about Salt and see whats going on with Salt development! The Salt mailing list
-is hosted by Google Groups. It is open to new members.
-.sp
-\fI\%http://groups.google.com/group/salt-users\fP
-.SS IRC
-.sp
-The Salt IRC channel is hosted on the \fI\%OFTC\fP network. Connect to the OFTC
-server:
-.sp
-\fI\%irc://irc.oftc.net:6667\fP
-.sp
-and join us in \fB#salt\fP.
-.SS Follow on Github
-.sp
-The Salt code is developed via Github. Follow Salt for constant updates on what
-is happening in Salt development:
-.sp
-\fI\%https://github.com/thatch45/salt\fP
-.SS The Red45 Blog
-.sp
-News and thoughts on Salt and related projects is often posted on Thomas\(aq blog
-\fI\%The Red45\fP:
-.sp
-\fI\%http://red45.wordpress.com/\fP
-.SS Follow on ohloh
-.sp
-\fI\%https://www.ohloh.net/p/salt\fP
-.SS Developing Salt
-.sp
-If you want to help develop Salt there is a great need and your patches are
-welcome!
-.sp
-To assist in Salt development, you can help in a number of ways.
-.SS Posting patches to the mailing list
-.sp
-If you have a patch for Salt, please format it via \fBgit format\-patch\fP and
-send it to the Salt users mailing list. This allows the patch to give you the
-contributor the credit for your patch, and gives the Salt community an archive
-of the patch and a place for discussion.
-.SS Setting a Github pull request
-.sp
-This is probably the preferred method for contributions, simply create a Github
-fork, commit your changes to the fork, and then open up a pull request.
-.SS Contributions Welcome!
-.sp
-The goal here it to make contributions clear, make sure there is a trail for
-where the code has come from, but most importantly, to give credit where credit
-is due!
-.SS Release notes and upgrade instructions
+To make this possible the need is to build up the Salt modules to support
+more stuff
+.SH RELEASE NOTES AND UPGRADE INSTRUCTIONS
 .SS Salt 0.6.0 release notes
 .sp
 The Salt remote execution manager has reached initial functionality! Salt is a
@@ -4402,317 +7038,8 @@ Here s the md5sum:
 .sp
 7d5aca4633bc22f59045f59e82f43b56
 .sp
-For instructions on how to set up Salt please see the tutorial
-.SS Tutorial
-.sp
-The Salt system setup is amazingly simple, as this is one of the central design
-goals of Salt. Setting up Salt only requires that the Salt \fImaster\fP be
-running and the Salt \fIminions\fP point to the master.
-.INDENT 0.0
-.TP
-.B master
-The Salt master is the central server that all minions connect to. You
-run commands on the minions through the master and minions send data
-back to the master (unless otherwise redirected with a \fBreturner\fP). It is started with the
-\fBsalt\-master\fP program.
-.TP
-.B minion
-Salt minions are the potentially hundreds or thousands of servers that
-you query and control from the master.
-.UNINDENT
-.SS Installing Salt
-.sp
-As of this writing packages for Salt only exist for Arch Linux, but rpms and
-debs will be available in the future (contributions welcome).
-.SS Instructions by operating system
-.INDENT 0.0
-.IP \(bu 2
-\fI\%Installing on Arch Linux\fP
-.IP \(bu 2
-\fI\%Installing on Debian or Ubuntu\fP
-.IP \(bu 2
-\fI\%Installing from the source tarball\fP
-.UNINDENT
-.SS Installing on Arch Linux
-.sp
-The Arch Linux Salt package is available in the Arch Linux AUR (if you like
-Salt vote for it on the Arch Linux AUR):
-.sp
-\fI\%https://aur.archlinux.org/packages.php?ID=47512\fP
-.sp
-For help using packages in the Arch Linux AUR:
-.sp
-\fI\%https://wiki.archlinux.org/index.php/AUR\fP
-.SS Installing on Debian or Ubuntu
-.sp
-Providing a .deb installer is on our short\-list of things to do; until then
-this is the best way to install Salt on Debian and Ubuntu systems:
-.INDENT 0.0
-.IP 1. 3
-Install the prerequisite packages:
-.sp
-.nf
-.ft C
-aptitude install python\-setuptools python\-yaml python\-crypto python\-m2crypto cython libzmq\-dev
-.ft P
-.fi
-.IP Note
-Installing on Ubuntu Lucid (10.04 LTS)
-.sp
-The ZeroMQ package is available starting with Maverick but it is not
-yet available in Lucid backports. Fortunately, Chris Lea has made a
-\fI\%ZeroMQ PPA\fP available. Install it before installing Salt:
-.sp
-.nf
-.ft C
-aptitude install python\-software\-properties
-add\-apt\-repository ppa:chris\-lea/zeromq
-aptitude update
-aptitude install libzmq\-dev
-.ft P
-.fi
-.RE
-.IP 2. 3
-Grab the latest Python ZeroMQ bindings:
-.sp
-.nf
-.ft C
-easy_install pyzmq
-.ft P
-.fi
-.IP 3. 3
-Install Salt:
-.sp
-.nf
-.ft C
-easy_install \-\-install\-layout=deb https://github.com/downloads/thatch45/salt/salt\-0.9.0\&.tar.gz
-.ft P
-.fi
-.sp
-Please take note of the \fB\-\-install\-layout=deb\fP flag. This is important
-for a functioning installation of Salt.
-.UNINDENT
-.SS Installing from the source tarball
-.INDENT 0.0
-.IP 1. 3
-Download the latest source tarball from the GitHub downloads directory for
-the Salt project: \fI\%https://github.com/thatch45/salt/downloads\fP
-.IP 2. 3
-Untar the tarball and run the \fBsetup.py\fP as root:
-.UNINDENT
-.sp
-.nf
-.ft C
-tar xvf salt\-0.9.0\&.tar.gz
-cd salt\-0.9.0
-python2 setup.py install
-.ft P
-.fi
-.SS Salt dependencies
-.sp
-This is a basic Python setup, nothing fancy. Salt does require a number of
-dependencies though, all of which should be available in your distribution\(aqs
-packages.
-.INDENT 0.0
-.IP \(bu 2
-\fI\%Python 2.6\fP
-.IP \(bu 2
-\fI\%pyzmq\fP \- ZeroMQ Python bindings
-.IP \(bu 2
-\fI\%M2Crypto\fP \- Python OpenSSL wrapper
-.IP \(bu 2
-\fI\%YAML\fP \- Python YAML bindings
-.IP \(bu 2
-\fI\%PyCrypto\fP \- The Python cryptography toolkit
-.UNINDENT
-.sp
-Optional Dependencies:
-.INDENT 0.0
-.IP \(bu 2
-gcc \- dynamic \fI\%Cython\fP module compiling
-.UNINDENT
-.SS Configuring Salt
-.sp
-Salt configuration is very simple. The default configuration for the
-\fImaster\fP will work for most installations and the only requirement for
-setting up a \fIminion\fP is to set the location of the master in the minion
-configuration file. The configuration files will be installed to
-\fB/etc/salt\fP and are named after the respective components,
-\fB/etc/salt/master\fP and \fB/etc/salt/minion\fP.
-.sp
-To make a minion check into the correct master simply edit the
-\fBmaster\fP variable in the minion configuration file to reference
-the master DNS name or IPv4 address.
-.IP "See also"
-.sp
-For further information consult the \fBconfiguration guide\fP.
-.RE
-.SS Running Salt
-.INDENT 0.0
-.IP 1. 3
-Start the \fImaster\fP in the foreground (to daemonize the process, pass
-the \fI\-d flag\fP):
-.sp
-.nf
-.ft C
-salt\-master
-.ft P
-.fi
-.IP 2. 3
-Start the \fIminion\fP in the foreground (to daemonize the process, pass
-the \fI\-d flag\fP):
-.sp
-.nf
-.ft C
-salt\-minion
-.ft P
-.fi
-.UNINDENT
-.IP "See also"
-.sp
-\fBsalt\-master manpage\fP and
-\fBsalt\-minion manpage\fP
-.RE
-.SS Arch Linux init scripts
-.sp
-.nf
-.ft C
-/etc/rc.d/salt\-master start
-/etc/rc.d/salt\-minion start
-.ft P
-.fi
-.SS Manage Salt public keys
-.sp
-Salt manages authentication with RSA public keys. The keys are managed on the
-\fImaster\fP via the \fBsalt\-key\fP command. Once a \fIminion\fP
-checks into the master the master will save a copy of the minion key. Before
-the master can send commands to the minion the key needs to be "accepted".
-.INDENT 0.0
-.IP 1. 3
-List the accepted and unaccepted salt keys:
-.sp
-.nf
-.ft C
-salt\-key \-L
-.ft P
-.fi
-.IP 2. 3
-Accept a minion key:
-.sp
-.nf
-.ft C
-salt\-key \-a <minion id>
-.ft P
-.fi
-.sp
-or accept all unaccepted minion keys:
-.sp
-.nf
-.ft C
-salt\-key \-A
-.ft P
-.fi
-.UNINDENT
-.IP "See also"
-.sp
-\fBsalt\-key manpage\fP
-.RE
-.SS Order your minions around
-.sp
-Now that you have a \fImaster\fP and at least one \fIminion\fP
-communicating with each other you can perform commands on the minion via the
-\fBsalt\fP command. Salt calls are comprised of three main components:
-.sp
-.nf
-.ft C
-salt \(aq<target>\(aq <function> [arguments]
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBsalt manpage\fP
-.RE
-.SS target
-.sp
-The target component allows you to filter which minions should run the
-following function. The default filter is a glob on the minion id. E.g.:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq test.ping
-salt \(aq*.example.org\(aq test.ping
-.ft P
-.fi
-.sp
-Targets can be based on minion system information using the grains system:
-.sp
-.nf
-.ft C
-salt \-G \(aqos:Ubuntu\(aq test.ping
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBGrains system\fP
-.RE
-.sp
-Targets can be filtered by regular expression:
-.sp
-.nf
-.ft C
-salt \-E \(aqvirtmach[0\-9]\(aq test.ping
-.ft P
-.fi
-.sp
-Finally, targets can be explicitly specified in a list:
-.sp
-.nf
-.ft C
-salt \-L foo,bar,baz,quo test.ping
-.ft P
-.fi
-.SS function
-.sp
-A function is some functionality provided by a module. Salt ships with a large
-collection of available functions. List all available functions on your
-minions:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq sys.doc
-.ft P
-.fi
-.sp
-Here are some examples:
-.sp
-Show all currently available minions:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq test.ping
-.ft P
-.fi
-.sp
-Run an arbitrary shell command:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq cmd.run \(aquname \-a\(aq
-.ft P
-.fi
-.IP "See also"
-.sp
-\fBthe full list of modules\fP
-.RE
-.SS arguments
-.sp
-Space\-delimited arguments to the function:
-.sp
-.nf
-.ft C
-salt \(aq*\(aq cmd.exec_code python \(aqimport sys; print sys.version\(aq
-.ft P
-.fi
+For instructions on how to set up Salt please see the \fBinstallation
+instructions\fP.
 .SS New Features
 .SS Salt Run
 .sp
@@ -4796,15 +7123,450 @@ Send the return information to a mongodb server.
 .SS manage
 .sp
 Display minions that are up or down.
-.SH INDICES, GLOSSARY AND TABLES
+.SS Salt 0.9.0 Release Notes
+.sp
+Salt 0.9.0 is here. This is an exciting release, 0.9.0 includes the new network
+topology features allowing peer salt commands and masters of masters via the
+syndic interface.
+.sp
+0.9.0 also introduces many more modules, improvements to the api and
+improvements to the ZeroMQ systems.
+.SS Download!
+.sp
+The Salt source can be downloaded from the salt github site:
+.sp
+\fI\%https://github.com/downloads/thatch45/salt/salt-0.9.0.tar.gz\fP
+.sp
+Or from PiPy:
+.sp
+\fI\%http://pypi.python.org/packages/source/s/salt/salt-0.9.0.tar.gz\fP
+.sp
+Here is the md5sum:
+.sp
+9a925da04981e65a0f237f2e77ddab37
+.sp
+For instructions on how to set up Salt please see the \fBinstallation
+instructions\fP.
+.SS New Features
+.SS Salt Syndic
+.sp
+The new Syndic interface allows a master to be commanded via another higher
+level salt master. This is a powerful solution allowing a master control
+structure to exist, allowing salt to scale to much larger levels then before.
+.sp
+\fI\%http://saltstack.org/ref/syndic.html\fP
+.SS Peer Communication
+.sp
+0.9.0 introduces the capability for a minion to call a publication on the
+master and receive the return from another set of minions. This allows salt
+to act as a communication channel between minions and as a general
+infrastructure message bus.
+.sp
+Peer communication is turned off by default but can be enabled via the \fBpeer\fP
+option in the master configuration file. Documentation on the new peer
+interface can be found here:
+.sp
+\fI\%http://saltstack.org/ref/peer.html\fP
+.SS Easily Extensible API
+.sp
+The minion and master classes have been redesigned to allow for specialized
+minion and master servers to be easily created. An example on how this is done
+for the master can be found in the \fBmaster.py\fP salt module:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/master/salt/master.py\fP
+.sp
+The \fBMaster\fP class extends the \fBSMaster\fP class and set up the main master
+server.
+.sp
+The minion functions can now also be easily added to another application via
+the \fBSMinion\fP class, this class can be found in the \fBminion.py\fP module:
+.sp
+\fI\%https://github.com/thatch45/salt/blob/master/salt/minion.py\fP
+.SS Cleaner Key Management
+.sp
+This release changes some of the key naming to allow for multiple master keys
+to be held based on the type of minion gathering the master key.
+.sp
+The \-d option has also been added to the salt\-key command allowing for easy
+removal of accepted public keys.
+.sp
+The \-\-gen\-keys option is now available as well for salt\-key, this allows
+for a salt specific RSA key pair to be easily generated from the command line.
+.SS Improved 0MQ Master Workers
+.sp
+The 0MQ worker system has been further refined to be faster and more robust.
+This new system has been able to handle a much larger load than the previous
+setup. The new system uses the ipc protocol in 0MQ instead of tcp.
+.SS New Modules
+.sp
+Quite a few new modules have been made.
+.SS New Minion Modules
+.SS apache
+.sp
+Work directly with apache servers, great for managing balanced web servers
+.SS cron
+.sp
+Read out the contents of a systems crontabs
+.SS mdadm
+.sp
+Module to manage raid devices in Linux, appears as the \fBraid\fP module
+.SS mysql
+.sp
+Gather simple data from MySQL databases
+.SS ps
+.sp
+Extensive utilities for managing processes
+.SS publish
+.sp
+Used by the peer interface to allow minions to make publications
+.SS Salt 0.9.2 Release Notes
+.sp
+Salt 0.9.2 has arrived! 0.9.2 is primarily a bugfix release, the exciting
+component in 0.9.2 is greatly improved support for salt states. All of the
+salt states interfaces have been more thoroughly tested and the new salt\-states
+git repo is growing with example of how to use states.
+.sp
+This release introduces salt states for early developers and testers to start
+helping us clean up the states interface and make it ready for the world!
+.sp
+0.9.2 also fixes a number of bugs found on python 2.6.
+.SS Download!
+.sp
+The Salt source can be downloaded from the salt github site:
+.sp
+\fI\%https://github.com/downloads/thatch45/salt/salt-0.9.2.tar.gz\fP
+.sp
+Or from PiPy:
+.sp
+\fI\%http://pypi.python.org/packages/source/s/salt/salt-0.9.2.tar.gz\fP
+.sp
+For instructions on how to set up Salt please see the \fBinstallation
+instructions\fP.
+.SS New Features
+.SS Salt\-Call Additions
+.sp
+The salt\-call command has received an overhaul, it now hooks into the outputter
+system so command output looks clean, and the logging system has been hooked
+into salt\-call, so the \-l option allows the logging output from salt minion
+functions to be displayed.
+.sp
+The end result is that the salt\-call command can execute the state system and
+return clean output:
+.sp
+.nf
+.ft C
+# salt\-call state.highstate
+.ft P
+.fi
+.SS State System Fixes
+.sp
+The state system has been tested and better refined. As of this release the
+state system is ready for early testers to start playing with. If you are
+interested in working with the state system please check out the (still very
+small) salt\-states github repo:
+.sp
+\fI\%https://github.com/thatch45/salt-states\fP
+.sp
+This git repo is the active development branch for determining how a clean
+salt\-state database should look and act. Since the salt state system is still
+very young a lot of help is still needed here. Please fork the salt\-states
+repo and help us develop a truly large and scalable system for configuration
+management!
+.SS Notable Bug Fixes
+.SS Python 2.6 String Formatting
+.sp
+Python 2.6 does not support format strings without an index identifier, all of
+them have been repaired.
+.SS Cython Loading Disabled by Default
+.sp
+Cython loading requires a development tool chain to be installed on the minion,
+requiring this by default can cause problems for most Salt deployments. If
+Cython auto loading is desired it will need to be turned on in the minion
+config.
+.SS Salt 0.9.3 Release Notes
+.sp
+Salt 0.9.3 is finally arrived. This is another big step forward for Salt, new
+features range from proper FreeBSD support to fixing issues seen when
+attaching a minion to a master over the Internet.
+.sp
+The biggest improvements in 0.9.3 though can be found in the state system, it
+has progressed from something ready for early testers to a system ready to
+compete with platforms such as Puppet and Chef. The backbone of the state
+system has been greatly refined and many new features are available.
+.SS Download!
+.sp
+The Salt source can be downloaded from the salt github site:
+.sp
+\fI\%https://github.com/downloads/thatch45/salt/salt-0.9.3.tar.gz\fP
+.sp
+Or from PiPy:
+.sp
+\fI\%http://pypi.python.org/packages/source/s/salt/salt-0.9.3.tar.gz\fP
+.sp
+For instructions on how to set up Salt please see the \fBinstallation
+instructions\fP.
+.SS New Features
+.SS WAN Support
+.sp
+Recently more people have been testing Salt minions connecting to Salt Masters
+over the Internet. It was found that Minions would commonly loose their
+connection to the master when working over the internet. The minions can now
+detect if the connection has been lost and reconnect to the master, making
+WAN connections much more reliable.
+.SS State System Fixes
+.sp
+Substantial testing has gone into the state system and it is ready for real
+world usage. A great deal has been added to the documentation for states and
+the modules and functions available to states have been cleanly documented.
+.sp
+A number of State System bugs have also been founds and repaired, the output
+from the state system has also been refined to be extremely clear and concise.
+.sp
+Error reporting has also been introduced, issues found in sls files will now
+be clearly reported when executing Salt States.
+.SS Extend Declaration
+.sp
+The Salt States have also gained the \fBextend\fP declaration. This declaration
+allows for states to be cleanly modified in a post environment. Simply said,
+if there is an apache.sls file that declares the apache service, then another
+sls can include apache and then extend it:
+.sp
+.nf
+.ft C
+include:
+  \- apache
+
+extend:
+  apache:
+    service:
+      \- require:
+        \- pkg: mod_python
+
+mod_python:
+  pkg:
+    \- installed
+.ft P
+.fi
+.sp
+The notable behavior with the extend functionality is that it literally extends
+or overwrites a declaration set up in another sls module. This means that Salt
+will behave as though the modifications were made directly to the apache sls.
+This ensures that the apache service in this example is directly tied to all
+requirements.
+.SS Highstate Structure Specification
+.sp
+This release comes with a clear specification of the Highstate data structure
+that is used to declare Salt States. This specification explains everything
+that can be declared in the Salt SLS modules.
+.sp
+The specification is extremely simple, and illustrates how Salt has been able
+to fulfill the requirements of a central configuration manager within a simple
+and easy to understand format and specification.
+.SS SheBang Renderer Switch
+.sp
+It came to our attention that having many renderers means that there may be a
+situation where more than one State Renderer should be available within a
+single State Tree.
+.sp
+The method chosen to accomplish this was something already familiar to
+developers and systems administrators, a SheBang. The Python State Renderer
+displays this new capability.
+.SS Python State Renderer
+.sp
+Until now Salt States could only be declared in yaml or json using jinja or
+mako. A new, very powerful, renderer has been added, making it possible to
+write Salt States in pure python:
+.sp
+.nf
+.ft C
+#!py
+
+def run():
+    \(aq\(aq\(aq
+    Install the python\-mako package
+    \(aq\(aq\(aq
+    return {\(aqinclude\(aq: [\(aqpython\(aq],
+            \(aqpython\-mako\(aq: {\(aqpkg\(aq: [\(aqinstalled\(aq]}}
+.ft P
+.fi
+.sp
+This renderer is used by making a run function that returns the Highstate data
+structure. Any capabilities of python can be used in pure python sls modules.
+.sp
+This example of a pure python sls module is the same as this example in yaml:
+.sp
+.nf
+.ft C
+include:
+  \- python
+
+python\-mako:
+  pkg:
+    \- installed
+.ft P
+.fi
+.SS FreeBSD Support
+.sp
+Additional support has been added for FreeBSD, this is Salt\(aqs first branch out
+of the Linux world and proves the viability of Salt on non\-Linux platforms.
+.sp
+Salt remote execution already worked on FreeBSD, and should work without issue
+on any Unix\-like platform. But this support comes in the form of package
+management and user support, so Salt States also work on FreeBSD now.
+.sp
+The new freebsdpkg module provides package management support for FreeBSD
+and the new pw_user and pw_group provide user and group management.
+.SS Module and State Additions
+.SS Cron Support
+.sp
+Support for managing the system crontab has been added, declaring a cron state
+can be done easily:
+.sp
+.nf
+.ft C
+date > /tmp/datestamp:
+  cron:
+    \- present
+    \- user: fred
+    \- minute: 5
+    \- hour: 3
+.ft P
+.fi
+.SS File State Additions
+.sp
+The file state has been given a number of new features, primarily the
+directory, recurse, symlink and absent functions.
 .INDENT 0.0
-.IP \(bu 2
-\fIgenindex\fP
-.IP \(bu 2
-\fImodindex\fP
-.IP \(bu 2
-\fIsearch\fP
+.TP
+.B file.directory
+Make sure that a directory exists and has the right permissions.
+.sp
+.nf
+.ft C
+/srv/foo:
+  file:
+    \- directory
+    \- user: root
+    \- group: root
+    \- mode: 1755
+.ft P
+.fi
+.TP
+.B file.symlink
+Make a symlink.
+.sp
+.nf
+.ft C
+/var/lib/www:
+  file:
+    \- symlink
+    \- target: /srv/www
+    \- force: True
+.ft P
+.fi
+.TP
+.B file.recurse
+The recurse state function will recursively download a directory on the
+master file server and place it on the minion. Any change in the files on
+the master will be pushed to the minion. The recuse function is very
+powerful and has been tested by pushing out the full Linux kernel source.
+.sp
+.nf
+.ft C
+/opt/code:
+  file:
+    \- recurse
+    \- source: salt://linux
+.ft P
+.fi
+.TP
+.B file.absent
+Make sure that the file is not on the system, recursively delets
+directories, files and symlinks.
+.sp
+.nf
+.ft C
+/etc/httpd/conf.d/somebogusfile.conf:
+  file:
+    \- absent
+.ft P
+.fi
 .UNINDENT
+.SS Sysctl Module and State
+.sp
+The sysctl module and state allows for sysctl components in the kernel to be
+managed easily. the sysctl module contains the following functions:
+.INDENT 0.0
+.TP
+.B sysctl.show
+Return a list of sysctl parameters for this minion
+.TP
+.B sysctl.get
+Return a single sysctl parameter for this minion
+.TP
+.B sysctl.assign
+Assign a single sysctl parameter for this minion
+.TP
+.B sysctl.persist
+Assign and persist a simple sysctl parameter for this minion
+.UNINDENT
+.sp
+The sysctl state allows for sysctl parameters to be assigned:
+.sp
+.nf
+.ft C
+vm.swappiness:
+  sysctl:
+    \- present
+    \- value: 20
+.ft P
+.fi
+.SS Kernel Module Management
+.sp
+A module for managing Linux kernel modules has been added. The new functions
+are as follows:
+.INDENT 0.0
+.TP
+.B kmod.available
+Return a list of all available kernel modules
+.TP
+.B kmod.check_available
+Check to see if the specified kernel module is available
+.TP
+.B kmod.lsmod
+Return a dict containing information about currently loaded modules
+.TP
+.B kmod.load
+Load the specified kernel module
+.TP
+.B kmod.remove
+Unload the specified kernel module
+.UNINDENT
+.sp
+The kmod state can enforce modules be either present or absent:
+.sp
+.nf
+.ft C
+kvm_intel:
+  kmod:
+    \- present
+.ft P
+.fi
+.SS Ssh Authorized Keys
+.sp
+The ssh_auth state can distribute ssh authorized keys out to minions. Ssh
+authorized keys can be present or absent.
+.sp
+.nf
+.ft C
+AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyYvlRBsJdDOo49CNfhlWHWXQRqul6rwL4KIuPrhY7hBw0tV7UNC7J9IZRNO4iGod9C+OYutuWGJ2x5YNf7P4uGhH9AhBQGQ4LKOLxhDyT1OrDKXVFw3wgY3rHiJYAbd1PXNuclJHOKL27QZCRFjWSEaSrUOoczvAAAAFQD9d4jp2dCJSIseSkk4Lez3LqFcqQAAAIAmovHIVSrbLbXAXQE8eyPoL9x5C+x2GRpEcA7AeMH6bGx/xw6NtnQZVMcmZIre5Elrw3OKgxcDNomjYFNHuOYaQLBBMosyO++tJe1KTAr3A2zGj2xbWO9JhEzu8xvSdF8jRu0N5SRXPpzSyU4o1WGIPLVZSeSq1VFTHRT4lXB7PQAAAIBXUz6ZO0bregF5xtJRuxUN583HlfQkXvxLqHAGY8WSEVlTnuG/x75wolBDbVzeTlxWxgxhafj7P6Ncdv25Wz9wvc6ko/puww0b3rcLNqK+XCNJlsM/7lB8Q26iK5mRZzNsGeGwGTyzNIMBekGYQ5MRdIcPv5dBIP/1M6fQDEsAXQ==:
+  ssh_auth:
+    \- present
+    \- user: frank
+    \- enc: dsa
+    \- comment: \(aqFrank\(aqs key\(aq
+.ft P
+.fi
 .SH AUTHOR
 Thomas S. Hatch <thatch@gmail.com> and many others, please see the Authors file
 .SH COPYRIGHT


### PR DESCRIPTION
I built these while I was building the other 0.9.3 docs, but there is an argument to be made that this pull request should be ignored:
- The individual `salt-*` command manpages are not up-to-date; they are missing flags.
- The ginormous salt.7 manpage is just too large to be useful reference at the command-line.

Fixing/organizing the manpages is on my todo for the next release.
