### PR TITLE
Rework os, osrelease, and oscodename grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -18,6 +18,13 @@ import socket
 import sys
 import re
 import platform
+
+# Extend the default list of supported distros. This will be used for the
+# /etc/DISTRO-release checking that is part of platform.linux_distribution()
+from platform import _supported_dists
+_supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
+                     'slamd64', 'enterprise', 'ovs', 'system')
+
 import salt.utils
 
 # Solve the Chicken and egg problem where grains need to run before any
@@ -26,38 +33,21 @@ import salt.modules.cmdmod
 __salt__ = {'cmd.run': salt.modules.cmdmod._run_quiet}
 
 
-def _kernel():
-    '''
-    Return the kernel type
-    '''
-    # Provides:
-    # kernel
-    grains = {}
-    grains['kernel'] = __salt__['cmd.run']('uname -s').strip()
-
-    if grains['kernel'] == 'aix':
-        grains['kernelrelease'] = __salt__['cmd.run']('oslevel -s').strip()
-    else:
-        grains['kernelrelease'] = __salt__['cmd.run']('uname -r').strip()
-    if 'kernel' not in grains:
-        grains['kernel'] = 'Unknown'
-    if not grains['kernel']:
-        grains['kernel'] = 'Unknown'
-    return grains
-
-
 def _windows_cpudata():
     '''
     Return the cpu information for Windows systems architecture
     '''
     # Provides:
     #   cpuarch
-    #   num_cpus
     #   cpu_model
     grains = {}
-    grains['cpuarch'] = platform.machine()
     if 'NUMBER_OF_PROCESSORS' in os.environ:
-        grains['num_cpus'] = os.environ['NUMBER_OF_PROCESSORS']
+        # Cast to int so that the logic isn't broken when used as a
+        # conditional in templating. Also follows _linux_cpudata()
+        try:
+            grains['num_cpus'] = int(os.environ['NUMBER_OF_PROCESSORS'])
+        except ValueError:
+            grains['num_cpus'] = 1
     grains['cpu_model'] = platform.processor()
     return grains
 
@@ -67,25 +57,11 @@ def _linux_cpudata():
     Return the cpu information for Linux systems architecture
     '''
     # Provides:
-    #   cpuarch
     #   num_cpus
     #   cpu_model
     #   cpu_flags
     grains = {}
     cpuinfo = '/proc/cpuinfo'
-    # Grab the Arch
-    arch = __salt__['cmd.run']('uname -m').strip()
-    grains['cpuarch'] = arch
-    # Some systems such as Debian don't like uname -m
-    # so fallback gracefully to the processor type
-    if not grains['cpuarch'] or grains['cpuarch'] == 'unknown':
-        arch = __salt__['cmd.run']('uname -p')
-        grains['cpuarch'] = arch
-    if not grains['cpuarch'] or grains['cpuarch'] == 'unknown':
-        arch = __salt__['cmd.run']('uname -i')
-        grains['cpuarch'] = arch
-    if not grains['cpuarch'] or grains['cpuarch'] == 'unknown':
-        grains['cpuarch'] = 'Unknown'
     # Parse over the cpuinfo file
     if os.path.isfile(cpuinfo):
         for line in open(cpuinfo, 'r').readlines():
@@ -126,8 +102,8 @@ def _bsd_cpudata(osdata):
     grains['cpu_flags'] = []
     try:
         grains['num_cpus'] = int(grains['num_cpus'])
-    except Exception:
-        grains['num_cpus'] = 0
+    except ValueError:
+        grains['num_cpus'] = 1
 
     return grains
 
@@ -319,33 +295,11 @@ def _ps(osdata):
         grains['ps'] = 'ps -efH'
     return grains
 
-
-def _linux_platform_data(osdata):
-    '''
-    The platform module is very smart about figuring out linux distro
-    information. Instead of re-inventing the wheel, lets use it!
-    '''
-    # Provides:
-    #    osrelease
-    #    oscodename
-    grains = {}
-    (osname, osrelease, oscodename) = platform.dist()
-    if 'os' not in osdata and osname:
-        grains['os'] = osname
-    if osrelease:
-        grains['osrelease'] = osrelease
-    if oscodename:
-        grains['oscodename'] = oscodename
-    return grains
-
-
 def _windows_platform_data(osdata):
     '''
     Use the platform module for as much as we can.
     '''
     # Provides:
-    #    osrelease
-    #    osversion
     #    osmanufacturer
     #    manufacturer
     #    productname
@@ -356,13 +310,6 @@ def _windows_platform_data(osdata):
     #    windowsdomain
 
     grains = {}
-    (osname, hostname, osrelease, osversion, machine, processor) = platform.uname()
-    if 'os' not in osdata and osname:
-        grains['os'] = osname
-    if osrelease:
-        grains['osrelease'] = osrelease
-    if osversion:
-        grains['osversion'] = osversion
     get_these_grains = {
         'OS Manufacturer': 'osmanufacturer',
         'System Manufacturer': 'manufacturer',
@@ -392,145 +339,103 @@ def id_():
     return {'id': __opts__['id']}
 
 
+_os_family_map = {
+    'Ubuntu': 'Debian',
+    'Fedora': 'RedHat',
+    'CentOS': 'RedHat',
+    'GoOSe': 'RedHat',
+    'Scientific': 'RedHat',
+    'Amazon': 'RedHat',
+    'Mandrake': 'Mandriva',
+    'ESXi': 'VMWare',
+    'VMWareESX': 'VMWare',
+    'Bluewhite64': 'Bluewhite',
+    'Slamd64': 'Slackware',
+    'OVS': 'Oracle',
+    'OEL': 'Oracle',
+    'SLES': 'Suse',
+    'SLED': 'Suse',
+    'openSUSE': 'Suse',
+    'SUSE': 'Suse'
+}
+
+
 def os_data():
     '''
     Return grains pertaining to the operating system
     '''
     grains = {}
-    if 'os' in os.environ:
-        if os.environ['os'].startswith('Windows'):
-            grains['os'] = 'Windows'
-            grains['os_family'] = 'Windows'
-            grains['kernel'] = 'Windows'
-            grains.update(_memdata(grains))
-            grains.update(_windows_platform_data(grains))
-            grains.update(_windows_cpudata())
-            grains.update(_ps(grains))
-            return grains
-    grains.update(_kernel())
-
-    if grains['kernel'] == 'Linux':
+    # Windows Server 2008 64-bit
+    # ('Windows', 'MINIONNAME', '2008ServerR2', '6.1.7601', 'AMD64', 'Intel64 Fam ily 6 Model 23 Stepping 6, GenuineIntel')
+    # Ubuntu 10.04
+    # ('Linux', 'FIRE66VMA01', '2.6.32-38-server', '#83-Ubuntu SMP Wed Jan 4 11:26:59 UTC 2012', 'x86_64', '')
+    (grains['kernel'], grains['host'],
+     grains['kernelrelease'], version, grains['cpuarch'], _) = platform.uname()
+    if grains['kernel'] == 'Windows':
+        grains['osrelease'] = grains['kernelrelease']
+        grains['osversion'] = grains['kernelrelease'] = version
+        grains['os'] = 'Windows'
+        grains['os_family'] = 'Windows'
+        grains.update(_memdata(grains))
+        grains.update(_windows_platform_data(grains))
+        grains.update(_windows_cpudata())
+        grains.update(_ps(grains))
+        return grains
+    elif grains['kernel'] == 'Linux':
         # Add lsb grains on any distro with lsb-release
-        if os.path.isfile('/etc/lsb-release'):
-            for line in open('/etc/lsb-release').readlines():
-                # Matches any possible format:
-                #     DISTRIB_ID="Ubuntu"
-                #     DISTRIB_ID='Mageia'
-                #     DISTRIB_ID=Fedora
-                #     DISTRIB_RELEASE='10.10'
-                #     DISTRIB_CODENAME='squeeze'
-                #     DISTRIB_DESCRIPTION='Ubuntu 10.10'
-                regex = re.compile('^(DISTRIB_(?:ID|RELEASE|CODENAME|DESCRIPTION))=(?:\'|")?([\w\s\.-_]+)(?:\'|")?')
-                match = regex.match(line)
-                if match:
-                    # Adds: lsb_distrib_{id,release,codename,description}
-                    grains['lsb_{0}'.format(match.groups()[0].lower())] = match.groups()[1].rstrip()
         try:
             import lsb_release
             release = lsb_release.get_distro_information()
             for key, value in release.iteritems():
                 grains['lsb_{0}'.format(key.lower())] = value  # override /etc/lsb-release
         except ImportError:
-            pass
-        if os.path.isfile('/etc/arch-release'):
-            grains['os'] = 'Arch'
-            grains['os_family'] = 'Arch'
-        elif os.path.isfile('/etc/debian_version'):
-            grains['os'] = 'Debian'
-            grains['os_family'] = 'Debian'
-            if 'lsb_distrib_id' in grains:
-                if 'Ubuntu' in grains['lsb_distrib_id']:
-                    grains['os'] = 'Ubuntu'
-                elif os.path.isfile('/etc/issue.net') and \
-                  'Ubuntu' in open('/etc/issue.net').readline():
-                    grains['os'] = 'Ubuntu'
-        elif os.path.isfile('/etc/gentoo-release'):
-            grains['os'] = 'Gentoo'
-            grains['os_family'] = 'Gentoo'
-        elif os.path.isfile('/etc/fedora-release'):
-            grains['os'] = 'Fedora'
-            grains['os_family'] = 'RedHat'
-        elif os.path.isfile('/etc/mandriva-version'):
-            grains['os'] = 'Mandriva'
-            grains['os_family'] = 'Mandriva'
-        elif os.path.isfile('/etc/mandrake-version'):
-            grains['os'] = 'Mandrake'
-            grains['os_family'] = 'Mandriva'
-        elif os.path.isfile('/etc/mageia-version'):
-            grains['os'] = 'Mageia'
-            grains['os_family'] = 'Mageia'
-        elif os.path.isfile('/etc/meego-version'):
-            grains['os'] = 'MeeGo'
-            grains['os_family'] = 'MeeGo'
-        elif os.path.isfile('/etc/vmware-version'):
-            grains['os'] = 'VMWareESX'
-            grains['os_family'] = 'VMWare'
-        elif os.path.isfile('/etc/bluewhite64-version'):
-            grains['os'] = 'Bluewhite64'
-            grains['os_family'] = 'Bluewhite'
-        elif os.path.isfile('/etc/slamd64-version'):
-            grains['os'] = 'Slamd64'
-            grains['os_family'] = 'Slackware'
-        elif os.path.isfile('/etc/slackware-version'):
-            grains['os'] = 'Slackware'
-            grains['os_family'] = 'Slackware'
-        elif os.path.isfile('/etc/enterprise-release'):
-            grains['os_family'] = 'Oracle'
-            if os.path.isfile('/etc/ovs-release'):
-                grains['os'] = 'OVS'
-            else:
-                grains['os'] = 'OEL'
-        elif os.path.isfile('/etc/redhat-release'):
-            grains['os_family'] = 'RedHat'
-            data = open('/etc/redhat-release', 'r').read()
-            if 'centos' in data.lower():
-                grains['os'] = 'CentOS'
-            elif 'scientific' in data.lower():
-                grains['os'] = 'Scientific'
-            elif 'goose' in data.lower():
-                grains['os'] = 'GoOSe'
-            else:
-                grains['os'] = 'RedHat'
-        elif os.path.isfile('/etc/system-release'):
-            grains['os_family'] = 'RedHat'
-            data = open('/etc/system-release', 'r').read()
-            if 'amazon' in data.lower():
-                grains['os'] = 'Amazon'
-        elif os.path.isfile('/etc/SuSE-release'):
-            grains['os_family'] = 'Suse'
-            data = open('/etc/SuSE-release', 'r').read()
-            if 'SUSE LINUX Enterprise Server' in data:
-                grains['os'] = 'SLES'
-            elif 'SUSE LINUX Enterprise Desktop' in data:
-                grains['os'] = 'SLED'
-            elif 'openSUSE' in data:
-                grains['os'] = 'openSUSE'
-            else:
-                grains['os'] = 'SUSE'
+            # if the python library isn't available, default to regex
+            if os.path.isfile('/etc/lsb-release'):
+                for line in open('/etc/lsb-release').readlines():
+                    # Matches any possible format:
+                    #     DISTRIB_ID="Ubuntu"
+                    #     DISTRIB_ID='Mageia'
+                    #     DISTRIB_ID=Fedora
+                    #     DISTRIB_RELEASE='10.10'
+                    #     DISTRIB_CODENAME='squeeze'
+                    #     DISTRIB_DESCRIPTION='Ubuntu 10.10'
+                    regex = re.compile('^(DISTRIB_(?:ID|RELEASE|CODENAME|DESCRIPTION))=(?:\'|")?([\w\s\.-_]+)(?:\'|")?')
+                    match = regex.match(line)
+                    if match:
+                        # Adds: lsb_distrib_{id,release,codename,description}
+                        grains['lsb_{0}'.format(match.groups()[0].lower())] = match.groups()[1].rstrip()
         # Use the already intelligent platform module to get distro info
-        grains.update(_linux_platform_data(grains))
-        # If the Linux version can not be determined
-        if not 'os' in grains:
-            grains['os'] = 'Unknown {0}'.format(grains['kernel'])
-            grains['os_family'] = 'Unknown'
+        (osname, osrelease, oscodename) = platform.linux_distribution(
+                                              supported_dists=_supported_dists)
+        # Try to assign these three names based on the lsb info, they tend to
+        # be more accurate than what python gets from /etc/DISTRO-release.
+        # It's worth noting that Ubuntu has patched their Python distribution
+        # so that platform.linux_distribution() does the /etc/lsb-release
+        # parsing, but we do it anyway here for the sake for full portability.
+        grains['os'] = grains.get('lsb_distrib_id', osname)
+        grains['osrelease'] = grains.get('lsb_distrib_release', osrelease)
+        grains['oscodename'] = grains.get('lsb_distrib_codename', oscodename)
+        grains.update(_linux_cpudata())
     elif grains['kernel'] == 'SunOS':
         grains['os'] = 'Solaris'
-        grains['os_family'] = 'Solaris'
         grains.update(_sunos_cpudata(grains))
     elif grains['kernel'] == 'VMkernel':
         grains['os'] = 'ESXi'
-        grains['os_family'] = 'VMWare'
     elif grains['kernel'] == 'Darwin':
         grains['os'] = 'MacOS'
-        grains['os_family'] = 'MacOS'
         grains.update(_bsd_cpudata(grains))
     else:
         grains['os'] = grains['kernel']
-        grains['os_family'] = grains['kernel']
-    if grains['kernel'] == 'Linux':
-        grains.update(_linux_cpudata())
-    elif grains['kernel'] in ('FreeBSD', 'OpenBSD'):
+    if grains['kernel'] in ('FreeBSD', 'OpenBSD'):
         grains.update(_bsd_cpudata(grains))
+    if not grains['os']:
+        grains['os'] = 'Unknown {0}'.format(grains['kernel'])
+        grains['os_family'] = 'Unknown'
+    else:
+        # this assigns family names based on the os name
+        # family defaults to the os name if not found
+        grains['os_family'] = _os_family_map.get(grains['os'],
+                                                 grains['os'])
 
     grains.update(_memdata(grains))
 
@@ -555,14 +460,9 @@ def hostname():
     #   localhost
     #   domain
     grains = {}
-    grains['fqdn'] = socket.getfqdn()
-    comps = grains['fqdn'].split('.')
-    grains['host'] = comps[0]
     grains['localhost'] = socket.gethostname()
-    if len(comps) > 1:
-        grains['domain'] = '.'.join(comps[1:])
-    else:
-        grains['domain'] = ''
+    grains['fqdn'] = socket.getfqdn()
+    (grains['host'], grains['domain']) = grains['fqdn'].partition('.')[::2]
     return grains
 
 


### PR DESCRIPTION
- Rework the above three grains
- Rework data flow for Windows and Linux core grains
- Optimize some repeated calls

As noted in #2054, I had some issues when using CentOS-built frozen installs on Ubuntu. The grains were incorrect and insisted that my Ubuntu box was Debian Sid. This comes about from some custom patches that Ubuntu runs to read `/etc/lsb-release` before `/etc/debian-release` in `platform.linux_distribution()`

I've also taken the liberty of optimizing some of the code paths. There were some unnecessary calls to the command-line `uname` when Python's own `platform.uname()` provides the info we want. I removed the massive switchblock to read `/etc/DISTRO-release` and instead am using functionality from `platform.linux_distribution()`. As part of that cleanup I added an `os` -> `os_family` map.

I've tested these changes on CentOS 6.3 and Ubuntu 10.04 as well as a frozen build from CentOS 6.3 _on_ Ubuntu 10.04. I also tested Windows Server 2008 R2. All the grains produce the same exact values as from an unmodified tree (except for the new `'kernelversion'` grain on Windows , and `'num_cpus'` is now an integer on Windows).
