### PR TITLE
Fix problem with test=True for binary pkg install

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -302,7 +302,7 @@ def installed(
     if __opts__['test']:
         if targets:
             if sources:
-                summary = ', '.join(sources)
+                summary = ', '.join(targets)
             else:
                 summary = ', '.join([_get_desired_pkg(x, targets)
                                      for x in targets])


### PR DESCRIPTION
Thought I had fixed this in 4149529 but I was mistaken.
