### PR TITLE
Support pkg module on Amazon Linux.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -439,6 +439,11 @@ def os_data():
                 grains['os'] = 'Scientific'
             else:
                 grains['os'] = 'RedHat'
+        elif os.path.isfile('/etc/system-release'):
+            grains['os_family'] = 'RedHat'
+            data = open('/etc/system-release', 'r').read()
+            if 'amazon' in data.lower():
+                grains['os'] = 'Amazon'
         elif os.path.isfile('/etc/SuSE-release'):
             grains['os_family'] = 'Suse'
             data = open('/etc/SuSE-release', 'r').read()

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -13,6 +13,7 @@ grainmap = {
            'Ubuntu': '/etc/init.d',
            'Gentoo': '/etc/init.d',
            'CentOS': '/etc/init.d',
+           'Amazon': '/etc/init.d',
            'SunOS': '/etc/init.d',
           }
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -30,6 +30,8 @@ def __virtual__():
             return 'pkg'
         else:
             return False
+    elif __grains__['os'] == 'Amazon':
+        return 'pkg'
     else:
         if __grains__['os'] in dists:
             if int(__grains__['osrelease'].split('.')[0]) >= 6:

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -45,6 +45,8 @@ def _run_check(cmd_kwargs, onlyif, unless, cwd, user, group, shell):
     '''
     Execute the onlyif logic and return data if the onlyif fails
     '''
+    ret = {}
+
     if group:
         try:
             egid = grp.getgrnam(group).gr_gid


### PR DESCRIPTION
I found that due to /etc/redhat-release not existing in Amazon Linux that the yumpkg module would not be enabled. Considering that Amazon Linux is very close to CentOS 6 and supports yum, it seemed like an easy fix to make it work.
