### PR TITLE
Fix pw(8) syntax for group changes

### DIFF
--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -89,7 +89,7 @@ def chgid(name, gid):
     pre_gid = __salt__['file.group_to_gid'](name)
     if gid == pre_gid:
         return True
-    cmd = 'pw groupmod -g {0} {1}'.format(gid, name)
+    cmd = 'pw groupmod {0} -g {1}'.format(name, gid)
     __salt__['cmd.run'](cmd)
     post_gid = __salt__['file.group_to_gid'](name)
     if post_gid != pre_gid:


### PR DESCRIPTION
Changing group gid's doesn't work currently on FreeBSD 8.3 and 9.0.

According to the [pw(8) manual](http://www.freebsd.org/cgi/man.cgi?query=pw&apropos=0&sektion=8&manpath=FreeBSD+9.1-RELEASE&arch=default&format=html) the correct syntax is `pw NAME -g NEWGID`, and salt currently tries to run `pw -g NEWGID NAME`, which fails.

After changing the invocation of `pw` all gid changes work correctly.
