### PR TITLE
Hardened __grant_generate

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -24,6 +24,7 @@ Required python modules: MySQLdb
 # Import Python libs
 import time
 import logging
+import re
 
 # Import third party libs
 try:
@@ -612,8 +613,8 @@ def __grant_generate(grant,
                     grant_option=False,
                     escape=True):
     # todo: Re-order the grant so it is according to the SHOW GRANTS for xxx@yyy query (SELECT comes first, etc)
-    grant = grant.replace(',', ', ').upper()
-
+    grant = re.sub(r'\s*,\s*', ', ', grant).upper()
+    
     # MySQL normalizes ALL to ALL PRIVILEGES, we do the same so that
     # grant_exists and grant_add ALL work correctly
     if grant == 'ALL':


### PR DESCRIPTION
Grants are now correctly recognized as existing even if they have one or more spaces after the comma. 

I had the following test-case which failed and now it works as expected:

```
permissions = 'SELECT, INSERT, UPDATE, CREATE, DROP'
res = client.cmd('db1', 'mysql.grant_add', [permissions, '*.*', 'foo', '%']) 
# -> res['db1'] == False -> which is wrong
```

After applying my patch res['db1'] becomes True. 

It was necessary to add a space after the comma because anyther function in MySQL module required that.
