### PR TITLE
Add __all__ = ['render'] to avoid helper functions showing up in the mod...

### DIFF
--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -206,6 +206,7 @@ import salt.utils
 from salt.renderers.yaml import HAS_ORDERED_DICT
 from salt.exceptions import SaltRenderError
 
+__all__ = [ 'render' ]
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
...ule doc.
