### PR TITLE
Allow the passage of a timeout value to salt runners.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -815,6 +815,13 @@ class SaltRun(object):
                 help=('Change the location of the master configuration; '
                       'default=/etc/salt/master'))
 
+        parser.add_option('-t',
+                '--timeout',
+                dest='timeout',
+                default='1',
+                help=('Change the timeout, if applicable, for the salt runner; '
+                      'default=1'))
+
         parser.add_option('-d',
                 '--doc',
                 '--documentation',

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -24,7 +24,7 @@ def active():
     ret = {}
     job_dir = os.path.join(__opts__['cachedir'], 'jobs')
     client = salt.client.LocalClient(__opts__['conf_file'])
-    active_ = client.cmd('*', 'saltutil.running', timeout=1)
+    active = client.cmd('*', 'saltutil.running', timeout=__opts__['timeout'])
     for minion, data in active_.items():
         if not isinstance(data, list):
             continue

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -24,7 +24,7 @@ def active():
     ret = {}
     job_dir = os.path.join(__opts__['cachedir'], 'jobs')
     client = salt.client.LocalClient(__opts__['conf_file'])
-    active = client.cmd('*', 'saltutil.running', timeout=__opts__['timeout'])
+    active_ = client.cmd('*', 'saltutil.running', timeout=__opts__['timeout'])
     for minion, data in active_.items():
         if not isinstance(data, list):
             continue

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -13,7 +13,7 @@ def down():
     '''
     client = salt.client.LocalClient(__opts__['conf_file'])
     key = salt.cli.key.Key(__opts__)
-    minions = client.cmd('*', 'test.ping', timeout=1)
+    minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
     keys = key._keys('acc')
 
     ret = sorted(keys - set(minions))
@@ -27,7 +27,7 @@ def up():
     Print a list of all of the minions that are up
     '''
     client = salt.client.LocalClient(__opts__['conf_file'])
-    minions = client.cmd('*', 'test.ping', timeout=1)
+    minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
 
     for minion in sorted(minions):
         print(minion)


### PR DESCRIPTION
This is needed in larger environments as 2-3k machines take about 8-9
seconds to all respond to a test.ping.  I've updated both runners that
set a default timeout value of 1 to accept the timeout from **opts**
