### PR TITLE
Copy grain matcher to create pillar matcher.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -105,6 +105,15 @@ class SaltCMD(object):
                 action='store_true',
                 help=('Instead of using shell globs use the return code '
                       'of a function.'))
+        parser.add_option('-I',
+                '--pillar',
+                default=False,
+                dest='pillar',
+                action='store_true',
+                help=('Instead of using shell globs to evaluate the target '
+                      'use a pillar value to identify targets, the syntax '
+                      'for the target is the pillar key followed by a glob'
+                      'expression:\n"role:production*"'))
         parser.add_option('-N',
                 '--nodegroup',
                 default=False,
@@ -286,6 +295,8 @@ class SaltCMD(object):
                 args.append('grain_pcre')
             elif self.opts['exsel']:
                 args.append('exsel')
+            elif self.opts['pillar']:
+                args.append('pillar')
             elif self.opts['nodegroup']:
                 args.append('nodegroup')
             elif self.opts['range']:

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -38,6 +38,8 @@ class Batch(object):
             args.append('grain_pcre')
         elif self.opts['exsel']:
             args.append('exsel')
+        elif self.opts['pillar']:
+            args.append('pillar')
         elif self.opts['nodegroup']:
             args.append('nodegroup')
         elif self.opts['compound']:

--- a/salt/client.py
+++ b/salt/client.py
@@ -657,6 +657,7 @@ class LocalClient(object):
                 'grain': self._check_grain_minions,
                 'grain_pcre': self._check_grain_minions,
                 'exsel': self._check_grain_minions,
+                'pillar': self._check_grain_minions,
                 'compound': self._check_grain_minions,
                 }[expr_form](expr)
 


### PR DESCRIPTION
First, please see the pillars documentation:
http://salt.readthedocs.org/en/latest/topics/pillar/index.html. Next,
perhaps an example will explain this best...

Let's say you have a `/src/pillar/top.sls` that looks like:

```
base:
  'hostname1':
    - production
  'hostname2':
    - development
```

And a `/srv/pillar/production.sls` that looks like:

```
role: production
countrycode: us
```

And a `/srv/pillar/development.sls` that looks like:

```
role: development
countrycode: cl
```

This means that `/srv/salt/top.sls` could now look like:

```
base:
  '*':
    - ssh
  'role:production':
    - match: pillar
    - users.production
    - default
    - clojure
  'role:development':
    - match: pillar
    - users.development
    - default.dev
    - clojure.dev
```

Both `role` and `countrycode` may also be used as a template variable
as explained in the pillar documentation above.

For a real-world example, please see:
- https://github.com/rentalita/ubuntu-setup
- https://github.com/rentalita/ubuntu-setup/blob/master/salt/apt/init.sls.
- https://github.com/rentalita/ubuntu-setup/blob/master/salt/apt/sources.list

This commit also extends the salt command-line client so that it too
may use the pillar matcher, like:

```
salt -I 'role:production' test.ping
```

Documentation and tests are not included in this commit. These will
come in a later commit.

The `pillar_match` routine is simply a copy of the `grain_match`
routine. But I grep'd for the `exsel` matcher to figure out what parts
of the code needed to be touched in order to (hopefully) make this
work. I suppose a pillar pcre matcher could be made just as easily.
