### PR TITLE
Tolerate trailing whitespace in package metadata

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -36,12 +36,12 @@ def _parse_pkg_meta(path):
     if result['retcode'] == 0:
         for line in result['stdout'].split('\n'):
             if not name:
-                m = re.match('^Name\s*:\s*(.+)$',line)
+                m = re.match('^Name\s*:\s*(.+)\s*$',line)
                 if m:
                     name = m.group(1)
                     continue
             if not version:
-                m = re.match('^Version\s*:\s*(.+)$',line)
+                m = re.match('^Version\s*:\s*(.+)\s*$',line)
                 if m:
                     version = m.group(1)
                     continue


### PR DESCRIPTION
This is an addendum to pull req #2306 that will make _parse_pkg_meta()
tolerant of trailing whitespace, should there be any. I did this with the
yumpkg.py modifications last night and wanted to add the same support
back to my earlier modifications for pacman.
