### PR TITLE
add X-Python-Version to debian/control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,6 +15,7 @@ Standards-Version: 3.9.3
 Homepage: http://saltstack.org
 #Vcs-Git: git://git.debian.org/collab-maint/salt.git
 #Vcs-Browser: http://git.debian.org/?p=collab-maint/salt.git;a=summary
+#X-Python-Version: >= 2.6, <= 2.7
 
 
 Package: salt-common


### PR DESCRIPTION
In Debian Squeeze if you have more python versions installed, for example python2.5 and python2.6, debhelper without this uses old 2.5 version.
