### PR TITLE
Fix Ubuntu bug in pkg.purged, pkg.removed states

### DIFF
--- a/doc/topics/community.rst
+++ b/doc/topics/community.rst
@@ -77,6 +77,7 @@ A few examples of salt states from the community:
 * https://github.com/mattmcclean/salt-openstack/tree/master/salt
 * https://github.com/rentalita/ubuntu-setup/
 * https://github.com/brutasse/states
+* https://github.com/bclermont/states
 
 Follow on ohloh
 ===============

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -10,7 +10,7 @@
 
 Name: salt
 Version: 0.12.0
-Release: 1%{?dist}
+Release: 2%{?dist}
 Summary: A parallel remote execution system
 
 Group:   System Environment/Daemons
@@ -44,6 +44,7 @@ BuildRequires: python26-devel
 BuildRequires: python26-PyYAML
 BuildRequires: python26-m2crypto
 BuildRequires: python26-msgpack
+BuildRequires: python26-unittest2
 
 Requires: python26-crypto
 Requires: python26-zmq
@@ -60,6 +61,7 @@ BuildRequires: python-devel
 BuildRequires: PyYAML
 BuildRequires: m2crypto
 BuildRequires: python-msgpack
+BuildRequires: python-unittest2
 
 Requires: python-crypto
 Requires: python-zmq
@@ -147,7 +149,10 @@ install -p %{SOURCE7} .
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/salt/
 install -p -m 0640 conf/minion $RPM_BUILD_ROOT%{_sysconfdir}/salt/minion
 install -p -m 0640 conf/master $RPM_BUILD_ROOT%{_sysconfdir}/salt/master
- 
+
+%check
+%{__python} setup.py test
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 
@@ -296,6 +301,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Thu Jan 17 2013 Wendall Cada <wendallc@83864.com> - 0.12.0-2
+- Added unittest support
+
 * Wed Jan 16 2013 Clint Savage <herlo1@gmail.com> - 0.12.0-1
 - Upstream release 0.12.0
 

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -220,7 +220,10 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
         fromrepo = repo
 
     if kwargs.get('env'):
-        os.environ.update(kwargs.get('env'))
+        try:
+            os.environ.update(kwargs.get('env'))
+        except Exception as e:
+            log.exception(e)
 
     if pkg_params is None or len(pkg_params) == 0:
         return {}
@@ -253,7 +256,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def remove(pkg):
+def remove(pkg, **kwargs):
     '''
     Remove a single package via ``apt-get remove``
 
@@ -267,7 +270,10 @@ def remove(pkg):
     old_pkgs = list_pkgs()
 
     if kwargs.get('env'):
-        os.environ.update(kwargs.get('env'))
+        try:
+            os.environ.update(kwargs.get('env'))
+        except Exception as e:
+            log.exception(e)
 
     cmd = 'apt-get -q -y remove {0}'.format(pkg)
     __salt__['cmd.run'](cmd)
@@ -279,7 +285,7 @@ def remove(pkg):
     return ret_pkgs
 
 
-def purge(pkg):
+def purge(pkg, **kwargs):
     '''
     Remove a package via ``apt-get purge`` along with all configuration
     files and unused dependencies.
@@ -294,7 +300,10 @@ def purge(pkg):
     old_pkgs = list_pkgs()
 
     if kwargs.get('env'):
-        os.environ.update(kwargs.get('env'))
+        try:
+            os.environ.update(kwargs.get('env'))
+        except Exception as e:
+            log.exception(e)
 
     # Remove inital package
     purge_cmd = 'apt-get -q -y purge {0}'.format(pkg)

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -204,7 +204,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     salt.utils.daemonize_if(__opts__, **kwargs)
 
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     if debconf:
@@ -339,7 +339,7 @@ def upgrade(refresh=True, **kwargs):
     salt.utils.daemonize_if(__opts__, **kwargs)
 
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     ret_pkgs = {}
@@ -459,7 +459,7 @@ def list_upgrades(refresh=True):
         salt '*' pkg.list_upgrades
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
     return _get_upgradable()
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -81,7 +81,7 @@ def available_version(*names):
         return ret
 
 
-def remove(pkgs):
+def remove(pkgs, **kwargs):
     '''
     Removes packages with ``brew uninstall``
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -121,7 +121,7 @@ def _get_upgradable():
     return ret
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades.
 
@@ -129,6 +129,9 @@ def list_upgrades():
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
+        refresh_db()
     return _get_upgradable()
 
 
@@ -267,7 +270,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
         }
     ))
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or refresh.lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -317,15 +320,15 @@ def update(pkg, refresh=False):
                 continue
             else:
                 ret_pkgs[pkg] = {'old': old_pkgs[pkg],
-                             'new': new_pkgs[pkg]}
+                                 'new': new_pkgs[pkg]}
         else:
             ret_pkgs[pkg] = {'old': '',
-                         'new': new_pkgs[pkg]}
+                             'new': new_pkgs[pkg]}
 
     return ret_pkgs
 
 
-def upgrade(refresh=False):
+def upgrade(refresh=True):
     '''
     Run a full system upgrade (emerge --update world)
 
@@ -338,7 +341,8 @@ def upgrade(refresh=False):
 
         salt '*' pkg.upgrade
     '''
-    if(refresh):
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
         refresh_db()
 
     ret_pkgs = {}

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -130,7 +130,7 @@ def list_upgrades(refresh=True):
         salt '*' pkg.list_upgrades
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
     return _get_upgradable()
 
@@ -270,7 +270,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
         }
     ))
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -342,7 +342,7 @@ def upgrade(refresh=True):
         salt '*' pkg.upgrade
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     ret_pkgs = {}

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -361,7 +361,7 @@ def upgrade(refresh=False):
     return ret_pkgs
 
 
-def remove(pkg):
+def remove(pkg, **kwargs):
     '''
     Remove a single package via emerge --unmerge
 
@@ -385,7 +385,7 @@ def remove(pkg):
     return ret_pkgs
 
 
-def purge(pkg):
+def purge(pkg, **kwargs):
     '''
     Portage does not have a purge, this function calls remove followed
     by depclean to emulate a purge process

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -230,7 +230,7 @@ def upgrade():
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def remove(name=None, pkgs=None):
+def remove(name=None, pkgs=None, **kwargs):
     '''
     Remove a single package.
 
@@ -284,7 +284,7 @@ def remove(name=None, pkgs=None):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name):
+def purge(name, **kwargs):
     '''
     Remove a single package with pkg_delete
 

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -159,7 +159,7 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
 
 
 
-def remove(name):
+def remove(name, **kwargs):
     '''
     Remove a single package with pkg_delete
 
@@ -178,7 +178,7 @@ def remove(name):
     return _list_removed(_format_pkgs(old), new)
 
 
-def purge(name):
+def purge(name, **kwargs):
     '''
     Remove a single package with pkg_delete
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -233,7 +233,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
                     fname = '"{0}{1}{2}"'.format(fname, vsign, kwargs[vkey])
                     break
         # Catch both boolean input from state and string input from CLI
-        if refresh is True or refresh.lower() == 'true':
+        if refresh is True or str(refresh).lower() == 'true':
             cmd = 'pacman -Syu --noprogressbar --noconfirm {0}'.format(fname)
         else:
             cmd = 'pacman -S --noprogressbar --noconfirm {0}'.format(fname)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -88,8 +88,8 @@ def list_upgrades():
     '''
     upgrades = {}
     lines = __salt__['cmd.run'](
-            'pacman -Sypu --print-format "%n %v" | egrep -v "^\s|^:"'
-            ).splitlines()
+        'pacman -Sypu --print-format "%n %v" | egrep -v "^\s|^:"'
+    ).splitlines()
     for line in lines:
         comps = line.split(' ')
         if len(comps) < 2:
@@ -146,7 +146,6 @@ def list_pkgs():
             __salt__['pkg_resource.add_pkg'](ret, name, version)
     __salt__['pkg_resource.sort_pkglist'](ret)
     return ret
-
 
 
 def refresh_db():
@@ -234,7 +233,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
                     fname = '"{0}{1}{2}"'.format(fname, vsign, kwargs[vkey])
                     break
         # Catch both boolean input from state and string input from CLI
-        if refresh is True or refresh == 'True':
+        if refresh is True or refresh.lower() == 'true':
             cmd = 'pacman -Syu --noprogressbar --noconfirm {0}'.format(fname)
         else:
             cmd = 'pacman -S --noprogressbar --noconfirm {0}'.format(fname)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -281,7 +281,7 @@ def upgrade():
     return pkgs
 
 
-def remove(name):
+def remove(name, **kwargs):
     '''
     Remove a single package with ``pacman -R``
 
@@ -298,7 +298,7 @@ def remove(name):
     return _list_removed(old, new)
 
 
-def purge(name):
+def purge(name, **kwargs):
     '''
     Recursively remove a package and all dependencies which were installed
     with it, this will call a ``pacman -Rsc``

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -111,7 +111,7 @@ def upgrade(refresh=True, **kwargs):
         salt '*' pkgutil.upgrade
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or (refresh).lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     # Get a list of the packages before install so we can diff after to see

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -82,7 +82,7 @@ def list_upgrades(refresh=True):
         salt '*' pkgutil.list_upgrades
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
     upgrades = {}
     lines = __salt__['cmd.run_stdout'](
@@ -111,7 +111,7 @@ def upgrade(refresh=True, **kwargs):
         salt '*' pkgutil.upgrade
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh.lower() == 'true':
+    if refresh is True or (refresh).lower() == 'true':
         refresh_db()
 
     # Get a list of the packages before install so we can diff after to see

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -2,6 +2,7 @@
 Pkgutil support for Solaris
 '''
 
+
 def __virtual__():
     '''
     Set the virtual pkg module if the os is Solaris
@@ -59,15 +60,16 @@ def upgrade_available(name):
         salt '*' pkgutil.upgrade_available CSWpython
     '''
     version = None
-    cmd = '/opt/csw/bin/pkgutil -c --parse --single {0} 2>/dev/null'.format(name)
+    cmd = '/opt/csw/bin/pkgutil -c --parse --single {0} 2>/dev/null'.format(
+        name)
     out = __salt__['cmd.run_stdout'](cmd)
     if out:
-       version = out.split()[2].strip() 
+        version = out.split()[2].strip()
     if version:
         if version == "SAME":
             return ''
         else:
-            return version        
+            return version
     return ''
 
 
@@ -80,7 +82,8 @@ def list_upgrades():
         salt '*' pkgutil.list_upgrades
     '''
     upgrades = {}
-    lines = __salt__['cmd.run_stdout']('/opt/csw/bin/pkgutil -A --parse').splitlines()
+    lines = __salt__['cmd.run_stdout'](
+        '/opt/csw/bin/pkgutil -A --parse').splitlines()
     for line in lines:
         comps = line.split('\t')
         if comps[2] == "SAME":
@@ -89,7 +92,6 @@ def list_upgrades():
             continue
         upgrades[comps[0]] = comps[1]
     return upgrades
-
 
 
 def upgrade(refresh=True, **kwargs):
@@ -108,12 +110,12 @@ def upgrade(refresh=True, **kwargs):
     if refresh:
         refresh_db()
 
-    # Get a list of the packages before install so we can diff after to see 
+    # Get a list of the packages before install so we can diff after to see
     # what got installed.
     old = _get_pkgs()
 
     # Install or upgrade the package
-    # If package is already installed  
+    # If package is already installed
     cmd = '/opt/csw/bin/pkgutil -yu'
     __salt__['cmd.run'](cmd)
 
@@ -170,7 +172,7 @@ def available_version(name):
 def install(name, refresh=False, version=None, **kwargs):
     '''
     Install the named package using the pkgutil tool.
-        
+
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
@@ -192,12 +194,12 @@ def install(name, refresh=False, version=None, **kwargs):
 
     cmd = '/opt/csw/bin/pkgutil -yu '
 
-    # Get a list of the packages before install so we can diff after to see 
+    # Get a list of the packages before install so we can diff after to see
     # what got installed.
     old = _get_pkgs()
 
     # Install or upgrade the package
-    # If package is already installed  
+    # If package is already installed
     cmd += '{0}'.format(pkg)
     __salt__['cmd.run'](cmd)
 
@@ -218,12 +220,12 @@ def remove(name, **kwargs):
     CLI Example::
 
         salt '*' pkgutil.remove <package name>
-        salt '*' pkgutil.remove SMCliconv 
+        salt '*' pkgutil.remove SMCliconv
     '''
 
     # Check to see if the package is installed before we proceed
     if version(name) == '':
-        return '' 
+        return ''
 
     # Get a list of the currently installed pkgs.
     old = _get_pkgs()
@@ -234,7 +236,7 @@ def remove(name, **kwargs):
 
     # Get a list of the packages after the uninstall
     new = _get_pkgs()
-     
+
     # Compare the pre and post remove package objects and report the uninstalled pkgs.
     return _list_removed(old, new)
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -73,7 +73,7 @@ def upgrade_available(name):
     return ''
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
@@ -81,6 +81,9 @@ def list_upgrades():
 
         salt '*' pkgutil.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
+        refresh_db()
     upgrades = {}
     lines = __salt__['cmd.run_stdout'](
         '/opt/csw/bin/pkgutil -A --parse').splitlines()
@@ -107,7 +110,8 @@ def upgrade(refresh=True, **kwargs):
 
         salt '*' pkgutil.upgrade
     '''
-    if refresh:
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or refresh.lower() == 'true':
         refresh_db()
 
     # Get a list of the packages before install so we can diff after to see

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -355,7 +355,7 @@ def upgrade():
     return {}
 
 
-def remove(name, version=None):
+def remove(name, version=None, **kwargs):
     '''
     Remove a single package
 
@@ -388,7 +388,7 @@ def remove(name, version=None):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name):
+def purge(name, **kwargs):
     '''
     Recursively remove a package and all dependencies which were installed
     with it

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -31,7 +31,7 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is Windows
     '''
-    if salt.utils.is_windows() and  HAS_DEPENDENCIES:
+    if salt.utils.is_windows() and HAS_DEPENDENCIES:
         return 'pkg'
     return False
 
@@ -76,7 +76,7 @@ def upgrade_available(name):
     return False
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
@@ -85,6 +85,12 @@ def list_upgrades():
         salt '*' pkg.list_upgrades
     '''
     log.warning('pkg.list_upgrades not implemented on Windows yet')
+
+    # Uncomment the below once pkg.list_upgrades has been implemented
+
+    # Catch both boolean input from state and string input from CLI
+    #if refresh is True or str(refresh).lower() == 'true':
+    #    refresh_db()
     return {}
 
 
@@ -116,8 +122,8 @@ def list_pkgs(*args):
     pythoncom.CoInitialize()
     if len(args) == 0:
         pkgs = dict(
-                   list(_get_reg_software().items()) +
-                   list(_get_msi_software().items()))
+            list(_get_reg_software().items()) +
+            list(_get_msi_software().items()))
     else:
         # get package version for each package in *args
         pkgs = {}
@@ -125,6 +131,7 @@ def list_pkgs(*args):
             pkgs.update(_search_software(arg))
     pythoncom.CoUninitialize()
     return pkgs
+
 
 def _search_software(target):
     '''
@@ -134,13 +141,14 @@ def _search_software(target):
     '''
     search_results = {}
     software = dict(
-                    list(_get_reg_software().items()) +
-                    list(_get_msi_software().items()))
+        list(_get_reg_software().items()) +
+        list(_get_msi_software().items()))
     for key, value in software.items():
         if key is not None:
             if target.lower() in key.lower():
                 search_results[key] = value
     return search_results
+
 
 def _get_msi_software():
     '''
@@ -150,13 +158,14 @@ def _get_msi_software():
     win32_products = {}
     this_computer = "."
     wmi_service = win32com.client.Dispatch("WbemScripting.SWbemLocator")
-    swbem_services = wmi_service.ConnectServer(this_computer,"root\cimv2")
+    swbem_services = wmi_service.ConnectServer(this_computer, "root\cimv2")
     products = swbem_services.ExecQuery("Select * from Win32_Product")
     for product in products:
         prd_name = product.Name.encode('ascii', 'ignore')
         prd_ver = product.Version.encode('ascii', 'ignore')
         win32_products[prd_name] = prd_ver
     return win32_products
+
 
 def _get_reg_software():
     '''
@@ -187,10 +196,10 @@ def _get_reg_software():
         for reg_key in reg_keys:
             try:
                 reg_handle = win32api.RegOpenKeyEx(
-                                reg_hive,
-                                reg_key,
-                                0,
-                                win32con.KEY_READ)
+                    reg_hive,
+                    reg_key,
+                    0,
+                    win32con.KEY_READ)
             except Exception:
                 pass
                 #Unsinstall key may not exist for all users
@@ -212,6 +221,7 @@ def _get_reg_software():
                         reg_software[prd_name] = prd_ver
     return reg_software
 
+
 def _get_machine_keys():
     '''
     This will return the hive 'const' value and some registry keys where
@@ -222,10 +232,11 @@ def _get_machine_keys():
     machine_keys = [
         "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall",
         "Software\\Wow6432Node\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
-        ]
+    ]
     machine_hive = win32con.HKEY_LOCAL_MACHINE
     machine_hive_and_keys[machine_hive] = machine_keys
     return machine_hive_and_keys
+
 
 def _get_user_keys():
     '''
@@ -244,10 +255,10 @@ def _get_user_keys():
                   'S-1-5-20']
     sw_uninst_key = "Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall"
     reg_handle = win32api.RegOpenKeyEx(
-                    users_hive,
-                    '',
-                    0,
-                    win32con.KEY_READ)
+        users_hive,
+        '',
+        0,
+        win32con.KEY_READ)
     for name, num, blank, time in win32api.RegEnumKeyEx(reg_handle):
         #this is some identical key of a sid that contains some software names
         #but no detailed information about the software installed for that user
@@ -258,6 +269,7 @@ def _get_user_keys():
             user_keys.append(usr_sw_uninst_key)
     user_hive_and_keys[users_hive] = user_keys
     return user_hive_and_keys
+
 
 def _get_reg_value(reg_hive, reg_key, value_name=''):
     '''
@@ -326,7 +338,8 @@ def install(name=None, refresh=False, **kwargs):
         cached_pkg = __salt__['cp.is_cached'](pkginfo[version]['installer'])
         if not cached_pkg:
             # It's not cached. Cache it, mate.
-            cached_pkg = __salt__['cp.cache_file'](pkginfo[version]['installer'])
+            cached_pkg = __salt__['cp.cache_file'](pkginfo[
+                                                   version]['installer'])
     else:
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
@@ -338,7 +351,7 @@ def install(name=None, refresh=False, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade
 
@@ -352,6 +365,12 @@ def upgrade():
         salt '*' pkg.upgrade
     '''
     log.warning('pkg.upgrade not implemented on Windows yet')
+
+    # Uncomment the below once pkg.upgrade has been implemented
+
+    # Catch both boolean input from state and string input from CLI
+    #if refresh is True or str(refresh).lower() == 'true':
+    #    refresh_db()
     return {}
 
 
@@ -374,13 +393,15 @@ def remove(name, version=None, **kwargs):
         cached_pkg = __salt__['cp.is_cached'](pkginfo[version]['uninstaller'])
         if not cached_pkg:
             # It's not cached. Cache it, mate.
-            cached_pkg = __salt__['cp.cache_file'](pkginfo[version]['uninstaller'])
+            cached_pkg = __salt__['cp.cache_file'](pkginfo[
+                                                   version]['uninstaller'])
     else:
         cached_pkg = pkginfo[version]['uninstaller']
     cached_pkg = cached_pkg.replace('/', '\\')
     if not os.path.exists(os.path.expandvars(cached_pkg)) and '(x86)' in cached_pkg:
         cached_pkg = cached_pkg.replace('(x86)', '')
-    cmd = '"' + str(os.path.expandvars(cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
+    cmd = '"' + str(os.path.expandvars(
+        cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
         log.error(stderr)
@@ -400,6 +421,7 @@ def purge(name, **kwargs):
         salt '*' pkg.purge <package name>
     '''
     return remove(name)
+
 
 def _get_package_info(name):
     '''
@@ -424,8 +446,9 @@ def _get_package_info(name):
     if name in repodata:
         return repodata[name]
     else:
-        return False #name, ' is not available.'
-    return False #name, ' is not available.'
+        return False  # name, ' is not available.'
+    return False  # name, ' is not available.'
+
 
 def _reverse_cmp_pkg_versions(pkg1, pkg2):
     '''
@@ -435,6 +458,7 @@ def _reverse_cmp_pkg_versions(pkg1, pkg2):
         return 1
     else:
         return -1
+
 
 def _get_latest_pkg_version(pkginfo):
     if len(pkginfo) == 1:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -101,7 +101,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def list_upgrades(*args):
+def list_upgrades(refresh=True):
     '''
     Check whether or not an upgrade is available for all packages
 
@@ -109,6 +109,10 @@ def list_upgrades(*args):
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
+
     pkgs = list_pkgs()
 
     yumbase = yum.YumBase()
@@ -319,7 +323,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
         name = '{0}-{1}'.format(name, kwargs.get('version'))
 
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -399,7 +403,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade, a yum upgrade
 
@@ -412,6 +416,9 @@ def upgrade():
 
         salt '*' pkg.upgrade
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
 
     yumbase = yum.YumBase()
     setattr(yumbase.conf, 'assumeyes', True)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -158,7 +158,7 @@ def available_version(*names):
         )
         for pkg in exactmatch:
             if pkg.name in ret \
-            and (pkg.arch == getBaseArch() or pkg.arch == 'noarch'):
+                    and (pkg.arch == getBaseArch() or pkg.arch == 'noarch'):
                 ret[pkg.name] = '-'.join([pkg.version, pkg.release])
 
     # Return a string if only one package name passed
@@ -194,7 +194,7 @@ def version(*names):
     ret = {}
     pkgs = list_pkgs()
     for name in names:
-        ret[name] = pkgs.get(name,'')
+        ret[name] = pkgs.get(name, '')
     # Return a string if only one package name passed
     if len(names) == 1:
         return ret[names[0]]
@@ -437,7 +437,7 @@ def upgrade():
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def remove(pkgs):
+def remove(pkgs, **kwargs):
     '''
     Removes packages with yum remove
 
@@ -470,7 +470,7 @@ def remove(pkgs):
     return _list_removed(old, new)
 
 
-def purge(pkgs):
+def purge(pkgs, **kwargs):
     '''
     Yum does not have a purge, this function calls remove
 
@@ -655,7 +655,7 @@ def del_repo(repo, basedir='/etc/yum.repos.d'):
     if onlyrepo:
         os.remove(repofile)
         return 'File {0} containing repo {1} has been removed'.format(
-                                                            repofile, repo)
+            repofile, repo)
 
     # There must be other repos in this file, write the file with them
     header, filerepos = _parse_repo_file(repofile)
@@ -739,11 +739,11 @@ def mod_repo(repo, basedir=None, **kwargs):
     # Error out if they tried to delete baseurl or mirrorlist improperly
     if 'baseurl' in todelete:
         if 'mirrorlist' not in kwargs and 'mirrorlist' \
-                        not in filerepos[repo].keys():
+                not in filerepos[repo].keys():
             return 'Error: Cannot delete baseurl without specifying mirrorlist'
     if 'mirrorlist' in todelete:
         if 'baseurl' not in kwargs and 'baseurl' \
-                        not in filerepos[repo].keys():
+                not in filerepos[repo].keys():
             return 'Error: Cannot delete mirrorlist without specifying baseurl'
 
     # Delete anything in the todelete list
@@ -803,6 +803,7 @@ def _parse_repo_file(filename):
             repos[repo][comps[0].strip()] = '='.join(comps[1:])
 
     return (header, repos)
+
 
 def compare(version1='', version2=''):
     '''

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -119,7 +119,7 @@ def version(*names):
     ret = {}
     pkgs = list_pkgs()
     for name in names:
-        ret[name] = pkgs.get(name,'')
+        ret[name] = pkgs.get(name, '')
     # Return a string if only one package name passed
     if len(names) == 1:
         return ret[names[0]]
@@ -148,7 +148,7 @@ def list_pkgs():
     return ret
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     Check whether or not an upgrade is available for all packages
 
@@ -156,6 +156,9 @@ def list_upgrades():
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     out = _parse_yum('check-update')
     return dict([(i.name, i.version) for i in out])
 
@@ -240,7 +243,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
                        'new': '<new-version>'}}
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -281,7 +284,7 @@ def install(name=None, refresh=False, fromrepo=None, skip_verify=False,
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade, a yum upgrade
 
@@ -294,6 +297,9 @@ def upgrade():
 
         salt '*' pkg.upgrade
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     old = list_pkgs()
     cmd = 'yum -q -y upgrade'
     __salt__['cmd.retcode'](cmd)

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -315,7 +315,7 @@ def upgrade():
     return pkgs
 
 
-def remove(pkg):
+def remove(pkg, **kwargs):
     '''
     Remove a single package with yum remove
 
@@ -332,7 +332,7 @@ def remove(pkg):
     return _list_removed(old, new)
 
 
-def purge(pkg):
+def purge(pkg, **kwargs):
     '''
     Yum does not have a purge, this function calls remove
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -267,7 +267,7 @@ def upgrade():
     return pkgs
 
 
-def remove(name):
+def remove(name, **kwargs):
     '''
     Remove a single package with ``zypper remove``
 
@@ -284,7 +284,7 @@ def remove(name):
     return _list_removed(old, new)
 
 
-def purge(name):
+def purge(name, **kwargs):
     '''
     Recursively remove a package and all dependencies which were installed
     with it, this will call a ``zypper remove -u``

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -34,7 +34,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def list_upgrades():
+def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
@@ -42,6 +42,9 @@ def list_upgrades():
 
         salt '*' pkg.list_upgrades
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     ret = {}
     out = __salt__['cmd.run_stdout']('zypper list-updates').splitlines()
     for line in out:
@@ -215,7 +218,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
                        'new': '<new-version>'}}
     '''
     # Catch both boolean input from state and string input from CLI
-    if refresh is True or refresh == 'True':
+    if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -233,7 +236,7 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade, a zypper upgrade
 
@@ -246,6 +249,9 @@ def upgrade():
 
         salt '*' pkg.upgrade
     '''
+    # Catch both boolean input from state and string input from CLI
+    if refresh is True or str(refresh).lower() == 'true':
+        refresh_db()
     old = list_pkgs()
     cmd = 'zypper -n up -l'
     __salt__['cmd.retcode'](cmd)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -410,7 +410,7 @@ def latest(
                 'comment': comment}
 
 
-def removed(name):
+def removed(name, **kwargs):
     '''
     Verify that the package is removed, this will remove the package via
     the remove function in the salt pkg module for the platform.
@@ -431,7 +431,7 @@ def removed(name):
                     'result': None,
                     'comment': 'Package {0} is set to be installed'.format(
                         name)}
-        changes['removed'] = __salt__['pkg.remove'](name)
+        changes['removed'] = __salt__['pkg.remove'](name, **kwargs)
     if not changes:
         return {'name': name,
                 'changes': changes,
@@ -443,7 +443,7 @@ def removed(name):
             'comment': 'Package {0} removed'.format(name)}
 
 
-def purged(name):
+def purged(name, **kwargs):
     '''
     Verify that the package is purged, this will call the purge function in the
     salt pkg module for the platform.
@@ -463,7 +463,7 @@ def purged(name):
                     'changes': {},
                     'result': None,
                     'comment': 'Package {0} is set to be purged'.format(name)}
-        changes['removed'] = __salt__['pkg.purge'](name)
+        changes['removed'] = __salt__['pkg.purge'](name, **kwargs)
 
     if not changes:
         return {'name': name,


### PR DESCRIPTION
17e35529 introduced a bug in which a nonexistant kwargs dict was being
referenced in the pkg.purge and pkg.remove functions. This is a blocker
for pkg.purged and pkg.removed states in Ubuntu.

I added kwargs to the pkg.purged and pkg.removed states, as well as to
each pkg provider which had a purge or remove function.

Note that this commit contains a lot of the same pep8 fixes that I made
in pull request #3311, so let me know if you want me to rebase once this
is merged.
