### PR TITLE
Fix timezone state to do more accurate check

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -40,6 +40,9 @@ def get_zone():
         return open('/etc/timezone','r').read()
     elif 'Gentoo' in __grains__['os_family']:
         return open('/etc/timezone','r').read()
+    elif 'FreeBSD' in __grains__['os_family']:
+        return ('FreeBSD does not store a human-readable timezone. Please'
+                'consider using timezone.get_zonecode or timezone.zonecompare')
     out = __salt__['cmd.run'](cmd).split('=')
     ret = out[1].replace('"', '')
     return ret

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -4,6 +4,7 @@ Module for managing timezone on posix-like systems.
 
 # Import python libs
 import os
+import md5
 import logging
 
 log = logging.getLogger(__name__)
@@ -100,6 +101,34 @@ def set_zone(timezone):
         open('/etc/timezone', 'w').write(timezone)
 
     return True
+
+
+def zone_compare(timezone):
+    '''
+    Checks the md5sum between the given timezone, and the one set in
+    /etc/localtime. Returns True if they match, and False if not. Mostly useful
+    for running state checks.
+
+    Example::
+
+        salt '*' timezone.zone_compare 'America/Denver'
+    '''
+    if not os.path.exists('/etc/localtime'):
+        return 'Error: /etc/localtime does not exist.'
+
+    zonepath = '/usr/share/zoneinfo/{0}'.format(timezone)
+
+    f = open(zonepath, 'r')
+    usrzone = f.read()
+    f.close()
+
+    f = open('/etc/localtime', 'r')
+    etczone = f.read()
+    f.close()
+
+    if usrzone == etczone:
+        return True
+    return False
 
 
 def get_hwclock():

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -72,7 +72,11 @@ def get_offset():
 
 def set_zone(timezone):
     '''
-    Unlinks, then symlinks /etc/localtime to the set timezone
+    Unlinks, then symlinks /etc/localtime to the set timezone.
+
+    The timezone is crucial to several system processes, each of which SHOULD
+    be restarted (for instance, whatever you system uses as its cron and
+    syslog daemons). This will not be magically done for you!
 
     CLI Example::
 

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -5,6 +5,7 @@ Module for managing timezone on posix-like systems.
 # Import python libs
 import os
 import md5
+import salt.utils
 import logging
 
 log = logging.getLogger(__name__)
@@ -121,13 +122,11 @@ def zone_compare(timezone):
 
     zonepath = '/usr/share/zoneinfo/{0}'.format(timezone)
 
-    f = open(zonepath, 'r')
-    usrzone = md5.new(f.read()).hexdigest()
-    f.close()
+    with salt.utils.fopen(zonepath, 'r') as fp_:
+        usrzone = md5.new(fp_.read()).hexdigest()
 
-    f = open('/etc/localtime', 'r')
-    etczone = md5.new(f.read()).hexdigest()
-    f.close()
+    with salt.utils.fopen('/etc/localtime', 'r') as fp_:
+        etczone = md5.new(fp_.read()).hexdigest()
 
     if usrzone == etczone:
         return True

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -122,11 +122,11 @@ def zone_compare(timezone):
     zonepath = '/usr/share/zoneinfo/{0}'.format(timezone)
 
     f = open(zonepath, 'r')
-    usrzone = f.read()
+    usrzone = md5.new(f.read()).hexdigest()
     f.close()
 
     f = open('/etc/localtime', 'r')
-    etczone = f.read()
+    etczone = md5.new(f.read()).hexdigest()
     f.close()
 
     if usrzone == etczone:

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -36,14 +36,14 @@ def system(name, utc=''):
     # Set up metadata
     do_utc = False
     do_zone = False
-    myzone = __salt__['timezone.get_zone']()
+    compzone = __salt__['timezone.zone_compare'](name)
     myutc = True
     messages = []
     if __salt__['timezone.get_hwclock']() == 'localtime':
         myutc = False
 
     # Check the time zone
-    if myzone == name:
+    if compzone is True:
         ret['result'] = True
         messages.append('Timezone {0} already set'.format(name))
     else:
@@ -62,7 +62,7 @@ def system(name, utc=''):
 
     if __opts__['test']:
         messages = []
-        if myzone != name:
+        if compzone is False:
             messages.append('Timezone {0} needs to be set'.format(name))
         if utc != '' and myutc != utc:
             messages.append('UTC needs to be set to {0}'.format(utc))

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -21,7 +21,7 @@ def __virtual__():
 
 def system(name, utc=''):
     '''
-    Set the timezone for the system
+    Set the timezone for the system.
 
     name
         The name of the timezone to use (e.g.: America/Denver)


### PR DESCRIPTION
These commits fix an issue on FreeBSD, which doesn't store a human-readable version of the timezone anywhere. This also makes the state more accurately reflect the contents of the timezone, whose underlying data may have changed since the last time it was set.
