### PR TITLE
Declare out in local client sys.doc

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -308,6 +308,7 @@ class SaltCMD(object):
                         self._output_ret(ret, out)
                     elif self.opts['fun'] == 'sys.doc':
                         ret = {}
+                        out = ''
                         for full_ret in local.cmd_cli(*args):
                             ret_, out = self._format_ret(full_ret)
                             ret.update(ret_)


### PR DESCRIPTION
When this is undeclared we get an unbound local var error which is masking the actual cause that there are no connected minions to check docs on.
