### PR TITLE
0.10.3

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,7 +2,7 @@ salt (0.10.3) precise; urgency=low
 
   * New upstream version
 
- -- Thomas S Hatch <thatch@saltstack.com>  Sun, 30 Aug 2012 13:34:10 -0700
+ -- Tom Vaughan <thomas.david.vaughan@gmail.com>  Sun, 30 Aug 2012 13:34:10 -0700
 
 salt (0.10.2) precise; urgency=low
 

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,7 +1,7 @@
 Format: http://dep.debian.net/deps/dep5
 Upstream-Name: salt
 Upstream-Contact: salt-users@googlegroups.com
-Source: https://github.com/downloads/saltstack/salt/salt-0.9.9.tar.gz
+Source: https://github.com/downloads/saltstack/salt/salt-0.10.3.tar.gz
 
 Files: *
 Copyright: 2012 Thomas S Hatch <thatch45@gmail.com>


### PR DESCRIPTION
Sorry @thatch45. I don't mean to steal your thunder, but the person who creates the debian package needs to be the one listed in the changelog entry for whichever version is built (0.10.3 in this case) because it is this person's key that is used to sign the debian package. And a version number may only ever be listed once. This was just the quickest way to get a new .deb built in the Launchpad PPA.

For future reference, to upload a new version to the Launchpad PPA:

```
Create a new debian/changelog entry
Run `debuild -S`
cd ..
dput ppa:saltstack/salt salt_0.10.3_source.changes
```
