### PR TITLE
The pwd & grp modules are only available for unix

### DIFF
--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -77,15 +77,19 @@ print-opts: a comma and/or space separated list of one or more of the following:
     user:  user name
 '''
 
-import grp
 import hashlib
 import logging
 import os
-import pwd
 import re
 import stat
 import sys
 import time
+try:
+    import grp
+    import pwd
+except ImportError:
+    pass
+
 
 from salt._compat import MAX_SIZE
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -5,11 +5,14 @@ Set up the Salt integration test suite
 # Import Python libs
 import multiprocessing
 import os
-import pwd
 import sys
 import shutil
 import signal
 import subprocess
+try:
+    import pwd
+except ImportError:
+    pass
 
 # Import Salt libs
 import salt


### PR DESCRIPTION
Avoid import error for non-unix
