### PR TITLE
Fix for Oracle Linux os grains definitions

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -25,7 +25,7 @@ import locale
 # /etc/DISTRO-release checking that is part of platform.linux_distribution()
 from platform import _supported_dists
 _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
-                     'slamd64', 'enterprise', 'ovs', 'system', 'mint')
+                     'slamd64', 'ovs', 'system', 'mint', 'oracle')
 
 # Import salt libs
 import salt.log
@@ -507,6 +507,7 @@ _OS_NAME_MAP = {
     'fedoraremi': 'Fedora',
     'amazonami': 'Amazon',
     'alt': 'ALT',
+    'oracleserv': 'OEL',
 }
 
 # Map the 'os' grain to the 'os_family' grain


### PR DESCRIPTION
I was having issues with salt properly identifying Oracle Linux Server 5.9.  It came up with the following information in grains:

``` yaml
  os: Enterprise  Enterprise  Server
  os_family: Enterprise  Enterprise  Server
  oscodename: Carthage
  osfullname: Enterprise Linux Enterprise Linux Server
```

I know this is due to salt using the /etc/enterprise-release file.  But this file seems pretty much useless to identifying exactly which distro salt is on.  And better yet, on Oracle Linux Server 6.3 they don't even have a /etc/enterprise-release file.  I think that having salt look at the /etc/oracle-release file would be a better choice.  I get the following output in grains with the included changes:

``` yaml
  os: OEL
  os_family: RedHat
  oscodename: 
  osfullname: Oracle Linux Server
```

Also, after looking at /etc/redhat-release and /etc/oracle-release.  I noticed that oracle actually keeps the /etc/redhat-release file untouched and it contains the "Red Hat Enterprise Linux Server release 5.9" string.  Again making it confusing about exactly what distro your running.  This is just something to note since CentOS actually creates a symlink from /etc/centos-release to the /etc/redhat-release file (This seems like a MUCH better way to do it).  

Really my only other concern would be which distros actually use the /etc/enterprise-release file?  Since i removed it from the list because it was matching "enterprise" before "oracle".  

~Rob
