### PR TITLE
Deprecate `--*-out` in favour of `--out/--output`. Fixes #2566. 

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -28,19 +28,25 @@ def get_printout(out, opts=None, **kwargs):
     '''
     if opts is None:
         opts = {}
-    for outputter in STATIC:
-        if outputter in opts:
-            if opts[outputter]:
-                if outputter == 'text_out':
-                    out = 'txt'
-                else:
-                    out = outputter
+
+    if 'output' in opts:
+        # new --out option
+        out = opts['output']
+    else:
+        # XXX: This should be removed before 0.10.8 comes out
+        for outputter in STATIC:
+            if outputter in opts:
+                if opts[outputter]:
+                    if outputter == 'text_out':
+                        out = 'txt'
+                    else:
+                        out = outputter
+        if out and out.endswith('_out'):
+            out = out[:-4]
+
     if out is None:
         out = 'pprint'
-    if out.endswith('_out'):
-        out = out[:-4]
-    if opts is None:
-        opts = {}
+
     opts.update(kwargs)
     if not 'color' in opts:
         opts['color'] = not bool(opts.get('no_color', False))
@@ -55,4 +61,3 @@ def out_format(data, out, opts=None):
     Return the formatted outputter string for the passed data
     '''
     return get_printout(out, opts)(data).rstrip()
-

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -12,7 +12,7 @@ import sys
 import logging
 import optparse
 from functools import partial
-from salt import config, log, version
+from salt import config, loader, log, version
 
 
 def _sorted(mixins_or_funcs):
@@ -578,6 +578,25 @@ class OutputOptionsMixIn(object):
                 help=('Print the output from the \'{0}\' command in the same '
                       'form the shell would.'.format(self.get_prog_name()))
             )
+
+        outputters = loader.outputters(
+            config.minion_config(
+                '/etc/salt/minion', check_dns=False
+            )
+        )
+
+        group.add_option(
+            '--out', '--output'.
+            dest='output',
+            choices=outputters.keys(),
+            help=(
+                'Print the output from the \'{0}\' command using the '
+                'specified outputter. One of {1}.'.format(
+                    self.get_prog_name(),
+                    ', '.join([repr(k) for k in outputters])
+                )
+            )
+        )
         group.add_option(
             '--no-color',
             default=False,
@@ -585,19 +604,50 @@ class OutputOptionsMixIn(object):
             help='Disable all colored output'
         )
 
-        for option in group.option_list:
+        for option in self.output_options_group.option_list:
             def process(opt):
-                if getattr(self.options, opt.dest):
-                    self.selected_output_option = opt.dest
+                default = self.defaults.get(opt.dest)
+                if getattr(self.options, opt.dest, default) is False:
+                    return
+
+                # XXX: CLEAN THIS CODE WHEN 0.10.8 is about to come out
+                if version.__version_info__ >= (0, 10, 7):
+                    self.error(
+                        'The option {0} is deprecated. You must now use '
+                        '\'--out {1}\' instead.'.format(
+                            opt.get_opt_string(),
+                            opt.dest.split('_', 1)[0]
+                        )
+                    )
+
+                if opt.dest != 'out':
+                    msg = (
+                        'The option {0} is deprecated. Please consider using '
+                        '\'--out {1}\' instead.'.format(
+                            opt.get_opt_string(),
+                            opt.dest.split('_', 1)[0]
+                        )
+                    )
+                    if log.is_console_configured():
+                        logging.getLogger(__name__).warning(msg)
+                    else:
+                        sys.stdout.write('WARNING: {0}\n'.format(msg))
+
+                self.selected_output_option = opt.dest
 
             funcname = 'process_{0}'.format(option.dest)
             if not hasattr(self, funcname):
                 setattr(self, funcname, partial(process, option))
 
+    def process_output(self):
+        self.selected_output_option = self.options.output
+
     def _mixin_after_parsed(self):
         group_options_selected = filter(
-            lambda option: getattr(self.options, option.dest) and
-                           option.dest.endswith('_out'),
+            lambda option: (
+                getattr(self.options, option.dest) and
+                (option.dest.endswith('_out') or option.dest=='output')
+            ),
             self.output_options_group.option_list
         )
         if len(group_options_selected) > 1:

--- a/salt/version.py
+++ b/salt/version.py
@@ -3,6 +3,7 @@ import sys
 __version_info__ = (0, 10, 4)
 __version__ = '.'.join(map(str, __version_info__))
 
+
 # If we can get a version from Git use that instead, otherwise carry on
 try:
     import subprocess
@@ -15,9 +16,12 @@ try:
         out, err = p.communicate()
         if out:
             __version__ = '{0}'.format(out.strip().lstrip('v'))
-            __version_info__ = tuple(__version__.split('-', 1)[0].split('.'))
+            __version_info__ = tuple(
+                [int(i) for i in __version__.split('-', 1)[0].split('.')]
+            )
 except Exception:
     pass
+
 
 def versions_report():
     libs = (


### PR DESCRIPTION
- Added the necessary code to support the new `--output` option.
- Added the code to warn users on salt < 0.10.7 and error on salt >= 0.10.7
- In order to get the outputters at runtime, I need to add a switch to `salt.config.minion_config()`, `check_dns` which default to `True` to keep behaviour and when `False` speeds up it's use.
