### PR TITLE
Add cwd and runas options to virtualenv and pip modules

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -45,7 +45,8 @@ def install(pkgs=None,
             no_install=False,
             no_download=False,
             install_options=None,
-            runas=None):
+            runas=None,
+            cwd=None):
     '''
     Install packages with pip
 
@@ -120,6 +121,8 @@ def install(pkgs=None,
         path, be sure to use absolute path.
     runas
         User to run pip as
+    cwd
+        Current working directory to run pip from
 
 
     CLI Example::
@@ -253,7 +256,7 @@ def install(pkgs=None,
         cmd = '{cmd} --install-options={install_options} '.format(
             cmd=cmd, install_options=install_options)
 
-    return __salt__['cmd.run'](cmd, runas=runas)
+    return __salt__['cmd.run'](cmd, runas=runas, cwd=cwd)
 
 
 def uninstall(pkgs=None,
@@ -261,7 +264,9 @@ def uninstall(pkgs=None,
               bin_env=None,
               log=None,
               proxy=None,
-              timeout=None):
+              timeout=None,
+              runas=None,
+              cwd=None):
     '''
     Uninstall packages with pip
 
@@ -289,7 +294,10 @@ def uninstall(pkgs=None,
         password.
     timeout
         Set the socket timeout (default 15 seconds)
-
+    runas
+        User to run pip as
+    cwd
+        Current working directory to run pip from
 
     CLI Example::
 
@@ -334,10 +342,12 @@ def uninstall(pkgs=None,
         cmd = '{cmd} --timeout={timeout} '.format(
             cmd=cmd, timeout=timeout)
 
-    return __salt__['cmd.run'](cmd).split('\n')
+    return __salt__['cmd.run'](cmd, runas=runas, cwd=cwd).split('\n')
 
 
-def freeze(bin_env=None):
+def freeze(bin_env=None,
+           runas=None,
+           cwd=None):
     '''
     Return a list of installed packages either globally or in the specified
     virtualenv
@@ -348,21 +358,28 @@ def freeze(bin_env=None):
         pip-2.6, etc..) just specify the pip bin you want.
         If uninstalling from a virtualenv, just use the path to the virtualenv
         (/home/code/path/to/virtualenv/)
+    runas
+        User to run pip as
+    cwd
+        Current working directory to run pip from
     '''
 
     cmd = '{0} freeze'.format(_get_pip_bin(bin_env))
 
-    return __salt__['cmd.run'](cmd).split('\n')
+    return __salt__['cmd.run'](cmd, runas=runas, cwd=cwd).split('\n')
 
 
-def list(prefix='', bin_env=None):
+def list(prefix='',
+         bin_env=None,
+         runas=None,
+         cwd=None):
     '''
     Filter list of instaslled apps from ``freeze`` and check to see if ``prefix``
     exists in the list of packages installed.
     '''
     packages = {}
     cmd = '{0} freeze'.format(_get_pip_bin(bin_env))
-    for line in __salt__['cmd.run'](cmd).split("\n"):
+    for line in __salt__['cmd.run'](cmd, runas=runas, cwd=cwd).split("\n"):
         if line.startswith('-e'):
             line = line.split('-e ')[1]
             line, name = line.split('#egg=')
@@ -377,6 +394,3 @@ def list(prefix='', bin_env=None):
             else:
                 packages[name]=version
     return packages
-
-
-

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -39,7 +39,8 @@ def installed(name,
               no_install=False,
               no_download=False,
               install_options=None,
-              user=None):
+              user=None,
+              cwd=None):
     '''
     Make sure the package is installed
 
@@ -59,7 +60,7 @@ def installed(name,
         bin_env = env
 
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-    if name in __salt__['pip.list'](name, bin_env):
+    if name in __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd):
         ret['result'] = True
         ret['comment'] = 'Package already installed'
         return ret
@@ -94,8 +95,9 @@ def installed(name,
                                no_install=no_install,
                                no_download=no_download,
                                install_options=install_options,
-                               runas=user):
-        pkg_list = __salt__['pip.list'](name, bin_env) 
+                               runas=user,
+                               cwd=cwd):
+        pkg_list = __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd)
         version = pkg_list.values()[0]
         pkg_name = pkg_list.keys()[0]
         ret['result'] = True
@@ -114,7 +116,9 @@ def removed(name,
             bin_env=None,
             log=None,
             proxy=None,
-            timeout=None):
+            timeout=None,
+            user=None,
+            cwd=None):
     """
     Make sure that a package is not installed.
 
@@ -125,7 +129,8 @@ def removed(name,
     """
 
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-    if name not in __salt__["pip.list"](packages=name, bin_env=bin_env):
+    if name not in __salt__["pip.list"](packages=name, bin_env=bin_env,
+                                        runas=user, cwd=cwd):
         ret["result"] = True
         ret["comment"] = "Pacakge is not installed."
         return ret
@@ -140,7 +145,9 @@ def removed(name,
                                  bin_env=bin_env,
                                  log=log,
                                  proxy=proxy,
-                                 timeout=timeout):
+                                 timeout=timeout,
+                                 runas=user,
+                                 cwd=cwd):
         ret["result"] = True
         ret["changes"][name] = "Removed"
         ret["comment"] = "Package was successfully removed."

--- a/salt/states/virtualenv.py
+++ b/salt/states/virtualenv.py
@@ -19,7 +19,8 @@ def managed(name,
         never_download=False,
         prompt='',
         __env__='base',
-        runas=None):
+        runas=None,
+        cwd=None):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -28,6 +29,8 @@ def managed(name,
     requirements
         Path to a pip requirements file. If the path begins with ``salt://``
         the file will be transfered from the master file server.
+    cwd
+        Path to the working directory where "pip install" is executed.
 
     Also accepts any kwargs that the virtualenv module will.
 
@@ -117,7 +120,7 @@ def managed(name,
                 new_reqs = __salt__['cp.cache_local_file'](requirements)
 
             before = set(__salt__['pip.freeze'](bin_env=name))
-            __salt__['pip.install'](requirements=new_reqs, bin_env=name)
+            __salt__['pip.install'](requirements=new_reqs, bin_env=name, runas=runas, cwd=cwd)
             after = set(__salt__['pip.freeze'](bin_env=name))
 
             new = list(after - before)

--- a/salt/states/virtualenv.py
+++ b/salt/states/virtualenv.py
@@ -1,7 +1,6 @@
 '''
 virtualenv management
 '''
-import hashlib
 import logging
 import os
 
@@ -102,38 +101,19 @@ def managed(name,
 
     # Populate the venv via a requirements file
     if requirements:
-        reqs_cached = __salt__['cp.is_cached'](requirements)
+        if requirements.startswith('salt://'):
+            requirements = __salt__['cp.cache_file'](requirements, __env__)
+        before = set(__salt__['pip.freeze'](bin_env=name))
+        __salt__['pip.install'](requirements=requirements, bin_env=name, runas=runas, cwd=cwd)
+        after = set(__salt__['pip.freeze'](bin_env=name))
 
-        # If we already have a local cache, we've already run pip against it
-        if reqs_cached and not clear:
-            reqs_cached_hash = __salt__['cp.hash_file'](reqs_cached)
-            is_new = reqs_hash['hsum'] != reqs_cached_hash['hsum']
-        else:
-            # We don't have a local cache, so anything is new :)
-            is_new = True
+        new = list(after - before)
+        old = list(before - after)
 
-        # reqs file changed, cache the latest version and run pip against it
-        if is_new:
-            if requirements.startswith('salt://'):
-                new_reqs = __salt__['cp.cache_file'](requirements, __env__)
-            else:
-                new_reqs = __salt__['cp.cache_local_file'](requirements)
-
-            before = set(__salt__['pip.freeze'](bin_env=name))
-            __salt__['pip.install'](requirements=new_reqs, bin_env=name, runas=runas, cwd=cwd)
-            after = set(__salt__['pip.freeze'](bin_env=name))
-
-            new = list(after - before)
-            old = list(before - after)
-
-            if new or old:
-                ret['changes']['packages'] = {
-                    'new': new if new else '',
-                    'old': old if old else ''}
-        else:
-            logger.debug("Requirements file '{0}' not changed since last "
-                    "invocation; skipping pip".format(requirements))
-
+        if new or old:
+            ret['changes']['packages'] = {
+                'new': new if new else '',
+                'old': old if old else ''}
     ret['result'] = True
     return ret
 


### PR DESCRIPTION
Sometimes "cd dirname && pip install ./requirements.pip" is more preferable than "pip install ./dirname/requirements.pip" . It is especially important for those who want to add "-e ../my-other-package" in their requirements.pip.

Basically, it reflects my convention I use to deploy a complex project with a number of internal dependencies. I do a number of "git clone"s in the same directory (/opt/git-repos , for example), and then do "pip install -r requirements.pip" in the primary repository which installs everything else as dependency.

Additionally, there is a minor fix which performs "pip install" under the account defined in virtualenv.managed runas and there is a change in handling cached requirements files. The reasoning behind latter change is described in the commit message.

It seems that there is quite a lot of changes for one pull request, but I hope they will be accepted, as there should be no changes breaking any previously written rules. Thanks
