### PR TITLE
Remove references to pub_refresh.

### DIFF
--- a/conf/master.template
+++ b/conf/master.template
@@ -16,10 +16,6 @@
 # The tcp port used by the publisher
 #publish_port: 4505
 
-# Refresh the publisher connections when sending out commands, this is a fix
-# for zeromq losing some minion connections. Default: False
-#pub_refresh: False
-
 # The user to run the salt-master as. Salt will update all permissions to
 # allow the specified user to run the master. If the modified files cause
 # conflicts set verify_env to False.

--- a/salt/config.py
+++ b/salt/config.py
@@ -317,7 +317,6 @@ def master_config(path):
             'max_open_files': 100000,
             'hash_type': 'md5',
             'conf_file': path,
-            'pub_refresh': False,
             'open_mode': False,
             'auto_accept': False,
             'renderer': 'yaml_jinja',

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -14,7 +14,6 @@ peer:
     - 'test.*'
 log_file: master
 key_logfile: key
-pub_refresh: False
 token_file: /tmp/ksfjhdgiuebfgnkefvsikhfjdgvkjahcsidk
 
 file_buffer_size: 8192


### PR DESCRIPTION
The configuration option was removed in 0.10.5.

It confused me deeply when I grepped the source and found it defined in config.py but not used anywhere. I thought there was some magic going on (like splitting on '_' and putting 'refresh' in a 'pub' key somewhere). It turned out that the option was removed, but not entirely wiped in the source.
