### PR TITLE
Fix the batch mode not printing the results

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -46,7 +46,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
         if self.options.batch:
             batch = salt.cli.batch.Batch(self.config)
-            batch.run()
+            # Printing the output is already taken care of in run() itself
+            for res in batch.run():
+                pass
         else:
             if self.options.timeout <= 0:
                 self.options.timeout = local.opts['timeout']


### PR DESCRIPTION
I was a bit surprised that executing `salt -b 2 '*' test.ping` was not showing any results, so I researched a bit and discovered that there is in fact an iterator returned that is not being iterated over, hence the main function is not executed.

Output before the change:

```
# salt -b 2 '*' test.ping
m1 Detected for this batch run
m2 Detected for this batch run
m3 Detected for this batch run
m4 Detected for this batch run
```

Output after the change:

```
# salt -b 2 '*' test.ping
m1 Detected for this batch run
m2 Detected for this batch run
m3 Detected for this batch run
m4 Detected for this batch run

Executing run on ['m4', 'm3']

m3: True
m4: True

Executing run on ['m2', 'm1']

m1: True
m2: True
```

I made up the names, but otherwise the output is what I saw.
