### PR TITLE
adding check to bypass kvm on FreeBSD

### DIFF
--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -46,6 +46,8 @@ def __virtual__():
         return False
     if __grains__['virtual'] != 'physical':
         return False
+    if __grains__['kernel'] != 'Linux':
+        return False
     if 'kvm_' not in open('/proc/modules').read():
         return False
     if not has_libvirt:


### PR DESCRIPTION
without this check it tries to read /proc/modules, chokes and dies killing all remote execution on FreeBSD.
