### PR TITLE
Modify the mysql module to be more consistent on SELECT queries

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -163,16 +163,16 @@ def query(database, query):
     else:
         elapsed_h = str(round(elapsed, 2)) + 's'
     ret['query time'] = {'human': elapsed_h, 'raw': str(round(elapsed, 5))}
-    if len(results) == 0:
-        ret['rows affected'] = affected
-        return ret
-    else:
+    if query.upper().strip().startswith("SELECT"):
         ret['rows returned'] = affected
         columns = ()
         for column in cur.description:
             columns += (column[0],)
         ret['columns'] = columns
         ret['results'] = results
+        return ret
+    else:
+        ret['rows affected'] = affected
         return ret
 
 


### PR DESCRIPTION
Modified the mysql.py module to alter the behavior when 0 rows are returned.  This is because some SELECT statements might return 0 rows and the difference in returned verbiage is problematic / requires that the developer code for either 'rows affected' or 'rows returned', which is tedious.  We alter the code so that if the query is a SELECT, we always describe the results as 'rows returned'.  If the query does not start with that, then we use 'rows affected'
