### PR TITLE
More virt.py and butterkvm.py fixups

### DIFF
--- a/salt/modules/butterkvm.py
+++ b/salt/modules/butterkvm.py
@@ -103,14 +103,20 @@ def libvirt_creds():
 
         salt '*' butterkvm.libvirt_creds
     '''
-    g_cmd = 'grep group /etc/libvirt/qemu.conf'
-    u_cmd = 'grep user /etc/libvirt/qemu.conf'
-    group = subprocess.Popen(g_cmd,
+    g_cmd = 'grep ^\s*group /etc/libvirt/qemu.conf'
+    u_cmd = 'grep ^\s*user /etc/libvirt/qemu.conf'
+    try:
+        group = subprocess.Popen(g_cmd,
             shell=True,
             stdout=subprocess.PIPE).communicate()[0].split('"')[1]
-    user = subprocess.Popen(u_cmd,
+    except IndexError:
+        group = "root"
+    try:
+        user = subprocess.Popen(u_cmd,
             shell=True,
             stdout=subprocess.PIPE).communicate()[0].split('"')[1]
+    except IndexError:
+        user = "root"
     return {'user': user, 'group': group}
 
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -49,8 +49,8 @@ def _libvirt_creds():
     '''
     Returns the user and group that the disk images should be owned by
     '''
-    g_cmd = 'grep ^group /etc/libvirt/qemu.conf'
-    u_cmd = 'grep ^user /etc/libvirt/qemu.conf'
+    g_cmd = 'grep ^\s*group /etc/libvirt/qemu.conf'
+    u_cmd = 'grep ^\s*user /etc/libvirt/qemu.conf'
     try:
         group = subprocess.Popen(g_cmd,
             shell=True,

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -30,7 +30,7 @@ def __get_conn():
     Detects what type of dom this node is and attempts to connect to the
     correct hypervisor via libvirt.
     '''
-    # This only supports kvm right now, it needs to be expanded to support
+    # This has only been tested on kvm and xen, it needs to be expanded to support
     # all vm layers supported by libvirt
     return libvirt.open("qemu:///system")
 

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -12,6 +12,12 @@ controlled via the ssh_auth state:
         - present
         - user: root
         - enc: ssh-dss
+
+    thatch:
+      ssh_auth:
+        - present
+        - user: root
+        - source: salt://ssh_keys/thatch.id_rsa.pub
 '''
 
 
@@ -20,6 +26,7 @@ def present(
         user,
         enc='ssh-rsa',
         comment='',
+        source='',
         options=[],       # FIXME: mutable type; http://goo.gl/ToU2z
         config='.ssh/authorized_keys'):
     '''
@@ -37,6 +44,11 @@ def present(
     comment
         The comment to be placed with the ssh public key
 
+    source
+        The source file for the key(s). Can contain any number of public keys, 
+        in standard "authorized_keys" format. If this is set, comment, enc, 
+        and options will be ignored.
+
     options
         The options passed to the key, pass a list object
 
@@ -49,13 +61,20 @@ def present(
            'result': True,
            'comment': ''}
 
-    data = __salt__['ssh.set_auth_key'](
-            user,
-            name,
-            enc,
-            comment,
-            options,
-            config)
+    if source != '':
+        data = __salt__['ssh.set_auth_key_from_file'](
+                user,
+                source,
+                config)
+    else:
+        data = __salt__['ssh.set_auth_key'](
+                user,
+                name,
+                enc,
+                comment,
+                source,
+                options,
+                config)
 
     if data == 'replace':
         ret['changes'][name] = 'Updated'
@@ -72,7 +91,7 @@ def present(
     elif data == 'fail':
         ret['result'] = False
         ret['comment'] = ('Failed to add the ssh key, is the home directory'
-                          ' available?')
+                          ' available and/or does the key file exist?')
 
     return ret
 


### PR DESCRIPTION
Fixup butterkvm.py in the same way I did virt.py (the code was copy&pasted between the two). Also, for both of them, add support for the variables being defined with space to the left of them.  I.e.:

```
# The user ID for QEMU processes run by the system instance.
 user = "root"
```

will now work.
