### PR TITLE
Actually install RVM (like it says in the docstring)

### DIFF
--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -108,11 +108,11 @@ import re
 
 def _check_rvm(ret):
     '''
-    Check to see if rvm is installed and install it
+    Check to see if rvm is installed.
     '''
     if not __salt__['rvm.is_installed']():
         ret['result'] = False
-        ret['comment'] = 'Could not install RVM.'
+        ret['comment'] = 'RVM is not installed.'
     return ret
 
 
@@ -182,7 +182,8 @@ def installed(name, default=False, runas=None):
 
     ret = _check_rvm(ret)
     if ret['result'] == False:
-        return ret
+        if not __salt__['rvm.install']():
+            return ret
 
     if __opts__['test']:
         ret['comment'] = 'Ruby {0} is set to be installed'.format(name)


### PR DESCRIPTION
The comment claimed that RVM would be installed if it's not there, but the state really just checked if RVM is installed, and exited if it wasn't.

Now it installs RVM if not present.
