### PR TITLE
SLES grain fix (#3275)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -529,6 +529,7 @@ _OS_FAMILY_MAP = {
     'Slamd64': 'Slackware',
     'SLES': 'Suse',
     'SUSE Enterprise Server': 'Suse',
+    'SUSE  Enterprise Server': 'Suse',
     'SLED': 'Suse',
     'openSUSE': 'Suse',
     'SUSE': 'Suse',


### PR DESCRIPTION
The 'os' grain in SLES 11 SP2 is 'SUSE  Enterprise Server' (two spaces).
Tried to fix this a couple days ago but didn't notice the extra space
after 'SUSE'. See the following:

https://github.com/saltstack/salt/issues/3275#issuecomment-12425372
