### PR TITLE
fixed invalid doc example for cmd.run

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -28301,7 +28301,7 @@ echo "Working hard..."
 
 # writing the state line
 echo  # an empty line here so the next line will be the last.
-echo "changed=yes comment="something\(aqs changed!" whatever=123"
+echo "changed=yes comment='something has changed' whatever=123"
 .ft P
 .fi
 .sp

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -72,7 +72,7 @@ a simple protocol described below:
 
       # writing the state line
       echo  # an empty line here so the next line will be the last.
-      echo "changed=yes comment=\"something's changed!\" whatever=123"
+      echo "changed=yes comment='something has changed' whatever=123"
 
 
     And an example salt file using this module::


### PR DESCRIPTION
the example given in the documentation is invalid with the `!` mark, but it is also a bit confusing. I hope this helps!

``` bash
$ echo "changed=yes comment="something's changed!" whatever=123"

quote> 
```

This works:

``` bash
$ echo "changed=yes comment='something has changed' whatever=123"                                                        

changed=yes comment='something has changed' whatever=123
```

From reviewing the [documentation](https://salt.readthedocs.org/en/latest/ref/states/all/salt.states.cmd.html), it looks like the entire line needs to be a string? I think I got this right...

> the stdout must be either in JSON or its last non-empty line 
> must be a string of key=value pairs delimited by spaces
> (no spaces on the sides of =).
