### PR TITLE
Split package that doesn't autodep everything

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,15 @@
+salt (0.9.7~pre2-0ppa1) lucid; urgency=low
+
+  * Fix arch and deps issue
+
+ -- Corey Quinn <corey@sequestered.net>  Wed, 08 Feb 2012 17:22:47 -0800
+
+salt (0.9.7~pre1-0ppa1) lucid; urgency=low
+
+  * Version bump, fixed a few issues
+
+ -- Corey Quinn <corey@sequestered.net>  Wed, 08 Feb 2012 16:35:59 -0800
+
 salt (0.9.6-1) lucid; urgency=low
 
   *  Bump version; time to upgrade

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,6 @@ Build-Depends: debhelper (>= 7.0.50~),
                python-m2crypto,
                python-zmq (>= 2.1.9),
                libzmq-dev (>= 2.1.9),
-               python-all-dev,
                python-jinja2
 Standards-Version: 3.9.2
 Homepage: http://saltstack.org
@@ -19,19 +18,15 @@ Homepage: http://saltstack.org
 
 
 Package: salt-common
-Architecture: any
+Architecture: all
 Depends: ${python:Depends},
          ${misc:Depends},
          ${shlibs:Depends},
-         cython,
-         python-setuptools,
          python-yaml,
          python-crypto,
          python-m2crypto,
          python-zmq (>= 2.1.9),
-         libzmq-dev (>= 2.1.9),
          python,
-         python-dev,
          python-jinja2,
          msgpack-python
 Description: Shared libraries that salt requires for all packages

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://dep.debian.net/deps/dep5
 Upstream-Name: salt
 Upstream-Contact: salt-users@googlegroups.com
-Source: https://github.com/downloads/saltstack/salt/salt-0.9.6.tar.gz
+Source: https://github.com/downloads/saltstack/salt/salt-0.9.7.tar.gz
 
 Files: *
 Copyright: 2012 Thomas S Hatch <thatch45@gmail.com>

--- a/debian/rules
+++ b/debian/rules
@@ -2,10 +2,10 @@
 #export DH_VERBOSE=1
 %:
 	dh $@ #--with python2
-#dh_override_auto_build:
+dh_override_auto_build:
 	python setup.py build #--install-layout=deb build
 get-orig-source:
 	git clone https://github.com/saltstack/salt.git
-	mv salt salt-0.9.6
-	tar -zcvf salt_0.9.6.orig.tar.gz --exclude "debian*" --exclude-vcs salt-0.9.6
-	rm -rf salt-0.9.6
+	mv salt salt-0.9.7
+	tar -zcvf salt_0.9.7.orig.tar.gz --exclude "debian*" --exclude-vcs salt-0.9.7
+	rm -rf salt-0.9.7


### PR DESCRIPTION
This now makes for a less painful installation.  Build is queued on launchpad.
