### PR TITLE
Fixes for bugs causing minion to crash on Windows.

### DIFF
--- a/salt/grains/extra.py
+++ b/salt/grains/extra.py
@@ -6,4 +6,4 @@ def shell():
     '''
     # Provides:
     #   shell
-    return {'shell': os.environ.get('SHELL', '/bin/sh'}
+    return {'shell': os.environ.get('SHELL', '/bin/sh')}

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -56,9 +56,7 @@ def _run(cmd,
     if not cwd:
         cwd = os.path.expanduser('~{0}'.format('' if not runas else runas))
     
-    if os.environ['os'].startswith('Windows'):
-        pass
-    else:
+    if 'os' in os.environ and not os.environ['os'].startswith('Windows'):
         if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
             msg = 'The shell {0} is not available'.format(shell)
             raise CommandExecutionError(msg)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -55,10 +55,13 @@ def _run(cmd,
     # of the user salt-minion is running as.  Default:  /root
     if not cwd:
         cwd = os.path.expanduser('~{0}'.format('' if not runas else runas))
-
-    if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
-        msg = 'The shell {0} is not available'.format(shell)
-        raise CommandExecutionError(msg)
+    
+    if os.environ['os'].startswith('Windows'):
+        pass
+    else:
+        if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
+            msg = 'The shell {0} is not available'.format(shell)
+            raise CommandExecutionError(msg)
 
     # TODO: Figure out the proper way to do this in windows
     disable_runas = [

--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -40,4 +40,9 @@ def enable_sigusr1_handler():
     Pretty print a stack trace to the console or a debug log under /tmp
     when any of the salt daemons such as salt-master are sent a SIGUSR1
     '''
-    signal.signal(signal.SIGUSR1, _handle_sigusr1)
+    #  Skip setting up this signal on Windows
+    #  SIGUSR1 doesn't exist on Windows and causes the minion to crash
+    if os.environ['os'].startswith('Windows'):
+        pass
+    else:
+        signal.signal(signal.SIGUSR1, _handle_sigusr1)

--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -42,7 +42,5 @@ def enable_sigusr1_handler():
     '''
     #  Skip setting up this signal on Windows
     #  SIGUSR1 doesn't exist on Windows and causes the minion to crash
-    if os.environ['os'].startswith('Windows'):
-        pass
-    else:
+    if 'os' in os.environ and not os.environ['os'].startswith('Windows'):
         signal.signal(signal.SIGUSR1, _handle_sigusr1)


### PR DESCRIPTION
The first commit fixes a small bug that I believe appears on all operating systems, due to a missing paren.

The last two commits skip some checks that fail on Windows.
