### PR TITLE
Travis failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,14 @@
 language: python
 
 python:
-  - '2.6'
   - '2.7'
 
 before_install:
+  - sudo add-apt-repository -y ppa:saltstack/salt
   - sudo apt-get update
-  - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig supervisor rabbitmq-server ruby
+  - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig supervisor rabbitmq-server ruby salt-common
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
-  - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://testpypi.python.org/pypi unittest2 ordereddict; fi"
+  - "for i in /usr/lib/python${TRAVIS_PYTHON_VERSION}/dist-packages/*; do ln -s $i /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/lib/python${TRAVIS_PYTHON_VERSION}/site-packages/ || true; done"
   - pip install mock --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi


### PR DESCRIPTION
The ZQM library doesn't seem to be installing correctly at the moment, with the result that the run_function() calls are all timing out and the build is exceeding its 50 minutes maximum.

Have made an alternate config that installs from ppa:saltstack/salt and then links them onto the virtualenv.  The downside is that it only works for 2.7, the plus side is it runs in less than 10 minutes.

See the build output at https://travis-ci.org/tf198/salt/builds/5303428 (its still failing but at least it is failing for the right reasons :-) ).

You can always go back to a proper PIP install later, but this might be a good quick fix before travis get annoyed at us for wasting machine time...
