### PR TITLE
fix crash bug in linux_sysctl.assign() on Virtuozzo containers

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -65,6 +65,8 @@ def assign(name, value):
     cmd = 'sysctl -w {0}={1}'.format(name, value)
     ret = {}
     out = __salt__['cmd.run'](cmd).strip()
+    if ' = ' not in out:
+        raise CommandExecutionError('sysctl -w failed: {0}'.format(out))
     comps = out.split(' = ')
     ret[comps[0]] = comps[1]
     return ret


### PR DESCRIPTION
On systems like Virtuozzo containers, "sysctl -w" is not allowed, ever, and will fail with EPERM errors even if one is root.  Since assign() doesn't check exit status or the returned string, this leads to a nasty-looking stack trace.
