### PR TITLE
Don't hide error detail on pkgrepo.managed failure

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -161,12 +161,12 @@ def managed(name, **kwargs):
             ret['changes'] = { 'repo': name }
         ret['result'] = True
         ret['comment'] = 'Configured package repo {0}'.format(name)
-        return ret
-    except:
-        pass
-    ret['result'] = False
-    ret['comment'] = 'Failed to configure repo {0}'.format(name)
+    except Exception, e:
+        ret['result'] = False
+        ret['comment'] = 'Failed to confirm config of repo {0}: {1}'.format(
+            name, str(e))
     return ret
+
 
 def absent(name):
     '''


### PR DESCRIPTION
Also, replaces `except:` clause with `except Exception:`, so as not to
get in the way of SystemExit and KeyboardInterrupt.
