### PR TITLE
Add ifmain to make setup.py import safe

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -199,4 +199,5 @@ else:
                                'scripts/salt-run',
                                'scripts/salt']
 
-setup(**setup_kwargs)
+if __name__ == '__main__':
+    setup(**setup_kwargs)


### PR DESCRIPTION
This makes setup.py import safe. Some of us would like to customize the build process to our own environment. Now we can do it without maintaining a separate patchset.
