### PR TITLE
Add scripts/salt-write-launchd-plist.py

### DIFF
--- a/salt/runners/launchd.py
+++ b/salt/runners/launchd.py
@@ -1,0 +1,40 @@
+import os
+import sys
+
+def write_launchd_plist(program):
+    '''
+    Write a launchd plist for managing salt-master or salt-minion
+    '''
+    plist_sample_text="""
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>org.saltstack.{program}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python}</string>
+        <string>{script}</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+    """.strip()
+
+    supported_programs = ['salt-master', 'salt-minion']
+
+    if program not in supported_programs:
+        sys.stderr.write("Supported programs: %r\n" % supported_programs)
+        sys.exit(-1)
+    
+    sys.stdout.write(
+        plist_sample_text.format(
+            program=program,
+            python=sys.executable,
+            script=os.path.join(os.path.dirname(sys.executable), program)
+        )
+    )


### PR DESCRIPTION
This is experimental and I am open to ideas for improvements.

This adds a new script that aids in generating plist files for running `salt-master` and `salt-minion` with Mac OS X's [launchd](http://en.wikipedia.org/wiki/Launchd) process manager.

Sample usage:

```
$ scripts/salt-write-launchd-plist.py salt-minion | sudo tee /Library/LaunchDaemons/org.saltstack.salt-minion.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Label</key>
    <string>org.saltstack.salt-minion</string>

    <key>ProgramArguments</key>
    <array>
        <string>/Users/marca/dev/git-repos/salt/salt-virtualenv/bin/python</string>
        <string>/Users/marca/dev/git-repos/salt/salt-virtualenv/bin/salt-minion</string>
    </array>

    <key>RunAtLoad</key>
    <true/>
</dict>
$ sudo launchctl load -w /Library/LaunchDaemons/org.saltstack.salt-minion.plist

$ python scripts/salt-write-launchd-plist.py salt-master | sudo tee /Library/LaunchDaemons/org.saltstack.salt-master.plist
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
    <key>Label</key>
    <string>org.saltstack.salt-master</string>

    <key>ProgramArguments</key>
    <array>
        <string>/Users/marca/dev/git-repos/salt/salt-virtualenv/bin/python</string>
        <string>/Users/marca/dev/git-repos/salt/salt-virtualenv/bin/salt-master</string>
    </array>

    <key>RunAtLoad</key>
    <true/>
</dict>
$ sudo launchctl load -w /Library/LaunchDaemons/org.saltstack.salt-master.plist

$ sudo launchctl list | grep salt
59935   -   org.saltstack.salt-master
59340   -   org.saltstack.salt-minion
```

Along these lines, it might be an interesting future addition to add a similar script for generating files for [supervisord](http://supervisord.org/)
