### PR TITLE
Add 'debian' back to the os grains map.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -416,6 +416,7 @@ _OS_NAME_MAP = {
     'redhatente': 'RedHat',
     'gentoobase': 'Gentoo',
     'arch': 'Arch',
+    'debian': 'Debian',
 }
 
 # Map the 'os' grain to the 'os_family' grain


### PR DESCRIPTION
This adds a lowercase 'debian' back to the os name map to fix #2655.
