### PR TITLE
First step toward Windows software repo

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -237,6 +237,7 @@ def minion_config(path, check_dns=True):
             'update_restart_services': [],
             'retry_dns': 30,
             'recon_max': 5000,
+            'win_repo_cachefile': '/var/cache/salt/minion/win_repo',
             }
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
@@ -387,6 +388,8 @@ def master_config(path):
             'verify_env': True,
             'permissive_pki_access': False,
             'default_include': 'master.d/*.conf',
+            'win_repo': '/srv/salt/win/repo',
+            'win_repo_cachefile': '/srv/salt/win/repo/win_repo',
     }
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -2,15 +2,42 @@
 Runner to manage Windows software repo
 '''
 
+# Import python libs
+import os
+import yaml
+from pprint import pprint
+import msgpack
+
 # Import salt libs
 import salt.output
+import salt.utils
+import logging
+
+log = logging.getLogger(__name__)
 
 
 def genrepo():
     '''
     Generate win_repo_cachefile based on sls files in the win_repo
     '''
-
-    result = __opts__['win_repo']
-    salt.output.display_output(result, 'pprint', __opts__)
-    return result
+    ret = {}
+    repo = __opts__['win_repo']
+    for root, dirs, files in os.walk(repo):
+        for name in files:
+            if name.endswith('.sls'):
+                with salt.utils.fopen(os.path.join(root, name), 'r') as slsfile:
+                    try:
+                        config = yaml.safe_load(slsfile.read()) or {}
+                    except yaml.parser.ParserError as exc:
+                        # log.debug doesn't seem to be working
+                        # delete the following print statement 
+                        # when log.debug works
+                        log.debug('Failed to compile'
+                                '{0}: {1}'.format(os.path.join(root, name), exc))
+                        print 'Failed to compile {0}: {1}'.format(os.path.join(root, name), exc)
+                if config:
+                    ret.update(config)
+    with salt.utils.fopen(os.path.join(repo, 'winrepo.cache'), 'w') as repo:
+        repo.write(msgpack.dumps(ret))
+    salt.output.display_output(ret, 'pprint', __opts__)
+    return ret

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -1,0 +1,16 @@
+'''
+Runner to manage Windows software repo
+'''
+
+# Import salt libs
+import salt.output
+
+
+def genrepo():
+    '''
+    Generate win_repo_cachefile based on sls files in the win_repo
+    '''
+
+    result = __opts__['win_repo']
+    salt.output.display_output(result, 'pprint', __opts__)
+    return result


### PR DESCRIPTION
This is the first step towards a Windows software repo.

Right now the runner  salt/runners/winrepo has a function, genrepo, that collects all the sls file inside the configured windows repo and builds a cache file of the results.
