### PR TITLE
Strip extra spaces from command before comparison.

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -202,6 +202,7 @@ def absent(name,
         The information to be set in the day of day of week section. Default is
         ``*``
     '''
+    name = ' '.join(name.strip().split())
     ret = {'name': name,
            'result': True,
            'changes': {},


### PR DESCRIPTION
This makes  cron.absent strip spaces before comparison like cron.present
