### PR TITLE
modules/useradd: Allow home dir creation for system users.

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -92,13 +92,15 @@ def add(name,
     if groups:
         cmd += '-G "{0}" '.format(','.join(groups))
     if home:
-        if home is not True:
-            if system:
-                cmd += '-d {0} '.format(home)
-            else:
+        if system:
+            if home is not True:
                 cmd += '-m -d {0} '.format(home)
+            else:
+                cmd += '-d {0} '.format(home)
         else:
-            if not system:
+            if home is not True:
+                cmd += '-m -d {0} '.format(home)
+            else:
                 cmd += '-m '
     if not unique:
         cmd += '-o '


### PR DESCRIPTION
If we create user with flag system=True then useradd utility will not
create user home directory even if it defined in login.defs.
This patch adds posibility to create explicitly set home directory (e.g system=/path/to/dir)
for system users.
