### PR TITLE
Added optional 'host' parameter

### DIFF
--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -162,10 +162,10 @@ def _format_url(handler,host=None,core_name=None,extra=[]):
     else:
         if extra is None or len(extra) == 0:
             return "http://{0}:{1}{2}/{3}/{4}?wt=json".format(
-                    host,port,baseurl,handler,core_name)
+                    host,port,baseurl,core_name,handler)
         else:
             return "http://{0}:{1}{2}/{3}/{4}?wt=json&{5}".format(
-                    host,port,baseurl,handler,core_name,"&".join(extra))
+                    host,port,baseurl,core_name,handler,"&".join(extra))
 
 def _http_request(url):
     '''
@@ -589,7 +589,7 @@ def match_index_versions(host=None,core_name=None):
                             'failed_list' : slave['replicationFailedAtList']
                            }
                 #check the index versions
-                if index_versions['master'] != index_versions['slave']:
+                if versions['master'] != versions['slave']:
                     success = False
                     err = "Master and Slave index versions do not match."
                     resp['errors'].append(err)


### PR DESCRIPTION
Since solr uses alot of http api, it didn't really make sense to ALWAYS limit api calls to the local configured instance. So I added the optional 'host' parameter which if passed to slave or master only methods ignores the constraint.  If it's not passed however, then the check will be performed.

Also fixed a bug in the match_index_versions method, where there was no else condition if the call to replication_status failed.
