### PR TITLE
Fix for #2582. Replaced git-pull with git-fetch; git-merge FETCH_HEAD.

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -297,7 +297,7 @@ def merge(cwd, branch='@{upstream}', opts=None, user=None):
 
     if not opts:
         opts = ''
-    cmd = 'git merge {0}{1} {2}'.format(
+    cmd = 'git merge {0} {1}'.format(
             branch,
             opts)
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -66,21 +66,34 @@ def latest(name,
         try:
             current_rev = __salt__['git.revision'](target, user=runas)
 
-            if __opts__['test']:
-                return _neutral_test(
+            #only do something, if the specified rev differs from the
+            #current_rev
+            if rev == current_rev:
+                new_rev = current_rev
+            else:
+
+                if __opts__['test']:
+                    return _neutral_test(
                         ret,
                         ('Repository {0} update is probably required (current '
-                        'revision is {1})').format(target, current_rev))
+                         'revision is {1})').format(target, current_rev))
 
-            __salt__['git.pull'](target, user=runas)
+                __salt__['git.fetch'](target, user=runas)
 
-            if rev:
-                __salt__['git.checkout'](target, rev, user=runas)
+                if rev:
+                    __salt__['git.checkout'](target, rev, user=runas)
 
-            if submodules:
-                __salt__['git.submodule'](target, user=runas, opts='--recursive')
+                # check if we are on a branch to merge changes
+                cmd = "git symbolic-ref -q HEAD > /dev/null"
+                retcode = __salt__['cmd.retcode'](cmd, cwd=target, runas=runas)
+                if 0 == retcode:
+                    __salt__['git.merge'](target, 'FETCH_HEAD', user=runas)
 
-            new_rev = __salt__['git.revision'](cwd=target, user=runas)
+                if submodules:
+                    __salt__['git.submodule'](target, user=runas,
+                                              opts='--recursive')
+
+                new_rev = __salt__['git.revision'](cwd=target, user=runas)
 
         except Exception as exc:
             return _fail(


### PR DESCRIPTION
Where the merge only happens, if there is a branch currently checked out. The whole function still needs to be checked for consistency in all tests and log messages
