### PR TITLE
Print a message to the console or /tmp when sent a SIGUSR1

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -26,6 +26,7 @@ import salt.crypt
 import salt.loader
 import salt.utils
 import salt.payload
+from salt.utils.debug import enable_sigusr1_handler
 
 log = logging.getLogger(__name__)
 
@@ -475,6 +476,10 @@ class Minion(object):
         socket.setsockopt(zmq.SUBSCRIBE, '')
         socket.setsockopt(zmq.IDENTITY, self.opts['id'])
         socket.connect(self.master_pub)
+
+        # Make sure to gracefully handle SIGUSR1
+        enable_sigusr1_handler()
+
         if self.opts['sub_timeout']:
             last = time.time()
             while True:

--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -1,0 +1,43 @@
+'''
+Print a stacktrace when sent a SIGUSR1 for debugging
+'''
+
+import os
+import sys
+import time
+import signal
+import datetime
+import tempfile
+import traceback
+
+def _makepretty(printout, stack):
+    '''
+    Pretty print the stack trace and environment information
+    for debugging those hard to reproduce user problems.  :)
+    '''
+    printout.write('======== Salt Debug Stack Trace =========\n')
+    traceback.print_stack(stack, file=printout)
+    printout.write('=========================================\n')
+
+
+def _handle_sigusr1(sig, stack):
+    '''
+    Signal handler for SIGUSR1, only available on Unix-like systems
+    '''
+    # When running in the foreground, do the right  thing
+    # and spit out the debug info straight to the console
+    if sys.stderr.isatty():
+        output = sys.stderr
+        _makepretty(output, stack)
+    else:
+        filename = 'salt-debug-{0}.log'.format(int(time.time()))
+        destfile = os.path.join(tempfile.gettempdir(), filename)
+        with open(destfile, 'w') as output:
+            _makepretty(output, stack)
+
+def enable_sigusr1_handler():
+    '''
+    Pretty print a stack trace to the console or a debug log under /tmp
+    when any of the salt daemons such as salt-master are sent a SIGUSR1
+    '''
+    signal.signal(signal.SIGUSR1, _handle_sigusr1)


### PR DESCRIPTION
Please _do_ test this out before merging.

This will print a stacktrace of the currently running code when any
of the salt-minion or salt-master processes are sent a SIGUSR1 signal.
This is for seeing what's going on and to help with debugging.

Here is how I was testing this patch out:

```
# ps -efH | grep salt-mast[e]r
root     12740  2783  1 20:56 pts/0    00:00:00         python /home/jeff/git/salt/scripts/salt-master -l debug
root     12741 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root     12748 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root     12751 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root     12754 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root     12757 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root     12760 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root     12763 12740  0 20:56 pts/0    00:00:00           python /home/jeff/git/salt/scripts/salt-master -l debug
root@desktopmonster:~# kill -SIGUSR1 12740
root@desktopmonster:~# kill -SIGUSR1 12741
```

Minion example:

```
======== Salt Debug Stack Trace =========
  File "/home/jeff/git/salt/scripts/salt-minion", line 18, in <module>
    main()
  File "/home/jeff/git/salt/scripts/salt-minion", line 15, in main
    minion.start()
  File "/home/jeff/git/salt/salt/__init__.py", line 202, in start
    minion.tune_in()
  File "/home/jeff/git/salt/salt/minion.py", line 510, in tune_in
    time.sleep(0.05)
=========================================
```

Master watchdog process example:

```
======== Salt Debug Stack Trace =========
  File "/home/jeff/git/salt/scripts/salt-master", line 17, in <module>
    main()
  File "/home/jeff/git/salt/scripts/salt-master", line 14, in main
    master.start()
  File "/home/jeff/git/salt/salt/__init__.py", line 110, in start
    master.start()
  File "/home/jeff/git/salt/salt/master.py", line 192, in start
    reqserv.run()
  File "/home/jeff/git/salt/salt/master.py", line 304, in run
    self.__bind()
  File "/home/jeff/git/salt/salt/master.py", line 286, in __bind
    zmq.device(zmq.QUEUE, self.clients, self.workers)
=========================================
```

Master worker example:

```
======== Salt Debug Stack Trace =========
  File "/home/jeff/git/salt/scripts/salt-master", line 17, in <module>
    main()
  File "/home/jeff/git/salt/scripts/salt-master", line 14, in main
    master.start()
  File "/home/jeff/git/salt/salt/__init__.py", line 110, in start
    master.start()
  File "/home/jeff/git/salt/salt/master.py", line 158, in start
    clear_old_jobs_proc.start()
  File "/usr/lib/python2.6/multiprocessing/process.py", line 104, in start
    self._popen = Popen(self)
  File "/usr/lib/python2.6/multiprocessing/forking.py", line 99, in __init__
    code = process_obj._bootstrap()
  File "/usr/lib/python2.6/multiprocessing/process.py", line 232, in _bootstrap
    self.run()
  File "/usr/lib/python2.6/multiprocessing/process.py", line 88, in run
    self._target(*self._args, **self._kwargs)
  File "/home/jeff/git/salt/salt/master.py", line 145, in _clear_old_jobs
    time.sleep(60)
=========================================
```

I'm sure there are places missed as this needs a _lot_ more testing,
but for the moment, it "works for me TM". I'd like to test this out on a `salt-minion` process right in the middle of a long-running state-highstate just to see what happens, but don't have that setup on this machine at the moment.

Checking the exception for `errno.EINTR` as an idea was shamelessly lifted from [this commit](https://github.com/minrk/ipython/commit/379a29008cb614143024772f7146a926ce0e9278) in ipython.

Spin the wheels, test this out, and let me know what you think.
