### PR TITLE
Add event firing code for delete and delete_all key management operations

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -376,6 +376,10 @@ class Key(object):
             for key in keys:
                 try:
                     os.remove(os.path.join(self.opts['pki_dir'], status, key))
+                    eload = {'result': True,
+                             'act': 'delete',
+                             'id': key}
+                    self.event.fire_event(eload, 'key')
                 except (OSError, IOError):
                     pass
         return self.list_keys()
@@ -388,6 +392,10 @@ class Key(object):
             for key in keys:
                 try:
                     os.remove(os.path.join(self.opts['pki_dir'], status, key))
+                    eload = {'result': True,
+                             'act': 'delete',
+                             'id': key}
+                    self.event.fire_event(eload, 'key')
                 except (OSError, IOError):
                     pass
         return self.list_keys()


### PR DESCRIPTION
While playing with event listeners I have noticed that deleting a minion key is the only event that is not fired by key management APIs. It was rather simple to implement (8 lines in total), so I've made the changes myself.

If there are test to be written I'd be more than happy to do it.
