### PR TITLE
Choose shell

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -56,6 +56,10 @@ def _run(cmd,
     if not cwd:
         cwd = os.path.expanduser('~{0}'.format('' if not runas else runas))
 
+    if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
+        msg = 'The shell {0} is not available'.format(shell)
+        raise CommandExecutionError(msg)
+
     # TODO: Figure out the proper way to do this in windows
     disable_runas = [
         'Windows',

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -30,18 +30,11 @@ syslog if there is no disk space:
       cmd:
         - run
         - unless: echo 'foo' > /tmp/.test
-
-.. warning::
-
-    Please be advised that on Unix systems the shell being used by python
-    to run executions is /bin/sh, this requires that commands are formatted
-    to execute under /bin/sh. Some capabilities of newer shells such as bash,
-    zsh and ksh will not always be available on minions.
-
 '''
 
 import grp
 import os
+import os.path
 from salt.exceptions import CommandExecutionError
 
 def wait(name,
@@ -112,6 +105,9 @@ def run(name,
 
     group
         The group context to run the command as
+
+    shell
+        The shell to use for execution, defaults to /bin/sh
     '''
     ret = {'name': name,
            'changes': {},
@@ -144,6 +140,10 @@ def run(name,
             except KeyError:
                 ret['comment'] = 'The group {0} is not available'.format(group)
                 return ret
+
+        if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
+            ret['comment'] = 'The shell {0} is not available'.format(shell)
+            return ret
 
         cmd_kwargs = {'cwd': cwd,
                       'runas': user,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -167,7 +167,7 @@ def run(name,
             try:
                 cmd_all = __salt__['cmd.run_all'](name, **cmd_kwargs)
             except CommandExecutionError as e:
-                ret['comment'] = e
+                ret['comment'] = e.message
                 return ret
 
             ret['changes'] = cmd_all

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -34,7 +34,6 @@ syslog if there is no disk space:
 
 import grp
 import os
-import os.path
 from salt.exceptions import CommandExecutionError
 
 def wait(name,
@@ -145,10 +144,6 @@ def run(name,
             except KeyError:
                 ret['comment'] = 'The group {0} is not available'.format(group)
                 return ret
-
-        if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
-            ret['comment'] = 'The shell {0} is not available'.format(shell)
-            return ret
 
         cmd_kwargs = {'cwd': cwd,
                       'runas': user,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -42,7 +42,9 @@ def wait(name,
         unless=None,
         cwd='/root',
         user=None,
-        group=None):
+        group=None,
+        shell='/bin/sh',
+        env=()):
     '''
     Run the given command only if the watch statement calls it
 
@@ -67,6 +69,9 @@ def wait(name,
 
     group
         The group context to run the command as
+
+    shell
+        The shell to use for execution, defaults to /bin/sh
     '''
     return {'name': name,
             'changes': {},


### PR DESCRIPTION
I saw the disclaimer on the shell the could be used in cmd state and it made me mad and I thought to myself, "Why!?" So I decided to fix it. After looking at the code I was more confused, since the functionality is already there. I added a little bit of logic checking that a specified shell exists and is executable in cmdmod since shells can be defined and I modified the comments so that the generated documentation will reflect that.

Was there a reason that you were saying people where limited to /bin/sh for executing commands?
