### PR TITLE
Adding xmlutil to salt.util

### DIFF
--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -1,0 +1,46 @@
+'''
+Various XML utilities
+'''
+
+# Import python libs
+import xml.etree.ElementTree as ET
+
+def to_dict(xmltree):
+    ''' 
+    Convert an XML tree into a dict. The tree that is passed in must be an
+    ElementTree object.
+    '''
+    # If this object has no children, the for..loop below will return nothing
+    # for it, so just return a single dict representing it.
+    if len(xmltree.getchildren()) < 1:
+        name = xmltree.tag
+        if '}' in name:
+            comps = name.split('}')
+            name = comps[1]
+        return {name: xmltree.text}
+
+    xmldict = {}
+    for item in xmltree:
+        name = item.tag
+        if '}' in name:
+            # If this xml tree has an xmlns attribute, then etree will add it
+            # to the beginning of the tag, like: "{http://path}tag". This
+            # aggression will not stand, man.
+            comps = name.split('}')
+            name = comps[1]
+        if not name in xmldict.keys():
+            if len(item.getchildren()) > 0:
+                xmldict[name] = to_dict(item)
+            else:
+                xmldict[name] = item.text
+        else:
+            # If a tag appears more than once in the same place, convert it to
+            # a list. This may require that the caller watch for such a thing
+            # to happen, and behave accordingly.
+            if type(xmldict[name]) is not list:
+                tempvar = xmldict[name]
+                xmldict[name] = []
+                xmldict[name].append(tempvar)
+            xmldict[name].append(to_dict(item))
+    return xmldict
+


### PR DESCRIPTION
I've started to use this function in enough code across three different salt projects, that I figured it was time to add it to salt proper.

This doesn't use a Class like most of the other files in salt/util/, but neither does dictupdate.py. Please advise as to whether this is correct.
