### PR TITLE
Fix broken sys.doc function

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -3,6 +3,12 @@ The sys module provides information about the available functions on the
 minion.
 '''
 
+# Import python libs
+import logging
+
+log = logging.getLogger(__name__)
+
+
 def __virtual__():
     '''
     Return as sys
@@ -28,9 +34,11 @@ def doc(module=''):
     if module:
         # allow both "sys" and "sys." to match sys, without also matching
         # sysctl
-        module = module + '.' if not module.endswith('.') else module
+        target_mod = module + '.' if not module.endswith('.') else module
+    else:
+        target_mod = ''
     for fun in __salt__:
-        if fun.startswith(module):
+        if fun == module or fun.startswith(target_mod):
             docs[fun] = __salt__[fun].__doc__
     return docs
 


### PR DESCRIPTION
03d264b broke sys.doc by adding a '.' to the end of the module if it is
not an empty string. While this succeeds in making 'sys' not match the
sysctl modules functions, it also means that passing a specific function
name (ex. 'network.interfaces') would result in the passed value having
that same '.' appended (i.e. 'network.interfaces.', note the trailing
dot). This causes sys.doc to fail in returning the docstring for this
function since 'network.interfaces.' will not match any of the functions
in the **salt** dict.
