### PR TITLE
Work around Python 2.6 bug involving relative paths from root

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -249,14 +249,13 @@ class Client(object):
                 else:
                     return ''
         else:
-            dest = os.path.join(
-                self.opts['cachedir'],
-                'extrn_files',
-                env,
-                os.path.join(
+            dest = os.path.normpath(
+                os.sep.join([
+                    self.opts['cachedir'],
+                    'extrn_files',
+                    env,
                     url_data.netloc,
-                    os.path.relpath(os.path.relpath(url_data.path, '/'), '..')
-                ))
+                    url_data.path]))
             destdir = os.path.dirname(dest)
             if not os.path.isdir(destdir):
                 os.makedirs(destdir)


### PR DESCRIPTION
In Python 2.6, calling `os.path.relpath('/foo/bar', '/')` incorrectly returns a path `../foo/bar`. In Python 2.7 this is fixed, but this commit adds a workaround that works in both 2.6 and 2.7.

I had previously tried to fix this in #928, but I wasn't careful and didn't actually fix the problem. This time I wrote some tests around my fix (see https://gist.github.com/2126960), showing that it works.

I'd like to add the tests as well if possible, but I'm not sure where/how to work them in.
