### PR TITLE
Fix directory creation errors when using the file state

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -255,7 +255,7 @@ class Client(object):
                 env,
                 os.path.join(
                     url_data.netloc,
-                    os.path.relpath(url_data.path, '/'))
+                    os.path.relpath(os.path.relpath(url_data.path, '/'), '..')
                 )
             destdir = os.path.dirname(dest)
             if not os.path.isdir(destdir):


### PR DESCRIPTION
This fixes a bug in which Salt attempts to create a directory of the form `/var/cache/salt/extrn_files/example.com/..` when running a Salt state of the form:

``` yml
/tmp/foo:
  file:
    - managed
    - source: http://example.com/foo
    - source_hash: md5=baa20a10c24bb1a385694ce88f930e9f
```

Since the path ends in `..`, a `makedirs` call fails (since it tries to create a directory that already exists).

The problem is caused by the relpath call in some of the caching logic.

I'm not convinced this is the _best_ way to fix it, but it does the job.
