### PR TITLE
Test cleanup

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -39,6 +39,10 @@ class TestDaemon(object):
     '''
     Set up the master and minion daemons, and run related cases
     '''
+
+    def __init__(self, clean):
+        self.clean = clean
+
     def __enter__(self):
         '''
         Start a master and minion
@@ -142,6 +146,8 @@ class TestDaemon(object):
         '''
         Clean out the tmp files
         '''
+        if not self.clean:
+            return
         if os.path.isdir(self.sub_minion_opts['root_dir']):
             shutil.rmtree(self.sub_minion_opts['root_dir'])
         if os.path.isdir(self.master_opts['root_dir']):

--- a/tests/integration/modules/aliases.py
+++ b/tests/integration/modules/aliases.py
@@ -1,10 +1,4 @@
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class AliasesTest(integration.ModuleCase):
@@ -71,10 +65,7 @@ class AliasesTest(integration.ModuleCase):
         self.assertIsInstance(tgt_ret, dict)
         self.assertNotIn('alias=frank', tgt_ret)
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(AliasesTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(AliasesTest)

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -1,11 +1,5 @@
-# Import python libs
 import os
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class CMDModuleTest(integration.ModuleCase):
@@ -95,10 +89,7 @@ sys.stdout.write('cheese')
                 'cheese'
                 )
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(CMDModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(CMDModuleTest)

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -1,12 +1,7 @@
 # Import python libs
 import os
-import sys
 import hashlib
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class CPModuleTest(integration.ModuleCase):
@@ -199,10 +194,7 @@ class CPModuleTest(integration.ModuleCase):
                     hashlib.md5(fn_.read()).hexdigest()
                     )
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(CPModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(CPModuleTest)

--- a/tests/integration/modules/data.py
+++ b/tests/integration/modules/data.py
@@ -1,10 +1,4 @@
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class DataModuleTest(integration.ModuleCase):
@@ -58,14 +52,11 @@ class DataModuleTest(integration.ModuleCase):
                     'data.getvals',
                     ['spam', 'unladen']
                     ),
-                ('eggs', 'swallow')
+                ['eggs', 'swallow']
                 )
         self._clear_db()
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(DataModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(DataModuleTest)

--- a/tests/integration/modules/disk.py
+++ b/tests/integration/modules/disk.py
@@ -1,10 +1,4 @@
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class DiskModuleTest(integration.ModuleCase):
@@ -41,10 +35,7 @@ class DiskModuleTest(integration.ModuleCase):
             self.assertTrue('use' in val)
             self.assertTrue('filesystem' in val)
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(DiskModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(DiskModuleTest)

--- a/tests/integration/modules/django.py
+++ b/tests/integration/modules/django.py
@@ -1,14 +1,10 @@
 '''
 Test the django module
 '''
-# Import python libs
-import sys
-
-# Import Salt libs
-from saltunittest import TestLoader, TextTestRunner, skipIf
+from saltunittest import skipIf
 import integration
-from integration import TestDaemon
 from salt.modules import django
+
 django.__salt__ = {}
 
 try:
@@ -89,9 +85,5 @@ class DjangoModuleTest(integration.ModuleCase):
 
 
 if __name__ == '__main__':
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(DjangoModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+    from integration import run_tests
+    run_tests(DjangoModuleTest)

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -113,3 +113,7 @@ class FileModuleTest(integration.ModuleCase):
         ret = self.run_function('file.remove', args=['/dev/tty'])
         self.assertEqual(
             'ERROR executing file.remove: File path must be absolute.', ret)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(FileModuleTest)

--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -1,13 +1,7 @@
 '''
 Test the grains module
 '''
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class TestModulesGrains(integration.ModuleCase):
@@ -63,10 +57,7 @@ class TestModulesGrains(integration.ModuleCase):
         for grain_name in check_for:
             self.assertTrue(grain_name in lsgrains)
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(TestModulesGrains)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(TestModulesGrains)

--- a/tests/integration/modules/hosts.py
+++ b/tests/integration/modules/hosts.py
@@ -1,15 +1,11 @@
 '''
 Test the hosts module
 '''
-# Import python libs
 import os
-import sys
 import shutil
 
 # Import Salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 HFN = os.path.join(integration.TMP, 'hosts')
 
@@ -177,10 +173,7 @@ class HostsModuleTest(integration.ModuleCase):
             "192.168.1.1\t\thost1.fqdn.com\thost1\thost1-reorder\n",
             ])
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(HostsModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(HostsModuleTest)

--- a/tests/integration/modules/pillar.py
+++ b/tests/integration/modules/pillar.py
@@ -1,10 +1,4 @@
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class PillarModuleTest(integration.ModuleCase):
@@ -32,10 +26,7 @@ class PillarModuleTest(integration.ModuleCase):
                 self.run_function('pillar.data')['ext_spam'], 'eggs'
                 )
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(PillarModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PillarModuleTest)

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -1,10 +1,5 @@
 # Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class PipModuleTest(integration.ModuleCase):
@@ -27,10 +22,7 @@ class PipModuleTest(integration.ModuleCase):
         self.assertIsInstance(ret, list)
         self.assertGreater(len(ret), 1)
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(PipModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PipModuleTest)

--- a/tests/integration/modules/publish.py
+++ b/tests/integration/modules/publish.py
@@ -1,10 +1,4 @@
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class PublishModuleTest(integration.ModuleCase):
@@ -76,10 +70,7 @@ class PublishModuleTest(integration.ModuleCase):
                 )
         self.assertEqual(ret, {})
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(PublishModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PublishModuleTest)

--- a/tests/integration/modules/ssh.py
+++ b/tests/integration/modules/ssh.py
@@ -4,12 +4,9 @@ Test the ssh module
 # Import python libs
 import os
 import shutil
-import sys
 
 # Import Salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 AUTHORIZED_KEYS = os.path.join('/tmp/subsalttest', 'authorized_keys')
@@ -159,10 +156,7 @@ class SSHModuleTest(integration.ModuleCase):
                                 config=KNOWN_HOSTS)
         self.assertEqual(ret['status'], 'exists')
 
+
 if __name__ == '__main__':
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(SSHModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+    from integration import run_tests
+    run_tests(SSHModuleTest)

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1,10 +1,5 @@
 # Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class StateModuleTest(integration.ModuleCase):
@@ -49,10 +44,7 @@ class StateModuleTest(integration.ModuleCase):
         sls = self.run_function('state.show_sls', mods='recurse_ok_two')
         self.assertIn('/etc/nagios/nrpe.cfg', sls)
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(StateModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(StateModuleTest)

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -1,10 +1,4 @@
-# Import python libs
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class SysModuleTest(integration.ModuleCase):
@@ -27,10 +21,7 @@ class SysModuleTest(integration.ModuleCase):
         self.assertTrue('hosts' in mods)
         self.assertTrue('pkg' in mods)
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(SysModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SysModuleTest)

--- a/tests/integration/modules/test.py
+++ b/tests/integration/modules/test.py
@@ -1,11 +1,6 @@
 # Import python libs
 import os
-import sys
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class TestModuleTest(integration.ModuleCase):
@@ -94,10 +89,7 @@ class TestModuleTest(integration.ModuleCase):
         '''
         self.assertEqual(self.run_function('test.outputter', ['text']), 'text')
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(TestModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(TestModuleTest)

--- a/tests/integration/modules/virtualenv.py
+++ b/tests/integration/modules/virtualenv.py
@@ -1,12 +1,7 @@
 # Import python libs
-import sys
 import os
 import tempfile
-
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class VirtualenvModuleTest(integration.ModuleCase):
@@ -57,10 +52,7 @@ class VirtualenvModuleTest(integration.ModuleCase):
     def tearDown(self):
         self.run_function('file.remove', [self.venv_test_dir])
 
-if __name__ == "__main__":
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(VirtualenvModuleTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(VirtualenvModuleTest)

--- a/tests/integration/states/cmd.py
+++ b/tests/integration/states/cmd.py
@@ -29,3 +29,8 @@ class CMDTest(integration.ModuleCase):
                              cwd=tempfile.gettempdir(), test=True)
         result = ret[next(iter(ret))]['result']
         self.assertIsNone(result)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(CMDTest)

--- a/tests/integration/states/compiler.py
+++ b/tests/integration/states/compiler.py
@@ -1,14 +1,7 @@
 '''
 tests for host state
 '''
-
-# Import python libs
-import os
-#
-# Import salt libs
-from saltunittest import TestLoader, TextTestRunner
 import integration
-from integration import TestDaemon
 
 
 class CompileTest(integration.ModuleCase):
@@ -22,3 +15,8 @@ class CompileTest(integration.ModuleCase):
         ret = self.run_function('state.sls', mods='fuzz.multi_state')
         # Verify that the return is a list, aka, an error
         self.assertIsInstance(ret, list)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(CompileTest)

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -1,10 +1,7 @@
 '''
 Tests for the file state
 '''
-# Import python libs
 import os
-#
-# Import salt libs
 import integration
 
 
@@ -346,14 +343,6 @@ class FileTest(integration.ModuleCase):
         self.assertIsNone(result)
 
 
-if __name__ == "__main__":
-    import sys
-    from saltunittest import TestLoader, TextTestRunner
-    from integration import TestDaemon
-
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(FileTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(FileTest)

--- a/tests/integration/states/host.py
+++ b/tests/integration/states/host.py
@@ -38,3 +38,8 @@ class HostTest(integration.ModuleCase):
         with open(HFILE) as fp_:
             output = fp_.read()
             self.assertIn('{0}\t\t{1}'.format(ip, name), output)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(HostTest)

--- a/tests/integration/states/ssh.py
+++ b/tests/integration/states/ssh.py
@@ -99,14 +99,6 @@ class SSHKnownHostsStateTest(integration.ModuleCase):
         self.assertEqual(ret['result'], None, ret)
 
 
-if __name__ == "__main__":
-    import sys
-    from saltunittest import TestLoader, TextTestRunner
-    from integration import TestDaemon
-
-    loader = TestLoader()
-    tests = loader.loadTestsFromTestCase(SSHKnownHostsStateTest)
-    print('Setting up Salt daemons to execute tests')
-    with TestDaemon():
-        runner = TextTestRunner(verbosity=1).run(tests)
-        sys.exit(runner.wasSuccessful())
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SSHKnownHostsStateTest)

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -5,10 +5,8 @@ user present
 user present with custom homedir
 '''
 import os
-
-from saltunittest import TestLoader, TextTestRunner, skipIf
+from saltunittest import skipIf
 import integration
-from integration import TestDaemon
 
 
 class UserTest(integration.ModuleCase):
@@ -21,7 +19,7 @@ class UserTest(integration.ModuleCase):
         self.assertTrue(result)
 
     def test_user_if_present(self):
-        ret = self.run_state('user.present', name='nobody') 
+        ret = self.run_state('user.present', name='nobody')
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
 
@@ -32,7 +30,7 @@ class UserTest(integration.ModuleCase):
         And then destroys that user.
         Assume that it will break any system you run it on.
         """
-        ret = self.run_state('user.present', name='salt_test') 
+        ret = self.run_state('user.present', name='salt_test')
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
         ret = self.run_state('user.absent', name='salt_test')
@@ -43,9 +41,13 @@ class UserTest(integration.ModuleCase):
         This is a DESTRUCTIVE TEST it creates a new user on the on the minion.
         """
         ret = self.run_state('user.present', name='salt_test',
-                             home='/var/lib/salt_test') 
+                             home='/var/lib/salt_test')
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
         self.assertTrue(os.stat('/var/lib/salt_test'))
         ret = self.run_state('user.absent', name='salt_test')
 
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(UserTest)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -60,7 +60,7 @@ def run_integration_tests(opts):
     if not any([opts.client, opts.module, opts.runner,
                 opts.shell, opts.state, opts.name]):
         return status
-    with TestDaemon():
+    with TestDaemon(clean=opts.clean):
         if opts.name:
             results = run_suite(opts, '', opts.name)
             status.append(results)
@@ -152,6 +152,17 @@ def parse_opts():
             dest='name',
             default='',
             help='Specific test name to run')
+    parser.add_option('--clean',
+            dest='clean',
+            default=True,
+            action='store_true',
+            help=('Clean up test environment before and after '
+                  'integration testing (default behaviour)'))
+    parser.add_option('--no-clean',
+            dest='clean',
+            action='store_false',
+            help=('Don\'t clean up test environment before and after '
+                  'integration testing (speed up test process)'))
 
     options, _ = parser.parse_args()
     if not any((options.module, options.client,


### PR DESCRIPTION
I made some cleanup in testing code, and also added the option `--no-clean` in runtests.py as well as in every file within `tests/integration/*/*.py`. I see these changes can be quite useful if you run tests repeatedly during the process of development. Please consider reviewing and pulling this changeset.
