### PR TITLE
Add missing import of random module

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -5,6 +5,7 @@ Some of the utils used by salt
 # Import Python libs
 import os
 import imp
+import random
 import sys
 import socket
 import logging


### PR DESCRIPTION
'random' module is used but not imported.

Ref: http://ec2-23-21-15-64.compute-1.amazonaws.com:8080/job/pylint-salt/46/violations/file/salt/utils/__init__.py/?
