### PR TITLE
modules.pip editable to handle use case with local module w/o egg.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -235,8 +235,14 @@ def install(pkgs=None,
             cmd=cmd, timeout=timeout)
 
     if editable:
-        if editable.find('egg') == -1:
-            raise Exception('You must specify an egg for this editable')
+        # Is the editable local?
+        if not editable.startswith(('file://', '/')):
+            import re
+            match = re.search(r'(?:#|#.*?&)egg=([^&]*)', editable)
+
+            if not match or not match.group(1):
+                # Missing #egg=theEggName
+                raise Exception('You must specify an egg for this editable')
         cmd = '{0} install --editable={editable}'.format(
             _get_pip_bin(bin_env), editable=editable)
 


### PR DESCRIPTION
ref #3751, #2052
- Update pip's regex for detecting egg's (https://github.com/pypa/pip/blob/develop/pip/req.py#L1402) from editable.find('egg').
- Use `startswith` to detect if local file. Note that `pip install -e` will handle the use case of `file://` and `/` paths itself.

Only raise the exception if it's non local (vcs) and egg not found.
