### PR TITLE
Postgres fails if username is the empty string

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -76,11 +76,11 @@ def _psql_cmd(*args, **kwargs):
                                               kwargs.get('host'),
                                               kwargs.get('port'))
     cmd = ['psql', '--no-align', '--no-readline', '--no-password']
-    if user is not None:
+    if user:
         cmd += ['--username', user]
-    if host is not None:
+    if host:
         cmd += ['--host', host]
-    if port is not None:
+    if port:
         cmd += ['--port', port]
     cmd += args
     cmdstr = ' '.join(map(pipes.quote, cmd))


### PR DESCRIPTION
This could be a side effect of 351b5b6, where config.option
was introduced. Since we don't need to pass in the empty string
anyway, a simple "if" should be fine.

For the record: the error thrown by Postgres is 

```
psql: FATAL:  no PostgreSQL user name specified in startup packet
```
