### PR TITLE
Minion key sleep time

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -102,7 +102,7 @@
 
 ######  Miscellaneous configuration   #####
 ###########################################
-# When waiting for a master to accept the minion's public key, it will
+# When waiting for a master to accept the minion's public key, salt will
 # contiuously attempt to reconnect until successful. This is the time, in
 # seconds, between those reconnection attempts.
 # acceptance_wait_time = 10

--- a/conf/minion
+++ b/conf/minion
@@ -102,11 +102,11 @@
 
 ######  Miscellaneous configuration   #####
 ###########################################
-# When a master is in 'verify' trust_mode, the minion key will be put in
-# pending, and the minion will continuously attempt to reconnect until the key
-# is accepted on the master. This is the wait time, in seconds, between
-# connection attempts.
+# When waiting for a master to accept the minion's public key, it will
+# contiuously attempt to reconnect until successful. This is the time, in
+# seconds, between those reconnection attempts.
 # acceptance_wait_time = 10
+
 
 ######      Module configuration      #####
 ###########################################

--- a/conf/minion
+++ b/conf/minion
@@ -100,6 +100,14 @@
 #log_granular_levels: {}
 
 
+######  Miscellaneous configuration   #####
+###########################################
+# When a master is in 'verify' trust_mode, the minion key will be put in
+# pending, and the minion will continuously attempt to reconnect until the key
+# is accepted on the master. This is the wait time, in seconds, between
+# connection attempts.
+# acceptance_wait_time = 10
+
 ######      Module configuration      #####
 ###########################################
 # Salt allows for modules to be passed arbitrary configuration data, any data

--- a/salt/config.py
+++ b/salt/config.py
@@ -82,6 +82,7 @@ def minion_config(path):
             'test': False,
             'cython_enable': False,
             'state_verbose': False,
+            'acceptance_wait_time': 10,
             }
 
     load_config(opts, path, 'SALT_MINION_CONFIG')

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -208,8 +208,9 @@ class Auth(object):
                 else:
                     log.error(
                         'The Salt Master has cached the public key for this '
-                        'node, this salt minion will wait for 10 seconds '
-                        'before attempting to re-authenticate'
+                        'node, this salt minion will wait for %s seconds '
+                        'before attempting to re-authenticate',
+                        self.opts['acceptance_wait_time']
                     )
                     return 'retry'
         if not self.verify_master(payload['pub_key'], payload['token']):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -307,8 +307,7 @@ class Minion(object):
                 log.info('Authentication with master successful!')
                 break
             log.info('Waiting for minion key to be accepted by the master.')
-            # TODO: Make this a configuration setting and default to 10
-            time.sleep(10)
+            time.sleep(self.opts['acceptance_wait_time'])
         self.aes = creds['aes']
         self.publish_port = creds['publish_port']
         self.crypticle = salt.crypt.Crypticle(self.opts, self.aes)


### PR DESCRIPTION
Found a to-do in minion.py, figured I'd do it. Added a minion config parameter 'acceptance_wait_time', which is the sleep time between reconnect attempts when waiting on a master to accept the minion public key.
