### PR TITLE
Allow alternative executables

### DIFF
--- a/pkg/rpm/salt-master
+++ b/pkg/rpm/salt-master
@@ -19,8 +19,12 @@
 #
 # processname: /usr/bin/salt-master
 
-SALTMASTER=/usr/bin/salt-master
-PYTHON=/usr/bin/python
+if [ -f /etc/default/salt ]; then
+    . /etc/default/salt
+else
+    SALTMASTER=/usr/bin/salt-master
+    PYTHON=/usr/bin/python
+fi
 
 # Sanity checks.
 [ -x $SALTMASTER ] || exit 0

--- a/pkg/rpm/salt-master
+++ b/pkg/rpm/salt-master
@@ -6,18 +6,23 @@
 # LSB header
 
 ### BEGIN INIT INFO
-# Description: This is a daemon that controls the salt minions
-# Provides: salt-master
-# Required-Start: network
-# Short-Description: salt master control daemon
+# Provides:          salt-master
+# Required-Start:    $all
+# Required-Stop:     
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Salt master control daemon
+# Description:       This is a daemon that controls the Salt minions.
 ### END INIT INFO
+
 
 # chkconfig header
 
 # chkconfig: 345 99 99 
-# description:  This is a daemon that controls the salt minions
+# description:  This is a daemon that controls the Salt minions
 #
 # processname: /usr/bin/salt-master
+
 
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt

--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -6,18 +6,24 @@
 # LSB header
 
 ### BEGIN INIT INFO
-# Provides: salt-minion
-# Required-Start: network
-# Short-Description: salt minion control daemon
-# Description: This is a daemon that controls the salt minions
+# Provides:          salt-minion
+# Required-Start:    $all
+# Required-Stop:     
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Salt minion daemon
+# Description:       This is the Salt minion daemon that can be controlled by the
+#                    Salt master.
 ### END INIT INFO
+
 
 # chkconfig header
 
 # chkconfig: 345 99 99 
-# description:  This is a daemon that controls the salt mininons
+# description:  This is the Salt minion daemon that can be controlled by the Salt master.
 #
 # processname: /usr/bin/salt-minion
+
 
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt

--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -19,8 +19,12 @@
 #
 # processname: /usr/bin/salt-minion
 
-SALTMINION=/usr/bin/salt-minion
-PYTHON=/usr/bin/python
+if [ -f /etc/default/salt ]; then
+    . /etc/default/salt
+else
+    SALTMINION=/usr/bin/salt-minion
+    PYTHON=/usr/bin/python
+fi
 
 # Sanity checks.
 [ -x $SALTMINION ] || exit 0

--- a/pkg/rpm/salt-syndic
+++ b/pkg/rpm/salt-syndic
@@ -19,8 +19,12 @@
 #
 # processname: /usr/bin/salt-syndic
 
-SALTSYNDIC=/usr/bin/salt-syndic
-PYTHON=/usr/bin/python
+if [ -f /etc/default/salt ]; then
+    . /etc/default/salt
+else
+    SALTSYNDIC=/usr/bin/salt-syndic
+    PYTHON=/usr/bin/python
+fi
 
 # Sanity checks.
 [ -x $SALTSYNDIC ] || exit 0

--- a/pkg/rpm/salt-syndic
+++ b/pkg/rpm/salt-syndic
@@ -6,18 +6,24 @@
 # LSB header
 
 ### BEGIN INIT INFO
-# Provides: salt-syndic
-# Required-Start: network
-# Short-Description: salt syndic master-minion passthrough daemon
-# Description: This is a daemon that controls the salt syndic
+# Provides:          salt-syndic
+# Required-Start:    $all
+# Required-Stop:     
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: Salt syndic master-minion passthrough daemon
+# Description:       This is a the Salt syndic daemon that enables Salt master-minion
+#                    remote control passthrough.
 ### END INIT INFO
+
 
 # chkconfig header
 
 # chkconfig: 345 99 99 
-# description:  This is a daemon that controls the salt mininons
+# description:  This is a the Salt syndic daemon that enables Salt master-minion remote control passthrough.
 #
 # processname: /usr/bin/salt-syndic
+
 
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt


### PR DESCRIPTION
With this commit it is possible to use virtualenv with the init scripts.

For example, I have this in my /etc/default/salt:

```
SALTMASTER=/srv/venvs/venv-1/bin/salt-master
SALTMINION=/srv/venvs/venv-1/bin/salt-minion
SALTSYNDIC=/srv/venvs/venv-1/bin/salt-syndic
SALTAPI=/srv/venvs/venv-1/bin/salt-api
PYTHON=/srv/venvs/venv-1/bin/python
```
