### PR TITLE
Some minor cleanup of unit and integration tests.

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -45,7 +45,12 @@ SCRIPT_DIR = os.path.join(CODE_DIR, 'scripts')
 
 PYEXEC = 'python{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
 
-SYS_TMP_DIR = tempfile.gettempdir()
+if os.environ.has_key('TMPDIR'):
+    # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
+    SYS_TMP_DIR = os.environ['TMPDIR']
+else:
+    SYS_TMP_DIR = tempfile.gettempdir()
+
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
 MOCKBIN = os.path.join(INTEGRATION_TEST_DIR, 'mockbin')

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -104,8 +104,16 @@ sys.stdout.write('cheese')
         '''
         cmd = '''echo 'SELECT * FROM foo WHERE bar="baz"' '''
         expected_result = 'SELECT * FROM foo WHERE bar="baz"'
+
+        try:
+            runas=os.getlogin()
+        except:
+            # On some distros (notably Gentoo) os.getlogin() fails
+            import pwd
+            runas=pwd.getpwuid(os.getuid())[0]
+
         result = self.run_function('cmd.run_stdout', [cmd],
-                                   runas=os.getlogin()).strip()
+                                   runas=runas).strip()
         self.assertEqual(result, expected_result)
 
 

--- a/tests/integration/states/match.py
+++ b/tests/integration/states/match.py
@@ -15,6 +15,8 @@ import os
 import salt.utils
 import integration
 
+from saltunittest import skipIf
+
 STATE_DIR = os.path.join(integration.FILES, 'file', 'base')
 
 
@@ -30,8 +32,10 @@ class StateMatchTest(integration.ModuleCase):
             ret
         )
 
+    @skipIf(os.geteuid() is not 0, 'you must be root to run this test')
     def test_issue_2167_ipcidr_no_AttributeError(self):
         subnets = self.run_function('network.subnets')
+        self.assertTrue(len(subnets) > 0)
         top_filename = 'issue-2167-ipcidr-match.sls'
         top_file = os.path.join(STATE_DIR, top_filename)
         try:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -350,11 +350,11 @@ if __name__ == '__main__':
 
         no_problems_found = False
 
-        print_header(u'\u22c6\u22c6\u22c6 {0}  '.format(name), sep=u'\u22c6', inline=True)
+        print_header(u'*** {0}  '.format(name), sep=u'*', inline=True)
         if results.skipped:
             print_header(u' --------  Skipped Tests  ', sep='-', inline=True)
             maxlen = len(max([tc.id() for (tc, reason) in results.skipped], key=len))
-            fmt = u'   \u2192 {0: <{maxlen}}  \u2192  {1}'
+            fmt = u'   -> {0: <{maxlen}}  ->  {1}'
             for tc, reason in results.skipped:
                 print(fmt.format(tc.id(), reason, maxlen=maxlen))
             print_header(u' ', sep='-', inline=True)
@@ -362,7 +362,7 @@ if __name__ == '__main__':
         if results.errors:
             print_header(u' --------  Tests with Errors  ', sep='-', inline=True)
             for tc, reason in results.errors:
-                print_header(u'   \u2192 {0}  '.format(tc.id()), sep=u'.', inline=True)
+                print_header(u'   -> {0}  '.format(tc.id()), sep=u'.', inline=True)
                 for line in reason.rstrip().splitlines():
                     print('       {0}'.format(line.rstrip()))
                 print_header(u'   ', sep=u'.', inline=True)
@@ -371,18 +371,18 @@ if __name__ == '__main__':
         if results.failures:
             print_header(u' --------  Failed Tests  ', sep='-', inline=True)
             for tc, reason in results.failures:
-                print_header(u'   \u2192 {0}  '.format(tc.id()), sep=u'.', inline=True)
+                print_header(u'   -> {0}  '.format(tc.id()), sep=u'.', inline=True)
                 for line in reason.rstrip().splitlines():
                     print('       {0}'.format(line.rstrip()))
                 print_header(u'   ', sep=u'.', inline=True)
             print_header(u' ', sep='-', inline=True)
 
-        print_header(u'', sep=u'\u22c6', inline=True)
+        print_header(u'', sep=u'*', inline=True)
 
     if no_problems_found:
         print_header(
-            u'\u22c6\u22c6\u22c6  No Problems Found While Running Tests  ',
-            sep=u'\u22c6', inline=True
+            u'***  No Problems Found While Running Tests  ',
+            sep=u'*', inline=True
         )
 
     print_header('  Overall Tests Report  ', sep='=', centered=True, inline=True)

--- a/tests/unit/modules/rvm_test.py
+++ b/tests/unit/modules/rvm_test.py
@@ -13,7 +13,9 @@ except ImportError:
 if has_mock:
     import salt.modules.rvm as rvm
     rvm.__salt__ = {
-        'cmd.has_exec': MagicMock(return_value=True)}
+        'cmd.has_exec': MagicMock(return_value=True),
+        'config.option' : MagicMock(return_value=None)
+    }
 
 
 @skipIf(has_mock is False, "mock python module is unavailable")


### PR DESCRIPTION
I ran into a couple issues with the tests:
- the rvm unit test was bombing trying to resolve **salt**[config.option].  I'm not 100% sure I resolved the issue correctly.
- os.getlogin() seems particularly buggy on Gentoo.  See: http://mail.python.org/pipermail/python-bugs-list/2002-July/012691.html  I worked around this  in the cmdmod module integration test.
- When portage runs a packages unit tests they prefer they use ${TMPDIR}.  Added support for this.  Currently portage sets ${TMPDIR} to /tmp so this isn't strictly necessary.
- The integration.states.match test was only working for me as root.  Added the same skipIf as other tests requiring root.
- My terminal (Terminator) was bombing trying to print Unicode arrows and stars, I replaced those with -> and *. in print_header().
