### PR TITLE
git state should report "changed" on first clone, also adding git.submodule

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -312,3 +312,26 @@ def init(cwd, opts=None, user=None):
 
     cmd = 'git init {0} {1}'.format(cwd, opts)
     return __salt__['cmd.run'](cmd, runas=user)
+
+def submodule(cwd, init=True, opts=None, user=None):
+    '''
+    Initialize git submodules
+
+    cwd
+        The path to the Git repository
+
+    init : True
+        Ensure that new submodules are initialized
+
+    opts : None
+        Any additional options to add to the command line
+
+    user : None
+        Run git as a user other than what the minion runs as
+    '''
+    _check_git()
+
+    if not opts:
+        opts = ''
+    cmd = 'git submodule update {0} {1}'.format('--init' if init else '', opts)
+    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -30,7 +30,9 @@ def latest(name,
            rev=None,
            target=None,
            runas=None,
-           force=None):
+           force=None,
+           submodules=False,
+        ):
     '''
     Make sure the repository is cloned to the given directory and is up to date
 
@@ -44,6 +46,8 @@ def latest(name,
         Name of the user performing repository management operations
     force
         Force git to clone into pre-existing directories (deletes contents)
+    submodules
+        Update submodules on clone or branch change (Default: False)
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
@@ -68,6 +72,10 @@ def latest(name,
         if rev:
             __salt__['git.checkout'](target, rev, user=runas)
         __salt__['git.pull'](target, user=runas)
+
+        if submodules:
+            __salt__['git.submodule'](target, user=runas)
+
         new_rev = __salt__['git.revision'](cwd=target, user=runas)
         if current_rev != new_rev:
             log.info('Repository {0} updated: {1} => {2}'.format(target,
@@ -103,6 +111,9 @@ def latest(name,
 
         if rev:
             __salt__['git.checkout'](target, rev, user=runas)
+
+        if submodules:
+            __salt__['git.submodule'](target, user=runas)
 
         new_rev = __salt__['git.revision'](cwd=target, user=runas)
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -100,13 +100,18 @@ def latest(name,
         result = __salt__['git.clone'](target, name, user=runas)
         if not os.path.isdir(target):
             return _fail(ret, result)
+
         if rev:
             __salt__['git.checkout'](target, rev, user=runas)
-        else:
-            message = 'Repository {0} cloned to {1}'.format(name, target)
-            log.info(message)
-            ret['comment'] = message
-            ret['changes']['new'] = name
+
+        new_rev = __salt__['git.revision'](cwd=target, user=runas)
+
+        message = 'Repository {0} cloned to {1}'.format(name, target)
+        log.info(message)
+        ret['comment'] = message
+
+        ret['changes']['new'] = name
+        ret['changes']['revision'] = new_rev
     return ret
 
 


### PR DESCRIPTION
Was trying to write a state that recompiled when the repo changed,
without something like this it wouldn't compile the first time it was
cloned

Didn't realize it, but none of my dependencies were checked out
because they were submodules. This adds a "submodules" option to
git.clone
