### PR TITLE
Add environment to duplicate id error to aid debug

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1591,9 +1591,11 @@ class BaseHighState(object):
                                 errors.append(('Detected conflicting IDs, SLS'
                                 ' IDs need to be globally unique.\n    The'
                                 ' conflicting ID is "{0}" and is found in SLS'
-                                ' "{1}" and SLS "{2}"').format(
+                                ' "{1}:{2}" and SLS "{3}:{4}"').format(
                                         id_,
+                                        highstate[id_]['__env__'],
                                         highstate[id_]['__sls__'],
+                                        state[id_]['__env__'],
                                         state[id_]['__sls__'])
                                 )
                     if state:


### PR DESCRIPTION
This adds the environment to duplicate id errors that may crop up in the rendering of the highstate. Aids debugging in multiple environments.

Original message:

```
Detected conflicting IDs, SLS IDs need to be globally unique.
The conflicting ID is "minion_pkgs" and is found in SLS "salt.minion" and SLS "salt.minion"
```

New message:

```
Detected conflicting IDs, SLS IDs need to be globally unique.
The conflicting ID is "minion_pkgs" and is found in SLS "base:salt.minion" and SLS "mgmt:salt.minion"
```
