### PR TITLE
Filtered the content of requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-# pip requirements file for Salt
 Jinja2
 M2Crypto
 msgpack-python

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,11 @@ else:
 
 libraries = ['ws2_32'] if sys.platform == 'win32' else []
 
-requirements = ''
 with open(salt_reqs) as f:
-    requirements = f.read()
+    lines = f.read().split('\n')
+    requirements = [
+        line for line in lines if (line and not line.startswith('#'))
+    ]
 
 
 setup_kwargs = {'name': NAME,

--- a/setup.py
+++ b/setup.py
@@ -99,9 +99,7 @@ libraries = ['ws2_32'] if sys.platform == 'win32' else []
 
 with open(salt_reqs) as f:
     lines = f.read().split('\n')
-    requirements = [
-        line for line in lines if (line and not line.startswith('#'))
-    ]
+    requirements = [line for line in lines if line]
 
 
 setup_kwargs = {'name': NAME,


### PR DESCRIPTION
This sanitizes what goes into install_requires. External packaging tools such
as FPM fail when they see a requirement starting with '#'.
