### PR TITLE
Fix path access check windows

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -93,7 +93,7 @@ class LocalClient(object):
                 self.opts['cachedir'], '.{0}_key'.format(key_user)
                 )
         # Make sure all key parent directories are accessible
-        salt.utils.verify.check_parent_dirs(keyfile, key_user)
+        salt.utils.verify.check_path_traversal(self.opts['cachedir'], key_user)
 
         try:
             with salt.utils.fopen(keyfile, 'r') as KEY:

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -146,7 +146,7 @@ class Auth(object):
         key = None
         # Make sure all key parent directories are accessible
         user = self.opts.get('user', 'root')
-        salt.utils.verify.check_parent_dirs(self.rsa_path, user)
+        salt.utils.verify.check_path_traversal(self.opts['pki_dir'], user)
 
         if os.path.exists(self.rsa_path):
             try:

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -266,24 +266,23 @@ def list_path_traversal(path):
     return out
 
 
-def check_parent_dirs(fname, user='root'):
+def check_path_traversal(path, user='root'):
     '''
     Walk from the root up to a directory and verify that the current
     user has access to read each directory. This is used for  making
     sure a user can read all parent directories of the minion's  key
     before trying to go and generate a new key and raising an IOError
     '''
-    for dirname in list_path_traversal(fname):
-        if not os.access(dirname, os.R_OK):
-            msg = 'Could not access directory {0}.'.format(dirname)
+    for p in list_path_traversal(path):
+        if not os.access(p, os.R_OK):
+            msg = 'Could not access {0}.'.format(p)
             current_user = getpass.getuser()
             # Make the error message more intelligent based on how
             # the user invokes salt-call or whatever other script.
             if user != current_user:
                 msg += ' Try running as user {0}.'.format(user)
             else:
-                msg += ' Please give {0} read permissions.'.format(user,
-                                                                   dirname)
+                msg += ' Please give {0} read permissions.'.format(user, p)
             # Propagate this exception up so there isn't a sys.exit()
             # in the middle of code that could be imported elsewhere.
             raise SaltClientError(msg)


### PR DESCRIPTION
I ran into the following error when setting up a new minion in Windows:

```
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "__main__.py", line 726, in <module>
  File "__main__.py", line 332, in bootstrap
  File "__main__.py", line 359, in chainload
  File "__main__.py", line 715, in _chainload
  File "__main__.py", line 128, in <module>
  File "__main__firehost-mgmt__.py", line 17, in <module>
  File "salt/scripts.py", line 28, in salt_minion
  File "salt/__init__.py", line 116, in start
  File "salt/minion.py", line 178, in __init__
  File "salt/minion.py", line 533, in authenticate
  File "salt/crypt.py", line 256, in sign_in
  File "salt/crypt.py", line 172, in minion_sign_in_payload
  File "salt/crypt.py", line 149, in get_keys
  File "salt/utils/verify.py", line 269, in check_parent_dirs
salt.exceptions.SaltClientError: Could not access directory \etc\salt\pki\minion. Try running as user root.
```

The message is troubling given that 'root' doesn't mean anything on Windows. But it's also not clear where the path is actually rooted. 

This patch adds some platform agnosticism to the approach, producing a slightly less confusing error below:

```
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "__main__.py", line 726, in <module>
  File "__main__.py", line 332, in bootstrap
  File "__main__.py", line 359, in chainload
  File "__main__.py", line 715, in _chainload
  File "__main__.py", line 128, in <module>
  File "__main__firehost-mgmt__.py", line 17, in <module>
  File "salt/scripts.py", line 28, in salt_minion
  File "salt/__init__.py", line 116, in start
  File "salt/minion.py", line 178, in __init__
  File "salt/minion.py", line 533, in authenticate
  File "salt/crypt.py", line 256, in sign_in
  File "salt/crypt.py", line 172, in minion_sign_in_payload
  File "salt/crypt.py", line 149, in get_keys
  File "salt/utils/verify.py", line 288, in check_path_traversal
salt.exceptions.SaltClientError: Could not access c:\etc\salt\pki\minion. Try running as user root.
```

This means it now supports running on an alternate drive as well.

This patch comes with a function for generating a list of directories leading up to a path. And revises the calling code so that the context is a little more clear.
