### PR TITLE
Develop

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -193,6 +193,10 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     if not fromrepo and repo:
         fromrepo = repo
 
+    if kwargs.get('env'):
+        print kwargs.get('env')
+        os.environ.update(kwargs.get('env'))
+
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
@@ -237,6 +241,9 @@ def remove(pkg):
     ret_pkgs = []
     old_pkgs = list_pkgs()
 
+    if kwargs.get('env'):
+        os.environ.update(kwargs.get('env'))
+
     cmd = 'apt-get -q -y remove {0}'.format(pkg)
     __salt__['cmd.run'](cmd)
     new_pkgs = list_pkgs()
@@ -260,6 +267,9 @@ def purge(pkg):
     '''
     ret_pkgs = []
     old_pkgs = list_pkgs()
+
+    if kwargs.get('env'):
+        os.environ.update(kwargs.get('env'))
 
     # Remove inital package
     purge_cmd = 'apt-get -q -y purge {0}'.format(pkg)

--- a/scripts/salt
+++ b/scripts/salt
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 Publish commands to the salt system from the command line on the master.
 '''

--- a/scripts/salt-call
+++ b/scripts/salt-call
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 Directly call a salt command in the modules, does not require a running salt
 minion to run.

--- a/scripts/salt-cp
+++ b/scripts/salt-cp
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 Publish commands to the salt system from the command line on the master.
 '''

--- a/scripts/salt-key
+++ b/scripts/salt-key
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 Manage the authentication keys with salt-key
 '''

--- a/scripts/salt-master
+++ b/scripts/salt-master
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 Start the salt-master
 '''

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 This script is used to kick off a salt minion daemon
 '''

--- a/scripts/salt-run
+++ b/scripts/salt-run
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 Execute a salt convenience routine
 '''

--- a/scripts/salt-syndic
+++ b/scripts/salt-syndic
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 '''
 This script is used to kick off a salt syndic daemon
 '''


### PR DESCRIPTION
In some cases, ubuntu forces you to set environment variables to force install or remove packages. 

For instance if you do not set sudo password and would like to install sudo-ldap instead, ubuntu dpkg package refuses to remove sudo with this alert:

```
You have asked that the sudo package be removed,
but no root password has been set.
Without sudo, you may not be able to gain administrative privileges.

If you would prefer to access the root account with su(1)
or by logging in directly,
you must set a root password with "sudo passwd".

If you have arranged other means to access the root account,
and you are sure this is what you want,
you may bypass this check by setting an environment variable 
(export SUDO_FORCE_REMOVE=yes).

Refusing to remove sudo.
```

So for installing sudo-ldap without setting a root password you have to set SUDO_FORCE_REMOVE environment variable. 

Normally if you set an env dict in a state file this is passed through to modules as a kwargs. But it is not used in apt.py module.

Also I've changed hasbangs of the scripts to #!/usr/bin/env python for virtual environments.
