### PR TITLE
Generic keyword argument usage documentation

### DIFF
--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -135,6 +135,22 @@ Calling the Function
 The function to call on the specified target is placed after the target
 specification.
 
+.. versionadded:: 0.9.8
+
+Functions may also accept arguments, space-delimited:
+
+.. code-block:: bash
+
+    salt '*' cmd.exec_code python 'import sys; print sys.version'
+
+Optional, keyword arguments are also supported:
+
+.. code-block:: bash
+
+    salt '*' pip.install salt timeout=5 upgrade=True
+
+They are always in the form of ``kwarg=argument``. 
+
 Finding available minion functions
 ``````````````````````````````````
 

--- a/doc/topics/tutorials/modules.rst
+++ b/doc/topics/tutorials/modules.rst
@@ -65,3 +65,9 @@ arguments
 Space-delimited arguments to the function::
 
     salt '*' cmd.exec_code python 'import sys; print sys.version'
+
+Optional, keyword arguments are also supported::
+
+    salt '*' pip.install salt timeout=5 upgrade=True
+
+They are always in the form of ``kwarg=argument``.


### PR DESCRIPTION
Document how to use keyword arguments, outside of the release notes for 0.9.8 and their implicit usage in various places (e.g. module documentation). I feel like the two places I added to were appropriate, though, it's basically copy-paste from one to the other. Maybe that's not the best approach and there should be a reference. But I'll defer to your judgment.
