### PR TITLE
Expr_form is not passed through with publish module

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -65,6 +65,7 @@ def _publish(
             'fun': fun,
             'arg': arg,
             'tgt': tgt,
+            'expr_form': expr_form,
             'ret': returner,
             'tok': tok,
             'tmo': timeout,


### PR DESCRIPTION
expr_form is an option for the publish command, but doesnt work actually cause the parameter is not passed through. This commit will fix this.
