### PR TITLE
Build docs before trying to copy doc files in the Debian build process

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -4,11 +4,11 @@ PKGFILES = pkg/*.service pkg/*.upstart pkg/*.logrotate
 SALT_BIN = common minion master syndic
 
 %:
+	make -C doc html
 	cp $(PKGFILES) debian
 	for d in $(SALT_BIN); do \
 	    cp pkg/salt.postrm debian/salt-$${d}.postrm; done
 	dh $@ 
-	make -C doc html
 
 dh_override_auto_build:
 	python setup.py build


### PR DESCRIPTION
`debian/rules binary` fails with
`[...]
dh_install: salt-doc missing files (doc/_build/html/*), aborting`

The fix is to simply build the documentation first.
