### PR TITLE
Add other sources of examples

### DIFF
--- a/doc/topics/community.rst
+++ b/doc/topics/community.rst
@@ -77,6 +77,7 @@ A few examples of salt states from the community:
 * https://github.com/mattmcclean/salt-openstack/tree/master/salt
 * https://github.com/rentalita/ubuntu-setup/
 * https://github.com/brutasse/states
+* https://github.com/bclermont/states
 
 Follow on ohloh
 ===============


### PR DESCRIPTION
I have a lengthy and growing "public" states repository that I build my various clients production on top of it.

some of them can be a little exotic.

and I think that I have the only public example of file.accumulated
