### PR TITLE
Minidom fixups to prevent Exceptions

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -223,7 +223,7 @@ def get_nics(vm_):
                 # driver, source, and match can all have optional attributes
                 if re.match('(driver|source|address)', v_node.tagName):
                     temp = {}
-                    for key in v_node.attributes:
+                    for key in v_node.attributes.keys():
                         temp[key] = v_node.getAttribute(key)
                     nic[str(v_node.tagName)] = temp
                 # virtualport needs to be handled separately, to pick up the
@@ -231,7 +231,7 @@ def get_nics(vm_):
                 if v_node.tagName == "virtualport":
                     temp = {}
                     temp['type'] = v_node.getAttribute('type')
-                    for key in v_node.attributes:
+                    for key in v_node.attributes.keys():
                         temp[key] = v_node.getAttribute(key)
                     nic['virtualport'] = temp
             if 'mac' not in nic:
@@ -275,7 +275,7 @@ def get_graphics(vm_):
     for node in doc.getElementsByTagName("domain"):
         g_nodes = node.getElementsByTagName("graphics")
         for g_node in g_nodes:
-            for key in g_node.attributes:
+            for key in g_node.attributes.keys():
                 out[key] = g_node.getAttribute(key)
     return out
 
@@ -301,7 +301,7 @@ def get_disks(vm_):
             target = targets[0]
         else:
             continue
-        if 'dev' in list(target.attributes) and 'file' in list(source.attributes):
+        if target.attributes.has_key('dev') and source.attributes.has_key('file'):
             disks[target.getAttribute('dev')] = {
                 'file': source.getAttribute('file')}
     for dev in disks:


### PR DESCRIPTION
I'm not sure when this broke but I do seem to recall this working at some point previously, but it looks like some changes have broken a number of the virt functions that deal with minidom `NamedNodeMap`s

```
[#167]: salt-call virt.vm_info ibolapp1.fatboxes.com
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.6/dist-packages/salt/scripts.py", line 70, in salt_call
    client.run()
  File "/usr/lib/python2.6/dist-packages/salt/cli/__init__.py", line 792, in run
    caller.run()
  File "/usr/lib/python2.6/dist-packages/salt/cli/caller.py", line 112, in run
    ret = self.call()
  File "/usr/lib/python2.6/dist-packages/salt/cli/caller.py", line 46, in call
    ret['return'] = self.minion.functions[fun](*args, **kw)
  File "/usr/lib/python2.6/dist-packages/salt/modules/virt.py", line 163, in vm_info
    info[vm_] = _info(vm_)
  File "/usr/lib/python2.6/dist-packages/salt/modules/virt.py", line 156, in _info
    'disks': get_disks(vm_),
  File "/usr/lib/python2.6/dist-packages/salt/modules/virt.py", line 304, in get_disks
    if 'dev' in list(target.attributes) and 'file' in list(source.attributes):
  File "/usr/lib/python2.6/xml/dom/minidom.py", line 530, in __getitem__
    return self._attrs[attname_or_tuple]
KeyError: 0
```
