### PR TITLE
Some fixes for freebsdpkg module

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -7705,7 +7705,7 @@ salt \(aq*\(aq pkg.available_version <package name>
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.freebsdpkg.install(name, *args, **kwargs)
+.B salt.modules.freebsdpkg.install(name, refresh=False, repo='', **kwargs)
 Install the passed package
 .sp
 Return a dict containing the new package names and versions:
@@ -7807,20 +7807,20 @@ salt \(aq*\(aq pkg.remove <package name>
 .INDENT 0.0
 .TP
 .B salt.modules.freebsdpkg.search(pkg_name)
-Use \fIpkg search\fP if pkg is being used.
+Use \fIpkg search\fP if pkgng is being used.
 .sp
 CLI Example:
 .sp
 .nf
 .ft C
-salt \(aq*\(aq pkg.pkgng_search \(aqmysql\-server\(aq
+salt \(aq*\(aq pkg.search \(aqmysql\-server\(aq
 .ft P
 .fi
 .UNINDENT
 .INDENT 0.0
 .TP
 .B salt.modules.freebsdpkg.upgrade()
-Run a full system upgrade, a \fBfreebsd\-update fetch install\fP
+Run \fBpkg upgrade\fP, if pkgng used. Otherwise do nothing
 .sp
 Return a dict containing the new package names and versions:
 .sp


### PR DESCRIPTION
*) Handle refresh param in install()
*) Fix upgrade(): freebsd-update does'nt care about packages, it's about OS itself. But there is not easy way to upgrade package with old package system.
*) Fix docstring example in search()
*) Bring the changes above to the man page
