### PR TITLE
Add template support to cp.get_file paths

### DIFF
--- a/doc/ref/file_server/index.rst
+++ b/doc/ref/file_server/index.rst
@@ -38,6 +38,17 @@ the master, the syntax looks like this:
 This will instruct all Salt minions to download the vimrc file and copy it
 to /etc/vimrc
 
+Template rendering can be enabled on both the source and destination file names
+like so:
+
+.. code-block:: bash
+
+    # salt '*' cp.get_file "salt://{{grains.os}}/vimrc" /etc/vimrc template=jinja
+
+This example would instruct all Salt minions to download the vimrc from a
+directory with the same name as their os grain and copy it to /etc/vimrc
+
+
 File Server Client API
 ----------------------
 

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -86,12 +86,12 @@ def get_file(path, dest, env='base', template=None):
         try:
             path = _render(path)
         except CommandExecutionError as exc:
-            log.error(exc.message)
+            log.error(str(exc))
             return ''
         try:
             dest = _render(dest)
         except CommandExecutionError as exc:
-            log.error(exc.message)
+            log.error(str(exc))
             return ''
 
     if not hash_file(path, env):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -4,10 +4,12 @@ Minion side functions for salt-cp
 # Import python libs
 import os
 import logging
+import tempfile
 
 # Import salt libs
 import salt.minion
 import salt.fileclient
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -40,7 +42,7 @@ def recv(files, dest):
     return ret
 
 
-def get_file(path, dest, env='base'):
+def get_file(path, dest, env='base', template=None):
     '''
     Used to get a single file from the salt master
 
@@ -48,6 +50,50 @@ def get_file(path, dest, env='base'):
 
         salt '*' cp.get_file salt://path/to/file /minion/dest
     '''
+    if template is not None:
+        # render the path as a template using path_template_engine as the engine
+        if template not in salt.utils.templates.template_registry:
+            log.error('Attempted to render file paths with unavailable engine '
+                      '{0}'.format(template))
+            return ''
+
+        kwargs = {}
+        kwargs['salt'] = __salt__
+        kwargs['pillar'] = __pillar__
+        kwargs['grains'] = __grains__
+        kwargs['opts'] = __opts__
+        kwargs['env'] = env
+
+        def _render(contents):
+            # write out path to temp file
+            fd_, tmp_path_fn = tempfile.mkstemp()
+            os.close(fd_)
+            with open(tmp_path_fn, 'w+') as fp_:
+                fp_.write(contents)
+            data = salt.utils.templates.template_registry[template](
+                tmp_path_fn,
+                string=True,
+                **kwargs
+            )
+            if not data['result']:
+                # Failed to render the template
+                raise CommandExecutionError('Failed to render file path with error: {0}'.format(
+                    data['data']
+                ))
+            else:
+                return data['data']
+
+        try:
+            path = _render(path)
+        except CommandExecutionError as exc:
+            log.error(exc.message)
+            return ''
+        try:
+            dest = _render(dest)
+        except CommandExecutionError as exc:
+            log.error(exc.message)
+            return ''
+
     if not hash_file(path, env):
         return ''
     else:

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -75,6 +75,7 @@ def get_file(path, dest, env='base', template=None):
                 string=True,
                 **kwargs
             )
+            salt.utils.safe_rm(tmp_path_fn)
             if not data['result']:
                 # Failed to render the template
                 raise CommandExecutionError('Failed to render file path with error: {0}'.format(
@@ -82,6 +83,7 @@ def get_file(path, dest, env='base', template=None):
                 ))
             else:
                 return data['data']
+
 
         try:
             path = _render(path)

--- a/tests/integration/files/file/base/cheese
+++ b/tests/integration/files/file/base/cheese
@@ -1,0 +1,1 @@
+I could just fancy some cheese, Gromit. What do you say? Cheddar?

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -24,7 +24,7 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
-    def text_get_file_templated_paths(self):
+    def test_get_file_templated_paths(self):
         '''
         cp.get_file
         '''
@@ -32,9 +32,11 @@ class CPModuleTest(integration.ModuleCase):
         self.run_function(
             'cp.get_file',
             [
-                'salt://{{grain.test_grain}}',
-                tgt.replace('cheese', '{{grain.test_grain}}'),
-            ])
+                'salt://{{grains.test_grain}}',
+                tgt.replace('cheese', '{{grains.test_grain}}')
+            ],
+            template='jinja'
+        )
         with open(tgt, 'r') as cheese:
             data = cheese.read()
             self.assertIn('Gromit', data)

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -24,6 +24,24 @@ class CPModuleTest(integration.ModuleCase):
             self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
             self.assertNotIn('bacon', data)
 
+    def text_get_file_templated_paths(self):
+        '''
+        cp.get_file
+        '''
+        tgt = os.path.join(integration.TMP, 'cheese')
+        self.run_function(
+            'cp.get_file',
+            [
+                'salt://{{grain.test_grain}}',
+                tgt.replace('cheese', '{{grain.test_grain}}'),
+            ])
+        with open(tgt, 'r') as cheese:
+            data = cheese.read()
+            self.assertIn('Gromit', data)
+            self.assertNotIn('bacon', data)
+
+
+
     def test_get_template(self):
         '''
         cp.get_template


### PR DESCRIPTION
Here's a much smaller scoped Pull Request than the x509 stuff. :)

The goal of this change is to allow cp.get_file paths to be templated, so that minions can grab unique files without having to send a unique cp.get_file command to each minion.

Basically, this allows one to run:

``` bash
  salt '*' cp.get_file "salt://{{grains.cpuarch}}/vimrc" /etc/vimrc template=jinja
```

To grab your vimrc that's custom tailored to your CPU arch.. :)

[ We're using this in our environment in conjunction with custom grains to distribute some custom job information to different minions with a single cp.get_file command rather than using a series of commands with different targets ]

Both the source and destination names are 'rendered' using the template engine passed in.  

Currently the default template is None, in which case get_file behaves as it did.  If the rendering engines supported templating on a in-memory string instead of a (temp) file I'd be more inclined to make the default template jinja.

Updated docs, and added an integration test.

Thanks,
Ryan
