### PR TITLE
Replace hardcoded python executable with sys.executable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,7 @@ class TestCommand(Command):
         self.run_command('build')
         build_cmd = self.get_finalized_command('build_ext')
         runner = os.path.abspath('tests/runtests.py')
-        test_cmd = 'python {0}'.format(runner)
+        test_cmd = sys.executable + ' {0}'.format(runner)
         if self.runtests_opts:
             test_cmd += ' {0}'.format(self.runtests_opts)
 


### PR DESCRIPTION
This allows for running: python2.7 setup.py test

As-is, test executes tests/runtests.py using the default system python, not the python setup.py was executed with.
