### PR TITLE
Unify user checks

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -616,7 +616,7 @@ class SaltKey(object):
                 dest='conf_file',
                 default='/etc/salt/master',
                 help='Pass in an alternative configuration file')
-        
+
         parser.add_option('--raw-out',
                 default=False,
                 action='store_true',
@@ -847,4 +847,10 @@ class SaltRun(object):
         Execute salt-run
         '''
         runner = salt.runner.Runner(self.opts)
-        runner.run()
+        # Run this here so SystemExit isn't raised
+        # anywhere else when someone tries to  use
+        # the runners via the python api
+        try:
+            runner.run()
+        except SaltClientError as exc:
+            raise SystemExit(str(exc))

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -38,7 +38,7 @@ class Caller(object):
         try:
             self.minion = salt.minion.SMinion(opts)
         except SaltClientError as exc:
-            sys.exit(1)
+            raise SystemExit(str(exc))
 
     def call(self):
         '''

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -16,7 +16,11 @@ import salt.minion
 from salt._compat import string_types
 
 # Custom exceptions
-from salt.exceptions import CommandExecutionError, CommandNotFoundError
+from salt.exceptions import (
+    SaltClientError,
+    CommandNotFoundError,
+    CommandExecutionError,
+)
 
 
 class Caller(object):
@@ -28,7 +32,13 @@ class Caller(object):
         Pass in the command line options
         '''
         self.opts = opts
-        self.minion = salt.minion.SMinion(opts)
+        # Handle this here so other deeper code which might
+        # be imported as part of the salt api doesn't do  a
+        # nasty sys.exit() and tick off our developer users
+        try:
+            self.minion = salt.minion.SMinion(opts)
+        except SaltClientError as exc:
+            sys.exit(1)
 
     def call(self):
         '''

--- a/salt/client.py
+++ b/salt/client.py
@@ -82,14 +82,16 @@ class LocalClient(object):
         '''
         Read in the rotating master authentication key
         '''
+        keyfile = os.path.join(self.opts['cachedir'], '.root_key')
+        # Make sure all key parent directories are accessible
+        user = self.opts.get('user', 'root')
+        salt.utils.verify.check_parent_dirs(keyfile, user)
+
         try:
-            keyfile = os.path.join(self.opts['cachedir'], '.root_key')
-            # Make sure all key parent directories are accessible
-            user = self.opts.get('user', 'root')
-            salt.utils.verify.check_parent_dirs(keyfile, user)
             with open(keyfile, 'r') as KEY:
                 return KEY.read()
         except (OSError, IOError):
+            # In theory, this should never get hit. Belt & suspenders baby!
             raise SaltClientError(('Problem reading the salt root key. Are'
                                    ' you root?'))
 

--- a/salt/client.py
+++ b/salt/client.py
@@ -42,6 +42,7 @@ import zmq
 import salt.config
 import salt.payload
 import salt.utils
+import salt.utils.verify
 import salt.utils.event
 from salt.exceptions import SaltClientError, SaltInvocationError
 
@@ -83,8 +84,11 @@ class LocalClient(object):
         '''
         try:
             keyfile = os.path.join(self.opts['cachedir'], '.root_key')
-            key = open(keyfile, 'r').read()
-            return key
+            # Make sure all key parent directories are accessible
+            user = self.opts.get('user', 'root')
+            salt.utils.verify.check_parent_dirs(keyfile, user)
+            with open(keyfile, 'r') as KEY:
+                return KEY.read()
         except (OSError, IOError):
             raise SaltClientError(('Problem reading the salt root key. Are'
                                    ' you root?'))


### PR DESCRIPTION
This request unifies the code for checking that a user has access to read the keys for `salt`, `salt-call`, and `salt-run`. It fixes bugs #1553 and #1554 that @KB1JWQ reported at the salt sprint yesterday.

``` bash

$ whoami
jeff
$ grep ^user: /etc/salt/master
user: jeff
$ ./salt '*' test.ping
Could not access directory /var/cache/salt. Please give jeff read permissions.
$ ./salt-run manage.up
Could not access directory /var/cache/salt. Please give jeff read permissions.
$ ./salt-call state.highstate
Could not access directory /etc/salt/pki. Please give jeff read permissions.
$ sudo vim /etc/salt/minion
$ grep ^user: /etc/salt/master
user: root
$ ./salt-call state.highstate
Could not access directory /etc/salt/pki. Try running as user root.
```
