### PR TITLE
NFS3 lets you specify multiple shares per line

### DIFF
--- a/salt/modules/nfs3.py
+++ b/salt/modules/nfs3.py
@@ -73,6 +73,15 @@ def del_export(exports='/etc/exports', path=None):
 def _write_exports(exports, edict):
     '''
     Write an exports file to disk
+
+    If multiple shares were initially configured per line, like:
+
+        /media/storage /media/data *(ro,sync,no_subtree_check)
+
+    ...then they will be saved to disk with only one share per line:
+
+        /media/storage *(ro,sync,no_subtree_check)
+        /media/data *(ro,sync,no_subtree_check)
     '''
     f = open(exports, 'w')
     for export in edict:

--- a/salt/modules/nfs3.py
+++ b/salt/modules/nfs3.py
@@ -40,12 +40,18 @@ def list_exports(exports='/etc/exports'):
             continue
         comps = line.split()
         ret[comps[0]] = []
+        newshares = []
         for perm in comps[1:]:
+            if perm.startswith('/'):
+                newshares.append(perm)
+                continue
             permcomps = perm.split('(')
             permcomps[1] = permcomps[1].replace(')', '')
             hosts = permcomps[0].split(',')
             options = permcomps[1].split(',')
             ret[comps[0]].append({'hosts': hosts, 'options': options})
+        for share in newshares:
+            ret[share] = ret[comps[0]]
     f.close()
     return ret
 


### PR DESCRIPTION
Apparently NFS3 lets you configure multiple shares per configuration line, like:

/media/storage /media/data *(ro,sync,no_subtree_check)

This patch allows the nfs3 module to parse that. However, when the new configuration is written to disk, it will be written with only one share per line, like:

/media/storage *(ro,sync,no_subtree_check)
/media/data *(ro,sync,no_subtree_check)
