### PR TITLE
Fix exception thrown when symlink target is missing. Fixes #2830

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -836,7 +836,7 @@ def directory(name,
             if targets:
                 file_tree = __salt__['file.find'](name)
                 for path in file_tree:
-                    fstat = os.stat(path)
+                    fstat = os.lstat(path)
                     if 'user' in targets and fstat.st_uid != uid:
                             needs_fixed['user'] = True
                             if needs_fixed.get('group'):


### PR DESCRIPTION
Fixes #2830
os.stat() follows symlinks to their targets.
If the target is missing, os.stat() throws an exception when it tries
to stat the symlink.

Switch to using os.lstat(), which works on the actual symlink and acts
on files and directories as usual.

I believe this also closes a potential security issue where someone
could slip in a symlink to /etc/passwd, for example and change ownership.

The current behavior will cause file.directory to ONLY do work
on the directory structure specified. Symlinks to files outside the
specified directory are not followed.
