### PR TITLE
Preserve the final newline in Jinja templates

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -73,6 +73,11 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     opts = context['opts']
     env = context['env']
     loader = None
+    newline = False
+
+    if tmplstr.endswith('\n'):
+        newline = True
+
     if not env:
         if tmplpath:
             # ie, the template is from a file outside the state tree
@@ -85,9 +90,16 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         jinja_env = jinja2.Environment(
                         loader=loader, undefined=jinja2.StrictUndefined)
     try:
-        return jinja_env.from_string(tmplstr).render(**context)
+        output = jinja_env.from_string(tmplstr).render(**context)
     except jinja2.exceptions.TemplateSyntaxError, exc:
         raise SaltTemplateRenderError(str(exc))
+
+    # Workaround a bug in Jinja that removes the final newline
+    # (https://github.com/mitsuhiko/jinja2/issues/75)
+    if newline:
+        output += '\n'
+
+    return output
 
 
 def render_mako_tmpl(tmplstr, context, tmplpath=None):

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -120,7 +120,7 @@ class TestGetTemplate(TestCase):
             out = render_jinja_tmpl(
                     fp_.read(),
                     dict(opts=self.local_opts, env='other'))
-        self.assertEqual(out, 'world')
+        self.assertEqual(out, 'world\n')
 
     def test_fallback_noloader(self):
         '''
@@ -131,7 +131,7 @@ class TestGetTemplate(TestCase):
         out = render_jinja_tmpl(
                 salt.utils.fopen(filename).read(),
                 dict(opts=self.local_opts, env='other'))
-        self.assertEqual(out, 'Hey world !a b !')
+        self.assertEqual(out, 'Hey world !a b !\n')
 
     def test_env(self):
         '''
@@ -149,6 +149,6 @@ class TestGetTemplate(TestCase):
                 salt.utils.fopen(filename).read(),
                 dict(opts={'cachedir': TEMPLATES_DIR, 'file_client': 'remote'},
                      a='Hi', b='Salt', env='test'))
-        self.assertEqual(out, 'Hey world !Hi Salt !')
+        self.assertEqual(out, 'Hey world !Hi Salt !\n')
         self.assertEqual(fc.requests[0]['path'], 'salt://macro')
         SaltCacheLoader.file_client = _fc


### PR DESCRIPTION
The fix of #503 (which is caused by mitsuhiko/jinja2#75) got removed with the implementation of render pipes (in fd1cb0219716e941fa2cf8d224a2f7818bcf3c1e to be exact). This adds the workaround back again, so jinja rendered configuration files don't lose their final newlines.
