### PR TITLE
updated formatting for consistency. typos fixed.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -4,8 +4,8 @@
 # Values that are commented out but have no space after the comment are
 # defaults that need not be set in the config. If there is a space after the
 # comment that the value is presented as an example and is not the default.
-#
-# Per default the master will automatically include all config files
+
+# Per default, the master will automatically include all config files
 # from master.d/*.conf (master.d is a directory in the same directory
 # as the main master config file)
 #default_include: master.d/*.conf
@@ -133,11 +133,10 @@
 # master or minion as root, but have a non-root group be given access to
 # your pki_dir.  To make the access explicit, root must belong to the group
 # you've given access to.  This is potentially quite insecure.
-#
-# If an autosign_file is specified permissive access will allow group access
+# If an autosign_file is specified, enabling permissive_pki_access will allow group access
 # to that specific file.
 #permissive_pki_access: False
-#
+
 # Allow users on the master access to execute specific commands on minions.
 # This setting should be treated with care since it opens up execution
 # capabilities to non root users. By default this capability is completely
@@ -163,7 +162,6 @@
 #   modules:
 #     - cmd
 
-
 # The external auth system uses the Salt auth modules to authenticate and
 # validate users to access areas of the Salt system
 #
@@ -175,16 +173,17 @@
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 # token_expire: 43200
 
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded
-#
+
 # Add any additional locations to look for master runners
 #runner_dirs: []
-#
+
 # Enable Cython for master side modules
 #cython_enable: False
-#
+
 
 #####      State System settings     #####
 ##########################################
@@ -192,41 +191,41 @@
 # use and what modules to use. The state_top file is defined relative to the
 # root of the base environment as defined in "File Server settings" below.
 #state_top: top.sls
-#
+
 # The master_tops option replaces the external_nodes option by creating
 # a plugable system for the generation of external top data. The external_nodes
 # option is deprecated by the master_tops option.
-# To gain the capabilities of the classic external_nodes system use the
-# following configuration
-#
+# To gain the capabilities of the classic external_nodes system, use the
+# following configuration:
 # master_tops:
 #   ext_nodes: <Shell command which returns yaml>
 #
 #master_tops: {}
-#
+
 # The external_nodes option allows Salt to gather data that would normally be
 # placed in a top file. The external_nodes option is the executable that will
 # return the ENC data. Remember that Salt will look for external nodes AND top
 # files and combine the results if both are enabled!
 #external_nodes: None
-#
+
 # The renderer to use on the minions to render the state data
 #renderer: yaml_jinja
-#
+
 # The failhard option tells the minions to stop immediately after the first
 # failure detected in the state execution, defaults to False
 #failhard: False
-#
+
 # The state_verbose and state_output settings can be used to change the way
 # state system data is printed to the display. By default all data is printed.
 # The state_verbose setting can be set to True or False, when set to False
 # all data that has a result of True and no changes will be suppressed.
 #state_verbose: True
-#
+
 # The state_output setting changes if the output is the full multi line
 # output for each changed state if set to 'full', but if set to 'terse'
 # the output will be shortened to a single line.
 #state_output: full
+
 
 #####      File Server settings      #####
 ##########################################
@@ -248,8 +247,7 @@
 #   prod:
 #     - /srv/salt/prod/services
 #     - /srv/salt/prod/states
-#
-# Default:
+
 #file_roots:
 #  base:
 #    - /srv/salt
@@ -268,35 +266,32 @@
 # For example, if you manage your custom modules and states in subversion
 # and don't want all the '.svn' folders and content synced to your minions,
 # you could set this to '/\.svn($|/)'. By default nothing is ignored.
-#file_ignore_regex:
-# - '/\.svn($|/)'
-# - '/\.git($|/)'
+# file_ignore_regex:
+#   - '/\.svn($|/)'
+#   - '/\.git($|/)'
 
 # A file glob (or list of file globs) that will be matched against the file
 # path before syncing the modules and states to the minions. This is similar
 # to file_ignore_regex above, but works on globs instead of regex. By default
 # nothing is ignored.
-#file_ignore_glob:
-#  - '*.pyc'
-#  - '*/somefolder/*.bak'
+# file_ignore_glob:
+#   - '*.pyc'
+#   - '*/somefolder/*.bak'
 
 # File Server Backend
 # Salt supports a modular fileserver backend system, this system allows
 # the salt master to link directly to third party systems to gather and
 # manage the files available to minions. Multiple backends can be
 # configured and will be searched for the requested file in the order in which
-# they are defined here. The defult setting only enables the standard backend
+# they are defined here. The default setting only enables the standard backend
 # "roots" which uses the "file_roots" option.
-# To enable the git backend change the option to look like this:
-# fileserver_backend:
-#   - git
+#fileserver_backend:
+#  - roots
 # To use multiple backends list them in the order they are searched:
 # fileserver_backend:
 #   - git
 #   - roots
-#fileserver_backend:
-#   - roots
-#
+
 # Git fileserver backend configuration
 # When using the git fileserver backend at least one git remote needs to be
 # defined. The user running the salt master will need read access to the repo.
@@ -308,26 +303,28 @@
 # When using the git backend branches and tags are translated into salt
 # environments.
 
-# Pillar Configurations:
-# The Salt Pillar, is a system that allows for the building of global data
-# that is refined based on minion. Basically, the pillar creates data that
-# can be generated to be specific based on the grains of the minion. Pillar
-# is laid out in the same fashion as the file server, with environments, a top
-# file and sls files. The difference is that the data does not need to be
-# in the highstate format, and is generally just key/value pairs.
-#
+
+#####         Pillar settings        #####
+##########################################
+# Salt Pillars allow for the building of global data that can be made selectively
+# available to different minions based on minion grain filtering. The Salt 
+# Pillar is laid out in the same fashion as the file server, with environments, 
+# a top file and sls files. However, pillar data does not need to be in the 
+# highstate format, and is generally just key/value pairs.
+
 #pillar_roots:
 #  base:
 #    - /srv/pillar
-#
+
 # ext_pillar:
 #   - hiera: /etc/hiera.yaml
 #   - cmd_yaml: cat /etc/salt/yaml
-#
+
 # The pillar_opts option adds the master configuration file data to a dict in
 # the pillar called "master". This is used to set simple configurations in the
 # master config file that can then be used on minions.
 #pillar_opts: True
+
 
 #####          Syndic settings       #####
 ##########################################
@@ -337,14 +334,15 @@
 # is a master that will be running a syndic daemon for passthrough the
 # "syndic_master" setting needs to be set to the location of the master server
 # to receive commands from.
-#
+
 # Set the order_masters setting to True if this master will command lower
 # masters' syndic interfaces.
 #order_masters: False
-#
+
 # If this master will be running a salt syndic daemon, syndic_master tells
 # this master where to receive commands from.
 #syndic_master: masterofmaster
+
 
 #####      Peer Publish settings     #####
 ##########################################
@@ -352,7 +350,7 @@
 # allowed to. By default "Peer Publication" is disabled, and when enabled it
 # is enabled for specific minions and specific commands. This allows secure
 # compartmentalization of commands based on individual minions.
-#
+
 # The configuration uses regular expressions to match minions and then a list
 # of regular expressions to match functions. The following will allow the
 # minion authenticated as foo.example.com to execute functions from the test
@@ -368,7 +366,7 @@
 #       - .*
 # This is not recommended, since it would allow anyone who gets root on any
 # single minion to instantly have root on all of the minions!
-#
+
 # Minions can also be allowed to execute runners from the salt master.
 # Since executing a runner from the minion could be considered a security risk,
 # it needs to be enabled. This setting functions just like the peer setting
@@ -386,7 +384,7 @@
 # peer_run:
 #   foo.example.com:
 #     - manage.up
-#
+
 
 #####         Logging settings       #####
 ##########################################
@@ -398,30 +396,28 @@
 #	log_file: /var/log/salt/master
 #	log_file: file:///dev/log
 #	log_file: udp://loghost:10514
-#
+
 #log_file: /var/log/salt/master
 #key_logfile: /var/log/salt/key
-#
+
 # The level of messages to send to the console.
 # One of 'garbage', 'trace', 'debug', info', 'warning', 'error', 'critical'.
-# Default: 'warning'
 #log_level: warning
-#
+
 # The level of messages to send to the log file.
 # One of 'garbage', 'trace', 'debug', info', 'warning', 'error', 'critical'.
-# Default: 'warning'
-#log_level_logfile:
+#log_level_logfile: warning
 
 # The date and time format used in log messages. Allowed date/time formating
 # can be seen here: http://docs.python.org/library/time.html#time.strftime
 #log_datefmt: '%H:%M:%S'
 #log_datefmt_logfile: '%Y-%m-%d %H:%M:%S'
-#
+
 # The format of the console logging messages. Allowed formatting options can
 # be seen here	http://docs.python.org/library/logging.html#logrecord-attributes
 #log_fmt_console: '[%(levelname)-8s] %(message)s'
 #log_fmt_logfile: '%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s'
-#
+
 # This can be used to control logging levels more specificically.  This
 # example sets the main salt library at the 'warning' level, but sets
 # 'salt.modules' to log at the 'debug' level:
@@ -441,6 +437,7 @@
 #   group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com and bl*.domain.com'
 #   group2: 'G@os:Debian and foo.domain.com'
 
+
 #####     Range Cluster settings     #####
 ##########################################
 # The range server (and optional port) that serves your cluster information
@@ -453,10 +450,10 @@
 ##############################################
 # Location of the repo on the master
 # win_repo: '/srv/salt/win/repo'
-#
+
 # Location of the master's repo cache file
 # win_repo_mastercachefile: '/srv/salt/win/repo/winrepo.p'
-#
+
 # List of git repositories to include with the local repo
 # win_gitrepos:
 #   - 'https://github.com/saltstack/salt-winrepo.git'


### PR DESCRIPTION
tried to remove some redundant language also. I tried to ensure that the file was keeping to the formatting instructions at the top of the file:

```
Values that are commented out but have no space after the comment are
defaults that need not be set in the config. If there is a space after the
comment that the value is presented as an example and is not the default.
```
