### PR TITLE
Handle re.search on empty lines

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -134,6 +134,7 @@ def _validate_keys(key_file):
     Return a dict containing validated keys in the passed file
     '''
     ret = {}
+    linere = re.compile(r'^(.*?)\s?((?:ssh\-|ecds).+)$')
     try:
         for line in open(key_file, 'r').readlines():
             if line.startswith('#'):
@@ -145,7 +146,7 @@ def _validate_keys(key_file):
                 continue
 
             # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            ln = re.search(linere, line)
             if not ln:
                 return "Invalid SSH key"
 
@@ -185,6 +186,7 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
         salt '*' ssh.rm_auth_key <user> <key>
     '''
     current = auth_keys(user, config)
+    linere = re.compile(r'^(.*?)\s?((?:ssh\-|ecds).+)$')
     if key in current:
         # Remove the key
         uinfo = __salt__['user.info'](user)
@@ -204,7 +206,7 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
                 continue
 
             # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            ln = re.search(linere, line)
             if not ln:
                 return "Invalid SSH key"
 

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -141,17 +141,18 @@ def _validate_keys(key_file):
                 # Commented Line
                 continue
 
-            if len(comps) < 2:
-                # Not a valid line
-                continue
-
             # get "{options} key"
             ln = re.search(linere, line)
             if not ln:
-                return "Invalid SSH key"
+                # not an auth ssh key, perhaps a blank line
+                continue
 
             opts = ln.group(1)
             comps = ln.group(2).split()
+
+            if len(comps) < 2:
+                # Not a valid line
+                continue
 
             if opts:
                 # It has options, grab them
@@ -200,18 +201,19 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
                 lines.append(line)
                 continue
 
+            # get "{options} key"
+            ln = re.search(linere, line)
+            if not ln:
+                # not an auth ssh key, perhaps a blank line
+                continue
+
+            opts = ln.group(1)
+            comps = ln.group(2).split()
+
             if len(comps) < 2:
                 # Not a valid line
                 lines.append(line)
                 continue
-
-            # get "{options} key"
-            ln = re.search(linere, line)
-            if not ln:
-                return "Invalid SSH key"
-
-            opts = ln.group(1)
-            comps = ln.group(2).split()
 
             if opts:
                 # It has options, grab them

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -140,17 +140,18 @@ def _validate_keys(key_file):
                 # Commented Line
                 continue
 
-            # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
-            opts = ''
-            comps = ''
-            if ln:
-                opts = ln.group(1)
-                comps = ln.group(2).split()
-
             if len(comps) < 2:
                 # Not a valid line
                 continue
+
+            # get "{options} key"
+            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            if not ln:
+                return "Invalid SSH key"
+
+            opts = ln.group(1)
+            comps = ln.group(2).split()
+
             if opts:
                 # It has options, grab them
                 options = opts.split(',')
@@ -197,15 +198,19 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
                 lines.append(line)
                 continue
 
-            # get "{options} key"
-            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line);
-            opts = ln.group(1)
-            comps = ln.group(2).split()
-
             if len(comps) < 2:
                 # Not a valid line
                 lines.append(line)
                 continue
+
+            # get "{options} key"
+            ln = re.search('(.*?)\s?((?:ssh\-|ecds).+)$', line)
+            if not ln:
+                return "Invalid SSH key"
+
+            opts = ln.group(1)
+            comps = ln.group(2).split()
+
             if opts:
                 # It has options, grab them
                 options = opts.split(',')


### PR DESCRIPTION
This was failing on empty lines, and would fail if there was an invalid line in the authorized_keys file. Now, however, it just skips them just like salt used to do without the re.search.
