### PR TITLE
Minor correction to comments

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -43,7 +43,7 @@ def search(pkg_name):
 
 def __virtual__():
     '''
-    Set the virtual pkg module if the os is Arch
+    Set the virtual pkg module if the os is FreeBSD
     '''
     return 'pkg' if __grains__['os'] == 'FreeBSD' else False
 


### PR DESCRIPTION
The **virtual** function in freebsdpkg.py has a comment that refers to
Arch Linux. Corrected this to "FreeBSD".
