### PR TITLE
Enhanced Logging For Executing User

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -836,7 +836,12 @@ class ClearFuncs(object):
                 'tgt': clear_load['tgt'],
                 'jid': clear_load['jid'],
                 'ret': clear_load['ret'],
+                'user': clear_load['user'],
                }
+
+        log.info('{0[user]} published command {0[fun]} with jid {0[jid]}'.format(load))
+        log.debug('Published command details {0}'.format(load))
+
         if 'tgt_type' in clear_load:
             load['tgt_type'] = clear_load['tgt_type']
         if 'to' in clear_load:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -159,7 +159,8 @@ class Minion(object):
         # from returning a predictable exception
         #if data['fun'] not in self.functions:
         #    return
-        log.debug('Executing command {0[fun]} with jid {0[jid]}'.format(data))
+        log.info('{0[user]} executed command {0[fun]} with jid {0[jid]}'.format(data))
+        log.debug('Command details {0}'.format(data))
         self._handle_decoded_payload(data)
 
     def _handle_pub(self, load):
@@ -471,8 +472,9 @@ class Syndic(salt.client.LocalClient, Minion):
            or 'to' not in data or 'arg' not in data:
             return
         data['to'] = int(data['to']) - 1
-        log.debug(('Executing syndic command {0[fun]} with jid {0[jid]}'
-                  .format(data)))
+        log.info(('{0[user]} executed syndic command {0[fun]} with jid {0[jid]}'
+                 .format(data)))
+        log.debug('Command details {0}'.format(data))
         self._handle_decoded_payload(data)
 
     def _handle_decoded_payload(self, data):


### PR DESCRIPTION
Track the executing user and do some best effort work to figure out who
it is based on environment variables.  Pass the user in the payload
and allow for logging of the user in the summary information about 
the job.  Move the job summary up to info, move a full dump of the job
payload to debug.
The info level messages will tell a local user that's trying to figure out
"what happened" and the raw dump helps dramatically in actually trying
to figure out what's really being passed around.
