### PR TITLE
Add envionment and sls information to extend error

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -624,9 +624,10 @@ class State(object):
             for name, body in ext_chunk.items():
                 if name not in high:
                     errors.append(
-                        'Extension {0} is not part of the high state'.format(
-                            name
-                            )
+                        'Cannot extend ID {0} in "{1}:{2}". It is not part '
+                        'of the high state.'.format(name,
+                                                    body['__env__'],
+                                                    body['__sls__'])
                         )
                     continue
                 for state, run in body.items():


### PR DESCRIPTION
This adds additional debugging information to the error presented when an ID is not available to extend. The error message now explains where the extend declaration is made.

Original:

```
Extension nginx is not part of the high state
```

Extra Crispy:

```
Cannot extend ID nginx in "mgmt:salt.master". It is not part of the high state.
```

I've followed the convention set in #2255, but it probably doesn't need quotes in this case.
