### PR TITLE
Hardcode /tmp/subsalttest dir in ssh module integration tests

### DIFF
--- a/tests/integration/modules/ssh.py
+++ b/tests/integration/modules/ssh.py
@@ -12,8 +12,8 @@ import integration
 from integration import TestDaemon
 
 
-AUTHORIZED_KEYS = os.path.join(integration.TMP, 'authorized_keys')
-KNOWN_HOSTS = os.path.join(integration.TMP, 'known_hosts')
+AUTHORIZED_KEYS = os.path.join('/tmp/subsalttest', 'authorized_keys')
+KNOWN_HOSTS = os.path.join('/tmp/subsalttest', 'known_hosts')
 GITHUB_FINGERPRINT = '16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48'
 
 


### PR DESCRIPTION
I don't really like doing this, but `/tmp/subsalttest` dir is already
hardcoded in other places for running tests.

Without this, when running tests under a mounted Vagrant drive,
`ssh-keygen` doesn't have permission to create the symlink for
known_hosts to known_hosts.old, causing a test to fail.

```
======================================================================
FAIL: test_rm_known_host (integration.modules.ssh.SSHModuleTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/vagrant/tests/integration/modules/ssh.py", line 143, in
test_rm_known_host
    self.assertEqual(ret, 'add')
AssertionError: 'exists' != 'add'
```

`link /vagrant/tests/integration/tmp/known_hosts to /vagrant/tests/integration/tmp/known_hosts.old: Operation not permitted`
