### PR TITLE
handle psql error

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -282,7 +282,11 @@ def user_exists(name, user=None, host=None, port=None, runas=None):
     cmd = _psql_cmd('-c', query, host=host, user=user, port=port)
     cmdret = __salt__['cmd.run'](cmd, runas=runas)
     log.debug(cmdret.splitlines())
-    val = cmdret.splitlines()[1]
+    try:
+        val = cmdret.splitlines()[1]
+    except IndexError:
+        log.error("Invalid PostgreSQL result: '%s'", cmdret)
+        return False
     return True if val.strip() == 't' else False
 
 


### PR DESCRIPTION
I was running postgres_user without runas argument.

psql was returning:

```
psql: FATAL:  role "root" does not exist
```

and this code could not handle output without multiple lines
