### PR TITLE
Rework some Windows grains to use WMI

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -350,17 +350,26 @@ def _windows_platform_data(osdata):
     import wmi
     from datetime import datetime
     wmi_c = wmi.WMI()
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394102%28v=vs.85%29.aspx
     systeminfo = wmi_c.Win32_ComputerSystem()[0]
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394239%28v=vs.85%29.aspx
     osinfo = wmi_c.Win32_OperatingSystem()[0]
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394077(v=vs.85).aspx
     biosinfo = wmi_c.Win32_BIOS()[0]
+    # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394498(v=vs.85).aspx
     timeinfo = wmi_c.Win32_TimeZone()[0]
 
+    # the name of the OS comes with a bunch of other data about the install
+    # location. For example:
+    # 'Microsoft Windows Server 2008 R2 Standard |C:\\Windows|\\Device\\Harddisk0\\Partition2'
     (osfullname, _) = osinfo.Name.split('|', 1)
     osfullname = osfullname.strip()
     grains = {
         'osmanufacturer': osinfo.Manufacturer,
         'manufacturer': systeminfo.Manufacturer,
         'productname': systeminfo.Model,
+        # bios name had a bunch of whitespace appended to it in my testing
+        # 'PhoenixBIOS 4.0 Release 6.0     '
         'biosversion': biosinfo.Name.strip(),
         'osfullname': osfullname,
         'timezone': timeinfo.Description,

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -19,6 +19,7 @@ import sys
 import re
 import platform
 import logging
+import locale
 
 # Extend the default list of supported distros. This will be used for the
 # /etc/DISTRO-release checking that is part of platform.linux_distribution()
@@ -343,30 +344,29 @@ def _windows_platform_data(osdata):
     #    productname
     #    biosversion
     #    osfullname
-    #    inputlocale
     #    timezone
     #    windowsdomain
 
-    grains = {}
-    get_these_grains = {
-        'OS Manufacturer': 'osmanufacturer',
-        'System Manufacturer': 'manufacturer',
-        'System Model': 'productname',
-        'BIOS Version': 'biosversion',
-        'OS Name': 'osfullname',
-        'Input Locale': 'inputlocale',
-        'Time Zone': 'timezone',
-        'Domain': 'windowsdomain',
-        }
-    systeminfo = __salt__['cmd.run']('SYSTEMINFO')
-    for line in  systeminfo.split('\n'):
-        comps = line.split(':', 1)
-        if not len(comps) > 1:
-            continue
-        item = comps[0].strip()
-        value = comps[1].strip()
-        if item in get_these_grains:
-            grains[get_these_grains[item]] = value
+    import wmi
+    from datetime import datetime
+    wmi_c = wmi.WMI()
+    systeminfo = wmi_c.Win32_ComputerSystem()[0]
+    osinfo = wmi_c.Win32_OperatingSystem()[0]
+    biosinfo = wmi_c.Win32_BIOS()[0]
+    timeinfo = wmi_c.Win32_TimeZone()[0]
+
+    (osfullname, _) = osinfo.Name.split('|', 1)
+    osfullname = osfullname.strip()
+    grains = {
+        'osmanufacturer': osinfo.Manufacturer,
+        'manufacturer': systeminfo.Manufacturer,
+        'productname': systeminfo.Model,
+        'biosversion': biosinfo.Name.strip(),
+        'osfullname': osfullname,
+        'timezone': timeinfo.Description,
+        'windowsdomain': systeminfo.Domain,
+    }
+
     return grains
 
 
@@ -412,10 +412,12 @@ def os_data():
     Return grains pertaining to the operating system
     '''
     grains = {}
+    (grains['defaultlanguage'],
+     grains['defaultencoding']) = locale.getdefaultlocale()
     # Windows Server 2008 64-bit
     # ('Windows', 'MINIONNAME', '2008ServerR2', '6.1.7601', 'AMD64', 'Intel64 Fam ily 6 Model 23 Stepping 6, GenuineIntel')
     # Ubuntu 10.04
-    # ('Linux', 'FIRE66VMA01', '2.6.32-38-server', '#83-Ubuntu SMP Wed Jan 4 11:26:59 UTC 2012', 'x86_64', '')
+    # ('Linux', 'MINIONNAME', '2.6.32-38-server', '#83-Ubuntu SMP Wed Jan 4 11:26:59 UTC 2012', 'x86_64', '')
     (grains['kernel'], grains['host'],
      grains['kernelrelease'], version, grains['cpuarch'], _) = platform.uname()
     if grains['kernel'] == 'Windows':

--- a/setup.py
+++ b/setup.py
@@ -163,8 +163,10 @@ if sys.platform.startswith('win'):
         'win32con',
         'win32security',
         'ntsecuritycon',
-        '_winreg'
+        '_winreg',
+        'wmi',
     ])
+    setup_kwargs['install_requires'] += '\nwmi'
 elif sys.platform.startswith('linux'):
     freezer_includes.extend([
         'yum'


### PR DESCRIPTION
This pull request comes about as a part of some discussion in #2123. This reworks some Windows grains to use WMI instead of `cmd.exe` to call `systeminfo`. Calls to `systeminfo` on my test VM take at least 1.5s.

Here's some output from my testing.

```
running old windows platform data
2012-10-05 13:22:17.390000
2012-10-05 13:22:19.250000
done running old windows platform data
===== 0:00:01.860000 ====
running new windows platform data
2012-10-05 13:22:19.250000
2012-10-05 13:22:19.515000
done running new windows platform data
===== 0:00:00.265000 ====
---------------------------
total savings: 0:00:01.595000
```

It also replaces the `'inputlocale'` grain with two more grains that come from the Python standard library: `'defaultencoding'` and `'defaultlanguage'`.

This is what it returns now for my Windows test minion:

``` yaml
timezone: (UTC-08:00) Pacific Time (US & Canada)
windowsdomain: WORKGROUP
productname: VMware Virtual Platform
defaultencoding: cp1252
defaultlanguage: en_US
biosversion: PhoenixBIOS 4.0 Release 6.0
osfullname: Microsoft Windows Server 2008 R2 Standard
osmanufacturer: Microsoft Corporation
manufacturer: VMware, Inc.
```

This is exactly the same data returned by the previous implementation in my testing (save for the re-appropriated locale grain)

This introduces a new runtime dependency for Windows through the `wmi` module. I've done my best to make sure that it gets included in the `setup.py` requirements, but it's kind of a hack. If there are better solutions for platform-specific dependencies, please let me know.
