### PR TITLE
Bugfix + documentation update for 'include' option

### DIFF
--- a/conf/minion.template
+++ b/conf/minion.template
@@ -54,6 +54,26 @@
 # your environment then set this value to False.
 #dns_check: True
 
+# The minion can include configuration from other files. To enable this,
+# pass a list of paths to this option. The paths can be either relative or
+# absolute; if relative, they are considered to be relative to the directory
+# the main minion configuration file lives in (this file). Paths can make use
+# of shell-style globbing. If no files are matched by a path passed to this
+# option then the minion will log a warning message.
+# 
+# Examples:
+# Include any config files in minion.d (minion.d is a directory
+# in the same directory as the main minion config file)
+#include: minion.d/*
+# 
+# Include a config file from some other path:
+#include: /etc/salt/extra_config
+#
+# Include config from several files and directories:
+#include:
+# - /etc/salt/extra_config
+# - /etc/roles/webserver
+# - minion.d/*
 
 #####   Minion module management     #####
 ##########################################

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -415,8 +415,8 @@ Default: ``not defined``
 The minion can include configuration from other files. To enable this,
 pass a list of paths to this option. The paths can be either relative or
 absolute; if relative, they are considered to be relative to the directory
-the main minion configuration file lives in (this file). Paths can make use
-of shell-style globbing. If no files are matched by a path passed to this
+the main minion configuration file lives in . Paths can make use of 
+shell-style globbing. If no files are matched by a path passed to this
 option then the minion will log a warning message.
 
 .. code-block:: yaml

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -404,3 +404,32 @@ still wish to have 'salt.modules' at the 'debug' level:
   log_granular_levels:
     'salt': 'warning',
     'salt.modules': 'debug'
+
+.. conf_minion:: include
+
+``include``
+-----------
+
+Default: ``not defined``
+
+The minion can include configuration from other files. To enable this,
+pass a list of paths to this option. The paths can be either relative or
+absolute; if relative, they are considered to be relative to the directory
+the main minion configuration file lives in (this file). Paths can make use
+of shell-style globbing. If no files are matched by a path passed to this
+option then the minion will log a warning message.
+
+.. code-block:: yaml
+    
+    # Include files from a minion.d directory in the same
+    # directory as the minion config file
+    include: minion.d/*
+
+    # Include a single extra file into the configuration
+    include: /etc/roles/webserver
+
+    # Include several files and the minion.d directory
+    include:
+      - extra_config
+      - minion.d/*
+      - /etc/roles/webserver


### PR DESCRIPTION
The 'include' option lacked an example in the template configuration file. I've added a few for common use cases.

The glob method didn't work properly, because rather than using the path return from glob.glob, the code used the originally supplied path from the config file (which contained the shell metacharacter).

We also got an ugly stacktrace if an empty value was supplied to the 'include' option; this is fixed.
