### PR TITLE
Refine esky support in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,22 @@ if 'USE_SETUPTOOLS' in os.environ:
 if with_setuptools is False:
     from distutils.core import setup
 
+try:
+    # Add the esky bdist target if the module is available
+    # may require additional modules depending on platform
+    from esky import bdist_esky
+    # bbfreeze chosen for its tight integration with distutils
+    import bbfreeze
+    HAS_ESKY = True
+except ImportError:
+    # print function that supports the 'file' argument isn't available until
+    # 2.6 http://docs.python.org/2.6/library/__future__.html
+    # Using this method until 2.5 support is dropped.
+    print >> sys.stderr, 'Cannot load esky build target'
+    print >> sys.stderr, ('Please install the \'esky\' and the \'bbfreeze\' '
+                          'modules to enable this functionality')
+    HAS_ESKY = False
+
 salt_version = os.path.join(os.path.abspath(
     os.path.dirname(__file__)), 'salt', 'version.py')
 
@@ -100,8 +116,6 @@ if 'SYSCONFDIR' in os.environ:
 else:
     etc_path = os.path.join(os.path.dirname(PREFIX), 'etc')
 
-libraries = ['ws2_32'] if sys.platform == 'win32' else []
-
 with open(salt_reqs) as f:
     lines = f.read().split('\n')
     requirements = [line for line in lines if line]
@@ -160,9 +174,10 @@ setup_kwargs = {'name': NAME,
                                  ]),
                                ('share/man/man7', ['doc/man/salt.7']),
                                ],
+                # Required for esky builds
                 'install_requires': requirements,
                 # The dynamic module loading in salt.modules makes this
-                # package zip unsafe.
+                # package zip unsafe. Required for esky builds
                 'zip_safe': False
                 }
 
@@ -193,19 +208,16 @@ if sys.platform.startswith('win'):
         '_winreg',
         'wmi',
     ])
-    setup_kwargs['install_requires'] += '\nwmi'
+    setup_kwargs['install_requires'].append('wmi')
 elif sys.platform.startswith('linux'):
     freezer_includes.extend([
         'yum',
         'spwd',
     ])
 
-if 'bdist_esky' in sys.argv:
-    # Add the esky bdist target if the module is available
-    # may require additional modules depending on platform
-    from esky import bdist_esky
-    # bbfreeze chosen for its tight integration with distutils
-    import bbfreeze
+if HAS_ESKY:
+    # if the user has the esky / bbfreeze libraries installed, add the
+    # appropriate kwargs to setup
     options = setup_kwargs.get('options', {})
     options['bdist_esky'] = {
         "freezer_module": "bbfreeze",
@@ -236,10 +248,6 @@ else:
                                'scripts/salt-call',
                                'scripts/salt-run',
                                'scripts/salt']
-    # Distutils does not know what these are and throws warnings.
-    # Stop the warning.
-    setup_kwargs.pop('install_requires')
-    setup_kwargs.pop('zip_safe')
 
 if __name__ == '__main__':
     setup(**setup_kwargs)


### PR DESCRIPTION
- Add HAS_ESKY flag based on import tests rather than command line
  arguments.
- Add comments on reasoning for some setup kwargs
- Fix append bug for wmi dependency
- Revert part of e70d70aa75fedb90a6ef774a0131e0f3f2b6e516. Esky uses
  those kwargs regardless of the distribution stack used.
- Remove unused 'libraries' variable

This should fix #2986. This will restore the distutils warnings about unknown setup kwargs.
