### PR TITLE
Fix TypeError in cmd.script state when 'onlyif' or 'unless' are defined

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -315,12 +315,16 @@ def script(name,
                   'cwd': cwd,
                   'template': template})
 
-    # Changet the source to be the name arg if it is nto specified
+    run_check_cmd_kwargs = {'cwd': cwd,
+                  'runas': user,
+                  'shell': shell or __grains__['shell'], }
+
+    # Change the source to be the name arg if it is not specified
     if source is None:
         source = name
 
     try:
-        cret = _run_check(cmd_kwargs, onlyif, unless, cwd, user, group, shell)
+        cret = _run_check(run_check_cmd_kwargs, onlyif, unless, cwd, user, group, shell)
         if isinstance(cret, dict):
             ret.update(cret)
             return ret


### PR DESCRIPTION
I was getting this error (https://gist.github.com/6a3ae764b83470c82cbd) when I added an 'unless' condition to the cmd.script state.

It was happening because cmd_kwargs had many more values than were needed for the call to `_run_check`, so I created a second dict called `run_check_cmd_kwargs` to pass to the check.

Also fixed some comment typos.
