### PR TITLE
Improve `salt.utils.build_whitepace_splited_regex()`. Fixes #2379.

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -562,12 +562,8 @@ def build_whitepace_splited_regex(text):
     regex = r''
     for line in text.splitlines():
         parts = [re.escape(s) for s in __build_parts(line)]
-        regex += r'(?:(?:[^])?(?:[\s]+)?|(?:[\s]+)?)'
-        regex += r'{0}'.format(
-            r'(?:(?:[^])?(?:[\s]+)?|(?:[\s]+)?)'.join(parts)
-        )
-        regex += r'(?:(?:[^])?(?:[\s]+)?|(?:[\s]+)?)'
-    return regex
+        regex += r'(?:[\s]+)?{0}(?:[\s]+)?'.format(r'(?:[\s]+)?'.join(parts))
+    return r'^{0}$'.format(regex)
 
 
 def format_call(fun, data):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -563,7 +563,7 @@ def build_whitepace_splited_regex(text):
     for line in text.splitlines():
         parts = [re.escape(s) for s in __build_parts(line)]
         regex += r'(?:[\s]+)?{0}(?:[\s]+)?'.format(r'(?:[\s]+)?'.join(parts))
-    return r'^{0}$'.format(regex)
+    return r'(?m)^{0}$'.format(regex)
 
 
 def format_call(fun, data):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -721,41 +721,34 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, TimeoutMixIn,
         )
 
     def _mixin_after_parsed(self):
-        if self.options.query:
-            if len(self.args) < 1:
-                self.error(
-                    'Please pass in a command to query the old salt calls for.'
-                )
-            self.config['cmd'] = self.args[0]
+        # Catch invalid invocations of salt such as: salt run
+        if len(self.args) <= 1 and not self.options.doc:
+            self.print_help()
+            self.exit(1)
+
+        if self.options.doc:
+            # Include the target
+            self.args.insert(0, '*')
+            # Include the function
+            self.args.insert(1, 'sys.doc')
+
+        if self.options.list:
+            self.config['tgt'] = self.args[0].split(',')
         else:
-            # Catch invalid invocations of salt such as: salt run
-            if len(self.args) <= 1 and not self.options.doc:
-                self.print_help()
-                self.exit(1)
+            self.config['tgt'] = self.args[0]
 
-            if self.options.doc:
-                # Include the target
-                self.args.insert(0, '*')
-                # Include the function
-                self.args.insert(1, 'sys.doc')
-
-            if self.options.list:
-                self.config['tgt'] = self.args[0].split(',')
-            else:
-                self.config['tgt'] = self.args[0]
-
-            # Detect compound command and set up the data for it
-            if ',' in self.args[1]:
-                self.config['fun'] = self.args[1].split(',')
-                self.config['arg'] = []
-                for comp in ' '.join(self.args[2:]).split(','):
-                    self.config['arg'].append(comp.split())
-                if len(self.config['fun']) != len(self.config['arg']):
-                    self.exit(42, 'Cannot execute compound command without '
-                                  'defining all arguments.')
-            else:
-                self.config['fun'] = self.args[1]
-                self.config['arg'] = self.args[2:]
+        # Detect compound command and set up the data for it
+        if ',' in self.args[1]:
+            self.config['fun'] = self.args[1].split(',')
+            self.config['arg'] = []
+            for comp in ' '.join(self.args[2:]).split(','):
+                self.config['arg'].append(comp.split())
+            if len(self.config['fun']) != len(self.config['arg']):
+                self.exit(42, 'Cannot execute compound command without '
+                              'defining all arguments.')
+        else:
+            self.config['fun'] = self.args[1]
+            self.config['arg'] = self.args[2:]
 
     def setup_config(self):
         return config.client_config(self.get_config_file_path('master'))


### PR DESCRIPTION
- Although we're building a regex which should ignore white space and new lines, the built regex should always match start and end of string.
