### PR TITLE
setup.py falls down, goes boom when building package for Debian Squeeze

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,9 @@
 The setup script for salt
 '''
 
+# For Python 2.5.  A no-op on 2.6 and above.
+from __future__ import with_statement
+
 import os
 import sys
 from glob import glob


### PR DESCRIPTION
For reasons I can't be compelled to care about, `dpkg-buildpackage` on Debian Squeeze tries to evaluate the `setup.py` for salt with Python 2.5.  This causes pain and suffering:

```
$ dpkg-buildpackage -us -uc
dpkg-buildpackage: export CFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export CPPFLAGS from dpkg-buildflags (origin: vendor):
dpkg-buildpackage: export CXXFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export FFLAGS from dpkg-buildflags (origin: vendor): -g -O2
dpkg-buildpackage: export LDFLAGS from dpkg-buildflags (origin: vendor):
dpkg-buildpackage: source package salt
dpkg-buildpackage: source version 0.9.9.1
dpkg-buildpackage: source changed by Tom Vaughan <thomas.david.vaughan@gmail.com>
dpkg-buildpackage: host architecture amd64
 dpkg-source --before-build salt-0.9.9.1
 fakeroot debian/rules clean
dh clean #--with python2
   dh_testdir
   dh_auto_clean
setup.py:55: Warning: 'with' will become a reserved keyword in Python 2.6
  File "setup.py", line 55
    with open('requirements.txt') as f:
            ^
SyntaxError: invalid syntax
dh_auto_clean: python2.5 setup.py clean -a returned exit code 1
make: *** [clean] Error 1
dpkg-buildpackage: error: fakeroot debian/rules clean gave error exit status 2
```

`import`ing the `with` statement from `__future__` makes it build, and should be harmless to all the other Pythons out there.
