### PR TITLE
Less intrusive logging setup when in use as an API access to salt. Fixes #3155

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -378,6 +378,15 @@
 #
 # Make sure you have a properly configured syslog or you won't get any warnings
 #
+# If you're thinking on doing remote logging you might also be thinking that
+# you could point salt's logging to the remote syslog. **Please Don't!**
+# An issue has been reported when doing this over TCP when the logged lines
+# get concatenated. See #3061.
+#
+# The preferred way to do remote logging is setup a local syslog, point
+# salt's logging to the local syslog(unix socket is much faster) and then
+# have the local syslog forward the log messages to the remote syslog.
+#
 #log_file: /var/log/salt/master
 #key_logfile: /var/log/salt/key
 #

--- a/conf/minion
+++ b/conf/minion
@@ -295,7 +295,16 @@
 # The above examples are self explanatory, but:
 #	<file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>
 #
-# Make sure you have a properly configured syslog or you won't get any warnings
+# Make sure you have a properly configured syslog or you won't get any warnings.
+#
+# If you're thinking on doing remote logging you might also be thinking that
+# you could point salt's logging to the remote syslog. **Please Don't!**
+# An issue has been reported when doing this over TCP when the logged lines
+# get concatenated. See #3061.
+#
+# The preferred way to do remote logging is setup a local syslog, point
+# salt's logging to the local syslog(unix socket is much faster) and then
+# have the local syslog forward the log messages to the remote syslog.
 #
 #log_file: /var/log/salt/minion
 #


### PR DESCRIPTION
- An effort is now made to try and find out if any other library has setup python's logging. If it has, we cooperate, if not, we rule.
- More doc strings.
- Explain a bit on the preferred way to do remote logging using syslog. Refs #3061.
