### PR TITLE
typos in states/file.py dot instead of comma _mako and _jinja arg list

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -86,7 +86,7 @@ def _is_bin(path):
     return False
 
 
-def _mako(sfn, name, source, user, group. mode, env):
+def _mako(sfn, name, source, user, group, mode, env):
     '''
     Render a jinja2 template, returns the location of the rendered file,
     return False if render fails.
@@ -115,7 +115,7 @@ def _mako(sfn, name, source, user, group. mode, env):
                 'data': trb}
 
 
-def _jinja(sfn, name, source, user, group. mode, env):
+def _jinja(sfn, name, source, user, group, mode, env):
     '''
     Render a jinja2 template, returns the location of the rendered file,
     return False if render fails.


### PR DESCRIPTION
Per irc suggestion, first ever contrib, changed 2 dots to commas.
