### PR TITLE
Use consistent signature for json_mako renderer

### DIFF
--- a/salt/renderers/json_mako.py
+++ b/salt/renderers/json_mako.py
@@ -13,11 +13,11 @@ from salt.exceptions import SaltRenderError
 import salt.utils.templates
 
 
-def render(template):
+def render(template_file, env='', sls=''):
     '''
     Render the data passing the functions and grains into the rendering system
     '''
-    if not os.path.isfile(template):
+    if not os.path.isfile(template_file):
         return {}
 
     tmp_data = salt.utils.templates.mako(


### PR DESCRIPTION
Use the same signature for both jinja2 and mako templates
The `env` & `sls` names were undefined
Ref: http://jenkins.saltstack.org/job/pyflakes/199/violations/file/salt/renderers/json_mako.py/?
