### PR TITLE
Add the state file for Subversion

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -1,0 +1,67 @@
+import logging
+import os
+import shutil
+from salt import exceptions
+
+log = logging.getLogger(__name__)
+
+def __virtual__():
+    '''
+    Only load if svn is available
+    '''
+    if __salt__["cmd.has_exec"]("svn"):
+        return "svn"
+    return False
+
+def latest(target,
+           remote,
+           rev=None,
+           user=None,
+           username=None,
+           force=None,
+           externals=True):
+    """
+    Make sure the repository is cloned to the given directory and is up to date
+
+    target
+        Name of the target directory where the checkout will put the working directory
+    remote
+        Address of the remote repository as passed to "svn checkout"
+    rev : None
+        The remote revision number to checkout. Enable "force" if the directory already exists.
+    user : None
+        Name of the user performing repository management operations
+    username : None
+        The user to access the remote repository with. The svn default is the current user
+    force : Fasle
+        Force svn to checkout into pre-existing directories (deletes contents)
+    externals : True
+        Checkout externally tracked files.
+    """
+    svn_cmd = "svn.checkout"
+    cwd, basename = os.path.split(target)
+    opts = tuple()
+
+    if os.path.exists(target) and not os.path.isdir(target):
+        log.fatal("The path, %s, exists and is not a directory." % target)
+        return False
+
+    try:
+        __salt["svn.info"](".", target, user=user)
+        svn_cmd = "svn.update"
+    except exceptions.CommandExecutionError:
+        pass
+
+    if rev:
+        opts += ("-r", str(rev))
+
+    if force:
+        opts += ("--force",)
+
+    if externals is False:
+        opts += ("--ignore-externals",)
+
+    if svn_cmd == "svn.update":
+        __salt__[svn_cmd](cwd, basename, user=user, username=username, *opts)
+    else:
+        __salt__[svn_cmd](cwd, remote, basename, user=user, username=username, *opts)

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -65,3 +65,11 @@ def latest(target,
         __salt__[svn_cmd](cwd, basename, user=user, username=username, *opts)
     else:
         __salt__[svn_cmd](cwd, remote, basename, user=user, username=username, *opts)
+
+def dirty(target,
+          user=None,
+          ignore_unversioned=False):
+    """
+    Determine if the working directory has been changed.
+    """
+    pass

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import shutil
 from salt import exceptions
 from salt.states.git import _fail, _neutral_test
 
@@ -22,28 +21,32 @@ def latest(name,
            force=None,
            externals=True):
     """
-    Make sure the repository is cloned to the given directory and is up to date
-
-    target
-        Name of the target directory where the checkout will put the working directory
+    Checkout or update the working directory to the latest revision from the
+    remote repository.
 
     name
         Address of the name repository as passed to "svn checkout"
 
+    target
+        Name of the target directory where the checkout will put the working
+        directory
+
     rev : None
-        The name revision number to checkout. Enable "force" if the directory already exists.
+        The name revision number to checkout. Enable "force" if the directory
+        already exists.
 
     user : None
         Name of the user performing repository management operations
 
     username : None
-        The user to access the name repository with. The svn default is the current user
+        The user to access the name repository with. The svn default is the
+        current user
 
-    force : Fasle
-        Force svn to checkout into pre-existing directories (deletes contents)
+    force : False
+        Continue if conflicts are encountered
 
     externals : True
-        Checkout externally tracked files.
+        Change to False to not checkout or update externals
     """
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
@@ -54,7 +57,8 @@ def latest(name,
     opts = tuple()
 
     if os.path.exists(target) and not os.path.isdir(target):
-        return _fail(ret, "The path, %s, exists and is not a directory." % target)
+        return _fail(ret,
+                "The path, %s, exists and is not a directory." % target)
 
     try:
         __salt__["svn.info"](".", target, user=user)
@@ -84,4 +88,5 @@ def dirty(target,
     """
     Determine if the working directory has been changed.
     """
-    pass
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    return _fail(ret, "This function is not implemented yet.")


### PR DESCRIPTION
This adds the "latest" state for Subversion, mimicking the git and hg states. More to follow, as shown by the stubbed-out `dirty()` definition, for determining the cleanliness of a working directory, in `states/svn.py`.

Given the state file, svn_test.sls:

<pre>
https://tshdw-svn-test.googlecode.com/svn/trunk:
  svn.latest:
    - target: /root/tshdw-svn-test
    - username: accornehl@gmail.com
    - force: True

https://tshdw-svn-test.googlecode.com/svn/trunk/nofun:
  svn.latest:
    - target: /root/nofun
    - username: accornehl@gmail.com
</pre>


Useful errors:

<pre>
----------
    State: - svn
    Name:      https://tshdw-svn-test.googlecode.com/svn/trunk/nofun
    Function:  latest
        Result:    False
        Comment:   An exception occured in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 885, in call
    ret = self.states[cdata['full']](*cdata['args'])
  File "/var/cache/salt/extmods/states/svn.py", line 77, in latest
    out = __salt__[svn_cmd](cwd, name, basename, user, username, *opts)
  File "/usr/lib/python2.7/site-packages/salt/modules/svn.py", line 121, in checkout
    return _run_svn("checkout", cwd, user, username, opts)
  File "/usr/lib/python2.7/site-packages/salt/modules/svn.py", line 54, in _run_svn
    raise exceptions.CommandExecutionError(result['stderr'] + '\n\n' + cmd)
CommandExecutionError: svn: E170000: URL 'https://tshdw-svn-test.googlecode.com/svn/trunk/nofun' doesn't exist

svn --non-interactive checkout "https://tshdw-svn-test.googlecode.com/svn/trunk/nofun" "nofun" "--username" "accornehl@gmail.com"
</pre>


After creating the directory, checkouts and updates also provide userful tidbits:

<pre>
----------
    State: - svn
    Name:      https://tshdw-svn-test.googlecode.com/svn/trunk/nofun
    Function:  latest
        Result:    True
        Comment:   Checked out revision 6.
        Changes:
----------
    State: - svn
    Name:      https://tshdw-svn-test.googlecode.com/svn/trunk
    Function:  latest
        Result:    True
        Comment:   Updating 'tshdw-svn-test':
D    tshdw-svn-test/test
A    tshdw-svn-test/the flash
Updated to revision 5.
        Changes:
</pre>
