### PR TITLE
Debian Service Module now supports reloads

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -100,6 +100,16 @@ def restart(name):
     cmd = 'service {0} restart'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
+def reload(name):
+    '''
+    Reload the named service
+
+    CLI Example::
+
+        salt '*' service.reload <service name>
+    '''
+    cmd = 'service {0} reload'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
 
 def status(name, sig=None):
     '''


### PR DESCRIPTION
Debian service management lost the ability to handle reloads, this commit should fix that.

Moved back to my proper workstation instead of fixing the changes from the other. Set my username properly and opened a new pull request.

Pull requests + headache doesn't work too well.
