### PR TITLE
Systemd generalization

### DIFF
--- a/pkg/arch/salt-master.service
+++ b/pkg/arch/salt-master.service
@@ -1,0 +1,1 @@
+../salt-master.service

--- a/pkg/arch/salt-minion.service
+++ b/pkg/arch/salt-minion.service
@@ -1,0 +1,1 @@
+../salt-minion.service

--- a/pkg/arch/salt-syndic.service
+++ b/pkg/arch/salt-syndic.service
@@ -1,0 +1,1 @@
+../salt-syndic.service

--- a/pkg/rpm/salt-master.service
+++ b/pkg/rpm/salt-master.service
@@ -1,10 +1,1 @@
-[Unit]
-Description=The Salt Master Server
-After=syslog.target network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/salt-master
-
-[Install]
-WantedBy=multi-user.target
+../salt-master.service

--- a/pkg/rpm/salt-minion.service
+++ b/pkg/rpm/salt-minion.service
@@ -1,10 +1,1 @@
-[Unit]
-Description=The Salt Minion
-After=syslog.target network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/salt-minion
-
-[Install]
-WantedBy=multi-user.target
+../salt-minion.service

--- a/pkg/rpm/salt-syndic.service
+++ b/pkg/rpm/salt-syndic.service
@@ -1,10 +1,1 @@
-[Unit]
-Description=The Salt Master Server
-After=syslog.target network.target
-
-[Service]
-Type=simple
-ExecStart=/usr/bin/salt-syndic
-
-[Install]
-WantedBy=multi-user.target
+../salt-syndic.service

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=The Salt Master Server
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/salt-master
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -3,8 +3,8 @@ Description=The Salt Master Server
 After=syslog.target network.target
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/salt-master
+Type=forking
+ExecStart=/usr/bin/salt-master -d
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=The Salt Minion
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/salt-minion
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/salt-minion.service
+++ b/pkg/salt-minion.service
@@ -3,8 +3,8 @@ Description=The Salt Minion
 After=syslog.target network.target
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/salt-minion
+Type=forking
+ExecStart=/usr/bin/salt-minion -d
 
 [Install]
 WantedBy=multi-user.target

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=The Salt Master Server
+After=syslog.target network.target
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/salt-syndic
+
+[Install]
+WantedBy=multi-user.target

--- a/pkg/salt-syndic.service
+++ b/pkg/salt-syndic.service
@@ -3,8 +3,8 @@ Description=The Salt Master Server
 After=syslog.target network.target
 
 [Service]
-Type=simple
-ExecStart=/usr/bin/salt-syndic
+Type=forking
+ExecStart=/usr/bin/salt-syndic -d
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Arch's primary init daemon is now systemd, and in the future other distros could be using it as well.

So I thought it doesn't make sense to have them only in rpm. I have moved them to the general `pkg` directory,
and symlinked them to `arch` and `rpm`. Since they are much simpler and less distro-specific than init.d scripts tend to be.

I have also changed the main service files to start forking, daemonized services rather than simple ones. This would seem more appropriate if you are using systemd to manage them.

Note for the future, systemd has some neato tricks like being able to restart services whenever they crash, either always or for a certain number of times or other conditions.
