### PR TITLE
Make salt's loader differentiate internal from external resources.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -5,7 +5,6 @@ Routines to set up a minion
 # This module still needs package support, so that the functions dict
 # returned can send back functions like: foo.bar.baz
 
-
 # Import python libs
 import os
 import imp
@@ -256,9 +255,9 @@ class Loader(object):
                                 return getattr(
                                     mod, fun[fun.rindex('.') + 1:])(*arg)
                 except ImportError:
-                    log.info("Cython is enabled in options though it's not "
-                             "present in the system path. Skipping Cython "
-                             "modules.")
+                    log.info('Cython is enabled in options though it\'s not '
+                             'present in the system path. Skipping Cython '
+                             'modules.')
         return getattr(mod, fun[fun.rindex('.') + 1:])(*arg)
 
     def gen_module(self, name, functions, pack=None):
@@ -305,12 +304,12 @@ class Loader(object):
                     ), fn_, path, desc
                 )
         except ImportError as exc:
-            log.debug(('Failed to import module {0}: {1}').format(name, exc))
+            log.debug('Failed to import module {0}: {1}'.format(name, exc))
             return mod
         except Exception as exc:
             trb = traceback.format_exc()
-            log.warning(('Failed to import module {0}, this is due most'
-                ' likely to a syntax error: {1}').format(name, trb))
+            log.warning('Failed to import module {0}, this is due most likely '
+                        'to a syntax error: {1}'.format(name, trb))
             return mod
         if hasattr(mod, '__opts__'):
             mod.__opts__.update(self.opts)
@@ -429,13 +428,13 @@ class Loader(object):
                         except AttributeError:
                             continue
             except ImportError as exc:
-                log.debug(('Failed to import module {0}, this is most likely'
-                           ' NOT a problem: {1}').format(name, exc))
+                log.debug('Failed to import module {0}, this is most likely '
+                          'NOT a problem: {1}'.format(name, exc))
                 continue
             except Exception as exc:
                 trb = traceback.format_exc()
-                log.warning(('Failed to import module {0}, this is due most'
-                    ' likely to a syntax error: {1}').format(name, trb))
+                log.warning('Failed to import module {0}, this is due most '
+                            'likely to a syntax error: {1}'.format(name, trb))
                 continue
             modules.append(mod)
         for mod in modules:

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -1,5 +1,5 @@
 '''
-A conveniance system to manage jobs, both active and already run
+A convenience system to manage jobs, both active and already run
 '''
 
 # Import Python Modules
@@ -56,7 +56,7 @@ def active():
 
 def lookup_jid(jid):
     '''
-    Return the printout from a previousely executed job
+    Return the printout from a previously executed job
     '''
     def _format_ret(full_ret):
         '''
@@ -78,7 +78,9 @@ def lookup_jid(jid):
         ret = formatted[0]
         out = formatted[1]
     else:
-        ret = SaltException('Job {0} hasn\'t finished. No data yet :('.format(jid))
+        ret = SaltException(
+            'Job {0} hasn\'t finished. No data yet :('.format(jid)
+        )
         out = ''
 
     # Determine the proper output method and run it

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -67,7 +67,7 @@ def is_empty(filename):
     try:
         return os.stat(filename).st_size == 0
     except OSError:
-        # Non-existant file or permission denied to the parent dir
+        # Non-existent file or permission denied to the parent dir
         return False
 
 
@@ -185,7 +185,7 @@ def daemonize():
     # A normal daemonization redirects the process output to /dev/null.
     # Unfortunately when a python multiprocess is called the output is
     # not cleanly redirected and the parent process dies when the
-    # multiprocessing process attemps to access stdout or err.
+    # multiprocessing process attempts to access stdout or err.
     #dev_null = open('/dev/null', 'rw')
     #os.dup2(dev_null.fileno(), sys.stdin.fileno())
     #os.dup2(dev_null.fileno(), sys.stdout.fileno())
@@ -421,12 +421,11 @@ def jid_dir(jid, cachedir, sum_type):
 
 def check_or_die(command):
     '''
-    Simple convienence function for modules to  use
-    for gracefully blowing up if a required tool is
-    not available in the system path.
+    Simple convenience function for modules to use for gracefully blowing up
+    if a required tool is not available in the system path.
 
-    Lazily import salt.modules.cmdmod to avoid any
-    sort of circular dependencies.
+    Lazily import `salt.modules.cmdmod` to avoid any sort of circular
+    dependencies.
     '''
     if command is None:
         raise CommandNotFoundError("'None' is not a valid command.")


### PR DESCRIPTION
1. Salt's loader now differentiates internal from external loaded resources, for example, internal:

```
2012-09-10 17:52:27,940 [salt.loaded.int.module.cmdmod            ][INFO    ] Executing command df -P in directory /home/vampas
```

and external:

```
2012-09-10 17:52:27,940 [salt.loaded.ext.module.cmdmod            ][INFO    ] Executing command df -P in directory /home/vampas
```

This is mostly a cosmetic change though in case for problems or when helping out a user, if we request his logs, we know what's getting loaded and from where.
1. Minor PEP-8 changes.
