### PR TITLE
Improvements to the virt module

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -490,7 +490,7 @@ def create_xml_str(xml):
         salt '*' virt.create_xml_str <xml in string format>
     '''
     conn = __get_conn()
-    return conn.createXML(xml, 0)
+    return conn.createXML(xml, 0) is not None
 
 
 def create_xml_path(path):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -604,7 +604,8 @@ def purge(vm_, dirs=False):
         salt '*' virt.purge <vm name>
     '''
     disks = get_disks(vm_)
-    destroy(vm_)
+    if not destroy(vm_):
+        return False
     directories = set()
     for disk in disks:
         os.remove(disks[disk]['file'])

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -388,8 +388,7 @@ def shutdown(vm_):
         salt '*' virt.shutdown <vm name>
     '''
     dom = _get_dom(vm_)
-    dom.shutdown()
-    return True
+    return dom.shutdown() == 0
 
 
 def pause(vm_):
@@ -401,8 +400,7 @@ def pause(vm_):
         salt '*' virt.pause <vm name>
     '''
     dom = _get_dom(vm_)
-    dom.suspend()
-    return True
+    return dom.suspend() == 0
 
 
 def resume(vm_):
@@ -414,8 +412,7 @@ def resume(vm_):
         salt '*' virt.resume <vm name>
     '''
     dom = _get_dom(vm_)
-    dom.resume()
-    return True
+    return dom.resume() == 0
 
 
 def create(vm_):
@@ -427,8 +424,7 @@ def create(vm_):
         salt '*' virt.create <vm name>
     '''
     dom = _get_dom(vm_)
-    dom.create()
-    return True
+    return dom.create() == 0
 
 
 def start(vm_):
@@ -451,8 +447,7 @@ def create_xml_str(xml):
         salt '*' virt.create_xml_str <xml in string format>
     '''
     conn = __get_conn()
-    conn.createXML(xml, 0)
-    return True
+    return conn.createXML(xml, 0)
 
 
 def create_xml_path(path):
@@ -581,12 +576,8 @@ def destroy(vm_):
 
         salt '*' virt.destroy <vm name>
     '''
-    try:
-        dom = _get_dom(vm_)
-        dom.destroy()
-    except Exception:
-        return False
-    return True
+    dom = _get_dom(vm_)
+    return dom.destroy() == 0
 
 
 def undefine(vm_):
@@ -598,12 +589,8 @@ def undefine(vm_):
 
         salt '*' virt.undefine <vm name>
     '''
-    try:
-        dom = _get_dom(vm_)
-        dom.undefine()
-    except Exception:
-        return False
-    return True
+    dom = _get_dom(vm_)
+    return dom.undefine() == 0
 
 
 def purge(vm_, dirs=False):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -447,7 +447,10 @@ def reboot(vm_):
         salt '*' virt.reboot <vm name>
     '''
     dom = _get_dom(vm_)
-    return dom.reboot() == 0
+
+    # reboot has a few modes of operation, passing 0 in means the
+    # hypervisor will pick the best method for rebooting
+    return dom.reboot(0) == 0
 
 
 def reset(vm_):
@@ -459,7 +462,11 @@ def reset(vm_):
         salt '*' virt.reset <vm name>
     '''
     dom = _get_dom(vm_)
-    return dom.reset() == 0
+
+    # reset takes a flag, like reboot, but it is not yet used
+    # so we just pass in 0
+    # see: http://libvirt.org/html/libvirt-libvirt.html#virDomainReset
+    return dom.reset(0) == 0
 
 
 def ctrl_alt_del(vm_):
@@ -471,7 +478,7 @@ def ctrl_alt_del(vm_):
         salt '*' virt.ctrl_alt_del <vm name>
     '''
     dom = _get_dom(vm_)
-    return dom.sendKey(0, 0, [29, 56, 111], 3, 0)
+    return dom.sendKey(0, 0, [29, 56, 111], 3, 0) == 0
 
 
 def create_xml_str(xml):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -438,6 +438,42 @@ def start(vm_):
     return create(vm_)
 
 
+def reboot(vm_):
+    '''
+    Reboot a domain via ACPI request
+
+    CLI Example::
+    
+        salt '*' virt.reboot <vm name>
+    '''
+    dom = _get_dom(vm_)
+    return dom.reboot() == 0
+
+
+def reset(vm_):
+    '''
+    Reset a VM by emulating the reset button on a physical machine
+
+    CLI Example::
+
+        salt '*' virt.reset <vm name>
+    '''
+    dom = _get_dom(vm_)
+    return dom.reset() == 0
+
+
+def ctrl_alt_del(vm_):
+    '''
+    Sends CTRL+ALT+DEL to a VM
+
+    CLI Example::
+    
+        salt '*' virt.ctrl_alt_del <vm name>
+    '''
+    dom = _get_dom(vm_)
+    return dom.sendKey(0, 0, [29, 56, 111], 3, 0)
+
+
 def create_xml_str(xml):
     '''
     Start a domain based on the xml passed to the function


### PR DESCRIPTION
This adds two main improvements to the virt module.
1. We no longer blindly return success for calls such as undefine, create, shutdown, etc. Instead now we ensure that the actual libvirt call succeeded by ensure the return is 0. Libvirt's convention for success it to return 0 and all changes were verified against http://libvirt.org/html/libvirt-libvirt.html to ensure that 0 is indeed a successful return.
2. I've added three different reboot functions.

There were also two functions that were catching all Exceptions to determine success or failure. I've removed the try/catch statements as I think catching all Exceptions is too broad. If there was a special reason why they were wrapped in try/catch then I can amend to have a more narrow scope for the catch.
