### PR TITLE
fix bug in available_version

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -88,7 +88,7 @@ def available_version(*names):
     for name in names:
         ret[name] = ''
     # Get updates for specified package(s)
-    updates = _parse_yum('list updates {0}'.format(' '.join(names)))
+    updates = _parse_yum('list available {0}'.format(' '.join(names)))
     for pkg in updates:
         ret[pkg.name] = pkg.version
     # Return a string if only one package name passed


### PR DESCRIPTION
Thanks to @kfdm for finding this. This commit fixes a problem with
available_version where it does not return information for packages
which are not already installed.
