### PR TITLE
Raise max open files when starting master. Refs #1964

### DIFF
--- a/conf/master.template
+++ b/conf/master.template
@@ -15,6 +15,24 @@
 # The user to run salt
 #user: root
 
+# Max open files
+# Each minion connecting to the master uses AT LEAST one file descriptor, the
+# master subscription connection. If enough minions connect you might start
+# seeing on the console(and then salt-master crashes):
+#   Too many open files (tcp_listener.cpp:335)
+#   Aborted (core dumped)
+#
+# By default this value will be the one of `ulimit -Hn`, ie, the hard limit for
+# max open files.
+#
+# If you wish to set a different value than the default one, uncomment and
+# configure this setting. Remember that this value CANNOT be higher that the
+# hard limit. Raising the hard limit depends on your OS and/or distribution,
+# so go to your preferred search engine and search for(for example):
+#   raise max open files hard limit debian
+#
+#max_open_files:
+
 # The number of worker threads to start, these threads are used to manage
 # return calls made from minions to the master, if the master seems to be
 # running slowly, increase the number of threads

--- a/salt/config.py
+++ b/salt/config.py
@@ -7,6 +7,7 @@ import glob
 import os
 import socket
 import logging
+import resource
 import tempfile
 
 # import third party libs
@@ -264,6 +265,7 @@ def master_config(path):
                 },
             'client_acl': {},
             'file_buffer_size': 1048576,
+            'max_open_files': resource.getrlimit(resource.RLIMIT_NOFILE)[1],
             'hash_type': 'md5',
             'conf_file': path,
             'pub_refresh': True,

--- a/salt/master.py
+++ b/salt/master.py
@@ -196,9 +196,9 @@ class Master(SMaster):
         if mof_c > mof_h:
             # The configured value is higher than what's allowed
             log.warning(
-                'The value for \'max_open_files\' setting, {0}, is higher '
-                'than what the user running salt is allowed to raise, {1}. '
-                'Defaulting to {0}'.format(mof_c, mof_h)
+                'The value for the \'max_open_files\' setting, {0}, is higher '
+                'than what the user running salt is allowed to raise to, {1}. '
+                'Defaulting to {1}.'.format(mof_c, mof_h)
             )
             mof_c = mof_h
 


### PR DESCRIPTION
When `salt-master` starts, it checks the soft and hard limits for max open files, it then raises it's process allowed max open files to the maximum if `max_open_files` is unset on the configuration file or to the set value.
