### PR TITLE
Fix reversed diff on file.comment

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1680,7 +1680,7 @@ def comment(name, regex, char='#', backup='.bak'):
     if slines != nlines:
         # Changes happened, add them
         ret['changes']['diff'] = (
-                ''.join(difflib.unified_diff(nlines, slines))
+                ''.join(difflib.unified_diff(slines, nlines))
                 )
 
     if ret['result']:


### PR DESCRIPTION
I have an SLS file that comments out a line like so

```
-l 127.0.0.1
```

The diff it reported was in the wrong direction:

```
----------
    State: - file
    Name:      /etc/memcached.conf
    Function:  comment
        Result:    True
        Comment:   Commented lines successfully
        Changes:   diff: ---  
+++  
@@ -32,7 +32,7 @@
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
-#-l 127.0.0.1
+-l 127.0.0.1

 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 # -c 1024

```

The value was indeed commented out correctly, so only the diff summary was broken. This pull request fixes that.
