### PR TITLE
Updated RPM to use 0.9.6 as source

### DIFF
--- a/pkg/rpm/README.fedora
+++ b/pkg/rpm/README.fedora
@@ -1,0 +1,11 @@
+These packages are *optional* dependencies for salt. By default, they are not included in the salt RPMs.
+Install any of these packages to enable the functionality within salt.
+
+MySQL-python 
+libvirt-python 
+python-mako
+pymongo
+python-redis / redis
+
+A semi-canonical list of the optional salt modules can be found at 
+https://github.com/saltstack/salt/blob/develop/doc/conf.py#L30

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -9,8 +9,8 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name: salt
-Version: 0.9.4
-Release: 6%{?dist}
+Version: 0.9.6
+Release: 2%{?dist}
 Summary: A parallel remote execution system
 
 Group:   System Environment/Daemons
@@ -23,6 +23,7 @@ Source3: %{name}-minion
 Source4: %{name}-master.service
 Source5: %{name}-syndic.service
 Source6: %{name}-minion.service
+Source7: README.fedora
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch: noarch
@@ -33,6 +34,7 @@ BuildRequires: python26-crypto
 BuildRequires: python26-devel
 BuildRequires: python26-PyYAML
 BuildRequires: python26-m2crypto
+BuildRequires: python26-msgpack
 
 Requires: python26-crypto
 Requires: python26-zmq
@@ -40,6 +42,7 @@ Requires: python26-jinja2
 Requires: python26-PyYAML
 Requires: python26-m2crypto
 Requires: python26-PyXML
+Requires: python26-msgpack
 
 %else
 
@@ -48,6 +51,7 @@ BuildRequires: python-crypto
 BuildRequires: python-devel
 BuildRequires: PyYAML
 BuildRequires: m2crypto
+BuildRequires: python-msgpack
 
 Requires: python-crypto
 Requires: python-zmq
@@ -55,6 +59,7 @@ Requires: python-jinja2
 Requires: PyYAML
 Requires: m2crypto
 Requires: PyXML
+Requires: python-msgpack
 
 %endif
 
@@ -71,7 +76,7 @@ BuildRequires: systemd-units
 
 %endif
 
-Requires: MySQL-python libvirt-python yum
+#Requires: MySQL-python libvirt-python yum
 
 %description
 Salt is a distributed remote execution system used to execute commands and 
@@ -119,6 +124,11 @@ install -p -m 0644 %{SOURCE4} $RPM_BUILD_ROOT%{_unitdir}/
 install -p -m 0644 %{SOURCE5} $RPM_BUILD_ROOT%{_unitdir}/
 install -p -m 0644 %{SOURCE6} $RPM_BUILD_ROOT%{_unitdir}/
 %endif
+
+install -p %{SOURCE7} .
+
+install -p -m 0640 %{_sysconfdir}/minion.template $RPM_BUILD_ROOT%{_sysconfdir}/minion
+install -p -m 0640 %{_sysconfdir}/master.template $RPM_BUILD_ROOT%{_sysconfdir}/master
  
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -129,6 +139,7 @@ rm -rf $RPM_BUILD_ROOT
 %{python_sitelib}/%{name}/*
 %{python_sitelib}/%{name}-%{version}-py?.?.egg-info
 %doc %{_mandir}/man7/salt.7.*
+%doc README.fedora
 
 %files -n salt-minion
 %defattr(-,root,root)
@@ -143,7 +154,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_unitdir}/salt-minion.service
 %endif
 
-%config(noreplace) /etc/salt/minion
+%config(noreplace) %{_sysconfdir}/salt/minion
 
 %files -n salt-master
 %defattr(-,root,root)
@@ -166,7 +177,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_unitdir}/salt-master.service
 %{_unitdir}/salt-syndic.service
 %endif
-%config(noreplace) /etc/salt/master
+%config(noreplace) %{_sysconfdir}/salt/master
 
 %if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
 
@@ -242,6 +253,12 @@ fi
 %endif
 
 %changelog
+* Tue Jan 24 2012 Clint Savage <herlo1@gmail.com> - 0.9.6-2
+- Added README.fedora and removed deps for optional modules
+
+* Sat Jan 21 2012 Clint Savage <herlo1@gmail.com> - 0.9.6-1
+- New upstream release
+
 * Sun Jan 8 2012 Clint Savage <herlo1@gmail.com> - 0.9.4-6
 - Missed some critical elements for SysV and rpmlint cleanup
 


### PR DESCRIPTION
Updated RPM to use 0.9.6 as source, added README.fedora for reference to optional libs which can be installed.
