### PR TITLE
fix grains usage example and syntax

### DIFF
--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -9,7 +9,7 @@ Synopsis
 
     salt -E '.*' [ options ] sys.doc cmd
 
-    salt -F 'os:Arch.*' [ options ] test.ping
+    salt -G 'os:Arch.*' [ options ] test.ping
 
     salt -C 'G@os:Arch.* and webserv* or G@kernel:FreeBSD' [ options ] test.ping
 


### PR DESCRIPTION
Port of change from e5aea88fbf7a which will get overwritten when the
manpages are generated from Sphinx.
