### PR TITLE
The test suite local client now properly receives the events. Fixes #3214.

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -77,7 +77,7 @@ class LocalClient(object):
         self.serial = salt.payload.Serial(self.opts)
         self.salt_user = self.__get_user()
         self.key = self.__read_master_key()
-        self.event = salt.utils.event.MasterEvent(self.opts['sock_dir'])
+        self.event = salt.utils.event.LocalClientEvent(self.opts['sock_dir'])
 
     def __read_master_key(self):
         '''
@@ -163,9 +163,10 @@ class LocalClient(object):
         Common checks on the pub_data data structure returned from running pub
         '''
         if not pub_data:
-            err = ('Failed to authenticate, is this user permitted to execute '
-                   'commands?')
-            raise EauthAuthenticationError(err)
+            raise EauthAuthenticationError(
+                'Failed to authenticate, is this user permitted to execute '
+                'commands?'
+            )
 
         # Failed to connect to the master and send the pub
         if not 'jid' in pub_data or pub_data['jid'] == '0':


### PR DESCRIPTION
- We were instantiating the integration testing local client too soon in the process. Deferring it to a little latter made it all work.
- Added the ability to dump the master and minion testing configurations to files. Just prepend the `runtests` call with `DUMP_SALT_CONFIG=1` and you'll get the computed configuration files in `/tmp/salttest/{master,minion}`.
- We now also un-subscribe from the event's once done.
- Added `salt.utils.event.LocalClientEvent` just to differentiate from `salt.utils.event.MasterEvent` in the logs so we know who's who. It's just a subclass of the latter.
