### PR TITLE
Make pkg.list_upgrades, pkg.upgrade default to refresh=True

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -204,7 +204,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     salt.utils.daemonize_if(__opts__, **kwargs)
 
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     if debconf:
@@ -330,7 +330,7 @@ def upgrade(refresh=True, **kwargs):
     salt.utils.daemonize_if(__opts__, **kwargs)
 
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     ret_pkgs = {}
@@ -450,7 +450,7 @@ def list_upgrades(refresh=True):
         salt '*' pkg.list_upgrades
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
     return _get_upgradable()
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -121,7 +121,7 @@ def _get_upgradable():
     return ret
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades.
 
@@ -129,6 +129,9 @@ def list_upgrades():
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
+        refresh_db()
     return _get_upgradable()
 
 
@@ -267,7 +270,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
         }
     ))
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or refresh.lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -317,15 +320,15 @@ def update(pkg, refresh=False):
                 continue
             else:
                 ret_pkgs[pkg] = {'old': old_pkgs[pkg],
-                             'new': new_pkgs[pkg]}
+                                 'new': new_pkgs[pkg]}
         else:
             ret_pkgs[pkg] = {'old': '',
-                         'new': new_pkgs[pkg]}
+                             'new': new_pkgs[pkg]}
 
     return ret_pkgs
 
 
-def upgrade(refresh=False):
+def upgrade(refresh=True):
     '''
     Run a full system upgrade (emerge --update world)
 
@@ -338,7 +341,8 @@ def upgrade(refresh=False):
 
         salt '*' pkg.upgrade
     '''
-    if(refresh):
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
         refresh_db()
 
     ret_pkgs = {}

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -130,7 +130,7 @@ def list_upgrades(refresh=True):
         salt '*' pkg.list_upgrades
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
     return _get_upgradable()
 
@@ -270,7 +270,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
         }
     ))
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -342,7 +342,7 @@ def upgrade(refresh=True):
         salt '*' pkg.upgrade
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     ret_pkgs = {}

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -233,7 +233,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
                     fname = '"{0}{1}{2}"'.format(fname, vsign, kwargs[vkey])
                     break
         # Catch both boolean input from state and string input from CLI
-        if refresh is True or refresh.lower() == 'true':
+        if refresh is True or str(refresh).lower() == 'true':
             cmd = 'pacman -Syu --noprogressbar --noconfirm {0}'.format(fname)
         else:
             cmd = 'pacman -S --noprogressbar --noconfirm {0}'.format(fname)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -88,8 +88,8 @@ def list_upgrades():
     '''
     upgrades = {}
     lines = __salt__['cmd.run'](
-            'pacman -Sypu --print-format "%n %v" | egrep -v "^\s|^:"'
-            ).splitlines()
+        'pacman -Sypu --print-format "%n %v" | egrep -v "^\s|^:"'
+    ).splitlines()
     for line in lines:
         comps = line.split(' ')
         if len(comps) < 2:
@@ -146,7 +146,6 @@ def list_pkgs():
             __salt__['pkg_resource.add_pkg'](ret, name, version)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
-
 
 
 def refresh_db():
@@ -234,7 +233,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
                     fname = '"{0}{1}{2}"'.format(fname, vsign, kwargs[vkey])
                     break
         # Catch both boolean input from state and string input from CLI
-        if refresh is True or refresh == 'True':
+        if refresh is True or refresh.lower() == 'true':
             cmd = 'pacman -Syu --noprogressbar --noconfirm {0}'.format(fname)
         else:
             cmd = 'pacman -S --noprogressbar --noconfirm {0}'.format(fname)

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -2,6 +2,7 @@
 Pkgutil support for Solaris
 '''
 
+
 def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
@@ -62,16 +63,16 @@ def upgrade_available(name):
     cmd = '/opt/csw/bin/pkgutil -c --parse --single {0} 2>/dev/null'.format(name)
     out = __salt__['cmd.run_stdout'](cmd)
     if out:
-       version = out.split()[2].strip() 
+        version = out.split()[2].strip()
     if version:
         if version == "SAME":
             return ''
         else:
-            return version        
+            return version
     return ''
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
@@ -79,6 +80,9 @@ def list_upgrades():
 
         salt '*' pkgutil.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
+        refresh_db()
     upgrades = {}
     lines = __salt__['cmd.run_stdout']('/opt/csw/bin/pkgutil -A --parse').splitlines()
     for line in lines:
@@ -89,7 +93,6 @@ def list_upgrades():
             continue
         upgrades[comps[0]] = comps[1]
     return upgrades
-
 
 
 def upgrade(refresh=True, **kwargs):
@@ -105,15 +108,16 @@ def upgrade(refresh=True, **kwargs):
 
         salt '*' pkgutil.upgrade
     '''
-    if refresh:
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
         refresh_db()
 
-    # Get a list of the packages before install so we can diff after to see 
+    # Get a list of the packages before install so we can diff after to see
     # what got installed.
     old = _get_pkgs()
 
     # Install or upgrade the package
-    # If package is already installed  
+    # If package is already installed
     cmd = '/opt/csw/bin/pkgutil -yu'
     __salt__['cmd.run'](cmd)
 
@@ -170,7 +174,7 @@ def available_version(name):
 def install(name, refresh=False, version=None, **kwargs):
     '''
     Install the named package using the pkgutil tool.
-        
+
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
@@ -192,12 +196,12 @@ def install(name, refresh=False, version=None, **kwargs):
 
     cmd = '/opt/csw/bin/pkgutil -yu '
 
-    # Get a list of the packages before install so we can diff after to see 
+    # Get a list of the packages before install so we can diff after to see
     # what got installed.
     old = _get_pkgs()
 
     # Install or upgrade the package
-    # If package is already installed  
+    # If package is already installed
     cmd += '{0}'.format(pkg)
     __salt__['cmd.run'](cmd)
 
@@ -218,12 +222,12 @@ def remove(name, **kwargs):
     CLI Example::
 
         salt '*' pkgutil.remove <package name>
-        salt '*' pkgutil.remove SMCliconv 
+        salt '*' pkgutil.remove SMCliconv
     '''
 
     # Check to see if the package is installed before we proceed
     if version(name) == '':
-        return '' 
+        return ''
 
     # Get a list of the currently installed pkgs.
     old = _get_pkgs()
@@ -234,7 +238,7 @@ def remove(name, **kwargs):
 
     # Get a list of the packages after the uninstall
     new = _get_pkgs()
-     
+
     # Compare the pre and post remove package objects and report the uninstalled pkgs.
     return _list_removed(old, new)
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -81,7 +81,7 @@ def list_upgrades(refresh=True):
         salt '*' pkgutil.list_upgrades
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
     upgrades = {}
     lines = __salt__['cmd.run_stdout']('/opt/csw/bin/pkgutil -A --parse').splitlines()
@@ -109,7 +109,7 @@ def upgrade(refresh=True, **kwargs):
         salt '*' pkgutil.upgrade
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or (refresh).lower() == 'true':
         refresh_db()
 
     # Get a list of the packages before install so we can diff after to see

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -109,7 +109,7 @@ def upgrade(refresh=True, **kwargs):
         salt '*' pkgutil.upgrade
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or (refresh).lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     # Get a list of the packages before install so we can diff after to see

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -31,7 +31,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Windows
     '''
-    if salt.utils.is_windows() and  HAS_DEPENDENCIES:
+    if salt.utils.is_windows() and HAS_DEPENDENCIES:
         return 'pkg'
     return False
 
@@ -76,7 +76,7 @@ def upgrade_available(name):
     return False
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
@@ -85,6 +85,12 @@ def list_upgrades():
         salt '*' pkg.list_upgrades
     '''
     log.warning('pkg.list_upgrades not implemented on Windows yet')
+
+    # Uncomment the below once pkg.list_upgrades has been implemented
+
+    # Catch both boolean input from state and string input from CLI
+    #if refresh is True or str(refresh).lower() == 'true':
+    #    refresh_db()
     return {}
 
 
@@ -116,8 +122,8 @@ def list_pkgs(*args):
     pythoncom.CoInitialize()
     if len(args) == 0:
         pkgs = dict(
-                   list(_get_reg_software().items()) +
-                   list(_get_msi_software().items()))
+            list(_get_reg_software().items()) +
+            list(_get_msi_software().items()))
     else:
         # get package version for each package in *args
         pkgs = {}
@@ -125,6 +131,7 @@ def list_pkgs(*args):
             pkgs.update(_search_software(arg))
     pythoncom.CoUninitialize()
     return pkgs
+
 
 def _search_software(target):
     '''
@@ -134,13 +141,14 @@ def _search_software(target):
     '''
     search_results = {}
     software = dict(
-                    list(_get_reg_software().items()) +
-                    list(_get_msi_software().items()))
+        list(_get_reg_software().items()) +
+        list(_get_msi_software().items()))
     for key, value in software.items():
         if key is not None:
             if target.lower() in key.lower():
                 search_results[key] = value
     return search_results
+
 
 def _get_msi_software():
     '''
@@ -150,13 +158,14 @@ def _get_msi_software():
     win32_products = {}
     this_computer = "."
     wmi_service = win32com.client.Dispatch("WbemScripting.SWbemLocator")
-    swbem_services = wmi_service.ConnectServer(this_computer,"root\cimv2")
+    swbem_services = wmi_service.ConnectServer(this_computer, "root\cimv2")
     products = swbem_services.ExecQuery("Select * from Win32_Product")
     for product in products:
         prd_name = product.Name.encode('ascii', 'ignore')
         prd_ver = product.Version.encode('ascii', 'ignore')
         win32_products[prd_name] = prd_ver
     return win32_products
+
 
 def _get_reg_software():
     '''
@@ -187,10 +196,10 @@ def _get_reg_software():
         for reg_key in reg_keys:
             try:
                 reg_handle = win32api.RegOpenKeyEx(
-                                reg_hive,
-                                reg_key,
-                                0,
-                                win32con.KEY_READ)
+                    reg_hive,
+                    reg_key,
+                    0,
+                    win32con.KEY_READ)
             except Exception:
                 pass
                 #Unsinstall key may not exist for all users
@@ -212,6 +221,7 @@ def _get_reg_software():
                         reg_software[prd_name] = prd_ver
     return reg_software
 
+
 def _get_machine_keys():
     '''
     This will return the hive 'const' value and some registry keys where
@@ -222,10 +232,11 @@ def _get_machine_keys():
     machine_keys = [
         "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
         "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
-        ]
+    ]
     machine_hive = win32con.HKEY_LOCAL_MACHINE
     machine_hive_and_keys[machine_hive] = machine_keys
     return machine_hive_and_keys
+
 
 def _get_user_keys():
     '''
@@ -244,10 +255,10 @@ def _get_user_keys():
                   'S-1-5-20']
     sw_uninst_key = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
     reg_handle = win32api.RegOpenKeyEx(
-                    users_hive,
-                    '',
-                    0,
-                    win32con.KEY_READ)
+        users_hive,
+        '',
+        0,
+        win32con.KEY_READ)
     for name, num, blank, time in win32api.RegEnumKeyEx(reg_handle):
         #this is some identical key of a sid that contains some software names
         #but no detailed information about the software installed for that user
@@ -258,6 +269,7 @@ def _get_user_keys():
             user_keys.append(usr_sw_uninst_key)
     user_hive_and_keys[users_hive] = user_keys
     return user_hive_and_keys
+
 
 def _get_reg_value(reg_hive, reg_key, value_name=''):
     '''
@@ -326,7 +338,8 @@ def install(name=None, refresh=False, **kwargs):
         cached_pkg = __salt__['cp.is_cached'](pkginfo[version]['installer'])
         if not cached_pkg:
             # It's not cached. Cache it, mate.
-            cached_pkg = __salt__['cp.cache_file'](pkginfo[version]['installer'])
+            cached_pkg = __salt__['cp.cache_file'](pkginfo[
+                                                   version]['installer'])
     else:
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
@@ -338,7 +351,7 @@ def install(name=None, refresh=False, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade
 
@@ -352,6 +365,12 @@ def upgrade():
         salt '*' pkg.upgrade
     '''
     log.warning('pkg.upgrade not implemented on Windows yet')
+
+    # Uncomment the below once pkg.upgrade has been implemented
+
+    # Catch both boolean input from state and string input from CLI
+    #if refresh is True or str(refresh).lower() == 'true':
+    #    refresh_db()
     return {}
 
 
@@ -374,13 +393,15 @@ def remove(name, version=None):
         cached_pkg = __salt__['cp.is_cached'](pkginfo[version]['uninstaller'])
         if not cached_pkg:
             # It's not cached. Cache it, mate.
-            cached_pkg = __salt__['cp.cache_file'](pkginfo[version]['uninstaller'])
+            cached_pkg = __salt__['cp.cache_file'](pkginfo[
+                                                   version]['uninstaller'])
     else:
         cached_pkg = pkginfo[version]['uninstaller']
     cached_pkg = cached_pkg.replace('/', '\\')
     if not os.path.exists(os.path.expandvars(cached_pkg)) and '(x86)' in cached_pkg:
         cached_pkg = cached_pkg.replace('(x86)', '')
-    cmd = '"' + str(os.path.expandvars(cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
+    cmd = '"' + str(os.path.expandvars(
+        cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
         log.error(stderr)
@@ -400,6 +421,7 @@ def purge(name):
         salt '*' pkg.purge <package name>
     '''
     return remove(name)
+
 
 def _get_package_info(name):
     '''
@@ -424,8 +446,9 @@ def _get_package_info(name):
     if name in repodata:
         return repodata[name]
     else:
-        return False #name, ' is not available.'
-    return False #name, ' is not available.'
+        return False  # name, ' is not available.'
+    return False  # name, ' is not available.'
+
 
 def _reverse_cmp_pkg_versions(pkg1, pkg2):
     '''
@@ -435,6 +458,7 @@ def _reverse_cmp_pkg_versions(pkg1, pkg2):
         return 1
     else:
         return -1
+
 
 def _get_latest_pkg_version(pkginfo):
     if len(pkginfo) == 1:

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -119,7 +119,7 @@ def version(*names):
     ret = {}
     pkgs = list_pkgs()
     for name in names:
-        ret[name] = pkgs.get(name,'')
+        ret[name] = pkgs.get(name, '')
     # Return a string if only one package name passed
     if len(names) == 1:
         return ret[names[0]]
@@ -148,7 +148,7 @@ def list_pkgs():
     return ret
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     Check whether or not an upgrade is available for all packages
 
@@ -156,6 +156,9 @@ def list_upgrades():
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     out = _parse_yum('check-update')
     return dict([(i.name, i.version) for i in out])
 
@@ -240,7 +243,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
                        'new': '<new-version>'}}
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -281,7 +284,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade, a yum upgrade
 
@@ -294,6 +297,9 @@ def upgrade():
 
         salt '*' pkg.upgrade
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     old = list_pkgs()
     cmd = 'yum -q -y upgrade'
     __salt__['cmd.retcode'](cmd)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -34,7 +34,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
@@ -42,6 +42,9 @@ def list_upgrades():
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     ret = {}
     out = __salt__['cmd.run_stdout']('zypper list-updates').splitlines()
     for line in out:
@@ -215,7 +218,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
                        'new': '<new-version>'}}
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -233,7 +236,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade, a zypper upgrade
 
@@ -246,6 +249,9 @@ def upgrade():
 
         salt '*' pkg.upgrade
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     old = list_pkgs()
     cmd = 'zypper -n up -l'
     __salt__['cmd.retcode'](cmd)


### PR DESCRIPTION
These commits make these two functions consistent across pkg providers, as decided in issue #3302.

I also made a number of pep8 fixes.
