### PR TITLE
Fix log option in pip module

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -167,7 +167,7 @@ def install(pkgs=None,
             os.path.exists(log)
         except IOError:
             raise IOError("'%s' is not writeable" % log)
-        cmd = '{cmd} --{log} '.format(
+        cmd = '{cmd} --log {log} '.format(
             cmd=cmd, log=log)
 
     if proxy:


### PR DESCRIPTION
The Pip module was incorrectly generating the arguments to pass down to pip for logging. Simple fix =)
