### PR TITLE
Added check for version string.

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -151,7 +151,7 @@ def installed(
                                 'correct version').format(name)}
 
         # if cver is not an empty string, the package is already installed
-        elif cver:
+        elif cver and version is None:
             # The package is installed
             return {'name': name,
                     'changes': {},


### PR DESCRIPTION
Previously this state would be true if ANY package version was installed regardless of version specified.

Meaning that if you specified app version 2, if version 1 was installed it would return true. This simply checks to see if you specified a version.
