### PR TITLE
Fix a couple of problems with systemd service status command

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -106,9 +106,14 @@ def status(name):
 
         salt '*' service.status <service name>
     '''
-    cmd = ("systemctl restart {0}.service"
-           " | awk '/Main PID/{print $3}'").format(name)
-    return __salt__['cmd.run'](cmd).strip()
+    cmd = 'systemctl show {0}.service'.format(name)
+    ret = __salt__['cmd.run'](cmd)
+    index1 = ret.find('\nMainPID=')
+    index2 = ret.find('\n', index1+9)
+    mainpid = ret[index1+9:index2]
+    if mainpid == '0':
+        return ''
+    return mainpid
 
 
 def enable(name):


### PR DESCRIPTION
The status command for systemd services had a couple of problems:

1) The awk script used braces which needed to be escaped when using .format
2) It was using the 'systemctl restart' subcommand instead of status.

Also, using awk to parse the output of systemctl doesn't seem very
efficient, especially when we have a perfectly good Python interpreter
at hand.

This fixes the above problems by using Python code to look for the
main pid from the 'systemctl show' command output.  'systemctl show'
has the same information as 'systemctl status' except in a more
machine-readable format.
