### PR TITLE
Add configurable tcp keepalive support enabled by default

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -377,10 +377,10 @@
 # or leave to the OS defaults (-1), on linux, typically disabled. Default True, enabled.
 #tcp_keepalive: True
 #
-# How long before the first keepalive should be sent in seconds. Default -1 
-# to use OS defaults, typically 7200 seconds on Linux see 
-# /proc/sys/net/ipv4/tcp_keepalive_time.
-#tcp_keepalive_idle: -1
+# How long before the first keepalive should be sent in seconds. Default 300
+# to send the first keepalive after 5 minutes, OS default (-1) is typically 7200 seconds 
+# on Linux see /proc/sys/net/ipv4/tcp_keepalive_time.
+#tcp_keepalive_idle: 300
 #
 # How many lost probes are needed to consider the connection lost. Default -1
 # to use OS defaults, typically 9 on Linux, see /proc/sys/net/ipv4/tcp_keepalive_probes.

--- a/conf/minion
+++ b/conf/minion
@@ -362,3 +362,32 @@
 #
 # The list of services to restart after a successful update. Empty by default.
 #update_restart_services: []
+
+
+######      Keepalive settings        ######
+############################################
+# ZeroMQ now includes support for configuring SO_KEEPALIVE if supported by
+# the OS. If connections between the minion and the master pass through
+# a state tracking device such as a firewall or VPN gateway, there is
+# the risk that it could tear down the connection the master and minion
+# without informing either party that their connection has been taken away.
+# Enabling TCP Keepalives prevents this from happening.
+#
+# Overall state of TCP Keepalives, enable (1 or True), disable (0 or False) 
+# or leave to the OS defaults (-1), on linux, typically disabled. Default True, enabled.
+#tcp_keepalive: True
+#
+# How long before the first keepalive should be sent in seconds. Default -1 
+# to use OS defaults, typically 7200 seconds on Linux see 
+# /proc/sys/net/ipv4/tcp_keepalive_time.
+#tcp_keepalive_idle: -1
+#
+# How many lost probes are needed to consider the connection lost. Default -1
+# to use OS defaults, typically 9 on Linux, see /proc/sys/net/ipv4/tcp_keepalive_probes.
+#tcp_keepalive_cnt: -1
+#
+# How often, in seconds, to send keepalives after the first one. Default -1 to 
+# use OS defaults, typically 75 seconds on Linux, see 
+# /proc/sys/net/ipv4/tcp_keepalive_intvl.
+#tcp_keepalive_intvl: -1
+

--- a/salt/config.py
+++ b/salt/config.py
@@ -239,6 +239,10 @@ def minion_config(path, check_dns=True):
             'recon_max': 5000,
             'win_repo_cachefile': 'salt://win/repo/winrepo.p',
             'pidfile': '/var/run/salt-minion.pid',
+            'tcp_keepalive': True,
+            'tcp_keepalive_idle': 300,
+            'tcp_keepalive_cnt': -1,
+            'tcp_keepalive_intvl': -1,
             }
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -657,6 +657,11 @@ class Minion(object):
             self.socket.setsockopt(
                 zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
             )
+        if hasattr(zmq, 'TCP_KEEPALIVE'):
+            self.socket.setsockopt(zmq.TCP_KEEPALIVE, self.opts['tcp_keepalive'])
+            self.socket.setsockopt(zmq.TCP_KEEPALIVE_IDLE, self.opts['tcp_keepalive_idle'])
+            self.socket.setsockopt(zmq.TCP_KEEPALIVE_CNT, self.opts['tcp_keepalive_cnt'])
+            self.socket.setsockopt(zmq.TCP_KEEPALIVE_INTVL, self.opts['tcp_keepalive_intvl'])
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
         self.epoller.register(self.epull_sock, zmq.POLLIN)


### PR DESCRIPTION
After ZeroMQ added TCP Keepalive support earlier this year, it's now available for salt. This can really help with loss of minions when firewalls, VPN gateways or similar are in between them and the master.
Included here is an update to the minion config to allow TCP Keepalive to be configured and the related use of those options to activate and configure the use of TCP Keepalives. 
This has been set as enabled by default as I suspect it is likely to prevent problems people may encounter without causing new ones.
