### PR TITLE
Fix LSB distro detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -502,9 +502,11 @@ def os_data():
         # It's worth noting that Ubuntu has patched their Python distribution
         # so that platform.linux_distribution() does the /etc/lsb-release
         # parsing, but we do it anyway here for the sake for full portability.
-        grains['osfullname'] = grains.get('lsb_distrib_id', osname)
-        grains['osrelease'] = grains.get('lsb_distrib_release', osrelease)
-        grains['oscodename'] = grains.get('lsb_distrib_codename', oscodename)
+        grains['osfullname'] = grains.get('lsb_distrib_id', osname).strip()
+        grains['osrelease'] = grains.get('lsb_distrib_release',
+                                         osrelease).strip()
+        grains['oscodename'] = grains.get('lsb_distrib_codename',
+                                          oscodename).strip()
         # return the first ten characters with no spaces, lowercased
         shortname = grains['osfullname'].replace(' ', '').lower()[:10]
         # this maps the long names from the /etc/DISTRO-release files to the


### PR DESCRIPTION
OpenSUSE 12.2 has odd output from platform.linux_distribution(), as can
be seen below:

> > > platform.linux_distribution()
> > > ('openSUSE ', '12.2', 'x86_64')

Notice the trailing space after openSUSE. This causes the lookup in
_OS_FAMILY_MAP to fail, causing the os_family grain to be set to
'openSUSE ' instead of 'Suse'. By stripping leading and trailing
whitespace from the values returned by platform_linux_distribution(),
this issue is fixed.
