### PR TITLE
Migrate states tests to use SaltReturnAssertsMixIn

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -939,6 +939,16 @@ class SaltReturnAssertsMixIn(object):
             )
         return True
 
+    def assertSaltCommentRegexpMatches(self, ret, pattern):
+        self.assertReturnSaltType(ret)
+        for part in ret.itervalues():
+            if 'comment' in part:
+                return self.assertRegexpMatches(part['comment'], pattern)
+        else:
+            raise AssertionError(
+                'There\'s no comment key in any of salt\'s return parts'
+            )
+
     def __assertSaltStateChanges(self, ret, keys=()):
         self.assertSaltTrueReturn(ret)
         if keys and isinstance(keys, tuple):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -582,15 +582,6 @@ class ModuleCase(TestCase, SaltClientTestCaseMixIn):
             )
         return orig[minion_tgt]
 
-    def state_result(self, ret, raw=False):
-        '''
-        Return the result data from a single state return
-        '''
-        res = ret[next(iter(ret))]
-        if raw:
-            return res
-        return res['result']
-
     def run_state(self, function, **kwargs):
         '''
         Run the state.single command and return the state return structure
@@ -623,20 +614,6 @@ class ModuleCase(TestCase, SaltClientTestCaseMixIn):
         return salt.config.master_config(
             os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'master')
         )
-
-    def assert_success(self, ret):
-        try:
-            res = self.state_result(ret, raw=True)
-        except TypeError:
-            pass
-        else:
-            if isinstance(res, dict):
-                if res['result'] is True:
-                    return
-                if 'comment' in res:
-                    raise AssertionError(res['comment'])
-                ret = res
-        raise AssertionError('bad result: %r' % (ret))
 
 
 class SyndicCase(TestCase, SaltClientTestCaseMixIn):

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -7,7 +7,8 @@ import salt.utils
 import integration
 
 
-class StateModuleTest(integration.ModuleCase):
+class StateModuleTest(integration.ModuleCase,
+                      integration.SaltReturnAssertsMixIn):
     '''
     Validate the test module
     '''
@@ -61,37 +62,13 @@ class StateModuleTest(integration.ModuleCase):
             os.unlink(testfile)
 
         ret = self.run_function('state.sls', mods='testappend')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         ret = self.run_function('state.sls', mods='testappend.step-1')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         ret = self.run_function('state.sls', mods='testappend.step-2')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         self.assertMultiLineEqual('''\
 # set variable identifying the chroot you work in (used in the prompt below)
@@ -107,26 +84,10 @@ fi
 
         # Re-append switching order
         ret = self.run_function('state.sls', mods='testappend.step-2')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         ret = self.run_function('state.sls', mods='testappend.step-1')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         self.assertMultiLineEqual('''\
 # set variable identifying the chroot you work in (used in the prompt below)
@@ -180,39 +141,15 @@ fi
 
         # Create the file
         ret = self.run_function('state.sls', mods='issue-1879')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         # The first append
         ret = self.run_function('state.sls', mods='issue-1879.step-1')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         # The second append
         ret = self.run_function('state.sls', mods='issue-1879.step-2')
-        try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-        except AssertionError:
-            print ret
-            raise
+        self.assertSaltTrueReturn(ret)
 
         # Does it match?
         try:
@@ -222,23 +159,10 @@ fi
             )
             # Make sure we don't re-append existing text
             ret = self.run_function('state.sls', mods='issue-1879.step-1')
-            try:
-                self.assertTrue(isinstance(ret, dict)), ret
-                self.assertNotEqual(ret, {})
-                for key in ret.iterkeys():
-                    self.assertTrue(ret[key]['result'])
-            except AssertionError:
-                print ret
-                raise
+            self.assertSaltTrueReturn(ret)
+
             ret = self.run_function('state.sls', mods='issue-1879.step-2')
-            try:
-                self.assertTrue(isinstance(ret, dict)), ret
-                self.assertNotEqual(ret, {})
-                for key in ret.iterkeys():
-                    self.assertTrue(ret[key]['result'])
-            except AssertionError:
-                print ret
-                raise
+            self.assertSaltTrueReturn(ret)
             self.assertMultiLineEqual(
                 contents,
                 salt.utils.fopen(testfile, 'r').read()
@@ -261,8 +185,8 @@ fi
         )
         try:
             ret = self.run_function('state.sls', mods='include-test')
-            for part in ret.itervalues():
-                self.assertTrue(part['result'])
+            self.assertSaltTrueReturn(ret)
+
             for fname in fnames:
                 self.assertTrue(os.path.isfile(fname))
             self.assertFalse(os.path.isfile(exclude_test_file))
@@ -281,8 +205,8 @@ fi
         )
         try:
             ret = self.run_function('state.sls', mods='exclude-test')
-            for part in ret.itervalues():
-                self.assertTrue(part['result'])
+            self.assertSaltTrueReturn(ret)
+
             for fname in fnames:
                 self.assertTrue(os.path.isfile(fname))
             self.assertFalse(os.path.isfile(to_include_test_file))
@@ -300,10 +224,7 @@ fi
             ret = self.run_function(
                 'state.sls', mods='issue-2068-template-str-no-dot'
             )
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-            for part in ret.itervalues():
-                self.assertTrue(part['result'])
+            self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
@@ -318,12 +239,7 @@ fi
         template = salt.utils.fopen(template_path, 'r').read()
         try:
             ret = self.run_function('state.template_str', [template])
-
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
+            self.assertSaltTrueReturn(ret)
 
             self.assertTrue(
                 os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
@@ -335,10 +251,7 @@ fi
         # Now using state.template
         try:
             ret = self.run_function('state.template', [template_path])
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-            for part in ret.itervalues():
-                self.assertTrue(part['result'])
+            self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
@@ -348,10 +261,7 @@ fi
             ret = self.run_function(
                 'state.sls', mods='issue-2068-template-str'
             )
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-            for part in ret.itervalues():
-                self.assertTrue(part['result'])
+            self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
@@ -366,12 +276,7 @@ fi
         template = salt.utils.fopen(template_path, 'r').read()
         try:
             ret = self.run_function('state.template_str', [template])
-
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
+            self.assertSaltTrueReturn(ret)
 
             self.assertTrue(
                 os.path.isfile(os.path.join(venv_dir, 'bin', 'pep8'))
@@ -383,10 +288,7 @@ fi
         # Now using state.template
         try:
             ret = self.run_function('state.template', [template_path])
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-            for part in ret.itervalues():
-                self.assertTrue(part['result'])
+            self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -6,7 +6,7 @@ import shutil
 import integration
 
 
-class GitTest(integration.ModuleCase):
+class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
     '''
     Validate the git state
     '''
@@ -24,9 +24,8 @@ class GitTest(integration.ModuleCase):
                 target=name,
                 submodules=True
             )
+            self.assertSaltTrueReturn(ret)
             self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
-            result = self.state_result(ret)
-            self.assertTrue(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -43,9 +42,8 @@ class GitTest(integration.ModuleCase):
                 target=name,
                 submodules=True
             )
+            self.assertSaltFalseReturn(ret)
             self.assertFalse(os.path.isdir(os.path.join(name, '.git')))
-            result = self.state_result(ret)
-            self.assertFalse(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -64,9 +62,8 @@ class GitTest(integration.ModuleCase):
                 target=name,
                 submodules=True
             )
+            self.assertSaltTrueReturn(ret)
             self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
-            result = self.state_result(ret)
-            self.assertTrue(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -82,6 +79,7 @@ class GitTest(integration.ModuleCase):
                 target=name,
                 submodules=True
             )
+            self.assertSaltTrueReturn(ret)
             self.assertTrue(
                 # with git 1.7.9.5, it's not a directory, it's a file with the
                 # contents:
@@ -96,8 +94,6 @@ class GitTest(integration.ModuleCase):
                     )
                 )
             )
-            result = self.state_result(ret)
-            self.assertTrue(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -112,9 +108,8 @@ class GitTest(integration.ModuleCase):
                 name=name,
                 bare=True
             )
+            self.assertSaltTrueReturn(ret)
             self.assertTrue(os.path.isfile(os.path.join(name, 'HEAD')))
-            result = self.state_result(ret)
-            self.assertTrue(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -134,9 +129,8 @@ class GitTest(integration.ModuleCase):
                 name=name,
                 bare=True
             )
+            self.assertSaltFalseReturn(ret)
             self.assertFalse(os.path.isfile(os.path.join(name, 'HEAD')))
-            result = self.state_result(ret)
-            self.assertFalse(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -153,9 +147,8 @@ class GitTest(integration.ModuleCase):
                 name=name,
                 bare=True
             )
+            self.assertSaltTrueReturn(ret)
             self.assertTrue(os.path.isfile(os.path.join(name, 'HEAD')))
-            result = self.state_result(ret)
-            self.assertTrue(result)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 

--- a/tests/integration/states/host.py
+++ b/tests/integration/states/host.py
@@ -13,7 +13,7 @@ import integration
 HFILE = os.path.join(integration.TMP, 'hosts')
 
 
-class HostTest(integration.ModuleCase):
+class HostTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
     '''
     Validate the host state
     '''
@@ -34,8 +34,7 @@ class HostTest(integration.ModuleCase):
         name = 'spam.bacon'
         ip = '10.10.10.10'
         ret = self.run_state('host.present', name=name, ip=ip)
-        result = self.state_result(ret)
-        self.assertTrue(result)
+        self.assertSaltTrueReturn(ret)
         with salt.utils.fopen(HFILE) as fp_:
             output = fp_.read()
             self.assertIn('{0}\t\t{1}'.format(ip, name), output)

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -12,7 +12,7 @@ import shutil
 import integration
 
 
-class PipStateTest(integration.ModuleCase):
+class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
 
     def setUp(self):
         super(PipStateTest, self).setUp()
@@ -28,16 +28,12 @@ class PipStateTest(integration.ModuleCase):
             # Since we don't have the virtualenv created, pip.installed will
             # thrown and error.
             ret = self.run_function('state.sls', mods='pip-installed-errors')
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-
-            for key in ret.keys():
-                self.assertFalse(ret[key]['result'])
-                self.assertRegexpMatches(
-                    ret[key]['comment'],
-                    'Error installing \'supervisor\': .* '
-                    '[nN]o such file or directory'
-                )
+            self.assertSaltFalseReturn(ret)
+            self.assertSaltCommentRegexpMatches(
+                ret,
+                'Error installing \'supervisor\': .* '
+                '[nN]o such file or directory'
+            )
 
             # We now create the missing virtualenv
             ret = self.run_function('virtualenv.create', [venv_dir])
@@ -45,11 +41,7 @@ class PipStateTest(integration.ModuleCase):
 
             # The state should not have any issues running now
             ret = self.run_function('state.sls', mods='pip-installed-errors')
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
-
-            for key in ret.keys():
-                self.assertTrue(ret[key]['result'])
+            self.assertSaltTrueReturn(ret)
         finally:
             if os.path.isdir(venv_dir):
                 shutil.rmtree(venv_dir)
@@ -82,9 +74,10 @@ class PipStateTest(integration.ModuleCase):
             ret = self.run_function(
                 'state.sls', mods='pip-installed-weird-install'
             )
-            self.assertTrue(isinstance(ret, dict))
-            self.assertNotEqual(ret, {})
+            self.assertSaltTrueReturn(ret)
 
+            # We cannot use assertInSaltComment here because we need to skip
+            # some of the state return parts
             for key in ret.keys():
                 self.assertTrue(ret[key]['result'])
                 if ret[key]['comment'] == 'Created new virtualenv':
@@ -108,12 +101,7 @@ class PipStateTest(integration.ModuleCase):
         )
 
         try:
-            self.assertTrue(isinstance(ret, dict)), ret
-            self.assertNotEqual(ret, {})
-
-            for key in ret.iterkeys():
-                self.assertTrue(ret[key]['result'])
-
+            self.assertSaltTrueReturn(ret)
             self.assertTrue(
                 os.path.isfile(os.path.join(venv_dir, 'bin', 'supervisord'))
             )
@@ -127,11 +115,9 @@ class PipStateTest(integration.ModuleCase):
         )
 
         try:
-            # XXX: Once state.template_str is fixed, consider not using a file
-            # for this test.
-
             # Let's create the testing virtualenv
-            self.run_function('virtualenv.create', [venv_dir])
+            ret = self.run_function('virtualenv.create', [venv_dir])
+            self.assertEqual(ret['retcode'], 0)
 
             # Let's remove the pip binary
             pip_bin = os.path.join(venv_dir, 'bin', 'pip')
@@ -143,9 +129,9 @@ class PipStateTest(integration.ModuleCase):
 
             # Let's run the state which should fail because pip is missing
             ret = self.run_function('state.sls', mods='issue-2087-missing-pip')
-            self.assertFalse(ret.values()[0]['result'])
-            self.assertEqual(
-                ret.values()[0]['comment'],
+            self.assertSaltFalseReturn(ret)
+            self.assertInSaltComment(
+                ret,
                 'Error installing \'pep8\': Could not find a `pip` binary'
             )
         finally:

--- a/tests/integration/states/rabbitmq_user.py
+++ b/tests/integration/states/rabbitmq_user.py
@@ -23,17 +23,15 @@ class RabbitUserTestCase(integration.ModuleCase):
         rabbitmq_user.present null_name
         '''
         ret = self.run_state(
-            'rabbitmq_user.present', name='null_name', test=True)
-
-        self.assertTrue(ret)
-        self.assertFalse(self.state_result(ret))
+            'rabbitmq_user.present', name='null_name', test=True
+        )
+        self.assertSaltTrueReturn(ret)
 
     def absent(self):
         '''
         rabbitmq_user.absent null_name
         '''
         ret = self.run_state(
-            'rabbitmq_user.absent', name='null_name', test=True)
-
-        self.assertTrue(ret)
-        self.assertFalse(self.state_result(ret))
+            'rabbitmq_user.absent', name='null_name', test=True
+        )
+        self.assertSaltFalseReturn(ret)

--- a/tests/integration/states/rabbitmq_user.py
+++ b/tests/integration/states/rabbitmq_user.py
@@ -5,7 +5,8 @@ import os
 import integration
 
 
-class RabbitUserTestCase(integration.ModuleCase):
+class RabbitUserTestCase(integration.ModuleCase,
+                         integration.SaltReturnAssertsMixIn):
     '''
     Validate the rabbitmq user states.
     '''

--- a/tests/integration/states/rabbitmq_user.py
+++ b/tests/integration/states/rabbitmq_user.py
@@ -26,7 +26,8 @@ class RabbitUserTestCase(integration.ModuleCase,
         ret = self.run_state(
             'rabbitmq_user.present', name='null_name', test=True
         )
-        self.assertSaltTrueReturn(ret)
+        self.assertSaltFalseReturn(ret)
+        self.assertInSaltComment(ret, 'User null_name is set to be created')
 
     def absent(self):
         '''

--- a/tests/integration/states/rabbitmq_vhost.py
+++ b/tests/integration/states/rabbitmq_vhost.py
@@ -5,7 +5,8 @@ import os
 import integration
 
 
-class RabbitVHostTestCase(integration.ModuleCase):
+class RabbitVHostTestCase(integration.ModuleCase,
+                          integration.SaltReturnAssertsMixIn):
     '''
     Validate the rabbitmq virtual host states.
     '''

--- a/tests/integration/states/rabbitmq_vhost.py
+++ b/tests/integration/states/rabbitmq_vhost.py
@@ -23,17 +23,15 @@ class RabbitVHostTestCase(integration.ModuleCase):
         rabbitmq_vhost.present null_host
         '''
         ret = self.run_state(
-            'rabbitmq_vhost.present', name='null_host', test=True)
-
-        self.assertTrue(ret)
-        self.assertFalse(self.state_result(ret))
+            'rabbitmq_vhost.present', name='null_host', test=True
+        )
+        self.assertSaltFalseReturn(ret)
 
     def absent(self):
         '''
         rabbitmq_vhost.absent null_host
         '''
         ret = self.run_state(
-            'rabbitmq_vhost.absent', name='null_host', test=True)
-
-        self.assertTrue(ret)
-        self.assertFalse(self.state_result(ret))
+            'rabbitmq_vhost.absent', name='null_host', test=True
+        )
+        self.assertSaltFalseReturn(ret)

--- a/tests/integration/states/supervisord.py
+++ b/tests/integration/states/supervisord.py
@@ -5,7 +5,8 @@ import os
 import integration
 
 
-class SupervisordTest(integration.ModuleCase):
+class SupervisordTest(integration.ModuleCase,
+                      integration.SaltReturnAssertsMixIn):
     '''
     Validate the supervisord states.
     '''

--- a/tests/integration/states/supervisord.py
+++ b/tests/integration/states/supervisord.py
@@ -22,10 +22,9 @@ class SupervisordTest(integration.ModuleCase):
         supervisord.running restart = False
         '''
         ret = self.run_state(
-            'supervisord.running', name='null_service', test=True)
-
-        self.assertTrue(ret)
-        self.assertEqual(self.state_result(ret), False)
+            'supervisord.running', name='null_service', test=True
+        )
+        self.assertSaltFalseReturn(ret)
 
     def test_restart(self):
         '''
@@ -33,17 +32,15 @@ class SupervisordTest(integration.ModuleCase):
         '''
         ret = self.run_state(
             'supervisord.running', name='null_service', restart=True,
-            test=True)
-
-        self.assertTrue(ret)
-        self.assertEqual(self.state_result(ret), False)
+            test=True
+        )
+        self.assertSaltFalseReturn(ret)
 
     def test_stop(self):
         '''
         supervisord.dead
         '''
         ret = self.run_state(
-            'supervisord.dead', name='null_service', test=True)
-
-        self.assertTrue(ret)
-        self.assertEqual(self.state_result(ret), False)
+            'supervisord.dead', name='null_service', test=True
+        )
+        self.assertSaltFalseReturn(ret)


### PR DESCRIPTION
`SaltReturnAssertsMixIn` was crated in order to get more output out of the test when it fails and testing other things which would normally not be tested.
