### PR TITLE
Fixes #2583 Remove check for configs. Only check for libraries

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -35,14 +35,10 @@ __opts__ = {}
 
 def __virtual__():
     '''
-    Only load this module if the mysql config is set
+    Only load this module if the mysql libraries exist
     '''
-    if any(k.startswith('mysql.') for k in list(__opts__)):
-        if has_mysqldb:
-            return 'mysql'
-    elif any(k.startswith('mysql.') for k in list(__pillar__)):
-        if has_mysqldb:
-            return 'mysql'
+    if has_mysqldb:
+        return 'mysql'
     return False
 
 


### PR DESCRIPTION
Fixes #2583
the **virtual** function was checking for the existence of configs
in **opts** and **pillar**. The virtual function doesn't have
access to config.option and so couldn't see the configs that existed
on the master.

Just check for the libraries now.
