### PR TITLE
Teach pip.py about Fedora-derived naming

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -10,7 +10,13 @@ def _get_pip_bin(bin_env):
     passed in, or from the global modules options
     '''
     if not bin_env:
-        pip_bin = 'pip'
+        # this should be a define somewhere else; pip probably isn't the only
+        # thing that cares about this
+        rh_like = ('CentOS','Scientific','RedHat','Fedora')
+        if __grains__['os'] in rh_like:
+            pip_bin = 'pip-python'
+        else:
+            pip_bin = 'pip'
     else:
         # try to get pip bin from env
         if os.path.exists(os.path.join(bin_env, 'bin', 'pip')):


### PR DESCRIPTION
System pip is located at /usr/bin/pip-python
if installed from the python-pip package. This
affects at least Fedora, RedHat, CentOS,
Scientific, possibly other derived systems.

Note, working inside a virtualenv on rh-derived
systems probably isn't affected as virtualenv will
generally install its own pip and make sure that
it is named ($ENV)/bin/pip
