### PR TITLE
Salt State pkg.installed enforce package versions

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -40,9 +40,7 @@ def installed(
         sources=None,
         **kwargs):
     '''
-    Verify that the package is installed, and only that it is installed. This
-    state will not upgrade an existing package and only verify that it is
-    installed
+    Verify that the package is installed, and that it is the correct version.
 
     name
         The name of the package to be installed. This parameter is ignored if
@@ -146,12 +144,6 @@ def installed(
                     'result': True,
                     'comment': ('Package {0} is already installed and is the '
                                 'correct version').format(name)}
-        elif cver:
-            # The package is installed
-            return {'name': name,
-                    'changes': {},
-                    'result': True,
-                    'comment': 'Package {0} is already installed'.format(name)}
 
     if __opts__['test']:
         if len(targets) > 1:


### PR DESCRIPTION
Previously if there was a version installed (any version) it would return as "enforced" this patch makes sure that salt state enforces the correct version.
