### PR TITLE
lower logging level that informs the user that debconf-utils is absent

### DIFF
--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -22,7 +22,7 @@ def __virtual__():
         return False
 
     if salt.utils.which('debconf-get-selections') is None:
-        log.warning('Package debconf-utils is not installed.')
+        log.info('Package debconf-utils is not installed.')
         return False
 
     return 'debconf'


### PR DESCRIPTION
This is supposed to close issue #4016, or at least encourage discussion on how to handle this.
