### PR TITLE
Fix yumpkg logging

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -324,7 +324,7 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, **kwargs):
                 if len(a) == 0:
                   a = yb.downgrade(pattern=target)
         except Exception:
-            log.error('Package {0} failed to install'.format(target))
+            log.exception('Package {0} failed to install'.format(target))
     # Resolve Deps before attempting install.  This needs to be improved
     # by also tracking any deps that may get upgraded/installed during this
     # process.  For now only the version of the package(s) you request be

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -307,29 +307,36 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, **kwargs):
     setattr(yb.conf, 'gpgcheck', not skip_verify)
 
     if repo:
+        log.debug("Enabling repo '{0}'".format(repo))
         yb.repos.enableRepo(repo)
     for i in range(0,len(pkgs)):
         try:
             if sources is not None:
                 target = sources[i]
+                log.debug("Selecting '{0}' for local installation".format(target))
                 a = yb.installLocal(target)
                 # if yum didn't install anything, maybe its a downgrade?
                 if len(a) == 0:
-                  a = yb.downgradeLocal(target)
+                    log.debug('Upgrade failed, trying local downgrade')
+                    a = yb.downgradeLocal(target)
             else:
                 target = pkgs[i]
+                log.debug("Selecting '{0}' for installation".format(target))
                 # Changed to pattern to allow specific package versions
                 a = yb.install(pattern=target)
                 # if yum didn't install anything, maybe its a downgrade?
                 if len(a) == 0:
-                  a = yb.downgrade(pattern=target)
+                    log.debug('Upgrade failed, trying downgrade')
+                    a = yb.downgrade(pattern=target)
         except Exception:
             log.exception('Package {0} failed to install'.format(target))
     # Resolve Deps before attempting install.  This needs to be improved
     # by also tracking any deps that may get upgraded/installed during this
     # process.  For now only the version of the package(s) you request be
     # installed is tracked.
+    log.debug('Resolving dependencies')
     yb.resolveDeps()
+    log.debug('Processing transaction')
     yb.processTransaction(rpmDisplay=yum.rpmtrans.NoOutputCallBack())
     yb.closeRpmDB()
 


### PR DESCRIPTION
I was having trouble installing nscd on one of my test boxes and ended up on a witch hunt to find the culprit (it was SELinux policy causing the problem). `yumpkg`s error reporting was nonexistent, making debugging the issue quite difficult.

This patch adds some error logging to the process. It also provides a potential method for collecting better information about the packages installed / upgraded / failed by yum. `_YumErrorLogger` only logs errors at the moment, but it could easily be extended to collect all the transactional details and hopefully make faster decisions than the pre/post `list_pkgs()` that we do now.

I also took the liberty of promoting `kwargs['sources']` (added in adccb3378db1ddd254ccadb7186cf9b00281c762) to a first-class keyword argument. This will make documentation and debugging easier.

Here's some example output from the new logging facility.

```
[INFO    ] Selecting 'nscd' for installation
Loading mirror speeds from cached hostfile
 * base: dallas.tx.mirror.xygenhosting.com
 * epel: mirror.steadfast.net
 * extras: dist1.800hosting.com
 * updates: dallas.tx.mirror.xygenhosting.com
[DEBUG   ] Added 1 transactions
[INFO    ] Resolving dependencies
[INFO    ] Processing transaction
Setting up and reading Presto delta metadata
Processing delta metadata
Package(s) data still to download: 209 k
Running rpm_check_debug
[ERROR   ] Error unpacking rpm package nscd-2.12-1.80.el6_3.6.x86_64
[ERROR   ] nscd-2.12-1.80.el6_3.6.x86_64 error: unpacking of archive failed on file /etc/rc.d/init.d/nscd;509c4978: cpio: open failed - Permission denied

Loaded plugins: fastestmirror, presto
Loading mirror speeds from cached hostfile
 * base: dallas.tx.mirror.xygenhosting.com
 * epel: mirror.steadfast.net
 * extras: dist1.800hosting.com
 * updates: dallas.tx.mirror.xygenhosting.com
{'local': {}}
```

I'm thinking that the return data structure from `pkg.install` could probably use a new member called `'failed'`. This would give us a more solid vector for returning errors back to the master or other facilities depending on that data.
