### PR TITLE
Fix mysql module from breaking a highstate run due to mistake in grant

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -672,7 +672,8 @@ def grant_exists(grant,
     # perhaps should be replaced/reworked with a better/cleaner solution.
     target = __grant_generate(grant, database, user, host, grant_option, escape)
 
-    if target in user_grants(user, host):
+    grants = user_grants(user, host)
+    if grants is not False and target in grants:
         log.debug("Grant exists.")
         return True
 


### PR DESCRIPTION
I had `host: 'loalhost'` (notice the misspelling) set for the grant but
the correct `host: 'localhost'` set for the user & database and when
applying highstate it would bail out with:

```
[INFO    ] Executing state mysql_user.present for gladca_prod
[INFO    ] User 'gladca_prod'@'localhost' has been created
[INFO    ] {'gladca_prod': 'Present'}
[INFO    ] Executing state mysql_grants.present for gladca_prod
[INFO    ] User 'gladca_prod'@'loalhost' does not exist
Error running 'state.highstate': argument of type 'bool' is not iterable
```
