### PR TITLE
Improve PostgreSQL support

### DIFF
--- a/salt/states/postgres_database.py
+++ b/salt/states/postgres_database.py
@@ -12,23 +12,53 @@ Databases can be set as either absent or present
 '''
 
 
-def present(name, owner=None):
+def present(name,
+            tablespace=None,
+            encoding=None,
+            locale=None,
+            lc_collate=None,
+            lc_ctype=None,
+            owner=None,
+            template=None,
+            runas=None):
     '''
-    Ensure that the named database is present with the specified properties
+    Ensure that the named database is present with the specified properties.
+    For more information about all of these options see man createdb(1)
 
     name
         The name of the database to manage
 
+    tablespace
+        Default tablespace for the database
+
+    encoding
+        The character encoding scheme to be used in this database
+
+    locale
+        The locale to be used in this database
+
+    lc_collate
+        The LC_COLLATE setting to be used in this database
+
+    lc_ctype
+        The LC_CTYPE setting to be used in this database
+
     owner
         The username of the database owner
+
+    template
+        The template database from which to build this database
+
+    runas
+        System user all operation should be preformed on behalf of
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': 'Database {0} is already present'.format(name)}
-    
+
     # check if database exists
-    if __salt__['postgres.db_exists'](name):
+    if __salt__['postgres.db_exists'](name, runas=runas):
         return ret
 
     # The database is not present, make it!
@@ -36,7 +66,15 @@ def present(name, owner=None):
         ret['result'] = None
         ret['comment'] = 'Database {0} is set to be created'.format(name)
         return ret
-    if __salt__['postgres.db_create'](name, owner=owner):
+    if __salt__['postgres.db_create'](name,
+                                    tablespace=tablespace,
+                                    encoding=encoding,
+                                    locale=locale,
+                                    lc_collate=lc_collate,
+                                    lc_ctype=lc_ctype,
+                                    owner=owner,
+                                    template=template,
+                                    runas=runas):
         ret['comment'] = 'The database {0} has been created'.format(name)
         ret['changes'][name] = 'Present'
     else:
@@ -46,12 +84,15 @@ def present(name, owner=None):
     return ret
 
 
-def absent(name):
+def absent(name, runas=None):
     '''
     Ensure that the named database is absent
 
     name
         The name of the database to remove
+
+    runas
+        System user all operation should be preformed on behalf of
     '''
     ret = {'name': name,
            'changes': {},
@@ -59,12 +100,12 @@ def absent(name):
            'comment': ''}
 
     #check if db exists and remove it
-    if __salt__['postgres.db_exists'](name):
+    if __salt__['postgres.db_exists'](name, runas=runas):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'Database {0} is set to be removed'.format(name)
             return ret
-        if __salt__['postgres.db_remove'](name):
+        if __salt__['postgres.db_remove'](name, runas=runas):
             ret['comment'] = 'Database {0} has been removed'.format(name)
             ret['changes'][name] = 'Absent'
             return ret

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -14,7 +14,9 @@ def present(name,
             createdb=False,
             createuser=False,
             encrypted=False,
-            password=None):
+            superuser=False,
+            password=None,
+            runas=None):
     '''
     Ensure that the named user is present with the specified privileges
 
@@ -30,8 +32,14 @@ def present(name,
     encrypted
         Shold the password be encrypted in the system catalog?
 
+    superuser
+        Shold the new user be a "superuser"
+
     password
         The user's pasword
+
+    runas
+        System user all operation should be preformed on behalf of
     '''
     ret = {'name': name,
            'changes': {},
@@ -39,7 +47,7 @@ def present(name,
            'comment': 'User {0} is already present'.format(name)}
 
     # check if user exists
-    if __salt__['postgres.user_exists'](name):
+    if __salt__['postgres.user_exists'](name, runas=runas):
         return ret
 
     # The user is not present, make it!
@@ -49,7 +57,7 @@ def present(name,
         return ret
     if __salt__['postgres.user_create'](username=name, createdb=createdb,
                                         createuser=createuser, encrypted=encrypted,
-                                        password=password):
+                                        password=password, runas=runas):
         ret['comment'] = 'The user {0} has been created'.format(name)
         ret['changes'][name] = 'Present'
     else:
@@ -59,12 +67,15 @@ def present(name,
     return ret
 
 
-def absent(name):
+def absent(name, runas=None):
     '''
     Ensure that the named user is absent
 
     name
         The username of the user to remove
+
+    runas
+        System user all operation should be preformed on behalf of
     '''
     ret = {'name': name,
            'changes': {},
@@ -72,16 +83,16 @@ def absent(name):
            'comment': ''}
 
     # check if user exists and remove it
-    if __salt__['postgres.user_exists'](name):
+    if __salt__['postgres.user_exists'](name, runas=runas):
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'User {0} is set to be removed'.format(name)
             return ret
-        if __salt__['postgres.user_remove'](name):
+        if __salt__['postgres.user_remove'](name, runas=runas):
             ret['comment'] = 'User {0} has been removed'.format(name)
             ret['changes'][name] = 'Absent'
             return ret
     else:
         ret['comment'] = 'User {0} is not present, so it cannot be removed'.format(name)
-    
+
     return ret


### PR DESCRIPTION
- Unified way of invocation of the "psql" command, get rid of
  "dropdb" and similar command wrappers
- "host", "port" and "user" are not required options of psql command
  anymore
- Fix "local" -> "locale"
- Add "runas" option to all posgres module functions and states
- Add "superuser" argument to user_create command
- Add all available module function arguments to
  postgres_database.present state

Default values for host and port made it impossible to use "local"
method of authentication.

Lack of "runas" option made it hard to "start off from scratch", at
least in Debian/Ubuntu installation, where the recommended way to create
the very first new user is to make it with "su - postgres"

Please note, some functions work without the fix #1698, unfortunately
