### PR TITLE
A Python DSL(module and renderer) for generating Salt's highstate data structure.

### DIFF
--- a/salt/modules/pydsl.py
+++ b/salt/modules/pydsl.py
@@ -26,7 +26,7 @@ class Sls(object):
 
     def extend(self, *states):
         for s in states:
-            self.extends.append(self.all_decls.pop(state.id))
+            self.extends.append(self.all_decls.pop(s._id))
         
     def state(self, id=None):
         if not id:
@@ -38,37 +38,44 @@ class Sls(object):
             self.decls.append(s)
             return s
 
-    def to_highstate(self):
+    def to_highstate(self, slsmod):
+        # generate a state that uses the stateconf.set state, which
+        # is a no-op state, to hold a reference to the sls module
+        # containing the DSL statements. This is to prevent the module
+        # from being GC'ed, so that objects defined in it will be
+        # available while salt is executing the states.
+        self.state().stateconf.set(slsmod=slsmod)
+
         highstate = Dict()
         highstate['include'] = self.includes[:]
         highstate['extend'] = extend = Dict()
         for ext in self.extends:
-            extend[ext.id] = ext
+            extend[ext._id] = ext
         for decl in self.decls:
-            highstate[decl.id] = decl._repr()
+            highstate[decl._id] = decl._repr()
         return highstate
 
 
 class StateDeclaration(object):
 
     def __init__(self, id=None):
-        self.id = id
-        self.mods = []
+        self._id = id
+        self._mods = []
 
     def __getattr__(self, name):
-        for m in self.mods:
-            if m.name == name:
+        for m in self._mods:
+            if m._name == name:
                 return m
         else:
-            m = StateModule(name, self.id)
-            self.mods.append(m)
+            m = StateModule(name, self._id)
+            self._mods.append(m)
             return m
 
     def __str__(self):
-        return self.id
+        return self._id
 
     def __iter__(self):
-        return iter(self.mods)
+        return iter(self._mods)
 
     def _repr(self):
         return dict(m._repr() for m in self)
@@ -77,33 +84,33 @@ class StateDeclaration(object):
 class StateModule(object):
 
     def __init__(self, name, parent_decl):
-        self.state_id = parent_decl
-        self.name = name
-        self.func = None
+        self._state_id = parent_decl
+        self._name = name
+        self._func = None
 
     def __getattr__(self, name):
-        if self.func:
-            if name == self.func.name:
-                return self.func
+        if self._func:
+            if name == self._func.name:
+                return self._func
             else:
-                return getattr(self.func, name)
-        self.func = f = StateFunction(name)
+                return getattr(self._func, name)
+        self._func = f = StateFunction(name)
         return f
 
     def __call__(self, name, *args, **kws):
         return getattr(self, name).configure(args, kws)
 
     def __str__(self):
-        return self.name
+        return self._name
 
     def _repr(self):
-        return (self.name, [self.func.name]+self.func.args)
+        return (self._name, [self._func.name]+self._func.args)
 
 
 
 def _generate_requsite_method(t):
-    def req(self, ref, mod=None):
-        self.reference(t, ref, mod)
+    def req(self, mod, ref=None):
+        self.reference(t, mod, ref)
         return self
     return req
 
@@ -120,20 +127,26 @@ class StateFunction(object):
     def configure(self, args, kws):
         args = list(args)
         if args:
+            first = args[0]
+            if self.name == 'call' and callable(first):
+                args[0] = first.__name__
+                kws = dict(func=first, args=args[1:], kws=kws)
+                del args[1:]
+
             args[0] = dict(name=args[0])
+
         for k, v in kws.iteritems():
             args.append({k: v})
+
         self.args.extend(args)
         return self
 
-    def reference(self, req_type, ref, mod):
-        if isinstance(ref, StateModule):
-            mod = ref.name
-            ref = ref.state_id
-        elif ref and mod:
-            ref = str(ref)
-            mod = str(mod)
-        self.args.append({req_type: [{mod: ref}]})
+    def reference(self, req_type, mod, ref):
+        if isinstance(mod, StateModule):
+            ref = mod._state_id
+        elif not (mod and ref):
+            raise ValueError("Invalid argument(s) to a requisite expression!")
+        self.args.append({req_type: [{str(mod): str(ref)}]})
         return self
 
     ns = locals()

--- a/salt/modules/pydsl.py
+++ b/salt/modules/pydsl.py
@@ -1,0 +1,144 @@
+import weakref
+from uuid import uuid4 as _uuid
+
+try:
+    from collections import OrderedDict
+    Dict = OrderedDict
+except ImportError:
+    Dict = dict
+
+def sls(sls):
+    return Sls(sls)
+
+class Sls(object):
+
+    # tracks all state declarations globally across sls files
+    all_decls = weakref.WeakValueDictionary()
+
+    def __init__(self, sls):
+        self.name = sls
+        self.includes = []
+        self.extends = []
+        self.decls = []
+
+    def include(self, *sls_names):
+        self.includes.extend(sls_names)
+
+    def extend(self, *states):
+        for s in states:
+            self.extends.append(self.all_decls.pop(state.id))
+        
+    def state(self, id=None):
+        if not id:
+            id = str(_uuid())
+        try:
+            return self.all_decls[id]
+        except KeyError:
+            self.all_decls[id] = s = StateDeclaration(id)
+            self.decls.append(s)
+            return s
+
+    def to_highstate(self):
+        highstate = Dict()
+        highstate['include'] = self.includes[:]
+        highstate['extend'] = extend = Dict()
+        for ext in self.extends:
+            extend[ext.id] = ext
+        for decl in self.decls:
+            highstate[decl.id] = decl._repr()
+        return highstate
+
+
+class StateDeclaration(object):
+
+    def __init__(self, id=None):
+        self.id = id
+        self.mods = []
+
+    def __getattr__(self, name):
+        for m in self.mods:
+            if m.name == name:
+                return m
+        else:
+            m = StateModule(name, self.id)
+            self.mods.append(m)
+            return m
+
+    def __str__(self):
+        return self.id
+
+    def __iter__(self):
+        return iter(self.mods)
+
+    def _repr(self):
+        return dict(m._repr() for m in self)
+
+
+class StateModule(object):
+
+    def __init__(self, name, parent_decl):
+        self.state_id = parent_decl
+        self.name = name
+        self.func = None
+
+    def __getattr__(self, name):
+        if self.func:
+            if name == self.func.name:
+                return self.func
+            else:
+                return getattr(self.func, name)
+        self.func = f = StateFunction(name)
+        return f
+
+    def __call__(self, name, *args, **kws):
+        return getattr(self, name).configure(args, kws)
+
+    def __str__(self):
+        return self.name
+
+    def _repr(self):
+        return (self.name, [self.func.name]+self.func.args)
+
+
+
+def _generate_requsite_method(t):
+    def req(self, ref, mod=None):
+        self.reference(t, ref, mod)
+        return self
+    return req
+
+class StateFunction(object):
+    
+    def __init__(self, name):
+        self.name = name
+        self.args = []
+
+    def __call__(self, *args, **kws):
+        self.configure(args, kws)
+        return self
+
+    def configure(self, args, kws):
+        args = list(args)
+        if args:
+            args[0] = dict(name=args[0])
+        for k, v in kws.iteritems():
+            args.append({k: v})
+        self.args.extend(args)
+        return self
+
+    def reference(self, req_type, ref, mod):
+        if isinstance(ref, StateModule):
+            mod = ref.name
+            ref = ref.state_id
+        elif ref and mod:
+            ref = str(ref)
+            mod = str(mod)
+        self.args.append({req_type: [{mod: ref}]})
+        return self
+
+    ns = locals()
+    for req_type in "require watch use require_in watch_in use_in".split():
+        ns[req_type] = _generate_requsite_method(req_type)
+    del ns
+    del req_type
+

--- a/salt/modules/pydsl.py
+++ b/salt/modules/pydsl.py
@@ -1,3 +1,75 @@
+"""A Python DSL for generating Salt's highstate data structure.
+
+This module is intended to be used with the `pydsl` renderer,
+but can also be used on its own. Here's what you can do with
+Salt PyDSL::
+
+    # Example translated from the online salt tutorial
+
+    apache = state('apache')
+    apache.pkg.installed()
+    apache.service.running() \
+                  .watch(pkg='apache',
+                         file='/etc/httpd/conf/httpd.conf',
+                         user='apache')
+
+    if __grains__['os'] == 'RedHat':
+        apache.pkg.installed(name='httpd')
+        apache.service.running(name='httpd')
+
+    apache.group.present(gid=87).require(apache.pkg)
+    apache.user.present(uid=87, gid=87,
+                        home='/var/www/html',
+                        shell='/bin/nologin') \
+               .require(apache.group)
+
+    state('/etc/httpd/conf/httpd.conf').file.managed(
+        source='salt://apache/httpd.conf',
+        user='root',
+        group='root',
+        mode=644)
+
+
+Example with ``include`` and ``extend``, translated from
+the online salt tutorial::
+
+    include('http', 'ssh')
+    extend(
+        state('apache').file(
+            name='/etc/httpd/conf/httpd.conf',
+            source='salt://http/httpd2.conf'
+        ),
+        state('ssh-server').service.watch(file='/etc/ssh/banner')
+    )
+    state('/etc/ssh/banner').file.managed(source='salt://ssh/banner')
+
+
+Example of a ``cmd`` state calling a python function::
+
+    def hello(s):
+        s = "hello world, %s" % s
+        return dict(result=True, changes=dict(changed=True, output=s))
+
+    state('hello').cmd.call(hello, 'pydsl!')
+        
+"""
+
+#TODOs:
+#
+#  - modify the stateconf renderer so that we can pipe pydsl to
+#    it to make use of its features, particularly the implicit
+#    ordering of states using ordered dict.
+#
+#  - allow this:
+#      state('X').cmd.run.cwd = '/'
+#      assert state('X').cmd.run.cwd == '/'
+#
+#  - make it possible to remove:
+#    - state declarations
+#    - state module declarations
+#    - state func and args
+#
+
 import weakref
 from uuid import uuid4 as _uuid
 
@@ -6,6 +78,11 @@ try:
     Dict = OrderedDict
 except ImportError:
     Dict = dict
+
+
+REQUISITES = set("require watch use require_in watch_in use_in".split())
+class PyDslError(Exception):
+    pass
 
 def sls(sls):
     return Sls(sls)
@@ -24,9 +101,11 @@ class Sls(object):
     def include(self, *sls_names):
         self.includes.extend(sls_names)
 
-    def extend(self, *states):
-        for s in states:
-            self.extends.append(self.all_decls.pop(s._id))
+    def extend(self, *state_funcs):
+        for f in state_funcs:
+            self.extends.append(self.all_decls[f.mod._state_id])
+        for f in state_funcs:
+            self.decls.pop()
         
     def state(self, id=None):
         if not id:
@@ -39,13 +118,14 @@ class Sls(object):
             self.decls.append(s)
             return s
 
-    def to_highstate(self, slsmod):
+    def to_highstate(self, slsmod=None):
         # generate a state that uses the stateconf.set state, which
         # is a no-op state, to hold a reference to the sls module
         # containing the DSL statements. This is to prevent the module
         # from being GC'ed, so that objects defined in it will be
         # available while salt is executing the states.
-        self.state().stateconf.set(slsmod=slsmod)
+        if slsmod:
+            self.state().stateconf.set(slsmod=slsmod)
 
         highstate = Dict()
         if self.includes:
@@ -53,10 +133,28 @@ class Sls(object):
         if self.extends:
             highstate['extend'] = extend = Dict()
         for ext in self.extends:
-            extend[ext._id] = ext
+            extend[ext._id] = ext._repr(context='extend')
         for decl in self.decls:
             highstate[decl._id] = decl._repr()
         return highstate
+
+    def load_highstate(self, highstate):
+        for sid, decl in highstate.iteritems():
+            s = self.state(sid)
+            for modname, args in decl.iteritems():
+                if '.' in modname:
+                    modname, funcname = modname.rsplit('.', 1)
+                else:
+                    funcname = (x for x in args if isinstance(x, basestring)).next()
+                    args.remove(funcname)
+                mod = getattr(s, modname)
+                named_args = {}
+                for x in args:
+                    if isinstance(x, dict):
+                        k, v = x.iteritems().next()
+                        named_args[k] = v
+                mod(funcname, **named_args)
+
 
 
 class StateDeclaration(object):
@@ -80,8 +178,9 @@ class StateDeclaration(object):
     def __iter__(self):
         return iter(self._mods)
 
-    def _repr(self):
-        return dict(m._repr() for m in self)
+    def _repr(self, context=None):
+        return dict(m._repr(context) for m in self)
+
 
 
 class StateModule(object):
@@ -96,18 +195,30 @@ class StateModule(object):
             if name == self._func.name:
                 return self._func
             else:
+                if name not in REQUISITES:
+                    if self._func.name:
+                        raise PyDslError(
+                            ('Multiple state functions({0}) not allowed in a '
+                             'state module({1})!').format(name, self._name))
+                    self._func.name = name
+                    return self._func
                 return getattr(self._func, name)
-        self._func = f = StateFunction(name, self._name)
-        return f
 
-    def __call__(self, name, *args, **kws):
-        return getattr(self, name).configure(args, kws)
+        if name in REQUISITES:
+            self._func = f = StateFunction(None, self)
+            return getattr(f, name)
+        else:
+            self._func = f = StateFunction(name, self)
+            return f
+
+    def __call__(self, _fname, *args, **kws):
+        return getattr(self, _fname).configure(args, kws)
 
     def __str__(self):
         return self._name
 
-    def _repr(self):
-        return (self._name, [self._func.name]+self._func.args)
+    def _repr(self, context=None):
+        return (self._name, self._func._repr(context))
 
 
 
@@ -120,7 +231,7 @@ def _generate_requsite_method(t):
 class StateFunction(object):
     
     def __init__(self, name, parent_mod):
-        self.mod_name = parent_mod
+        self.mod = parent_mod
         self.name = name
         self.args = []
 
@@ -128,11 +239,19 @@ class StateFunction(object):
         self.configure(args, kws)
         return self
 
+    def _repr(self, context=None):
+        if not self.name and context != 'extend':
+            raise PyDslError("No state function specified for module: "
+                             "{0}".format(self.mod._name))
+        if not self.name and context == 'extend':
+            return self.args
+        return [self.name]+self.args
+
     def configure(self, args, kws):
         args = list(args)
         if args:
             first = args[0]
-            if self.mod_name == 'cmd' and self.name == 'call' and callable(first):
+            if self.mod._name == 'cmd' and self.name == 'call' and callable(first):
                 args[0] = first.__name__
                 kws = dict(func=first, args=args[1:], kws=kws)
                 del args[1:]
@@ -149,12 +268,12 @@ class StateFunction(object):
         if isinstance(mod, StateModule):
             ref = mod._state_id
         elif not (mod and ref):
-            raise ValueError("Invalid argument(s) to a requisite expression!")
+            raise PyDslError("Invalid argument(s) to a requisite expression!")
         self.args.append({req_type: [{str(mod): str(ref)}]})
         return self
 
     ns = locals()
-    for req_type in "require watch use require_in watch_in use_in".split():
+    for req_type in REQUISITES:
         ns[req_type] = _generate_requsite_method(req_type)
     del ns
     del req_type

--- a/salt/renderers/pydsl.py
+++ b/salt/renderers/pydsl.py
@@ -1,0 +1,21 @@
+import imp
+
+
+def render(template, env='', sls='', tmplpath=None, **kws):
+    mod = imp.new_module(sls)
+    dsl_sls = __salt__['pydsl.sls'](sls)
+    mod.__dict__.update(
+        include=dsl_sls.include,
+        extend=dsl_sls.extend,
+        state=dsl_sls.state,
+        __salt__=__salt__,
+        __grains__=__grains__,
+        __opts__=__opts__,
+        __pillar__=__pillar__,
+        env=env,
+        sls=sls,
+        tmplpath=tmplpath,
+        **kws)
+    exec template.read() in mod.__dict__
+    return dsl_sls.to_highstate()
+    

--- a/salt/renderers/pydsl.py
+++ b/salt/renderers/pydsl.py
@@ -3,6 +3,15 @@ import imp
 
 def render(template, env='', sls='', tmplpath=None, **kws):
     mod = imp.new_module(sls)
+    # Note: mod object is transient. It's existence only lasts as long as
+    #       the lowstate data structure that the highstate in the sls file
+    #       is compiled to.
+
+    mod.__name__ = sls
+
+    # to workaround state.py's use of copy.deepcopy(chunck)
+    mod.__deepcopy__ = lambda x: mod
+
     dsl_sls = __salt__['pydsl.sls'](sls)
     mod.__dict__.update(
         include=dsl_sls.include,
@@ -12,10 +21,10 @@ def render(template, env='', sls='', tmplpath=None, **kws):
         __grains__=__grains__,
         __opts__=__opts__,
         __pillar__=__pillar__,
-        env=env,
-        sls=sls,
-        tmplpath=tmplpath,
+        __env__=env,
+        __sls__=sls,
+        __file__=tmplpath,
         **kws)
     exec template.read() in mod.__dict__
-    return dsl_sls.to_highstate()
+    return dsl_sls.to_highstate(mod)
     

--- a/salt/renderers/pydsl.py
+++ b/salt/renderers/pydsl.py
@@ -14,6 +14,7 @@ def render(template, env='', sls='', tmplpath=None, **kws):
 
     dsl_sls = __salt__['pydsl.sls'](sls)
     mod.__dict__.update(
+        __pydsl__=dsl_sls,
         include=dsl_sls.include,
         extend=dsl_sls.extend,
         state=dsl_sls.state,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -594,7 +594,8 @@ def call(name, func, args=(), kws=None,
         kws = {}
     result = func(*args, **kws)
     if isinstance(result, dict):
-        return result 
+        ret.update(result)
+        return ret
     elif isinstance(result, basestring) and stateful:
         return _reinterpreted_state(result)
     else:

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -120,10 +120,10 @@ import copy
 import json
 import shlex
 import logging
+import sys
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError
-import salt.state
 
 log = logging.getLogger(__name__)
 
@@ -564,6 +564,47 @@ def script(name,
 
     finally:
         os.setegid(pgid)
+
+
+def call(name, func, args=(), kws=None,
+         onlyif=None,
+         unless=None,
+         stateful=False,
+         **kwargs):
+    '''
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    cmd_kwargs = {'cwd': kwargs.get('cwd'),
+                  'runas': kwargs.get('user'),
+                  'shell': kwargs.get('shell') or __grains__['shell'],
+                  'env': kwargs.get('env')}
+    pgid = os.getegid()
+    try:
+        cret = _run_check(cmd_kwargs, onlyif, unless, None, None, None, None)
+        if isinstance(cret, dict):
+            ret.update(cret)
+            return ret
+    finally:
+        os.setegid(pgid)
+    if not kws:
+        kws = {}
+    result = func(*args, **kws)
+    if isinstance(result, dict):
+        return result 
+    elif isinstance(result, basestring) and stateful:
+        return _reinterpreted_state(result)
+    else:
+        # result must be json serializable else we get an error
+        ret['changes'] = {'retval': result}
+        ret['result'] = True if result is None else bool(result)
+        if isinstance(result, basestring):
+            ret['comment'] = result
+        return ret
+            
 
 
 def mod_watch(name, **kwargs):

--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -17,12 +17,11 @@ OPTS = salt.config.master_config('whatever, just load the defaults!')
 OPTS['id'] = 'whatever'
 OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/'])
-
+OPTS['test'] = False
 OPTS['grains'] = salt.loader.grains(OPTS)
 STATE = State(OPTS)
 
 def render_sls(content, sls='', env='base', **kws):
-    sys.modules['salt.loaded.int.render.pydsl'].__salt__ = STATE.functions
     return STATE.rend['pydsl'](
                 StringIO(content), env=env, sls=sls,
                 **kws)
@@ -31,17 +30,31 @@ def render_sls(content, sls='', env='base', **kws):
 
 class PyDSLRendererTestCase(TestCase):
 
+    def setUp(self):
+        STATE.load_modules()
+        sys.modules['salt.loaded.int.render.pydsl'].__salt__ = STATE.functions
+        self.PyDslError = sys.modules['salt.loaded.int.module.pydsl'].PyDslError
+
     def test_state_declarations(self):
         result = render_sls('''
 state('A').cmd.run('ls -la', cwd='/var/tmp')
 state().file.managed('myfile.txt', source='salt://path/to/file')
 state('X').cmd('run', 'echo hello world', cwd='/')
+
+a_cmd = state('A').cmd
+a_cmd.run(shell='/bin/bash')
+state('A').service.running(name='apache')
 ''')
         self.assertTrue('A' in result and 'X' in result)
         A_cmd = result['A']['cmd']
         self.assertEqual(A_cmd[0], 'run')
         self.assertEqual(A_cmd[1]['name'], 'ls -la')
         self.assertEqual(A_cmd[2]['cwd'], '/var/tmp')
+        self.assertEqual(A_cmd[3]['shell'], '/bin/bash')
+
+        A_service = result['A']['service']
+        self.assertEqual(A_service[0], 'running')
+        self.assertEqual(A_service[1]['name'], 'apache')
 
         X_cmd = result['X']['cmd']
         self.assertEqual(X_cmd[0], 'run')
@@ -58,5 +71,129 @@ state('X').cmd('run', 'echo hello world', cwd='/')
         self.assertEqual(s[0], 'managed')
         self.assertEqual(s[1]['name'], 'myfile.txt')
         self.assertEqual(s[2]['source'], 'salt://path/to/file')
+
+
+    def test_requisite_declarations(self):
+        result = render_sls('''
+state('X').cmd.run('echo hello')
+state('A').cmd.run('mkdir tmp', cwd='/var')
+state('B').cmd.run('ls -la', cwd='/var/tmp') \
+              .require(state('X').cmd) \
+              .require('cmd', 'A') \
+              .watch('service', 'G')
+state('G').service.running(name='collectd')
+state('G').service.watch_in(state('A').cmd)
+
+state('H').cmd.require_in('cmd', 'echo hello')
+state('H').cmd.run('echo world')
+''')
+        self.assertTrue(len(result), 6)            
+        self.assertTrue(set("X A B G H".split()).issubset(set(result.keys())))
+        b = result['B']['cmd']
+        self.assertEqual(b[0], 'run')
+        self.assertEqual(b[1]['name'], 'ls -la')
+        self.assertEqual(b[2]['cwd'], '/var/tmp')
+        self.assertEqual(b[3]['require'][0]['cmd'], 'X')
+        self.assertEqual(b[4]['require'][0]['cmd'], 'A')
+        self.assertEqual(b[5]['watch'][0]['service'], 'G')
+        self.assertEqual(result['G']['service'][2]['watch_in'][0]['cmd'], 'A')
+        self.assertEqual(result['H']['cmd'][1]['require_in'][0]['cmd'], 'echo hello')
+
+
+    def test_include_extend(self):
+        result = render_sls('''
+include(
+    'some.sls.file',
+    'another.sls.file',
+    'more.sls.file'
+)
+extend(
+    state('X').cmd.run(cwd='/a/b/c'),
+    state('Y').file('managed', name='a_file.txt'),
+    state('Z').service.watch('file', 'A')
+)
+''')
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result['include'],
+                         'some.sls.file another.sls.file more.sls.file'.split())
+        extend = result['extend']
+        self.assertEqual(extend['X']['cmd'][0], 'run')
+        self.assertEqual(extend['X']['cmd'][1]['cwd'], '/a/b/c')
+        self.assertEqual(extend['Y']['file'][0], 'managed')
+        self.assertEqual(extend['Y']['file'][1]['name'], 'a_file.txt')
+        self.assertEqual(len(extend['Z']['service']), 1)
+        self.assertEqual(extend['Z']['service'][0]['watch'][0]['file'], 'A')
+
+
+    def test_cmd_call(self):
+        result = STATE.call_template_str('''#!pydsl
+state('A').cmd.run('echo this is state A', cwd='/')
+
+some_var = 12345
+def do_something(a, b, *args, **kws):
+    return dict(result=True, changes={'a': a, 'b': b, 'args': args, 'kws': kws, 'some_var': some_var})
+
+state('C').cmd.call(do_something, 1, 2, 3, x=1, y=2) \
+              .require(state('A').cmd)
+
+state('G').cmd.wait('echo this is state G', cwd='/') \
+              .watch(state('C').cmd)
+''')
+        ret = (result[k] for k in result.keys() if 'do_something' in k).next()
+        changes = ret['changes']
+        self.assertEqual(changes, dict(a=1, b=2, args=(3,), kws=dict(x=1, y=2), some_var=12345))
+
+        ret = (result[k] for k in result.keys() if '-G_' in k).next()
+        self.assertEqual(ret['changes']['stdout'], 'this is state G')
+
+
+    def test_multiple_state_func_in_state_mod(self):
+        with self.assertRaisesRegexp(self.PyDslError, 'Multiple state functions'):
+            render_sls('''
+state('A').cmd.run('echo hoho')
+state('A').cmd.wait('echo hehe')
+''')
+
+
+    def test_no_state_func_in_state_mod(self):
+        with self.assertRaisesRegexp(self.PyDslError, 'No state function specified'):
+            render_sls('''
+state('B').cmd.require('cmd', 'hoho')
+''')
+
+
+    def test_load_highstate(self):
+        result = render_sls('''
+import yaml
+__pydsl__.load_highstate(yaml.load("""
+A:
+  cmd.run:
+    - name: echo hello
+    - cwd: /
+B:
+  pkg:
+    - installed
+  service:
+    - running
+    - require:
+      - pkg: B
+    - watch:
+      - cmd: A
+"""))
+
+state('A').cmd.run(name='echo hello world')
+''')
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result['A']['cmd'][0], 'run')
+        self.assertEqual(result['A']['cmd'][1]['name'], 'echo hello')
+        self.assertEqual(result['A']['cmd'][2]['cwd'], '/')
+        self.assertEqual(result['A']['cmd'][3]['name'], 'echo hello world')
+
+        self.assertEqual(len(result['B']['pkg']), 1)
+        self.assertEqual(result['B']['pkg'][0], 'installed')
+
+        self.assertEqual(result['B']['service'][0], 'running')
+        self.assertEqual(result['B']['service'][1]['require'][0]['pkg'], 'B')
+        self.assertEqual(result['B']['service'][2]['watch'][0]['cmd'], 'A')
 
 

--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -1,0 +1,62 @@
+# Import Python libs
+import sys
+from cStringIO import StringIO
+
+# Import Salt libs
+from saltunittest import TestCase
+import salt.loader
+import salt.config
+from salt.state import State
+
+REQUISITES = ['require', 'require_in', 'use', 'use_in', 'watch', 'watch_in']
+
+OPTS = salt.config.master_config('whatever, just load the defaults!')
+# we should have used minion_config(), but that would try to resolve
+# the master hostname, and retry for 30 seconds! Lucily for our purpose,
+# master conf or minion conf, it doesn't matter.
+OPTS['id'] = 'whatever'
+OPTS['file_client'] = 'local'
+OPTS['file_roots'] = dict(base=['/'])
+
+OPTS['grains'] = salt.loader.grains(OPTS)
+STATE = State(OPTS)
+
+def render_sls(content, sls='', env='base', **kws):
+    sys.modules['salt.loaded.int.render.pydsl'].__salt__ = STATE.functions
+    return STATE.rend['pydsl'](
+                StringIO(content), env=env, sls=sls,
+                **kws)
+
+            
+
+class PyDSLRendererTestCase(TestCase):
+
+    def test_state_declarations(self):
+        result = render_sls('''
+state('A').cmd.run('ls -la', cwd='/var/tmp')
+state().file.managed('myfile.txt', source='salt://path/to/file')
+state('X').cmd('run', 'echo hello world', cwd='/')
+''')
+        self.assertTrue('A' in result and 'X' in result)
+        A_cmd = result['A']['cmd']
+        self.assertEqual(A_cmd[0], 'run')
+        self.assertEqual(A_cmd[1]['name'], 'ls -la')
+        self.assertEqual(A_cmd[2]['cwd'], '/var/tmp')
+
+        X_cmd = result['X']['cmd']
+        self.assertEqual(X_cmd[0], 'run')
+        self.assertEqual(X_cmd[1]['name'], 'echo hello world')
+        self.assertEqual(X_cmd[2]['cwd'], '/')
+
+        del result['A']
+        del result['X']
+        self.assertEqual(len(result), 2)
+        # 2 rather than 1 because pydsl adds an extra no-op state
+        # declaration.
+
+        s = result.itervalues().next()['file']
+        self.assertEqual(s[0], 'managed')
+        self.assertEqual(s[1]['name'], 'myfile.txt')
+        self.assertEqual(s[2]['source'], 'salt://path/to/file')
+
+


### PR DESCRIPTION
not that it's better or more powerful than using yaml+jinja; but at day job I have to use Chef, and I guess it got into me... and I just want to see if it's possible to do something similar in Salt. 

I think this renderer proves again that Salt's idea of using a common data structure that can be transformed and also rendered from other forms of input data is a very powerful one.

It still needs more docs and there's more to be done to make it more feature-complete and user-friendly, but I'd just like to toss it out to get some feedback and see people's reactions.
