### PR TITLE
Address `pip.installed` regarding weird packages setup. Fixes #2028.

### DIFF
--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -100,10 +100,19 @@ def installed(name,
     )
 
     if pip_install_call and pip_install_call['retcode']==0:
+        ret['result'] = True
+
         pkg_list = __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd)
+        if not pkg_list:
+            ret['comment'] = (
+                'There was no error installing package \'{0}\' although '
+                'it does not show when calling \'pip.freeze\'.'.format(name)
+            )
+            ret['changes']["{0}==???".format(name)] = 'Installed'
+            return ret
+
         version = list(pkg_list.values())[0]
         pkg_name = next(iter(pkg_list))
-        ret['result'] = True
         ret['changes']["{0}=={1}".format(pkg_name, version)] = 'Installed'
         ret['comment'] = 'Package was successfully installed'
     elif pip_install_call:

--- a/tests/integration/files/file/base/pip-installed-errors.sls
+++ b/tests/integration/files/file/base/pip-installed-errors.sls
@@ -1,0 +1,4 @@
+supervisord-pip:
+    pip.installed:
+      - name: supervisor
+      - bin_env: /tmp/pip-installed-errors

--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -1,0 +1,12 @@
+/tmp/pip-installed-weird-install:
+  virtualenv.managed:
+    - no_site_packages: True
+    - distribute: True
+
+carbon-weird-setup:
+  pip.installed:
+    - name: carbon
+    - no_deps: True
+    - bin_env: /tmp/pip-installed-weird-install
+    - require:
+      - virtualenv: /tmp/pip-installed-weird-install

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -53,6 +53,50 @@ class PipStateTest(integration.ModuleCase):
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
 
+    def test_pip_installed_weird_install(self):
+        ographite = '/opt/graphite'
+        if os.path.isdir(ographite):
+            self.skipTest(
+                'You already have \'{0}\'. This test would overwrite this '
+                'directory'.format(ographite)
+            )
+        try:
+            os.makedirs(ographite)
+        except OSError, err:
+            if err.errno == 13:
+                # Permission denied
+                self.skipTest(
+                    'You don\'t have the required permissions to run this test'
+                )
+        finally:
+            if os.path.isdir(ographite):
+                shutil.rmtree(ographite)
+
+        venv_dir = '/tmp/pip-installed-weird-install'
+        try:
+            # Since we don't have the virtualenv created, pip.installed will
+            # thrown and error.
+            ret = self.run_function(
+                'state.sls', mods='pip-installed-weird-install'
+            )
+            self.assertTrue(isinstance(ret, dict))
+            self.assertNotEqual(ret, {})
+
+            for key in ret.keys():
+                self.assertTrue(ret[key]['result'])
+                if ret[key]['comment'] == 'Created new virtualenv':
+                    continue
+                self.assertEqual(
+                    ret[key]['comment'],
+                    'There was no error installing package \'carbon\' '
+                    'although it does not show when calling \'pip.freeze\'.'
+                )
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
+            if os.path.isdir('/opt/graphite'):
+                shutil.rmtree('/opt/graphite')
+
     def test_issue_2028_pip_installed_state(self):
         ret = self.run_function('state.sls', mods='issue-2028-pip-installed')
 


### PR DESCRIPTION
Some packages, carbon and graphite-web for example, install their packages to a specific root, using a `virtualenv` or not. `pip freeze` won't show those packages as installed.
