### PR TITLE
fix wait argument. 

### DIFF
--- a/doc/topics/event/index.rst
+++ b/doc/topics/event/index.rst
@@ -35,7 +35,7 @@ default all events will be returned, but if only authentication events are
 desired, then pass the tag "auth". Also, the get_event method has a default
 poll time assigned of 5 seconds, to change this time set the "wait" option.
 This example will only listen for auth events and will wait for 10 seconds
-instead of the default 5.
+instead of the default 5. The wait options takes milliseconds as input.
 
 .. code-block:: python
 
@@ -43,7 +43,7 @@ instead of the default 5.
 
     event = salt.utils.event.MasterEvent('/tmp/.salt-unix')
 
-    data = event.get_event(wait=10, tag='auth')
+    data = event.get_event(wait=10000, tag='auth')
 
 Instead of looking for a single event, the iter_event method can be used to
 make a generator which will continually yield salt events. The iter_event

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -70,7 +70,7 @@ class SaltEvent(object):
         self.push.connect(self.pulluri)
         self.cpush = True
 
-    def get_event(self, wait=5, tag='', full=False):
+    def get_event(self, wait=5000, tag='', full=False):
         '''
         Get a single publication
         '''


### PR DESCRIPTION
Documented as seconds, is used by pyzmq Poller.poll that takes milliseconds according to:

http://zeromq.github.com/pyzmq/api/generated/zmq.core.poll.htmla
