### PR TITLE
clean up svn state and module

### DIFF
--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -4,13 +4,14 @@ Subversion SCM
 
 import re
 import shlex
+from subprocess import list2cmdline
 from salt import utils, exceptions
 
 _INI_RE = re.compile(r"^([^:]+):\s+(\S.*)$", re.M)
 
 
 def _check_svn():
-    """Check for svn on this node."""
+    '''Check for svn on this node.'''
     utils.check_or_die('svn')
 
 
@@ -39,10 +40,9 @@ def _run_svn(cmd, cwd, user, username, opts, **kwargs):
     '''
     cmd = 'svn --non-interactive {0} '.format(cmd)
     if username:
-        opts += ("--username", username)
+        opts += ('--username', username)
     if opts:
-        cmd += '"{0}"'.format('" "'.join(
-            [optstr.replace('"', r'\"') for optstr in opts]))
+        cmd += list2cmdline(opts)
 
     result = __salt__['cmd.run_all'](cmd, cwd=cwd, runas=user, **kwargs)
 
@@ -86,7 +86,7 @@ def info(cwd, targets=None, user=None, username=None, fmt='str'):
         return infos
 
     info_list = []
-    for infosplit in infos.split("\n\n"):
+    for infosplit in infos.split('\n\n'):
         info_list.append(_INI_RE.findall(infosplit))
 
     if fmt == 'list':

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -36,7 +36,7 @@ def latest(name,
            rev=None,
            user=None,
            username=None,
-           force=None,
+           force=False,
            externals=True):
     '''
     Checkout or update the working directory to the latest revision from the
@@ -76,7 +76,9 @@ def latest(name,
 
     if os.path.exists(target) and not os.path.isdir(target):
         return _fail(ret,
-                'The path "{0}" exists and is not a directory.'.format(target))
+                     'The path "{0}" exists and is not '
+                     'a directory.'.format(target)
+                     )
 
     try:
         __salt__['svn.info']('.', target, user=user)
@@ -99,6 +101,7 @@ def latest(name,
         out = __salt__[svn_cmd](cwd, name, basename, user, username, *opts)
     ret['comment'] = out
     return ret
+
 
 def dirty(name,
           target,


### PR DESCRIPTION
- use subprocess function list2cmdline() instead loop for prepare cmd string from args list
- pep8 fix
- replace double quotes by single quotes
