### PR TITLE
Fix file.comment/file.uncomment states

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -531,7 +531,7 @@ def contains_regex(path, regex, lchar=''):
     try:
         with open(path, 'r') as fp_:
             for line in  fp_:
-                if re.match(regex, line.lstrip(lchar)):
+                if re.search(regex, line.lstrip(lchar)):
                     return True
             return False
     except (IOError, OSError):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1415,7 +1415,7 @@ def comment(name, regex, char='#', backup='.bak'):
 
         /etc/fstab:
           file.comment:
-            - regex: ^//10.10.20.5
+            - regex: ^bind 127.0.0.1
 
     .. versionadded:: 0.9.5
     '''


### PR DESCRIPTION
Function "file.contains_regex" used to search values from the beginning of lines and thus couldn't find patterns like "hello world" in a "#hello world" string.

I'm not sure whether my minor correction results in the expected behaviour, but I really hope it makes sence.

Thank you.
