### PR TITLE
Use zypper for all Suse products instead of only for openSUSE

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -7,7 +7,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is openSUSE
     '''
-    return 'pkg' if __grains__['os'] == 'openSUSE' else False
+    return 'pkg' if __grains__['os_family'] == 'Suse' else False
 
 
 def _list_removed(old, new):


### PR DESCRIPTION
Currently the zypper module is only used for openSUSE but other SUSE products also support zypper. This patch will use os_family instead of os.
