### PR TITLE
Support subexpressions in compound matcher.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1028,8 +1028,9 @@ class Matcher(object):
                'S': 'ipcidr',
                'E': 'pcre'}
         results = []
-        opers = ['and', 'or', 'not']
-        for match in tgt.split():
+        opers = ['and', 'or', 'not', '(', ')']
+        tokens = re.findall(r'[^\s()]+|[()]', tgt)
+        for match in tokens:
             # Try to match tokens from the compound target, first by using
             # the 'G, X, I, L, S, E' matcher types, then by hostname glob.
             if '@' in match and match[1] == '@':
@@ -1046,7 +1047,7 @@ class Matcher(object):
                     )
                 )
             elif match in opers:
-                # We didn't match a target, so append a boolean operator
+                # We didn't match a target, so append a boolean operator or subexpression
                 results.append(match)
             else:
                 # The match is not explicitly defined, evaluate it as a glob


### PR DESCRIPTION
Currently, given an expression like:

```
G@roles:production and G@roles:frontend or G@roles:db
```

There's no way to express the desired logic `G@roles:production and (G@roles:frontend or G@roles:db)`. This change adds support for subexpressions.

Unfortunately this is untested (I verified the regex works though) as I don't currently have time. I thought I'd throw it over the fence anyway.
