### PR TITLE
chgroup updates for linux and freebsd

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -223,12 +223,10 @@ def chgroups(name, groups, append=False):
     ugrps = set(list_groups(name))
     if ugrps == set(groups):
         return True
-    cmd = 'pw usermod -G {0} -n {1} '.format(','.join(groups), name)
     if append:
-        cmd += '-a'
-    __salt__['cmd.run'](cmd)
-    agrps = set(list_groups(name))
-    return len(ugrps - agrps) == 0
+        groups += ugrps
+    cmd = 'pw usermod -G {0} -n {1}'.format(','.join(groups), name)
+    return not __salt__['cmd.retcode'](cmd)
 
 
 def chfullname(name, fullname):

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -252,12 +252,11 @@ def chgroups(name, groups, append=False):
     ugrps = set(list_groups(name))
     if ugrps == set(groups):
         return True
-    cmd = 'usermod -G {0} {1} '.format(','.join(groups), name)
+    cmd = 'usermod '
     if append:
-        cmd += '-a'
-    __salt__['cmd.run'](cmd)
-    agrps = set(list_groups(name))
-    return len(ugrps - agrps) == 0
+        cmd += '-a '
+    cmd += '-G {0} {1}'.format(','.join(groups), name)
+    return not __salt__['cmd.retcode'](cmd)
 
 
 def chfullname(name, fullname):


### PR DESCRIPTION
I went to update linux and freebsd's chgroups return code so it would work properly and found a few other things off in them.
- The '-a' (append) option in usermod  on linux cannot be at the end of the command as it was, so I moved it towards the front of the command. Now the append option works for linux.
- Freebsd's 'pw usermod' doesn't have an '-a' (append) option so I removed that and handle it like I did in the solaris module. Which is just to grab the current list of groups the user is assigned to and add it to the new groups they want the user assigned to. It essentially mimics the '-a' option even though the platform doesn't provide it.
