### PR TITLE
standardized install docs for code-blocks

### DIFF
--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -18,7 +18,9 @@ currently stable and -git packages available.
 Stable Release
 --------------
 
-To install Salt stable releases from the Arch Linux AUR, use the commands::
+To install Salt stable releases from the Arch Linux AUR, use the commands:
+
+.. code-block:: bash
 
     wget https://aur.archlinux.org/packages/sa/salt/salt.tar.gz
     tar xf salt.tar.gz
@@ -39,7 +41,7 @@ currently relies on the following packages only available via the AUR:
 
     The command to install salt using the yaourt tool is:
 
-    .. code-block:: none
+    .. code-block:: bash
 
         yaourt salt
 
@@ -49,7 +51,9 @@ Tracking develop
 ----------------
 
 To install the bleeding edge version of Salt (**may include bugs!**), you can use
-the -git package. Installing the -git package can be done using the commands::
+the -git package. Installing the -git package can be done using the commands:
+
+.. code-block:: bash
 
     wget https://aur.archlinux.org/packages/sa/salt-git/salt-git.tar.gz
     tar xf salt-git.tar.gz
@@ -70,7 +74,7 @@ currently relies on the following packages only available via the AUR:
 
     The command to install salt using the yaourt tool is:
 
-    .. code-block:: none
+    .. code-block:: bash
 
         yaourt salt-git
 
@@ -82,9 +86,12 @@ Configuration
 In the sections below I'll outline configuration options for both the Salt
 Master and Salt Minions.
 
-The Salt package installs two template configuration files, /etc/salt/master.template and
-/etc/salt/minion.template. You'll need to copy these .template files into place and
-make a few edits. First, copy them into place as seen here::
+The Salt package installs two template configuration files,
+``/etc/salt/master.template`` and ``/etc/salt/minion.template``. You'll need
+to copy these .template files into place and make a few edits. First, copy
+them into place as seen here:
+
+.. code-block:: bash
 
    cp /etc/salt/master.template /etc/salt/master
    cp /etc/salt/minion.template /etc/salt/minion
@@ -107,22 +114,30 @@ configuration paths.
 
 By default the Salt master listens on ports 4505 and 4506 on all interfaces
 (0.0.0.0). If you have a need to bind Salt to a specific IP, redefine the
-"interface" directive as seen here::
+"interface" directive as seen here:
+
+.. code-block:: diff
 
    - #interface: 0.0.0.0
    + interface: 10.0.0.1
 
 **rc.conf**
 
-Last but not least you'll need to activate the Salt Master in your rc.conf
-file. Using your favorite editor, open /etc/rc.conf and add the salt-master::
+You'll need to activate the Salt Master in your rc.conf file. Using your
+favorite editor, open ``/etc/rc.conf`` and add the  salt-master.
+
+.. code-block:: diff
 
     -DAEMONS=(syslog-ng network crond)
     +DAEMONS=(syslog-ng network crond @salt-master)
 
+**Start the Master**
+
 Once you've completed all of these steps you're ready to start your Salt
 Master. You should be able to start your Salt Master now using the command
-seen here::
+seen here:
+
+.. code-block:: bash
 
     rc.d start salt-master
 
@@ -145,7 +160,9 @@ this you likely can do without any minion configuration at all.
 
 If you are not able to update DNS, you'll simply need to update one entry in
 the configuration file. Using your favorite editor, open the minion
-configuration file and update the "master" entry as seen here::
+configuration file and update the "master" entry as seen here.
+
+.. code-block:: diff
 
    - #master: salt
    + master: 10.0.0.1
@@ -157,15 +174,20 @@ configuration options are covered in another chapter.
 **rc.conf**
 
 Before you're able to start the Salt Minion you'll need to update your rc.conf
-file. Using your favorite editor open /etc/rc.conf or /etc/rc.conf.local and
-add this line::
+file. Using your favorite editor open ``/etc/rc.conf`` and add this line:
+
+.. code-block:: diff
 
     -DAEMONS=(syslog-ng network crond)
     +DAEMONS=(syslog-ng network crond @salt-minion)
 
+**Start the Minion**
+
 Once you've completed all of these steps you're ready to start your Salt
 Minion. You should be able to start your Salt Minion now using the command
-seen here::
+seen here:
+
+.. code-block:: bash
 
     rc.d start salt-minion
 
@@ -192,28 +214,32 @@ only done through trusted, accepted keys.
 
 Before you'll be able to do any remote execution or configuration management you'll
 need to accept any pending keys on the Master. Run the ``salt-key`` command to
-list the keys known to the Salt Master::
+list the keys known to the Salt Master.
+
+.. code-block:: bash
 
    [root@master ~]# salt-key -L
    Unaccepted Keys:
-   avon
-   bodie
-   bubbles
-   marlo
+   alpha
+   bravo
+   charlie
+   delta
    Accepted Keys:
 
 This example shows that the Salt Master is aware of four Minions, but none of
 the keys have been accepted. To accept the keys and allow the Minions to be
-controlled by the Master, again use the ``salt-key`` command::
+controlled by the Master, again use the ``salt-key`` command:
+
+.. code-block:: bash
 
    [root@master ~]# salt-key -A
    [root@master ~]# salt-key -L
    Unaccepted Keys:
    Accepted Keys:
-   avon
-   bodie
-   bubbles
-   marlo
+   alpha
+   bravo
+   charlie
+   delta
 
 The ``salt-key`` command allows for signing keys individually or in bulk. The
 example above, using ``-A`` bulk-accepts all pending keys. To accept keys
@@ -228,10 +254,12 @@ Whether you have a few or a few-dozen, Salt can help you manage them easily!
 For final verification, send a test function from your Salt Master to your
 minions. If all of your minions are properly communicating with your Master,
 you should "True" responses from each of them. See the example below to send
-the ``test.ping`` remote command::
+the ``test.ping`` remote command:
+
+.. code-block:: bash
 
    [root@master ~]# salt '*' test.ping
-   {'avon': True}
+   {'alpha': True}
 
 Where Do I Go From Here
 ========================

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -6,7 +6,9 @@ Ubuntu
 ------
 
 We are working to get Salt into apt. In the meantime we have a PPA available
-for Lucid::
+for Lucid:
+
+.. code-block:: bash
 
     aptitude -y install python-software-properties
     add-apt-repository ppa:saltstack/salt
@@ -29,7 +31,9 @@ accepted you can install Salt by downloading the latest ``.deb`` in the
 
     There is a `python-zmq`__ package available in Debian \"wheezy (testing)\".
     If you don't have that repo enabled the best way to install Salt and pyzmq
-    is by using ``pip`` (or ``easy_install``)::
+    is by using ``pip`` (or ``easy_install``):
+
+    .. code-block:: bash
 
         pip install pyzmq salt
 

--- a/doc/topics/installation/fedora.rst
+++ b/doc/topics/installation/fedora.rst
@@ -11,7 +11,9 @@ makes it a great place to help improve Salt!
 
     We are still working to get msgpack packaged for Python 2.6 so Salt is not
     yet (but nearly) in EPEL 5. In the meantime you can install Salt via our
-    Fedora People repository::
+    Fedora People repository:
+
+    .. code-block:: bash
 
         wget -O /etc/yum.repos.d/epel-salt.repo \\
             http://repos.fedorapeople.org/repos/herlo/salt/epel-salt.repo
@@ -27,7 +29,9 @@ Stable Release
 
 Salt is packaged separately for the minion and the master. You'll only need to
 install the appropriate package for the role you need the machine to play. This
-means you're going to want one master and a whole bunch of minions!::
+means you're going to want one master and a whole bunch of minions!
+
+.. code-block:: bash
 
     yum install salt-master
     yum install salt-minion
@@ -50,7 +54,9 @@ configuration paths.
 
 By default the Salt master listens on ports 4505 and 4506 on all interfaces
 (0.0.0.0). If you have a need to bind Salt to a specific IP, redefine the
-"interface" directive as seen here::
+"interface" directive as seen here:
+
+.. code-block:: diff
 
    - #interface: 0.0.0.0
    + interface: 10.0.0.1
@@ -58,13 +64,19 @@ By default the Salt master listens on ports 4505 and 4506 on all interfaces
 **Enable the Master**
 
 You'll also likely want to activate the Salt Master in systemd, configuring the
-Salt Master to start automatically at boot.::
+Salt Master to start automatically at boot.
+
+.. code-block:: bash
 
     systemctl enable salt-master.service
 
+**Start the Master**
+
 Once you've completed all of these steps you're ready to start your Salt
 Master. You should be able to start your Salt Master now using the command
-seen here::
+seen here:
+
+.. code-block:: bash
 
     systemctl start salt-master.service
 
@@ -87,7 +99,9 @@ this you likely can do without any minion configuration at all.
 
 If you are not able to update DNS, you'll simply need to update one entry in
 the configuration file. Using your favorite editor, open the minion
-configuration file and update the "master" entry as seen here::
+configuration file and update the "master" entry as seen here:
+
+.. code-block:: diff
 
    - #master: salt
    + master: 10.0.0.1
@@ -99,13 +113,19 @@ configuration options are covered in another chapter.
 **Enable the Minion**
 
 You'll need to configure the minion to auto-start at boot. You can toggle
-that option through systemd.::
+that option through systemd.
+
+.. code-block:: bash
 
     systemctl enable salt-minion.service
 
+**Start the Minion**
+
 Once you've completed all of these steps you're ready to start your Salt
 Minion. You should be able to start your Salt Minion now using the command
-here::
+here:
+
+.. code-block:: bash
 
     systemctl start salt-minion.service
 
@@ -132,28 +152,32 @@ only done through trusted, accepted keys.
 
 Before you'll be able to do any remote execution or configuration management you'll
 need to accept any pending keys on the Master. Run the ``salt-key`` command to
-list the keys known to the Salt Master::
+list the keys known to the Salt Master:
+
+.. code-block:: bash
 
    [root@master ~]# salt-key -L
    Unaccepted Keys:
-   avon
-   bodie
-   bubbles
-   marlo
+   alpha
+   bravo
+   charlie
+   delta
    Accepted Keys:
 
 This example shows that the Salt Master is aware of four Minions, but none of
 the keys have been accepted. To accept the keys and allow the Minions to be
-controlled by the Master, again use the ``salt-key`` command::
+controlled by the Master, again use the ``salt-key`` command:
+
+.. code-block:: bash
 
    [root@master ~]# salt-key -A
    [root@master ~]# salt-key -L
    Unaccepted Keys:
    Accepted Keys:
-   avon
-   bodie
-   bubbles
-   marlo
+   alpha
+   bravo
+   charlie
+   delta
 
 The ``salt-key`` command allows for signing keys individually or in bulk. The
 example above, using ``-A`` bulk-accepts all pending keys. To accept keys
@@ -168,10 +192,12 @@ Whether you have a few or a few-dozen, Salt can help you manage them easily!
 For final verification, send a test function from your Salt Master to your
 minions. If all of your minions are properly communicating with your Master,
 you should "True" responses from each of them. See the example below to send
-the ``test.ping`` remote command::
+the ``test.ping`` remote command:
+
+.. code-block:: bash
 
    [root@master ~]# salt '*' test.ping
-   {'avon': True}
+   {'alpha': True}
 
 Where Do I Go From Here
 ========================

--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -3,11 +3,11 @@ FreeBSD
 =======
 
 Salt was added to the FreeBSD ports tree Dec 26th, 2011 by Christer Edwards
-<christer.edwards@gmail.com>. It has been tested on FreeBSD 8.2 and 9.0
+<christer.edwards@gmail.com>. It has been tested on FreeBSD 7.4, 8.2 and 9.0
 releases.
 
 Salt is dependent on the following additional ports. These will be installed as
-dependencies of the ``sysutils/salt`` port::
+dependencies of the ``sysutils/salt`` port. ::
 
    /devel/py-yaml
    /devel/py-pyzmq
@@ -19,7 +19,9 @@ dependencies of the ``sysutils/salt`` port::
 Installation
 ============
 
-To install Salt from the FreeBSD ports tree, use the command::
+To install Salt from the FreeBSD ports tree, use the command:
+
+.. code-block:: bash
 
    cd /usr/ports/sysutils/salt && make install clean
 
@@ -36,7 +38,9 @@ Master and Salt Minions.
 The Salt port installs two sample configuration files, ``salt/master.sample`` and
 ``salt/minion.sample`` (these should be installed in ``/usr/local/etc/``, unless you use a
 different ``%%PREFIX%%``). You'll need to copy these .sample files into place and
-make a few edits. First, copy them into place as seen here::
+make a few edits. First, copy them into place as seen here:
+
+.. code-block:: bash
 
    cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master
    cp /usr/local/etc/salt/minion.sample /usr/local/etc/salt/minion
@@ -69,17 +73,21 @@ By default the Salt master listens on ports 4505 and 4506 on all interfaces
 **rc.conf**
 
 Last but not least you'll need to activate the Salt Master in your rc.conf
-file. Using your favorite editor, open /etc/rc.conf or /etc/rc.conf.local and
-add this line.
+file. Using your favorite editor, open ``/etc/rc.conf`` or
+``/etc/rc.conf.local`` and add this line.
 
 .. code-block:: diff
 
    + salt_master_enable="YES"
 
+**Start the Master**
+
 Once you've completed all of these steps you're ready to start your Salt
 Master. The Salt port installs an rc script which should be used to manage your
 Salt Master. You should be able to start your Salt Master now using the command
-seen here::
+seen here:
+
+.. code-block:: bash
 
    service salt_master start
 
@@ -116,8 +124,8 @@ configuration options are covered in another chapter.
 **rc.conf**
 
 Before you're able to start the Salt Minion you'll need to update your rc.conf
-file. Using your favorite editor open /etc/rc.conf or /etc/rc.conf.local and
-add this line.
+file. Using your favorite editor open ``/etc/rc.conf`` or
+``/etc/rc.conf.local`` and add this line.
 
 .. code-block:: diff
 
@@ -126,7 +134,9 @@ add this line.
 Once you've completed all of these steps you're ready to start your Salt
 Minion. The Salt port installs an rc script which should be used to manage your
 Salt Minion. You should be able to start your Salt Minion now using the command
-seen here. ::
+seen here.
+
+.. code-block:: bash
 
    service salt_minion start
 
@@ -153,7 +163,9 @@ only done through trusted, accepted keys.
 
 Before you'll be able to do any remote execution or state management you'll
 need to accept any pending keys on the Master. Run the ``salt-key`` command to
-list the keys known to the Salt Master::
+list the keys known to the Salt Master:
+
+.. code-block:: bash
 
    [root@master ~]# salt-key -L
    Unaccepted Keys:
@@ -165,7 +177,9 @@ list the keys known to the Salt Master::
 
 This example shows that the Salt Master is aware of four Minions, but none of
 the keys have been accepted. To accept the keys and allow the Minions to be
-controlled by the Master, again use the ``salt-key`` command::
+controlled by the Master, again use the ``salt-key`` command:
+
+.. code-block:: bash
 
    [root@master ~]# salt-key -A
    [root@master ~]# salt-key -L
@@ -202,3 +216,4 @@ able to send remote commands. I'm sure you're eager to learn more about what
 Salt can do. Depending on the primary way you want to manage your machines you
 may either want to visit the section regarding Salt States, or the section on
 Modules.
+

--- a/doc/topics/installation/gentoo.rst
+++ b/doc/topics/installation/gentoo.rst
@@ -2,17 +2,23 @@
 Gentoo
 ======
 
-Salt can be easily installed on Gentoo::
+Salt can be easily installed on Gentoo:
+
+.. code-block:: bash
 
     emerge pyyaml m2crypto pycrypto jinja pyzmq
 
 Then download and install from source:
 
-1.  Download the latest source tarball from the GitHub downloads directory for
-    the Salt project:
+1.  Download the latest source tarball from the `GitHub downloads`_ directory for
+    the Salt project.
 
-2.  Untar the tarball and run the ``setup.py`` as root::
+2.  Untar the tarball and run the ``setup.py`` as root:
 
-        tar xvf salt-<version>.tar.gz
-        cd salt-<version>
-        python2 setup.py install
+.. code-block:: bash
+
+    tar xf salt-<version>.tar.gz
+    cd salt-<version>
+    python setup.py install
+
+.. _GitHub downloads: https://github.com/saltstack/salt/downloads


### PR DESCRIPTION
I propose example commands should standardize on using ".. code-block:: bash" and configuration file changes should use ".. code-block:: diff". Applied this to the install docs.
