### PR TITLE
Added eclean_dist function to gentoolkit module

### DIFF
--- a/salt/modules/gentoolkit.py
+++ b/salt/modules/gentoolkit.py
@@ -30,3 +30,45 @@ def revdep_rebuild(lib=None):
     if lib is not None:
         cmd += ' --library={0}'.format(lib)
     return __salt__['cmd.retcode'](cmd) == 0
+
+def eclean_dist(destructive=False, pkg_names=False, size=False, time=False, restricted=False):
+    '''
+    Clean obsolete portage sources
+
+    destructive
+        Only keep minimum for reinstallation
+
+    pkg_names
+        Protect all versions of installed packages. Only meaningful if used
+        with destructive=True
+
+    size <size>
+        Don't delete distfiles bigger than <size>.
+        <size> is a size specification: "10M" is "ten megabytes",
+        "200K" is "two hundreds kilobytes", etc. Units are: G, M, K and B.
+
+    time <time>
+        Don't delete distfiles files modified since <time>
+        <time> is an amount of time: "1y" is "one year", "2w" is
+        "two weeks", etc. Units are: y (years), m (months), w (weeks),
+        d (days) and h (hours).
+
+    restricted
+        Protect fetch-restricted files. Only meaningful if used with
+        destructive=True
+
+    CLI Example::
+        salt '*' gentoolkit.eclean_dist destructive=True
+    '''
+    cmd = 'eclean-dist --quiet'
+    if destructive:
+        cmd += ' --destructive'
+    if pkg_names:
+        cmd += ' --package-names'
+    if size:
+        cmd += ' --size-limit={0}'.format(size)
+    if time:
+        cmd += ' --time-limit={0}'.format(time)
+    if restricted:
+        cmd += ' --fetch-restricted'
+    return __salt__['cmd.retcode'](cmd) == 0

--- a/salt/modules/gentoolkit.py
+++ b/salt/modules/gentoolkit.py
@@ -31,7 +31,8 @@ def revdep_rebuild(lib=None):
         cmd += ' --library={0}'.format(lib)
     return __salt__['cmd.retcode'](cmd) == 0
 
-def eclean_dist(destructive=False, pkg_names=False, size=False, time=False, restricted=False):
+def eclean_dist(destructive=False, pkg_names=False, size=None,
+                time=None, restricted=False):
     '''
     Clean obsolete portage sources
 
@@ -65,9 +66,9 @@ def eclean_dist(destructive=False, pkg_names=False, size=False, time=False, rest
         cmd += ' --destructive'
     if pkg_names:
         cmd += ' --package-names'
-    if size:
+    if size is not None:
         cmd += ' --size-limit={0}'.format(size)
-    if time:
+    if time is not None:
         cmd += ' --time-limit={0}'.format(time)
     if restricted:
         cmd += ' --fetch-restricted'


### PR DESCRIPTION
Added a function to call eclean-dist from the gentoolkit module. This is another tool provided by gentoolkit, it removes obsolete package sources.

Most users probably run this out of cron, but it can be useful to manually run it.
