### PR TITLE
Fix typo (more or less) in recent commit.

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -156,7 +156,7 @@ class Auth(object):
         payload = {}
         key = self.get_keys()
         fd_, tmp_pub = tempfile.mkstemp()
-        fd_.colse()
+        os.close(fd_)
         key.save_pub_key(tmp_pub)
         payload['enc'] = 'clear'
         payload['load'] = {}
@@ -191,7 +191,7 @@ class Auth(object):
         Returns a bool
         '''
         fd_, tmp_pub = tempfile.mkstemp()
-        fd_.close()
+        os.close(fd_)
         with open(tmp_pub, 'w+') as fp_:
             fp_.write(master_pub)
         os.remove(tmp_pub)


### PR DESCRIPTION
mkstemp returns a low-level os file descriptor, like the one returned
by open(2), and must be closed using os.close.

But then this happens:

```
Traceback (most recent call last):
  File "/home/tvaughan/.local/bin/salt-minion", line 18, in <module>
    main()
  File "/home/tvaughan/.local/bin/salt-minion", line 15, in main
    minion.start()
  File "/home/tvaughan/.local/lib/python2.7/site-packages/salt/__init__.py", line 190, in start
    minion = salt.minion.Minion(self.opts)
  File "/home/tvaughan/.local/lib/python2.7/site-packages/salt/minion.py", line 134, in __init__
    self.authenticate()
  File "/home/tvaughan/.local/lib/python2.7/site-packages/salt/minion.py", line 437, in authenticate
    creds = auth.sign_in()
  File "/home/tvaughan/.local/lib/python2.7/site-packages/salt/crypt.py", line 248, in sign_in
    if not self.verify_master(payload['pub_key'], payload['token']):
  File "/home/tvaughan/.local/lib/python2.7/site-packages/salt/crypt.py", line 199, in verify_master
    pub = RSA.load_pub_key(tmp_pub)
  File "/usr/lib/python2.7/dist-packages/M2Crypto/RSA.py", line 405, in load_pub_key
    bio = BIO.openfile(file) 
  File "/usr/lib/python2.7/dist-packages/M2Crypto/BIO.py", line 186, in openfile
    return File(open(filename, mode))
IOError: [Errno 2] No such file or directory: '/tmp/tmpSDbDdq'
```
