### PR TITLE
Demo of saltstack/salt#2417 module standards choice "1"

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -5,7 +5,7 @@ Support for the Git SCM
 import os
 from salt import utils
 
-def _git_run(**kwargs):
+def _git_run(cmd, cwd=None, **kwargs):
     '''
     simple, throw an exception with the error message on an error return code.
 
@@ -13,7 +13,7 @@ def _git_run(**kwargs):
     'cmd.run_all', and used as an alternative to 'cmd.run_all'. Some
     commands don't return proper retcodes, so this can't replace 'cmd.run_all'.
     '''
-    result = __salt__['cmd.run_all'](**kwargs)
+    result = __salt__['cmd.run_all'](cmd, cwd=None, **kwargs)
 
     retcode = result['retcode']
 

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -3,7 +3,7 @@ Support for the Git SCM
 '''
 
 import os
-from salt import utils
+from salt import utils, exceptions
 
 def _git_run(cmd, cwd=None, **kwargs):
     '''
@@ -13,14 +13,14 @@ def _git_run(cmd, cwd=None, **kwargs):
     'cmd.run_all', and used as an alternative to 'cmd.run_all'. Some
     commands don't return proper retcodes, so this can't replace 'cmd.run_all'.
     '''
-    result = __salt__['cmd.run_all'](cmd, cwd=None, **kwargs)
+    result = __salt__['cmd.run_all'](cmd, cwd=cwd, **kwargs)
 
     retcode = result['retcode']
 
     if retcode == 0:
         return result['stdout']
     else:
-        raise CommandExecutionError(result['stderr'])
+        raise exceptions.CommandExecutionError(result['stderr'])
 
 def _git_getdir(cwd, user=None):
     '''

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -20,7 +20,7 @@ def _git_run(cmd, cwd=None, **kwargs):
     if retcode == 0:
         return result['stdout']
     else:
-        raise Exception(result['stderr'])
+        raise CommandExecutionError(result['stderr'])
 
 def _git_getdir(cwd, user=None):
     '''

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -5,6 +5,23 @@ Support for the Git SCM
 import os
 from salt import utils
 
+def _git_run(**kwargs):
+    '''
+    simple, throw an exception with the error message on an error return code.
+
+    this function may be moved to the command module, spliced with
+    'cmd.run_all', and used as an alternative to 'cmd.run_all'. Some
+    commands don't return proper retcodes, so this can't replace 'cmd.run_all'.
+    '''
+    result = __salt__['cmd.run_all'](**kwargs)
+
+    retcode = result['retcode']
+
+    if retcode == 0:
+        return result['stdout']
+    else:
+        raise Exception(result['stderr'])
+
 def _git_getdir(cwd, user=None):
     '''
     Returns the absolute path to the top-level of a given repo because some Git
@@ -45,12 +62,7 @@ def revision(cwd, rev='HEAD', short=False, user=None):
     _check_git()
 
     cmd = 'git rev-parse {0}{1}'.format('--short ' if short else '', rev)
-    result = __salt__['cmd.run_all'](cmd, cwd, runas=user)
-
-    if result['retcode'] == 0:
-        return result['stdout']
-    else:
-        return ''
+    return _git_run(cmd, cwd, runas=user)
 
 def clone(cwd, repository, opts=None, user=None):
     '''
@@ -82,7 +94,7 @@ def clone(cwd, repository, opts=None, user=None):
         opts = ''
     cmd = 'git clone {0} {1} {2}'.format(repository, cwd, opts)
 
-    return __salt__['cmd.run'](cmd, runas=user)
+    return _git_run(cmd, runas=user)
 
 def describe(cwd, rev='HEAD', user=None):
     '''
@@ -146,7 +158,7 @@ def archive(cwd, output, rev='HEAD', fmt=None, prefix=None, user=None):
         fmt = ' --format={0}'.format(fmt) if fmt else '',
         prefix = ' --prefix="{0}"'.format(prefix if prefix else basename))
 
-    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)
+    return _git_run(cmd, cwd=cwd, runas=user)
 
 def fetch(cwd, opts=None, user=None):
     '''
@@ -173,7 +185,7 @@ def fetch(cwd, opts=None, user=None):
         opts = ''
     cmd = 'git fetch {0}'.format(opts)
 
-    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)
+    return _git_run(cmd, cwd=cwd, runas=user)
 
 def pull(cwd, opts=None, user=None):
     '''
@@ -196,7 +208,7 @@ def pull(cwd, opts=None, user=None):
 
     if not opts:
         opts = ''
-    return __salt__['cmd.run']('git pull {0}'.format(opts), cwd=cwd, runas=user)
+    return _git_run('git pull {0}'.format(opts), cwd=cwd, runas=user)
 
 def rebase(cwd, rev='master', opts=None, user=None):
     '''
@@ -224,7 +236,7 @@ def rebase(cwd, rev='master', opts=None, user=None):
 
     if not opts:
         opts = ''
-    return __salt__['cmd.run']('git rebase {0}'.format(opts), cwd=cwd, runas=user)
+    return _git_run('git rebase {0}'.format(opts), cwd=cwd, runas=user)
 
 def checkout(cwd, rev, force=False, opts=None, user=None):
     '''
@@ -258,7 +270,7 @@ def checkout(cwd, rev, force=False, opts=None, user=None):
     if not opts:
         opts = ''
     cmd = 'git checkout {0} {1} {2}'.format(' -f' if force else '', rev, opts)
-    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)
+    return _git_run(cmd, cwd=cwd, runas=user)
 
 def merge(cwd, branch='@{upstream}', opts=None, user=None):
     '''
@@ -289,7 +301,7 @@ def merge(cwd, branch='@{upstream}', opts=None, user=None):
             branch,
             opts)
 
-    return __salt__['cmd.run'](cmd, cwd, runas=user)
+    return _git_run(cmd, cwd, runas=user)
 
 def init(cwd, opts=None, user=None):
     '''
@@ -311,7 +323,7 @@ def init(cwd, opts=None, user=None):
     _check_git()
 
     cmd = 'git init {0} {1}'.format(cwd, opts)
-    return __salt__['cmd.run'](cmd, runas=user)
+    return _git_run(cmd, runas=user)
 
 def submodule(cwd, init=True, opts=None, user=None):
     '''
@@ -334,4 +346,4 @@ def submodule(cwd, init=True, opts=None, user=None):
     if not opts:
         opts = ''
     cmd = 'git submodule update {0} {1}'.format('--init' if init else '', opts)
-    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user)
+    return _git_run(cmd, cwd=cwd, runas=user)

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -65,6 +65,8 @@ class GitTest(integration.ModuleCase):
         git.present
         '''
         name = os.path.join(integration.TMP, 'salt_repo')
+        os.mkdir(name)
+        fname = os.path.join(name, 'stoptheprocess')
         with file(fname, 'a'):
             pass
         ret = self.run_state(

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -1,0 +1,48 @@
+'''
+Tests for the Git state
+'''
+import os
+import shutil
+import integration
+
+
+class GitTest(integration.ModuleCase):
+    '''
+    Validate the git state
+    '''
+
+    def test_latest(self):
+        '''
+        git.latest
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        ret = self.run_state(
+            'git.latest',
+            name='https://github.com/saltstack/salt.git',
+            rev='develop',
+            target=name,
+            submodules=True
+        )
+        self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
+        result = self.state_result(ret)
+        self.assertTrue(result)
+        shutil.rmtree(name, ignore_errors=True)
+
+    def test_present(self):
+        '''
+        git.present
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        ret = self.run_state(
+            'git.present',
+            name=name,
+            bare=True
+        )
+        self.assertTrue(os.path.isfile(os.path.join(name, 'HEAD')))
+        result = self.state_result(ret)
+        self.assertTrue(result)
+        shutil.rmtree(name, ignore_errors=True)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(GitTest)

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -28,6 +28,23 @@ class GitTest(integration.ModuleCase):
         self.assertTrue(result)
         shutil.rmtree(name, ignore_errors=True)
 
+    def test_latest_failure(self):
+        '''
+        git.latest
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        ret = self.run_state(
+            'git.latest',
+            name='https://youSpelledGithubWrong.com/saltstack/salt.git',
+            rev='develop',
+            target=name,
+            submodules=True
+        )
+        self.assertFalse(os.path.isdir(os.path.join(name, '.git')))
+        result = self.state_result(ret)
+        self.assertFalse(result)
+        shutil.rmtree(name, ignore_errors=True)
+
     def test_present(self):
         '''
         git.present
@@ -42,6 +59,24 @@ class GitTest(integration.ModuleCase):
         result = self.state_result(ret)
         self.assertTrue(result)
         shutil.rmtree(name, ignore_errors=True)
+
+    def test_present_failure(self):
+        '''
+        git.present
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        with file(fname, 'a'):
+            pass
+        ret = self.run_state(
+            'git.present',
+            name=name,
+            bare=True
+        )
+        self.assertFalse(os.path.isfile(os.path.join(name, 'HEAD')))
+        result = self.state_result(ret)
+        self.assertFalse(result)
+        shutil.rmtree(name, ignore_errors=True)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
I left a note in "salt/modules/git.py" for the _git_run method.

For "salt/states/git.py", the two public methods illustrate the
two different methods utilizing the proposed module standards in
a salt state.
- "git.latest" uses "try[..]catch" blocks to return the error from the module
  as part of the state's return output.
- errors from modules called in "git.present" pass through to the minion which
  "[...]itself does catch all published executions exceptions and returns based
  on that information" [1]

As you will see, implementing the standard is quick, easy, simple, and non
invasive. In fact, most of my time was spent writing this commit message.

[1] thatch45, https://github.com/saltstack/salt/issues/2417#issuecomment-9969939
