### PR TITLE
Remove platform-specific code from pkg state

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -165,6 +165,30 @@ def _verify_binary_pkg(srcinfo):
     return problems
 
 
+def check_targets(targets=[]):
+    '''
+    Examines target package names to make sure they were formatted properly.
+    Returns a list of problems encountered.
+    '''
+    problems = []
+    # If minion is Gentoo-based, check targeted packages to ensure they are
+    # properly submitted as category/pkgname. For any package that does not
+    # follow this format, offer matches from the portage tree.
+    if __grains__['os_family'] == 'Gentoo':
+        for pkg in targets:
+            if '/' not in pkg:
+                matches = __salt__['pkg.porttree_matches'](pkg)
+                if matches:
+                    msg = 'Package category missing for "{0}" (possible ' \
+                          'matches: {1}).'.format(pkg, ', '.join(matches))
+                else:
+                    msg = 'Package category missing for "{0}" and no match ' \
+                          'found in portage tree.'.format(pkg)
+                log.error(msg)
+                problems.append(msg)
+    return problems
+
+
 def parse_targets(name=None, pkgs=None, sources=None):
     '''
     Parses the input to pkg.install and returns back the package(s) to be

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -154,22 +154,8 @@ def installed(
                     'result': True,
                     'comment': 'Package {0} is already installed'.format(name)}
 
-    # If minion is Gentoo-based, check targeted packages to ensure they are
-    # properly submitted as category/pkgname. For any package that does not
-    # follow this format, offer matches from the portage tree.
-    if not sources and  __grains__['os_family'] == 'Gentoo':
-        problems = []
-        for pkg in targets:
-            if '/' not in pkg:
-                matches = __salt__['pkg.porttree_matches'](pkg)
-                if matches:
-                    msg = 'Package category missing for "{0}" (possible ' \
-                          'matches: {1}).'.format(pkg, ', '.join(matches))
-                else:
-                    msg = 'Package category missing for "{0}" and no match ' \
-                          'found in portage tree.'.format(pkg)
-                log.error(msg)
-                problems.append(msg)
+    if not sources:
+        problems = __salt__['pkg_resource.check_targets'](targets)
         if problems:
             return {'name': name,
                     'changes': {},


### PR DESCRIPTION
Platform-specific code from #3019 has been moved to pkg_resource module.
This code may evolve a bit down the road. Presently it will only check
syntax if the package is coming from the portage tree via ebuild.
However, future support for entropy (binary pkg manager), as well as
expanding syntax checking for binary package files should be considered
TODO items.
