### PR TITLE
Tests sync timer accuracy, cleanup, etc

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -334,10 +334,11 @@ class TestDaemon(object):
             running = self.__client_job_running(targets, jid)
             sys.stdout.write('\r' + ' ' * PNUM + '\r')
             if not running:
+                print
                 return True
             sys.stdout.write(
                 '    * [Quit in {0}] Waiting for {1}'.format(
-                    '{0}'.format(expire-now).rsplit('.', 1)[0],
+                    '{0}'.format(expire - now).rsplit('.', 1)[0],
                     ', '.join(running)
                 )
             )

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -11,7 +11,7 @@ import shutil
 import subprocess
 import tempfile
 import time
-from datetime import timedelta
+from datetime import datetime, timedelta
 try:
     import pwd
 except ImportError:
@@ -328,19 +328,23 @@ class TestDaemon(object):
             shutil.rmtree(TMP)
 
     def wait_for_jid(self, targets, jid, timeout=120):
-        while timeout > 0:
+        now = datetime.now()
+        expire = now + timedelta(seconds=timeout)
+        while now <= expire:
             running = self.__client_job_running(targets, jid)
             sys.stdout.write('\r' + ' ' * PNUM + '\r')
             if not running:
                 return True
             sys.stdout.write(
                 '    * [Quit in {0}] Waiting for {1}'.format(
-                    timedelta(seconds=timeout), ', '.join(running)
+                    '{0}'.format(expire-now).rsplit('.', 1)[0],
+                    ', '.join(running)
                 )
             )
             sys.stdout.flush()
             timeout -= 1
             time.sleep(1)
+            now = datetime.now()
         else:
             sys.stdout.write('\n    * ERROR: Failed to get information back\n')
             sys.stdout.flush()

--- a/tests/integration/shell/key.py
+++ b/tests/integration/shell/key.py
@@ -39,14 +39,15 @@ class KeyTest(integration.ShellCase,
         '''
         data = self.run_key('-L --json-out')
         if version.__version_info__ < (0, 10, 8):
-            expect = [
+            self.assertEqual(
                 "WARNING: The option --json-out is deprecated. Please "
-                "consider using '--out json' instead."
-            ]
-        else:
-            expect = []
+                "consider using '--out json' instead.",
+                data[0]
+            )
 
-        expect += [
+        data = self.run_key('-L --out json')
+
+        expect = [
             '{',
             '    "minions_rejected": [], ',
             '    "minions_pre": [], ',
@@ -64,14 +65,15 @@ class KeyTest(integration.ShellCase,
         '''
         data = self.run_key('-L --yaml-out')
         if version.__version_info__ < (0, 10, 8):
-            expect = [
+            self.assertEqual(
                 "WARNING: The option --yaml-out is deprecated. Please "
-                "consider using '--out yaml' instead."
-            ]
-        else:
-            expect = []
+                "consider using '--out yaml' instead.",
+                data[0]
+            )
 
-        expect += [
+        data = self.run_key('-L --out yaml')
+
+        expect = [
             'minions:',
             '- minion',
             '- sub_minion',
@@ -86,14 +88,15 @@ class KeyTest(integration.ShellCase,
         '''
         data = self.run_key('-L --raw-out')
         if version.__version_info__ < (0, 10, 8):
-            expect = [
+            self.assertEqual(
                 "WARNING: The option --raw-out is deprecated. Please "
-                "consider using '--out raw' instead."
-            ]
-        else:
-            expect = []
+                "consider using '--out raw' instead.",
+                data[0]
+            )
 
-        expect += [
+        data = self.run_key('-L --out raw')
+
+        expect = [
             "{'minions_rejected': [], 'minions_pre': [], "
             "'minions': ['minion', 'sub_minion']}"
         ]


### PR DESCRIPTION
- Use actual time, to reduce `time.sleep()` inaccuracy. 
- Test for deprecation message first and then use the new `--out` format.
- Minor cosmetic change.
