### PR TITLE
nginx.version fails on Fedora 16

### DIFF
--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -31,7 +31,7 @@ def version():
     cmd = __detect_os() + ' -v'
     out = __salt__['cmd.run'](cmd).split('\n')
     ret = out[0].split(': ')
-    return ret[2]
+    return ret[-1]
 
 def signal(signal=None):
     '''


### PR DESCRIPTION
At least on Fedora 16, "nginx -v" looks like "nginx version: nginx/1.0.14". Changed nginx.version to return the last element of the ":" split, rather than an arbitrary position.
