### PR TITLE
Quiet exception logging on non-windows platforms

### DIFF
--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -17,8 +17,9 @@ try:
     import wmi
     has_required_packages = True
 except ImportError:
-    log.exception('pywin32 and wmi python packages are required '
-                  'in order to use the status module.')
+    if salt.utils.is_windows():
+        log.exception('pywin32 and wmi python packages are required '
+                      'in order to use the status module.')
     has_required_packages = False
 
 


### PR DESCRIPTION
Some commits from earlier today in the win_status module result in
numerous exceptions being logged on non-windows platforms. They are
useful in Windows to notify the user that the proper prerequisites are
not installed, but they are just noise on other platforms. This commit
quiets that logging if the minion is not on a Windows platform.
