### PR TITLE
add proc subdir of cachedir to the verify_env dir list

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -40,6 +40,7 @@ class Master(parsers.MasterOptionParser):
                     os.path.join(self.config['pki_dir'], 'minions_rejected'),
                     self.config['cachedir'],
                     os.path.join(self.config['cachedir'], 'jobs'),
+                    os.path.join(self.config['cachedir'], 'proc'),
                     os.path.dirname(self.config['log_file']),
                     self.config['sock_dir'],
                     self.config['token_dir'],


### PR DESCRIPTION
When trying to run minions as non-root users, I get a permission denied error when the minion starts up complaining about access to the salt/cache/proc directory. So this change just adds that directory to the list of dirs that are checked by verify_env.

Note that I'm not sure if that same list needs to be updated elsewhere or not. I didn't see any other calls to verify_env that included cachedir in the parameter list, but I may be overlooking something...
