### PR TITLE
fix solaris ps grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -298,7 +298,7 @@ def _ps(osdata):
     bsd_choices = ('FreeBSD', 'NetBSD', 'OpenBSD', 'MacOS')
     if osdata['os'] in bsd_choices:
         grains['ps'] = 'ps auxwww'
-    if osdata['os'] == 'SunOS':
+    if osdata['os'] == 'Solaris':
         grains['ps'] = '/usr/ucb/ps auxwww'
     elif osdata['os'] == 'Windows':
         grains['ps'] = 'tasklist.exe'


### PR DESCRIPTION
Since we're now correctly identifying the OS as Solaris and not SunOS (the kernel) I'm updating the ps grain to reflect this.
