### PR TITLE
modules.pacman - pacman -Syu is the wrong way to install a package imho

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -271,7 +271,7 @@ def install(name=None,
 
         # Catch both boolean input from state and string input from CLI
         if refresh is True or str(refresh).lower() == 'true':
-            cmd = 'pacman -Syu --noprogressbar --noconfirm ' \
+            cmd = 'pacman -Sy --noprogressbar --noconfirm ' \
                   '"{0}"'.format('" "'.join(targets))
         else:
             cmd = 'pacman -S --noprogressbar --noconfirm ' \


### PR DESCRIPTION
I think I've found a bug in modules.pacman but I'm not sure.

pacman -Syu is the wrong way to install a package imho. pacman -Sy should be used instead.

I've discussed with cedwards and UtahDave in #salt on irc.freenode.net about this issue.
