### PR TITLE
Dependencies version printing.

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -6,12 +6,12 @@ from salt.version import __version__
 # Import python libs
 import os
 import sys
-import optparse
 
 # Import salt libs, the try block bypasses an issue at build time so that c
 # modules don't cause the build to fail
 try:
     import salt.config
+    from salt.utils import parser as optparse
     from salt.utils.process import set_pidfile
     from salt.utils.verify import check_user, verify_env, verify_socket
 except ImportError as e:

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -3,7 +3,6 @@ The management of salt command line utilities are stored in here
 '''
 
 # Import python libs
-import optparse
 import os
 import sys
 
@@ -16,6 +15,7 @@ import salt.client
 import salt.output
 import salt.runner
 
+from salt.utils import parser as optparse
 from salt.utils.verify import verify_env
 from salt import __version__ as VERSION
 from salt.exceptions import SaltInvocationError, SaltClientError, \
@@ -659,7 +659,7 @@ class SaltKey(object):
         for k, v in options.__dict__.items():
             if k == 'keysize':
                 if v < 2048:
-                    opts[k] = 2048 
+                    opts[k] = 2048
                 else:
                     opts[k] = v
             elif v is not None:

--- a/salt/utils/parser.py
+++ b/salt/utils/parser.py
@@ -1,0 +1,37 @@
+# -*- coding: utf-8 -*-
+"""
+    salt.utils.parser
+    ~~~~~~~~~~~~~~~~~
+
+    :copyright: © 2012 UfSoft.org - :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :license: Apache 2.0, see LICENSE for more details.
+"""
+
+import sys
+import optparse
+from salt import version
+
+
+class OptionParser(optparse.OptionParser):
+
+    def __init__(self, *args, **kwargs):
+        kwargs.setdefault("version", version.__version__)
+        kwargs.setdefault('usage', '%%prog')
+        optparse.OptionParser.__init__(self, *args, **kwargs)
+
+    def parse_args(self, args=None, values=None):
+        options, args = optparse.OptionParser.parse_args(self, args, values)
+        if options.versions_report:
+            self.print_versions_report()
+        return options, args
+
+    def _add_version_option(self):
+        optparse.OptionParser._add_version_option(self)
+        self.add_option(
+            '--versions-report', action='store_true',
+            help="show program's dependencies version number and exit"
+        )
+
+    def print_versions_report(self, file=sys.stdout):
+        print >> file, '\n'.join(version.versions_report())
+        self.exit()

--- a/salt/version.py
+++ b/salt/version.py
@@ -1,5 +1,35 @@
+import sys
+
 __version_info__ = (0, 10, 1)
 __version__ = '.'.join(map(str, __version_info__))
 
+def versions_report():
+    libs = (
+        ("Jinja2", "jinja2", "__version__"),
+        ("M2Crypto", "M2Crypto", "version"),
+        ("msgpack-python", "msgpack", "version"),
+        ("pycrypto", "Crypto", "__version__"),
+        ("PyYAML", "yaml", "__version__"),
+        ("PyZMQ", "zmq", "__version__"),
+
+    )
+    fmt = "{0:>15}: {1}"
+
+    yield fmt.format("Salt", __version__)
+
+    yield fmt.format("Python", sys.version.rsplit('\n')[0].strip())
+
+    for name, imp, attr in libs:
+        try:
+            imp = __import__(imp)
+            version = getattr(imp, attr)
+            if not isinstance(version, basestring):
+                version = '.'.join(map(str, version))
+            yield fmt.format(name, version)
+        except ImportError:
+            yield fmt.format(name, "not installed")
+
+
+
 if __name__ == '__main__':
-        print(__version__)
+    print '\n'.join(versions_report())

--- a/salt/version.py
+++ b/salt/version.py
@@ -32,4 +32,4 @@ def versions_report():
 
 
 if __name__ == '__main__':
-    print '\n'.join(versions_report())
+    print(__version__)


### PR DESCRIPTION
This commit allows printing the deps version numbers from salt's cli tools(as long as the option parser used is `salt.utils.parser`). It can be useful in some debugging report situations.

Example output:

```
$ salt --versions-report
           Salt: 0.10.1
         Python: 2.7.3 (default, Apr 20 2012, 22:44:07)
         Jinja2: 2.6
       M2Crypto: 0.21.1
 msgpack-python: 0.1.13
       pycrypto: 2.4.1
         PyYAML: 3.10
          PyZMQ: 2.1.11
```
