### PR TITLE
Targeting->Grains did not actually document how to target minions based on grain information.

### DIFF
--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -16,6 +16,14 @@ information in grains is unchanging, therefore the nature of the data is
 static. So grains information are things like the running kernel, or the
 operating system.
 
+Match all CentOS minions::
+
+    salt -G 'os:CentOS' test.ping
+
+Match all minions with 64 bit CPUs and return number of available cores::
+
+    salt -G 'cpuarch:x86_64' grains.item num_cpus
+
 Grains in the Minion Config
 ===========================
 


### PR DESCRIPTION
Added CLI example to Targeting->Grains documentation page.

There are two other things missing - but I'm not 100% sure on the syntax so you should be able to fix it better:
- On Targeting->Grains, add top.sls example of how to target based on grains (similar to Targeting->Node Groups page).
- On Targeting->Compound, document how to target based on node groups ("N" I presume).
