### PR TITLE
Make it clearer that a user-switch error can be solved through a configuration change

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -108,11 +108,8 @@ def check_user(user, log):
             os.setgid(p.pw_gid)
             os.setuid(p.pw_uid)
         except OSError:
-            if user == 'root':
-                msg = 'Sorry, the salt must run as root.  http://xkcd.com/838'
-            else:
-                msg = 'Salt must be run from root or user "{0}"'.format(user)
-            log.critical(msg)
+            msg = 'Salt configured to run as user "{0}" but unable to switch.'
+            log.critical(msg.format(user))
             return False
     except KeyError:
         msg = 'User not found: "{0}"'.format(user)


### PR DESCRIPTION
The current error message when salt is configured (as it is by default) to run as root suggests that salt can _only_ be run as root. Change this to point out that it is simply unable to switch to the target user and thus suggest that the user can be changed via configuration.
