### PR TITLE
Set up owner of ~/.ssh/known_hosts

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -381,12 +381,14 @@ def set_auth_key(
         if not os.path.isdir(os.path.dirname(fconfig)):
             dpath = os.path.dirname(fconfig)
             os.makedirs(dpath)
-            os.chown(dpath, uinfo['uid'], uinfo['gid'])
+            if os.geteuid() == 0:
+                os.chown(dpath, uinfo['uid'], uinfo['gid'])
             os.chmod(dpath, 448)
 
         if not os.path.isfile(fconfig):
             open(fconfig, 'a+').write('{0}'.format(auth_line))
-            os.chown(fconfig, uinfo['uid'], uinfo['gid'])
+            if os.geteuid() == 0:
+                os.chown(fconfig, uinfo['uid'], uinfo['gid'])
             os.chmod(fconfig, 384)
         else:
             open(fconfig, 'a+').write('{0}'.format(auth_line))
@@ -549,6 +551,8 @@ def set_known_host(user, hostname,
     line = '{hostname} {enc} {key}\n'.format(**remote_host)
     with open(full, 'a') as fd:
         fd.write(line)
+    if os.geteuid() == 0:
+        os.chown(full, uinfo['uid'], uinfo['gid'])
     return {'status': 'updated', 'old': stored_host, 'new': remote_host}
 
     status = check_known_host(user, hostname, fingerprint=fingerprint,


### PR DESCRIPTION
I found one more bug in my code and fixed it with this commit. Please consider merging. Thanks.
- Fixed behaviour, when if known_hosts is created by salt, then the
  owner of the file will be the salt process (usually, root)
- On the other hand, non-roots cannot set up ownership, and we skip
  this step for them (useful mostly in tests, though).
