### PR TITLE
Fix the escaping issue in cmd.run

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -5,6 +5,7 @@ Keep in mind that this module is insecure, in that it can give whomever has
 access to the master root execution access to all salt minions
 '''
 
+import pipes
 import logging
 import os
 import subprocess
@@ -90,7 +91,7 @@ def _run(cmd,
             cmd = 'cd {0} && {1}'.format(cwd, cmd)
 
         cmd_prefix += ' {0} -c'.format(runas)
-        cmd = '{0} "{1}"'.format(cmd_prefix, cmd)
+        cmd = '{0} {1}'.format(cmd_prefix, pipes.quote(cmd))
 
     if not quiet:
         # Put the most common case first

--- a/tests/integration/mockbin/su
+++ b/tests/integration/mockbin/su
@@ -1,0 +1,12 @@
+#!/bin/bash
+# "Fake" su command
+#
+# Just executes the command without changing effective uid. Used in integration
+# tests.
+while true; do
+    shift
+    test "x$1" == "x-c" && break
+    test "x$1" == "x" && break
+done
+shift
+exec /bin/bash -c "$@"

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -89,6 +89,25 @@ sys.stdout.write('cheese')
                 'cheese'
                 )
 
+    def test_quotes(self):
+        '''
+        cmd.run with quoted command
+        '''
+        cmd = '''echo 'SELECT * FROM foo WHERE bar="baz"' '''
+        expected_result = 'SELECT * FROM foo WHERE bar="baz"'
+        result = self.run_function('cmd.run_stdout', [cmd]).strip()
+        self.assertEqual(result, expected_result)
+
+    def test_quotes_runas(self):
+        '''
+        cmd.run with quoted command
+        '''
+        cmd = '''echo 'SELECT * FROM foo WHERE bar="baz"' '''
+        expected_result = 'SELECT * FROM foo WHERE bar="baz"'
+        result = self.run_function('cmd.run_stdout', [cmd],
+                                   runas=os.getlogin()).strip()
+        self.assertEqual(result, expected_result)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
It seems that cmd.run with runas option didn't escape quotes in command, which could lead to incorrect behavior in some cases. In fact, the fix is trivial, but I'm not 100% sure that it doesn't break the backward compatibility for somebody (maybe someone has already "fixed" it for himself, by adding some extra escape symbols in commands.)

Additionally, to test the change, I slightly improved the testing environment by adding a "mockbin" directory into it. The idea is that while running tests, the system must search commands in this directory first. To make it happen, the patched version of $PATH environment variable is used during the course of testing.

Please consider reviewing, criticizing and, it everything is OK, pulling the changeset. Thank you.
