### PR TITLE
we run fine on 2.7 too

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,14 @@ from salt import __version__
 
 NAME = 'salt'
 VER = __version__
-DESC = 'Portable, distrubuted, remote execution and configuration management system'
+DESC = 'Portable, distributed, remote execution and configuration management system'
 
 mod_path = os.path.join(get_python_lib(), 'salt/modules')
 doc_path = os.path.join(PREFIX, 'share/doc', NAME + '-' + VER)
 example_path = os.path.join(doc_path, 'examples')
 template_path = os.path.join(example_path, 'templates')
-if os.environ.has_key('SYSCONFDIR'):
+
+if 'SYSCONFDIR' in os.environ:
     etc_path = os.environ['SYSCONFDIR']
 else:
     etc_path = os.path.join(os.path.dirname(PREFIX), 'etc')
@@ -43,7 +44,7 @@ setup(
       classifiers = [
           'Programming Language :: Python',
           'Programming Language :: Cython',
-          'Programming Language :: Python :: 2.5',
+          'Programming Language :: Python :: 2.6',
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',
           'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
           'Programming Language :: Python',
           'Programming Language :: Cython',
           'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',
           'Intended Audience :: Developers',


### PR DESCRIPTION
I tried to build salt (which includes libzmq, pyzmq, pycrypto, m2crypto... all from their current HEADs) on Debian with Python 2.[67] and 3.3 (current HEAD as well). I succeeded for anything except m2crypto on 3.3 (which we decided has to go).
