### PR TITLE
Use proper exception when checking for user information at salt-master startup

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -30,7 +30,7 @@ def set_pidfile(pidfile, user):
         uid = pwnam[2]
         gid = pwnam[3]
         groups = [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
-    except KeyError:
+    except IndexError:
         err = ('Failed to set the pid to user: '
                 '{0}. The user is not available.\n').format(user)
         sys.stderr.write(err)

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -37,8 +37,9 @@ def set_pidfile(pidfile, user):
         sys.exit(2)
     try:
         os.chown(pidfile, uid, gid)
-    except Exception as e:
-        msg = ('Failed to set the pid to user {0}').format(user)
+    except OSError as e:
+        msg = ('Failed to set the ownership of PID file {0} '
+               'to user {1}\n').format(pidfile, user)
         log.debug(msg, exc_info=True)
         sys.stderr.write(msg)
         sys.exit(e.errno)


### PR DESCRIPTION
Use IndexError instead of KeyError
