### PR TITLE
Batch.run() should return minion name as dictionary key

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -119,7 +119,7 @@ class Batch(object):
                     pass
             for minion, data in parts.items():
                 active.remove(minion)
-                yield data['ret']
+                yield {minion: data['ret']}
                 ret[minion] = data['ret']
                 data[minion] = data.pop('ret')
                 if 'out' in data:


### PR DESCRIPTION
- When using Batch.run() (or client.cmd_batch()) there was no way to tell
  from what minion the returned date came from.
- Batch.run() returns a dictionary which has minion id as a key, and
  returned data as a value
