### PR TITLE
Add a feature to retrieve a server ID based on FQDN

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -589,3 +589,12 @@ def _hw_data(osdata):
         }
         grains.update(_dmidecode_data(linux_dmi_regex))
     return grains
+
+def get_server_id():
+    '''
+    Provides an integer based on the FQDN of a machine. 
+    Useful as server-id in MySQL replication or anywhere else you'll need an ID like this.
+    '''
+    # Provides:
+    #   server_id    
+    return { 'server_id': abs(hash(socket.getfqdn()) % 2**31) }


### PR DESCRIPTION
This feature generates a (more or less) unique integer based on the FQDN of a machine. 
I'm using this to generate the server-id key for MySQL replication.
