### PR TITLE
salt-syndic exec script instantiates a minion rather than a syndic

### DIFF
--- a/scripts/salt-syndic
+++ b/scripts/salt-syndic
@@ -3,8 +3,8 @@
 This script is used to kick off a salt syndic daemon
 '''
 
-from salt.scripts import salt_minion
+from salt.scripts import salt_syndic
 
 
 if __name__ == '__main__':
-    salt_minion()
+    salt_syndic()


### PR DESCRIPTION
Fixing the issue introduced in https://github.com/saltstack/salt/commit/ee0072d3e8d394ef16843cb9b65ce75a1d2d325b#scripts/salt-syndic

The issue is reproducible by setting up a simple master->syndic->minion setup. When running salt-syndic on the syndic host, the  logs show that a salt minion is started and issuing commands via the master confirms that a minion is running rather than a syndic.
