### PR TITLE
define abstract methods for file client

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -103,6 +103,18 @@ class Client(object):
         yield dest
         os.umask(cumask)
 
+    def get_file(self, path, dest='', makedirs=False, env='base'):
+        '''
+        Copies a file from the local files or master depending on implementation
+        '''
+        raise NotImplementedError
+
+    def file_list_emptydirs(self, env='base'):
+        '''
+        List the empty dirs
+        '''
+        raise NotImplementedError
+
     def cache_file(self, path, env='base'):
         '''
         Pull a file down from the file server and store it in the minion


### PR DESCRIPTION
Defining abstract methods with proper method signature and docstring will help the implementation.
Especially if the methods are already used from other methods in the base class.

Raising NotImplementedError exception will force the implementation to define methods which are not
implemented.

BTW, this change will make Pylint more happy: http://ec2-23-21-15-64.compute-1.amazonaws.com:8080/job/pylint-salt/39/violations/file/salt/fileclient.py/?
