### PR TITLE
SYSTEMINFO gives memory with "." as separator

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -151,7 +151,7 @@ def _memdata(osdata):
            if not len(comps) > 1:
                continue
            if comps[0].strip() == 'Total Physical Memory':
-               grains['mem_total'] = int(comps[1].split()[0].replace(',', ''))
+               grains['mem_total'] = int(comps[1].split()[0].replace('.', ''))
                break
 
     return grains

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -151,7 +151,8 @@ def _memdata(osdata):
            if not len(comps) > 1:
                continue
            if comps[0].strip() == 'Total Physical Memory':
-               grains['mem_total'] = int(comps[1].split()[0].replace('.', ''))
+               # Windows XP use '.' as separator and Windows 2008 Server R2 use ','
+               grains['mem_total'] = int(comps[1].split()[0].replace('.', '').replace(',', ''))
                break
 
     return grains


### PR DESCRIPTION
The "SYSTEMINFO /FO LIST" command gives total
physical memory with "." as separator in MBs

Well, this is the output I am getting in Windows XP.
I am not sure whether this is due to some locale settings.

If this output is not reliable across systems, may be we
can use API available through pywin32 or ctypes.
