### PR TITLE
syndic_cmd malforms loads to 'glob' type

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -493,15 +493,15 @@ class Syndic(salt.client.LocalClient, Minion):
         '''
         Take the now clear load and forward it on to the client cmd
         '''
-        # Set up default expr_form
-        if 'expr_form' not in data:
-            data['expr_form'] = 'glob'
+        # Set up default tgt_type
+        if 'tgt_type' not in data:
+            data['tgt_type'] = 'glob'
         # Send out the publication
         pub_data = self.pub(
                 data['tgt'],
                 data['fun'],
                 data['arg'],
-                data['expr_form'],
+                data['tgt_type'],
                 data['ret'],
                 data['jid'],
                 data['to']


### PR DESCRIPTION
syndic_cmd looks for the expr_form key in the upstream data, it never finds it since that key name doesn't exist in the payload.  It then sets a default (glob) and feeds this to pub() as a positional argument.  This effectively squashes all expression forms to glob when the syndication master passes them along.
