### PR TITLE
Proposed fix for saltstack/salt#1756

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -5,6 +5,7 @@ Make me some salt!
 # Import python libs
 import os
 import sys
+import logging
 
 # Import salt libs, the try block bypasses an issue at build time so that c
 # modules don't cause the build to fail
@@ -46,8 +47,6 @@ class Master(parsers.MasterOptionParser):
 
         self.setup_logfile_logger()
 
-        import logging
-        log = logging.getLogger(__name__)
         # Late import so logging works correctly
         if not verify_socket(self.config['interface'],
                              self.config['publish_port'],
@@ -58,7 +57,7 @@ class Master(parsers.MasterOptionParser):
         master = salt.master.Master(self.config)
         self.daemonize_if_required()
         self.set_pidfile()
-        if check_user(self.config['user'], log):
+        if check_user(self.config['user']):
             try:
                 master.start()
             except salt.master.MasterExit:
@@ -90,10 +89,8 @@ class Minion(parsers.MinionOptionParser):
 
         self.setup_logfile_logger()
 
-        import logging
         # Late import so logging works correctly
         import salt.minion
-        log = logging.getLogger(__name__)
         # If the minion key has not been accepted, then Salt enters a loop
         # waiting for it, if we daemonize later then the minion could halt
         # the boot process waiting for a key to be accepted on the master.
@@ -102,10 +99,10 @@ class Minion(parsers.MinionOptionParser):
         try:
             minion = salt.minion.Minion(self.config)
             self.set_pidfile()
-            if check_user(self.config['user'], log):
+            if check_user(self.config['user']):
                 minion.tune_in()
         except KeyboardInterrupt:
-            log.warn('Stopping the Salt Minion')
+            logging.getLogger(__name__).warn('Stopping the Salt Minion')
             raise SystemExit('\nExiting on Ctrl-c')
 
 
@@ -133,19 +130,17 @@ class Syndic(parsers.SyndicOptionParser):
 
         self.setup_logfile_logger()
 
-        import logging
-
         # Late import so logging works correctly
         import salt.minion
-        log = logging.getLogger(__name__)
-
         self.daemonize_if_required()
         self.set_pidfile()
 
-        if check_user(self.config['user'], log):
+        if check_user(self.config['user']):
             try:
                 syndic = salt.minion.Syndic(self.config)
                 syndic.tune_in()
             except KeyboardInterrupt:
-                log.warn('Stopping the Salt Syndic Minion')
+                logging.getLogger(__name__).warn(
+                    'Stopping the Salt Syndic Minion'
+                )
                 raise SystemExit('\nExiting on Ctrl-c')

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -210,13 +210,15 @@ class ConfigDirMixIn(DeprecatedConfigMessage):
                         self.config[option.dest] = value
 
     def process_config_dir(self):
-        # XXX: Remove deprecation warning in next release
+        # Make sure we have an absolute path
+        self.options.config_dir = os.path.abspath(self.options.config_dir)
         if os.path.isfile(self.options.config_dir):
+            # XXX: Remove deprecation warning in next release
             self.print_config_warning()
 
         if hasattr(self, 'setup_config'):
             self.config = self.setup_config()
-            # Add an additional function that will merge the cli options with
+            # Add an additional function that will merge the shell options with
             # the config options and if needed override them
             self._mixin_after_parsed_funcs.append(self.__merge_config_with_cli)
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -170,13 +170,19 @@ class ConfigDirMixIn(DeprecatedConfigMessage):
                 # will have the dest attribute set
                 continue
 
-            value = getattr(self.options, option.dest, None)
+
+            # Get the passed value from shell. If empty get the default one
             default = self.defaults.get(option.dest)
-            if value is not None and default is not None and (value != default):
-                # Only override if there's a cli value, and if the cli value
-                # is not the defined default(we need to be able to make changes
-                # on the config file be respected, IF there's no value, other
-                # than the default one from cli)
+            value = getattr(self.options, option.dest, default)
+            if option.dest not in self.config:
+                # There's no value in the configuration file
+                if value:
+                    # There's an actual value, add it to the config
+                    self.config[option.dest] = value
+            elif value and value != default:
+                # Only set the value in the config file IF it's not the default
+                # value, this allows to tweak settings on the configuration
+                # files bypassing the shell option flags
                 self.config[option.dest] = value
 
         # Merge parser group options if any
@@ -187,6 +193,21 @@ class ConfigDirMixIn(DeprecatedConfigMessage):
                 value = getattr(self.options, option.dest, None)
                 if value is not None:
                     self.config[option.dest] = value
+
+                # Get the passed value from shell. If empty get the default one
+                default = self.defaults.get(option.dest)
+                value = getattr(self.options, option.dest, default)
+                if option.dest not in self.config:
+                    # There's no value in the configuration file
+                    if value:
+                        # There's an actual value, add it to the config
+                        self.config[option.dest] = value
+                else:
+                    if value and value != default:
+                        # Only set the value in the config file IF it's not the
+                        # default value, this allows to tweak settings on the
+                        # configuration files bypassing the shell option flags
+                        self.config[option.dest] = value
 
     def process_config_dir(self):
         # XXX: Remove deprecation warning in next release


### PR DESCRIPTION
- Only use logging if the console logging has been properly setup, in case it hasn't been, write the message to `sys.stderr`.
- Removed the log argument passed to `salt.verify.check_user`, it's not needed anymore.
