### PR TITLE
Misc cleanups

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -253,6 +253,14 @@ class Loader(object):
                 else:
                     setattr(mod, pack['name'], pack['value'])
 
+            # Call a module's initialization method if it exists
+            if hasattr(mod, '__init__'):
+                if callable(mod.__init__):
+                    try:
+                        mod.__init__()
+                    except TypeError:
+                        pass
+
             if hasattr(mod, '__virtual__'):
                 if callable(mod.__virtual__):
                     virtual = mod.__virtual__()

--- a/salt/master.py
+++ b/salt/master.py
@@ -655,7 +655,7 @@ class ClearFuncs(object):
             else:
                 log.info(
                     'Authentication failed from host %(id)s, the key is in '
-                    'pending and needs to be accepted with saltkey -a %(id)s',
+                    'pending and needs to be accepted with salt-key -a %(id)s',
                     load
                 )
                 return {'enc': 'clear',


### PR DESCRIPTION
Fix gh-138 by allowing modules to have their own top level `__init__()`. This blew up on stuff such as the `grains/__init__.py`, so it is wrapped in a try/except.

I'm not sure if this is the way you intended to implement this feature, but in my limited testing, it does what I think needs to be done. This also fixes a small typo found in the master log.
