### PR TITLE
Fix import typo in rpm build patch

### DIFF
--- a/pkg/rpm/0003-Late-stage-jinja2-dependency.patch
+++ b/pkg/rpm/0003-Late-stage-jinja2-dependency.patch
@@ -28,7 +28,7 @@ index 290339d..11f428d 100644
 +
 +    # Late import salt libs to overcome circular imports and to allow building
 +    # salt without making Jinja2 a build dependency
-+    import salt.minon
++    import salt.minion
 +    import salt.payload
 +
      serial = salt.payload.Serial(opts)


### PR DESCRIPTION
When running minions on CentOS (but, not Ubuntu), was getting the following error when executing salt 'target' state.highstate from the master:

[WARNING ] The minion function caused an exception: Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/minion.py", line 359, in _thread_return
    ret['return'] = func(_args, *_kwargs)
  File "/usr/lib/python2.6/site-packages/salt/modules/state.py", line 129, in highstate
    salt.utils.daemonize_if(__opts__, **kwargs)
  File "/usr/lib/python2.6/site-packages/salt/utils/**init**.py", line 200, in daemonize_if
    import salt.minon
ImportError: No module named minon

Fixing the typo allows running of state.highstate.
