### PR TITLE
Allowing more permissive pki group ownership

### DIFF
--- a/conf/master.template
+++ b/conf/master.template
@@ -65,6 +65,13 @@
 # public keys from the minions. Note that this is insecure.
 #auto_accept: False
 
+# Enable permissive access to the salt keys.  This allows you to run the
+# master or minion as root, but have a non-root group be given access to
+# your pki_dir.  To make the access explicit, root must belong to the group 
+# you've given access to.  This is potentially quite insecure.
+#permissive_pki_access: False
+
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded

--- a/conf/minion.template
+++ b/conf/minion.template
@@ -194,6 +194,12 @@
 # you do so at your own risk!
 #open_mode: False
 
+# Enable permissive access to the salt keys.  This allows you to run the
+# master or minion as root, but have a non-root group be given access to
+# your pki_dir.  To make the access explicit, root must belong to the group 
+# you've given access to. This is potentially quite insecure.
+#permissive_pki_access: False
+
 
 ######         Thread settings        #####
 ###########################################

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -98,7 +98,8 @@ class Master(object):
                 os.path.join(self.opts['cachedir'], 'jobs'),
                 os.path.dirname(self.opts['log_file']),
                 self.opts['sock_dir'],
-            ], self.opts['user'])
+            ], self.opts['user'],
+            permissive=self.opts['permissive_pki_access'])
         except OSError, err:
             sys.exit(err.errno)
 
@@ -212,7 +213,8 @@ class Minion(object):
                 self.opts['sock_dir'],
                 self.opts['extension_modules'],
                 os.path.dirname(self.opts['log_file']),
-            ], self.opts['user'])
+            ], self.opts['user'],
+            permissive=self.opts['permissive_pki_access'])
         except OSError, err:
             sys.exit(err.errno)
 
@@ -347,7 +349,8 @@ class Syndic(object):
             verify_env([
                 self.opts['pki_dir'], self.opts['cachedir'],
                 os.path.dirname(self.opts['log_file']),
-            ], self.opts['user'])
+            ], self.opts['user'],
+            permissive=self.opts['permissive_pki_access'])
         except OSError, err:
             sys.exit(err.errno)
         import salt.log

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -789,7 +789,7 @@ class SaltCall(object):
                     os.path.dirname(opts['log_file']),
                     ],
                     opts['user'],
-                    permissive=self.opts['permissive_pki_access'])
+                    permissive=opts['permissive_pki_access'])
 
         return opts
 

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -679,7 +679,8 @@ class SaltKey(object):
             os.path.join(self.opts['pki_dir'], 'minions_rejected'),
             os.path.dirname(self.opts['log_file']),
             ],
-            self.opts['user'])
+            self.opts['user'],
+            permissive=self.opts['permissive_pki_access'])
         import salt.log
         salt.log.setup_logfile_logger(self.opts['key_logfile'],
                                       self.opts['loglevel'])
@@ -787,7 +788,8 @@ class SaltCall(object):
                     opts['cachedir'],
                     os.path.dirname(opts['log_file']),
                     ],
-                    opts['user'])
+                    opts['user'],
+                    permissive=self.opts['permissive_pki_access'])
 
         return opts
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -196,6 +196,7 @@ def minion_config(path):
             'acceptance_wait_time': 10,
             'dns_check': True,
             'grains': {},
+            'permissive_pki_access': False,
             }
 
     load_config(opts, path, 'SALT_MINION_CONFIG')
@@ -281,6 +282,7 @@ def master_config(path):
             'nodegroups': {},
             'cython_enable': False,
             'key_logfile': '/var/log/salt/key.log',
+            'permissive_pki_access': False,
     }
 
     load_config(opts, path, 'SALT_MASTER_CONFIG')


### PR DESCRIPTION
Allow for an optional directive that allows the salt pki_dir
to be owned by any group that root is a member of, not just
the primary group listed in the passwd directory.  This is
potentially insecure, but allows some limited access for
headless accounts to run salt via the API or without sudo
if there are reasons for that to happen.

Please review closely as I don't specifically know if this
fits into acceptable parameters of your security model.
Let me know if you have any questions.
