### PR TITLE
Fix host file setup and fix tests.integration.states.host

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -71,6 +71,10 @@ class TestDaemon(object):
         self._clean()
         self.master_opts['hosts.file'] = os.path.join(TMP, 'hosts')
         self.minion_opts['hosts.file'] = os.path.join(TMP, 'hosts')
+        shutil.copy(os.path.join(INTEGRATION_TEST_DIR, 'files', 'hosts'),
+                    self.master_opts['hosts.file'])
+        shutil.copy(os.path.join(INTEGRATION_TEST_DIR, 'files', 'hosts'),
+                    self.minion_opts['hosts.file'])
         verify_env([
                     os.path.join(self.master_opts['pki_dir'], 'minions'),
                     os.path.join(self.master_opts['pki_dir'], 'minions_pre'),

--- a/tests/integration/states/host.py
+++ b/tests/integration/states/host.py
@@ -6,9 +6,7 @@ tests for host state
 import os
 #
 # Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 HFILE = os.path.join(integration.TMP, 'hosts')
 
@@ -21,8 +19,11 @@ class HostTest(integration.ModuleCase):
         '''
         host.present
         '''
-        ret = self.run_state('host.present', name='spam.bacon', ip='10.10.10.10')
+        name = 'spam.bacon'
+        ip = '10.10.10.10'
+        ret = self.run_state('host.present', name=name, ip=ip)
         result = self.state_result(ret)
         self.assertTrue(result)
         with open(HFILE) as fp_:
-            self.assertIn('{0}\t\t{1}'.format(ip, name), fp_.read())
+            output = fp_.read()
+            self.assertIn('{0}\t\t{1}'.format(ip, name), output)


### PR DESCRIPTION
Currently, the hosts file does not get installed to tests/integration/tmp/host where the tests expect it to be.
