### PR TITLE
Init logger in MySQL module

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -16,6 +16,7 @@ import logging
 import MySQLdb
 import MySQLdb.cursors
 
+log = logging.getLogger(__name__)
 __opts__ = {}
 
 def __check_table(name, table):


### PR DESCRIPTION
Forgot to initialize the logger, which triggers a NameError: global name 'log' is not defined
