### PR TITLE
Fail gracefully as non-privileged user

### DIFF
--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -49,7 +49,10 @@ def __virtual__():
         return False
     if not os.path.exists('/proc/modules'):
         return False
-    if 'kvm_' not in salt.utils.fopen('/proc/modules').read():
+    try:
+        if 'kvm_' not in salt.utils.fopen('/proc/modules').read():
+            return False
+    except IOError:
         return False
     if not HAS_LIBVIRT:
         return False


### PR DESCRIPTION
When running as a non-privileged user, salt gives a traceback on failing to open /proc/modules.  The open is now wrapped in a try/except, with the exceptional condition returning False from the `__virtual__()` function in kvm_hyper.py.

This should be correct as non-privileged users can't manage a hypervisor anyway.
