### PR TITLE
Fix errors when running sysctl.assign against a nonexistent sysctl

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -11,6 +11,8 @@ import salt
 import salt.loader
 import salt.minion
 
+# Custom exceptions
+from salt.exceptions import CommandExecutionError
 
 class Caller(object):
     '''
@@ -36,7 +38,7 @@ class Caller(object):
             ret['return'] = self.minion.functions[self.opts['fun']](
                     *self.opts['arg']
                     )
-        except TypeError, exc:
+        except (TypeError, CommandExecutionError) as exc:
             sys.stderr.write('Error running \'{0}\': {1}\n'.format(self.opts['fun'], str(exc)))
             sys.exit(1)
         if hasattr(self.minion.functions[self.opts['fun']], '__outputter__'):

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -26,6 +26,13 @@ class CommandNotFoundError(SaltException):
     '''
     pass
 
+class CommandExecutionError(SaltException):
+    '''
+    Used when a module runs a command which returns an error  and
+    wants to show the user the output gracefully instead of dying
+    '''
+    pass
+
 class LoaderError(SaltException):
     '''
     Problems loading the right renderer

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -23,7 +23,8 @@ import urlparse
 import zmq
 
 # Import salt libs
-from salt.exceptions import AuthenticationError, MinionError
+from salt.exceptions import AuthenticationError, MinionError, \
+    CommandExecutionError
 import salt.client
 import salt.crypt
 import salt.loader
@@ -206,6 +207,9 @@ class Minion(object):
         if function_name in self.functions:
             try:
                 ret['return'] = self.functions[data['fun']](*data['arg'])
+            except CommandExecutionError as exc:
+                log.error('A command in {0} had a problem: {1}'.format(function_name, str(exc)))
+                ret['return'] = 'ERROR: {0}'.format(str(exc))
             except Exception as exc:
                 trb = traceback.format_exc()
                 log.warning('The minion function caused an exception: {0}'.format(exc))

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -11,7 +11,11 @@ def usage():
 
         salt '*' disk.usage
     '''
-    cmd = 'df -P'
+    # TODO: Windows support
+    if __grains__['kernel'] == 'Linux':
+        cmd = 'df -P'
+    else:
+        cmd = 'df'
     ret = {}
     out = __salt__['cmd.run'](cmd).split('\n')
     for line in out:

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -5,6 +5,10 @@ Module for viewing and modifying sysctl parameters
 import os
 from salt.exceptions import CommandExecutionError
 
+__outputter__ = {
+    'assign': 'txt',
+}
+
 
 def __virtual__():
     '''

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -3,6 +3,7 @@ Module for viewing and modifying sysctl parameters
 '''
 
 import os
+from salt.exceptions import CommandExecutionError
 
 
 def __virtual__():
@@ -53,6 +54,10 @@ def assign(name, value):
     CLI Example:
     salt '*' sysctl.assign net.ipv4.ip_forward 1
     '''
+    sysctl_file = '/proc/sys/{0}'.format(name.replace('.', '/'))
+    if not os.path.exists(sysctl_file):
+        raise CommandExecutionError('sysctl {0} does not exist'.format(name))
+
     cmd = 'sysctl -w {0}={1}'.format(name, value)
     ret = {}
     out = __salt__['cmd.run'](cmd).strip()


### PR DESCRIPTION
After this branch

```
[root@omniscience ~]$ salt-call sysctl.assign foo.bar 60
Error running 'sysctl.assign': sysctl foo.bar does not exist

[root@omniscience ~]$ salt '*' sysctl.assign foo.bar 60
localhost.localdomain: ERROR: sysctl foo.bar does not exist

[root@omniscience ~]$ salt '*' sysctl.assign vm.swappiness 60
localhost.localdomain: {'vm.swappiness': '60'}
```
