### PR TITLE
recognize Amazon Linux properly

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -394,6 +394,7 @@ _os_name_map = {
     'redhatente': 'RedHat',
     'debian': 'Debian',
     'arch': 'Arch',
+    'amazonlinu': 'Amazon',
 }
 
 # Map the 'os' grain to the 'os_family' grain


### PR DESCRIPTION
Salt 0.10.3 has an issue with recognizing Amazon linux properly .. which cascades to broken service and package management (as they seem to be depending on known os/os_family grains

```
$ /opt/ve/system/bin/salt --version
salt 0.10.3

$ sudo /opt/ve/system/bin/salt-call grains.items | grep ' os'
  os: Amazon Linux AMI
  os_family: Amazon Linux AMI
  oscodename: ''
  osfullname: Amazon Linux AMI
  osrelease: '2012.09'

$ cat /etc/system-release
Amazon Linux AMI release 2012.09

$ python
Python 2.6.8 (unknown, Sep 17 2012, 03:13:50) 
[GCC 4.6.2 20111027 (Red Hat 4.6.2-1)] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import platform
>>> from platform import _supported_dists
>>> _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
...                      'slamd64', 'enterprise', 'ovs', 'system')
>>> platform.linux_distribution(supported_dists=_supported_dists)
('Amazon Linux AMI', '2012.09', '')
```
