### PR TITLE
fix bugs in file.recurse state and pkg.install

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1151,6 +1151,8 @@ def recurse(name,
     if include_empty:
         mdirs = __salt__['cp.list_master_dirs'](env)
         for mdir in mdirs:
+            if not mdir.startswith('{0}{1}'.format(srcpath, os.path.sep)):
+                continue
             mdest = os.path.join(name, os.path.relpath(mdir, srcpath))
             manage_directory(mdest)
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -286,6 +286,9 @@ def installed(
     '''
     rtag = __gen_rtag()
 
+    if not isinstance(version, basestring) and version is not None:
+        version = str(version)
+
     result = _find_install_targets(name, version, pkgs, sources)
     try:
         desired, targets = result


### PR DESCRIPTION
- when include_empty=true file.recurse bring full states directory tree from master to minion
- version should be always string even if yaml thinks it's float or int
