### PR TITLE
Don't assume digits in logging format strings. Refs #2859, fixes #2853.

### DIFF
--- a/salt/log.py
+++ b/salt/log.py
@@ -110,7 +110,24 @@ class Logging(LoggingLoggerClass):
                 fmt = formatter._fmt.replace('%', '%%')
 
                 match = MODNAME_PATTERN.search(fmt)
-                if match and match.group('digits') is not None and int(match.group('digits')) < max_logger_length:
+                if not match:
+                    # Not matched. Release handler and return.
+                    handler.release()
+                    return instance
+
+                if 'digits' not in match.groupdict():
+                    # No digits group. Release handler and return.
+                    handler.release()
+                    return instance
+
+                digits = match.group('digits')
+                if not digits or not (digits and digits.isdigit()):
+                    # No valid digits. Release handler and return.
+                    handler.release()
+                    return instance
+
+                if int(digits) < max_logger_length:
+                    # Formatter digits value is lower than current max, update.
                     fmt = fmt.replace(match.group('name'), '%%(name)-%ds')
                     formatter = logging.Formatter(
                         fmt % max_logger_length,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -957,7 +957,7 @@ def recurse(name,
         (default is False)
 
     include_pat
-	When copying, include only this pattern from the source. Default
+        When copying, include only this pattern from the source. Default
         is glob match , if prefixed with E@ then regexp match
         Example::
 
@@ -965,7 +965,7 @@ def recurse(name,
           - include_pat: E@hello      :: regexp matches 'otherhello', 'hello01' ...
 
     exclude_pat
-	When copying, exclude this pattern from the source. If both
+        When copying, exclude this pattern from the source. If both
         include_pat and exclude_pat are supplied, then it will apply
         conditions cumulatively. i.e. first select based on include_pat and
         then with in that result, applies exclude_pat.

--- a/tests/saltunittest.py
+++ b/tests/saltunittest.py
@@ -182,3 +182,17 @@ class TestsLoggingHandler(object):
     def __exit__(self, type, value, traceback):
         self.deactivate()
         self.activated = False
+
+    # Mimic some handler attributes and methods
+    @property
+    def lock(self):
+        if self.activated:
+            return self.handler.lock
+
+    def createLock(self):
+        if self.activated:
+            return self.handler.createLock()
+
+    def acquire(self):
+        if self.activated:
+            return self.handler.acquire()

--- a/tests/unit/log_test.py
+++ b/tests/unit/log_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.log_test
+    ~~~~~~~~~~~~~~~~~~~
+
+    Test salt's "hacked" logging
+
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2012 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+'''
+
+# Import python libs
+import logging
+
+# Import salt libs
+from salt import log as saltlog
+from saltunittest import (
+    TestCase, TestLoader, TextTestRunner, TestsLoggingHandler
+)
+
+
+class TestLog(TestCase):
+    '''Test several logging settings'''
+
+    def test_issue_2853_regex_TypeError(self):
+        from salt import log as saltlog
+        # Now, python's logging logger class is ours.
+        # Let's make sure we have at least one instance
+        log = saltlog.Logging(__name__)
+
+        # Test for a format which includes digits in name formatting.
+        log_format = '[%(name)-15s] %(message)s'
+        handler = TestsLoggingHandler(format=log_format)
+        log.addHandler(handler)
+
+        # Trigger TestsLoggingHandler.__enter__
+        with handler:
+            # Let's create another log instance to trigger salt's logging class
+            # calculations.
+            try:
+                saltlog.Logging('{0}.with_digits'.format(__name__))
+            except Exception, err:
+                raise AssertionError(
+                    'No exception should have been raised: {0}'.format(err)
+                )
+
+        # Remove the testing handler
+        log.removeHandler(handler)
+
+        # Test for a format which does not include digits in name formatting.
+        log_format = '[%(name)s] %(message)s'
+        handler = TestsLoggingHandler(format=log_format)
+        log.addHandler(handler)
+
+        # Trigger TestsLoggingHandler.__enter__
+        with handler:
+            # Let's create another log instance to trigger salt's logging class
+            # calculations.
+            try:
+                saltlog.Logging('{0}.without_digits'.format(__name__))
+            except Exception, err:
+                raise AssertionError(
+                    'No exception should have been raised: {0}'.format(err)
+                )
+
+            # Remove the testing handler
+            log.removeHandler(handler)
+
+
+if __name__ == "__main__":
+    loader = TestLoader()
+    tests = loader.loadTestsFromTestCase(ConfigTestCase)
+    TextTestRunner(verbosity=1).run(tests)


### PR DESCRIPTION
Sorry @ryanschneider for stepping in on your fix.

Nothing is assumed now, and several checks are made. If any of the checks fail, nothing else is done in [`salt.log.Logging.__new__()`](https://github.com/saltstack/salt/blob/a704410cbc0ae00346949808d079db04bac5da19/salt/log.py#L86).
Added a test case which will take care of possible regressions on this bug fix.
