### PR TITLE
Add multiple permissions to a single export

### DIFF
--- a/salt/modules/nfs.py
+++ b/salt/modules/nfs.py
@@ -39,12 +39,12 @@ def list_exports(exports='/etc/exports'):
         if line.startswith('#'):
             continue
         comps = line.split()
-        ret[comps[0]] = {'hosts': [], 'options': []}
+        ret[comps[0]] = []
         for perm in comps[1:]:
             permcomps = perm.split('(')
             permcomps[1] = permcomps[1].replace(')', '')
-            ret[comps[0]]['hosts'] = permcomps[0].split(',')
-            ret[comps[0]]['options'] = permcomps[1].split(',')
+            hosts = permcomps[0].split(',')
+            options = permcomps[1].split(',')
+            ret[comps[0]].append({'hosts': hosts, 'options': options})
     f.close()
     return ret
-


### PR DESCRIPTION
Before, each subsequent set of permissions would overwrite any previous permissions. For instance:

/media/storage *(ro,sync,no_subtree_check) 192.168.1.101(rw,sync,no_subtree_check)

would effectively be displayed as:

/media/storage 192.168.1.101(rw,sync,no_subtree_check)

This has been repaired.
