### PR TITLE
fix typo in ssh module and small change in ssh_known_hosts state

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -593,7 +593,7 @@ def set_known_host(user, hostname,
         return {'status': 'exists', 'key': stored_host}
 
     remote_host = recv_known_host(user, hostname, enc=enc, port=port,
-                                  hash_hostname=True)
+                                  hash_hostname=hash_hostname)
     if not remote_host:
         return {'status': 'error',
                 'error': 'Unable to receive remote host key'}

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -25,7 +25,8 @@ def present(
         fingerprint=None,
         port=None,
         enc=None,
-        config='.ssh/known_hosts'):
+        config='.ssh/known_hosts',
+        hash_hostname=True):
     '''
     Verifies that the specified host is known by the specified user
 
@@ -50,6 +51,9 @@ def present(
     config
         The location of the authorized keys file relative to the user's home
         directory, defaults to ".ssh/known_hosts"
+
+    hash_hostname : True
+        Hash all hostnames and addresses in the output.
     '''
     ret = {'name': name,
            'changes': {},
@@ -75,7 +79,8 @@ def present(
                 fingerprint=fingerprint,
                 port=port,
                 enc=enc,
-                config=config)
+                config=config,
+                hash_hostname=hash_hostname)
     if result['status'] == 'exists':
         return dict(ret,
                     comment='{0} already exists in {1}'.format(name, config))


### PR DESCRIPTION
- fix: ssh.set_known_host() did not evaluate hash_hostname argument
- use argument hash_hostname in ssh_known_hosts.present state
