### PR TITLE
Updated docs for grains, modules, and states

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -12,8 +12,11 @@ Easy Modules to write
 =====================
 
 Salt modules are amazingly simple to write. Just write a regular Python module
-or a regular `Cython`_ module and place it in the ``salt/modules`` directory. You
-can also place them in a directory called ``_modules/`` in your state directory.
+or a regular `Cython`_ module and place it in the ``salt/modules`` directory.
+You can also place them in a directory called ``_modules/`` within the
+:conf_master:`file_roots` specified by the master config file, and they will be
+synced to the minions when `state.highstate`_ is run, or by executing the
+`saltutil.sync_modules`_ or `saltutil.sync_all`_ functions.
 
 Since Salt modules are just Python/Cython modules, there are no restraints on
 what you can put inside of a Salt module. If a Salt module has errors and
@@ -26,6 +29,9 @@ compilation of the Cython module is automatic and happens when the minion
 starts, so only the ``*.pyx`` file is required.
 
 .. _`Cython`: http://cython.org/
+.. _`state.highstate`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.state.html#salt.modules.state.highstate
+.. _`saltutil.sync_modules`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.sync_modules
+.. _`saltutil.sync_all`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.sync_all
 
 Cross Calling Modules
 =====================

--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -35,10 +35,15 @@ Using Custom State Modules
 ==========================
 
 Place your custom state modules inside a ``_states`` directory within the
-``file_roots`` specified by the master config file. These custom state modules
-can then be distributed in a number of ways. Custom state modules are
-distributed when state.highstate is run, or via the saltutil.sync_states
-function.
+:conf_master:`file_roots` specified by the master config file. These custom
+state modules can then be distributed in a number of ways. Custom state modules
+are distributed when `state.highstate`_ is run, or by executing the
+`saltutil.sync_states`_ or `saltutil.sync_all`_ functions.
+
+.. _`state.highstate`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.state.html#salt.modules.state.highstate
+.. _`saltutil.sync_states`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.sync_states
+.. _`saltutil.sync_all`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.sync_all
+
 
 Cross Calling Modules
 =====================

--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -59,11 +59,19 @@ package or the custom grains directory. The functions in the modules of
 the grains must return a Python `dict`_, where the keys in the dict are the
 names of the grains and the values are the values.
 
-Custom grains should be placed in a ``_grains`` directory located under
-your :conf_master:`file_roots`. Before adding a grain to Salt, consider
-what the grain is and remember that grains need to be static data.
+Custom grains should be placed in a ``_grains`` directory located under the
+:conf_master:`file_roots` specified by the master config file. They will be
+distributed to the minions when `state.highstate`_ is run, or by executing the
+`saltutil.sync_grains`_ or `saltutil.sync_all`_ functions.
+
+Before adding a grain to Salt, consider what the grain is and remember that
+grains need to be static data. If the data is something that is likely to
+change, consider using :doc:`Pillar <../pillar/index>` instead.
 
 .. _`dict`: http://docs.python.org/library/stdtypes.html#typesmapping
+.. _`state.highstate`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.state.html#salt.modules.state.highstate
+.. _`saltutil.sync_grains`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.sync_grains
+.. _`saltutil.sync_all`: https://salt.readthedocs.org/en/latest/ref/modules/all/salt.modules.saltutil.html#salt.modules.saltutil.sync_all
 
 Examples of Grains
 ------------------


### PR DESCRIPTION
Added links to module function documentation, as well as to
"file_roots", and mentioned the saltutil.sync_\* functions. Will probably
do the same for returners and renderers soon. This should help people
navigate through the docs easier.
