### PR TITLE
Fixes #2062 Fix error when grains are in minion.d/

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -157,7 +157,7 @@ def grains(opts):
         salt.config.load_config(
             pre_opts, opts['conf_file'], 'SALT_MINION_CONFIG'
         )
-        default_include = pre_opts.get('default_include', [])
+        default_include = pre_opts.get('default_include', opts['default_include'])
         include = pre_opts.get('include', [])
         pre_opts = salt.config.include_config(
             default_include, pre_opts, opts['conf_file'], verbose=False


### PR DESCRIPTION
Fixes #2062

If the 'default_include' directive was commented out, any grains
existing in the minion.d/*conf files would fail in states.
The grains would appear in salt-call -g
