### PR TITLE
corrected error in error message for json renderers (jinja and wempy onl...

### DIFF
--- a/salt/renderers/json_jinja.py
+++ b/salt/renderers/json_jinja.py
@@ -32,5 +32,5 @@ def render(template_file, env='', sls=''):
             sls=sls)
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
-            'Unknown render error in yaml_jinja renderer'))
+            'Unknown render error in json_jinja renderer'))
     return json.loads(tmp_data['data'])

--- a/salt/renderers/json_wempy.py
+++ b/salt/renderers/json_wempy.py
@@ -31,5 +31,5 @@ def render(template_file, env='', sls=''):
             sls=sls)
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
-            'Unknown render error in yaml_wempy renderer'))
+            'Unknown render error in json_wempy renderer'))
     return json.loads(tmp_data['data'])


### PR DESCRIPTION
...y)

The json renders for jinja and wempy had an error message indicating that they were yaml_\* renderers. I corrected this to properly reflect that it is in fact the json_\* renderers.
