### PR TITLE
Fixed false grep match in the Debian init script

### DIFF
--- a/debian/salt.salt-master.init
+++ b/debian/salt.salt-master.init
@@ -46,7 +46,7 @@ PROC_LIST=""
 RETVAL=0
 
 findproc() {
-    PROC_LIST=`$PS_CMD | grep $PROCESS | grep -v grep | grep -v sh | grep -v vi | awk '{ print $1 }'`
+    PROC_LIST=`$PS_CMD | grep 'bin/python.*salt-master' | grep -v grep | grep -v sh | grep -v vi | awk '{ print $1 }'`
 }
 
 start() {

--- a/debian/salt.salt-minion.init
+++ b/debian/salt.salt-minion.init
@@ -46,7 +46,7 @@ PROC_LIST=""
 RETVAL=0
 
 findproc() {
-    PROC_LIST=`$PS_CMD | grep $PROCESS | grep -v grep | grep -v sh | grep -v vi | awk '{ print $1 }'`
+    PROC_LIST=`$PS_CMD | grep 'bin/python.*salt-minion' | grep -v grep | grep -v sh | grep -v vi | awk '{ print $1 }'`
 }
 
 start() {

--- a/debian/salt.salt-syndic.init
+++ b/debian/salt.salt-syndic.init
@@ -46,7 +46,7 @@ PROC_LIST=""
 RETVAL=0
 
 findproc() {
-    PROC_LIST=`$PS_CMD | grep $PROCESS | grep -v grep | grep -v sh | grep -v vi | awk '{ print $1 }'`
+    PROC_LIST=`$PS_CMD | grep 'bin/python.*salt-syndic' | grep -v grep | grep -v sh | grep -v vi | awk '{ print $1 }'`
 }
 
 start() {


### PR DESCRIPTION
When run on a sufficiently fast system, grep would also match the call
to the init script itself.
