### PR TITLE
Restrict APT package version search to "Version".

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -42,7 +42,7 @@ def available_version(name):
         salt '*' pkg.available_version <package name>
     '''
     version = ''
-    cmd = 'apt-cache -q show {0} | grep Version'.format(name)
+    cmd = 'apt-cache -q show {0} | grep ^Version'.format(name)
 
     out = __salt__['cmd.run_stdout'](cmd)
 


### PR DESCRIPTION
For example, `python-setuptools` has both:

```
Version: 0.6.24-1ubuntu1
Python-Version: 2.6, 2.7
```

and version winds-up as "2.7".

Did someone say fire? :)
