### PR TITLE
Fix esky docs and depends

### DIFF
--- a/doc/topics/tutorials/esky.rst
+++ b/doc/topics/tutorials/esky.rst
@@ -28,7 +28,7 @@ Building and Freezing
 =====================
 
 Once you have your tools installed and the environment configured, you can then
-``python setup.py sdist`` to get the eggs prepared. After that is done, run
+``python setup.py bdist`` to get the eggs prepared. After that is done, run
 ``python setup.py bdist_esky`` to have Esky traverse the module tree and pack
 all the scripts up into a redistributable. There will be an appropriately
 versioned ``salt-VERSION.zip`` in ``dist/`` if everything went smoothly.

--- a/setup.py
+++ b/setup.py
@@ -172,7 +172,8 @@ freezer_includes = [
     'ast',
     'difflib',
     'distutils',
-    'distutils.version'
+    'distutils.version',
+    'json',
 ]
 
 if sys.platform.startswith('win'):
@@ -188,7 +189,8 @@ if sys.platform.startswith('win'):
     setup_kwargs['install_requires'] += '\nwmi'
 elif sys.platform.startswith('linux'):
     freezer_includes.extend([
-        'yum'
+        'yum',
+        'spwd',
     ])
 
 if 'bdist_esky' in sys.argv:


### PR DESCRIPTION
This fixes an issue @utahdave, Lecole Cole, and I all have experienced with Esky. The issue manifests itself as a KeyError when important grains are missing during the module detection phase.
