### PR TITLE
more generic way to do raid.list

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -30,15 +30,14 @@ def list():
         if ' ' not in line:
             continue
         comps = line.split()
-        metadata = comps[2].split('=')
-        raidname = comps[3].split('=')
-        raiduuid = comps[4].split('=')
-        ret[comps[1]] = {
-            'device': comps[1],
-            'metadata': metadata[1],
-            'name': raidname[1],
-            'uuid': raiduuid[1],
-        }
+        device = comps[1]
+        print comps
+        ret[device] = {"device": device}
+        for comp in comps[2:]:
+             key = comp.split('=')[0].lower()
+             value = comp.split('=')[1]
+             ret[device][key] = value
+
     return ret
 
 

--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -31,13 +31,11 @@ def list():
             continue
         comps = line.split()
         device = comps[1]
-        print comps
         ret[device] = {"device": device}
         for comp in comps[2:]:
              key = comp.split('=')[0].lower()
              value = comp.split('=')[1]
              ret[device][key] = value
-
     return ret
 
 


### PR DESCRIPTION
On some systems there is diferent number of fields in result of  `mdadm --detail --scan`. For example there doesn't have to be a name field.

```
ARRAY /dev/md1 metadata=0.90 UUID=b3abc3c5:cde48c3b:f8031c3e:594fcefe
ARRAY /dev/md0 metadata=0.90 UUID=b4e9a9fc:a8db9577:f8031c3e:594fcefe
```

It results to `IndexError: list index out of range`

This commit solves it.
