### PR TITLE
fix typo s/_state/state

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -103,7 +103,7 @@ def find_name(name, state, high):
         for nid in high:
             if state in high[nid]:
                 if isinstance(
-                        high[nid][_state],
+                        high[nid][state],
                         list):
                     for arg in high[nid][state]:
                         if not isinstance(arg, dict):


### PR DESCRIPTION
Pylint was warning about an undefined name here:
http://ec2-23-21-15-64.compute-1.amazonaws.com:8080/job/pylint-salt/38/violations/file/salt/state.py/?

Looks like a typo.
