### PR TITLE
Fix connections using read_default_file in modules/mysql

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -110,6 +110,7 @@ def _connect(**kwargs):
     _connarg('conv')
     _connarg('unix_socket')
     _connarg('default_file', 'read_default_file')
+    _connarg('default_group', 'read_default_group')
 
     dbc = MySQLdb.connect(**connargs)
     dbc.autocommit(True)


### PR DESCRIPTION
In minion config file we can set option 'mysql.default_file' to allow MySQLdb (read_default_file native option) to read file with defaults to use it's data for auth.

But if we do not set option read_default_group for MySQLdb no defaults are really used. So we need explicitly set read_default_group to use defaults file.
In example if we use defaults file
/root/.my.cnf:

 [mysql]
 password=foobarpassword

and in /etc/salt/minion exists:

  mysql.default_file: '/root/.my.cnf'

there will be error if we do not supply password:

foo salt # salt 'testhost' mysql.user_exists user=foobar
testhost:
    Traceback (most recent call last):
      File "/usr/lib64/python2.7/site-packages/salt/minion.py", line 411, in _thread_return
        ret['return'] = func(_args, *_kwargs)
      File "/usr/lib64/python2.7/site-packages/salt/modules/mysql.py", line 438, in user_exists
        dbc = _connect()
      File "/usr/lib64/python2.7/site-packages/salt/modules/mysql.py", line 115, in _connect
        dbc = MySQLdb.connect(**connargs)
      File "/usr/lib64/python2.7/site-packages/MySQLdb/__init__.py", line 81, in Connect
        return Connection(_args, *_kwargs)
      File "/usr/lib64/python2.7/site-packages/MySQLdb/connections.py", line 187, in **init**
        super(Connection, self).**init**(_args, *_kwargs2)
    OperationalError: (1045, "Access denied for user 'root'@'localhost' (using password: NO)")

If /etc/salt/minion contains:
  mysql.default_file: '/root/.my.cnf'
  mysql.default_group: 'mysql'

all will be OK:

foo salt # salt 'testhost' mysql.user_exists user=foobar
testhost:
    False
