### PR TITLE
sys.stdout could be StringIO or fake object

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -92,7 +92,12 @@ def get_colors(use=True):
             'ENDC': '\033[0m',
             }
 
-    if not use or not os.isatty(sys.stdout.fileno()):
+    try:
+        fileno = sys.stdout.fileno()
+    except AttributeError:
+        fileno = -1  # sys.stdout is StringIO or fake
+
+    if not use or not os.isatty(fileno):
         for color in colors:
             colors[color] = ''
 


### PR DESCRIPTION
`sys.stdout.fileno` attribute is not available for StringIO.
Changing sys.stdout is convenient for capturing test results.

There is an error in Jenkins like this:
http://jenkins.saltstack.org/job/all_tests_ubuntu1204_32bit/251/testReport/integration.runners.manage/ManageTest/test_down/
This happens because the test runner (XML output) changes the sys.stdout to a StringIO
