### PR TITLE
 fix grains['ps'] for BSD

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -323,7 +323,7 @@ def _ps(osdata):
     bsd_choices = ('FreeBSD', 'NetBSD', 'OpenBSD', 'MacOS')
     if osdata['os'] in bsd_choices:
         grains['ps'] = 'ps auxwww'
-    if osdata['os'] == 'Solaris':
+    elif osdata['os'] == 'Solaris':
         grains['ps'] = '/usr/ucb/ps auxwww'
     elif osdata['os'] == 'Windows':
         grains['ps'] = 'tasklist.exe'


### PR DESCRIPTION
Currently, `grains['ps']` gets set to `ps -efH` on BSD systems.

`-H` is not illegal on MacOS.  So, `salt \* status.procs` returns `ps` usage instead of list of procs.
