### PR TITLE
Add utils.which() and clean up some _virtual() logic

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import re
 import platform
-from salt.utils import which
+import salt.utils
 
 
 def _kernel():
@@ -87,7 +87,7 @@ def _freebsd_cpudata():
     Return cpu information for FreeBSD systems
     '''
     grains = {}
-    sysctl = which("sysctl")
+    sysctl = salt.utils.which("sysctl")
 
     if sysctl:
         grains['cpuarch'] = subprocess.Popen(
@@ -127,7 +127,7 @@ def _memdata(osdata):
                 if comps[0].strip() == 'MemTotal':
                     grains['mem_total'] = int(comps[1].split()[0]) / 1024
     elif osdata['kernel'] in ('FreeBSD','OpenBSD'):
-        sysctl = which("sysctl")
+        sysctl = salt.utils.which("sysctl")
         if sysctl:
             mem = subprocess.Popen(
                     '{0} -n hw.physmem'.format(sysctl),
@@ -148,8 +148,8 @@ def _virtual(osdata):
     # Provides:
     #   virtual
     grains = {'virtual': 'physical'}
-    lspci = which("lspci")
-    dmidecode = which("dmidecode")
+    lspci = salt.utils.which("lspci")
+    dmidecode = salt.utils.which("dmidecode")
 
     if dmidecode:
         output=subprocess.Popen(dmidecode,
@@ -205,7 +205,7 @@ def _virtual(osdata):
             if 'QEMU Virtual CPU' in open('/proc/cpuinfo', 'r').read():
                 grains['virtual'] = 'kvm'
     elif osdata['kernel'] == 'FreeBSD':
-        sysctl = which("sysctl")
+        sysctl = salt.utils.which("sysctl")
         if sysctl:
             model = subprocess.Popen(
                     '{0} hw.model'.format(sysctl),

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -19,7 +19,7 @@ import subprocess
 import sys
 import re
 import platform
-from utils import which
+from salt.utils import which
 
 
 def _kernel():

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -163,7 +163,7 @@ def _virtual(osdata):
         elif 'VirtualBox' in output:
             grains['virtual'] = 'VirtualBox'
         # Product Name: VMware Virtual Platform
-        elif 'VMware' in output
+        elif 'VMware' in output:
             grains['virtual'] = 'VMware'
         # Manufacturer: Microsoft Corporation
         # Product Name: Virtual Machine

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -124,13 +124,14 @@ def which(exe=None):
     '''
     Python clone of POSIX's /usr/bin/which
     '''
-    (path, name) = os.path.split(exe)
-    if os.access(exe, os.X_OK):
-        return exe
-    for path in os.environ.get('PATH').split(os.pathsep):
-        full_path = os.path.join(path, exe)
-        if os.access(full_path, os.X_OK):
-            return full_path
+    if exe:
+        (path, name) = os.path.split(exe)
+        if os.access(exe, os.X_OK):
+            return exe
+        for path in os.environ.get('PATH').split(os.pathsep):
+            full_path = os.path.join(path, exe)
+            if os.access(full_path, os.X_OK):
+                return full_path
     return None
 
 def list_files(directory):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -118,3 +118,16 @@ def profile_func(filename=None):
             return retval
         return profiled_func
     return proffunc
+
+def which(exe):
+    '''
+    Python clone of POSIX's /usr/bin/which
+    '''
+    (path, name) = os.path.split(exe)
+    if os.access(exe, os.X_OK):
+        return exe
+    for path in os.environ.get('PATH').split(os.pathsep):
+        full_path = os.path.join(path, exe)
+        if os.access(full_path, os.X_OK):
+            return full_path
+    return None

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -119,7 +119,7 @@ def profile_func(filename=None):
         return profiled_func
     return proffunc
 
-def which(exe):
+def which(exe=None):
     '''
     Python clone of POSIX's /usr/bin/which
     '''


### PR DESCRIPTION
Make things prettier and run a bit faster. Also default to running dmidecode for checking if a node is virtual and fall back to lspci if dmidecode isn't available.
