### PR TITLE
Some changes for freebsdservice module

### DIFF
--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -3,11 +3,15 @@ The service module for FreeBSD
 '''
 
 # Import python libs
+import logging
 import os
 
 # Import salt libs
 import salt.utils
 from salt.exceptions import CommandNotFoundError
+
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -20,6 +24,47 @@ def __virtual__():
     return False
 
 
+@salt.utils.memoize
+def _cmd():
+    '''
+    Return full path to service command
+    '''
+    service = salt.utils.which('service')
+    if not service:
+        raise CommandNotFoundError
+    return service
+
+
+def _get_rcscript(name):
+    '''
+    Return full path to service rc script
+    '''
+    cmd = '{0} -r'.format(_cmd())
+    for line in __salt__['cmd.run_stdout'](cmd).splitlines():
+        if line.endswith('{0}{1}'.format(os.path.sep, name)):
+            return line
+    return None
+
+
+def _get_rcvar(name):
+    '''
+    Return rcvar
+    '''
+    if not available(name):
+        log.error('Service {0} not found'.format(name))
+        return False
+
+    cmd = '{0} {1} rcvar'.format(_cmd(), name)
+
+    for line in __salt__['cmd.run_stdout'](cmd).splitlines():
+        if not '_enable="' in line:
+            continue
+        rcvar, _ = line.split('=', 1)
+        return rcvar
+
+    return None
+
+
 def get_enabled():
     '''
     Return what services are set to run on boot
@@ -29,11 +74,19 @@ def get_enabled():
         salt '*' service.get_enabled
     '''
     ret = []
-    service = salt.utils.which('service')
-    if not service:
-        raise CommandNotFoundError
+    service = _cmd()
     for svc in __salt__['cmd.run']('{0} -e'.format(service)).splitlines():
         ret.append(os.path.basename(svc))
+
+    # This is workaround for bin/173454 bug
+    for svc in get_all():
+        if svc in ret:
+            continue
+        if not os.path.exists('/etc/rc.conf.d/{0}'.format(svc)):
+            continue
+        if enabled(svc):
+            ret.append(svc)
+
     return sorted(ret)
 
 
@@ -52,65 +105,116 @@ def get_disabled():
 
 def _switch(name,                   # pylint: disable-msg=C0103
             on,                     # pylint: disable-msg=C0103
-            config='/etc/rc.conf',
             **kwargs):
     '''
+    Switch on/off service start at boot.
     '''
+    if not available(name):
+        return False
+
+    rcvar = _get_rcvar(name)
+    if not rcvar:
+        log.error('rcvar for service {0} not found'.format(name))
+        return False
+
+    config = kwargs.get('config',
+                        __salt__['config.option']('service.config',
+                                                  default='/etc/rc.conf'
+                                                  )
+                        )
+
+    if not config:
+        rcdir = '/etc/rc.conf.d'
+        if not os.path.exists(rcdir) or not os.path.isdir(rcdir):
+            log.error('{0} not exists'.format(rcdir))
+            return False
+        config = os.path.join(rcdir, rcvar.replace('_enable', ''))
+
     nlines = []
     edited = False
 
     if on:
-        val = "YES"
+        val = 'YES'
     else:
-        val = "NO"
+        val = 'NO'
 
     if os.path.exists(config):
         with salt.utils.fopen(config, 'r') as ifile:
             for line in ifile:
-                if not line.startswith('{0}_enable='.format(name)):
+                if not line.startswith('{0}='.format(rcvar)):
                     nlines.append(line)
                     continue
                 rest = line[len(line.split()[0]):]  # keep comments etc
-                nlines.append('{0}_enable="{1}"{2}'.format(name, val, rest))
+                nlines.append('{0}="{1}"{2}'.format(rcvar, val, rest))
                 edited = True
     if not edited:
-        nlines.append("{0}_enable=\"{1}\"\n".format(name, val))
+        nlines.append('{0}="{1}"\n'.format(rcvar, val))
+
     with salt.utils.fopen(config, 'w') as ofile:
         ofile.writelines(nlines)
+
     return True
 
 
-def enable(name, config='/etc/rc.conf', **kwargs):
+def enable(name, **kwargs):
     '''
     Enable the named service to start at boot
+
+    name
+        service name
+
+    config : /etc/rc.conf
+        Config file for managing service. If config value is
+        empty string, then /etc/rc.conf.d/<service> used.
+        See man rc.conf(5) for details.
+
+        Also service.config variable can be used to change default.
 
     CLI Example::
 
         salt '*' service.enable <service name>
     '''
-    return _switch(name, True, config, **kwargs)
+    return _switch(name, True, **kwargs)
 
 
-def disable(name, config='/etc/rc.conf', **kwargs):
+def disable(name, **kwargs):
     '''
     Disable the named service to start at boot
+
+    Arguments the same as for enable()
 
     CLI Example::
 
         salt '*' service.disable <service name>
     '''
-    return _switch(name, False, config, **kwargs)
+    return _switch(name, False, **kwargs)
 
 
 def enabled(name):
     '''
     Return True if the named servioce is enabled, false otherwise
 
+    name
+        Service name
+
     CLI Example::
 
         salt '*' service.enabled <service name>
     '''
-    return name in get_enabled()
+    if not available(name):
+        log.error('Service {0} not found'.format(name))
+        return False
+
+    cmd = '{0} {1} rcvar'.format(_cmd(), name)
+
+    for line in __salt__['cmd.run_stdout'](cmd).splitlines():
+        if not '_enable="' in line:
+            continue
+        _, state, _ = line.split('"', 2)
+        return state.lower() in ('yes', 'true', 'on', '1')
+
+    # probably will never reached
+    return False
 
 
 def disabled(name):
@@ -121,7 +225,7 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
-    return name in get_disabled()
+    return not enabled(name)
 
 
 def get_all():
@@ -133,11 +237,8 @@ def get_all():
         salt '*' service.get_all
     '''
     ret = []
-    service = salt.utils.which('service')
-    if not service:
-        raise CommandNotFoundError
-    for svc in __salt__['cmd.run']('{0} -r'.format(service)).splitlines():
-        srv = os.path.basename(svc)
+    service = _cmd()
+    for srv in __salt__['cmd.run']('{0} -l'.format(service)).splitlines():
         if not srv.isupper():
             ret.append(srv)
     return sorted(ret)
@@ -151,7 +252,7 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
-    cmd = 'service {0} onestart'.format(name)
+    cmd = '{0} {1} onestart'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -163,7 +264,7 @@ def stop(name):
 
         salt '*' service.stop <service name>
     '''
-    cmd = 'service {0} onestop'.format(name)
+    cmd = '{0} {1} onestop'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -177,7 +278,7 @@ def restart(name):
     '''
     if name == 'salt-minion':
         salt.utils.daemonize_if(__opts__)
-    cmd = 'service {0} onerestart'.format(name)
+    cmd = '{0} {1} onerestart'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -189,25 +290,31 @@ def reload(name):
 
         salt '*' service.reload <service name>
     '''
-    cmd = 'service {0} onereload'.format(name)
+    cmd = '{0} {1} onereload'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
 
 
-def status(name, sig=None):
+def status(name, **kwargs):
     '''
     Return the status for a service (True or False).
 
     name
         Name of service.
 
-    sig : None
-        Signature. If sig is passed use as service name instead of
-        name argument.
-
-
     CLI Example::
 
         salt '*' service.status <service name>
     '''
-    cmd = 'service {0} onestatus'.format(sig if sig else name)
+    cmd = '{0} {1} onestatus'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
+
+
+def available(name, **kwargs):
+    '''
+    Check that the given service is available.
+
+    CLI Example::
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()


### PR DESCRIPTION
- fix bug: enable/disable service did not work if rcvar doesn't like <service>_enable (for example mysql-server)
- add workaround for service(8) bug (see PR bin/173454), it must fix #3876
- rewrite enabled/disabled function, now this func-s not based on get_enabled which is quite slow
- move service(8) look up in separate function with memoize decorator and remove direct use service(8)
- feature: service.config can be defined in minion config
- clean double quotes
