### PR TITLE
Add --yaml-out, --json-out, and --raw-out outputters to salt-key CLI

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -617,6 +617,24 @@ class SaltKey(object):
                 dest='conf_file',
                 default='/etc/salt/master',
                 help='Pass in an alternative configuration file')
+        
+        parser.add_option('--raw-out',
+                default=False,
+                action='store_true',
+                dest='raw_out',
+                help=('Print the output from the salt-key command in raw python '
+                      'form, this is suitable for re-reading the output into '
+                      'an executing python script with eval.'))
+        parser.add_option('--yaml-out',
+                default=False,
+                action='store_true',
+                dest='yaml_out',
+                help='Print the output from the salt-key command in yaml.')
+        parser.add_option('--json-out',
+                default=False,
+                action='store_true',
+                dest='json_out',
+                help='Print the output from the salt-key command in json.')
 
         options, args = parser.parse_args()
 

--- a/tests/integration/shell/key.py
+++ b/tests/integration/shell/key.py
@@ -24,6 +24,49 @@ class KeyTest(integration.ShellCase):
                 '\x1b[1;34mRejected:\x1b[0m', '']
         self.assertEqual(data, expect)
 
+    def test_list_json_out(self):
+        '''
+        test salt-key -L --json-out
+        '''
+        data = self.run_key('-L --json-out')
+        expect = [
+            '{',
+            '  "unaccepted": [], ',
+            '  "accepted": [',
+            '    "minion", ',
+            '    "sub_minion"',
+            '  ], ',
+            '  "rejected": []',
+            '}',
+            ''
+        ]
+        self.assertEqual(data, expect)
+
+    def test_list_yaml_out(self):
+        '''
+        test salt-key -L --yaml-out
+        '''
+        data = self.run_key('-L --yaml-out')
+        expect = [
+            'accepted: [minion, sub_minion]', 
+            'rejected: []', 
+            'unaccepted: []', 
+            '', 
+            ''
+        ]
+        self.assertEqual(data, expect)
+    
+    def test_list_raw_out(self):
+        '''
+        test salt-key -L --raw-out
+        '''
+        data = self.run_key('-L --raw-out')
+        expect = [
+            "{'unaccepted': [], 'accepted': ['minion', 'sub_minion'], 'rejected': []}", 
+            ''
+        ] 
+        self.assertEqual(data, expect)
+
     def test_list_acc(self):
         '''
         test salt-key -l


### PR DESCRIPTION
Serialized outputters so external tools can better manage keys
