### PR TITLE
fixing the salt/tests/integration/states/cmd.py test

### DIFF
--- a/tests/integration/states/cmd.py
+++ b/tests/integration/states/cmd.py
@@ -18,7 +18,7 @@ class CMDTest(integration.ModuleCase):
         '''
         cmd.run
         '''
-        ret = self.run_state('cmd.run', name='ls')
+        ret = self.run_state('cmd.run', name='ls', cwd='/')
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
 


### PR DESCRIPTION
override the default cwd to be '/' rather than '/root'
