### PR TITLE
switch list_pkgs on yum-based systems to using the rpmdb

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -201,16 +201,13 @@ def list_pkgs(*args):
 
         salt '*' pkg.list_pkgs
     '''
-    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
     ret = {}
-    for line in __salt__['cmd.run'](cmd).splitlines():
-        if not '_|-' in line:
-            continue
-        name, version, rel = line.split('_|-')
-        pkgver = version
-        if rel:
-            pkgver += '-{0}'.format(rel)
-        __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
+    yb = yum.YumBase()
+    for p in yb.rpmdb:
+        pkgver = p.version
+        if p.release:
+            pkgver += '-{0}'.format(p.release)
+        __salt__['pkg_resource.add_pkg'](ret, p.name, pkgver)
     __salt__['pkg_resource.sort_pkglist'](ret)
     if args:
         pkgs = ret


### PR DESCRIPTION
(instead of using cmd.run)

the rest of this module likes to use YumBase(), so do that for list_pkgs
as well.  this is just a straight-forward switch to how the package list is
queried, it doesn't change anything functionality-wise.
