### PR TITLE
Makeconf del

### DIFF
--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -71,6 +71,29 @@ def set_var(var, value):
     new_value = get_var(var)
     return {var: {'old': old_value, 'new': new_value}}
 
+def remove_var(var):
+    '''
+    Remove a variable from the make.conf
+
+    Return a dict containing the new value for the variable::
+
+        {'<variable>': {'old': '<old-value>',
+                        'new': '<new-value>'}}
+    CLI Example::
+
+        salt '*' makeconf.remove_var 'LINGUAS'
+    '''
+    makeconf = _get_makeconf()
+
+    old_value = get_var(var)
+
+    # If var is in file
+    if old_value is not None:
+        __salt__['file.sed'](makeconf, '^{0}=.*'.format(var), '')
+
+    new_value = get_var(var)
+    return {var: {'old': old_value, 'new': new_value}}
+
 def append_var(var, value):
     '''
     Add to or create a new variable in the make.conf

--- a/salt/states/makeconf.py
+++ b/salt/states/makeconf.py
@@ -152,3 +152,43 @@ def present(name, value=None, contains=None, excludes=None):
 
     # Now finally return
     return ret
+
+def absent(name):
+    '''
+    Verify that the variable is not in the make.conf.
+
+    name
+        The variable name. This will automatically be converted to all Upper
+        Case since variables in make.conf are Upper Case
+    '''
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': True}
+
+    # Make name all Uppers since make.conf uses all Upper vars
+    upper_name = name.upper()
+
+    old_value = __salt__['makeconf.get_var'](upper_name)
+
+    if old_value is None:
+        msg = 'Variable {0} is already absent from make.conf'
+        ret['comment'] = msg.format(name)
+    else:
+        if __opts__['test']:
+            msg = 'Variable {0} is set to be removed from make.conf'
+            ret['comment'] = msg.format(name)
+            ret['result'] = None
+        else:
+            __salt__['makeconf.remove_var'](upper_name)
+
+            new_value = __salt__['makeconf.get_var'](upper_name)
+            if new_value is not None:
+                msg = 'Variable {0} failed to be removed from make.conf'
+                ret['comment'] = msg.format(name)
+                ret['result'] = False
+            else:
+                msg = 'Variable {0} was removed from make.conf'
+                ret['comment'] = msg.format(name)
+                ret['result'] = True
+    return ret


### PR DESCRIPTION
Added delete related functionality to makeconf module and state. The makeconf module now has a remove_var function to completely remove a var from the make.conf file. The makeconf state now has an absent function that ensures the variable is not in the make.conf file.
