### PR TITLE
Prepare pkg providers for #3278

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -508,6 +508,7 @@ def compare(version1='', version2=''):
         log.error(e)
     return None
 
+
 def _split_repo_str(repo):
     split = sourceslist.SourceEntry(repo)
     return split.type, split.uri, split.dist, split.comps
@@ -544,6 +545,7 @@ def _consolidate_repo_sources(sources):
             pass
     return sources
 
+
 def list_repos():
     '''
     Lists all repos in the sources.list (and sources.lists.d) files
@@ -572,6 +574,7 @@ def list_repos():
         repo['architectures'] = source.architectures
         repos.setdefault(source.uri, []).append(repo)
     return repos
+
 
 def get_repo(repo):
     '''
@@ -610,14 +613,15 @@ def get_repo(repo):
             for sub in source:
                 if (sub['type'] == repo_type and
                     sub['uri'] == repo_uri and
-                    sub['dist'] == repo_dist):
+                        sub['dist'] == repo_dist):
                     if not repo_comps:
-                       return sub
+                        return sub
                     for comp in repo_comps:
                         if comp in sub.get('comps', []):
                             return sub
 
     raise Exception('repo "{0}" was not found'.format(repo))
+
 
 def del_repo(repo, refresh=False):
     '''
@@ -660,7 +664,7 @@ def del_repo(repo, refresh=False):
 
         for source in repos:
             if (source.type == repo_type and source.uri == repo_uri and
-                source.dist == repo_dist):
+                    source.dist == repo_dist):
 
                 s_comps = set(source.comps)
                 r_comps = set(repo_comps)
@@ -674,8 +678,8 @@ def del_repo(repo, refresh=False):
                             pass
             # PPAs are special and can add deb-src where expand_ppa_line doesn't
             # always reflect this.  Lets just cleanup here for good measure
-            if (is_ppa and repo_type == 'deb' and  source.type == 'deb-src' and
-                source.uri == repo_uri and source.dist == repo_dist):
+            if (is_ppa and repo_type == 'deb' and source.type == 'deb-src' and
+                    source.uri == repo_uri and source.dist == repo_dist):
 
                 s_comps = set(source.comps)
                 r_comps = set(repo_comps)
@@ -691,9 +695,9 @@ def del_repo(repo, refresh=False):
         if deleted_from:
             ret = ''
             for source in sources:
-                if deleted_from.has_key(source.file):
+                if source.file in deleted_from:
                     deleted_from[source.file] += 1
-            for repo_file,c in deleted_from.iteritems():
+            for repo_file, c in deleted_from.iteritems():
                 msg = 'Repo "{0}" has been removed from {1}.\n'
                 if c == 0 and 'sources.list.d/' in repo_file:
                     if os.path.isfile(repo_file):
@@ -708,6 +712,7 @@ def del_repo(repo, refresh=False):
             return ret
 
     return "Repo {0} doesn't exist in the sources.list(s)".format(repo)
+
 
 def mod_repo(repo, refresh=False, **kwargs):
     '''
@@ -736,7 +741,8 @@ def mod_repo(repo, refresh=False, **kwargs):
 
     # to ensure no one sets some key values that _shouldn't_ be changed on the
     # object itself, this is just a white-list of "ok" to set properties
-    _MODIFY_OK = set(['comps', 'architectures', 'disabled', 'file', 'dist'])
+    _MODIFY_OK = set(
+        ['uri', 'comps', 'architectures', 'disabled', 'file', 'dist'])
     if repo.startswith('ppa:') and __grains__['os'] == 'Ubuntu':
         if not ppa_format_support:
             error_str = 'cannot parse "ppa:" style repo definitions: {0}'
@@ -767,7 +773,8 @@ def mod_repo(repo, refresh=False, **kwargs):
         if repos:
             mod_source = None
             try:
-                repo_type, repo_uri, repo_dist, repo_comps = _split_repo_str(repo)
+                repo_type, repo_uri, repo_dist, repo_comps = _split_repo_str(
+                    repo)
             except SyntaxError:
                 error_str = 'Error: repo "{0}" not a well formatted definition'
                 raise SyntaxError(error_str.format(repo))
@@ -847,17 +854,17 @@ def mod_repo(repo, refresh=False, **kwargs):
             # not destined to be disabled/enabled in
             # the original state
             if ('disabled' in kwargs and
-                mod_source.disabled != kwargs['disabled']):
+                    mod_source.disabled != kwargs['disabled']):
 
                 s_comps = set(mod_source.comps)
                 r_comps = set(repo_comps)
                 if s_comps.symmetric_difference(r_comps):
-                   new_source = sourceslist.SourceEntry(source.line)
-                   new_source.file = source.file
-                   new_source.comps = list(r_comps.difference(s_comps))
-                   source.comps = list(s_comps.difference(r_comps))
-                   sources.insert(sources.index(source), new_source)
-                   sources.save()
+                    new_source = sourceslist.SourceEntry(source.line)
+                    new_source.file = source.file
+                    new_source.comps = list(r_comps.difference(s_comps))
+                    source.comps = list(s_comps.difference(r_comps))
+                    sources.insert(sources.index(source), new_source)
+                    sources.save()
 
             for key in kwargs:
                 if key in _MODIFY_OK and hasattr(mod_source, key):
@@ -866,14 +873,13 @@ def mod_repo(repo, refresh=False, **kwargs):
             sources.save()
             if refresh is True or str(refresh).lower() == 'true':
                 refresh_db()
-            return { repo: {
-                            'architectures': mod_source.architectures,
-                            'comps': mod_source.comps,
-                            'disabled': mod_source.disabled,
-                            'file': mod_source.file,
-                            'type': mod_source.type,
-                            'uri': mod_source.uri,
-                            'line': mod_source.line,
-                           }
-                   }
-
+            return {repo: {
+                    'architectures': mod_source.architectures,
+                    'comps': mod_source.comps,
+                    'disabled': mod_source.disabled,
+                    'file': mod_source.file,
+                    'type': mod_source.type,
+                    'uri': mod_source.uri,
+                    'line': mod_source.line,
+                    }
+                    }

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -192,7 +192,7 @@ def install(name=None,
         installation.
 
     version
-        Install a specific version of the package, e.g. 1.0.9~ubuntu. Ignored
+        Install a specific version of the package, e.g. 1.2.3~0ubuntu0. Ignored
         if "pkgs" or "sources" is passed.
 
 
@@ -203,7 +203,8 @@ def install(name=None,
         passed as a python list.
 
         CLI Example::
-            salt '*' pkg.install pkgs='["foo","bar"]'
+            salt '*' pkg.install pkgs='["foo", "bar"]'
+            salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-0ubuntu0"}]'
 
     sources
         A list of DEB packages to install. Must be passed as a list of dicts,

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -500,15 +500,16 @@ def upgrade_available(name):
     return available_version(name) != ''
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0ubuntu1' '0.2.4.1-0ubuntu1'
+        salt '*' pkg.perform_cmp '0.2.4-0ubuntu1' '0.2.4.1-0ubuntu1'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0ubuntu1' pkg2='0.2.4.1-0ubuntu1'
     '''
     try:
         for oper, ret in (('lt', -1), ('eq', 0), ('gt', 1)):
@@ -519,6 +520,18 @@ def compare(version1='', version2=''):
     except Exception as e:
         log.error(e)
     return None
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)
 
 
 def _split_repo_str(repo):

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -5,6 +5,7 @@ Homebrew for Mac OS X
 # Import salt libs
 import salt
 
+
 def __virtual__():
     '''
     Confine this module to Mac OS with Homebrew.
@@ -127,10 +128,10 @@ def install(name=None, pkgs=None, **kwargs):
 
         salt '*' pkg.install 'package package package'
     '''
-    pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name,
-            pkgs,
-            kwargs.get('sources', {}))
+    pkg_params, pkg_type = \
+        __salt__['pkg_resource.parse_targets'](name,
+                                               pkgs,
+                                               kwargs.get('sources', {}))
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 
@@ -172,14 +173,27 @@ def upgrade_available(pkg):
     return pkg in list_upgrades()
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -479,14 +479,27 @@ def depclean(pkg=None, slot=None):
     return ret_pkgs
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -312,14 +312,27 @@ def rehash():
         __salt__['cmd.run']('rehash')
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -353,14 +353,27 @@ def purge(name, **kwargs):
     return _list_removed(old, new)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -280,7 +280,7 @@ def parse_targets(name=None, pkgs=None, sources=None):
         return [x[2] for x in srcinfo], 'file'
 
     elif name and __grains__['os_family'] != 'Solaris':
-        return [name], 'repository'
+        return {name: None}, 'repository'
 
     else:
         log.error('No package sources passed to pkg.install.')

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -339,7 +339,7 @@ def find_changes(old=None, new=None):
     return pkgs
 
 
-def compare(pkg1='', pkg2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
     Compares two version strings using distutils.version.LooseVersion. This is
     a fallback for providers which don't have a version comparison utility
@@ -360,3 +360,24 @@ def compare(pkg1='', pkg2=''):
     except Exception as e:
         log.exception(e)
     return None
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Package version comparison function.
+    '''
+    cmp_map = {'<': (-1,), '<=': (-1, 0), '==': (0,),
+               '>=': (0, 1), '>': (1,)}
+    if oper not in ['!='] + cmp_map.keys():
+        log.error('Invalid operator "{0}" for package '
+                  'comparison'.format(oper))
+        return False
+
+    cmp_result = __salt__['pkg.perform_cmp'](pkg1, pkg2)
+    if cmp_result is None:
+        return False
+
+    if oper == '!=':
+        return cmp_result not in cmp_map['==']
+    else:
+        return cmp_result in cmp_map[oper]

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -95,23 +95,40 @@ def _parse_pkg_meta(path):
 
 def pack_pkgs(pkgs):
     '''
-    Accepts list (or a string representing a list) and returns back either the
-    list passed, or the list represenation of the string passed.
+    Accepts a list of packages or package/version pairs (or a string
+    representing said list) and returns a dict of name/version pairs. For a
+    given package, if no version was specified (i.e. the value is a string and
+    not a dict, then the dict returned will use None as the value for that
+    package.
 
-    Example: '["foo","bar","baz"]' would become ["foo","bar","baz"]
+    Example: '["foo", {"bar": 1.2}, "baz"]' would become
+             {'foo': None, 'bar': 1.2, 'baz': None}
     '''
     if isinstance(pkgs, basestring):
         try:
             pkgs = yaml.safe_load(pkgs)
         except yaml.parser.ParserError as err:
             log.error(err)
-            return []
+            return {}
     if not isinstance(pkgs, list) \
-            or [x for x in pkgs if not isinstance(x, basestring)]:
+            or [x for x in pkgs if not isinstance(x, (basestring, int,
+                                                      float, dict))]:
         log.error('Invalid input: {0}'.format(pprint.pformat(pkgs)))
-        log.error('Input must be a list of strings')
-        return []
-    return pkgs
+        log.error('Input must be a list of strings/dicts')
+        return {}
+    ret = {}
+    for pkg in pkgs:
+        if isinstance(pkg, (basestring, int, float)):
+            ret[pkg] = None
+        else:
+            if len(pkg) != 1:
+                log.error('Invalid input: package name/version pairs must '
+                          'contain only one element (data passed: '
+                          '{0}).'.format(pkg))
+                return {}
+            ret.update(pkg)
+    return dict([(str(x), str(y) if y is not None else y)
+                 for x, y in ret.iteritems()])
 
 
 def pack_sources(sources):

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -107,7 +107,7 @@ def pack_pkgs(pkgs):
             log.error(err)
             return []
     if not isinstance(pkgs, list) \
-    or [x for x in pkgs if not isinstance(x, basestring)]:
+            or [x for x in pkgs if not isinstance(x, basestring)]:
         log.error('Invalid input: {0}'.format(pprint.pformat(pkgs)))
         log.error('Input must be a list of strings')
         return []
@@ -248,7 +248,7 @@ def parse_targets(name=None, pkgs=None, sources=None):
 
         # Check metadata to make sure the name passed matches the source
         if __grains__['os_family'] not in ('Solaris',) \
-        and __grains__['os'] not in ('Gentoo', 'OpenBSD', 'FreeBSD'):
+                and __grains__['os'] not in ('Gentoo', 'OpenBSD', 'FreeBSD'):
             problems = _verify_binary_pkg(srcinfo)
             # If any problems are found in the caching or metadata parsing done
             # in the above for loop, log each problem and return None,None,
@@ -332,13 +332,13 @@ def compare(pkg1='', pkg2=''):
     '''
     try:
         if distutils.version.LooseVersion(pkg1) < \
-           distutils.version.LooseVersion(pkg2):
+                distutils.version.LooseVersion(pkg2):
             return -1
         elif distutils.version.LooseVersion(pkg1) == \
-             distutils.version.LooseVersion(pkg2):
+                distutils.version.LooseVersion(pkg2):
             return 0
         elif distutils.version.LooseVersion(pkg1) > \
-             distutils.version.LooseVersion(pkg2):
+                distutils.version.LooseVersion(pkg2):
             return 1
     except Exception as e:
         log.exception(e)

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -108,7 +108,7 @@ def stats(local=False, remote=False):
             Display stats only for the remote package database(s).
 
             CLI Example::
-        
+
                 salt '*' pkgng.stats remote=True
     '''
 
@@ -188,7 +188,7 @@ def install(pkg_name, orphan=False, force=False, glob=False, local=False,
     CLI Example::
 
         salt '*' pkgng.install <package name>
-        
+
         orphan
             Mark the installed package as orphan. Will be automatically removed
             if no other packages depend on them. For more information please
@@ -263,7 +263,7 @@ def install(pkg_name, orphan=False, force=False, glob=False, local=False,
             Treat the package names as extended regular expressions.
 
             CLI Example::
-            
+
                 salt '*' pkgng.install <extended regular expression> pcre=True
     '''
 
@@ -498,7 +498,7 @@ def clean():
 
 def autoremove(dryrun=False):
     '''
-    Delete packages which were automatically installed as dependencies and are 
+    Delete packages which were automatically installed as dependencies and are
     not required anymore
 
     CLI Example::
@@ -601,7 +601,7 @@ def which(file_name, origin=False, quiet=False):
     return __salt__['cmd.run'](cmd)
 
 
-def search(pkg_name, exact=False, glob=False, regex=False, pcre=False, 
+def search(pkg_name, exact=False, glob=False, regex=False, pcre=False,
             comment=False, desc=False, full=False, depends=False,
             size=False, quiet=False, origin=False, prefix=False, ):
     '''
@@ -729,11 +729,11 @@ def search(pkg_name, exact=False, glob=False, regex=False, pcre=False,
     return __salt__['cmd.run'](cmd)
 
 
-def fetch(pkg_name, all=False, quiet=False, reponame=None, glob=True, 
+def fetch(pkg_name, all=False, quiet=False, reponame=None, glob=True,
             regex=False, pcre=False, local=False, depends=False):
     '''
     Fetches remote packages
-    
+
     CLI Example::
 
         salt '*' pkgng.fetch <package name>
@@ -795,7 +795,7 @@ def fetch(pkg_name, all=False, quiet=False, reponame=None, glob=True,
             CLI Example::
 
                 salt '*' pkgng.fetch <package name> depends=True
-    ''' 
+    '''
 
     opts = ''
     if all:
@@ -828,7 +828,7 @@ def updating(pkg_name, filedate=None, filename=None):
     Displays UPDATING entries of software packages
 
     CLI Example::
-    
+
         salt '*' pkgng.updating foo
 
         filedate
@@ -858,14 +858,27 @@ def updating(pkg_name, filedate=None, filename=None):
     return __salt__['cmd.run'](cmd)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -259,14 +259,27 @@ def purge(name, **kwargs):
     return remove(name, **kwargs)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -400,14 +400,27 @@ def purge(name, **kwargs):
     return remove(name, **kwargs)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -467,14 +467,27 @@ def _get_latest_pkg_version(pkginfo):
     return sorted(pkgkeys, cmp=_reverse_cmp_pkg_versions).pop()
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -284,7 +284,7 @@ def install(name=None,
         Skip the GPG verification check. (e.g., ``--nogpgcheck``)
 
     version
-        Install a specific version of the package, e.g. 1.0.9. Ignored
+        Install a specific version of the package, e.g. 1.2.3-4.el6. Ignored
         if "pkgs" or "sources" is passed.
 
 
@@ -307,10 +307,13 @@ def install(name=None,
 
     pkgs
         A list of packages to install from a software repository. Must be
-        passed as a python list.
+        passed as a python list. A specific version number can be specified
+        by using a single-element dict representing the package and its
+        version.
 
-        CLI Example::
-            salt '*' pkg.install pkgs='["foo","bar"]'
+        CLI Examples::
+            salt '*' pkg.install pkgs='["foo", "bar"]'
+            salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-4.el6"}]'
 
     sources
         A list of RPM packages to install. Must be passed as a list of dicts,
@@ -346,8 +349,8 @@ def install(name=None,
     disablerepo = kwargs.get('disablerepo', '')
     enablerepo = kwargs.get('enablerepo', '')
     repo = kwargs.get('repo', '')
-    version = kwargs.get('version')
 
+    version = kwargs.get('version')
     if version:
         if pkgs is None and sources is None:
             # Allow "version" to work for single package target

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -326,15 +326,6 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    # This allows modules to specify the version in a kwarg, like the other
-    # package modules
-    if kwargs.get('version'):
-        if pkgs is None and sources is None:
-            name = '{0}-{1}'.format(name, kwargs.get('version'))
-        else:
-            log.warning('"version" parameter will be ignored for muliple '
-                        'package targets')
-
     # Catch both boolean input from state and string input from CLI
     if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
@@ -355,6 +346,15 @@ def install(name=None,
     disablerepo = kwargs.get('disablerepo', '')
     enablerepo = kwargs.get('enablerepo', '')
     repo = kwargs.get('repo', '')
+    version = kwargs.get('version')
+
+    if version:
+        if pkgs is None and sources is None:
+            # Allow "version" to work for single package target
+            pkg_params = {name: version}
+        else:
+            log.warning('"version" parameter will be ignored for muliple '
+                        'package targets')
 
     # Support old "repo" argument
     if not fromrepo and repo:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -873,14 +873,27 @@ def _parse_repo_file(filename):
     return (header, repos)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -252,15 +252,6 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    # This allows modules to specify the version in a kwarg, like the other
-    # package modules
-    if kwargs.get('version'):
-        if pkgs is None and sources is None:
-            name = '{0}-{1}'.format(name, kwargs.get('version'))
-        else:
-            log.warning('"version" parameter will be ignored for muliple '
-                        'package targets')
-
     # Catch both boolean input from state and string input from CLI
     if refresh is True or str(refresh).lower() == 'true':
         refresh_db()
@@ -275,6 +266,15 @@ def install(name=None,
     disablerepo = kwargs.get('disablerepo', '')
     enablerepo = kwargs.get('enablerepo', '')
     repo = kwargs.get('repo', '')
+    version = kwargs.get('version')
+
+    if version:
+        if pkgs is None and sources is None:
+            # Allow "version" to work for single package target
+            pkg_params = {name: version}
+        else:
+            log.warning('"version" parameter will be ignored for muliple '
+                        'package targets')
 
     # Support old "repo" argument
     if not fromrepo and repo:
@@ -292,7 +292,7 @@ def install(name=None,
             log.info('Enabling repo "{0}"'.format(enablerepo))
             repo_arg += '--enablerepo="{0}" '.format(enablerepo)
 
-    if pkg_type == 'repository' and pkgs:
+    if pkg_type == 'repository':
         targets = []
         for param, version in pkg_params.iteritems():
             if version is None:

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -210,7 +210,7 @@ def install(name=None,
         Skip the GPG verification check (e.g., ``--nogpgcheck``)
 
     version
-        Install a specific version of the package, e.g. 1.0.9. Ignored
+        Install a specific version of the package, e.g. 1.2.3-4.el5. Ignored
         if "pkgs" or "sources" is passed.
 
 
@@ -233,10 +233,13 @@ def install(name=None,
 
     pkgs
         A list of packages to install from a software repository. Must be
-        passed as a python list.
+        passed as a python list. A specific version number can be specified
+        by using a single-element dict representing the package and its
+        version.
 
-        CLI Example::
-            salt '*' pkg.install pkgs='["foo","bar"]'
+        CLI Examples::
+            salt '*' pkg.install pkgs='["foo", "bar"]'
+            salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-4.el5"}]'
 
     sources
         A list of RPM packages to install. Must be passed as a list of dicts,
@@ -266,8 +269,8 @@ def install(name=None,
     disablerepo = kwargs.get('disablerepo', '')
     enablerepo = kwargs.get('enablerepo', '')
     repo = kwargs.get('repo', '')
-    version = kwargs.get('version')
 
+    version = kwargs.get('version')
     if version:
         if pkgs is None and sources is None:
             # Allow "version" to work for single package target

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -383,14 +383,27 @@ def purge(pkg, **kwargs):
     return remove(pkg)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -368,14 +368,27 @@ def purge(name, **kwargs):
     return _list_removed(old, new)
 
 
-def compare(version1='', version2=''):
+def perform_cmp(pkg1='', pkg2=''):
     '''
-    Compare two version strings. Return -1 if version1 < version2,
-    0 if version1 == version2, and 1 if version1 > version2. Return None if
-    there was a problem making the comparison.
+    Do a cmp-style comparison on two packages. Return -1 if pkg1 < pkg2, 0 if
+    pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
+    making the comparison.
 
     CLI Example::
 
-        salt '*' pkg.compare '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp '0.2.4-0' '0.2.4.1-0'
+        salt '*' pkg.perform_cmp pkg1='0.2.4-0' pkg2='0.2.4.1-0'
     '''
-    return __salt__['pkg_resource.compare'](version1, version2)
+    return __salt__['pkg_resource.perform_cmp'](pkg1=pkg1, pkg2=pkg2)
+
+
+def compare(pkg1='', oper='==', pkg2=''):
+    '''
+    Compare two version strings.
+
+    CLI Example::
+
+        salt '*' pkg.compare '0.2.4-0' '<' '0.2.4.1-0'
+        salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
+    '''
+    return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -4,6 +4,7 @@ Package support for openSUSE via the zypper package manager
 
 # Import python libs
 import logging
+import re
 
 # Import salt libs
 import salt.utils
@@ -175,7 +176,11 @@ def refresh_db():
     return ret
 
 
-def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
+def install(name=None,
+            refresh=False,
+            pkgs=None,
+            sources=None,
+            **kwargs):
     '''
     Install the passed package(s), add refresh=True to run 'zypper refresh'
     before package is installed.
@@ -193,15 +198,25 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     refresh
         Whether or not to refresh the package database before installing.
 
+    version
+        Can be either a version number, or the combination of a comparison
+        operator (<, >, <=, >=, =) and a version number (ex. '>1.2.3-4').
+        This parameter is ignored if "pkgs" or "sources" is passed.
+
 
     Multiple Package Installation Options:
 
     pkgs
         A list of packages to install from a software repository. Must be
-        passed as a python list.
+        passed as a python list. A specific version number can be specified
+        by using a single-element dict representing the package and its
+        version. As with the ``version`` parameter above, comparison operators
+        can be used to target a specific version of a package.
 
-        CLI Example::
-            salt '*' pkg.install pkgs='["foo","bar"]'
+        CLI Examples::
+            salt '*' pkg.install pkgs='["foo", "bar"]'
+            salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-4"}]'
+            salt '*' pkg.install pkgs='["foo", {"bar": "<1.2.3-4"}]'
 
     sources
         A list of RPM packages to install. Must be passed as a list of dicts,
@@ -227,11 +242,56 @@ def install(name=None, refresh=False, pkgs=None, sources=None, **kwargs):
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 
-    cmd = 'zypper -n install -l {0}'.format(' '.join(pkg_params))
+    version = kwargs.get('version')
+    if version:
+        if pkgs is None and sources is None:
+            # Allow "version" to work for single package target
+            pkg_params = {name: version}
+        else:
+            log.warning('"version" parameter will be ignored for muliple '
+                        'package targets')
+
+    if pkg_type == 'repository':
+        targets = []
+        problems = []
+        for param, version in pkg_params.iteritems():
+            if version is None:
+                targets.append(param)
+            else:
+                match = re.match('^([<>])?(=)?([^<>=]+)$', version)
+                if match:
+                    gt_lt, eq, verstr = match.groups()
+                    prefix = gt_lt or ''
+                    prefix += eq or ''
+                    # If no prefix characters were supplied, use '='
+                    prefix = prefix or '='
+                    targets.append('{0}{1}{2}'.format(param, prefix, verstr))
+                    log.debug(targets)
+                else:
+                    msg = 'Invalid version string "{0}" for package ' \
+                          '"{1}"'.format(name, version)
+                    problems.append(msg)
+        if problems:
+            for problem in problems:
+                log.error(problem)
+            return {}
+    else:
+        targets = pkg_params
+
     old = list_pkgs()
-    stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
-    if stderr:
-        log.error(stderr)
+    # Quotes needed around package targets because of the possibility of output
+    # redirection characters "<" or ">" in zypper command.
+    cmd = 'zypper -n install -l "{0}"'.format(' '.join(targets))
+    stdout = __salt__['cmd.run_all'](cmd).get('stdout', '')
+    downgrades = []
+    for line in stdout.splitlines():
+        match = re.match("^The selected package '([^']+)'.+has lower version",
+                         line)
+        if match:
+            downgrades.append(match.group(1))
+    if downgrades:
+        cmd = 'zypper -n install -l --force {0}'.format(' '.join(downgrades))
+        __salt__['cmd.run_all'](cmd)
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -269,7 +269,7 @@ def install(name=None,
                     log.debug(targets)
                 else:
                     msg = 'Invalid version string "{0}" for package ' \
-                          '"{1}"'.format(name, version)
+                          '"{1}"'.format(version, name)
                     problems.append(msg)
         if problems:
             for problem in problems:
@@ -281,7 +281,7 @@ def install(name=None,
     old = list_pkgs()
     # Quotes needed around package targets because of the possibility of output
     # redirection characters "<" or ">" in zypper command.
-    cmd = 'zypper -n install -l "{0}"'.format(' '.join(targets))
+    cmd = 'zypper -n install -l "{0}"'.format('" "'.join(targets))
     stdout = __salt__['cmd.run_all'](cmd).get('stdout', '')
     downgrades = []
     for line in stdout.splitlines():

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -303,8 +303,10 @@ def latest(
                 msg = 'No information found for "{0}".'.format(pkg)
                 log.error(msg)
                 problems.append(msg)
-        elif not cur[pkg] or __salt__['pkg.compare'](cur[pkg],
-                                                     avail[pkg]) == -1:
+        elif not cur[pkg] or \
+                __salt__['pkg.compare'](pkg1=cur[pkg],
+                                        oper='<',
+                                        pkg2=avail[pkg]):
             targets[pkg] = avail[pkg]
 
     if problems:


### PR DESCRIPTION
These commits do the following:
1. Fix yumpkg5.py so that single-package installs work with the "version"
   kwarg in pkg.install states (this already worked in yumpkg.py).
2. pkg_resource.pack_pkgs now returns a dict of name/version pairs, instead of
   a list. This will allow #3278 to be implemented, by allowing for versions to
   be specified for each package in the "pkgs" list. Packages without a
   specified version will have a value of None in the return dict. Note that
   the pkg.install state does not yet support #3278, as a version check will
   need to be added in order to enforce the specified version. Backwards
   compatibility has been confirmed to work, however, as the data returned from
   pkg_resource.pack_pkgs (a list) is joined into a string, and passing a dict
   to str.join() will join the keys (which are the targeted packages).
3. Both yum providers, as well as apt, zypper, and pacman are updated to work
   for #3278.

**UPDATE:** This is all set for the modifications to be made in
states.pkg.installed. I finished all the Linux pkg providers and re-did the
version comparison functions that I added for 0.12.0 to implement multi-pkg for
the pkg.latest state so that version comparison in salt code is more
user-friendly.

Feel free to merge, but I'll probably come back to this tomorrow to add the
last bits to finish up #3278.
