### PR TITLE
add debconf-utils dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -77,6 +77,7 @@ Architecture: all
 Depends: ${misc:Depends},
          python,
          python-pkg-resources,
+         debconf-utils,
          salt-common (= ${source:Version})
 Recommends: dmidecode, pciutils
 Description: This package represents the client package for salt


### PR DESCRIPTION
debconf module depend on `debconf-get-selections`:

https://github.com/saltstack/salt/blob/develop/salt/modules/debconfmod.py#L24

which is provided by package `debconf-utils`.

Salt minion must have this package to have this module work properly.
