### PR TITLE
Defer imports to a later stage so Jinja2 does not become a build dependency. Fixes #3293.

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -30,8 +30,6 @@ except ImportError:
     HAS_FNCTL = False
 
 # Import salt libs
-import salt.minion
-import salt.payload
 from salt.exceptions import SaltClientError, CommandNotFoundError
 
 
@@ -196,6 +194,12 @@ def daemonize_if(opts, **kwargs):
             data[key[6:]] = val
     if not 'jid' in data:
         return
+
+    # Late import salt libs to overcome circular imports and to allow building
+    # salt without making Jinja2 a build dependency
+    import salt.minon
+    import salt.payload
+
     serial = salt.payload.Serial(opts)
     proc_dir = salt.minion.get_proc_dir(opts['cachedir'])
     fn_ = os.path.join(proc_dir, data['jid'])


### PR DESCRIPTION
Defer imports to a later stage so Jinja2 does not become a build dependency. Fixes #3293.
