### PR TITLE
apt-get install some dependencies ahead of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ branches:
   only:
     - develop
 
+before_install:
+  - sudo apt-get install swig libssl-dev libzmq1-dev
+
 install: pip install -r requirements.txt --use-mirrors
 script: python setup.py test
 


### PR DESCRIPTION
Both python-m2crypto and python-zmq have C extensions which need some
libraries installed inorder to compile.

Travis CI runs Ubuntu Server 11.0. See also:

```
http://about.travis-ci.org/docs/user/ci-environment/
```

See Build-Depends:

```
http://packages.ubuntu.com/oneiric/python-m2crypto
http://packages.ubuntu.com/oneiric/python-zmq
```
