### PR TITLE
Implementing lowpkg module for apt/deb

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -929,24 +929,7 @@ def file_list(*packages):
         salt '*' pkg.file_list httpd postfix
         salt '*' pkg.file_list
     '''
-    errors = []
-    ret = set([])
-    pkgs = {}
-    cmd = 'dpkg -l {0}'.format(' '.join(packages))
-    for line in __salt__['cmd.run'](cmd).splitlines():
-        if line.startswith('ii '):
-            comps = line.split()
-            pkgs[comps[1]] = {'version': comps[2], 'description': ' '.join(comps[3:])}
-        if 'No packages found' in line:
-            errors.append(line)
-    for pkg in pkgs.keys():
-        files = []
-        cmd = 'dpkg -L {0}'.format(pkg)
-        for line in __salt__['cmd.run'](cmd).splitlines():
-            files.append(line)
-        fileset = set(files)
-        ret = ret.union(fileset)
-    return {'errors': errors, 'files': list(ret)}
+    return __salt__['lowpkg.file_list'](*packages)
 
 
 def file_dict(*packages):
@@ -961,20 +944,4 @@ def file_dict(*packages):
         salt '*' pkg.file_list httpd postfix
         salt '*' pkg.file_list
     '''
-    errors = []
-    ret = {}
-    pkgs = {}
-    cmd = 'dpkg -l {0}'.format(' '.join(packages))
-    for line in __salt__['cmd.run'](cmd).splitlines():
-        if line.startswith('ii '):
-            comps = line.split()
-            pkgs[comps[1]] = {'version': comps[2], 'description': ' '.join(comps[3:])}
-        if 'No packages found' in line:
-            errors.append(line)
-    for pkg in pkgs.keys():
-        files = []
-        cmd = 'dpkg -L {0}'.format(pkg)
-        for line in __salt__['cmd.run'](cmd).splitlines():
-            files.append(line)
-        ret[pkg] = files
-    return {'errors': errors, 'packages': ret}
+    return __salt__['lowpkg.file_dict'](*packages)

--- a/salt/modules/deb.py
+++ b/salt/modules/deb.py
@@ -1,0 +1,89 @@
+'''
+Support for DEB packages
+'''
+
+# Import python libs
+import os
+import re
+import logging
+
+try:
+    deb_support = True
+except ImportError:
+    deb_support = False
+
+# Import salt libs
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Confirm this module is on a Debian based system
+    '''
+    return 'lowpkg' if __grains__['os_family'] == 'Debian' else False
+
+
+def file_list(*packages):
+    '''
+    List the files that belong to a package. Not specifying any packages will
+    return a list of _every_ file on the system's package database (not
+    generally recommended).
+
+    CLI Examples::
+
+        salt '*' lowpkg.file_list httpd
+        salt '*' lowpkg.file_list httpd postfix
+        salt '*' lowpkg.file_list
+    '''
+    errors = []
+    ret = set([])
+    pkgs = {}
+    cmd = 'dpkg -l {0}'.format(' '.join(packages))
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        if line.startswith('ii '):
+            comps = line.split()
+            pkgs[comps[1]] = {'version': comps[2], 'description': ' '.join(comps[3:])}
+        if 'No packages found' in line:
+            errors.append(line)
+    for pkg in pkgs.keys():
+        files = []
+        cmd = 'dpkg -L {0}'.format(pkg)
+        for line in __salt__['cmd.run'](cmd).splitlines():
+            files.append(line)
+        fileset = set(files)
+        ret = ret.union(fileset)
+    return {'errors': errors, 'files': list(ret)}
+
+
+def file_dict(*packages):
+    '''
+    List the files that belong to a package, grouped by package. Not
+    specifying any packages will return a list of _every_ file on the system's
+    package database (not generally recommended).
+
+    CLI Examples::
+
+        salt '*' lowpkg.file_list httpd
+        salt '*' lowpkg.file_list httpd postfix
+        salt '*' lowpkg.file_list
+    '''
+    errors = []
+    ret = {}
+    pkgs = {}
+    cmd = 'dpkg -l {0}'.format(' '.join(packages))
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        if line.startswith('ii '):
+            comps = line.split()
+            pkgs[comps[1]] = {'version': comps[2], 'description': ' '.join(comps[3:])}
+        if 'No packages found' in line:
+            errors.append(line)
+    for pkg in pkgs.keys():
+        files = []
+        cmd = 'dpkg -L {0}'.format(pkg)
+        for line in __salt__['cmd.run'](cmd).splitlines():
+            files.append(line)
+        ret[pkg] = files
+    return {'errors': errors, 'packages': ret}
+


### PR DESCRIPTION
Tagging @archtaku, @valintinr.

Mimics yum/rpm functionality added in #3501 and addresses #3473.

This is the first step towards decoupling apt and deb. The same is happening for yum and rpm. The idea is to keep repo management in yumpky.py and apt.py, but move the underlying package management functions into modules that return lowpkg in their virtual function. This is necessary to make package management work on apt-rpm systems, such as ALT Linux.
