### PR TITLE
Added Service support for Oracle Enterprise Linux

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -21,6 +21,7 @@ def __virtual__():
                'Amazon',
                'Fedora',
                'ALT',
+               'OEL',
               ]
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -21,6 +21,7 @@ GRAINMAP = {
            'CloudLinux': '/etc/init.d',
            'Amazon': '/etc/init.d',
            'SunOS': '/etc/init.d',
+           'OEL': '/etc/init.d',
           }
 
 def __virtual__():
@@ -40,6 +41,7 @@ def __virtual__():
                'Debian',
                'Arch',
                'ALT',
+               'OEL',
               ]
     if __grains__['os'] in disable:
         return False


### PR DESCRIPTION
I was getting the following error when trying to start services during the `state.highstate`:

```
---------
    State: - service
    Name:      ntpd
    Function:  running
        Result:    False
        Comment:   An exception occured in this state: Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/state.py", line 1206, in call
    *cdata['args'], **cdata['kwargs'])
  File "/usr/lib/python2.6/site-packages/salt/states/service.py", line 242, in running
    changes = {name: __salt__['service.start'](name)}
  File "/usr/lib/python2.6/site-packages/salt/modules/service.py", line 59, in start
    cmd = os.path.join(grainmap[__grains__['os']],
KeyError: 'OEL'
```
