### PR TITLE
New states and modules for managing node.js packages with NPM

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -1,0 +1,122 @@
+'''
+Manage and query NPM packages.
+'''
+
+import json
+
+from salt.exceptions import CommandExecutionError
+
+def install(pkg=None,
+            dir=None,
+            runas=None):
+    '''
+    Install an NPM package.
+
+    If no directory is specified, the package will be installed globally. If
+    no package is specified, the dependencies (from package.json) of the
+    package in the given directory will be installed.
+
+    pkg
+        A package name in any format accepted by NPM
+
+    dir
+        The target directory in which to install the package, or None for
+        global installation
+
+    runas
+        The user to run NPM with
+
+    CLI example::
+
+        salt '*' npm.install coffee-script
+
+    '''
+    cmd = 'npm install --json'
+
+    if dir is None:
+        cmd += ' --global'
+
+    if pkg:
+        cmd += ' ' + pkg
+
+    result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    lines = result['stdout'].splitlines()
+
+    while ' -> ' in lines[0]:
+        lines = lines[1:]
+
+    return json.loads(''.join(lines))
+
+def uninstall(pkg,
+              dir=None,
+              runas=None):
+    '''
+    Uninstall an NPM package.
+
+    If no directory is specified, the package will be uninstalled globally.
+
+    pkg
+        A package name in any format accepted by NPM
+
+    dir
+        The target directory from which to uninstall the package, or None for
+        global installation
+
+    runas
+        The user to run NPM with
+
+    CLI example::
+
+        salt '*' npm.uninstall coffee-script
+
+    '''
+    cmd = 'npm uninstall'
+
+    if dir is None:
+        cmd += ' --global'
+
+    cmd += ' ' + pkg
+
+    result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+def list(pkg=None,
+         dir=None):
+    '''
+    List installed NPM packages.
+
+    If no directory is specified, this will return the list of globally-
+    installed packages.
+
+    pkg
+        Limit package listing by name
+
+    dir
+        The directory whose packages will be listed, or None for global
+        installation
+
+    CLI example::
+
+        salt '*' npm.list
+
+    '''
+    cmd = 'npm list --json'
+
+    if dir is None:
+        cmd += ' --global'
+
+    if pkg:
+        cmd += ' ' + pkg
+
+    result = __salt__['cmd.run_all'](cmd, cwd=dir)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    return json.loads(result['stdout']).get('dependencies', {})

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -1,0 +1,113 @@
+'''
+A state module to manage installed NPM packages.
+'''
+
+from salt.exceptions import CommandExecutionError, CommandNotFoundError
+
+def installed(name,
+              dir=None,
+              runas=None,
+              force_reinstall=False,
+              **kwargs):
+    '''
+    Verify that the given package is installed and is at the correct version
+    (if specified).
+
+    dir
+        The target directory in which to install the package, or None for
+        global installation
+
+    runas
+        The user to run NPM with
+
+    force_reinstall
+        Install the package even if it is already installed
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    prefix = name.split('@')[0].split('<')[0].split('>')[0].strip()
+
+    try:
+        installed = __salt__['npm.list'](dir=dir)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
+        return ret
+
+    if prefix.lower() in (p.lower() for p in installed):
+        if force_reinstall is False:
+            ret['result'] = True
+            ret['comment'] = 'Package already installed'
+            return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'NPM package {0} is set to be installed'.format(name)
+        return ret
+
+    try:
+        call = __salt__['npm.install'](
+            pkg=name,
+            dir=dir,
+            runas=runas
+        )
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
+        return ret
+
+    if call:
+        ret['result'] = True
+        version = call[0]['version']
+        pkg_name = call[0]['name']
+        ret['changes']["{0}@{1}".format(pkg_name, version)] = 'Installed'
+        ret['comment'] = 'Package was successfully installed'
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Could not install package'
+
+    return ret
+
+def removed(name,
+            dir=None,
+            runas=None,
+            **kwargs):
+    '''
+    Verify that the given package is not installed.
+
+    dir
+        The target directory in which to install the package, or None for
+        global installation
+
+    runas
+        The user to run NPM with
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    try:
+        installed = __salt__['npm.list'](dir=dir)
+    except (CommandExecutionError, CommandNotFoundError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)
+        return ret
+
+    if name not in installed:
+        ret["result"] = True
+        ret["comment"] = "Package is not installed."
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Package {0} is set to be removed'.format(name)
+        return ret
+
+    call = __salt__["npm.uninstall"](
+        pkg=name,
+        dir=dir,
+        runas=runas)
+
+    ret["result"] = True
+    ret["changes"][name] = "Removed"
+    ret["comment"] = "Package was successfully removed."
+
+    return ret


### PR DESCRIPTION
This pull request adds new states and modules that make it easier to manage NPM packages. This lets you do things in your SLS files like

```
coffee-script:
  npm.installed:
    - name: coffee-script
```
