### PR TITLE
Re-register with poller after reconnecting socket

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -510,6 +510,7 @@ class Minion(object):
                     socket.setsockopt(zmq.SUBSCRIBE, '')
                     socket.setsockopt(zmq.IDENTITY, self.opts['id'])
                     socket.connect(self.master_pub)
+                    poller.register(socket, zmq.POLLIN)
                     last = time.time()
                 time.sleep(0.05)
                 multiprocessing.active_children()


### PR DESCRIPTION
This seems like a horrendous bug that other people should have encountered as well, so unless I'm missing something, please take a look at this.

When the minion reaches `sub_timeout`, it closes the socket and creates a new one. However, it does not register the new socket with the poller, with the effect that it no longer receives publishes from the master.

The proposed patch fixes this, but it seems that there is still cleanup work to do (e.g. unregister the old socket from the poller; remove the duplicated lines that create the socket and set its options).
