### PR TITLE
Fix documentation of network runner

### DIFF
--- a/salt/runners/network.py
+++ b/salt/runners/network.py
@@ -16,9 +16,9 @@ def wollist(maclist, bcast='255.255.255.255', destport=9):
 
     CLI Example::
 
-        salt-run '/path/to/maclist'
-        salt-run '/path/to/maclist' 255.255.255.255 7
-        salt-run '/path/to/maclist' 255.255.255.255 7
+        salt-run network.wollist '/path/to/maclist'
+        salt-run network.wollist '/path/to/maclist' 255.255.255.255 7
+        salt-run network.wollist '/path/to/maclist' 255.255.255.255 7
     '''
     ret = []
     try:


### PR DESCRIPTION
The documentation of the 'wollist' command in the network runner were
missing the command name in the example invocations.
