### PR TITLE
On Windows the salt-minion seems to run just fine even as a regular user...

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -25,6 +25,9 @@ def check_root():
     Most of the salt scripts need to run as root, this function will simply
     verify that root is the user before the application discovers it.
     '''
+    if 'os' in os.environ:
+        if os.environ['os'].startswith('Windows'):
+            return True
     if os.getuid():
         log.critical('Sorry, the salt must run as root. It needs to operate in a privileged environment to do what it does. http://xkcd.com/838/')
         return False


### PR DESCRIPTION
....

It's possible to check for an admin user using ctypes-    print ctypes.windll.shell32.IsUserAnAdmin(), but it isn't helpful because unless the administrator opened up the terminal as an admin, it will always return 0.

So unless further testing reveals that salt MUST be run as an administrator, check_root() should just return true when on Windows.
