### PR TITLE
Fix bug and clean up version handling in pacman.install.

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -142,14 +142,10 @@ def install(name, refresh=False, **kwargs):
         salt '*' pkg.install <package name>
     '''
     fname = name
-    if 'gt' in kwargs:
-        fname = '"{0}>{1}"'.format(name, kwargs['gt'])
-    if 'lt' in kwargs:
-        fname = '"{0}<{1}"'.format(name, kwargs['lt'])
-    if 'eq' in kwargs:
-        fname = '"{0}={1}"'.format(name, kwargs['eq'])
-    if 'version' in kwargs:
-        fname = '"{0}={1}"'.format(name, kwargs['version'])
+    for vkey, vsign in (('gt', '>'), ('lt', '<'), ('eq', '='), ('version', '=')):
+        if vkey in kwargs and kwargs[vkey] is not None:
+            fname = '"{0}{1}{2}"'.format(name, vsign, kwargs[vkey])
+            break
     old = list_pkgs()
     cmd = 'pacman -S --noprogressbar --noconfirm {0}'.format(fname)
     if refresh:


### PR DESCRIPTION
Since the check for 'version' in kwarg did not check that the version
value was not None installation of new packages through the pkg
state (which always passes version as a kwarg) resulted in the following
commandline if no version was specified in the state file:

```
pacman -Syu --noprogressbar --noconfirm "bash-completion=None"
```
