### PR TITLE
Removed camelcase from the pycrypto requirement as it's not the original package's spelling

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@
 Jinja2
 M2Crypto
 msgpack-python
-PyCrypto
+pycrypto
 PyYAML
 pyzmq >= 2.1.9


### PR DESCRIPTION
This may sound minor but pypi.python.org is case-insensitive while mirrors or custom pypi's are not. The canonical name of `pycrypto` is not camel-cased, so this change helps installing salt from custom pypi mirror/indices by using the real name from pypi.

Other deps are properly spelled with regards to this issue :)

Thanks,
Bruno
