### PR TITLE
Add tests for nested grain/pillar matching

### DIFF
--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -21,3 +21,15 @@ grains:
   test_grain: cheese
   script: grail
   alot: many
+  planets:
+    - mercury
+    - venus
+    - earth
+    - mars
+  level1:
+    level2: foo
+  companions:
+    one:
+      - susan
+      - ian
+      - barbara

--- a/tests/integration/files/conf/sub_minion
+++ b/tests/integration/files/conf/sub_minion
@@ -20,6 +20,16 @@ integration.test: True
 grains:
   test_grain: spam
   role: sub
-
+  planets:
+    - jupiter
+    - saturn
+    - uranus
+    - neptune
+  level1:
+    level2: bar
+  companions:
+    two:
+      - jamie
+      - zoe
 
 ipc_mode: tcp

--- a/tests/integration/files/pillar/base/generic.sls
+++ b/tests/integration/files/pillar/base/generic.sls
@@ -11,3 +11,12 @@ knights:
   - Galahad
   - Bedevere
   - Robin
+
+level1:
+  level2: foo
+
+companions:
+  three:
+    - liz
+    - jo
+    - sarah jane

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -57,11 +57,39 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         '''
         test salt grain matcher
         '''
+        # First-level grain (string value)
         data = self.run_salt('-t 1 -G "test_grain:cheese" test.ping')
         data = '\n'.join(data)
         self.assertIn('minion', data)
         self.assertNotIn('sub_minion', data)
         data = self.run_salt('-G "test_grain:spam" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('sub_minion', data)
+        self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
+        # First-level grain (list member)
+        data = self.run_salt('-t 1 -G "planets:earth" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('minion', data)
+        self.assertNotIn('sub_minion', data)
+        data = self.run_salt('-G "planets:saturn" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('sub_minion', data)
+        self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
+        # Nested grain (string value)
+        data = self.run_salt('-t 1 -G "level1:level2:foo" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('minion', data)
+        self.assertNotIn('sub_minion', data)
+        data = self.run_salt('-G "level1:level2:bar" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('sub_minion', data)
+        self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
+        # Nested grain (list member)
+        data = self.run_salt('-t 1 -G "companions:one:ian" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('minion', data)
+        self.assertNotIn('sub_minion', data)
+        data = self.run_salt('-G "companions:two:jamie" test.ping')
         data = '\n'.join(data)
         self.assertIn('sub_minion', data)
         self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
@@ -85,15 +113,28 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         '''
         test pillar matcher
         '''
+        # First-level pillar (string value)
         data = self.run_salt('-I "monty:python" test.ping')
         data = '\n'.join(data)
         self.assertIn('minion', data)
         self.assertIn('sub_minion', data)
+        # First-level pillar (string value, only in sub_minion)
         data = self.run_salt('-I "sub:sub_minion" test.ping')
         data = '\n'.join(data)
         self.assertIn('sub_minion', data)
         self.assertNotIn('minion', data.replace('sub_minion', 'stub'))
+        # First-level pillar (list member)
         data = self.run_salt('-I "knights:Bedevere" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('minion', data)
+        self.assertIn('sub_minion', data)
+        # Nested pillar (string value)
+        data = self.run_salt('-I "level1:level2:foo" test.ping')
+        data = '\n'.join(data)
+        self.assertIn('minion', data)
+        self.assertIn('sub_minion', data)
+        # Nested pillar (list member)
+        data = self.run_salt('-I "companions:three:sarah jane" test.ping')
         data = '\n'.join(data)
         self.assertIn('minion', data)
         self.assertIn('sub_minion', data)
@@ -119,7 +160,7 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         self.assertIn('minion', data)
         self.assertIn('sub_minion', data)
 
-    def test_ipcadr(self):
+    def test_ipcidr(self):
         subnets_data = self.run_salt('--out yaml \'*\' network.subnets')
         yaml_data = yaml.load('\n'.join(subnets_data))
 
@@ -160,7 +201,6 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         self.assertIn('user.add:', data)
         data = self.run_salt('\'*\' sys.doc user.add')
         self.assertIn('user.add:', data)
-
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Also added tests for traditional grain matching when target grain is a
list.
