### PR TITLE
Set temporary write permission for minion.pem file

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -39,7 +39,17 @@ def clean_old_key(rsa_path):
         os.remove(rsa_path)
     except (IOError, OSError):
         pass
+    # Set write permission for minion.pem file - reverted after saving the key
+    if sys.platform == 'win32':
+        import win32api
+        import win32con
+        win32api.SetFileAttributes(rsa_path, win32con.FILE_ATTRIBUTE_NORMAL)
     mkey.save_key(rsa_path, None)
+    # Set read-only permission for minion.pem file
+    if sys.platform == 'win32':
+        import win32api
+        import win32con
+        win32api.SetFileAttributes(rsa_path, win32con.FILE_ATTRIBUTE_READONLY)
     return mkey
 
 


### PR DESCRIPTION
The RSA private key file for minion (`minion.pem`) in
Windows require write permission while saving the key.
So, temporarily set write permission and revert back
to read-only permission after saving the key.
This fixes the Issue #1307
