### PR TITLE
Reduce requirements to generate keys.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -160,12 +160,17 @@ class SaltKey(parsers.SaltKeyOptionParser):
         self.parse_args()
 
         if self.config['verify_env']:
-            verify_env([
+            verify_env_dirs = []
+            if not self.config['gen_keys']:
+                verify_env_dirs.extend([
                     os.path.join(self.config['pki_dir'], 'minions'),
                     os.path.join(self.config['pki_dir'], 'minions_pre'),
                     os.path.join(self.config['pki_dir'], 'minions_rejected'),
-                    os.path.dirname(self.config['key_logfile']),
-                ],
+                    os.path.dirname(self.config['key_logfile'])
+                ])
+
+            verify_env(
+                verify_env_dirs,
                 self.config['user'],
                 permissive=self.config['permissive_pki_access'],
                 pki_dir=self.config['pki_dir'],

--- a/salt/cli/key.py
+++ b/salt/cli/key.py
@@ -25,7 +25,10 @@ class Key(object):
         self.colors = salt.utils.get_colors(
                 not bool(self.opts.get('no_color', False))
                 )
-        self._check_master()
+        if not opts.get('gen_keys', None):
+            # Only check for a master running IF we need it.
+            # While generating keys we don't
+            self._check_master()
 
     def _check_master(self):
         '''
@@ -426,6 +429,7 @@ class Key(object):
                     self.opts['gen_keys_dir'],
                     self.opts['gen_keys'],
                     self.opts['keysize'])
+            self._log('Keys generation complete', level='info')
             return
         if self.opts['list']:
             self._list(self.opts['list'])

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -402,13 +402,13 @@ class ShellCase(TestCase):
         ret['fun'] = runner.run()
         return ret
 
-    def run_key(self, arg_str):
+    def run_key(self, arg_str, catch_stderr=False):
         '''
         Execute salt-key
         '''
         mconf = os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf')
         arg_str = '-c {0} {1}'.format(mconf, arg_str)
-        return self.run_script('salt-key', arg_str)
+        return self.run_script('salt-key', arg_str, catch_stderr=catch_stderr)
 
     def run_cp(self, arg_str):
         '''


### PR DESCRIPTION
The generation of keys does not involve all the checks required to accept/deny/list keys. This code change allows:
- regular users to generate keys
- `/etc/salt` and `/var/log/salt` not to exist or not to be readable by the current user

It also does not check for a running master. We have now lowered the requirements to run this script just for generating keys.
