### PR TITLE
updated documentation for user, fixed configuration template links

### DIFF
--- a/doc/ref/cli/salt-master.rst
+++ b/doc/ref/cli/salt-master.rst
@@ -30,3 +30,13 @@ Options
 .. option:: -c CONFIG, --config=CONFIG
 
     The master configuration file to use, the default is /etc/salt/master
+
+.. option:: -u USER, --user=USER
+
+    Specify user to run minion
+
+.. option:: -l LOG_LEVEL, --log-level=LOG_LEVEL
+
+    Console log level. One of ``info``, ``none``, ``garbage``,
+    ``trace``, ``warning``, ``error``, ``debug``. For the logfile
+    settings see the config file. Default: ``warning``.

--- a/doc/ref/cli/salt-minion.rst
+++ b/doc/ref/cli/salt-minion.rst
@@ -31,3 +31,13 @@ Options
 .. option:: -c CONFIG, --config=CONFIG
 
     The minion configuration file to use, the default is /etc/salt/minion
+
+.. option:: -u USER, --user=USER
+
+    Specify user to run minion
+
+.. option:: -l LOG_LEVEL, --log-level=LOG_LEVEL
+
+    Console log level. One of ``info``, ``none``, ``garbage``,
+    ``trace``, ``warning``, ``error``, ``debug``. For the logfile
+    settings see the config file. Default: ``warning``.

--- a/doc/ref/configuration/examples.rst
+++ b/doc/ref/configuration/examples.rst
@@ -11,7 +11,7 @@ Configuration file examples
 Example master configuration file
 =================================
 
-.. literalinclude:: ../../../conf/master
+.. literalinclude:: ../../../conf/master.template
     :language: ini
     :linenos:
 
@@ -20,6 +20,6 @@ Example master configuration file
 Example minion configuration file
 =================================
 
-.. literalinclude:: ../../../conf/minion
+.. literalinclude:: ../../../conf/minion.template
     :language: ini
     :linenos:

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -7,8 +7,8 @@ of the Salt system each have a respective configuration file. The
 :command:`salt-master` is configured via the master configuration file, and the
 :command:`salt-minion` is configured via the minion configuration file.
 
-.. seealso:: 
-    :ref:`example master configuration file <configuration-examples-master>` 
+.. seealso::
+    :ref:`example master configuration file <configuration-examples-master>`
 
 The configuration file for the salt-master is located at
 :file:`/etc/salt/master`. The available options are as follows:
@@ -41,6 +41,19 @@ The network port to set up the publication interface
 .. code-block:: yaml
 
     publish_port: 4505
+
+.. conf_master:: user
+
+``user``
+----------------
+
+Default: ``root``
+
+The user to run the Salt processes
+
+.. code-block:: yaml
+
+    user: root
 
 .. conf_master:: worker_threads
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -43,6 +43,19 @@ option on the salt master.
 
     master_port: 4506
 
+.. conf_minion:: user
+
+``user``
+----------------
+
+Default: ``root``
+
+The user to run the Salt processes
+
+.. code-block:: yaml
+
+    user: root
+
 .. conf_minion:: pki_dir
 
 ``pki_dir``

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -34,12 +34,12 @@ Running Salt
 1.  Start the master in the foreground (to daemonize the process, pass the
     :option:`-d flag <salt-master -d>`)::
 
-        salt-master
+        # salt-master
 
 2.  Start the minion in the foreground (to daemonize the process, pass the
     :option:`-d flag <salt-minion -d>`)::
 
-        salt-minion
+        # salt-minion
 
 .. admonition:: Having trouble?
 
@@ -47,6 +47,12 @@ Running Salt
     the foreground with :option:`log level <salt-master -l>` set to ``debug``::
 
         salt-master --log-level=debug
+
+.. admonition:: Run as an unprivileged (non-root) user?
+
+    To run Salt as another user, specify ``--user`` in the command
+    line or assign ``user`` in the
+    :doc:`configuration file</ref/configuration/master>`.
 
 Manage Salt public keys
 =======================


### PR DESCRIPTION
Fixed the documentation links for my earlier update of the configuration files: master.template, minion.template.

Added documentation for the 'user' option in #529.
