### PR TITLE
Spurious Salt CLI error messages on CentOS 6.3 machines without "git" installed

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -19,6 +19,7 @@ def __get_version_info_from_git(version, version_info):
         process = subprocess.Popen(
                 'which git',
                 stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 shell=True
         )
         git, _ = process.communicate()


### PR DESCRIPTION
On stock CentOS 6.3 machines without "git" installed the command "which git"
returns an error to stderr and as a consequence every Salt command prints this
same error to the screen. This one-line fix prevents this from occurring.

If "git" is not used then it should not be generating these spurious error messages.
