### PR TITLE
Update doc/topics/tutorials/bootstrap_ec2.rst

### DIFF
--- a/doc/topics/tutorials/bootstrap_ec2.rst
+++ b/doc/topics/tutorials/bootstrap_ec2.rst
@@ -23,7 +23,8 @@ Here is a sample script::
     # Install saltstack
     add-apt-repository ppa:saltstack/salt -y
     apt-get update -y
-    apt-get install salt -y
+    apt-get install salt-minion -y
+    apt-get install salt-master -y
     apt-get upgrade -y
 
     # Set salt master location and start minion


### PR DESCRIPTION
'E: Unable to locate package salt'

I think you have to install `salt-master` and `salt-minion` packages as shown on the Ubuntu install page: http://docs.saltstack.org/en/latest/topics/installation/ubuntu.html

(I assume we're on Ubuntu since we're also using Canonical CloudInit and the `apt-get` command is used)
