### PR TITLE
Fixes #2518 Remove a try/except. Let the IOError bubble up

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -459,15 +459,12 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     if backup_mode == 'master' or backup_mode == 'both' and bkroot:
         # TODO, backup to master
         pass
-    try:
-        shutil.move(tgt, dest)
-        # If SELINUX is available run a restorecon on the file
-        rcon = which('restorecon')
-        if rcon:
-            cmd = [rcon, dest]
-            subprocess.call(cmd)
-    except Exception:
-        pass
+    shutil.move(tgt, dest)
+    # If SELINUX is available run a restorecon on the file
+    rcon = which('restorecon')
+    if rcon:
+        cmd = [rcon, dest]
+        subprocess.call(cmd)
     if os.path.isfile(tgt):
         # The temp file failed to move
         try:


### PR DESCRIPTION
An Exception was suppressing a failure. Let the IOError bubble
up and be caught by the calling function.
