### PR TITLE
Remove `pub_refresh` and `sub_timeout` from both documentation and `salt.config`

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -45,21 +45,6 @@ The network port to set up the publication interface
     publish_port: 4505
 
 
-.. conf_master:: pub_refresh
-
-``pub_refresh``
----------------
-
-Default: ``False``
-
-The pub_refresh system manually refreshed the master ZeroMQ publisher. It is
-used in some cases where the minions loose connection to the master and it
-is solved by restarting the master.
-
-.. code-block:: yaml
-
-    pub_refresh: False
-
 .. conf_master:: user
 
 ``user``

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -131,19 +131,6 @@ FQDN (for instance, Solaris).
 
     append_domain: foo.org
 
-.. conf_minion:: sub_timeout
-
-``sub_timeout``
----------------
-
-The minion connection to the master may be interrupted. The minion will
-verify the connection every so many seconds, to disable connection
-verification set this value to 0.
-
-.. code-block:: yaml
-
-    sub_timeout: 60
-
 .. conf_minion:: cachedir
 
 ``cachedir``

--- a/salt/config.py
+++ b/salt/config.py
@@ -216,7 +216,6 @@ def minion_config(path, check_dns=True):
             'clean_dynamic_modules': True,
             'open_mode': False,
             'multiprocessing': True,
-            'sub_timeout': 0,
             'ipc_mode': 'ipc',
             'tcp_pub_port': 4510,
             'tcp_pull_port': 4511,


### PR DESCRIPTION
Remove `pub_refresh` and `sub_timeout` from both documentation and `salt.config`
