### PR TITLE
Be more helpful when missing arguments.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -38,6 +38,8 @@ import salt.loader
 import salt.utils
 import salt.payload
 import salt.utils.schedule
+# TODO: should probably use _getargs() from salt.utils?
+from salt.state import _getargs
 from salt._compat import string_types
 from salt.utils.debug import enable_sigusr1_handler
 
@@ -424,6 +426,11 @@ class Minion(object):
                 ret['return'] = 'ERROR executing {0}: {1}'.format(
                     function_name, exc
                 )
+            except TypeError as exc:
+                aspec = _getargs(minion_instance.functions[data['fun']])
+                msg = 'Missing arguments executing "{0}": {1}'
+                log.warning(msg.format(function_name, aspec))
+                ret['return'] = msg.format(function_name, aspec)
             except Exception:
                 trb = traceback.format_exc()
                 msg = 'The minion function caused an exception: {0}'


### PR DESCRIPTION
BEFORE:

```
(code-salt)salt:~/code/salt # salt salt test.echo
salt:
    Traceback (most recent call last):
      File "/root/code/salt/salt/minion.py", line 411, in _thread_return
        ret['return'] = func(*args, **kwargs)
    TypeError: echo() takes exactly 1 argument (0 given)
```

AFTER:

```
(code-salt)salt:~/code/salt # salt salt test.echo
salt:
    Missing arguments executing "test.echo": ArgSpec(args=['text'], varargs=None, keywords=None, defaults=None)
```
