### PR TITLE
Fix typo s/reps/resp (response object)

### DIFF
--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -498,7 +498,7 @@ def version(core_name=None):
         if resp['success']:
             version = resp['data']['lucene']['solr-spec-version']
             return _get_return_dict(True, {'version':version},
-                                    reps['errors'], resp['warnings'])
+                                    resp['errors'], resp['warnings'])
         else:
             return resp
 


### PR DESCRIPTION
'resp' is spelled incorrectly

Ref: http://ec2-23-21-15-64.compute-1.amazonaws.com:8080/job/pylint-salt/46/violations/file/salt/modules/solr.py/?
