### PR TITLE
Correct inadvertent indent made in 79c03a6.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1477,7 +1477,7 @@ class BaseHighState(object):
                    'in the top file or the top file was not found on the '
                    'master')
             ret[tag_name]['comment'] = msg
-        return ret
+            return ret
         err += self.verify_tops(top)
         matches = self.top_matches(top)
         self.load_dynamic(matches)


### PR DESCRIPTION
I think whomever corrected this may have mistaken the correct indent level because of mixed tabs and spaces. Running a version of the tests with `python -tt` may help uncover more of these. https://github.com/rentalita/salt/commit/79c03a6#L6L1480
