### PR TITLE
Fix #3015

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -323,12 +323,15 @@ class Publisher(multiprocessing.Process):
                     raise exc
 
         except KeyboardInterrupt:
-            pub_sock.setsockopt(zmq.LINGER, 2500)
-            pub_sock.close()
-            pull_sock.setsockopt(zmq.LINGER, 2500)
-            pull_sock.close()
+            if pub_sock.closed is False:
+                pub_sock.setsockopt(zmq.LINGER, 2500)
+                pub_sock.close()
+            if pull_sock.closed is False:
+                pull_sock.setsockopt(zmq.LINGER, 2500)
+                pull_sock.close()
         finally:
-            context.term()
+            if self.context.closed is False:
+                context.term()
 
 
 class ReqServer(object):
@@ -410,11 +413,14 @@ class ReqServer(object):
         self.__bind()
 
     def destroy(self):
-        self.clients.setsockopt(zmq.LINGER, 2500)
-        self.clients.close()
-        self.workers.setsockopt(zmq.LINGER, 2500)
-        self.workers.close()
-        self.context.term()
+        if self.clients.closed is False:
+            self.clients.setsockopt(zmq.LINGER, 2500)
+            self.clients.close()
+        if self.work_procs.closed is False:
+            self.workers.setsockopt(zmq.LINGER, 2500)
+            self.workers.close()
+        if self.context.closed is False:
+            self.context.term()
 
     def __del__(self):
         self.destroy()
@@ -462,10 +468,12 @@ class MWorker(multiprocessing.Process):
                         continue
                     raise exc
         except KeyboardInterrupt:
-            socket.setsockopt(zmq.LINGER, 2500)
-            socket.close()
+            if socket.closed is False:
+                socket.setsockopt(zmq.LINGER, 2500)
+                socket.close()
         finally:
-            context.term()
+            if context.closed is False:
+                context.term()
 
     def _handle_payload(self, payload):
         '''
@@ -1097,9 +1105,11 @@ class AESFuncs(object):
                     timeout
                 )
             finally:
-                pub_sock.setsockopt(zmq.LINGER, 2500)
-                pub_sock.close()
-                context.term()
+                if pub_sock.closed is False:
+                    pub_sock.setsockopt(zmq.LINGER, 2500)
+                    pub_sock.close()
+                if context.closed is False:
+                    context.term()
         elif ret_form == 'full':
             ret = self.local.get_full_returns(
                     jid,
@@ -1113,9 +1123,11 @@ class AESFuncs(object):
             try:
                 return ret
             finally:
-                pub_sock.setsockopt(zmq.LINGER, 2500)
-                pub_sock.close()
-                context.term()
+                if pub_sock.closed is False:
+                    pub_sock.setsockopt(zmq.LINGER, 2500)
+                    pub_sock.close()
+                if context.closed is False:
+                    context.term()
 
     def run_func(self, func, load):
         '''
@@ -1728,6 +1740,8 @@ class ClearFuncs(object):
                 }
             }
         finally:
-            pub_sock.setsockopt(zmq.LINGER, 2500)
-            pub_sock.close()
-            context.term()
+            if pub_sock.closed is False:
+                pub_sock.setsockopt(zmq.LINGER, 2500)
+                pub_sock.close()
+            if context.closed is False:
+                context.term()

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -171,14 +171,15 @@ class SREQ(object):
 
     def destroy(self):
         for socket in self.poller.sockets.keys():
-            if not socket.closed:
+            if socket.closed is False:
                 socket.setsockopt(zmq.LINGER, 2500)
                 socket.close()
             self.poller.unregister(socket)
-        if not self.socket.closed:
+        if self.socket.closed is False:
             self.socket.setsockopt(zmq.LINGER, 2500)
             self.socket.close()
-        self.context.term()
+        if self.context.closed is False:
+            self.context.term()
 
     def __del__(self):
         self.destroy()

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -177,7 +177,7 @@ class SaltEvent(object):
     def __del__(self):
         try:
             # This blows up horribly during the unit tests
-	    self.destroy()
+            self.destroy()
         except ZMQBaseError:
             pass
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -24,11 +24,6 @@ from multiprocessing import Process
 
 # Import third party libs
 import zmq
-try:
-    # Work on older and newer zeromq versions
-    from zmq.core.error import ZMQBaseError
-except ImportError:
-    from zmq import ZMQBaseError
 
 # Import salt libs
 import salt.payload
@@ -154,32 +149,29 @@ class SaltEvent(object):
         return True
 
     def destroy(self):
-        if self.cpub:
+        if self.cpub is True and self.sub.closed is False:
             # Wait at most 2.5 secs to send any remaining messages in the
             # socket or the context.term() bellow will hang indefinitely.
             # See https://github.com/zeromq/pyzmq/issues/102
             self.sub.setsockopt(zmq.LINGER, 2500)
             self.sub.close()
-        if self.cpush:
+        if self.cpush is True and self.push.closed is False:
             self.push.setsockopt(zmq.LINGER, 2500)
             self.push.close()
         # If socket's are not unregistered from a poller, nothing which touches
         # that poller get's garbage collected. The Poller itself, it's
         # registered sockets and the Context
         for socket in self.poller.sockets.keys():
-            if not socket.closed:
+            if socket.closed is False:
                 # Should already be closed from above, but....
                 socket.setsockopt(zmq.LINGER, 2500)
                 socket.close()
             self.poller.unregister(socket)
-        self.context.term()
+        if self.context.closed is False:
+            self.context.term()
 
     def __del__(self):
-        try:
-            # This blows up horribly during the unit tests
-            self.destroy()
-        except ZMQBaseError:
-            pass
+        self.destroy()
 
 
 class MasterEvent(SaltEvent):
@@ -254,12 +246,15 @@ class EventPublisher(Process):
                         continue
                     raise exc
         except KeyboardInterrupt:
-            self.epub_sock.setsockopt(zmq.LINGER, 2500)
-            self.epub_sock.close()
-            self.epull_sock.setsockopt(zmq.LINGER, 2500)
-            self.epull_sock.close()
+            if self.epub_sock.closed is False:
+                self.epub_sock.setsockopt(zmq.LINGER, 2500)
+                self.epub_sock.close()
+            if self.epull_sock.closed is False:
+                self.epull_sock.setsockopt(zmq.LINGER, 2500)
+                self.epull_sock.close()
         finally:
-            self.context.term()
+            if self.context.closed is False:
+                self.context.term()
 
 
 class Reactor(multiprocessing.Process, salt.state.Compiler):


### PR DESCRIPTION
- Convert tabs to spaces. Refs #3015.
- Don't touch closed ZMQ socket's and/or context's. Fixes #3015: On some occasions it seems that `salt.utils.event.SaltEvent.destroy()` is called twice and the errors exhibited on #3015 would show up on the second time we would try to set the linger socket option since that socket was already closed. So, even though on some parts of code which I changed in this commit weren't giving any problems, I ended up using the same recipe all around, if the socket is open, set the linger option and close it, plus, if open, also close the context.
