### PR TITLE
Small change in upstart.py service module to correctly report a target service start/stop status.

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -221,9 +221,9 @@ def status(name, sig=None):
         salt '*' service.status <service name>
     '''
     cmd = 'service {0} status'.format(name)
-    if _service_is_sysv(name):
-        return not bool(__salt__['cmd.retcode'](cmd))
-    return 'start/running' in __salt__['cmd.run'](cmd)
+    if _service_is_upstart(name):
+        return 'start/running' in __salt__['cmd.run'](cmd)
+    return not bool(__salt__['cmd.retcode'](cmd))
 
 
 def _get_service_exec():


### PR DESCRIPTION
This change causes the upstart.py module to check if the target service is an upstart service first rather than a sysv service. 

This is needed because 
a) a lot of ubuntu services have both an upstart AND a sysv scripts and ubuntu will try upstart verstion first if given a 'service <target> status' command
b) a lot of the sysv scripts defer to the upstart version of the target anyway, if it exists  (for example the ssh service) which breaks the sysv return code contract when running 'service <target> status' to get its status.

Note this is also consistent with the other upstart.py service methods such as 'start', 'stop', etc.
