### PR TITLE
split reading conf file from actual configuration

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -271,6 +271,8 @@ def load_config(path, env_var):
     else:
         log.debug('Missing configuration file: {0}'.format(path))
 
+    return {}
+
 
 def include_config(include, orig_path, verbose):
     '''

--- a/salt/config.py
+++ b/salt/config.py
@@ -35,6 +35,162 @@ _DFLT_LOG_FMT_LOGFILE = (
     '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
 )
 
+# default configurations
+DEFAULT_MINION_OPTS = {
+    'master': 'salt',
+    'master_port': '4506',
+    'master_finger': '',
+    'user': 'root',
+    'root_dir': '/',
+    'pki_dir': '/etc/salt/pki/minion',
+    'id': socket.getfqdn(),
+    'cachedir': '/var/cache/salt/minion',
+    'cache_jobs': False,
+    'conf_file': '/etc/salt/minion',
+    'sock_dir': '/var/run/salt/minion',
+    'backup_mode': '',
+    'renderer': 'yaml_jinja',
+    'failhard': False,
+    'autoload_dynamic_modules': True,
+    'environment': None,
+    'state_top': 'top.sls',
+    'startup_states': '',
+    'sls_list': [],
+    'top_file': '',
+    'file_client': 'remote',
+    'file_roots': {
+        'base': ['/srv/salt'],
+        },
+    'pillar_roots': {
+        'base': ['/srv/pillar'],
+        },
+    'hash_type': 'md5',
+    'external_nodes': '',
+    'disable_modules': [],
+    'disable_returners': [],
+    'whitelist_modules': [],
+    'module_dirs': [],
+    'returner_dirs': [],
+    'states_dirs': [],
+    'render_dirs': [],
+    'providers': {},
+    'clean_dynamic_modules': True,
+    'open_mode': False,
+    'multiprocessing': True,
+    'ipc_mode': 'ipc',
+    'tcp_pub_port': 4510,
+    'tcp_pull_port': 4511,
+    'log_file': '/var/log/salt/minion',
+    'log_level': None,
+    'log_level_logfile': None,
+    'log_datefmt': _DFLT_LOG_DATEFMT,
+    'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,
+    'log_fmt_console': _DFLT_LOG_FMT_CONSOLE,
+    'log_fmt_logfile': _DFLT_LOG_FMT_LOGFILE,
+    'log_granular_levels': {},
+    'test': False,
+    'cython_enable': False,
+    'state_verbose': True,
+    'state_output': 'full',
+    'acceptance_wait_time': 10,
+    'loop_interval': 60,
+    'dns_check': True,
+    'verify_env': True,
+    'grains': {},
+    'permissive_pki_access': False,
+    'default_include': 'minion.d/*.conf',
+    'update_url': False,
+    'update_restart_services': [],
+    'retry_dns': 30,
+    'recon_max': 5000,
+    'win_repo_cachefile': 'salt://win/repo/winrepo.p',
+    'pidfile': '/var/run/salt-minion.pid',
+    'tcp_keepalive': True,
+    'tcp_keepalive_idle': 300,
+    'tcp_keepalive_cnt': -1,
+    'tcp_keepalive_intvl': -1,
+}
+
+DEFAULT_MASTER_OPTS = {
+    'interface': '0.0.0.0',
+    'publish_port': '4505',
+    'auth_mode': 1,
+    'user': 'root',
+    'worker_threads': 5,
+    'sock_dir': '/var/run/salt/master',
+    'ret_port': '4506',
+    'timeout': 5,
+    'keep_jobs': 24,
+    'root_dir': '/',
+    'pki_dir': '/etc/salt/pki/master',
+    'cachedir': '/var/cache/salt/master',
+    'file_roots': {
+        'base': ['/srv/salt'],
+        },
+    'master_roots': {
+        'base': ['/srv/salt-master'],
+        },
+    'pillar_roots': {
+        'base': ['/srv/pillar'],
+        },
+    'gitfs_remotes': [],
+    'ext_pillar': [],
+    'pillar_version': 2,
+    'pillar_opts': True,
+    'syndic_master': '',
+    'runner_dirs': [],
+    'client_acl': {},
+    'external_auth': {},
+    'token_expire': 43200,
+    'file_buffer_size': 1048576,
+    'file_ignore_regex': None,
+    'file_ignore_glob': None,
+    'fileserver_backend': ['roots'],
+    'max_open_files': 100000,
+    'hash_type': 'md5',
+    'conf_file': '/etc/salt/master',
+    'open_mode': False,
+    'auto_accept': False,
+    'renderer': 'yaml_jinja',
+    'failhard': False,
+    'state_top': 'top.sls',
+    'master_tops': {},
+    'external_nodes': '',
+    'order_masters': False,
+    'job_cache': True,
+    'ext_job_cache': '',
+    'master_ext_job_cache': '',
+    'minion_data_cache': True,
+    'log_file': '/var/log/salt/master',
+    'log_level': None,
+    'log_level_logfile': None,
+    'log_datefmt': _DFLT_LOG_DATEFMT,
+    'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,
+    'log_fmt_console': _DFLT_LOG_FMT_CONSOLE,
+    'log_fmt_logfile': _DFLT_LOG_FMT_LOGFILE,
+    'log_granular_levels': {},
+    'pidfile': '/var/run/salt-master.pid',
+    'cluster_masters': [],
+    'cluster_mode': 'paranoid',
+    'range_server': 'range:80',
+    'reactors': [],
+    'serial': 'msgpack',
+    'state_verbose': True,
+    'state_output': 'full',
+    'search': '',
+    'search_index_interval': 3600,
+    'loop_interval': 60,
+    'nodegroups': {},
+    'cython_enable': False,
+    'key_logfile': '/var/log/salt/key',
+    'verify_env': True,
+    'permissive_pki_access': False,
+    'default_include': 'master.d/*.conf',
+    'win_repo': '/srv/salt/win/repo',
+    'win_repo_mastercachefile': '/srv/salt/win/repo/winrepo.p',
+    'win_gitrepos': ['https://github.com/saltstack/salt-winrepo.git'],
+}
+
 
 def _validate_file_roots(opts):
     '''
@@ -77,15 +233,15 @@ def _read_conf_file(path):
         return conf_opts
 
 
-def load_config(opts, path, env_var):
+def load_config(path, env_var):
     '''
-    Attempts to update ``opts`` dict by parsing either the file described by
+    Returns configuration dict from parsing either the file described by
     ``path`` or the environment variable described by ``env_var`` as YAML.
     '''
     if path is None:
         # When the passed path is None, we just want the configuration
         # defaults, not actually loading the whole configuration.
-        return opts
+        return {}
 
     if not path or not os.path.isfile(path):
         path = os.environ.get(env_var, path)
@@ -102,8 +258,9 @@ def load_config(opts, path, env_var):
 
     if os.path.isfile(path):
         try:
-            opts.update(_read_conf_file(path))
+            opts = _read_conf_file(path)
             opts['conf_file'] = path
+            return opts
         except Exception as err:
             import salt.log
             msg = 'Error parsing configuration file: {0} - {1}'
@@ -115,23 +272,24 @@ def load_config(opts, path, env_var):
         log.debug('Missing configuration file: {0}'.format(path))
 
 
-def include_config(include, opts, orig_path, verbose):
+def include_config(include, orig_path, verbose):
     '''
     Parses extra configuration file(s) specified in an include list in the
     main config file.
     '''
     # Protect against empty option
     if not include:
-        return opts
+        return {}
 
     if orig_path is None:
         # When the passed path is None, we just want the configuration
         # defaults, not actually loading the whole configuration.
-        return opts
+        return {}
 
     if isinstance(include, str):
         include = [include]
 
+    include_config = {}
     for path in include:
         if not os.path.isabs(path):
             path = os.path.join(os.path.dirname(orig_path), path)
@@ -147,14 +305,14 @@ def include_config(include, opts, orig_path, verbose):
 
         for fn_ in glob.glob(path):
             try:
-                opts.update(_read_conf_file(fn_))
+                include_config.update(_read_conf_file(fn_))
             except Exception as err:
                 log.warn(
                     'Error parsing configuration file: {0} - {1}'.format(
                         fn_, err
                     )
                 )
-    return opts
+    return include_config
 
 
 def prepend_root_dir(opts, path_options):
@@ -176,90 +334,26 @@ def minion_config(path, check_dns=True):
     '''
     Reads in the minion configuration file and sets up special options
     '''
-    opts = {'master': 'salt',
-            'master_port': '4506',
-            'master_finger': '',
-            'user': 'root',
-            'root_dir': '/',
-            'pki_dir': '/etc/salt/pki/minion',
-            'id': socket.getfqdn(),
-            'cachedir': '/var/cache/salt/minion',
-            'cache_jobs': False,
-            'conf_file': path,
-            'sock_dir': '/var/run/salt/minion',
-            'backup_mode': '',
-            'renderer': 'yaml_jinja',
-            'failhard': False,
-            'autoload_dynamic_modules': True,
-            'environment': None,
-            'state_top': 'top.sls',
-            'startup_states': '',
-            'sls_list': [],
-            'top_file': '',
-            'file_client': 'remote',
-            'file_roots': {
-                'base': ['/srv/salt'],
-                },
-            'pillar_roots': {
-                'base': ['/srv/pillar'],
-                },
-            'hash_type': 'md5',
-            'external_nodes': '',
-            'disable_modules': [],
-            'disable_returners': [],
-            'whitelist_modules': [],
-            'module_dirs': [],
-            'returner_dirs': [],
-            'states_dirs': [],
-            'render_dirs': [],
-            'providers': {},
-            'clean_dynamic_modules': True,
-            'open_mode': False,
-            'multiprocessing': True,
-            'ipc_mode': 'ipc',
-            'tcp_pub_port': 4510,
-            'tcp_pull_port': 4511,
-            'log_file': '/var/log/salt/minion',
-            'log_level': None,
-            'log_level_logfile': None,
-            'log_datefmt': _DFLT_LOG_DATEFMT,
-            'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,
-            'log_fmt_console': _DFLT_LOG_FMT_CONSOLE,
-            'log_fmt_logfile': _DFLT_LOG_FMT_LOGFILE,
-            'log_granular_levels': {},
-            'test': False,
-            'cython_enable': False,
-            'state_verbose': True,
-            'state_output': 'full',
-            'acceptance_wait_time': 10,
-            'loop_interval': 60,
-            'dns_check': True,
-            'verify_env': True,
-            'grains': {},
-            'permissive_pki_access': False,
-            'default_include': 'minion.d/*.conf',
-            'update_url': False,
-            'update_restart_services': [],
-            'retry_dns': 30,
-            'recon_max': 5000,
-            'win_repo_cachefile': 'salt://win/repo/winrepo.p',
-            'pidfile': '/var/run/salt-minion.pid',
-            'tcp_keepalive': True,
-            'tcp_keepalive_idle': 300,
-            'tcp_keepalive_cnt': -1,
-            'tcp_keepalive_intvl': -1,
-            }
+    overrides = load_config(path, 'SALT_MINION_CONFIG')
+    default_include = overrides.get('default_include', DEFAULT_MINION_OPTS['default_include'])
+    include = overrides.get('include', [])
+
+    overrides.update(include_config(default_include, path, verbose=False))
+    overrides.update(include_config(include, path, verbose=True))
+
+    return apply_minion_config(overrides, check_dns)
+
+
+def apply_minion_config(overrides=None, check_dns=True):
+    '''
+    Returns minion configurations dict.
+    '''
+    opts = DEFAULT_MINION_OPTS.copy()
+    if overrides:
+        opts.update(overrides)
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
-
-    load_config(opts, path, 'SALT_MINION_CONFIG')
-
-    default_include = opts.get('default_include', [])
-    include = opts.get('include', [])
-
-    opts = include_config(default_include, opts, path, verbose=False)
-    opts = include_config(include, opts, path, verbose=True)
 
     if 'append_domain' in opts:
         opts['id'] = _append_domain(opts)
@@ -326,95 +420,25 @@ def master_config(path):
     '''
     Reads in the master configuration file and sets up default options
     '''
-    opts = {'interface': '0.0.0.0',
-            'publish_port': '4505',
-            'auth_mode': 1,
-            'user': 'root',
-            'worker_threads': 5,
-            'sock_dir': '/var/run/salt/master',
-            'ret_port': '4506',
-            'timeout': 5,
-            'keep_jobs': 24,
-            'root_dir': '/',
-            'pki_dir': '/etc/salt/pki/master',
-            'cachedir': '/var/cache/salt/master',
-            'file_roots': {
-                'base': ['/srv/salt'],
-                },
-            'master_roots': {
-                'base': ['/srv/salt-master'],
-                },
-            'pillar_roots': {
-                'base': ['/srv/pillar'],
-                },
-            'gitfs_remotes': [],
-            'ext_pillar': [],
-            'pillar_version': 2,
-            'pillar_opts': True,
-            'syndic_master': '',
-            'runner_dirs': [],
-            'client_acl': {},
-            'external_auth': {},
-            'token_expire': 43200,
-            'file_buffer_size': 1048576,
-            'file_ignore_regex': None,
-            'file_ignore_glob': None,
-            'fileserver_backend': ['roots'],
-            'max_open_files': 100000,
-            'hash_type': 'md5',
-            'conf_file': path,
-            'open_mode': False,
-            'auto_accept': False,
-            'renderer': 'yaml_jinja',
-            'failhard': False,
-            'state_top': 'top.sls',
-            'master_tops': {},
-            'external_nodes': '',
-            'order_masters': False,
-            'job_cache': True,
-            'ext_job_cache': '',
-            'master_ext_job_cache': '',
-            'minion_data_cache': True,
-            'log_file': '/var/log/salt/master',
-            'log_level': None,
-            'log_level_logfile': None,
-            'log_datefmt': _DFLT_LOG_DATEFMT,
-            'log_datefmt_logfile': _DFLT_LOG_DATEFMT_LOGFILE,
-            'log_fmt_console': _DFLT_LOG_FMT_CONSOLE,
-            'log_fmt_logfile': _DFLT_LOG_FMT_LOGFILE,
-            'log_granular_levels': {},
-            'pidfile': '/var/run/salt-master.pid',
-            'cluster_masters': [],
-            'cluster_mode': 'paranoid',
-            'range_server': 'range:80',
-            'reactors': [],
-            'serial': 'msgpack',
-            'state_verbose': True,
-            'state_output': 'full',
-            'search': '',
-            'search_index_interval': 3600,
-            'loop_interval': 60,
-            'nodegroups': {},
-            'cython_enable': False,
-            'key_logfile': '/var/log/salt/key',
-            'verify_env': True,
-            'permissive_pki_access': False,
-            'default_include': 'master.d/*.conf',
-            'win_repo': '/srv/salt/win/repo',
-            'win_repo_mastercachefile': '/srv/salt/win/repo/winrepo.p',
-            'win_gitrepos': ['https://github.com/saltstack/salt-winrepo.git'],
-    }
+
+    overrides = load_config(path, 'SALT_MASTER_CONFIG')
+    default_include = overrides.get('default_include', DEFAULT_MASTER_OPTS['default_include'])
+    include = overrides.get('include', [])
+
+    overrides.update(include_config(default_include, path, verbose=False))
+    overrides.update(include_config(include, path, verbose=True))
+    return apply_master_config(overrides)
+
+def apply_master_config(overrides=None):
+    '''
+    Returns master configurations dict.
+    '''
+    opts = DEFAULT_MASTER_OPTS.copy()
+    if overrides:
+        opts.update(overrides)
 
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
-
-    load_config(opts, path, 'SALT_MASTER_CONFIG')
-
-    default_include = opts.get('default_include', [])
-    include = opts.get('include', [])
-
-    opts = include_config(default_include, opts, path, verbose=False)
-    opts = include_config(include, opts, path, verbose=True)
 
     opts['aes'] = salt.crypt.Crypticle.generate_key_string()
 
@@ -482,7 +506,7 @@ def client_config(path):
     opts = {'token_file': os.path.expanduser('~/.salt_token')}
     opts.update(master_config(path))
     cpath = os.path.expanduser('~/.salt')
-    load_config(opts, cpath, 'SALT_CLIENT_CONFIG')
+    opts.update(load_config(cpath, 'SALT_CLIENT_CONFIG'))
     if 'token_file' in opts:
         opts['token_file'] = os.path.expanduser(opts['token_file'])
     if os.path.isfile(opts['token_file']):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -200,19 +200,19 @@ def grains(opts):
     '''
     if not 'grains' in opts:
         pre_opts = {}
-        salt.config.load_config(
-            pre_opts, opts['conf_file'], 'SALT_MINION_CONFIG'
-        )
+        pre_opts.update(salt.config.load_config(
+            opts['conf_file'], 'SALT_MINION_CONFIG'
+        ))
         default_include = pre_opts.get(
             'default_include', opts['default_include']
         )
         include = pre_opts.get('include', [])
-        pre_opts = salt.config.include_config(
-            default_include, pre_opts, opts['conf_file'], verbose=False
-        )
-        pre_opts = salt.config.include_config(
-            include, pre_opts, opts['conf_file'], verbose=True
-        )
+        pre_opts.update(salt.config.include_config(
+            default_include, opts['conf_file'], verbose=False
+        ))
+        pre_opts.update(salt.config.include_config(
+            include, opts['conf_file'], verbose=True
+        ))
         if 'grains' in pre_opts:
             opts['grains'] = pre_opts['grains']
         else:


### PR DESCRIPTION
This should allow for configuring salt without a conf file on disk,
useful when embedding salt in other systems and running tests.
