### PR TITLE
glsa check list function

### DIFF
--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -211,6 +211,12 @@ def _glsa_list_process_output(output):
     for line in output:
         try:
             glsa_id, status, desc = line.split(None, 2)
+            if 'U' in status:
+                status += ' Not Affected'
+            elif 'N' in status:
+                status += ' Might be Affected'
+            elif 'A' in status:
+                status += ' Applied (injected)'
             if 'CVE' in desc:
                 desc, cves = desc.rsplit(None, 1)
             else:

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -201,23 +201,24 @@ def eclean_pkg(destructive=False, package_names=False, time_limit=0,
     finally:
         return ret
 
-def _glsa_list_process_output(line):
+def _glsa_list_process_output(output):
     '''
-    Process a single output line from glsa_check_list
+    Process output from glsa_check_list into a dict
 
     Returns a dict containing the glsa id, description, status, and CVEs
     '''
     ret = dict()
-    try:
-        glsa_id, status, line = line.split(None, 2)
-        if 'CVE' in line:
-            desc, cves = line.rsplit(None, 1)
-        else:
-            desc = line
-            cves = ''
-        ret[glsa_id] = {'description': desc, 'status': status, 'CVEs': cves}
-    except ValueError:
-        pass
+    for line in output:
+        try:
+            glsa_id, status, desc = line.split(None, 2)
+            if 'CVE' in desc:
+                desc, cves = desc.rsplit(None, 1)
+            else:
+                cves = ''
+            ret[glsa_id] = {'description': desc, 'status': status,
+                            'CVEs': cves}
+        except ValueError:
+            pass
     return ret
 
 def glsa_check_list(glsa_list):
@@ -250,6 +251,5 @@ def glsa_check_list(glsa_list):
 
     ret = dict()
     out = __salt__['cmd.run'](cmd).split('\n')
-    for line in out:
-        ret.update(_glsa_list_process_output(line))
+    ret = _glsa_list_process_output(out)
     return ret

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -242,7 +242,7 @@ def glsa_check_list(glsa_list):
     cmd = 'glsa-check --quiet --nocolor --cve --list '
     if isinstance(glsa_list, list):
         for glsa in glsa_list:
-            cmd += glsa
+            cmd += glsa + ' '
     elif glsa_list is 'all' or glsa_list is 'affected':
         cmd += glsa_list
     else:

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -219,8 +219,9 @@ def _glsa_list_process_output(output):
                 status += ' Applied (injected)'
             if 'CVE' in desc:
                 desc, cves = desc.rsplit(None, 1)
+                cves = cves.split(',')
             else:
-                cves = ''
+                cves = list()
             ret[glsa_id] = {'description': desc, 'status': status,
                             'CVEs': cves}
         except ValueError:
@@ -239,7 +240,7 @@ def glsa_check_list(glsa_list):
 
         {<glsa id>: {'description': <glsa description>,
             'status': <glsa status>,
-            'CVEs': <list of CVEs>}}
+            'CVEs': [<list of CVEs>]}}
 
     CLI Example::
 

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -250,7 +250,7 @@ def glsa_check_list(glsa_list):
     if isinstance(glsa_list, list):
         for glsa in glsa_list:
             cmd += glsa + ' '
-    elif glsa_list is 'all' or glsa_list is 'affected':
+    elif glsa_list == 'all' or glsa_list == 'affected':
         cmd += glsa_list
     else:
         # TODO: Should this return some type of error? or just fail quietly?


### PR DESCRIPTION
Added a function to gentoolkitmod to preform a glsa-check --list. glsa-check is another tool provided from gentoolkit. It is used monitor and manage Gentoo Linux Security Advisories.  This function implements the --list option to glsa-check, which provides a summary status of the provided GLSAs.  It allows the user to get a list of any packages that have known vulnerabilities recorded in the GLSAs by running:

<pre>
salt '*' gentoolkit.glsa_check_list 'affected'
</pre>
