### PR TITLE
Minor mongo pillar fix

### DIFF
--- a/salt/pillar/mongo.py
+++ b/salt/pillar/mongo.py
@@ -129,7 +129,7 @@ def ext_pillar(pillar, collection='pillar', id_field='_id', re_pattern=None,
 
 
     result = db[collection].find_one({id_field: minion_id}, fields=fields)
-    if result :
+    if result:
         if fields:
             log.debug("ext_pillar.mongo: found document, returning fields "
                       "'{0}'".format(fields))

--- a/salt/pillar/mongo.py
+++ b/salt/pillar/mongo.py
@@ -135,7 +135,7 @@ def ext_pillar(pillar, collection='pillar', id_field='_id', re_pattern=None,
                       "'{0}'".format(fields))
         else:
             log.debug("ext_pillar.mongo: found document, returning whole doc")
-        if '_id' in result :
+        if '_id' in result:
             # Converting _id to a string
             # will avoid the most common serialization error cases, but DBRefs
             # and whatnot will still cause problems.

--- a/salt/pillar/mongo.py
+++ b/salt/pillar/mongo.py
@@ -128,19 +128,19 @@ def ext_pillar(pillar, collection='pillar', id_field='_id', re_pattern=None,
              "in mongo".format(id_field, minion_id))
 
 
-    pillar = db[collection].find_one({id_field: minion_id}, fields=fields)
-    if pillar:
+    result = db[collection].find_one({id_field: minion_id}, fields=fields)
+    if result :
         if fields:
             log.debug("ext_pillar.mongo: found document, returning fields "
                       "'{0}'".format(fields))
         else:
             log.debug("ext_pillar.mongo: found document, returning whole doc")
-        if '_id' in pillar:
+        if '_id' in result :
             # Converting _id to a string
             # will avoid the most common serialization error cases, but DBRefs
             # and whatnot will still cause problems.
-            pillar['_id'] = str(pillar['_id'])
-        return pillar
+            result['_id'] = str(result['_id'])
+        return result
     else:
         # If we can't find the minion the database it's not necessarily an
         # error.


### PR DESCRIPTION
There were a few changes in e704fa5896ee455d59283e4739c78c107ee5665f and 827394bd0d09d76cc0b8cd08dd1b226b1e1c7e87 that added the ability for a pillar to inherit existing data. This was a good patch, but the mongo pillar already used the name `pillar` to reference returned data. So the new parameter makes its behavior a bit ambiguous. Mongo now assigns its result to `result` rather than `pillar` to make it clearer how the returned data is to be handled.
