### PR TITLE
Rework Linux and FreeBSD insatllation pages

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -8,8 +8,8 @@ Full Table of Contents
 
     topics/index
     topics/installation/index
-    topics/hacking
     topics/configuration
+    topics/hacking
     topics/targeting/index
     topics/tutorials/modules
     topics/tutorials/starting_states

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -10,23 +10,53 @@ configuration file.
 .. glossary::
 
     master
-        The Salt master is the central server that all minions connect to. You
-        run commands on the minions through the master and minions send data
+        The Salt master is the central server that all minions connect to. 
+        Commands are run on the minions through the master, and minions send data
         back to the master (unless otherwise redirected with a :doc:`returner
         </ref/returners/index>`). It is started with the
         :command:`salt-master` program.
 
     minion
         Salt minions are the potentially hundreds or thousands of servers that
-        you query and control from the master.
+        may be queried and controlled from the master.
 
 The configuration files will be installed to :file:`/etc/salt` and are named
 after the respective components, :file:`/etc/salt/master` and
 :file:`/etc/salt/minion`.
 
-To make a minion check into the correct master simply edit the
-:conf_minion:`master` variable in the minion configuration file to reference
-the master DNS name or IPv4 address.
+Master Configuration
+====================
+
+By default the Salt master listens on ports 4505 and 4506 on all
+interfaces (0.0.0.0). To bind Salt to a specific IP, redefine the
+"interface" directive in the master configuration file, typically
+``/etc/salt/master``, as follows:
+
+.. code-block:: diff
+
+   - #interface: 0.0.0.0
+   + interface: 10.0.0.1
+
+After updating the configuration file, restart the Salt master.
+
+Minion Configuration
+====================
+
+Although there are many Salt Minion configuration options, configuring
+a Salt Minion is very simple. By default a Salt Minion will
+try to connect to the DNS name "salt"; if the Minion is able to
+resolve that name correctly, no configuration is needed.
+
+If the DNS name "salt" does not resolve to point to the correct
+location of the Master, redefine the "master" directive in the minion
+configuration file, typically ``/etc/salt/minion``, as follows:
+
+.. code-block:: diff
+
+   - #master: salt
+   + master: 10.0.0.1
+
+After updating the configuration file, restart the Salt minion.
 
 Running Salt
 ============
@@ -58,24 +88,74 @@ Running Salt
 There is also a full :doc:`troubleshooting guide</topics/troubleshooting/index>`
 available.
 
-Manage Salt Public Keys
-=======================
+Key Management
+==============
 
-Salt manages authentication with RSA public keys. The keys are managed on the
-:term:`master` via the :command:`salt-key` command. Once a :term:`minion`
-checks into the master the master will save a copy of the minion key. Before
-the master can send commands to the minion the key needs to be "accepted".
+Salt uses AES encryption for all communication between the Master and
+the Minion. This ensures that the commands sent to the Minions cannot
+be tampered with, and that communication between Master and Minion is
+authenticated through trusted, accepted keys.
 
-1.  List the accepted and unaccepted Salt keys::
+Before commands can be sent to a Minion, its key must be accepted on
+the Master. Run the ``salt-key`` command to list the keys known to
+the Salt Master:
 
-        salt-key -L
+.. code-block:: bash
 
-2.  Accept a minion key::
+   [root@master ~]# salt-key -L
+   Unaccepted Keys:
+   alpha
+   bravo
+   charlie
+   delta
+   Accepted Keys:
 
-        salt-key -a <minion id>
+This example shows that the Salt Master is aware of four Minions, but none of
+the keys has been accepted. To accept the keys and allow the Minions to be
+controlled by the Master, again use the ``salt-key`` command:
 
-    or accept all unaccepted minion keys::
+.. code-block:: bash
 
-        salt-key -A
+   [root@master ~]# salt-key -A
+   [root@master ~]# salt-key -L
+   Unaccepted Keys:
+   Accepted Keys:
+   alpha
+   bravo
+   charlie
+   delta
+
+The ``salt-key`` command allows for signing keys individually or in bulk. The
+example above, using ``-A`` bulk-accepts all pending keys. To accept keys
+individually use the lowercase of the same option, ``-a keyname``.
 
 .. seealso:: :doc:`salt-key manpage </ref/cli/salt-key>`
+
+Sending Commands
+================
+
+Communication between the Master and a Minion may be verified by running
+the ``test.ping`` remote command. ::
+
+
+   [root@master ~]# salt 'alpha' test.ping
+   {'alpha': True}
+
+Communication between the Master and all Minions may be tested in a
+similar way. ::
+
+   [root@master ~]# salt '*' test.ping
+   {'alpha': True}
+   {'bravo': True}
+   {'charlie': True}
+   {'delta': True}
+
+Each of the Minions should send a "True" response as shown above.
+
+What's Next?
+============
+
+Depending on the primary way you want to manage your machines you may
+either want to visit the section regarding Salt States, or the section
+on Modules.
+

--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -2,13 +2,6 @@
 Arch Linux
 ==========
 
-Salt has primarily been developed on Arch Linux, meaning it is known to
-work very well on that distribution. The lead developer, Thomas S. Hatch
-(thatch45) has been a TU (Trusted User) for the Arch Linux distribution,
-and has written a number of Arch-specific tools in the past.
-
-Salt, while not Arch-specific, is packaged for and works well on Arch Linux.
-
 Installation
 ============
 
@@ -18,7 +11,7 @@ currently stable and -git packages available.
 Stable Release
 --------------
 
-To install Salt stable releases from the Arch Linux AUR, use the commands:
+Install Salt stable releases from the Arch Linux AUR as follows:
 
 .. code-block:: bash
 
@@ -27,17 +20,17 @@ To install Salt stable releases from the Arch Linux AUR, use the commands:
     cd salt/
     makepkg -is
 
-A few of Salt's dependencies are currently only found within the AUR, so you'll
-need to download and run ``makepkg -is`` on these as well. As a reference, Salt
-currently relies on the following packages only available via the AUR:
+A few of Salt's dependencies are currently only found within the AUR, so it is
+necessary to download and run ``makepkg -is`` on these as well. As a reference, Salt
+currently relies on the following packages which are only available via the AUR:
 
 * https://aur.archlinux.org/packages/py/python2-msgpack/python2-msgpack.tar.gz
 * https://aur.archlinux.org/packages/py/python2-psutil/python2-psutil.tar.gz
 
 .. note:: yaourt
 
-    If you chose to use a tool such as Yaourt_ the dependencies will be
-    gathered and built for you automatically.
+    If a tool such as Yaourt_ is used, the dependencies will be
+    gathered and built automatically.
 
     The command to install salt using the yaourt tool is:
 
@@ -51,8 +44,7 @@ Tracking develop
 ----------------
 
 To install the bleeding edge version of Salt (**may include bugs!**),
-you can use the -git package. Installing the -git package can be done
-using the commands:
+use the -git package. Installing the -git package as follows:
 
 .. code-block:: bash
 
@@ -61,76 +53,33 @@ using the commands:
     cd salt-git/
     makepkg -is
 
-A few of Salt's dependencies are currently only found within the AUR, so you'll
-need to download and run ``makepkg -is`` on these as well. As a reference, Salt
-currently relies on the following packages only available via the AUR:
+See the note above about Salt's dependencies.
 
-* https://aur.archlinux.org/packages/py/python2-msgpack/python2-msgpack.tar.gz
-* https://aur.archlinux.org/packages/py/python2-psutil/python2-psutil.tar.gz
+Post-installation tasks
+=======================
 
-.. note:: yaourt
-
-    If you chose to use a tool such as Yaourt_ the dependencies will be
-    gathered and built for you automatically.
-
-    The command to install salt using the yaourt tool is:
-
-    .. code-block:: bash
-
-        yaourt salt-git
-
-.. _Yaourt: https://aur.archlinux.org/packages.php?ID=5863
-
-Configuration
-=============
-
-In the sections below I'll outline configuration options for both the Salt
-Master and Salt Minions.
+**Configuration files**
 
 The Salt package installs two template configuration files,
-``/etc/salt/master.template`` and ``/etc/salt/minion.template``. You'll need
-to copy these .template files into place and make a few edits. First, copy
-them into place as seen here:
+``/etc/salt/master.template`` and ``/etc/salt/minion.template``. These
+files need to be copied as follows:
 
 .. code-block:: bash
 
    cp /etc/salt/master.template /etc/salt/master
    cp /etc/salt/minion.template /etc/salt/minion
 
-Note: You'll only need to copy the config for the service you're going to run.
-
-Once you've copied the config into place you'll need to make changes specific
-to your setup. Below I'll outline suggested configuration changes to the
-Master, after which I'll outline configuring the Minion.
-
-Master Configuration
-====================
-
-This section outlines configuration of a Salt Master, which is used to control
-other machines known as "minions" (see "Minion Configuration" for instructions
-on configuring a minion). This will outline IP configuration, and a few key
-configuration paths.
-
-**Interface**
-
-By default the Salt master listens on TCP ports 4505 and 4506 on all interfaces
-(0.0.0.0). If you have a need to bind Salt to a specific IP, redefine the
-"interface" directive as seen here:
-
-.. code-block:: diff
-
-   - #interface: 0.0.0.0
-   + interface: 10.0.0.1
+Note: only the configuration files for the services to be run need be
+copied.
 
 **rc.conf**
 
-You'll need to activate the Salt Master in your *rc.conf* file. Using your
-favorite editor, open ``/etc/rc.conf`` and add the  salt-master.
+Activate the Salt Master and/or Minion in ``/etc/rc.conf`` as follows:
 
 .. code-block:: diff
 
     -DAEMONS=(syslog-ng network crond)
-    +DAEMONS=(syslog-ng network crond @salt-master)
+    +DAEMONS=(syslog-ng network crond @salt-master @salt-minion)
 
 **Start the Master**
 
@@ -142,131 +91,5 @@ seen here:
 
     rc.d start salt-master
 
-If your Salt Master doesn't start successfully, go back through each step and
-see if anything was missed. Salt doesn't take much configuration (part of its
-beauty!), and errors are usually simple mistakes.
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
 
-Minion Configuration
-====================
-
-Configuring a Salt Minion is surprisingly simple. Unless you have a real need
-for customizing your minion configuration (which there are plenty of options if
-you are so inclined!), there is one simple directive that needs to be updated.
-That option is the location of the master.
-
-By default a Salt Minion will try to connect to the dns name "salt". If you
-have the ability to update DNS records for your domain you might create an A or
-CNAME record for "salt" that points to your Salt Master. If you are able to do
-this you likely can do without any minion configuration at all.
-
-If you are not able to update DNS, you'll simply need to update one entry in
-the configuration file. Using your favorite editor, open the minion
-configuration file and update the "master" entry as seen here.
-
-.. code-block:: diff
-
-   - #master: salt
-   + master: 10.0.0.1
-
-Simply update the master directive to the IP or hostname of your Salt Master.
-Save your changes and you're ready to start your Salt Minion. Advanced
-configuration options are covered in another chapter.
-
-**rc.conf**
-
-Before you're able to start the Salt Minion you'll need to update your rc.conf
-file. Using your favorite editor open ``/etc/rc.conf`` and add this line:
-
-.. code-block:: diff
-
-    -DAEMONS=(syslog-ng network crond)
-    +DAEMONS=(syslog-ng network crond @salt-minion)
-
-**Start the Minion**
-
-Once you've completed all of these steps you're ready to start your Salt
-Minion. You should be able to start your Salt Minion now using the command
-seen here:
-
-.. code-block:: bash
-
-    rc.d start salt-minion
-
-If your Salt Minion doesn't start successfully, go back through each step and
-see if anything was missed. Salt doesn't take much configuration (part of its
-beauty!), and errors are usually simple mistakes.
-
-Tying It All Together
-=====================
-
-If you've successfully completed each of the steps above you should have a
-running Salt Master and a running Salt Minion. The Minion should be configured
-to point to the Master. To verify that there is communication flowing between
-the Minion and Master we'll run a few initial ``salt`` commands. These commands
-will validate the Minions RSA encryption key, and then send a test command to
-the Minion to ensure that commands and responses are flowing as expected.
-
-**Key Management**
-
-Salt uses AES encryption for all communication between the Master and the
-Minion. This ensures that the commands you send to your Minions (your cloud)
-can not be tampered with, and that communication between Master and Minion is
-only done through trusted, accepted keys.
-
-Before you'll be able to do any remote execution or configuration management you'll
-need to accept any pending keys on the Master. Run the ``salt-key`` command to
-list the keys known to the Salt Master.
-
-.. code-block:: bash
-
-   [root@master ~]# salt-key -L
-   Unaccepted Keys:
-   alpha
-   bravo
-   charlie
-   delta
-   Accepted Keys:
-
-This example shows that the Salt Master is aware of four Minions, but none of
-the keys have been accepted. To accept the keys and allow the Minions to be
-controlled by the Master, again use the ``salt-key`` command:
-
-.. code-block:: bash
-
-   [root@master ~]# salt-key -A
-   [root@master ~]# salt-key -L
-   Unaccepted Keys:
-   Accepted Keys:
-   alpha
-   bravo
-   charlie
-   delta
-
-The ``salt-key`` command allows for signing keys individually or in bulk. The
-example above, using ``-A`` bulk-accepts all pending keys. To accept keys
-individually use the lowercase of the same option, ``-a keyname``.
-
-Sending Commands
-================
-
-Everything should be set for you to begin remote management of your Minions.
-Whether you have a few or a few-dozen, Salt can help you manage them easily!
-
-For final verification, send a test function from your Salt Master to your
-minions. If all of your minions are properly communicating with your Master,
-you should "True" responses from each of them. See the example below to send
-the ``test.ping`` remote command:
-
-.. code-block:: bash
-
-   [root@master ~]# salt '*' test.ping
-   {'alpha': True}
-
-Where Do I Go From Here
-=======================
-
-Congratulations! You've successfully configured your first Salt Minions and are
-able to send remote commands. I'm sure you're eager to learn more about what
-Salt can do. Depending on the primary way you want to manage your machines you
-may either want to visit the section regarding Salt States, or the section on
-Modules.

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -12,28 +12,29 @@ To install Salt on Wheezy or later use:
 
 .. code-block:: bash
 
-    sudo apt-get install salt-master
-    sudo apt-get install salt-minion
-
+    apt-get install salt-master
+    apt-get install salt-minion
 
 Squeeze
 =======
 
-Salt is available for squeeze in the Debian backports repository. For more
-information how to use debian-backports see
-http://backports-master.debian.org/Instructions/
+Salt is available for squeeze in the Debian backports repository, and may be
+installed as follows:
 
 .. code-block:: bash
 
     cat <<EOF | sudo tee /etc/apt/sources.list.d/backports.list
     deb http://backports.debian.org/debian-backports squeeze-backports main
     EOF
-    sudo apt-get update
-    sudo apt-get -t squeeze-backports install salt-master
-    sudo apt-get -t squeeze-backports install salt-minion
+    apt-get update
+    apt-get -t squeeze-backports install salt-master
+    apt-get -t squeeze-backports install salt-minion
 
+For more information how to use debian-backports see
+http://backports-master.debian.org/Instructions/
 
-Configuration
-=============
+Post-installation tasks
+=======================
 
-For more configuration have a look at the Ubuntu section :ref:`ubuntu-config`
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
+

--- a/doc/topics/installation/fedora.rst
+++ b/doc/topics/installation/fedora.rst
@@ -11,7 +11,7 @@ makes it a great place to help improve Salt!
 
     Salt and all dependencies have been *finally* accepted into the yum
     reposities for EPEL5 and EPEL6. Currently, the latest is in epel-testing
-    while awaiting promotion to epel proper. You can install it via:
+    while awaiting promotion to epel proper, and may be installed as follows:
 
     .. code-block:: bash
 
@@ -32,181 +32,45 @@ repositories.
 Stable Release
 --------------
 
-Salt is packaged separately for the minion and the master. You'll only need to
-install the appropriate package for the role you need the machine to play. This
-means you're going to want one master and a whole bunch of minions!
+Salt is packaged separately for the minion and the master. It is necessary only to
+install the appropriate package for the role the machine will play. Typically, there
+will be one master and multiple minions.
 
 .. code-block:: bash
 
     yum install salt-master
     yum install salt-minion
 
-Configuration
-=============
+Post-installation tasks
+=======================
 
-Below, we'll cover Salt Master and Minion configuration options.
+**Master**
 
-Master Configuration
-====================
-
-This section outlines configuration of a Salt Master, which is used to control
-other machines known as "minions" (see "Minion Configuration" for instructions
-on configuring a minion). This will outline IP configuration, and a few key
-configuration paths.
-
-**Interface**
-
-By default the Salt master listens on TCP ports ``4505`` and ``4506`` on all interfaces
-(0.0.0.0). If you have a need to bind Salt to a specific IP, redefine the
-"interface" directive as seen here:
-
-.. code-block:: diff
-
-   - #interface: 0.0.0.0
-   + interface: 10.0.0.1
-
-**Enable the Master**
-
-You'll also likely want to activate the Salt Master in *systemd*, configuring the
-Salt Master to start automatically at boot.
+To have the Master start automatically at boot time:
 
 .. code-block:: bash
 
     systemctl enable salt-master.service
 
-**Start the Master**
-
-Once you've completed all of these steps you're ready to start your Salt
-Master. You should be able to start your Salt Master now using the command
-seen here:
+To start the Master:
 
 .. code-block:: bash
 
     systemctl start salt-master.service
 
-If your Salt Master doesn't start successfully, go back through each step and
-see if anything was missed. Salt doesn't take much configuration (part of its
-beauty!), and errors are usually simple mistakes.
+**Minion**
 
-Minion Configuration
-====================
-
-Configuring a Salt Minion is surprisingly simple. Unless you have a real need
-for customizing your minion configuration (which there are plenty of options if
-you are so inclined!), there is one simple directive that needs to be updated.
-That option is the location of the master.
-
-By default a Salt Minion will try to connect to the dns name "salt". If you
-have the ability to update DNS records for your domain you might create an A or
-CNAME record for "salt" that points to your Salt Master. If you are able to do
-this you likely can do without any minion configuration at all.
-
-If you are not able to update DNS, you'll simply need to update one entry in
-the configuration file. Using your favorite editor, open the minion
-configuration file and update the "master" entry as seen here:
-
-.. code-block:: diff
-
-   - #master: salt
-   + master: 10.0.0.1
-
-Simply update the master directive to the IP or hostname of your Salt Master.
-Save your changes and you're ready to start your Salt Minion. Advanced
-configuration options are covered in another chapter.
-
-**Enable the Minion**
-
-You'll need to configure the minion to auto-start at boot. You can toggle
-that option through systemd.
+To have the Minion start automatically at boot time:
 
 .. code-block:: bash
 
     systemctl enable salt-minion.service
 
-**Start the Minion**
-
-Once you've completed all of these steps, start the Minion. This command
-should do the trick:
+To start the Minion:
 
 .. code-block:: bash
 
     systemctl start salt-minion.service
 
-If your Salt Minion doesn't start successfully, go back through each step and
-see if anything was missed. Salt doesn't take much configuration (part of its
-beauty!), and errors are usually simple mistakes.
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
 
-Tying It All Together
-=====================
-
-If you've successfully completed each of the steps above you should have a
-running Salt Master and a running Salt Minion. The Minion should be configured
-to point to the Master. To verify that there is communication flowing between
-the Minion and Master we'll run a few initial ``salt`` commands. These commands
-will validate the Minions RSA encryption key, and then send a test command to
-the Minion to ensure that commands and responses are flowing as expected.
-
-**Key Management**
-
-Salt uses AES encryption for all communication between the Master and the
-Minion. This ensures that the commands you send to your Minions (your cloud)
-can not be tampered with, and that communication between Master and Minion is
-only done through trusted, accepted keys.
-
-Before you'll be able to do any remote execution or configuration management
-you'll need to accept any pending keys on the Master. Run the ``salt-key``
-command to list the keys known to the Salt Master:
-
-.. code-block:: bash
-
-   [root@master ~]# salt-key -L
-   Unaccepted Keys:
-   alpha
-   bravo
-   charlie
-   delta
-   Accepted Keys:
-
-This example shows that the Salt Master is aware of four Minions, but none of
-the keys have been accepted. To accept the keys and allow the Minions to be
-controlled by the Master, again use the ``salt-key`` command:
-
-.. code-block:: bash
-
-   [root@master ~]# salt-key -A
-   [root@master ~]# salt-key -L
-   Unaccepted Keys:
-   Accepted Keys:
-   alpha
-   bravo
-   charlie
-   delta
-
-The ``salt-key`` command allows for signing keys individually or in bulk. The
-example above, using ``-A`` bulk-accepts all pending keys. To accept keys
-individually use the lowercase of the same option, ``-a keyname``.
-
-Sending Commands
-================
-
-Everything should be set for you to begin remote management of your Minions.
-Whether you have a few or a few-dozen, Salt can help you manage them easily!
-
-For final verification, send a test function from your Salt Master to your
-minions. If all of your minions are properly communicating with your Master,
-you should "True" responses from each of them. See the example below to send
-the ``test.ping`` remote command:
-
-.. code-block:: bash
-
-   [root@master ~]# salt '*' test.ping
-   {'alpha': True}
-
-Where Do I Go From Here
-=======================
-
-Congratulations! You've successfully configured your first Salt Minions and are
-able to send remote commands. I'm sure you're eager to learn more about what
-Salt can do. Depending on the primary way you want to manage your machines you
-may either want to visit the section regarding Salt States, or the section on
-Modules.

--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -25,57 +25,24 @@ To install Salt from the FreeBSD ports tree, use the command:
 
    cd /usr/ports/sysutils/salt && make install clean
 
-Once the port is installed you'll need to make a few configuration changes.
+Once the port is installed, it is necessary to make a few configuration changes.
 These include defining the IP to bind to (optional), and some configuration
 path changes to make salt fit more natively into the FreeBSD filesystem tree.
 
-Configuration
-=============
+Post-installation tasks
+=======================
 
-In the sections below I'll outline configuration options for both the Salt
-Master and Salt Minions.
+**Master**
 
-The Salt port installs two sample configuration files, ``salt/master.sample``
-and ``salt/minion.sample`` (these should be installed in ``/usr/local/etc/``,
-unless you use a different ``%%PREFIX%%``). You'll need to copy these
-.sample files into place and make a few edits. First, copy them into place
-as seen here:
+Copy the sample configuration file:
 
 .. code-block:: bash
 
    cp /usr/local/etc/salt/master.sample /usr/local/etc/salt/master
-   cp /usr/local/etc/salt/minion.sample /usr/local/etc/salt/minion
-
-Note: You'll only need to copy the config for the service you're going to run.
-
-Once you've copied the config into place you'll need to make changes specific
-to your setup. Below I'll outline suggested configuration changes to the
-Master, after which I'll outline configuring the Minion.
-
-Master Configuration
-====================
-
-This section outlines configuration of a Salt Master, which is used to control
-other machines known as "minions" (see "Minion Configuration" for instructions
-on configuring a minion). This will outline IP configuration, and a few key
-configuration paths.
-
-**Interface**
-
-By default the Salt master listens on ports 4505 and 4506 on all interfaces
-(0.0.0.0). If you have a need to bind Salt to a specific IP, redefine the
-"interface" directive as seen here.
-
-.. code-block:: diff
-
-   - #interface: 0.0.0.0
-   + interface: 10.0.0.1
 
 **rc.conf**
 
-Last but not least you'll need to activate the Salt Master in your rc.conf
-file. Using your favorite editor, open ``/etc/rc.conf`` or
-``/etc/rc.conf.local`` and add this line.
+Activate the Salt Master in ``/etc/rc.conf`` or ``/etc/rc.conf.local`` and add:
 
 .. code-block:: diff
 
@@ -83,138 +50,36 @@ file. Using your favorite editor, open ``/etc/rc.conf`` or
 
 **Start the Master**
 
-Once you've completed all of these steps you're ready to start your Salt
-Master. The Salt port installs an rc script which should be used to manage your
-Salt Master. You should be able to start your Salt Master now using the command
-seen here:
+Start the Salt Master as follows:
 
 .. code-block:: bash
 
    service salt_master start
 
-If your Salt Master doesn't start successfully, go back through each step and
-see if anything was missed. Salt doesn't take much configuration (part of its
-beauty!), and errors are usually simple mistakes.
+**Minion**
 
-Minion Configuration
-====================
+Copy the sample configuration file:
 
-Configuring a Salt Minion is surprisingly simple. Unless you have a real need
-for customizing your minion configuration (which there are plenty of options if
-you are so inclined!), there is one simple directive that needs to be updated.
-That option is the location of the master.
+.. code-block:: bash
 
-By default a Salt Minion will try to connect to the dns name "salt". If you
-have the ability to update DNS records for your domain you might create an A or
-CNAME record for "salt" that points to your Salt Master. If you are able to do
-this you likely can do without any minion configuration at all.
-
-If you are not able to update DNS, you'll simply need to update one entry in
-the configuration file. Using your favorite editor, open the minion
-configuration file and update the "master" entry as seen here.
-
-.. code-block:: diff
-
-   - #master: salt
-   + master: 10.0.0.1
-
-Simply update the master directive to the IP or hostname of your Salt Master.
-Save your changes and you're ready to start your Salt Minion. Advanced
-configuration options are covered in another chapter.
+   cp /usr/local/etc/salt/minion.sample /usr/local/etc/salt/minion
 
 **rc.conf**
 
-Before you're able to start the Salt Minion you'll need to update your rc.conf
-file. Using your favorite editor open ``/etc/rc.conf`` or
-``/etc/rc.conf.local`` and add this line.
+Activate the Salt Minion in ``/etc/rc.conf`` or ``/etc/rc.conf.local`` and add:
 
 .. code-block:: diff
 
    + salt_minion_enable="YES"
 
-Once you've completed all of these steps you're ready to start your Salt
-Minion. The Salt port installs an *rc* script which should be used to manage your
-Salt Minion. You should be able to start your Salt Minion now using the command
-seen here.
+**Start the Minion**
+
+Start the Salt Minion as follows:
 
 .. code-block:: bash
 
    service salt_minion start
 
-If your Salt Minion doesn't start successfully, go back through each step and
-see if anything was missed. Salt doesn't take much configuration (part of its
-beauty!), and errors are usually simple mistakes.
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
 
-Tying It All Together
-=====================
-
-If you've successfully completed each of the steps above you should have a
-running Salt Master and a running Salt Minion. The Minion should be configured
-to point to the Master. To verify that there is communication flowing between
-the Minion and Master we'll run a few initial ``salt`` commands. These commands
-will validate the Minions RSA encryption key, and then send a test command to
-the Minion to ensure that commands and responses are flowing as expected.
-
-**Key Management**
-
-Salt uses AES encryption for all communication between the Master and the
-Minion. This ensures that the commands you send to your Minions (your cloud)
-can not be tampered with, and that communication between Master and Minion is
-only done through trusted, accepted keys.
-
-Before you'll be able to do any remote execution or state management you'll
-need to accept any pending keys on the Master. Run the ``salt-key`` command to
-list the keys known to the Salt Master:
-
-.. code-block:: bash
-
-   [root@master ~]# salt-key -L
-   Unaccepted Keys:
-   alpha
-   bravo
-   charlie
-   delta
-   Accepted Keys:
-
-This example shows that the Salt Master is aware of four Minions, but none of
-the keys have been accepted. To accept the keys and allow the Minions to be
-controlled by the Master, again use the ``salt-key`` command:
-
-.. code-block:: bash
-
-   [root@master ~]# salt-key -A
-   [root@master ~]# salt-key -L
-   Unaccepted Keys:
-   Accepted Keys:
-   alpha
-   bravo
-   charlie
-   delta
-
-The ``salt-key`` command allows for signing keys individually or in bulk. The
-example above, using ``-A`` bulk-accepts all pending keys. To accept keys
-individually use the lowercase of the same option, ``-a keyname``.
-
-Sending Commands
-================
-
-Everything should be set for you to begin remote management of your Minions.
-Whether you have a few or a few-dozen, Salt can help you manage them easily!
-
-For final verification, send a test function from your Salt Master to your
-minions. If all of your minions are properly communicating with your Master,
-you should "True" responses from each of them. See the example below to send
-the ``test.ping`` remote command. ::
-
-   [root@master ~]# salt 'alpha' test.ping
-   {'alpha': True}
-
-Where Do I Go From Here
-=======================
-
-Congratulations! You've successfully configured your first Salt Minions and are
-able to send remote commands. I'm sure you're eager to learn more about what
-Salt can do. Depending on the primary way you want to manage your machines you
-may either want to visit the section regarding Salt States, or the section on
-Modules.
 

--- a/doc/topics/installation/gentoo.rst
+++ b/doc/topics/installation/gentoo.rst
@@ -21,4 +21,9 @@ Then download and install from source:
     cd salt-<version>
     python setup.py install
 
+Post-installation tasks
+=======================
+
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
+
 .. _GitHub downloads: https://github.com/saltstack/salt/downloads

--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -5,8 +5,8 @@ Ubuntu Installation
 Add repository
 --------------
 
-The latest packages for Ubuntu are published in the saltstack PPA. Add the repository 
-to your system, import the PPA key, and refresh the package data with the following 
+The latest packages for Ubuntu are published in the saltstack PPA. Add the
+repository, import the PPA key, and refresh the package data with the following
 commands:
 
 .. code-block:: bash
@@ -36,29 +36,8 @@ may be given at a time:
 
 .. _ubuntu-config:
 
-Configuration
--------------
+Post-installation tasks
+=======================
 
-Debian based systems will launch the daemons right after package install, but you 
-may need to make changes to the configuration files in /etc/salt (see the configuration
-files), such as:
-
-- set the minion id and salt master name in /etc/salt/minion
-- enable the file_roots and pillar_roots options in /etc/salt/master
-- configure syndic to relay commands from another master
-
-After making any configuration changes, re-start the affected daemons (or use 'stop' and 'start' as needed). E.g.:
-
-.. code-block:: bash
-
-    sudo /etc/init.d/salt-minion restart
-
-.. code-block:: bash
-
-    sudo /etc/init.d/salt-master restart
-
-.. code-block:: bash
-
-    sudo /etc/init.d/salt-syndic stop
-    sudo /etc/init.d/salt-syndic start
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
 


### PR DESCRIPTION
Moved all non-distro-specific configuration to the configuration page.
Removed all second person ("you/your") references.
Removed 'sudo' from all commands except on Ubuntu page (maybe it should be removed there as well).
Not touched Windows or Solaris pages.
Removed from Arch page the fact that Salt is developed on Arch, and also the fact that Thomas is a TU for Arch. Both bits of info are interesting, but I felt they detracted from the professionalism of the doco: after all, all Linux distros should be treated equally.

Question: I've moved the 'configuration' page to immediately after the installation pages in the 'contents' file; however, the 'next' link on the last installation page (Solaris) still goes to 'hacking' rather than 'configuration'. I don't know how to fix that, but it seems more logical to go to configuration at that point. I think there are other page re-orderings that would be helpful, so it would be good to know how to fix this.
