### PR TITLE
Rudimentary multi-pkg support for homebrew

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -36,19 +36,49 @@ def list_pkgs(*args):
     return result_dict
 
 
-def version(name):
+def version(*names):
     '''
-    Returns a version if the package is installed, else returns an empty string
+    Returns a string representing the package version or an empty string if not
+    installed. If more than one package name is specified, a dict of
+    name/version pairs is returned.
 
     CLI Example::
 
         salt '*' pkg.version <package name>
+        salt '*' pkg.version <package1> <package2> <package3>
     '''
-    pkgs = list_pkgs(name)
-    if name in pkgs:
-        return pkgs[name]
-    else:
+    pkgs = list_pkgs()
+    if len(names) == 0:
         return ''
+    elif len(names) == 1:
+        return pkgs.get(names[0], '')
+    else:
+        ret = {}
+        for name in names:
+            ret[name] = pkgs.get(name, '')
+        return ret
+
+
+def available_version(*names):
+    '''
+    Return the latest version of the named package available for upgrade or
+    installation
+
+    Note that this currently not fully implemented but needs to return
+    something to avoid a traceback when calling pkg.latest.
+
+    CLI Example::
+
+        salt '*' pkg.available_version <package name>
+        salt '*' pkg.available_version <package1> <package2> <package3>
+    '''
+    if len(names) <= 1:
+        return ''
+    else:
+        ret = {}
+        for name in names:
+            ret[name] = ''
+        return ret
 
 
 def remove(pkgs):
@@ -67,14 +97,28 @@ def remove(pkgs):
     return __salt__['cmd.run'](cmd)
 
 
-def install(pkgs, refresh=False, skip_verify=False, **kwargs):
+def install(name=None, pkgs=None, **kwargs):
     '''
     Install the passed package(s) with ``brew install``
 
-    pkgs
-        The names of the packages to be installed
+    name
+        The name of the formula to be installed. Note that this parameter is
+        ignored if "pkgs" is passed.
 
-    Return a dict containing the new package names and versions::
+        CLI Example::
+            salt '*' pkg.install <package name>
+
+
+    Multiple Package Installation Options:
+
+    pkgs
+        A list of formulas to install. Must be passed as a python list.
+
+        CLI Example::
+            salt '*' pkg.install pkgs='["foo","bar"]'
+
+
+    Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
@@ -83,14 +127,14 @@ def install(pkgs, refresh=False, skip_verify=False, **kwargs):
 
         salt '*' pkg.install 'package package package'
     '''
-    if ',' in pkgs:
-        pkgs = pkgs.split(',')
-    else:
-        pkgs = pkgs.split(' ')
+    pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
+                                                                  pkgs,
+                                                                  sources)
+    if pkg_params is None or len(pkg_params) == 0:
+        return {}
 
-    old = list_pkgs(*pkgs)
-
-    formulas = ' '.join(pkgs)
+    formulas = ' '.join(pkg_params)
+    old = list_pkgs()
     homebrew_prefix = __salt__['cmd.run']('brew --prefix')
     user = __salt__['file.get_user'](homebrew_prefix)
     cmd = 'brew install {0}'.format(formulas)
@@ -99,8 +143,9 @@ def install(pkgs, refresh=False, skip_verify=False, **kwargs):
     else:
         __salt__['cmd.run'](cmd)
 
-    new = list_pkgs(*pkgs)
+    new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
+
 
 def list_upgrades():
     '''

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -208,6 +208,8 @@ def parse_targets(name=None, pkgs=None, sources=None):
         if not sources:
             log.error('"sources" option required with Solaris pkg installs')
             return None, None
+    elif __grains__['os'] == 'MacOS' and sources:
+        log.warning('Parameter "sources" ignored on MacOS hosts.')
 
     # "pkgs" is always ignored on Solaris.
     if pkgs and sources and __grains__['os_family'] != 'Solaris':
@@ -223,7 +225,7 @@ def parse_targets(name=None, pkgs=None, sources=None):
         else:
             return pkgs, 'repository'
 
-    elif sources:
+    elif sources and __grains__['os'] != 'MacOS':
         # No need to warn for Solaris, warning taken care of above.
         if name and __grains__['os_family'] != 'Solaris':
             log.warning('"name" parameter will be ignored in favor of '


### PR DESCRIPTION
This got left out when implementing multi-pkg support. This commit adds
support for "pkgs" but not "sources". I'm unable to test it currently
but would like to improve this in the future. But as it is, this commit
will prevent a few tracebacks in pkg states for Mac users, and that's a
good first step.
