### PR TITLE
patch to fix #2640

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -212,9 +212,10 @@ def _run(cmd,
         kwargs['executable'] = shell
         kwargs['close_fds'] = True
 
-    # If all we want is the return code then don't block on gathering input.
+    # Setting stdout to None seems to cause the Process to fail.
+    # See bug #2640 for more info
     if retcode:
-        kwargs['stdout'] = None
+        #kwargs['stdout'] = None
         kwargs['stderr'] = None
 
     # This is where the magic happens


### PR DESCRIPTION
Changed _run to not set stdout=None when retcode=True
See bug #2640 for more details

Not sure if this is the best solution, but it does allow cmd.retcode to function in all cases. Currently cmd.retcode is causing other commands to break such as ebuild.upgrade
