### PR TITLE
Ignore file created by ctags -R

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ coverage.xml
 htmlcov/
 /.project
 /.pydevproject
+
+# ignore ctags file
+tags


### PR DESCRIPTION
Hopefully this doesn't trample other's configs, but I typically also add a line in .gitignore to ignore the file dumped by invoking ctags -R .
