### PR TITLE
Handle `__version_info__` when local git tags are not up to date.

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -26,10 +26,27 @@ try:
         )
         out, err = p.communicate()
         if out:
-            __version__ = '{0}'.format(out.strip().lstrip('v'))
-            __version_info__ = tuple(
-                [int(i) for i in __version__.split('-', 1)[0].split('.')]
+            parsed_version = '{0}'.format(out.strip().lstrip('v'))
+            parsed_version_info = tuple(
+                [int(i) for i in parsed_version.split('-', 1)[0].split('.')]
             )
+            if parsed_version_info != __version_info__:
+                msg = ('In order to get the proper salt version with the git '
+                       'hash you need to update salt\'s local git tags. '
+                       'Something like: \'git fetch --tags\' or '
+                       '\'git fetch --tags upstream\' if you followed '
+                       'salt\'s contribute documentation. The version string '
+                       'WILL NOT include the git hash.')
+                from salt import log
+                if log.is_console_configured():
+                    import logging
+                    logging.getLogger(__name__).warning(msg)
+                else:
+                    sys.stderr.write('WARNING: {0}\n'.format(msg))
+            else:
+                __version__ = parsed_version
+                __version_info__ = parsed_version_info
+
 except Exception:
     pass
 


### PR DESCRIPTION
- We now Warn users about missing local git tags, let them know how to update them and, if not up to date, use the defined `__version__` and `__version_info__` instead of the parsed one.
