### PR TITLE
Protect cache files

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -25,9 +25,12 @@ def verify_env(dirs):
     for dir_ in dirs:
         if not os.path.isdir(dir_):
             try:
+                cumask = os.umask(191)
                 os.makedirs(dir_)
+                os.umask(cumask)
             except OSError, e:
                 print 'Failed to create directory path "%s" - %s' % (dir_, e)
+        os.chmod(dir_, 448)
     # Run the extra verification checks
     salt.utils.verify.run()
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -640,10 +640,13 @@ class FileClient(object):
                         data['dest']
                         )
                     destdir = os.path.dirname(dest)
+                    cumask = os.umask(191)
                     if not os.path.isdir(destdir):
                         os.makedirs(destdir)
                     if not os.path.exists(dest):
                         open(dest, 'w+').write(data['data'])
+                    os.chmod(dest, 384)
+                    os.umask(cumask)
                 break
             if not fn_:
                 dest = os.path.join(
@@ -653,9 +656,12 @@ class FileClient(object):
                     data['dest']
                     )
                 destdir = os.path.dirname(dest)
+                cumask = os.umask(191)
                 if not os.path.isdir(destdir):
                     os.makedirs(destdir)
                 fn_ = open(dest, 'w+')
+                os.chmod(dest, 384)
+                os.umask(cumask)
             fn_.write(data['data'])
         return dest
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -36,10 +36,10 @@ def _sync(form, env):
             dsth = hashlib.md5(open(dest, 'r').read()).hexdigest()
             if srch != dsth:
                 # The downloaded file differes, replace!
-                shutil.copy(fn_, dest)
+                shutil.copyfile(fn_, dest)
                 ret.append('{0}.{1}'.format(form, os.path.basename(fn_)))
         else:
-            shutil.copy(fn_, dest)
+            shutil.copyfile(fn_, dest)
             ret.append('{0}.{1}'.format(form, os.path.basename(fn_)))
     if ret:
         open(os.path.join(__opts__['cachedir'], '.module_refresh'), 'w+').write()

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -435,7 +435,7 @@ def managed(name,
                                                                   slines)))
             # Pre requisites are met, and the file needs to be replaced, do it
             if not __opts__['test']:
-                shutil.copy(sfn, name)
+                shutil.copyfile(sfn, name)
         # Check permissions
         perms = {}
         perms['luser'] = __salt__['file.get_user'](name)
@@ -504,7 +504,7 @@ def managed(name,
                     ret['result'] = False
                     ret['comment'] = 'Parent directory not present'
                     return ret
-            shutil.copy(sfn, name)
+            shutil.copyfile(sfn, name)
         # Check permissions
         perms = {}
         perms['luser'] = __salt__['file.get_user'](name)
@@ -736,12 +736,14 @@ def recurse(name,
             dsth = hashlib.md5(open(dest, 'r').read()).hexdigest()
             if srch != dsth:
                 # The downloaded file differes, replace!
-                shutil.copy(fn_, dest)
+                # FIXME: no metadata (ownership, permissions) available
+                shutil.copyfile(fn_, dest)
                 ret['changes'][dest] = 'updated'
         else:
             keep.add(dest)
             # The destination file is not present, make it
-            shutil.copy(fn_, dest)
+            # FIXME: no metadata (ownership, permissions) available
+            shutil.copyfile(fn_, dest)
             ret['changes'][dest] = 'new'
     keep = list(keep)
     if clean:


### PR DESCRIPTION
Found a rather important issue I'd consider a bug...cache files and dirs are created with current umask, which is usually going to mean world-readable. Users may be surprised to find a managed file with restrictive ownership/modes is also contained in a world-accessible cache dir. I know I was. :)

This patch indtroduces a few changes:

in salt/**init**.py in the verify_env function which creates cache dir, the pki dirs, the jobs dir, log file, socket dir...set a restrictive umask and chmod. None of these need to be accessible to anyone but the user as which minion runs (always root as of now).

in salt/minion.py when retreiving files to the cache, use restrictive umask/chmod. should be controlled by the restrictive cache dir permissions, but this doesnt hurt and was minimal code. I didn't touch directory creation as that would have been a fair amount more code for little benefit.

in salt/states/file.py use shutil.copyfile() over shutil.copy(). This will keep current behavior in that files will be created with default umask when copied over, and then managed the same as before by the mode: setting.
