### PR TITLE
Fix exception in log.py.

### DIFF
--- a/salt/log.py
+++ b/salt/log.py
@@ -110,7 +110,7 @@ class Logging(LoggingLoggerClass):
                 fmt = formatter._fmt.replace('%', '%%')
 
                 match = MODNAME_PATTERN.search(fmt)
-                if match and match.group('digits') and int(match.group('digits')) < max_logger_length:
+                if match and match.group('digits') is not None and int(match.group('digits')) < max_logger_length:
                     fmt = fmt.replace(match.group('name'), '%%(name)-%ds')
                     formatter = logging.Formatter(
                         fmt % max_logger_length,

--- a/salt/log.py
+++ b/salt/log.py
@@ -110,7 +110,7 @@ class Logging(LoggingLoggerClass):
                 fmt = formatter._fmt.replace('%', '%%')
 
                 match = MODNAME_PATTERN.search(fmt)
-                if match and int(match.group('digits')) < max_logger_length:
+                if match and match.group('digits') and int(match.group('digits')) < max_logger_length:
                     fmt = fmt.replace(match.group('name'), '%%(name)-%ds')
                     formatter = logging.Formatter(
                         fmt % max_logger_length,


### PR DESCRIPTION
When I swtiched to the latest 10.6 develop branch I was hitting an exception in log.py when using the LocalClient API.  The regex was matching, but the digits group was None instead of a digit, as the group is optional.  This small fix checks that digits is not None before casting it with int().
