### PR TITLE
split rhel install instructions out from fedora instructions. updated index / toc to link to new rhel instructions

### DIFF
--- a/doc/topics/installation/fedora.rst
+++ b/doc/topics/installation/fedora.rst
@@ -1,27 +1,11 @@
 ==================================
-Fedora & CentOS / Enterprise Linux
+Fedora
 ==================================
 
 Beginning with version 0.9.4, Salt has been available in the primary Fedora
 repositories and `EPEL`_. It is installable using yum. Fedora will have more
 up to date versions of Salt than other members of the Red Hat family, which
 makes it a great place to help improve Salt!
-
-.. admonition:: CentOS / RHEL 5 / RHEL 6
-
-    Salt and all dependencies have been *finally* accepted into the yum
-    reposities for EPEL5 and EPEL6. Currently, the latest is in epel-testing
-    while awaiting promotion to epel proper, and may be installed as follows:
-
-    .. code-block:: bash
-
-        yum --enablerepo=epel-testing install salt
-
-    On RHEL6, the proper jinja packages were moved from EPEL to the
-    "RHEL Server Optional Channel". Verify this repository is enabled before
-    installing salt on RHEL6.
-
-.. _`EPEL`: http://fedoraproject.org/wiki/EPEL
 
 Installation
 ============
@@ -41,6 +25,8 @@ will be one master and multiple minions.
     yum install salt-master
     yum install salt-minion
 
+.. _`EPEL`: http://fedoraproject.org/wiki/EPEL
+
 Post-installation tasks
 =======================
 
@@ -52,24 +38,11 @@ To have the Master start automatically at boot time:
 
     systemctl enable salt-master.service
 
-or
-
-.. code-block:: bash
-
-    chkconfig salt-master on
-
-
 To start the Master:
 
 .. code-block:: bash
 
     systemctl start salt-master.service
-
-or
-
-.. code-block:: bash
-
-    service salt-master start
 
 **Minion**
 
@@ -79,23 +52,11 @@ To have the Minion start automatically at boot time:
 
     systemctl enable salt-minion.service
 
-or
-
-.. code-block:: bash
-
-    chkconfig salt-minion on
-
 To start the Minion:
 
 .. code-block:: bash
 
     systemctl start salt-minion.service
-
-or 
-
-.. code-block:: bash
-
-    service salt-minion start
 
 Now go to the :doc:`Configuring Salt</topics/configuration>` page.
 

--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -65,11 +65,12 @@ Salt should run on any Unix-like platform so long as the dependencies are met.
 * `PyCrypto`_ - The Python cryptography toolkit
 * `msgpack-python`_ - High-performance message interchange format
 * `YAML`_ - Python YAML bindings
+* `Jinja2`_ - the default parser for Salt States (configurable in the master settings)
 
 Optional Dependencies
 ---------------------
 
-* `Jinja2`_ - parsing Salt States (configurable in the master settings)
+* `mako`_ - an optional parser for Salt States (configurable in the master settings)
 * gcc - dynamic `Cython`_ module compiling
 
 .. _`Python 2.6`: http://python.org/download/
@@ -80,4 +81,6 @@ Optional Dependencies
 .. _`PyCrypto`: http://www.dlitz.net/software/pycrypto/
 .. _`Cython`: http://cython.org/
 .. _`Jinja2`: http://jinja.pocoo.org/
+.. _`mako`: http://www.makotemplates.org/
+
 

--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -21,10 +21,11 @@ Many popular distributions will be able to install the salt minion by executing 
 
 The script should also make it simple to install a salt master, if desired.
 
-Currently the install script supports:
+Currently the install script has been tested to work on:
 
 * Ubuntu 10.x/11.x/12.x
 * Debian 6.x
+* RHEL 6.3
 * CentOS 6.3
 * Fedora
 * Arch
@@ -45,13 +46,13 @@ These guides go into detail how to install salt on a given platform.
 
     arch
     debian
-    ubuntu
     fedora
     freebsd
     gentoo
-    windows
+    rhel
+    ubuntu
     solaris
-
+    windows
 
 Dependencies
 ------------

--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -1,0 +1,79 @@
+==========================================================================
+RHEL 5 / RHEL 6 / CentOS / Scientific Linux / Oracle Linux / Amazon Linux
+==========================================================================
+
+Beginning with version 0.9.4, Salt has been available in `EPEL`_. It is installable using yum. Salt should work properly with all mainstream derivatives
+of RHEL, including CentOS, Scientific Linux, Oracle Linux and Amazon Linux. Report any bugs or issues to the salt github project.
+
+Installation
+============
+
+Salt and all dependencies have been accepted into the yum 
+reposities for EPEL5 and EPEL6. The latest salt version can be found in epel-testing, while an older but more tested version can be found in regular epel.
+
+Example showing how to install salt from epel-testing:
+
+.. code-block:: bash
+
+    yum --enablerepo=epel-testing install salt-minion
+    
+On RHEL6, the proper jinja package 'python-jinja2' was moved from EPEL to the
+"RHEL Server Optional Channel". Verify this repository is enabled before
+installing salt on RHEL6.
+
+.. _`EPEL`: http://fedoraproject.org/wiki/EPEL
+
+
+Salt can be installed using ``yum`` and is available in the standard Fedora
+repositories.
+
+Stable Release
+--------------
+
+Salt is packaged separately for the minion and the master. It is necessary only to install the appropriate package for the role the machine will play. Typically, there will be one master and multiple minions.
+
+On the salt-master, run this:
+.. code-block:: bash
+
+    yum install salt-master
+
+On each salt-minion, run this:
+.. code-block:: bash
+
+    yum install salt-master
+
+Post-installation tasks
+=======================
+
+**Master**
+
+To have the Master start automatically at boot time:
+
+.. code-block:: bash
+
+    chkconfig salt-master on
+
+
+To start the Master:
+
+.. code-block:: bash
+
+    service salt-master start
+
+**Minion**
+
+To have the Minion start automatically at boot time:
+
+.. code-block:: bash
+
+    chkconfig salt-minion on
+
+
+To start the Minion:
+
+.. code-block:: bash
+
+    service salt-minion start
+
+Now go to the :doc:`Configuring Salt</topics/configuration>` page.
+

--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -1,5 +1,5 @@
 ==========================================================================
-RHEL 5 / RHEL 6 / CentOS / Scientific Linux / Oracle Linux / Amazon Linux
+RHEL / CentOS / Scientific Linux / Oracle Linux / Amazon Linux
 ==========================================================================
 
 Beginning with version 0.9.4, Salt has been available in `EPEL`_. It is installable using yum. Salt should work properly with all mainstream derivatives


### PR DESCRIPTION
This should be a start at least... good to have these separated per suggestion from @thatch45 
