### PR TITLE
fix ENCRYPTED usage on user creation

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -320,14 +320,14 @@ def user_create(username,
 
     sub_cmd = 'CREATE USER "{0}" WITH'.format(username, )
     if password:
+        if encrypted:
+            sub_cmd = "{0} ENCRYPTED".format(sub_cmd, )
         escaped_password = password.replace("'", "''")
         sub_cmd = "{0} PASSWORD '{1}'".format(sub_cmd, escaped_password)
     if createdb:
         sub_cmd = "{0} CREATEDB".format(sub_cmd, )
     if createuser:
         sub_cmd = "{0} CREATEUSER".format(sub_cmd, )
-    if encrypted:
-        sub_cmd = "{0} ENCRYPTED".format(sub_cmd, )
     if superuser:
         sub_cmd = "{0} SUPERUSER".format(sub_cmd, )
 


### PR DESCRIPTION
from [8.4](http://www.postgresql.org/docs/8.4/interactive/sql-createrole.html) to [9.2](http://www.postgresql.org/docs/9.2/interactive/sql-createrole.html) (I did not looked in previous versions) the doc says `ENCRYPTED` must be **before** the `PASSWORD` statement.

and I made it used only if a password is specified, if not the `ENCRYPTED` statement will be in the SQL statement and break it.
