### PR TITLE
Adding hardcoded appendable domain

### DIFF
--- a/conf/minion.template
+++ b/conf/minion.template
@@ -24,6 +24,11 @@
 # clusters.
 #id:
 
+# Append a domain to a hostname in the event that it does not exist.  This is
+# usefule for systems where socket.getfqdn() does not actually result in a
+# FQDN (for instance, Solaris).
+#append_domain:
+
 # If the the connection to the server is interrupted, the minion will
 # attempt to reconnect. sub_timeout allows you to control the rate
 # of reconnection attempts (in seconds). To disable reconnects, set

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -119,7 +119,7 @@ class SaltCMD(object):
                 dest='range',
                 action='store_true',
                 help=('Instead of using shell globs to evaluate the target '
-                      'use a range expressions to identify targets. '
+                      'use a range expression to identify targets. '
                       'Range expressions look like %cluster'))
         parser.add_option('-C',
                 '--compound',

--- a/salt/config.py
+++ b/salt/config.py
@@ -42,6 +42,17 @@ def _validate_file_roots(file_roots):
             file_roots[env] = []
     return file_roots
 
+def _append_domain(opts):
+    '''
+    Append a domain to the existing id if it doesn't already exist
+    '''
+    # Domain already exists
+    if opts['id'].endswith(opts['append_domain']):
+        return opts['id']
+    # Trailing dot should mean an FQDN that is terminated, leave it alone.
+    if opts['id'].endswith('.'):
+        return opts['id']
+    return "{0[id]}.{0[append_domain]}".format(opts)
 
 def _read_conf_file(path):
     with open(path, 'r') as conf_file:
@@ -163,6 +174,9 @@ def minion_config(path):
 
     if 'include' in opts:
         opts = include_config(opts, path)
+
+    if 'append_domain' in conf_opts:
+        opts['id'] = _append_domain(opts)
 
     opts['master_ip'] = salt.utils.dns_check(opts['master'])
 


### PR DESCRIPTION
Solaris gives back a short name when calling socket.getfqdn().  Probably has to do with our setup, but there may be others out there that want systems to be normalized to have a full domain name.  So I added this code to normalize out short names by appending a given domain name.

I'm not terribly satisfied with this solution, but outside of terrible hackery this seems to be the safest way to move forward.  I welcome more elegant solutions and am happy to implement them.
