### PR TITLE
Correcting a logic error where for loop would continue

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -21,8 +21,9 @@ def __catalina_home():
     locations = ['/usr/share/tomcat*', '/opt/tomcat']
     for location in locations:
         catalina_home = glob.glob(location)
-    if catalina_home:
-        return catalina_home[-1]
+        if catalina_home:
+            return catalina_home[-1]
+    return False
 
 
 def version():


### PR DESCRIPTION
instead of returning when the catalina_home is found.

Additionally using glob.glob('/usr/local/tomcat*') might be
dangerous because it could return invalid catalina_homes::

> > > import glob
> > > glob.glob( '/usr/share/tomcat*' )
> > >  ['/usr/share/tomcat7-root', '/usr/share/tomcat7']

```
modified:   tomcat.py
```
