### PR TITLE
Add missing space to log message

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1353,7 +1353,7 @@ class ClearFuncs(object):
             else:
                 log.info(
                     'Authentication failed from host {id}, the key is in '
-                    'pending and needs to be accepted with salt-key'
+                    'pending and needs to be accepted with salt-key '
                     '-a {id}'.format(**load)
                 )
                 eload = {'result': True,


### PR DESCRIPTION
When testing a new virtualenv installation today, I noticed the
following log message:

[INFO    ] Authentication failed from host foo, the key is in pending
and needs to be accepted with salt-key-a foo

This commit adds a space between "salt-key" and "-a".
