### PR TITLE
Extend the manage runner to allow surveying minion version

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -3,6 +3,8 @@ General management functions for salt, tools like seeing what hosts are up
 and what hosts are down
 '''
 
+import distutils.version
+
 # Import salt libs
 import salt.key
 import salt.client
@@ -35,3 +37,33 @@ def up():  # pylint: disable-msg=C0103
         print(minion)
 
     return sorted(minions)
+
+
+def versions():
+    '''
+    Check the version of active minions
+    '''
+    client = salt.client.LocalClient(__opts__['conf_file'])
+    minions = client.cmd('*', 'test.version', timeout=__opts__['timeout'])
+
+    labels = {
+        -1: 'Minion requires update',
+        0: 'Up to date',
+        1: 'Minion newer than master',
+    }
+
+    sorted_minions = {}
+
+    master_version = distutils.version.StrictVersion(salt.__version__)
+    for minion in minions:
+        minion_version = distutils.version.StrictVersion(minions[minion])
+        ver_diff = cmp(minion_version, master_version)
+
+        if ver_diff not in sorted_minions:
+            sorted_minions[ver_diff] = []
+        sorted_minions[ver_diff].append(minion)
+
+    for key in sorted_minions:
+        print labels[key]
+        for minion in sorted(sorted_minions[key]):
+            print '\t', minion

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -52,18 +52,18 @@ def versions():
         1: 'Minion newer than master',
     }
 
-    sorted_minions = {}
+    version_status = {}
 
     master_version = distutils.version.StrictVersion(salt.__version__)
     for minion in minions:
         minion_version = distutils.version.StrictVersion(minions[minion])
         ver_diff = cmp(minion_version, master_version)
 
-        if ver_diff not in sorted_minions:
-            sorted_minions[ver_diff] = []
-        sorted_minions[ver_diff].append(minion)
+        if ver_diff not in version_status:
+            version_status[ver_diff] = []
+        version_status[ver_diff].append(minion)
 
-    for key in sorted_minions:
+    for key in version_status:
         print labels[key]
-        for minion in sorted(sorted_minions[key]):
+        for minion in sorted(version_status[key]):
             print '\t', minion


### PR DESCRIPTION
When upgrading a cluster, it's nice to know which minions still need to be updated.

I could use an argument to the runner to only show outdated minions but wasn't sure the best argument to use for that. Could just use the presence or absence of the argument to determine that.
