### PR TITLE
setup.py : use console_scripts instead of scripts when setuptools is available

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -1,0 +1,77 @@
+"""Salt scripts."""
+import os
+
+import salt
+import salt.cli
+import salt.log
+
+
+def salt_master():
+    '''Start the salt-master.'''
+    master = salt.Master()
+    master.start()
+
+
+def salt_minion():
+    '''Kick off a salt minion daemon.'''
+    minion = salt.Minion()
+    minion.start()
+
+
+def salt_syndic():
+    '''Kick off a salt syndic daemon.'''
+    pid = os.getpid()
+    try:
+        syndic = salt.Syndic()
+        syndic.start()
+    except KeyboardInterrupt:
+        os.kill(pid, 15)
+
+
+def salt_key():
+    '''Manage the authentication keys with salt-key.'''
+    try:
+        saltkey = salt.cli.SaltKey()
+        saltkey.run()
+    except KeyboardInterrupt:
+        raise SystemExit('\nExiting gracefully on Ctrl-c')
+
+
+def salt_cp():
+    '''Publish commands to the salt system from the command line on the
+    master.'''
+    try:
+        cp_ = salt.cli.SaltCP()
+        cp_.run()
+    except KeyboardInterrupt:
+        raise SystemExit('\nExiting gracefully on Ctrl-c')
+
+
+def salt_call():
+    '''Directly call a salt command in the modules, does not require a running
+    salt minion to run.'''
+    salt.log.setup_console_logger()
+    try:
+        client = salt.cli.SaltCall()
+        client.run()
+    except KeyboardInterrupt:
+        raise SystemExit('\nExiting gracefully on Ctrl-c')
+
+
+def salt_run():
+    '''Execute a salt convenience routine.'''
+    try:
+        client = salt.cli.SaltRun()
+        client.run()
+    except KeyboardInterrupt:
+        raise SystemExit('\nExiting gracefully on Ctrl-c')
+
+
+def salt_main():
+    '''Publish commands to the salt system from the command line on the
+    master.'''
+    try:
+        client = salt.cli.SaltCMD()
+        client.run()
+    except KeyboardInterrupt:
+        raise SystemExit('\nExiting gracefully on Ctrl-c')

--- a/scripts/salt
+++ b/scripts/salt
@@ -3,18 +3,8 @@
 Publish commands to the salt system from the command line on the master.
 '''
 
-import salt.cli
+from salt.scripts import salt_main
 
-
-def main():
-    '''
-    The main function
-    '''
-    client = salt.cli.SaltCMD()
-    client.run()
 
 if __name__ == '__main__':
-    try:
-        main()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    salt_main()

--- a/scripts/salt-call
+++ b/scripts/salt-call
@@ -4,20 +4,8 @@ Directly call a salt command in the modules, does not require a running salt
 minion to run.
 '''
 
-import salt.cli
-import salt.log
-salt.log.setup_console_logger()
+from salt.scripts import salt_call
 
-
-def main():
-    '''
-    The main function
-    '''
-    client = salt.cli.SaltCall()
-    client.run()
 
 if __name__ == '__main__':
-    try:
-        main()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    salt_call()

--- a/scripts/salt-cp
+++ b/scripts/salt-cp
@@ -3,18 +3,8 @@
 Publish commands to the salt system from the command line on the master.
 '''
 
-import salt.cli
+from salt.scripts import salt_cp
 
-
-def main():
-    '''
-    The main function
-    '''
-    cp_ = salt.cli.SaltCP()
-    cp_.run()
 
 if __name__ == '__main__':
-    try:
-        main()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    salt_cp()

--- a/scripts/salt-key
+++ b/scripts/salt-key
@@ -3,18 +3,8 @@
 Manage the authentication keys with salt-key
 '''
 
-import salt.cli
+from salt.scripts import salt_key
 
-
-def main():
-    '''
-    The main function
-    '''
-    saltkey = salt.cli.SaltKey()
-    saltkey.run()
 
 if __name__ == '__main__':
-    try:
-        main()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    salt_key()

--- a/scripts/salt-master
+++ b/scripts/salt-master
@@ -3,15 +3,8 @@
 Start the salt-master
 '''
 
-import salt
+from salt.scripts import salt_master
 
-
-def main():
-    '''
-    The main function
-    '''
-    master = salt.Master()
-    master.start()
 
 if __name__ == '__main__':
-    main()
+    salt_master()

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -3,16 +3,8 @@
 This script is used to kick off a salt minion daemon
 '''
 
-import os
-import salt
+from salt.scripts import salt_minion
 
-
-def main():
-    '''
-    The main function
-    '''
-    minion = salt.Minion()
-    minion.start()
 
 if __name__ == '__main__':
-    main()
+    salt_minion()

--- a/scripts/salt-run
+++ b/scripts/salt-run
@@ -3,18 +3,8 @@
 Execute a salt convenience routine
 '''
 
-import salt.cli
+from salt.scripts import salt_run
 
-
-def main():
-    '''
-    The main function
-    '''
-    client = salt.cli.SaltRun()
-    client.run()
 
 if __name__ == '__main__':
-    try:
-        main()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    salt_run()

--- a/scripts/salt-syndic
+++ b/scripts/salt-syndic
@@ -3,20 +3,8 @@
 This script is used to kick off a salt syndic daemon
 '''
 
-import os
-import salt
+from salt.scripts import salt_minion
 
-
-def main():
-    '''
-    The main function
-    '''
-    pid = os.getpid()
-    try:
-        syndic = salt.Syndic()
-        syndic.start()
-    except KeyboardInterrupt:
-        os.kill(pid, 15)
 
 if __name__ == '__main__':
-    main()
+    salt_minion()

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,19 @@ from __future__ import with_statement
 import os
 import sys
 from glob import glob
-from distutils.core import setup, Extension
-from distutils.command.sdist import sdist
 from distutils.cmd import Command
 from distutils.sysconfig import get_python_lib, PREFIX
 
-if os.environ.get('VIRTUAL_ENV'):
+# Use setuptools if available, else fallback to distutils.
+# As an example, setuptools is available in virtualenvs and buildouts through
+# Setuptools or Distribute.
+try:
     from setuptools import setup
+    with_setuptools = True
+except ImportError:
+    from distutils.core import setup
+    with_setuptools = False
+
 
 exec(compile(open("salt/version.py").read(), "salt/version.py", 'exec'))
 
@@ -59,64 +65,78 @@ requirements=''
 with open('requirements.txt') as f:
     requirements = f.read()
 
-setup(
-      name=NAME,
-      version=VER,
-      description=DESC,
-      author='Thomas S Hatch',
-      author_email='thatch45@gmail.com',
-      url='http://saltstack.org',
-      cmdclass={'test': TestCommand},
-      classifiers=[
-          'Programming Language :: Python',
-          'Programming Language :: Cython',
-          'Programming Language :: Python :: 2.6',
-          'Programming Language :: Python :: 2.7',
-          'Development Status :: 5 - Production/Stable',
-          'Environment :: Console',
-          'Intended Audience :: Developers',
-          'Intended Audience :: Information Technology',
-          'Intended Audience :: System Administrators',
-          'License :: OSI Approved :: Apache Software License',
-          'Operating System :: POSIX :: Linux',
-          'Topic :: System :: Clustering',
-          'Topic :: System :: Distributed Computing',
-          ],
-      packages=['salt',
-                'salt.cli',
-                'salt.ext',
-                'salt.grains',
-                'salt.modules',
-                'salt.renderers',
-                'salt.returners',
-                'salt.runners',
-                'salt.states',
-                'salt.utils',
-                ],
-      package_data = {
-          'salt.modules': ['rh_ip/*.jinja'],
-      },
-      scripts=['scripts/salt-master',
-               'scripts/salt-minion',
-               'scripts/salt-syndic',
-               'scripts/salt-key',
-               'scripts/salt-cp',
-               'scripts/salt-call',
-               'scripts/salt-run',
-               'scripts/salt'],
-      data_files=[('share/man/man1',
-                    ['doc/man/salt-master.1',
-                     'doc/man/salt-key.1',
-                     'doc/man/salt.1',
-                     'doc/man/salt-cp.1',
-                     'doc/man/salt-call.1',
-                     'doc/man/salt-syndic.1',
-                     'doc/man/salt-run.1',
-                     'doc/man/salt-minion.1',
-                    ]),
-                ('share/man/man7',
-                    ['doc/man/salt.7',
-                    ]),
-                 ],
-      install_requires=requirements,
-     )
+
+setup_kwargs = {'name': NAME,
+                'version': VER,
+                'description': DESC,
+                'author': 'Thomas S Hatch',
+                'author_email': 'thatch45@gmail.com',
+                'url': 'http://saltstack.org',
+                'cmdclass': {'test': TestCommand},
+                'classifiers': ['Programming Language :: Python',
+                                'Programming Language :: Cython',
+                                'Programming Language :: Python :: 2.6',
+                                'Programming Language :: Python :: 2.7',
+                                'Development Status :: 5 - Production/Stable',
+                                'Environment :: Console',
+                                'Intended Audience :: Developers',
+                                'Intended Audience :: Information Technology',
+                                'Intended Audience :: System Administrators',
+                                'License :: OSI Approved :: Apache Software License',
+                                'Operating System :: POSIX :: Linux',
+                                'Topic :: System :: Clustering',
+                                'Topic :: System :: Distributed Computing',
+                                ],
+                'packages': ['salt',
+                             'salt.cli',
+                             'salt.ext',
+                             'salt.grains',
+                             'salt.modules',
+                             'salt.renderers',
+                             'salt.returners',
+                             'salt.runners',
+                             'salt.states',
+                             'salt.utils',
+                             ],
+                'package_data': {
+                                 'salt.modules': ['rh_ip/*.jinja'],
+                                 },
+                'data_files': [('share/man/man1',
+                                ['doc/man/salt-master.1',
+                                 'doc/man/salt-key.1',
+                                 'doc/man/salt.1',
+                                 'doc/man/salt-cp.1',
+                                 'doc/man/salt-call.1',
+                                 'doc/man/salt-syndic.1',
+                                 'doc/man/salt-run.1',
+                                 'doc/man/salt-minion.1',
+                                ]),
+                               ('share/man/man7', ['doc/man/salt.7']),
+                               ],
+                'install_requires': requirements,
+                }
+
+if with_setuptools:
+    setup_kwargs['entry_points'] = {
+        "console_scripts": [
+                            "salt-master = salt.scripts:salt_master",
+                            "salt-minion = salt.scripts:salt_minion",
+                            "salt-syndic = salt.scripts:salt_syndic",
+                            "salt-key = salt.scripts:salt_key",
+                            "salt-cp = salt.scripts:salt_cp",
+                            "salt-call = salt.scripts:salt_call",
+                            "salt-run = salt.scripts:salt_run",
+                            "salt = salt.scripts:salt_main"
+                            ],
+    }
+else:
+    setup_kwargs['scripts'] = ['scripts/salt-master',
+                               'scripts/salt-minion',
+                               'scripts/salt-syndic',
+                               'scripts/salt-key',
+                               'scripts/salt-cp',
+                               'scripts/salt-call',
+                               'scripts/salt-run',
+                               'scripts/salt']
+
+setup(**setup_kwargs)


### PR DESCRIPTION
Hi,

See also #1028.

As @loupgaroublond, I'd like to use salt in a buildout environment (with or without virtualenv). So I'd like salt to support setuptools' console_scripts entry point.

**These changes should work with both distutils and setuptools. So that it shouldn't be backward incompatible.**

However, I must admit I tried within a setuptools-enabled environment, and not in a "only distutils" environment. I tried not to break distutils support, but tell me if I did something wrong.
