### PR TITLE
Template loader for json_jinja and yaml_jinja renderers

### DIFF
--- a/salt/renderers/json_jinja.py
+++ b/salt/renderers/json_jinja.py
@@ -9,14 +9,15 @@ import json
 import os
 
 # Import Third Party libs
-from jinja2 import Template
+from jinja2 import Template, FileSystemLoader
+from jinja2.environment import Environment
 
 
-def render(template, env='', sls=''):
+def render(template_file, env='', sls=''):
     '''
     Render the data passing the functions and grains into the rendering system
     '''
-    if not os.path.isfile(template):
+    if not os.path.isfile(template_file):
         return {}
 
     passthrough = {}
@@ -25,7 +26,15 @@ def render(template, env='', sls=''):
     passthrough['env'] = env
     passthrough['sls'] = sls
 
-    template = Template(open(template, 'r').read())
+    file_cache = '/files/%s/' % env
+    if file_cache in template_file:
+        cache_dir, file_rel = template_file.split(file_cache, 1)
+        loader = FileSystemLoader(cache_dir + file_cache)
+        jinja_env = Environment(loader=loader)
+        template = jinja_env.get_template(file_rel)
+    else:
+        template = Template(open(template_file, 'r').read())
+
     json_data = template.render(**passthrough)
 
     return json.loads(json_data)

--- a/salt/renderers/json_jinja.py
+++ b/salt/renderers/json_jinja.py
@@ -28,9 +28,13 @@ def render(template_file, env='', sls=''):
 
     file_cache = '/files/%s/' % env
     if file_cache in template_file:
+        def cachefile_filter(value):
+            __salt__['cp.cache_file']('salt://%s' % value)
+            return value
         cache_dir, file_rel = template_file.split(file_cache, 1)
         loader = FileSystemLoader(cache_dir + file_cache)
         jinja_env = Environment(loader=loader)
+        jinja_env.filters['cachefile'] = cachefile_filter
         template = jinja_env.get_template(file_rel)
     else:
         template = Template(open(template_file, 'r').read())

--- a/salt/renderers/yaml_jinja.py
+++ b/salt/renderers/yaml_jinja.py
@@ -28,9 +28,13 @@ def render(template_file, env='', sls=''):
 
     file_cache = '/files/%s/' % env
     if file_cache in template_file:
+        def cachefile_filter(value):
+            __salt__['cp.cache_file']('salt://%s' % value)
+            return value
         cache_dir, file_rel = template_file.split(file_cache, 1)
         loader = FileSystemLoader(cache_dir + file_cache)
         jinja_env = Environment(loader=loader)
+        jinja_env.filters['cachefile'] = cachefile_filter
         template = jinja_env.get_template(file_rel)
     else:
         template = Template(open(template_file, 'r').read())

--- a/salt/renderers/yaml_jinja.py
+++ b/salt/renderers/yaml_jinja.py
@@ -8,15 +8,16 @@ high data format for salt states.
 import os
 
 # Import Third Party libs
-from jinja2 import Template
+from jinja2 import Template, FileSystemLoader
 import yaml
+from jinja2.environment import Environment
 
 
-def render(template, env='', sls=''):
+def render(template_file, env='', sls=''):
     '''
     Render the data passing the functions and grains into the rendering system
     '''
-    if not os.path.isfile(template):
+    if not os.path.isfile(template_file):
         return {}
 
     passthrough = {}
@@ -25,7 +26,15 @@ def render(template, env='', sls=''):
     passthrough['env'] = env
     passthrough['sls'] = sls
 
-    template = Template(open(template, 'r').read())
+    file_cache = '/files/%s/' % env
+    if file_cache in template_file:
+        cache_dir, file_rel = template_file.split(file_cache, 1)
+        loader = FileSystemLoader(cache_dir + file_cache)
+        jinja_env = Environment(loader=loader)
+        template = jinja_env.get_template(file_rel)
+    else:
+        template = Template(open(template_file, 'r').read())
+
     yaml_data = template.render(**passthrough)
 
     return yaml.safe_load(yaml_data)


### PR DESCRIPTION
jinja's extend and include features are very powerful and allow for external templates and macros.
for me this feature replaces puppet defines.

including a file is as easy as:
{% include 'myapp/parameterized.sls'|cachefile with context %}

it would probably be better to extract the template setup code and the custom filter.
and i am willing to change that.
