### PR TITLE
Added msgpack header files to MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include salt/msgpack/*.h


### PR DESCRIPTION
We've learned this is the best way to include header files into an sdist
from StackOverflow. Many Bothans died to bring us this information.
