### PR TITLE
Fix traceback in format_log

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -134,8 +134,9 @@ def format_log(ret):
                         msg = 'Installed Packages:\n'
                         for pkg in chg:
                             old = chg[pkg]['old'] or 'absent'
+                            new = chg[pkg]['new'] or 'absent'
                             msg += '{0} changed from {1} to ' \
-                                   '{2}\n'.format(pkg, old, chg[pkg]['new'])
+                                   '{2}\n'.format(pkg, old, new)
             if not msg:
                 msg = str(ret['changes'])
             if ret['result'] is True or ret['result'] is None:

--- a/salt/state.py
+++ b/salt/state.py
@@ -127,7 +127,7 @@ def format_log(ret):
                 if 'diff' in chg:
                     if isinstance(chg['diff'], string_types):
                         msg = 'File changed:\n{0}'.format(chg['diff'])
-                if all([isinstance(chg[x], dict) for x in iter(chg)]):
+                if all([isinstance(x, dict) for x in chg.values()]):
                     if all([('old' in x and 'new' in x)
                             for x in chg.values()]):
                         # This is the return data from a package install

--- a/salt/state.py
+++ b/salt/state.py
@@ -127,17 +127,15 @@ def format_log(ret):
                 if 'diff' in chg:
                     if isinstance(chg['diff'], string_types):
                         msg = 'File changed:\n{0}'.format(chg['diff'])
-                chgfirst = next(iter(chg))
-                if isinstance(chg[chgfirst], dict):
-                    if 'new' in chg[chgfirst]:
+                if all([isinstance(chg[x], dict) for x in iter(chg)]):
+                    if all([('old' in x and 'new' in x)
+                            for x in chg.values()]):
                         # This is the return data from a package install
                         msg = 'Installed Packages:\n'
                         for pkg in chg:
-                            old = 'absent'
-                            if chg[pkg]['old']:
-                                old = chg[pkg]['old']
-                            msg += '{0} changed from {1} to {2}\n'.format(
-                                    pkg, old, chg[pkg]['new'])
+                            old = chg[pkg]['old'] or 'absent'
+                            msg += '{0} changed from {1} to ' \
+                                   '{2}\n'.format(pkg, old, chg[pkg]['new'])
             if not msg:
                 msg = str(ret['changes'])
             if ret['result'] is True or ret['result'] is None:


### PR DESCRIPTION
format_log assumes that if the first value it sees in the changes dict
is a dict with a key 'new', that the information in the changes dict is
from a pkg state. However, this causes format_log to traceback (and
causes the state to output nothing) when the changes dict contains mixed
data. This commit uses a more precise method of determining if the
changes dict contains information from a pkg state. It checks to see
that all values in the changes dict are dicts themselves, and that all
of these sub-dicts contain both "new" and "old" keys. Technically, this
is not a perfect solution since someone could write a state which
returns changes in a similar format, but it at least gets rid of the
traceback.
