### PR TITLE
Fix output from salt-call to look like normal salt output

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -122,8 +122,15 @@ class Caller(object):
         '''
         Execute the salt call logic
         '''
+
         ret = self.call()
+        out = ret['return']
+        # If the type of return is not a dict we wrap the return data
+        # This will ensure that --local and local functions will return the
+        # same data structure as publish commands.
+        if type(ret['return']) != type({}):
+            out = {'local': ret['return']}
         salt.output.display_output(
-                {'local': ret['return']},
+                out,
                 ret.get('out', 'pprint'),
                 self.opts)


### PR DESCRIPTION
salt-call --local test.ping,
salt-call test.ping and
salt-call publish.publish test.ping

will now all return the same data structure

{hostname: return}

instead of previously when publish would return
{'local': {hostname: return}, ... }
