### PR TITLE
Use return code to determine service status in Upstart module.

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -221,7 +221,7 @@ def status(name, sig=None):
         salt '*' service.status <service name>
     '''
     cmd = 'service {0} status'.format(name)
-    return 'start/running' in __salt__['cmd.run'](cmd)
+    return not bool(__salt__['cmd.retcode'](cmd))
 
 
 def _get_service_exec():


### PR DESCRIPTION
This also broke the "dead" state.

This is because `service` will call `/etc/init.d/<service-name>` for
System V style services. Each of which could have different output.

For example:

```
$ sudo invoke-rc.d exim4 stop
 * Stopping MTA                                               [ OK ]
$ sudo service exim4 status
 * checking separate queue runner daemon...                   [ OK ]
 * checking combined SMTP listener and queue runner daemon... [ OK ]
$ echo $?
3
$ sudo invoke-rc.d exim4 start
 * Starting MTA                                               [ OK ]
$ sudo service exim4 status
 * checking separate queue runner daemon...                   [ OK ]
 * checking combined SMTP listener and queue runner daemon... [ OK ]
$ echo $?
0
```

Ask and ye shall receive. :)
