### PR TITLE
Update salt/modules/network.py: get all interfaces for the `ip` command

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -233,8 +233,9 @@ def interfaces():
     '''
     ifaces = dict()
     if __salt__['cmd.has_exec']('ip'):
-        cmd = __salt__['cmd.run']('ip addr show')
-        ifaces = _interfaces_ip(cmd)
+        cmd1 = __salt__['cmd.run']('ip link show')
+        cmd2 = __salt__['cmd.run']('ip addr show')
+        ifaces = _interfaces_ip(cmd1 + cmd2)
     elif __salt__['cmd.has_exec']('ifconfig'):
         cmd = __salt__['cmd.run']('ifconfig -a')
         ifaces = _interfaces_ifconfig(cmd)


### PR DESCRIPTION
The `ip address` command does not list interfaces that are not up/configured. It now gets the output from the `ip link` command as well for those interfaces.

Before:

<pre>
{'brynhilde': {'eth1': {'hwaddr': '00:30:48:34:2a:cb',
                        'inet': [{'address': '10.7.161.4',
                                  'broadcast': '10.7.175.255',
                                  'label': 'eth1',
                                  'netmask': '255.255.240.0'}],
                        'inet6': [{'address': '2620:0:170:9900:230:48ff:fe34:2acb',
                                   'prefixlen': '64'},
                                  {'address': 'fe80::230:48ff:fe34:2acb',
                                   'prefixlen': '64'}],
                        'up': True},
               'eth4': {'hwaddr': '00:02:c9:32:06:30',
                        'inet': [{'address': '75.75.11.23',
                                  'broadcast': '75.75.11.255',
                                  'label': 'eth4',
                                  'netmask': '255.255.255.0'}],
                        'inet6': [{'address': 'fe80::202:c9ff:fe32:630',
                                   'prefixlen': '64'}],
                        'up': True},
               'lo': {'hwaddr': '00:00:00:00:00:00',
                      'inet': [{'address': '127.0.0.1',
                                'broadcast': None,
                                'label': 'lo',
                                'netmask': '255.0.0.0'}],
                      'inet6': [{'address': '::1', 'prefixlen': '128'}],
                      'up': True}}}
</pre>


After, the unconfigured eth0, eth2, and eth3 interfaces appear now:

<pre>
{'brynhilde': {'eth0': {'hwaddr': '00:30:48:34:2a:ca', 'up': False},
               'eth1': {'hwaddr': '00:30:48:34:2a:cb',
                        'inet': [{'address': '10.7.161.4',
                                  'broadcast': '10.7.175.255',
                                  'label': 'eth1',
                                  'netmask': '255.255.240.0'}],
                        'inet6': [{'address': '2620:0:170:9900:230:48ff:fe34:2acb',
                                   'prefixlen': '64'},
                                  {'address': 'fe80::230:48ff:fe34:2acb',
                                   'prefixlen': '64'}],
                        'up': True},
               'eth2': {'hwaddr': '00:07:43:13:48:00', 'up': False},
               'eth3': {'hwaddr': '00:07:43:13:48:08', 'up': False},
               'eth4': {'hwaddr': '00:02:c9:32:06:30',
                        'inet': [{'address': '75.75.11.23',
                                  'broadcast': '75.75.11.255',
                                  'label': 'eth4',
                                  'netmask': '255.255.255.0'}],
                        'inet6': [{'address': 'fe80::202:c9ff:fe32:630',
                                   'prefixlen': '64'}],
                        'up': True},
               'lo': {'hwaddr': '00:00:00:00:00:00', 'up': True}}}
</pre>
