### PR TITLE
Removed reference to nonexistent variable

### DIFF
--- a/salt/output.py
+++ b/salt/output.py
@@ -149,7 +149,6 @@ class JSONOutputter(Outputter):
     JSON output.
     '''
     supports = 'json'
-    enabled = JSON
 
     def __call__(self, data, **kwargs):
         if hasattr(self, 'indent'):


### PR DESCRIPTION
This installed fine, but failed on run because JSON = True was no
longer at the top of the file. The 'enabled' variable was removed because
it was not used anywhere else in scope.
Signed-off-by: Jonas Buckner buckner.jonas@gmail.com
