### PR TITLE
Fix virtualenv integration tests.

### DIFF
--- a/salt/modules/virtualenv.py
+++ b/salt/modules/virtualenv.py
@@ -5,7 +5,9 @@ Create virtualenv environments
 from salt import utils
 
 
-__opts__ = {}
+__opts__ = {
+    'venv_bin': 'virtualenv'
+}
 __pillar__ = {}
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -421,6 +421,9 @@ def check_or_die(command):
     Lazily import salt.modules.cmdmod to avoid any
     sort of circular dependencies.
     '''
+    if command is None:
+        raise CommandNotFoundError("'None' is not a valid command.")
+
     import salt.modules.cmdmod
     __salt__ = {'cmd.has_exec': salt.modules.cmdmod.has_exec}
 

--- a/tests/integration/modules/virtualenv.py
+++ b/tests/integration/modules/virtualenv.py
@@ -26,27 +26,21 @@ class VirtualenvModuleTest(integration.ModuleCase):
 
     def test_site_packages(self):
         pip_bin = os.path.join(self.venv_dir, 'bin', 'pip')
-        self.run_function('virtualenv.create',
-                          [self.venv_dir],
-                          system_site_packages=True)
+        self.run_function(
+            'virtualenv.create', [self.venv_dir], system_site_packages=True
+        )
         with_site = self.run_function('pip.freeze', bin_env=pip_bin)
         self.run_function('file.remove', [self.venv_dir])
-        self.run_function('virtualenv.create',
-                          [self.venv_dir])
+        self.run_function('virtualenv.create', [self.venv_dir])
         without_site = self.run_function('pip.freeze', bin_env=pip_bin)
         self.assertFalse(with_site == without_site)
 
     def test_clear(self):
         pip_bin = os.path.join(self.venv_dir, 'bin', 'pip')
-        self.run_function('virtualenv.create',
-                          [self.venv_dir])
+        self.run_function('virtualenv.create', [self.venv_dir])
         self.run_function('pip.install', [], pkgs='pep8', bin_env=pip_bin)
-        self.run_function('virtualenv.create',
-                          [self.venv_dir],
-                          clear=True)
-        packages = self.run_function('pip.list',
-                                     prefix='pep8',
-                                     bin_env=pip_bin)
+        self.run_function('virtualenv.create', [self.venv_dir], clear=True)
+        packages = self.run_function('pip.list', prefix='pep8', bin_env=pip_bin)
         self.assertFalse('pep8' in packages)
 
     def tearDown(self):


### PR DESCRIPTION
The virtualenv module needs to have a default for `venv_bin`.
