### PR TITLE
Fix #2068

### DIFF
--- a/tests/integration/files/file/base/exclude-test.sls
+++ b/tests/integration/files/file/base/exclude-test.sls
@@ -1,0 +1,10 @@
+exclude:
+  - to-include-test
+
+include:
+  - include-test
+
+/tmp/exclude-test:
+  file:
+    - managed
+    - source: salt://testfile

--- a/tests/integration/files/file/base/include-test.sls
+++ b/tests/integration/files/file/base/include-test.sls
@@ -1,0 +1,7 @@
+include:
+  - to-include-test
+
+/tmp/include-test:
+  file:
+    - managed
+    - source: salt://testfile

--- a/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
@@ -5,10 +5,10 @@
     - distribute: True
 
 pep8-pip:
-    pip:
-      - installed
-      - name: pep8
-      - bin_env: /tmp/issue-2068-template-str
-      - mirrors: http://testpypi.python.org/pypi
-      - require:
-        - virtualenv: /tmp/issue-2068-template-str
+  pip:
+    - installed
+    - name: pep8
+    - bin_env: /tmp/issue-2068-template-str
+    - mirrors: http://testpypi.python.org/pypi
+    - require:
+      - virtualenv: /tmp/issue-2068-template-str

--- a/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str-no-dot.sls
@@ -1,0 +1,14 @@
+/tmp/issue-2068-template-str:
+  virtualenv:
+    - managed
+    - no_site_packages: True
+    - distribute: True
+
+pep8-pip:
+    pip:
+      - installed
+      - name: pep8
+      - bin_env: /tmp/issue-2068-template-str
+      - mirrors: http://testpypi.python.org/pypi
+      - require:
+        - virtualenv: /tmp/issue-2068-template-str

--- a/tests/integration/files/file/base/issue-2068-template-str.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str.sls
@@ -1,0 +1,12 @@
+/tmp/issue-2068-template-str:
+  virtualenv.managed:
+    - no_site_packages: True
+    - distribute: True
+
+pep8-pip:
+    pip.installed:
+      - name: pep8
+      - bin_env: /tmp/issue-2068-template-str
+      - mirrors: http://testpypi.python.org/pypi
+      - require:
+        - virtualenv: /tmp/issue-2068-template-str

--- a/tests/integration/files/file/base/issue-2068-template-str.sls
+++ b/tests/integration/files/file/base/issue-2068-template-str.sls
@@ -4,9 +4,9 @@
     - distribute: True
 
 pep8-pip:
-    pip.installed:
-      - name: pep8
-      - bin_env: /tmp/issue-2068-template-str
-      - mirrors: http://testpypi.python.org/pypi
-      - require:
-        - virtualenv: /tmp/issue-2068-template-str
+  pip.installed:
+    - name: pep8
+    - bin_env: /tmp/issue-2068-template-str
+    - mirrors: http://testpypi.python.org/pypi
+    - require:
+      - virtualenv: /tmp/issue-2068-template-str

--- a/tests/integration/files/file/base/to-include-test.sls
+++ b/tests/integration/files/file/base/to-include-test.sls
@@ -1,0 +1,4 @@
+/tmp/to-include-test:
+  file:
+    - managed
+    - source: salt://testfile

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -268,6 +268,28 @@ fi
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
 
+    def test_template_invalid_items(self):
+        TEMPLATE = '''\
+{0}:
+  - issue-2068-template-str
+
+/tmp/test-template-invalid-items:
+  file:
+    - managed
+    - source: salt://testfile
+'''
+        for item in ('include', 'exclude', 'extends'):
+            ret = self.run_function(
+                'state.template_str', [TEMPLATE.format(item)]
+            )
+            self.assertTrue(isinstance(ret, list))
+            self.assertNotEqual(ret, [])
+            self.assertEqual(
+                ['The \'{0}\' declaration found on \'<template-str>\' is '
+                 'invalid when rendering single templates'.format(item)],
+                ret
+            )
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -209,6 +209,17 @@ fi
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
 
+        # Now using state.template
+        try:
+            ret = self.run_function('state.template', [template_path])
+            self.assertTrue(isinstance(ret, dict))
+            self.assertNotEqual(ret, {})
+            for part in ret.itervalues():
+                self.assertTrue(part['result'])
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
+
         # Now the problematic #2068 including dot's
         try:
             ret = self.run_function(
@@ -242,6 +253,17 @@ fi
             self.assertTrue(
                 os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
             )
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
+
+        # Now using state.template
+        try:
+            ret = self.run_function('state.template', [template_path])
+            self.assertTrue(isinstance(ret, dict))
+            self.assertNotEqual(ret, {})
+            for part in ret.itervalues():
+                self.assertTrue(part['result'])
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -141,6 +141,35 @@ fi
         finally:
             os.unlink('/tmp/salttest/issue-1879')
 
+    def test_include(self):
+        fnames = ('/tmp/include-test', '/tmp/to-include-test')
+        try:
+            ret = self.run_function('state.sls', mods='include-test')
+            for part in ret.itervalues():
+                self.assertTrue(part['result'])
+            for fname in fnames:
+                self.assertTrue(os.path.isfile(fname))
+            self.assertFalse(os.path.isfile('/tmp/exclude-test'))
+        finally:
+            for fname in list(fnames) + ['/tmp/exclude-test']:
+                if os.path.isfile(fname):
+                    os.remove(fname)
+
+    def test_exclude(self):
+        fnames = ('/tmp/include-test', '/tmp/exclude-test')
+        try:
+            ret = self.run_function('state.sls', mods='exclude-test')
+            for part in ret.itervalues():
+                self.assertTrue(part['result'])
+            for fname in fnames:
+                self.assertTrue(os.path.isfile(fname))
+            self.assertFalse(os.path.isfile('/tmp/to-include-test'))
+        finally:
+            for fname in list(fnames) + ['/tmp/to-include-test']:
+                if os.path.isfile(fname):
+                    os.remove(fname)
+
+
 
 
 if __name__ == '__main__':

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -1,5 +1,6 @@
 # Import python libs
 import os
+import shutil
 import integration
 
 
@@ -169,7 +170,81 @@ fi
                 if os.path.isfile(fname):
                     os.remove(fname)
 
+    def test_issue_2068_template_str(self):
+        venv_dir = '/tmp/issue-2068-template-str'
 
+        try:
+            ret = self.run_function(
+                'state.sls', mods='issue-2068-template-str-no-dot'
+            )
+            self.assertTrue(isinstance(ret, dict))
+            self.assertNotEqual(ret, {})
+            for part in ret.itervalues():
+                self.assertTrue(part['result'])
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
+
+        # Let's load the template from the filesystem. If running this state
+        # with state.sls works, so should using state.template_str
+        template_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'files', 'file', 'base', 'issue-2068-template-str-no-dot.sls'
+        )
+
+        template = open(template_path, 'r').read()
+        try:
+            ret = self.run_function('state.template_str', [template])
+
+            self.assertTrue(isinstance(ret, dict)), ret
+            self.assertNotEqual(ret, {})
+
+            for key in ret.iterkeys():
+                self.assertTrue(ret[key]['result'])
+
+            self.assertTrue(
+                os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
+            )
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
+
+        # Now the problematic #2068 including dot's
+        try:
+            ret = self.run_function(
+                'state.sls', mods='issue-2068-template-str'
+            )
+            self.assertTrue(isinstance(ret, dict))
+            self.assertNotEqual(ret, {})
+            for part in ret.itervalues():
+                self.assertTrue(part['result'])
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
+
+        # Let's load the template from the filesystem. If running this state
+        # with state.sls works, so should using state.template_str
+        template_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'files', 'file', 'base', 'issue-2068-template-str.sls'
+        )
+
+        template = open(template_path, 'r').read()
+        try:
+            ret = self.run_function('state.template_str', [template])
+
+            self.assertTrue(isinstance(ret, dict)), ret
+            self.assertNotEqual(ret, {})
+
+            for key in ret.iterkeys():
+                self.assertTrue(ret[key]['result'])
+
+            self.assertTrue(
+                os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
+            )
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)
 
 
 if __name__ == '__main__':

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -114,33 +114,6 @@ class PipStateTest(integration.ModuleCase):
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
 
-    def test_issue_2028_pip_installed_template(self):
-        venv_dir = '/tmp/issue-2028-pip-installed'
-
-        # Let's load the template from the filesystem. If from state it works
-        # so should like this.
-        template_path = os.path.join(
-            os.path.dirname(os.path.dirname(__file__)),
-            'files', 'file', 'base', 'issue-2028-pip-installed.sls'
-        )
-
-        template = open(template_path, 'r').read()
-        try:
-            ret = self.run_function('state.template_str', [template])
-
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-
-            self.assertTrue(
-                os.path.isfile(os.path.join(venv_dir, 'bin', 'supervisord'))
-            )
-        finally:
-            if os.path.isdir(venv_dir):
-                shutil.rmtree(venv_dir)
-
     def test_issue_2087_missing_pip(self):
         venv_dir = '/tmp/issue-2087-missing-pip'
         try:

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -71,3 +71,35 @@ class PipStateTest(integration.ModuleCase):
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
+
+    def test_issue_2028_pip_installed_template(self):
+        venv_dir = '/tmp/issue-2028-pip-installed'
+        template = '''
+/tmp/issue-2028-pip-installed:
+  virtualenv.managed:
+    - no_site_packages: True
+    - distribute: True
+
+
+supervisord-pip:
+    pip.installed:
+      - name: supervisor
+      - bin_env: /tmp/issue-2028-pip-installed
+      - require:
+        - virtualenv: /tmp/issue-2028-pip-installed
+'''
+        try:
+            ret = self.run_function('state.template_str', [template])
+
+            self.assertTrue(isinstance(ret, dict)), ret
+            self.assertNotEqual(ret, {})
+
+            for key in ret.iterkeys():
+                self.assertTrue(ret[key]['result'])
+
+            self.assertTrue(
+                os.path.isfile(os.path.join(venv_dir, 'bin', 'supervisord'))
+            )
+        finally:
+            if os.path.isdir(venv_dir):
+                shutil.rmtree(venv_dir)

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -116,20 +116,15 @@ class PipStateTest(integration.ModuleCase):
 
     def test_issue_2028_pip_installed_template(self):
         venv_dir = '/tmp/issue-2028-pip-installed'
-        template = '''
-/tmp/issue-2028-pip-installed:
-  virtualenv.managed:
-    - no_site_packages: True
-    - distribute: True
 
+        # Let's load the template from the filesystem. If from state it works
+        # so should like this.
+        template_path = os.path.join(
+            os.path.dirname(os.path.dirname(__file__)),
+            'files', 'file', 'base', 'issue-2028-pip-installed.sls'
+        )
 
-supervisord-pip:
-    pip.installed:
-      - name: supervisor
-      - bin_env: /tmp/issue-2028-pip-installed
-      - require:
-        - virtualenv: /tmp/issue-2028-pip-installed
-'''
+        template = open(template_path, 'r').read()
         try:
             ret = self.run_function('state.template_str', [template])
 


### PR DESCRIPTION
Previously using `state.template` or `state.template_str` would not be checked/rendered into proper formatting resulting in some templates not being correctly executed. For example, the following template worked:

```
/tmp/issue-2068-template-str:
  virtualenv:
    - managed
    - no_site_packages: True
    - distribute: True

pep8-pip:
  pip:
    - installed
    - name: pep8
    - bin_env: /tmp/issue-2068-template-str
    - mirrors: http://testpypi.python.org/pypi
    - require:
      - virtualenv: /tmp/issue-2068-template-str
```

as opposed to the following which did not work:

```
/tmp/issue-2068-template-str:
  virtualenv.managed:
    - no_site_packages: True
    - distribute: True

pep8-pip:
  pip.installed:
    - name: pep8
    - bin_env: /tmp/issue-2068-template-str
    - mirrors: http://testpypi.python.org/pypi
    - require:
      - virtualenv: /tmp/issue-2068-template-str
```

The dotted names should be converted into lists for example, which was the problems with the two examples above.
