### PR TITLE
Add missing re import to yumpkg

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -5,6 +5,8 @@ Support for YUM
             - rpm Python module
             - rpmUtils Python module
 '''
+import re
+
 try:
     import yum
     import rpm


### PR DESCRIPTION
I upgraded to latest develop so I could work on a fix for a different problem and ran into this one

```
[MINION] out: ----------
[MINION] out:     State: - pkg
[MINION] out:     Name:      epel-release
[MINION] out:     Function:  installed
[MINION] out:         Result:    False
[MINION] out:         Comment:   An exception occured in this state: Traceback (most recent call last):
[MINION] out:   File "salt/state.py", line 886, in call
[MINION] out:   File "salt/states/pkg.py", line 62, in installed
[MINION] out:   File "salt/modules/yumpkg.py", line 181, in version
[MINION] out: NameError: global name 're' is not defined
[MINION] out: 
[MINION] out:         Changes:   
```

This patch adds the necessary import to resolve the issue.
