### PR TITLE
Fixing Salt Runners documentation

### DIFF
--- a/doc/ref/runners/index.rst
+++ b/doc/ref/runners/index.rst
@@ -46,7 +46,7 @@ responding to Salt calls would look like this:
         '''
         Print a list of all of the minions that are up
         '''
-        client = salt.client.LocalClient(__opts__['config'])
+        client = salt.client.LocalClient(__opts__['conf_file'])
         minions = client.cmd('*', 'test.ping', timeout=1)
         for minion in sorted(minions):
             print minion


### PR DESCRIPTION
Changing `__opts__['config']` to `__opts__['conf_file']` to fix issue #4018.
