### PR TITLE
salt-key: reject keys

### DIFF
--- a/doc/ref/cli/salt-key.rst
+++ b/doc/ref/cli/salt-key.rst
@@ -28,8 +28,8 @@ Options
 
 .. option:: -L, --list-all
 
-    List all public keys on this salt master, both accepted and pending
-    acceptance.
+    List all public keys on this salt master: accepted, pending,
+    and rejected.
 
 .. option:: -a ACCEPT, --accept=ACCEPT
 
@@ -38,6 +38,14 @@ Options
 .. option:: -A, --accept-all
 
     Accepts all pending public keys.
+
+.. option:: -r REJECT, --reject=REJECT
+
+    Reject the named minion public key.
+
+.. option:: -R, --reject-all
+
+    Rejects all pending public keys.
 
 .. option:: -c CONFIG, --config=CONFIG
 

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -128,6 +128,7 @@ class Master(object):
         '''
         verify_env([os.path.join(self.opts['pki_dir'], 'minions'),
                     os.path.join(self.opts['pki_dir'], 'minions_pre'),
+                    os.path.join(self.opts['pki_dir'], 'minions_rejected'),
                     os.path.join(self.opts['cachedir'], 'jobs'),
                     os.path.dirname(self.opts['log_file']),
                     self.opts['sock_dir'],

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -447,6 +447,19 @@ class SaltKey(object):
                 action='store_true',
                 help='Accept all pending keys')
 
+        parser.add_option('-r',
+                '--reject',
+                dest='reject',
+                default='',
+                help='Reject the specified public key')
+
+        parser.add_option('-R',
+                '--reject-all',
+                dest='reject_all',
+                default=False,
+                action='store_true',
+                help='Reject all pending keys')
+
         parser.add_option('-p',
                 '--print',
                 dest='print_',
@@ -500,6 +513,8 @@ class SaltKey(object):
         opts['list_all'] = options.list_all
         opts['accept'] = options.accept
         opts['accept_all'] = options.accept_all
+        opts['reject'] = options.reject
+        opts['reject_all'] = options.reject_all
         opts['print'] = options.print_
         opts['print_all'] = options.print_all
         opts['delete'] = options.delete

--- a/salt/master.py
+++ b/salt/master.py
@@ -646,6 +646,9 @@ class ClearFuncs(object):
         pubfn_pend = os.path.join(self.opts['pki_dir'],
                 'minions_pre',
                 load['id'])
+        pubfn_rejected = os.path.join(self.opts['pki_dir'],
+                'minions_rejected',
+                load['id'])
         if self.opts['open_mode']:
             # open mode is turned on, nuts to checks and overwrite whatever
             # is there
@@ -661,6 +664,12 @@ class ClearFuncs(object):
                 ret = {'enc': 'clear',
                        'load': {'ret': False}}
                 return ret
+        elif os.path.isfile(pubfn_rejected):
+            # The key has been rejected, don't place it in pending
+            log.info('Public key rejected for %(id)s', load)
+            ret = {'enc': 'clear',
+                   'load': {'ret': False}}
+            return ret
         elif not os.path.isfile(pubfn_pend)\
                 and not self.opts['auto_accept']:
             # This is a new key, stick it in pre

--- a/salt/master.py
+++ b/salt/master.py
@@ -42,7 +42,7 @@ def prep_jid(opts, load):
         os.makedirs(jid_dir)
         serial.dump(load, open(os.path.join(jid_dir, '.load.p'), 'w+'))
     else:
-        return prep_jid(cachedir, load)
+        return prep_jid(opts['cachedir'], load)
     return jid
 
 


### PR DESCRIPTION
### Option to reject a submitted key

salt-key -L

Unaccepted Keys:
`bogus.example.com`
Accepted Keys:
Rejected:

salt-key -r bogus.example.com

salt-key -L

Unaccepted Keys:
Accepted Keys:
Rejected:
`bogus.example.com`
### Log output:

11:25:07,901 [salt.crypt ][CRITICAL] The Salt Master has rejected this minion's public key!
To repair this issue, delete the public key for this minion on the Salt Master and restart this minion.
Or restart the Salt Master in open mode to clean out the keys. The Salt Minion will now exit.
### Option to reject all pending keys:

salt-key -R
