### PR TITLE
Adding Range Support to Salt

### DIFF
--- a/conf/master.template
+++ b/conf/master.template
@@ -202,3 +202,8 @@
 #   group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com and bl*.domain.com',
 #   group2: 'G@os:Debian and foo.domain.com',
 
+#####     Range Cluster settings     #####
+##########################################
+# The range server (and optional port) that
+# serves your cluster information
+#range_server: range:80

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -171,7 +171,7 @@ class Master(object):
                 # Late import so logging works correctly
                 import salt.utils
                 salt.utils.daemonize()
-            set_pidfile(self.cli['pidfile'])
+            set_pidfile(self.opts['pidfile'])
             try:
                 master.start()
             except salt.master.MasterExit:

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -172,7 +172,10 @@ class Master(object):
                 import salt.utils
                 salt.utils.daemonize()
             set_pidfile(self.cli['pidfile'])
-            master.start()
+            try:
+                master.start()
+            except salt.master.MasterExit:
+                sys.exit()
 
 
 class Minion(object):

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -112,6 +112,14 @@ class SaltCMD(object):
                 help=('Instead of using shell globs to evaluate the target '
                       'use one of the predefined nodegroups to identify a '
                       'list of targets.'))
+        parser.add_option('-R',
+                '--range',
+                default=False,
+                dest='range',
+                action='store_true',
+                help=('Instead of using shell globs to evaluate the target '
+                      'use a range expressions to identify targets. '
+                      'Range expressions look like %cluster'))
         parser.add_option('-C',
                 '--compound',
                 default=False,
@@ -270,6 +278,8 @@ class SaltCMD(object):
                 args.append('exsel')
             elif self.opts['nodegroup']:
                 args.append('nodegroup')
+            elif self.opts['range']:
+                args.append('range')
             elif self.opts['compound']:
                 args.append('compound')
             else:
@@ -413,6 +423,14 @@ class SaltCP(object):
                 help=('Instead of using shell globs to evaluate the target '
                       'use one of the predefined nodegroups to identify a '
                       'list of targets.'))
+        parser.add_option('-R',
+                '--range',
+                default=False,
+                dest='range',
+                action='store_true',
+                help=('Instead of using shell globs to evaluate the target '
+                      'use a range expressions to identify targets. '
+                      'Range expressions look like %cluster'))
         parser.add_option('-c',
                 '--config',
                 default='/etc/salt/master',

--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -78,6 +78,8 @@ class SaltCP(object):
             args.append('grain_pcre')
         elif self.opts['nodegroup']:
             args.append('nodegroup')
+        elif self.opts['range']:
+            args.append('range')
 
         ret = local.cmd(*args)
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -229,6 +229,7 @@ def master_config(path):
             'pidfile': '/var/run/salt-master.pid',
             'cluster_masters': [],
             'cluster_mode': 'paranoid',
+            'range_server': 'range:80',
             'serial': 'msgpack',
             'nodegroups': {},
             'key_logfile': '/var/log/salt/key.log',

--- a/salt/master.py
+++ b/salt/master.py
@@ -50,7 +50,7 @@ def prep_jid(opts, load):
         return prep_jid(opts['cachedir'], load)
     return jid
 
-def clean_proc(proc, wait_for_kill=1):
+def clean_proc(proc, wait_for_kill=10):
     '''
     Generic method for cleaning up multiprocessing procs
     '''
@@ -62,7 +62,7 @@ def clean_proc(proc, wait_for_kill=1):
         while proc.is_alive():
             proc.terminate()
             waited += 1
-            time.sleep(1)
+            time.sleep(0.1)
             if proc.is_alive() and (waited >= wait_for_kill):
                 log.error(('Process did not die with terminate(): {0}'
                     .format(proc.pid)))


### PR DESCRIPTION
Range is a cluster based metadata store.  It was used internally at yahoo and recently open source.  You can read about range here:

https://github.com/grierj/range/wiki/Introduction-to-Range-with-YAML-files

Range allows arbitrary grouping of hosts via clusters and the storage of metadata along with them.  Additionally there is a powerful DSL that allows for set operations, regexes, and multilayer cluster referencing.

The implementation here runs the range query and reduces it to a list style expression format, which means only the salt master needs to know about range or have the range libraries installed.

I've also cleaned up the signal handler and multiprocessing cleaner.  The cleaner is now much faster (sleeps for less time, so it checks more often).  Additionally it raises a MasterExit which you can catch (and I do) to make for a clean exit code.
