### PR TITLE
Fix windows meminfo

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -162,14 +162,15 @@ def _memdata(osdata):
             if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
                 grains['mem_total'] = int(comps[2].strip())
     elif osdata['kernel'] == 'Windows':
-        for line in __salt__['cmd.run']('SYSTEMINFO /FO LIST').split('\n'):
-            comps = line.split(':')
-            if not len(comps) > 1:
-                continue
-            if comps[0].strip() == 'Total Physical Memory':
-                # Windows XP use '.' as separator and Windows 2008 Server R2 use ','
-                grains['mem_total'] = int(comps[1].split()[0].replace('.', '').replace(',', ''))
-                break
+        import wmi
+        wmi_c = wmi.WMI()
+        total = 0
+        # this is a list of each stick of ram in a system
+        for mem in wmi_c.Win32_PhysicalMemory():
+            # capacity is listed in bytes
+            total += int(mem.Capacity)
+        # return memory info in gigabytes
+        grains['mem_total'] = int(total / (1024 ** 2))
     return grains
 
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -164,13 +164,12 @@ def _memdata(osdata):
     elif osdata['kernel'] == 'Windows':
         import wmi
         wmi_c = wmi.WMI()
-        total = 0
         # this is a list of each stick of ram in a system
-        for mem in wmi_c.Win32_PhysicalMemory():
-            # capacity is listed in bytes
-            total += int(mem.Capacity)
+        # WMI returns it as the string value of the number of bytes
+        tot_bytes = sum(map(lambda x: int(x.Capacity),
+                            wmi_c.Win32_PhysicalMemory()), 0)
         # return memory info in gigabytes
-        grains['mem_total'] = int(total / (1024 ** 2))
+        grains['mem_total'] = int(tot_bytes / (1024 ** 2))
     return grains
 
 


### PR DESCRIPTION
I was still unsatisfied with the ping times I would get with Windows minions that have multiprocessing enabled. 

```
[root@MASTER ~]# time salt MINION test.ping
MINIONt: True

real    0m6.376s
user    0m0.201s
sys     0m0.066s
```

I hooked up some profiling harnesses and found that about 45% of the time consumed in a ping was spent on `salt.grains.core._memdata()`. More specifically, on a call to the `cmd` module.

I stripped out the `SYSTEMINFO` call and replaced it with WMI and cut the ping time in half.

```
[root@MASTER ~]# time salt MINION test.ping
MINION: True

real    0m2.861s
user    0m0.188s
sys     0m0.073s
```

It's worth noting that there is still optimization to be done on the minion process forking in Windows. This is the same call with multiprocessing disabled:

```
[root@MASTER ~]# time salt MINION test.ping
MINION: True

real    0m0.273s
user    0m0.193s
sys     0m0.067s
```

This follows the work I did in #2177 and some of the discussion in #2123.
