### PR TITLE
issue 3202 file recurse does not exclude '..' directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1086,6 +1086,8 @@ def recurse(name,
         merge_ret(path, _ret)
 
     def manage_directory(path):
+        if os.path.basename(path) == '..':
+            return
         if clean and os.path.exists(path) and not os.path.isdir(path):
             _ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
             if __opts__['test']:


### PR DESCRIPTION
After some fiddling with the issue. I reproduced it via the method I mentioned in the tracker. And fixed it with this patch
