### PR TITLE
Fix missing FileSystemLoader import

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -6,7 +6,8 @@ from os import path
 import logging
 
 # Import third-party libs
-from jinja2 import Template, BaseLoader, Environment, StrictUndefined
+from jinja2 import (Template, BaseLoader, Environment, StrictUndefined,
+                    FileSystemLoader)
 from jinja2.exceptions import TemplateNotFound
 
 # Import Salt libs


### PR DESCRIPTION
Some tweaks to the jinja template loader left out an import. Needed FileSystemLoader for line 34.
