### PR TITLE
Some fixes for the 0.9.8 milestone

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -266,3 +266,30 @@ def list_pkgs(regex_string=""):
             ret[cols[1]] = cols[2]
 
     return ret
+
+
+def upgrade_available(name):
+
+    '''
+    Check whether or not an upgrade is available for a given package
+
+    CLI Example::
+
+        salt '*' pkg.upgrade_available <package name>
+    '''
+    cmd = 'apt-get --just-print upgrade'
+    out = __salt__['cmd.run_stdout'](cmd)
+
+    # Mini filter function
+    def _to_update(line):
+        return line.startswith("Conf ")
+
+    upgraded_packages = filter(_to_update, out.split('\n'))
+
+    # Example line:
+    # 'Conf linux-image-2.6.35-32-generic (2.6.35-32.66 Ubuntu:10.10/maverick-updates [amd64])'
+    for line in upgraded_packages:
+        data = line.split()
+        if name == data[1]:
+            return True
+    return False

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -2,13 +2,30 @@
 Support for APT (Advanced Packaging Tool)
 '''
 
+import os
 
 def __virtual__():
     '''
     Confirm this module is on a Debian based system
     '''
 
-    return 'pkg' if __grains__['os'] in [ 'Debian', 'Ubuntu' ] else False
+    return 'pkg' if __grains__['os'] in ('Debian', 'Ubuntu') else False
+
+
+def __init__():
+    '''
+    For Debian and derivative systems, set up
+    a few env variables to keep apt happy and
+    non-interactive.
+    '''
+    if __virtual__():
+        env_vars = {
+            'APT_LISTBUGS_FRONTEND': 'none',
+            'APT_LISTCHANGES_FRONTEND': 'none',
+            'DEBIAN_FRONTENT': 'noninteractive',
+        }
+        # Export these puppies so they persist
+        os.environ.update(env_vars)
 
 
 def available_version(name):
@@ -113,8 +130,7 @@ def install(pkg, refresh=False, repo='', skip_verify=False,
     ret_pkgs = {}
     old_pkgs = list_pkgs()
 
-    cmd = '{nonint} apt-get -q -y {confold}{verify}{target} install {pkg}'.format(
-            nonint='DEBIAN_FRONTEND=noninteractive',
+    cmd = 'apt-get -q -y {confold}{verify}{target} install {pkg}'.format(
             confold=' -o DPkg::Options::=--force-confold',
             verify=' --allow-unauthenticated' if skip_verify else '',
             target=' -t {0}'.format(repo) if repo else '',
@@ -150,7 +166,7 @@ def remove(pkg):
     ret_pkgs = []
     old_pkgs = list_pkgs()
 
-    cmd = 'DEBIAN_FRONTEND=noninteractive apt-get -q -y remove {0}'.format(pkg)
+    cmd = 'apt-get -q -y remove {0}'.format(pkg)
     __salt__['cmd.run'](cmd)
     new_pkgs = list_pkgs()
     for pkg in old_pkgs:
@@ -175,7 +191,7 @@ def purge(pkg):
     old_pkgs = list_pkgs()
 
     # Remove inital package
-    purge_cmd = 'DEBIAN_FRONTEND=noninteractive apt-get -q -y purge {0}'.format(pkg)
+    purge_cmd = 'apt-get -q -y purge {0}'.format(pkg)
     __salt__['cmd.run'](purge_cmd)
 
     new_pkgs = list_pkgs()
@@ -211,7 +227,7 @@ def upgrade(refresh=True):
 
     ret_pkgs = {}
     old_pkgs = list_pkgs()
-    cmd = 'DEBIAN_FRONTEND=noninteractive apt-get -q -y -o DPkg::Options::=--force-confold dist-upgrade'
+    cmd = 'apt-get -q -y -o DPkg::Options::=--force-confold dist-upgrade'
     __salt__['cmd.run'](cmd)
     new_pkgs = list_pkgs()
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -11,14 +11,15 @@ The data sent to the state calls is as follows:
       }
 '''
 
+import os
 import copy
 import inspect
 import fnmatch
 import logging
-import os
 import tempfile
 import collections
 
+import salt.utils
 import salt.loader
 import salt.minion
 
@@ -553,7 +554,11 @@ class State(object):
         '''
         if not isinstance(template, basestring):
             return {}
+        # No highstate data from invalid or empty files
         if not os.path.isfile(template):
+            return {}
+
+        if salt.utils.is_empty(template):
             return {}
         return self.rend[self.template_shebang(template)](template, env, sls)
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2,9 +2,9 @@
 Some of the utils used by salt
 '''
 
-import logging
 import os
 import sys
+import logging
 
 log = logging.getLogger(__name__)
 
@@ -42,6 +42,16 @@ months = {'01': 'Jan',
           '10': 'Oct',
           '11': 'Nov',
           '12': 'Dec'}
+
+def is_empty(filename):
+    '''
+    Is a file empty?
+    '''
+    try:
+        return os.stat(filename).st_size == 0
+    except OSError:
+        # Non-existant file or permission denied to the parent dir
+        return False
 
 
 def get_colors(use=True):


### PR DESCRIPTION
- Don't blow up when including an empty state file
- Add `update_available()` to the apt `pkg` module
- Add a few env vars to the apt `pkg` module (idea from [here](https://github.com/puppetlabs/puppet/blob/master/lib/puppet/provider/package/apt.rb#L14))

If I wasn't so bloody tired this evening I'd have gotten more done. C'est la vie!
