### PR TITLE
Fix "undefined name" errors spotted by pyflakes

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -144,10 +144,10 @@ def set_special(user, special, cmd):
         salt '*' cron.set_special @hourly 'echo foobar'
     '''
     lst = list_tab(user)
-    for spec in lst['special']:
-        if special == cron['special'] and \
-            cmd == cron['cmd']:
-            return 'present'
+    for cron in lst['crons']:
+        for spec in lst['special']:
+            if special == cron['special'] and cmd == cron['cmd']:
+                return 'present'
     spec = {'special': special,
             'cmd': cmd}
     lst['special'].append(spec)

--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -426,7 +426,7 @@ def resume(name):
     return True
 
 
-def set_autostart(name):
+def set_autostart(name, state='on'):
     '''
     Set the named virtual machine to autostart when the hypervisor boots
 

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -709,7 +709,8 @@ def grant_revoke(grant,
                  database,
                  user,
                  host='localhost',
-                 grant_option=False):
+                 grant_option=False,
+                 escape=True):
     '''
     Removes a grant from the MySQL server.
 

--- a/salt/pillar/hiera.py
+++ b/salt/pillar/hiera.py
@@ -8,6 +8,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+from salt._compat import string_types
 
 # Import third party libs
 import yaml

--- a/salt/state.py
+++ b/salt/state.py
@@ -1586,6 +1586,7 @@ class RemoteHighState(object):
         self.grains = grains
         self.serial = salt.payload.Serial(self.opts)
         self.auth = salt.crypt.SAuth(opts)
+        self.sreq = salt.payload.SREQ(self.opts['master_uri'])
 
     def compile_master(self):
         '''
@@ -1595,7 +1596,7 @@ class RemoteHighState(object):
                 'opts': self.opts,
                 'cmd': '_master_state'}
         try:
-            return self.auth.crypticle.loads(sreq.send(
+            return self.auth.crypticle.loads(self.sreq.send(
                     'aes',
                     self.auth.crypticle.dumps(load),
                     3,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -585,7 +585,7 @@ def _check_dir_meta(
     '''
     Check the changes in directory metadata
     '''
-    stats = __salt__['file.stats'](name, source_sum['hash_type'])
+    stats = __salt__['file.stats'](name)
     changes = {}
     if not user is None and user != stats['user']:
         changes['user'] = user

--- a/tests/integration/runners/jobs.py
+++ b/tests/integration/runners/jobs.py
@@ -39,7 +39,7 @@ class ManageTest(integration.ShellCase):
 
 if __name__ == "__main__":
     loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(RunTest)
+    tests = loader.loadTestsFromTestCase(ManageTest)
     print('Setting up Salt daemons to execute tests')
     with TestDaemon():
         runner = TextTestRunner(verbosity=1).run(tests)

--- a/tests/integration/runners/manage.py
+++ b/tests/integration/runners/manage.py
@@ -36,7 +36,7 @@ class ManageTest(integration.ShellCase):
 
 if __name__ == "__main__":
     loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(RunTest)
+    tests = loader.loadTestsFromTestCase(ManageTest)
     print('Setting up Salt daemons to execute tests')
     with TestDaemon():
         runner = TextTestRunner(verbosity=1).run(tests)

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -117,7 +117,7 @@ class MatchTest(integration.ShellCase):
 
 if __name__ == "__main__":
     loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(KeyTest)
+    tests = loader.loadTestsFromTestCase(MatchTest)
     print('Setting up Salt daemons to execute tests')
     with TestDaemon():
         runner = TextTestRunner(verbosity=1).run(tests)


### PR DESCRIPTION
This fixes the "undefined name" warnings from pyflakes that are actually real errors. We should probably fix all the other pyflakes warnings so real errors aren't lost in the noise (and we should of course have 100% test coverage, but that's a bit harder to achieve).
