### PR TITLE
removed reference to JSON from salt/output.py

### DIFF
--- a/salt/output.py
+++ b/salt/output.py
@@ -149,7 +149,6 @@ class JSONOutputter(Outputter):
     JSON output.
     '''
     supports = 'json'
-    enabled = JSON
 
     def __call__(self, data, **kwargs):
         if hasattr(self, 'indent'):


### PR DESCRIPTION
Whatever JSON was, it's gone now. Don't go looking for it.
