### PR TITLE
improve module documentation examples

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -202,7 +202,7 @@ Objects Loaded Into the Salt Minion
 
     class baz:
         def __init__(self, quo):
-            return quo
+            pass
 
 Objects NOT Loaded into the Salt Minion
 ---------------------------------------

--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -176,8 +176,9 @@ Documenting Salt modules is easy! Just add a python docstring to the function.
         '''
         A function to make some spam with eggs!
 
-        CLI Example:
-        salt '*' test.spam eggs
+        CLI Example::
+
+            salt '*' test.spam eggs
         '''
         return eggs
 
@@ -234,7 +235,8 @@ function, test.ping:
         Just used to make sure the minion is up and responding
         Return True
 
-        CLI Example:
-        salt '*' test.ping
+        CLI Example::
+
+            salt '*' test.ping
         '''
         return True


### PR DESCRIPTION
Two small improvements:
- Use reStructuredText syntax in example docstring
- simplify example (`__init__` can only return None)
