### PR TITLE
Fixes #2649 remove extension before comparing to pkg_list()

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -189,6 +189,10 @@ def version(name):
         pkgs = {}
         for h in mi:
             pkgs[h['name']] = "-".join([h['version'], h['release']])
+    # check for '.arch' appended to pkg name (i.e. 32 bit installed on 64 bit
+    # machine is '.i386')
+    if name.find('.') >= 0:
+        name = name.split('.')[0]
     if name in pkgs:
         return pkgs[name]
     else:


### PR DESCRIPTION
pkg_list() doesn't have the arch appended to the end.

Oops. Accidentally pushed this feature branch to the Salt Stack repo instead of my github fork.

This needs to be tested by someone on Fedora/RHEL

Fixes #2649
