### PR TITLE
Logic and test fixes for version, ri, rdoc support in gem state

### DIFF
--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -43,7 +43,11 @@ def installed(name, ruby=None, runas=None, version=None, rdoc=False, ri=False):
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     gems = __salt__['gem.list'](name, ruby, runas=runas)
-    if name in gems and version in gems[name]:
+    if name in gems and version and version in gems[name]:
+        ret['result'] = True
+        ret['comment'] = 'Gem is already installed.'
+        return ret
+    elif name in gems:
         ret['result'] = True
         ret['comment'] = 'Gem is already installed.'
         return ret

--- a/tests/unit/states/gem_test.py
+++ b/tests/unit/states/gem_test.py
@@ -19,7 +19,7 @@ gem.__opts__ = {'test': False}
 class TestGemState(TestCase):
 
     def test_installed(self):
-        gems = ['foo', 'bar']
+        gems = {'foo' : ['1.0'], 'bar' : ['2.0']}
         gem_list = MagicMock(return_value=gems)
         gem_install_succeeds = MagicMock(return_value=True)
         gem_install_fails = MagicMock(return_value=False)
@@ -32,14 +32,14 @@ class TestGemState(TestCase):
                 ret = gem.installed('quux')
                 self.assertEqual(True, ret['result'])
                 gem_install_succeeds.assert_called_once_with(
-                    'quux', None, runas=None)
+                    'quux', ruby=None, runas=None, version=None, rdoc=False, ri=False)
 
             with patch.dict(gem.__salt__,
                             {'gem.install': gem_install_fails}):
                 ret = gem.installed('quux')
                 self.assertEqual(False, ret['result'])
                 gem_install_fails.assert_called_once_with(
-                    'quux', None, runas=None)
+                    'quux', ruby=None, runas=None, version=None, rdoc=False, ri=False)
 
     def test_removed(self):
         gems = ['foo', 'bar']


### PR DESCRIPTION
The logic needed to be fixed in the gem state so that it only checks the version if the user has specified a version.

The test needed to be fixed to reflect the return value of gem.list (a dict with lists as values, rather than just a list) and the new arguments to gem.installed.
