### PR TITLE
Enable the usage of existing 'salt-call -m' option.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -32,6 +32,7 @@ def _create_loader(
     Creates Loader instance
 
     Order of module_dirs:
+        cli flag -m MODULE_DIRS
         opts[ext_type_dirs],
         extension types,
         base types.
@@ -49,7 +50,21 @@ def _create_loader(
         if ext_type_dirs in opts:
             ext_type_types.extend(opts[ext_type_dirs])
 
-    module_dirs = ext_type_types + [ext_types, sys_types]
+    cli_module_dirs = []
+    # The dirs can be any module dir, or a in-tree _{ext_type} dir
+    for _dir in opts.get('module_dirs', []):
+        # Prepend to the list to match cli argument ordering
+        maybe_dir = os.path.join(_dir, ext_type)
+        if (os.path.isdir(maybe_dir)):
+            cli_module_dirs.insert(0, maybe_dir)
+            continue
+
+        maybe_dir = os.path.join(_dir, '_{0}'.format(ext_type))
+        if (os.path.isdir(maybe_dir)):
+            cli_module_dirs.insert(0, maybe_dir)
+
+
+    module_dirs = cli_module_dirs + ext_type_types + [ext_types, sys_types]
     _generate_module('{0}.int'.format(LOADED_BASE_NAME))
     _generate_module('{0}.int.{1}'.format(LOADED_BASE_NAME, tag))
     _generate_module('{0}.ext'.format(LOADED_BASE_NAME))

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1139,10 +1139,9 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             # delimited format
             if ',' in module_dir:
                 self.config.setdefault('module_dirs', []).extend(
-                    module_dir.split(',')
-                )
+                    os.path.abspath(x) for x in module_dir.split(','))
                 continue
-            self.config.setdefault('module_dirs', []).append(module_dir)
+            self.config.setdefault('module_dirs', []).append(os.path.abspath(module_dir))
 
 
 class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,


### PR DESCRIPTION
Currently, the `-m` flag for salt-call has no effect in the loaders.
This commit allows users to specify exactly the module dirs to load
given that they follow the naming conventions for 'grains', 'runners',
'modules', 'states', etc. This is a shortcut for having to refresh cache
state when using a masterless salt-call.
