### PR TITLE
Leave off trailing slash

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -439,7 +439,7 @@ Example:
 
     file_roots:
       base:
-        - /srv/salt/
+        - /srv/salt
       dev:
         - /srv/salt/dev/services
         - /srv/salt/dev/states


### PR DESCRIPTION
None of the other directory paths have a trailing slash, this commit
makes a small aesthetic change to remove this slash.
