### PR TITLE
Correctly return with jid 0 if no minions match the target

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -833,7 +833,7 @@ class LocalClient(object):
             # forms possible
             minions = tgt
         elif not minions:
-            return {'jid': '',
+            return {'jid': '0',
                     'minions': minions}
 
         # Generate the standard keyword args to feed to format_payload


### PR DESCRIPTION
When running as a syndic, the jid was returned as '' instead of the
correct '0' in the case where no minions match the target. This causes the syndic
to throw an exception:

``` python
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 231, in _bootstrap
    self.run()
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 88, in run
    self._target(*self._args, **self._kwargs)
  File "/local/tlib/nextra_venv/lib/python2.6/site-packages/salt/minion.py", line 575, in <lambda>
    target=lambda: self.syndic_cmd(data)
  File "/local/tlib/nextra_venv/lib/python2.6/site-packages/salt/minion.py", line 603, in syndic_cmd
    data['to']
  File "/local/tlib/nextra_venv/lib/python2.6/site-packages/salt/client.py", line 538, in get_returns
    if int(jid) == 0:
ValueError: invalid literal for int() with base 10: ''
```
