### PR TITLE
Document the right ebuild package name format

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -2,6 +2,9 @@
 Support for Portage
 
 :optdepends:    - portage Python adapter
+
+For now all package names *MUST* include the package category,
+i.e. :code:`'vim'` will not work, :code:`'app-editors/vim'` will.
 '''
 
 # Import python libs


### PR DESCRIPTION
It was discovered that pkg module for Gentoo-based systems does not work
as expected if the full package name (including the category) is not
specified. This is not documented anywhere, so this should give users
better changes to know about it.
Check issue #3008 on GitHub to know about further development.
