### PR TITLE
pki umask should permit user write permission (077)

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -26,7 +26,7 @@ def verify_env(dirs):
     for dir_ in dirs:
         if not os.path.isdir(dir_):
             try:
-                cumask = os.umask(191)
+                cumask = os.umask(63)  # 077
                 os.makedirs(dir_)
                 os.umask(cumask)
             except OSError, e:


### PR DESCRIPTION
The current umask permission 0277 (191) prevents salt from being run in user space.  It assumes root user will override the no-write user bit.
