### PR TITLE
Changed options to emerge for ebuild.update

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -221,7 +221,7 @@ def update(pkg, refresh=False):
 
     ret_pkgs = {}
     old_pkgs = list_pkgs()
-    cmd = 'emerge --update --quiet {0}'.format(pkg)
+    cmd = 'emerge --update --newuse --oneshot --quiet {0}'.format(pkg)
     __salt__['cmd.retcode'](cmd)
     new_pkgs = list_pkgs()
 


### PR DESCRIPTION
Added options --newuse and --oneshot to emerge command in ebuild.update.
The --newuse option will detect USE flag changes in packages, allowing a
package to be reinstalled at the same version but updated with new USE
flags. The --oneshot will prevent the package from being recorded in the
world file. Gentoo maintains a "world" set that is all the packages that
were explicitly installed. If the user is updating a dependancy, they
would not want the package added to the world file, if they are updating
a package already in the world file, it will remain there.
