### PR TITLE
Add test to test if os_family grain is provided.

### DIFF
--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -45,6 +45,7 @@ class TestModulesGrains(integration.ModuleCase):
             'mem_total',
             'num_cpus',
             'os',
+            'os_family',
             'path',
             'ps',
             'pythonpath',


### PR DESCRIPTION
Corey Quinn reported a issue where **grains**['os_family'] returned a
KeyError. This commits adds a check to the grains module test to ensure
os_family is present.
