### PR TITLE
Fix bug in nested outputter when displaying floats

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -1,5 +1,5 @@
 '''
-Recursively display nested data, this is the default outputter. 
+Recursively display nested data, this is the default outputter.
 '''
 
 # Import salt libs
@@ -22,7 +22,7 @@ class NestDisplay(object):
                     prefix,
                     ret,
                     self.colors['ENDC'])
-        elif isinstance(ret, int):
+        elif isinstance(ret, (int, float)):
             out += '{0}{1}{2}{3}{4}\n'.format(
                     self.colors['YELLOW'],
                     ' ' * indent,


### PR DESCRIPTION
Just a simple fix for a bug that was keeping floating-point numbers from
showing up in the new nested outputter.
