### PR TITLE
Add `tests.saltunittest.RedirectStdStreams`.

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -24,7 +24,7 @@ import salt.minion
 import salt.runner
 from salt.utils import get_colors
 from salt.utils.verify import verify_env
-from saltunittest import TestCase
+from saltunittest import TestCase, RedirectStdStreams
 
 try:
     import console
@@ -641,8 +641,9 @@ class ShellCase(TestCase):
             os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'master')
         )
         opts.update({'doc': False, 'fun': fun, 'arg': arg})
-        runner = salt.runner.Runner(opts)
-        ret['fun'] = runner.run()
+        with RedirectStdStreams():
+            runner = salt.runner.Runner(opts)
+            ret['fun'] = runner.run()
         return ret
 
     def run_key(self, arg_str, catch_stderr=False):

--- a/tests/saltunittest.py
+++ b/tests/saltunittest.py
@@ -13,9 +13,6 @@ import sys
 import logging
 from functools import wraps
 
-# Import salt libs
-from salt.utils import fopen
-
 # support python < 2.7 via unittest2
 if sys.version_info[0:2] < (2, 7):
     try:
@@ -67,9 +64,9 @@ class RedirectStdStreams(object):
 
     def __init__(self, stdout=None, stderr=None):
         if stdout is None:
-            stdout = fopen(os.devnull, 'w')
+            stdout = open(os.devnull, 'w')
         if stderr is None:
-            stderr = fopen(os.devnull, 'w')
+            stderr = open(os.devnull, 'w')
 
         self.__stdout = stdout
         self.__stderr = stderr
@@ -95,7 +92,9 @@ class RedirectStdStreams(object):
             return
 
         self.__stdout.flush()
+        self.__stdout.close()
         self.__stderr.flush()
+        self.__stderr.close()
         sys.stdout = self.old_stdout
         sys.stderr = self.old_stderr
 


### PR DESCRIPTION
- The `RedirectStdStreams` tests helper will allow to temporarily catch `stdout` and `stderr` output. Right now it's only used to **mute** the `tests.integration.runners.jobs.ManageTest.test_active()` output.
