### PR TITLE
Check version using correct user

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -253,7 +253,7 @@ def user_list(user=None, host=None, port=None, db=None, runas=None):
                   host=None,
                   port=None,
                   db=None,
-                  runas=None).split('.')
+                  runas=runas).split('.')
     if len(ver) >= 2 and ver[0] >= 9 and ver[1] >= 1:
         query = (
             'SELECT rolname, rolsuper, rolinherit, rolcreaterole, '


### PR DESCRIPTION
Version check fails if the correct user is not used (postgres on my system, the user root does not exist). By respecting the runas argument we avoid an error.
