### PR TITLE
Adding missing create/remove functions to LVM

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -87,6 +87,8 @@ def vgdisplay(vgname=''):
     cmd = 'vgdisplay -c {0}'.format(vgname)
     out = __salt__['cmd.run'](cmd).splitlines()
     for line in out:
+        if 'No volume groups found' in line:
+            return {}
         comps = line.strip().split(':')
         ret[comps[0]] = {
             'Volume Group Name': comps[0],
@@ -122,6 +124,8 @@ def lvdisplay(lvname=''):
     cmd = 'lvdisplay -c {0}'.format(lvname)
     out = __salt__['cmd.run'](cmd).splitlines()
     for line in out:
+        if 'No volume groups found' in line:
+            return {}
         comps = line.strip().split(':')
         ret[comps[0]] = {
             'Logical Volume Name': comps[0],

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -239,7 +239,7 @@ def vgremove(vgname):
     return out.strip()
 
 
-def lvremove(lvname, vgname, force=False):
+def lvremove(lvname, vgname):
     '''
     Remove a given existing logical volume from a named existing volume group
 
@@ -247,9 +247,6 @@ def lvremove(lvname, vgname, force=False):
 
         salt '*' lvm.lvremove lvname vgname force=True
     '''
-    forcearg = ''
-    if force:
-        forcearg = '-f'
-    cmd = 'lvremove {0} {1}/{2}'.format(forcearg, vgname, lvname)
+    cmd = 'lvremove -f {0}/{1}'.format(vgname, lvname)
     out = __salt__['cmd.run'](cmd)
     return out.strip()

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -6,6 +6,12 @@ Some functions may not be available, depending on your version of parted.
 Check man 8 parted for more information, or the online docs at:
 
 http://www.gnu.org/software/parted/manual/html_chapter/parted_2.html
+
+In light of parted not directly supporting partition IDs, some of this module
+has been written to utilize sfdisk instead. For further information, please
+reference the man page for sfdisk::
+
+    man 8 sfdisk
 '''
 
 # Import python libs
@@ -130,6 +136,50 @@ def cp(device, from_minor, to_minor):  # pylint: disable-msg=C0103
         salt '*' partition.cp /dev/sda 2 3
     '''
     cmd = 'parted -m -s {0} cp {1} {2}'.format(device, from_minor, to_minor)
+    out = __salt__['cmd.run'](cmd).splitlines()
+    return out
+
+
+def get_id(device, minor):
+    '''
+    partition.get_id
+
+    Prints the system ID for the partition. Some typical values are::
+
+         b: FAT32 (vfat)
+         7: HPFS/NTFS
+        82: Linux Swap
+        83: Linux
+        8e: Linux LVM
+        fd: Linux RAID Auto
+
+    CLI Example::
+
+        salt '*' partition.get_id /dev/sda 1
+    '''
+    cmd = 'sfdisk --print-id {0} {1}'.format(device, minor)
+    out = __salt__['cmd.run'](cmd).splitlines()
+    return out
+
+
+def set_id(device, minor, system_id):
+    '''
+    partition.set_id
+
+    Sets the system ID for the partition. Some typical values are::
+
+         b: FAT32 (vfat)
+         7: HPFS/NTFS
+        82: Linux Swap
+        83: Linux
+        8e: Linux LVM
+        fd: Linux RAID Auto
+
+    CLI Example::
+
+        salt '*' partition.set_id /dev/sda 1 83
+    '''
+    cmd = 'sfdisk --change-id {0} {1} {2}'.format(device, minor, system_id)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 


### PR DESCRIPTION
Updates the partition module to be able to set the LVM system ID, and adds create and remove functions to LVM. The [vg|lv]create commands now also return the output from their respective display functions, in addition to any output returned from the create command itself. Does not add pvremove, since that performs a different kind of operations than the others.

@torhve will want to see this, since I slightly altered some of his functionality.
