### PR TITLE
Add the ability to use args with disk.usage and disk.inodeusage

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -19,7 +19,7 @@ def __virtual__():
         return False
     return 'disk'
 
-def usage():
+def usage(args=None):
     '''
     Return usage information for volumes mounted on this minion
 
@@ -31,6 +31,7 @@ def usage():
         cmd = 'df -P'
     else:
         cmd = 'df'
+    cmd = cmd + ' -' + args
     ret = {}
     out = __salt__['cmd.run'](cmd).split('\n')
     for line in out:
@@ -52,7 +53,7 @@ def usage():
             ret = {}
     return ret
 
-def inodeusage():
+def inodeusage(args=None):
     '''
     Return inode usage information for volumes mounted on this minion
 
@@ -61,6 +62,7 @@ def inodeusage():
         salt '*' disk.inodeusage
     '''
     cmd = 'df -i'
+    cmd = cmd + ' -' + args
     ret = {}
     out = __salt__['cmd.run'](cmd).split('\n')
     for line in out:


### PR DESCRIPTION
This probably should have been added last year, when disk.py was added.... it's annoying at best to have to look at 1K-blocks, and not be able to see human-readable formats.
