### PR TITLE
remove localfqdn grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -461,7 +461,6 @@ def hostname():
     comps = grains['fqdn'].split('.')
     grains['host'] = comps[0]
     grains['localhost'] = socket.gethostname()
-    grains['localfqdn'] = __salt__['cmd.run']('hostname -f').strip()
     if len(comps) > 1:
         grains['domain'] = '.'.join(comps[1:])
     else:


### PR DESCRIPTION
I realize I added this grain just a couple of days ago, but as I've thought about it, I've become more convinced by the argument (sorry, I forget who - dzen maybe?) from #salt that we should instead fix the fqdn grain. By "fix", I will rejigger it to check if socket.getfqdn() returns localhost, and fall back to 'hostname -f', etc. But I wanted to remove the localfqdn grain before the 0.9.8 release, so that we weren't stuck with it for all time (or at least a couple of releases).
