### PR TITLE
Fix Unicode encoding issue on log messages. Fixes #3074.

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -70,6 +70,10 @@ def _read_conf_file(path):
         # allow using numeric ids: convert int to string
         if 'id' in conf_opts:
             conf_opts['id'] = str(conf_opts['id'])
+        for key, value in conf_opts.copy().iteritems():
+            if isinstance(value, unicode):
+                # We do not want unicode settings
+                conf_opts[key] = value.encode('utf-8')
         return conf_opts
 
 

--- a/salt/log.py
+++ b/salt/log.py
@@ -142,7 +142,7 @@ class Logging(LoggingLoggerClass):
     def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None,
                    extra=None):
         # Let's try to make every logging message unicode
-        if not isinstance(msg, unicode):
+        if isinstance(msg, basestring) and not isinstance(msg, unicode):
             try:
                 return LoggingLoggerClass.makeRecord(
                     self, name, level, fn, lno,

--- a/salt/log.py
+++ b/salt/log.py
@@ -139,6 +139,26 @@ class Logging(LoggingLoggerClass):
             pass
         return instance
 
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None,
+                   extra=None):
+        # Let's try to make every logging message unicode
+        if not isinstance(msg, unicode):
+            try:
+                return LoggingLoggerClass.makeRecord(
+                    self, name, level, fn, lno,
+                    msg.decode('utf-8', 'replace'),
+                    args, exc_info, func, extra
+                )
+            except UnicodeEncodeError:
+                return LoggingLoggerClass.makeRecord(
+                    self, name, level, fn, lno,
+                    msg.decode('utf-8', 'ignore'),
+                    args, exc_info, func, extra
+                )
+        return LoggingLoggerClass.makeRecord(
+            self, name, level, fn, lno, msg, args, exc_info, func, extra
+        )
+
     def garbage(self, msg, *args, **kwargs):
         return LoggingLoggerClass.log(self, GARBAGE, msg, *args, **kwargs)
 
@@ -310,9 +330,13 @@ def setup_logfile_logger(log_path, log_level='error', log_format=None,
         handler = logging.handlers.SysLogHandler(**syslog_opts)
     else:
         try:
+            # Logfile logging is UTF-8 on purpose.
+            # Since salt uses yaml and yaml uses either UTF-8 or UTF-16, if a
+            # user is not using plain ascii, he's system should be ready to
+            # handle UTF-8.
             handler = getattr(
                 logging.handlers, 'WatchedFileHandler', logging.FileHandler
-            )(log_path, 'a', 'utf-8', delay=0)
+            )(log_path, mode='a', encoding='utf-8', delay=0)
         except (IOError, OSError):
             sys.stderr.write(
                 'Failed to open log file, do you have permission to write to '


### PR DESCRIPTION
The way this was fixed was to convert all log messages to Unicode so that they can, later, be properly encoded for the console and the log file. Also, we convert any Unicode configuration values to the original UTF-8(since that's yaml default, or UTF-16). This latter fix was needed because if I set the `user` setting to a non ascii value in order to trigger this issue, we would trigger other issues, the `pwd` module does not like Unicode that much ;)
