### PR TITLE
Fix #1772. Use `apt-cache policy` to find available package version.

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -43,15 +43,11 @@ def available_version(name):
         salt '*' pkg.available_version <package name>
     '''
     version = ''
-    cmd = 'apt-cache -q show {0} | grep ^Version'.format(name)
+    cmd = 'apt-cache -q policy {0} | grep Candidate'.format(name)
 
     out = __salt__['cmd.run_stdout'](cmd)
 
     version_list = out.split()
-    for comp in version_list:
-        if comp == 'Version:':
-            continue
-        return comp
 
     if len(version_list) >= 2:
         version = version_list[-1]


### PR DESCRIPTION
See also issue #1454: https://github.com/saltstack/salt/issues/1454
