### PR TITLE
Develop

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -240,6 +240,8 @@ def user_list(user=None, host=None, port=None, runas=None):
     (user, host, port) = _connection_defaults(user, host, port)
 
     ret = []
+    # TODO Is it not better to specifically request rolname and avoid having
+    # to split up the lines below?
     cmd = _psql_cmd('-c', 'SELECT * FROM pg_roles',
             host=host, user=user, port=port)
 
@@ -264,12 +266,16 @@ def user_exists(name, user=None, host=None, port=None, runas=None):
     '''
     (user, host, port) = _connection_defaults(user, host, port)
 
-    users = user_list(user=user, host=host, port=port, runas=runas)
-    for user in users:
-        if name == dict(user).get('rolname'):
-            return True
+    query = (
+        "SELECT true "
+        "FROM pg_roles "
+        "WHERE (select rolname where rolname='{user}')"
+    ).format(user=user)
+    cmd = _psql_cmd('-c', query, host=host, user=user, port=port)
+    cmdret = __salt__['cmd.run'](cmd, runas=runas)
+    val = cmdret.splitlines()[2]
+    return True if val.strip() == 't' else False
 
-    return False
 
 def user_create(username,
                 user=None,

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -269,11 +269,13 @@ def user_exists(name, user=None, host=None, port=None, runas=None):
     query = (
         "SELECT true "
         "FROM pg_roles "
-        "WHERE (select rolname where rolname='{user}')"
-    ).format(user=user)
+        "WHERE EXISTS "
+        "(SELECT rolname WHERE rolname='{role}')".format(role=name)
+    )
     cmd = _psql_cmd('-c', query, host=host, user=user, port=port)
     cmdret = __salt__['cmd.run'](cmd, runas=runas)
-    val = cmdret.splitlines()[2]
+    log.debug(cmdret.splitlines())
+    val = cmdret.splitlines()[1]
     return True if val.strip() == 't' else False
 
 

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -240,8 +240,6 @@ def user_list(user=None, host=None, port=None, runas=None):
     (user, host, port) = _connection_defaults(user, host, port)
 
     ret = []
-    # TODO Is it not better to specifically request rolname and avoid having
-    # to split up the lines below?
     cmd = _psql_cmd('-c', 'SELECT * FROM pg_roles',
             host=host, user=user, port=port)
 


### PR DESCRIPTION
Put a partial fix in place for #1766. I have left the user_list function for now, as I don't know whether there are differences in the number of columns in the pg_roles table between versions of Postgres.

Perhaps the user_list function just lists the users? This would mean using SELECT rolname FROM pg_roles; and evading the column count issue altogether.
