### PR TITLE
"git checkout" needs to be run as "runas"

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -66,7 +66,7 @@ def latest(name,
                     ('Repository {0} update is probably required (current '
                     'revision is {1})').format(target, current_rev))
         if rev:
-            __salt__['git.checkout'](target, rev)
+            __salt__['git.checkout'](target, rev, user=runas)
         __salt__['git.pull'](target, user=runas)
         new_rev = __salt__['git.revision'](cwd=target, user=runas)
         if current_rev != new_rev:
@@ -101,7 +101,7 @@ def latest(name,
         if not os.path.isdir(target):
             return _fail(ret, result)
         if rev:
-            __salt__['git.checkout'](target, rev)
+            __salt__['git.checkout'](target, rev, user=runas)
         else:
             message = 'Repository {0} cloned to {1}'.format(name, target)
             log.info(message)


### PR DESCRIPTION
Any files created when switching branches were owned by root, which
makes the directory effectively unusable by the intended user.
