### PR TITLE
Add grains sanitize

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -20,14 +20,20 @@ def _serial_sanitizer(instr):
     index = int(floor(length * .75))
     return "{0}{1}".format(instr[:index], 'X' * (length - index))
 
+_fqdn_sanitizer = lambda x: 'MINION.DOMAINNAME'
+_hostname_sanitizer = lambda x: 'MINION'
+_domainname_sanitizer = lambda x: 'DOMAINNAME'
+
 # A dictionary of grain -> function mappings for sanitizing grain output. This
 # is used when the 'sanitize' flag is given.
 _sanitizers = {
     'serialnumber': _serial_sanitizer,
-    'domain': lambda x: 'domain',
-    'fqdn': lambda x: 'minion.domain',
-    'host': lambda x: 'minion',
-    'id': lambda x: 'minion.domain',
+    'domain': _domainname_sanitizer,
+    'fqdn': _fqdn_sanitizer,
+    'id': _fqdn_sanitizer,
+    'host': _hostname_sanitizer,
+    'localhost': _hostname_sanitizer,
+    'nodename': _hostname_sanitizer,
 }
 
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -12,26 +12,58 @@ __outputter__ = {
 }
 
 
-def items():
+def _str_sanitizer(instr):
+    return "{0}{1}".format(instr[:-4], 'X' * 4)
+
+# A dictionary of grain -> function mappings for sanitizing grain output. This
+# is used when the 'sanitize' flag is given.
+_sanitizers = {
+    'serialnumber': _str_sanitizer,
+    'domain': lambda x: 'domain',
+    'fqdn': lambda x: 'minion.domain',
+    'host': lambda x: 'minion',
+    'id': lambda x: 'minion.domain',
+}
+
+
+def items(sanitize=False):
     '''
     Return the grains data
 
     CLI Example::
 
         salt '*' grains.items
+
+    Sanitized CLI output::
+
+        salt '*' grains.items sanitize=True
     '''
-    return __grains__
+    if sanitize:
+        out = dict(__grains__)
+        for (k, f) in _sanitizers.items():
+            if k in out:
+                out[k] = f(out[k])
+        return out
+    else:
+        return __grains__
 
 
-def item(key=None):
+def item(key=None, sanitize=False):
     '''
     Return a singe component of the grains data
 
     CLI Example::
 
         salt '*' grains.item os
+
+    Sanitized CLI output::
+
+        salt '*' grains.items serialnumber sanitize=True
     '''
-    return __grains__.get(key, '')
+    if sanitize and key in _sanitizers:
+        return _sanitizers[key](_grains__.get(key, ''))
+    else:
+        return __grains__.get(key, '')
 
 
 def ls():

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -2,6 +2,8 @@
 Control aspects of the grains data
 '''
 
+from math import floor
+
 # Seed the grains dict so cython will build
 __grains__ = {}
 
@@ -12,13 +14,16 @@ __outputter__ = {
 }
 
 
-def _str_sanitizer(instr):
-    return "{0}{1}".format(instr[:-4], 'X' * 4)
+def _serial_sanitizer(instr):
+    '''Replaces the last 1/4 of a string with X's'''
+    length = len(instr)
+    index = int(floor(length * .75))
+    return "{0}{1}".format(instr[:index], 'X' * (length - index))
 
 # A dictionary of grain -> function mappings for sanitizing grain output. This
 # is used when the 'sanitize' flag is given.
 _sanitizers = {
-    'serialnumber': _str_sanitizer,
+    'serialnumber': _serial_sanitizer,
     'domain': lambda x: 'domain',
     'fqdn': lambda x: 'minion.domain',
     'host': lambda x: 'minion',


### PR DESCRIPTION
This pull request fixes #2295.

This adds the 'sanitize' option to the grains module, making for safer pastbin diagnostics among community members.

An example of the sanitized output:

``` yaml
biosreleasedate: 07/09/2012
biosversion: '6.00'
cpu_flags:
- fpu
- vme
- de
- pse
- tsc
- msr
- pae
- mce
- cx8
- apic
- mtrr
- pge
- mca
- cmov
- pat
- pse36
- clflush
- dts
- acpi
- mmx
- fxsr
- sse
- sse2
- ss
- syscall
- nx
- rdtscp
- lm
- constant_tsc
- up
- arch_perfmon
- pebs
- bts
- xtopology
- tsc_reliable
- nonstop_tsc
- aperfmperf
- unfair_spinlock
- pni
- ssse3
- cx16
- sse4_1
- sse4_2
- popcnt
- hypervisor
- lahf_lm
- ida
- dts
cpu_model: Intel(R) Xeon(R) CPU           X5550  @ 2.67GHz
cpuarch: x86_64
defaultencoding: UTF8
defaultlanguage: en_US
domain: DOMAINNAME
fqdn: MINION.DOMAINNAME
host: MINION
id: MINION.DOMAINNAME
kernel: Linux
kernelrelease: 2.6.32-279.11.1.el6.x86_64
localhost: MINION
manufacturer: VMware, Inc.
mem_total: 996
nodename: MINION
num_cpus: 1
os: CentOS
os_family: RedHat
oscodename: Final
osfullname: CentOS
osrelease: '6.3'
path: /venvs/salt/salt-0.10.5.linux-x86_64:/sbin:/usr/sbin:/bin:/usr/bin
productname: VMware Virtual Platform
ps: ps -efH
pythonpath:
- /venvs/salt/salt-0.10.5.linux-x86_64/library.zip
- /venvs/salt/salt-0.10.5.linux-x86_64/setuptools-0.6c11-py2.6.egg
- /venvs/salt/salt-0.10.5.linux-x86_64/salt-0.10.5-py2.6.egg
- /venvs/salt/salt-0.10.5.linux-x86_64/M2Crypto-0.21.1-py2.6-linux-x86_64.egg
- /venvs/salt/salt-0.10.5.linux-x86_64/esky-0.9.7-py2.6.egg
- /venvs/salt/salt-0.10.5.linux-x86_64
pythonversion:
- 2
- 6
- 6
- final
- 0
saltpath: /venvs/salt/salt-0.10.5.linux-x86_64/salt-0.10.5-py2.6.egg/salt
saltversion: 0.10.5
serialnumber: VMware-42 15 33 65 7d b0 f3 32-d3 5d 5b XXXXXXXXXXXXXX
server_id: 1129568707
shell: /bin/sh
virtual: VMware
```

Note that all the uniquely identifying names have been replaced with generics. And that the last 1/4 of the serial number has been replaced with `X`s.
