### PR TITLE
Small fixes to file.sed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -637,10 +637,11 @@ def contains(path, text):
     if not os.path.exists(path):
         return False
 
+    stripped_text = test.strip()
     try:
         with BufferedReader(path) as breader:
             for chunk in breader:
-                if text.strip() == chunk.strip():
+                if stripped_text in chunk:
                     return True
         return False
     except (IOError, OSError):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1205,7 +1205,7 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
     # Look for the pattern before attempting the edit
     if not __salt__['file.contains_regex'](name, before):
         # Pattern not found; try to guess why
-        if __salt__['file.contains_regex'](name, after):
+        if __salt__['file.contains'](name, after):
             ret['comment'] = 'Edit already performed'
             ret['result'] = True
             return ret
@@ -1225,7 +1225,7 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
         nlines = fp_.readlines()
 
     # check the result
-    ret['result'] = __salt__['file.contains_regex'](name, after)
+    ret['result'] = __salt__['file.contains'](name, after)
     if slines != nlines:
         # Changes happened, add them
         ret['changes']['diff'] = (


### PR DESCRIPTION
The file.sed state checks the file to see if the "after" string is present. However, it treats the string as a regular expression, so fails to match if it contains any regular expression characters. 

This pull request also fixes the file.contains module function, which was trying to match the entire retrieved chunk against the search string, rather than searching for the search string.
