### PR TITLE
Fix references to __manage_mode()

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -334,8 +334,8 @@ def _check_dir_meta(
     if not group is None and group != stats['group']:
         changes['group'] = group
     # Normalize the dir mode
-    smode = __manage_mode(stats['mode'])
-    mode = __manage_mode(mode)
+    smode = __salt__['config.manage_mode'](stats['mode'])
+    mode = __salt__['config.manage_mode'](mode)
     if not mode is None and mode != smode:
         changes['mode'] = mode
     if changes:
@@ -730,7 +730,7 @@ def directory(name,
         Require other resources such as packages or files
 
     '''
-    mode = __manage_mode(mode)
+    mode = __salt__['config.manage_mode'](mode)
     ret = {'name': name,
            'changes': {},
            'result': True,


### PR DESCRIPTION
__manage_mode() was moved to the new "config" module. Thought I had caught all references to this function in the existing code, but I missed a few, sorry. This should fix all (or at least most) of the issues encountered in testing (https://travis-ci.org/?_escaped_fragment_=/saltstack/salt/jobs/2639479#!/saltstack/salt/jobs/2639479).
