### PR TITLE
Fix `salt-call` bug with default outputter.

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -101,4 +101,6 @@ class Caller(object):
         printout = salt.output.get_printout(
             ret, ret.get('out', None), self.opts, indent=2
         )
+        if printout is None:
+            printout = salt.output.get_outputter(None)
         printout({'local': ret['return']}, color=not bool(self.opts['no_color']))

--- a/salt/output.py
+++ b/salt/output.py
@@ -37,7 +37,7 @@ def get_printout(ret, out, opts, indent=None):
             if printout and indent is not None:
                 printout.indent = indent
             return printout
-        elif opts.get('txt_out', False):
+        elif opts.get('text_out', False):
             return get_outputter('txt')
         elif opts['yaml_out']:
             return get_outputter('yaml')

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -402,6 +402,11 @@ class ShellCase(TestCase):
         arg_str = '--config-dir {0} {1}'.format(mconf, arg_str)
         return self.run_script('salt-cp', arg_str)
 
+    def run_call(self, arg_str):
+        mconf = os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf')
+        arg_str = '--config-dir {0} {1}'.format(mconf, arg_str)
+        return self.run_script('salt-call', arg_str)
+
 
 class ShellCaseCommonTestsMixIn(object):
 

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -19,6 +19,16 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
     _call_binary_ = 'salt-call'
 
+    def test_default_output(self):
+        out = self.run_call('test.fib 3')
+        self.assertEqual(
+            "local: !!python/tuple\n- [0, 1, 1, 2]", '\n'.join(out[:-3])
+        )
+
+    def test_text_output(self):
+        out = self.run_call('--text-out test.fib 3')
+        self.assertEqual("local: ([0, 1, 1, 2]", ''.join(out).rsplit(",", 1)[0])
+
 if __name__ == "__main__":
     loader = TestLoader()
     tests = loader.loadTestsFromTestCase(CallTest)


### PR DESCRIPTION
- `salt-call` default outputter returned from `salt.output.get_printout()` was `None` and `None` isn't callable neither outputs anything useful. In this case, the fault Outputter  should be used.
- `get_printout()` also tested for `txt_out` which now is, in the cleaned up parsers, `text_out`. Fixed.
