### PR TITLE
Add SSH key based authentication to git commands

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -22,6 +22,15 @@ def _git_getdir(cwd, user=None):
 def _check_git():
     utils.check_or_die('git')
 
+def _git_environ(identity=None, **kwargs):
+    if identity:
+        os.environ["GIT_SSH_IDENTITY"] = identity
+        os.environ['GIT_SSH']='salt-git-ssh'
+    else:
+        del os.environ['GIT_SSH']
+        del os.environ["GIT_SSH_IDENTITY"]
+
+
 def revision(cwd, rev='HEAD', short=False, user=None):
     '''
     Returns the long hash of a given identifier (hash, branch, tag, HEAD, etc)
@@ -52,7 +61,7 @@ def revision(cwd, rev='HEAD', short=False, user=None):
     else:
         return ''
 
-def clone(cwd, repository, opts=None, user=None):
+def clone(cwd, repository, opts=None, user=None, **kwargs):
     '''
     Clone a new repository
 
@@ -77,6 +86,7 @@ def clone(cwd, repository, opts=None, user=None):
 
     '''
     _check_git()
+    _git_environ(**kwargs)
 
     if not opts:
         opts = ''
@@ -142,7 +152,7 @@ def archive(cwd, output, rev='HEAD', fmt=None, prefix=None, user=None):
 
     return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)
 
-def fetch(cwd, opts=None, user=None):
+def fetch(cwd, opts=None, user=None, **kwargs):
     '''
     Perform a fetch on the given repository
 
@@ -162,6 +172,7 @@ def fetch(cwd, opts=None, user=None):
         salt '*' git.fetch cwd=/path/to/repo opts='--all' user=johnny
     '''
     _check_git()
+    _git_environ(**kwargs)
 
     if not opts:
         opts = ''
@@ -169,7 +180,7 @@ def fetch(cwd, opts=None, user=None):
 
     return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)
 
-def pull(cwd, opts=None, user=None):
+def pull(cwd, opts=None, user=None, **kwargs):
     '''
     Perform a pull on the given repository
 
@@ -187,10 +198,11 @@ def pull(cwd, opts=None, user=None):
         salt '*' git.pull /path/to/repo opts='--rebase origin master'
     '''
     _check_git()
+    _git_environ(**kwargs)
 
     if not opts:
         opts = ''
-    return __salt__['cmd.run']('git pull {0}'.format(opts), cwd=cwd, runas=user)
+    return __salt__['cmd.run']('git pull {1}'.format(opts),cwd=cwd, runas=user)
 
 def rebase(cwd, rev='master', opts=None, user=None):
     '''

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -202,7 +202,7 @@ def pull(cwd, opts=None, user=None, **kwargs):
 
     if not opts:
         opts = ''
-    return __salt__['cmd.run']('git pull {1}'.format(opts),cwd=cwd, runas=user)
+    return __salt__['cmd.run']('git pull {0}'.format(opts),cwd=cwd, runas=user)
 
 def rebase(cwd, rev='master', opts=None, user=None):
     '''

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -21,6 +21,7 @@ log = logging.getLogger(__name__)
 def latest(name,
            rev=None,
            target=None,
+           identity=None,
            runas=None):
     '''
     Make sure the repository is cloned to the given directory and is up to date
@@ -57,7 +58,7 @@ def latest(name,
                     'revision is {1})').format(target, current_rev))
         if rev:
             __salt__['git.checkout'](target, rev)
-        __salt__['git.pull'](target, user=runas)
+        __salt__['git.pull'](target, user=runas, identity=identity)
         new_rev = __salt__['git.revision'](cwd=target, user=runas)
         if current_rev != new_rev:
             log.info('Repository {0} updated: {1} => {2}'.format(target,
@@ -77,7 +78,7 @@ def latest(name,
                     'Repository {0} is about to be cloned to {1}'.format(
                         name, target))
         # make the clone
-        result = __salt__['git.clone'](target, name, user=runas)
+        result = __salt__['git.clone'](target, name, user=runas, identity=identity)
         if not os.path.isdir(target):
             return _fail(ret, result)
         if rev:

--- a/scripts/salt-git-ssh
+++ b/scripts/salt-git-ssh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+IDENTITY=""
+
+if [ "x$GIT_SSH_IDENTITY" != "x" ]; then
+	IDENTITY="-i $GIT_SSH_IDENTITY"
+fi
+
+ssh $IDENTITY -o StrictHostKeyChecking=no -o PasswordAuthentication=no $@

--- a/setup.py
+++ b/setup.py
@@ -100,6 +100,7 @@ setup(
                'scripts/salt-cp',
                'scripts/salt-call',
                'scripts/salt-run',
+               'scripts/salt-git-ssh',
                'scripts/salt'],
       data_files=[('share/man/man1',
                     ['doc/man/salt-master.1',


### PR DESCRIPTION
This change will allow someone to specify an SSH identity when doing git commands by adding identity=<minion-local private key>.

This is an example of the expected use case:

``` bash
salt '*' git.clone /opt/myproject git@gitosis-server:myproject.git identity=/opt/mykeys/id_rsa.git
```
