### PR TITLE
Correct logic error, the if condition produces KeyError instead

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -77,7 +77,7 @@ def signal(signal=None):
                      'start': 'start',
                      'stop': 'stop'}
 
-    if not valid_signals[signal]:
+    if signal not in valid_signals:
         return
 
     cmd = '{0}/bin/catalina.sh {1}'.format(


### PR DESCRIPTION
Correct logic error, the if condition produces KeyError instead
of verifying if signal is in valid_signals dictionary.

```
modified:   tomcat.py
```
