### PR TITLE
Add 'centoslinu' to _os_name_map

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -406,6 +406,7 @@ _os_name_map = {
     'debian': 'Debian',
     'arch': 'Arch',
     'amazonlinu': 'Amazon',
+    'centoslinu': 'CentOS',
 }
 
 # Map the 'os' grain to the 'os_family' grain


### PR DESCRIPTION
This is for fixing #2297.

I tested by adding the word 'Linux' to both `/etc/issue` and `/etc/redhat-release`. Always reports the correct grains.

``` yaml
  os: CentOS
  os_family: RedHat
  oscodename: Final
  osfullname: CentOS
  osrelease: '6.3'
```
