### PR TITLE
Fix pw(8) syntax for user uid/gid changes

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -142,7 +142,7 @@ def chuid(name, uid):
     pre_info = info(name)
     if uid == pre_info['uid']:
         return True
-    cmd = 'pw usermod -u {0} {1}'.format(uid, name)
+    cmd = 'pw usermod -u {0} -n {1}'.format(uid, name)
     __salt__['cmd.run'](cmd)
     post_info = info(name)
     if post_info['uid'] != pre_info['uid']:
@@ -161,7 +161,7 @@ def chgid(name, gid):
     pre_info = info(name)
     if gid == pre_info['gid']:
         return True
-    cmd = 'pw usermod -g {0} {1}'.format(gid, name)
+    cmd = 'pw usermod -g {0} -n {1}'.format(gid, name)
     __salt__['cmd.run'](cmd)
     post_info = info(name)
     if post_info['gid'] != pre_info['gid']:


### PR DESCRIPTION
Just like with group gid changes, changing the users uid and gid is broken. 

`pw(8)` requires specifying the name explicitly with the -n switch, which is what this pull request changes.
