### PR TITLE
Add gzip and template to cp.get_dir, expose make_dirs on cp.get_file

### DIFF
--- a/doc/ref/file_server/index.rst
+++ b/doc/ref/file_server/index.rst
@@ -62,6 +62,23 @@ on the master (and minion), 9 uses the most.
     # salt '*' cp.get_file salt://vimrc /etc/vimrc gzip_compression=5
 
 
+get_dir
+```````
+
+The cp.get_dir function can be used on the minion to download an entire
+directory from the master.  The syntax is very similar to get_file:
+
+.. code-block:: bash
+
+    # salt '*' cp.get_dir salt://etc/apache2 /etc
+
+get_dir supports template rendering and gzip compression just like get_file:
+
+
+.. code-block:: bash
+
+    # salt '*' cp.get_dir salt://etc/{{pillar.webserver}} /etc gzip_compression=5 template=jinja
+
 
 File Server Client API
 ----------------------

--- a/doc/ref/file_server/index.rst
+++ b/doc/ref/file_server/index.rst
@@ -49,18 +49,26 @@ This example would instruct all Salt minions to download the vimrc from a
 directory with the same name as their os grain and copy it to /etc/vimrc
 
 For larger files, the cp.get_file module also supports gzip compression.
-Because gzip compression is CPU-intensive, this should only be used in
+Because gzip is CPU-intensive, this should only be used in
 scenarios where the compression ratio is very high (e.g. pretty-printed JSON
 or YAML files).
 
-Use the *gzip_compression* named argument to enable it.  Valid values are 1..9,
+Use the *gzip* named argument to enable it.  Valid values are 1..9,
 where 1 is the lightest compression and 9 the heaviest.  1 uses the least CPU
 on the master (and minion), 9 uses the most.
 
 .. code-block:: bash
 
-    # salt '*' cp.get_file salt://vimrc /etc/vimrc gzip_compression=5
+    # salt '*' cp.get_file salt://vimrc /etc/vimrc gzip=5
 
+Finally, note that by default cp.get_file does *not* create new destination
+directories if they do not exist.  To change this, use the *makedirs* argument:
+
+.. code-block:: bash
+
+    # salt '*' cp.get_file salt://vimrc /etc/vim/vimrc makedirs=True
+
+In this example, /etc/vim/ would be created if it didn't already exist.
 
 get_dir
 ```````
@@ -72,12 +80,12 @@ directory from the master.  The syntax is very similar to get_file:
 
     # salt '*' cp.get_dir salt://etc/apache2 /etc
 
-get_dir supports template rendering and gzip compression just like get_file:
-
+cp.get_dir supports *template* rendering and *gzip* compression arguments just
+like get_file:
 
 .. code-block:: bash
 
-    # salt '*' cp.get_dir salt://etc/{{pillar.webserver}} /etc gzip_compression=5 template=jinja
+    # salt '*' cp.get_dir salt://etc/{{pillar.webserver}} /etc gzip=5 template=jinja
 
 
 File Server Client API

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -96,7 +96,7 @@ class Client(object):
         yield dest
         os.umask(cumask)
 
-    def get_file(self, path, dest='', makedirs=False, env='base'):
+    def get_file(self, path, dest='', makedirs=False, env='base', gzip_compression=None):
         '''
         Copies a file from the local files or master depending on
         implementation
@@ -257,7 +257,7 @@ class Client(object):
                 return dest
         return False
 
-    def get_dir(self, path, dest='', env='base'):
+    def get_dir(self, path, dest='', env='base', gzip_compression=None):
         '''
         Get a directory recursively from the salt-master
         '''
@@ -284,7 +284,7 @@ class Client(object):
                     self.get_file(
                         'salt://{0}'.format(fn_),
                         '{0}/{1}'.format(dest, minion_relpath),
-                        True, env
+                        True, env, gzip_compression
                     )
                 )
         # Replicate empty dirs from master

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -96,7 +96,7 @@ class Client(object):
         yield dest
         os.umask(cumask)
 
-    def get_file(self, path, dest='', makedirs=False, env='base', gzip_compression=None):
+    def get_file(self, path, dest='', makedirs=False, env='base', gzip=None):
         '''
         Copies a file from the local files or master depending on
         implementation
@@ -257,7 +257,7 @@ class Client(object):
                 return dest
         return False
 
-    def get_dir(self, path, dest='', env='base', gzip_compression=None):
+    def get_dir(self, path, dest='', env='base', gzip=None):
         '''
         Get a directory recursively from the salt-master
         '''
@@ -284,7 +284,7 @@ class Client(object):
                     self.get_file(
                         'salt://{0}'.format(fn_),
                         '{0}/{1}'.format(dest, minion_relpath),
-                        True, env, gzip_compression
+                        True, env, gzip
                     )
                 )
         # Replicate empty dirs from master
@@ -413,10 +413,10 @@ class LocalClient(Client):
                 return fnd
         return fnd
 
-    def get_file(self, path, dest='', makedirs=False, env='base', gzip_compression=None):
+    def get_file(self, path, dest='', makedirs=False, env='base', gzip=None):
         '''
         Copies a file from the local files directory into :param:`dest`
-        gzip_compression settings are ignored for local files
+        gzip compression settings are ignored for local files
         '''
         path = self._check_proto(path)
         fnd = self._find_file(path, env)
@@ -555,7 +555,7 @@ class RemoteClient(Client):
         self.auth = salt.crypt.SAuth(opts)
         self.sreq = salt.payload.SREQ(self.opts['master_uri'])
 
-    def get_file(self, path, dest='', makedirs=False, env='base', gzip_compression=None):
+    def get_file(self, path, dest='', makedirs=False, env='base', gzip=None):
         '''
         Get a single file from the salt-master
         path must be a salt server location, aka, salt://path/to/file, if
@@ -567,9 +567,9 @@ class RemoteClient(Client):
         load = {'path': path,
                 'env': env,
                 'cmd': '_serve_file'}
-        if gzip_compression:
-            gzip_compression = int(gzip_compression)
-            load['gzip_compression'] = gzip_compression
+        if gzip:
+            gzip = int(gzip)
+            load['gzip'] = gzip
 
         fn_ = None
         if dest:
@@ -609,8 +609,7 @@ class RemoteClient(Client):
                 with self._cache_loc(data['dest'], env) as cache_dest:
                     dest = cache_dest
                     fn_ = open(dest, 'wb+')
-            gzip_compression = data.get('gzip_compression', None)
-            if gzip_compression:
+            if data.get('gzip', None):
                 data = salt.utils.gzip_util.uncompress(data['data'])
             else:
                 data = data['data']

--- a/salt/master.py
+++ b/salt/master.py
@@ -630,14 +630,14 @@ class AESFuncs(object):
         if not fnd['path']:
             return ret
         ret['dest'] = fnd['rel']
-        gzip_compression = load.get('gzip_compression', None)
+        gzip = load.get('gzip', None)
 
         with open(fnd['path'], 'rb') as fp_:
             fp_.seek(load['loc'])
             data = fp_.read(self.opts['file_buffer_size'])
-            if gzip_compression and data:
-                data = salt.utils.gzip_util.compress(data, gzip_compression)
-                ret['gzip_compression'] = gzip_compression
+            if gzip and data:
+                data = salt.utils.gzip_util.compress(data, gzip)
+                ret['gzip'] = gzip
             ret['data'] = data
         return ret
 

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -81,7 +81,7 @@ def _render_filenames(path, dest, env, template):
     return (path, dest)
 
 
-def get_file(path, dest, env='base', make_dirs=False, template=None, gzip_compression=None):
+def get_file(path, dest, env='base', makedirs=False, template=None, gzip=None):
     '''
     Used to get a single file from the salt master
 
@@ -95,7 +95,7 @@ def get_file(path, dest, env='base', make_dirs=False, template=None, gzip_compre
         return ''
     else:
         client = salt.fileclient.get_file_client(__opts__)
-        return client.get_file(path, dest, make_dirs, env, gzip_compression)
+        return client.get_file(path, dest, makedirs, env, gzip)
 
 
 def get_template(path, dest, template='jinja', env='base', **kwargs):
@@ -118,7 +118,7 @@ def get_template(path, dest, template='jinja', env='base', **kwargs):
     return client.get_template(path, dest, template, False, env, **kwargs)
 
 
-def get_dir(path, dest, env='base', template=None, gzip_compression=None):
+def get_dir(path, dest, env='base', template=None, gzip=None):
     '''
     Used to recursively copy a directory from the salt master
 
@@ -129,7 +129,7 @@ def get_dir(path, dest, env='base', template=None, gzip_compression=None):
     (path, dest) = _render_filenames(path, dest, env, template)
 
     client = salt.fileclient.get_file_client(__opts__)
-    return client.get_dir(path, dest, env, gzip_compression)
+    return client.get_dir(path, dest, env, gzip)
 
 
 def get_url(path, dest, env='base'):

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -41,8 +41,47 @@ def recv(files, dest):
 
     return ret
 
+def _render_filenames(path, dest, env, template):
+    if not template:
+        return (path, dest)
 
-def get_file(path, dest, env='base', template=None, gzip_compression=None):
+    # render the path as a template using path_template_engine as the engine
+    if template not in salt.utils.templates.template_registry:
+        raise CommandExecutionError('Attempted to render file paths with unavailable engine '
+                  '{0}'.format(template))
+
+    kwargs = {}
+    kwargs['salt'] = __salt__
+    kwargs['pillar'] = __pillar__
+    kwargs['grains'] = __grains__
+    kwargs['opts'] = __opts__
+    kwargs['env'] = env
+
+    def _render(contents):
+        # write out path to temp file
+        tmp_path_fn = salt.utils.mkstemp()
+        with open(tmp_path_fn, 'w+') as fp_:
+            fp_.write(contents)
+        data = salt.utils.templates.template_registry[template](
+            tmp_path_fn,
+            to_str=True,
+            **kwargs
+        )
+        salt.utils.safe_rm(tmp_path_fn)
+        if not data['result']:
+            # Failed to render the template
+            raise CommandExecutionError('Failed to render file path with error: {0}'.format(
+                data['data']
+            ))
+        else:
+            return data['data']
+
+    path = _render(path)
+    dest = _render(dest)
+    return (path, dest)
+
+
+def get_file(path, dest, env='base', make_dirs=False, template=None, gzip_compression=None):
     '''
     Used to get a single file from the salt master
 
@@ -50,56 +89,13 @@ def get_file(path, dest, env='base', template=None, gzip_compression=None):
 
         salt '*' cp.get_file salt://path/to/file /minion/dest
     '''
-    if template is not None:
-        # render the path as a template using path_template_engine as the engine
-        if template not in salt.utils.templates.template_registry:
-            log.error('Attempted to render file paths with unavailable engine '
-                      '{0}'.format(template))
-            return ''
-
-        kwargs = {}
-        kwargs['salt'] = __salt__
-        kwargs['pillar'] = __pillar__
-        kwargs['grains'] = __grains__
-        kwargs['opts'] = __opts__
-        kwargs['env'] = env
-
-        def _render(contents):
-            # write out path to temp file
-            tmp_path_fn = salt.utils.mkstemp()
-            with open(tmp_path_fn, 'w+') as fp_:
-                fp_.write(contents)
-            data = salt.utils.templates.template_registry[template](
-                tmp_path_fn,
-                to_str=True,
-                **kwargs
-            )
-            salt.utils.safe_rm(tmp_path_fn)
-            if not data['result']:
-                # Failed to render the template
-                raise CommandExecutionError('Failed to render file path with error: {0}'.format(
-                    data['data']
-                ))
-            else:
-                return data['data']
-
-
-        try:
-            path = _render(path)
-        except CommandExecutionError as exc:
-            log.error(str(exc))
-            return ''
-        try:
-            dest = _render(dest)
-        except CommandExecutionError as exc:
-            log.error(str(exc))
-            return ''
+    (path, dest) = _render_filenames(path, dest, env, template)
 
     if not hash_file(path, env):
         return ''
     else:
         client = salt.fileclient.get_file_client(__opts__)
-        return client.get_file(path, dest, False, env, gzip_compression)
+        return client.get_file(path, dest, make_dirs, env, gzip_compression)
 
 
 def get_template(path, dest, template='jinja', env='base', **kwargs):
@@ -122,7 +118,7 @@ def get_template(path, dest, template='jinja', env='base', **kwargs):
     return client.get_template(path, dest, template, False, env, **kwargs)
 
 
-def get_dir(path, dest, env='base'):
+def get_dir(path, dest, env='base', template=None, gzip_compression=None):
     '''
     Used to recursively copy a directory from the salt master
 
@@ -130,8 +126,10 @@ def get_dir(path, dest, env='base'):
 
         salt '*' cp.get_dir salt://path/to/dir/ /minion/dest
     '''
+    (path, dest) = _render_filenames(path, dest, env, template)
+
     client = salt.fileclient.get_file_client(__opts__)
-    return client.get_dir(path, dest, env)
+    return client.get_dir(path, dest, env, gzip_compression)
 
 
 def get_url(path, dest, env='base'):

--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -19,3 +19,5 @@ integration.test: True
 # Grains addons
 grains:
   test_grain: cheese
+  script: grail
+  alot: many

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -57,7 +57,7 @@ class CPModuleTest(integration.ModuleCase):
                 'salt://file.big',
                 tgt,
             ],
-            gzip_compression=5
+            gzip=5
         )
         with open(tgt, 'r') as scene:
             data = scene.read()
@@ -65,7 +65,7 @@ class CPModuleTest(integration.ModuleCase):
             self.assertNotIn('bacon', data)
             self.assertEqual(hash, hashlib.md5(data).hexdigest())
 
-    def test_get_file_make_dirs(self):
+    def test_get_file_makedirs(self):
         '''
         cp.get_file
         '''
@@ -76,7 +76,7 @@ class CPModuleTest(integration.ModuleCase):
                 'salt://grail/scene33',
                 tgt,
             ],
-            make_dirs=True
+            makedirs=True
         )
         with open(tgt, 'r') as scene:
             data = scene.read()

--- a/tests/integration/modules/cp.py
+++ b/tests/integration/modules/cp.py
@@ -65,6 +65,24 @@ class CPModuleTest(integration.ModuleCase):
             self.assertNotIn('bacon', data)
             self.assertEqual(hash, hashlib.md5(data).hexdigest())
 
+    def test_get_file_make_dirs(self):
+        '''
+        cp.get_file
+        '''
+        tgt = os.path.join(integration.TMP, 'make/dirs/scene33')
+        self.run_function(
+            'cp.get_file',
+            [
+                'salt://grail/scene33',
+                tgt,
+            ],
+            make_dirs=True
+        )
+        with open(tgt, 'r') as scene:
+            data = scene.read()
+            self.assertIn('KNIGHT:  They\'re nervous, sire.', data)
+            self.assertNotIn('bacon', data)
+
     def test_get_template(self):
         '''
         cp.get_template
@@ -93,6 +111,23 @@ class CPModuleTest(integration.ModuleCase):
                     'salt://grail',
                     tgt
                 ])
+        self.assertIn('grail', os.listdir(tgt))
+        self.assertIn('36', os.listdir(os.path.join(tgt, 'grail')))
+        self.assertIn('empty', os.listdir(os.path.join(tgt, 'grail')))
+        self.assertIn('scene', os.listdir(os.path.join(tgt, 'grail', '36')))
+
+    def test_get_dir_templated_paths(self):
+        '''
+        cp.get_dir
+        '''
+        tgt = os.path.join(integration.TMP, 'many')
+        self.run_function(
+            'cp.get_dir',
+            [
+                'salt://{{grains.script}}',
+                tgt.replace('many', '{{grains.alot}}')
+            ]
+        )
         self.assertIn('grail', os.listdir(tgt))
         self.assertIn('36', os.listdir(os.path.join(tgt, 'grail')))
         self.assertIn('empty', os.listdir(os.path.join(tgt, 'grail')))


### PR DESCRIPTION
Another small Pull Request (the TLS stuff will probably have to be on hold until next year, I need to do Proof-of-Concepting of the rest of the ways we plan on using Salt before I can return to it).

Changes:
- Add gzip_compression and template args to cp.get_dir
- Expose make_dirs arg on cp.get_file (allows you to do cp.get_file salt://etc/foo /etc/some/new/dir/foo make_dirs=True)
- Added a short cp.get_dir section to the docs (highlighting that the same args are supported)

Thanks,
Ryan
