### PR TITLE
When going through the API, selected_target_option is always 'None'.

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -36,7 +36,7 @@ class Batch(object):
         if selected_target_option is not None:
             args.append(selected_target_option)
         else:
-            args.append('glob')
+            args.append(self.opts['expr_form'])
 
         fret = []
         for ret in self.local.cmd_iter(*args):


### PR DESCRIPTION
That breaks grains-based minion-discovery for the batch run when running through the API. The expr_form-variable is always set, so we can default to that safely instead of glob.

Tested with own client (derived from LocalClient()) and salt binary using batch mode and grains-based minion-discovery.
