### PR TITLE
Adding all lists/gets to openstack keystone module

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -376,7 +376,6 @@ def _item_list():
     tenant-update       Update tenant name, description, enabled status
     token-get
     user-role-add       Add role to user
-    user-role-list      List roles granted to a user
     user-role-remove    Remove role from user
     discover            Discover Keystone servers and show authentication
                         protocols and

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -45,6 +45,57 @@ def _auth():
     return nt
 
 
+def ec2_credentials_list(id=None, name=None):
+    '''
+    Return a list of ec2_credentials for a specific user (keystone ec2-credentials-list)
+
+    CLI Examples::
+
+        salt '*' keystone.ec2_credentials_list 298ce377245c4ec9b70e1c639c89e654
+        salt '*' keystone.ec2_credentials_list id=298ce377245c4ec9b70e1c639c89e654
+        salt '*' keystone.ec2_credentials_list name=jack
+    '''
+    nt = _auth()
+    ret = {}
+    if name:
+        for user in nt.users.list():
+            if user.name == name:
+                id = user.id
+                continue
+    if not id:
+        return {'Error': 'Unable to resolve user id'}
+    for ec2_credential in nt.ec2.list(id):
+        ret[ec2_credential.user_id] = {
+                'user_id': ec2_credential.user_id,
+                'tenant_id': ec2_credential.tenant_id,
+                'access': ec2_credential.access,
+                'secret': ec2_credential.secret,
+                }
+    return ret
+
+
+def endpoint_list():
+    '''
+    Return a list of available endpoints (keystone endpoints-list)
+
+    CLI Example::
+
+        salt '*' keystone.endpoint_list
+    '''
+    nt = _auth()
+    ret = {}
+    for endpoint in nt.endpoints.list():
+        ret[endpoint.id] = {
+                'id': endpoint.id,
+                'region': endpoint.region,
+                'adminurl': endpoint.adminurl,
+                'internalurl': endpoint.internalurl,
+                'publicurl': endpoint.publicurl,
+                'service_id': endpoint.service_id,
+                }
+    return ret
+
+
 def user_list():
     '''
     Return a list of available users (keystone user-list)
@@ -62,7 +113,7 @@ def user_list():
                 'email': user.email,
                 'enabled': user.enabled,
                 'tenant_id': user.tenantId,
-            }
+                }
     return ret
 
 
@@ -92,7 +143,7 @@ def user_get(id=None, name=None):
             'email': user.email,
             'enabled': user.enabled,
             'tenant_id': user.tenantId,
-        }
+            }
     return ret
 
 
@@ -111,7 +162,7 @@ def user_create(name, password, email, tenant_id=None, enabled=True):
         email=email,
         tenant_id=tenant_id,
         enabled=enabled,
-    )
+        )
     return user_get(item.id)
 
 
@@ -187,6 +238,98 @@ def user_password_update(id=None, name=None, password=None):
     return ret
 
 
+def role_list():
+    '''
+    Return a list of available roles (keystone role-list)
+
+    CLI Example::
+
+        salt '*' keystone.role_list
+    '''
+    nt = _auth()
+    ret = {}
+    for role in nt.roles.list():
+        ret[role.name] = {
+                'id': role.id,
+                'name': role.name,
+                }
+    return ret
+
+
+def service_list():
+    '''
+    Return a list of available services (keystone services-list)
+
+    CLI Example::
+
+        salt '*' keystone.service_list
+    '''
+    nt = _auth()
+    ret = {}
+    for service in nt.services.list():
+        ret[service.name] = {
+                'id': service.id,
+                'name': service.name,
+                'description': service.description,
+                'type': service.type,
+                }
+    return ret
+
+
+def tenant_list():
+    '''
+    Return a list of available tenants (keystone tenants-list)
+
+    CLI Example::
+
+        salt '*' keystone.tenant_list
+    '''
+    nt = _auth()
+    ret = {}
+    for tenant in nt.tenants.list():
+        ret[tenant.name] = {
+                'id': tenant.id,
+                'name': tenant.name,
+                'description': tenant.description,
+                'enabled': tenant.enabled,
+                }
+    return ret
+
+
+def user_role_list(user_id=None, tenant_id=None, user_name=None, tenant_name=None):
+    '''
+    Return a list of available user_roles (keystone user_roles-list)
+
+    CLI Example::
+
+        salt '*' keystone.user_role_list
+    '''
+    nt = _auth()
+    ret = {}
+    if user_name:
+        for user in nt.users.list():
+            if user.name == user_name:
+                user_id = user.id
+                continue
+    if tenant_name:
+        for tenant in nt.tenants.list():
+            if tenant.name == tenant_name:
+                tenant_id = tenant.id
+                continue
+    if not user_id and not tenant_id:
+        return {'Error': 'Unable to resolve user or tenant id'}
+    #ret = []
+    for role in nt.roles.roles_for_user(user=user_id, tenant=tenant_id):
+        #ret.append(role.__dict__)
+        ret[role.name] = {
+                'id': role.id,
+                'name': role.name,
+                'user_id': role.user_id,
+                'tenant_id': role.tenant_id,
+                }
+    return ret
+
+
 def _item_list():
     '''
     Template for writing list functions
@@ -202,45 +345,39 @@ def _item_list():
     for item in nt.items.list():
         ret.append(item.__dict__)
         #ret[item.name] = {
+        #        'id': item.id,
         #        'name': item.name,
-        #    }
+        #        }
     return ret
+
 
     '''
     The following is a list of functions that need to be incorporated in the
     keystone module. This list should be updated as functions are added.
 
-    catalog
     ec2-credentials-create
                         Create EC2-compatibile credentials for user per tenant
     ec2-credentials-delete
                         Delete EC2-compatibile credentials
     ec2-credentials-get
                         Display EC2-compatibile credentials
-    ec2-credentials-list
-                        List EC2-compatibile credentials for a user
     endpoint-create     Create a new endpoint associated with a service
     endpoint-delete     Delete a service endpoint
     endpoint-get
-    endpoint-list       List configured service endpoints
     role-create         Create new role
     role-delete         Delete role
     role-get            Display role details
-    role-list           List all roles
     service-create      Add service to Service Catalog
     service-delete      Delete service from Service Catalog
     service-get         Display service from Service Catalog
-    service-list        List all services in Service Catalog
     tenant-create       Create new tenant
     tenant-delete       Delete tenant
     tenant-get          Display tenant details
-    tenant-list         List all tenants
     tenant-update       Update tenant name, description, enabled status
     token-get
     user-role-add       Add role to user
     user-role-list      List roles granted to a user
     user-role-remove    Remove role from user
-    user-update         Update user's name, email, and enabled status
     discover            Discover Keystone servers and show authentication
                         protocols and
     bootstrap           Grants a new role to a new user on a new tenant, after

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -300,9 +300,12 @@ def user_role_list(user_id=None, tenant_id=None, user_name=None, tenant_name=Non
     '''
     Return a list of available user_roles (keystone user_roles-list)
 
-    CLI Example::
+    CLI Examples::
 
-        salt '*' keystone.user_role_list
+        salt '*' keystone.user_role_list user_id=298ce377245c4ec9b70e1c639c89e654
+        salt '*' keystone.user_role_list tenant_id=7167a092ece84bae8cead4bf9d15bb3b
+        salt '*' keystone.user_role_list user_name=admin
+        salt '*' keystone.user_role_list tenant_name=admin
     '''
     nt = _auth()
     ret = {}

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -523,6 +523,4 @@ def _item_list():
                         protocols and
     bootstrap           Grants a new role to a new user on a new tenant, after
                         creating each.
-    bash-completion     Prints all of the commands and options to stdout.
-
     '''

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -96,6 +96,64 @@ def endpoint_list():
     return ret
 
 
+def role_list():
+    '''
+    Return a list of available roles (keystone role-list)
+
+    CLI Example::
+
+        salt '*' keystone.role_list
+    '''
+    nt = _auth()
+    ret = {}
+    for role in nt.roles.list():
+        ret[role.name] = {
+                'id': role.id,
+                'name': role.name,
+                }
+    return ret
+
+
+def service_list():
+    '''
+    Return a list of available services (keystone services-list)
+
+    CLI Example::
+
+        salt '*' keystone.service_list
+    '''
+    nt = _auth()
+    ret = {}
+    for service in nt.services.list():
+        ret[service.name] = {
+                'id': service.id,
+                'name': service.name,
+                'description': service.description,
+                'type': service.type,
+                }
+    return ret
+
+
+def tenant_list():
+    '''
+    Return a list of available tenants (keystone tenants-list)
+
+    CLI Example::
+
+        salt '*' keystone.tenant_list
+    '''
+    nt = _auth()
+    ret = {}
+    for tenant in nt.tenants.list():
+        ret[tenant.name] = {
+                'id': tenant.id,
+                'name': tenant.name,
+                'description': tenant.description,
+                'enabled': tenant.enabled,
+                }
+    return ret
+
+
 def user_list():
     '''
     Return a list of available users (keystone user-list)
@@ -235,64 +293,6 @@ def user_password_update(id=None, name=None, password=None):
     ret = 'Password updated for user ID {0}'.format(id)
     if name:
         ret += ' ({0})'.format(name)
-    return ret
-
-
-def role_list():
-    '''
-    Return a list of available roles (keystone role-list)
-
-    CLI Example::
-
-        salt '*' keystone.role_list
-    '''
-    nt = _auth()
-    ret = {}
-    for role in nt.roles.list():
-        ret[role.name] = {
-                'id': role.id,
-                'name': role.name,
-                }
-    return ret
-
-
-def service_list():
-    '''
-    Return a list of available services (keystone services-list)
-
-    CLI Example::
-
-        salt '*' keystone.service_list
-    '''
-    nt = _auth()
-    ret = {}
-    for service in nt.services.list():
-        ret[service.name] = {
-                'id': service.id,
-                'name': service.name,
-                'description': service.description,
-                'type': service.type,
-                }
-    return ret
-
-
-def tenant_list():
-    '''
-    Return a list of available tenants (keystone tenants-list)
-
-    CLI Example::
-
-        salt '*' keystone.tenant_list
-    '''
-    nt = _auth()
-    ret = {}
-    for tenant in nt.tenants.list():
-        ret[tenant.name] = {
-                'id': tenant.id,
-                'name': tenant.name,
-                'description': tenant.description,
-                'enabled': tenant.enabled,
-                }
     return ret
 
 


### PR DESCRIPTION
The current EPEL version of python-keystone has a bug in it that seems to be fixed in the current version in git. Therefore, keystone.user_role_list will not work until EPEL has been updated, or unless the user decides to run python-keystone straight out of git.
