### PR TITLE
Made the docstring a bit clearer about the format of the key. Commonly

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -337,7 +337,10 @@ def set_auth_key(
         options=[],
         config='.ssh/authorized_keys'):
     '''
-    Add a key to the authorized_keys file
+    Add a key to the authorized_keys file. The "key" parameter must only be the
+    string of text that is the encoded key. If the key begins with "ssh-rsa"
+    or ends with user@host, remove those from the key before passing it to this
+    function.
 
     CLI Example::
 


### PR DESCRIPTION
if you are copying this from our .ssh/id_rsa.pub you will have the
type of key and user@host at the beginning and end of the key. The
"Invalid" message returned from set_auth_key isn't clear about why
the key is invalid, or that it's the key specifically it's complaining
about and not the user, type, or something else if it was passed.
