### PR TITLE
Moved locale_info grain outside of os_data

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -540,14 +540,6 @@ def os_data():
         'gpus': [],
     }
 
-    try:
-        (grains['defaultlanguage'],
-         grains['defaultencoding']) = locale.getdefaultlocale()
-    except Exception:
-        # locale.getdefaultlocale can ValueError!! Catch anything else it
-        # might do, per #2205
-        grains['defaultlanguage'] = 'unknown'
-        grains['defaultencoding'] = 'unknown'
     # Windows Server 2008 64-bit
     # ('Windows', 'MINIONNAME', '2008ServerR2', '6.1.7601', 'AMD64', 'Intel64 Fam ily 6 Model 23 Stepping 6, GenuineIntel')
     # Ubuntu 10.04
@@ -664,6 +656,24 @@ def os_data():
     grains.update(_ps(grains))
 
     return grains
+
+
+def locale_info():
+    '''
+    Provides
+        defaultlanguage
+        defaultencoding
+    '''
+    grains = {}
+    try:
+        (grains['defaultlanguage'], grains['defaultencoding']) = locale.getdefaultlocale()
+    except Exception:
+        # locale.getdefaultlocale can ValueError!! Catch anything else it
+        # might do, per #2205
+        grains['defaultlanguage'] = 'unknown'
+        grains['defaultencoding'] = 'unknown'
+    return grains
+
 
 
 def hostname():


### PR DESCRIPTION
cleaning up os_data function
created locale_info function to provides defaultlanguage and
defaultencoding
These were previously in os_data, but no reason to be
