### PR TITLE
Speed up yum/rpm version() if we're not looking for something specific

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -175,7 +175,18 @@ def version(name):
 
         salt '*' pkg.version <package name>
     '''
-    pkgs = list_pkgs(name)
+    # since list_pkgs is used to support matching complex versions
+    # we can search for a digit in the name and if one doesn't exist
+    # then just use the dbMatch function, which is 1000 times quicker
+    m = re.search("[0-9]", name)
+    if m:
+        pkgs = list_pkgs(name)
+    else:
+        ts = rpm.TransactionSet()
+        mi = ts.dbMatch('name', name)
+        pkgs = {}
+        for h in mi:
+            pkgs[h['name']] = "-".join([h['version'], h['release']])
     if name in pkgs:
         return pkgs[name]
     else:


### PR DESCRIPTION
While testing things I end up applying state a lot, and when yum is
invoked for every single `pkg.installed` state it ends up taking a
really long time.

Since the comments for list_pkgs say it's being used to handle version
matching I think it's a reasonable assumption to make that if the
package name provided to `version` does not contain a number then the user
doesn't have any complex version matching requirements.

This makes my state run times go from:

```
real    1m16.450s
user    0m3.016s
sys     0m0.657s
```

To:

```
real    0m4.689s
user    0m1.780s
sys     0m0.333s
```

Let me know if you have any conerns about this.
