### PR TITLE
Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+language: python
+
 python:
   - '2.6'
   - '2.7'
@@ -6,10 +8,5 @@ branches:
   only:
     - develop
 
-before-install:
-  - sudo add-apt-repository ppa:saltstack/salt
-  - sudo apt-get update -y
-  - sudo apt-get install salt-master salt-syndic salt-minion
-
-script: cd tests && python runtests.py
-after_script: python setup.py bdist
+install: pip install -r requirements.txt --use-mirrors
+script: python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,9 @@ branches:
 
 install: pip install -r requirements.txt --use-mirrors
 script: python setup.py test
+
+notifications:
+  irc:
+    channels: "irc.freenode.org#salt"
+    on_success: change
+    on_failure: change


### PR DESCRIPTION
I took the liberty to assume that build notices should go to IRC.

Based on:

```
https://github.com/fabric/fabric/blob/master/.travis.yml
```

See also:

```
http://about.travis-ci.org/docs/user/build-configuration/
http://about.travis-ci.org/docs/user/languages/python/
```
