### PR TITLE
insserv before update-rc.d enable, on Debian 6+

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -156,6 +156,9 @@ def enable(name, **kwargs):
         salt '*' service.enable <service name>
     '''
     cmd = 'update-rc.d {0} enable'.format(name)
+    osmajor = __grains__['osrelease'].split('.')[0]
+    if int(osmajor) >= 6:
+        cmd = 'insserv {0} && '.format(name) + cmd
     return not __salt__['cmd.retcode'](cmd)
 
 


### PR DESCRIPTION
The `update-rc.d enable` fails if the init.d script is installed
manually by another salt state, because `update-rc.d enable` works only
on existing runlevel links. Running `insserv` first fixes that.

NOTE: I'm not entirely sure whether this is the correct fix. Possibly this is
out of scope for `debian_service.enable` and belongs in a separate
`debian_service.install` or somesuch, which the `service.managed` state
should call before calling `enable`. And possibly there should be
corresponding install-service support for Debian systems where
[DependencyBasedBoot](http://wiki.debian.org/LSBInitScripts/DependencyBasedBoot) is not enabled. It is the default in Squeeze
upwards though.
