### PR TITLE
Update salt/modules/django.py

### DIFF
--- a/salt/modules/django.py
+++ b/salt/modules/django.py
@@ -1,3 +1,8 @@
+
+"""
+Manage Django sites
+"""
+
 import os
 
 def _get_django_admin(bin_env):


### PR DESCRIPTION
Hoping adding a docstring makes this module show up at http://salt.readthedocs.org/en/latest/ref/modules/all/index.html
