### PR TITLE
Fixed typo's in 0.9.9 releas notes

### DIFF
--- a/doc/topics/releases/0.9.9.rst
+++ b/doc/topics/releases/0.9.9.rst
@@ -96,7 +96,7 @@ easily. A simple example:
       file.present:
         - source: salt://edit/vimrc
 
-This makes the 2 lower state decs inherit the options from thier respectively
+This makes the 2 lower state decs inherit the options from their respectively
 "used" state decs.
 
 Network State
@@ -128,7 +128,7 @@ The original ssh_auth state was limited to accepting only arguments to apply
 to a public key, and the key itself. This was restrictive due to the way the
 we learned that many people were using the state, so the key section has been
 expanded to accept options and arguments to the key that over ride arguments
-passed in the stae. This gives substantial power to using ssh_auth with names:
+passed in the state. This gives substantial power to using ssh_auth with names:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Just found a couple of typo's thought I'd fix them.
