### PR TITLE
Add Local Logging of User When Necessary

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -94,6 +94,11 @@ class LocalClient(object):
             for evar in env_vars:
                 if evar in os.environ:
                     return os.environ[evar]
+            return None
+        # If the running user is just the specified user in the
+        # conf file, don't pass the user as it's implied.
+        elif user == self.opts['user']:
+          return None
         return user
 
     def _check_glob_minions(self, expr):
@@ -454,31 +459,27 @@ class LocalClient(object):
         if not minions:
             return {'jid': '',
                     'minions': minions}
+
+        # Generate the standard keyword args to feed to format_payload
+        payload_kwargs = { 'cmd': 'publish',
+                           'tgt': tgt,
+                           'fun': fun,
+                           'arg': arg,
+                           'key': self.key,
+                           'tgt_type': expr_form,
+                           'ret': ret,
+                           'jid': jid }
+
+        # If we have a salt user, add it to the payload
+        if self.salt_user:
+            payload_kwargs['user'] = self.salt_user
+
+        # If we're a syndication master, pass the timeout
         if self.opts['order_masters']:
-            package = salt.payload.format_payload(
-                    'clear',
-                    cmd='publish',
-                    tgt=tgt,
-                    fun=fun,
-                    arg=arg,
-                    key=self.key,
-                    tgt_type=expr_form,
-                    ret=ret,
-                    jid=jid,
-                    user=self.salt_user,
-                    to=timeout)
-        else:
-            package = salt.payload.format_payload(
-                    'clear',
-                    cmd='publish',
-                    tgt=tgt,
-                    fun=fun,
-                    arg=arg,
-                    key=self.key,
-                    tgt_type=expr_form,
-                    jid=jid,
-                    user=self.salt_user,
-                    ret=ret)
+            payload_kwargs['to'] = timeout
+
+        package = salt.payload.format_payload( 'clear', **payload_kwargs)
+
         # Prep zmq
         context = zmq.Context()
         socket = context.socket(zmq.REQ)

--- a/salt/master.py
+++ b/salt/master.py
@@ -857,6 +857,7 @@ class ClearFuncs(object):
         if 'user' in clear_load:
             log.info(('User {0[user]} Published command {0[fun]} with jid'
                       ' {0[jid]}').format(clear_load))
+            load['user'] = clear_load['user']
         else:
             log.info(('Published command {0[fun]} with jid'
                       ' {0[jid]}').format(clear_load))

--- a/salt/master.py
+++ b/salt/master.py
@@ -854,8 +854,12 @@ class ClearFuncs(object):
         if 'to' in clear_load:
             load['to'] = clear_load['to']
 
-        log.info(('User {0[user]} Published command {0[fun]} with jid'
-                  ' {0[jid]}').format(clear_load))
+        if 'user' in clear_load:
+            log.info(('User {0[user]} Published command {0[fun]} with jid'
+                      ' {0[jid]}').format(clear_load))
+        else:
+            log.info(('Published command {0[fun]} with jid'
+                      ' {0[jid]}').format(clear_load))
         log.debug('Published command details {0}'.format(load))
 
         payload['load'] = self.crypticle.dumps(load)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -159,7 +159,12 @@ class Minion(object):
         # from returning a predictable exception
         #if data['fun'] not in self.functions:
         #    return
-        log.info('Executing command {0[fun]} with jid {0[jid]}'.format(data))
+        if 'user' in data:
+            log.info(('User {0[user]} Executing command {0[fun]} with jid '
+                '{0[jid]}'.format(data)))
+        else:
+            log.info(('Executing command {0[fun]} with jid {0[jid]}'
+                .format(data)))
         log.debug('Command details {0}'.format(data))
         self._handle_decoded_payload(data)
 
@@ -472,9 +477,13 @@ class Syndic(salt.client.LocalClient, Minion):
            or 'to' not in data or 'arg' not in data:
             return
         data['to'] = int(data['to']) - 1
-        log.debug(('Executing syndic command {0[fun]} with jid {0[jid]}'
-            .format(data)))
-        log.debug('Command details {0}'.format(data))
+        if 'user' in data:
+            log.debug(('User {0[user]} Executing syndic command {0[fun]} with '
+                'jid {0[jid]}'.format(data)))
+        else:
+            log.debug(('Executing syndic command {0[fun]} with jid {0[jid]}'
+                .format(data)))
+        log.debug('Command details: {0}'.format(data))
         self._handle_decoded_payload(data)
 
     def _handle_decoded_payload(self, data):


### PR DESCRIPTION
Modification to pull #777 that'll only pass the user when necessary (when not implied) and will protect the minions from bombing out if the master does not pass a user (old master or implied user).  Also some minor cleanup on the way keyword args are passed to the format payload command.
