### PR TITLE
Quiet down error reporting from libvirt.

### DIFF
--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -10,6 +10,7 @@ interact with kvm on behalf of the salt-virt interface
 
 
 # Import python libs
+import logging
 import os
 import shutil
 import string
@@ -27,6 +28,8 @@ except ImportError:
 # Import salt libs
 import salt.utils
 from salt._compat import StringIO
+
+log = logging.getLogger(__name__)
 
 VIRT_STATE_NAME_MAP = {0: "running",
                        1: "running",
@@ -56,11 +59,17 @@ def __virtual__():
         return False
     if not HAS_LIBVIRT:
         return False
+
+    #Libvirt is very noisy. This will quiet it down
+    def quiet_errors(ignored, err):
+        log.debug(err[2])
+
+    libvirt.registerErrorHandler(quiet_errors, None)
     try:
         libvirt_conn = libvirt.open('qemu:///system')
         libvirt_conn.close()
         return 'hyper'
-    except Exception:
+    except libvirt.libvirtError:
         return False
 
 


### PR DESCRIPTION
On a system where `qemu:///system` is not writable by the user running
salt, the `kvm_hyper` module will report a lot of noise due to
permission denials. Registering an error handler will prevent those
messages from displaying in salt output unless the log level is set to
debug. It will be clear to users that the 'virtual' module did not load
from existing log output. The normal action to debug module load misses
is to use debug logging to resolve load issues. I believe this will not
lead to surprising behavior in the intenional use cases because the use
of debug logging will show the libvirt errors. I also believe that
quieting down the logs will be less confusing when users have no
intention of using `virtual` and have probably not configured it
correctly, but it was installed on their system.
