### PR TITLE
improve states.cmd.run options support

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -204,7 +204,7 @@ def run(name,
         ret['comment'] = 'Desired working directory is not available'
         return ret
 
-    if env:
+    if env and not isinstance(env, dict):
         _env = {}
         for var in env.split():
             try:
@@ -217,10 +217,11 @@ def run(name,
 
     pgid = os.getegid()
 
-    cmd_kwargs = {'cwd': cwd,
+    cmd_kwargs = copy.deepcopy(kwargs)
+    cmd_kwargs.update({'cwd': cwd,
                   'runas': user,
                   'shell': shell or __grains__['shell'],
-                  'env': env}
+                  'env': env})
 
     try:
         cret = _run_check(cmd_kwargs, onlyif, unless, cwd, user, group, shell)


### PR DESCRIPTION
In the states.cmd.run function, inherit kwargs, so misc variables may
be passed to the modules.cmd.run function.

For env, environmental, variables, allow dicts in addition to a string.
The string is converted into a dict anyways.
