### PR TITLE
Layman bug fixes

### DIFF
--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -82,5 +82,5 @@ def list_local():
     '''
     cmd = 'layman --quietness=1 --list-local --nocolor'
     out = __salt__['cmd.run'](cmd).split('\n')
-    ret = [line.split()[1] for line in out]
+    ret = [line.split()[1] for line in out if len(line.split()) > 2]
     return ret


### PR DESCRIPTION
Fixed bugs with layman module. It would fail on adding the first overlay.  It also ensures that the layman make.conf file is sources in the portage make.conf if an overlay has been added, otherwise emerge would not see the overlays added to layman. Likewise, it ensures that the portage make.conf is not sourcing the layman make.conf if there are not any overlays added (ie when deleting the last overaly). This is necessary since emerge will break if it sources the layman make.conf with no overlays added.
