### PR TITLE
Fix mdadm module: do not return False on Linux kernel

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -18,7 +18,7 @@ def __virtual__():
     '''
     mdadm provides raid functions for Linux
     '''
-    if __grains__['kernel'] == 'Linux':
+    if not __grains__['kernel'] == 'Linux':
         return False
     if not salt.utils.which('mdadm'):
         return False


### PR DESCRIPTION
Fix an overlooked typo which prevents mdadm module running on Linux kernel.
