### PR TITLE
Do a true deepcopy as the docstring suggests.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -4,6 +4,7 @@ Routines to set up a minion
 '''
 
 # Import python libs
+import copy
 import logging
 import getpass
 import multiprocessing
@@ -252,11 +253,9 @@ class Minion(object):
         '''
         Returns a deep copy of the opts with key bits stripped out
         '''
-        mod_opts = {}
-        for key, val in self.opts.items():
-            if key == 'logger':
-                continue
-            mod_opts[key] = val
+        mod_opts = copy.deepcopy(self.opts)
+        if 'logger' in mod_opts:
+            del mod_opts['logger']
         return mod_opts
 
     def __load_modules(self):


### PR DESCRIPTION
Previously, the options were only shallowly copied by looping over the
dict and copying the top level keys. This is equivalent to `dict.copy`
which is a shallow copy. If that was the true intention this commit is
not needed, but a docstring update is. Future thought should be put into
a nice way to manage which keys should be included in copied dict. I
think dictviews are worth a look.
