### PR TITLE
debian_service.status - more debian way for getting status of service

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -113,17 +113,15 @@ def reload(name):
 
 def status(name, sig=None):
     '''
-    Return the status for a service, returns the PID or an empty string if the
-    service is running or not, pass a signature to use to find the service via
-    ps
+    Return the status for a service
 
     CLI Example::
 
-        salt '*' service.status <service name> [service signature]
+        salt '*' service.status <service name>
     '''
-    sig = sig or name
-    cmd = 'pgrep -f {0}'.format(sig)
-    return __salt__['cmd.run'](cmd).strip().split('\n')
+    cmd = 'service {0} status'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
+
 
 def enable(name):
     '''

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -122,8 +122,8 @@ def status(name, sig=None):
         salt '*' service.status <service name> [service signature]
     '''
     sig = sig or name
-    cmd = 'pgrep {0}'.format(sig)
-    return __salt__['cmd.run'](cmd).strip()
+    cmd = 'pgrep -f {0}'.format(sig)
+    return __salt__['cmd.run'](cmd).strip().split('\n')
 
 def enable(name):
     '''


### PR DESCRIPTION
Here is a change to modules/debian_service.py to handle a service status in a more Debian way.
It uses a "service" command, just like the start/stop methods of the same module.
- the 'sig' argument is unused, but required for a consistency in the state system (like in modules/systemd.py)
- init scripts must have a "status" parameter
