### PR TITLE
Fix saltstack/salt#1900

### DIFF
--- a/salt/cli/key.py
+++ b/salt/cli/key.py
@@ -21,7 +21,7 @@ class Key(object):
     '''
     def __init__(self, opts):
         self.opts = opts
-        self.event = salt.utils.event.SaltEvent(opts['sock_dir'], 'master')
+        self.event = salt.utils.event.MasterEvent(opts['sock_dir'])
         self.colors = salt.utils.get_colors(
                 not bool(self.opts.get('no_color', False))
                 )

--- a/salt/master.py
+++ b/salt/master.py
@@ -299,7 +299,7 @@ class Publisher(multiprocessing.Process):
                             con = True
                         except zmq.ZMQError:
                             pass
-                
+
         except KeyboardInterrupt:
             pub_sock.close()
             pull_sock.close()
@@ -484,10 +484,7 @@ class AESFuncs(object):
     #
     def __init__(self, opts, crypticle):
         self.opts = opts
-        self.event = salt.utils.event.SaltEvent(
-                self.opts['sock_dir'],
-                'master'
-                )
+        self.event = salt.utils.event.MasterEvent(self.opts['sock_dir'])
         self.serial = salt.payload.Serial(opts)
         self.crypticle = crypticle
         # Make a client
@@ -1005,10 +1002,7 @@ class ClearFuncs(object):
         self.master_key = master_key
         self.crypticle = crypticle
         # Create the event manager
-        self.event = salt.utils.event.SaltEvent(
-                self.opts['sock_dir'],
-                'master'
-                )
+        self.event = salt.utils.event.MasterEvent(self.opts['sock_dir'])
         # Make a client
         self.local = salt.client.LocalClient(self.opts['conf_file'])
 

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -35,5 +35,5 @@ def fire(data, tag):
 
         salt '*' event.fire 'stuff to be in the event' 'tag'
     '''
-    esock = salt.utils.event.MinionEvent(__opts__['sock_dir'])
+    esock = salt.utils.event.MinionEvent(__opts__['sock_dir'], **__opts__)
     return esock.fire_event(data, tag)

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -35,5 +35,4 @@ def fire(data, tag):
 
         salt '*' event.fire 'stuff to be in the event' 'tag'
     '''
-    esock = salt.utils.event.MinionEvent(__opts__['sock_dir'], **__opts__)
-    return esock.fire_event(data, tag)
+    return salt.utils.event.MinionEvent(**__opts__).fire_event(data, tag)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -30,7 +30,7 @@ class SaltEvent(object):
     '''
     The base class used to manage salt events
     '''
-    def __init__(self, sock_dir, node, **kwargs):
+    def __init__(self, node, sock_dir=None, **kwargs):
         self.serial = salt.payload.Serial({'serial': 'msgpack'})
         self.context = zmq.Context()
         self.poller = zmq.Poller()
@@ -142,7 +142,7 @@ class MasterEvent(SaltEvent):
     Create a master event management object
     '''
     def __init__(self, sock_dir):
-        super(MasterEvent, self).__init__(sock_dir, 'master')
+        super(MasterEvent, self).__init__('master', sock_dir)
         self.connect_pub()
 
 
@@ -150,8 +150,8 @@ class MinionEvent(SaltEvent):
     '''
     Create a master event management object
     '''
-    def __init__(self, sock_dir, **kwargs):
-        super(MinionEvent, self).__init__(sock_dir, 'minion', **kwargs)
+    def __init__(self, **kwargs):
+        super(MinionEvent, self).__init__('minion', **kwargs)
 
 
 class EventPublisher(multiprocessing.Process):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -15,6 +15,7 @@ Manage events
 # Import Python libs
 import os
 import errno
+import logging
 import multiprocessing
 
 # Import Third Party libs
@@ -23,6 +24,7 @@ import zmq
 # Import Salt libs
 import salt.payload
 
+log = logging.getLogger(__name__)
 
 class SaltEvent(object):
     '''
@@ -67,6 +69,12 @@ class SaltEvent(object):
                     sock_dir,
                     'minion_event_{0}_pull.ipc'.format(kwargs.get('id', ''))
                     ))
+        log.debug(
+            '{0} PUB socket URI: {1}'.format(self.__class__.__name__, puburi)
+        )
+        log.debug(
+            '{0} PULL socket URI: {1}'.format(self.__class__.__name__, pulluri)
+        )
         return puburi, pulluri
 
     def connect_pub(self):
@@ -123,8 +131,7 @@ class SaltEvent(object):
         '''
         if not self.cpush:
             self.connect_pull()
-        tag += 20 * '|'
-        tag = tag[:20]
+        tag = '{0:|<20}'.format(tag)
         event = '{0}{1}'.format(tag, self.serial.dumps(data))
         self.push.send(event)
         return True


### PR DESCRIPTION
- Replace `SaltEvent` for `MasterEvent` where applicable;
- Pass `__opts__` to `salt.modules.event.fire`, it was missing;
- Add some more debug logging to `salt.utils.event`
- Instead of appending and slicing the event tag string, make use of python's string `format()`
- Change `SaltEvent`, `MasterEvent` and `MinionEvent` class signatures to simplify it's use and passing `kwargs` to it.
