### PR TITLE
New methods for freebsdjail.py

### DIFF
--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -138,3 +138,14 @@ def status(jail):
     cmd='jls | grep {0}'.format(jail)
     return not __salt__['cmd.retcode'](cmd)
 
+
+def sysctl():
+    '''
+    Dump all jail related kernel states (sysctl)
+    '''
+    ret = {}
+    sysctl=__salt__['cmd.run']('sysctl security.jail')
+    for s in sysctl.split('\n'):
+        k, v = s.split(':')
+        ret[k.strip()] = v.strip()
+    return ret

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -94,6 +94,39 @@ def show_config(jail):
                 ret[k.split('_',2)[2]] = v.split('"')[1]
     return ret
 
+
+def fstab(jail):
+    '''
+    Display contents of a fstab(5) file defined in specified
+    jail's configuration. If no file defined return False.
+
+    CLI Example::
+
+        salt '*' jail.fstab <jail name>
+    '''
+    ret = []
+    config = __salt__['jail.show_config'](jail)
+    if 'fstab' in config:
+        fstab = config['fstab']
+        if os.path.isfile(fstab):
+            for line in open(fstab, 'r').readlines():
+                if not line.strip():
+                    continue
+                if line.strip().startswith('#'):
+                    continue
+                dv, m, f, o, dm, p = line.split()
+                ret.append({
+                    'device': dv, 'mountpoint': m,
+                    'fstype': f,  'options': o,
+                    'dump': dm,   'pass': p
+                    })
+        else:
+            ret = False
+    else:
+        ret = False
+    return ret
+
+
 def status(jail):
     '''
     See if specified jail is currently running

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -94,4 +94,14 @@ def show_config(jail):
                 ret[k.split('_',2)[2]] = v.split('"')[1]
     return ret
 
+def status(jail):
+    '''
+    See if specified jail is currently running
+
+    CLI Example::
+
+        salt '*' jail.status <jail name>
+    '''
+    cmd='jls | grep {0}'.format(jail)
+    return not __salt__['cmd.retcode'](cmd)
 


### PR DESCRIPTION
Adds three methods:
- `fstab` - display contents of jail's fstab(5) file,
- `status` - check if jail is currently up and running,
- `sysctl` - dump sysctl states for jail subsystem.
