### PR TITLE
Add a module for SVN

### DIFF
--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -79,7 +79,7 @@ def info(cwd, targets=None, user=None, username=None, fmt="str"):
     if fmt == "xml":
         opts.append("--xml")
     if targets:
-        opts.append(shlex.split(targets))
+        opts += shlex.split(targets)
     infos = _run_svn("info", cwd, user, username, opts)
 
     if fmt in ("str", "xml"):

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -181,7 +181,6 @@ def add(cwd, targets, user=None, *opts):
 
     targets : None
         files and directories to pass to the command as arguments
-        Default: svn uses '.'
 
     user : None
         Run svn as a user other than what the minion runs as
@@ -191,7 +190,7 @@ def add(cwd, targets, user=None, *opts):
     return _run_svn("add", cwd, user, None, opts)
 
 
-def remove(cwd, targets, user=None, username=None, *opts):
+def remove(cwd, targets, msg=None, user=None, username=None, *opts):
     """
     Remove files and directories from the Subversion repository
 
@@ -200,7 +199,9 @@ def remove(cwd, targets, user=None, username=None, *opts):
 
     targets : None
         files, directories, and URLs to pass to the command as arguments
-        Default: svn uses '.'
+
+    msg : None
+        Message to attach to the commit log
 
     user : None
         Run svn as a user other than what the minion runs as
@@ -210,6 +211,8 @@ def remove(cwd, targets, user=None, username=None, *opts):
     """
     if username:
         opts += ("--username", username)
+    if msg:
+        opts += ("-m", msg)
     if targets:
         opts += tuple(shlex.split(targets))
     return _run_svn("remove", cwd, user, username, opts)

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -1,0 +1,74 @@
+'''
+Subversion SCM
+'''
+
+import os
+import re
+from salt import utils
+
+_kv_re = re.compile("^([^:]+):\s+(\S.*)$")
+
+def _check_svn():
+    utils.check_or_die('svn')
+
+def _run_svn(cmd, cwd, user, opts):
+    cmd = "svn --non-interactive %s " % cmd
+    if opts:
+        cmd += "'" + "' '".join(opts) + "'"
+
+    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user).rstrip()
+
+def info(cwd, user, targets=None, format="str"):
+    """
+    format: str
+        How to format the output from info.
+        (str, xml, list, dict)
+    """
+    opts = []
+    if format == "xml":
+        opts.append("--xml")
+    if targets:
+        opts.append(targets)
+    infos = _run_svn("info", cwd, user, opts)
+
+    if format in ("str", "xml"):
+        return infos
+
+    for infosplit in infos.split("\n\n"):
+        info_list = _kv_re(infosplit)
+
+    if format == "list":
+        return info_list
+    if format == "dict":
+        return [dict(tmp) for tmp in info_list]
+
+def checkout(remote, cwd, user, target=None, opts=[]):
+    opts.append(remote)
+    if target:
+        opts.append(target)
+    return _run_svn("checkout", cwd, user, opts)
+
+def update(cwd, user, files=None, opts=None):
+    if files:
+        opts.append(files)
+    return _run_svn("update", cwd, user, opts)
+
+def commit(cwd, user, files=None, msg=None, opts=[]):
+    if msg:
+        opts += ["-m", msg]
+    if files:
+        opts.append(files)
+    return _run_svn("commit", cwd, user, opts)
+
+def add(cwd, user, files, opts=[]):
+    if files:
+        opts.append(files)
+    return _run_svn("add", cwd, user, opts)
+
+def remove(cwd, user, files, opts=[]):
+    if files:
+        opts.append(files)
+    return _run_svn("remove", cwd, user, opts)
+
+def status(cwd, user, opts=[]):
+    return _run_svn("status", cwd, user, opts)

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -2,73 +2,108 @@
 Subversion SCM
 '''
 
-import os
 import re
-from salt import utils
+from salt import utils, exceptions
 
-_kv_re = re.compile("^([^:]+):\s+(\S.*)$")
+_INI_RE = re.compile(r"^([^:]+):\s+(\S.*)$")
 
 def _check_svn():
     utils.check_or_die('svn')
 
-def _run_svn(cmd, cwd, user, opts):
-    cmd = "svn --non-interactive %s " % cmd
+def _run_svn(cmd, cwd, user, opts, **kwargs):
+    """
+    Execute svn
+    return the output of the command
+
+    cmd
+        The command to run.
+
+    cwd
+        The path to the Subversion repository
+
+    user
+        Run svn as a user other than what the minion runs as
+
+    opts
+        Any additional options to add to the command line
+    """
+    cmd = "svn --non-interactive %s" % cmd
     if opts:
         cmd += "'" + "' '".join(opts) + "'"
 
-    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user).rstrip()
+    result = __salt__['cmd.run_all'](cmd, cwd=cwd, runas=user)
 
-def info(cwd, user, targets=None, format="str"):
+    retcode = result['retcode']
+
+    if retcode == 0:
+        return result['stdout']
+    else:
+        raise exceptions.CommandExecutionError(result['stderr'])
+
+def info(cwd, user=None, targets=None, fmt="str"):
     """
-    format: str
-        How to format the output from info.
+    Display the Subversion information from the checkout.
+    cwd
+        The path to the Subversion repository
+
+    user : None
+        Run svn as a user other than what the minion runs as
+
+    fmt : str
+        How to fmt the output from info.
         (str, xml, list, dict)
     """
-    opts = []
-    if format == "xml":
+    opts = list()
+    if fmt == "xml":
         opts.append("--xml")
     if targets:
         opts.append(targets)
     infos = _run_svn("info", cwd, user, opts)
 
-    if format in ("str", "xml"):
+    if fmt in ("str", "xml"):
         return infos
 
     for infosplit in infos.split("\n\n"):
-        info_list = _kv_re(infosplit)
+        info_list = _INI_RE.findall(infosplit, re.M)
 
-    if format == "list":
+    if fmt == "list":
         return info_list
-    if format == "dict":
+    if fmt == "dict":
         return [dict(tmp) for tmp in info_list]
 
-def checkout(remote, cwd, user, target=None, opts=[]):
-    opts.append(remote)
+def checkout(cwd, remote, user=None, target=None, *opts):
+    opts += (remote,)
     if target:
-        opts.append(target)
+        opts += (target,)
     return _run_svn("checkout", cwd, user, opts)
 
-def update(cwd, user, files=None, opts=None):
-    if files:
-        opts.append(files)
+def update(cwd, user=None, targets=None, *opts):
+    if targets:
+        opts += (targets,)
     return _run_svn("update", cwd, user, opts)
 
-def commit(cwd, user, files=None, msg=None, opts=[]):
+def commit(cwd, user=None, targets=None, msg=None, *opts):
     if msg:
-        opts += ["-m", msg]
-    if files:
-        opts.append(files)
+        opts += ("-m", msg)
+    if targets:
+        opts += (targets,)
     return _run_svn("commit", cwd, user, opts)
 
-def add(cwd, user, files, opts=[]):
-    if files:
-        opts.append(files)
+def add(cwd, targets, user=None, *opts):
+    if targets:
+        opts += (targets,)
     return _run_svn("add", cwd, user, opts)
 
-def remove(cwd, user, files, opts=[]):
-    if files:
-        opts.append(files)
+def remove(cwd, targets, user=None, *opts):
+    """
+    targets:
+        This can either be a list of local files, or, a remote URL.
+    """
+    if targets:
+        opts += (targets,)
     return _run_svn("remove", cwd, user, opts)
 
-def status(cwd, user, opts=[]):
+def status(cwd, targets=None, user=None, *opts):
+    if targets:
+        opts += (targets,)
     return _run_svn("status", cwd, user, opts)


### PR DESCRIPTION
The Salt state for SVN will be done soon. I went a little pedantic with handling shell strings since `cmdmod.py` uses `shell=True` for all commands, so I figured I would see how well my little stunt in `_run_svn()` goes down.

This is part of #2430

Committing files from the working-directory

<pre>
% salt 'brynhilde' svn.commit /root/tshdw-svn-test targets="test foobar" msg="I don't know what I'm doing" username="accornehl@gmail.com"

{'brynhilde': 'Adding         foobar\nTransmitting file data .\nCommitted revision 3.'}
</pre>


Info on multiple files and URLs

<pre>
% salt 'brynhilde' svn.info /root/tshdw-svn-test targets="test foobar . http://tshdw-svn-test.googlecode.com/svn/trunk" fmt="dict"

{'brynhilde': [{'Checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
                'Last Changed Author': 'accornehl@gmail.com',
                'Last Changed Date': '2012-11-04 05:05:32 +0000 (Sun, 04 Nov 2012)',
                'Last Changed Rev': '2',
                'Name': 'test',
                'Node Kind': 'file',
                'Path': 'test',
                'Repository Root': 'https://tshdw-svn-test.googlecode.com/svn',
                'Repository UUID': '68e35d6d-ba10-8cfd-e90d-990ce18119f9',
                'Revision': '2',
                'Schedule': 'normal',
                'Text Last Updated': '2012-11-03 20:53:57 +0000 (Sat, 03 Nov 2012)',
                'URL': 'https://tshdw-svn-test.googlecode.com/svn/trunk/test',
                'Working Copy Root Path': '/root/tshdw-svn-test'},
               {'Checksum': 'da39a3ee5e6b4b0d3255bfef95601890afd80709',
                'Last Changed Author': 'accornehl@gmail.com',
                'Last Changed Date': '2012-11-04 06:12:53 +0000 (Sun, 04 Nov 2012)',
                'Last Changed Rev': '3',
                'Name': 'foobar',
                'Node Kind': 'file',
                'Path': 'foobar',
                'Repository Root': 'https://tshdw-svn-test.googlecode.com/svn',
                'Repository UUID': '68e35d6d-ba10-8cfd-e90d-990ce18119f9',
                'Revision': '3',
                'Schedule': 'normal',
                'Text Last Updated': '2012-11-03 20:59:50 +0000 (Sat, 03 Nov 2012)',
                'URL': 'https://tshdw-svn-test.googlecode.com/svn/trunk/foobar',
                'Working Copy Root Path': '/root/tshdw-svn-test'},
               {'Last Changed Author': 'accornehl@gmail.com',
                'Last Changed Date': '2012-11-04 05:05:32 +0000 (Sun, 04 Nov 2012)',
                'Last Changed Rev': '2',
                'Node Kind': 'directory',
                'Path': '.',
                'Repository Root': 'https://tshdw-svn-test.googlecode.com/svn',
                'Repository UUID': '68e35d6d-ba10-8cfd-e90d-990ce18119f9',
                'Revision': '2',
                'Schedule': 'normal',
                'URL': 'https://tshdw-svn-test.googlecode.com/svn/trunk',
                'Working Copy Root Path': '/root/tshdw-svn-test'},
               {'Last Changed Author': 'accornehl@gmail.com',
                'Last Changed Date': '2012-11-04 06:12:53 +0000 (Sun, 04 Nov 2012)',
                'Last Changed Rev': '3',
                'Node Kind': 'directory',
                'Path': 'trunk',
                'Repository Root': 'http://tshdw-svn-test.googlecode.com/svn',
                'Repository UUID': '68e35d6d-ba10-8cfd-e90d-990ce18119f9',
                'Revision': '3',
                'URL': 'http://tshdw-svn-test.googlecode.com/svn/trunk'}]}
</pre>


Checkout of a SVN repository. You don't expect me to evaluate newlines in strings, right?

<pre>
salt 'brynhilde' svn.checkout /home/root http://dpkt.googlecode.com/svn/trunk/ target=dpkt

{'brynhilde': 'A    dpkt/LICENSE\nA    dpkt/dpkt\nA    dpkt/dpkt/udp.py\nA    dpkt/dpkt/rx.py\nA    dpkt/dpkt/loopback.py\nA    dpkt/dpkt/ip6.py\nA    dpkt/dpkt/__init__.py\nA    dpkt/dpkt/ipx.py\nA    dpkt/dpkt/mrt.py\nA    dpkt/dpkt/asn1.py\nA    dpkt/dpkt/netbios.py\nA
  dpkt/dpkt/ieee80211.py\nA    dpkt/dpkt/tns.py\nA    dpkt/dpkt/bgp.py\nA    dpkt/dpkt/gre.py\nA    dpkt/dpkt/tftp.py\nA    dpkt/dpkt/crc32c.py\nA    dpkt/dpkt/pppoe.py\nA    dpkt/dpkt/pcap.py\nA    dpkt/dpkt/vrrp.py\nA    dpkt/dpkt/rip.py\nA    dpkt/dpkt/ntp.py\nA    dpkt/
dpkt/radiotap.py\nA    dpkt/dpkt/rtp.py\nA    dpkt/dpkt/cdp.py\nA    dpkt/dpkt/ospf.py\nA    dpkt/dpkt/hsrp.py\nA    dpkt/dpkt/dhcp.py\nA    dpkt/dpkt/h225.py\nA    dpkt/dpkt/rpc.py\nA    dpkt/dpkt/pim.py\nA    dpkt/dpkt/radius.py\nA    dpkt/dpkt/ssl_ciphersuites.py\nA    d
pkt/dpkt/sll.py\nA    dpkt/dpkt/telnet.py\nA    dpkt/dpkt/sip.py\nA    dpkt/dpkt/snoop.py\nA    dpkt/dpkt/ssl.py\nA    dpkt/dpkt/dpkt.py\nA    dpkt/dpkt/aim.py\nA    dpkt/dpkt/stp.py\nA    dpkt/dpkt/gzip.py\nA    dpkt/dpkt/rfb.py\nA    dpkt/dpkt/ethernet.py\nA    dpkt/dpkt/
http.py\nA    dpkt/dpkt/qq.py\nA    dpkt/dpkt/tpkt.py\nA    dpkt/dpkt/tcp.py\nA    dpkt/dpkt/dtp.py\nA    dpkt/dpkt/ah.py\nA    dpkt/dpkt/sccp.py\nA    dpkt/dpkt/icmp.py\nA    dpkt/dpkt/stun.py\nA    dpkt/dpkt/diameter.py\nA    dpkt/dpkt/igmp.py\nA    dpkt/dpkt/pmap.py\nA
  dpkt/dpkt/ppp.py\nA    dpkt/dpkt/ip.py\nA    dpkt/dpkt/sctp.py\nA    dpkt/dpkt/llc.py\nA    dpkt/dpkt/icmp6.py\nA    dpkt/dpkt/netflow.py\nA    dpkt/dpkt/yahoo.py\nA    dpkt/dpkt/smb.py\nA    dpkt/dpkt/arp.py\nA    dpkt/dpkt/dns.py\nA    dpkt/dpkt/esp.py\nA    dpkt/tests\
nA    dpkt/tests/test-perf.py\nA    dpkt/tests/test-perf2.py\nA    dpkt/HACKING\nA    dpkt/AUTHORS\nA    dpkt/setup.py\nA    dpkt/CHANGES\nA    dpkt/README\nA    dpkt/Makefile\nA    dpkt/examples\nA    dpkt/examples/ping.py\nA    dpkt/examples/nbtping.py\nA    dpkt/examples
/dnsping.py\nA    dpkt/examples/dhcprequest.py\nChecked out revision 84.'}
</pre>


Removing a remote file and updating the working-directory

<pre>
% salt 'brynhilde' svn.remove . https://tshdw-svn-test.googlecode.com/svn/trunk/test username="accornehl@gmail.com" msg="Don't pick up wooden nickels"
{'brynhilde': '\nCommitted revision 4.'}

% salt 'brynhilde' svn.update /root/tshdw-svn-test
{'brynhilde': "Updating '.':\nD    test\nUpdated to revision 4."}
</pre>
