### PR TITLE
Fix name overriding

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -908,10 +908,10 @@ class State(object):
                             if key == 'names':
                                 names.update(val)
                                 continue
-                            elif key == 'name':
-                                if not isinstance(val, string_types):
-                                    # Invalid name, fall back to ID
-                                    chunk[key] = name
+                            elif (key == 'name' and
+                                  not isinstance(val, string_types)):
+                                # Invalid name, fall back to ID
+                                chunk[key] = name
                             else:
                                 chunk.update(arg)
                 if names:

--- a/salt/state.py
+++ b/salt/state.py
@@ -907,13 +907,12 @@ class State(object):
                         for key, val in arg.items():
                             if key == 'names':
                                 names.update(val)
-                                continue
                             elif (key == 'name' and
                                   not isinstance(val, string_types)):
                                 # Invalid name, fall back to ID
                                 chunk[key] = name
                             else:
-                                chunk.update(arg)
+                                chunk[key] = val
                 if names:
                     for low_name in names:
                         live = copy.deepcopy(chunk)


### PR DESCRIPTION
f4ac4a63cd592f50cf1494c932703e1ef195200a has broken name overriding.

SLS:

```
"echo id":
  cmd.run:
    - name: "echo override"
```

Expected output (confirmed in current master HEAD 1d31da637a84a0209a4da0ce7f51fb9d679ab8f2):

```
    State: - cmd
    Name:      echo override
    Function:  run
        Result:    True
        Comment:   Command "echo override" run
        Changes:   pid: 40306
                   retcode: 0
                   stderr:
                   stdout: override
```

Actual output as of d4ba15d298ec7fd589ae1012e2b0088fb089b269 (current develop HEAD):

```
    State: - cmd
    Name:      echo id
    Function:  run
        Result:    True
        Comment:   Command "echo id" run
        Changes:   pid: 40269
                   retcode: 0
                   stderr:
                   stdout: id
```

However, this SLS behaves differently (i.e. works correctly) because the `chunk` is updated with the whole `arg` for the `foo` key:

```
"echo id":
  cmd.run:
    - name: "echo override"
      foo: bar
```

This "problem" is addressed in the second commit.

`$ salt --versions-report`

```
           Salt: 0.13.0-507-gd4ba15d
         Python: 2.7.2 (default, Jun 20 2012, 16:23:33)
         Jinja2: 2.6
       M2Crypto: 0.21.1
 msgpack-python: 0.3.0
   msgpack-pure: not installed
       pycrypto: 2.6
         PyYAML: 3.10
          PyZMQ: 13.0.0
```
