### PR TITLE
Fix #1948

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -744,6 +744,9 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, TimeoutMixIn,
         self.config['src'] = self.args[1:-1]
         self.config['dest'] = self.args[-1]
 
+    def setup_config(self):
+        return config.master_config(self.get_config_file_path('master'))
+
 
 class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, LogLevelMixIn,
                           OutputOptionsMixIn):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -22,7 +22,6 @@ def _sorted(mixins_or_funcs):
 
 
 class MixInMeta(type):
-
     # This attribute here won't actually do anything. But, if you need to
     # specify an order or a dependency within the mix-ins, please define the
     # attribute on your own MixIn
@@ -48,7 +47,7 @@ class OptionParserMeta(MixInMeta):
         if not hasattr(instance, '_mixin_after_parsed_funcs'):
             instance._mixin_after_parsed_funcs = []
 
-        for base in _sorted(bases+(instance,)):
+        for base in _sorted(bases + (instance,)):
             func = getattr(base, '_mixin_setup', None)
             if func is not None and func not in instance._mixin_setup_funcs:
                 instance._mixin_setup_funcs.append(func)
@@ -155,6 +154,7 @@ class DeprecatedConfigMessage(object):
             '-c/--config-dir to point to a directory which holds all of '
             'salt\'s configuration files.\n'
         )
+
 
 class ConfigDirMixIn(DeprecatedConfigMessage):
     __metaclass__ = MixInMeta
@@ -273,8 +273,8 @@ class LogLevelMixIn(object):
             choices=list(log.LOG_LEVELS),
             help=('Logging log level. One of {0}. For the logfile settings see '
                   'the configuration file. Default: \'{1}\'.').format(
-                    ', '.join([repr(l) for l in log.SORTED_LEVEL_NAMES]),
-                    getattr(self, '_default_logging_level_', 'warning')
+                      ', '.join([repr(l) for l in log.SORTED_LEVEL_NAMES]),
+                      getattr(self, '_default_logging_level_', 'warning')
             )
         )
 
@@ -309,6 +309,7 @@ class LogLevelMixIn(object):
             log_format=self.config['log_fmt_console'],
             date_format=self.config['log_datefmt']
         )
+
 
 class RunUserMixin(object):
     __metaclass__ = MixInMeta
@@ -544,7 +545,6 @@ class OutputOptionsMixIn(object):
             help='Disable all colored output'
         )
 
-
         for option in group.option_list:
             def process(opt):
                 if getattr(self.options, opt.dest):
@@ -672,7 +672,7 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, TimeoutMixIn,
                   'send the return data from the command back to the master, '
                   'but the return data can be redirected into any number of '
                   'systems, databases or applications.')
-            )
+        )
         self.add_option(
             '-Q', '--query',
             action='store_true',
@@ -836,7 +836,6 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, LogLevelMixIn,
             help='Print the named key\'s fingerprint'
         )
         self.add_option_group(actions_group)
-
 
         self.add_option(
             '--key-logfile',

--- a/tests/integration/shell/cp.py
+++ b/tests/integration/shell/cp.py
@@ -11,7 +11,6 @@
 import os
 import sys
 import yaml
-import time
 
 # Import salt libs
 from saltunittest import TestLoader, TextTestRunner

--- a/tests/integration/shell/cp.py
+++ b/tests/integration/shell/cp.py
@@ -9,10 +9,9 @@
 
 # Import python libs
 import os
-import re
 import sys
-import string
-import random
+import yaml
+import time
 
 # Import salt libs
 from saltunittest import TestLoader, TextTestRunner
@@ -24,30 +23,35 @@ class CopyTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
     _call_binary_ = 'salt-cp'
 
-    def setUp(self):
-        self.testfile = os.path.join(integration.TMP, 'testfile')
-        self.testcontents = ''.join(
-            random.choice(string.ascii_uppercase) for x in range(128)
-        )
-        open(self.testfile, 'w').write(self.testcontents)
-
-    def tearDown(self):
-        os.unlink(self.testfile)
-
     def test_cp_testfile(self):
         '''
         test salt-cp
         '''
-        data = ''.join(self.run_salt('"*" test.ping'))
-        for minion in re.findall(r"{['|\"]([^:]+)['|\"]: True}", data):
+        minions = []
+        for line in self.run_salt('--yaml-out "*" test.ping'):
+            if not line:
+                continue
+            data = yaml.load(line)
+            minions.extend(data.keys())
+
+        self.assertNotEqual(minions, [])
+
+        testfile = os.path.abspath(
+            os.path.join(
+                os.path.dirname(os.path.dirname(__file__)),
+                'files', 'file', 'base', 'testfile'
+            )
+        )
+        testfile_contents = open(testfile, 'r').read()
+
+        for minion in minions:
             minion_testfile = os.path.join(
                 integration.TMP, "{0}_testfile".format(minion)
             )
-            self.run_cp("minion {0} {1}".format(self.testfile, minion_testfile))
+            self.run_cp('{} {} {}'.format(minion, testfile, minion_testfile))
             self.assertTrue(os.path.isfile(minion_testfile))
-            self.assertTrue(open(minion_testfile, 'r').read()==self.testcontents)
+            self.assertTrue(open(minion_testfile, 'r').read() == testfile_contents)
             os.unlink(minion_testfile)
-
 
 if __name__ == "__main__":
     loader = TestLoader()

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -61,13 +61,15 @@ def run_integration_tests(opts):
         print('~' * PNUM)
         print('Max open files setting is too low({0}) for running the tests'.format(smax_open_files))
         print('Trying to raise the limit to {0}'.format(REQUIRED_OPEN_FILES))
+        if hmax_open_files < 4096:
+            hmax_open_files = 4096  # Decent default?
         try:
             resource.setrlimit(
                 resource.RLIMIT_NOFILE,
-                (REQUIRED_OPEN_FILES, 2*REQUIRED_OPEN_FILES)
+                (REQUIRED_OPEN_FILES, hmax_open_files)
             )
         except Exception, err:
-            print('ERROR: Failed to raise the max open files setting -> {0}'.format(err)))
+            print('ERROR: Failed to raise the max open files setting -> {0}'.format(err))
             print('Please issue the following command on your console:')
             print('  ulimit -n {0}'.format(REQUIRED_OPEN_FILES))
             sys.exit(1)


### PR DESCRIPTION
- `SaltCPOptionParser` was not reading any configuration file. It should!
- Fixed the `salt-cp` test which was not testing anything, until now.
- Some PEP8 fixes
