### PR TITLE
fix conflict with rpm module

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -666,6 +666,7 @@ def os_data():
         grains['os'] = grains['kernel']
     if grains['kernel'] in ('FreeBSD', 'OpenBSD'):
         grains.update(_bsd_cpudata(grains))
+        grains['osrelease'] = grains['kernelrelease'].split('-')[0]
     if not grains['os']:
         grains['os'] = 'Unknown {0}'.format(grains['kernel'])
         grains['os_family'] = 'Unknown'


### PR DESCRIPTION
Someone thinks osrelease is mandatory grain (see rpm.**virtual**()).
But actually in *BSD "osrelease" is more match name for "os version" parameter, because there is no difference between kernel and os at this point.
