### PR TITLE
Allow specifying the configuration file name at the parser's class level.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -37,9 +37,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         self.parse_args()
 
         try:
-            local = salt.client.LocalClient(
-                self.get_config_file_path('master')
-            )
+            local = salt.client.LocalClient(self.get_config_file_path())
         except SaltClientError as exc:
             self.exit(2, '{0}\n'.format(exc))
             return

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -226,6 +226,7 @@ class MergeConfigMixIn(object):
 class ConfigDirMixIn(object):
     __metaclass__ = MixInMeta
     _mixin_prio_ = -10
+    _config_filename_ = None
 
     def _mixin_setup(self):
         self.add_option(
@@ -249,7 +250,9 @@ class ConfigDirMixIn(object):
         if hasattr(self, 'setup_config'):
             self.config = self.setup_config()
 
-    def get_config_file_path(self, configfile):
+    def get_config_file_path(self, configfile=None):
+        if configfile is None:
+            configfile = self._config_filename_
         return os.path.join(self.options.config_dir, configfile)
 
 
@@ -279,7 +282,9 @@ class LogLevelMixIn(object):
             if self.config['log_level'] is not None:
                 self.options.log_level = self.config['log_level']
             else:
-                self.options.log_level = getattr(self, '_default_logging_level_')
+                self.options.log_level = getattr(
+                    self, '_default_logging_level_'
+                )
 
         # Setup the console as the last _mixin_after_parsed_func to run
         self._mixin_after_parsed_funcs.append(self.__setup_console_logger)
@@ -659,8 +664,11 @@ class MasterOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     description = "The Salt master, used to control the Salt minions."
 
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
+
     def setup_config(self):
-        return config.master_config(self.get_config_file_path('master'))
+        return config.master_config(self.get_config_file_path())
 
 
 class MinionOptionParser(MasterOptionParser):
@@ -671,8 +679,11 @@ class MinionOptionParser(MasterOptionParser):
         'The Salt minion, receives commands from a remote Salt master.'
     )
 
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'minion'
+
     def setup_config(self):
-        return config.minion_config(self.get_config_file_path('minion'))
+        return config.master_config(self.get_config_file_path())
 
 
 class SyndicOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
@@ -686,18 +697,21 @@ class SyndicOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         'across many different networks.'
     )
 
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
+
     def setup_config(self):
-        opts = config.master_config(self.get_config_file_path('master'))
+        opts = config.master_config(self.get_config_file_path())
         user = opts.get('user', 'root')
         opts['_minion_conf_file'] = opts['conf_file']
         opts.update(config.minion_config(self.get_config_file_path('minion')))
-        # Over ride the user from the master config file
+        # Override the user from the master config file
         opts['user'] = user
 
         if 'syndic_master' not in opts:
             self.error(
-                "The syndic_master needs to be configured in the salt master "
-                "config, EXITING!"
+                'The syndic_master needs to be configured in the salt master '
+                'config, EXITING!'
             )
 
         from salt import utils
@@ -723,6 +737,9 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
     default_timeout = 5
 
     usage = "%prog [options] '<target>' <function> [arguments]"
+
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
 
     def _mixin_setup(self):
         self.add_option(
@@ -814,7 +831,7 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             self.config['arg'] = self.args[2:]
 
     def setup_config(self):
-        return config.client_config(self.get_config_file_path('master'))
+        return config.client_config(self.get_config_file_path())
 
 
 class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
@@ -831,6 +848,9 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     usage = "%prog [options] '<target>' SOURCE DEST"
 
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
+
     def _mixin_after_parsed(self):
         # salt-cp needs arguments
         if len(self.args) <= 1:
@@ -845,7 +865,7 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         self.config['dest'] = self.args[-1]
 
     def setup_config(self):
-        return config.master_config(self.get_config_file_path('master'))
+        return config.master_config(self.get_config_file_path())
 
 
 class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
@@ -857,6 +877,9 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
     description = 'Salt key is used to manage Salt authentication keys'
 
     usage = '%prog [options]'
+
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
 
     def _mixin_setup(self):
 
@@ -1003,7 +1026,7 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         super(SaltKeyOptionParser, self).process_config_dir()
 
     def setup_config(self):
-        keys_config = config.master_config(self.get_config_file_path('master'))
+        keys_config = config.master_config(self.get_config_file_path())
         if self.options.gen_keys:
             # Since we're generating the keys, some defaults can be assumed
             # or tweaked
@@ -1043,6 +1066,9 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                    'on a minion')
 
     usage = '%prog [options] <function> [arguments]'
+
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'minion'
 
     def _mixin_setup(self):
         self.add_option(
@@ -1096,7 +1122,7 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     def setup_config(self):
         return config.minion_config(
-            self.get_config_file_path('minion'),
+            self.get_config_file_path(),
             check_dns=not self.options.local
         )
 
@@ -1120,6 +1146,9 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     usage = "%prog [options]"
 
+    # ConfigDirMixIn config filename attribute
+    _config_filename_ = 'master'
+
     def _mixin_setup(self):
         self.add_option(
             '-d', '--doc', '--documentation',
@@ -1141,4 +1170,4 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             self.config['arg'] = []
 
     def setup_config(self):
-        return config.master_config(self.get_config_file_path('master'))
+        return config.master_config(self.get_config_file_path())


### PR DESCRIPTION
We should now provide the configuration filename to load configurations from at the parser's class level.
The calls to `ConfigDirMixIn.get_config_file_path()` still accept a filename, though, if that filename is `None`(the default), it grabs the filename from the class level attribute `_config_filename_`.
