### PR TITLE
Change kvm_hyper __virtual__ to use libvirt instead of ps

### DIFF
--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -40,10 +40,13 @@ def __virtual__():
         return False
     if 'kvm_' not in open('/proc/modules').read():
         return False
-    libvirt_ret = __salt__['cmd.run'](__grains__['ps']).count('libvirtd')
-    if not libvirt_ret:
+    #libvirt_ret = __salt__['cmd.run'](__grains__['ps']).count('libvirtd')
+    try:
+        libvirt_conn = libvirt.open('qemu:///system')
+        libvirt_conn.close()
+        return 'hyper'
+    except:
         return False
-    return 'hyper'
 
 
 def __get_conn():


### PR DESCRIPTION
kvm_hyper.py was causing minion to crash due to a module cross call before **virtual** returned.  Updated the **virtual** function to detect if the localsystem is running libvirtd by attempting to connect to libvirtd instead of using ps to look for the process.  If connection in successful it returns 'hyper', otherwise returns False.
