### PR TITLE
gentoolkit module

### DIFF
--- a/salt/modules/gentoolkit.py
+++ b/salt/modules/gentoolkit.py
@@ -3,10 +3,6 @@ Support for Gentoolkit
 
 '''
 
-__outputter__ = {
-    'revdep_rebuild':  'txt',
-}
-
 def revdep_rebuild(lib=None):
     '''
     Fix up broken reverse dependencies
@@ -23,4 +19,4 @@ def revdep_rebuild(lib=None):
     cmd = 'revdep-rebuild --quiet --no-progress'
     if lib is not None:
         cmd += ' --library={0}'.format(lib)
-    return __salt__['cmd.run'](cmd)
+    return __salt__['cmd.retcode'](cmd) == 0

--- a/salt/modules/gentoolkit.py
+++ b/salt/modules/gentoolkit.py
@@ -1,0 +1,26 @@
+'''
+Support for Gentoolkit
+
+'''
+
+__outputter__ = {
+    'revdep_rebuild':  'txt',
+}
+
+def revdep_rebuild(lib=None):
+    '''
+    Fix up broken reverse dependencies
+
+    lib
+        Search for reverse dependencies for a particular library rather
+        than every library on the system. It can be a full path to a
+        library or basic regular expression.
+
+    CLI Example::
+
+        salt '*' gentoolkit.revdep_rebuild
+    '''
+    cmd = 'revdep-rebuild --quiet --no-progress'
+    if lib is not None:
+        cmd += ' --library={0}'.format(lib)
+    return __salt__['cmd.run'](cmd)


### PR DESCRIPTION
Gentoo has a package gentoolkit. The package is not part of the base install, but it is an essential package for any Gentoo user. The major program from this package is revdep-rebuild which fixes broken reverse dependencies after removing old packages (via depclean).  Various packages often advise the user to run revdep-rebuild after updating, and emerge advises the user to run it after any depclean. 

Since this is not a direct part of portage/emerge, I thought it might belong in a separate module. This is an initial attempt at providing access to revdep-rebuild via salt.

As far as I know, no other distro has a tool like this. Distros with binary packages would not need such a tool anyway, but it is a must have for a distro like Gentoo that builds everything from source.
