### PR TITLE
Somebody forgot to return False on non-Macs

### DIFF
--- a/salt/modules/osxdesktop.py
+++ b/salt/modules/osxdesktop.py
@@ -6,6 +6,7 @@ Mac OS X implementations of various commands in the "desktop" interface
 def __virtual__():
     if __grains__['os'] == 'MacOS':
         return 'desktop'
+    return False
 
 
 def get_output_volume():


### PR DESCRIPTION
If you don't return False, you get things like:

None.get_output_volume:
    Get the output volume (range 0 to 100)
    CLI Example::
        salt '*' desktop.get_output_volume

On unsupported systems.
