### PR TITLE
Add 'distutils.version' to bbfreeze includes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -145,7 +145,8 @@ freezer_includes = [
     'zmq.utils.*',
     'ast',
     'difflib',
-    'distutils'
+    'distutils',
+    'distutils.version'
 ]
 
 if sys.platform.startswith('win'):


### PR DESCRIPTION
This fixes a bug on frozen Linux builds. Without `distutils.version` the `pkg` state can't import `LooseVersion`.
