### PR TITLE
Remove bash-ism from pip state test

### DIFF
--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -30,10 +30,10 @@ class PipStateTest(integration.ModuleCase):
 
             for key in ret.keys():
                 self.assertFalse(ret[key]['result'])
-                self.assertEqual(
+                self.assertRegexpMatches(
                     ret[key]['comment'],
-                    'Error installing \'supervisor\': /bin/bash: '
-                    '/tmp/pip-installed-errors: No such file or directory'
+                    'Error installing \'supervisor\': .* '
+                    '[nN]o such file or directory'
                 )
 
             # We now create the missing virtualenv


### PR DESCRIPTION
This one is pretty silly; hopefully the regex match is still specific
enough to be a good test.

% bash -c '/tmp/someenv/bin/pip install something'
bash: /tmp/someenv/bin/pip: No such file or directory

% zsh -c '/tmp/someenv/bin/pip install something'
zsh:1: no such file or directory: /tmp/someenv/bin/pip
