### PR TITLE
syntax fix for the timezone.system example

### DIFF
--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -8,7 +8,7 @@ The timezone can be managed for the system:
 
     America/Denver:
       timezone.system:
-        utc: True
+        - utc: True
 '''
 
 


### PR DESCRIPTION
The example was missing a '-' which was incorrect.
