### PR TITLE
Fix service.running when a service is stopped

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -239,7 +239,7 @@ def running(name, enable=None, sig=None):
     # Check if the service is available
     if 'service.get_all' in __salt__:
         # get_all is available, we can reliable check for the service
-        services = __salt__['service.get_all']
+        services = __salt__['service.get_all']()
         if not name in services:
             ret['result'] = False
             ret['comment'] = 'The named service {0} is not available'.format(


### PR DESCRIPTION
When the service corresponding to a service.running state is stopped and needs to be started, the following error occurs:

```
Function:  running
        Result:    False
        Comment:   An exception occured in this state: Traceback (most recent call last):
  File ".../salt/state.py", line 823, in call
    ret = self.states[cdata['full']](*cdata['args'])
  File ".../salt/states/service.py", line 243, in running
    if not name in services:
TypeError: argument of type 'function' is not iterable
```

This commit, suggested by mrud on irc, appears to fix that error.
