### PR TITLE
Moved ca.py -> tls.py. Fixing up create_self_signed_cert

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -74,11 +74,14 @@ Requires(preun): initscripts
 Requires(postun): initscripts
 
 %else
-  %if 0%{?systemd_preun:1}
-    Requires(post): systemd-units
-    Requires(preun): systemd-units
-    Requires(postun): systemd-units
-  %endif
+
+%if 0%{?systemd_preun:1}
+
+Requires(post): systemd-units
+Requires(preun): systemd-units
+Requires(postun): systemd-units
+
+%endif
 
 BuildRequires: systemd-units
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -379,6 +379,7 @@ def create_csr(
 def create_self_signed_cert(
         tls_dir='tls',
         bits=2048,
+        days=365,
         CN='localhost',
         C='US',
         ST='Utah',

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -479,10 +479,10 @@ def create_self_signed_cert(
         _cert_base_path,
         tls_dir,
         CN)
-    ret += 'Created Certificate: {0}/{1}/certs/{2}.crt"').format(
+    ret.join('Created Certificate: {0}/{1}/certs/{2}.crt"'.format(
         _cert_base_path(),
         tls_dir,
-        CN)
+        CN))
 
     return ("Wrote self-signed certificate to: {0}\n"
             "Wrote private key for self-signed certificate to: {1}".format(

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -378,7 +378,7 @@ def create_csr(
 
 
 def create_self_signed_cert(
-        tls_dir='tls'
+        tls_dir='tls',
         bits=2048,
         CN='localhost',
         C='US',

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -485,14 +485,14 @@ def create_self_signed_cert(
 
     _write_cert_to_database(tls_dir, cert)
 
-    ret = "Created Private Key: {0}/{1}/certs/{2}.key\n".format(
+    ret = 'Created Private Key: {0}/{1}/certs/{2}.key\n'.format(
         _cert_base_path(),
         tls_dir,
         CN)
-    ret.join('Created Certificate: {0}/{1}/certs/{2}.crt"'.format(
+    ret += 'Created Certificate: {0}/{1}/certs/{2}.crt'.format(
         _cert_base_path(),
         tls_dir,
-        CN))
+        CN)
 
     return ret
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -486,7 +486,7 @@ def create_self_signed_cert(
     _write_cert_to_database(tls_dir, cert)
 
     ret = "Created Private Key: {0}/{1}/certs/{2}.key\n".format(
-        _cert_base_path,
+        _cert_base_path(),
         tls_dir,
         CN)
     ret.join('Created Certificate: {0}/{1}/certs/{2}.crt"'.format(

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -430,11 +430,10 @@ def create_self_signed_cert(
     if not os.path.exists('{0}/{1}/certs/'.format(_cert_base_path(), tls_dir)):
         os.makedirs("{0}/{1}/certs/".format(_cert_base_path(), tls_dir))
 
-    print '{0}/{1}/{2}.crt'.format(_cert_base_path(), tls_dir, CN)
     if os.path.exists(
             '{0}/{1}/certs/{2}.crt'.format(_cert_base_path(), tls_dir, CN)
             ):
-        return 'Certificate "{0}" already exists'.format(tls_dir)
+        return 'Certificate "{0}" already exists'.format(CN)
 
     key = OpenSSL.crypto.PKey()
     key.generate_key(OpenSSL.crypto.TYPE_RSA, bits)

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -485,7 +485,7 @@ def create_self_signed_cert(
 
     _write_cert_to_database(tls_dir, cert)
 
-    ret = "Created Private Key: {0}/{1}/certs/{2}.key".format(
+    ret = "Created Private Key: {0}/{1}/certs/{2}.key\n".format(
         _cert_base_path,
         tls_dir,
         CN)
@@ -494,10 +494,7 @@ def create_self_signed_cert(
         tls_dir,
         CN))
 
-    return ("Wrote self-signed certificate to: {0}\n"
-            "Wrote private key for self-signed certificate to: {1}".format(
-                os.path.abspath(cert_file),
-                os.path.abspath(key_file)))
+    return ret
 
 def create_ca_signed_cert(ca_name, CN, days=365):
     '''

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -376,7 +376,6 @@ def create_csr(
                     CN
                     )
 
-
 def create_self_signed_cert(
         tls_dir='tls',
         bits=2048,
@@ -441,9 +440,19 @@ def create_self_signed_cert(
     # create certificate
     cert = OpenSSL.crypto.X509()
     cert.set_version(3)
-    cert.set_subject(req.get_subject())
+
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(int(days) * 24 * 60 * 60)
+
+    cert.get_subject().C = C
+    cert.get_subject().ST = ST
+    cert.get_subject().L = L
+    cert.get_subject().O = O
+    if OU:
+        cert.get_subject().OU = OU
+    cert.get_subject().CN = CN
+    cert.get_subject().emailAddress = emailAddress
+
     cert.set_serial_number(_new_serial(tls_dir, CN))
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(key)

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -1,6 +1,7 @@
 '''
-A salt interface for running a Certificate Authority (CA)
-which provides signed/unsigned SSL certificates
+A salt module for SSL/TLS.
+Can create a Certificate Authority (CA)
+or use Self-Signed certificates.
 
 REQUIREMENT 1:
 
@@ -32,21 +33,12 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
-cert_sample_meta = {
-    'CN': 'localhost',
-    'C': 'US',
-    'ST': 'Utah',
-    'L': 'Salt Lake City',
-    'O': 'Salt Stack',
-    'emailAddress': 'salt@saltstack.org',
-}
-
 def __virtual__():
     '''
     Only load this module if the ca config options are set
     '''
     if has_ssl:
-        return 'ca'
+        return 'tls'
     return False
 
 
@@ -274,7 +266,6 @@ def create_ca(
                     ca_name
                     )
 
-
 def create_csr(
         ca_name,
         bits=2048,
@@ -386,36 +377,112 @@ def create_csr(
                     )
 
 
-def create_self_signed_cert(cert_file, key_file, bits=2048, **kwargs):
+def create_self_signed_cert(
+        tls_dir='tls'
+        bits=2048,
+        CN='localhost',
+        C='US',
+        ST='Utah',
+        L='Salt Lake City',
+        O='Salt Stack',
+        OU=None,
+        emailAddress='xyz@pdq.net'):
+
     '''
     Create a Self-Signed Certificate (CERT)
+
+    tls_dir
+        location appended to the ca.cert_base_path, default is 'tls'
+    bits
+        number of RSA key bits, default is 2048
+    CN
+        common name in the request, default is "localhost"
+    C
+        country, default is "US"
+    ST
+        state, default is "Utah"
+    L
+        locality, default is "Centerville", the city where SaltStack originated
+    O
+        organization, default is "Salt Stack"
+        NOTE: Must the same as CA certificate or an error will be raised
+    OU
+        organizational unit, default is None
+    emailAddress
+        email address for the request, default is 'xyz@pdq.net'
+
+    Writes out a Self-Signed Certificate (CERT). If the file already
+    exists, the function just returns.
+
+    If the following values were set:
+
+    ca.cert_base_path='/etc/pki/koji'
+    tls_dir='koji'
+    CN='test.egavas.org'
+
+    the resulting CERT, and corresponding key, would be written in the
+    following location:
+
+    /etc/pki/tls/certs/test.egavas.org.crt
+    /etc/pki/tls/certs/test.egavas.org.key
     '''
-    # http://blog.richardknop.com/2012/08/create-a-self-signed-x509-certificate-in-python/
 
-    # create a key pair
-    k = OpenSSL.crypto.PKey()
-    k.generate_key(OpenSSL.crypto.TYPE_RSA, bits)
+    if not os.path.exists('{0}/{1}/certs/'.format(_cert_base_path(), tls_dir)):
+        os.makedirs("{0}/{1}/certs/".format(_cert_base_path(), tls_dir))
 
-    # create a self-signed cert
+    if os.path.exists(
+            '{0}/{1}/{2}.crt'.format(_cert_base_path(), tls_dir, CN)
+            ):
+        return 'Certificate "{0}" already exists'.format(tls_dir)
+
+    key = OpenSSL.crypto.PKey()
+    key.generate_key(OpenSSL.crypto.TYPE_RSA, bits)
+
+    # create certificate
     cert = OpenSSL.crypto.X509()
-
-    # Set default meta attributes or override with data from kwargs
-    cert_meta = dict(**cert_sample_meta)
-    cert_meta.update(kwargs)
-    for name, val in cert_meta.items():
-        setattr(cert.get_subject(), name, val)
-
-    cert.set_serial_number(1000)
+    cert.set_version(3)
+    cert.set_subject(req.get_subject())
     cert.gmtime_adj_notBefore(0)
-    cert.gmtime_adj_notAfter(10*365*24*60*60)
+    cert.gmtime_adj_notAfter(int(days) * 24 * 60 * 60)
+    cert.set_serial_number(_new_serial(tls_dir, CN))
     cert.set_issuer(cert.get_subject())
-    cert.set_pubkey(k)
+    cert.set_pubkey(key)
     cert.sign(k, 'sha1')
 
-    open(cert_file, "wt").write(
-        OpenSSL.crypto.dump_certificate(OpenSSL.crypto.FILETYPE_PEM, cert))
-    open(key_file, "wt").write(
-        OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, k))
+    # Write private key and cert
+    priv_key = open(
+            '{0}/{1}/certs/{2}.key'.format(_cert_base_path(), tls_dir, CN),
+            'w+'
+            )
+    priv_key.write(
+            OpenSSL.crypto.dump_privatekey(OpenSSL.crypto.FILETYPE_PEM, key)
+            )
+    priv_key.close()
+
+
+    crt = open('{0}/{1}/certs/{2}.crt'.format(
+        _cert_base_path(),
+        tls_dir,
+        CN
+        ), 'w+')
+    crt.write(
+            OpenSSL.crypto.dump_certificate(
+                OpenSSL.crypto.FILETYPE_PEM,
+                cert
+                )
+            )
+    crt.close()
+
+    _write_cert_to_database(tls_dir, cert)
+
+    ret = "Created Private Key: {0}/{1}/certs/{2}.key".format(
+        _cert_base_path,
+        tls_dir,
+        CN)
+    ret += 'Created Certificate: {0}/{1}/certs/{2}.crt"').format(
+        _cert_base_path(),
+        tls_dir,
+        CN)
 
     return ("Wrote self-signed certificate to: {0}\n"
             "Wrote private key for self-signed certificate to: {1}".format(
@@ -425,7 +492,7 @@ def create_self_signed_cert(cert_file, key_file, bits=2048, **kwargs):
 def create_ca_signed_cert(ca_name, CN, days=365):
     '''
     Create a Certificate (CERT) signed by a
-    particular Certificate Authority (CA)
+    named Certificate Authority (CA)
 
     ca_name
         name of the CA

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -430,8 +430,9 @@ def create_self_signed_cert(
     if not os.path.exists('{0}/{1}/certs/'.format(_cert_base_path(), tls_dir)):
         os.makedirs("{0}/{1}/certs/".format(_cert_base_path(), tls_dir))
 
+    print '{0}/{1}/{2}.crt'.format(_cert_base_path(), tls_dir, CN)
     if os.path.exists(
-            '{0}/{1}/{2}.crt'.format(_cert_base_path(), tls_dir, CN)
+            '{0}/{1}/certs/{2}.crt'.format(_cert_base_path(), tls_dir, CN)
             ):
         return 'Certificate "{0}" already exists'.format(tls_dir)
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -485,11 +485,11 @@ def create_self_signed_cert(
 
     _write_cert_to_database(tls_dir, cert)
 
-    ret = 'Created Private Key: {0}/{1}/certs/{2}.key\n'.format(
+    ret = 'Created Private Key: {0}/{1}/certs/{2}.key. '.format(
         _cert_base_path(),
         tls_dir,
         CN)
-    ret += 'Created Certificate: {0}/{1}/certs/{2}.crt'.format(
+    ret += 'Created Certificate: {0}/{1}/certs/{2}.crt.'.format(
         _cert_base_path(),
         tls_dir,
         CN)

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -457,7 +457,7 @@ def create_self_signed_cert(
     cert.set_serial_number(_new_serial(tls_dir, CN))
     cert.set_issuer(cert.get_subject())
     cert.set_pubkey(key)
-    cert.sign(k, 'sha1')
+    cert.sign(key, 'sha1')
 
     # Write private key and cert
     priv_key = open(


### PR DESCRIPTION
fixed up the file to be more in line with the rest of the tls module. Renaming seemed appropriate since it's more about tls than just a CA anymore.
