### PR TITLE
Fix bug where only the last extend across a highstate was realized.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1054,6 +1054,12 @@ class HighState(object):
             mods = set()
             for sls in states:
                 state, mods, err = self.render_state(sls, env, mods)
+                if '__extend__' in state:
+                    ext = state.pop('__extend__')
+                    if '__extend__' in highstate:
+                        highstate['__extend__'].extend(ext)
+                    else:
+                        highstate['__extend__'] = ext
                 for id_ in state:
                     if id_ in highstate:
                         if highstate[id_] != state[id_]:


### PR DESCRIPTION
This bug also exited in 0.9.7. The highstate.update(state) overwrote previous **extend** members of the highstate dict.
