### PR TITLE
Adding basic nzbget (server) support to salt

### DIFF
--- a/salt/modules/nzbget.py
+++ b/salt/modules/nzbget.py
@@ -118,7 +118,7 @@ def pause(user=None):
 
     CLI Example::
 
-        salt '*' nzbget.stop curly
+        salt '*' nzbget.pause shemp
     '''
     cmd = 'nzbget -P'
     if user:
@@ -133,7 +133,7 @@ def unpause(user=None):
 
     CLI Example::
 
-        salt '*' nzbget.stop curly
+        salt '*' nzbget.unpause shemp
     '''
     cmd = 'nzbget -U'
     if user:

--- a/salt/modules/nzbget.py
+++ b/salt/modules/nzbget.py
@@ -1,0 +1,143 @@
+'''
+Support for nzbget
+'''
+
+import salt.utils
+
+def __virtual__():
+    '''
+    Only load the module if apache is installed
+    '''
+    cmd = 'nzbget'
+    if salt.utils.which(cmd):
+        return 'nzbget'
+    return False
+
+def version():
+    '''
+    Return version from nzbget -v.
+
+    CLI Example::
+
+        salt '*' nzbget.version
+    '''
+    cmd = 'nzbget -v'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    ret = out[0].split(': ')
+    return { 'version': ret[1] }
+
+def serverversion():
+    '''
+    Return server version from nzbget -V.
+    Default user is root.
+
+    CLI Example::
+
+        salt '*' nzbget.serverversion moe
+    '''
+    cmd = 'ps aux | grep "nzbget -D" | grep -v grep | cut -d " " -f 1'
+    user = __salt__['cmd.run'](cmd).strip()
+    if not user:
+        return 'Server not running'
+    cmd = 'nzbget -V -c ~' + user + '/.nzbget | grep "server returned"'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    ret = out[0].split(': ')
+    return { 'user': user,
+             'version': ret[1], }
+
+def start(user=None):
+    '''
+    Start nzbget as a daemon using -D option
+    Default user is root.
+
+    CLI Example::
+
+        salt '*' nzbget.start
+    '''
+    cmd = 'nzbget -D'
+    if user:
+        cmd = 'su - ' + user + ' -c "' + cmd + '"'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    return cmd
+
+def stop(user=None):
+    '''
+    Stop nzbget daemon using -Q option.
+    Default user is root.
+
+    CLI Example::
+
+        salt '*' nzbget.stop curly
+    '''
+    cmd = 'nzbget -Q'
+    if user:
+        cmd = 'su - ' + user + ' -c "' + cmd + '"'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    return cmd
+
+def list(user=None):
+    '''
+    Return list of active downloads using nzbget -L.
+    Default user is root.
+
+    CLI Example::
+
+        salt '*' nzbget.list larry
+    '''
+    ret = {}
+    inqueue = ''
+    queuelist = []
+    cmd = 'nzbget -L'
+    if user:
+        cmd = cmd + ' -c ~' + user + '/.nzbget'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    for line in out:
+        if 'Queue List' in line:
+            inqueue = 1
+        if '----------' in line:
+            if inqueue == 1:
+                inqueue = 2
+            else:
+                inqueue = ''
+            continue
+        if inqueue:
+            queuelist.append(line)
+            continue
+        if ': ' not in line:
+            continue
+        comps = line.split(': ')
+        ret[comps[0]] = comps[1]
+    if queuelist:
+        ret['Queue List'] = queuelist
+    return ret
+
+def pause(user=None):
+    '''
+    Stop nzbget daemon using -Q option.
+    Default user is root.
+
+    CLI Example::
+
+        salt '*' nzbget.stop curly
+    '''
+    cmd = 'nzbget -P'
+    if user:
+        cmd = cmd + ' -c ~' + user + '/.nzbget'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    return cmd
+
+def unpause(user=None):
+    '''
+    Stop nzbget daemon using -Q option.
+    Default user is root.
+
+    CLI Example::
+
+        salt '*' nzbget.stop curly
+    '''
+    cmd = 'nzbget -U'
+    if user:
+        cmd = cmd + ' -c ~' + user + '/.nzbget'
+    out = __salt__['cmd.run'](cmd).split('\n')
+    return cmd
+

--- a/salt/modules/nzbget.py
+++ b/salt/modules/nzbget.py
@@ -113,7 +113,7 @@ def list(user=None):
 
 def pause(user=None):
     '''
-    Stop nzbget daemon using -Q option.
+    Pause nzbget daemon using -P option.
     Default user is root.
 
     CLI Example::
@@ -128,7 +128,7 @@ def pause(user=None):
 
 def unpause(user=None):
     '''
-    Stop nzbget daemon using -Q option.
+    Unpause nzbget daemon using -U option.
     Default user is root.
 
     CLI Example::


### PR DESCRIPTION
Contrary to popular belief, downloading files from the Usenet can be legitimate, and nzbget is currently the best mechanism for doing it. This patch adds some basic support to start, stop, pause and unpause the server, as well as list files in the queue.
