### PR TITLE
Make remove in the file module also remove broken symlinks

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -799,16 +799,15 @@ def remove(path):
     if not os.path.isabs(path):
         raise SaltInvocationError('File path must be absolute.')
 
-    if os.path.exists(path):
-        try:
-            if os.path.isfile(path) or os.path.islink(path):
-                os.remove(path)
-                return True
-            elif os.path.isdir(path):
-                shutil.rmtree(path)
-                return True
-        except (OSError, IOError):
-            raise CommandExecutionError('Could not remove "{0}"'.format(path))
+    try:
+        if os.path.isfile(path) or os.path.islink(path):
+            os.remove(path)
+            return True
+        elif os.path.isdir(path):
+            shutil.rmtree(path)
+            return True
+    except (OSError, IOError):
+        raise CommandExecutionError('Could not remove "{0}"'.format(path))
     return False
 
 

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -23,10 +23,22 @@ class FileModuleTest(integration.ModuleCase):
         if not os.path.isdir(self.mydir):
             # left behind... Don't fail because of this!
             os.makedirs(self.mydir)
+        self.mysymlink = os.path.join(integration.TMP, 'mysymlink')
+        if os.path.islink(self.mysymlink):
+            os.remove(self.mysymlink)
+        os.symlink(self.myfile, self.mysymlink)
+        self.mybadsymlink = os.path.join(integration.TMP, 'mybadsymlink')
+        if os.path.islink(self.mybadsymlink):
+            os.remove(self.mybadsymlink)
+        os.symlink('/nonexistantpath', self.mybadsymlink)
         super(FileModuleTest, self).setUp()
 
     def tearDown(self):
         os.remove(self.myfile)
+        if os.path.islink(self.mysymlink):
+            os.remove(self.mysymlink)
+        if os.path.islink(self.mybadsymlink):
+            os.remove(self.mybadsymlink)
         shutil.rmtree(self.mydir, ignore_errors=True)
         super(FileModuleTest, self).tearDown()
 
@@ -123,6 +135,14 @@ class FileModuleTest(integration.ModuleCase):
 
     def test_remove_dir(self):
         ret = self.run_function('file.remove', args=[self.mydir])
+        self.assertTrue(ret)
+
+    def test_remove_symlink(self):
+        ret = self.run_function('file.remove', args=[self.mysymlink])
+        self.assertTrue(ret)
+
+    def test_remove_broken_symlink(self):
+        ret = self.run_function('file.remove', args=[self.mybadsymlink])
         self.assertTrue(ret)
 
     def test_cannot_remove(self):


### PR DESCRIPTION
The remove command in the file module had guard, `os.path.exists`, in front of all remove actions. That guard failed on broken symlinks, i.e. it returned `false` even though the broken symlink existed. Since the remove actions are properly guarded without the `os.path.exists` guard, this commits removes it. Now the remove command will also remove broken symlinks.

---

I'm a bit unsure of the tests written here, when I added `self.assertFalse(os.path.isfile(self.myfile))` as the last statement in the `test_remove_file` that assertion failed (similarly for the other test_remove tests). I don't believe such statements should fail, but I'm not very familiar with this so I'm assuming it is ok.

I also had some issues with my added tests for removing symlinks succeeded before I changed the actual code. I did not find that to be the case in "real" test cases though.
