### PR TITLE
Attempt to fix `TestProcsComInitialization`. Refs #3749.

### DIFF
--- a/tests/unit/modules/win_status_test.py
+++ b/tests/unit/modules/win_status_test.py
@@ -18,6 +18,8 @@ pythoncom = new.module('pythoncom')
 sys.modules['pythoncom'] = pythoncom
 wrong_version = True
 
+from salt.utils.winapi import Com
+
 try:
     from mock import Mock, patch
     has_mock = True
@@ -176,16 +178,19 @@ class TestEmptyCommandLine(TestProcsBase):
         self.assertEqual(self.proc['cmd'], '')
 
 
-#class TestProcsComInitialization(TestProcsBase):
-#    def setUp(self):
-#        call_count = 5
-#        for _ in range(call_count):
-#            self.call_procs()
-#        self.expected_calls = [call()] * call_count
-#
-#    def test_initialize_and_unintialize_called(self):
-#        pythoncom.CoInitialize.assert_has_calls(self.expected_calls)
-#        pythoncom.CoUninitialize.assert_has_calls(self.expected_calls)
+class TestProcsComInitialization(TestProcsBase):
+    def setUp(self):
+        call_count = 5
+        for _ in range(call_count):
+            self.call_procs()
+        if not Com().need_com_init:
+            self.expected_calls = []
+        else:
+            self.expected_calls = [call()] * call_count
+
+    def test_initialize_and_unintialize_called(self):
+        pythoncom.CoInitialize.assert_has_calls(self.expected_calls)
+        pythoncom.CoUninitialize.assert_has_calls(self.expected_calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
@vlaci also commented on https://github.com/saltstack/salt/pull/3759#issuecomment-13693978 that this test case could also be removed.
