### PR TITLE
Fix NameError in yumpkg sources

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -335,7 +335,7 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, sources=None,
         pkgs = pkgs.split(' ')
 
     if sources is not None:
-        if ',' in source:
+        if ',' in sources:
             srcsplit = sources.split(',')
         else:
             srcsplit = sources.split(' ')


### PR DESCRIPTION
There's a `NameError` that crops up when using `sources` in `pkg.install` for `yumpkg.py`

```
[MINION] out:         Comment:   An exception occured in this state: Traceback (most recent call last):
[MINION] out:   File "salt/state.py", line 884, in call
[MINION] out:   File "salt/states/pkg.py", line 87, in installed
[MINION] out:   File "salt/modules/yumpkg.py", line 338, in install
[MINION] out: NameError: global name 'source' is not defined
[MINION] out: 
```

This pull request fixes that.
