### PR TITLE
Regex fixes for file.uncomment state, Fixes #4003

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -529,8 +529,7 @@ def uncomment(path, regex, char='#', backup='.bak'):
         character will be stripped for convenience (for easily switching
         between comment() and uncomment()).
     char : ``#``
-        The character to remove in order to uncomment a line; if a single
-        whitespace character follows the comment it will also be removed
+        The character to remove in order to uncomment a line
     backup : ``.bak``
         The file will be backed up before edit with this file extension;
         **WARNING:** each time ``sed``/``comment``/``uncomment`` is called will
@@ -545,7 +544,7 @@ def uncomment(path, regex, char='#', backup='.bak'):
     # Largely inspired by Fabric's contrib.files.uncomment()
 
     return __salt__['file.sed'](path,
-        before=r'^([[:space:]]*){0}[[:space:]]?'.format(char),
+        before=r'^([[:space:]]*){0}'.format(char),
         after=r'\1',
         limit=regex.lstrip('^'),
         backup=backup)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1415,7 +1415,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         character will be stripped for convenience (for easily switching
         between comment() and uncomment()).  The regex will be searched for
         from the beginning of the line, ignoring leading spaces (we prepend
-        '^[ ]*')
+        '^[ \\t]*')
     char : ``#``
         The character to remove in order to uncomment a line; if a single
         whitespace character follows the comment it will also be removed
@@ -1439,7 +1439,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         return _error(ret, check_msg)
 
     # Make sure the pattern appears in the file
-    if __salt__['file.contains_regex'](name, '^[ ]*' + regex.lstrip('^')):
+    if __salt__['file.contains_regex'](name, '^[ \t]*' + regex.lstrip('^')):
         ret['comment'] = 'Pattern already uncommented'
         ret['result'] = True
         return ret
@@ -1465,7 +1465,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
 
     # Check the result
     ret['result'] = \
-        __salt__['file.contains_regex'](name, '^[ ]*' + regex.lstrip('^'))
+        __salt__['file.contains_regex'](name, '^[ \t]*' + regex.lstrip('^'))
 
     if slines != nlines:
         # Changes happened, add them

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1437,7 +1437,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         return _error(ret, check_msg)
 
     # Make sure the pattern appears in the file
-    if __salt__['file.contains_regex'](name, regex):
+    if __salt__['file.contains_regex'](name, '^[ ]*' + regex.lstrip('^')):
         ret['comment'] = 'Pattern already uncommented'
         ret['result'] = True
         return ret
@@ -1462,7 +1462,8 @@ def uncomment(name, regex, char='#', backup='.bak'):
         nlines = fp_.readlines()
 
     # Check the result
-    ret['result'] = __salt__['file.contains_regex'](name, regex)
+    ret['result'] = \
+        __salt__['file.contains_regex'](name, '^[ ]*' + regex.lstrip('^'))
 
     if slines != nlines:
         # Changes happened, add them

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1417,8 +1417,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         from the beginning of the line, ignoring leading spaces (we prepend
         '^[ \\t]*')
     char : ``#``
-        The character to remove in order to uncomment a line; if a single
-        whitespace character follows the comment it will also be removed
+        The character to remove in order to uncomment a line
     backup : ``.bak``
         The file will be backed up before edit with this file extension;
         **WARNING:** each time ``sed``/``comment``/``uncomment`` is called will
@@ -1443,7 +1442,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         ret['comment'] = 'Pattern already uncommented'
         ret['result'] = True
         return ret
-    elif __salt__['file.contains_regex'](name, char + '[ ]?' + regex):
+    elif __salt__['file.contains_regex'](name, char + '[ \t]*' + regex):
         # Line exists and is commented
         pass
     else:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1441,7 +1441,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
         ret['comment'] = 'Pattern already uncommented'
         ret['result'] = True
         return ret
-    elif __salt__['file.contains_regex'](name, regex, lchar=char):
+    elif __salt__['file.contains_regex'](name, char + '[ ]?' + regex):
         # Line exists and is commented
         pass
     else:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1413,7 +1413,9 @@ def uncomment(name, regex, char='#', backup='.bak'):
         A regular expression used to find the lines that are to be uncommented.
         This regex should not include the comment character. A leading ``^``
         character will be stripped for convenience (for easily switching
-        between comment() and uncomment()).
+        between comment() and uncomment()).  The regex will be searched for
+        from the beginning of the line, ignoring leading spaces (we prepend
+        '^[ ]*')
     char : ``#``
         The character to remove in order to uncomment a line; if a single
         whitespace character follows the comment it will also be removed


### PR DESCRIPTION
Fixes #4003

Initial check for the regex doesn't anchor to beginning of line or check for lack of comment character.
