### PR TITLE
apt module: Forcing an explicit match on virtual package names

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -287,7 +287,7 @@ def list_pkgs(regex_string=""):
     # If ret is empty at this point, check to see if the package is virtual.
     # We also need aptitude past this point.
     if not ret and __salt__['cmd.has_exec']('aptitude'):
-        cmd = ('aptitude search "^{0}$ ?virtual ?reverse-provides(?installed)"'
+        cmd = ('aptitude search "?name(^{0}$) ?virtual ?reverse-provides(?installed)"'
                 .format(regex_string))
 
         out = __salt__['cmd.run_stdout'](cmd)

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -287,7 +287,7 @@ def list_pkgs(regex_string=""):
     # If ret is empty at this point, check to see if the package is virtual.
     # We also need aptitude past this point.
     if not ret and __salt__['cmd.has_exec']('aptitude'):
-        cmd = ('aptitude search "{0} ?virtual ?reverse-provides(?installed)"'
+        cmd = ('aptitude search "^{0}$ ?virtual ?reverse-provides(?installed)"'
                 .format(regex_string))
 
         out = __salt__['cmd.run_stdout'](cmd)


### PR DESCRIPTION
Fixes tate_'s issue where 'salt-call pkg.version "curl"' was matching all virtual packages that had "curl" in them, like python2.6-pycurl, etc.
