### PR TITLE
Error handle invalid keys, properly add/rm/replace/update existing keys

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -275,7 +275,7 @@ def set_auth_key(
         salt '*' ssh.set_auth_key <user> <key> dsa 'my key' '[]' .ssh/authorized_keys
     '''
     if len(key.split()) > 1:
-        return "Fail: SSH key has spaces"
+        return "invalid"
 
     enc = _refine_enc(enc)
     replace = False

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -61,6 +61,7 @@ def _replace_auth_key(
                 enc,
                 comment,
                 options)
+
     lines = []
     uinfo = __salt__['user.info'](user)
     full = os.path.join(uinfo['home'], config)
@@ -161,13 +162,8 @@ def _validate_keys(key_file):
                 options = []
 
             enc = comps[0]
-            # check if key has a space
-            if len(comps) == 3:
-                key = comps[1] + ' ' + comps[2]
-                comment = ' '.join(comps[3:])
-            else:
-                key = comps[1]
-                comment = ' '.join(comps[2:])
+            key = comps[1]
+            comment = ' '.join(comps[2:])
 
             ret[key] = {'enc': enc,
                         'comment': comment,
@@ -221,10 +217,7 @@ def rm_auth_key(user, key, config='.ssh/authorized_keys'):
             else:
                 options = []
 
-            if len(comps) == 3:
-                pkey = comps[1] + ' ' + comps[2]
-            else:
-                pkey = comps[1]
+            pkey = comps[1]
 
             if pkey == key:
                 continue
@@ -281,6 +274,9 @@ def set_auth_key(
 
         salt '*' ssh.set_auth_key <user> <key> dsa 'my key' '[]' .ssh/authorized_keys
     '''
+    if len(key.split()) > 1:
+        return "Fail: SSH key has spaces"
+
     enc = _refine_enc(enc)
     replace = False
     uinfo = __salt__['user.info'](user)

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -91,6 +91,9 @@ def present(
         ret['result'] = False
         ret['comment'] = ('Failed to add the ssh key, is the home directory'
                           ' available and/or does the key file exist?')
+    elif data == 'invalid':
+        ret['result'] = False
+        ret['comment'] = ('Invalid public ssh key, most likely has spaces')
 
     return ret
 


### PR DESCRIPTION
This fixes several things:
1. Fixed a bug where if the key had no spaces but had a comment, it would append the key on every run
2. Returns 'invalid' on a key with spaces, which is handled by the ssh_auth state
3. Includes the fix for options before the key
