### PR TITLE
Strip the word 'Linux' for os grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -408,14 +408,10 @@ def id_():
 
 # This maps (at most) the first ten characters (no spaces, lowercased) of
 # 'osfullname' to the 'os' grain that Salt traditionally uses.
+# Please see _supported_dists defined at the top of the file
 _OS_NAME_MAP = {
     'redhatente': 'RedHat',
-    'debian': 'Debian',
-    'arch': 'Arch',
     'gentoobase': 'Gentoo',
-    'amazonlinu': 'Amazon',
-    'centoslinu': 'CentOS',
-    'scientific': 'Scientific',
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -508,11 +504,12 @@ def os_data():
                                          osrelease).strip()
         grains['oscodename'] = grains.get('lsb_distrib_codename',
                                           oscodename).strip()
+        distroname = grains['osfullname'].replace(' Linux', '')
         # return the first ten characters with no spaces, lowercased
-        shortname = grains['osfullname'].replace(' ', '').lower()[:10]
+        shortname = distroname.replace(' ', '').lower()[:10]
         # this maps the long names from the /etc/DISTRO-release files to the
         # traditional short names that Salt has used.
-        grains['os'] = _OS_NAME_MAP.get(shortname, grains['osfullname'])
+        grains['os'] = _OS_NAME_MAP.get(shortname, distroname)
         grains.update(_linux_cpudata())
     elif grains['kernel'] == 'SunOS':
         grains['os'] = 'Solaris'


### PR DESCRIPTION
We are seeing a number of issues crop up where the presence of 'Linux' in the 'os' grain causes problems for the family mapper and dependent module selection algorithms.

This pull request strips the word 'Linux' from the 'osfullname' grain before attempting to find another name in `_OS_NAME_MAP`, or defaulting to the stripped name. This should reduce the number of bugs we are seeing that require another addition to the map. 

This patch is in response to #2537.

Please carefully consider this pull request. I would be best if this could be tested on a couple different platforms before acceptance.
