### PR TITLE
More multiple-version support for pkg.list_pkgs()

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -336,11 +336,13 @@ def list_pkgs(regex_string=''):
 
     out = __salt__['cmd.run_stdout'](cmd)
 
+    # Typical line of output:
+    # install ok installed zsh 4.3.17-1ubuntu1
     for line in out.splitlines():
         cols = line.split()
         if len(cols) and ('install' in cols[0] or 'hold' in cols[0]) and \
                                                         'installed' in cols[2]:
-            ret[cols[3]] = cols[4]
+            __salt__['pkg_resource.add_pkg'](ret, cols[3], cols[4])
 
     # If ret is empty at this point, check to see if the package is virtual.
     # We also need aptitude past this point.
@@ -357,6 +359,7 @@ def list_pkgs(regex_string=''):
             ret[regex_string] = '1'  # Setting all 'installed' virtual package
                                      # versions to '1'
 
+    __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
 
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -69,6 +69,10 @@ def list_pkgs():
     pkgs = _vartree().dbapi.cpv_all()
     for cpv in pkgs:
         ret[_cpv_to_name(cpv)] = _cpv_to_version(cpv)
+        __salt__['pkg_resource.add_pkg'](ret,
+                                         _cpv_to_name(cpv),
+                                         _cpv_to_version(cpv))
+    __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
 
 def refresh_db():

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -127,7 +127,10 @@ def list_pkgs():
         if not line:
             continue
         comps = line.split(' ')[0].split('-')
-        ret['-'.join(comps[0:-1])] = comps[-1]
+        __salt__['pkg_resource.add_pkg'](ret,
+                                        '-'.join(comps[0:-1]),
+                                        comps[-1])
+    __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
 
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -4,7 +4,6 @@ A module to wrap pacman calls, since Arch is the best
 '''
 
 import logging
-from types import StringTypes
 
 log = logging.getLogger(__name__)
 
@@ -100,14 +99,8 @@ def list_pkgs():
     for line in out:
         if not line:
             continue
-        pkg, version = line.split()[0:2]
-        cur = ret.get(pkg)
-        if cur is None:
-            ret[pkg] = version
-        elif type(cur) in StringTypes:
-            ret[pkg] = [cur, version]
-        else:
-            ret[pkg].append(version)
+        name, version = line.split()[0:2]
+        __salt__['pkg_resource.add_pkg'](ret, name, version)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -99,8 +99,13 @@ def list_pkgs():
     for line in out:
         if not line:
             continue
-        name, version = line.split()[0:2]
-        __salt__['pkg_resource.add_pkg'](ret, name, version)
+        try:
+            name, version = line.split()[0:2]
+        except ValueError:
+            log.error('Problem parsing pacman -Q: Unexpected formatting in '
+                      'line: "{0}"'.format(line))
+        else:
+            __salt__['pkg_resource.add_pkg'](ret, name, version)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
 

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -7,7 +7,6 @@ import os
 import re
 import yaml
 from pprint import pformat
-from types import StringTypes
 
 log = logging.getLogger(__name__)
 
@@ -99,14 +98,14 @@ def _pack_pkgs(sources):
 
     Example: '["foo","bar","baz"]' would become ["foo","bar","baz"]
     '''
-    if type(sources) in StringTypes:
+    if isinstance(sources, basestring):
         try:
             sources = yaml.load(sources)
         except yaml.parser.ParserError as e:
             log.error(e)
             return []
     if not isinstance(sources,list) \
-    or [x for x in sources if type(x) not in StringTypes]:
+    or [x for x in sources if not isinstance(x, basestring)]:
         log.error('Invalid input: {0}'.format(pformat(source)))
         log.error('Input must be a list of strings')
         return []
@@ -121,7 +120,7 @@ def _pack_sources(sources):
     Example: '[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]' would
     become {"foo": "salt://foo.rpm", "bar": "salt://bar.rpm"}
     '''
-    if type(sources) in StringTypes:
+    if isinstance(sources, basestring):
         try:
             sources = yaml.load(sources)
         except yaml.parser.ParserError as e:
@@ -249,7 +248,7 @@ def add_pkg(pkgs, name, version):
     cur = pkgs.get(name)
     if cur is None:
         pkgs[name] = version
-    elif type(cur) in StringTypes:
+    elif isinstance(cur, basestring):
         pkgs[name] = [cur, version]
     else:
         pkgs[name].append(version)

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -242,6 +242,19 @@ def parse_targets(name=None, pkgs=None, sources=None):
         return None,None
 
 
+def add_pkg(pkgs, name, version):
+    '''
+    Add a package to a dict of installed packages.
+    '''
+    cur = pkgs.get(name)
+    if cur is None:
+        pkgs[name] = version
+    elif type(cur) in StringTypes:
+        pkgs[name] = [cur, version]
+    else:
+        pkgs[name].append(version)
+
+
 def sort_pkglist(pkgs):
     '''
     Accepts a dict obtained from pkg.list_pkgs() and sorts in place the list of

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -245,6 +245,8 @@ def add_pkg(pkgs, name, version):
     '''
     Add a package to a dict of installed packages.
     '''
+
+    ''' multiple-version support (not yet implemented)
     cur = pkgs.get(name)
     if cur is None:
         pkgs[name] = version
@@ -252,6 +254,8 @@ def add_pkg(pkgs, name, version):
         pkgs[name] = [cur, version]
     else:
         pkgs[name].append(version)
+    '''
+    pkgs[name] = version
 
 
 def sort_pkglist(pkgs):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -209,13 +209,15 @@ def list_pkgs(*args):
 
         salt '*' pkg.list_pkgs
     '''
-    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
+    cmd = 'rpm -qa --queryformat ' \
+          '"%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}\n"'
     ret = {}
     for line in __salt__['cmd.run'](cmd).splitlines():
-        name, version, rel = line.split('_|-')
+        name, version, rel, arch = line.split('_|-')
         pkgver = version
         if rel:
             pkgver += '-{0}'.format(rel)
+        pkgver += '.{0}'.format(arch)
         __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -209,15 +209,13 @@ def list_pkgs(*args):
 
         salt '*' pkg.list_pkgs
     '''
-    cmd = 'rpm -qa --queryformat ' \
-          '"%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}\n"'
+    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
     ret = {}
     for line in __salt__['cmd.run'](cmd).splitlines():
-        name, version, rel, arch = line.split('_|-')
+        name, version, rel = line.split('_|-')
         pkgver = version
         if rel:
             pkgver += '-{0}'.format(rel)
-        pkgver += '.{0}'.format(arch)
         __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -209,30 +209,16 @@ def list_pkgs(*args):
 
         salt '*' pkg.list_pkgs
     '''
-    ts = rpm.TransactionSet()
-    pkgs = {}
-    # In order to support specific package versions, we are going to use the
-    # yum libraries to handle pattern matching
-    yb = yum.YumBase()
-    setattr(yb.conf, 'assumeyes', True)
-
-    # if no args are passed in get all packages
-    if len(args) == 0:
-        for h in ts.dbMatch():
-            pkgs[h['name']] = '-'.join([h['version'], h['release']])
-    else:
-        # get package version for each package in *args
-        for arg in args:
-            # Make yum do the pattern matching
-            a = yb.pkgSack.returnPackages(patterns=[arg], ignore_case=False)
-            # make sure there is an a
-            if len(a) > 0:
-                arg = a[0].name
-            # use the name from yum to do an rpm lookup
-            for h in ts.dbMatch('name', arg):
-                pkgs[h['name']] = '-'.join([h['version'], h['release']])
-
-    return pkgs
+    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
+    ret = {}
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        name, version, rel = line.split('_|-')
+        pkgver = version
+        if rel:
+            pkgver += '-{0}'.format(rel)
+        __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
+    __salt__['pkg_resource.sort_pkglist'](ret)
+    return ret
 
 
 def refresh_db():

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -109,15 +109,13 @@ def list_pkgs():
 
         salt '*' pkg.list_pkgs
     '''
-    cmd = 'rpm -qa --queryformat ' \
-          '"%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}\n"'
+    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
     ret = {}
     for line in __salt__['cmd.run'](cmd).splitlines():
-        name, version, rel, arch = line.split('_|-')
+        name, version, rel = line.split('_|-')
         pkgver = version
         if rel:
             pkgver += '-{0}'.format(rel)
-        pkgver += '.{0}'.format(arch)
         __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -95,8 +95,10 @@ def list_pkgs():
     for line in __salt__['cmd.run'](cmd).splitlines():
         name, version, rel = line.split('_|-')
         pkgver = version
-        if rel: pkgver += '-{0}'.format(rel)
-        ret[name] = pkgver
+        if rel:
+            pkgver += '-{0}'.format(rel)
+        __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
+    __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
 
 


### PR DESCRIPTION
I did zypper and both yumpkg modules. I have a few important notes to make, though:

1) I changed the yum modules to parse rpm instead of yum. This provides a considerable performance boost because the yum overhead is not needed when all you want is to list the installed packages. I saw my test VM go from ~10 secs to run list_pkgs to 1 sec.

2) (IMPORTANT) The yumpkg modules have been changed so that the package architecture is displayed in the version string. This is important because RedHat-based systems like Fedora, CentOS, and RHEL don't name the x86_64 and i686 versions of a package differently, they'll just be the same name but with different architectures. Note that this change was not needed for zypper (another RPM-based provider) since Suse puts "-32bit" in the 32-bit versions of packages that get installed on x86_64 hosts.

3) Due to #2 above, we may want to think of a way to make salt use the minion's "cpuarch" grain to manually specify the arch to install when no arch is provided, to keep backwards compatibility in states. I'll bring this up on the mailing list for further discussion.

4) The previous version of yumpkg.py's list_pkgs function can be found here: https://gist.github.com/4238643
