### PR TITLE
Esky / bbfreeze support

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -204,6 +204,8 @@ def minion_config(path):
             'grains': {},
             'permissive_pki_access': False,
             'default_include': 'minion.d/*.conf',
+            'update_url': False,
+            'update_restart_services': [],
             }
 
     load_config(opts, path, 'SALT_MINION_CONFIG')

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -4,7 +4,11 @@ This script is used to kick off a salt minion daemon
 '''
 
 from salt.scripts import salt_minion
+from multiprocessing import freeze_support
 
 
 if __name__ == '__main__':
+    # This handles the bootstrapping code that is included with frozen
+    # scripts. It is a no-op on unfrozen code.
+    freeze_support()
     salt_minion()

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,49 @@ setup_kwargs = {'name': NAME,
                                ('share/man/man7', ['doc/man/salt.7']),
                                ],
                 'install_requires': requirements,
+                # The dynamic module loading in salt.modules makes this
+                # package zip unsafe.
+                'zip_safe': False
                 }
+
+
+# bbfreeze explicit includes
+# Sometimes the auto module traversal doesn't find everything, so we
+# explicitly add it. The auto dependency tracking especially does not work for
+# imports occurring in salt.modules, as they are loaded at salt runtime.
+# Specifying includes that don't exist doesn't appear to cause a freezing
+# error.
+freezer_includes = [
+    'zmq.core.*',
+    'zmq.utils.*',
+    'ast',
+]
+
+if sys.platform == 'win32':
+    freezer_includes.extend([
+        'win32con',
+        'win32security',
+        'ntsecuritycon'
+    ])
+elif sys.platform.startswith('linux'):
+    freezer_includes.extend([
+        'yum'
+    ])
+
+if 'bdist_esky' in sys.argv:
+    # Add the esky bdist target if the module is available
+    # may require additional modules depending on platform
+    from esky import bdist_esky
+    # bbfreeze chosen for its tight integration with distutils
+    import bbfreeze
+    options = setup_kwargs.get('options', {})
+    options['bdist_esky'] = {
+         "freezer_module": "bbfreeze",
+         "freezer_options": {
+             "includes": freezer_includes
+         }
+    }
+    setup_kwargs['options'] = options
 
 if with_setuptools:
     setup_kwargs['entry_points'] = {


### PR DESCRIPTION
This patch adds support for the Esky updating framework. A frozen app, built with the `bdist_esky` setup target can be deployed and updated as a complete application - including shared object dependencies. This patch also adds an `update()` function to the `saltutil` module, allowing the minion's software to be updated and restarted on the fly.

I've tested the freezing on Centos 6.3 64-bit, Ubuntu 10.04 64-bit, and Windows Server 2008 32-bit. As it stands, it seems like the easiest way to deploy Salt on Windows.

It needs some documentation, which I will be adding soon.
