### PR TITLE
Repair include_config() usage in the loader.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -129,11 +129,12 @@ def grains(opts):
                 opts['conf_file'],
                 'SALT_MINION_CONFIG'
                 )
-        if 'include' in pre_opts:
-            pre_opts = salt.config.include_config(
-                    pre_opts,
-                    opts['conf_file']
-                    )
+        default_include = pre_opts.get('default_include', [])
+        include = pre_opts.get('include', [])
+        pre_opts = salt.config.include_config(default_include, pre_opts,
+                                              opts['conf_file'], verbose=False)
+        pre_opts = salt.config.include_config(include, pre_opts,
+                                              opts['conf_file'], verbose=True)
         if 'grains' in pre_opts:
             opts['grains'] = pre_opts['grains']
         else:


### PR DESCRIPTION
The include_config() function seems to have changed in 5ca6939b14755f04dce6436c37cb63cfeeb6f391 and the caller in loader.py to not have been updated.

This is my quick attempt to fix that, based on reading the above commit. I'm not sure what this default_include stuff is about, but this at least allows me to highstate without getting a traceback.
