### PR TITLE
Add get_nics() and get_macs() to virt.py

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -173,6 +173,22 @@ def node_info():
             'sockets': raw[5]}
     return info
 
+def get_macs(vm_):
+    '''
+    Return a list off MAC addresses from the named vm
+
+    CLI Example::
+
+        salt '*' virt.get_macs <vm name>
+    '''
+    macs = []
+    doc = minidom.parse(StringIO.StringIO(get_xml(vm_)))
+    for node in doc.getElementsByTagName("devices"):
+        i_nodes = node.getElementsByTagName("interface")
+        for i_node in i_nodes:
+            for v_node in i_node.getElementsByTagName('mac'):
+                macs.append(v_node.getAttribute('address'))
+    return macs
 
 def get_graphics(vm_):
     '''

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -173,6 +173,45 @@ def node_info():
             'sockets': raw[5]}
     return info
 
+def get_nics(vm_):
+    '''
+    Return info about the network interfaces of a named vm
+
+    CLI Example::
+
+        salt '*' virt.get_nics <vm name>
+    '''
+    nics = {}
+    doc = minidom.parse(StringIO.StringIO(get_xml(vm_)))
+    for node in doc.getElementsByTagName("devices"):
+        i_nodes = node.getElementsByTagName("interface")
+        for i_node in i_nodes:
+            nic = {}
+            nic['type'] = i_node.getAttribute('type')
+            for v_node in i_node.getElementsByTagName('*'):
+                if v_node.tagName == "mac":
+                    nic['mac'] = v_node.getAttribute('address')
+                if v_node.tagName == "model":
+                    nic['model'] = v_node.getAttribute('type')
+                # driver, source, and match can all have optional attributes
+                if re.match('(driver|source|address)', v_node.tagName):
+                    temp = {}
+                    for key in v_node.attributes.keys():
+                        temp[key] = v_node.getAttribute(key)
+                    nic[str(v_node.tagName)] = temp
+                # virtualport needs to be handled separately, to pick up the
+                # type attribute of the virtualport itself
+                if v_node.tagName == "virtualport":
+                    temp = {}
+                    temp['type'] = v_node.getAttribute('type')
+                    for key in v_node.attributes.keys():
+                        temp[key] = v_node.getAttribute(key)
+                    nic['virtualport'] = temp
+            if 'mac' not in nic:
+                continue
+            nics[nic['mac']] = nic
+    return nics
+
 def get_macs(vm_):
     '''
     Return a list off MAC addresses from the named vm


### PR DESCRIPTION
Example output from get_macs() on a machine with one interface, then two:

```[ david@brampton100 ]  $ sudo salt-call virt.get_macs testing123
{'local': [u'00:16:36:e7:2f:e9']}
[ david@brampton100 ]  $ sudo salt-call virt.get_macs new_test
{'local': [u'00:16:36:9d:d9:30', u'52:54:00:ab:cd:ef']}

```
Example output from get_nics() on a machine with one interface, then two:

    [ david@brampton100 ]  $ sudo salt-call virt.get_nics testing123
    {'local': {u'00:16:36:e7:2f:e9': {'address': {u'bus': u'0x00',
                                              u'domain': u'0x0000',
                                              u'function': u'0x0',
                                              u'slot': u'0x03',
                                              u'type': u'pci'},
                                  'mac': u'00:16:36:e7:2f:e9',
                                  'model': u'virtio',
                                  'source': {u'bridge': u'br104'},
                                  'type': u'bridge'}}}

    [ david@brampton100 ]  $ sudo salt-call virt.get_nics new_test
    {'local': {u'00:16:36:9d:d9:30': {'address': {u'bus': u'0x00',
                                              u'domain': u'0x0000',
                                              u'function': u'0x0',
                                              u'slot': u'0x03',
                                              u'type': u'pci'},
                                  'mac': u'00:16:36:9d:d9:30',
                                  'model': u'virtio',
                                  'source': {u'bridge': u'br104'},
                                  'type': u'bridge'},
           u'52:54:00:ab:cd:ef': {'address': {u'bus': u'0x00',
                                              u'domain': u'0x0000',
                                              u'function': u'0x0',
                                              u'slot': u'0x06',
                                              u'type': u'pci'},
                                  'mac': u'52:54:00:ab:cd:ef',
                                  'model': u'virtio',
                                  'source': {u'bridge': u'br104'},
                                  'type': u'bridge'}}}
```
