### PR TITLE
Fix where re.search applied to empty lines

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -134,6 +134,7 @@ def _validate_keys(key_file):
     Return a dict containing validated keys in the passed file
     '''
     ret = {}
+    linere = re.compile(r'^(.*?)\s?((?:ssh\-|ecds).+)$')
     try:
         for line in open(key_file, 'r').readlines():
             if line.startswith('#'):
@@ -145,7 +146,7 @@ def _validate_keys(key_file):
                 continue
 
             # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            ln = re.search(linere, line)
             if not ln:
                 return "Invalid SSH key"
 
@@ -185,6 +186,7 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
         salt '*' ssh.rm_auth_key <user> <key>
     '''
     current = auth_keys(user, config)
+    linere = re.compile(r'^(.*?)\s?((?:ssh\-|ecds).+)$')
     if key in current:
         # Remove the key
         uinfo = __salt__['user.info'](user)
@@ -204,7 +206,7 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
                 continue
 
             # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            ln = re.search(linere, line)
             if not ln:
                 return "Invalid SSH key"
 

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -140,17 +140,18 @@ def _validate_keys(key_file):
                 # Commented Line
                 continue
 
-            # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
-            opts = ''
-            comps = ''
-            if ln:
-                opts = ln.group(1)
-                comps = ln.group(2).split()
-
             if len(comps) < 2:
                 # Not a valid line
                 continue
+
+            # get "{options} key"
+            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            if not ln:
+                return "Invalid SSH key"
+
+            opts = ln.group(1)
+            comps = ln.group(2).split()
+
             if opts:
                 # It has options, grab them
                 options = opts.split(',')
@@ -197,15 +198,19 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
                 lines.append(line)
                 continue
 
-            # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line);
-            opts = ln.group(1)
-            comps = ln.group(2).split()
-
             if len(comps) < 2:
                 # Not a valid line
                 lines.append(line)
                 continue
+
+            # get "{options} key"
+            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            if not ln:
+                return "Invalid SSH key"
+
+            opts = ln.group(1)
+            comps = ln.group(2).split()
+
             if opts:
                 # It has options, grab them
                 options = opts.split(',')


### PR DESCRIPTION
Move the re.search method to ensure that lines are valid ssh key lines, break
out of loop when it encounters errors. Might want to change this into exception
handling of some sort.

We have some things to think about with this fix (stuff that I didn't feel comfortable doing without knowing the salt code base better):
- we assume that the authorized_keys file is valid and only contains comment and valid ssh keys
- if there is an error, it only returns "Invalid ssh key" this is _not_ optimal, should have an exception
