### PR TITLE
Add example configuration for non-root master.

### DIFF
--- a/doc/topics/nonroot.rst
+++ b/doc/topics/nonroot.rst
@@ -9,11 +9,66 @@ the option ``user`` in the master configuration file and all salt system
 components will be updated to function under the new user when the master
 is started.
 
-If running a version older that 0.9.10 then a number of files need to be
-owned by the user intended to run the master:
+.. note::
+    If running a version older that 0.9.10 then a number of files need to be
+    owned by the user intended to run the master:
 
-.. code-block:: bash
+    .. code-block:: bash
 
-    # chown -R <user> /var/cache/salt
-    # chown -R <user> /var/log/salt
-    # chown -R <user> /etc/salt/pki
+        # chown -R <user> /var/cache/salt
+        # chown -R <user> /var/log/salt
+        # chown -R <user> /etc/salt/pki
+
+.. note::
+    When running as a non-root account, Salt Master will warn about being
+    unable to use `dmidecode` and as a result grains output might not be
+    accurate.
+
+
+Configuration Example
+---------------------
+
+Here is an configuration example for running Salt Master as a non-root
+account named `salt`. The account is configured using `/srv/salt` as home
+folder.
+
+To simplify file permissions configuration, all files are stored
+inside user's home folder.
+
+The following folder layout is used::
+
+    /srv/salt       - Base folder to store all files used by Salt Master.
+    /srv/salt/pki   - Public and private keys storage.
+    /srv/salt/base  - Store states, files, modules ... etc.
+                      This is the base folder for Salt file server.
+    /srv/salt/cache - Cacke folder for internal usage.
+    /srv/salt/sock  - Socket files for internal usage.
+    /srv/salt/log   - Store logs files.
+
+Make sure only `salt` account has read (and write) access to `/srv/salt/pki`
+folder::
+
+    sudo chmod 600 /srv/salt/pki
+
+The `top.sls` file is located in `/srv/salt/base/top.sls`. Custom grains
+and modules are located in `/srv/salt/base/_grains` and
+'/srv/salt/base/_modules', respectively.
+
+This is the configuration for the above layout::
+
+    #
+    # Configuration for running salt-master as non-root.
+    #
+    user: salt
+
+    root_dir: /srv/salt/
+    pki_dir: /pki
+    cachedir: /cache/
+    sock_dir: /sock/
+
+    log_file: /log/master
+    key_logfile: /log/key
+
+    file_roots:
+      base:
+        - /srv/salt/base


### PR DESCRIPTION
I would like to extend the documentation for running master as non-root.

It is a bit different than the default configuration as all files are moved inside a single folder.

I had to create a new /etc/salt/master configuration file.

I tried to put this file in /etc/salt/master.d/non-root-config but I don't know why it was not used by salt and salt-key.

Please let me know if you find it useful and it requires changes.

Feel free to discard this request if you don't find it useful.

Thanks!
