### PR TITLE
Fill in description for salt-minion and salt-master

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -678,7 +678,7 @@ class MasterOptionParser(OptionParser, ConfigDirMixIn, LogLevelMixIn,
 
     __metaclass__ = OptionParserMeta
 
-    description = "TODO: explain what salt-master is"
+    description = "The Salt master, used to control the Salt minions."
 
     def setup_config(self):
         return config.master_config(self.get_config_file_path('master'))
@@ -688,7 +688,7 @@ class MinionOptionParser(MasterOptionParser):
 
     __metaclass__ = OptionParserMeta
 
-    description = "TODO: explain what salt-minion is"
+    description = "The Salt minion, receives commands from a remote Salt master."
 
     def setup_config(self):
         return config.minion_config(self.get_config_file_path('minion'))


### PR DESCRIPTION
Fill in description for salt-minion and salt-master to remove TODOs from output when --help option is used.

Currently, output of --help looks like:

``` bash
$ salt-master --help
Usage: salt-master

TODO: explain what salt-master is

Options:
...
```
