### PR TITLE
Updated comments for root_dir

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -52,7 +52,7 @@
 #pidfile: /var/run/salt-master.pid
 
 # The root directory prepended to these options: pki_dir, cachedir,
-# sock_dir, log_file, autosign_file, extension_modules
+# sock_dir, log_file, autosign_file, extension_modules, key_logfile, pidfile.
 #root_dir: /
 
 # Directory used to store public key data

--- a/conf/minion
+++ b/conf/minion
@@ -24,7 +24,8 @@
 # Specify the location of the daemon process ID file
 #pidfile: /var/run/salt-minion.pid
 
-# The root directory prepended to these options: pki_dir, cachedir, log_file.
+# The root directory prepended to these options: pki_dir, cachedir, log_file,
+# sock_dir, pidfile.
 #root_dir: /
 
 # The directory to store the pki information in


### PR DESCRIPTION
Forgot to change the comments in the master and minion config files for `root_dir` to mention `pidfile`, and also spotted a couple of other missing param names that are affected by `root_dir`

See 8d723cddc1459a6366a26dd47cfd1edce4b9b957
