### PR TITLE
Fixes #2464 check for i386 pkgs on 64bit systems

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -70,14 +70,12 @@ def version(name):
 
         salt '*' pkg.version <package name>
     '''
-    # check for :i386 appended to 32bit name installed on 64bit machine
-    name32bit = '{0}:i386'.format(name)
-
     pkgs = list_pkgs(name)
+    # check for ':arch' appended to pkg name (i.e. 32 bit installed on 64 bit machine is ':i386')
+    if name.find(':') >= 0:
+        name = name.split(':')[0]
     if name in pkgs:
         return pkgs[name]
-    if name32bit in pkgs:
-        return pkgs[name32bit]
     else:
         return ''
 


### PR DESCRIPTION
@UtahDave's fix was close; it appended the ':arch' instead of removing it to do the search within pkgs. I also generalized the case to fit arch's other than i386.

The problem in detail was that you need to use packagename:arch when running list_pkgs. However in the dict returned by list_pkgs, you will find "packagename" and not "packagename:arch". This is why I am stripping the ":arch" off before searching the dict to find the package.
