### PR TITLE
When add_host re-ordered hosts it would leave out trailing new lines

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -178,7 +178,7 @@ def add_host(ip, alias):
             newline = comps[0] + '\t'
             for existing in comps[1:]:
                 newline += '\t' + existing
-            newline += '\t' + alias
+            newline += '\t' + alias + '\n'
             lines.remove(lines[ind])
             lines.append(newline)
             ovr = True

--- a/tests/integration/modules/hosts.py
+++ b/tests/integration/modules/hosts.py
@@ -128,11 +128,13 @@ class HostsModuleTest(integration.ModuleCase):
         assert self.run_function('hosts.add_host', ['192.168.1.2', 'host2'])
         assert self.run_function('hosts.add_host', ['192.168.1.2', 'oldhost2'])
         assert self.run_function('hosts.add_host', ['192.168.1.3', 'host3.fqdn.com'])
+        assert self.run_function('hosts.add_host', ['192.168.1.2', 'host2-reorder'])
+        assert self.run_function('hosts.add_host', ['192.168.1.1', 'host1-reorder'])
 
         # now read the lines and ensure they're formatted correctly
         lines = open(HFN, 'r').readlines()
         self.assertEqual(lines, [
-            "192.168.1.1\t\thost1.fqdn.com\thost1\n",
-            "192.168.1.2\t\thost2.fqdn.com\thost2\toldhost2\n",
             "192.168.1.3\t\thost3.fqdn.com\n",
+            "192.168.1.2\t\thost2.fqdn.com\thost2\toldhost2\thost2-reorder\n",
+            "192.168.1.1\t\thost1.fqdn.com\thost1\thost1-reorder\n",
             ])


### PR DESCRIPTION
This caused problems when adding another host and you'd end up with
entries such as:

```
192.168.1.2\t\thost2\thost2alias192.168.1.1\t\thost1\thost1alias
```

Test updated to reflect.
