### PR TITLE
The pip module now uses `cmd.run_all`. Fixes #2113.

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -140,10 +140,10 @@ def _run(cmd,
         out, err = proc.communicate()
 
     if rstrip:
-        if out:
+        if out is not None:
             out = out.rstrip()
         # None lacks a rstrip() method
-        if err:
+        if err is not None:
             err = err.rstrip()
 
     ret['stdout'] = out

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -12,7 +12,7 @@ A state module to manage system installed python packages
 '''
 
 # Import Salt libs
-from salt.exceptions import CommandNotFoundError
+from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
 def installed(name,
@@ -64,9 +64,9 @@ def installed(name,
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     try:
         pip_list = __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd)
-    except CommandNotFoundError, err:
+    except (CommandNotFoundError, CommandExecutionError), err:
         ret['result'] = False
-        ret['comment'] = 'Error installing \'{0}\': \'{1}\''.format(name, err)
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
         return ret
 
     if name in pip_list:
@@ -159,11 +159,9 @@ def removed(name,
 
     try:
         pip_list = __salt__["pip.list"](bin_env=bin_env, runas=user, cwd=cwd)
-    except CommandNotFoundError, err:
+    except (CommandExecutionError, CommandNotFoundError), err:
         ret['result'] = False
-        ret['comment'] = 'Error uninstalling \'{0}\': \'{1}\''.format(
-            name, err
-        )
+        ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)
         return ret
 
     if name not in pip_list:

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -48,6 +48,17 @@ class PipModuleTest(integration.ModuleCase):
                 'a `pip` binary'.format(func)
             )
 
+    def test_pip_uninstall(self):
+        # Let's create the testing virtualenv
+        self.run_function('virtualenv.create', [self.venv_dir])
+        ret = self.run_function('pip.install', ['pep8'], bin_env=self.venv_dir)
+        self.assertEqual(ret['retcode'], 0)
+        self.assertIn('installed pep8', ret['stdout'])
+        ret = self.run_function('pip.uninstall', ['pep8'], bin_env=self.venv_dir)
+        self.assertEqual(ret['retcode'], 0)
+        self.assertIn('installed pep8', ret['stdout'])
+
+
     def tearDown(self):
         super(PipModuleTest, self).tearDown()
         if os.path.isdir(self.venv_test_dir):

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -32,7 +32,7 @@ class PipStateTest(integration.ModuleCase):
                 self.assertFalse(ret[key]['result'])
                 self.assertEqual(
                     ret[key]['comment'],
-                    'Failed to install package supervisor. Error: /bin/bash: '
+                    'Error installing \'supervisor\': /bin/bash: '
                     '/tmp/pip-installed-errors: No such file or directory'
                 )
 
@@ -136,7 +136,7 @@ class PipStateTest(integration.ModuleCase):
             self.assertFalse(ret.values()[0]['result'])
             self.assertEqual(
                 ret.values()[0]['comment'],
-                'Error installing \'pep8\': \'Could not find a `pip` binary\''
+                'Error installing \'pep8\': Could not find a `pip` binary'
             )
         finally:
             if os.path.isdir(venv_dir):


### PR DESCRIPTION
- In order to check if something went wrong while running the various pip commands using the command module, we need to know, at least, the return code, this way we can report the failure.
- `salt.modules.pip.uninstall()` now returns the `cmd.run_all` `dict` instead of a list of strings. **This breaks previous behaviour**.
- Added a test case for `salt.modules.pip.uninstall()` changes.
