### PR TITLE
python setup.py sdist didn't add scripts folder

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,6 @@ include tests/integration/files/*
 include tests/integration/tmp/_README
 include tests/unit/templates/files/*
 recursive-include doc *
+recursive-include scripts *
 include conf/*
 recursive-include salt *.jinja


### PR DESCRIPTION
You'll notice that the tarball for download of version 0.10.0 doesn't include the scripts folder. I'm assuming that python setup.py sdist was used to generate that tarball. This change will make it so scripts is included.
