### PR TITLE
Make /usr/bin first in path to ensure that system python is used

### DIFF
--- a/pkg/salt-master.upstart
+++ b/pkg/salt-master.upstart
@@ -5,4 +5,7 @@ start on (net-device-up
           and runlevel [2345])
 stop on runlevel [!2345]
 
-exec /usr/bin/salt-master >/dev/null 2>&1
+script
+export PATH=/usr/bin:$PATH
+exec /usr/bin/salt-minion >/dev/null 2>&1
+end script

--- a/pkg/salt-minion.upstart
+++ b/pkg/salt-minion.upstart
@@ -10,4 +10,7 @@ normal exit 0 1 2 6 9 15 143 SIGKILL SIGINT SIGABRT
 respawn
 respawn limit 10 5
 
+script
+export PATH=/usr/bin:$PATH
 exec /usr/bin/salt-minion >/dev/null 2>&1
+end script


### PR DESCRIPTION
On Ubuntu, /usr/local/bin is listed before /usr/bin based on /etc/environment:
$ cat /etc/environment 
PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games"

On some systems, a different version of python could be installed outside of the package manager to /usr/local/bin/python.  The different version would not contain the salt system package, causing /usr/bin/salt-minion to fail to import salt when the service is started.

Although the real issue is the non-system python installation, the salt-minion service should always invoke system python.
