### PR TITLE
Fix spelling mistakes reported by lintian

### DIFF
--- a/doc/topics/releases/0.10.3.rst
+++ b/doc/topics/releases/0.10.3.rst
@@ -4,7 +4,7 @@ Salt 0.10.3 Release Notes
 
 The latest taste of Salt has come, this release has many fixes and feature
 additions. Modifications have been made to make ZeroMQ connections more
-reliable, the begining of the ACL system is in place, a new command line
+reliable, the beginning of the ACL system is in place, a new command line
 parsing system has been added, dynamic module distribution has become more
 environment aware, the new `master_finger` option and many more!
 
@@ -162,7 +162,7 @@ a non-existing file on a non-existing directory:
             makedirs: True
 
 
-The second, `source`, allows to append the contents of a file instead of 
+The second, `source`, allows one to append the contents of a file instead of
 specifying the text.
 
 .. code-block:: yaml

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -76,7 +76,7 @@ def valid_fileproto(uri):
 
 def option(value, default=''):
     '''
-    Pass in a generic option and recieve the value that will be assigned
+    Pass in a generic option and receive the value that will be assigned
     '''
     if value in __opts__:
         return __opts__[value]
@@ -91,7 +91,7 @@ def option(value, default=''):
 
 def dot_vals(value):
     '''
-    Pass in a configuration value that should be preceeded by the module name
+    Pass in a configuration value that should be preceded by the module name
     and a dot, this will return a list of all read key/value pairs
     '''
     ret = {}

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -10,7 +10,7 @@ set in the minion config to change the output of the ``salt-call`` command.
 state_verbose:
     By default `state_verbose` is set to `True`, setting this to `False` will
     instruct the highstate outputter to omit displaying anything in green, this
-    means that nothing with a result of True and no chnages will not be printed
+    means that nothing with a result of True and no changes will not be printed
 state_output:
     The highstate outputter has two output modes, `full` and `terse`. The
     default is set to full, which will display many lines of detailed


### PR DESCRIPTION
While building salt 0.10.5 for debian lintian noticed following spelling mistakes (which should be fixed with this pull request):

I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz preceeded preceded
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz recieve receive
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz chnages changes
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz begining beginning
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz allows to allows one to
