### PR TITLE
Use `systemctl list-unit-files` for finding systemd units.

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -39,7 +39,7 @@ def _get_all_unit_files():
                       '|'.join(VALID_UNIT_TYPES) +
                       ')\s+(?P<state>.+)$')
 
-    out = __salt__['cmd.run_stdout']('systemctl list-unit-files')
+    out = __salt__['cmd.run_stdout']('systemctl --no-legend list-unit-files | col -b')
 
     ret = {}
     for match in rexp.finditer(out):


### PR DESCRIPTION
Since we get the state of each unit with one command we don't
have to call `systemctl is-enabled` one time per unit to find
all enabled or disabled services. In addition we now get
a list of all units, not only those of the service type.
