### PR TITLE
More iterative cleanups and a few new features

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -8,11 +8,12 @@ import sys
 
 # Import salt libs
 import salt
+import salt.utils
 import salt.loader
 import salt.minion
 
 # Custom exceptions
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 class Caller(object):
     '''
@@ -31,18 +32,25 @@ class Caller(object):
         Call the module
         '''
         ret = {}
-        if self.opts['fun'] not in self.minion.functions:
-            sys.stderr.write('Function {0} is not available\n'.format(self.opts['fun']))
+        fun = self.opts['fun']
+
+        if fun not in self.minion.functions:
+            sys.stderr.write('Function {0} is not available\n'.format(fun))
             sys.exit(1)
         try:
-            ret['return'] = self.minion.functions[self.opts['fun']](
+            ret['return'] = self.minion.functions[fun](
                     *self.opts['arg']
                     )
         except (TypeError, CommandExecutionError) as exc:
-            sys.stderr.write('Error running \'{0}\': {1}\n'.format(self.opts['fun'], str(exc)))
+            msg = 'Error running \'{0}\': {1}\n'
+            sys.stderr.write(msg.format(yellow, end, fun, str(exc)))
             sys.exit(1)
-        if hasattr(self.minion.functions[self.opts['fun']], '__outputter__'):
-            oput = self.minion.functions[self.opts['fun']].__outputter__
+        except CommandNotFoundError as exc:
+            msg = 'Command not found in \'{0}\': {1}\n'
+            sys.stderr.write(msg.format(fun, str(exc)))
+            sys.exit(1)
+        if hasattr(self.minion.functions[fun], '__outputter__'):
+            oput = self.minion.functions[fun].__outputter__
             if isinstance(oput, str):
                 ret['out'] = oput
         return ret

--- a/salt/config.py
+++ b/salt/config.py
@@ -4,9 +4,10 @@ All salt configuration loading and defaults should be in this module
 
 # Import python modules
 import os
-import tempfile
-import socket
 import sys
+import socket
+import logging
+import tempfile
 
 # import third party libs
 import yaml
@@ -21,6 +22,8 @@ except:
 import salt.crypt
 import salt.loader
 import salt.utils
+
+log = logging.getLogger(__name__)
 
 
 def load_config(opts, path, env_var):
@@ -54,9 +57,10 @@ def load_config(opts, path, env_var):
             opts.update(conf_opts)
             opts['conf_file'] = path
         except Exception, e:
-            print 'Error parsing configuration file: {0} - {1}'.format(path, e)
+            msg = 'Error parsing configuration file: {0} - {1}'
+            log.warn(msg.format(path, e))
     else:
-        print 'Missing configuration file: {0}'.format(path)
+        log.debug('Missing configuration file: {0}'.format(path))
 
 
 def prepend_root_dir(opts, path_options):

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -5,16 +5,16 @@ authenticating peers
 '''
 
 # Import python libs
-import hashlib
-import hmac
-import logging
 import os
 import sys
+import hmac
+import hashlib
+import logging
 import tempfile
 
 # Import Cryptography libs
-from Crypto.Cipher import AES
 from M2Crypto import RSA
+from Crypto.Cipher import AES
 
 # Import zeromq libs
 import zmq
@@ -320,8 +320,8 @@ class SAuth(Auth):
         '''
         creds = self.sign_in()
         if creds == 'retry':
-            print 'Failed to authenticate with the master, verify that this'\
-                + ' minion\'s public key has been accepted on the salt master'
+            log.error('Failed to authenticate with the master, verify that this'\
+                + ' minion\'s public key has been accepted on the salt master')
             sys.exit(2)
         return Crypticle(self.opts, creds['aes'])
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -24,7 +24,7 @@ import zmq
 
 # Import salt libs
 from salt.exceptions import AuthenticationError, MinionError, \
-    CommandExecutionError, SaltInvocationError
+    CommandExecutionError, CommandNotFoundError, SaltInvocationError
 import salt.client
 import salt.crypt
 import salt.loader
@@ -208,6 +208,10 @@ class Minion(object):
         if function_name in self.functions:
             try:
                 ret['return'] = self.functions[data['fun']](*data['arg'])
+            except CommandNotFoundError as exc:
+                msg = 'Command not found in \'{0}\': {1}'
+                log.debug(msg.format(function_name, str(exc)))
+                ret['return'] = msg.format(function_name, str(exc))
             except CommandExecutionError as exc:
                 msg = 'A command in {0} had a problem: {1}'
                 log.error(msg.format(function_name, str(exc)))

--- a/salt/modules/cytest.pyx
+++ b/salt/modules/cytest.pyx
@@ -12,7 +12,6 @@ def echo(text):
     CLI Example:
     salt '*' test.echo 'foo bar baz quo qux'
     '''
-    print 'Echo got called!'
     return text
 
 

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -2,6 +2,11 @@
 Module for gathering disk information
 '''
 
+import logging
+
+log = logging.getLogger(__name__)
+
+
 def __virtual__():
     '''
     Only work on posix-like systems
@@ -34,13 +39,17 @@ def usage():
         if line.startswith('Filesystem'):
             continue
         comps = line.split()
-        ret[comps[5]] = {
-            'filesystem': comps[0],
-            '1K-blocks':  comps[1],
-            'used':       comps[2],
-            'available':  comps[3],
-            'capacity':   comps[4],
-        }
+        try:
+            ret[comps[5]] = {
+                'filesystem': comps[0],
+                '1K-blocks':  comps[1],
+                'used':       comps[2],
+                'available':  comps[3],
+                'capacity':   comps[4],
+            }
+        except IndexError:
+            log.warn("Problem parsing disk usage information")
+            ret = {}
     return ret
 
 def inodeusage():
@@ -71,5 +80,6 @@ def inodeusage():
                 'filesystem': comps[0],
             }
         except IndexError:
-            print "DEBUG: comps='%s'" % comps
+            log.warn("Problem parsing inode usage information")
+            ret = {}
     return ret

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -2,6 +2,7 @@
 Execute puppet routines
 '''
 
+from salt.exceptions import CommandNotFoundError
 
 def _check_puppet():
     '''
@@ -10,7 +11,7 @@ def _check_puppet():
     # I thought about making this a virtual module, but then I realized that I
     # would require the minion to restart if puppet was installed after the
     # minion was started, and that would be rubbish
-    return __salt__['cmd.has_exec']('puppet')
+    return __salt__['cmd.has_exec']('puppetd')
 
 
 def run():
@@ -25,4 +26,18 @@ def run():
     if _check_puppet():
         return __salt__['cmd.run_all']('puppetd --test')
     else:
-        return {}
+        raise CommandNotFoundError("puppetd not available")
+
+def noop():
+    '''
+    Execute a puppet noop run and return a dict with the stderr,stdout,return code
+    etc.
+
+    CLI Example::
+
+        salt '*' puppet.noop
+    '''
+    if _check_puppet():
+        return __salt__['cmd.run_all']('puppetd --test --noop')
+    else:
+        raise CommandNotFoundError("puppetd not available")

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -4,6 +4,11 @@ Execute puppet routines
 
 from salt.exceptions import CommandNotFoundError
 
+__outputter__ = {
+    'run':  'txt',
+    'noop': 'txt',
+}
+
 def _check_puppet():
     '''
     Checks if puppet is installed

--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -800,9 +800,7 @@ def backup(host=None, core_name=None, append_core_to_path=False):
         salt '*' solr.backup music
     '''
     path = __opts__['solr.backup_path']
-    print path
     numBackups = __opts__['solr.num_backups']
-    print numBackups
     if path is not None:
         if not path.endswith(os.path.sep):
             path += os.path.sep
@@ -1027,7 +1025,6 @@ def core_status(host=None, core_name=None):
         return ret
     extra = ['action=STATUS', 'core={0}'.format(core_name)]
     url = _format_url('admin/cores', host=host, core_name=None, extra=extra)
-    print url
     return _http_request(url)
 
 ################### DIH (Direct Import Handler) COMMANDS #####################

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -23,7 +23,6 @@ def echo(text):
 
         salt '*' test.echo 'foo bar baz quo qux'
     '''
-    print 'Echo got called!'
     return text
 
 
@@ -76,8 +75,9 @@ def get_opts():
 # FIXME: mutable types as default parameter values
 def cross_test(func, args=[]):
     '''
-    Execute a minion function via the __salt__ object in the test module, used
-    to verify that the minion functions can be called via the __salt__module
+    Execute a minion function via the __salt__ object in the test
+    module, used to verify that the minion functions can be called
+    via the __salt__ module.
 
     CLI Example::
 
@@ -88,8 +88,8 @@ def cross_test(func, args=[]):
 
 def fib(num):
     '''
-    Return a Fibonacci sequence up to the passed number, and the time it took
-    to compute in seconds. Used for performance tests
+    Return a Fibonacci sequence up to the passed number, and the
+    timeit took to compute in seconds. Used for performance tests
 
     CLI Example::
 
@@ -106,8 +106,9 @@ def fib(num):
 
 def collatz(start):
     '''
-    Execute the collatz conjecture from the passed starting number, returns
-    the sequence and the time it took to compute. Used for performance tests.
+    Execute the collatz conjecture from the passed starting number,
+    returns the sequence and the time it took to compute. Used for
+    performance tests.
 
     CLI Example::
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -145,7 +145,6 @@ def _clean_dir(root, keep):
                 if fn_ == '/':
                     break
     rm_files = []
-    print real_keep
     for roots, dirs, files in os.walk(root):
         for name in files:
             nfn = os.path.join(roots, name)
@@ -259,7 +258,7 @@ def _py(sfn, name, source, user, group, mode, env, context=None):
         trb = traceback.format_exc()
         return {'result': False,
                 'data': trb}
-        
+
 
 def symlink(name, target, force=False, makedirs=False):
     '''

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -59,7 +59,6 @@ def present(
            'result': True,
            'comment': 'User {0} is present and up to date'.format(name)}
 
-    print password
     if __grains__['os'] != 'FreeBSD':
         lshad = __salt__['shadow.info'](name)
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -107,8 +107,9 @@ def daemonize():
         if pid > 0:
             # exit first parent
             sys.exit(0)
-    except OSError, e:
-        print >> sys.stderr, "fork #1 failed: %d (%s)" % (e.errno, e.strerror)
+    except OSError as exc:
+        msg = 'fork #1 failed: {0} ({1})'.format(e.errno, e.strerror)
+        log.error(msg)
         sys.exit(1)
 
     # decouple from parent environment
@@ -120,10 +121,10 @@ def daemonize():
     try:
         pid = os.fork()
         if pid > 0:
-            # print "Daemon PID %d" % pid
             sys.exit(0)
-    except OSError, e:
-        print >> sys.stderr, "fork #2 failed: %d (%s)" % (e.errno, e.strerror)
+    except OSError as exc:
+        msg = 'fork #2 failed: {0} ({1})'
+        log.error(msg.format(e.errno, e.strerror))
         sys.exit(1)
 
     dev_null = open('/dev/null', 'rw')

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -23,4 +23,4 @@ def run():
     for func in __all__:
         if func == "run": continue
         if not globals().get(func)():
-            sys.exit(1)
+            continue


### PR DESCRIPTION
- Add `puppet.noop`
- Start removing spurious prints
- Move valid prints or prints to stderr over to use the logging framework
- Make `salt-call foo.bar` and `salt '*' foobar` properly handle `CommandNotFoundError`
