### PR TITLE
ignore code coverage outputs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@ share/
 
 # setuptools stuff
 *.egg-info
+
+# code coverage outputs genereated by coverage.py
+.coverage
+coverage.xml
+htmlcov/


### PR DESCRIPTION
Added code coverage outputs genereated by
coverage.py to .gitignore .  To generate code
coverage report, run this command:

  coverage run tests/runtests.py

To produce HTML coverage repot (`htmlcov/index.html`):

  coverage html --omit=tests/*

To produce Cobertura compliant XML for Jenkins:

  coverage xml --omit=tests/*
