### PR TITLE
Fix traceback because outputter expects data in {'host', data.. } format

### DIFF
--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -20,7 +20,7 @@ def over(env='base', os_fn=None):
             print('Stage execution results:')
             for key, val in stage.items():
                 salt.output.display_output(
-                        {key: val},
+                        {'local': {key: val}},
                         'highstate',
                         opts=__opts__)
         elif isinstance(stage, list):


### PR DESCRIPTION
To reproduce error I got just make invalid requisite in overstate.
Before my commit I get tracebacks in the output module or state module depending on wheter state_verbose is True or False.

After the commit I get:

local:
----------
    State: - No
    Name:      fail
    Function:  None
        Result:    False
        Comment:   Requisite testreq was not found

Which seems like the correct output, but it looks like maybe it continues on executing states even if I had a failure, but a failure in finding a requisite not running it. I think maybe the execution should stop, but I'm not too sure.

Feel free to scrap this pull if I'm on the wrong track, I was just trying to be helpful :)
