### PR TITLE
Add verification of top file (#345)

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -975,6 +975,7 @@ class BaseHighState(object):
                             env=env
                             )
                         )
+	#print tops
 
         # Search initial top files for includes
         for env, ctops in tops.items():
@@ -1010,6 +1011,14 @@ class BaseHighState(object):
                 if env in include:
                     include.pop(env)
 
+        for env,ctops in tops.items():
+            if env == '':
+                return 'invalid'
+            for ctop in ctops:
+                for key,val in ctop.items():
+                    if val['']:
+                        return 'invalid'
+
         return tops
 
     def merge_tops(self, tops):
@@ -1042,6 +1051,8 @@ class BaseHighState(object):
         Returns the high data derived from the top file
         '''
         tops = self.get_tops()
+	if tops == 'invalid':
+            return tops
         return self.merge_tops(tops)
 
     def top_matches(self, top):
@@ -1057,6 +1068,8 @@ class BaseHighState(object):
             if self.opts['environment']:
                 if not env == self.opts['environment']:
                     continue
+            if not isinstance(body, list):
+                return {'env': []}
             for match, data in body.items():
                 if self.matcher.confirm_top(
                         match,
@@ -1221,6 +1234,14 @@ class BaseHighState(object):
         Run the sequence to execute the salt highstate for this minion
         '''
         top = self.get_top()
+        if top == 'invalid':
+            return {'no_|-states_|-states_|-None': {
+                        'result': False,
+                        'comment': 'Invalid top syntax',
+                        'name': 'Invalid sls',
+                        'changes': {},
+                        '__run_num__': 0,
+                   }}
         matches = self.top_matches(top)
         self.load_dynamic(matches)
         high, errors = self.render_highstate(matches)
@@ -1242,6 +1263,14 @@ class BaseHighState(object):
         Return just the highstate or the errors
         '''
         top = self.get_top()
+        if top == 'invalid':
+            return {'no_|-states_|-states_|-None': {
+                        'result': False,
+                        'comment': 'Invalid top syntax',
+                        'name': 'Invalid sls',
+                        'changes': {},
+                        '__run_num__': 0,
+                   }}
         matches = self.top_matches(top)
         high, errors = self.render_highstate(matches)
 
@@ -1257,6 +1286,14 @@ class BaseHighState(object):
         '''
         err = []
         top = self.get_top()
+        if top == 'invalid':
+            return {'no_|-states_|-states_|-None': {
+                        'result': False,
+                        'comment': 'Invalid top syntax',
+                        'name': 'Invalid sls',
+                        'changes': {},
+                        '__run_num__': 0,
+                   }}
         matches = self.top_matches(top)
         high, errors = self.render_highstate(matches)
 


### PR DESCRIPTION
Checks completely built top file for invalid keys, such as `''`. This can be
expanded to check for other things that are not expected by salt.

Note:
This is only a prototype, feel free to reject and have me update more

This is the output from `salt-call -l debug state.highstate` the the `top.sls` file contains `''`:

```
salt-call -l debug state.highstate
[DEBUG   ] Failed to import module json_mako, this is most likely NOT a problem: No module named mako.template
[DEBUG   ] Failed to import module yaml_mako, this is most likely NOT a problem: No module named mako.template
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion.pem
[DEBUG   ] Decrypting the current master AES key
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion.pem
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] Failed to import module json_mako, this is most likely NOT a problem: No module named mako.template
[DEBUG   ] Failed to import module yaml_mako, this is most likely NOT a problem: No module named mako.template
local:
----------
    State: - no
    Name:      states
    Function:  None
        Result:    False
        Comment:   Invalid top syntax
        Changes:   

```
