### PR TITLE
Clean up last remnants of _compare_versions funcs

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -4,8 +4,6 @@ Homebrew for Mac OS X
 
 # Import salt libs
 import salt
-from salt.modules.yumpkg import _compare_versions
-
 
 def __virtual__():
     '''
@@ -102,9 +100,7 @@ def install(pkgs, refresh=False, skip_verify=False, **kwargs):
         __salt__['cmd.run'](cmd)
 
     new = list_pkgs(*pkgs)
-
-    return _compare_versions(old, new)
-
+    return __salt__['pkg_resource.find_changes'](old,new)
 
 def list_upgrades():
     '''

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -22,28 +22,6 @@ def _list_removed(old, new):
     return pkgs
 
 
-def _compare_versions(old, new):
-    '''
-    Returns a dict that that displays old and new versions for a package after
-    install/upgrade of package.
-    '''
-    pkgs = {}
-    for npkg in new:
-        if npkg in old:
-            if old[npkg] == new[npkg]:
-                # no change in the package
-                continue
-            else:
-                # the package was here before and the version has changed
-                pkgs[npkg] = {'old': old[npkg],
-                              'new': new[npkg]}
-        else:
-            # the package is freshly installed
-            pkgs[npkg] = {'old': '',
-                          'new': new[npkg]}
-    return pkgs
-
-
 def _get_pkgs():
     '''
     Get a full list of the package installed on the machine
@@ -143,7 +121,7 @@ def upgrade(refresh=True, **kwargs):
     new = _get_pkgs()
 
     # Return a list of the new package installed.
-    return _compare_versions(old, new)
+    return __salt__['pkg_resource.find_changes'](old,new)
 
 
 def list_pkgs():
@@ -227,7 +205,7 @@ def install(name, refresh=False, version=None, **kwargs):
     new = _get_pkgs()
 
     # Return a list of the new package installed.
-    return _compare_versions(old, new)
+    return __salt__['pkg_resource.find_changes'](old,new)
 
 
 def remove(name, **kwargs):


### PR DESCRIPTION
pkg_resource.find_changes does what _compare_versions once did. Found
some places where this function was still used (including a rather ugly
import in brew.py) and replaced them with calls to
pkg_resource.find_changes.
