### PR TITLE
Remove need for sudo, fix logic mistake in RVM module

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -47,7 +47,7 @@ def install():
     #   bash coreutils gzip bzip2 gawk sed curl git-core subversion
     installer = 'https://get.rvm.io'
     return 0 == __salt__['cmd.retcode'](
-        # the RVM installer automaticall does a multi-user install when it is invoked with root privileges
+        # the RVM installer automatically does a multi-user install when it is invoked with root privileges
         'curl -s {installer} | bash -s stable'.format(installer=installer))
 
 

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -45,7 +45,7 @@ def install():
     '''
     # RVM dependencies on Ubuntu 10.04:
     #   bash coreutils gzip bzip2 gawk sed curl git-core subversion
-    installer = 'https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
+    installer = 'https://get.rvm.io'
     return 0 == __salt__['cmd.retcode'](
         # the RVM installer automaticall does a multi-user install when it is invoked with root privileges
         'curl -s {installer} | bash -s stable'.format(installer=installer))

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -45,7 +45,7 @@ def install():
     '''
     # RVM dependencies on Ubuntu 10.04:
     #   bash coreutils gzip bzip2 gawk sed curl git-core subversion
-    installer = 'https://get.rvm.io'
+    installer = 'https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
     return 0 == __salt__['cmd.retcode'](
         # the RVM installer automatically does a multi-user install when it is invoked with root privileges
         'curl -s {installer} | bash -s stable'.format(installer=installer))

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -44,11 +44,11 @@ def install():
     Install RVM system wide.
     '''
     # RVM dependencies on Ubuntu 10.04:
-    #   bash coreutils gzip bzip2 gawk sed curl git-core subversion sudo
+    #   bash coreutils gzip bzip2 gawk sed curl git-core subversion
     installer = 'https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
     return 0 == __salt__['cmd.retcode'](
-        # the RVM installer only does a multi-user install when it is invoked under sudo
-        'curl -s {installer} | sudo bash -s stable'.format(installer=installer))
+        # the RVM installer automaticall does a multi-user install when it is invoked with root privileges
+        'curl -s {installer} | bash -s stable'.format(installer=installer))
 
 
 def install_ruby(ruby, runas=None):

--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -34,7 +34,6 @@ configuration could look like:
           - curl
           - git-core
           - subversion
-          - sudo
 
     mri-deps:
       pkg.installed:

--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -186,10 +186,11 @@ def installed(name, default=False, runas=None):
     ret = _check_rvm(ret)
     if ret['result'] == False:
         if not __salt__['rvm.install']():
+            ret['comment'] = 'RVM failed to install'
+            ret['result'] = False
             return ret
-
-    return _check_and_install_ruby(ret, name, default, runas=runas)
-
+        else:
+            return _check_and_install_ruby(ret, name, default, runas=runas)     
 
 def gemset_present(name, ruby='default', runas=None):
     '''

--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -186,11 +186,13 @@ def installed(name, default=False, runas=None):
     ret = _check_rvm(ret)
     if ret['result'] == False:
         if not __salt__['rvm.install']():
-            ret['comment'] = 'RVM failed to install'
-            ret['result'] = False
+            ret['comment'] = 'RVM failed to install.'
             return ret
         else:
-            return _check_and_install_ruby(ret, name, default, runas=runas)     
+            return _check_and_install_ruby(ret, name, default, runas=runas)
+    else:
+        return _check_and_install_ruby(ret, name, default, runas=runas)
+
 
 def gemset_present(name, ruby='default', runas=None):
     '''


### PR DESCRIPTION
RVM doesn't need sudo since salt-minion runs as root anyhow. This way, we can remove the dependency on sudo.

Also, I think I fixed a logic mistake while installing that could lead to RVM not ever actually installing the rubies you ask it for.

Tested on Debian wheezy and Debian sid minions, seems to work!
