### PR TITLE
Fix broken esky documentation reference

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -203,7 +203,7 @@ Salt is many splendid things.
     Use Salt programmatically from your own scripts and programs easily and
     simply via ``import salt``.
 
-:doc:`Automatic Updates and Frozen Binary Deployments <ref/esky>`
+:doc:`Automatic Updates and Frozen Binary Deployments <topics/tutorials/esky>`
     Use a frozen install to make deployments easier (Even on Windows!). Or
     take advantage of automatic updates to keep your minions running your
     latest builds.


### PR DESCRIPTION
The esky stuff got moved to the new tutorials section and the link on the front page broke. This fixes that.
