### PR TITLE
Toplevel wmi import

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -27,7 +27,6 @@ from platform import _supported_dists
 _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
                      'slamd64', 'enterprise', 'ovs', 'system')
 
-
 import salt.log
 import salt.utils
 
@@ -51,6 +50,7 @@ if sys.platform.startswith('win'):
     except ImportError:
         log.exception("Unable to import Python wmi module, some core grains "
                       "will be missing")
+
 
 def _windows_cpudata():
     '''
@@ -363,7 +363,6 @@ def _windows_platform_data(osdata):
     if not has_wmi:
         return {}
 
-    from datetime import datetime
     wmi_c = wmi.WMI()
     # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394102%28v=vs.85%29.aspx
     systeminfo = wmi_c.Win32_ComputerSystem()[0]

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -27,6 +27,7 @@ from platform import _supported_dists
 _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
                      'slamd64', 'enterprise', 'ovs', 'system')
 
+
 import salt.log
 import salt.utils
 
@@ -40,6 +41,16 @@ __salt__ = {
 
 log = logging.getLogger(__name__)
 
+has_wmi = False
+if sys.platform.startswith('win'):
+    # attempt to import the python wmi module
+    # the Windows minion uses WMI for some of its grains
+    try:
+        import wmi
+        has_wmi = True
+    except ImportError:
+        log.exception("Unable to import Python wmi module, some core grains "
+                      "will be missing")
 
 def _windows_cpudata():
     '''
@@ -164,8 +175,7 @@ def _memdata(osdata):
             comps = line.split(' ')
             if comps[0].strip() == 'Memory' and comps[1].strip() == 'size:':
                 grains['mem_total'] = int(comps[2].strip())
-    elif osdata['kernel'] == 'Windows':
-        import wmi
+    elif osdata['kernel'] == 'Windows' and has_wmi:
         wmi_c = wmi.WMI()
         # this is a list of each stick of ram in a system
         # WMI returns it as the string value of the number of bytes
@@ -350,7 +360,9 @@ def _windows_platform_data(osdata):
     #    timezone
     #    windowsdomain
 
-    import wmi
+    if not has_wmi:
+        return {}
+
     from datetime import datetime
     wmi_c = wmi.WMI()
     # http://msdn.microsoft.com/en-us/library/windows/desktop/aa394102%28v=vs.85%29.aspx


### PR DESCRIPTION
This addresses some concerns that @SEJeff had with the `wmi` import in core grains in 1d97e6bcbb51cfb23f816e122d2591e028a18b4c.

Technically, the Windows minion can limp along without wmi. So I've added the `has_wmi` variable to allow it to continue without that data. But I'd like to decide if that really should be a soft failure. It doesn't seem like any of the dependent grains are 'critical', I'd just hate to find out someone's template was silently failing. (The import failure is appropriately logged)
