### PR TITLE
Catch AttributeError on yumpkg import test

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -8,7 +8,7 @@ try:
     import rpm
     from rpmUtils.arch import getBaseArch
     has_yumdeps = True
-except ImportError:
+except (ImportError, AttributeError):
     has_yumdeps = False
 
 import logging


### PR DESCRIPTION
This resolves an issue with frightening looking error message from the `brew` module.

```
[WARNING ] Failed to import module brew, this is due most likely to a syntax error: Traceback (most recent call last):
  File "salt/loader.py", line 412, in gen_functions
    ), fn_, path, desc
  File "salt/modules/brew.py", line 2, in <module>
    from salt.modules.yumpkg import _compare_versions
  File "salt/modules/yumpkg.py", line 7, in <module>
    import yum
  File "yum/__init__.py", line 49, in <module>
AttributeError: 'module' object has no attribute 'i18n'
```

This occurs on my frozen CentOS -> Ubuntu builds. 

It comes about because the `brew` module is importing `_compare_versions()` from `salt.modules.yumpkg`. On this kind of installation, the `import yum` in the `yumpkg` module failing from an AttributeError rather than an ImportError. Must be looking for some file on the system or something.
