### PR TITLE
Fix Docstring reference to httpd in nginx module

### DIFF
--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -35,7 +35,7 @@ def version():
 
 def signal(signal=None):
     '''
-    Signals httpd to start, restart, or stop.
+    Signals nginx to start, restart, or stop.
 
     CLI Example::
 


### PR DESCRIPTION
The Docstring of the signal function in the nginx module still referred to
'httpd' instead of 'nginx'.
