### PR TITLE
cleanup: use isinstance() instead of type(foo) == type(bar)

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -507,7 +507,7 @@ class Loader(object):
                     # reload all submodules if necessary
                     submodules = [
                         getattr(mod, sname) for sname in dir(mod) if
-                        type(getattr(mod, sname))==type(mod)
+                        isinstance(getattr(mod, sname), mod.__class__)
                     ]
                     # reload only custom "sub"modules i.e is a submodule in
                     # parent module that are still available on disk (i.e. not

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -5,7 +5,6 @@ A module to wrap pacman calls, since Arch is the best
 
 # Import python libs
 import logging
-from types import StringTypes
 
 log = logging.getLogger(__name__)
 
@@ -106,7 +105,7 @@ def list_pkgs():
         cur = ret.get(pkg)
         if cur is None:
             ret[pkg] = version
-        elif type(cur) in StringTypes:
+        elif isinstance(cur, basestring):
             ret[pkg] = [cur, version]
         else:
             ret[pkg].append(version)
@@ -169,7 +168,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
             salt '*' pkg.install pkgs='["foo","bar"]'
 
     sources
-        A list of packages to install. Must be passed as a list of dicts, 
+        A list of packages to install. Must be passed as a list of dicts,
         with the keys being package names, and the values being the source URI
         or local path to the package.
 

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -3,12 +3,11 @@ Resources needed by pkg providers
 '''
 
 # Import python libs
-import logging
 import os
 import re
 import yaml
-from pprint import pformat
-from types import StringTypes
+import pprint
+import logging
 
 log = logging.getLogger(__name__)
 
@@ -100,15 +99,15 @@ def _pack_pkgs(sources):
 
     Example: '["foo","bar","baz"]' would become ["foo","bar","baz"]
     '''
-    if type(sources) in StringTypes:
+    if isinstance(sources, basestring):
         try:
             sources = yaml.load(sources)
         except yaml.parser.ParserError as e:
             log.error(e)
             return []
-    if not isinstance(sources,list) \
-    or [x for x in sources if type(x) not in StringTypes]:
-        log.error('Invalid input: {0}'.format(pformat(source)))
+    if not isinstance(sources, list) \
+    or [x for x in sources if not isinstance(x, basestring)]:
+        log.error('Invalid input: {0}'.format(pprint.pformat(source)))
         log.error('Input must be a list of strings')
         return []
     return sources
@@ -122,7 +121,7 @@ def _pack_sources(sources):
     Example: '[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]' would
     become {"foo": "salt://foo.rpm", "bar": "salt://bar.rpm"}
     '''
-    if type(sources) in StringTypes:
+    if instance(sources, basestring):
         try:
             sources = yaml.load(sources)
         except yaml.parser.ParserError as e:
@@ -131,7 +130,7 @@ def _pack_sources(sources):
     ret = {}
     for source in sources:
         if (not isinstance(source,dict)) or len(source) != 1:
-            log.error('Invalid input: {0}'.format(pformat(sources)))
+            log.error('Invalid input: {0}'.format(pprint.pformat(sources)))
             log.error('Input must be a list of 1-element dicts')
             return {}
         else:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -803,7 +803,7 @@ def directory(name,
                     # file.user_to_uid returns '' if user does not exist. Above
                     # check for user is not fatal, so we need to be sure user
                     # exists.
-                    if type(uid).__name__ == 'str':
+                    if isinstance(uid, basestring):
                         ret['result'] = False
                         ret['comment'] = 'Failed to enforce ownership for ' \
                                          'user {0} (user does not ' \
@@ -820,7 +820,7 @@ def directory(name,
                 if group:
                     gid = __salt__['file.group_to_gid'](group)
                     # As above with user, we need to make sure group exists.
-                    if type(gid).__name__ == 'str':
+                    if isinstance(gid, basestring):
                         ret['result'] = False
                         ret['comment'] = 'Failed to enforce group ownership ' \
                                          'for group {0}'.format(group, user)


### PR DESCRIPTION
Pretty straightforward for the most part. The remove trailing whitespace hunk is due to a vim macro I use to automatically do that on `:w`

cc: @archtaku 
