### PR TITLE
Fix systemd service status.

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -166,20 +166,15 @@ def reload(name):
 # system
 def status(name, sig=None):
     '''
-    Return the status for a service via systemd, returns the PID if the service
-    is running or an empty string if the service is not running
+    Return the status for a service via systemd, returns a bool
+    whether the service is running.
 
     CLI Example::
 
         salt '*' service.status <service name>
     '''
-    ret = __salt__['cmd.run'](_systemctl_cmd('show', name))
-    index1 = ret.find('\nMainPID=')
-    index2 = ret.find('\n', index1+9)
-    mainpid = ret[index1+9:index2]
-    if mainpid == '0':
-        return ''
-    return mainpid
+    cmd = 'systemctl is-active {0}'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
 
 
 def enable(name):


### PR DESCRIPTION
Under systemd, not every service has a "Main PID" so using that to
determine whether a service was running failed for a number of useful
cases, especially services that use systemd's init script
compatibility layer.

Instead, use the 'systemctl is-active' command to determine the status
of a service.
