### PR TITLE
Warn if a module is wrongly returning `None` instead of `False`.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -593,6 +593,17 @@ class Loader(object):
                                 # not supposed to load for some other reason.
                                 # Some modules might accidentally return None
                                 # and are improperly loaded
+                                if virtual is None:
+                                    log.warning(
+                                        '{0}.__virtual__() is wrongly '
+                                        'returning `None`. It should either '
+                                        'return `True` or `False`. If '
+                                        'you\'re the developer of the module '
+                                        '{1!r}, please fix this.'.format(
+                                            mod.__name__,
+                                            module_name
+                                        )
+                                    )
                                 continue
 
                             if module_name != virtual:

--- a/salt/modules/sysbench.py
+++ b/salt/modules/sysbench.py
@@ -25,7 +25,7 @@ def __virtual__():
     # finding the path of the binary
     if salt.utils.which('sysbench'):
         return 'sysbench'
-    return None
+    return False
 
 
 def _parser(result):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -12,7 +12,7 @@ declarations are typically rather simple:
       pkg.installed
 '''
 
-# Import python ilbs
+# Import python libs
 import logging
 import os
 from distutils.version import LooseVersion
@@ -40,7 +40,8 @@ def installed(
         sources=None,
         **kwargs):
     '''
-    Verify that the package is installed, and that it is the correct version (if specified).
+    Verify that the package is installed, and that it is the correct version
+    (if specified).
 
     name
         The name of the package to be installed. This parameter is ignored if
@@ -113,7 +114,7 @@ def installed(
             return {'name': name,
                     'changes': {},
                     'result': False,
-                    'comment': 'Invalidly formatted "{0}" parameter. See ' \
+                    'comment': 'Invalidly formatted "{0}" parameter. See '
                                'minion log.'.format('pkgs' if pkgs
                                                     else 'sources')}
 
@@ -124,7 +125,7 @@ def installed(
             return {'name': name,
                     'changes': {},
                     'result': True,
-                    'comment': 'All specified packages are already ' \
+                    'comment': 'All specified packages are already '
                                'installed'.format(name)}
         else:
             if pkgs:
@@ -137,7 +138,7 @@ def installed(
     else:
         targets = [name]
 
-        cver = old_pkgs.get(name,'')
+        cver = old_pkgs.get(name, '')
         if cver == version:
             # The package is installed and is the correct version
             return {'name': name,
@@ -253,13 +254,16 @@ def latest(name, refresh=False, repo='', skip_verify=False, **kwargs):
         try:
             has_newer = LooseVersion(avail) > LooseVersion(version)
         except AttributeError:
-            log.debug('Error comparing versions'
-                         ' for "{0}" ({1} > {2})'.format(name,
-                                                         avail,
-                                                         version)
-                         )
-            ret['comment'] = 'No version could be retrieved' \
-                             ' for "{0}"'.format(name)
+            flog.debug(
+                'Error comparing versions' ' for "{0}" ({1} > {2})'.format(
+                    name,
+                    avail,
+                    version
+                )
+            )
+            ret['comment'] = 'No version could be retrieved for "{0}"'.format(
+                name
+            )
             return ret
 
     if has_newer:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -254,7 +254,7 @@ def latest(name, refresh=False, repo='', skip_verify=False, **kwargs):
         try:
             has_newer = LooseVersion(avail) > LooseVersion(version)
         except AttributeError:
-            flog.debug(
+            log.debug(
                 'Error comparing versions' ' for "{0}" ({1} > {2})'.format(
                     name,
                     avail,


### PR DESCRIPTION
- Fixed the `brew` and `sysbench` modules which were returning `None` instead of `False`.
- Additionally, regarding the module `sysbench`, @sharan-monikantan, why are the parsed returned keys white-space padded?
