### PR TITLE
Adding introspection for package groups (in yum)

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -540,7 +540,7 @@ def verify(*package):
     return ret
 
 
-def grouplist():
+def group_list():
     '''
     Lists all groups known by yum on this system
 
@@ -563,7 +563,7 @@ def grouplist():
     return ret
 
 
-def groupinfo(groupname):
+def group_info(groupname):
     '''
     Lists packages belonging to a certain group
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -582,6 +582,48 @@ def groupinfo(groupname):
                     'description': group.description}
 
 
+def group_detail(groupname):
+    '''
+    Lists packages belonging to a certain group, and which are installed
+
+    CLI Example::
+
+        salt '*' pkg.group_detail 'Perl Support'
+    '''
+    ret = {
+           'mandatory packages': {'installed': [], 'not installed': []},
+           'optional packages': {'installed': [], 'not installed': []},
+           'default packages': {'installed': [], 'not installed': []},
+           'conditional packages': {'installed': [], 'not installed': []},
+           }
+    pkgs = list_pkgs()
+    yumbase = yum.YumBase()
+    (installed, available) = yumbase.doGroupLists()
+    for group in installed:
+        if group.name == groupname:
+            for pkg in group.mandatory_packages:
+                if pkg in pkgs:
+                    ret['mandatory packages']['installed'].append(pkg)
+                else:
+                    ret['mandatory packages']['not installed'].append(pkg)
+            for pkg in group.optional_packages:
+                if pkg in pkgs:
+                    ret['optional packages']['installed'].append(pkg)
+                else:
+                    ret['optional packages']['not installed'].append(pkg)
+            for pkg in group.default_packages:
+                if pkg in pkgs:
+                    ret['default packages']['installed'].append(pkg)
+                else:
+                    ret['default packages']['not installed'].append(pkg)
+            for pkg in group.conditional_packages:
+                if pkg in pkgs:
+                    ret['conditional packages']['installed'].append(pkg)
+                else:
+                    ret['conditional packages']['not installed'].append(pkg)
+            return ret
+
+
 def list_repos(basedir='/etc/yum.repos.d'):
     '''
     Lists all repos in <basedir> (default: /etc/yum.repos.d/).


### PR DESCRIPTION
Produces output like:

```
# salt-call pkg.group_detail 'SNMP Support'
conditional packages:
    installed:
    not installed:
default packages:
    installed:
        - net-snmp-utils
    not installed:
mandatory packages:
    installed:
        - net-snmp
    not installed:
optional packages:
    installed:
        - net-snmp-python
    not installed:
        - net-snmp-perl
```
