### PR TITLE
Fix for "pip" detection so that setuptools is used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,10 @@ if setup_dirname != '':
 # Use setuptools only if the user opts-in by setting the USE_SETUPTOOLS env var
 # This ensures consistent behavior but allows for advanced usage with
 # virtualenv, buildout, and others.
+#
+# from what I can tell the proper mechanis
 with_setuptools = False
-if 'USE_SETUPTOOLS' in os.environ:
+if 'USE_SETUPTOOLS' in os.environ or 'pip' in __file__:
     try:
         from setuptools import setup
         from setuptools.command.install import install

--- a/setup.py
+++ b/setup.py
@@ -22,8 +22,6 @@ if setup_dirname != '':
 # Use setuptools only if the user opts-in by setting the USE_SETUPTOOLS env var
 # This ensures consistent behavior but allows for advanced usage with
 # virtualenv, buildout, and others.
-#
-# from what I can tell the proper mechanis
 with_setuptools = False
 if 'USE_SETUPTOOLS' in os.environ or 'pip' in __file__:
     try:


### PR DESCRIPTION
I am no "expert" with pip deployment, but this bug seems rather obnoxious.
If there is a better way to detect the usage of pip, please reject this pull request
and use it instead.  I do think that pip installation should not require the exporting
of env variables to be successful.  It seems the core is that pip _requires_ setuptools and 
unless USE_SETUPTOOLS is set in environment variables pip fails.

The issue appears on 12.04 Ubuntu and OS X for sure.  I am sure we will see it other places as well.
