### PR TITLE
virtualization detection fix for freebsd/jail

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -319,7 +319,7 @@ def _virtual(osdata):
         if sysctl:
             model = __salt__['cmd.run']('{0} hw.model'.format(sysctl))
             jail = __salt__['cmd.run']('{0} -n security.jail.jailed'.format(sysctl))
-            if jail:
+            if jail == '1':
                 grains['virtual_subtype'] = 'jail'
             if 'QEMU Virtual CPU' in model:
                 grains['virtual'] = 'kvm'


### PR DESCRIPTION
sysctl -n security.jail.jailed always return non empty string and we should evaluate this string
