### PR TITLE
Add iptables salt state module.

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -116,7 +116,7 @@ def set_policy(table='filter', chain=None, policy=None):
     return out
 
 
-def save(filename):
+def save(filename=None):
     '''
     Save the current in-memory rules to disk
 
@@ -124,6 +124,9 @@ def save(filename):
 
         salt '*' iptables.save /etc/sysconfig/iptables
     '''
+    if _conf() and not filename:
+        filename = _conf()
+
     parent_dir = os.path.dirname(filename)
     if not os.path.isdir(parent_dir):
         os.makedirs(parent_dir)
@@ -250,6 +253,7 @@ def _parse_conf(conf_file=None, in_mem=False):
             ret[table][chain]['packet count'] = pcount
             ret[table][chain]['byte count'] = bcount
             ret[table][chain]['rules'] = []
+            ret[table][chain]['rules_comment'] = {}
         elif line.startswith('-A'):
             parser = _parser()
             parsed_args = []
@@ -263,6 +267,9 @@ def _parse_conf(conf_file=None, in_mem=False):
             for arg in parsed_args:
                 if parsed_args[arg] and arg is not 'append':
                     ret_args[arg] = parsed_args[arg]
+            if parsed_args['comment'] is not None:
+                comment = parsed_args['comment'][0].strip('"')
+                ret[table][chain[0]]['rules_comment'][comment]=ret_args
             ret[table][chain[0]]['rules'].append(ret_args)
     return ret
 

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -1,0 +1,119 @@
+'''
+Management of iptables.
+=======================
+
+Insert any arbitrary iptables rule with the insert function:
+
+.. code-block:: yaml
+
+    tcp-22:
+        iptables.insert:
+            - table: filter
+            - rule: INPUT -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
+'''
+
+def insert(
+        name,
+        table="filter",
+        chain="INPUT",
+        rule=None,
+        ):
+    '''
+    Verify that a rule is inserted
+    
+    name
+        The rule comment. Used for checking if the rule is already loaded
+    
+    table
+        The table to load the rule in
+    
+    rule
+        The IPTables rule to load
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+    if not rule:
+        ret['result'] = False
+        ret['comment'] = 'Rule needs to be specified'
+        return ret
+    
+    iptables_data = __salt__['iptables.get_saved_rules']()
+    if not name in iptables_data[table][chain]['rules_comment']:
+        run_rule='{0} {1} -m comment --comment {2}'.format(chain,rule,name)
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'State iptables inserted rule -t {0} -I {1}'.format(table,run_rule)
+            return ret
+        __salt__['iptables.insert'](table,run_rule)
+        ret['comment'] = 'Inserted rule -t {0} -I {1}'.format(table,run_rule)
+        ret['changes']['insert'] = name
+    else:
+      ret['comment'] = '{0} already installed'.format(name)
+    return ret
+
+def append(
+        name,
+        table="filter",
+        chain="INPUT",
+        rule=None,
+        ):
+    '''
+    Verify that a rule is appended
+    
+    name
+        The rule comment. Used for checking if the rule is already loaded
+    
+    table
+        The table to load the rule in
+    
+    rule
+        The IPTables rule to load
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+    if not rule:
+        ret['result'] = False
+        ret['comment'] = 'Rule needs to be specified'
+        return ret
+    
+    iptables_data = __salt__['iptables.get_saved_rules']()
+    if not name in iptables_data[table][chain]['rules_comment']:
+        run_rule='{0} {1} -m comment --comment {2}'.format(chain,rule,name)
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'State iptables appended rule -t {0} -A {1}'.format(table,run_rule)
+            return ret
+        __salt__['iptables.append'](table,run_rule)
+        ret['comment'] = 'Inserted rule -t {0} -A {1}'.format(table,run_rule)
+        ret['changes']['append'] = name
+    else:
+      ret['comment'] = '{0} already installed'.format(name)
+    return ret
+
+def save(
+        name,
+        ):
+    '''
+    Save the rules file
+    
+    name
+        Path to the file to save the rules in
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'State iptables saved rules to {0}'.format(name)
+        return ret
+    
+    __salt__['iptables.save'](name)
+    ret['comment'] = 'Saved to {0}'.format(name)
+    ret['changes']['saved'] = name
+    return ret


### PR DESCRIPTION
This adds a very basic salt state module for iptables.  This at least provides a starting point.  I also enhanced the  iptables salt module to allow lookup of states by comment and execute saves without passing the file to save to. 

To use on RHEL6 with the default iptables rules:

```
tcp-22:
  iptables:
    - append
    - rule: -p tcp -m state --state NEW -m tcp --dport 22 -j ACCEPT
    - require_in:
      - iptables: /etc/sysconfig/iptables

/etc/sysconfig/iptables:
  iptables:
    - save
```

This provides:
- Flexibility to allow the user to specify the command for full complexity
- Uses comments to see if the rule has been added previously
- Only save once after the rules have been processed by using require_in

This should help solve issue https://github.com/saltstack/salt/issues/126
