### PR TITLE
Fix MAC address handling in FreeBSD

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -146,7 +146,7 @@ def _interfaces_ifconfig():
     ret = {}
 
     piface = re.compile('^(\w+)')
-    pmac = re.compile('.*?(?:HWaddr|ether) (.*?)\s')
+    pmac = re.compile('.*?(?:HWaddr|ether) ([0-9a-fA-F:]+)')
     pip = re.compile('.*?(?:inet addr:|inet )(.*?)\s')
     pip6 = re.compile('.*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)')
     pmask = re.compile('.*?(?:Mask:|netmask )(?:(0x[0-9a-fA-F]{8})|([\d\.]+))')
@@ -393,7 +393,7 @@ def hwaddr(interface):
         salt '*' network.hwaddr eth0
     '''
     data = interfaces().get(interface)
-    if data:
+    if data and 'hwaddr' in data:
         return data['hwaddr']
     else:
         return None


### PR DESCRIPTION
- The `ifconfig` command on FreeBSD, and as I've seen on CentOS too, displays MAC address information on a single line (FreeBSD) or as a last entry in line (CentOS), so there's no `\s` at the end, but a new line.
- Loopback interfaces (`lo*`) on FreeBSD have no MAC addresses assigned, so instead of Traceback `network.hwaddr` should return `None`.
