### PR TITLE
Also skip a run_function test-case in case the minion does not reply.

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -323,6 +323,11 @@ class SyndicCase(TestCase):
         behavior of the raw function call
         '''
         orig = self.client.cmd('minion', function, arg)
+        if 'minion' not in orig:
+            self.skipTest(
+                'WARNING(SHOULD NOT HAPPEN #1935): Failed to get a reply '
+                'from the minion. Received: \'{0}\''.format(orig)
+            )
         return orig['minion']
 
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -250,7 +250,12 @@ class ModuleCase(TestCase):
             minion_tgt, function, arg, timeout=100, kwarg=kwargs
         )
 
-        if orig[minion_tgt] is None and function not in know_to_return_none:
+        if minion_tgt not in orig:
+            self.skipTest(
+                'WARNING(SHOULD NOT HAPPEN #1935): Failed to get a reply '
+                'from the minion \'{0}\''.format(minion_tgt)
+            )
+        elif orig[minion_tgt] is None and function not in know_to_return_none:
             self.skipTest(
                 'WARNING(SHOULD NOT HAPPEN #1935): Failed to get \'{0}\' from '
                 'the minion \'{1}\''.format(function, minion_tgt)


### PR DESCRIPTION
Also skip a run_function test-case in case the minion does not reply. Refs #1935.
