### PR TITLE
Fix unhandled importerrors

### DIFF
--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -1,6 +1,8 @@
 '''
 Provide the hyper module for kvm hypervisors. This is the interface used to
 interact with kvm on behalf of the salt-virt interface
+
+Required python modules: libvirt
 '''
 
 # This is a test interface for the salt-virt system. The api in this file is
@@ -8,14 +10,18 @@ interact with kvm on behalf of the salt-virt interface
 
 
 # Import Python Libs
-from xml.dom import minidom
-import StringIO
 import os
 import shutil
+import StringIO
 import subprocess
+from xml.dom import minidom
 
 # Import libvirt
-import libvirt
+try:
+    import libvirt
+    has_libvirt = True
+except ImportError:
+    has_libvirt = True
 
 # Import Third party modules
 import yaml
@@ -39,6 +45,8 @@ def __virtual__():
     if __grains__['virtual'] != 'physical':
         return False
     if 'kvm_' not in open('/proc/modules').read():
+        return False
+    if not has_libvirt:
         return False
     try:
         libvirt_conn = libvirt.open('qemu:///system')

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1,17 +1,23 @@
 '''
 Work with virtual machines managed by libvirt
+
+Required python modules: libvirt
 '''
 # Special Thanks to Michael Dehann, many of the concepts, and a few structures
 # of his in the virt func module have been used
 
-from xml.dom import minidom
-from salt.exceptions import CommandExecutionError
-import StringIO
 import os
 import shutil
+import StringIO
 import subprocess
+from xml.dom import minidom
+from salt.exceptions import CommandExecutionError
 
-import libvirt
+try:
+    import libvirt
+    has_libvirt = True
+except ImportError:
+    has_libvirt = False
 
 # Import Third Party Libs
 import yaml
@@ -24,6 +30,12 @@ VIRT_STATE_NAME_MAP = {0: "running",
                        4: "shutdown",
                        5: "shutdown",
                        6: "crashed"}
+
+
+def __virtual__():
+    if not has_libvirt:
+        return False
+    return 'virt'
 
 
 def __get_conn():
@@ -572,7 +584,7 @@ def is_xen_hyper():
         if __grains__['virtual_subtype'] != 'Xen Dom0':
             return False
     except KeyError:
-            # virtual_subtype isn't set everywhere. 
+            # virtual_subtype isn't set everywhere.
             return False
     try:
         if 'xen_' not in open('/proc/modules').read():

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -1,7 +1,7 @@
 '''
-Return data to a Cassandra ColumFamily
+Return data to a Cassandra ColumnFamily
 
-Here's an example Keyspace/ColumnFamily setup that works with this
+Here's an example Keyspace / ColumnFamily setup that works with this
 returner::
 
     create keyspace salt;
@@ -10,10 +10,22 @@ returner::
       with key_validation_class='UTF8Type'
       and comparator='UTF8Type'
       and default_validation_class='UTF8Type';
+
+Required python modules: pycassa
 '''
 
 import logging
-import pycassa
+
+try:
+    import pycassa
+    has_pycassa = True
+except ImportError
+    has_pycassa = False
+
+def __virtual__():
+    if not has_pycassa:
+        return False
+    return 'cassandra'
 
 log = logging.getLogger(__name__)
 

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -19,13 +19,8 @@ import logging
 try:
     import pycassa
     has_pycassa = True
-except ImportError
+except ImportError:
     has_pycassa = False
-
-def __virtual__():
-    if not has_pycassa:
-        return False
-    return 'cassandra'
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +28,13 @@ __opts__ = {'cassandra.servers': ['localhost:9160'],
             'cassandra.keyspace': 'salt',
             'cassandra.column_family': 'returns',
             'cassandra.consistency_level': 'ONE'}
+
+
+def __virtual__():
+    if not has_pycassa:
+        return False
+    return 'cassandra'
+
 
 def returner(ret):
     '''

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -11,7 +11,7 @@ import logging
 try:
     import pymongo
     has_pymongo = True
-except ImportError
+except ImportError:
     has_pymongo = False
 
 

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -2,10 +2,17 @@
 Return data to a mongodb server
 
 This is the default interface for returning data for the butter statd subsytem
+
+Required python modules: pymongo
 '''
 
 import logging
-import pymongo
+
+try:
+    import pymongo
+    has_pymongo = True
+except ImportError
+    has_pymongo = False
 
 
 log = logging.getLogger(__name__)
@@ -15,6 +22,12 @@ __opts__ = {'mongo.db': 'salt',
             'mongo.password': '',
             'mongo.port': 27017,
             'mongo.user': ''}
+
+
+def __virtual__():
+    if not has_pymongo:
+        return False
+    return 'mongo_return'
 
 
 def returner(ret):

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -2,14 +2,27 @@
 Return data to a redis server
 This is a VERY simple example for pushing data to a redis server and is not
 necessarily intended as a usable interface.
+
+Required python modules: redis
 '''
 
 import json
-import redis
+
+try:
+    import redis
+    has_redis = True
+except ImportError:
+    has_redis = False
 
 __opts__ = {'redis.db': '0',
             'redis.host': 'mcp',
             'redis.port': 6379}
+
+
+def __virtual__():
+    if not has_redis:
+        return False
+    return 'redis_return'
 
 
 def returner(ret):


### PR DESCRIPTION
Other than the change to the windows registry module to lazy load _winreg, this seems to all be pretty obvious.

I didn't have a chance to actually test sending to a returner, as it apparently lets you specify nonexistent returners and won't complain, but the rest seems relatively obvious.
