### PR TITLE
Documentation : Avoid any ambiguity about dots in IDs.

### DIFF
--- a/doc/ref/states/highstate.rst
+++ b/doc/ref/states/highstate.rst
@@ -65,14 +65,16 @@ ID declaration
 
         Occurs on the top level or under the :term:`extend declaration`.
 
-.. note:: Naming gotchas
-
-        Must **not** contain a dot, otherwise highstate summary output will be
-        unpredictable. (This has been fixed in versions 0.9.7 and above)
-
         Must be unique across entire state tree. If the same ID declaration is
         used twice, only the first one matched will be used. All subsequent
         ID declarations with the same name will be ignored.
+
+.. note:: Naming gotchas
+
+        Until 0.9.6, IDs could **not** contain a dot, otherwise highstate summary output was
+        unpredictable. (It was fixed in versions 0.9.7 and above)
+
+
 
 Extend declaration
 ------------------


### PR DESCRIPTION
Avoid any ambiguity about dots in IDs.
