### PR TITLE
add logging to salt-key using salt logging framework.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -487,11 +487,12 @@ class SaltKey(object):
                 default=False,
                 action='store_true',
                 help='Supress output')
-
-        parser.add_option('--outfile',
-                dest='outfile',
-                default=None,
-                help='Send all output to a file.')
+        
+        parser.add_option('--logfile',
+                dest='logfile',
+                default='/var/log/salt/key.log',
+                help=('Send all output to a file. '
+                      'Default is /var/log/salt/key.log'))
 
         parser.add_option('--gen-keys',
                 dest='gen_keys',
@@ -524,7 +525,10 @@ class SaltKey(object):
         opts = {}
 
         opts['quiet'] = options.quiet
-        opts['outfile'] = options.outfile
+        opts['logfile'] = options.logfile
+        # I decided to always set this to info, since it really all is info or
+        # error.
+        opts['loglevel'] = 'info'
         opts['list'] = options.list_
         opts['list_all'] = options.list_all
         opts['accept'] = options.accept
@@ -536,6 +540,7 @@ class SaltKey(object):
         opts['delete'] = options.delete
         opts['gen_keys'] = options.gen_keys
         opts['gen_keys_dir'] = options.gen_keys_dir
+        opts['outfile'] = 'turd'
         if options.keysize < 2048:
             opts['keysize'] = 2048
         else:
@@ -549,6 +554,9 @@ class SaltKey(object):
         '''
         Execute saltkey
         '''
+        import salt.log
+        salt.log.setup_logfile_logger(self.opts['logfile'], 
+                                      self.opts['loglevel'])
         key = salt.cli.key.Key(self.opts)
         key.run()
 


### PR DESCRIPTION
Updated salt-key to log actions related to accept/delete/reject of keys.  Default log path is /var/log/salt/key.log, but can be changed with --logfile option at command line, or by setting opts['logfile'].
