### PR TITLE
Make comment reflect reality

### DIFF
--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -9,7 +9,7 @@ from salt.exceptions import CommandExecutionError
 
 def __virtual__():
     '''
-    Only run on Linux systems
+    Only run on FreeBSD systems
     '''
     return 'sysctl' if __grains__['os'] == 'FreeBSD' else False
 


### PR DESCRIPTION
freebsd_sysctl "Only run on Linux systems" ? I think not.
