### PR TITLE
Implemented the file_ignore_regex and file_ignore_glob feature (#2681)

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -231,6 +231,24 @@
 # The buffer size in the file server can be adjusted here:
 #file_buffer_size: 1048576
 
+# A regular expression (or a list of expressions) that will be matched
+# against the file path before syncing the modules and states to the minions.
+# This includes files affected by the file.recurse state.
+# For example, if you manage your custom modules and states in subversion
+# and don't want all the '.svn' folders and content synced to your minions,
+# you could set this to '/\.svn($|/)'. By default nothing is ignored.
+#file_ignore_regex:
+# - '/\.svn($|/)'
+# - '/\.git($|/)'
+
+# A file glob (or list of file globs) that will be matched against the file
+# path before syncing the modules and states to the minions. This is similar
+# to file_ignore_regex above, but works on globs instead of regex. By default
+# nothing is ignored.
+#file_ignore_glob:
+#  - '*.pyc'
+#  - '*/somefolder/*.bak'
+
 # Pillar Configurations:
 # The Salt Pillar, is a system that allows for the building of global data
 # that is refined based on minion. Basically, the pillar creates data that

--- a/salt/config.py
+++ b/salt/config.py
@@ -5,6 +5,7 @@ All salt configuration loading and defaults should be in this module
 # Import python modules
 import glob
 import os
+import re
 import socket
 import logging
 import time
@@ -326,6 +327,8 @@ def master_config(path):
             'external_auth': {},
             'token_expire': 720,
             'file_buffer_size': 1048576,
+            'file_ignore_regex': None,
+            'file_ignore_glob': None,
             'max_open_files': 100000,
             'hash_type': 'md5',
             'conf_file': path,
@@ -393,6 +396,29 @@ def master_config(path):
     opts['open_mode'] = opts['open_mode'] is True
     opts['auto_accept'] = opts['auto_accept'] is True
     opts['file_roots'] = _validate_file_roots(opts['file_roots'])
+
+    if opts['file_ignore_regex']:
+        # If file_ignore_regex was given, make sure it's wrapped in a list.
+        # Only keep valid regex entries for improved performance later on.
+        if isinstance(opts['file_ignore_regex'], str):
+            ignore_regex = [ opts['file_ignore_regex'] ]
+        elif isinstance(opts['file_ignore_regex'], list):
+            ignore_regex = opts['file_ignore_regex']
+
+        opts['file_ignore_regex'] = []
+        for r in ignore_regex:
+            try:
+                # Can't store compiled regex itself in opts (breaks serialization)
+                re.compile(r)
+                opts['file_ignore_regex'].append(r)
+            except:
+                log.warning('Unable to parse file_ignore_regex. Skipping: {0}'.format(r))
+
+    if opts['file_ignore_glob']:
+        # If file_ignore_glob was given, make sure it's wrapped in a list.
+        if isinstance(opts['file_ignore_glob'], str):
+            opts['file_ignore_glob'] = [ opts['file_ignore_glob'] ]
+
     return opts
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -576,22 +576,22 @@ class AESFuncs(object):
                   .format(id_))
         return False
 
-    def __is_file_ignored(self, fn, file_ignore_regex, file_ignore_glob):
+    def __is_file_ignored(self, fn):
         '''
         If file_ignore_regex or file_ignore_glob were given in config,
         compare the given file path against all of them and return True
         on the first match.
         '''
-        if (file_ignore_regex):
-            for r in file_ignore_regex:
-                if r.search(fn):
-                    log.debug('File matching file_ignore_regex. Skipping: {0}'.format(fn) )
+        if self.opts['file_ignore_regex']:
+            for r in self.opts['file_ignore_regex']:
+                if re.search(r, fn):
+                    log.debug('File matching file_ignore_regex. Skipping: {0}'.format(fn))
                     return True
 
-        if (file_ignore_glob):
-            for g in file_ignore_glob:
+        if self.opts['file_ignore_glob']:
+            for g in self.opts['file_ignore_glob']:
                 if fnmatch.fnmatch(fn, g):
-                    log.debug('File matching file_ignore_glob. Skipping: {0}'.format(fn) )
+                    log.debug('File matching file_ignore_glob. Skipping: {0}'.format(fn))
                     return True
         return False
 
@@ -700,29 +700,6 @@ class AESFuncs(object):
         if load['env'] not in self.opts['file_roots']:
             return ret
 
-        # Make sure all the configured regex are wrapped in a list
-        file_ignore_regex = []
-        if (self.opts.get('file_ignore_regex')):
-            if isinstance(self.opts.get('file_ignore_regex'), str):
-                ignore_regex = [ self.opts.get('file_ignore_regex') ]
-            elif isinstance(self.opts.get('file_ignore_regex'), list):
-                ignore_regex = self.opts.get('file_ignore_regex')
-
-            # Then parse them and keep only the valid ones
-            for r in ignore_regex:
-                try:
-                    file_ignore_regex.append(re.compile(r))
-                except:
-                    log.warning('Unable to parse file_ignore_regex. Skipping: {0}'.format(r))
-
-        # Make sure all the configured globs are wrapped in a list
-        file_ignore_glob = []
-        if (self.opts.get('file_ignore_glob')):
-            if isinstance(self.opts.get('file_ignore_glob'), str):
-                file_ignore_glob = [ self.opts.get('file_ignore_glob') ]
-            elif isinstance(self.opts.get('file_ignore_glob'), list):
-                file_ignore_glob = self.opts.get('file_ignore_glob')
-
         for path in self.opts['file_roots'][load['env']]:
             for root, dirs, files in os.walk(path, followlinks=True):
                 for fn in files:
@@ -730,7 +707,7 @@ class AESFuncs(object):
                                 os.path.join(root, fn),
                                 path
                             )
-                    if not self.__is_file_ignored(rel_fn, file_ignore_regex, file_ignore_glob):
+                    if not self.__is_file_ignored(rel_fn):
                         ret.append(rel_fn)
         return ret
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -540,7 +540,7 @@ class AESFuncs(object):
             return fnd
         for root in self.opts['file_roots'][env]:
             full = os.path.join(root, path)
-            if os.path.isfile(full):
+            if os.path.isfile(full) and not self.__is_file_ignored(full):
                 fnd['path'] = full
                 fnd['rel'] = path
                 return fnd
@@ -721,7 +721,9 @@ class AESFuncs(object):
         for path in self.opts['file_roots'][load['env']]:
             for root, dirs, files in os.walk(path, followlinks=True):
                 if len(dirs) == 0 and len(files) == 0:
-                    ret.append(os.path.relpath(root, path))
+                    rel_fn = os.path.relpath(root, path)
+                    if not self.__is_file_ignored(rel_fn):
+                        ret.append(rel_fn)
         return ret
 
     def _dir_list(self, load):


### PR DESCRIPTION
The idea originated in a [discussion between Thomas and I](https://groups.google.com/d/topic/salt-users/yb8f3xzlwBg/discussion) in the Salt-users group.

It provides the user with two new options to set a list of regular expressions and/or file globs that will be evaluated during file transfers (states, modules, file.recurse). This allows you to exclude version control files like ".git", ".svn" or "CVS" folders from being synced to all minions.

I had some time to work on this and offer my implementation for consideration.

This closes  issue #2681.
