### PR TITLE
Add stack trace to ext_pillar load failures.

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -327,7 +327,7 @@ class Pillar(object):
                     else:
                         ext.update(self.ext_pillars[key](val))
                 except Exception:
-                    log.critical('Failed to load ext_pillar {0}'.format(key))
+                    log.exception('Failed to load ext_pillar {0}'.format(key))
         return ext
 
     def compile_pillar(self):


### PR DESCRIPTION
This adds the stack trace to exceptions on ext_pillar load.

```
[ERROR   ] Failed to load ext_pillar mongo
Traceback (most recent call last):
  File "/.firehost/venvs/salt/lib/python2.6/site-packages/salt/pillar/__init__.py", line 324, in ext_pillar
    ext.update(self.ext_pillars[key](**val))
  File "/.firehost/venvs/salt/lib/python2.6/site-packages/salt/pillar/mongo.py", line 107, in ext_pillar
    conn = pymongo.Connection(__opts__['mongo.host'], __opts__['mongo.port'])
  File "/.firehost/venvs/salt/lib/python2.6/site-packages/pymongo/connection.py", line 290, in __init__
    self.__find_node()
  File "/.firehost/venvs/salt/lib/python2.6/site-packages/pymongo/connection.py", line 586, in __find_node
    raise AutoReconnect(', '.join(errors))
AutoReconnect: could not connect to mongo1:27017: timed out, could not connect to mongo2:27017: timed out, could not connect to mongo3:27017: timed out
```
