### PR TITLE
Make solarispkg work with multi-pkg for pkg.latest

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -252,7 +252,8 @@ def latest(
 
     Multiple Package Installation Options:
 
-    (Currently supported for: apt, pacman, yumpkg5)
+    (Not yet supported for: Windows, FreeBSD, OpenBSD, MacOS, and Solaris
+    pkgutil)
 
     pkgs
         A list of packages to maintain at the latest available version.


### PR DESCRIPTION
Currently solarispkg doesn't support repositories for pkgadd, so these
changes won't really allow pkg.latest to work as intended. This commit
does however bring this module in line with the changes being made in
other providers for #2906.
