### PR TITLE
Clarify virtualenv installation/configuration docs

### DIFF
--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -152,8 +152,10 @@ Edit the master config file:
 1.  Uncomment and change the ``user: root`` value to your own user.
 2.  Uncomment and change the ``root_dir: /`` value to point to
     ``/path/to/your/virtualenv``.
-3.  Uncomment and change the ``pidfile: /var/run/salt-master.pid`` value to
-    point to ``/path/to/your/virtualenv/salt-master.pid``.
+3.  If you are running version 0.11.1 or older, uncomment and change the
+    ``pidfile: /var/run/salt-master.pid`` value to point to
+    ``/path/to/your/virtualenv/salt-master.pid``. This step is unnecessary if
+    you are running from a recent git checkout.
 4.  If you are also running a non-development version of Salt you will have to
     change the ``publish_port`` and ``ret_port`` values as well.
 
@@ -161,8 +163,10 @@ Edit the minion config file:
 
 1.  Repeat the edits you made in the master config for the ``user`` and
     ``root_dir`` values as well as any port changes.
-2.  Uncomment and change the ``pidfile: /var/run/salt-minion.pid`` value to
-    point to ``/path/to/your/virtualenv/salt-minion.pid``.
+2.  If you are running version 0.11.1 or older, uncomment and change the
+    ``pidfile: /var/run/salt-minion.pid`` value to point to
+    ``/path/to/your/virtualenv/salt-minion.pid``. This step is unnecessary if
+    you are running from a recent git checkout.
 3.  Uncomment and change the ``master: salt`` value to point at ``localhost``.
 4.  Uncomment and change the ``id:`` value to something descriptive like
     "saltdev". This isn't strictly necessary but it will serve as a reminder of


### PR DESCRIPTION
Since the "pidfile" param has been added to the list of params for which
root_dir is prepended, editing the pidfile is no longer necessary when
running from a recent git checkout. Added a note to clarify this.
