### PR TITLE
Some minor fixes

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -69,7 +69,7 @@ class LocalClient(object):
     '''
     Connect to the salt master via the local server and via root
     '''
-    def __init__(self, c_path='/etc/salt', mopts=None):
+    def __init__(self, c_path='/etc/salt/master', mopts=None):
         if mopts:
             self.opts - mopts
         else:

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -79,7 +79,7 @@ def start(job_label, runas=None):
     '''
     cmd = 'launchctl start {0}'.format(job_label, runas=runas)
 
-    return __salt__['cmd.run'](cmd, runas='marca')
+    return __salt__['cmd.run'](cmd, runas=runas)
 
 
 def restart(job_label, runas=None):


### PR DESCRIPTION
1. Fix in launchctl.py module: not using user 'marca' by default.
2. Fix in client.py: default master config is located at /etc/salt/master by default: http://docs.saltstack.org/en/latest/ref/configuration/master.html
