### PR TITLE
bug fixes for conformity because cult code is good code

### DIFF
--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -45,6 +45,40 @@ class GitTest(integration.ModuleCase):
         self.assertFalse(result)
         shutil.rmtree(name, ignore_errors=True)
 
+    def test_latest_empty_dir(self):
+        '''
+        git.latest
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        os.mkdir(name)
+        ret = self.run_state(
+            'git.latest',
+            name='https://github.com/saltstack/salt.git',
+            rev='develop',
+            target=name,
+            submodules=True
+        )
+        self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
+        result = self.state_result(ret)
+        self.assertTrue(result)
+        shutil.rmtree(name, ignore_errors=True)
+
+    def test_latest_recursive(self):
+        '''
+        git.latest
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        ret = self.run_state(
+            'git.latest',
+            name='https://github.com/mozilla/zamboni.git',
+            target=name,
+            submodules=True
+        )
+        self.assertTrue(os.path.isdir(os.path.join(name, 'vendor', 'js', 'receiptverifier', '.git')))
+        result = self.state_result(ret)
+        self.assertTrue(result)
+        shutil.rmtree(name, ignore_errors=True)
+
     def test_present(self):
         '''
         git.present
@@ -77,6 +111,22 @@ class GitTest(integration.ModuleCase):
         self.assertFalse(os.path.isfile(os.path.join(name, 'HEAD')))
         result = self.state_result(ret)
         self.assertFalse(result)
+        shutil.rmtree(name, ignore_errors=True)
+
+    def test_present_empty_dir(self):
+        '''
+        git.present
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        os.mkdir(name)
+        ret = self.run_state(
+            'git.present',
+            name=name,
+            bare=True
+        )
+        self.assertTrue(os.path.isfile(os.path.join(name, 'HEAD')))
+        result = self.state_result(ret)
+        self.assertTrue(result)
         shutil.rmtree(name, ignore_errors=True)
 
 


### PR DESCRIPTION
- don't overwrite or delete when the force option is not true
  - when the user `runas` doesn't have permission to create a directory in the
    parent directory of `target` or `name`, the directory may be created in
    preparation of git. So, don't remove the empty directory before cloning.
  - the force option still removes the directory even if it is empty
- ensure submodules are initiated recursively everywhere for consistency
- catch all module calls for consistency
- tests to test
