### PR TITLE
Add option to apt-get calls to update unmodified config files

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -204,8 +204,9 @@ def install(name=None, refresh=False, repo='', skip_verify=False,
                 if kwargs.get(vkey) is not None:
                     fname = '"{0}{1}{2}"'.format(fname, vsign, kwargs[vkey])
                     break
-        cmd = 'apt-get -q -y {confold} {verify} {target} install {pkg}'.format(
+        cmd = 'apt-get -q -y {confold} {confdef} {verify} {target} install {pkg}'.format(
             confold='-o DPkg::Options::=--force-confold',
+            confdef='-o DPkg::Options::=--force-confdef',
             verify='--allow-unauthenticated' if skip_verify else '',
             target='-t {0}'.format(repo) if repo else '',
             pkg=fname,
@@ -293,7 +294,7 @@ def upgrade(refresh=True, **kwargs):
 
     ret_pkgs = {}
     old_pkgs = list_pkgs()
-    cmd = 'apt-get -q -y -o DPkg::Options::=--force-confold dist-upgrade'
+    cmd = 'apt-get -q -y -o DPkg::Options::=--force-confold -o DPkg::Options::=--force-confdef dist-upgrade'
     __salt__['cmd.run'](cmd)
     new_pkgs = list_pkgs()
 


### PR DESCRIPTION
This patch changes apt-get behavior to update unmodified config files instead of always keeping the old version.

More details about the issue here: http://askubuntu.com/questions/104899/make-apt-get-or-aptitude-run-with-y-but-not-prompt-for-replacement-of-configu
