### PR TITLE
Updated jobs runner to handle printing of job return data.

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -117,3 +117,38 @@ def list_jobs():
                         'Target-type': load['tgt_type']}
     print(yaml.dump(ret))
     return ret
+
+def print_job(job_id):
+    '''
+    Print job available details, including return data.
+    '''
+    serial = salt.payload.Serial(__opts__)
+    ret = {}
+    job_dir = os.path.join(__opts__['cachedir'], 'jobs')
+    for top in os.listdir(job_dir):
+        t_path = os.path.join(job_dir, top)
+        for final in os.listdir(t_path):
+            loadpath = os.path.join(t_path, final, '.load.p')
+            if not os.path.isfile(loadpath):
+                continue
+            load = serial.load(open(loadpath, 'rb'))
+            jid = load['jid']
+            if job_id == jid:
+                hosts_path = os.path.join(t_path, final)
+                hosts_return = {}
+                for host in os.listdir(hosts_path):
+                    host_path = os.path.join(hosts_path, host)
+                    if os.path.isdir(host_path):
+                        returnfile = os.path.join(host_path, 'return.p')
+                        if not os.path.isfile(returnfile):
+                            continue
+                        return_data = serial.load(open(returnfile, 'rb'))
+                        hosts_return[host] = return_data
+                        ret[jid] = {'Start Time': salt.utils.jid_to_time(jid),
+                                    'Function': load['fun'],
+                                    'Arguments': list(load['arg']),
+                                    'Target': load['tgt'],
+                                    'Target-type': load['tgt_type'],
+                                    'Result': hosts_return}
+                        salt.output.get_outputter('yaml')(ret)
+    return ret


### PR DESCRIPTION
This should be useful when a peer publishes a command
and wants to fetch details back.
