### PR TITLE
Use explicit field name declarations in user_list

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -240,11 +240,16 @@ def user_list(user=None, host=None, port=None, runas=None):
     (user, host, port) = _connection_defaults(user, host, port)
 
     ret = []
-    cmd = _psql_cmd('-c', 'SELECT * FROM pg_roles',
+    query = (
+        '''SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
+        rolcatupdate, rolcanlogin, rolconnlimit, rolvaliduntil, rolconfig, oid
+        FROM pg_roles'''
+    )
+    cmd = _psql_cmd('-c', query,
             host=host, user=user, port=port)
 
     cmdret = __salt__['cmd.run'](cmd, runas=runas)
-    lines = [x for x in cmdret.splitlines() if len(x.split("|")) == 13]
+    lines = [x for x in cmdret.splitlines() if len(x.split("|")) == 11]
     log.debug(lines)
     header = [x.strip() for x in lines[0].split("|")]
     for line in lines[1:]:


### PR DESCRIPTION
I've amended the user_list() function so that it explicitly names the pg_roles fields that are in all supported versions of Postgres.

I made a mistake in my initial report on #1766, I appear to be running Postgres 8.4, which has one less field in its pg_roles view than Postgres 9.1 (thus the error when constructing lines).

The downside is that users of newer versions of Postgres cannot view the status of rolreplication. Perhaps a future fix will check the version of Postgres and use the correct information.
