### PR TITLE
Skip or fix unit tests on Windows

### DIFF
--- a/tests/saltunittest.py
+++ b/tests/saltunittest.py
@@ -16,14 +16,14 @@ if sys.version_info[0:2] < (2, 7):
     try:
         from unittest2 import TestLoader, TextTestRunner,\
                               TestCase, expectedFailure, \
-                              TestSuite
+                              TestSuite, skipIf
     except ImportError:
         print("You need to install unittest2 to run the salt tests")
         sys.exit(1)
 else:
     from unittest import TestLoader, TextTestRunner,\
                          TestCase, expectedFailure, \
-                         TestSuite
+                         TestSuite, skipIf
 
 # Set up paths
 TEST_DIR = os.path.dirname(os.path.normpath(os.path.abspath(__file__)))

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -43,7 +43,8 @@ class TestSaltCacheLoader(TestCase):
         fc = MockFileClient(loader)
         res = loader.get_source(None, 'hello_simple')
         assert len(res) == 3
-        self.assertEqual(res[0], 'world\n')
+        # res[0] on Windows is unicode and use os.linesep so it works cross OS
+        self.assertEqual(str(res[0]), 'world' + os.linesep)
         tmpl_dir = os.path.join(TEMPLATES_DIR, 'files', 'test', 'hello_simple')
         self.assertEqual(res[1], tmpl_dir)
         assert res[2](), "Template up to date?"

--- a/tests/unit/utils/find_test.py
+++ b/tests/unit/utils/find_test.py
@@ -3,7 +3,8 @@ import sys
 import shutil
 import tempfile
 import stat
-from saltunittest import TestCase, TestLoader, TextTestRunner
+import platform
+from saltunittest import TestCase, TestLoader, TextTestRunner, skipIf
 
 import salt.utils.find
 
@@ -176,12 +177,14 @@ class TestFind(TestCase):
         option = salt.utils.find.TypeOption('type', 's')
         self.assertEqual(option.match('', '', [stat.S_IFSOCK]), True)
 
+    @skipIf(sys.platform.startswith('win'), 'No /dev/null on Windows')
     def test_owner_option_requires(self):
         self.assertRaises(ValueError, salt.utils.find.OwnerOption, 'owner', 'notexist')
 
         option = salt.utils.find.OwnerOption('owner', 'root')
         self.assertEqual(option.requires(), salt.utils.find._REQUIRES_STAT)
 
+    @skipIf(sys.platform.startswith('win'), 'No /dev/null on Windows')
     def test_owner_option_match(self):
         option = salt.utils.find.OwnerOption('owner', 'root')
         self.assertEqual(option.match('', '', [0] * 5), True)
@@ -189,12 +192,14 @@ class TestFind(TestCase):
         option = salt.utils.find.OwnerOption('owner', '500')
         self.assertEqual(option.match('', '', [500] * 5), True)
 
+    @skipIf(sys.platform.startswith('win'), 'No /dev/null on Windows')
     def test_group_option_requires(self):
         self.assertRaises(ValueError, salt.utils.find.GroupOption, 'group', 'notexist')
 
         option = salt.utils.find.GroupOption('group', 'root')
         self.assertEqual(option.requires(), salt.utils.find._REQUIRES_STAT)
 
+    @skipIf(sys.platform.startswith('win'), 'No /dev/null on Windows')
     def test_group_option_match(self):
         option = salt.utils.find.GroupOption('group', 'root')
         self.assertEqual(option.match('', '', [0] * 6), True)
@@ -257,6 +262,7 @@ class TestGrepOption(TestCase):
         option = salt.utils.find.GrepOption('grep', 'bar')
         self.assertEqual(option.match(self.tmpdir, 'hello.txt', os.stat(hello_file)), None)
 
+    @skipIf(sys.platform.startswith('win'), 'No /dev/null on Windows')
     def test_grep_option_match_dev_null(self):
         option = salt.utils.find.GrepOption('grep', 'foo')
         self.assertEqual(option.match('dev', 'null', os.stat('/dev/null')), None)
@@ -324,25 +330,31 @@ class TestPrintOption(TestCase):
         option = salt.utils.find.PrintOption('print', 'mtime')
         self.assertEqual(option.execute(hello_file, range(10)), 8)
 
-        option = salt.utils.find.PrintOption('print', 'user')
-        self.assertEqual(option.execute('', [0] * 10), 'root')
+        @skipIf(sys.platform.startswith('Windows'), "no /dev/null on windows")
+        def _test_print_user():
+            option = salt.utils.find.PrintOption('print', 'user')
+            self.assertEqual(option.execute('', [0] * 10), 'root')
 
-        option = salt.utils.find.PrintOption('print', 'user')
-        self.assertEqual(option.execute('', [2 ** 31] * 10), 2 ** 31)
+            option = salt.utils.find.PrintOption('print', 'user')
+            self.assertEqual(option.execute('', [2 ** 31] * 10), 2 ** 31)
 
-        option = salt.utils.find.PrintOption('print', 'group')
-        self.assertEqual(option.execute('', [0] * 10), 'root')
+        @skipIf(sys.platform.startswith('Windows'), "no /dev/null on windows")
+        def _test_print_group():
+            option = salt.utils.find.PrintOption('print', 'group')
+            self.assertEqual(option.execute('', [0] * 10), 'root')
 
-        # This seems to be not working in Ubuntu 12.04 32 bit
-        #option = salt.utils.find.PrintOption('print', 'group')
-        #self.assertEqual(option.execute('', [2 ** 31] * 10), 2 ** 31)
+            # This seems to be not working in Ubuntu 12.04 32 bit
+            #option = salt.utils.find.PrintOption('print', 'group')
+            #self.assertEqual(option.execute('', [2 ** 31] * 10), 2 ** 31)
 
         option = salt.utils.find.PrintOption('print', 'md5')
         self.assertEqual(option.execute(hello_file, os.stat(hello_file)),
             'acbd18db4cc2f85cedef654fccc4a4d8')
 
-        option = salt.utils.find.PrintOption('print', 'md5')
-        self.assertEqual(option.execute('/dev/null', os.stat('/dev/null')), '')
+        @skipIf(sys.platform.startswith('Windows'), "no /dev/null on windows")
+        def _test_print_md5():
+            option = salt.utils.find.PrintOption('print', 'md5')
+            self.assertEqual(option.execute('/dev/null', os.stat('/dev/null')), '')
 
         option = salt.utils.find.PrintOption('print', 'path name')
         self.assertEqual(option.execute('test_name', [0] * 9),
@@ -362,7 +374,7 @@ class TestFinder(TestCase):
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
         super(TestFinder, self).tearDown()
-
+    @skipIf(sys.platform.startswith('win'), 'No /dev/null on Windows')
     def test_init(self):
         finder = salt.utils.find.Finder({})
         self.assertEqual(str(finder.actions[0].__class__)[-13:-2],


### PR DESCRIPTION
@SEJeff and @UtahDave 

We're skipping unit tests that depend on find.py because pwd and grp and /dev/null don't exist on Windows.

The jinja test is now fixed on Windows.

`skipIf` will be later used to properly disable the rvm tests when the `mock` python module is not available.
