### PR TITLE
The apt module now has a non-standard external dep

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -251,9 +251,15 @@ def list_pkgs(regex_string=""):
 
         {'<package_name>': '<version>'}
 
+    External dependencies::
+
+        Virtual package resolution requires aptitude.
+        Without aptitude virtual packages will be reported as not installed.
+
     CLI Example::
 
         salt '*' pkg.list_pkgs
+        salt '*' pkg.list_pkgs httpd
     '''
     ret = {}
     cmd = 'dpkg --list {0}'.format(regex_string)


### PR DESCRIPTION
Before this note gets lost in time, let's document it.
