### PR TITLE
user creation tests work properly for issue #1482

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -4,8 +4,9 @@ user absent
 user present
 user present with custom homedir
 '''
+import os
 
-from saltunittest import TestLoader, TextTestRunner
+from saltunittest import TestLoader, TextTestRunner, skipIf
 import integration
 from integration import TestDaemon
 
@@ -19,8 +20,27 @@ class UserTest(integration.ModuleCase):
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
 
-#    def test_user_present(self):
+    def test_user_if_present(self):
+        ret = self.run_state('user.present', name='nobody') 
+        result = ret[next(iter(ret))]['result']
+        self.assertTrue(result)
 
-#    def test_user_present_nondefault(self):
+    @skipIf(not (os.geteuid()==0)) #you must be this root
+    def test_user_not_present(self):
+        """
+        This is a DESTRUCTIVE TEST it creates a new user on the minion.
+        Assume that it will break any system you run it on.
+        """
+        ret = self.run_state('user.present', name='salt_test') 
+        result = ret[next(iter(ret))]['result']
+        self.assertTrue(result)
 
-       
+    @skipIf(not (os.geteuid()==0)) #you must be this root
+    def test_user_present_nondefault(self):
+        """
+        This is a DESTRUCTIVE TEST it creates a new user on the on the minion.
+        """
+        ret = self.run_state('user.present', name='salt_test',
+                             home='/var/lib/salt_test') 
+        result = ret[next(iter(ret))]['result']
+        self.assertTrue(result)

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -29,11 +29,13 @@ class UserTest(integration.ModuleCase):
     def test_user_not_present(self):
         """
         This is a DESTRUCTIVE TEST it creates a new user on the minion.
+        And then destroys that user.
         Assume that it will break any system you run it on.
         """
         ret = self.run_state('user.present', name='salt_test') 
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
+        ret = self.run_state('user.absent', name='salt_test')
 
     @skipIf(not (os.geteuid()==0), 'you must be this root to run this test')
     def test_user_present_nondefault(self):
@@ -44,3 +46,6 @@ class UserTest(integration.ModuleCase):
                              home='/var/lib/salt_test') 
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
+        self.assertTrue(os.stat('/var/lib/salt_test'))
+        ret = self.run_state('user.absent', name='salt_test')
+

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -25,7 +25,7 @@ class UserTest(integration.ModuleCase):
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
 
-    @skipIf(not (os.geteuid()==0)) #you must be this root
+    @skipIf(not (os.geteuid()==0),'you must be this root to run this test')
     def test_user_not_present(self):
         """
         This is a DESTRUCTIVE TEST it creates a new user on the minion.
@@ -35,7 +35,7 @@ class UserTest(integration.ModuleCase):
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
 
-    @skipIf(not (os.geteuid()==0)) #you must be this root
+    @skipIf(not (os.geteuid()==0), 'you must be this root to run this test')
     def test_user_present_nondefault(self):
         """
         This is a DESTRUCTIVE TEST it creates a new user on the on the minion.


### PR DESCRIPTION
the user creation tests will be skipped unless the tests are run as root, in which case they will create a 'salt_test' user and remove it.

Currently the last test will fail.

https://github.com/saltstack/salt/issues/1482
