### PR TITLE
Fix the boolean logic to support RHEL/Fedora pkg

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -11,17 +11,17 @@ def __virtual__():
     '''
     Confine this module to yum based systems
     '''
-    # Return this for pkg on RHEL/Fedora based distros that do not ship with
+    # Return 'pkg' on RHEL/Fedora based distros that ship with
     # python 2.6 or greater.
     dists = ('CentOS', 'Scientific', 'RedHat')
     if __grains__['os'] == 'Fedora':
-        if int(__grains__['osrelease'].split('.')[0]) < 11:
+        if int(__grains__['osrelease'].split('.')[0]) >= 11:
             return 'pkg'
         else:
             return False
     else:
         if __grains__['os'] in dists:
-            if int(__grains__['osrelease'].split('.')[0]) <= 5:
+            if int(__grains__['osrelease'].split('.')[0]) >= 6:
                 return 'pkg'
             else:
                 return False


### PR DESCRIPTION
Python 2.6 is available in Fedora 11 and RHEL 6/CentOS 6
releases onwards.  Fix the 'osrelease' version parsing logic.
