### PR TITLE
Add brew & win_pkg to `pkg` virtual module index

### DIFF
--- a/doc/ref/modules/all/salt.modules.pkg.rst
+++ b/doc/ref/modules/all/salt.modules.pkg.rst
@@ -14,3 +14,5 @@ salt.modules.pkg
 * :mod:`salt.modules.yumpkg`
 * :mod:`salt.modules.yumpkg5`
 * :mod:`salt.modules.zypper`
+* :mod:`salt.modules.brew`
+* :mod:`salt.modules.win_pkg`


### PR DESCRIPTION
Links to `brew` & `win_pkg` virtual modules were missing from `pkg` virtual module index
