### PR TITLE
Added example showing how to use pcre matching in salt pillar files. Som...

### DIFF
--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -16,7 +16,9 @@ structure of the file_roots used in the Salt file server. Like the
 Salt file server the ``pillar_roots`` option in the master config is based
 on environments mapping to directories. The pillar data is then mapped to
 minions based on matchers in a top file which is laid out in the same way
-as the state top file.
+as the state top file. Salt pillars can use the same matcher types as the
+standard top file, and if you are having difficulty matching a specific minion
+in your pillar top file, you may want to specify PCRE matching.  
 
 The configuration for the ``pillar_roots`` in the master config is identical in
 behavior and function as the ``file_roots`` configuration:
@@ -45,6 +47,20 @@ This simple pillar top file declares that information for all minions can be
 found in the ``packages.sls`` file [#nokeyvalueintop]_, while
 ``someminion-specials.sls`` contains overriding or additional information just
 for one special minion.
+
+.. code-block:: yaml
+
+    base:
+      '.*':
+        - match: pcre
+        - packages
+      '(someminion|anotherminion)':
+        - match: pcre
+        - someminion-specials
+
+This further example shows how to enable pcre matching in the salt pillar file. 
+The flexibility enabled by pcre matching is particularly useful in salt pillar
+files.
 
 ``/srv/pillar/packages.sls``
 

--- a/doc/topics/tutorials/firewall.rst
+++ b/doc/topics/tutorials/firewall.rst
@@ -12,6 +12,16 @@ rules for allowing these incoming connections to the master.
     **No firewall configuration needs to be done on Salt minions. These changes
     refer to the master only.**
 
+lokkit
+========
+
+The lokkit command packaged with some linux distributions makes opening 
+iptables firewall ports really simple.
+
+**RHEL 6 / CentOS 6** ::
+
+   lokkit -p 4505:tcp -p 4506:tcp
+
 iptables
 ========
 
@@ -19,7 +29,7 @@ Different Linux distributions store their `iptables`_ rules in different places,
 which makes it difficult to standardize firewall documentation. I've included
 some of the more common locations, but your mileage may vary.
 
-**Fedora / Red Hat / CentOS** ::
+**Fedora / RHEL / CentOS** ::
 
     /etc/sysconfig/iptables
 


### PR DESCRIPTION
...etimes the '*' glob matching doesn't seem to work perfectly for all ascii characters. pcre always works as expected. wanted to give an example of the different match states available within the salt pillars.
