### PR TITLE
Minor tweaks to doc headings

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -8,8 +8,8 @@ Salt modules are the functions called by the :command:`salt` command.
 
     Salt ships with many modules that cover a wide variety of tasks.
 
-Easy Modules to write
-=====================
+Modules Are Easy to Write!
+==========================
 
 Salt modules are amazingly simple to write. Just write a regular Python module
 or a regular `Cython`_ module and place it in the ``salt/modules`` directory.
@@ -201,8 +201,8 @@ to the calling terminal.
 
 .. _`Python docstring`: #term-docstring
 
-Add Module meta data
---------------------
+Add Module metadata
+-------------------
 
 Add information about the module using the following field lists:
 

--- a/doc/ref/states/writing.rst
+++ b/doc/ref/states/writing.rst
@@ -5,8 +5,8 @@ State Modules
 State Modules are the components that map to actual enforcement and management
 of Salt states.
 
-States are - Easy to Write!
-===========================
+States are Easy to Write!
+=========================
 
 State Modules should be easy to write and straightforward. The information
 passed to the SLS data structures will map directly to the states modules.


### PR DESCRIPTION
Corrected odd grammar on the Modules doc page, and changed a similar
heading in the States docs to match the same wording.
