### PR TITLE
Add optional key argument to display subtree of pillar data

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -6,7 +6,7 @@ Extract the pillar data for this minion
 import salt.pillar
 
 
-def data():
+def data(key=''):
     '''
     Returns the pillar derived from the configured pillar source. The pillar
     source is derived from the file_client option in the minion config
@@ -14,16 +14,32 @@ def data():
     CLI Example::
 
         salt '*' pillar.data
+
+    With the optional key argument, you can select a subtree of the
+    pillar data.::
+
+        salt '*' pillar.data key='roles'
     '''
     pillar = salt.pillar.get_pillar(
             __opts__,
             __grains__,
             __opts__['id'],
             __opts__['environment'])
-    return pillar.compile_pillar()
+
+    compiled_pillar = pillar.compile_pillar()
+
+    if key:
+        try:
+            ret = compiled_pillar[key]
+        except KeyError:
+            ret = {}
+    else:
+        ret = compiled_pillar
+
+    return ret
 
 
-def raw():
+def raw(key=''):
     '''
     Return the raw pillar data that is available in the module. This will
     show the pillar as it is loaded as the __pillar__ dict.
@@ -31,5 +47,18 @@ def raw():
     CLI Example::
 
         salt '*' pillar.raw
+
+    With the optional key argument, you can select a subtree of the
+    pillar raw data.::
+
+        salt '*' pillar.raw key='roles'
     '''
-    return __pillar__
+    if key:
+        try:
+            ret = __pillar__[key]
+        except KeyError:
+            ret = {}
+    else:
+        ret = __pillar__
+
+    return ret


### PR DESCRIPTION
The output of pillar.data comprises a substantial chunk of data.
By introducing key selection on the dictionary, we can display
the subtree of immediate interest.

Inadequacy: Should allow for arbitrary keying into subsections
of the data. Current change is the simplest useful improvement.
