### PR TITLE
Added layman module for layman tool (for Gentoo).

### DIFF
--- a/salt/modules/gentoolkit.py
+++ b/salt/modules/gentoolkit.py
@@ -3,6 +3,8 @@ Support for Gentoolkit
 
 '''
 
+import salt.utils
+
 def __virtual__():
     '''
     Only work on Gentoo systems with gentoolkit installed

--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -3,6 +3,8 @@ Support for Layman
 
 '''
 
+import salt.utils
+
 __outputter__ = {
     'list_local':  'txt',
 }
@@ -64,4 +66,6 @@ def list_local():
         salt '*' layman.list_local
     '''
     cmd = 'layman --quietness=1 --list-local'
+    # TODO: This would probably be nicer if we return a list.
+    # Need to figure out how to easily get that list from layman.
     return __salt__['cmd.run'](cmd)

--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -1,0 +1,67 @@
+'''
+Support for Layman
+
+'''
+
+__outputter__ = {
+    'list_local':  'txt',
+}
+
+def __virtual__():
+    '''
+    Only work on Gentoo systems with layman installed
+    '''
+    if __grains__['os'] == 'Gentoo' and salt.utils.which('layman'):
+        return 'layman'
+    return False
+
+def add(overlay):
+    '''
+    Add the given overlay from the caced remote list to your locally
+    installed overlays. Specify 'ALL' to add all overlays from the
+    remote list.
+
+    CLI Example::
+
+        salt '*' layman.add <overlay name>
+    '''
+    cmd = 'layman --quietness=0 --add {0}'.format(overlay)
+    return __salt__['cmd.retcode'](cmd) == 0
+
+def delete(overlay):
+    '''
+    Remove the given overlay from the your locally installed overlays.
+    Specify 'ALL' to remove all overlays.
+
+    CLI Example::
+
+        salt '*' layman.delete <overlay name>
+    '''
+    cmd = 'layman --quietness=0 --delete {0}'.format(overlay)
+    return __salt__['cmd.retcode'](cmd) == 0
+
+def sync(overlay='ALL'):
+    '''
+    Update the specified overlay. Use 'ALL' to synchronize all overlays.
+    This is the default if no overlay is specified.
+
+    overlay
+        Name of the overlay to sync. (Defaults to 'ALL')
+
+    CLI Example::
+
+        salt '*' layman.sync
+    '''
+    cmd = 'layman --quietness=0 --sync {0}'.format(overlay)
+    return __salt__['cmd.retcode'](cmd) == 0
+
+def list_local():
+    '''
+    List the locally installed overlays.
+
+    CLI Example::
+
+        salt '*' layman.list_local
+    '''
+    cmd = 'layman --quietness=1 --list-local'
+    return __salt__['cmd.run'](cmd)


### PR DESCRIPTION
Layman is a third-party package repository (overlay) management tool for Gentoo. Layman is the go-to tool for adding any syncing additional package repositories to allow managed installs of non-standard/experimental packages for Gentoo.

I know other distros also provide ways to add additional repositories, but I am not sure if they have applications to manage those repositories or simply rely on editing config files. If there are similar tools for other distros, it might be nice to make a more generic salt interface for these actions.

(I also have a bugfix for gentoolkit module as a changeset, was missing an import)
