### PR TITLE
`W0142` added to `.pylintrc` disabled checkers.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -41,7 +41,7 @@ load-plugins=
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-#disable=
+disable=W0142
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -170,7 +170,7 @@ dummy-variables-rgx=_|dummy
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__
+additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__
 
 
 [SIMILARITIES]

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -45,7 +45,7 @@ def returner(ret):
     serv.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
     serv.lpush('{0}:{1}'.format(ret['id'], ret['fun']), ret['jid'])
     serv.sadd('minions', ret['id'])
-    serv.sadd('jids', jid)
+    serv.sadd('jids', ret['jid'])
 
 
 def save_load(jid, load):

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -24,9 +24,8 @@ def set_pidfile(pidfile, user):
     except IOError:
         pass
     log.debug(('Created pidfile: {0}').format(pidfile))
-    if 'os' in os.environ:
-        if os.environ['os'].startswith('Windows'):
-            return True
+    if salt.utils.is_windows():
+        return True
     import pwd  # after confirming not running Windows
     #import grp
     try:


### PR DESCRIPTION
`W0142` is triggered when `*` or `**` magic is used, for example:

``` python
my_func(*args, **kwargs)
```

This PyLint checker is now disabled since we use it quite a lot, and, in fact, take advantage of this magic.
