### PR TITLE
Fixed freebsdpkg install() method to accept a non-keyworded argument list

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -85,7 +85,7 @@ def refresh_db():
         __salt__['cmd.run']('portsnap update')
 
 
-def install(name, **kwargs):
+def install(name, *args, **kwargs):
     '''
     Install the passed package
 


### PR DESCRIPTION
I was having problems running a .sls that required installing packages on minions with FreeBSD 9.0, Salt 0.9.7.  I noticed that the install method was not accepting all the arguments being passed to it. This did the trick. 
