### PR TITLE
Fix `stateconf` test failing in 2.6 because `OrderedDict` was not available.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
 before_install:
   - sudo apt-get update && sudo apt-get install swig supervisor rabbitmq-server ruby
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi"
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi"
 
 install: pip install -r requirements.txt --use-mirrors
 script: sudo -E python setup.py test --runtests-opts='--run-destructive --sysinfo -v'

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -180,6 +180,7 @@ re-write or renames state id's and their references.
 #
 
 # Import python libs
+import sys
 import logging
 import re
 import getopt
@@ -259,7 +260,9 @@ def render(template_file, env='', sls='', argline='', **kws):
         name, rd_argline = (args[0] + ' ').split(' ', 1)
         render_data = renderers[name]  # eg, the yaml renderer
         if ('-o', '') in opts:
-            if name == 'yaml':
+            if name == 'yaml' and (sys.version_info > (2, 6) or
+                                   (sys.version_info < (2, 7) and
+                                    'OrderedDict' not in sys.modules)):
                 IMPLICIT_REQUIRE = True
                 rd_argline = '-o ' + rd_argline
             else:

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -27,7 +27,6 @@ except ImportError:
         HAS_ORDERED_DICT = False
 
 
-
 def get_yaml_loader(argline):
     try:
         opts, args = getopt.getopt(argline.split(), 'o')

--- a/tests/unit/stateconf_test.py
+++ b/tests/unit/stateconf_test.py
@@ -1,4 +1,5 @@
 # Import Python libs
+import sys
 from cStringIO import StringIO
 
 # Import Salt libs
@@ -22,7 +23,7 @@ def render_sls(content, sls='', env='base', argline='-G yaml . jinja', **kws):
     return RENDERERS['stateconf'](
                 StringIO(content), env=env, sls=sls,
                 argline=argline,
-                renderers=RENDERERS, 
+                renderers=RENDERERS,
                 **kws)
 
 
@@ -40,7 +41,7 @@ class StateConfigRendererTestCase(TestCase):
     - set
     - name: value
 
-# --- end of state config ---  
+# --- end of state config ---
 
 test:
   cmd.run:
@@ -104,7 +105,7 @@ state_id:
             self.assertTrue('state_id' in result)
             self.assertEqual(result['state_id']['cmd.run'][2][req][0]['cmd'],
                          'test::test')
-                  
+
 
     def test_relative_include_with_requisites(self):
         for req in REQUISITES:
@@ -156,6 +157,9 @@ extend:
                          set('ABCDE'))
 
     def test_implicit_require_with_goal_state(self):
+        if sys.version_info < (2, 7) and 'OrderedDict' not in sys.modules:
+            self.skipTest('OrderedDict is not available')
+
         result = render_sls('''
 {% for sid in "ABCDE": %}
 {{sid}}:
@@ -206,4 +210,3 @@ G:
         self.assertEqual(
                 [i.itervalues().next() for i in goal_args[0]['require']],
                 list('ABCDEFG'))
-


### PR DESCRIPTION
Fix `stateconf` test failing in 2.6 because `OrderedDict` was not available.
