### PR TITLE
salt-key revert `--key-logfile` deprecation + Travis-CI related fixes

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -166,7 +166,7 @@ class SaltKey(parsers.SaltKeyOptionParser):
                 os.path.join(self.config['pki_dir'], 'minions'),
                 os.path.join(self.config['pki_dir'], 'minions_pre'),
                 os.path.join(self.config['pki_dir'], 'minions_rejected'),
-                os.path.dirname(self.config['log_file']),
+                os.path.dirname(self.config['key_logfile']),
             ],
             self.config['user'],
             permissive=self.config['permissive_pki_access']

--- a/salt/cli/key.py
+++ b/salt/cli/key.py
@@ -87,7 +87,7 @@ class Key(object):
         if hasattr(log, level):
             log_msg = getattr(log, level)
             log_msg(message)
-        if not self.opts['quiet']:
+        if not self.opts.get('quiet', False):
             print(message)
 
     def _list_pre(self, header=True, printer=None):

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -43,7 +43,7 @@ class Runner(object):
         '''
         Execute the runner sequence
         '''
-        if self.opts['doc']:
+        if self.opts.get('doc', False):
             self._print_docs()
         else:
             self._verify_fun()

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -109,6 +109,8 @@ def verify_env(dirs, user, permissive=False):
         sys.stderr.write(err)
         sys.exit(2)
     for dir_ in dirs:
+        if not dir_:
+            continue
         if not os.path.isdir(dir_):
             try:
                 cumask = os.umask(63)  # 077
@@ -146,8 +148,8 @@ def verify_env(dirs, user, permissive=False):
                         if permissive and fmode.st_gid in groups:
                             pass
                         else:
-                          # chown the file for the new user
-                          os.chown(path, uid, gid)
+                            # chown the file for the new user
+                            os.chown(path, uid, gid)
                 for name in dirs:
                     path = os.path.join(root, name)
                     fmode = os.stat(path)
@@ -155,8 +157,8 @@ def verify_env(dirs, user, permissive=False):
                         if permissive and fmode.st_gid in groups:
                             pass
                         else:
-                           # chown the file for the new user
-                           os.chown(path, uid, gid)
+                            # chown the file for the new user
+                            os.chown(path, uid, gid)
         # Allow the pki dir to be 700 or 750, but nothing else.
         # This prevents other users from writing out keys, while
         # allowing the use-case of 3rd-party software (like django)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -335,7 +335,6 @@ class ShellCase(TestCase):
         )
         data = process.communicate()
         process.stdout.close()
-        process.stderr.close()
         return data[0].split('\n')
 
     def run_salt(self, arg_str):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -335,6 +335,7 @@ class ShellCase(TestCase):
         )
         data = process.communicate()
         process.stdout.close()
+        process.stderr.close()
         return data[0].split('\n')
 
     def run_salt(self, arg_str):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -320,14 +320,21 @@ class ShellCase(TestCase):
         cmd = '{0} {1} {2} {3}'.format(ppath, PYEXEC, path, arg_str)
 
         if catch_stderr:
-            out, err = subprocess.Popen(
+            process = subprocess.Popen(
                 cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
-            ).communicate()
+            )
+            out, err = process.communicate()
+            # Let's see if travis stops failing on 2.6 with
+            # "filedescriptor out of range in select()"
+            process.stdout.close()
+            process.stderr.close()
             return out.split('\n'), err.split('\n')
 
-        data = subprocess.Popen(
+        process = subprocess.Popen(
             cmd, shell=True, stdout=subprocess.PIPE
-        ).communicate()
+        )
+        data = process.communicate()
+        process.stdout.close()
         return data[0].split('\n')
 
     def run_salt(self, arg_str):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -323,9 +323,25 @@ class ShellCase(TestCase):
             process = subprocess.Popen(
                 cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE
             )
-            out, err = process.communicate()
-            # Let's see if travis stops failing on 2.6 with
-            # "filedescriptor out of range in select()"
+            if sys.version_info[0:2] < (2, 7):
+                # On python 2.6, the subprocess'es communicate() method uses
+                # select which, is limited by the OS to 1024 file descriptors
+                # We need more available descriptors to run the tests which
+                # need the stderr output.
+                # So instead of .communicate() we wait for the process to
+                # finish, but, as the python docs state "This will deadlock
+                # when using stdout=PIPE and/or stderr=PIPE and the child
+                # process generates enough output to a pipe such that it
+                # blocks waiting for the OS pipe buffer to accept more data.
+                # Use communicate() to avoid that." <- a catch, catch situation
+                #
+                # Use this work around were it's needed only, python 2.6
+                process.wait()
+                out = process.stdout.read()
+                err = process.stderr.read()
+            else:
+                out, err = process.communicate()
+            # Force closing stderr/stdout to release file descriptors
             process.stdout.close()
             process.stderr.close()
             return out.split('\n'), err.split('\n')

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -13,3 +13,4 @@ peer:
   '.*':
     - 'test.*'
 log_file: master
+key_logfile: key

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -59,11 +59,14 @@ class FileTest(integration.ModuleCase):
         file.absent
         '''
         name = os.path.join(integration.TMP, 'link_to_kill')
-        os.symlink(name, '{0}.tgt'.format(name))
+        if not os.path.islink('{0}.tgt'.format(name)):
+            os.symlink(name, '{0}.tgt'.format(name))
         ret = self.run_state('file.absent', name=name)
         result = ret[next(iter(ret))]['result']
         self.assertTrue(result)
         self.assertFalse(os.path.islink(name))
+        if os.path.islink('{0}.tgt'.format(name)):
+            os.unlink('{0}.tgt'.format(name))
 
     def test_test_absent(self):
         '''

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+"""
+    tests.unit.config
+    ~~~~~~~~~~~~~~~~~
+
+    :copyright: © 2012 UfSoft.org - :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :license: Apache 2.0, see LICENSE for more details.
+"""
+
+import os
+import tempfile
+from saltunittest import TestCase, TestLoader, TextTestRunner
+from salt import config as sconfig
+
+class ConfigTestCase(TestCase):
+    def test_proper_path_joining(self):
+        fpath = tempfile.mktemp()
+        open(fpath, 'w').write(
+            "root_dir: /\n"
+            "key_logfile: key\n"
+        )
+        config = sconfig.master_config(fpath)
+        # os.path.join behaviour
+        self.assertEqual(config['key_logfile'], os.path.join('/', 'key'))
+        # os.sep.join behaviour
+        self.assertNotEqual(config['key_logfile'], '//key')
+
+
+if __name__ == "__main__":
+    loader = TestLoader()
+    tests = loader.loadTestsFromTestCase(ConfigTestCase)
+    TextTestRunner(verbosity=1).run(tests)


### PR DESCRIPTION
salt-key revert `--key-logfile` deprecation + Travis-CI related fixes

Please see the commit messages for the full "report" about what has been done.

Also, know why travis fails randomly at some tests?
