### PR TITLE
Indicate Python 2.7 is okay

### DIFF
--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -10,7 +10,7 @@ Dependencies
 
 Salt should run on any Unix-like platform so long as the dependencies are met.
 
-* `Python 2.6`_
+* `Python 2.6`_ >= 2.6 <3.0
 * `ZeroMQ`_ >= 2.1.9
 * `pyzmq`_ >= 2.1.9 - ZeroMQ Python bindings
 * `PyCrypto`_ - The Python cryptography toolkit


### PR DESCRIPTION
Saltstack works with Python 2.7.   I'm told 3.0 isn't likely to work right now.
