### PR TITLE
Fixes 2071

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -30,8 +30,13 @@ def get_template(filename, opts, env):
         return jinja.get_template(relpath)
     else:
         # fallback for templates outside the state tree
-        with open(filename, 'r') as f:
-            return Template(f.read())
+        loader = FileSystemLoader(path.dirname(filename))
+        if opts.get('allow_undefined', False):
+            jinja = Environment(loader=loader)
+        else:
+            jinja = Environment(loader=loader, undefined=StrictUndefined)
+        relpath = path.relpath(filename, path.dirname(filename))
+        return jinja.get_template(relpath)
 
 
 class SaltCacheLoader(BaseLoader):


### PR DESCRIPTION
In short, use a Jinja Loader, reading directly from the file system can cause jinja specific directives (that the loader handles) to make the renderer confused.  #2071 is a result of this.

Fixes the ability to utilize {% include %} (and other similar jinja
specifics) in pillar data.  This is an issue since pillar is rendered
on the master but is outside the SaltCache loader's search path.
