### PR TITLE
Add options to gem.install module and gem.installed state for version, ri, and rdoc

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -22,7 +22,7 @@ def _gem(command, ruby=None, runas=None):
         return False
 
 
-def install(gems, ruby=None, runas=None):
+def install(gems, ruby=None, runas=None, version=None, rdoc=False, ri=False):
     '''
     Installs one or several gems.
 
@@ -32,8 +32,23 @@ def install(gems, ruby=None, runas=None):
         If RVM is installed, the ruby version and gemset to use.
     runas : None
         The user to run gem as.
+    version : None
+        Specify the version to install for the gem.
+        Doesn't play nice with multiple gems at once
+    rdoc : False
+        Generate RDoc documentation for the gem(s).
+    ri : False
+        Generate RI documentation for the gem(s).
     '''
-    return _gem('install {gems}'.format(gems=gems), ruby, runas=runas)
+    options = ''
+    if version:
+        options += ' --version {0}'.format(version)
+    if not rdoc:
+        options += ' --no-rdoc'
+    if not ri:
+        options += ' --no-ri'
+
+    return _gem('install {gems} {options}'.format(gems=gems, options=options), ruby, runas=runas)
 
 
 def uninstall(gems, ruby=None, runas=None):

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -22,7 +22,7 @@ def __virtual__():
     return 'gem' if 'gem.list' in __salt__ else False
 
 
-def installed(name, ruby=None, runas=None):
+def installed(name, ruby=None, runas=None, version=None, rdoc=False, ri=False):
     '''
     Make sure that a gem is installed.
 
@@ -32,9 +32,18 @@ def installed(name, ruby=None, runas=None):
         For RVM installations: the ruby version and gemset to target.
     runas : None
         The user to run gem as.
+    version : None
+        Specify the version to install for the gem.
+        Doesn't play nice with multiple gems at once
+    rdoc : False
+        Generate RDoc documentation for the gem(s).
+    ri : False
+        Generate RI documentation for the gem(s).
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-    if name in __salt__['gem.list'](name, ruby, runas=runas):
+
+    gems = __salt__['gem.list'](name, ruby, runas=runas)
+    if name in gems and version in gems[name]:
         ret['result'] = True
         ret['comment'] = 'Gem is already installed.'
         return ret
@@ -42,7 +51,12 @@ def installed(name, ruby=None, runas=None):
     if __opts__['test']:
         ret['comment'] = 'The gem {0} would have been installed'.format(name)
         return ret
-    if __salt__['gem.install'](name, ruby, runas=runas):
+    if __salt__['gem.install'](name,
+                               ruby    = ruby,
+                               runas   = runas,
+                               version = version,
+                               rdoc    = rdoc,
+                               ri      = ri,     ):
         ret['result'] = True
         ret['changes'][name] = 'Installed'
         ret['comment'] = 'Gem was successfully installed'


### PR DESCRIPTION
I've added the ability to control whether ri and rdoc documentation are generated for gems, and they're now disabled by default (which speeds up gem installation).

I've also added the ability to specify a version for installed gems, although this causes problems when multiple gems are specified (which I note in the docstrings); so gems with versions should be specified individually. It's worth mentioning this is also a problem with the gem CLI, so I figured it was acceptable.

Let me know if you have any feedback!
