### PR TITLE
Fixes #2397 Failure to authenticate

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -83,8 +83,7 @@ class LocalClient(object):
             if self.opts.get('user', 'root') != 'root':
                 key_user = self.opts.get('user', 'root')
         if key_user.startswith('sudo_'):
-            if self.opts.get('user', 'root') != 'root':
-                key_user = self.opts.get('user', 'root')
+            key_user = self.opts.get('user', 'root')
         keyfile = os.path.join(
                 self.opts['cachedir'], '.{0}_key'.format(key_user)
                 )

--- a/salt/master.py
+++ b/salt/master.py
@@ -1518,13 +1518,10 @@ class ClearFuncs(object):
         # Verify that the caller has root on master
         elif 'user' in clear_load:
             if clear_load['user'].startswith('sudo_'):
-                if not clear_load.pop('key') == self.key.get(getpass.getuser(), ''):
+                if not clear_load.pop('key') == self.key[self.opts.get('user', 'root')]:
                     return ''
             elif clear_load['user'] == self.opts.get('user', 'root'):
                 if not clear_load.pop('key') == self.key[self.opts.get('user', 'root')]:
-                    return ''
-            elif clear_load['user'] == getpass.getuser():
-                if not clear_load.pop('key') == self.key.get(getpass.getuser()):
                     return ''
             elif clear_load['user'] == 'root':
                 if not clear_load.pop('key') == self.key.get(self.opts.get('user', 'root')):


### PR DESCRIPTION
This largely had to do with sudo not being dealt with
correctly. Running salt-master as a non-root user should work
correctly now.
