### PR TITLE
Improve the tests minion swarm.

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -449,11 +449,12 @@ class ShellCaseCommonTestsMixIn(object):
 
         cfgfile = os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'master')
         out, err = self.run_script(
-            self._call_binary_, "--config {0}".format(cfgfile), catch_stderr=True
+            self._call_binary_,
+            '--config {0}'.format(cfgfile),
+            catch_stderr=True
         )
         self.assertIn('Usage: {0}'.format(self._call_binary_), '\n'.join(err))
         self.assertIn('deprecated', '\n'.join(err))
-
 
     def test_version_includes_binary_name(self):
         if getattr(self, '_call_binary_', None) is None:


### PR DESCRIPTION
The `pki` and all minion's configuration directories are now all created under the same temporary directory.
The minion's ID's are now something more meaningful and less random to ease the interpretation of what's going on while running.
Minor pep-8 corrections.
