### PR TITLE
Ability to check which arguments is expected from an execution module.

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -6,6 +6,10 @@ minion.
 # Import python libs
 import logging
 
+# Import salt libs
+# TODO: should probably use _getargs() from salt.utils?
+from salt.state import _getargs
+
 log = logging.getLogger(__name__)
 
 
@@ -92,3 +96,43 @@ def reload_modules():
     # This is handled inside the minion.py file, the function is caught before
     # it ever gets here
     return True
+
+def argspec(module=''):
+    '''
+    Return the argument specification of functions in Salt execution
+    modules.
+
+    CLI Example::
+
+        salt '*' sys.argspec pkg.install
+        salt '*' sys.argspec sys
+        salt '*' sys.argspec
+    '''
+    ret = {}
+    # TODO: cp.get_file will also match cp.get_file_str. this is the
+    # same logic as sys.doc, and it is not working as expected, see
+    # issue #3614
+    if module:
+        # allow both "sys" and "sys." to match sys, without also matching
+        # sysctl
+        comps = module.split('.')
+        comps = filter(None, comps)
+        if len(comps) < 2:
+            module = module + '.' if not module.endswith('.') else module
+    for fun in __salt__:
+        if fun.startswith(module):
+            try:
+                aspec = _getargs(__salt__[fun])
+            except TypeError:
+                # this happens if not callable
+                continue
+            
+            args, varargs, kwargs, defaults = aspec
+            
+            ret[fun] = {}
+            ret[fun]['args'] = args if args else None
+            ret[fun]['defaults'] = defaults if defaults else None
+            ret[fun]['varargs'] = True if varargs else None
+            ret[fun]['kwargs'] = True if kwargs else None
+
+    return ret


### PR DESCRIPTION
The execution module sys.doc is great, but sometimes it is helpful to
see the full argument specification of a function.
