### PR TITLE
Added "force" option to git.latest state

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -14,6 +14,7 @@ It may be replaced with a generic VCS module if this proves viable.
 '''
 import logging
 import os
+import shutil
 
 log = logging.getLogger(__name__)
 
@@ -21,7 +22,8 @@ log = logging.getLogger(__name__)
 def latest(name,
            rev=None,
            target=None,
-           runas=None):
+           runas=None,
+           force=None):
     '''
     Make sure the repository is cloned to the given directory and is up to date
 
@@ -33,13 +35,15 @@ def latest(name,
         Name of the target directory where repository is about to be cloned
     runas
         Name of the user performing repository management operations
+    force
+        Force git to clone into pre-existing directories (deletes contnents)
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
         return _fail(ret, '"target" option is required')
 
 
-    if os.path.isdir(target):
+    if os.path.isdir(target) and os.path.isdir('{0}/.git'.format(target)):
         # git pull is probably required
         log.debug(
                 'target {0} is found, "git pull" is probably required'.format(
@@ -67,10 +71,20 @@ def latest(name,
             ret['changes']['revision'] = '{0} => {1}'.format(
                     current_rev, new_rev)
     else:
-        # git clone is required
-        log.debug(
-                'target {0} is not found, "git clone" is required'.format(
-                    target))
+        if os.path.isdir(target):
+            # git clone is required, but target exists and is non-empty
+            if not force:
+                return _fail(ret, 'Directory exists, is non-empty, and force '
+                    'option not in use')
+            log.debug(
+                    'target {0} found, but not a git repository. force option'
+                    ' is in use, deleting {0}...'.format(target))
+            shutil.rmtree(target)
+        else:
+            # git clone is required
+            log.debug(
+                    'target {0} is not found, "git clone" is required'.format(
+                        target))
         if __opts__['test']:
             return _neutral_test(
                     ret,


### PR DESCRIPTION
This commit adds a "force" option to git.latest. It now checks for both target and target/.git to determine whether the target is a git repository that should be pulled, or if cloning is necessary. If cloning is necessary and the target exists, the force option can be used with will delete the existing target directory to allow git to clone the repository in it's place. Otherwise, it returns an error indicating that the target already exists, but isn't a git repository.
