### PR TITLE
sysctl can return permission denied messages on stderr

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -33,7 +33,7 @@ def show():
     '''
     cmd = 'sysctl -a'
     ret = {}
-    for line in __salt__['cmd.run'](cmd).splitlines():
+    for line in __salt__['cmd.run_stdout'](cmd).splitlines():
         if not line or ' = ' not in line:
             continue
         comps = line.split(' = ', 1)


### PR DESCRIPTION
Since sysctl can return error messages on stderr, they end up mingled in the middle of the output and can interfere with the parsing, using cmd.run_stdout prevents this.
