### PR TITLE
Add multiple-package support to pkg.latest state

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -124,3 +124,16 @@ def upgrade_available(pkg):
         salt '*' pkg.upgrade_available <package name>
     '''
     return pkg in list_upgrades()
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -338,3 +338,16 @@ def depclean(pkg=None):
             ret_pkgs.append(pkg)
 
     return ret_pkgs
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -310,3 +310,16 @@ def rehash():
     shell = __salt__['cmd.run']('echo $SHELL').split('/')
     if shell[len(shell) - 1] in ['csh', 'tcsh']:
         __salt__['cmd.run']('rehash')
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/notify-upower.sh
+++ b/salt/modules/notify-upower.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-[ "$1" = "post" ] && exec /usr/bin/dbus-send	\
-	--system --type=signal			\
-	--dest=org.freedesktop.UPower		\
-	/org/freedesktop/UPower			\
-	org.freedesktop.UPower.Resuming

--- a/salt/modules/notify-upower.sh
+++ b/salt/modules/notify-upower.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+[ "$1" = "post" ] && exec /usr/bin/dbus-send	\
+	--system --type=signal			\
+	--dest=org.freedesktop.UPower		\
+	/org/freedesktop/UPower			\
+	org.freedesktop.UPower.Resuming

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -189,3 +189,16 @@ def purge(name):
         salt '*' pkg.purge <package name>
     '''
     return remove(name)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -278,3 +278,16 @@ def purge(name):
     __salt__['cmd.retcode'](cmd)
     new = list_pkgs()
     return _list_removed(old, new)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -8,6 +8,7 @@ import re
 import yaml
 import pprint
 import logging
+import distutils
 
 log = logging.getLogger(__name__)
 
@@ -317,3 +318,23 @@ def find_changes(old=None, new=None):
             pkgs[npkg] = {'old': old[npkg],
                           'new': new[npkg]}
     return pkgs
+
+
+def compare(pkg1='', pkg2=''):
+    '''
+    Compares two version strings using distutils.LooseVersion. This is a
+    fallback for providers which don't have a version comparison utility built
+    into them.  Return -1 if version1 < version2, 0 if version1 == version2,
+    and 1 if version1 > version2. Return None if there was a problem making the
+    comparison.
+    '''
+    try:
+        if distutils.LooseVersion(pkg1) < distutils.LooseVersion(pkg2):
+            return -1
+        elif distutils.LooseVersion(pkg1) == distutils.LooseVersion(pkg2):
+            return 0
+        elif distutils.LooseVersion(pkg1) > distutils.LooseVersion(pkg2):
+            return 1
+    except Exception as e:
+        log.exception(e)
+    return None

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -8,7 +8,7 @@ import re
 import yaml
 import pprint
 import logging
-import distutils
+import distutils.version
 
 log = logging.getLogger(__name__)
 
@@ -322,18 +322,21 @@ def find_changes(old=None, new=None):
 
 def compare(pkg1='', pkg2=''):
     '''
-    Compares two version strings using distutils.LooseVersion. This is a
-    fallback for providers which don't have a version comparison utility built
-    into them.  Return -1 if version1 < version2, 0 if version1 == version2,
-    and 1 if version1 > version2. Return None if there was a problem making the
-    comparison.
+    Compares two version strings using distutils.version.LooseVersion. This is
+    a fallback for providers which don't have a version comparison utility
+    built into them.  Return -1 if version1 < version2, 0 if version1 ==
+    version2, and 1 if version1 > version2. Return None if there was a problem
+    making the comparison.
     '''
     try:
-        if distutils.LooseVersion(pkg1) < distutils.LooseVersion(pkg2):
+        if distutils.version.LooseVersion(pkg1) < \
+           distutils.version.LooseVersion(pkg2):
             return -1
-        elif distutils.LooseVersion(pkg1) == distutils.LooseVersion(pkg2):
+        elif distutils.version.LooseVersion(pkg1) == \
+             distutils.version.LooseVersion(pkg2):
             return 0
-        elif distutils.LooseVersion(pkg1) > distutils.LooseVersion(pkg2):
+        elif distutils.version.LooseVersion(pkg1) > \
+             distutils.version.LooseVersion(pkg2):
             return 1
     except Exception as e:
         log.exception(e)

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -218,3 +218,16 @@ def upgrade():
 
     cmd = 'pkg upgrade -y'
     return __salt__['cmd.run'](cmd)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -251,3 +251,16 @@ def purge(name, **kwargs):
         salt '*' pkgutil.purge <package name>
     '''
     return remove(name, **kwargs)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -362,3 +362,16 @@ def purge(name, **kwargs):
         salt '*' pkg.purge <package name>
     '''
     return remove(name, **kwargs)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -441,3 +441,16 @@ def _get_latest_pkg_version(pkginfo):
         return pkginfo.keys().pop()
     pkgkeys = pkginfo.keys()
     return sorted(pkgkeys, cmp=_reverse_cmp_pkg_versions).pop()
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -781,3 +781,14 @@ def _parse_repo_file(filename):
 
     return (header, repos)
 
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -317,3 +317,16 @@ def purge(pkg):
         salt '*' pkg.purge <package name>
     '''
     return remove(pkg)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -258,3 +258,16 @@ def purge(name):
     __salt__['cmd.retcode'](cmd)
     new = list_pkgs()
     return _list_removed(old, new)
+
+
+def compare(version1='', version2=''):
+    '''
+    Compare two version strings. Return -1 if version1 < version2,
+    0 if version1 == version2, and 1 if version1 > version2. Return None if
+    there was a problem making the comparison.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](version1, version2)


### PR DESCRIPTION
Currently only apt is supported, will work on the rest in the coming
days.

As part of this commit, a new function has been added to pkg_resource
called "compare". This will do version-checking where a specific package
provider does not provide a means of reliably comparing versions. This
was made necessary by the fact that distutils.LooseVersion does not
properly handle Ubuntu's weird version strings (like '1.2.3-0ubuntu1').
apt now has its own "compare" function which uses dpkg --compare-versions
to do the comparison. (thanks @thekuffs!)

As I start adding multiple package support for pkg.latest in other
platforms, I will (where possible) create provider-specific "compare"
functions. This should make version checking more reliable, and moving
forward should also make the audit of version support in pkg.installed
much easier to accomplish for providers which don't allow you to install
a package using the following syntax: pkgname>=1.2.3
