### PR TITLE
Changed groupadd.getent to not call a grp.getgrnam against each item returned by grp.getgrall

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -78,7 +78,10 @@ def getent():
     '''
     ret = []
     for grinfo in grp.getgrall():
-        ret.append(info(grinfo.gr_name))
+        ret.append({'name': grinfo.gr_name,
+                    'passwd': grinfo.gr_passwd,
+                    'gid': grinfo.gr_gid,
+                    'members': grinfo.gr_mem})
     return ret
 
 


### PR DESCRIPTION
modules/groupadd.py:
This module is currently calling a grp.getgrnam against each item returned by grp.getgrall. grp.getgrall() already returns all the data that's available via grp.getgrnam(name). The only thing this call to info() accomplishes is adding a large amount of wait time. We have a few thousand groups in our organization and this brings the getent() function from a short 1-2 seconds to a long 30+ seconds for every single group.present state.

This patch simply removes the additional call for each entity. The formatting is kept the same so everything that relies on this piece of code will keep working without noticing the difference.

... I know, a bit wordy for such a simple patch.
