### PR TITLE
probably bug in Client.cache_dir()

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -144,7 +144,7 @@ class Client(object):
             )
         )
         for fn_ in self.file_list(env):
-            if fn_.startswith(path):
+            if fn_.startswith('{0}{1}'.format(path, os.path.sep)):
                 local = self.cache_file('salt://{0}'.format(fn_), env)
                 if not fn_.strip():
                     continue


### PR DESCRIPTION
fix bug: Client.cache_dir() evaluate path arg as "start with" pattern and return anything that starts with this. So if we ask about dir/a Client.cache_dir() return all files in dir/a and all files in dir which start with a.
