### PR TITLE
Fixes #3797 Handle requirement specifiers in pip.installed state

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -176,6 +176,10 @@ def install(pkgs=None,
 
     if pkgs:
         pkg = pkgs.replace(',', ' ')
+        # It's possible we replaced version-range commas with semicolons so
+        # they would survive the previous line (in the pip.installed state).
+        # Put the commas back in
+        pkg = pkg.replace(';', ',')
         cmd = '{cmd} {pkg} '.format(
             cmd=cmd, pkg=pkg)
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -98,7 +98,8 @@ def install(pkgs=None,
     timeout
         Set the socket timeout (default 15 seconds)
     editable
-        install something editable(ie git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed)
+        install something editable (i.e.
+        git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed)
     find_links
         URL to look for packages at
     index_url
@@ -122,7 +123,8 @@ def install(pkgs=None,
     upgrade
         Upgrade all packages to the newest available version
     force_reinstall
-        When upgrading, reinstall all packages even if they are already up-to-date.
+        When upgrading, reinstall all packages even if they are already
+        up-to-date.
     ignore_installed
         Ignore the installed packages (reinstalling instead)
     no_deps

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -158,7 +158,7 @@ def install(pkgs=None,
 
         salt '*' pip.install <package name> bin_env=/path/to/pip_bin
 
-    Comlicated CLI example::
+    Complicated CLI example::
 
         salt '*' pip.install markdown,django editable=git+https://github.com/worldcompany/djangoembed.git#egg=djangoembed upgrade=True no_deps=True
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -175,7 +175,7 @@ def install(pkgs=None,
     cmd = '{0} install'.format(_get_pip_bin(bin_env))
 
     if pkgs:
-        pkg = pkgs.replace(",", " ")
+        pkg = pkgs.replace(',', ' ')
         cmd = '{cmd} {pkg} '.format(
             cmd=cmd, pkg=pkg)
 
@@ -249,19 +249,19 @@ def install(pkgs=None,
             _get_pip_bin(bin_env), editable=editable)
 
     if find_links:
-        if not find_links.startswith("http://"):
+        if not find_links.startswith('http://'):
             raise Exception('\'{0}\' must be a valid url'.format(find_links))
         cmd = '{cmd} --find-links={find_links}'.format(
             cmd=cmd, find_links=find_links)
 
     if index_url:
-        if not index_url.startswith("http://"):
+        if not index_url.startswith('http://'):
             raise Exception('\'{0}\' must be a valid url'.format(index_url))
         cmd = '{cmd} --index-url="{index_url}" '.format(
             cmd=cmd, index_url=index_url)
 
     if extra_index_url:
-        if not extra_index_url.startswith("http://"):
+        if not extra_index_url.startswith('http://'):
             raise Exception(
                 '\'{0}\' must be a valid url'.format(extra_index_url)
             )
@@ -272,7 +272,7 @@ def install(pkgs=None,
         cmd = '{cmd} --no-index '.format(cmd=cmd)
 
     if mirrors:
-        if not mirrors.startswith("http://"):
+        if not mirrors.startswith('http://'):
             raise Exception('\'{0}\' must be a valid url'.format(mirrors))
         cmd = '{cmd} --use-mirrors --mirrors={mirrors} '.format(
             cmd=cmd, mirrors=mirrors)
@@ -393,7 +393,7 @@ def uninstall(pkgs=None,
     cmd = '{0} uninstall -y '.format(_get_pip_bin(bin_env))
 
     if pkgs:
-        pkg = pkgs.replace(",", " ")
+        pkg = pkgs.replace(',', ' ')
         cmd = '{cmd} {pkg} '.format(
             cmd=cmd, pkg=pkg)
 
@@ -509,9 +509,9 @@ def list(prefix='',
             line, name = line.split('#egg=')
             packages[name] = line
 
-        elif len(line.split("==")) >= 2:
-            name = line.split("==")[0]
-            version = line.split("==")[1]
+        elif len(line.split('==')) >= 2:
+            name = line.split('==')[0]
+            version = line.split('==')[1]
             if prefix:
                 if line.lower().startswith(prefix.lower()):
                     packages[name] = version

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -70,7 +70,8 @@ def installed(name,
         ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
         return ret
 
-    if ignore_installed is False and name.lower() in (p.lower() for p in pip_list):
+    if ignore_installed is False and name.lower() in (p.lower()
+                                                      for p in pip_list):
         if force_reinstall is False and upgrade is False:
             ret['result'] = True
             ret['comment'] = 'Package already installed'

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -62,16 +62,19 @@ def installed(name,
     elif env and not bin_env:
         bin_env = env
 
+    # Pull off any requirements specifiers
+    prefix = name.split('=')[0].split('<')[0].split('>')[0].strip()
+
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     try:
-        pip_list = __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd)
+        pip_list = __salt__['pip.list'](prefix, bin_env, runas=user, cwd=cwd)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
         return ret
 
-    if ignore_installed is False and name.lower() in (p.lower()
-                                                      for p in pip_list):
+    if ignore_installed is False and prefix.lower() in (p.lower()
+                                                        for p in pip_list):
         if force_reinstall is False and upgrade is False:
             ret['result'] = True
             ret['comment'] = 'Package already installed'
@@ -82,6 +85,12 @@ def installed(name,
         ret['comment'] = 'Python package {0} is set to be installed'.format(
                 name)
         return ret
+
+    # Replace commas (used for version ranges) with semicolons (which are not
+    # supported) in name so it does not treat them as multiple packages.  Comma
+    # will be re-added in pip.install call.  Wrap in double quotes to allow for
+    # version ranges
+    name = '"' + name.replace(',', ';') + '"'
 
     if repo:
         name = repo
@@ -119,7 +128,7 @@ def installed(name,
     if pip_install_call and (pip_install_call['retcode'] == 0):
         ret['result'] = True
 
-        pkg_list = __salt__['pip.list'](name, bin_env, runas=user, cwd=cwd)
+        pkg_list = __salt__['pip.list'](prefix, bin_env, runas=user, cwd=cwd)
         if not pkg_list:
             ret['comment'] = (
                 'There was no error installing package \'{0}\' although '

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -70,8 +70,8 @@ def installed(name,
         ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
         return ret
 
-    if ignore_installed == False and name.lower() in (p.lower() for p in pip_list):
-        if force_reinstall == False and upgrade == False:
+    if ignore_installed is False and name.lower() in (p.lower() for p in pip_list):
+        if force_reinstall is False and upgrade is False:
             ret['result'] = True
             ret['comment'] = 'Package already installed'
             return ret


### PR DESCRIPTION
The `pip.installed` state will now double-quote the named package and take precautions to make sure comma-separated requirement specifiers are not treated as different packages in the `pip.install` function.

Additionally, when attempting to find if a package is installed via `pip.list`, it cuts off all requirement specifiers so that `pip.list` will correctly identify if that package is installed.

NOTE:  We are not currently verifying that the package version installed matches the requirements specifiers.
