### PR TITLE
Fixes #1888 Add daemonize_if to service.restart

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -97,6 +97,8 @@ def restart(name):
 
         salt '*' service.restart <service name>
     '''
+    if name == 'salt-minion':
+        salt.utils.daemonize_if(__opts__)
     cmd = 'service {0} restart'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 


### PR DESCRIPTION
This adds daemonize_if to the debian service.restart.

I checked all the service modules and they all have this now.
