### PR TITLE
Fix unit tests

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -24,6 +24,7 @@ from multiprocessing import Process
 
 # Import third party libs
 import zmq
+from zmq.core.error import ZMQBaseError
 
 # Import salt libs
 import salt.payload
@@ -170,7 +171,11 @@ class SaltEvent(object):
         self.context.term()
 
     def __del__(self):
-        self.destroy()
+        try:
+            # This blows up horribly during the unit tests
+	    self.destroy()
+        except ZMQBaseError:
+            pass
 
 
 class MasterEvent(SaltEvent):

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -3,6 +3,7 @@ Tests for the Git state
 '''
 import os
 import shutil
+import socket
 import integration
 
 
@@ -10,6 +11,18 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
     '''
     Validate the git state
     '''
+
+    def setUp(self):
+        super(GitTest, self).setUp()
+        self.__domain = 'github.com'
+        try:
+            if hasattr(socket, 'setdefaulttimeout'):
+                # 10 second dns timeout
+                socket.setdefaulttimeout(10)
+            socket.gethostbyname(self.__domain)
+        except socket.error:
+            msg = 'error resolving {0}, possible network issue?'
+            self.skipTest(msg.format(self.__domain))
 
     def test_latest(self):
         '''
@@ -19,7 +32,7 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         try:
             ret = self.run_state(
                 'git.latest',
-                name='https://github.com/saltstack/salt.git',
+                name='https://{0}/saltstack/salt.git'.format(self.__domain),
                 rev='develop',
                 target=name,
                 submodules=True
@@ -57,7 +70,7 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         try:
             ret = self.run_state(
                 'git.latest',
-                name='https://github.com/saltstack/salt.git',
+                name='https://{0}/saltstack/salt.git'.format(self.__domain),
                 rev='develop',
                 target=name,
                 submodules=True
@@ -75,7 +88,7 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         try:
             ret = self.run_state(
                 'git.latest',
-                name='https://github.com/mozilla/zamboni.git',
+                name='https://{0}/mozilla/zamboni.git'.format(self.__domain),
                 target=name,
                 submodules=True
             )

--- a/tests/integration/states/virtualenv.py
+++ b/tests/integration/states/virtualenv.py
@@ -14,11 +14,17 @@ import shutil
 
 # Import salt libs
 import integration
+
 from saltunittest import skipIf, destructiveTest
 
 
 class VirtualenvTest(integration.ModuleCase,
                      integration.SaltReturnAssertsMixIn):
+    def setUp(self):
+        super(VirtualenvTest, self).setUp()
+        ret = self.run_function('cmd.has_exec', ['virtualenv'])
+        if not ret:
+            self.skipTest('virtualenv not installed')
 
     @destructiveTest
     @skipIf(os.geteuid() is not 0, 'you must be root to run this test')


### PR DESCRIPTION
I lifted `setUp()` from the pip tests verbatim. I think someone should look into why `__del__()` on `MasterEvent()` blows up horribly when `self.destroy()` runs.
