### PR TITLE
Add append_domain grain if its set in the config

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -722,6 +722,16 @@ def hostname():
     return grains
 
 
+def append_domain():
+    '''
+    Return append_domain if set
+    '''
+    grain = {}
+    if 'append_domain' in __opts__:
+        grain['append_domain'] = __opts__['append_domain']
+    return grain
+
+
 def path():
     '''
     Return the path


### PR DESCRIPTION
If the `append_domain` option is set in the minion config file, then add it as a grain.
