### PR TITLE
Provide functions to returners via __salt__

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -73,11 +73,13 @@ def raw_mod(opts, name, functions):
     return load.gen_module(name, functions)
 
 
-def returners(opts):
+def returners(opts, functions):
     '''
     Returns the returner modules
     '''
     load = _create_loader(opts, 'returners', 'returner')
+    pack = {'name': '__salt__',
+            'value': functions}
     return load.filter_func('returner')
 
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -80,7 +80,7 @@ def returners(opts, functions):
     load = _create_loader(opts, 'returners', 'returner')
     pack = {'name': '__salt__',
             'value': functions}
-    return load.filter_func('returner')
+    return load.filter_func('returner', pack)
 
 
 def pillars(opts, functions):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -109,7 +109,7 @@ class SMinion(object):
                 self.opts['environment'],
                 ).compile_pillar()
         self.functions = salt.loader.minion_mods(self.opts)
-        self.returners = salt.loader.returners(self.opts)
+        self.returners = salt.loader.returners(self.opts, self.functions)
         self.states = salt.loader.states(self.opts, self.functions)
         self.rend = salt.loader.render(self.opts, self.functions)
         self.matcher = Matcher(self.opts, self.functions)
@@ -161,7 +161,7 @@ class Minion(object):
         '''
         self.opts['grains'] = salt.loader.grains(self.opts)
         functions = salt.loader.minion_mods(self.opts)
-        returners = salt.loader.returners(self.opts)
+        returners = salt.loader.returners(self.opts, functions)
         return functions, returners
 
     def _handle_payload(self, payload):


### PR DESCRIPTION
As per: https://groups.google.com/forum/#!topic/salt-users/cMhBxlXtU_4

This packs the functions into `__salt__` for returners.
