### PR TITLE
Allowing source in file.recurse to be a list object, as in file.manage. ...

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -675,6 +675,18 @@ class AESFuncs(object):
                     ret.append(os.path.relpath(root, path))
         return ret
 
+    def _dir_list(self, load):
+        '''
+        Return a list of all directories on the master
+        '''
+        ret = []
+        if load['env'] not in self.opts['file_roots']:
+            return ret
+        for path in self.opts['file_roots'][load['env']]:
+            for root, dirs, files in os.walk(path, followlinks=True):
+                ret.append(os.path.relpath(root, path))
+        return ret
+
     def _master_opts(self, load):
         '''
         Return the master options to the minion

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -200,6 +200,18 @@ def list_master(env='base'):
     return client.file_list(env)
 
 
+def list_master_dirs(env='base'):
+    '''
+    List all of the directories stored on the master
+
+    CLI Exmaple::
+
+        salt '*' cp.list_master_dirs
+    '''
+    client = salt.fileclient.get_file_client(__opts__)
+    return client.dir_list(env)
+
+
 def list_minion(env='base'):
     '''
     List all of the files cached on the minion

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -286,6 +286,7 @@ def _source_list(source, source_hash, env):
     if isinstance(source, list):
         # get the master file list
         mfiles = __salt__['cp.list_master'](env)
+        mdirs = __salt__['cp.list_master_dirs'](env)
         for single in source:
             if isinstance(single, dict):
                 # check the proto, if it is http or ftp then download the file
@@ -309,7 +310,7 @@ def _source_list(source, source_hash, env):
                         source_hash = single_hash
                         break
             elif isinstance(single, string_types):
-                if single[7:] in mfiles:
+                if single[7:] in mfiles or single[7:] in mdirs:
                     source = single
                     break
     return source, source_hash
@@ -1500,6 +1501,9 @@ def recurse(name,
             comments.extend(_ret['comment'])
         if _ret['changes']:
             ret['changes'][path] = changetype
+
+    # If source is a list, find which in the list actually exists
+    source, source_hash = _source_list(source, '', env)
 
     vdir = set()
     for fn_ in __salt__['cp.cache_dir'](source, env, include_empty):


### PR DESCRIPTION
... This also includes the to specify salt-call cp.list_master_dirs.

fixes #2106
