### PR TITLE
Update pkg/rpm/salt-master and pkg/rpm/salt-minion

### DIFF
--- a/pkg/rpm/salt-master
+++ b/pkg/rpm/salt-master
@@ -27,8 +27,8 @@
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt
 else
-    SALTMASTER=/usr/bin/salt-master
-    PYTHON=/usr/bin/python
+    SALTMASTER=$(which salt-master)
+    PYTHON=$(which python)
 fi
 
 # Sanity checks.

--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -28,8 +28,8 @@
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt
 else
-    SALTMINION=/usr/bin/salt-minion
-    PYTHON=/usr/bin/python
+    SALTMINION=$(which salt-minion)
+    PYTHON=$(which python)
 fi
 
 # Sanity checks.


### PR DESCRIPTION
Change absolute paths for salt and python to generated paths, so that different installation paths will work with this init script.
