### PR TITLE
Use `__all__` when loading modules(if provided).

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -69,9 +69,9 @@ def minion_mods(opts, context=None, whitelist=None):
     if not whitelist:
         whitelist = opts.get('whitelist_modules', None)
     functions = load.gen_functions(
-                    pack,
-                    whitelist=whitelist
-                )
+        pack,
+        whitelist=whitelist
+    )
     if opts.get('providers', False):
         if isinstance(opts['providers'], dict):
             for mod, provider in opts['providers'].items():
@@ -500,8 +500,8 @@ class Loader(object):
                     )
                     continue
                 if (fn_.endswith(('.py', '.pyc', '.pyo', '.so'))
-                    or (cython_enabled and fn_.endswith('.pyx'))
-                    or os.path.isdir(os.path.join(mod_dir, fn_))):
+                        or (cython_enabled and fn_.endswith('.pyx'))
+                        or os.path.isdir(os.path.join(mod_dir, fn_))):
 
                     extpos = fn_.rfind('.')
                     if extpos > 0:
@@ -547,11 +547,15 @@ class Loader(object):
                     for submodule in submodules:
                         try:
                             smname = '{0}.{1}.{2}'.format(
-                                    LOADED_BASE_NAME,
-                                    self.tag,
-                                    name)
-                            smfile = os.path.splitext(submodule.__file__)[0] + '.py'
-                            if submodule.__name__.startswith(smname) and os.path.isfile(smfile):
+                                LOADED_BASE_NAME,
+                                self.tag,
+                                name
+                            )
+                            smfile = '{0}.py'.format(
+                                os.path.splitext(submodule.__file__)[0]
+                            )
+                            if submodule.__name__.startswith(smname) and \
+                                    os.path.isfile(smfile):
                                 reload(submodule)
                         except AttributeError:
                             continue
@@ -757,7 +761,7 @@ class Loader(object):
                 trb = traceback.format_exc()
                 log.critical(
                     'Failed to load grains defined in grain file {0} in '
-                    'function {1}, error:\n{2}').format(
+                    'function {1}, error:\n{2}'.format(
                         key, fun, trb
                     )
                 )

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -390,14 +390,20 @@ class Loader(object):
                     ), fn_, path, desc
                 )
         except ImportError as exc:
-            log.debug('Failed to import {0} {1}: {2}'.format(
-                self.tag, name, exc)
+            log.debug(
+                'Failed to import {0} {1}: {2}'.format(
+                    self.tag, name, exc
                 )
+            )
             return mod
         except Exception:
             trb = traceback.format_exc()
-            log.warning('Failed to import {0} {1}, this is due most likely '
-                        'to a syntax error: {2}'.format(self.tag, name, trb))
+            log.warning(
+                'Failed to import {0} {1}, this is due most likely to a '
+                'syntax error: {2}'.format(
+                    self.tag, name, trb
+                )
+            )
             return mod
         if hasattr(mod, '__opts__'):
             mod.__opts__.update(self.opts)
@@ -424,8 +430,11 @@ class Loader(object):
                 except TypeError:
                     pass
         funcs = {}
-        for attr in dir(mod):
-            if attr.startswith('_'):
+        mod_provides_all = hasattr(mod, '__all__')
+        for attr in getattr(mod, '__all__', dir(mod)):
+            if attr.startswith('_') and not mod_provides_all:
+                # private functions are skipped if not provided in that
+                # module's __all__
                 continue
             if callable(getattr(mod, attr)):
                 func = getattr(mod, attr)
@@ -465,12 +474,18 @@ class Loader(object):
                          'in the system path. Skipping Cython modules.')
         for mod_dir in self.module_dirs:
             if not os.path.isabs(mod_dir):
-                log.debug(('Skipping {0}, it is not an abosolute '
-                           'path').format(mod_dir))
+                log.debug(
+                    'Skipping {0}, it is not an absolute path'.format(
+                        mod_dir
+                    )
+                )
                 continue
             if not os.path.isdir(mod_dir):
-                log.debug(('Skipping {0}, it is not a '
-                           'directory').format(mod_dir))
+                log.debug(
+                    'Skipping {0}, it is not a directory'.format(
+                        mod_dir
+                    )
+                )
                 continue
             for fn_ in os.listdir(mod_dir):
                 if fn_.startswith('_'):
@@ -478,8 +493,11 @@ class Loader(object):
                     # log messages omitted for obviousness
                     continue
                 if fn_.split('.')[0] in disable:
-                    log.debug(('Skipping {0}, it is disabled by '
-                               'configuration').format(fn_))
+                    log.debug(
+                        'Skipping {0}, it is disabled by configuration'.format(
+                            fn_
+                        )
+                    )
                     continue
                 if (fn_.endswith(('.py', '.pyc', '.pyo', '.so'))
                     or (cython_enabled and fn_.endswith('.pyx'))
@@ -492,8 +510,12 @@ class Loader(object):
                         _name = fn_
                     names[_name] = os.path.join(mod_dir, fn_)
                 else:
-                    log.debug(('Skipping {0}, it does not end with an '
-                               'expected extension').format(fn_))
+                    log.debug(
+                        'Skipping {0}, it does not end with an expected '
+                        'extension'.format(
+                            fn_
+                        )
+                    )
         for name in names:
             try:
                 if names[name].endswith('.pyx'):
@@ -534,15 +556,21 @@ class Loader(object):
                         except AttributeError:
                             continue
             except ImportError as exc:
-                log.debug('Failed to import {0} {1}, this is most likely '
-                          'NOT a problem: {2}'.format(self.tag, name, exc))
+                log.debug(
+                    'Failed to import {0} {1}, this is most likely NOT a '
+                    'problem: {2}'.format(
+                        self.tag, name, exc
+                    )
+                )
                 continue
             except Exception:
                 trb = traceback.format_exc()
-                log.warning('Failed to import {0} {1}, this is due most '
-                            'likely to a syntax error: {2}'.format(
-                                self.tag, name, trb)
-                            )
+                log.warning(
+                    'Failed to import {0} {1}, this is due most likely to a '
+                    'syntax error: {2}'.format(
+                        self.tag, name, trb
+                    )
+                )
                 continue
             modules.append(mod)
         for mod in modules:
@@ -627,8 +655,12 @@ class Loader(object):
                 except Exception:
                     # If the module throws an exception during __virtual__()
                     # then log the information and continue to the next.
-                    log.exception(('Failed to read the virtual function for '
-                                   '{0}: {1}').format(self.tag, module_name))
+                    log.exception(
+                        'Failed to read the virtual function for '
+                        '{0}: {1}'.format(
+                            self.tag, module_name
+                        )
+                    )
                     continue
 
             if whitelist:
@@ -723,9 +755,12 @@ class Loader(object):
                 ret = fun()
             except Exception:
                 trb = traceback.format_exc()
-                log.critical(('Failed to load grains defined in grain file '
-                              '{0} in function {1}, error:\n{2}').format(
-                                  key, fun, trb))
+                log.critical(
+                    'Failed to load grains defined in grain file {0} in '
+                    'function {1}, error:\n{2}').format(
+                        key, fun, trb
+                    )
+                )
                 continue
             if not isinstance(ret, dict):
                 continue

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -430,13 +430,12 @@ class Loader(object):
                 except TypeError:
                     pass
         funcs = {}
-        mod_name = mod.__name__[mod.__name__.rindex('.') + 1:]
-        mod_provides_load = hasattr(mod, '__load__')
-        if mod_provides_load:
+        module_name = mod.__name__[mod.__name__.rindex('.') + 1:]
+        if getattr(mod, '__load__', False) is not False:
             log.info(
                 'The functions from module {0!r} are being loaded from the '
                 'provided __load__ attribute'.format(
-                    mod_name
+                    module_name
                 )
             )
         for attr in getattr(mod, '__load__', dir(mod)):
@@ -450,7 +449,7 @@ class Loader(object):
                         # the callable object is an exception, don't load it
                         continue
 
-                funcs['{0}.{1}'.format(mod_name, attr)] = func
+                funcs['{0}.{1}'.format(module_name, attr)] = func
                 self._apply_outputter(func, mod)
         if not hasattr(mod, '__salt__'):
             mod.__salt__ = functions
@@ -681,7 +680,14 @@ class Loader(object):
                 if module_name not in whitelist:
                     continue
 
-            for attr in dir(mod):
+            if getattr(mod, '__load__', False) is not False:
+                log.info(
+                    'The functions from module {0!r} are being loaded from '
+                    'the provided __load__ attribute'.format(
+                        module_name
+                    )
+                )
+            for attr in getattr(mod, '__load__', dir(mod)):
                 # functions are namespaced with their module name
                 attr_name = '{0}.{1}'.format(module_name, attr)
 


### PR DESCRIPTION
- When loading the module's functions, if the module provides `__all__`, that's what's iterated.
- If a function provided in `__all__` starts with `_` it's not skipped because the module explicitly provided it.
- Minor formatting in the logging messages.
