### PR TITLE
Add support for force-reload

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -119,6 +119,18 @@ def reload(name):
     return not __salt__['cmd.retcode'](cmd)
 
 
+def force_reload(name):
+    '''
+    Force-reload the named service
+
+    CLI Example::
+
+        salt '*' service.force_reload <service name>
+    '''
+    cmd = 'service {0} force-reload'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
+
+
 def status(name, sig=None):
     '''
     Return the status for a service, pass a signature to use to find

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -166,6 +166,17 @@ def reload(name):
     return not __salt__['cmd.retcode'](_systemctl_cmd('reload', name))
 
 
+def force_reload(name):
+    '''
+    Force-reload the specified service with systemd
+
+    CLI Example::
+
+        salt '*' service.force_reload <service name>
+    '''
+    return not __salt__['cmd.retcode'](_systemctl_cmd('force-reload', name))
+
+
 # The unused sig argument is required to maintain consistency in the state
 # system
 def status(name, sig=None):

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -313,6 +313,18 @@ def reload(name):
     return not __salt__['cmd.retcode'](cmd)
 
 
+def force_reload(name):
+    '''
+    Force-reload the named service
+
+    CLI Example::
+
+        salt '*' service.force_reload <service name>
+    '''
+    cmd = 'service {0} force-reload'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
+
+
 def status(name, sig=None):
     '''
     Return the status for a service, returns a bool whether the service is


### PR DESCRIPTION
This adds force_reload for debian_service, upstart and systemd and use it as default in mod_watch if available. See also the thread on the mailinglist about it:

https://groups.google.com/d/topic/salt-users/AK4zB1EsnFQ/discussion

For Debian/Ubuntu it is a requirement that init scripts support force-reload and both upstart and systemd implement the force-reload command. There are probably more that support force-reload, but I think it's better if somebody with more knowledge about those init systems look at it.
