### PR TITLE
Correctly handle empty group list in user.present

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -86,7 +86,7 @@ def add(name,
     if gid not in (None, ''):
         cmd += '-g {0} '.format(gid)
     if groups:
-        cmd += '-G {0} '.format(','.join(groups))
+        cmd += '-G "{0}" '.format(','.join(groups))
     if home:
         if home is not True:
             if system:
@@ -255,7 +255,7 @@ def chgroups(name, groups, append=False):
     cmd = 'usermod '
     if append:
         cmd += '-a '
-    cmd += '-G {0} {1}'.format(','.join(groups), name)
+    cmd += '-G "{0}" {1}'.format(','.join(groups), name)
     return not __salt__['cmd.retcode'](cmd)
 
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -71,7 +71,7 @@ def _changes(
             # comparison purposes
             if __salt__['file.gid_to_group'](gid or lusr['gid']) in lusr['groups']:
                 lusr['groups'].remove(__salt__['file.gid_to_group'](gid or lusr['gid']))
-            if wanted_groups:
+            if groups is not None or wanted_groups:
                 if lusr['groups'] != wanted_groups:
                     change['groups'] = wanted_groups
             if home:
@@ -139,6 +139,8 @@ def present(
     groups
         A list of groups to assign the user to, pass a list object. If a group
         specified here does not exist on the minion, the state will fail.
+        If set to the empty list, the user will be removed from all groups
+        except the default group.
 
     optional_groups
         A list of groups to assign the user to, pass a list object. If a group

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -103,6 +103,78 @@ class UserTest(integration.ModuleCase,
         ret = self.run_state('group.absent', name='salt_test')
         self.assertSaltTrueReturn(ret)
 
+    @destructiveTest
+    @skipIf(os.geteuid() is not 0, 'you must be root to run this test')
+    def test_user_present_groups_is_none(self):
+        """
+        This is a DESTRUCTIVE TEST, it creates a new user and two groups on the
+        minion.
+        """
+        ret = self.run_state('group.present', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.present', name='salt_test_2')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('user.present', name='salt_test',
+                             gid_from_name=True, home='/var/lib/salt_test',
+                             groups=['salt_test_2'])
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_function('user.info', ['salt_test'])
+        self.assertReturnNonEmptySaltType(ret)
+        in_groups = set(ret['groups'])
+        self.assertEqual(in_groups, set(['salt_test', 'salt_test_2']))
+
+        ret = self.run_state('user.present', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_function('user.info', ['salt_test'])
+        self.assertReturnNonEmptySaltType(ret)
+        in_groups = set(ret['groups'])
+        self.assertEqual(in_groups, set(['salt_test', 'salt_test_2']))
+
+        ret = self.run_state('user.absent', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.absent', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.absent', name='salt_test_2')
+        self.assertSaltTrueReturn(ret)
+
+    @destructiveTest
+    @skipIf(os.geteuid() is not 0, 'you must be root to run this test')
+    def test_user_present_groups_is_empty_list(self):
+        """
+        This is a DESTRUCTIVE TEST, it creates a new user and two groups on the
+        minion.
+        """
+        ret = self.run_state('group.present', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.present', name='salt_test_2')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('user.present', name='salt_test',
+                             gid_from_name=True, home='/var/lib/salt_test',
+                             groups=['salt_test_2'])
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_function('user.info', ['salt_test'])
+        self.assertReturnNonEmptySaltType(ret)
+        in_groups = set(ret['groups'])
+        self.assertEqual(in_groups, set(['salt_test', 'salt_test_2']))
+
+        ret = self.run_state('user.present', name='salt_test', groups=[])
+        self.assertSaltTrueReturn(ret)
+
+        ret = self.run_function('user.info', ['salt_test'])
+        self.assertReturnNonEmptySaltType(ret)
+        in_groups = set(ret['groups'])
+        self.assertEqual(in_groups, set(['salt_test']))
+
+        ret = self.run_state('user.absent', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.absent', name='salt_test')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('group.absent', name='salt_test_2')
+        self.assertSaltTrueReturn(ret)
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Proposed fix for  #2724
- In states.user.present, differentiate between None and empty list for
  'groups': The empty list means the equivalent to passing '-G ""' to usermod,
  i.e. remove all but the default group.
- In modules.useradd, always quote the value passed after the '-G' switch to
  usermod and useradd, so they don't fail when we pass an empty string.
