### PR TITLE
Fix gentoo pkg

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -277,7 +277,7 @@ def install(name=None,
                        'new': '<new-version>'}}
     '''
 
-    logging.debug('Called modules.pkg.install: {0}'.format(
+    log.debug('Called modules.pkg.install: {0}'.format(
         {
             'name': name,
             'refresh': refresh,
@@ -307,7 +307,16 @@ def install(name=None,
     else:
         emerge_opts = ''
 
-    cmd = 'emerge --quiet {0} {1}'.format(emerge_opts, ' '.join(pkg_params))
+    if pkg_type == 'repository':
+        targets = list()
+        for param, version in pkg_params.iteritems():
+            if version is None:
+                targets.append(param)
+            else:
+                targets.append('={0}-{1}'.format(param, version))
+    else:
+        targets = pkg_params
+    cmd = 'emerge --quiet {0} {1}'.format(emerge_opts, ' '.join(targets))
     old = list_pkgs()
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -194,7 +194,7 @@ def check_desired(desired=None):
     # category/pkgname. For any package that does not follow this format, offer
     # matches from the portage tree.
     if __grains__['os_family'] == 'Gentoo':
-        for pkg in (targets or []):
+        for pkg in (desired or []):
             if '/' not in pkg:
                 matches = __salt__['pkg.porttree_matches'](pkg)
                 if matches:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -211,6 +211,7 @@ def installed(
         Install a specific version of a package. This option is ignored if
         either "pkgs" or "sources" is used. Currently, this option is supported
         for the following pkg providers: :mod:`apt <salt.modules.apt>`,
+        :mod:`ebuild <salt.modules.ebuild>`,
         :mod:`pacman <salt.modules.pacman>`,
         :mod:`yumpkg <salt.modules.yumpkg>`,
         :mod:`yumpkg5 <salt.modules.yumpkg5>`, and
@@ -240,6 +241,7 @@ def installed(
               - baz
 
     ``NOTE:`` For :mod:`apt <salt.modules.apt>`,
+    :mod:`ebuild <salt.modules.ebuild>`,
     :mod:`pacman <salt.modules.pacman>`, :mod:`yumpkg <salt.modules.yumpkg>`,
     :mod:`yumpkg5 <salt.modules.yumpkg5>`,
     and :mod:`zypper <salt.modules.zypper>`, version numbers can be specified


### PR DESCRIPTION
Fixed up gentoo related code so pkg.install still works and supports the new pkgs with versions state format that @archtaku implemented
