### PR TITLE
Implement support for granting/revoking mysql permissions.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -189,7 +189,7 @@ def db_list():
 
     CLI Example::
 
-        salt '*' mysqldb.db_list
+        salt '*' mysql.db_list
     '''
     ret = []
     db = connect()
@@ -208,7 +208,7 @@ def db_tables(name):
 
     CLI Example::
 
-        salt '*' mysqldb.db_tables 'database'
+        salt '*' mysql.db_tables 'database'
     '''
     if not db_exists(name):
        log.info("Database '{0}' does not exist".format(name,))
@@ -233,7 +233,7 @@ def db_exists(name):
 
     CLI Example::
 
-        salt '*' mysqldb.db_exists 'dbname'
+        salt '*' mysql.db_exists 'dbname'
     '''
     db = connect()
     cur = db.cursor()
@@ -252,7 +252,7 @@ def db_create(name):
 
     CLI Example::
 
-        salt '*' mysqldb.db_create 'dbname'
+        salt '*' mysql.db_create 'dbname'
     '''
     # check if db exists
     if db_exists(name):
@@ -275,7 +275,7 @@ def db_remove(name):
 
     CLI Example::
 
-        salt '*' mysqldb.db_remove 'dbname'
+        salt '*' mysql.db_remove 'dbname'
     '''
     # check if db exists
     if not db_exists(name):
@@ -309,7 +309,7 @@ def user_list():
 
     CLI Example::
 
-        salt '*' mysqldb.user_list
+        salt '*' mysql.user_list
     '''
     db = connect()
     cur = db.cursor(MySQLdb.cursors.DictCursor)
@@ -325,7 +325,7 @@ def user_exists(user,
 
     CLI Example::
 
-        salt '*' mysqldb.user_exists 'username' 'hostname'
+        salt '*' mysql.user_exists 'username' 'hostname'
     '''
     db = connect()
     cur = db.cursor()
@@ -343,7 +343,7 @@ def user_info(user,
 
     CLI Example::
 
-        salt '*' mysqldb.user_info root localhost
+        salt '*' mysql.user_info root localhost
     '''
     db = connect()
     cur = db.cursor (MySQLdb.cursors.DictCursor)
@@ -362,7 +362,7 @@ def user_create(user,
 
     CLI Example::
 
-        salt '*' mysqldb.user_create 'username' 'hostname' 'password'
+        salt '*' mysql.user_create 'username' 'hostname' 'password'
     '''
     if user_exists(user,host):
        log.info("User '{0}'@'{1}' already exists".format(user,host,))
@@ -392,7 +392,7 @@ def user_chpass(user,
 
     CLI Example::
 
-        salt '*' mysqldb.user_chpass frank localhost newpassword
+        salt '*' mysql.user_chpass frank localhost newpassword
     '''
     if password is None:
        log.error('No password provided')
@@ -410,13 +410,13 @@ def user_chpass(user,
     return False
 
 def user_remove(user,
-               host='localhost'):
+                host='localhost'):
     '''
     Delete MySQL user
 
     CLI Example::
 
-        salt '*' mysqldb.user_remove frank localhost
+        salt '*' mysql.user_remove frank localhost
     '''
     db = connect()
     cur = db.cursor ()
@@ -441,7 +441,7 @@ def db_check(name,
 
     CLI Example::
 
-        salt '*' mysqldb.db_check dbname
+        salt '*' mysql.db_check dbname
     '''
     ret = []
     if table is None:
@@ -462,7 +462,7 @@ def db_repair(name,
 
     CLI Example::
 
-        salt '*' mysqldb.db_repair dbname
+        salt '*' mysql.db_repair dbname
     '''
     ret = []
     if table is None:
@@ -483,7 +483,7 @@ def db_optimize(name,
 
     CLI Example::
 
-        salt '*' mysqldb.db_optimize dbname
+        salt '*' mysql.db_optimize dbname
     '''
     ret = []
     if table is None:
@@ -496,3 +496,105 @@ def db_optimize(name,
         log.info("Optimizing table '%s' in db '%s'..".format(name,table,))
         ret = __optimize_table(name,table)
     return ret
+
+'''
+Grants
+'''
+def __grant_generate(grant, 
+                    database, 
+                    user, 
+                    host='localhost'):
+    # todo: Re-order the grant so it is according to the SHOW GRANTS for xxx@yyy query (SELECT comes first, etc)
+    grant = grant.replace(',', ', ').upper()
+    
+    db_part = database.partition('.')
+    db = db_part[0]
+    table = db_part[2]
+    
+    query = "GRANT %s ON `%s`.`%s` TO '%s'@'%s'" % (grant, db, table, user, host,)
+    log.debug("Query generated: {0}".format(query,))
+    return query      
+    
+def user_grants(user, 
+                host='localhost'):
+    '''
+    Shows the grants for the given MySQL user (if it exists)
+
+    CLI Example::
+
+        salt '*' mysql.user_grants 'frank' 'localhost'
+    '''
+    if not user_exists(user):
+       log.info("User '{0}' does not exist".format(user,))
+       return False
+
+    ret = []
+    db = connect()
+    cur = db.cursor()
+    query = "SHOW GRANTS FOR '%s'@'%s'" % (user,host,)
+    log.debug("Doing query: {0}".format(query,))
+
+    cur.execute(query)
+    results = cur.fetchall()
+    for grant in results:
+       ret.append(grant[0])
+    log.debug(ret)
+    return ret
+
+def grant_exists(grant, 
+                database, 
+                user, 
+                host='localhost'):
+    # todo: This function is a bit tricky, since it requires the ordering to be exactly the same.
+    # perhaps should be replaced/reworked with a better/cleaner solution.
+    target = __grant_generate(grant, database, user, host)
+    
+    if target in user_grants(user, host):
+        log.debug("Grant exists.")
+        return True       
+    
+    log.debug("Grant does not exist, or is perhaps not ordered properly?")
+    return False   
+
+def grant_add(grant,
+              database, 
+              user, 
+              host='localhost'):
+    '''
+    Adds a grant to the MySQL server.
+
+    CLI Example::
+
+        salt '*' mysql.grant_add 'SELECT|INSERT|UPDATE|...' 'database.*' 'frank' 'localhost'
+    '''
+    # todo: validate grant
+    db = connect()
+    cur = db.cursor()
+    
+    query = __grant_generate(grant, database, user, host)
+    log.debug("Query: {0}".format(query,))
+    if cur.execute( query ):
+       log.info("Grant '{0}' created")
+       return True
+    return False
+
+def grant_revoke(grant, 
+                 database, 
+                 user, 
+                 host='localhost'):
+    '''
+    Removes a grant from the MySQL server.
+
+    CLI Example::
+
+        salt '*' mysql.grant_revoke 'SELECT,INSERT,UPDATE' 'database.*' 'frank' 'localhost'
+    '''
+    # todo: validate grant
+    db = connect() 
+    cur = db.cursor()     
+    query = "REVOKE %s ON %s FROM '%s'@'%s';" % (grant, database, user, host,)
+    log.debug("Query: {0}".format(query,))
+    if cur.execute( query ):
+       log.info("Grant '{0}' revoked")
+       return True
+    return False

--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -1,0 +1,71 @@
+'''
+MySQL Grant Management
+=====================
+The mysql_grants module is used to grant and revoke MySQL permissions
+
+.. code-block:: yaml
+
+   frank_exampledb:
+      mysql_user:
+       - present
+       - grant: select,insert,update
+       - database: exampledb
+       - user: frank
+       - host: localhost
+'''
+
+def present(name,
+		    grant=None,
+			database=None,
+			user=None,
+			host='localhost'):
+    '''
+    Ensure that the grant is present with the specified properties
+
+    name
+        The name (key) of the grant to add
+    '''    
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Grant {0} for {1}@{2} on {3} is already present'.format(grant,user,host,database,)}
+    # check if grant exists
+    if __salt__['mysql.grant_exists'](grant,database,user,host):
+        return ret        
+
+    # The grant is not present, make it!
+    if __salt__['mysql.grant_add'](grant,database,user,host)
+        ret['comment'] = 'Grant {0} for {1}@{2} on {3} has been added'.format(grant,user,host,database,)
+        ret['changes'][name] = 'Present'
+    else:
+        ret['comment'] = 'Failed to grant {0} for {1}@{2} on {3}'.format(grant,user,host,database,)
+        ret['result'] = False
+    return ret
+
+
+def absent(name,
+		   grant=None,
+		   database=None,
+		   user=None,
+           host='localhost'):
+    '''
+    Ensure that the grant is absent
+
+    name
+        The name (key) of the grant to revoke
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    #check if db exists and remove it
+    if __salt__['mysql.grant_exists'](grant,database,user,host,):
+        if __salt__['mysql.grant_revoke'](grant,database,user,host):
+            ret['comment'] = 'Grant {0} for {1}@{2} on {3} has been revoked'.format(grant,user,host,database,)
+            ret['changes'][name] = 'Absent'
+            return ret
+        
+    # fallback
+    ret['comment'] = 'Grant {0} for {1}@{2} on {3} is not present, so it cannot be revoked'.format(grant,user,host,database,)
+    return ret


### PR DESCRIPTION
Added support for GRANT/REVOKE in module & states. 
There is one minor thing that should be improved and that is the grant exists verification part. 
Right now it requires to be exactly as the "SHOW GRANTS FOR" query is showing.

E.g:
Checking if someone has `insert,select` will return a false even if they have `select,insert`(which is what mysql makes it to be when you grant a permission)

Perhaps someone has an idea on how to do this properly or who can implement this.
