### PR TITLE
Listing grains and grain data

### DIFF
--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -30,6 +30,17 @@ Match all minions with 64-bit CPUs and return number of available cores::
 
     salt -G 'cpuarch:x86_64' grains.item num_cpus
 
+Listing Grains
+==============
+
+Available grains can be listed by using the 'grains.ls' module::
+
+    salt '*' grains.ls
+
+Grains data can be listed by using the 'grains.items' module::
+
+    salt '*' grains.ls
+
 Grains in the Minion Config
 ===========================
 


### PR DESCRIPTION
Grain module usage is documented elsewhere ( http://docs.saltstack.com/ref/modules/all/salt.modules.grains.html ), but I think it makes sense to show how to pull info about your grains in the overview.

Alternatively, link to that page above with a comment like "To get info on existing grains ... "
