### PR TITLE
Quote and brace escaping

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -275,7 +275,7 @@ def list_pkgs(regex_string=""):
         salt '*' pkg.list_pkgs httpd
     '''
     ret = {}
-    cmd = 'dpkg-query --showformat='${Status} ${Package} ${Version}\n' -W {0}'.format(regex_string)
+    cmd = 'dpkg-query --showformat=\'${Status} ${Package} ${Version}\n\' -W {0}'.format(regex_string)
 
     out = __salt__['cmd.run_stdout'](cmd)
 

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -275,7 +275,7 @@ def list_pkgs(regex_string=""):
         salt '*' pkg.list_pkgs httpd
     '''
     ret = {}
-    cmd = 'dpkg-query --showformat=\'${Status} ${Package} ${Version}\n\' -W {0}'.format(regex_string)
+    cmd = 'dpkg-query --showformat=\'${{Status}} ${{Package}} ${{Version}}\n\' -W {0}'.format(regex_string)
 
     out = __salt__['cmd.run_stdout'](cmd)
 


### PR DESCRIPTION
Quote and brace escaping fixes for the `dpkg-query` patch. Whoops.
