### PR TITLE
Fix a bug, small performance improvement

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -177,12 +177,14 @@ class LocalClient(object):
                     continue
                 if comps[0] not in grains:
                     minions.remove(id_)
+                    continue
                 if isinstance(grains[comps[0]], list):
                     # We are matching a single component to a single list member
                     found = False
                     for member in grains[comps[0]]:
                         if fnmatch.fnmatch(str(member).lower(), comps[1].lower()):
                             found = True
+                            break
                     if found:
                         continue
                     minions.remove(id_)


### PR DESCRIPTION
The `break` is the performance improvement, once we set found to True we can stop the enclosing for loop.

The `continue` statement is the bug, I'm pretty sure it's supposed to be there. Here's the traceback that I encountered:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "boxen/controller.py", line 95, in start
    self.take_inventory()
  File "boxen/controller.py", line 224, in take_inventory
    for hypervisor in _inventory('hypervisor'):
  File "boxen/controller.py", line 209, in _inventory
    timeout=2)
  File "/usr/lib/python2.6/dist-packages/salt/client.py", line 290, in cmd
    timeout=timeout)
  File "/usr/lib/python2.6/dist-packages/salt/client.py", line 992, in pub
    minions = self.check_minions(tgt, expr_form)
  File "/usr/lib/python2.6/dist-packages/salt/client.py", line 937, in check_minions
    }[expr_form](expr)
  File "/usr/lib/python2.6/dist-packages/salt/client.py", line 180, in _check_grain_minions
    if isinstance(grains[comps[0]], list):
KeyError: 'roles'
```

And the code that triggers this (line 209 in controller.py) is:

```
self.client.cmd("roles:{0}".format(role), 'test.ping',
                        expr_form='grain',
                        timeout=2)
```

However, while adding that continue statement fixes things I still don't fully understand what's going on that causes it. Do you have any insight into what causes this?
