### PR TITLE
Unregister socket from poller in SREQ.send()

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -153,14 +153,17 @@ class SREQ(object):
             polled = self.poller.poll(timeout * 1000)
             tried += 1
             if polled:
-                break
+                ret = self.serial.loads(self.socket.recv())
+                self.poller.unregister(self.socket)
+                return ret
             elif tried >= tries:
+                self.poller.unregister(self.socket)
                 raise SaltReqTimeoutError(
                     'Waited {0} seconds'.format(
                         timeout * tried
                     )
                 )
-        return self.serial.loads(self.socket.recv())
+        return None
 
     def send_auto(self, payload):
         '''


### PR DESCRIPTION
Ran into trouble with SREQ.send() while using ~100 threads submitting each one salt request to a peer-publishing minion. SREQ.send() would often hang the entire process, after investigation, it turned out that the likely culprit was SREQ.send(). The fix here (+ an upgrade of pyzmq) solved the problem.

I'm submitting this on the 0.13 branch, but I didn't get a chance to test this with 0.13 yet. I've seen the above described bug in 0.10.3. Can't upgrade yet, but will do as soon as possible.

This is basically simply unregistering the socket from the poller. I see that you are now doing this in destroy(), so this may not be needed anymore... Submitting anyway, in case you are still getting reports of SREQ.send() hanging in 0.13. Sorry I couldn't test this yet with 0.13.
