### PR TITLE
Switch integration `tmp` to the system's temporary directory.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi"
 
 install: pip install -r requirements.txt --use-mirrors
-script: sudo -E python setup.py test --runtests-opts='--run-destructive'
+script: sudo -E python setup.py test --runtests-opts='--run-destructive -v'
 
 notifications:
   irc:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,7 +7,6 @@ include tests/*.py
 recursive-include tests *.py
 include tests/integration/modules/files/*
 include tests/integration/files/*
-include tests/integration/tmp/_README
 include tests/unit/templates/files/*
 recursive-include doc *
 recursive-include scripts *

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -33,9 +33,6 @@ SCRIPT_DIR = os.path.join(CODE_DIR, 'scripts')
 PYEXEC = 'python{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
 
 TMP = os.path.join(tempfile.gettempdir(), 'salt-tests-tmpdir')
-if not os.path.isdir(TMP):
-    os.makedirs(TMP)
-
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
 MOCKBIN = os.path.join(INTEGRATION_TEST_DIR, 'mockbin')
 
@@ -151,6 +148,7 @@ class TestDaemon(object):
                     self.smaster_opts['sock_dir'],
                     self.sub_minion_opts['sock_dir'],
                     self.minion_opts['sock_dir'],
+                    TMP
                     ],
                    pwd.getpwuid(os.getuid()).pw_name)
 

--- a/tests/integration/tmp/_README
+++ b/tests/integration/tmp/_README
@@ -1,5 +1,0 @@
-=======
-TMP DIR
-=======
-The tmp dir is used to place files that need to be modified durring the
-execution of the test suite

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -340,12 +340,11 @@ if __name__ == '__main__':
     overall_status.extend(status)
     false_count = overall_status.count(False)
 
-    if opts.coverage:
-        print('Stopping and saving coverage info')
-        code_coverage.stop()
-        code_coverage.save()
-
     if opts.no_report:
+        if opts.coverage:
+            code_coverage.stop()
+            code_coverage.save()
+
         if false_count > 0:
             sys.exit(1)
         else:
@@ -399,8 +398,11 @@ if __name__ == '__main__':
     print_header('  Overall Tests Report  ', sep='=', centered=True, inline=True)
 
     if opts.coverage:
-        report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
+        print('Stopping and saving coverage info')
+        code_coverage.stop()
+        code_coverage.save()
 
+        report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
         print(
             '\nGenerating Coverage HTML Report Under {0!r} ...'.format(
                 report_dir


### PR DESCRIPTION
While running the tests within a VirtualBox(vagrant) machine, if the salt source is mounted using shared folders, any tests involving hard links WILL fail. Any tests involving symlinks, can be made to work by setting some properties on the VirtualBox shared folder. By moving the tests `tmp` directory to `tempfile.gettempdir()` we avoid this false test case errors.
