### PR TITLE
Use shell grain as default in modules/cmdmod.py

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -523,17 +523,6 @@ def saltversion():
     from salt import __version__
     return {'saltversion': __version__}
 
-def shell():
-    '''
-    Return the default shell to use on this system
-    '''
-    # Provides:
-    #   shell
-    ret = {'shell': '/bin/sh'}
-    if 'SHELL' in os.environ:
-        ret['shell'] = os.environ['SHELL']
-    return ret
-
 # Relatively complex mini-algorithm to iterate over the various
 # sections of dmidecode output and return matches for  specific
 # lines containing data we want, but only in the right section.

--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -1,0 +1,13 @@
+import os
+
+def shell():
+    '''
+    Return the default shell to use on this system
+    '''
+    # Provides:
+    #   shell
+    ret = {'shell': '/bin/sh'}
+    if 'SHELL' in os.environ:
+        ret['shell'] = os.environ['SHELL']
+    return ret
+

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import salt.utils
 from salt.exceptions import CommandExecutionError
+from salt.grains.extra import shell as shell_grain
 
 # Only available on posix systems, nonfatal on windows
 try:
@@ -27,8 +28,7 @@ __outputter__ = {
     'run': 'txt',
 }
 
-
-DEFAULT_SHELL = '/bin/sh'
+DEFAULT_SHELL = shell_grain()['shell']
 
 def __virtual__():
     '''


### PR DESCRIPTION
This required moving the shell grain out of the core file so that
it could be imported into cmdmod. This was required because
**grains** isn't part of the globals when cmdmod is first called
because grains/core imports it and for this same reason a function
in core couldn't be imported into cmdmod.
