### PR TITLE
Include exception message

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -98,9 +98,11 @@ def verify_socket(interface, pub_port, ret_port):
         retsock.bind((interface, int(ret_port)))
         retsock.close()
         result = True
-    except Exception:
+    except Exception as e:
         msg = ("Unable to bind socket, this might not be a problem."
                " Is there another salt-master running?")
+        if e.args:
+            msg += " " + str(e)
         if is_console_configured():
             log.warn(msg)
         else:


### PR DESCRIPTION
I ran into a problem and kept getting the warning from verify_socket.
It made me think the port or socket was already in use.
When in fact it was an invalid address when checking
the exception message. "Cannot assign requested address"
I'm simply checking the exception for args and appending
it to the message.
