### PR TITLE
fix function definition for _check_recurse

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -186,7 +186,7 @@ def _error(ret, err_msg):
     return ret
 
 
-def check_recurse(
+def _check_recurse(
         name,
         source,
         clean,


### PR DESCRIPTION
I had initially moved this to the file module along with other pieces
that were moved to implement issue #817, but moved it back to the file
state and did not put the leading underscore back in the function
definition.
