### PR TITLE
Modified ebuild upgrade command to preform a full system upgrade.

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -254,7 +254,8 @@ def upgrade(refresh=False):
 
     ret_pkgs = {}
     old_pkgs = list_pkgs()
-    __salt__['cmd.retcode']('emerge --update --quiet world')
+    cmd = 'emerge --update --newuse --deep --with-bdeps=y --quiet world'
+    __salt__['cmd.retcode'](cmd)
     new_pkgs = list_pkgs()
 
     for pkg in new_pkgs:


### PR DESCRIPTION
See: http://www.gentoo.org/doc/en/handbook/handbook-amd64.xml?part=2&chap=1#doc_chap3
"Code Listing 3.13: Performing a full update"
