### PR TITLE
Restrict import of pkgutil.py to Solaris only

### DIFF
--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -2,6 +2,14 @@
 Pkgutil support for Solaris
 '''
 
+def __virtual__():
+    '''
+    Set the virtual pkg module if the os is Solaris
+    '''
+    if __grains__['os'] == 'Solaris':
+        return 'pkg'
+    return False
+
 
 def _list_removed(old, new):
     '''


### PR DESCRIPTION
This fixes #2994.
