### PR TITLE
Add a "manage.status" runner that gives a combined up/down report

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -3,6 +3,7 @@ General management functions for salt, tools like seeing what hosts are up
 and what hosts are down
 '''
 
+import yaml
 import distutils.version
 
 # Import salt libs
@@ -10,9 +11,9 @@ import salt.key
 import salt.client
 
 
-def down():
+def status(output=True):
     '''
-    Print a list of all the down or unresponsive salt minions
+    Print the status of all known salt minions
     '''
     client = salt.client.LocalClient(__opts__['conf_file'])
     minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
@@ -20,7 +21,19 @@ def down():
     key = salt.key.Key(__opts__)
     keys = key.list_keys()
 
-    ret = sorted(set(keys['minions']) - set(minions))
+    ret = {}
+    ret['up'] = sorted(minions)
+    ret['down'] = sorted(set(keys['minions']) - set(minions))
+    if output:
+        print(yaml.safe_dump(ret, default_flow_style=False))
+    return ret
+
+
+def down():
+    '''
+    Print a list of all the down or unresponsive salt minions
+    '''
+    ret = status(output=False).get('down')
     for minion in ret:
         print(minion)
     return ret
@@ -30,13 +43,10 @@ def up():  # pylint: disable-msg=C0103
     '''
     Print a list of all of the minions that are up
     '''
-    client = salt.client.LocalClient(__opts__['conf_file'])
-    minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
-
-    for minion in sorted(minions):
+    ret = status(output=False).get('up')
+    for minion in ret:
         print(minion)
-
-    return sorted(minions)
+    return ret
 
 
 def versions():

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -33,7 +33,7 @@ def down():
     '''
     Print a list of all the down or unresponsive salt minions
     '''
-    ret = status(output=False).get('down')
+    ret = status(output=False).get('down', [])
     for minion in ret:
         print(minion)
     return ret
@@ -43,7 +43,7 @@ def up():  # pylint: disable-msg=C0103
     '''
     Print a list of all of the minions that are up
     '''
-    ret = status(output=False).get('up')
+    ret = status(output=False).get('up', [])
     for minion in ret:
         print(minion)
     return ret


### PR DESCRIPTION
It would be nice to get the up/down state of all salt minions in a single command.  The current runners make it so that two commands are needed to get this information

This adds a new "manage.status" runner that will print a report of the up/down state in a consumable format (YAML).  It also refactors the up() and down() runners to use a common code path

Example output:

```
# salt-run manage.status
down:
- minion1
up:
- master
- minion2
- minion3
```
