### PR TITLE
Fixed hash_func call in file.manage_file

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1282,7 +1282,6 @@ def manage_file(name,
                     tmp_fh = open(tmp_file, 'w').write(dlfile.read())
                     dl_sum = get_hash(tmp_file, source_sum['hash_type'])
                     os.remove(tmp_file)
-                    #dl_sum = hash_func(dlfile.read()).hexdigest()
                 if dl_sum != source_sum['hsum']:
                     ret['comment'] = ('File sum set for file {0} of {1} does '
                                       'not match real sum of {2}'

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1278,7 +1278,11 @@ def manage_file(name,
             # that it matches the intended sum value
             if urlparse(source).scheme != 'salt':
                 with salt.utils.fopen(sfn, 'rb') as dlfile:
-                    dl_sum = hash_func(dlfile.read()).hexdigest()
+                    tmp_fd, tmp_file = tempfile.mkstemp()
+                    tmp_fh = open(tmp_file, 'w').write(dlfile.read())
+                    dl_sum = get_hash(tmp_file, source_sum['hash_type'])
+                    os.remove(tmp_file)
+                    #dl_sum = hash_func(dlfile.read()).hexdigest()
                 if dl_sum != source_sum['hsum']:
                     ret['comment'] = ('File sum set for file {0} of {1} does '
                                       'not match real sum of {2}'


### PR DESCRIPTION
this must be an old reference, this function was calling hash_func which was an undefined variable. I have made it create a temp file, then use the get_hash function to achieve the same outcome.
