### PR TITLE
remove trailing whitespaces

### DIFF
--- a/salt/cli/key.py
+++ b/salt/cli/key.py
@@ -46,7 +46,7 @@ class Key(object):
         else:
             ret = set(keys)
         return ret
-    
+
     def _log(self, message, level=''):
         if hasattr(log, level):
             log_msg = getattr(log, level)
@@ -122,13 +122,13 @@ class Key(object):
                 self._log(kfn.read())
         self._log(utils.LIGHT_GREEN + 'Accepted keys:' + utils.ENDC)
         for key in sorted(self._keys('acc', True)):
-            self._log('  ' + utils.GREEN + os.path.basename(key) + 
+            self._log('  ' + utils.GREEN + os.path.basename(key) +
                          utils.ENDC)
             with open(key, 'r') as kfn:
                 self._log(kfn.read())
         self._log(utils.LIGHT_BLUE + 'Rejected keys:' + utils.ENDC)
         for key in sorted(self._keys('pre', True)):
-            self._log('  ' + utils.BLUE + os.path.basename(key) + 
+            self._log('  ' + utils.BLUE + os.path.basename(key) +
                          utils.ENDC)
             with open(key, 'r') as kfn:
                 self._log(kfn.read())
@@ -190,7 +190,7 @@ class Key(object):
                          level='info')
     def _delete_all(self):
         '''
-        Delete all keys 
+        Delete all keys
         '''
         for dir in ("acc", "rej", "pre"):
             for key in self._keys(dir):
@@ -227,7 +227,7 @@ class Key(object):
     def _check_minions_directories(self):
         minions_accepted = os.path.join(self.opts['pki_dir'], 'minions')
         minions_pre = os.path.join(self.opts['pki_dir'], 'minions_pre')
-        minions_rejected = os.path.join(self.opts['pki_dir'], 
+        minions_rejected = os.path.join(self.opts['pki_dir'],
                                         'minions_rejected')
         for dir_ in [minions_accepted, minions_pre, minions_rejected]:
             if not os.path.isdir(dir_):

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -304,7 +304,7 @@ def _windows_platform_data(osdata):
     #    inputlocale
     #    timezone
     #    windowsdomain
-        
+
     grains = {}
     (osname, hostname, osrelease, osversion, machine, processor) = platform.uname()
     if 'os' not in osdata and osname:
@@ -315,7 +315,7 @@ def _windows_platform_data(osdata):
         grains['osversion'] = osversion
     get_these_grains = {
         'OS Manufacturer': 'osmanufacturer',
-        'System Manufacturer': 'manufacturer', 
+        'System Manufacturer': 'manufacturer',
         'System Model': 'productname',
         'BIOS Version': 'biosversion',
         'OS Name': 'osfullname',
@@ -635,9 +635,9 @@ def _hw_data(osdata):
 
 def get_server_id():
     '''
-    Provides an integer based on the FQDN of a machine. 
+    Provides an integer based on the FQDN of a machine.
     Useful as server-id in MySQL replication or anywhere else you'll need an ID like this.
     '''
     # Provides:
-    #   server_id    
+    #   server_id
     return { 'server_id': abs(hash(__opts__['id']) % 2**31) }

--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -23,7 +23,7 @@ def __get_aliases_filename():
 def __parse_aliases():
     '''
     Parse the aliases file, and return a list of line components:
-    
+
     [
       (alias1, target1, comment1),
       (alias2, target2, comment2),
@@ -69,7 +69,7 @@ def __write_aliases_file(lines):
 
     out.close()
     os.rename(out.name, afn)
-    
+
     newaliases_path = '/usr/bin/newaliases'
     if os.path.exists(newaliases_path):
         __salt__['cmd.run'](newaliases_path)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -55,7 +55,7 @@ def _run(cmd,
     # of the user salt-minion is running as.  Default:  /root
     if not cwd:
         cwd = os.path.expanduser('~{0}'.format('' if not runas else runas))
-    
+
     if 'os' in os.environ and not os.environ['os'].startswith('Windows'):
         if not os.path.isfile(shell) or not os.access(shell, os.X_OK):
             msg = 'The shell {0} is not available'.format(shell)

--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -44,7 +44,7 @@ def dump(new_data):
 
     CLI Example::
 
-        salt '*' data.dump '{'eggs': 'spam'}' 
+        salt '*' data.dump '{'eggs': 'spam'}'
     '''
     if not isinstance(new_data, dict):
         if isinstance(ast.literal_eval(new_data), dict):
@@ -54,10 +54,10 @@ def dump(new_data):
 
     try:
         fn_ = open(os.path.join(__opts__['cachedir'], 'datastore'), "w")
-        
+
         serial = salt.payload.Serial(__opts__)
         serial.dump(new_data, fn_)
-        
+
         return True
 
     except (IOError, OSError):
@@ -81,7 +81,7 @@ def getval(key):
     Get a value from the minion datastore
 
     CLI Example::
-        
+
         salt '*' data.getval <key>
     '''
     store = load()
@@ -92,7 +92,7 @@ def getvals(keys):
     Get values from the minion datastore
 
     CLI Example::
-        
+
         salt '*' data.getvals <key>
     '''
     store = load()

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -35,7 +35,7 @@ def get_enabled():
 def get_disabled():
     '''
     Return a set of services that are installed but disabled
-    
+
     CLI Example::
 
         salt '*' service.get_disabled

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -401,27 +401,27 @@ def hwaddr(interface):
 def host_to_ip(host):
     '''
     Returns the IP address of a given hostname
-    
+
     CLI Example::
-        
+
         salt '*' network.host_to_ip example.com
     '''
     try:
         ip = socket.gethostbyname( host )
     except:
-        ip = None        
+        ip = None
     return ip
-        
+
 def ip_to_host(ip):
     '''
     Returns the hostname of a given IP
-    
+
     CLI Example::
-        
+
         salt '*' network.ip_to_host 8.8.8.8
     '''
     try:
         hostname, aliaslist, ipaddrlist = socket.gethostbyaddr( ip )
     except:
-        hostname = None        
+        hostname = None
     return hostname

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -396,7 +396,7 @@ def list(prefix='',
             line = line.split('-e ')[1]
             line, name = line.split('#egg=')
             packages[name]=line
-            
+
         elif len(line.split("==")) >= 2:
             name = line.split("==")[0]
             version = line.split("==")[1]

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -222,7 +222,7 @@ def user_create(username,
 
     if sub_cmd.endswith("WITH"):
         sub_cmd = sub_cmd.replace(" WITH", "")
-    
+
     cmd = 'psql -h {host} -U {user} -p {port} -c "{sub_cmd}"'.format(
         host=host, user=user, port=port, sub_cmd=sub_cmd)
     return __salt__['cmd.run'](cmd)

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -1,5 +1,5 @@
 '''
-The networking module for RHEL/Fedora based distros 
+The networking module for RHEL/Fedora based distros
 '''
 # Import python libs
 import logging
@@ -30,7 +30,7 @@ _ETHTOOL_CONFIG_OPTS = [
     'rx', 'tx', 'sg', 'tso', 'ufo',
     'gso', 'gro', 'lro'
 ]
-_RH_CONFIG_OPTS = [ 
+_RH_CONFIG_OPTS = [
     'domain', 'peerdns', 'defaultroute',
     'mtu', 'static-routes'
 ]
@@ -45,7 +45,7 @@ _MAC_REGEX = re.compile('([0-9A-F]{1,2}:){5}[0-9A-F]{1,2}')
 _CONFIG_TRUE = [ 'yes', 'on', 'true', '1', True]
 _CONFIG_FALSE = [ 'no', 'off', 'false', '0', False]
 _IFACE_TYPES = [
-    'eth', 'bond', 'alias', 'clone', 
+    'eth', 'bond', 'alias', 'clone',
     'ipsec', 'dialup', 'slave', 'vlan',
 ]
 
@@ -65,11 +65,11 @@ def _parse_ethtool_opts(opts, iface):
     '''
     Fiters given options and outputs valid settings for ETHTOOLS_OPTS
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
     config = {}
-    
+
     if opts.has_key('autoneg'):
         if opts['autoneg'] in _CONFIG_TRUE:
             config.update( {'autoneg':'on'} )
@@ -77,28 +77,28 @@ def _parse_ethtool_opts(opts, iface):
             config.update( {'autoneg':'off'} )
         else:
             _raise_error(iface, 'autoneg', _CONFIG_TRUE + _CONFIG_FALSE)
-        
+
     if opts.has_key('duplex'):
         valid = ['full', 'half']
         if opts['duplex'] in valid:
             config.update( {'duplex':opts['duplex']} )
         else:
             _raise_error(iface, 'duplex', valid)
-            
+
     if opts.has_key('mtu'):
         try:
             int(opts['mtu'])
             config.update( {'mtu': opts['mtu']} )
         except:
             _raise_error(iface, 'mtu', ['integer'])
-            
+
     if opts.has_key('speed'):
         valid = ['10', '100', '1000']
         if str(opts['speed']) in valid:
             config.update( {'speed':opts['speed']} )
         else:
             _raise_error(iface, opts['speed'], valid)
-    
+
     valid = _CONFIG_TRUE + _CONFIG_FALSE
     for option in ('rx', 'tx', 'sg', 'tso', 'ufo', 'gso', 'gro', 'lro'):
         if opts.has_key(option):
@@ -115,10 +115,10 @@ def _parse_settings_bond(opts, iface):
     '''
     Fiters given options and outputs valid settings for requested
     operation. If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
-    
+
     # Bonding settings
     if 'mode' not in opts:
         #TODO raise an error
@@ -130,23 +130,23 @@ def _parse_settings_bond(opts, iface):
         'arp_interval':'250',
         # miimon * 2
         'downdelay':'200',
-        # lacp_rate 0: Slow - every 30 seconds 
+        # lacp_rate 0: Slow - every 30 seconds
         # lacp_rate 1: Fast - every 1 second
         'lacp_rate':'0',
         # Max bonds for this driver
         'max_bonds':'1',
         # Specifies the time, in milliseconds, to wait before
-        # enabling a slave after a link recovery has been 
+        # enabling a slave after a link recovery has been
         # detected. Only used with miimon.
         'updelay':'0',
-        # Used with miimon. 
+        # Used with miimon.
         # On: driver sends mii
         # Off: ethtool sends mii
         'use_carrier':'on',
         # Defualt. Don't change unless you know what you are doing.
         'xmit_hash_policy':'layer2',
     }
-    
+
     if opts['mode'] in ['balance-rr', '0']:
         return _parse_settings_bond_0(opts, iface, bond_def)
     elif opts['mode'] in ['active-backup', '1']:
@@ -162,18 +162,18 @@ def _parse_settings_bond(opts, iface):
     elif opts['mode'] in ['balance-alb', '6']:
         return _parse_settings_bond_6(opts, iface, bond_def)
     else:
-        valid = [ 
-            '0', '1', '2', '3', '4', '5', '6', 
-            'balance-rr', 'active-backup', 'balance-xor', 
+        valid = [
+            '0', '1', '2', '3', '4', '5', '6',
+            'balance-rr', 'active-backup', 'balance-xor',
             'broadcast', '802.3ad', 'balance-tlb', 'balance-alb'
         ]
         _raise_error(iface, 'mode', valid)
-    
+
 def _parse_settings_bond_0(opts, iface, bond_def):
     '''
-    Fiters given options and outputs valid settings for bond0. 
+    Fiters given options and outputs valid settings for bond0.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
     bond = {'mode':'0'}
@@ -192,7 +192,7 @@ def _parse_settings_bond_0(opts, iface, bond_def):
             _raise_error(iface, 'arp_ip_target', valid)
     else:
         _raise_error(iface, 'arp_ip_target', valid)
-    
+
     if opts.has_key('arp_interval'):
         try:
             int(opts['arp_interval'])
@@ -202,19 +202,19 @@ def _parse_settings_bond_0(opts, iface, bond_def):
     else:
         _log_default(iface, 'arp_interval', bond_def['arp_interval'])
         bond.update( {'arp_interval':bond_def['arp_interval']} )
-         
+
     return bond
-    
+
 def _parse_settings_bond_1(opts, iface, bond_def):
-    
+
     '''
-    Fiters given options and outputs valid settings for bond1. 
+    Fiters given options and outputs valid settings for bond1.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
     bond = {'mode':'1'}
-    
+
     for bo in ['miimon', 'downdelay', 'updelay']:
         if opts.has_key(bo):
             try:
@@ -236,20 +236,20 @@ def _parse_settings_bond_1(opts, iface, bond_def):
             _raise_error(face, 'use_carrier', valid)
     else:
         _log_default(iface, 'use_carrier', bond_def['use_carrier'])
-        bond.update( {'use_carrier': bond_def['use_carrier']} )    
+        bond.update( {'use_carrier': bond_def['use_carrier']} )
 
     return bond
-                    
+
 def _parse_settings_bond_2(opts, iface, bond_def):
     '''
-    Fiters given options and outputs valid settings for bond2. 
+    Fiters given options and outputs valid settings for bond2.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
-    
+
     bond = {'mode':'2'}
-    
+
     valid = ['list of ips (up to 16)']
     if opts.has_key('arp_ip_target'):
         if isinstance(opts['arp_ip_target'], list):
@@ -263,7 +263,7 @@ def _parse_settings_bond_2(opts, iface, bond_def):
             _raise_error(iface, 'arp_ip_target', valid)
     else:
         _raise_error(iface, 'arp_ip_target', valid)
-    
+
     if opts.has_key('arp_interval'):
         try:
             int(opts['arp_interval'])
@@ -273,25 +273,25 @@ def _parse_settings_bond_2(opts, iface, bond_def):
     else:
         _log_default(iface, 'arp_interval', bond_def['arp_interval'])
         bond.update( {'arp_interval':bond_def['arp_interval']} )
-    
+
     if opts.has_key('primary'):
         bond.update( {'primary': opts['primary']} )
-    
+
     if opts.has_key('hashing-algorithm'):
         valid = ['layer2', 'layer3+4']
         if opts['hashing-algorithm'] in valid:
             bond.update( {'xmit_hash_policy':opts['hashing-algorithm']})
         else:
             _raise_error(iface, 'hashing-algorithm', valid)
-         
+
     return bond
-        
+
 def _parse_settings_bond_3(opts, iface, bond_def):
 
     '''
-    Fiters given options and outputs valid settings for bond3. 
+    Fiters given options and outputs valid settings for bond3.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
     bond = {'mode':'3'}
@@ -306,7 +306,7 @@ def _parse_settings_bond_3(opts, iface, bond_def):
         else:
             _log_default(iface, bo, bond_def[bo])
             bond.update( {bo:bond_def[bo]} )
-            
+
     if opts.has_key('use_carrier'):
         if opts['use_carrier'] in _CONFIG_TRUE:
             bond.update( {'use_carrier': 'on'} )
@@ -317,15 +317,15 @@ def _parse_settings_bond_3(opts, iface, bond_def):
             _raise_error(iface, 'use_carrier', valid)
     else:
         _lod_default(iface, 'use_carrier', bond_def['use_carrier'])
-        bond.update( {'use_carrier': bond_def['use_carrier'] } )    
+        bond.update( {'use_carrier': bond_def['use_carrier'] } )
 
     return bond
-        
+
 def _parse_settings_bond_4(opts, iface, bond_def):
     '''
-    Fiters given options and outputs valid settings for bond4. 
+    Fiters given options and outputs valid settings for bond4.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
 
@@ -361,7 +361,7 @@ def _parse_settings_bond_4(opts, iface, bond_def):
     else:
         _log_default(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update( {'use_carrier': bond_def['use_carrier'] } )
-    
+
     if opts.has_key('hashing-algorithm'):
         valid = ['layer2', 'layer3+4']
         if opts['hashing-algorithm'] in valid:
@@ -370,13 +370,13 @@ def _parse_settings_bond_4(opts, iface, bond_def):
             _raise_error(iface, 'hashing-algorithm', valid)
 
     return bond
-    
+
 def _parse_settings_bond_5(opts, iface, bond_def):
 
     '''
-    Fiters given options and outputs valid settings for bond5. 
+    Fiters given options and outputs valid settings for bond5.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
     bond = {'mode':'5'}
@@ -403,15 +403,15 @@ def _parse_settings_bond_5(opts, iface, bond_def):
     else:
         _log_default(iface, 'use_carrier', bond_def['use_carrier'])
         bond.update( {'use_carrier': bond_def['use_carrier'] } )
-        
-    return bond    
-        
+
+    return bond
+
 def _parse_settings_bond_6(opts, iface, bond_def):
 
     '''
-    Fiters given options and outputs valid settings for bond6. 
+    Fiters given options and outputs valid settings for bond6.
     If an option has a value that is not expected, this
-    fuction will log what the Interface, Setting and what it was 
+    fuction will log what the Interface, Setting and what it was
     expecting.
     '''
     bond = {'mode':'6'}
@@ -437,8 +437,8 @@ def _parse_settings_bond_6(opts, iface, bond_def):
             _raise_error(iface, 'use_carrier', valid)
     else:
         _log_default(iface, 'use_carrier', bond_def['use_carrier'])
-        bond.update( {'use_carrier': bond_def['use_carrier'] } )    
-    
+        bond.update( {'use_carrier': bond_def['use_carrier'] } )
+
     return bond
 
 def _parse_settings_eth(opts, iface):
@@ -474,7 +474,7 @@ def _parse_settings_eth(opts, iface):
     else:
         ifaces = __salt__['network.interfaces']()
         if iface in ifaces and 'hwaddr' in ifaces[iface]:
-            result['addr'] = ifaces[iface]['hwaddr']         
+            result['addr'] = ifaces[iface]['hwaddr']
 
     for opt in ['ipaddr', 'master', 'netmask', 'srcaddr']:
         if opt in opts:
@@ -514,7 +514,7 @@ def _write_file(iface, data, folder, pattern):
     '''
     Writes a file to disk
     '''
-    filename = join(folder, pattern % iface) 
+    filename = join(folder, pattern % iface)
     if not exists(folder):
         msg = '%s cannot be written. %s does not exists'
         msg = msg % (filename, folder)
@@ -548,7 +548,7 @@ def build_interface(iface, type, settings):
             msg = 'master is a required setting for slave interfaces'
             log.error(msg)
             raise AttributeError(msg)
-    
+
     if type == 'vlan':
         settings['vlan'] = 'yes'
 

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -30,7 +30,7 @@ def _runlevel():
     out = __salt__['cmd.run']('runlevel').strip()
     # unknown will be returned while inside a kickstart environment, since
     # this is usually a server deployment it should be safe to assume runlevel
-    # 3.  If not all service related states will throw an out of range 
+    # 3.  If not all service related states will throw an out of range
     # exception here which will cause other functions to fail.
     if 'unknown' in out:
         return '3'

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -162,7 +162,7 @@ def refresh_pillar():
         return True
     except IOError:
         return False
-    
+
 
 def running():
     '''

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -162,7 +162,7 @@ def disable(name):
 def enabled(name):
     '''
     Return if the named service is enabled to start on boot
-    
+
     CLI Example::
 
         salt '*' service.enabled <service name>

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -15,7 +15,7 @@ def add(name, gid=None):
 
     CLI Example::
 
-        salt '*' group.add foo 
+        salt '*' group.add foo
     '''
     cmd = 'net localgroup {0} /add'.format(name)
 
@@ -56,7 +56,7 @@ def info(name):
         if 'successfully' in line:
             memberline = False
         if memberline:
-            gr_mem.append(line.strip())    
+            gr_mem.append(line.strip())
         if '---' in line:
             memberline = True
     if not gr_name:
@@ -84,7 +84,7 @@ def getent():
         if 'successfully' in line:
             groupline = False
         if groupline:
-            ret.append(line.strip('*').strip())    
+            ret.append(line.strip('*').strip())
         if '---' in line:
             groupline = True
     for item in ret:
@@ -96,10 +96,10 @@ def getent():
             if 'successfully' in line:
                 memberline = False
             if memberline:
-                members.append(line.strip('*').strip())    
+                members.append(line.strip('*').strip())
             if '---' in line:
                 memberline = True
-        group = {'gid': gid, 
+        group = {'gid': gid,
                 'members': members,
                 'name': item,
                 'passwd': 'x'}

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -114,7 +114,7 @@ def traceroute(host):
                 'count': comps[0],
                 'hostname': None,
                 'ip': None,
-                'ms1': None, 
+                'ms1': None,
                 'ms2': None,
                 'ms3': None}
             ret.append(result)
@@ -144,7 +144,7 @@ def nslookup(host):
 def dig(host):
     '''
     Performs a DNS lookup with dig
-    
+
     Note: dig must be installed on the Windows minion
 
     CLI Example::
@@ -218,14 +218,14 @@ def interfaces():
             continue
         if configstart == 1:
             configname = line.strip(' :')
-            config = {configname: {}} 
+            config = {configname: {}}
             configstart = configstart + 1
             continue
     for iface in ifaces:
         for key, val in iface.iteritems():
-            item = {} 
-            itemdict = {'Physical Address': 'hwaddr', 
-                        'IPv4 Address': 'ipaddr', 
+            item = {}
+            itemdict = {'Physical Address': 'hwaddr',
+                        'IPv4 Address': 'ipaddr',
                         'Link-local IPv6 Address': 'ipaddr6',
                         'Subnet Mask': 'netmask',
                         }
@@ -237,7 +237,7 @@ def interfaces():
                 item['up'] = True
             else:
                 item['up'] = False
-            ret[key] = item 
+            ret[key] = item
     return ret
 
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -78,17 +78,17 @@ def version(name):
 def list_pkgs(*args):
     '''
         List the packages currently installed in a dict::
-    
+
             {'<package_name>': '<version>'}
-    
+
         CLI Example::
-    
+
             salt '*' pkg.list_pkgs
     '''
     pythoncom.CoInitialize()
     if len(args) == 0:
         pkgs = dict(
-                   _get_reg_software().items() + 
+                   _get_reg_software().items() +
                    _get_msi_software().items())
     else:
         # get package version for each package in *args
@@ -106,7 +106,7 @@ def _search_software(target):
     '''
     search_results = {}
     software = dict(
-                    _get_reg_software().items() + 
+                    _get_reg_software().items() +
                     _get_msi_software().items())
     for key, value in software.iteritems():
         if key is not None:
@@ -151,9 +151,9 @@ def _get_reg_software():
                    'SchedulingAgent',
                    'WIC'
                    ]
-    #attempt to corral the wild west of the multiple ways to install 
+    #attempt to corral the wild west of the multiple ways to install
     #software in windows
-    reg_entries = dict(_get_user_keys().items() + 
+    reg_entries = dict(_get_user_keys().items() +
                        _get_machine_keys().items())
     for reg_hive, reg_keys in reg_entries.iteritems():
         for reg_key in reg_keys:
@@ -186,8 +186,8 @@ def _get_reg_software():
 
 def _get_machine_keys():
     '''
-    This will return the hive 'const' value and some registry keys where 
-    installed software information has been known to exist for the 
+    This will return the hive 'const' value and some registry keys where
+    installed software information has been known to exist for the
     HKEY_LOCAL_MACHINE hive
     '''
     machine_hive_and_keys = {}
@@ -201,8 +201,8 @@ def _get_machine_keys():
 
 def _get_user_keys():
     '''
-    This will return the hive 'const' value and some registry keys where 
-    installed software information has been known to exist for the 
+    This will return the hive 'const' value and some registry keys where
+    installed software information has been known to exist for the
     HKEY_USERS hive
     '''
     user_hive_and_keys = {}
@@ -295,7 +295,7 @@ def upgrade():
 
 def remove(name):
     '''
-    Remove a single package 
+    Remove a single package
 
     Return a list containing the removed packages.
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -1,5 +1,5 @@
 '''
-Windows Service module. 
+Windows Service module.
 '''
 
 import time

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -35,7 +35,7 @@ def info(name):
 
 def set_password(name, password):
     '''
-    Set the password for a named user. 
+    Set the password for a named user.
 
     CLI Example::
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -6,7 +6,7 @@ NOTE: This currently only works with local user accounts, not domain accounts
 
 def __virtual__():
     '''
-    Set the user module if the kernel is Windows 
+    Set the user module if the kernel is Windows
     '''
     return 'user' if __grains__['kernel'] == 'Windows' else False
 
@@ -31,7 +31,7 @@ def delete(name):
 
     CLI Example::
 
-        salt '*' user.delete name 
+        salt '*' user.delete name
     '''
     cmd = 'net user {0} /delete'.format(name)
     ret = __salt__['cmd.run_all'](cmd)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -78,7 +78,7 @@ def list_upgrades(*args):
         salt '*' pkg.list_upgrades
     '''
     pkgs=list_pkgs()
-    
+
     yb=yum.YumBase()
     versions_list={}
     for pkgtype in ['updates']:
@@ -88,7 +88,7 @@ def list_upgrades(*args):
             for pkg in exactmatch:
                 if pkg.arch == getBaseArch():
                     versions_list[pkg['name']] = '-'.join([pkg['version'],pkg['release']])
-    return versions_list    
+    return versions_list
 
 def available_version(name):
     '''

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -37,7 +37,7 @@ then a new cron job will be added to the user's crontab.
 
 def _check_cron(cmd, user, minute, hour, dom, month, dow):
     '''
-    Return the changes 
+    Return the changes
     '''
     lst = __salt__['cron.list_tab'](user)
     for cron in lst['crons']:
@@ -201,7 +201,7 @@ def absent(name,
         elif status == 'present' or status == 'update':
             ret['comment'] = 'Cron {0} is set to be removed'.format(name)
         return ret
-    
+
     data = __salt__['cron.rm_job'](
             user,
             minute,

--- a/salt/states/mysql_database.py
+++ b/salt/states/mysql_database.py
@@ -17,14 +17,14 @@ def present(name):
 
     name
         The name of the database to manage
-    '''    
+    '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': 'Database {0} is already present'.format(name)}
     # check if database exists
     if __salt__['mysql.db_exists'](name):
-        return ret        
+        return ret
 
     if __opts__['test']:
         ret['result'] = None
@@ -65,7 +65,7 @@ def absent(name):
             ret['comment'] = 'Database {0} has been removed'.format(name)
             ret['changes'][name] = 'Absent'
             return ret
-        
+
     # fallback
     ret['comment'] = ('Database {0} is not present, so it cannot be removed'
             ).format(name)

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -3,8 +3,8 @@ import difflib
 '''
 Network Management
 ==================
-The network module is used to create and manage network settings, 
-interfaces can be set as either managed or ignored. By default 
+The network module is used to create and manage network settings,
+interfaces can be set as either managed or ignored. By default
 all interfaces are ignored unless specified.
 
 .. code-block:: yaml
@@ -25,7 +25,7 @@ eth2:
     - managed
     - type: slave
     - master: bond0
-    
+
 eth3:
   network:
     - managed
@@ -120,28 +120,28 @@ def managed(
         ):
     '''
     Ensure that the named interface is configured properly.
-    
+
     name
         The name of the interface to manage
-    
+
     type
         Type of interface and configuration.
-    
+
     enabled
         Designates the state of this interface.
-        
+
     kwargs
         The IP parameters for this interface.
-        
+
     '''
-    
+
     ret = {
         'name': name,
         'changes': {},
         'result': True,
         'comment': 'Interface {0} is up to date.'.format(name)
     }
-           
+
     # Build interface
     try:
         old = __salt__['ip.get_interface'](name)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -71,7 +71,7 @@ def installed(
                 'changes': {},
                 'result': True,
                 'comment': 'Package {0} is already installed'.format(name)}
-    
+
     if __opts__['test']:
         return {'name': name,
                 'changes': {},

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -46,7 +46,7 @@ def present(name, value, config='/etc/sysctl.conf'):
                     value
                     )
             return ret
-    
+
     update = __salt__['sysctl.persist'](name, value, config)
 
     if update == 'Updated':

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -41,7 +41,7 @@ def _changes(
     Return a dict of the changes required for a user if the user is present,
     otherwise return False.
     '''
-    
+
     change = {}
     found = False
 
@@ -142,7 +142,7 @@ def present(
 
 
     User comment field (GECOS) support (currently Linux-only):
-    
+
     The below values should be specified as strings to avoid ambiguities when
     the values are loaded. (Especially the phone and room number fields which
     are likely to contain numeric data)
@@ -152,10 +152,10 @@ def present(
 
     roomnumber
         The user's room number
-    
+
     workphone
         The user's work phone number
-    
+
     homephone
         The user's home phone number
 
@@ -219,7 +219,7 @@ def present(
         if ret['changes']:
             ret['comment'] = 'Updated user {0}'.format(name)
         return ret
- 
+
     if changes is False:
         # The user is not present, make it!
         if __opts__['test']:

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -78,7 +78,7 @@ def verify_env(dirs):
         # Allow the pki dir to be 700 or 750, but nothing else.
         # This prevents other users from writing out keys, while
         # allowing the use-case of 3rd-party software (like django)
-        # to read in what it needs to integrate. 
+        # to read in what it needs to integrate.
         #
         # If the permissions aren't correct, default to the more secure 700.
         smode = stat.S_IMODE(mode.st_mode)

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -55,7 +55,7 @@ class FileTest(integration.ModuleCase):
         result = ret[ret.keys()[0]]['result']
         self.assertTrue(result)
         self.assertFalse(os.path.isdir(name))
-    
+
     def test_absent_link(self):
         '''
         file.absent

--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -40,7 +40,7 @@ def parse():
                   'the terminal'))
 
     options, args = parser.parse_args()
-    
+
     opts = {}
 
     for key, val in options.__dict__.items():


### PR DESCRIPTION
This is how I removed trailing whitespaces

Run `pep8` command:

```
pep8 --select=W291,W293 salt tests > ws.txt
```

Open the pep8 output with `-q` option:

```
vim -q ws.txt
```

Inside Vim, set two options:

```
:nnoremap <silent> <F5> :let _s=@/<Bar>:%s/\s\+$//e<Bar>:let @/=_s<Bar>:nohl<CR>
:map z <F5>:w<cr>:cnfile<cr>
```

Press down `z` key multiple times
