### PR TITLE
parenthesis are more pythonic

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -586,9 +586,9 @@ class SaltRun(object):
                 dest='doc',
                 default=False,
                 action='store_true',
-                help='Display documentation for runners, pass a module or ' +\
-                     'a runner to see documentation on only that ' +\
-                     'module/runner')
+                help=('Display documentation for runners, pass a module or '
+                      'a runner to see documentation on only that '
+                      'module/runner.'))
 
         options, args = parser.parse_args()
 

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -579,15 +579,16 @@ class SaltRun(object):
                 default='/etc/salt/master',
                 help='Change the location of the master configuration;'\
                     + ' default=/etc/salt/master')
-        
+
         parser.add_option('-d',
                 '--doc',
                 '--documentation',
                 dest='doc',
                 default=False,
                 action='store_true',
-                help='Display documentation for runners, pass a module or a '\
-                    + ' runner to see documentation on only that module/runner')
+                help='Display documentation for runners, pass a module or ' +\
+                     'a runner to see documentation on only that ' +\
+                     'module/runner')
 
         options, args = parser.parse_args()
 

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,8 @@ from salt import __version__
 
 NAME = 'salt'
 VER = __version__
-DESC = 'Portable, distributed, remote execution and configuration management system'
-
+DESC = ('Portable, distributed, remote execution and '
+        'configuration management system')
 mod_path = os.path.join(get_python_lib(), 'salt/modules')
 doc_path = os.path.join(PREFIX, 'share/doc', NAME + '-' + VER)
 example_path = os.path.join(doc_path, 'examples')

--- a/setup.py
+++ b/setup.py
@@ -15,13 +15,14 @@ from salt import __version__
 
 NAME = 'salt'
 VER = __version__
-DESC = 'Portable, distrubuted, remote execution and configuration management system'
+DESC = 'Portable, distributed, remote execution and configuration management system'
 
 mod_path = os.path.join(get_python_lib(), 'salt/modules')
 doc_path = os.path.join(PREFIX, 'share/doc', NAME + '-' + VER)
 example_path = os.path.join(doc_path, 'examples')
 template_path = os.path.join(example_path, 'templates')
-if os.environ.has_key('SYSCONFDIR'):
+
+if 'SYSCONFDIR' in os.environ:
     etc_path = os.environ['SYSCONFDIR']
 else:
     etc_path = os.path.join(os.path.dirname(PREFIX), 'etc')
@@ -43,7 +44,7 @@ setup(
       classifiers = [
           'Programming Language :: Python',
           'Programming Language :: Cython',
-          'Programming Language :: Python :: 2.5',
+          'Programming Language :: Python :: 2.6',
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',
           'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
           'Programming Language :: Python',
           'Programming Language :: Cython',
           'Programming Language :: Python :: 2.6',
+          'Programming Language :: Python :: 2.7',
           'Development Status :: 5 - Production/Stable',
           'Environment :: Console',
           'Intended Audience :: Developers',


### PR DESCRIPTION
change on top of earlier pull request which really is the right thing with multi-line statements but not expressions such as multi-line string concatenation. Also, run pep8 on setup.py and fixed the lines too long error by doing the line-break (again with parenthesis rather than + operator).
