### PR TITLE
Check text from init.d instead of return code

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -222,7 +222,7 @@ def status(name, sig=None):
     '''
     cmd = 'service {0} status'.format(name)
     if _service_is_sysv(name):
-        return not bool(__salt__['cmd.retcode'](cmd))
+        return 'not\ running' in __salt__['cmd.run'](cmd)
     return 'start/running' in __salt__['cmd.run'](cmd)
 
 


### PR DESCRIPTION
Since the return code seems to be 0 for both upstart and init.d based services when checking status.

Fixes #1225 that I just posted.
