### PR TITLE
change from jinja's PackageLoader to FileSystemLoader

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -6,11 +6,12 @@ The networking module for RHEL/Fedora based distros
 import logging
 import re
 from os.path import exists, join
-from os import sep
+import os
 import StringIO
 
 # import third party libs
 import jinja2
+from jinja2.exceptions import TemplateNotFound
 
 # Import salt libs
 import salt.utils
@@ -20,7 +21,7 @@ from salt.modules import __path__ as saltmodpath
 log = logging.getLogger(__name__)
 
 # Set up template environment
-env = jinja2.Environment(loader=jinja2.FileSystemLoader(saltmodpath[0] + sep + 'rh_ip'))
+env = jinja2.Environment(loader=jinja2.FileSystemLoader(saltmodpath[0] + os.sep + 'rh_ip'))
 
 
 def __virtual__():
@@ -763,7 +764,7 @@ def build_bond(iface, settings):
     opts = _parse_settings_bond(settings, iface)
     try:
         template = env.get_template('conf.jinja')
-    except Exception:
+    except TemplateNotFound:
         log.error('Could not load template conf.jinja')
         return ''
     data = template.render({'name': iface, 'bonding': opts})
@@ -818,7 +819,7 @@ def build_interface(iface, iface_type, enabled, settings):
         opts = _parse_settings_eth(settings, iface_type, enabled, iface)
         try:
             template = env.get_template('rh{0}_eth.jinja'.format(rh_major))
-        except Exception:
+        except TemplateNotFound:
             log.error('Could not load template rh{0}_eth.jinja'.format(rh_major))
             return ''
         ifcfg = template.render(opts)
@@ -931,7 +932,7 @@ def build_network_settings(settings):
     opts = _parse_network_settings(settings, current_network_settings)
     try:
         template = env.get_template('network.jinja')
-    except Exception:
+    except TemplateNotFound:
         log.error('Could not load template network.jinja')
         return ''
     network = template.render(opts)

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -5,7 +5,7 @@ The networking module for RHEL/Fedora based distros
 # Import python libs
 import logging
 import re
-from os.path import exists, join
+import os.path
 import os
 import StringIO
 
@@ -721,9 +721,9 @@ def _write_file_iface(iface, data, folder, pattern):
     '''
     Writes a file to disk
     '''
-    filename = join(folder, pattern.format(iface))
-    if not exists(folder):
-        msg = '{0} cannot be written. {1} does not exists'
+    filename = os.path.join(folder, pattern.format(iface))
+    if not os.path.exists(folder):
+        msg = '{0} cannot be written. {1} does not exist'
         msg = msg.format(filename, folder)
         log.error(msg)
         raise AttributeError(msg)
@@ -769,7 +769,7 @@ def build_bond(iface, settings):
         return ''
     data = template.render({'name': iface, 'bonding': opts})
     _write_file_iface(iface, data, _RH_NETWORK_CONF_FILES, '{0}.conf')
-    path = join(_RH_NETWORK_CONF_FILES, '{0}.conf'.format(iface))
+    path = os.path.join(_RH_NETWORK_CONF_FILES, '{0}.conf'.format(iface))
     if rh_major == '5':
         __salt__['cmd.run'](
             'sed -i -e "/^alias\s{0}.*/d" /etc/modprobe.conf'.format(iface)
@@ -828,7 +828,7 @@ def build_interface(iface, iface_type, enabled, settings):
         return _read_temp(ifcfg)
 
     _write_file_iface(iface, ifcfg, _RH_NETWORK_SCRIPT_DIR, 'ifcfg-{0}')
-    path = join(_RH_NETWORK_SCRIPT_DIR, 'ifcfg-{0}'.format(iface))
+    path = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'ifcfg-{0}'.format(iface))
 
     return _read_file(path)
 
@@ -855,7 +855,7 @@ def get_bond(iface):
 
         salt '*' ip.get_bond bond0
     '''
-    path = join(_RH_NETWORK_CONF_FILES, '{0}.conf'.format(iface))
+    path = os.path.join(_RH_NETWORK_CONF_FILES, '{0}.conf'.format(iface))
     return _read_file(path)
 
 
@@ -867,7 +867,7 @@ def get_interface(iface):
 
         salt '*' ip.get_interface eth0
     '''
-    path = join(_RH_NETWORK_SCRIPT_DIR, 'ifcfg-{0}'.format(iface))
+    path = os.path.join(_RH_NETWORK_SCRIPT_DIR, 'ifcfg-{0}'.format(iface))
     return _read_file(path)
 
 


### PR DESCRIPTION
this removes the dependency on distribute (setuptools) at runtime.
added some checks around each of the calls to get_template, to
catch the exception thrown when the template environment cannot be
loaded by the FileSystemLoader.

a good TODO / follow-up to this would be to enhance
states/network.py to better handle the situations this creates...

see #2928 for discussion.
