### PR TITLE
Update Gentoo installation manual

### DIFF
--- a/doc/topics/installation/gentoo.rst
+++ b/doc/topics/installation/gentoo.rst
@@ -2,24 +2,11 @@
 Gentoo
 ======
 
-Salt can be easily installed on Gentoo:
+Salt can be easily installed on Gentoo via Portage:
 
 .. code-block:: bash
 
-    emerge pyyaml m2crypto pycrypto jinja pyzmq
-
-Then download and install from source:
-
-1.  Download the latest source tarball from the `GitHub downloads`_ directory for
-    the Salt project.
-
-2.  Untar the tarball and run the ``setup.py`` as root:
-
-.. code-block:: bash
-
-    tar xf salt-<version>.tar.gz
-    cd salt-<version>
-    python setup.py install
+    emerge salt
 
 Post-installation tasks
 =======================


### PR DESCRIPTION
Since Salt is in Portage now, there is no need for such a complicated installation instructions.
