### PR TITLE
Do not list any directories as keys in the 'salt-call -L' output.

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -279,7 +279,8 @@ class Key(object):
         for dir_ in acc, pre, rej:
             ret[os.path.basename(dir_)] = []
             for fn_ in salt.utils.isorted(os.listdir(dir_)):
-                ret[os.path.basename(dir_)].append(fn_)
+                if os.path.isfile(os.path.join(dir_, fn_)):
+                    ret[os.path.basename(dir_)].append(fn_)
         return ret
 
     def all_keys(self):


### PR DESCRIPTION
**salt-key will list directories as if they were minion key entries**

This is more a cosmetic bug. When using subversion to manage the `/etc/salt` directory, it creates `.svn` directories underneath the `/etc/salt/pki/master/minions`, `/etc/salt/pki/master/minions/minions_pre` and `/etc/salt/pki/master/minions/minions_rejected` directories. These directories (or any manually created subdirectories for that matter) show up in the `salt-key -L` output as if they were accepted, pending and rejected keys, respectively:

``` text
~ $ PYTHONPATH=. ./scripts/salt-key -L

Accepted Keys:
.svn
minion
Unaccepted Keys:
.svn
some_directory
Rejected Keys:
.svn
```

If I "accept" the `some_directory` key in the example above, this directory gets moved from the unaccepted keys to the accepted keys, but the operation makes no sense.

The list is generated in `salt.key.Key`'s `list_keys()` method by simply using an `os.listdir()` on the three minion key directories (approved, pending and rejected) and adding anything it returns. A simple extra check should make this a bit prettier, since (if I understand the code in `Key` correctly) directories as keys are not really supported.
