### PR TITLE
The text outputter will insert newlines, the tests must expect these

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -111,17 +111,17 @@ def _run(cmd,
     # This is where the magic happens
     proc = subprocess.Popen(cmd, **kwargs)
 
-    stdout, stderr = proc.communicate()
+    out, err = proc.communicate()
 
     if rstrip:
-        if stdout:
-            stdout = stdout.rstrip()
+        if out:
+            out = out.rstrip()
         # None lacks a rstrip() method
-        if stderr:
-            stderr = stderr.rstrip()
+        if err:
+            err = err.rstrip()
 
-    ret['stdout']  = stdout
-    ret['stderr']  = stderr
+    ret['stdout']  = out
+    ret['stderr']  = err
     ret['pid']     = proc.pid
     ret['retcode'] = proc.returncode
     return ret

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -21,7 +21,7 @@ class CMDModuleTest(integration.ModuleCase):
         self.assertEqual(
                 self.run_function('cmd.run',
                     ['echo $SHELL', 'shell={0}'.format(shell)]),
-                shell)
+                shell + '\n')
 
     def test_stdout(self):
         '''
@@ -30,7 +30,7 @@ class CMDModuleTest(integration.ModuleCase):
         self.assertEqual(
                 self.run_function('cmd.run_stdout',
                     ['echo "cheese"']),
-                'cheese')
+                'cheese\n')
 
     def test_stderr(self):
         '''
@@ -39,7 +39,7 @@ class CMDModuleTest(integration.ModuleCase):
         self.assertEqual(
                 self.run_function('cmd.run_stderr',
                     ['echo "cheese" 1>&2']),
-                'cheese')
+                'cheese\n')
 
     def test_run_all(self):
         '''
@@ -54,7 +54,7 @@ class CMDModuleTest(integration.ModuleCase):
         self.assertTrue(isinstance(ret.get('retcode'), int))
         self.assertTrue(isinstance(ret.get('stdout'), basestring))
         self.assertTrue(isinstance(ret.get('stderr'), basestring))
-        self.assertEqual(ret.get('stderr'), 'cheese')
+        self.assertEqual(ret.get('stderr'), 'cheese\n')
 
     def test_retcode(self):
         '''
@@ -68,7 +68,7 @@ class CMDModuleTest(integration.ModuleCase):
         cmd.which
         '''
         self.assertEqual(
-                self.run_function('cmd.which', ['echo']),
+                self.run_function('cmd.which', ['echo']) + '\n',
                 self.run_function('cmd.run', ['which echo']))
 
     def test_has_exec(self):


### PR DESCRIPTION
to be present.

Also rename some vars to avoid shadowing useful ones.
