### PR TITLE
Fix typo in grains.rst

### DIFF
--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -39,7 +39,7 @@ Available grains can be listed by using the 'grains.ls' module::
 
 Grains data can be listed by using the 'grains.items' module::
 
-    salt '*' grains.ls
+    salt '*' grains.items
 
 Grains in the Minion Config
 ===========================


### PR DESCRIPTION
Nuts, just after Thomas merged my change in I notice a typo (grains.items instead of grains.ls). Fixed!
