### PR TITLE
Adding documention to delete a minion key

### DIFF
--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -73,6 +73,10 @@ Reject the named minion public key.
 .TP
 .B \-R, \-\-reject\-all
 Rejects all pending public keys.
+.INDENT 0.0
+.TP
+.B \-d, \-\-delete=DELETE
+Delete the named minion public key for command execution.
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
Does the -D flag in salt-key delete all minion keys? I can add this too.
