### PR TITLE
Fix typo s/cpmment/comment

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -503,7 +503,7 @@ def _check_directory(
         comment = 'The following files will be changed:\n'
         for fn_ in changes:
             for key, val in changes[fn_].items():
-                cpmment += '{0}: {1} - {2}'.format(fn_, key, val)
+                comment += '{0}: {1} - {2}'.format(fn_, key, val)
         return None, comment
     return True, 'The directory {0} is in the correct state'.format(name)
 


### PR DESCRIPTION
'comment' is spelled incorrectly

Ref: http://ec2-23-21-15-64.compute-1.amazonaws.com:8080/job/pylint-salt/46/violations/file/salt/states/file.py/?
