### PR TITLE
Adding file_list and file_dict to pacman.py

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -377,3 +377,55 @@ def compare(pkg1='', oper='==', pkg2=''):
         salt '*' pkg.compare pkg1='0.2.4-0' oper='<' pkg2='0.2.4.1-0'
     '''
     return __salt__['pkg_resource.compare'](pkg1=pkg1, oper=oper, pkg2=pkg2)
+
+
+def file_list(*packages):
+    '''
+    List the files that belong to a package. Not specifying any packages will
+    return a list of _every_ file on the system's rpm database (not generally
+    recommended).
+
+    CLI Examples::
+
+        salt '*' pkg.file_list httpd
+        salt '*' pkg.file_list httpd postfix
+        salt '*' pkg.file_list
+    '''
+    errors = []
+    ret = []
+    cmd = 'pacman -Ql {0}'.format(' '.join(packages))
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        if line.startswith('error'):
+            errors.append(line)
+        else:
+            comps = line.split()
+            ret.append(' '.join(comps[1:]))
+    return {'errors': errors, 'files': ret}
+
+
+def file_dict(*packages):
+    '''
+    List the files that belong to a package, grouped by package. Not
+    specifying any packages will return a list of _every_ file on the system's
+    rpm database (not generally recommended).
+
+    CLI Examples::
+
+        salt '*' pkg.file_list httpd
+        salt '*' pkg.file_list httpd postfix
+        salt '*' pkg.file_list
+    '''
+    errors = []
+    ret = {}
+    cmd = 'pacman -Ql {0}'.format(' '.join(packages))
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        if line.startswith('error'):
+            errors.append(line)
+        else:
+            comps = line.split()
+            if not comps[0] in ret:
+                ret[comps[0]] = []
+            ret[comps[0]].append((' '.join(comps[1:])))
+    return {'errors': errors, 'packages': ret}
+
+


### PR DESCRIPTION
This feature is important to system introspection (#2735), and matches the file_list() function introduced to yumpkg.py in #3481.

@morganfainberg, sorry to tag you again, but you did the repo stuff for apt, so I assume you have the fu. This may be a better example than #3481.
