### PR TITLE
Add Windows support to disk.py

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -2,6 +2,17 @@
 Module for gathering disk information
 '''
 
+def __virtual__():
+    '''
+    Only work on posix-like systems
+    '''
+    # Disable on these platorms, specific service modules exist:
+    disable = [
+        'Windows',
+        ]
+    if __grains__['os'] in disable:
+        return False
+    return 'disk'
 
 def usage():
     '''
@@ -11,7 +22,6 @@ def usage():
 
         salt '*' disk.usage
     '''
-    # TODO: Windows support
     if __grains__['kernel'] == 'Linux':
         cmd = 'df -P'
     else:

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -7,7 +7,7 @@ try:
     import string
     import win32api
 except ImportError:
-    is_windows == False
+    is_windows = False
 
 def __virtual__():
     '''

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -1,0 +1,60 @@
+'''
+Module for gathering disk information on Windows
+'''
+is_windows = True
+try:
+    import ctypes
+    import string
+    import win32api
+except ImportError:
+    is_windows == False
+
+def __virtual__():
+    '''
+    Only works on Windows systems
+    '''
+    if not is_windows:
+        return False
+    return 'disk'
+
+def usage():
+    '''
+    Return usage information for volumes mounted on this minion
+
+    CLI Example::
+
+        salt '*' disk.usage
+    '''
+    if __grains__['kernel'] == 'Windows':
+        drives = []
+        ret = {}
+        drive_bitmask = ctypes.windll.kernel32.GetLogicalDrives()
+        for letter in string.uppercase:
+            if drive_bitmask & 1:
+                drives.append(letter)
+            drive_bitmask >>= 1
+        for drive in drives:
+            try:
+                sectorspercluster, bytespersector, freeclusters, totalclusters =\
+                        win32api.GetDiskFreeSpace('{0}:\\'.format(drive))
+                totalsize = sectorspercluster * bytespersector * totalclusters 
+                available_space = sectorspercluster * bytespersector * freeclusters 
+                used = totalsize - available_space
+                capacity = int(used / float(totalsize) * 100)
+                ret['{0}:\\'.format(drive)] = {
+                    'filesystem': '{0}:\\'.format(drive),
+                    '1K-blocks': totalsize, 
+                    'used': used, 
+                    'available': available_space,
+                    'capacity': '{0}%'.format(capacity),
+                }
+            except:
+                ret['{0}:\\'.format(drive)] = {
+                    'filesystem': '{0}:\\'.format(drive),
+                    '1K-blocks': None, 
+                    'used': None, 
+                    'available': None,
+                    'capacity': None, 
+                }
+        return ret
+


### PR DESCRIPTION
Disable Windows in disk.py
Add win_disk.py for Windows disk usage

Windows uses 512 blocks by default, but I went ahead and populated the 1k-blocks field with the Windows equivalent in order to maintain what is done on other operating systems.

I'm not a filesystem guru, but I think this accurately gives disk usage on Windows.
