### PR TITLE
cp.get_dir: Only makedirs if the path doesn't already exist.

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -294,7 +294,8 @@ class Client(object):
                 # the relative path on the minion.
                 minion_relpath = string.lstrip(fn_[len(prefix):], '/')
                 minion_mkdir = '{0}/{1}'.format(dest, minion_relpath)
-                os.makedirs(minion_mkdir)
+                if not os.path.isdir(minion_mkdir):
+                    os.makedirs(minion_mkdir)
                 ret.append(minion_mkdir)
         ret.sort()
         return ret


### PR DESCRIPTION
When testing 10.6 I ran into a traceback copying over an existing directory:

```
{'ret': 'Traceback (most recent call last):\n  File "/home/deploy-test/src/salt/salt/minion.py", line 349, in _thread_return\n    ret[\'return\'] = func(*args, **kw)\n  File "/home/deploy-test/src/salt/salt/modules/cp.py", line 156, in get_dir\n    return __context__[\'cp.fileclient\'].get_dir(path, dest, env, gzip)\n  File "/home/deploy-test/src/salt/salt/fileclient.py", line 297, in get_dir\n    os.makedirs(minion_mkdir)\n  File "/home/deploy-test/lib64/python2.7/os.py", line 157, in makedirs\n    mkdir(name, mode)\nOSError: [Errno 17] File exists: \'/var/deploys/test/1/code/resources\'\n'}
```

Doing a git blame I don't think this was introduced in 10.6, I just think it wasn't hit before.  My fix was simply to check if the dir existing before makedirs'ing it.  It's annoying that makedirs doesn't do that for you, as shown here:

```
Python 2.7.3 (default, Nov 29 2012, 01:36:47) 
[GCC 4.5.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> os.makedirs('/tmp')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/root/deploy-master/lib64/python2.7/os.py", line 157, in makedirs
    mkdir(name, mode)
OSError: [Errno 17] File exists: '/tmp'
```
