### PR TITLE
Test suite fixes

### DIFF
--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -69,8 +69,8 @@ class CMDModuleTest(integration.ModuleCase):
         cmd.which
         '''
         self.assertEqual(
-                self.run_function('cmd.which', ['echo']).rstrip(),
-                self.run_function('cmd.run', ['which echo']).rstrip())
+                self.run_function('cmd.which', ['cat']).rstrip(),
+                self.run_function('cmd.run', ['which cat']).rstrip())
 
     def test_has_exec(self):
         '''

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -11,6 +11,12 @@ class PipModuleTest(integration.ModuleCase):
     '''
     Validate the pip module
     '''
+    def setUp(self):
+        super(PipModuleTest, self).setUp()
+        ret = self.run_function('cmd.which_bin', [['pip2', 'pip', 'pip-python']])
+        if not ret:
+            self.skipTest("pip not installed")
+
     def test_freeze(self):
         '''
         pip.freeze

--- a/tests/unit/modules/rvm_test.py
+++ b/tests/unit/modules/rvm_test.py
@@ -47,7 +47,8 @@ rvm rubies
 #  * - default
 
 '''
-        with patch.object(rvm, '_rvm', return_value=list_output):
+        with patch.object(rvm, '_rvm') as mock_method:
+            mock_method.return_value = list_output
             self.assertEqual(
                 [['jruby', '1.6.5.1', False],
                  ['ree', '1.8.7-2011.03', False],
@@ -66,7 +67,8 @@ gemsets for ree-1.8.7-2012.02 (found in /usr/local/rvm/gems/ree-1.8.7-2012.02)
    foo
 
 '''
-        with patch.object(rvm, '_rvm_do', return_value=output):
+        with patch.object(rvm, '_rvm_do') as mock_method:
+            mock_method.return_value = output
             self.assertEqual(
                 ['global', 'bar', 'foo'],
                 rvm.gemset_list())
@@ -97,7 +99,8 @@ gemsets for ruby-1.9.2-p180 (found in /usr/local/rvm/gems/ruby-1.9.2-p180)
 
 
 '''
-        with patch.object(rvm, '_rvm_do', return_value=output):
+        with patch.object(rvm, '_rvm_do') as mock_method:
+            mock_method.return_value = output
             self.assertEqual(
                 {'jruby-1.6.5.1': ['global', 'jbar', 'jfoo'],
                  'ruby-1.9.2-p180': ['global'],

--- a/tests/unit/states/rvm_test.py
+++ b/tests/unit/states/rvm_test.py
@@ -54,8 +54,8 @@ class TestRvmState(TestCase):
                 self.assertEqual(result, ret['result'])
 
     def test_gemset_present(self):
-        with patch.object(rvm, '_check_rvm',
-                          return_value={'result': True, 'changes': {}}):
+        with patch.object(rvm, '_check_rvm') as mock_method:
+            mock_method.return_value = {'result': True, 'changes': {}}
             gems = ['global', 'foo', 'bar']
             gemset_list = MagicMock(return_value=gems)
             gemset_create = MagicMock(return_value=True)
@@ -75,7 +75,8 @@ class TestRvmState(TestCase):
 
     def test_installed(self):
         mock = MagicMock()
-        with patch.object(rvm, '_check_rvm', return_value={'result': True}):
+        with patch.object(rvm, '_check_rvm') as mock_method:
+            mock_method.return_value = {'result': True}
             with patch.object(rvm, '_check_and_install_ruby', new=mock):
                 rvm.installed("1.9.3", default=True)
         mock.assert_called_once_with(


### PR DESCRIPTION
Three fixes, the first is that on zsh echo is an built-in so the cmd.which test failed with
`AssertionError: '/bin/echo' != 'echo: shell built-in command'`

The second is that gem/rvm tests used patch.object in a way that isn't supported in mock 0.7, giving
`TypeError: _patch_object() got an unexpected keyword argument 'return_value'`

The third one skips the pip test if pip is not installed.
