### PR TITLE
Not make cpu_model grain rely on cpu0 existing

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -121,7 +121,7 @@ def _sunos_cpudata(osdata):
     grains['cpuarch'] = __salt__['cmd.run']('uname -p').strip()
     for line in __salt__['cmd.run']('/usr/sbin/psrinfo 2>/dev/null').split('\n'):
         grains['num_cpus'] += 1
-    grains['cpu_model'] = __salt__['cmd.run']('kstat -p cpu_info:0:cpu_info0:implementation').split()[1].strip()
+    grains['cpu_model'] = __salt__['cmd.run']('kstat -p cpu_info:*:*:implementation').split()[1].strip()
     
     return grains
 


### PR DESCRIPTION
In some cases, on solaris, the first cpu may not always be cpu0. This patch fixes the issue Sean mentioned here:

https://github.com/saltstack/salt/commit/9fd2a8669a7f1134205443c2f1f8724f6dca4eac#commitcomment-1964653

by making the kstat call not rely on any particular cpu# existing. It just calls all the cpu data and grabs the first one which ever # that may be.
