### PR TITLE
Ignoring check_minion in a master of master setup

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -665,7 +665,13 @@ class LocalClient(object):
         # return what we get back
         minions = self.check_minions(tgt, expr_form)
 
-        if not minions:
+        if self.opts['order_masters']:
+            # If we're a master of masters, ignore the check_minion and
+            # set the minions to the target.  This speeds up wait time
+            # for lists and ranges and makes regex and other expression
+            # forms possible
+            minions = tgt
+        elif not minions:
             return {'jid': '',
                     'minions': minions}
 


### PR DESCRIPTION
This allows things other than globs to return values back to a master of masters.  Otherwise the check_minion method sets empty minions and we get an empty return back.  If we don't set the minion to something when we bypass the empty minion check, then we get no return later on
due to the minion being empty and the wtag not being written quickly enough to trigger the wtag check and continue statement in get_cli_returns().  Instead the empty minion set is less than than len(fret) and we break out of the loop.

The master actually recognizes that returns are received in the log, but I the race described above causes the CLI to bomb out.  This can also be fixed by bypassing the empty minion check when 'order_masters' is true and then changing the all the instances of:

if len(fret) >= len(minions):

to:

if len(fret) >= len(minions) and minions:

But I prefer the fix from this pull request as it allows the cli to return more quickly when things like lists (and ranges) are passed.
