### PR TITLE
Changed default package name delimiter on yum module for consistency

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -172,12 +172,16 @@ def install(pkgs, refresh=False):
 
     CLI Example::
 
-        salt '*' pkg.install <package,package,package>
+        salt '*' pkg.install 'package package package'
     '''
     if refresh:
         refresh_db()
 
-    pkgs = pkgs.split(',')
+    if ',' in pkgs:
+        pkgs = pkgs.split(',')
+    else:
+        pkgs = pkgs.split(' ')
+
     old = list_pkgs(*pkgs)
 
     yb = yum.YumBase()


### PR DESCRIPTION
Most of the package modules will accept multiple package names delimited
by a space. E.g., `aptitude install p1 p2 p3` works and so `salt '*'
pkg.install 'p1 p2 p3'` also works.

There's a fallback so any existing code delimited by a comma will still
work. Perhaps this should be added to the other package modules since
it's nice not having to surround with quotes.

That said, there's a subtle difference between calling `yum install p1
p2 p3` and calling `yum install p1; yum install p2; yum install p3`
(this module essentially does the latter) and I'm not sure if that's a
problem or how best it should be reconciled.
