### PR TITLE
State-related documentation changes

### DIFF
--- a/doc/ref/states/highstate.rst
+++ b/doc/ref/states/highstate.rst
@@ -59,6 +59,9 @@ ID declaration
 
         Occurs on the top level or under the :term:`extend declaration`.
 
+        Must **not** contain a dot, otherwise highstate summary output will be
+        unpredictable.
+
 Extend declaration
 ------------------
 

--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -61,5 +61,5 @@ A State Module must return a dict containing the following keys/values:
   has one key for each package changed, with the "old" and "new" keys in its
   sub-dict containing the old and new versions of the package.
 - **result:** A boolean value. *True* if the action was successful, otherwise
-  *False*
+  *False*.
 - **comment:** A string containing a summary of the result.

--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -14,7 +14,6 @@ passed to the SLS data structures will map directly to the states modules.
 Mapping the information from the SLS data is simple, this example should
 illustrate:
 
-SLS file
 .. code-block:: yaml
 
     /etc/salt/master: # maps to "name"
@@ -35,11 +34,11 @@ directly define the user interface.
 Cross Calling Modules
 =====================
 
-As with Execution Modules State Modules can also make use of the ``__salt__``
+As with Execution Modules, State Modules can also make use of the ``__salt__``
 and ``__grains__`` data.
 
-It is important to note, that the real work of state management should not be
-done in the state module unless it is needed, a good example is the pkg state
+It is important to note that the real work of state management should not be
+done in the state module unless it is needed. A good example is the pkg state
 module. This module does not do any package management work, it just calls the
 pkg execution module. This makes the pkg state module completely generic, which
 is why there is only one pkg state module and many backend pkg execution
@@ -49,3 +48,18 @@ On the other hand some modules will require that the logic be placed in the
 state module, a good example of this is the file module. But in the vast
 majority of cases this is not the best approach, and writing specific
 execution modules to do the backend work will be the optimal solution.
+
+Return Data
+===========
+
+A State Module must return a dict containing the following keys/values:
+
+- **name:** The same value passed to the state as "name".
+- **changes:** A dict describing the changes made. Each thing changed should
+  be a key, with its value being another dict with keys called "old" and "new"
+  containing the old/new values. For example, the pkg state's **changes** dict
+  has one key for each package changed, with the "old" and "new" keys in its
+  sub-dict containing the old and new versions of the package.
+- **result:** A boolean value. *True* if the action was successful, otherwise
+  *False*
+- **comment:** A string containing a summary of the result.

--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -81,6 +81,9 @@ In this case it defines the name of the package to be installed. **NOTE:** the
 package name for the Apache httpd web server may differ on your OS or distro —
 for example, on Fedora it is ``httpd`` but on Debian/Ubuntu it is ``apache2``.
 
+Additionally, an ID declaration should not contain a dot, as this will produce
+unpredictable output in the summary returned from a highstate.
+
 The second line, called the :term:`state declaration`, defines which of the
 Salt States we are using. In this example, we are using the :mod:`pkg state
 <salt.states.pkg>` to ensure that a given package is installed.

--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -82,7 +82,8 @@ package name for the Apache httpd web server may differ on your OS or distro —
 for example, on Fedora it is ``httpd`` but on Debian/Ubuntu it is ``apache2``.
 
 Additionally, an ID declaration should not contain a dot, as this will produce
-unpredictable output in the summary returned from a highstate.
+unpredictable output in the summary returned from a call to
+:func:`state.highstate <salt.modules.state.highstate>`.
 
 The second line, called the :term:`state declaration`, defines which of the
 Salt States we are using. In this example, we are using the :mod:`pkg state


### PR DESCRIPTION
[output.py](https://github.com/saltstack/salt/blob/develop/salt/output.py#L74) separates state name, ID declaration, etc. from a string which is delimited by dots. Putting dots in an ID declaration will result in odd output in the highstate summary.

Also, added documentation on the type of data which must be returned from a state module.
