### PR TITLE
Add ability to sync runners to the salt cache dir.

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -130,6 +130,20 @@ def sync_returners(env='base'):
     return _sync('returners', env)
 
 
+def sync_runners(env='base'):
+    '''
+    Sync the runners from the _runners directory on the salt master file
+    server. This function is environment aware, pass the desired environment
+    to grab the contents of the _runners directory, base is the default
+    environment.
+
+    CLI Example::
+
+        salt '*' saltutil.sync_runners
+    '''
+    return _sync('runners', env)
+
+
 def sync_all(env='base'):
     '''
     Sync down all of the dynamic modules from the file server for a specific
@@ -145,6 +159,7 @@ def sync_all(env='base'):
     ret.append(sync_grains(env))
     ret.append(sync_renderers(env))
     ret.append(sync_returners(env))
+    ret.append(sync_runners(env))
     return ret
 
 


### PR DESCRIPTION
This adds "saltutil.sync_runners", enabling custom runners to be placed into {{ file_roots }}/_runners/.

Since the runners are only needed on the master, it might make sense to reject this patch in favor of modifying the runner loader to simply load directly from the file_roots, but this patch was simple and consistent with state/module/returner loading. I'm welcome to feedback.
