### PR TITLE
Deprecate `--xxx-out` in favour of `--out/--output`

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -231,6 +231,8 @@ def minion_config(path, check_dns=True):
         opts['id'] = _append_domain(opts)
 
     if check_dns:
+        # Because I import salt.log bellow I need to re-import salt.utils here
+        import salt.utils
         try:
             opts['master_ip'] = salt.utils.dns_check(opts['master'], True)
         except SaltClientError:
@@ -239,15 +241,15 @@ def minion_config(path, check_dns=True):
                     import salt.log
                     msg = ('Master hostname: {0} not found. Retrying in {1} '
                            'seconds').format(opts['master'], opts['retry_dns'])
-
-                    import salt.log
                     if salt.log.is_console_configured():
                         log.warn(msg)
                     else:
-                        print msg
+                        print('WARNING: {0}'.format(msg))
                     time.sleep(opts['retry_dns'])
                     try:
-                        opts['master_ip'] = salt.utils.dns_check(opts['master'], True)
+                        opts['master_ip'] = salt.utils.dns_check(
+                            opts['master'], True
+                        )
                         break
                     except SaltClientError:
                         pass
@@ -256,8 +258,7 @@ def minion_config(path, check_dns=True):
     else:
         opts['master_ip'] = '127.0.0.1'
 
-    opts['master_uri'] = 'tcp://{ip}:{port}'.format(
-        ip=opts['master_ip'],
+    opts['master_uri'] = 'tcp://{ip}:{port}'.format(ip=opts['master_ip'],
                                                     port=opts['master_port'])
 
     # Enabling open mode requires that the value be set to True, and

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -32,6 +32,8 @@ def get_printout(out, opts=None, **kwargs):
     if 'output' in opts:
         # new --out option
         out = opts['output']
+        if out == 'text':
+            out = 'txt'
     else:
         # XXX: This should be removed before 0.10.8 comes out
         for outputter in STATIC:

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -28,19 +28,25 @@ def get_printout(out, opts=None, **kwargs):
     '''
     if opts is None:
         opts = {}
-    for outputter in STATIC:
-        if outputter in opts:
-            if opts[outputter]:
-                if outputter == 'text_out':
-                    out = 'txt'
-                else:
-                    out = outputter
+
+    if 'output' in opts:
+        # new --out option
+        out = opts['output']
+    else:
+        # XXX: This should be removed before 0.10.8 comes out
+        for outputter in STATIC:
+            if outputter in opts:
+                if opts[outputter]:
+                    if outputter == 'text_out':
+                        out = 'txt'
+                    else:
+                        out = outputter
+        if out and out.endswith('_out'):
+            out = out[:-4]
+
     if out is None:
         out = 'pprint'
-    if out.endswith('_out'):
-        out = out[:-4]
-    if opts is None:
-        opts = {}
+
     opts.update(kwargs)
     if not 'color' in opts:
         opts['color'] = not bool(opts.get('no_color', False))
@@ -55,4 +61,3 @@ def out_format(data, out, opts=None):
     Return the formatted outputter string for the passed data
     '''
     return get_printout(out, opts)(data).rstrip()
-

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -12,7 +12,7 @@ import sys
 import logging
 import optparse
 from functools import partial
-from salt import config, log, version
+from salt import config, loader, log, version
 
 
 def _sorted(mixins_or_funcs):
@@ -578,6 +578,25 @@ class OutputOptionsMixIn(object):
                 help=('Print the output from the \'{0}\' command in the same '
                       'form the shell would.'.format(self.get_prog_name()))
             )
+
+        outputters = loader.outputters(
+            config.minion_config(
+                '/etc/salt/minion', check_dns=False
+            )
+        )
+
+        group.add_option(
+            '--out', '--output'.
+            dest='output',
+            choices=outputters.keys(),
+            help=(
+                'Print the output from the \'{0}\' command using the '
+                'specified outputter. One of {1}.'.format(
+                    self.get_prog_name(),
+                    ', '.join([repr(k) for k in outputters])
+                )
+            )
+        )
         group.add_option(
             '--no-color',
             default=False,
@@ -585,19 +604,50 @@ class OutputOptionsMixIn(object):
             help='Disable all colored output'
         )
 
-        for option in group.option_list:
+        for option in self.output_options_group.option_list:
             def process(opt):
-                if getattr(self.options, opt.dest):
-                    self.selected_output_option = opt.dest
+                default = self.defaults.get(opt.dest)
+                if getattr(self.options, opt.dest, default) is False:
+                    return
+
+                # XXX: CLEAN THIS CODE WHEN 0.10.8 is about to come out
+                if version.__version_info__ >= (0, 10, 7):
+                    self.error(
+                        'The option {0} is deprecated. You must now use '
+                        '\'--out {1}\' instead.'.format(
+                            opt.get_opt_string(),
+                            opt.dest.split('_', 1)[0]
+                        )
+                    )
+
+                if opt.dest != 'out':
+                    msg = (
+                        'The option {0} is deprecated. Please consider using '
+                        '\'--out {1}\' instead.'.format(
+                            opt.get_opt_string(),
+                            opt.dest.split('_', 1)[0]
+                        )
+                    )
+                    if log.is_console_configured():
+                        logging.getLogger(__name__).warning(msg)
+                    else:
+                        sys.stdout.write('WARNING: {0}\n'.format(msg))
+
+                self.selected_output_option = opt.dest
 
             funcname = 'process_{0}'.format(option.dest)
             if not hasattr(self, funcname):
                 setattr(self, funcname, partial(process, option))
 
+    def process_output(self):
+        self.selected_output_option = self.options.output
+
     def _mixin_after_parsed(self):
         group_options_selected = filter(
-            lambda option: getattr(self.options, option.dest) and
-                           option.dest.endswith('_out'),
+            lambda option: (
+                getattr(self.options, option.dest) and
+                (option.dest.endswith('_out') or option.dest=='output')
+            ),
             self.output_options_group.option_list
         )
         if len(group_options_selected) > 1:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -586,7 +586,7 @@ class OutputOptionsMixIn(object):
         )
 
         group.add_option(
-            '--out', '--output'.
+            '--out', '--output',
             dest='output',
             choices=outputters.keys(),
             help=(

--- a/salt/version.py
+++ b/salt/version.py
@@ -3,6 +3,7 @@ import sys
 __version_info__ = (0, 10, 4)
 __version__ = '.'.join(map(str, __version_info__))
 
+
 # If we can get a version from Git use that instead, otherwise carry on
 try:
     import subprocess
@@ -15,9 +16,12 @@ try:
         out, err = p.communicate()
         if out:
             __version__ = '{0}'.format(out.strip().lstrip('v'))
-            __version_info__ = tuple(__version__.split('-', 1)[0].split('.'))
+            __version_info__ = tuple(
+                [int(i) for i in __version__.split('-', 1)[0].split('.')]
+            )
 except Exception:
     pass
+
 
 def versions_report():
     libs = (

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -10,6 +10,7 @@
 import sys
 
 # Import salt libs
+from salt import version
 from saltunittest import TestLoader, TextTestRunner, skipIf
 import integration
 from integration import TestDaemon
@@ -30,9 +31,19 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
     def test_text_output(self):
         out = self.run_call('--text-out test.fib 3')
-        self.assertEqual(
-            'local: ([0, 1, 1, 2]', ''.join(out).rsplit(",", 1)[0]
-        )
+        if version.__version_info__ < (0, 10, 8):
+            expect = [
+                "WARNING: The option --text-out is deprecated. Please "
+                "consider using '--out text' instead."
+            ]
+        else:
+            expect = []
+
+        expect += [
+            'local: ([0, 1, 1, 2]'
+        ]
+
+        self.assertEqual(''.join(expect), ''.join(out).rsplit(",", 1)[0])
 
     @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
     def test_user_delete_kw_output(self):

--- a/tests/integration/shell/key.py
+++ b/tests/integration/shell/key.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 
 # Import salt libs
+from salt import version
 from saltunittest import TestLoader, TextTestRunner
 import integration
 from integration import TestDaemon
@@ -37,8 +38,15 @@ class KeyTest(integration.ShellCase,
         test salt-key -L --json-out
         '''
         data = self.run_key('-L --json-out')
+        if version.__version_info__ < (0, 10, 8):
+            expect = [
+                "WARNING: The option --json-out is deprecated. Please "
+                "consider using '--out json' instead."
+            ]
+        else:
+            expect = []
 
-        expect = [
+        expect += [
             '{',
             '    "minions_rejected": [], ',
             '    "minions_pre": [], ',
@@ -55,7 +63,15 @@ class KeyTest(integration.ShellCase,
         test salt-key -L --yaml-out
         '''
         data = self.run_key('-L --yaml-out')
-        expect = [
+        if version.__version_info__ < (0, 10, 8):
+            expect = [
+                "WARNING: The option --yaml-out is deprecated. Please "
+                "consider using '--out yaml' instead."
+            ]
+        else:
+            expect = []
+
+        expect += [
             'minions:',
             '- minion',
             '- sub_minion',
@@ -69,7 +85,15 @@ class KeyTest(integration.ShellCase,
         test salt-key -L --raw-out
         '''
         data = self.run_key('-L --raw-out')
-        expect = [
+        if version.__version_info__ < (0, 10, 8):
+            expect = [
+                "WARNING: The option --raw-out is deprecated. Please "
+                "consider using '--out raw' instead."
+            ]
+        else:
+            expect = []
+
+        expect += [
             "{'minions_rejected': [], 'minions_pre': [], "
             "'minions': ['minion', 'sub_minion']}"
         ]


### PR DESCRIPTION
-  Added the necessary code to support the new --output option.
- Added the code to warn users on salt < 0.10.7 and error on salt >= 0.10.7
- In order to get the outputters at runtime, I need to add a switch to salt.config.minion_config(),  check_dns which default to True to keep behaviour and when False speeds up it's use.

This might need to wait for tests fixing.
@thatch45 want this for 0.10.5?
