### PR TITLE
Fixed bug were the minimum keysize could be greater than 2048.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -651,7 +651,7 @@ class SaltKey(object):
         for k, v in options.__dict__.items():
             if k == 'keysize':
                 if v < 2048:
-                    opts[k] = v
+                    opts[k] = 2048 
                 else:
                     opts[k] = v
             elif v is not None:


### PR DESCRIPTION
Looks like this was introduced in saltstack/salt@4981752f1ddac498c74cd97280004aa16aca35cf
