### PR TITLE
adding /etc/salt template files to setup.py so they get packaged

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,6 +117,10 @@ setup(
                 ('share/man/man7',
                     ['doc/man/salt.7',
                     ]),
+                ('/etc/salt',
+                    ['conf/master.template',
+                     'conf/minion.template',
+                    ]),
                  ],
       install_requires=requirements,
      )


### PR DESCRIPTION
I just added the master.template and minion.template files to the setup.py script so that they'd get packaged/installed into /etc/salt.  I tested this with bdist_rpm and it worked as expected (and as I personally desire) but some more testing might be needed (although it's a pretty trivial change).
