### PR TITLE
[Issue 1568] Updated the regex to match when there is no [arch] field.

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -319,8 +319,8 @@ def _get_upgradable():
     rexp = re.compile('(?m)^Conf '
                       '([^ ]+) ' # Package name
                       '\(([^ ]+) ' # Version
-                      '([^ ]+) ' # Release
-                      '\[([^\]]+)\]\)$') # Arch
+                      '([^ ]+)' # Release
+                      '(?: \[([^\]]+)\])?\)$') # Arch
     keys = ['name', 'version', 'release', 'arch']
     _get = lambda l, k: l[keys.index(k)]
 


### PR DESCRIPTION
- Thanks @avimar for the suggested regexes
- Tested on 12.04, 10.04

https://github.com/saltstack/salt/issues/1568
