### PR TITLE
Fix docs for makedirs_perms

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1417,7 +1417,7 @@ def makedirs(path, user=None, group=None, mode=None):
         # follow the principal of least surprise method.
 
 
-def makedirs_perms(name, user=None, group=None, mode=0755):
+def makedirs_perms(name, user=None, group=None, mode='0755'):
     '''
     Taken and modified from os.makedirs to set user, group and mode for each
     directory created.


### PR DESCRIPTION
Make documentation for makedirs_perms show mode 0755 instead of 493
