### PR TITLE
add upgrade_available()

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -97,6 +97,20 @@ def available_version(name):
     return list(set(versions_list))[0]
 
 
+def upgrade_available(name):
+    '''
+    Check whether or not an upgrade is available for a given package
+
+    CLI Example::
+
+        salt '*' pkg.upgrade_available <package name>
+    '''
+    if available_version(name):
+        return True
+    else:
+        return False
+
+
 def version(name):
     '''
     Returns a version if the package is installed, else returns an empty string

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -73,6 +73,17 @@ def available_version(name):
     return out[0].version if out else ''
 
 
+def upgrade_available(name):
+    '''
+    Check whether or not an upgrade is available for a given package
+
+    CLI Example::
+
+        salt '*' pkg.upgrade_available <package name>
+    '''
+    return available_version(name) != ''
+
+
 def version(name):
     '''
     Returns a version if the package is installed, else returns an empty string


### PR DESCRIPTION
This commit adds these functions for yumpkg.py and yumpkg5.py. The code for yumpkg5.py is slightly more simplistic because available_version() returns a string value rather than a list like in yumpkg.py.
