### PR TITLE
Fix reversed diff on file.managed

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1106,8 +1106,8 @@ def managed(name,
                     nlines = name_.readlines()
                 # Print a diff equivalent to diff -u old new
                     ret['changes']['diff'] = (''.join(difflib
-                                                      .unified_diff(slines,
-                                                                    nlines)))
+                                                      .unified_diff(nlines,
+                                                                    slines)))
             # Pre requisites are met, and the file needs to be replaced, do it
             try:
                 salt.utils.copyfile(


### PR DESCRIPTION
I recently made some updates to config files with `file.managed` and found that the diff was reversed.

```
----------
    State: - file
    Name:      /etc/supervisord.d/salt-bridge.conf
    Function:  managed
        Result:    True
        Comment:   File /etc/supervisord.d/salt-bridge.conf updated
        Changes:   diff: ---  
+++  
@@ -1,4 +1,4 @@
-[program:salt-bridge]
+[program: salt-bridge]
```

In this case, I was removing that whitespace, not adding it.

I've read through the code a couple times to make sure I hadn't misunderstood it. I think the confusion comes from #2077 where the code is `unified_diff(slines, nlines)`. After reading the code related to #2077, I found that the file variables were just named inappropriately in `file.comment`.  In that commit `slines` ends up being the original unmodified file, and `nlines` is read into memory after the `file.comment` module is called.
