### PR TITLE
fix doc symlink

### DIFF
--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -1,1 +1,1 @@
-../../HACKING
+../../HACKING.rst


### PR DESCRIPTION
I moved HACKING to HACKING.rst after I made the symlink, so the symlink is wrong and causing the docs to fail. This fixes it.
