### PR TITLE
Properly avoid "File name too long" ZMQ exceptions.

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -71,13 +71,21 @@ class SaltRenderError(SaltException):
     Used when a renderer needs to raise an explicit error
     '''
 
+
 class SaltReqTimeoutError(SaltException):
     '''
     Thrown when a salt master request call fails to return within the timeout
     '''
-    
+
+
 class EauthAuthenticationError(SaltException):
     '''
     Thrown when eauth authentication fails
     '''
 
+
+class SaltSystemExit(SystemExit):
+    '''
+    This exception is raised when an unsolvable problem is found. There's
+    nothing else to do, salt should just exit.
+    '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -622,7 +622,9 @@ class Minion(object):
             epub_uri = 'ipc://{0}'.format(epub_sock_path)
             epull_uri = 'ipc://{0}'.format(epull_sock_path)
             for uri in (epub_uri, epull_uri):
-                break
+                if uri.startswith('tcp://'):
+                    # This check only applies to IPC sockets
+                    continue
                 # The socket path is limited to 107 characters on Solaris and
                 # Linux, and 103 characters on BSD-based systems.
                 # Let's fail at the lower level so no system checks are
@@ -632,7 +634,7 @@ class Minion(object):
                         'The socket path length is more that what ZMQ allows. '
                         'The length of {0!r} is more than 103 characters. '
                         'Either try to reduce the length of this setting\'s '
-                        'path or switch to TCP; On the config file set '
+                        'path or switch to TCP; In the configuration file set '
                         '"ipc_mode: tcp"'.format(
                             uri
                         )

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -20,9 +20,10 @@ import sys
 import zmq
 
 # Import salt libs
-from salt.exceptions import AuthenticationError, \
-    CommandExecutionError, CommandNotFoundError, SaltInvocationError, \
-    SaltReqTimeoutError
+from salt.exceptions import (
+    AuthenticationError, CommandExecutionError, CommandNotFoundError,
+    SaltInvocationError, SaltReqTimeoutError, SaltSystemExit
+)
 import salt.client
 import salt.crypt
 import salt.loader
@@ -620,7 +621,22 @@ class Minion(object):
         else:
             epub_uri = 'ipc://{0}'.format(epub_sock_path)
             epull_uri = 'ipc://{0}'.format(epull_sock_path)
-
+            for uri in (epub_uri, epull_uri):
+                break
+                # The socket path is limited to 107 characters on Solaris and
+                # Linux, and 103 characters on BSD-based systems.
+                # Let's fail at the lower level so no system checks are
+                # required.
+                if len(uri) > 103:
+                    raise SaltSystemExit(
+                        'The socket path length is more that what ZMQ allows. '
+                        'The length of {0!r} is more than 103 characters. '
+                        'Either try to reduce the length of this setting\'s '
+                        'path or switch to TCP; On the config file set '
+                        '"ipc_mode: tcp"'.format(
+                            uri
+                        )
+                    )
         log.debug(
             '{0} PUB socket URI: {1}'.format(
                 self.__class__.__name__, epub_uri

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -78,6 +78,25 @@ class SaltEvent(object):
                         sock_dir,
                         'minion_event_{0}_pull.ipc'.format(id_hash)
                         ))
+        for uri in (puburi, pulluri):
+            if uri.startswith('tcp://'):
+                # This check only applies to IPC sockets
+                continue
+            # The socket path is limited to 107 characters on Solaris and
+            # Linux, and 103 characters on BSD-based systems.
+            # Let's fail at the lower level so no system checks are
+            # required.
+            if len(uri) > 103:
+                raise SaltSystemExit(
+                    'The socket path length is more that what ZMQ allows. '
+                    'The length of {0!r} is more than 103 characters. '
+                    'Either try to reduce the length of this setting\'s '
+                    'path or switch to TCP; On the config file set '
+                    '"ipc_mode: tcp"'.format(
+                        uri
+                    )
+                )
+
         log.debug(
             '{0} PUB socket URI: {1}'.format(self.__class__.__name__, puburi)
         )

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -91,7 +91,7 @@ class SaltEvent(object):
                     'The socket path length is more that what ZMQ allows. '
                     'The length of {0!r} is more than 103 characters. '
                     'Either try to reduce the length of this setting\'s '
-                    'path or switch to TCP; On the config file set '
+                    'path or switch to TCP; In the configuration file set '
                     '"ipc_mode: tcp"'.format(
                         uri
                     )


### PR DESCRIPTION
Properly avoid "File name too long" ZMQ exceptions. Refs #3026, #2044 and #2926.

We do a proper length check when using the sockets in IPC mode and fail when it reaches 103 which is the lower value for this error on BSD systems, Linux and Solaris is 107. We just exit the master/minion since continuing would mean leaving it crippled.
