### PR TITLE
SSH module needs 6 arguments now, not 7

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -72,7 +72,6 @@ def present(
                 name,
                 enc,
                 comment,
-                source,
                 options,
                 config)
 


### PR DESCRIPTION
Fixed arguments for ssh module (needs 6 args, not 7) after the change in b568d103.
Source is now independent so no need to add that to the normal call.
