### PR TITLE
Fix pkg state regression

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -144,8 +144,9 @@ def installed(
                     'result': True,
                     'comment': ('Package {0} is already installed and is the '
                                 'correct version').format(name)}
-        # if a version wasn't specified, we are done
-        elif version is None:
+
+        # if cver is not an empty string, the package is already installed
+        elif cver:
             # The package is installed
             return {'name': name,
                     'changes': {},


### PR DESCRIPTION
acd949c and 0b5ce09 broke the pkg state, such that for single pkg
installs (i.e. no "pkgs" or "sources"), if the version arg is not
provided, a package will always be interpreted by the pkg state as being
installed, and the package will never be installed. This commit fixes
that regression.
