### PR TITLE
Support "system" users and groups.

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -12,7 +12,7 @@ def __virtual__():
     return 'group' if __grains__['kernel'] == 'Linux' else False
 
 
-def add(name, gid=None):
+def add(name, gid=None, system=False):
     '''
     Add the specified group
 
@@ -23,6 +23,8 @@ def add(name, gid=None):
     cmd = 'groupadd '
     if gid:
         cmd += '-g {0} '.format(gid)
+    if system:
+        cmd += '-r '
     cmd += name
 
     ret = __salt__['cmd.run_all'](cmd)

--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -1,5 +1,5 @@
 '''
-Manage groups on Linux
+Manage groups on FreeBSD
 '''
 
 import grp
@@ -12,7 +12,7 @@ def __virtual__():
     return 'group' if __grains__['kernel'] == 'FreeBSD' else False
 
 
-def add(name, gid=None):
+def add(name, gid=None, system=False):
     '''
     Add the specified group
 

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -20,6 +20,7 @@ def add(name,
         groups=None,
         home=True,
         shell=None,
+        system=False,
         **kwargs):
     '''
     Add a user to the minion

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -24,7 +24,8 @@ def add(name,
         workphone=None,
         homephone=None,
         other=None,
-        unique=True):
+        unique=True,
+        system=False):
     '''
     Add a user to the minion
 
@@ -44,12 +45,15 @@ def add(name,
     if groups:
         cmd += '-G {0} '.format(','.join(groups))
     if home:
-        if home is True:
-            cmd += '-m '
+        if home is not True:
+            cmd += '-d {0} '.format(home)
         else:
-            cmd += '-m -d {0} '.format(home)
+            if not system:
+                cmd += '-m '
     if not unique:
         cmd += '-o '
+    if system:
+        cmd += '-r '
     cmd += name
     ret = __salt__['cmd.retcode'](cmd)
     if ret != 0:

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -9,7 +9,7 @@ def __virtual__():
     return 'group' if __grains__['kernel'] == 'Windows' else False
 
 
-def add(name, gid=None):
+def add(name, gid=None, system=False):
     '''
     Add the specified group
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -11,7 +11,7 @@ def __virtual__():
     return 'user' if __grains__['kernel'] == 'Windows' else False
 
 
-def add(name, uid=None, gid=None, groups=None, home=False, shell=None):
+def add(name, uid=None, gid=None, groups=None, home=False, shell=None, system=False):
     '''
     Add a user to the minion
 

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -11,10 +11,11 @@ can be either present or absent:
       group:
         - present
         - gid: 7648
+        - system: True
 '''
 
 
-def present(name, gid=None):
+def present(name, gid=None, system=False):
     '''
     Ensure that a group is present
 
@@ -63,7 +64,7 @@ def present(name, gid=None):
         ret['comment'] = ('Group {0} is not present and should be created'
                 ).format(name)
         return ret
-    ret['result'] = __salt__['group.add'](name, gid)
+    ret['result'] = __salt__['group.add'](name, gid, system)
     if ret['result']:
         ret['changes'] = __salt__['group.info'](name)
         ret['comment'] = 'Added group {0}'.format(name)

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -109,6 +109,7 @@ def present(
         homephone=None,
         other=None,
         unique=True,
+        system=False,
         ):
     '''
     Ensure that the named user is present with the specified properties
@@ -165,6 +166,9 @@ def present(
 
     unique
         Require a unique UID, True by default
+
+    system
+        Choose UID in the range of FIRST_SYSTEM_UID and LAST_SYSTEM_UID.
     '''
     ret = {'name': name,
            'changes': {},
@@ -238,7 +242,8 @@ def present(
                                 workphone=workphone,
                                 homephone=homephone,
                                 other=other,
-                                unique=unique):
+                                unique=unique,
+                                system=system):
             ret['comment'] = 'New user {0} created'.format(name)
             ret['changes'] = __salt__['user.info'](name)
             if password:


### PR DESCRIPTION
Please see the secion marked "Add a system user" in
http://manpages.ubuntu.com/manpages/precise/en/man8/adduser.8.html and
"Add a system group" in
http://manpages.ubuntu.com/manpages/precise/en/man8/addgroup.8.html.

When a specifc home directory path (something other than "True") is
provided we omit the "-m" option to useradd so that the contents of
/etc/skel are not copied into the new home directory.

I don't know FreeBSD very well, but it seems that the `pw` command has no concept of system users and groups. Does that sound right?

This pull request probably shouldn't be accepted until I update the docs and tests.
