### PR TITLE
Added Gentoo support to keyboard module

### DIFF
--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -36,6 +36,8 @@ def get_sys():
         cmd = 'grep LAYOUT /etc/sysconfig/keyboard | grep -vE "^#"'
     elif 'Debian' in __grains__['os_family']:
         cmd = 'grep XKBLAYOUT /etc/default/keyboard | grep -vE "^#"'
+    elif 'Gentoo' in __grains__['os_family']:
+        cmd = 'grep "^keymap" /etc/conf.d/keymaps | grep -vE "^#"'
     out = __salt__['cmd.run'](cmd).split('=')
     ret = out[1].replace('"', '')
     return ret
@@ -55,6 +57,8 @@ def set_sys(layout):
         __salt__['file.sed']('/etc/sysconfig/keyboard', '^LAYOUT=.*', 'LAYOUT={0}'.format(layout))
     elif 'Debian' in __grains__['os_family']:
         __salt__['file.sed']('/etc/default/keyboard', '^XKBLAYOUT=.*', 'XKBLAYOUT={0}'.format(layout))
+    elif 'Gentoo' in __grains__['os_family']:
+        __salt__['file.sed']('/etc/conf.d/keymaps', '^keymap=.*', 'keymap={0}'.format(layout))
     return layout
 
 


### PR DESCRIPTION
Note, altough this changes the keyboard setting, it does not take affect unless a reboot (or a restart of the keymaps service). Not sure about other distros. Is this the desired behavior?
