### PR TITLE
Adding grains for ALT Linux

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -616,7 +616,9 @@ def os_data():
                     for line in ifile:
                         comps = line.split()
                         if comps[0] == 'ALT':
-                            grains['lsb_distrib_codename'] = comps[2]
+                            grains['lsb_distrib_release'] = comps[2]
+                            grains['lsb_distrib_codename'] = \
+                                comps[3].replace('(','').replace(')','')
         # Use the already intelligent platform module to get distro info
         (osname, osrelease, oscodename) = platform.linux_distribution(
             supported_dists=_supported_dists)

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -506,6 +506,7 @@ _OS_NAME_MAP = {
     'debiangnu/': 'Debian',
     'fedoraremi': 'RedHat',
     'amazonami': 'RedHat',
+    'alt': 'ALT',
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -536,6 +537,7 @@ _OS_FAMILY_MAP = {
     'Solaris': 'Solaris',
     'SmartOS': 'Solaris',
     'Arch ARM': 'Arch',
+    'ALT': 'RedHat',
 }
 
 
@@ -607,6 +609,14 @@ def os_data():
                             name, value = match.groups()
                             if name.lower() == 'name':
                                 grains['lsb_distrib_id'] = value.strip()
+            elif os.path.isfile('/etc/altlinux-release'):
+                # ALT Linux
+                grains['lsb_distrib_id'] = 'altlinux'
+                with salt.utils.fopen('/etc/altlinux-release') as ifile:
+                    for line in ifile:
+                        comps = line.split()
+                        if comps[0] == 'ALT':
+                            grains['lsb_distrib_codename'] = comps[2]
         # Use the already intelligent platform module to get distro info
         (osname, osrelease, oscodename) = platform.linux_distribution(
             supported_dists=_supported_dists)


### PR DESCRIPTION
Addresses issue #3444. Tagging @valintinr.

This OS uses /etc/altlinux-release (and /etc/fedora-release, /etc/redhat-release and /etc/system-release) for identification. With a release file that looks like:

ALT Linux Sisyphus (unstable)

...you get grains that look like:

 'lsb_distrib_codename': 'unstable',
 'lsb_distrib_id': 'altlinux',
 'lsb_distrib_release': 'Sisyphus',
 'os_family': 'RedHat',
 'oscodename': 'unstable',
 'osfullname': 'altlinux',
 'osrelease': 'Sisyphus',

This seems to be consistent with the CentOS 6.3 and Arch Linux boxes that I compared against.
