### PR TITLE
EC2 Master Discovery

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -28,7 +28,7 @@
 # allow_multiple is a boolean - True means that the filter will be allowed to
 # have multiple matches and will return one at random.  This can be used to 
 # emulate round robin DNS.  If it's set to False, having more than one match
-# raises an error
+# raises an error. Defaults to False
 #
 # access_key and secret_key are your AWS keys that allow you to list EC2 regions,
 # list all EC2 instances, and access tags.  There should be no write access on

--- a/conf/minion
+++ b/conf/minion
@@ -10,6 +10,43 @@
 # resolved, then the minion will fail to start.
 #master: salt
 
+# Alternatively, you can set master to ec2 and provide additional info/config
+# settings in ec2_info to resolve your master automatically inside ec2.
+#master: ec2
+
+# In the example below:
+# tags is a dict of Tag: Values that an instance must completely match in 
+# order to return.  Default is no filter
+# 
+# resolve_via is what attribute of the boto Instance object will be used to 
+# resolve the master IP, this can be any of public_dns_name, dns_name,
+# ip_address, private_ip_address, private_dns_name, etc.  Default is 
+# public_dns_name
+#
+# region is the region you'd like to connect to.  Default is us-east-1
+# 
+# allow_multiple is a boolean - True means that the filter will be allowed to
+# have multiple matches and will return one at random.  This can be used to 
+# emulate round robin DNS.  If it's set to False, having more than one match
+# raises an error
+#
+# access_key and secret_key are your AWS keys that allow you to list EC2 regions,
+# list all EC2 instances, and access tags.  There should be no write access on
+# the keys.  You can also omit these completely and boto will try and use IAM
+# roles to gain the necessary access.
+
+#ec2_info:
+# The tags to filter on, an instance must have all these tags to be returned
+#  tags:
+#    Type: SaltMaster
+#    Environment: Production
+#    App: YourApp 
+#  resolve_via: public_dns_name
+#  region: us-east-1
+#  allow_multiple: True
+#  access_key: AAAAAAAAAAAAAAAAA
+#  secret_key: MySuperSecretKeyFromAWS
+
 # Set the number of seconds to wait before attempting to resolve
 # the master hostname if name resolution fails. Defaults to 30 seconds.
 # Set to zero if the minion should shutdown and not retry.

--- a/conf/minion
+++ b/conf/minion
@@ -36,7 +36,6 @@
 # roles to gain the necessary access.
 
 #ec2_info:
-# The tags to filter on, an instance must have all these tags to be returned
 #  tags:
 #    Type: SaltMaster
 #    Environment: Production

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -25,11 +25,117 @@ Minion Primary Configuration
 
 Default: ``salt``
 
-The hostname or ipv4 of the master.
+The hostname or ipv4 of the master, or set to ``ec2`` to use EC2 auto-discovery.
 
 .. code-block:: yaml
 
     master: salt
+
+.. conf_minion:: ec2_info
+
+ec2_info
+------------
+
+This section configures EC2 auto-discovery, only applicable if you've set
+``master`` to ``ec2`` and are obviously running your infrastructure at EC2.  The
+boto_ library is required.  Everything in this section must be under the 
+``ec2_info`` stanza like so:
+
+.. _boto: http://boto.readthedocs.org/en/latest/
+
+.. code-block:: yaml
+    
+    ec2_info:
+      tags:
+        ILove: Salt
+
+.. conf_minion:: tags
+
+``tags``
+--------
+
+Default: No filters
+
+A dict of TagName: Values that instances must match.  Defaults to no filters.
+
+.. code-block:: yaml
+    
+    tags:
+      Type: SaltMaster
+      Environment: Production
+      App: YourApp
+
+.. conf_minion:: resolve_via
+
+``resolve_via``
+---------------
+
+Default: ``public_dns_name``
+
+What attribute to return to the minion on boto's Instance object. For a full list of attributes check `<http://boto.readthedocs.org/en/latest/ref/ec2.html#module-boto.ec2.instance>`_.
+
+.. code-block:: yaml
+    
+    resolve_via: public_dns_name
+
+.. conf_minion:: region
+
+``region``
+----------
+
+Default: ``us-east-1``
+
+The EC2 region to connect to when listing instances.
+
+.. code-block:: yaml
+    
+    region: us-east-1
+
+.. conf_minion:: allow_multiple
+
+``allow_multiple``
+------------------
+
+Default: ``False``
+
+When set to ``False``, this will throw an error whenever more than one instance
+matches the tags specified.  When set to ``True``, you can essentially emulate
+round robin DNS, as it will pick an instance from the matched set at random and
+return that value.
+
+.. code-block:: yaml
+    
+    allow_multiple: False
+
+.. conf_minion:: access_key
+
+``access_key``
+--------------
+
+Default: ``None``
+
+Your AWS access key.  This should have access to list EC2 regions as well as 
+your instances and tags.  If omitted, boto will try and resolve your credentials
+via IAM roles.
+
+.. code-block:: yaml
+    
+    access_key: AAAAAAAAAAAAAAAAA
+
+.. conf_minion:: secret_key
+
+``secret_key``
+--------------
+
+Default: ``None``
+
+Your AWS secret key.  This should have access to list EC2 regions as well as 
+your instances and tags.  If omitted, boto will try and resolve your credentials
+via IAM roles.
+
+.. code-block:: yaml
+    
+    secret_key: MySuperSecretKeyFromAWS
 
 .. conf_minion:: master_port
 

--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -58,6 +58,15 @@ configuration file, typically ``/etc/salt/minion``, as follows:
    - #master: salt
    + master: 10.0.0.1
 
+Alternatively, if you're hosted at EC2 you can use EC2 tags to facilitate
+auto-discovery of your master and even emulate round robin DNS.
+
+.. code-block::
+    master: ec2
+
+More information on EC2 configuration can be found on the :doc:`minion 
+configuration reference </ref/configuration/minion>` page.
+
 After updating the configuration file, restart the Salt minion.
 See the :doc:`minion configuration reference </ref/configuration/minion>`
 for more details about other configurable options.

--- a/salt/utils/ec2.py
+++ b/salt/utils/ec2.py
@@ -1,0 +1,84 @@
+from random import choice
+from salt.exceptions import SaltClientError
+
+try:
+    from boto.ec2 import connect_to_region
+    from boto.exception import EC2ResponseError
+except ImportError:
+    print "The boto library is required to make use of EC2 functionality."
+    raise ImportError
+
+
+def get_master_dns(opts):
+    '''
+    Returns a master IP given the EC2 filtering options provided
+    '''
+
+    access_key = opts.get('access_key', None)
+    secret_key = opts.get('secret_key', None)
+    region_name = opts.get('region_name', 'us-east-1')
+
+    allow_multiple = opts.get('allow_multiple', False)
+    resolve_via = opts.get('resolve_via', 'public_dns_name')
+
+    filters = _construct_filters(opts.get('tags', {}))
+
+    # Only get 'running' instances
+    filters['instance-state-name'] = 'running'
+
+    if not (access_key is None or secret_key is None):
+        try:
+            conn = connect_to_region(aws_access_key_id=access_key,
+                                     aws_secret_access_key=secret_key,
+                                     region_name=region_name)
+            reservations = conn.get_all_instances(filters=filters)
+        except EC2ResponseError:
+            raise SaltClientError("Couldn't connect to EC2 with the given"
+                                  " credentials. If you wish to use IAM roles"
+                                  ", please remove the access_key and "
+                                  "secret_key from the minion config.")
+    else:
+        # Try and use IAM Roles
+        try:
+            conn = connect_to_region(region_name=region_name)
+            reservations = conn.get_all_instances(filters=filters)
+        except EC2ResponseError:
+            raise SaltClientError("Couldn't connect to EC2 using IAM roles."
+                                  " If you were expecting to use Access Keys "
+                                  "instead, please make sure they are "
+                                  "properly configured in the ec2_info block.")
+
+    instances = [instance for reservation in reservations
+                 for instance in reservation.instances]
+
+    if len(instances) < 1:
+        raise SaltClientError("No EC2 instances returned for the given"
+                              " filters.")
+    elif len(instances) > 1 and not allow_multiple:
+        raise SaltClientError("Multiple EC2 instances returned for the"
+                              " given filters. If you'd like to pick a random"
+                              " return IPs you should set `allow_multiple` to "
+                              "True in ec2_info.")
+    elif len(instances) > 1 and allow_multiple:
+        hostname = getattr(choice(instances), resolve_via, None)
+    else:
+        hostname = getattr(instances[0], resolve_via, None)
+
+    if hostname is None:
+        raise SaltClientError("Couldn't get resolve_via ({0}) attribute on"
+                              " returned instances.".format(resolve_via))
+
+    return hostname
+
+
+def _construct_filters(filters):
+    '''
+    Converts filters from minion config into something boto can use
+    '''
+
+    return_filters = {}
+
+    for key, value in filters.iteritems():
+        return_filters['tag:%s' % key] = value
+
+    return return_filters


### PR DESCRIPTION
This PR allows you to change the `master` setting in a minion config file to `ec2`, then add an additional stanza labeled `ec2_info` with some extra info as to what to search for inside EC2, and it should resolve an instance to use as a Salt Master automatically.  It can even allow you to emulate round robin DNS using no more than EC2 tags to some degree.

This is my first PR for Salt - let me know if I've messed anything up here or not followed any style guides/updated docs and I'll be sure to fix.

Thanks!
