### PR TITLE
Settings noinput=True as default behavior.

### DIFF
--- a/salt/modules/django.py
+++ b/salt/modules/django.py
@@ -47,7 +47,8 @@ def syncdb(settings_module,
            bin_env=None,
            migrate=False,
            database=None,
-           pythonpath=None):
+           pythonpath=None,
+           noinput=True):
     '''
     Run syncdb
 
@@ -67,6 +68,8 @@ def syncdb(settings_module,
         cmd = '{0} --database={1}'.format(cmd, database)
     if pythonpath:
         cmd = '{0} --pythonpath={1}'.format(cmd, pythonpath)
+    if noinput:
+        cmd = '{0} --noinput'.format(cmd)
     return __salt__['cmd.run'](cmd)
 
 


### PR DESCRIPTION
This commit both adds a very necessary "noinput" option and sets the default to noinput=True, which is more appropriate as a salt module.
