### PR TITLE
Adding fedoraremi (Fedora Remix) to _OS_NAME_MAP

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -502,6 +502,7 @@ _OS_NAME_MAP = {
     'archarm': 'Arch ARM',
     'arch': 'Arch',
     'debian': 'Debian',
+    'fedoraremi': 'RedHat',
 }
 
 # Map the 'os' grain to the 'os_family' grain

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -99,6 +99,8 @@ def _linux_cpudata():
                     grains['cpu_model'] = val
                 elif key == 'flags':
                     grains['cpu_flags'] = val.split()
+                elif key == 'Features':
+                    grains['cpu_flags'] = val.split()
                 # ARM support - /proc/cpuinfo
                 #
                 # Processor       : ARMv6-compatible processor rev 7 (v6l)


### PR DESCRIPTION
This allows Fedora Remix to show up properly in the grains.
