### PR TITLE
RFC: Consistently detect windows

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -43,7 +43,7 @@ __salt__ = {
 log = logging.getLogger(__name__)
 
 has_wmi = False
-if sys.platform.startswith('win'):
+if salt.utils.is_windows():
     # attempt to import the python wmi module
     # the Windows minion uses WMI for some of its grains
     try:
@@ -547,7 +547,7 @@ def os_data():
     # ('Linux', 'MINIONNAME', '2.6.32-38-server', '#83-Ubuntu SMP Wed Jan 4 11:26:59 UTC 2012', 'x86_64', '')
     (grains['kernel'], grains['nodename'],
      grains['kernelrelease'], version, grains['cpuarch'], _) = platform.uname()
-    if grains['kernel'] == 'Windows':
+    if salt.utils.is_windows():
         grains['osrelease'] = grains['kernelrelease']
         grains['osversion'] = grains['kernelrelease'] = version
         grains['os'] = 'Windows'
@@ -557,7 +557,7 @@ def os_data():
         grains.update(_windows_cpudata())
         grains.update(_ps(grains))
         return grains
-    elif grains['kernel'] == 'Linux':
+    elif salt.utils.is_linux():
         # Add lsb grains on any distro with lsb-release
         try:
             import lsb_release

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -39,7 +39,7 @@ def __virtual__():
     Only work on posix-like systems
     '''
     # win_file takes care of windows
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         return False
     return 'file'
 

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -50,9 +50,10 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         if has_windows_modules:
             return 'reg'
+        # TODO: This needs to be reworked after the module dependency docstring was changed to :depends
         log.warn(salt.utils.required_modules_error(__file__, __doc__))
     return False
 

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -19,7 +19,7 @@ def __virtual__():
     '''
 
     # Disable on Windows, a specific file module exists:
-    if __grains__['os'] == 'Windows' or __grains__['kernel'] == 'SunOS':
+    if salt.utils.is_windows() or __grains__['kernel'] == 'SunOS':
         return False
     return 'shadow'
 

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -22,7 +22,7 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     # TODO: This could work on windows with some love
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         return False
     return 'ssh'
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -35,7 +35,7 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         if has_windows_modules:
             return 'file'
         log.warn(salt.utils.required_modules_error(__file__, __doc__))

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -6,6 +6,7 @@ Module for gathering and managing network information
 import re
 
 # Import salt libs
+import salt.utils
 from salt.utils.socket_util import sanitize_host
 
 __outputter__ = {
@@ -19,7 +20,7 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         return 'network'
     return False
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -13,8 +13,9 @@ try:
     import win32com.client
     import win32api
     import win32con
+    has_dependencies = True
 except ImportError:
-    pass
+    has_dependencies = False
 
 # Import python libs
 import logging
@@ -29,7 +30,10 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Windows
     '''
-    return 'pkg' if __grains__['os'] == 'Windows' else False
+    if salt.utils.is_windows():
+        if has_dependencies:
+		return 'pkg'
+    return False
 
 
 def _list_removed(old, new):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -30,9 +30,8 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Windows
     '''
-    if salt.utils.is_windows():
-        if has_dependencies:
-		return 'pkg'
+    if salt.utils.is_windows() and  has_dependencies:
+        return 'pkg'
     return False
 
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -13,8 +13,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return 'service'
-    else:
-        return False
+    return False
 
 def get_enabled():
     '''

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -4,13 +4,14 @@ Windows Service module.
 
 # Import python libs
 import time
+import salt.utils
 
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         return 'service'
     else:
         return False

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -2,12 +2,14 @@
 Manage the shadow file
 '''
 
+import salt.utils
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if __grains__['os'] == 'Windows':
+    if salt.utils.is_windows():
         return 'shadow'
     return False
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -7,19 +7,19 @@ from __future__ import absolute_import
 import os
 import re
 import imp
-import random
 import sys
+import time
+import shlex
+import shutil
+import random
 import socket
 import logging
 import inspect
 import hashlib
 import datetime
-import tempfile
-import shlex
-import shutil
-import subprocess
-import time
 import platform
+import tempfile
+import subprocess
 from calendar import month_abbr as months
 
 try:
@@ -257,6 +257,7 @@ def which_bin(exes):
         if not path:
             continue
         return path
+    return None
 
 
 def list_files(directory):
@@ -417,10 +418,7 @@ def check_or_die(command):
     if command is None:
         raise CommandNotFoundError("'None' is not a valid command.")
 
-    import salt.modules.cmdmod
-    __salt__ = {'cmd.has_exec': salt.modules.cmdmod.has_exec}
-
-    if not __salt__['cmd.has_exec'](command):
+    if not which(command):
         raise CommandNotFoundError(command)
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -780,3 +780,17 @@ def clean_kwargs(**kwargs):
         if not key.startswith('__pub'):
             ret[key] = val
     return ret
+
+@memoize
+def is_windows():
+    '''
+    Simple function to return if a host is Windows or not
+    '''
+    return sys.platform.startswith('win')
+
+@memoize
+def is_linux():
+    '''
+    Simple function to return if a host is Linux or not
+    '''
+    return sys.platform.startswith('linux')


### PR DESCRIPTION
I saw a few places where windows was detected in different ways and it irked me, so I cooked this up to unify it across all of the various bits. Since `salt.utils.is_windows()` is memoized, sys.platform() is only executed once and should be cached.

I'm not 100% sure that this is the right or blessed way to do things, but it might be a good idea. In the process of doing this, I noticed that @whiteinge broke the magical logging of required module dependencies and I added a TODO about it. We should figure out the "blessed" way of doing it and unify everything so it works.
