### PR TITLE
State and module for alternatives system

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -1,0 +1,92 @@
+'''
+Support for Alternatives system
+'''
+
+import os
+
+__outputter__ = {
+    'display': 'txt',
+    'install': 'txt',
+    'remove': 'txt',
+}
+
+
+def __virtual__():
+    '''
+    Only if update-alternatives command is available
+    '''
+    return 'alternatives' if __salt__['cmd.has_exec']('update-alternatives') else False
+
+
+def display(name):
+    '''
+    Display alteratives settings for defined command name.
+
+    CLI Example::
+
+        salt '*' alternatives.display <command name>
+    '''
+
+    cmd = "update-alternatives --display {0}".format(name)
+    out = __salt__['cmd.run_all'](cmd)
+    if out['retcode'] > 0 and out['stderr'] != '':
+        return out['stderr']
+    return out['stdout']
+
+def show_current(name):
+    '''
+    '''
+
+    alt_link_path = '/etc/alternatives/{0}'.format(name)
+    if os.path.islink(alt_link_path):
+        path = os.path.realpath(alt_link_path)
+        return path
+    return False
+
+
+def check_installed(name, path):
+    '''
+    Check if the alternatives link is set to desired path.
+
+    CLI Example::
+
+        salt '*' alternatives.check_installed link path
+    '''
+
+    alt_link_path = '/etc/alternatives/{0}'.format(name)
+    if os.path.realpath(alt_link_path) == path:
+        return True
+    return False
+
+
+def install(name, link, path, priority):
+    '''
+    Install symbolic links determining default commands.
+
+    CLI Example::
+
+        salt '*' alternatives.install name link path priority
+    '''
+
+    cmd = "update-alternatives --install {0} {1} {2} {3}".format(link, name, path, priority)
+    out = __salt__['cmd.run_all'](cmd)
+    if out['retcode'] > 0 and out['stderr'] != '':
+        return out['stderr']
+    return out['stdout']
+
+
+def remove(name, path):
+    '''
+    Remove symbolic links determining the default commands.
+
+    CLI Example::
+
+        salt '*' alternatives.remove name path
+    '''
+
+    cmd = "update-alternatives --remove {0} {1}".format(name, path)
+    out = __salt__['cmd.run_all'](cmd)
+    if out['retcode'] > 0:
+        return out['stderr']
+    return out['stdout']
+

--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -1,0 +1,128 @@
+'''
+Configuration of the alternatives system
+========================================
+
+Control the alternatives system
+
+.. code-block:: yaml
+
+  hadoop-0.20-conf:
+    alternatives.install:
+      - name: hadoop-0.20-conf
+      - link: /etc/hadoop-0.20/conf
+      - path: /opt/hadoop/conf
+      - priority: 30
+
+  hadoop-0.20-conf:
+    alternatives:
+        - remove
+        - name: hadoop-0.20-conf
+        - path: /opt/hadoop/conf
+    
+'''
+
+def __virtual__():
+    '''
+    Only if update-alternatives command is available
+    '''
+    return 'alternatives' if __salt__['cmd.has_exec']('update-alternatives') else False
+
+
+def install(name, link, path, priority):
+    '''
+    Install new alternative for defined <name>
+
+    name
+        is the master name for this link group
+        (e.g. pager)
+
+    link
+        is the symlink pointing to /etc/alternatives/<name>.
+        (e.g. /usr/bin/pager)
+
+    path
+        is the location of one of the alternative target files.
+        (e.g. /usr/bin/less) 
+
+    priority
+        is an integer; options with higher numbers have higher priority in
+        automatic mode.
+    '''
+    ret = {'name': name,
+           'link': link,
+           'path': path,
+           'priority': priority,
+           'result': True,
+           'changes': {},
+           'comment': ''}
+
+    isinstalled = __salt__['alternatives.check_installed'](name, path)
+    if not isinstalled:
+        install = __salt__['alternatives.install'](name, link, path, priority)
+        ret['comment'] = (
+            'Setting alternative for {0} to {1} with priority {2}'
+        ).format(name, path, priority)
+        ret['changes'] =  {'name': name,
+                          'link': link,
+                          'path': path,
+                          'priority': priority}
+
+        return ret
+
+
+    ret['comment'] = 'Alternatives for {0} is already set to {1}'.format(name, path)
+
+    return ret
+
+
+def remove(name, path):
+    '''
+    Removes installed alternative for defined <name> and <path>
+    or fallback to default alternative, if some defined before.
+
+    name
+        is the master name for this link group
+        (e.g. pager)
+
+    path
+        is the location of one of the alternative target files.
+        (e.g. /usr/bin/less) 
+    '''
+    ret = {'name': name,
+           'path': path,
+           'result': True,
+           'changes': {},
+           'comment': ''}
+
+    isinstalled = __salt__['alternatives.check_installed'](name, path)
+    if isinstalled:
+        __salt__['alternatives.remove'](name, path)
+        current = __salt__['alternatives.show_current'](name)
+        if current:
+            ret['result'] = True
+            ret['comment'] = (
+                'Alternative for {0} removed. Falling back to path {1}'
+            ).format(name, current)
+            ret['changes'] =  {'path': current}
+            return ret
+
+        ret['comment'] = 'Alternative for {0} removed'.format(name)
+        ret['changes'] = {}
+        return ret
+
+    current = __salt__['alternatives.show_current'](name)
+    if current:
+        ret['result'] = True
+        ret['comment'] = (
+            'Alternative for {0} is set to it\'s default path {1}'
+        ).format(name, current)
+        return ret
+
+   
+    ret['result'] = False
+    ret['comment'] = (
+	'Alternative for {0} doesn\'t exist'
+    ).format(name)
+
+    return ret
+


### PR DESCRIPTION
Hey guys,

I've just finished state and module for some simple control over the alternatives system. Currently you can install, remove and display the alternatives. I need this one to change the default path of Hadoop configuration path(it's set from package). Here is the overview how it works.

**alternatives.display**:

``` bash
# salt "minion" alternatives.display hadoop-0.20-conf     
minion: hadoop-0.20-conf - auto mode
minion:   link currently points to /etc/hadoop-0.20/conf.empty
minion: /etc/hadoop-0.20/conf.empty - priority 10 
minion: Current 'best' version is '/etc/hadoop-0.20/conf.empty'.
```

**alternatives.install**:

``` bash
# salt "minion" alternatives.install hadoop-0.20-conf /etc/hadoop-0.20/conf /opt/hadoop/conf 60
minion: update-alternatives: using /opt/hadoop/conf to provide /etc/hadoop-0.20/conf (hadoop-0.20-conf) in auto mode.
```

**alternatives.remove**:

``` bash
# salt "minion" alternatives.remove hadoop-0.20-conf /www/hadoop/conf
minion: update-alternatives: using /etc/hadoop-0.20/conf.empty to provide /etc/hadoop-0.20/conf (hadoop-0.20-conf) in auto mode.
```

State usage:

``` yaml
hadoop-0.20-conf:
    alternatives.install:
      - name: hadoop-0.20-conf
      - link: /etc/hadoop-0.20/conf
      - path: /opt/hadoop/conf
      - priority: 30

  hadoop-0.20-conf:
    alternatives:
        - remove
        - name: hadoop-0.20-conf
        - path: /opt/hadoop/conf
```

I hope it helps to someone else too.
