### PR TITLE
Node group support

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -168,3 +168,24 @@
 #   }
 #
 #log_granular_levels: {}
+
+
+#####         Node Groups           #####
+##########################################
+# Node groups allow for logical groupings of minion nodes.
+# A group consists of a target evalation form(ie; list, glob, grain)
+# and the value of that form. Currently a group can only consist
+# of one target eval form and the value for that form. 
+# 
+# nodegroups: {
+#   group1: {
+#     list: [
+#       'foo.domain.com',
+#       'bar.domain.com',
+#       'baz.domain.com',
+#       ]
+#   },
+#   group2: {
+#     glob: 'ba*.domain.com',
+#   },
+# }

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -79,6 +79,14 @@ class SaltCMD(object):
                 action='store_true',
                 help=('Instead of using shell globs use the return code '
                       'of a function.'))
+        parser.add_option('-N',
+                '--hostgroup',
+                default=False,
+                dest='hostgroup',
+                action='store_true',
+                help=('Instead of using shell globs to evaluate the target '
+                      'use one of the predefined hostgroups to identify a '
+                      'list of targets.'))
         parser.add_option('--return',
                 default='',
                 dest='return_',
@@ -134,6 +142,7 @@ class SaltCMD(object):
         opts['list'] = options.list_
         opts['grain'] = options.grain
         opts['exsel'] = options.exsel
+        opts['hostgroup'] = options.hostgroup
         opts['return'] = options.return_
         opts['conf_file'] = options.conf_file
         opts['raw_out'] = options.raw_out
@@ -204,6 +213,8 @@ class SaltCMD(object):
                 args.append('grain')
             elif self.opts['exsel']:
                 args.append('exsel')
+            elif self.opts['hostgroup']:
+                args.append('hostgroup')
             else:
                 args.append('glob')
 

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -80,12 +80,12 @@ class SaltCMD(object):
                 help=('Instead of using shell globs use the return code '
                       'of a function.'))
         parser.add_option('-N',
-                '--hostgroup',
+                '--nodegroup',
                 default=False,
-                dest='hostgroup',
+                dest='nodegroup',
                 action='store_true',
                 help=('Instead of using shell globs to evaluate the target '
-                      'use one of the predefined hostgroups to identify a '
+                      'use one of the predefined nodegroups to identify a '
                       'list of targets.'))
         parser.add_option('--return',
                 default='',
@@ -142,7 +142,7 @@ class SaltCMD(object):
         opts['list'] = options.list_
         opts['grain'] = options.grain
         opts['exsel'] = options.exsel
-        opts['hostgroup'] = options.hostgroup
+        opts['nodegroup'] = options.nodegroup
         opts['return'] = options.return_
         opts['conf_file'] = options.conf_file
         opts['raw_out'] = options.raw_out
@@ -213,8 +213,8 @@ class SaltCMD(object):
                 args.append('grain')
             elif self.opts['exsel']:
                 args.append('exsel')
-            elif self.opts['hostgroup']:
-                args.append('hostgroup')
+            elif self.opts['nodegroup']:
+                args.append('nodegroup')
             else:
                 args.append('glob')
 
@@ -318,6 +318,14 @@ class SaltCP(object):
                       'use a grain value to identify targets, the syntax '
                       'for the target is the grains key followed by a pcre '
                       'regular expression:\n"os:Arch.*"'))
+        parser.add_option('-N',
+                '--nodegroup',
+                default=False,
+                dest='nodegroup',
+                action='store_true',
+                help=('Instead of using shell globs to evaluate the target '
+                      'use one of the predefined nodegroups to identify a '
+                      'list of targets.'))
         parser.add_option('-c',
                 '--config',
                 default='/etc/salt/master',
@@ -334,6 +342,7 @@ class SaltCP(object):
         opts['pcre'] = options.pcre
         opts['list'] = options.list_
         opts['grain'] = options.grain
+        opts['nodegroup'] = options.nodegroup
         opts['conf_file'] = options.conf_file
 
         if opts['list']:

--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -76,6 +76,8 @@ class SaltCP(object):
             args.append('list')
         elif self.opts['grain']:
             args.append('grain')
+        elif self.opts['nodegroup']:
+            args.append('nodegroup')
 
         ret = local.cmd(*args)
 

--- a/salt/client.py
+++ b/salt/client.py
@@ -322,16 +322,15 @@ class LocalClient(object):
             minions:
                 A set, the targets that the tgt passed should match.
         '''
-
-
-        if expr_form == 'hostgroup':
-          group = self.opts['hostgroups'][tgt]
+        if expr_form == 'nodegroup':
+          group = self.opts['nodegroups'][tgt]
           forms = ['glob','pcre','list','grain','exsel']
 
           for form in forms:
             if form in group:
               tgt       = group[form]
               expr_form = form
+              break
 
         # Run a check_minions, if no minions match return False
         # format the payload - make a function that does this in the payload

--- a/salt/client.py
+++ b/salt/client.py
@@ -126,6 +126,18 @@ class LocalClient(object):
         os.chdir(cwd)
         return ret
 
+    def _check_hostgroup_minions(self, expr):
+        '''
+        Return the minions found by looking in the hostgroups
+        '''
+        targets = self.opts['hostgroups'][expr].split(',')
+        ret = []
+        for fn_ in os.listdir(os.path.join(self.opts['pki_dir'], 'minions')):
+            if targets.count(fn_):
+                if not ret.count(fn_):
+                    ret.append(fn_)
+        return ret
+
     def _check_grain_minions(self, expr):
         '''
         Return the minions found by looking via a list
@@ -297,6 +309,7 @@ class LocalClient(object):
                 'list': self._check_list_minions,
                 'grain': self._check_grain_minions,
                 'exsel': self._check_grain_minions,
+                'hostgroup': self._check_hostgroup_minions,
                 }[expr_form](expr)
 
     def pub(self, tgt, fun, arg=(), expr_form='glob',

--- a/salt/client.py
+++ b/salt/client.py
@@ -130,14 +130,9 @@ class LocalClient(object):
         '''
         Return the minions found by looking in the hostgroups
         '''
-        targets = self.opts['hostgroups'][expr].split(',')
-        ret = []
-        for fn_ in os.listdir(os.path.join(self.opts['pki_dir'], 'minions')):
-            if targets.count(fn_):
-                if not ret.count(fn_):
-                    ret.append(fn_)
-        return ret
-
+        members = self.opts['hostgroups'][expr]
+        return self._check_list_minions(members)
+        
     def _check_grain_minions(self, expr):
         '''
         Return the minions found by looking via a list
@@ -343,6 +338,11 @@ class LocalClient(object):
         # send!
         # return what we get back
         minions = self.check_minions(tgt, expr_form)
+
+        if expr_form == 'hostgroup':
+          tgt = self.opts['hostgroups'][tgt]
+          expr_form = 'list'
+
         if not minions:
             return {'jid': '',
                     'minions': minions}

--- a/salt/config.py
+++ b/salt/config.py
@@ -131,6 +131,7 @@ def master_config(path):
             'log_granular_levels': {},
             'cluster_masters': [],
             'cluster_mode': 'paranoid',
+            'hostgroups': [],
             }
 
     load_config(opts, path, 'SALT_MASTER_CONFIG')


### PR DESCRIPTION
Initial attempt to provide logical minion node grouping to salt. Groups are defined only on the master using the existing target evaluation forms. At present the groups only support one target form per group but when/if salt gets the ability to do compound commands then groups could include multiple forms.
