### PR TITLE
Fix errors regarding dns_check

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -151,6 +151,7 @@ def minion_config(path):
             'cython_enable': False,
             'state_verbose': False,
             'acceptance_wait_time': 10,
+            'dns_check': True,
             }
 
     load_config(opts, path, 'SALT_MINION_CONFIG')

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -26,7 +26,8 @@ import zmq
 
 # Import salt libs
 from salt.exceptions import AuthenticationError, MinionError, \
-    CommandExecutionError, CommandNotFoundError, SaltInvocationError
+    CommandExecutionError, CommandNotFoundError, SaltInvocationError, \
+    SaltClientError
 import salt.client
 import salt.crypt
 import salt.loader
@@ -76,6 +77,7 @@ def safe_dns_check(addr):
                   'will continue to be used').format(addr)
             log.error(err)
             raise SaltClientError
+    return addr
 
 
 class SMinion(object):
@@ -453,7 +455,7 @@ class Minion(object):
                     if self.opts['dns_check']:
                         try:
                             # Verify that the dns entry has not changed
-                            self.opts['master_ip'] = safe_dns_check()
+                            self.opts['master_ip'] = safe_dns_check(self.opts['master'])
                         except SaltClientError:
                             # Failed to update the dns, keep the old addr
                             pass


### PR DESCRIPTION
Added dns_check to the default opt config for the minion.
Added SaltClientError to the imports
Updated safe_dns_check() to return the ip address if the dns is good.
Fixed an instance of safe_dns_check() to use the master config as arg.
