### PR TITLE
Add Subnet/IP address matcher

### DIFF
--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -94,7 +94,11 @@ Options
 .. option:: -N, --nodegroup
 
     Use a predefined compound target defined in the Salt master configuration
-    file
+    file.
+
+.. option:: -S, --ipcidr
+
+    Match based on Subnet (CIDR notation) or IPv4 address.
 
 .. option:: -R, --range
 

--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -21,6 +21,7 @@ E      PCRE Minion id match ``E@web\d+\.(dev|qa|prod)\.loc``
 P      Grains PCRE match    ``P@os:(RedHat|Fedora|CentOS)``
 L      List of minions      ``L@minion1.example.com,minion3.domain.com and bl*.domain.com``
 I      Pillar glob match    ``I@pdata:foobar``
+S      Subnet/IP addr match ``S@192.168.1.0/24`` or ``S@192.168.1.100``
 ====== ==================== ===============================================================
 
 Matchers can be joined using boolean ``and``, ``or``, and ``not`` operators.

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -293,8 +293,6 @@ def in_subnet(cidr):
         log.error('Invalid CIDR \'{0}\''.format(cidr))
         return False
 
-    ifaces = interfaces()
-
     netstart_bin = _ipv4_to_bits(netstart)
 
     if netsize < 32 and len(netstart_bin.rstrip('0')) > netsize:
@@ -303,16 +301,39 @@ def in_subnet(cidr):
         return False
 
     netstart_leftbits = netstart_bin[0:netsize]
-    for ipv4_info in ifaces.values():
-        for ipv4 in ipv4_info.get('inet', []):
-            if ipv4['address'] == '127.0.0.1': continue
-            if netsize == 32:
-                if netstart == ipv4['address']: return True
-            else:
-                ip_leftbits = _ipv4_to_bits(ipv4['address'])[0:netsize]
-                if netstart_leftbits == ip_leftbits: return True
+    for ip_addr in ip_addrs():
+        if netsize == 32:
+            if netstart == ip_addr: return True
+        else:
+            ip_leftbits = _ipv4_to_bits(ip_addr)[0:netsize]
+            if netstart_leftbits == ip_leftbits: return True
 
     return False
+
+
+def ip_addrs():
+    '''
+    Returns a list of IPv4 addresses assigned to the host. (127.0.0.1 is
+    ignored)
+    '''
+    ret = []
+    ifaces = interfaces()
+    for ipv4_info in ifaces.values():
+        for ipv4 in ipv4_info.get('inet',[]):
+            if ipv4['address'] != '127.0.0.1': ret.append(ipv4['address'])
+    return ret
+
+
+def ip_addrs6():
+    '''
+    Returns a list of IPv6 addresses assigned to the host. (::1 is ignored)
+    '''
+    ret = []
+    ifaces = interfaces()
+    for ipv6_info in ifaces.values():
+        for ipv6 in ipv6_info.get('inet6',[]):
+            if ipv6['address'] != '::1': ret.append(ipv6['address'])
+    return ret
 
 
 def ping(host):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -487,6 +487,12 @@ class ExtendedTargetOptionsMixIn(TargetOptionsMixIn):
                   'for the target is the pillar key followed by a glob'
                   'expression:\n"role:production*"')
         )
+        group.add_option(
+            '-S', '--ipcidr',
+            default=False,
+            action='store_true',
+            help=('Match based on Subnet (CIDR notation) or IPv4 address.')
+        )
 
         self._create_process_functions()
 


### PR DESCRIPTION
This implements #653. Note that there appears to be an underlying
problem with how highstates instantiate Matcher objects, which is
keeping this from working in an SLS file. See issue #2167 for more
details on that.
