### PR TITLE
add missing path module

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -43,7 +43,7 @@ def add(name,
         if home is True:
             cmd += '-m '
         else:
-            cmd += '-m -b {0} '.format(os.dirname(home))
+            cmd += '-m -b {0} '.format(os.path.dirname(home))
     cmd += '-n {0}'.format(name)
     ret = __salt__['cmd.run_all'](cmd)
 


### PR DESCRIPTION
Fixes the following error in modules/pw_user.py:

 The minion function caused an exception: Traceback (most recent call last):
[..]
  File "/usr/local/lib/python2.7/site-packages/salt/modules/pw_user.py", line 46, in add
    cmd += '-m -b {0} '.format(os.dirname(home))
AttributeError: 'module' object has no attribute 'dirname'
