### PR TITLE
Indicate success to the returner functions

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -275,10 +275,12 @@ class Minion(object):
 
         function_name = data['fun']
         if function_name in self.functions:
+            ret['success'] = False
             try:
                 func = self.functions[data['fun']]
                 args, kw = detect_kwargs(func, data['arg'], data)
                 ret['return'] = func(*args, **kw)
+                ret['success'] = True
             except CommandNotFoundError as exc:
                 msg = 'Command required for \'{0}\' not found: {1}'
                 log.debug(msg.format(function_name, str(exc)))
@@ -334,10 +336,12 @@ class Minion(object):
                 except Exception:
                     pass
 
+            ret['success'][data['fun'][ind]] = False
             try:
                 func = self.functions[data['fun'][ind]]
                 args, kw = detect_kwargs(func, data['arg'][ind], data)
                 ret['return'][data['fun'][ind]] = func(*args, **kw)
+                ret['success'][data['fun'][ind]] = True
             except Exception as exc:
                 trb = traceback.format_exc()
                 log.warning(


### PR DESCRIPTION
As discussed in #1792 this adds a `success` attribute to the dict passed into the returner functions that indicates if the function ran without error or if salt could not execute it due to an Exception or other low level condition.
