### PR TITLE
Add module field list documentation

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -196,12 +196,36 @@ to the calling terminal.
 
 .. _`Python docstring`: #term-docstring
 
+Add Module meta data
+--------------------
+
+Add information about the module using the following field lists:
+
+.. code-block:: text
+
+    :maintainer:    Thomas Hatch <thatch@saltstack.com, Seth House <shouse@saltstack.com>
+    :maturity:      new
+    :depends:       python-mysqldb
+    :platform:      all
+
+The maintaner field is a comma-delimited list of developers who help maintain
+this module.
+
+The maturity field indicates the level of quality and testing for this module.
+Standard labels will be determined.
+
+The depends field is a comma-delimited list of modules that this module depends
+on.
+
+The platform field is a comma-delimited list of platforms that this modules is
+known to run on.
+
 How Functions are Read
 ======================
 
-In Salt, Python callable objects contained within a module are made available to
-the Salt minion for use. The only exception to this rule is a callable object
-with a name starting with an underscore ``_``.
+In Salt, Python callable objects contained within a module are made available
+to the Salt minion for use. The only exception to this rule is a callable
+object with a name starting with an underscore ``_``.
 
 Objects Loaded Into the Salt Minion
 -----------------------------------

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -1,6 +1,11 @@
 '''
 Return data to a mysql server
 
+:maintainer:    Dave Boucha <dave@saltstack.com>, Seth House <shouse@saltstack.com>
+:maturity:      new
+:depends:       python-mysqldb
+:platform:      all
+
 To enable this returner the minion will need the python client for mysql
 installed and the following values configured in the minion or master
 config, these are the defaults::


### PR DESCRIPTION
Add documentation about  field lists for modules.

The first fields are:

:maintainer: 
:maturity:
:depends:
:platform:

We can modify this list per community discussion and needs.
