### PR TITLE
Traceback is shown on logging, not on `sys.stderr`.

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -46,10 +46,13 @@ def set_pidfile(pidfile, user):
     try:
         os.chown(pidfile, uid, gid)
     except OSError as err:
-        msg = ('Failed to set the ownership of PID file {0} '
-               'to user {1}\n').format(pidfile, user)
-        log.debug(msg, exc_info=True)
-        sys.stderr.write(msg)
+        msg = (
+            'Failed to set the ownership of PID file {0} to user {1}.'.format(
+                pidfile, user
+            )
+        )
+        log.debug('{0} Traceback follows:\n'.format(msg), exc_info=True)
+        sys.stderr.write('{0}\n'.format(msg))
         sys.exit(err.errno)
     log.debug('Chowned pidfile: {0} to user: {1}'.format(pidfile, user))
 


### PR DESCRIPTION
Also, explicitly state that a traceback follows.
