### PR TITLE
yumpkg logging improvements

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -181,11 +181,11 @@ def install(name, refresh=False, source=None, **kwargs):
 
     if source is not None:
         if __salt__['config.valid_fileproto'](source):
-            # Cached RPM from master
+            # Cached package from master
             pkg_file = __salt__['cp.cache_file'](source)
             pkg_type = 'remote'
         else:
-            # RPM file local to the minion
+            # Package file local to the minion
             pkg_file = source
             pkg_type = 'local'
         pname,pversion = _parse_pkg_meta(pkg_file)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -12,6 +12,7 @@ except (ImportError, AttributeError):
     has_yumdeps = False
 
 import logging
+import os
 import re
 
 log = logging.getLogger(__name__)
@@ -105,17 +106,17 @@ def _parse_pkg_meta(path):
     if result['retcode'] == 0:
         for line in result['stdout'].splitlines():
             if not name:
-                m = re.match('^Name\s*:\s*(.+)\s*$', line)
+                m = re.match('^Name\s*:\s*(\S+)', line)
                 if m:
                     name = m.group(1)
                     continue
             if not version:
-                m = re.match('^Version\s*:\s*(.+)\s*$', line)
+                m = re.match('^Version\s*:\s*(\S+)', line)
                 if m:
                     version = m.group(1)
                     continue
             if not rel:
-                m = re.match('^Release\s*:\s*(.+)\s*$', line)
+                m = re.match('^Release\s*:\s*(\S+)', line)
                 if m:
                     version = m.group(1)
                     continue
@@ -294,27 +295,32 @@ def clean_metadata():
     return refresh_db()
 
 
-def install(pkgs, refresh=False, repo='', skip_verify=False, sources=None,
+def install(pkgs, refresh=False, repo='', skip_verify=False, source=None,
             **kwargs):
     '''
     Install the passed package(s)
 
     pkgs
-        The name of the package(s) to be installed
-    refresh : False
-        Clean out the yum database before executing
-    repo : (default)
-        Specify a package repository to install from
+        The name of the package(s) to be installed. Can be comma separated, or
+        space separated if the parameter is encased in quotes.
+
+    refresh
+        Clean out the yum database before executing. Defaults to False.
+
+    repo
+        Specify a package repository to install from.
         (e.g., ``yum --enablerepo=somerepo``)
-    skip_verify : False
-        Skip the GPG verification check (e.g., ``--nogpgcheck``)
-    sources: None
-        A list of rpm sources to use for installing these packages.
+
+    skip_verify
+        Skip the GPG verification check. (e.g., ``--nogpgcheck``)
+
+    source
+        A list of rpm sources to use for installing the package(s).
 
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>']}
 
     CLI Example::
 
@@ -328,11 +334,11 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, sources=None,
     else:
         pkgs = pkgs.split(' ')
 
-    if sources:
-        if ',' in sources:
-            srcsplit = sources.split(',')
+    if source is not None:
+        if ',' in source:
+            srcsplit = source.split(',')
         else:
-            srcsplit = sources.split(' ')
+            srcsplit = source.split(' ')
 
         # Ensure that number of sources matches number of packages specified
         if len(srcsplit) != len(pkgs):
@@ -341,20 +347,43 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, sources=None,
                       '({1})'.format(len(srcsplit), len(pkgs)))
             return {}
 
-        sources = [
-            __salt__['cp.cache_file'](x)
-            if __salt__['config.valid_fileproto'](x) else x
-            for x in srcsplit
-        ]
+        srcinfo = []
+        for src in srcsplit:
+            if __salt__['config.valid_fileproto'](src):
+                # Cached RPM from master
+                srcinfo.append((__salt__['cp.cache_file'](src),'remote'))
+            else:
+                # RPM file local to the minion
+                srcinfo.append((src,'local'))
 
         # Check metadata to make sure the name passed matches the source
+        problems = []
         for i in range(0, len(pkgs)):
-            pname, pversion = _parse_pkg_meta(sources[i])
-            if pkgs[i] != pname:
-                log.error('Package file {0} (Name: {1}) does not '
-                          'match the specified package name '
-                          '({2})'.format(sources[i], pname, pkgs[i]))
-                return {}
+            rpm_path, pkg_type = srcinfo[i]
+            pname, pversion = _parse_pkg_meta(rpm_path)
+            if not pname:
+                if pkg_type == 'remote':
+                    problems.append('Failed to cache {0}. Are you sure this '
+                                    'path is correct?'.format(srcsplit[i]))
+                elif pkg_type == 'local':
+                    if not os.path.isfile(rpm_path):
+                        problems.append('Package file {0} not found. Are '
+                                        'you sure this path is '
+                                        'correct?'.format(rpm_path))
+                    else:
+                        problems.append('Unable to parse package metadata for '
+                                        '{0}'.format(rpm_path))
+            elif pkgs[i] != pname:
+                problems.append('Package file {0} (Name: {1}) does not '
+                                'match the specified package name '
+                                '({2})'.format(srcsplit[i], pname, pkgs[i]))
+
+        # If any problems are found in the caching or metadata parsing done in
+        # the above for loop, log each problem and then return an empty dict.
+        # Do not proceed to attempt package installation.
+        if problems:
+            for problem in problems: log.error(problem)
+            return {}
 
     old = list_pkgs(*pkgs)
 
@@ -367,9 +396,10 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, sources=None,
         yb.repos.enableRepo(repo)
 
     for i in range(0, len(pkgs)):
+        rpm_path, pkg_type = srcinfo[i]
         try:
-            if sources is not None:
-                target = sources[i]
+            if source is not None:
+                target = rpm_path
                 log.info(
                     'Selecting \'{0}\' for local installation'.format(target)
                 )


### PR DESCRIPTION
More robust logging for problems with caching RPMs and invalid paths for
local RPM files. Also changed the name of the kwarg used for specifying
RPM files to install. It was "sources", and is now "source". Every other
implementation uses "source", so I made this change to provide a
consistent user experience.

Also, in an earlier commit I referred to package files in pacman.py as
RPM files in some of the comments. Fixed this to avoid confusion.
