### PR TITLE
Ensure that root_dir is an absolute path

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -136,10 +136,11 @@ def prepend_root_dir(opts, path_options):
     Prepends the options that represent filesystem paths with value of the
     'root_dir' option.
     '''
+    root_dir = os.path.abspath(opts['root_dir'])
     for path_option in path_options:
         if path_option in opts:
             opts[path_option] = os.path.normpath(
-                    os.sep.join([opts['root_dir'], opts[path_option]]))
+                    os.sep.join([root_dir, opts[path_option]]))
 
 
 def minion_config(path):


### PR DESCRIPTION
If root_dir is not an absolute path `salt.utils.verify.check_parent_dirs` will return a problem, e.g with `root_dir: .`:

```
    ~/src/salt ] -> scripts/salt-master -l debug -c conf/master.template
    [DEBUG   ] Loaded master key: etc/salt/pki/master.pem
    [INFO    ] Preparing the root key for local communication
    [WARNING ] Starting the Salt Master
    [INFO    ] Starting the Salt Publisher on tcp://0.0.0.0:4505
    [INFO    ] Setting up the master communication server
    [INFO    ] Starting Salt worker process 0
    [INFO    ] Starting Salt worker process 1
    [INFO    ] Starting Salt worker process 2
    [INFO    ] Starting Salt worker process 3
    [INFO    ] Starting Salt worker process 4
    Process MWorker-6:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
        self.run()
      File "/home/uli/src/salt/salt/master.py", line 420, in run
        self.crypticle)
      File "/home/uli/src/salt/salt/master.py", line 959, in __init__
        self.local = salt.client.LocalClient(self.opts['conf_file'])
      File "/home/uli/src/salt/salt/client.py", line 78, in __init__
    Process MWorker-7:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
        self.key = self.__read_master_key()
      File "/home/uli/src/salt/salt/client.py", line 89, in __read_master_key
        salt.utils.verify.check_parent_dirs(keyfile, user)
      File "/home/uli/src/salt/salt/utils/verify.py", line 228, in check_parent_dirs
        self.run()
      File "/home/uli/src/salt/salt/master.py", line 420, in run
        raise SaltClientError(msg)
    SaltClientError: Could not access directory /cache. Please give uli read permissions.
        self.crypticle)
      File "/home/uli/src/salt/salt/master.py", line 959, in __init__
        self.local = salt.client.LocalClient(self.opts['conf_file'])
      File "/home/uli/src/salt/salt/client.py", line 78, in __init__
        self.key = self.__read_master_key()
      File "/home/uli/src/salt/salt/client.py", line 89, in __read_master_key
        salt.utils.verify.check_parent_dirs(keyfile, user)
      File "/home/uli/src/salt/salt/utils/verify.py", line 228, in check_parent_dirs
        raise SaltClientError(msg)
    SaltClientError: Could not access directory /cache. Please give uli read permissions.
    Process MWorker-5:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
        self.run()
      File "/home/uli/src/salt/salt/master.py", line 420, in run
        self.crypticle)
      File "/home/uli/src/salt/salt/master.py", line 959, in __init__
        self.local = salt.client.LocalClient(self.opts['conf_file'])
      File "/home/uli/src/salt/salt/client.py", line 78, in __init__
        self.key = self.__read_master_key()
      File "/home/uli/src/salt/salt/client.py", line 89, in __read_master_key
        salt.utils.verify.check_parent_dirs(keyfile, user)
      File "/home/uli/src/salt/salt/utils/verify.py", line 228, in check_parent_dirs
        raise SaltClientError(msg)
    SaltClientError: Could not access directory /cache. Please give uli read permissions.
    Process MWorker-8:
    Traceback (most recent call last):
      File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
        self.run()
      File "/home/uli/src/salt/salt/master.py", line 420, in run
        self.crypticle)
      File "/home/uli/src/salt/salt/master.py", line 959, in __init__
        self.local = salt.client.LocalClient(self.opts['conf_file'])
      File "/home/uli/src/salt/salt/client.py", line 78, in __init__
        self.key = self.__read_master_key()
      File "/home/uli/src/salt/salt/client.py", line 89, in __read_master_key
        salt.utils.verify.check_parent_dirs(keyfile, user)
      File "/home/uli/src/salt/salt/utils/verify.py", line 228, in check_parent_dirs
        raise SaltClientError(msg)
    SaltClientError: Could not access directory /cache. Please give uli read permissions.
    ^C[WARNING ] Stopping the Salt Master
```

This commit fixes that problem by calling `os.path.abspath` before using `root_dir`
