### PR TITLE
Allow `salt-call` to run as if in a "masterless" setup. Fixes #2326.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -222,6 +222,9 @@ class SaltCall(parsers.SaltCallOptionParser):
                 pki_dir=self.config['pki_dir'],
             )
 
+        if self.options.local:
+            self.config['file_client'] = 'local'
+
         caller = salt.cli.caller.Caller(self.config)
 
         if self.options.doc:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1010,6 +1010,12 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, LogLevelMixIn,
             help=('Return the documentation for the specified module or for '
                   'all modules if none are specified.')
         )
+        self.add_option(
+            '--local',
+            default=False,
+            action='store_true',
+            help='Run salt-call locally, as if there was no master running.'
+        )
 
     def _mixin_after_parsed(self):
         if not self.args and not self.options.grains_run and not self.options.doc:


### PR DESCRIPTION
Allow `salt-call` to run as if in a "masterless" setup. Fixes #2326.
