### PR TITLE
Use an output renderer to show minions that did not return

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -543,10 +543,11 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if len(found.intersection(minions)) >= len(minions):
-                        fail = sorted(list(minions.difference(found)))
-                        for minion in fail:
-                            yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
+                    if tgt_type == 'glob' or tgt_type == 'pcre' or tgt_type == 'list':
+                        if len(found.intersection(minions)) >= len(minions):
+                            fail = sorted(list(minions.difference(found)))
+                            for minion in fail:
+                                yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
                 break
             time.sleep(0.01)
 
@@ -772,10 +773,11 @@ class LocalClient(object):
                 continue
             if int(time.time()) > start + timeout:
                 if verbose:
-                    if not len(found) >= len(minions):
-                        fail = sorted(list(minions.difference(found)))
-                        for minion in fail:
-                            yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
+                    if tgt_type == 'glob' or tgt_type == 'pcre' or tgt_type == 'list':
+                        if not len(found) >= len(minions):
+                            fail = sorted(list(minions.difference(found)))
+                            for minion in fail:
+                                yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
                 break
             time.sleep(0.01)
         return ret
@@ -857,10 +859,11 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if not len(found) >= len(minions):
-                        fail = sorted(list(minions.difference(found)))
-                        for minion in fail:
-                            yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
+                    if tgt_type == 'glob' or tgt_type == 'pcre' or tgt_type == 'list':
+                        if not len(found) >= len(minions):
+                            fail = sorted(list(minions.difference(found)))
+                            for minion in fail:
+                                yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
                 break
             time.sleep(0.01)
 

--- a/salt/client.py
+++ b/salt/client.py
@@ -543,12 +543,10 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if tgt_type == 'glob' or tgt_type == 'pcre':
-                        if len(found.intersection(minions)) >= len(minions):
-                            print('\nThe following minions did not return:')
-                            fail = sorted(list(minions.difference(found)))
-                            for minion in fail:
-                                print(minion)
+                    if len(found.intersection(minions)) >= len(minions):
+                        fail = sorted(list(minions.difference(found)))
+                        for minion in fail:
+                            yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
                 break
             time.sleep(0.01)
 
@@ -774,12 +772,10 @@ class LocalClient(object):
                 continue
             if int(time.time()) > start + timeout:
                 if verbose:
-                    if tgt_type == 'glob' or tgt_type == 'pcre':
-                        if not len(found) >= len(minions):
-                            print('\nThe following minions did not return:')
-                            fail = sorted(list(minions.difference(found)))
-                            for minion in fail:
-                                print(minion)
+                    if not len(found) >= len(minions):
+                        fail = sorted(list(minions.difference(found)))
+                        for minion in fail:
+                            yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
                 break
             time.sleep(0.01)
         return ret
@@ -861,12 +857,10 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if tgt_type == 'glob' or tgt_type == 'pcre':
-                        if not len(found) >= len(minions):
-                            print('\nThe following minions did not return:')
-                            fail = sorted(list(minions.difference(found)))
-                            for minion in fail:
-                                print(minion)
+                    if not len(found) >= len(minions):
+                        fail = sorted(list(minions.difference(found)))
+                        for minion in fail:
+                            yield({minion: {'out': 'no_return', 'ret': 'Minion did not return'}})
                 break
             time.sleep(0.01)
 

--- a/salt/output/no_return.py
+++ b/salt/output/no_return.py
@@ -1,0 +1,43 @@
+'''
+Display output for minions that did not return
+'''
+
+import salt.utils
+
+class NestDisplay(object):
+    '''
+    '''
+    def __init__(self):
+        self.colors = salt.utils.get_colors(__opts__.get('color'))
+
+    def display(self, ret, indent, prefix, out):
+        '''
+        Recursively interate down through data structures to determine output
+        '''
+        if isinstance(ret, str):
+            lines = ret.split('\n')
+            for line in lines:
+                out += '{0}{1}{2}{3}{4}\n'.format(
+                        self.colors['RED'],
+                        ' ' * indent,
+                        prefix,
+                        line,
+                        self.colors['ENDC'])
+        elif isinstance(ret, dict):
+            for key in sorted(ret):
+                val = ret[key]
+                out += '{0}{1}{2}{3}{4}:\n'.format(
+                        self.colors['CYAN'],
+                        ' ' * indent,
+                        prefix,
+                        key,
+                        self.colors['ENDC'])
+                out = self.display(val, indent + 4, '', out)
+        return out
+
+def output(ret):
+    '''
+    Display ret data
+    '''
+    nest = NestDisplay()
+    return nest.display(ret, 0, '', '')


### PR DESCRIPTION
Two main reasons:
1. Output can be customized / colored (minor)
2. Data on minions that did not return is passed up.  This allows custom
runners to process the data.

Thoughts?
