### PR TITLE
SIGCHLD handler attached only when multiprocessing is enabled

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -743,7 +743,8 @@ class Minion(object):
             'minion_start'
         )
 
-        signal.signal(signal.SIGCHLD, self.handle_sigchld)
+        if self.opts['multiprocessing'] and not sys.platform.startswith('win'):
+            signal.signal(signal.SIGCHLD, self.handle_sigchld)
         # Make sure to gracefully handle SIGUSR1
         enable_sigusr1_handler()
 


### PR DESCRIPTION
https://github.com/saltstack/salt/issues/3395
