### PR TITLE
Fix pkg.latest regression

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -299,9 +299,10 @@ def latest(
     problems = []
     for pkg in desired_pkgs:
         if not avail[pkg]:
-            msg = 'No information found for "{0}".'.format(pkg)
-            log.error(msg)
-            problems.append(msg)
+            if not cur[pkg]:
+                msg = 'No information found for "{0}".'.format(pkg)
+                log.error(msg)
+                problems.append(msg)
         elif not cur[pkg] or __salt__['pkg.compare'](cur[pkg],
                                                      avail[pkg]) == -1:
             targets[pkg] = avail[pkg]


### PR DESCRIPTION
This commit fixes a regression in which the pkg.latest state fails if
there is no new version of a package, even if the currently-installed
version matches the newest in the repositories.
