### PR TITLE
Add runtime check for systemd

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -8,13 +8,14 @@ import re
 
 # Import Python libs
 import salt.utils
+from .systemd import _sd_booted
 
 
 def __virtual__():
     '''
-    Only work on Debian
+    Only work on Debian and when systemd isn't running
     '''
-    if __grains__['os'] == 'Debian':
+    if __grains__['os'] == 'Debian' and not _sd_booted():
         return 'service'
     return False
 

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -2,6 +2,7 @@
 Provide the service module for systemd
 '''
 # Import Python libs
+import os
 import re
 # Import Salt libs
 import salt.utils
@@ -10,17 +11,33 @@ LOCAL_CONFIG_PATH = '/etc/systemd/system'
 VALID_UNIT_TYPES = ['service','socket', 'device', 'mount', 'automount',
                     'swap', 'target', 'path', 'timer']
 
+def _sd_booted():
+    '''
+    Return True if the system was booted with systemd, False otherwise.
+    '''
+    # We can cache this for as long as the minion runs.
+    if not "systemd.sd_booted" in __context__:
+        try:
+            # This check does the same as sd_booted() from libsystemd-daemon:
+            # http://www.freedesktop.org/software/systemd/man/sd_booted.html
+            a = os.stat('/sys/fs/cgroup')
+            b = os.stat('/sys/fs/cgroup/systemd')
+        except OSError:
+            __context__['systemd.sd_booted'] = False
+        else:
+            if a.st_dev != b.st_dev:
+                __context__['systemd.sd_booted'] = True
+            else:
+                __context__['systemd.sd_booted'] = False
+
+    return __context__['systemd.sd_booted']
+
+
 def __virtual__():
     '''
-    Only work on systems which default to systemd
+    Only work on systems that have been booted with systemd
     '''
-    enable = (
-            'Arch',
-            'openSUSE',
-            )
-    if __grains__['os'] == 'Fedora' and __grains__['osrelease'] > 15:
-        return 'service'
-    elif __grains__['os'] in enable:
+    if __grains__['kernel'] == 'Linux' and _sd_booted():
         return 'service'
     return False
 


### PR DESCRIPTION
Check whether the system was booted with systemd instead of using a list of distribution for which systemd should be enabled. Don't enable debian_service if the Debian system was booted with systemd. This makes it possible to use systemd on Debian.
