### PR TITLE
The addition of the django module breaks using a django app from other modules

### DIFF
--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -4,6 +4,8 @@ Manage Django sites
 
 import os
 
+def __virtual__():
+    return 'django'
 
 def _get_django_admin(bin_env):
     '''


### PR DESCRIPTION
We use our Django app's models from within one of our custom salt
modules. Upon a recent upgrade we found that our custom module broke
because our **virtual** function started returning False.

Since there was a django.py file in the modules it meant that our
attempt to import django.core.management resulted in an ImportError.
