### PR TITLE
Output function in Yaml outputter shold return data, not print. Fixes #2388

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -14,6 +14,7 @@ STATIC = (
           'json_out',
           )
 
+
 def display_output(data, out, opts=None):
     '''
     Print the passed data using the desired output

--- a/salt/output/yaml_out.py
+++ b/salt/output/yaml_out.py
@@ -9,8 +9,9 @@ import yaml
 def __virtual__():
     return 'yaml'
 
+
 def output(data):
     '''
     Print out YAML
     '''
-    print(yaml.dump(data))
+    return yaml.dump(data)


### PR DESCRIPTION
Output function in Yaml outputter shold return data, not print. Fixes #2388
