### PR TITLE
change type checks to isinstance

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -240,7 +240,7 @@ class Loader(object):
             mod.__grains__ = self.grains
 
             if pack:
-                if type(pack) == type(list()):
+                if isinstance(pack, list):
                     for chunk in pack:
                         setattr(mod, chunk['name'], chunk['value'])
                 else:
@@ -349,14 +349,14 @@ class Loader(object):
             if not key[key.index('.') + 1:] == 'core':
                 continue
             ret = fun()
-            if not type(ret) == type(dict()):
+            if not isinstance(ret, dict):
                 continue
             grains.update(ret)
         for key, fun in funcs.items():
             if key[key.index('.') + 1:] == 'core':
                 continue
             ret = fun()
-            if not type(ret) == type(dict()):
+            if not isinstance(ret, dict):
                 continue
             grains.update(ret)
         return grains

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -166,7 +166,7 @@ class Minion(object):
                 self.functions, self.returners = self.__load_modules()
 
         if self.opts['multiprocessing']:
-            if type(data['fun']) == type(list()):
+            if isinstance(data['fun'], list):
                 multiprocessing.Process(
                     target=lambda: self._thread_multi_return(data)
                 ).start()
@@ -175,7 +175,7 @@ class Minion(object):
                     target=lambda: self._thread_return(data)
                 ).start()
         else:
-            if type(data['fun']) == type(list()):
+            if isinstance(data['fun'], list):
                 threading.Thread(
                     target=lambda: self._thread_multi_return(data)
                 ).start()
@@ -473,7 +473,7 @@ class Matcher(object):
         '''
         matcher = 'glob'
         for item in data:
-            if type(item) == type(dict()):
+            if isinstance(item, dict):
                 if 'match' in item:
                     matcher = item['match']
         if hasattr(self, matcher + '_match'):

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -113,7 +113,7 @@ def set_fstab(
         salt '*' mount.set_fstab /mnt/foo /dev/sdz1 ext4
     '''
     # Fix the opts type if it is a list
-    if type(opts) == type(list()):
+    if isinstance(opts, list):
         opts = ','.join(opts)
     lines = []
     change = False
@@ -189,7 +189,7 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults'):
 
         salt '*' mount.mount /mnt/foo /dev/sdz1 True
     '''
-    if type(opts) == type(str()):
+    if isinstance(opts, basestring):
         opts = opts.split(',')
     if not os.path.exists(name) and mkmnt:
         os.makedirs(name)
@@ -212,7 +212,7 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults'):
 
         salt '*' mount.remount /mnt/foo /dev/sdz1 True
     '''
-    if type(opts) == type(str()):
+    if isinstance(opts, basestring):
         opts = opts.split(',')
     mnts = active()
     if name in mnts:

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -27,7 +27,7 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
-    if type(groups) == type(str()):
+    if isinstance(groups, basestring):
         groups = groups.split(',')
     cmd = 'pw useradd -s {0} '.format(shell)
     if uid:
@@ -169,7 +169,7 @@ def chgroups(name, groups, append=False):
 
         salt '*' user.chgroups foo wheel,root True
     '''
-    if type(groups) == type(str()):
+    if isinstance(groups, basestring):
         groups = groups.split(',')
     ugrps = set(list_groups(name))
     if ugrps == set(groups):

--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -112,10 +112,10 @@ def _get_none_or_value(value):
     '''
     if value is None:
         return None
-    elif value:
+    elif not value:
         return value
     # if it's a string, and it's not empty check for none
-    elif type(value) == str:
+    elif isinstance(value, basestring):
         if value.lower() == 'none':
             return None
         return value
@@ -333,11 +333,11 @@ def _merge_options(options):
         {option:boolean}
     '''
     defaults = __opts__['solr.dih.import_options']
-    if type(options) == dict:
+    if isinstance(options, dict):
         defaults.update(options)
     for (k,v) in defaults.items():
         if type(v) is bool:
-            defaults[k] = str(bool(v)).lower()
+            defaults[k] = str(v).lower()
     return defaults
 
 def _pre_index_check(handler, host=None, core_name=None):
@@ -415,11 +415,11 @@ def _find_value(ret_dict, key, path=None):
     for (k, v) in ret_dict.items():
         if k == key:
             ret.append({path:v})
-        if type(v) is list:
+        if isinstance(v, list):
             for x in v:
-                if type(x) is dict:
+                if isinstance(x, dict):
                     ret = ret + _find_value(x, key, path)
-        if type(v) is dict:
+        if isinstance(v, dict):
             ret = ret + _find_value(v, key, path)
     return ret
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -26,7 +26,7 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
-    if type(groups) == type(str()):
+    if isinstance(groups, basestring):
         groups = groups.split(',')
     cmd = 'useradd -s {0} '.format(shell)
     if uid:
@@ -170,7 +170,7 @@ def chgroups(name, groups, append=False):
 
         salt '*' user.chgroups foo wheel,root True
     '''
-    if type(groups) == type(str()):
+    if isinstance(groups, basestring):
         groups = groups.split(',')
     ugrps = set(list_groups(name))
     if ugrps == set(groups):

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -34,7 +34,7 @@ def returner(ret):
     col = db[ret['id']]
     back = {}
 
-    if type(ret['return']) == type(dict()):
+    if isinstance(ret['return'], dict):
         for key in ret['return']:
             back[key.replace('.', '-')] = ret['return'][key]
     else:

--- a/salt/state.py
+++ b/salt/state.py
@@ -29,19 +29,19 @@ def format_log(ret):
     Format the state into a log message
     '''
     msg = ''
-    if type(ret) == type(dict()):
+    if isinstance(ret, dict):
         # Looks like the ret may be a valid state return
         if 'changes' in ret:
             # Yep, looks like a valid state return
             chg = ret['changes']
             if not chg:
                 msg = 'No changes made for {0[name]}'.format(ret)
-            elif type(chg) == type(dict()):
+            elif isinstance(chg, dict):
                 if 'diff' in chg:
-                    if type(chg['diff']) == type(str()):
+                    if isinstance(chg['diff'], basestring):
                         msg = 'File changed:\n{0}'.format(
                                 chg['diff'])
-                if type(chg[chg.keys()[0]]) == type(dict()):
+                if isinstance(chg[chg.keys()[0]], dict):
                     if 'new' in chg[chg.keys()[0]]:
                         # This is the return data from a package install
                         msg = 'Installed Packages:\n'
@@ -319,9 +319,9 @@ class State(object):
         aspec = inspect.getargspec(self.states[ret['full']])
         arglen = 0
         deflen = 0
-        if type(aspec[0]) == type(list()):
+        if isinstance(aspec[0], list):
             arglen = len(aspec[0])
-        if type(aspec[3]) == type(tuple()):
+        if isinstance(aspec[3], tuple):
             deflen = len(aspec[3])
         kwargs = {}
         for ind in range(arglen - 1, 0, -1):
@@ -360,10 +360,10 @@ class State(object):
                 funcs = set()
                 names = set()
                 for arg in run:
-                    if type(arg) == type(str()):
+                    if isinstance(arg, str):
                         funcs.add(arg)
                         continue
-                    if type(arg) == type(dict()):
+                    if isinstance(arg, dict):
                         for key, val in arg.items():
                             if key == 'names':
                                 names.update(val)
@@ -847,7 +847,7 @@ class HighState(object):
                     if env not in matches:
                         matches[env] = []
                     for item in data:
-                        if type(item) == type(str()):
+                        if isinstance(item, basestring):
                             matches[env].append(item)
         return matches
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -71,7 +71,7 @@ def mounted(
 
     # Make sure that opts is correct, it can be a list or a comma delimited
     # string
-    if type(opts) == type(str()):
+    if isinstance(opts, basestring):
         opts = opts.split(',')
 
     # Get the active data
@@ -79,7 +79,7 @@ def mounted(
     if name not in active:
         # The mount is not present! Mount it
             out = __salt__['mount.mount'](name, device, mkmnt, fstype, opts)
-            if type(out) == type(str()):
+            if isinstance(out, basestring):
                 # Failed to remount, the state has failed!
                 ret['comment'] = out
                 ret['result'] = False


### PR DESCRIPTION
isinstance is just as fast and allows inheritance
and much faster than checking against a new instance

extend str type checks to match unicode as well.
this would cause bugs with non ascii characters in group names for example

fix unreachable code in solr _get_none_or_value
i could reconstruct the intended logic from the comment
