### PR TITLE
fixing host field syntax for salt.states.mysql_grants

### DIFF
--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -73,7 +73,7 @@ def present(name,
         The user to apply the grant to
 
     host
-        The MySQL server
+        The network/host that the grant should apply to
 
     grant_option
         Adds the WITH GRANT OPTION to the defined grant. default: False
@@ -134,7 +134,7 @@ def absent(name,
         The user to apply the grant to
 
     host
-        The MySQL server
+        The network/host that the grant should apply to
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
clarifying documentation to show that 'host' field in mysql_grants refers to the network or host that grant applies to.
