### PR TITLE
Fix the diff orientation for check_file_meta

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1083,7 +1083,7 @@ def check_file_meta(
                     slines = src.readlines()
                     nlines = name_.readlines()
                 changes['diff'] = (
-                        ''.join(difflib.unified_diff(slines, nlines))
+                        ''.join(difflib.unified_diff(nlines, slines))
                         )
             else:
                 changes['sum'] = 'Checksum differs'


### PR DESCRIPTION
The diff orientation when applying `file.managed` in testing mode was reversed.

```
    State: - file
    Name:      /etc/sysconfig/clock
    Function:  managed
        Result:    None
        Comment:   The following values are set to be changed:
diff: ---  
+++  
@@ -1,2 +1,2 @@
-ZONE="America/Chicago"
+ZONE="UTC"
 UTC=false
```

When I double-checked the content I found that `ZONE="UTC"` was already present and that the managed state was to change it to 'America/Chicago'.

I tested the proposed patch and it works as intended.
