### PR TITLE
Add msiexec flag for Windows Installer Packages. Fixes #3667

### DIFF
--- a/doc/ref/windows-package-manager.rst
+++ b/doc/ref/windows-package-manager.rst
@@ -41,7 +41,21 @@ The package definition file should look similar to this example for Firefox:
         uninstaller: '%ProgramFiles(x86)%/Mozilla Firefox/uninstall/helper.exe'
         uninstall_flags: ' /S'
 
+Add ``msiexec: True`` if using an msi installer requiring the use of msiexec.
+``/srv/salt/win/repo/7zip/init.sls``
 
+.. code-block:: yaml
+
+    7zip:
+      9.20:
+        installer: salt://win/repo/7zip/7z920-x64.msi
+        full_name: 7zip 9.22
+        reboot: False
+        install_flags: ' /q '
+        msiexec: True
+        uninstaller: salt://win/repo/7zip/7z920-x64.msi
+        uninstall_flags: ' /qn'
+ 
 
 Generate Repo Cache File
 ========================

--- a/doc/ref/windows-package-manager.rst
+++ b/doc/ref/windows-package-manager.rst
@@ -41,7 +41,8 @@ The package definition file should look similar to this example for Firefox:
         uninstaller: '%ProgramFiles(x86)%/Mozilla Firefox/uninstall/helper.exe'
         uninstall_flags: ' /S'
 
-Add ``msiexec: True`` if using an msi installer requiring the use of msiexec.
+Add ``msiexec: True`` if using an msi installer requiring the use of ``msiexec
+/i`` to install and ``msiexec /x`` to uninstall.
 ``/srv/salt/win/repo/7zip/init.sls``
 
 .. code-block:: yaml

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -376,7 +376,7 @@ def upgrade(refresh=True):
     return {}
 
 
-def remove(name, version=None, **kwargs):
+def remove(name, version=None, msiexec=False, **kwargs):
     '''
     Remove a single package
 
@@ -404,6 +404,8 @@ def remove(name, version=None, **kwargs):
         cached_pkg = cached_pkg.replace('(x86)', '')
     cmd = '"' + str(os.path.expandvars(
         cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
+    if msiexec:
+        cmd = 'msiexec /x ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
         log.error(stderr)
@@ -411,7 +413,7 @@ def remove(name, version=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name, **kwargs):
+def purge(name, version=None, msiexec=False, **kwargs):
     '''
     Recursively remove a package and all dependencies which were installed
     with it
@@ -422,7 +424,7 @@ def purge(name, **kwargs):
 
         salt '*' pkg.purge <package name>
     '''
-    return remove(name)
+    return remove(name, version=None, msiexec=False, **kwargs)
 
 
 def _get_package_info(name):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -344,7 +344,7 @@ def install(name=None, refresh=False, **kwargs):
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
     cmd = '"' + str(cached_pkg) + '"' + str(pkginfo[version]['install_flags'])
-    if pkginfo[msiexec]:
+    if pkginfo['msiexec']:
         cmd = 'msiexec /i ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
@@ -404,7 +404,7 @@ def remove(name, version=None, **kwargs):
         cached_pkg = cached_pkg.replace('(x86)', '')
     cmd = '"' + str(os.path.expandvars(
         cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
-    if pkginfo[msiexec]:
+    if pkginfo['msiexec']:
         cmd = 'msiexec /x ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
@@ -413,7 +413,7 @@ def remove(name, version=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name, version=None, msiexec=False, **kwargs):
+def purge(name, version=None, **kwargs):
     '''
     Recursively remove a package and all dependencies which were installed
     with it
@@ -424,7 +424,7 @@ def purge(name, version=None, msiexec=False, **kwargs):
 
         salt '*' pkg.purge <package name>
     '''
-    return remove(name, version=None, msiexec=False, **kwargs)
+    return remove(name, version, **kwargs)
 
 
 def _get_package_info(name):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -310,7 +310,7 @@ def refresh_db():
     return True
 
 
-def install(name=None, refresh=False, **kwargs):
+def install(name=None, refresh=False, msiexec=False, **kwargs):
     '''
     Install the passed package
 
@@ -344,6 +344,8 @@ def install(name=None, refresh=False, **kwargs):
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
     cmd = '"' + str(cached_pkg) + '"' + str(pkginfo[version]['install_flags'])
+    if msiexec:
+        cmd = 'msiexec /i ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
         log.error(stderr)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -376,7 +376,7 @@ def upgrade(refresh=True):
     return {}
 
 
-def remove(name, version=None, msiexec=False, **kwargs):
+def remove(name, version=None, **kwargs):
     '''
     Remove a single package
 
@@ -404,7 +404,7 @@ def remove(name, version=None, msiexec=False, **kwargs):
         cached_pkg = cached_pkg.replace('(x86)', '')
     cmd = '"' + str(os.path.expandvars(
         cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
-    if msiexec:
+    if pkginfo[msiexec]:
         cmd = 'msiexec /x ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -344,7 +344,7 @@ def install(name=None, refresh=False, **kwargs):
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
     cmd = '"' + str(cached_pkg) + '"' + str(pkginfo[version]['install_flags'])
-    if pkginfo['msiexec']:
+    if pkginfo[version]['msiexec']:
         cmd = 'msiexec /i ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:
@@ -404,7 +404,7 @@ def remove(name, version=None, **kwargs):
         cached_pkg = cached_pkg.replace('(x86)', '')
     cmd = '"' + str(os.path.expandvars(
         cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
-    if pkginfo['msiexec']:
+    if pkginfo[version]['msiexec']:
         cmd = 'msiexec /x ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -310,7 +310,7 @@ def refresh_db():
     return True
 
 
-def install(name=None, refresh=False, msiexec=False, **kwargs):
+def install(name=None, refresh=False, **kwargs):
     '''
     Install the passed package
 
@@ -344,7 +344,7 @@ def install(name=None, refresh=False, msiexec=False, **kwargs):
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
     cmd = '"' + str(cached_pkg) + '"' + str(pkginfo[version]['install_flags'])
-    if msiexec:
+    if pkginfo[msiexec]:
         cmd = 'msiexec /i ' + cmd
     stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
     if stderr:

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -24,6 +24,8 @@ def genrepo():
     '''
     ret = {}
     repo = __opts__['win_repo']
+    if not os.path.exists(repo):
+        os.makedirs(repo)
     winrepo = __opts__['win_repo_mastercachefile']
     for root, dirs, files in os.walk(repo):
         for name in files:


### PR DESCRIPTION
This allows for msi Windows Software Installers that require installation and uninstallation like this:

```
msiexec /i mysoftware.msi /qn

msiexec /x mysoftware.msi /qn
```

Fixes #3667
