### PR TITLE
Added some support for postgres groups to the postgres module

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -305,6 +305,7 @@ def _role_create(name,
                  superuser=False,
                  replication=False,
                  password=None,
+                 groups=None,
                  runas=None):
     '''
     Creates a Postgres role. Users and Groups are both roles in postgres.
@@ -336,6 +337,8 @@ def _role_create(name,
         sub_cmd = "{0} SUPERUSER".format(sub_cmd, )
     if replication:
         sub_cmd = "{0} REPLICATION".format(sub_cmd, )
+    if groups:
+        sub_cmd = "{0} IN GROUP {1}".format(sub_cmd, groups, )
 
     if sub_cmd.endswith("WITH"):
         sub_cmd = sub_cmd.replace(" WITH", "")
@@ -353,6 +356,7 @@ def user_create(username,
                 superuser=False,
                 replication=False,
                 password=None,
+                groups=None,
                 runas=None):
     '''
     Creates a Postgres user.
@@ -372,6 +376,7 @@ def user_create(username,
                         superuser,
                         replication,
                         password,
+                        groups,
                         runas)
 
 def user_update(username,
@@ -453,6 +458,7 @@ def group_create(groupname,
                  superuser=False,
                  replication=False,
                  password=None,
+                 groups=None,
                  runas=None):
     '''
     Creates a Postgres group. A group is postgres is similar to a user, but
@@ -473,4 +479,5 @@ def group_create(groupname,
                         superuser,
                         replication,
                         password,
+                        groups,
                         runas)


### PR DESCRIPTION
Postgres treats both users and groups as "roles". The only difference is that users can login, while groups cannot. This is an initial pass at adding postgres group support to salt. These functions are not fully "aware" of a postgres group vs. postgres user (ie you could run postgres.group_update on a user and it would still work). Only postgres.user_create and postgres.group_create take advantage of the difference. 

I am wondering if we should make salt fully aware of the difference. Should salt verify that the role is a group/user for the corresponding function? (ie before removing a role when postgres.group_remove is called, first salt verifies it is in fact a group?) I should be able to do this if it seems correct.
