### PR TITLE
pass pillar to ext_pillar so it can manipulate it

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -304,7 +304,7 @@ class Pillar(object):
                     errors += err
         return pillar, errors
 
-    def ext_pillar(self):
+    def ext_pillar(self, pillar={}):
         '''
         Render the external pillar data
         '''
@@ -326,11 +326,11 @@ class Pillar(object):
                     continue
                 try:
                     if isinstance(val, dict):
-                        ext.update(self.ext_pillars[key](**val))
+                        ext.update(self.ext_pillars[key](pillar=pillar, **val))
                     elif isinstance(val, list):
-                        ext.update(self.ext_pillars[key](*val))
+                        ext.update(self.ext_pillars[key](*val, pillar=pillar))
                     else:
-                        ext.update(self.ext_pillars[key](val))
+                        ext.update(self.ext_pillars[key](val, pillar=pillar))
                 except Exception:
                     log.exception('Failed to load ext_pillar {0}'.format(key))
         return ext
@@ -342,7 +342,7 @@ class Pillar(object):
         top, terrors = self.get_top()
         matches = self.top_matches(top)
         pillar, errors = self.render_pillar(matches)
-        pillar.update(self.ext_pillar())
+        pillar.update(self.ext_pillar(pillar=pillar))
         errors.extend(terrors)
         if self.opts.get('pillar_opts', False):
             pillar['master'] = self.opts

--- a/salt/pillar/cmd_json.py
+++ b/salt/pillar/cmd_json.py
@@ -13,7 +13,7 @@ import json
 log = logging.getLogger(__name__)
 
 
-def ext_pillar(command):
+def ext_pillar(command, pillar={}):
     '''
     Execute a command and read the output as JSON
     '''

--- a/salt/pillar/cmd_yaml.py
+++ b/salt/pillar/cmd_yaml.py
@@ -13,7 +13,7 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def ext_pillar(command):
+def ext_pillar(command, pillar={}):
     '''
     Execute a command and read the output as YAML
     '''

--- a/salt/pillar/hiera.py
+++ b/salt/pillar/hiera.py
@@ -24,7 +24,7 @@ def __virtual__():
     return 'hiera' if salt.utils.which('hiera') else False
 
 
-def ext_pillar(conf):
+def ext_pillar(conf, pillar={}):
     '''
     Execute hiera and return the data
     '''

--- a/salt/pillar/mongo.py
+++ b/salt/pillar/mongo.py
@@ -80,7 +80,7 @@ log = logging.getLogger(__name__)
 
 
 def ext_pillar(collection='pillar', id_field='_id', re_pattern=None,
-               re_replace='', fields=None):
+               re_replace='', fields=None, pillar={}):
     """
     Connect to a mongo database and read per-node pillar information.
 

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -141,7 +141,7 @@ def _do_search(conf):
     return result
 
 
-def ext_pillar(config_file):
+def ext_pillar(config_file, pillar={}):
     '''
     Execute LDAP searches and return the aggregated data
     '''


### PR DESCRIPTION
sometimes it can be useful to just manipulate original pillar (from `pillar_roots` files), not only `dict.update` that happens in `class Pillar` .

eg:
- generate new values from others
- update some keys from external storage
