### PR TITLE
Add M2Crypto dependency back in to the installation requirements

### DIFF
--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -77,6 +77,7 @@ Optional Dependencies
 .. _`msgpack-python`:  http://pypi.python.org/pypi/msgpack-python/0.1.12
 .. _`YAML`: http://pyyaml.org/
 .. _`PyCrypto`: http://www.dlitz.net/software/pycrypto/
+.. _`M2Crypto`: http://chandlerproject.org/Projects/MeTooCrypto
 .. _`Cython`: http://cython.org/
 .. _`Jinja2`: http://jinja.pocoo.org/
 


### PR DESCRIPTION
- It was removed 3867ffb3efff2df97b4bb82b9fb2afa703786a47 but not added
  back when the patch was reverted.
