### PR TITLE
Fix pip.installed error output and add loader debug output

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -531,9 +531,10 @@ class Loader(object):
                     if hasattr(mod, '__virtual__'):
                         if callable(mod.__virtual__):
                             virtual = mod.__virtual__()
-                            log.debug(('Loaded {0} as virtual '
-                                       '{1}').format(module_name, virtual))
-                            module_name = virtual
+                            if virtual:
+                                log.debug(('Loaded {0} as virtual '
+                                           '{1}').format(module_name, virtual))
+                                module_name = virtual
                 except Exception:
                     virtual = False
                     trb = traceback.format_exc()

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -409,8 +409,7 @@ class Loader(object):
         '''
         Return a dict of functions found in the defined module_dirs
         '''
-        log.debug('looking for {0}(er)s in {1}'.format(self.tag,
-                                                       self.module_dirs))
+        log.debug('loading {0} in {1}'.format(self.tag, self.module_dirs))
         names = {}
         modules = []
         funcs = {}
@@ -453,8 +452,7 @@ class Loader(object):
                     else:
                         _name = fn_
                     names[_name] = os.path.join(mod_dir, fn_)
-                    log.debug('Added {0} to the list of {1}s'.format(_name,
-                                                                     self.tag))
+                    log.debug('Added '{0}' to {1}'.format(_name, self.tag))
                 else:
                     log.debug(('Skipping {0}, it does not end with an '
                                'expected extension').format(fn_))

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -409,6 +409,7 @@ class Loader(object):
         '''
         Return a dict of functions found in the defined module_dirs
         '''
+        log.debug('looking for {0} in {1}'.format(self.tag, self.module_dirs))
         names = {}
         modules = []
         funcs = {}
@@ -425,13 +426,20 @@ class Loader(object):
                          'in the system path. Skipping Cython modules.')
         for mod_dir in self.module_dirs:
             if not os.path.isabs(mod_dir):
+                log.debug(('{0} is not an abosolute path, '
+                           'skipping').format(mod_dir))
                 continue
             if not os.path.isdir(mod_dir):
+                log.debug('{0} is not a directory, skipping'.format(mod_dir))
                 continue
             for fn_ in os.listdir(mod_dir):
                 if fn_.startswith('_'):
+                    log.debug(('{0} starts with an underscore, '
+                               'skipping').format(fn_))
                     continue
                 if fn_.split('.')[0] in disable:
+                    log.debug(('{0} is disabled by configuration, '
+                               'skipping').format(fn_))
                     continue
                 if (fn_.endswith(('.py', '.pyc', '.pyo', '.so'))
                     or (cython_enabled and fn_.endswith('.pyx'))
@@ -443,6 +451,11 @@ class Loader(object):
                     else:
                         _name = fn_
                     names[_name] = os.path.join(mod_dir, fn_)
+                    log.debug('Added {0} to the list of {0}'.format(_name,
+                                                                    self.tag))
+                else:
+                    log.debug(('{0} does not end with an expected extension, '
+                               'skipping').format(fn_))
         for name in names:
             try:
                 if names[name].endswith('.pyx'):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -435,8 +435,7 @@ class Loader(object):
                 continue
             for fn_ in os.listdir(mod_dir):
                 if fn_.startswith('_'):
-                    log.debug(('Skipping {0}, it starts with an '
-                               'underscore').format(fn_))
+                    # log messages omitted for obviousness
                     continue
                 if fn_.split('.')[0] in disable:
                     log.debug(('Skipping {0}, it is disabled by '
@@ -546,8 +545,7 @@ class Loader(object):
             for attr in dir(mod):
                 attr_name = '{0}.{1}'.format(module_name, attr)
                 if attr.startswith('_'):
-                    log.debug(('Skipping {0}, it starts with an '
-                               'underscore').format(attr_name))
+                    # log messages omitted for obviousness
                     continue
                 if callable(getattr(mod, attr)):
                     func = getattr(mod, attr)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -525,6 +525,7 @@ class Loader(object):
                     except TypeError:
                         pass
 
+            # Trim the full pathname to just the module
             module_name = mod.__name__.rsplit('.', 1)[-1]
             if virtual_enable:
                 try:
@@ -534,8 +535,11 @@ class Loader(object):
                             if virtual:
                                 log.debug(('Loaded {0} as virtual '
                                            '{1}').format(module_name, virtual))
+                                # update the module name with the new name
                                 module_name = virtual
                             else:
+                                # if __virtual__() returns false then the
+                                # module wasn't meant for this platform.
                                 continue
                 except Exception:
                     virtual = False
@@ -546,6 +550,7 @@ class Loader(object):
                     continue
 
             for attr in dir(mod):
+                # functions are namespaced with their module name
                 attr_name = '{0}.{1}'.format(module_name, attr)
                 if attr.startswith('_'):
                     # log messages omitted for obviousness

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -557,7 +557,7 @@ class Loader(object):
                             'Exception' in func.__name__]):
                             continue
                     funcs[attr_name] = func
-                    log.debug('Added {0} to {2}'.format(attr_name,
+                    log.debug('Added {0} to {1}'.format(attr_name,
                                                         self.tag))
                     self._apply_outputter(func, mod)
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -535,6 +535,8 @@ class Loader(object):
                                 log.debug(('Loaded {0} as virtual '
                                            '{1}').format(module_name, virtual))
                                 module_name = virtual
+                            else:
+                                continue
                 except Exception:
                     virtual = False
                     trb = traceback.format_exc()

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -409,7 +409,8 @@ class Loader(object):
         '''
         Return a dict of functions found in the defined module_dirs
         '''
-        log.debug('looking for {0} in {1}'.format(self.tag, self.module_dirs))
+        log.debug('looking for {0}(er)s in {1}'.format(self.tag,
+                                                       self.module_dirs))
         names = {}
         modules = []
         funcs = {}
@@ -426,20 +427,21 @@ class Loader(object):
                          'in the system path. Skipping Cython modules.')
         for mod_dir in self.module_dirs:
             if not os.path.isabs(mod_dir):
-                log.debug(('{0} is not an abosolute path, '
-                           'skipping').format(mod_dir))
+                log.debug(('Skipping {0}, it is not an abosolute '
+                           'path').format(mod_dir))
                 continue
             if not os.path.isdir(mod_dir):
-                log.debug('{0} is not a directory, skipping'.format(mod_dir))
+                log.debug(('Skipping {0}, it is not a '
+                           'directory').format(mod_dir))
                 continue
             for fn_ in os.listdir(mod_dir):
                 if fn_.startswith('_'):
-                    log.debug(('{0} starts with an underscore, '
-                               'skipping').format(fn_))
+                    log.debug(('Skipping {0}, it starts with an '
+                               'underscore').format(fn_))
                     continue
                 if fn_.split('.')[0] in disable:
-                    log.debug(('{0} is disabled by configuration, '
-                               'skipping').format(fn_))
+                    log.debug(('Skipping {0}, it is disabled by '
+                               'configuration').format(fn_))
                     continue
                 if (fn_.endswith(('.py', '.pyc', '.pyo', '.so'))
                     or (cython_enabled and fn_.endswith('.pyx'))
@@ -451,11 +453,11 @@ class Loader(object):
                     else:
                         _name = fn_
                     names[_name] = os.path.join(mod_dir, fn_)
-                    log.debug('Added {0} to the list of {0}'.format(_name,
-                                                                    self.tag))
+                    log.debug('Added {0} to the list of {1}s'.format(_name,
+                                                                     self.tag))
                 else:
-                    log.debug(('{0} does not end with an expected extension, '
-                               'skipping').format(fn_))
+                    log.debug(('Skipping {0}, it does not end with an '
+                               'expected extension').format(fn_))
         for name in names:
             try:
                 if names[name].endswith('.pyx'):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -452,7 +452,7 @@ class Loader(object):
                     else:
                         _name = fn_
                     names[_name] = os.path.join(mod_dir, fn_)
-                    log.debug('Added '{0}' to {1}'.format(_name, self.tag))
+                    log.debug('Added \'{0}\' to {1}'.format(_name, self.tag))
                 else:
                     log.debug(('Skipping {0}, it does not end with an '
                                'expected extension').format(fn_))

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -525,7 +525,7 @@ class Loader(object):
                     except TypeError:
                         pass
 
-            module_name = mod.__name__.split('.')[-1:][0]
+            module_name = mod.__name__.rsplit('.', 1)[-1]
             if virtual_enable:
                 try:
                     if hasattr(mod, '__virtual__'):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -452,7 +452,6 @@ class Loader(object):
                     else:
                         _name = fn_
                     names[_name] = os.path.join(mod_dir, fn_)
-                    log.debug('Added \'{0}\' to {1}'.format(_name, self.tag))
                 else:
                     log.debug(('Skipping {0}, it does not end with an '
                                'expected extension').format(fn_))
@@ -532,6 +531,8 @@ class Loader(object):
                     if hasattr(mod, '__virtual__'):
                         if callable(mod.__virtual__):
                             virtual = mod.__virtual__()
+                            log.debug(('Loaded {0} as virtual '
+                                       '{1}').format(mod, virtual))
                 except Exception:
                     virtual = False
                     trb = traceback.format_exc()
@@ -541,6 +542,8 @@ class Loader(object):
 
             for attr in dir(mod):
                 if attr.startswith('_'):
+                    log.debug(('Skipping {0}.{1}, it starts with an '
+                               'underscore').format(mod, attr))
                     continue
                 if callable(getattr(mod, attr)):
                     func = getattr(mod, attr)
@@ -551,6 +554,9 @@ class Loader(object):
                             continue
                     if virtual:
                         funcs['{0}.{1}'.format(virtual, attr)] = func
+                        log.debug('Added {0}.{1} to {2}'.format(virtual,
+                                                                attr,
+                                                                self.tag))
                         self._apply_outputter(func, mod)
                     elif virtual is False:
                         pass
@@ -561,6 +567,9 @@ class Loader(object):
                                 attr
                             )
                         ] = func
+                        log.debug('Added {0}.{1} to {2}'.format(mod,
+                                                                attr,
+                                                                self.tag))
                         self._apply_outputter(func, mod)
         for mod in modules:
             if not hasattr(mod, '__salt__'):

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -133,10 +133,9 @@ def installed(name,
     elif pip_install_call:
         ret['result'] = False
         ret['comment'] = ('Failed to install package {0}. '
-            'Error: {1} {2}').format(name,
-                                     pip_install_call['stdout'],
-                                     pip_install_call['stderr'])
-        )
+                          'Error: {1} {2}').format(name,
+                                                   pip_install_call['stdout'],
+                                                   pip_install_call['stderr'])
     else:
         ret['result'] = False
         ret['comment'] = 'Could not install package'

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -114,7 +114,7 @@ def installed(name,
         cwd=cwd
     )
 
-    if pip_install_call and pip_install_call['retcode']==0:
+    if pip_install_call and (pip_install_call['retcode'] == 0):
         ret['result'] = True
 
         pkg_list = __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd)
@@ -132,8 +132,10 @@ def installed(name,
         ret['comment'] = 'Package was successfully installed'
     elif pip_install_call:
         ret['result'] = False
-        ret['comment'] = 'Failed to install package {0}. Error: {1}'.format(
-            name, pip_install_call['stderr']
+        ret['comment'] = ('Failed to install package {0}. '
+            'Error: {1} {2}').format(name,
+                                     pip_install_call['stdout'],
+                                     pip_install_call['stderr'])
         )
     else:
         ret['result'] = False


### PR DESCRIPTION
This started out as a pull request to fix the error output for the `pip.installed` state. It turns out that build errors for pip are not passed to stderr, but to stdout. I have added both stderr and stdout to the returned comments if the pip command fails.

While testing this fix I found that the module wouldn't initially load. And frustrated with the lack of feedback from the loader I dove into it and added a bunch of logging. So now there are helpful messages in the debug log like this:

```
[DEBUG   ] loading output in ['/var/cache/salt/minion/extmods/output', '/salt/salt-0.10.5.linux-x86_64/salt-0.10.5-py2.6.egg/salt/output']
[DEBUG   ] Skipping /var/cache/salt/minion/extmods/output, it is not a directory
[DEBUG   ] Added overstatestage.output to output
[DEBUG   ] Loaded json_out as virtual json
[DEBUG   ] Added json.output to output
[DEBUG   ] Added raw.output to output
[DEBUG   ] Added highstate.output to output
[DEBUG   ] Loaded yaml_out as virtual yaml
[DEBUG   ] Added yaml.output to output
[DEBUG   ] Added key.output to output
[DEBUG   ] Added txt.output to output
[DEBUG   ] Loaded pprint_out as virtual pprint
[DEBUG   ] Added pprint.output to output
```

I eventually got a bug fixed in the module that was preventing it from being included in my build. But now we have some great logging!

**Please review this pull carefully. I made a few cleanups to the loader logic and I would like someone to verify that I have not missed a case.**
