### PR TITLE
Added module for eix tool (for Gentoo)

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -123,8 +123,9 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
-    cmd = 'emerge --sync --quiet'
-    return __salt__['eix.sync']() or __salt__['cmd.retcode'](cmd) == 0
+    if 'eix.sync' in __salt__:
+        return __salt__['eix.sync']()
+    return __salt__['cmd.retcode']('emerge --sync --quiet') == 0
 
 
 def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -117,13 +117,14 @@ def list_pkgs():
 
 def refresh_db():
     '''
-    Updates the portage tree (emerge --sync)
+    Updates the portage tree (emerge --sync. Uses eix to sync if available
 
     CLI Example::
 
         salt '*' pkg.refresh_db
     '''
-    return __salt__['cmd.retcode']('emerge --sync --quiet') == 0
+    cmd = 'emerge --sync --quiet'
+    return __salt__['eix.sync']() or __salt__['cmd.retcode'](cmd) == 0
 
 
 def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -117,7 +117,7 @@ def list_pkgs():
 
 def refresh_db():
     '''
-    Updates the portage tree (emerge --sync. Uses eix to sync if available
+    Updates the portage tree (emerge --sync). Uses eix-sync if available.
 
     CLI Example::
 

--- a/salt/modules/eix.py
+++ b/salt/modules/eix.py
@@ -1,0 +1,16 @@
+'''
+Support for Eix
+
+'''
+
+import salt.utils
+
+def __virtual__():
+    '''
+    Only work on Gentoo systems with eix installed
+    '''
+    if __grains__['os'] == 'Gentoo' and salt.utils.which('eix'):
+        return 'eix'
+    return False
+
+

--- a/salt/modules/eix.py
+++ b/salt/modules/eix.py
@@ -13,4 +13,24 @@ def __virtual__():
         return 'eix'
     return False
 
+def sync():
+    '''
+    Sync portage/overlay trees and update the eix database
 
+    CLI Example::
+
+        salt '*' eix.sync
+    '''
+    cmd = 'eix-sync -q'
+    return __salt__['cmd.retcode'](cmd) == 0
+
+def update():
+    '''
+    Update the eix database
+
+    CLI Example::
+
+        salt '*' eix.update
+    '''
+    cmd = 'eix-update --quiet'
+    return __salt__['cmd.retcode'](cmd) == 0


### PR DESCRIPTION
Eix is a tool that maintains a database of the portage tree to allow faster searching. It also allows the user to sync both the official portage tree and any overlays added via layman with a single command.

I have added a module for calling the sync and update command for eix as well as updated the ebuild.refresh_db function to first try calling eix-sync, if that fails, call emerge --sync as normal.

(I personally, as a Gentoo user, never use emerge --sync since eix-sync does it and more, but this allows those that do not have eix installed to sync the standard way).
