### PR TITLE
Add ability to install pkg from RPM file (zypper)

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -2,6 +2,11 @@
 Package support for openSUSE via the zypper package manager
 '''
 
+import logging
+import os
+import re
+
+log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
@@ -19,6 +24,36 @@ def _list_removed(old, new):
         if pkg not in new:
             pkgs.append(pkg)
     return pkgs
+
+
+def _parse_pkg_meta(path):
+    '''
+    Retrieve package name and version number from package metadata
+    '''
+    name = ''
+    version = ''
+    rel = ''
+    result = __salt__['cmd.run_all']('rpm -qpi "{0}"'.format(path))
+    if result['retcode'] == 0:
+        for line in result['stdout'].splitlines():
+            if not name:
+                m = re.match('^Name\s*:\s*(\S+)', line)
+                if m:
+                    name = m.group(1)
+                    continue
+            if not version:
+                m = re.match('^Version\s*:\s*(\S+)', line)
+                if m:
+                    version = m.group(1)
+                    continue
+            if not rel:
+                m = re.match('^Release\s*:\s*(\S+)', line)
+                if m:
+                    version = m.group(1)
+                    continue
+    if rel:
+        version += '-{0}'.format(rel)
+    return name, version
 
 
 def _available_versions():
@@ -76,19 +111,13 @@ def list_pkgs():
 
         salt '*' pkg.list_pkgs
     '''
-    cmd = 'zypper packages -i'
+    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
     ret = {}
-    out = __salt__['cmd.run'](cmd).splitlines()
-    for line in out:
-        if not line:
-            continue
-        if '|' not in line:
-            continue
-        comps = []
-        for comp in line.split('|'):
-            comps.append(comp.strip())
-        if comps[0] == 'i':
-            ret[comps[2]] = comps[3]
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        name, version, rel = line.split('_|-')
+        pkgver = version
+        if rel: pkgver += '-{0}'.format(rel)
+        ret[name] = pkgver
     return ret
 
 
@@ -119,39 +148,84 @@ def refresh_db():
     return ret
 
 
-def install(name, refresh=False, **kwargs):
+def install(name, refresh=False, source=None, **kwargs):
     '''
-    Install the passed package, add refresh=True to install with an -Sy
+    Install the passed package, add refresh=True to run 'zypper refresh' before
+    package is installed.
+
+    name
+        The name of the package to be installed.
+
+    refresh
+        Whether or not to refresh the package database before installing.
+        Defaults to False.
+
+    source
+        An RPM package to install.
 
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>']}
 
     CLI Example::
 
         salt '*' pkg.install <package name>
     '''
-    old = list_pkgs()
-    cmd = 'zypper -n install -l {0}'.format(name)
-    if refresh:
-        refresh_db()
-    __salt__['cmd.retcode'](cmd)
-    new = list_pkgs()
-    pkgs = {}
-    for npkg in new:
-        if npkg in old:
-            if old[npkg] == new[npkg]:
-                # no change in the package
-                continue
-            else:
-                # the package was here before and the version has changed
-                pkgs[npkg] = {'old': old[npkg],
-                              'new': new[npkg]}
+    if source is not None:
+        if __salt__['config.valid_fileproto'](source):
+            # Cached RPM from master
+            pkg_file = __salt__['cp.cache_file'](source)
+            pkg_type = 'remote'
         else:
-            # the package is freshly installed
-            pkgs[npkg] = {'old': '',
-                          'new': new[npkg]}
+            # RPM file local to the minion
+            pkg_file = source
+            pkg_type = 'local'
+        pname,pversion = _parse_pkg_meta(pkg_file)
+        if not pname:
+            zypper_param = None
+            if pkg_type == 'remote':
+                log.error('Failed to cache {0}. Are you sure this path is '
+                          'correct?'.format(source))
+            elif pkg_type == 'local':
+                if not os.path.isfile(source):
+                    log.error('RPM resource {0} not found. Are you sure this '
+                              'path is correct?'.format(source))
+                else:
+                    log.error('Unable to parse RPM metadata for '
+                              '{0}.'.format(source))
+        elif name == pname:
+            zypper_param = pkg_file
+        else:
+            log.error('Package file {0} (Name: {1}) does not match the '
+                      'specified package name ({2})'.format(source,
+                                                            pname,
+                                                            name))
+            zypper_param = None
+    else:
+        zypper_param = name
+
+    pkgs = {}
+    if zypper_param is not None:
+        old = list_pkgs()
+        if refresh:
+            refresh_db()
+        cmd = 'zypper -n install -l {0}'.format(zypper_param)
+        __salt__['cmd.retcode'](cmd)
+        new = list_pkgs()
+        for npkg in new:
+            if npkg in old:
+                if old[npkg] == new[npkg]:
+                    # no change in the package
+                    continue
+                else:
+                    # the package was here before and the version has changed
+                    pkgs[npkg] = {'old': old[npkg],
+                                  'new': new[npkg]}
+            else:
+                # the package is freshly installed
+                pkgs[npkg] = {'old': '',
+                              'new': new[npkg]}
     return pkgs
 
 


### PR DESCRIPTION
This implements #2291 for zypper. list_pkgs() was also modified. Running
"zypper packages -i" only returns information on installed packages
which are in the repositories. RPMs manually installed do not show up
and thus cannot be tracked. Additionally, running "zypper packages -i"
pulls in data from the repositories to include in its output, which
results in some latency in getting results. Parsing the output from an
rpm -qa both eliminates this latency and allows non-repo packages to be
tracked.
