### PR TITLE
Keep logging information when `__virtual__()` changes the module name.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -189,7 +189,9 @@ def grains(opts):
         salt.config.load_config(
             pre_opts, opts['conf_file'], 'SALT_MINION_CONFIG'
         )
-        default_include = pre_opts.get('default_include', opts['default_include'])
+        default_include = pre_opts.get(
+            'default_include', opts['default_include']
+        )
         include = pre_opts.get('include', [])
         pre_opts = salt.config.include_config(
             default_include, pre_opts, opts['conf_file'], verbose=False
@@ -243,6 +245,7 @@ def _mod_type(module_path):
     if module_path.startswith(salt_base_path):
         return 'int'
     return 'ext'
+
 
 def in_pack(pack, name):
     '''
@@ -426,7 +429,7 @@ class Loader(object):
 
                 funcs[
                     '{0}.{1}'.format(
-                        mod.__name__[mod.__name__.rindex('.')+1:], attr
+                        mod.__name__[mod.__name__.rindex('.') + 1:], attr
                     )
                 ] = func
                 self._apply_outputter(func, mod)
@@ -588,7 +591,7 @@ class Loader(object):
                             if module_name != virtual:
                                 # update the module name with the new name
                                 log.debug(
-                                    'Loaded {0} as virtual {1}').format(
+                                    'Loaded {0} as virtual {1}'.format(
                                         module_name, virtual
                                     )
                                 )
@@ -615,9 +618,8 @@ class Loader(object):
                     func = getattr(mod, attr)
                     if isinstance(func, type):
                         # skip callables that might be exceptions
-                        if any([
-                            'Error' in func.__name__,
-                            'Exception' in func.__name__]):
+                        if any(['Error' in func.__name__,
+                                'Exception' in func.__name__]):
                             continue
                     # now that callable passes all the checks, add it to the
                     # library of available functions of this type

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -579,13 +579,21 @@ class Loader(object):
                     if hasattr(mod, '__virtual__'):
                         if callable(mod.__virtual__):
                             virtual = mod.__virtual__()
-                            if virtual:
-                                # update the module name with the new name
-                                module_name = virtual
-                            else:
+                            if virtual is False:
                                 # if __virtual__() returns false then the
-                                # module wasn't meant for this platform.
+                                # module wasn't meant for this platform or it's
+                                # not supposed to load for some other reason.
                                 continue
+
+                            if module_name != virtual:
+                                # update the module name with the new name
+                                log.debug(
+                                    'Loaded {0} as virtual {1}').format(
+                                        module_name, virtual
+                                    )
+                                )
+                                module_name = virtual
+
                 except Exception:
                     # If the module throws an exception during __virtual__()
                     # then log the information and continue to the next.

--- a/salt/log.py
+++ b/salt/log.py
@@ -110,7 +110,24 @@ class Logging(LoggingLoggerClass):
                 fmt = formatter._fmt.replace('%', '%%')
 
                 match = MODNAME_PATTERN.search(fmt)
-                if match and match.group('digits') is not None and int(match.group('digits')) < max_logger_length:
+                if not match:
+                    # Not matched. Release handler and return.
+                    handler.release()
+                    return instance
+
+                if 'digits' not in match.groupdict():
+                    # No digits group. Release handler and return.
+                    handler.release()
+                    return instance
+
+                digits = match.group('digits')
+                if not digits or not (digits and digits.isdigit()):
+                    # No valid digits. Release handler and return.
+                    handler.release()
+                    return instance
+
+                if int(digits) < max_logger_length:
+                    # Formatter digits value is lower than current max, update.
                     fmt = fmt.replace(match.group('name'), '%%(name)-%ds')
                     formatter = logging.Formatter(
                         fmt % max_logger_length,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -957,7 +957,7 @@ def recurse(name,
         (default is False)
 
     include_pat
-	When copying, include only this pattern from the source. Default
+        When copying, include only this pattern from the source. Default
         is glob match , if prefixed with E@ then regexp match
         Example::
 
@@ -965,7 +965,7 @@ def recurse(name,
           - include_pat: E@hello      :: regexp matches 'otherhello', 'hello01' ...
 
     exclude_pat
-	When copying, exclude this pattern from the source. If both
+        When copying, exclude this pattern from the source. If both
         include_pat and exclude_pat are supplied, then it will apply
         conditions cumulatively. i.e. first select based on include_pat and
         then with in that result, applies exclude_pat.

--- a/tests/unit/log_test.py
+++ b/tests/unit/log_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.log_test
+    ~~~~~~~~~~~~~~~~~~~
+
+    Test salt's "hacked" logging
+
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2012 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+'''
+
+# Import python libs
+import logging
+
+# Import salt libs
+from salt import log as saltlog
+from saltunittest import (
+    TestCase, TestLoader, TextTestRunner, TestsLoggingHandler
+)
+
+
+class TestLog(TestCase):
+    '''Test several logging settings'''
+
+    def test_issue_2853_regex_TypeError(self):
+        from salt import log as saltlog
+        # Now, python's logging logger class is ours.
+        # Let's make sure we have at least one instance
+        log = saltlog.Logging(__name__)
+
+        # Test for a format which includes digits in name formatting.
+        log_format = '[%(name)-15s] %(message)s'
+        handler = TestsLoggingHandler(format=log_format)
+        log.addHandler(handler)
+
+        # Trigger TestsLoggingHandler.__enter__
+        with handler:
+            # Let's create another log instance to trigger salt's logging class
+            # calculations.
+            try:
+                saltlog.Logging('{0}.with_digits'.format(__name__))
+            except Exception, err:
+                raise AssertionError(
+                    'No exception should have been raised: {0}'.format(err)
+                )
+
+        # Remove the testing handler
+        log.removeHandler(handler)
+
+        # Test for a format which does not include digits in name formatting.
+        log_format = '[%(name)s] %(message)s'
+        handler = TestsLoggingHandler(format=log_format)
+        log.addHandler(handler)
+
+        # Trigger TestsLoggingHandler.__enter__
+        with handler:
+            # Let's create another log instance to trigger salt's logging class
+            # calculations.
+            try:
+                saltlog.Logging('{0}.without_digits'.format(__name__))
+            except Exception, err:
+                raise AssertionError(
+                    'No exception should have been raised: {0}'.format(err)
+                )
+
+            # Remove the testing handler
+            log.removeHandler(handler)
+
+
+if __name__ == "__main__":
+    loader = TestLoader()
+    tests = loader.loadTestsFromTestCase(ConfigTestCase)
+    TextTestRunner(verbosity=1).run(tests)


### PR DESCRIPTION
This addresses the fix on saltstack/salt@3fa8b42e3abe441a2b53165176d6e2d71b906a20 which introduced a bug, and saltstack/salt@9dbd90a3e621f441c8555452364a56f2a4afd9ea which fixed the bug. A win-win situation :)
