### PR TITLE
No gentoo version

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -171,9 +171,6 @@ def os_data():
             grains['os'] = 'Arch'
         elif os.path.isfile('/etc/debian_version'):
             grains['os'] = 'Debian'
-        elif os.path.isfile('/etc/gentoo-version'):
-            grains['os'] = 'Gentoo'
-        # All of my gentoo machines have gentoo-release, don't know if gentoo-version is necessary
         elif os.path.isfile('/etc/gentoo-release'):
             grains['os'] = 'Gentoo'
         elif os.path.isfile('/etc/fedora-version'):

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -173,6 +173,9 @@ def os_data():
             grains['os'] = 'Debian'
         elif os.path.isfile('/etc/gentoo-version'):
             grains['os'] = 'Gentoo'
+        # All of my gentoo machines have gentoo-release, don't know if gentoo-version is necessary
+        elif os.path.isfile('/etc/gentoo-release'):
+            grains['os'] = 'Gentoo'
         elif os.path.isfile('/etc/fedora-version'):
             grains['os'] = 'Fedora'
         elif os.path.isfile('/etc/mandriva-version'):


### PR DESCRIPTION
I checked a really old gentoo install and a brand new one, both use gentoo-release.  No evidence that gentoo-version has ever been used, so I think it can safely be removed.
