### PR TITLE
salt-key delete-all|-D   doesnt take arguments

### DIFF
--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -81,8 +81,8 @@ Delete the named minion key for command execution.
 .UNINDENT
 .INDENT 0.0
 .TP
-.B \-D DELETE_ALL, \-\-delete\-all=DELETE_ALL
-Deleta all keys
+.B \-D \-\-delete\-all
+Delete all minion keys
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
this fixex the man page to be consistent with behaviour of salt-key.
