### PR TITLE
Try to handle `SIGCHLD` as best as we can under python 2.6. Fixes #4008.

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -9,7 +9,6 @@ import hashlib
 import os
 import shutil
 import string
-import subprocess
 
 # Import third party libs
 import yaml
@@ -24,6 +23,7 @@ import salt.payload
 import salt.utils
 import salt.utils.templates
 import salt.utils.gzip_util
+from salt.utils.process import subprocess
 from salt._compat import (
     URLError, HTTPError, BaseHTTPServer, urlparse, url_open)
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -18,7 +18,6 @@ import datetime
 import pwd
 import getpass
 import resource
-import subprocess
 import multiprocessing
 import sys
 
@@ -47,6 +46,7 @@ import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
 from salt.utils.debug import enable_sigusr1_handler
+from salt.utils.process import subprocess
 from salt.exceptions import SaltMasterError
 
 log = logging.getLogger(__name__)

--- a/salt/master.py
+++ b/salt/master.py
@@ -18,7 +18,6 @@ import datetime
 import pwd
 import getpass
 import resource
-import multiprocessing
 import sys
 
 # Import third party libs
@@ -45,6 +44,7 @@ import salt.utils.event
 import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
+from salt.utils import multiprocess as multiprocessing
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.process import subprocess
 from salt.exceptions import SaltMasterError

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -6,7 +6,6 @@ Routines to set up a minion
 # Import python libs
 import logging
 import getpass
-import multiprocessing
 import fnmatch
 import os
 import hashlib
@@ -42,6 +41,7 @@ import salt.utils.schedule
 # TODO: should probably use _getargs() from salt.utils?
 from salt.state import _getargs
 from salt._compat import string_types
+from salt.utils import multiprocess as multiprocessing
 from salt.utils.debug import enable_sigusr1_handler
 
 log = logging.getLogger(__name__)

--- a/salt/modules/butterkvm.py
+++ b/salt/modules/butterkvm.py
@@ -6,8 +6,10 @@ Specialized routines used by the butter cloud component
 import copy
 import os
 import shutil
-import subprocess
 import tempfile
+
+# Import salt libs
+from salt.utils.process import subprocess
 
 
 def _place_image(image, vda):

--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -14,7 +14,6 @@ import logging
 import os
 import shutil
 import string
-import subprocess
 from xml.dom import minidom
 
 # Import third party libs
@@ -28,6 +27,7 @@ except ImportError:
 # Import salt libs
 import salt.utils
 from salt._compat import StringIO
+from salt.utils.process import subprocess
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -5,10 +5,10 @@ Subversion SCM
 # Import python libs
 import re
 import shlex
-import subprocess
 
 # Import salt libs
 from salt import utils, exceptions
+from salt.utils.process import subprocess
 
 _INI_RE = re.compile(r"^([^:]+):\s+(\S.*)$", re.M)
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -10,7 +10,6 @@ Work with virtual machines managed by libvirt
 import os
 import re
 import shutil
-import subprocess
 from xml.dom import minidom
 
 # Import third party libs
@@ -25,6 +24,7 @@ import yaml
 import salt.utils
 from salt._compat import StringIO as _StringIO
 from salt.exceptions import CommandExecutionError
+from salt.utils.process import subprocess
 
 
 VIRT_STATE_NAME_MAP = {0: 'running',

--- a/salt/pillar/libvirt.py
+++ b/salt/pillar/libvirt.py
@@ -5,7 +5,9 @@ been generated using the libvirt key runner.
 
 # Import python libs
 import os
-import subprocess
+
+# Import salt libs
+from salt.utils.process import subprocess
 
 
 def ext_pillar(pillar, command):

--- a/salt/tops/ext_nodes.py
+++ b/salt/tops/ext_nodes.py
@@ -19,11 +19,11 @@ sent from the ``cobbler-ext-nodes`` command, but converts the data into
 information that is used by a Salt top file.
 '''
 
-# Import python libs
-import subprocess
-
 # Import third party libs
 import yaml
+
+# Import salt libs
+from salt.utils.process import subprocess
 
 
 def __virtual__():
@@ -64,4 +64,4 @@ def top(**kwargs):
             ret[env] = ndata['classes']
         else:
             return ret
-    return ret 
+    return ret

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -19,7 +19,6 @@ import hashlib
 import datetime
 import platform
 import tempfile
-import subprocess
 import zmq
 from calendar import month_abbr as months
 
@@ -33,8 +32,9 @@ except ImportError:
 # Import salt libs
 import salt.minion
 import salt.payload
+from salt.utils.process import subprocess
 from salt.exceptions import (
-        SaltClientError, CommandNotFoundError, SaltSystemExit
+    SaltClientError, CommandNotFoundError, SaltSystemExit
 )
 
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -19,8 +19,6 @@ import glob
 import hashlib
 import errno
 import logging
-import multiprocessing
-from multiprocessing import Process
 
 # Import third party libs
 import zmq
@@ -32,6 +30,8 @@ import salt.loader
 import salt.state
 import salt.utils
 from salt._compat import string_types
+from salt.utils import multiprocess as multiprocessing
+
 log = logging.getLogger(__name__)
 
 
@@ -218,7 +218,7 @@ class MinionEvent(SaltEvent):
         super(MinionEvent, self).__init__('minion', **kwargs)
 
 
-class EventPublisher(Process):
+class EventPublisher(multiprocessing.Process):
     '''
     The interface that takes master events and republishes them out to anyone
     who wants to listen

--- a/salt/utils/multiprocess.py
+++ b/salt/utils/multiprocess.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.utils.multiprocess
+    ~~~~~~~~~~~~~~~~~~~~~~~
+
+    Work around some known bugs of python's multiprocessing module under 2.6
+
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+'''
+
+# Import python libs
+import os
+import sys
+import errno
+from multiprocessing import active_children, Process
+
+
+if sys.version_info < (2, 7):
+    # Until salt supports python 2.6 we need to work around some know bugs of
+    # the multiprocessing module. For additional information, see:
+    #   http://bugs.python.org/issue1731717
+
+    from multiprocessing.forking import Popen as _Popen
+
+    class Popen(_Popen):
+        # Let's patch the offending code using the fix provided on python's
+        # source code repository
+        def poll(self, flag=os.WNOHANG):
+            if self.returncode is None:
+                while True:
+                    try:
+                        pid, sts = os.waitpid(self.pid, flag)
+                    except OSError as e:
+                        if e.errno == errno.EINTR:
+                            continue
+                        # Child process not yet created. See #1731717
+                        # e.errno == errno.ECHILD == 10
+                        return None
+                    else:
+                        break
+                if pid == self.pid:
+                    if os.WIFSIGNALED(sts):
+                        self.returncode = -os.WTERMSIG(sts)
+                    else:
+                        assert os.WIFEXITED(sts)
+                        self.returncode = os.WEXITSTATUS(sts)
+            return self.returncode
+
+    Process._Popen = Popen

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -8,6 +8,25 @@ import sys
 # Import salt libs
 import salt.utils
 
+
+# Handle subprocess compatibility until python 2.6 is dropped
+SAFELY_HANDLE_SIGCHLD = True
+if sys.version_info < (2, 7):
+    try:
+        # We try to import subprocess32 because of a know bug in python 2.6
+        # which won't allow us to properly and safely cleanup subprocess
+        # children.
+        # For additional information, see:
+        #   https://github.com/saltstack/salt/issues/4008
+        #   http://bugs.python.org/issue9127
+        #   http://bugs.python.org/issue1731717
+        import subprocess32 as subprocess
+    except ImportError:
+        SAFELY_HANDLE_SIGCHLD = False
+        import subprocess
+else:
+    import subprocess
+
 log = logging.getLogger(__name__)
 
 

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -14,21 +14,23 @@ code-block:: yaml
         kwargs:
           test: True
 
-This will schedule the command: state.sls httpd test=True every 3600 seconds 
+This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour)
 '''
 
 # Import python libs
 import time
 import datetime
-import multiprocessing
 import threading
 import sys
+
+# Import salt libs
+from salt.utils import multiprocess as multiprocessing
 
 
 class Schedule(object):
     '''
-    Create a Schedule object, pass in the opts and the functions dict to use 
+    Create a Schedule object, pass in the opts and the functions dict to use
     '''
     def __init__(self, opts, functions, returners=None, intervals=None):
         self.opts = opts

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -4,16 +4,13 @@ Set up the Salt integration test suite
 
 # Import Python libs
 import optparse
-import multiprocessing
 import os
 import sys
 import shutil
 import tempfile
 import time
 import signal
-import subprocess
 from hashlib import md5
-from subprocess import PIPE, Popen
 from datetime import datetime, timedelta
 try:
     import pwd
@@ -29,6 +26,8 @@ import salt.runner
 import salt.output
 from salt.utils import fopen, get_colors
 from salt.utils.verify import verify_env
+from salt.utils import multiprocess as multiprocessing
+from salt.utils.process import subprocess
 from saltunittest import TestCase, RedirectStdStreams
 
 try:
@@ -273,7 +272,6 @@ class TestDaemon(object):
             print_header(
                 '~~~~~~~ Minion Grains Information ', inline=True,
             )
-
 
         print_header('', sep='=', inline=True)
 
@@ -686,11 +684,11 @@ class ShellCase(TestCase):
 
         popen_kwargs = {
             'shell': True,
-            'stdout': PIPE
+            'stdout': subprocess.PIPE
         }
 
         if catch_stderr is True:
-            popen_kwargs['stderr'] = PIPE
+            popen_kwargs['stderr'] = subprocess.PIPE
 
         if not sys.platform.lower().startswith('win'):
             popen_kwargs['close_fds'] = True
@@ -704,7 +702,7 @@ class ShellCase(TestCase):
         elif sys.platform.lower().startswith('win') and timeout is not None:
             raise RuntimeError('Timeout is not supported under windows')
 
-        process = Popen(cmd, **popen_kwargs)
+        process = subprocess.Popen(cmd, **popen_kwargs)
 
         if timeout is not None:
             stop_at = datetime.now() + timedelta(seconds=timeout)


### PR DESCRIPTION
- We do some try/except "magic" to see if we import a safe `subprocess` module on `salt.utils.process`.
- If we're running under python 2.6, we try to import `subprocess32` which properly handles our problem.
- If the above step fails, we import the build-in `subprocess` module.
- We also define `SAFELY_HANDLE_SIGCHLD` on `salt.utils.process` so we can know if we need to reset the `SIGCHLD` handler on `salt.modules.cmdmod` so the know bug is not triggered, again, under python 2.6

For some additional info, see:
- #4008
- http://bugs.python.org/issue912
- http://bugs.python.org/issue1731717
