### PR TITLE
Salt is now platform dependent. Use get_python_lib(1)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ NAME = 'salt'
 VER = __version__
 DESC = ('Portable, distributed, remote execution and '
         'configuration management system')
-mod_path = os.path.join(get_python_lib(), 'salt/modules')
+mod_path = os.path.join(get_python_lib(1), 'salt/modules')
 doc_path = os.path.join(PREFIX, 'share/doc', NAME + '-' + VER)
 example_path = os.path.join(doc_path, 'examples')
 template_path = os.path.join(example_path, 'templates')


### PR DESCRIPTION
I believe that after adding the Message Pack salt is no longer noarch. Therefore the mod_path should now be platform dependent and use get_python_lib(1).
