### PR TITLE
Fix NoneType error in file._symlink_check()

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -330,8 +330,8 @@ def _symlink_check(name, target, force):
             return None, ('The file or directory {0} is set for removal to '
                           'make way for a new symlink targeting {1}').format(
                                   name, target)
-        return _error(ret, ('File or directory exists where the symlink {0} '
-                            'should be. Did you mean to use force?'.format(name)))
+        return False, ('File or directory exists where the symlink {0} '
+                       'should be. Did you mean to use force?'.format(name))
 
 
 def _check_include_exclude(path_str,include_pat=None,exclude_pat=None):


### PR DESCRIPTION
I've been getting the following error when using the `file.symlink` state:

```
----------
    State: - file
    Name:      /etc/localtime
    Function:  symlink
        Result:    False
        Comment:   An exception occured in this state: Traceback (most recent call last):
  File "salt/state.py", line 885, in call
  File "salt/states/file.py", line 403, in symlink
  File "salt/states/file.py", line 334, in _symlink_check
  File "salt/states/file.py", line 192, in _error
TypeError: 'NoneType' object does not support item assignment

        Changes:  
```

This pull request removes the call to `_error()` for the case of a pre-existing, non-forced symlink test in `file._symlink_check()`. The call is not necessary as `file.symlink` does the return value tuple expansion itself (https://github.com/saltstack/salt/blob/develop/salt/states/file.py#L403).
