### PR TITLE
Missing import of `errno` built-in module

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -15,6 +15,7 @@ Manage events
 # Import Python libs
 import os
 import time
+import errno
 import multiprocessing
 
 # Import Third Party libs


### PR DESCRIPTION
The `errno` built-in module was not imported
