### PR TITLE
Add network.hwaddr function

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -239,6 +239,17 @@ def interfaces():
     return ifaces
 
 
+def hwaddr(iface):
+    '''
+    Return the hardware address (a.k.a. MAC address) for a given interface
+
+    CLI Example::
+
+        salt '*' network.hwaddr eth0
+    '''
+    return interfaces().get(iface, {}).get('hwaddr', '')
+
+
 def _get_net_start(ipaddr, netmask):
     ipaddr_octets = ipaddr.split('.')
     netmask_octets = netmask.split('.')


### PR DESCRIPTION
This function was part of salt in the past but was removed when the
output from network.interfaces was refactored a while back. This commit
adds it back.
