### PR TITLE
Fixes #2325  Remove extra spaces before comparison

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -113,7 +113,7 @@ def present(name,
         The information to be set in the day of day of week section. Default is
         ``*``
     '''
-    name = name.strip()
+    name = ' '.join(name.strip().split())
     ret = {'changes': {},
            'comment': '',
            'name': name,


### PR DESCRIPTION
This fix removes extra spaces in a command before comparing
to previous commands. This will cron.present from needlessly
appending the same cron job over and over.

Fixes #2325
