### PR TITLE
Since salt versioning changed, so should the depending deprecations.

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -635,8 +635,8 @@ class OutputOptionsMixIn(object):
                             opt.dest.split('_', 1)[0]
                         )
                     )
-                    if version.__version_info__ >= (0, 10, 7):
-                        # XXX: CLEAN THIS CODE WHEN 0.10.8 is about to come out
+                    if version.__version_info__ >= (0, 12):
+                        # XXX: CLEAN THIS CODE WHEN 0.13 is about to come out
                         self.error(msg)
                     elif log.is_console_configured():
                         logging.getLogger(__name__).warning(msg)

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -42,7 +42,7 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
     def test_text_output(self):
         out = self.run_call('-l quiet --text-out test.fib 3')
-        if version.__version_info__ < (0, 10, 8):
+        if version.__version_info__ < (0, 12):
             expect = [
                 "WARNING: The option --text-out is deprecated. Please "
                 "consider using '--out text' instead."


### PR DESCRIPTION
The are some output parser options which should be triggering warnings salt 0.10.6 and should start triggering failures when 0.10.7 came out. Adapt these dependable deprecations to the new versioning convention.
