### PR TITLE
Mru/upstart

### DIFF
--- a/debian/salt-master.upstart
+++ b/debian/salt-master.upstart
@@ -5,8 +5,7 @@ start on (net-device-up
           and runlevel [2345])
 stop on runlevel [!2345]
 
-expect daemon
 respawn limit 10 5
 respawn
 
-exec /usr/bin/salt-master -d
+exec /usr/bin/salt-master >/dev/null 2>&1

--- a/debian/salt-master.upstart
+++ b/debian/salt-master.upstart
@@ -6,6 +6,7 @@ start on (net-device-up
 stop on runlevel [!2345]
 
 expect daemon
+respawn limit 10 5
 respawn
 
 exec /usr/bin/salt-master -d

--- a/debian/salt-minion.upstart
+++ b/debian/salt-minion.upstart
@@ -8,6 +8,4 @@ stop on runlevel [!2345]
 respawn limit 10 5
 respawn
 
-script
-  exec /usr/bin/python /usr/bin/salt-minion > /dev/null 2>&1
-end script
+exec /usr/bin/salt-minion >/dev/null 2>&1

--- a/debian/salt-minion.upstart
+++ b/debian/salt-minion.upstart
@@ -6,6 +6,7 @@ start on (net-device-up
 stop on runlevel [!2345]
 
 respawn limit 10 5
+respawn
 
 script
   exec /usr/bin/python /usr/bin/salt-minion > /dev/null 2>&1

--- a/debian/salt-syndic.upstart
+++ b/debian/salt-syndic.upstart
@@ -8,6 +8,4 @@ stop on runlevel [!2345]
 respawn limit 10 5
 respawn
 
-script
-  exec /usr/bin/python /usr/bin/salt-syndic > /dev/null 2>&1
-end script
+exec /usr/bin/salt-syndic >/dev/null 2>&1

--- a/debian/salt-syndic.upstart
+++ b/debian/salt-syndic.upstart
@@ -6,6 +6,7 @@ start on (net-device-up
 stop on runlevel [!2345]
 
 respawn limit 10 5
+respawn
 
 script
   exec /usr/bin/python /usr/bin/salt-syndic > /dev/null 2>&1


### PR DESCRIPTION
The current upstart jobs have a problem as they seem to not track the correct PID of the master process (see the reported spawning of multiple master processes) and doesn't limit the respawning of the master process at all.

The minion and syndic jobs didn't respawn at all and explicitly specify the interpreter.
