### PR TITLE
Fix Debian grains again

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -502,6 +502,7 @@ _OS_NAME_MAP = {
     'archarm': 'Arch ARM',
     'arch': 'Arch',
     'debian': 'Debian',
+    'debiangnu/': 'Debian',
     'fedoraremi': 'RedHat',
 }
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -495,7 +495,8 @@ _REPLACE_LINUX_RE = re.compile(r'linux', re.IGNORECASE)
 
 # This maps (at most) the first ten characters (no spaces, lowercased) of
 # 'osfullname' to the 'os' grain that Salt traditionally uses.
-# Please see _supported_dists defined at the top of the file
+# Please see os_data() and _supported_dists.
+# If your system is not detecting properly it likely needs an entry here.
 _OS_NAME_MAP = {
     'redhatente': 'RedHat',
     'gentoobase': 'Gentoo',
@@ -507,8 +508,10 @@ _OS_NAME_MAP = {
 }
 
 # Map the 'os' grain to the 'os_family' grain
+# These should always be capitalized entries as the lookup comes
+# post-_OS_NAME_MAP. If your system is having trouble with detection, please
+# make sure that the 'os' grain is capitalized and working correctly first.
 _OS_FAMILY_MAP = {
-    'debian': 'Debian',
     'Ubuntu': 'Debian',
     'Fedora': 'RedHat',
     'CentOS': 'RedHat',


### PR DESCRIPTION
This is a fix for #2995.

It also removes an unnecessary change from 826e7e4d66 and adds documentation for those looking to fix platform detection. I realize the change from 826e7e4d66 is inconsequential, but I want to make sure that those working on the grains later don't get confused.
