### PR TITLE
Verify top file return failure on invalid (#345)

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1050,7 +1050,7 @@ class BaseHighState(object):
         Returns the high data derived from the top file
         '''
         tops = self.get_tops()
-	if tops == 'invalid':
+        if tops == 'invalid':
             return tops
         return self.merge_tops(tops)
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -1010,13 +1010,18 @@ class BaseHighState(object):
                 if env in include:
                     include.pop(env)
 
+        errors = []
         for env,ctops in tops.items():
             if env == '':
-                return 'invalid'
+                errors.append("Empty environment")
             for ctop in ctops:
                 for key,val in ctop.items():
                     if val['']:
-                        return 'invalid'
+                        errors.append("Empty string used as key in {0}".format(
+                            ctop))
+        if errors:
+            errors.insert(0, 'invalid')
+            return errors
 
         return tops
 
@@ -1050,7 +1055,7 @@ class BaseHighState(object):
         Returns the high data derived from the top file
         '''
         tops = self.get_tops()
-        if tops == 'invalid':
+        if tops[0] == 'invalid':
             return tops
         return self.merge_tops(tops)
 
@@ -1231,14 +1236,8 @@ class BaseHighState(object):
         Run the sequence to execute the salt highstate for this minion
         '''
         top = self.get_top()
-        if top == 'invalid':
-            return {'no_|-states_|-states_|-None': {
-                        'result': False,
-                        'comment': 'Invalid top syntax',
-                        'name': 'Invalid sls',
-                        'changes': {},
-                        '__run_num__': 0,
-                   }}
+        if top[0] == 'invalid':
+            return top
         matches = self.top_matches(top)
         self.load_dynamic(matches)
         high, errors = self.render_highstate(matches)
@@ -1260,14 +1259,8 @@ class BaseHighState(object):
         Return just the highstate or the errors
         '''
         top = self.get_top()
-        if top == 'invalid':
-            return {'no_|-states_|-states_|-None': {
-                        'result': False,
-                        'comment': 'Invalid top syntax',
-                        'name': 'Invalid sls',
-                        'changes': {},
-                        '__run_num__': 0,
-                   }}
+        if top[0] == 'invalid':
+            return top
         matches = self.top_matches(top)
         high, errors = self.render_highstate(matches)
 
@@ -1283,14 +1276,8 @@ class BaseHighState(object):
         '''
         err = []
         top = self.get_top()
-        if top == 'invalid':
-            return {'no_|-states_|-states_|-None': {
-                        'result': False,
-                        'comment': 'Invalid top syntax',
-                        'name': 'Invalid sls',
-                        'changes': {},
-                        '__run_num__': 0,
-                   }}
+        if top[0] == 'invalid':
+            return top
         matches = self.top_matches(top)
         high, errors = self.render_highstate(matches)
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -975,7 +975,6 @@ class BaseHighState(object):
                             env=env
                             )
                         )
-	#print tops
 
         # Search initial top files for includes
         for env, ctops in tops.items():

--- a/salt/state.py
+++ b/salt/state.py
@@ -1067,8 +1067,6 @@ class BaseHighState(object):
             if self.opts['environment']:
                 if not env == self.opts['environment']:
                     continue
-            if not isinstance(body, list):
-                return {'env': []}
             for match, data in body.items():
                 if self.matcher.confirm_top(
                         match,

--- a/salt/state.py
+++ b/salt/state.py
@@ -975,6 +975,7 @@ class BaseHighState(object):
                             env=env
                             )
                         )
+	#print tops
 
         # Search initial top files for includes
         for env, ctops in tops.items():
@@ -1010,6 +1011,14 @@ class BaseHighState(object):
                 if env in include:
                     include.pop(env)
 
+        for env,ctops in tops.items():
+            if env == '':
+                return 'invalid'
+            for ctop in ctops:
+                for key,val in ctop.items():
+                    if val['']:
+                        return 'invalid'
+
         return tops
 
     def merge_tops(self, tops):
@@ -1042,6 +1051,8 @@ class BaseHighState(object):
         Returns the high data derived from the top file
         '''
         tops = self.get_tops()
+	if tops == 'invalid':
+            return tops
         return self.merge_tops(tops)
 
     def top_matches(self, top):
@@ -1057,6 +1068,8 @@ class BaseHighState(object):
             if self.opts['environment']:
                 if not env == self.opts['environment']:
                     continue
+            if not isinstance(body, list):
+                return {'env': []}
             for match, data in body.items():
                 if self.matcher.confirm_top(
                         match,
@@ -1221,6 +1234,14 @@ class BaseHighState(object):
         Run the sequence to execute the salt highstate for this minion
         '''
         top = self.get_top()
+        if top == 'invalid':
+            return {'no_|-states_|-states_|-None': {
+                        'result': False,
+                        'comment': 'Invalid top syntax',
+                        'name': 'Invalid sls',
+                        'changes': {},
+                        '__run_num__': 0,
+                   }}
         matches = self.top_matches(top)
         self.load_dynamic(matches)
         high, errors = self.render_highstate(matches)
@@ -1242,6 +1263,14 @@ class BaseHighState(object):
         Return just the highstate or the errors
         '''
         top = self.get_top()
+        if top == 'invalid':
+            return {'no_|-states_|-states_|-None': {
+                        'result': False,
+                        'comment': 'Invalid top syntax',
+                        'name': 'Invalid sls',
+                        'changes': {},
+                        '__run_num__': 0,
+                   }}
         matches = self.top_matches(top)
         high, errors = self.render_highstate(matches)
 
@@ -1257,6 +1286,14 @@ class BaseHighState(object):
         '''
         err = []
         top = self.get_top()
+        if top == 'invalid':
+            return {'no_|-states_|-states_|-None': {
+                        'result': False,
+                        'comment': 'Invalid top syntax',
+                        'name': 'Invalid sls',
+                        'changes': {},
+                        '__run_num__': 0,
+                   }}
         matches = self.top_matches(top)
         high, errors = self.render_highstate(matches)
 


### PR DESCRIPTION
Sorry for all the other pull requests, I realized I forgot a test that ended up breaking with my patch. That is working now and tested. Tests were using `''` as the server name in various locations for the file.

Note:
This is only a prototype, feel free to reject and have me update more

Checks completely built top file for invalid keys, such as `''`. This can be
expanded to check for other things that are not expected by salt.

This is the output from `salt-call -l debug state.highstate` the the `top.sls` file contains `''`:

```
salt-call -l debug state.highstate
[DEBUG   ] Failed to import module json_mako, this is most likely NOT a problem: No module named mako.template
[DEBUG   ] Failed to import module yaml_mako, this is most likely NOT a problem: No module named mako.template
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion.pem
[DEBUG   ] Decrypting the current master AES key
[DEBUG   ] Loaded minion key: /etc/salt/pki/minion.pem
[INFO    ] Loading fresh modules for state activity
[DEBUG   ] Failed to import module json_mako, this is most likely NOT a problem: No module named mako.template
[DEBUG   ] Failed to import module yaml_mako, this is most likely NOT a problem: No module named mako.template
local:
----------
    State: - no
    Name:      states
    Function:  None
        Result:    False
        Comment:   Invalid top syntax
        Changes:   

```
