### PR TITLE
Adds "replication" permission for postgres users.

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -245,7 +245,7 @@ def user_list(user=None, host=None, port=None, runas=None):
     ret = []
     query = (
         '''SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb,
-        rolcatupdate, rolcanlogin, rolconnlimit, rolvaliduntil, rolconfig, oid
+        rolcatupdate, rolcanlogin, rolreplication, rolconnlimit, rolvaliduntil, rolconfig, oid
         FROM pg_roles'''
     )
     cmd = _psql_cmd('-c', query,
@@ -297,6 +297,7 @@ def user_create(username,
                 createuser=False,
                 encrypted=False,
                 superuser=False,
+                replication=False,
                 password=None,
                 runas=None):
     '''
@@ -325,6 +326,8 @@ def user_create(username,
         sub_cmd = "{0} CREATEUSER".format(sub_cmd, )
     if superuser:
         sub_cmd = "{0} SUPERUSER".format(sub_cmd, )
+    if replication:
+        sub_cmd = "{0} REPLICATION".format(sub_cmd, )
 
     if sub_cmd.endswith("WITH"):
         sub_cmd = sub_cmd.replace(" WITH", "")
@@ -339,6 +342,7 @@ def user_update(username,
                 createdb=False,
                 createuser=False,
                 encrypted=False,
+                replication=False,
                 password=None,
                 runas=None):
     '''
@@ -364,6 +368,8 @@ def user_update(username,
         sub_cmd = "{0} CREATEUSER".format(sub_cmd, )
     if encrypted:
         sub_cmd = "{0} ENCRYPTED".format(sub_cmd, )
+    if encrypted:
+        sub_cmd = "{0} REPLICATION".format(sub_cmd, )
 
     if sub_cmd.endswith("WITH"):
         sub_cmd = sub_cmd.replace(" WITH", "")

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -15,6 +15,7 @@ def present(name,
             createuser=False,
             encrypted=False,
             superuser=False,
+            replication=False,
             password=None,
             runas=None):
     '''
@@ -30,10 +31,13 @@ def present(name,
         Is the user allowed to create other users?
 
     encrypted
-        Shold the password be encrypted in the system catalog?
+        Should the password be encrypted in the system catalog?
 
     superuser
-        Shold the new user be a "superuser"
+        Should the new user be a "superuser"
+
+    replication
+        Should the new user be allowed to initiate streaming replication
 
     password
         The user's pasword
@@ -60,6 +64,7 @@ def present(name,
                                         createuser=createuser,
                                         encrypted=encrypted,
                                         superuser=superuser,
+                                        replication=replication,
                                         password=password,
                                         runas=runas):
         ret['comment'] = 'The user {0} has been created'.format(name)


### PR DESCRIPTION
Starting PostgreSQL 9.1 the "replication" permission has been added and it's very useful when setting up streaming replication. This adds support for managing the new permission when creating/updating users.
