### PR TITLE
Added log when debconf-utils is not installed on a Debian system.

### DIFF
--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -22,6 +22,7 @@ def __virtual__():
         return False
 
     if salt.utils.which('debconf-get-selections') is None:
+        log.exception('Package debconf-utils is not installed.')
         return False
 
     return 'debconf'


### PR DESCRIPTION
Extremely simple little tiny change...
