### PR TITLE
Added state for layman.

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -20,6 +20,7 @@ Full list of builtin state modules
     hg
     host
     kmod
+    layman
     module
     mongodb_database
     mongodb_user

--- a/doc/ref/states/all/salt.states.layman.rst
+++ b/doc/ref/states/all/salt.states.layman.rst
@@ -1,0 +1,6 @@
+==================
+salt.states.layman
+==================
+
+.. automodule:: salt.states.layman
+    :members:

--- a/salt/states/layman.py
+++ b/salt/states/layman.py
@@ -7,12 +7,12 @@ A state module to manage Gentoo package overlays via layman
 .. code-block:: yaml
 
     sunrise:
-        layman.added
+        layman.present
 '''
 
-def added(name):
+def present(name):
     '''
-    Verify that the overlay has been added.
+    Verify that the overlay is present
 
     name
         The name of the overlay to add
@@ -22,9 +22,9 @@ def added(name):
            'name': name,
            'result': True}
 
-    # Overlay already added
+    # Overlay already present
     if name in __salt__['layman.list_local']():
-        ret['comment'] = 'Overlay {0} already added'.format(name)
+        ret['comment'] = 'Overlay {0} already present'.format(name)
     else:
         # Attempt to add the overlay
         changes = __salt__['layman.add'](name)
@@ -40,9 +40,9 @@ def added(name):
 
     return ret
 
-def deleted(name):
+def absent(name):
     '''
-    Verify that the overlay has been removed.
+    Verify that the overlay is absent
 
     name
         The name of the overlay to delete
@@ -52,9 +52,9 @@ def deleted(name):
            'name': name,
            'result': True}
 
-    # Overlay already added
+    # Overlay is already absent
     if name not in __salt__['layman.list_local']():
-        ret['comment'] = 'Overlay {0} already deleted'.format(name)
+        ret['comment'] = 'Overlay {0} already absent'.format(name)
     else:
         # Attempt to delete the overlay
         changes = __salt__['layman.delete'](name)

--- a/salt/states/layman.py
+++ b/salt/states/layman.py
@@ -31,6 +31,8 @@ def present(name):
     # Overlay already present
     if name in __salt__['layman.list_local']():
         ret['comment'] = 'Overlay {0} already present'.format(name)
+    elif __opts__['test']:
+        ret['comment'] = 'Overlay {0} is set to be added'.format(name)
     else:
         # Attempt to add the overlay
         changes = __salt__['layman.add'](name)
@@ -61,6 +63,8 @@ def absent(name):
     # Overlay is already absent
     if name not in __salt__['layman.list_local']():
         ret['comment'] = 'Overlay {0} already absent'.format(name)
+    elif __opts__['test']:
+        ret['comment'] = 'Overlay {0} is set to be deleted'.format(name)
     else:
         # Attempt to delete the overlay
         changes = __salt__['layman.delete'](name)

--- a/salt/states/layman.py
+++ b/salt/states/layman.py
@@ -10,6 +10,12 @@ A state module to manage Gentoo package overlays via layman
         layman.present
 '''
 
+def __virtual__():
+    '''
+    Only load if the layman module is available in __salt__
+    '''
+    return 'layman' if 'layman.add' in __salt__ else False
+
 def present(name):
     '''
     Verify that the overlay is present

--- a/salt/states/layman.py
+++ b/salt/states/layman.py
@@ -1,0 +1,71 @@
+'''
+Mangement of Gentoo Overlays using layman
+=========================================
+
+A state module to manage Gentoo package overlays via layman
+
+.. code-block:: yaml
+
+    sunrise:
+        layman.added
+'''
+
+def added(name):
+    '''
+    Verify that the overlay has been added.
+
+    name
+        The name of the overlay to add
+    '''
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': True}
+
+    # Overlay already added
+    if name in __salt__['layman.list_local']():
+        ret['comment'] = 'Overlay {0} already added'.format(name)
+    else:
+        # Attempt to add the overlay
+        changes = __salt__['layman.add'](name)
+
+        # The overlay failed to add
+        if len(changes) < 1:
+            ret['comment'] = 'Overlay {0} failed to add'.format(name)
+            ret['result'] = False
+        # Sucess
+        else:
+            ret['changes']['added'] = changes
+            ret['comment'] = 'Overlay {0} added.'.format(name)
+
+    return ret
+
+def deleted(name):
+    '''
+    Verify that the overlay has been removed.
+
+    name
+        The name of the overlay to delete
+    '''
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': True}
+
+    # Overlay already added
+    if name not in __salt__['layman.list_local']():
+        ret['comment'] = 'Overlay {0} already deleted'.format(name)
+    else:
+        # Attempt to delete the overlay
+        changes = __salt__['layman.delete'](name)
+
+        # The overlay failed to delete
+        if len(changes) < 1:
+            ret['comment'] = 'Overlay {0} failed to delete'.format(name)
+            ret['result'] = False
+        # Sucess
+        else:
+            ret['changes']['deleted'] = changes
+            ret['comment'] = 'Overlay {0} deleted.'.format(name)
+
+    return ret


### PR DESCRIPTION
Adds the ability to ensure overlays are added or deleted via layman.

This is my first attempt at adding a state, so please let me know if I have any glaring mistakes.  I was able to use this to add and remove some layman overlays from a virtualenv install.  It should be rather helpful for configuring a state for a Gentoo machine, allowing salt to ensure the correct overlay is installed before trying to install a package that can only be found in the overlay.
