### PR TITLE
Use chkconfig --type to separate sysv and xinetd parsing.  Adds xinetd ...

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -54,7 +54,7 @@ def get_enabled():
     '''
     rlevel = _runlevel()
     ret = set()
-    cmd = '/sbin/chkconfig --list'
+    cmd = '/sbin/chkconfig --list --type sysv'
     lines = __salt__['cmd.run'](cmd).splitlines()
     for line in lines:
         comps = line.split()
@@ -62,6 +62,17 @@ def get_enabled():
             continue
         if '{0}:on'.format(rlevel) in line:
             ret.add(comps[0])
+    
+    cmd = '/sbin/chkconfig --list --type xinetd'
+    lines = __salt__['cmd.run'](cmd).splitlines()
+    for line in lines:
+        comps = line.split()
+        if not comps:
+            continue
+        if not comps[1]:
+            continue
+        if comps[1] == 'on':
+            ret.add(comps[0].strip(':'))
     return sorted(ret)
 
 def get_disabled():


### PR DESCRIPTION
...support to service.enabled 

This fixes https://github.com/saltstack/salt/issues/863
