### PR TITLE
Improve our tests runner.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -276,6 +276,7 @@ class Publisher(multiprocessing.Process):
         super(Publisher, self).__init__()
         self.opts = opts
 
+
     def run(self):
         '''
         Bind to the interface specified in the configuration file
@@ -586,7 +587,7 @@ class AESFuncs(object):
             return {}
         ret = {}
         # The old ext_nodes method is set to be deprecated in 0.10.4
-        # and should be removed within 3-5 releases in favor of the 
+        # and should be removed within 3-5 releases in favor of the
         # "master_tops" system
         if not self.opts['external_nodes']:
             return {}

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -148,7 +148,8 @@ class TestDaemon(object):
                     self.sub_minion_opts['sock_dir'],
                     self.minion_opts['sock_dir'],
                     ],
-                   pwd.getpwuid(os.getuid())[0])
+                   pwd.getpwuid(os.getuid()).pw_name)
+
         # Set up PATH to mockbin
         self._enter_mockbin()
 


### PR DESCRIPTION
- Show an error when the user tries to use `--xml` and `xmlrunner` is not installed.
- Add support to generate HTML reports of the tests coverage.
