### PR TITLE
Send stderr to subprocess.PIPE in version.py

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -24,8 +24,9 @@ def __get_version_info_from_git(version, version_info):
     '''
     try:
         process = subprocess.Popen(
-                'which git',
+                'command -v git',
                 stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
                 shell=True
         )
         git, _ = process.communicate()


### PR DESCRIPTION
If git is not installed, the stderr output from the shell out to 'which
git' is printed to the console whenever a salt CLI command is run. This
commit sends it to the subprocess pipe to keep it away from the console.

Also, I replaced the call to 'which git' with the POSIX-compliant
'command -v git'. The 'which' command should be avoided as it is not
POSIX-compliant, and doesn't set a nonzero return code on all platforms.
See below for an example of how which does not work as expected on
Solaris. I believe the MacOS version of which also has this problem. On
these platforms, if git was not found, the call to
subprocess.Popen.poll() would not find a nonzero exit status and salt
would therefore continue trying to obtain the current git commit ID.

``` bash
$ uname -a
SunOS foo.tld 5.10 Generic_139556-08 i86pc i386 i86pc
$ which foo
no foo in /usr/pkg/bin /usr/pkg/sbin /usr/sfw/bin /usr/sfw/sbin /sbin
/usr/sbin /usr/ccs/bin /usr/bin
$ echo $?
0
$ command -v foo
-bash: command: foo: not found
$ echo $?
1
```
