### PR TITLE
ignore 'tmp' directory created by integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ include/
 lib/
 pip/
 share/
+tests/integration/tmp/
 
 # tox - ignore any tox-created virtualenv dirs
 .tox


### PR DESCRIPTION
ignore 'tmp' directory created by integration tests
