### PR TITLE
Fix documentation example for Tomcat

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -40,7 +40,7 @@ def fullversion():
 
     CLI Example::
 
-        salt '*' full.fullversion
+        salt '*' tomcat.fullversion
     '''
     cmd = __catalina_home() + '/bin/catalina.sh version'
     ret = {}


### PR DESCRIPTION
There was an error in the documentation `full.fullversion` instead of `tomcat.fullversion` which has now been fixed.
