### PR TITLE
Fix mongo_return, don't allow dots in key names

### DIFF
--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -27,6 +27,13 @@ def __virtual__():
         return False
     return 'mongo_return'
 
+def _remove_dots(d):
+    output = {}
+    for k, v in d.iteritems():
+        if isinstance(v, dict):
+            v = remove_dots(v)
+        output[k.replace('.', '-')] = v
+    return output
 
 def returner(ret):
     '''
@@ -46,8 +53,7 @@ def returner(ret):
     back = {}
 
     if isinstance(ret['return'], dict):
-        for key in ret['return']:
-            back[key.replace('.', '-')] = ret['return'][key]
+        back = _remove_dots(ret['return'])
     else:
         back = ret['return']
 

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -31,7 +31,7 @@ def _remove_dots(d):
     output = {}
     for k, v in d.iteritems():
         if isinstance(v, dict):
-            v = remove_dots(v)
+            v = _remove_dots(v)
         output[k.replace('.', '-')] = v
     return output
 


### PR DESCRIPTION
Recursively replace dots with dashes, MongoDB doesn't allow dots in key names.
