### PR TITLE
Fix #2131

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -38,7 +38,9 @@ def _get_all_unit_files():
                       '|'.join(VALID_UNIT_TYPES) +
                       ')\s+(?P<state>.+)$')
 
-    out = __salt__['cmd.run_stdout']('systemctl --no-legend list-unit-files | col -b')
+    out = __salt__['cmd.run_stdout'](
+            'systemctl --full list-unit-files | col -b'
+    )
 
     ret = {}
     for match in rexp.finditer(out):


### PR DESCRIPTION
The --no-legend option is unnecessary, as each line is matched against a
regex to determine if it contains data about a unit file. The legend
does not match the regex and is therefore ignored.

Additionally, on my Fedora 16 VM I noticed that, even on a wide
terminal, unit names were being shortened with ellipses if they were
longer than a certain number of characters. Adding "--full" to the
systemctl command in _get_all_unit_files() fixed this.
