### PR TITLE
stringify the minions 'id:' declaration

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -31,6 +31,10 @@ def load_config(opts, path, env_var):
             if conf_opts == None:
                 # The config file is empty and the yaml.load returned None
                 conf_opts = {}
+            else:
+                # allow using numeric ids: convert int to string
+                if 'id' in conf_opts:
+                    conf_opts['id'] = str(conf_opts['id'])
             opts.update(conf_opts)
             opts['conf_file'] = path
         except Exception, e:


### PR DESCRIPTION
yaml returns an int if the id: ... declaration in minion config is numeric,
converting to a string allows numeric ids.
