### PR TITLE
Modified the tomcat.py module's search for CATALINA_HOME

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -2,17 +2,18 @@
 Support for Tomcat
 '''
 # Import Python Libs
-import os
+import glob
 
 
 def __catalina_home():
     '''
     Tomcat paths differ depending on packaging
     '''
-    locations = ['/usr/share/tomcat6', '/opt/tomcat']
+    locations = ['/usr/share/tomcat*', '/opt/tomcat']
     for location in locations:
-        if os.path.isdir(location):
-            return location
+        catalina_home = glob.glob(location)
+	if catalina_home:
+            return catalina_home[-1]
 
 
 def version():


### PR DESCRIPTION
The search for the install location of tomcat was written to statically look in /usr/share/ and /opt/ however it is set to statically look for tomcat6. This was already problematic on my system were we are running tomcat7. I changed the search from is.directory to glob which allows the use of wild-cards. I then check for tomcat\* rather than tomcat6.
