### PR TITLE
Fix upstart status command

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -75,7 +75,7 @@ def status(name, sig=None):
         salt '*' service.status <service name>
     '''
     cmd = 'service {0} status'.format(name)
-    return not __salt__['cmd.retcode'](cmd)
+    return 'start/running' in __salt__['cmd.run'](cmd)
 
 
 def _get_service_exec():


### PR DESCRIPTION
The output of upstart.status has been always True because the return code of "service FOO status" is always 0. This patch returns status based on the output of the service command, rather than the return code.
