### PR TITLE
Previous logging configuration should be checked against `logging.root.handlers`. Refs #3155

### DIFF
--- a/salt/log.py
+++ b/salt/log.py
@@ -217,7 +217,7 @@ if logging.getLoggerClass() is not SaltLoggingClass:
     logging.addLevelName(TRACE, 'TRACE')
     logging.addLevelName(GARBAGE, 'GARBAGE')
 
-    if not logging.Logger.manager.loggerDict:
+    if len(logging.root.handlers) == 0:
         # No configuration to the logging system has been done so far.
         # Set the root logger at the lowest level possible
         logging.getLogger().setLevel(GARBAGE)


### PR DESCRIPTION
``` python
>>> import logging
>>> logging.root.handlers
[]
>>> logging.basicConfig(level=logging.WARNING)
>>> logging.root.handlers
[<logging.StreamHandler object at 0xb70021cc>]
>>> logging.root.level
30
>>> import salt.client
>>> logging.root.level
30
>>> logging.root.handlers
[<logging.StreamHandler object at 0xb70021cc>]
>>> import salt.log
>>> salt.log.setup_console_logger()
>>> logging.root.handlers
[<logging.StreamHandler object at 0xb70021cc>, <logging.StreamHandler object at 0xb70336ec>]
>>> 
```
