### PR TITLE
Serialization of payload was not calling 'loads'

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -509,7 +509,7 @@ class Minion(object):
             while True:
                 payload = None
                 try:
-                    payload = self.serial(socket.recv(1))
+                    payload = self.serial.loads(socket.recv(1))
                     self._handle_payload(payload)
                 except:
                     pass


### PR DESCRIPTION
I am not sure whether this fix is correct or not, please review.

Jenkins warning about this: http://ec2-23-21-15-64.compute-1.amazonaws.com:8080/job/pylint-salt/43/violations/file/salt/minion.py/?
