### PR TITLE
Fix wrong examples for saltutil module & MySQL module enhancements

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -12,10 +12,11 @@ might look like::
     mysql.db: 'mysql'
 '''
 
+import logging
 import MySQLdb
+import MySQLdb.cursors
 
 __opts__ = {}
-
 
 def connect(**kwargs):
     '''
@@ -72,7 +73,6 @@ def version():
     cur.execute('SELECT VERSION()')
     row = cur.fetchone()
     return row
-
 
 def slave_lag():
     '''
@@ -136,3 +136,226 @@ def free_slave():
         return 'promoted'
     else:
         return 'failed'
+        
+'''
+Database related actions
+'''
+def db_list():
+    '''
+    Return a list of databases of a MySQL server using the output
+    from the ``SHOW DATABASES`` query.
+
+    CLI Example::
+
+        salt '*' mysqldb.db_list
+    '''
+    ret = []
+    db = connect()
+    cur = db.cursor()
+    cur.execute('SHOW DATABASES')
+    results = cur.fetchall()
+    for dbs in results:
+       ret.append(dbs[0])
+
+    log.debug(ret)
+    return ret
+
+def db_exists(name):
+    '''
+    Checks if atabases exists on the  MySQL server.
+
+    CLI Example::
+
+        salt '*' mysqldb.db_exists 'dbname'
+    '''
+    db = connect()
+    cur = db.cursor()
+    query = "SHOW DATABASES LIKE '%s'" % name
+    log.debug("Doing query: {0}".format(query,))
+    cur.execute( query )
+    result_set = cur.fetchall()
+    if cur.rowcount == 1:
+       return True
+    return False
+    
+def db_create(name):
+    '''
+    Adds a databases to the MySQL server.
+
+    CLI Example::
+
+        salt '*' mysqldb.db_create 'dbname'
+    '''
+    # check if db exists
+    if db_exists(name):
+        log.info("DB '{0}' already exists".format(name,))
+        return False
+
+    # db doesnt exist, proceed
+    db = connect()
+    cur = db.cursor()
+    query = "CREATE DATABASE %s;" % name
+    log.debug("Query: {0}".format(query,))
+    if cur.execute( query ):
+       log.info("DB '{0}' created".format(name,))
+       return True
+    return False
+
+def db_remove(name):
+    '''
+    Removes a databases from the MySQL server.
+
+    CLI Example::
+
+        salt '*' mysqldb.db_remove 'dbname'
+    '''
+    # check if db exists
+    if not db_exists(name):
+        log.info("DB '{0}' does not exist".format(name,))
+        return False
+
+    if name in ('mysql','information_scheme'):
+        log.info("DB '{0}' may not be removed".format(name,))
+        return False
+
+    # db doesnt exist, proceed
+    db = connect()
+    cur = db.cursor()
+    query = "DROP DATABASE %s;" % name
+    log.debug("Doing query: {0}".format(query,))
+    cur.execute( query )
+
+    if not db_exists(name):
+       log.info("Database '{0}' has been removed".format(name,))
+       return True
+
+    log.info("Database '{0}' has not been removed".format(name,))
+    return False
+
+'''
+User related actions
+'''
+def user_list():
+    '''
+    Return a list of users on a MySQL server
+
+    CLI Example::
+
+        salt '*' mysqldb.user_list
+    '''
+    db = connect()
+    cur = db.cursor(MySQLdb.cursors.DictCursor)
+    cur.execute('SELECT User,Host FROM mysql.user')
+    results = cur.fetchall()
+    log.debug(results)
+    return results
+
+def user_exists(user,
+                host='localhost'):
+    '''
+    Checks if a user exists on the  MySQL server.
+
+    CLI Example::
+
+        salt '*' mysqldb.user_exists 'username' 'hostname'
+    '''
+    db = connect()
+    cur = db.cursor()
+    query = "SELECT User,Host FROM mysql.user WHERE User = '%s' AND Host = '%s'" % (user, host,)
+    log.debug("Doing query: {0}".format(query,))
+    cur.execute( query )
+    if cur.rowcount == 1:
+       return True
+    return False
+def user_info(user,
+              host='localhost'):
+    '''
+    Get full info on a MySQL user
+
+    CLI Example::
+
+        salt '*' mysqldb.user_info root localhost
+    '''
+    db = connect()
+    cur = db.cursor (MySQLdb.cursors.DictCursor)
+    query = "SELECT * FROM mysql.user WHERE User = '%s' AND Host = '%s'" % (user, host,)
+    log.debug("Query: {0}".format(query,))
+    cur.execute(query)
+    result = cur.fetchone()
+    log.debug( result )
+    return result
+
+def user_create(user,
+                host='localhost',
+                password=None):
+    '''
+    Creates a MySQL user.
+
+    CLI Example::
+
+        salt '*' mysqldb.user_create 'username' 'hostname' 'password'
+    '''
+    if user_exists(user,host):
+       log.info("User '{0}'@'{1}' already exists".format(user,host,))
+       return False
+
+    db = connect()
+    cur = db.cursor ()
+    query = "CREATE USER '%s'@'%s'" % (user, host,)
+    if password is not None:
+       query = query + " IDENTIFIED BY '%s'" % password
+
+    log.debug("Query: {0}".format(query,))
+    if cur.execute( query ):
+       log.info("User '{0}'@'{1}' has been created".format(user,host,))
+       return True
+
+    log.info("User '{0}'@'{1}' is not created".format(user,host,))
+    return False
+
+def user_chpass(user,
+                host='localhost',
+                password=None):
+    '''
+    Change password for MySQL user
+
+    CLI Example::
+
+        salt '*' mysqldb.user_chpass frank localhost newpassword
+    '''
+    if password is None:
+       log.error('No password provided')
+       return False
+
+    db = connect()
+    cur = db.cursor ()
+    query = "UPDATE mysql.user SET password=PASSWORD(\"%s\") WHERE User='%s' AND Host = '%s';" % (password,user,host,)
+    log.debug("Query: {0}".format(query,))
+    if cur.execute( query ):
+       log.info("Password for user '{0}'@'{1}' has been changed".format(user,host,))
+       return True
+
+    log.info("Password for user '{0}'@'{1}' is not changed".format(user,host,))
+    return False
+
+def user_remove(user,
+               host='localhost'):
+    '''
+    Delete MySQL user
+
+    CLI Example::
+
+        salt '*' mysqldb.user_remove frank localhost
+    '''
+    db = connect()
+    cur = db.cursor ()
+    query = "DROP USER '%s'@'%s'" % (user, host,)
+    log.debug("Query: {0}".format(query,))
+    cur.execute(query)
+    result = cur.fetchone()
+    if not user_exists(user,host):
+       log.info("User '{0}'@'{1}' has been removed".format(user,host,))
+       return True
+
+    log.info("User '{0}'@'{1}' has NOT been removed".format(user,host,))
+    return False    

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1,5 +1,5 @@
 '''
-The Salt module is used to manage the state of the salt minion itself. It is
+The Saltutil module is used to manage the state of the salt minion itself. It is
 used to manage minion modules as well as automate updates to the salt minion
 '''
 
@@ -61,7 +61,7 @@ def sync_modules(env='base'):
 
     CLI Example::
 
-        salt '*' salt.sync_modules
+        salt '*' saltutil.sync_modules
     '''
     return _sync('modules', env)
 
@@ -75,7 +75,7 @@ def sync_states(env='base'):
 
     CLI Example::
 
-        salt '*' salt.sync_states
+        salt '*' saltutil.sync_states
     '''
     return _sync('states', env)
 
@@ -89,7 +89,7 @@ def sync_grains(env='base'):
 
     CLI Example::
 
-        salt '*' salt.sync_grains
+        salt '*' saltutil.sync_grains
     '''
     return _sync('grains', env)
 
@@ -103,7 +103,7 @@ def sync_renderers(env='base'):
 
     CLI Example::
 
-        salt '*' salt.sync_renderers
+        salt '*' saltutil.sync_renderers
     '''
     return _sync('renderers', env)
 
@@ -117,7 +117,7 @@ def sync_returners(env='base'):
 
     CLI Example::
 
-        salt '*' salt.sync_returners
+        salt '*' saltutil.sync_returners
     '''
     return _sync('returners', env)
 
@@ -129,7 +129,7 @@ def sync_all(env='base'):
 
     CLI Example::
 
-        salt '*' salt.sync_all
+        salt '*' saltutil.sync_all
     '''
     ret = []
     ret.append(sync_modules(env))


### PR DESCRIPTION
The saltutil module had examples such as `salt.sync_all` but this needs to be `saltutil.sync_all` or the saltutil module should be renamed instead.

Also, I've enhanced the MySQL module to include (basic) database and user management functionality.
Grants still need to be implemented, but I don't have a good idea on how this can be done best.
