### PR TITLE
Added check in modules.locale for empty string in locale. 

### DIFF
--- a/salt/modules/locale.py
+++ b/salt/modules/locale.py
@@ -53,7 +53,10 @@ def get_locale():
         cmd = 'eselect --brief locale show'
         return __salt__['cmd.run'](cmd).strip()
     out = __salt__['cmd.run'](cmd).split('=')
-    ret = out[1].replace('"', '')
+    if len(out) == 2:
+      ret = out[1].replace('"', '')
+    else:
+      ret = ""
     return ret
 
 


### PR DESCRIPTION
This safeguards against an empty string in locale.

This addresses the issue: [#3535](https://github.com/saltstack/salt/issues/3535)
