### PR TITLE
Expr_form is not passed through with publish module

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -65,6 +65,7 @@ def _publish(
             'fun': fun,
             'arg': arg,
             'tgt': tgt,
+            'expr_form': expr_form,
             'ret': returner,
             'tok': tok,
             'tmo': timeout,

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -65,7 +65,7 @@ def _publish(
             'fun': fun,
             'arg': arg,
             'tgt': tgt,
-            'expr_form': expr_form,
+            'tgt_type': expr_form,
             'ret': returner,
             'tok': tok,
             'tmo': timeout,


### PR DESCRIPTION
tgt_type is not set when publishing a command. This commit will fix this.
