### PR TITLE
Run master as non-root user

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -164,7 +164,8 @@ class LocalClient(object):
         try:
             jid = salt.utils.prep_jid(
                     self.opts['cachedir'],
-                    self.opts['hash_type']
+                    self.opts['hash_type'],
+                    user = __opts__['user']
                     )
         except Exception:
             jid = ''

--- a/salt/master.py
+++ b/salt/master.py
@@ -1465,9 +1465,10 @@ class ClearFuncs(object):
                     return ''
         # Verify that the caller has root on master
         elif 'user' in clear_load:
+            if clear_load['user'] == self.opts.get('user', 'root'):
+                pass
             if clear_load['user'].startswith('sudo_'):
-                if not clear_load.pop('key') == self.key.get(getpass.getuser(), ''):
-                    return ''
+                pass
             elif clear_load['user'] == self.opts.get('user', 'root'):
                 if not clear_load.pop('key') == self.key[self.opts.get('user', 'root')]:
                     return ''

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -372,7 +372,7 @@ def required_modules_error(name, docstring):
     return msg.format(filename, ', '.join(modules))
 
 
-def prep_jid(cachedir, sum_type):
+def prep_jid(cachedir, sum_type, user='root'):
     '''
     Return a job id and prepare the job id directory
     '''


### PR DESCRIPTION
Fixes #2220

Fixes some auth logic that was preventing salt-master from sucessfully accepting commands when run as a non-root user.

@thatch45, could you check line #1470 of salt/master.py and make sure this isn't removing some unnecessary logic?
