### PR TITLE
Misc cleanups and a few nice new features

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -58,7 +58,26 @@ class Caller(object):
         Print out the grains
         '''
         grains = salt.loader.grains(self.opts)
-        pprint.pprint(grains)
+        printout = self._get_outputter()
+        # If --json-out is specified, pretty print it
+        printout.indent = 2
+        printout(grains)
+
+    def _get_outputter(self, out=None):
+        get_outputter = salt.output.get_outputter
+        if self.opts['raw_out']:
+            printout = get_outputter('raw')
+        elif self.opts['json_out']:
+            printout = get_outputter('json')
+        elif self.opts['txt_out']:
+            printout = get_outputter('txt')
+        elif self.opts['yaml_out']:
+            printout = get_outputter('yaml')
+        elif out:
+            printout = get_outputter(out)
+        else:
+            printout = get_outputter(None)
+        return printout
 
     def run(self):
         '''
@@ -71,18 +90,9 @@ class Caller(object):
         else:
             ret = self.call()
             # Determine the proper output method and run it
-            get_outputter = salt.output.get_outputter
-            if self.opts['raw_out']:
-                printout = get_outputter('raw')
-            elif self.opts['json_out']:
-                printout = get_outputter('json')
-            elif self.opts['txt_out']:
-                printout = get_outputter('txt')
-            elif self.opts['yaml_out']:
-                printout = get_outputter('yaml')
-            elif 'out' in ret:
-                printout = get_outputter(ret['out'])
+            if 'out' in ret:
+                printout = self._get_outputter(ret['out'])
             else:
-                printout = get_outputter(None)
+                printout = self._get_outputter()
 
             printout({'local': ret['return']}, color=self.opts['color'])

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -58,7 +58,7 @@ class Caller(object):
         Print out the grains
         '''
         grains = salt.loader.grains(self.opts)
-        printout = self._get_outputter()
+        printout = self._get_outputter(out='yaml')
         # If --json-out is specified, pretty print it
         printout.indent = 2
         printout(grains)

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -222,7 +222,7 @@ def os_data():
                 match = regex.match(line)
                 if match:
                     # Adds: lsb_distrib_{id,release,codename,description}
-                    grains['lsb_{0}'.format(match.groups()[0].lower())] = match.groups()[1]
+                    grains['lsb_{0}'.format(match.groups()[0].lower())] = match.groups()[1].rstrip()
         if os.path.isfile('/etc/arch-release'):
             grains['os'] = 'Arch'
         elif os.path.isfile('/etc/debian_version'):

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -183,6 +183,24 @@ def _ps(osdata):
     return grains
 
 
+def _linux_platform_data(osdata):
+    '''
+    The platform module is very smart about figuring out linux distro
+    information. Instead of re-inventing the wheel, lets use it!
+    '''
+    # Provides:
+    #    osrelease
+    #    oscodename
+    grains = {}
+    (osname, osrelease, oscodename) = platform.dist()
+    if 'os' not in osdata and osname:
+        grains['os'] = osname
+    if osrelease:
+        grains['osrelease'] = osrelease
+    if oscodename:
+        grains['oscodename'] = oscodename
+    return grains
+
 def os_data():
     '''
     Return grains pertaining to the operating system
@@ -241,7 +259,6 @@ def os_data():
             else:
                 grains['os'] = 'OEL'
         elif os.path.isfile('/etc/redhat-release'):
-            grains['release'] = platform.dist()[1]
             data = open('/etc/redhat-release', 'r').read()
             if 'centos' in data.lower():
                 grains['os'] = 'CentOS'
@@ -259,6 +276,10 @@ def os_data():
                 grains['os'] = 'openSUSE'
             else:
                 grains['os'] = 'SUSE'
+
+        # Use the already intelligent platform module to get distro info
+        grains.update(_linux_platform_data(grains))
+
         # If the Linux version can not be determined
         if not 'os' in grains:
             grains['os'] = 'Unknown {0}'.format(grains['kernel'])

--- a/salt/output.py
+++ b/salt/output.py
@@ -151,6 +151,8 @@ class JSONOutputter(Outputter):
     enabled = JSON
 
     def __call__(self, data, **kwargs):
+        if hasattr(self, 'indent'):
+            kwargs.update({'indent': self.indent})
         try:
             # A good kwarg might be: indent=4
             if 'color' in kwargs:

--- a/salt/output.py
+++ b/salt/output.py
@@ -136,8 +136,12 @@ class TxtOutputter(Outputter):
         if hasattr(data, "keys"):
             for key in data.keys():
                 value = data[key]
-                for line in value.split('\n'):
-                    print "{0}: {1}".format(key, line)
+                # Don't blow up on non-strings
+                try:
+                    for line in value.split('\n'):
+                        print "{0}: {1}".format(key, line)
+                except AttributeError:
+                    print "key: %s" % value
         else:
             # For non-dictionary data, just use print
             RawOutputter()(data)


### PR DESCRIPTION
The commits should be pretty self explanatory.

Changing the default salt-call -g outputter to yaml can be reverted, but the output is more pleasant for humans and since states use yaml by default, it seems more fitting to use yaml.

I also did remove the 'release' grain recently added in favor of a distro agnostic osrelease grain. This is in line with facter's operatingsystemrelease fact.
