### PR TITLE
Fix user info not displayed correctly when group doesn't map cleanly

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -374,7 +374,12 @@ def list_groups(name):
     '''
     ugrp = set()
     # Add the primary user's group
-    ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
+    try:
+        ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
+    except KeyError:
+        # The user's applied default group is undefined on the system, so
+        # it does not exist
+        pass
     # Now, all other groups the user belongs to
     for group in grp.getgrall():
         if name in group.gr_mem:


### PR DESCRIPTION
This is identical to commit aec060e which fixed #3397. The same bug manifests itself when getting user information - when the users main group isn't in /etc/group all of the user fields are returned blank.
