### PR TITLE
Add a useful error message for IPC URI length failure

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -19,7 +19,7 @@ try:
 except ImportError as e:
     if e.args[0] != 'No module named _msgpack':
         raise
-
+from salt.exceptions import SaltSystemExit
 
 logger = logging.getLogger(__name__)
 
@@ -187,11 +187,14 @@ class Minion(parsers.MinionOptionParser):
         try:
             if check_user(self.config['user']):
                 self.minion.tune_in()
-        except KeyboardInterrupt:
+        except (KeyboardInterrupt, SaltSystemExit) as e:
             logger.warn('Stopping the Salt Minion')
-            self.shutdown()
+            if isinstance(e, KeyboardInterrupt):
+                logger.warn('Exiting on Ctrl-c')
+            else:
+                logger.error(str(e))
         finally:
-            raise SystemExit('\nExiting on Ctrl-c')
+            self.shutdown()
 
     def shutdown(self):
         '''


### PR DESCRIPTION
The docs have this:

> Once the minion starts, you may see an error like the following::
> 
> > zmq.core.error.ZMQError: ipc path "/path/to/your/virtualenv/var/run/salt/minion/minion_event_7824dcbcfd7a8f6755939af70b96249f_pub.ipc" is longer than 107 characters (sizeof(sockaddr_un.sun_path)).

When I encountered this problem the only unusual output I saw was the message "Exiting on Ctrl-C" - very misleading. This patch ought to fix this.
