### PR TITLE
Fixes #2064 Add option for minion to retry dns resolution

### DIFF
--- a/conf/minion.template
+++ b/conf/minion.template
@@ -10,6 +10,11 @@
 # resolved, then the minion will fail to start.
 #master: salt
 
+# Set the number of seconds to wait before attempting to resolve
+# the master hostname if name resolution fails. Defaults to 30 seconds.
+# Set to zero if the minion should shutdown and not retry.
+# retry_dns: 30
+
 # Set the port used by the master reply and authentication server
 #master_port: 4506
 

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -81,6 +81,7 @@ class Minion(parsers.MinionOptionParser):
         '''
         Execute this method to start up a minion.
         '''
+        self.daemonize_if_required()
         self.parse_args()
 
         try:
@@ -113,7 +114,6 @@ class Minion(parsers.MinionOptionParser):
         # waiting for it, if we daemonize later then the minion could halt
         # the boot process waiting for a key to be accepted on the master.
         # This is the latest safe place to daemonize
-        self.daemonize_if_required()
         try:
             minion = salt.minion.Minion(self.config)
             self.set_pidfile()

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -81,7 +81,6 @@ class Minion(parsers.MinionOptionParser):
         '''
         Execute this method to start up a minion.
         '''
-        self.daemonize_if_required()
         self.parse_args()
 
         try:
@@ -114,6 +113,7 @@ class Minion(parsers.MinionOptionParser):
         # waiting for it, if we daemonize later then the minion could halt
         # the boot process waiting for a key to be accepted on the master.
         # This is the latest safe place to daemonize
+        self.daemonize_if_required()
         try:
             minion = salt.minion.Minion(self.config)
             self.set_pidfile()

--- a/salt/config.py
+++ b/salt/config.py
@@ -212,6 +212,7 @@ def minion_config(path):
             'default_include': 'minion.d/*.conf',
             'update_url': False,
             'update_restart_services': [],
+            'retry_dns': 30,
             }
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
@@ -229,7 +230,8 @@ def minion_config(path):
         opts['id'] = _append_domain(opts)
 
     try:
-        opts['master_ip'] = salt.utils.dns_check(opts['master'], True)
+        opts['master_ip'] = salt.utils.dns_check(opts['master'], True,
+                                                            opts['retry_dns'])
     except SaltClientError:
         opts['master_ip'] = '127.0.0.1'
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -7,6 +7,7 @@ import glob
 import os
 import socket
 import logging
+import time
 
 # import third party libs
 import yaml
@@ -230,10 +231,23 @@ def minion_config(path):
         opts['id'] = _append_domain(opts)
 
     try:
-        opts['master_ip'] = salt.utils.dns_check(opts['master'], True,
-                                                            opts['retry_dns'])
+        opts['master_ip'] = salt.utils.dns_check(opts['master'], True)
     except SaltClientError:
-        opts['master_ip'] = '127.0.0.1'
+        if opts['retry_dns']:
+            while True:
+                msg = ('Master hostname: {0} not found. '
+                        'Retrying in {1} seconds').format(opts['master'], 
+                                                            opts['retry_dns'])
+                log.warn(msg)
+                print msg
+                time.sleep(opts['retry_dns'])
+                try:
+                    opts['master_ip'] = salt.utils.dns_check(opts['master'], True)
+                    break
+                except SaltClientError:
+                    pass
+        else:
+            opts['master_ip'] = '127.0.0.1'
 
     opts['master_uri'] = 'tcp://{ip}:{port}'.format(ip=opts['master_ip'],
                                                     port=opts['master_port'])

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -310,7 +310,7 @@ def gen_mac(prefix='52:54:'):
     return mac[:-1]
 
 
-def dns_check(addr, safe=False):
+def dns_check(addr, safe=False, retry_dns=30):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception.
@@ -325,6 +325,18 @@ def dns_check(addr, safe=False):
             err = ('This master address: \'{0}\' was previously resolvable '
                    'but now fails to resolve! The previously resolved ip addr '
                    'will continue to be used').format(addr)
+            if retry_dns:
+                msg = ('Hostname: \'{0}\' could not be reached.'
+                        'Waiting \'{1}\' seconds and then will try to'
+                        'resolve the name again.').format(addr, retry_dns)
+                import salt.log
+                if salt.log.is_console_configured():
+                    # If logging is not configured it also means that either
+                    # the master or minion instance calling this hasn't even
+                    # started running
+                    logging.getLogger(__name__).error(msg)
+                time.sleep(retry_dns)
+                self.dns_check(addr, safe, retry_dns)
             if safe:
                 import salt.log
                 if salt.log.is_console_configured():

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -310,7 +310,7 @@ def gen_mac(prefix='52:54:'):
     return mac[:-1]
 
 
-def dns_check(addr, safe=False, retry_dns=30):
+def dns_check(addr, safe=False):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception.
@@ -325,18 +325,6 @@ def dns_check(addr, safe=False, retry_dns=30):
             err = ('This master address: \'{0}\' was previously resolvable '
                    'but now fails to resolve! The previously resolved ip addr '
                    'will continue to be used').format(addr)
-            if retry_dns:
-                msg = ('Hostname: \'{0}\' could not be reached.'
-                        'Waiting \'{1}\' seconds and then will try to'
-                        'resolve the name again.').format(addr, retry_dns)
-                import salt.log
-                if salt.log.is_console_configured():
-                    # If logging is not configured it also means that either
-                    # the master or minion instance calling this hasn't even
-                    # started running
-                    logging.getLogger(__name__).error(msg)
-                time.sleep(retry_dns)
-                self.dns_check(addr, safe, retry_dns)
             if safe:
                 import salt.log
                 if salt.log.is_console_configured():
@@ -344,7 +332,7 @@ def dns_check(addr, safe=False, retry_dns=30):
                     # the master or minion instance calling this hasn't even
                     # started running
                     logging.getLogger(__name__).error(err)
-                raise SaltClientError
+                raise SaltClientError()
             else:
                 err = err.format(addr)
                 sys.stderr.write(err)


### PR DESCRIPTION
Previously if the minion couldn't resolve the master's hostname, the minion would fail and try to log into a master on the localhost.

New option in the minion config:
retry_dns: 30

Set to zero to fail instead of trying again to resolve the master hostname.
