### PR TITLE
include_dir

### DIFF
--- a/conf/minion.template
+++ b/conf/minion.template
@@ -49,6 +49,12 @@
 # seconds, between those reconnection attempts.
 #acceptance_wait_time = 10
 
+# Specify a directory where extra config files can be loaded from. These
+# config files are loaded last, so they will override anything already
+# defined in the main configuration file. This can be an absolute path
+# or relative to the location of the minion configuration file.
+#include_dir: minion.d
+
 # When healing a dns_check is run, this is to make sure that the originally
 # resolved dns has not changed, if this is something that does not happen in
 # your environment then set this value to False.

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -142,6 +142,23 @@ master.
 
     acceptance_wait_time: 10
 
+.. conf_minion:: include_dir
+
+``include_dir``
+------------------------
+
+Default: ``not defined``
+
+Specify a directory where extra config files can be loaded from. These
+config files are loaded last, so they will override anything already
+defined in the main configuration file. This can be an absolute path
+or relative to the location of the minion configuration file.
+
+.. code-block:: yaml
+    
+    include_dir: /etc/salt/minion.d
+    include_dir: minion.d
+
 Minion Module Management
 ------------------------
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -117,8 +117,18 @@ def include_config_dir(opts, orig_path):
     Parses extra configuration files specified in an include directory.
     '''
     include_dir_path = opts['include_dir']
+    if not include_dir_path:
+        log.warn('Error parsing configuration file: empty value for include_dir')
+        return opts
+
     if not os.path.isabs(include_dir_path):
         include_dir_path = os.path.join(os.path.dirname(orig_path), include_dir_path)
+
+    if not os.path.exists(include_dir_path):
+        msg = 'Error parsing configuration file: include_dir {0} does not exist'
+        log.warn(msg.format(include_dir_path))
+        return opts
+
     if os.path.isdir(include_dir_path):
         for path in os.listdir(include_dir_path):
             try:
@@ -127,6 +137,7 @@ def include_config_dir(opts, orig_path):
             except Exception as e:
                 msg = 'Error parsing configuration file: {0} - {1}'
                 log.warn(msg.format(path, e))
+
     return opts
 
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -112,6 +112,24 @@ def include_config(opts, orig_path):
     return opts
 
 
+def include_config_dir(opts, orig_path):
+    '''
+    Parses extra configuration files specified in an include directory.
+    '''
+    include_dir_path = opts['include_dir']
+    if not os.path.isabs(include_dir_path):
+        include_dir_path = os.path.join(os.path.dirname(orig_path), include_dir_path)
+    if os.path.isdir(include_dir_path):
+        for path in os.listdir(include_dir_path):
+            try:
+                path = os.path.join(include_dir_path, path)
+                opts.update(_read_conf_file(path))
+            except Exception as e:
+                msg = 'Error parsing configuration file: {0} - {1}'
+                log.warn(msg.format(path, e))
+    return opts
+
+
 def prepend_root_dir(opts, path_options):
     '''
     Prepends the options that represent filesystem paths with value of the
@@ -177,6 +195,9 @@ def minion_config(path):
 
     if 'include' in opts:
         opts = include_config(opts, path)
+
+    if 'include_dir' in opts:
+        opts = include_config_dir(opts, path)
 
     if 'append_domain' in opts:
         opts['id'] = _append_domain(opts)


### PR DESCRIPTION
This pull request adds a new option 'include_dir' that allows the minion to automatically load config files from a given directory.

This is useful in the case where you have static Grains in use, and you want to maintain a single common minion config file. You can push the static Grains into the include directory to keep your common config file common.
