### PR TITLE
Final fix for saltstack/salt#1756

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -5,14 +5,15 @@ Discover all instances of unittest.TestCase in this directory.
 # Import python libs
 import sys
 import os
+import logging
 import optparse
-
-# Import salt libs
 # Setup minimal logging and disable it so "no handler for..." errors
 # are not thrown anymore while running tests
-from salt.log import setup_console_logger
-setup_console_logger('quiet')
-# Import remaining salt libs
+rootLogger = logging.getLogger()
+handler = logging.NullHandler()
+rootLogger.addHandler(handler)
+
+# Import salt libs
 import saltunittest
 from integration import TestDaemon
 


### PR DESCRIPTION
Don't try to import `salt.log` during tests. Adapt `check_user` test accordingly.
