### PR TITLE
Fix test_chown_noop on MacOS X 10.8. Fixes #2328.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -88,6 +88,8 @@ def group_to_gid(group):
 
         salt '*' file.group_to_gid root
     '''
+    if not group:
+        return ''
     try:
         return grp.getgrnam(group).gr_gid
     except KeyError:


### PR DESCRIPTION
There seems to be a bug in Python 2.7 on OSX 10.8,
grp.getgrnam('') will return a map with gr_gid set to 0

This causes test_chown_noop to fail on OSX.
