### PR TITLE
Doc updates and renderer fixes

### DIFF
--- a/doc/ref/renderers/index.rst
+++ b/doc/ref/renderers/index.rst
@@ -47,7 +47,7 @@ The first line is a shebang that references the ``py`` renderer.
 
 Composing Renderers
 -------------------
-A render can be composed from other renderers by connecting them in a series
+A renderer can be composed from other renderers by connecting them in a series
 of pipes(``|``). In fact, the default ``Jinja + YAML`` renderer is implemented
 by combining a yaml renderer and a jinja renderer. Such renderer configuration
 is specified as: ``jinja | yaml``.
@@ -61,7 +61,7 @@ Other renderer combinations are possible, here's a few examples:
       pass the input to the ``mako`` renderer, whose output is then fed into the
       ``yaml`` renderer.
   
-  ``jinja | mako | yaml``
+  ``jinja | mako -s | yaml``
       This one allows you to use both jinja and mako templating syntax in the
       input and then parse the final rendererd output as YAML.
 
@@ -102,8 +102,9 @@ Here is a simple YAML renderer example:
 .. code-block:: python
 
     import yaml
-    def render(yaml_data, env='', sls='', argline='', **kws):
+    def render(yaml_data, env='', sls='', **kws):
         if not isinstance(yaml_data, basestring):
             yaml_data = yaml_data.read()
         data = yaml.load(yaml_data)
         return data if data else {}
+

--- a/doc/ref/renderers/index.rst
+++ b/doc/ref/renderers/index.rst
@@ -61,7 +61,7 @@ Other renderer combinations are possible, here's a few examples:
       pass the input to the ``mako`` renderer, whose output is then fed into the
       ``yaml`` renderer.
   
-  ``jinja | mako -s | yaml``
+  ``jinja | mako | yaml``
       This one allows you to use both jinja and mako templating syntax in the
       input and then parse the final rendererd output as YAML.
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -16,9 +16,8 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
         -s    Interpret renderer input as a string rather than as a file path.
 
     '''
-    if argline == '-s':
-        from_str = True
-    elif argline:
+    from_str = argline=='-s'
+    if not from_str and argline:
         raise SaltRenderError(
                   'Unknown renderer option: {opt}'.format(opt=argline)
               )

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from StringIO import StringIO
 
 # Import Salt libs
 from salt.exceptions import SaltRenderError
@@ -11,18 +12,14 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
     Render the template_file, passing the functions and grains into the
     Jinja rendering system.
 
-    Renderer options:
-
-        -s    Interpret renderer input as a string rather than as a file path.
-
+    :rtype: string
     '''
     from_str = argline=='-s'
     if not from_str and argline:
         raise SaltRenderError(
                   'Unknown renderer option: {opt}'.format(opt=argline)
               )
-    tmp_data = salt.utils.templates.jinja(
-                    template_file, from_str, to_str=True,
+    tmp_data = salt.utils.templates.jinja(template_file, to_str=True,
                     salt=__salt__,
                     grains=__grains__,
                     opts=__opts__,
@@ -33,5 +30,5 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in jinja renderer'))
-    return tmp_data['data']
+    return StringIO(tmp_data['data'])
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -1,8 +1,8 @@
 '''
-The default templating engine, process yaml with the jinja2 templating engine.
+The default templating engine, process sls file with the jinja2 templating engine.
 
-This renderer will take a yaml file with the jinja2 template and render it to a
-yaml string.
+This renderer will take a sls file authored as a jinja2 template, render it, and
+return the rendered result as a string.
 '''
 from __future__ import absolute_import
 
@@ -12,12 +12,24 @@ import salt.utils.templates
 
 
 
-def render(template_file, env='', sls='', context=None, **kws):
+def render(template_file, env='', sls='', argline='', context=None, **kws):
     '''
     Render the template_file, passing the functions and grains into the
     rendering system. Return rendered content as a string.
+
+    Renderer options:
+
+        -s    Interpret renderer input as a string rather than as a file path.
+
     '''
-    tmp_data = salt.utils.templates.jinja(template_file, to_str=True,
+    if argline == '-s':
+        from_str = True
+    elif argline:
+        raise SaltRenderError(
+                  'Unknown renderer option: {opt}'.format(opt=argline)
+              )
+    tmp_data = salt.utils.templates.jinja(
+                    template_file, from_str, to_str=True,
                     salt=__salt__,
                     grains=__grains__,
                     opts=__opts__,

--- a/salt/renderers/json.py
+++ b/salt/renderers/json.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 import json
 
-def render(json_data, env='', sls='', **kws):
+def render(json_data, env='', sls='', argline='', **kws):
     if not isinstance(json_data, basestring):
         json_data = json_data.read()
 

--- a/salt/renderers/mako.py
+++ b/salt/renderers/mako.py
@@ -3,8 +3,21 @@ from __future__ import absolute_import
 import salt.utils.templates
 from salt.exceptions import SaltRenderError
 
-def render(template_file, env='', sls='', context=None, **kws):
-    tmp_data = salt.utils.templates.mako(template_file, to_str=True,
+def render(template_file, env='', sls='', argline='', context=None, **kws):
+    '''
+    Renderer options:
+
+        -s    Interpret renderer input as a string rather than as a file path.
+
+    '''
+    if argline == '-s':
+        from_str = True
+    elif argline:
+        raise SaltRenderError(
+                  'Unknown renderer option: {opt}'.format(opt=argline)
+              )
+    tmp_data = salt.utils.templates.mako(
+                    template_file, from_str, to_str=True,
                     salt=__salt__,
                     grains=__grains__,
                     opts=__opts__,

--- a/salt/renderers/mako.py
+++ b/salt/renderers/mako.py
@@ -14,9 +14,8 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
 
     :rtype: string
     '''
-    if argline == '-s':
-        from_str = True
-    elif argline:
+    from_str = argline=='-s'
+    if not from_str and argline:
         raise SaltRenderError(
                   'Unknown renderer option: {opt}'.format(opt=argline)
               )

--- a/salt/renderers/mako.py
+++ b/salt/renderers/mako.py
@@ -1,26 +1,17 @@
 from __future__ import absolute_import
+from StringIO import StringIO
 
 import salt.utils.templates
 from salt.exceptions import SaltRenderError
 
-def render(template_file, env='', sls='', argline='', context=None, **kws):
+def render(template_file, env='', sls='', context=None, **kws):
     '''
     Render the template_file, passing the functions and grains into the
     Mako rendering system.
 
-    Renderer options:
-
-        -s    Interpret renderer input as a string rather than as a file path.
-
     :rtype: string
     '''
-    from_str = argline=='-s'
-    if not from_str and argline:
-        raise SaltRenderError(
-                  'Unknown renderer option: {opt}'.format(opt=argline)
-              )
-    tmp_data = salt.utils.templates.mako(
-                    template_file, from_str, to_str=True,
+    tmp_data = salt.utils.templates.mako(template_file, to_str=True,
                     salt=__salt__,
                     grains=__grains__,
                     opts=__opts__,
@@ -31,4 +22,4 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in mako renderer'))
-    return tmp_data['data']
+    return StringIO(tmp_data['data'])

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -6,14 +6,6 @@ arguments (including salt specific args, such as 'require', etc) as template
 context. The goal is to make writing reusable/configurable/ parameterized
 salt files easier and cleaner, therefore, additionally, it also:
 
-  - Adds support of absolute(eg, ``salt://path/to/salt/file``) and relative(eg,
-    ``path/to/salt/file``) template inclusion or import(ie, with ``<%include/>``
-    or ``<%namespace.../>``) for Mako. Example::
-
-
-       <%include file="templates/sls-parts.mako"/>
-       <%namespace file="salt://lib/templates/utils.mako" import="helper"/>
-
   - Recognizes the special state function, ``stateconf.set``, that configures a
     default list of named arguments useable within the template context of
     the salt file. Example::

--- a/salt/renderers/wempy.py
+++ b/salt/renderers/wempy.py
@@ -1,3 +1,5 @@
+from StringIO import StringIO
+
 # Import Salt libs
 from salt.exceptions import SaltRenderError
 import salt.utils.templates
@@ -7,19 +9,9 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
     '''
     Render the data passing the functions and grains into the rendering system
 
-    Renderer options:
-
-        -s    Interpret renderer input as a string rather than as a file path.
-
     :rtype: string
     '''
-    from_str = argline=='-s'
-    if not from_str and argline:
-        raise SaltRenderError(
-                  'Unknown renderer option: {opt}'.format(opt=argline)
-              )
-    tmp_data = salt.utils.templates.wempy(
-            template_file, from_str, to_str=True,
+    tmp_data = salt.utils.templates.wempy(template_file, to_str=True,
             salt=__salt__,
             grains=__grains__,
             opts=__opts__,
@@ -30,4 +22,4 @@ def render(template_file, env='', sls='', argline='', context=None, **kws):
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
             'Unknown render error in the wempy renderer'))
-    return tmp_data['data']
+    return StringIO(tmp_data['data'])

--- a/salt/renderers/wempy.py
+++ b/salt/renderers/wempy.py
@@ -3,7 +3,7 @@ from salt.exceptions import SaltRenderError
 import salt.utils.templates
 
 
-def render(template_file, env='', sls='', context=None, **kws):
+def render(template_file, env='', sls='', argline='', context=None, **kws):
     '''
     Render the data passing the functions and grains into the rendering system
 
@@ -13,9 +13,8 @@ def render(template_file, env='', sls='', context=None, **kws):
 
     :rtype: string
     '''
-    if argline == '-s':
-        from_str = True
-    elif argline:
+    from_str = argline=='-s'
+    if not from_str and argline:
         raise SaltRenderError(
                   'Unknown renderer option: {opt}'.format(opt=argline)
               )

--- a/salt/renderers/wempy.py
+++ b/salt/renderers/wempy.py
@@ -1,5 +1,5 @@
 '''
-Process yaml with the Wempy templating engine
+Process a sls file with the Wempy templating engine
 
 '''
 
@@ -11,10 +11,20 @@ import salt.utils.templates
 def render(template_file, env='', sls='', context=None, **kws):
     '''
     Render the data passing the functions and grains into the rendering system
+
+    Renderer options:
+
+        -s    Interpret renderer input as a string rather than as a file path.
+
     '''
+    if argline == '-s':
+        from_str = True
+    elif argline:
+        raise SaltRenderError(
+                  'Unknown renderer option: {opt}'.format(opt=argline)
+              )
     tmp_data = salt.utils.templates.wempy(
-            template_file,
-            True,
+            template_file, from_str, to_str=True,
             salt=__salt__,
             grains=__grains__,
             opts=__opts__,
@@ -24,5 +34,5 @@ def render(template_file, env='', sls='', context=None, **kws):
             context=context)
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',
-            'Unknown render error in yaml_wempy renderer'))
+            'Unknown render error in the wempy renderer'))
     return tmp_data['data']

--- a/salt/utils/mako.py
+++ b/salt/utils/mako.py
@@ -16,6 +16,11 @@ class SaltMakoTemplateLookup(TemplateCollection):
     If URL is an absolute path then it's treated as if it has been prefixed
     with salt://.
 
+    Examples::
+
+       <%include file="templates/sls-parts.mako"/>
+       <%namespace file="salt://lib/templates/utils.mako" import="helper"/>
+
     """
 
     def __init__(self, opts, env='base'):

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -44,6 +44,7 @@ def wrap_tmpl_func(render_str):
                     tmplstr = tmplsrc.read()
         else:  # assume tmplsrc is file-like.
             tmplstr = tmplsrc.read()
+            tmplsrc.close()
         try:
             output = render_str(tmplstr, context)
         except SaltTemplateRenderError, exc:


### PR DESCRIPTION
For a template renderer to be used in the middle of a pipeline(eg, jinja | mako | yaml) , there are several ways to solve this problem:
- make a template renderer accept an option(-s) that would cause the renderer to treat its input as the template string rather than as a file path. This is the current solution.
- add another renderer(eg, call it something like 'read') that takes input as file path and return output the string content of the file read from the file path.  Eg,  jinja | read | mako | yaml 
- make the output of a template renderer a file-like object rather than just a string.
  This will work because currently all renderers that take string as inputs will assume the input to be a file-like object and read from it if it's not a string. The only concern I have with this approach is then the receiving renderer needs to close the file object or the compile_template() function that calls each renderer needs to check if the output of a renderer has a callable close attribute and then call it if it has. Though, with this approach, we can just write jinja | mako | yaml without needing to specify an option.
