### PR TITLE
More tweaks to virt.py

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -33,12 +33,12 @@ def __get_conn():
     '''
     # This has only been tested on kvm and xen, it needs to be expanded to support
     # all vm layers supported by libvirt
-    conn = libvirt.open("qemu:///system")
-    if conn == None:
+    try:
+        conn = libvirt.open("qemu:///system")
+    except:
         msg = 'Sorry, {0} failed to open a connection to the hypervisor software'
         raise CommandExecutionError(msg.format(__grains__['fqdn']))
-    else:
-        return conn
+    return conn
 
 
 def _get_dom(vm_):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -32,7 +32,11 @@ def __get_conn():
     '''
     # This has only been tested on kvm and xen, it needs to be expanded to support
     # all vm layers supported by libvirt
-    return libvirt.open("qemu:///system")
+    conn = libvirt.open("qemu:///system")
+    if conn == None:
+        raise Exception('Failed to open a connection to the hypervisor')
+    else:
+        return conn
 
 
 def _get_dom(vm_):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -78,12 +78,38 @@ def list_vms():
 
         salt '*' virt.list_vms
     '''
+    vms = []
+    vms.extend(list_active_vms())
+    vms.extend(list_inactive_vms())
+    return vms
+
+def list_active_vms():
+    '''
+    Return a list of names for active virtual machine on the minion
+
+    CLI Example::
+
+        salt '*' virt.list_active_vms
+    '''
     conn = __get_conn()
     vms = []
     for id_ in conn.listDomainsID():
         vms.append(conn.lookupByID(id_).name())
     return vms
 
+def list_inactive_vms():
+    '''
+    Return a list of names for inactive virtual machine on the minion
+
+    CLI Example::
+
+        salt '*' virt.list_inactive_vms
+    '''
+    conn = __get_conn()
+    vms = []
+    for id_ in conn.listDefinedDomains():
+        vms.append(id_)
+    return vms
 
 def vm_info():
     '''

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -5,6 +5,7 @@ Work with virtual machines managed by libvirt
 # of his in the virt func module have been used
 
 from xml.dom import minidom
+from salt.exceptions import CommandExecutionError
 import StringIO
 import os
 import shutil
@@ -34,7 +35,8 @@ def __get_conn():
     # all vm layers supported by libvirt
     conn = libvirt.open("qemu:///system")
     if conn == None:
-        raise Exception('Failed to open a connection to the hypervisor')
+        msg = 'Sorry, {0} failed to open a connection to the hypervisor software'
+        raise CommandExecutionError(msg.format(__grains__['fqdn']))
     else:
         return conn
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -307,6 +307,17 @@ def create(vm_):
     return True
 
 
+def start(vm_):
+    '''
+    Alias for the obscurely named 'create' function
+
+    CLI Example::
+
+        salt '*' virt.start <vm name>
+    '''
+    return create(vm_)
+
+
 def create_xml_str(xml):
     '''
     Start a domain based on the xml passed to the function


### PR DESCRIPTION
1) Raise an exception in virt.py if you are unable to contact a hypervisor

2) Add an alias "start" to the oddly-named "create" function. Yes, I realize that we are mimicking the libvirt API by using 'create'. However, in 'virsh', the same function (power on a previously defined and created VM) is "start". This gives us both methods, and I hope, reduces confusion.

3) Fix list_vms, which previously only returned VMs if they were already running, not shutdown. As a result, the create/start functions now actually work. Before this, 'create' - which is supposed to power-on a VM - would check list_vms first, and only run if it existed. Seeing as it wouldn't be in the results of list_vms if it wasn't powered on...  sadness.
