### PR TITLE
Remove extra parse-time dependencies.

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -12,18 +12,9 @@ import time
 import urlparse
 
 # import third party libs
-import yaml
-try:
-    yaml.Loader = yaml.CLoader
-    yaml.Dumper = yaml.CDumper
-except Exception:
-    pass
 
 # Import salt libs
-import salt.crypt
-import salt.loader
 import salt.utils
-import salt.pillar
 from salt.exceptions import SaltClientError
 
 log = logging.getLogger(__name__)
@@ -221,6 +212,12 @@ def _append_domain(opts):
 
 
 def _read_conf_file(path):
+    import yaml
+    try:
+        yaml.Loader = yaml.CLoader
+        yaml.Dumper = yaml.CDumper
+    except Exception:
+        pass
     with salt.utils.fopen(path, 'r') as conf_file:
         conf_opts = yaml.safe_load(conf_file.read()) or {}
         # allow using numeric ids: convert int to string
@@ -460,6 +457,7 @@ def apply_master_config(overrides=None, defaults=None):
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
 
+    import salt.crypt
     opts['aes'] = salt.crypt.Crypticle.generate_key_string()
 
     opts['extension_modules'] = (

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -30,8 +30,6 @@ except ImportError:
     HAS_FNCTL = False
 
 # Import salt libs
-import salt.minion
-import salt.payload
 from salt.exceptions import SaltClientError, CommandNotFoundError
 
 
@@ -197,6 +195,8 @@ def daemonize_if(opts, **kwargs):
     if not 'jid' in data:
         return
 
+    import salt.minion
+    import salt.payload
     serial = salt.payload.Serial(opts)
     proc_dir = salt.minion.get_proc_dir(opts['cachedir'])
     fn_ = os.path.join(proc_dir, data['jid'])


### PR DESCRIPTION
Allows pip to install salt properly when run-time dependencies are not
there yet.

pip first runs 'setup.py egg_info' that used to require pyzmq, pyyaml,
M2Crypto already installed in the system. This commit fixes that.
