### PR TITLE
Changed modules to keep from making excessive and redundant calls...

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -62,10 +62,17 @@ def info(name):
     except KeyError:
         return {}
     else:
-        return {'name': grinfo.gr_name,
-                'passwd': grinfo.gr_passwd,
-                'gid': grinfo.gr_gid,
-                'members': grinfo.gr_mem}
+        return _format_info(grinfo)
+
+
+def _format_info(data):
+    '''
+    Return formatted information in a pretty way.
+    '''
+    return {'name': data.gr_name,
+            'passwd': data.gr_passwd,
+            'gid': data.gr_gid,
+            'members': data.gr_mem}
 
 
 def getent():
@@ -76,12 +83,14 @@ def getent():
 
         salt '*' group.getent
     '''
+    if 'groupadd_getent' in __context__:
+      return __context__['groupadd_getent']
+
     ret = []
     for grinfo in grp.getgrall():
-        ret.append({'name': grinfo.gr_name,
-                    'passwd': grinfo.gr_passwd,
-                    'gid': grinfo.gr_gid,
-                    'members': grinfo.gr_mem})
+        ret.append(_format_info(grinfo))
+    __context__['groupadd_getent'] = ret
+
     return ret
 
 

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -78,7 +78,10 @@ def getent():
     '''
     ret = []
     for grinfo in grp.getgrall():
-        ret.append(info(grinfo.gr_name))
+        ret.append({'name': grinfo.gr_name,
+                    'passwd': grinfo.gr_passwd,
+                    'gid': grinfo.gr_gid,
+                    'members': grinfo.gr_mem})
     return ret
 
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -391,9 +391,6 @@ def _format_info(data):
     '''
     # Put GECOS info into a list
     gecos_field = data.pw_gecos.split(',', 3)
-    # Assign empty strings for any unspecified GECOS fields
-    while len(gecos_field) < 4:
-        gecos_field.append('')
 
     return {'gid': data.pw_gid,
             'groups': list_groups(data.pw_name,),
@@ -402,10 +399,10 @@ def _format_info(data):
             'passwd': data.pw_passwd,
             'shell': data.pw_shell,
             'uid': data.pw_uid,
-            'fullname': gecos_field[0],
-            'roomnumber': gecos_field[1],
-            'workphone': gecos_field[2],
-            'homephone': gecos_field[3]}
+            'fullname': gecos_field.get(0, ''),
+            'roomnumber': gecos_field.get(1, ''),
+            'workphone': gecos_field.get(2, ''),
+            'homephone': gecos_field.get(3, '')}
 
 
 def list_groups(name):

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -394,7 +394,6 @@ def _format_info(data):
     # Assign empty strings for any unspecified GECOS fields
     while len(gecos_field) < 4: gecos_field.append('')
 
-    log.error('x')
     return {'gid': data.pw_gid,
             'groups': list_groups(data.pw_name,),
             'home': data.pw_dir,
@@ -417,10 +416,19 @@ def list_groups(name):
         salt '*' user.list_groups foo
     '''
     ugrp = set()
+
     # Add the primary user's group
     ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
+
+    # If we already grabbed the group list, it's overkill to grab it again
+    if 'useradd_getgrall' in __context__:
+        groups = __context__['useradd_getgrall']
+    else:
+        groups = grp.getgrall()
+        __context__['useradd_getgrall'] = groups
+
     # Now, all other groups the user belongs to
-    for group in grp.getgrall():
+    for group in groups:
         if name in group.gr_mem:
             ugrp.add(group.gr_name)
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -392,7 +392,8 @@ def _format_info(data):
     # Put GECOS info into a list
     gecos_field = data.pw_gecos.split(',', 3)
     # Assign empty strings for any unspecified GECOS fields
-    while len(gecos_field) < 4: gecos_field.append('')
+    while len(gecos_field) < 4:
+        gecos_field.append('')
 
     return {'gid': data.pw_gid,
             'groups': list_groups(data.pw_name,),


### PR DESCRIPTION
modules/groupadd.py && modules/groupadd.py:
This module is currently calling a grp.getgrnam against each item returned by grp.getgrall. grp.getgrall() already returns all the data that's available via grp.getgrnam(name). The only thing this call to info() accomplishes is adding a large amount of wait time. We have a few thousand groups in our organization and this brings the getent() function from a short 1-2 seconds to a long 30+ seconds for every single group.present state.

This patch simply removes the additional call for each entity. The formatting is kept the same so everything that relies on this piece of code will keep working without noticing the difference.
