### PR TITLE
Use Debian's patched M2Crypto on Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ branches:
     - develop
 
 before_install:
-  - sudo apt-get update
-  - sudo apt-get install swig libssl-dev libzmq-dev
+  - sudo apt-get update && sudo apt-get install swig
+  - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi"
 
 install: pip install -r requirements.txt --use-mirrors
 script: python setup.py test


### PR DESCRIPTION
I really did test it this time. :) The service hook needs to be re-enabled in the saltstack org on GitHub. Also, would be nice if the m2crypto tarball could be moved to saltstack.org.

This enables CI builds on http://travis-ci.org/. Please see also:
http://travis-ci.org/#!/saltstak/salt.

Travis uses 32-bit Ubuntu Linux 11.10 (server edition) plus some
additional repositories, like RabbitMQ's own repo which provides the
zeromq package. This already contains the zeromq development headers
and libraries necessary to build Python extenstions in C. FYI - This
zeromq packake doesn't play nicely with the standard Debian/Ubuntu
zeromq packages like libzmq-dev. Also included are libssl-dev and
python-dev (but swig is missing). See also:
http://about.travis-ci.org/docs/user/ci-environment/

One complication is that M2Crypto requires SSL Version 2 support in
libssl. Debian and Ubuntu have disabled Version 2 support in libssl
since Version 2 is know to be insecure. We use our own source tarball
of M2Crypto that has been patched with the Debian/Ubuntu patches that
remove SSL Version 2. Please see:
http://packages.ubuntu.com/oneiric/python-m2crypto.

Salt also requires unittest2 which must be installed when using Python
2.6. unittest2 comes included with Python 2.7.

Finally: http://www.youtube.com/watch?v=pele5vptVgc
