### PR TITLE
Simplify sub-classing `Master`, `Minion` and `Syndic` + PEP-8.

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -16,7 +16,7 @@ def salt_master():
     Start the salt-master.
     '''
     master = salt.Master()
-    master.start()
+    master.run()
 
 
 def salt_minion():
@@ -26,7 +26,7 @@ def salt_minion():
     if '' in sys.path:
         sys.path.remove('')
     minion = salt.Minion()
-    minion.start()
+    minion.run()
 
 
 def salt_syndic():
@@ -36,7 +36,7 @@ def salt_syndic():
     pid = os.getpid()
     try:
         syndic = salt.Syndic()
-        syndic.start()
+        syndic.run()
     except KeyboardInterrupt:
         os.kill(pid, 15)
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -36,7 +36,7 @@ def salt_syndic():
     pid = os.getpid()
     try:
         syndic = salt.Syndic()
-        syndic.run()
+        syndic.start()
     except KeyboardInterrupt:
         os.kill(pid, 15)
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -16,7 +16,7 @@ def salt_master():
     Start the salt-master.
     '''
     master = salt.Master()
-    master.run()
+    master.start()
 
 
 def salt_minion():
@@ -26,7 +26,7 @@ def salt_minion():
     if '' in sys.path:
         sys.path.remove('')
     minion = salt.Minion()
-    minion.run()
+    minion.start()
 
 
 def salt_syndic():


### PR DESCRIPTION
- Since we no longer suffer from too early logger initiation, replace any `logging.getLogger(__name__)` calls with an initial defined `logger`(not `log` so it does not clash with `salt.log`.
