### PR TITLE
fixed module network.traceroute

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -436,8 +436,6 @@ def netstat():
     return ret
 
 
-# FIXME: This is broken on: Modern traceroute for Linux, version 2.0.14, May 10 2010 (Ubuntu 10.10)
-# FIXME: traceroute is deprecated, make this fall back to tracepath
 def traceroute(host):
     '''
     Performs a traceroute to a 3rd party host
@@ -449,24 +447,47 @@ def traceroute(host):
     ret = []
     cmd = 'traceroute {0}'.format(salt.utils.socket_util.sanitize_host(host))
     out = __salt__['cmd.run'](cmd)
+    
+    # Parse version of traceroute
+    cmd2 = 'traceroute --version'
+    out2 = __salt__['cmd.run'](cmd2)
+    traceroute_version = re.findall(r'(?d+)', out2)[0:3] # FIXME: iprove regexp
 
-    for line in out:
+    for line in out.splitlines():
         if not ' ' in line:
             continue
         if line.startswith('traceroute'):
             continue
-        comps = line.split()
-        result = {
-            'count': comps[0],
-            'hostname': comps[1],
-            'ip': comps[2],
-            'ms1': comps[4],
-            'ms2': comps[6],
-            'ms3': comps[8],
-            'ping1': comps[3],
-            'ping2': comps[5],
-            'ping3': comps[7]}
+        comps = line.split('  ')
+
+        if (traceroute_version[0] >= 2 and traceroute_version[2] >= 14
+        or traceroute_version[0] >= 2 and traceroute_version[1] > 0):
+            if comps[1] == '* * *':
+                result = {
+                    'count': int(comps[0]),
+                    'hostname': '*'}
+            else:
+                result = {
+                    'count': int(comps[0]),
+                    'hostname': comps[1].split()[0],
+                    'ip': comps[1].split()[1].strip('()'),
+                    'ms1': float(comps[2].split()[0]),
+                    'ms2': float(comps[3].split()[0]),
+                    'ms3': float(comps[4].split()[0])}
+        else:
+            result = {
+                'count': comps[0],
+                'hostname': comps[1],
+                'ip': comps[2],
+                'ms1': comps[4],
+                'ms2': comps[6],
+                'ms3': comps[8],
+                'ping1': comps[3],
+                'ping2': comps[5],
+                'ping3': comps[7]}
+
         ret.append(result)
+
     return ret
 
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -458,10 +458,10 @@ def traceroute(host):
             continue
         if line.startswith('traceroute'):
             continue
-        comps = line.split('  ')
 
         if (traceroute_version[0] >= 2 and traceroute_version[2] >= 14
         or traceroute_version[0] >= 2 and traceroute_version[1] > 0):
+            comps = line.split('  ')
             if comps[1] == '* * *':
                 result = {
                     'count': int(comps[0]),
@@ -475,6 +475,7 @@ def traceroute(host):
                     'ms2': float(comps[3].split()[0]),
                     'ms3': float(comps[4].split()[0])}
         else:
+            comps = line.split()
             result = {
                 'count': comps[0],
                 'hostname': comps[1],


### PR DESCRIPTION
network.traceroute is not longer broken on: Modern traceroute for Linux, version 2.0.14.

I've tested this fix with: Modern traceroute for Linux, version 2.0.19, Jan  8 2013 on archLinux.

I'm not good with regexp. Can someone suggest a better one to parse the version number? That would be very helpful.
