### PR TITLE
Remove reference to schema

### DIFF
--- a/salt/states/postgres_database.py
+++ b/salt/states/postgres_database.py
@@ -1,5 +1,5 @@
 '''
-Management of PostgreSQL databases (schemas).
+Management of PostgreSQL databases.
 =============================================
 
 The postgres_database module is used to create and manage Postgres databases.


### PR DESCRIPTION
Postgresql has a meaningful difference between schema and database, so conflating them here could be confusing:

http://www.postgresql.org/docs/9.2/static/ddl-schemas.html
