### PR TITLE
Quick Documentation fixes for APT pkgrepo state

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -687,7 +687,7 @@ def mod_repo(repo, refresh=False, **kwargs):
 
     The following options are available to modify a repo definition::
 
-        uri (the uri of the repo, e.g. deb http://archive.ubuntu.com/ubuntu)
+        uri (the uri of the repo, e.g. http://archive.ubuntu.com/ubuntu )
         comps (a comma separated list of components for the repo, e.g. "main")
         file (a file name to be used)
         refresh (refresh the apt sources db when the mod is done)

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -56,7 +56,16 @@ def managed(name, **kwargs):
         in the repo configuration with a comment marker (#) in front.
     
 
-    For apt-based systems, take note of the following configuration vaolues:
+    For apt-based systems, take note of the following configuration values:
+
+    name:
+        on apt-based systems this must be the complete entry as it would be
+        seen in the sources.list file.  This can have a limited subset of 
+        components (i.e. 'main') which can be added/modified with the
+        "comps" option.
+
+          EXAMPLE: deb http://us.archive.ubuntu.com/ubuntu/ precise main
+
 
     uri
         On apt-based systems, uri refers to a direct URL to be used for the 


### PR DESCRIPTION
- the aptitude repo manager needs the name to be the complete
  entry from the sources.list file.  Documentation modified to
  make this clear (compared to say the YUM version)
- removed a superfluous reference to "deb" in the uri section
