### PR TITLE
force noinput

### DIFF
--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -150,7 +150,7 @@ def collectstatic(settings_module,
 
         salt '*' django.collectstatic settings.py
     '''
-    args = []
+    args = ['noinput']
     kwargs = {}
     if no_post_process:
         args.append('no-post-process')


### PR DESCRIPTION
collectstatic always ask for user intervention!

this is required, right now it just do that:

```
----------
    State: - module
    Name:      django.collectstatic
    Function:  wait
        Result:    True
        Comment:   Module function django.collectstatic executed
        Changes:   ret: 
You have requested to collect static files at the destination
location as specified in your settings file.

This will overwrite existing files.
Are you sure you want to do this?

Type 'yes' to continue, or 'no' to cancel: Traceback (most recent call last):
  File "/usr/local/deployments/sologroup/bin/django-admin.py", line 5, in <module>
    management.execute_from_command_line()
  File "/usr/local/deployments/sologroup/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 429, in execute_from_command_line
    utility.execute()
  File "/usr/local/deployments/sologroup/local/lib/python2.7/site-packages/django/core/management/__init__.py", line 379, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/usr/local/deployments/sologroup/local/lib/python2.7/site-packages/django/core/management/base.py", line 191, in run_from_argv
    self.execute(*args, **options.__dict__)
  File "/usr/local/deployments/sologroup/local/lib/python2.7/site-packages/django/core/management/base.py", line 220, in execute
    output = self.handle(*args, **options)
  File "/usr/local/deployments/sologroup/local/lib/python2.7/site-packages/django/core/management/base.py", line 351, in handle
    return self.handle_noargs(**options)
  File "/usr/local/deployments/sologroup/local/lib/python2.7/site-packages/django/contrib/staticfiles/management/commands/collectstatic.py", line 75, in handle_noargs
    Type 'yes' to continue, or 'no' to cancel: """)
EOFError: EOF when reading a line
```
