### PR TITLE
fix pkg.latest bugs

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -302,7 +302,8 @@ def latest(
             msg = 'No information found for "{0}".'.format(pkg)
             log.error(msg)
             problems.append(msg)
-        elif not cur[pkg] or cur[pkg] < avail[pkg]:
+        elif not cur[pkg] or __salt__['pkg.compare'](cur[pkg],
+                                                     avail[pkg]) == -1:
             targets[pkg] = avail[pkg]
 
     if problems:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -299,11 +299,10 @@ def latest(
     problems = []
     for pkg in desired_pkgs:
         if not avail[pkg]:
-            if not cur[pkg]:
-                msg = 'No information found for "{0}".'.format(pkg)
-                log.error(msg)
-                problems.append(msg)
-        else:
+            msg = 'No information found for "{0}".'.format(pkg)
+            log.error(msg)
+            problems.append(msg)
+        elif not cur[pkg] or cur[pkg] < avail[pkg]:
             targets[pkg] = avail[pkg]
 
     if problems:


### PR DESCRIPTION
1) state does not care about already installed packages and always try to install all of them
2) if we can not gether info about some available packages it's might be a problem despite of installed packages or not (now it's only become problem if desired package not installed)
