### PR TITLE
fixed link to freebsd installation tutorial

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -60,7 +60,7 @@ truly make it work for you.
 .. sidebar:: More tutorials!
 
     * :doc:`Bootstraping Salt on EC2 <topics/tutorials/bootstrap_ec2>`
-    * :doc:`Installing Salt on FreeBSD <topics/tutorials/freebsd>`
+    * :doc:`Installing Salt on FreeBSD <topics/installation/freebsd>`
 
 .. contents:: The components of Salt
     :local:


### PR DESCRIPTION
installation tutorials got moved into topics/installation. fixed link in content.
