### PR TITLE
Compare hashes to see if master version changed

### DIFF
--- a/salt/states/virtualenv.py
+++ b/salt/states/virtualenv.py
@@ -61,7 +61,10 @@ def managed(name,
         if not cached_requirements:
             # It's not cached, let's cache it.
             cached_requirements = __salt__['cp.cache_file'](requirements)
-
+        # Check if the master version has changed.
+        if __salt__['cp.hash_file'](requirements) != \
+                __salt__['cp.hash_file'](cached_requirements):
+                    cached_requirements = __salt__['cp.cache_file'](requirements)
         if not cached_requirements:
             ret.update({
                 'result': False,


### PR DESCRIPTION
Fixes #2594

Changes to the requirements.txt on the master were not being updated on the minion.

Basically, the file cache was not ever being invalidated, so a stale file was always being used.
