### PR TITLE
Grain fiddling on OpenBSD

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -659,14 +659,14 @@ def _hw_data(osdata):
             grains['productname'] = __salt__['cmd.run']('{0} smbios.system.product'.format(kenv)).strip()
     elif osdata['kernel'] == 'OpenBSD':
         sysctl = salt.utils.which('sysctl')
-        vendor_cmd = '{0} -n hw.vendor'.format(sysctl)
-        product_cmd = '{0} -n hw.product'.format(sysctl)
-        version_cmd = '{0} -n hw.version'.format(sysctl)
-        serial_cmd = '{0} -n hw.serialno'.format(sysctl)
-        grains['biosversion'] = __salt__['cmd.run'](version_cmd).strip()
-        grains['manufacturer'] = __salt__['cmd.run'](vendor_cmd).strip()
-        grains['productname'] = __salt__['cmd.run'](product_cmd).strip()
-        grains['serialnumber'] = __salt__['cmd.run'](serial_cmd).strip()
+        hwdata = {'biosversion': 'hw.version',
+                  'manufacturer': 'hw.vendor',
+                  'productname': 'hw.product',
+                  'serialnumber': 'hw.serialno'}
+        for key, oid in hwdata.items():
+            value = __salt__['cmd.run']('{0} -n {1}'.format(sysctl, oid))
+            if not value.endswith(' value is not available'):
+                grains[key] = value
     return grains
 
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -124,6 +124,10 @@ def _bsd_cpudata(osdata):
 
     grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
     grains['cpu_flags'] = []
+    try:
+        grains['num_cpus'] = int(grains['num_cpus'])
+    except Exception:
+        grains['num_cpus'] = 0
 
     return grains
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -112,12 +112,15 @@ def _bsd_cpudata(osdata):
     Return cpu information for BSD-like systems
     '''
     sysctl = salt.utils.which('sysctl')
+    arch = salt.utils.which('arch')
     cmds = {}
 
     if sysctl:
         cmds['num_cpus'] = '{0} -n hw.ncpu'.format(sysctl)
         cmds['cpu_model'] = '{0} -n hw.model'.format(sysctl)
         cmds['cpuarch'] = '{0} -n hw.machine'.format(sysctl)
+    if arch and osdata['kernel'] == 'OpenBSD':
+        cmds['cpuarch'] = '{0} -s'.format(arch)
 
     grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
     grains['cpu_flags'] = []

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -107,21 +107,21 @@ def _linux_cpudata():
     return grains
 
 
-def _freebsd_cpudata():
+def _bsd_cpudata(osdata):
     '''
-    Return cpu information for FreeBSD systems
+    Return cpu information for BSD-like systems
     '''
-    grains = {}
     sysctl = salt.utils.which('sysctl')
+    cmds = {}
 
     if sysctl:
-        machine_cmd = '{0} -n hw.machine'.format(sysctl)
-        ncpu_cmd = '{0} -n hw.ncpu'.format(sysctl)
-        model_cpu = '{0} -n hw.model'.format(sysctl)
-        grains['num_cpus'] = __salt__['cmd.run'](ncpu_cmd).strip()
-        grains['cpu_model'] = __salt__['cmd.run'](model_cpu).strip()
-        grains['cpuarch'] = __salt__['cmd.run'](machine_cmd).strip()
-        grains['cpu_flags'] = []
+        cmds['num_cpus'] = '{0} -n hw.ncpu'.format(sysctl)
+        cmds['cpu_model'] = '{0} -n hw.model'.format(sysctl)
+        cmds['cpuarch'] = '{0} -n hw.machine'.format(sysctl)
+
+    grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
+    grains['cpu_flags'] = []
+
     return grains
 
 
@@ -477,15 +477,14 @@ def os_data():
     elif grains['kernel'] == 'Darwin':
         grains['os'] = 'MacOS'
         grains['os_family'] = 'MacOS'
-        grains.update(_freebsd_cpudata())
+        grains.update(_bsd_cpudata(grains))
     else:
         grains['os'] = grains['kernel']
         grains['os_family'] = grains['kernel']
     if grains['kernel'] == 'Linux':
         grains.update(_linux_cpudata())
     elif grains['kernel'] in ('FreeBSD', 'OpenBSD'):
-        # _freebsd_cpudata works on OpenBSD as well.
-        grains.update(_freebsd_cpudata())
+        grains.update(_bsd_cpudata(grains))
 
     grains.update(_memdata(grains))
 

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -13,7 +13,12 @@ def __virtual__():
     Only work on OpenBSD
     '''
     if __grains__['os'] == 'OpenBSD' and os.path.exists('/etc/rc.d/rc.subr'):
-        return 'service'
+        print __grains__['kernelrelease'].split('.')
+        v = map(int, __grains__['kernelrelease'].split('.'))
+        # The -f flag, used to force a script to run even if disabled,
+        # was added after the 5.0 release.
+        if v[0] > 5 or (v[0] == 5 and v[1] > 0):
+            return 'service'
     return False
 
 


### PR DESCRIPTION
Set a few grains better on OpenBSD, and disable the OpenBSD service module on older systems where it's impractical to make it work reliably.
