### PR TITLE
Adding list_pkgs() to rpm.py

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -45,6 +45,32 @@ def __virtual__():
     return False
 
 
+def list_pkgs(*packages):
+    '''
+    List the packages currently installed in a dict::
+
+        {'<package_name>': '<version>'}
+
+    CLI Example::
+
+        salt '*' lowpkg.list_pkgs
+    '''
+    errors = []
+    ret = {}
+    pkgs = {}
+    if not packages:
+        cmd = "rpm -qa --qf '%{NAME} %{VERSION}\\n'"
+    else:
+        cmd = "rpm -q --qf '%{{NAME}} %{{VERSION}}\\n' {0}".format(' '.join(packages))
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        if 'is not installed' in line:
+            errors.append(line)
+            continue
+        comps = line.split()
+        pkgs[comps[0]] = comps[1]
+    return pkgs
+
+
 def verify(*package):
     '''
     Runs an rpm -Va on a system, and returns the results in a dict


### PR DESCRIPTION
Tagging @archtaku.

After a few test runs, it seems that the list_pkgs() function in yumpkg.py is somewhere around 25% faster than this version. However, a yum-free alternative is crucial to rpm.py (and lowpkg in general).
