### PR TITLE
Develop

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -29,7 +29,8 @@ class Master(object):
         # command line overrides config
         if self.cli['user']:
             self.opts['user'] = self.cli['user']
-        # Send the pidfile location to the opts
+        
+	# Send the pidfile location to the opts
         if self.cli['pidfile']:
             self.opts['pidfile'] = self.cli['pidfile']
 

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -98,14 +98,14 @@ class Master(object):
         import logging
         log = logging.getLogger(__name__)
         # Late import so logging works correctly
+        import salt.master
+        master = salt.master.Master(self.opts)
+        if self.cli['daemon']:
+            # Late import so logging works correctly
+            import salt.utils
+            salt.utils.daemonize()
+        set_pidfile(self.opts['pidfile'])
         if check_user(self.opts['user'], log):
-            import salt.master
-            master = salt.master.Master(self.opts)
-            if self.cli['daemon']:
-                # Late import so logging works correctly
-                import salt.utils
-                salt.utils.daemonize()
-            set_pidfile(self.opts['pidfile'])
             try:
                 master.start()
             except salt.master.MasterExit:
@@ -187,13 +187,13 @@ class Minion(object):
         # Late import so logging works correctly
         import salt.minion
         log = logging.getLogger(__name__)
+        if self.cli['daemon']:
+            # Late import so logging works correctly
+            import salt.utils
+            salt.utils.daemonize()
+        set_pidfile(self.cli['pidfile'])
         if check_user(self.opts['user'], log):
             try:
-                if self.cli['daemon']:
-                    # Late import so logging works correctly
-                    import salt.utils
-                    salt.utils.daemonize()
-                set_pidfile(self.cli['pidfile'])
                 minion = salt.minion.Minion(self.opts)
                 minion.tune_in()
             except KeyboardInterrupt:
@@ -304,14 +304,14 @@ class Syndic(object):
         # Late import so logging works correctly
         import salt.minion
         log = logging.getLogger(__name__)
+        if self.cli['daemon']:
+            # Late import so logging works correctly
+            import salt.utils
+            salt.utils.daemonize()
+        set_pidfile(self.cli['pidfile'])
         if check_user(self.opts['user'], log):
             try:
                 syndic = salt.minion.Syndic(self.opts)
-                if self.cli['daemon']:
-                    # Late import so logging works correctly
-                    import salt.utils
-                    salt.utils.daemonize()
-                set_pidfile(self.cli['pidfile'])
                 syndic.tune_in()
             except KeyboardInterrupt:
                 log.warn('Stopping the Salt Syndic Minion')

--- a/salt/master.py
+++ b/salt/master.py
@@ -131,7 +131,6 @@ class Master(SMaster):
         '''
         Clean out the old jobs
         '''
-        salt.utils.append_pid(self.opts['pidfile'])
         while True:
             cur = "{0:%Y%m%d%H}".format(datetime.datetime.now())
 
@@ -207,7 +206,6 @@ class Publisher(multiprocessing.Process):
         '''
         Bind to the interface specified in the configuration file
         '''
-        salt.utils.append_pid(self.opts['pidfile'])
         context = zmq.Context(1)
         pub_sock = context.socket(zmq.PUB)
         pull_sock = context.socket(zmq.PULL)
@@ -286,7 +284,6 @@ class ReqServer(object):
         '''
         Start up the ReqServer
         '''
-        salt.utils.append_pid(self.opts['pidfile'])
         self.__bind()
 
 
@@ -376,7 +373,6 @@ class MWorker(multiprocessing.Process):
         '''
         Start a Master Worker
         '''
-        salt.utils.append_pid(self.opts['pidfile'])
         self.__bind()
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -81,18 +81,6 @@ def get_colors(use=True):
     return colors
 
 
-def append_pid(pidfile):
-    '''
-    Save the pidfile
-    '''
-    try:
-        open(pidfile, 'a').write('\n{0}'.format(str(os.getpid())))
-    except IOError:
-        err = ('Failed to commit the pid to location {0}, please verify'
-              ' that the location is available').format(pidfile)
-        log.error(err)
-
-
 def daemonize():
     '''
     Daemonize a process


### PR DESCRIPTION
Handle pidfiles in a bit more standard way:
1) Do not write multiple master pid's into pidfile (it's very uncommon to do so, many initscript tools can't handle this)
2) If we are switching from root to user we must write pidfiles under root as files in /var/run/... are usualy owned by root.
