### PR TITLE
add kwargs to available_version

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -60,7 +60,7 @@ def version(*names):
         return ret
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -59,7 +59,7 @@ def _cpv_to_version(cpv):
     return str(cpv[len(_cpv_to_name(cpv) + '-'):])
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -48,7 +48,7 @@ def search(pkg_name):
         return {"Results": res}
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -75,7 +75,7 @@ def list_pkgs():
     return _format_pkgs(_get_pkgs())
 
 
-def available_version(name):
+def available_version(name, **kwargs):
     '''
     The available version of the package in the repository
 
@@ -156,7 +156,6 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
 
     # New way
     return __salt__['pkg_resource.find_changes'](_format_pkgs(old), new)
-
 
 
 def remove(name, **kwargs):

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -28,7 +28,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -56,7 +56,7 @@ def version():
     return __salt__['cmd.run'](cmd)
 
 
-def available_version(pkg_name):
+def available_version(pkg_name, **kwargs):
     '''
     The available version of the package in the repository
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -158,7 +158,7 @@ def version(name):
     return ''
 
 
-def available_version(name):
+def available_version(name, **kwargs):
     '''
     The available version of the package in the repository
 

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -94,7 +94,7 @@ def list_pkgs():
     return pkg
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -47,7 +47,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -79,7 +79,7 @@ def available_version(*names):
             ret[name] = ''
             if name in pkgs:
                 version = pkgs[name]
-            if __salt__['pkg_resource.perform_cmp'](str(candidate), 
+            if __salt__['pkg_resource.perform_cmp'](str(candidate),
                                                     str(version)) > 0:
                 ret[name] = candidate
             continue
@@ -90,7 +90,7 @@ def available_version(*names):
         ret[name] = ''
         if name in pkgs:
             version = pkgs[name]
-        if __salt__['pkg_resource.perform_cmp'](str(candidate), 
+        if __salt__['pkg_resource.perform_cmp'](str(candidate),
                                                 str(version)) > 0:
             ret[name] = candidate
     return ret

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -66,7 +66,7 @@ def list_upgrades(refresh=True):
 list_updates = list_upgrades
 
 
-def available_version(*names):
+def available_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of


### PR DESCRIPTION
This will avoid tracebacks once #3687 is implemented
