### PR TITLE
Add --disablerepo support for yumpkg modules

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -115,7 +115,7 @@ def refresh_db():
     return servers
 
 
-def install(name=None, refresh=False, repo='', skip_verify=False,
+def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
             debconf=None, pkgs=None, sources=None, **kwargs):
     '''
     Install the passed package, add refresh=True to update the dpkg database.
@@ -133,7 +133,7 @@ def install(name=None, refresh=False, repo='', skip_verify=False,
     refresh
         Whether or not to refresh the package database before installing.
 
-    repo
+    fromrepo
         Specify a package repository to install from
         (e.g., ``apt-get -t unstable install somepackage``)
 
@@ -171,7 +171,7 @@ def install(name=None, refresh=False, repo='', skip_verify=False,
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                       'new': '<new-version>']}
+                       'new': '<new-version>'}}
     '''
     # Note that this function will daemonize the subprocess
     # preventing a restart resulting from a salt-minion upgrade
@@ -187,12 +187,15 @@ def install(name=None, refresh=False, repo='', skip_verify=False,
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
                                                                   pkgs,
                                                                   sources)
+
+    # Support old "repo" argument
+    repo = kwargs.get('repo','')
+    if not fromrepo and repo:
+        fromrepo = repo
+
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
-        if repo:
-            log.debug('Skipping "repo" option (invalid for package file '
-                      'installation).')
         cmd = 'dpkg -i {verify} {pkg}'.format(
             verify='--force-bad-verify' if skip_verify else '',
             pkg=' '.join(pkg_params),
@@ -204,18 +207,19 @@ def install(name=None, refresh=False, repo='', skip_verify=False,
                 if kwargs.get(vkey) is not None:
                     fname = '"{0}{1}{2}"'.format(fname, vsign, kwargs[vkey])
                     break
-        cmd = 'apt-get -q -y {confold} {confdef} {verify} {target} install {pkg}'.format(
+        if fromrepo:
+            log.info('Targeting repo "{0}"'.format(fromrepo))
+        cmd = 'apt-get -q -y {confold} {confdef} {verify} {target} install ' \
+              '{pkg}'.format(
             confold='-o DPkg::Options::=--force-confold',
             confdef='-o DPkg::Options::=--force-confdef',
             verify='--allow-unauthenticated' if skip_verify else '',
-            target='-t {0}'.format(repo) if repo else '',
+            target='-t {0}'.format(fromrepo) if fromrepo else '',
             pkg=fname,
         )
 
     old = list_pkgs()
-    stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
-    if stderr:
-        log.error(stderr)
+    __salt__['cmd.run_all'](cmd).get('stderr', '')
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -69,7 +69,7 @@ def remove(pkgs):
     return __salt__['cmd.run'](cmd)
 
 
-def install(pkgs, refresh=False, repo='', skip_verify=False, **kwargs):
+def install(pkgs, refresh=False, skip_verify=False, **kwargs):
     '''
     Install the passed package(s) with ``brew install``
 
@@ -79,7 +79,7 @@ def install(pkgs, refresh=False, repo='', skip_verify=False, **kwargs):
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -168,7 +168,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                       'new': '<new-version>']}
+                       'new': '<new-version>'}}
     '''
 
     logging.debug('Called modules.pkg.install: {0}'.format(
@@ -210,7 +210,7 @@ def update(pkg, refresh=False):
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 
@@ -246,7 +246,7 @@ def upgrade(refresh=False):
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -116,23 +116,24 @@ def list_pkgs():
     return ret
 
 
-def install(name=None, refresh=False, repo=None,
+def install(name=None, refresh=False, fromrepo=None,
             pkgs=None, sources=None, **kwargs):
     '''
     Install the passed package
 
-    name : None
+    name
         The name of the package to be installed.
 
-    refresh : False
+    refresh
         Whether or not to refresh the package database before installing.
 
-    repo : None
+    fromrepo
         Specify a package repository to install from.
+
 
     Multiple Package Installation Options:
 
-    pkgs : None
+    pkgs
         A list of packages to install from a software repository. Must be
         passed as a python list.
 
@@ -140,7 +141,7 @@ def install(name=None, refresh=False, repo=None,
 
             salt '*' pkg.install pkgs='["foo","bar"]'
 
-    sources : None
+    sources
         A list of packages to install. Must be passed as a list of dicts,
         with the keys being package names, and the values being the source URI
         or local path to the package.
@@ -152,7 +153,7 @@ def install(name=None, refresh=False, repo=None,
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 
@@ -161,6 +162,12 @@ def install(name=None, refresh=False, repo=None,
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
                                                                   pkgs,
                                                                   sources)
+
+    # Support old "repo" argument
+    repo = kwargs.get('repo','')
+    if not fromrepo and repo:
+        fromrepo = repo
+
     if not pkg_params:
         return {}
 
@@ -168,12 +175,14 @@ def install(name=None, refresh=False, repo=None,
     args = []
     if _check_pkgng():
         cmd = _cmd('pkg')
-        if repo:
-            env.append(('PACKAGESITE', repo))
+        if fromrepo:
+            log.info('Setting PACKAGESITE={0}'.format(fromrepo))
+            env.append(('PACKAGESITE', fromrepo))
     else:
         cmd = _cmd('pkg_add')
-        if repo:
-            env.append(('PACKAGEROOT', repo))
+        if fromrepo:
+            log.info('Setting PACKAGEROOT={0}'.format(fromrepo))
+            env.append(('PACKAGEROOT', fromrepo))
 
     if pkg_type == 'file':
         if _check_pkgng():
@@ -204,7 +213,7 @@ def upgrade():
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -112,7 +112,7 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example, Install one package::
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -179,7 +179,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                       'new': '<new-version>']}
+                       'new': '<new-version>'}}
     '''
     pkg_params,pkg_type = __salt__['pkg_resource.parse_targets'](name,
                                                                  pkgs,
@@ -218,7 +218,7 @@ def upgrade():
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -121,7 +121,7 @@ def upgrade(refresh=True, **kwargs):
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 
@@ -196,7 +196,7 @@ def install(name, refresh=False, version=None, **kwargs):
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -135,7 +135,7 @@ def install(name=None, refresh=False, sources=None, **kwargs):
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                       'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example, installing a datastream pkg that already exists on the
     minion::

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -305,7 +305,7 @@ def install(name=None, refresh=False, **kwargs):
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 
@@ -345,7 +345,7 @@ def upgrade():
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -170,7 +170,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                       'new': '<new-version>']}
+                       'new': '<new-version>'}}
     '''
     # Catch both boolean input from state and string input from CLI
     if refresh is True or refresh == 'True':
@@ -198,7 +198,7 @@ def upgrade():
     Return a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
-                   'new': '<new-version>']}
+                       'new': '<new-version>'}}
 
     CLI Example::
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -34,7 +34,7 @@ def installed(
         name,
         version=None,
         refresh=False,
-        repo='',
+        fromrepo=None,
         skip_verify=False,
         pkgs=None,
         sources=None,
@@ -49,11 +49,14 @@ def installed(
         option can only be used to install packages from a software repository.
         To install a package file manually, use the "sources" option detailed
         below.
-    repo
-        Specify a non-default repository to install from
-    skip_verify : False
+
+    fromrepo
+        Specify a repository from which to install
+
+    skip_verify
         Skip the GPG verification check for the package to be installed
-    version : None
+
+    version
         Install a specific version of a package. This option is ignored if
         either "pkgs" or "sources" is used.
 
@@ -61,12 +64,12 @@ def installed(
 
         httpd:
           pkg.installed:
-            - repo: mycustomrepo
+            - fromrepo: mycustomrepo
             - skip_verify: True
             - version: 2.0.6~ubuntu3
 
 
-    Multiple Package Installation Options: (not supported in Windows, FreeBSD)
+    Multiple Package Installation Options: (not supported in Windows)
 
     pkgs
         A list of packages to install from a software repository.
@@ -178,7 +181,7 @@ def installed(
         changes = __salt__['pkg.install'](name,
                                           refresh=True,
                                           version=version,
-                                          repo=repo,
+                                          fromrepo=fromrepo,
                                           skip_verify=skip_verify,
                                           pkgs=pkgs,
                                           sources=sources,
@@ -188,7 +191,7 @@ def installed(
     else:
         changes = __salt__['pkg.install'](name,
                                           version=version,
-                                          repo=repo,
+                                          fromrepo=fromrepo,
                                           skip_verify=skip_verify,
                                           pkgs=pkgs,
                                           sources=sources,
@@ -223,7 +226,7 @@ def installed(
             'comment': comment}
 
 
-def latest(name, refresh=False, repo='', skip_verify=False, **kwargs):
+def latest(name, refresh=False, fromrepo=None, skip_verify=False, **kwargs):
     '''
     Verify that the named package is installed and the latest available
     package. If the package can be updated this state function will update
@@ -233,9 +236,11 @@ def latest(name, refresh=False, repo='', skip_verify=False, **kwargs):
 
     name
         The name of the package to maintain at the latest available version
-    repo : (default)
-        Specify a non-default repository to install from
-    skip_verify : False
+
+    fromrepo
+        Specify a repository from which to install
+
+    skip_verify
         Skip the GPG verification check for the package to be installed
     '''
     rtag = __gen_rtag()
@@ -274,7 +279,7 @@ def latest(name, refresh=False, repo='', skip_verify=False, **kwargs):
         if refresh or os.path.isfile(rtag):
             ret['changes'] = __salt__['pkg.install'](name,
                                                      refresh=True,
-                                                     repo=repo,
+                                                     fromrepo=fromrepo,
                                                      skip_verify=skip_verify,
                                                      **kwargs)
             if os.path.isfile(rtag):
@@ -282,7 +287,7 @@ def latest(name, refresh=False, repo='', skip_verify=False, **kwargs):
 
         else:
             ret['changes'] = __salt__['pkg.install'](name,
-                                                     repo=repo,
+                                                     fromrepo=fromrepo,
                                                      skip_verify=skip_verify,
                                                      **kwargs)
 


### PR DESCRIPTION
As part of this commit, the following changes were also made:

1) The "repo" argument for the package provider modules and the pkg
   state has been renamed to "fromrepo". If the "repo" keyword argument
   is specified and "fromrepo" was not, then the value from "repo" will
   be used, in order to provide backwards compatibility. Otherwise the
   "repo" argument is ignored.

2) The "repo" argument to brew.py was not used for anything. It has been
   removed.

3) yumpkg{,5}.py have been modified so that they both accept
   "enablerepo" and "disablerepo" arguments, in order to allow these
   yum-specific arguments to be passed through to yum. These args will
   be ignored however, if "fromrepo" or "repo" is passed.

4) The example return dicts in much of the pkg providers had invalid
   data structures in them. Corrected these so that the docs make more
   sense.
