### PR TITLE
Improvements to "hacking" docs

### DIFF
--- a/doc/ref/states/overstate.rst
+++ b/doc/ref/states/overstate.rst
@@ -6,7 +6,7 @@ Often servers need to be set up and configured in a specific order, and systems
 should only be set up if systems earlier in the sequence has been set up
 without any issues.
 
-The 0.10.6 release of Salt addresses this problem with a new layer in the state
+The 0.11.0 release of Salt addresses this problem with a new layer in the state
 system called the `Over State`. The concept of the `Over State` is managed on
 the master, a series of state executions is controlled from the master and
 executed in order. If an execution requires that another execution first run

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -108,23 +108,27 @@ the configuration, log, and cache files contained in the virtualenv as well.
 Copy the master and minion config files into your virtualenv::
 
     mkdir -p /path/to/your/virtualenv/etc/salt
-    cp ./salt/conf/master.template /path/to/your/virtualenv/etc/salt/master
-    cp ./salt/conf/minion.template /path/to/your/virtualenv/etc/salt/minion
+    cp ./salt/conf/master /path/to/your/virtualenv/etc/salt/master
+    cp ./salt/conf/minion /path/to/your/virtualenv/etc/salt/minion
 
 Edit the master config file:
 
 1.  Uncomment and change the ``user: root`` value to your own user.
 2.  Uncomment and change the ``root_dir: /`` value to point to
     ``/path/to/your/virtualenv``.
-3.  If you are also running a non-development version of Salt you will have to
+3.  Uncomment and change the ``pidfile: /var/run/salt-minion.pid`` value to
+    point to ``/path/to/your/virtualenv/salt-minion.pid``.
+4.  If you are also running a non-development version of Salt you will have to
     change the ``publish_port`` and ``ret_port`` values as well.
 
 Edit the minion config file:
 
 1.  Repeat the edits you made in the master config for the ``user`` and
     ``root_dir`` values as well as any port changes.
-2.  Uncomment and change the ``master: salt`` value to point at ``localhost``.
-3.  Uncomment and change the ``id:`` value to something descriptive like
+2.  Uncomment and change the ``pidfile: /var/run/salt-master.pid`` value to
+    point to ``/path/to/your/virtualenv/salt-master.pid``.
+3.  Uncomment and change the ``master: salt`` value to point at ``localhost``.
+4.  Uncomment and change the ``id:`` value to something descriptive like
     "saltdev". This isn't strictly necessary but it will serve as a reminder of
     which Salt installation you are working with.
 
@@ -140,8 +144,8 @@ Start the master and minion, accept the minon's key, and verify your local Salt
 installation is working::
 
     cd /path/to/your/virtualenv
-    salt-master -c ./etc/salt -d --pid-file ./salt-master.pid
-    salt-minion -c ./etc/salt -d --pid-file ./salt-minion.pid
+    salt-master -c ./etc/salt -d
+    salt-minion -c ./etc/salt -d
     salt-key -c ./etc/salt -L
     salt-key -c ./etc/salt -A
     salt -c ./etc/salt '*' test.ping

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -150,9 +150,10 @@ installation is working::
     salt-key -c ./etc/salt -A
     salt -c ./etc/salt '*' test.ping
 
-Running the master and minion in debug mode in the foreground can be helpful
-when developing. To do this, replace the ``-d`` in the calls to ``salt-master``
-and ``salt-minion`` above with ``-l debug``.
+Running the master and minion in debug mode can be helpful when developing. To
+do this, add ``-l debug`` to the calls to ``salt-master`` and ``salt-minion``.
+If you would like to log to the console instead of to the log file, remove the
+``-d``.
 
 File descriptor limit
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -48,9 +48,9 @@ Then::
 - The docs then are built in the ``docs/_build/html/`` folder. If you make
   changes and want to see the results, ``make html`` again.
 - The docs use ``reStructuredText`` for markup. See a live demo at
-  http://rst.ninjs.org/
+  http://rst.ninjs.org/.
 - The help information on each module or state is culled from the python code
-  that runs for that piece. Find them in ``salt/modules/`` or ``salt/states/``
+  that runs for that piece. Find them in ``salt/modules/`` or ``salt/states/``.
 - If you are developing using Arch Linux (or any other distribution for which
   Python 3 is the default Python installation), then ``sphinx-build`` may be
   named ``sphinx-build2`` instead. If this is the case, then you will need to
@@ -133,7 +133,8 @@ Edit the minion config file:
     If you plan to run `salt-call` with this self-contained development
     environment in a masterless setup, you should invoke `salt-call` with
     ``-c /path/to/your/virtualenv/etc/salt`` so that salt can find the minion
-    config file. Without the ``-c`` option, Salt finds its config files in `/etc/salt`.
+    config file. Without the ``-c`` option, Salt finds its config files in
+    `/etc/salt`.
 
 Start the master and minion, accept the minon's key, and verify your local Salt
 installation is working::
@@ -179,4 +180,4 @@ Finally you use setup.py to run the tests with the following command::
 
 For greater control while running the tests, please try::
 
-	./tests/runtests.py -h
+    ./tests/runtests.py -h

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -138,6 +138,7 @@ Edit the minion config file:
 Start the master and minion, accept the minon's key, and verify your local Salt
 installation is working::
 
+    cd /path/to/your/virtualenv
     salt-master -c ./etc/salt -d --pid-file ./salt-master.pid
     salt-minion -c ./etc/salt -d --pid-file ./salt-minion.pid
     salt-key -c ./etc/salt -L

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -51,6 +51,12 @@ Then::
   http://rst.ninjs.org/
 - The help information on each module or state is culled from the python code
   that runs for that piece. Find them in ``salt/modules/`` or ``salt/states/``
+- If you are developing using Arch Linux (or any other distribution for which
+  Python 3 is the default Python installation), then ``sphinx-build`` may be
+  named ``sphinx-build2`` instead. If this is the case, then you will need to
+  run the following ``make`` command::
+
+    make SPHINXBUILD=sphinx-build2 html
 
 Installing Salt for development
 -------------------------------
@@ -132,11 +138,15 @@ Edit the minion config file:
 Start the master and minion, accept the minon's key, and verify your local Salt
 installation is working::
 
-    salt-master -c ./etc/salt -d
-    salt-minion -c ./etc/salt -d
+    salt-master -c ./etc/salt -d --pid-file ./salt-master.pid
+    salt-minion -c ./etc/salt -d --pid-file ./salt-minion.pid
     salt-key -c ./etc/salt -L
     salt-key -c ./etc/salt -A
     salt -c ./etc/salt '*' test.ping
+
+Running the master and minion in debug mode in the foreground can be helpful
+when developing. To do this, replace the ``-d`` in the calls to ``salt-master``
+and ``salt-minion`` above with ``-l debug``.
 
 File descriptor limit
 ~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Salt has a lot of Arch Linux users (after all, Arch is the best!), so
I added some information on building the docs in Arch where the python2
version of sphinx-build is called sphinx-build2.

Also, when setting up a standalone development environment in a
virtualenv, unless you are running as root (and the docs explicitly
direct you not to do so) you will not have write access to /var/run in
order to create the pidfile. So, the --pid-file argument should be used
to specify a different path.

EDIT: s0undt3ch pointed out that this could also go into the master and
minion config files, so I made another commit that does this so that
less needs to be typed on the command line to start up your master
and minion instances.

Finally, a note on running the master and minion in the foreground in
debug mode was added.
