### PR TITLE
Add hostname grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -430,6 +430,7 @@ def hostname():
     #   host
     #   domain
     grains = {}
+    grains['hostname'] = socket.gethostname()
     grains['fqdn'] = socket.getfqdn()
     comps = grains['fqdn'].split('.')
     grains['host'] = comps[0]


### PR DESCRIPTION
I prefer to use the hardcoded hostname which always should be the same, rather than using fqdn which can return odd answers if your DNS or your hosts file is messed up.
