### PR TITLE
replace tab with space and trailing whitespace fix

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -29,8 +29,8 @@ class Master(object):
         # command line overrides config
         if self.cli['user']:
             self.opts['user'] = self.cli['user']
-        
-	# Send the pidfile location to the opts
+
+        # Send the pidfile location to the opts
         if self.cli['pidfile']:
             self.opts['pidfile'] = self.cli['pidfile']
 

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -19,7 +19,7 @@ def __virtual__():
         return False
     if not salt.utils.which('seinfo'):
         return False
-        
+
     global __selinux_fs_path__
     if __grains__['kernel'] == 'Linux':
         # systems running systemd (e.g. Fedora 15 and newer)
@@ -103,9 +103,9 @@ def setsebool(boolean, value, persist=False):
         salt '*' selinux.setsebool virt_use_usb off
     '''
     if persist:
-    	cmd = 'setsebool -P {0} {1}'.format(boolean, value)
+        cmd = 'setsebool -P {0} {1}'.format(boolean, value)
     else:
-    	cmd = 'setsebool {0} {1}'.format(boolean, value)
+        cmd = 'setsebool {0} {1}'.format(boolean, value)
     return not __salt__['cmd.retcode'](cmd)
 
 


### PR DESCRIPTION
Replaced few tab characters with space and few trailing whitespace fixes

The pep8 command is useful to identify these kind of issues:
http://jenkins.saltstack.org/job/pep8/45/violations/file/salt/__init__.py/?
http://jenkins.saltstack.org/job/pep8/45/violations/file/salt/modules/selinux.py/?
