### PR TITLE
Fix environment test

### DIFF
--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,2 @@
-flexmock==0.9.6
+mock
+unittest2

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -2,7 +2,7 @@ import os
 import integration
 import tempfile
 
-from flexmock import flexmock
+from mock import Mock, patch
 
 
 class CMDModuleTest(integration.ModuleCase):
@@ -20,44 +20,38 @@ class CMDModuleTest(integration.ModuleCase):
                     ['echo $SHELL', 'shell={0}'.format(shell)]).rstrip(),
                 shell)
 
-    def test_os_environment_remains_intact(self):
+    @patch('pwd.getpwnam')
+    @patch('subprocess.Popen')
+    @patch('json.loads')
+    def test_os_environment_remains_intact(self, *mocks):
         '''
         make sure the OS environment is not tainted after running a command that specifies runas.
         '''
-        import json
-        import pwd
-        import subprocess
-
         environment = os.environ.copy()
+	loads_mock, popen_mock, getpwnam_mock = mocks
 
-        (flexmock(pwd)
-                .should_receive('getpwnam')
-                .once())
+        popen_mock.return_value = Mock(
+            communicate=lambda *args, **kwags: ['hi', None],
+            pid=lambda: 1,
+            retcode=0
+        )
 
-        (flexmock(subprocess)
-                .should_receive('Popen')
-                .replace_with(lambda *args, **kwargs: flexmock(
-                    communicate=lambda *args, **kwags: [None, None],
-                    pid=lambda: 1,
-                    returncode=0))
-                .twice())
-
-        (flexmock(json)
-                .should_receive('loads')
-                .replace_with(lambda *args, **kwargs: {'data': {}})
-                .once())
+        loads_mock.return_value = {'data': {'USER': 'foo'}}
 
         from salt.modules import cmdmod
 
-        # inject grains via flexmock so cmdmod isn't tainted
-        cmdmod_mock = flexmock(cmdmod)
-        cmdmod_mock.__grains__ = { 'os': 'darwin' }
-
-        ret = cmdmod._run('ls', cwd=tempfile.gettempdir(), runas='foobar', shell='/bin/bash')
-
-        environment2 = os.environ.copy()
-
-        self.assertEquals(environment, environment2)
+	cmdmod.__grains__ = {'os': 'darwin'}
+	try:
+            ret = cmdmod._run('ls', cwd=tempfile.gettempdir(), runas='foobar', shell='/bin/bash')
+    
+            environment2 = os.environ.copy()
+    
+            self.assertEquals(environment, environment2)
+    
+            getpwnam_mock.assert_called_with('foobar')
+            loads_mock.assert_called_with('hi')
+        finally:
+            delattr(cmdmod, '__grains__')
 
     def test_stdout(self):
         '''


### PR DESCRIPTION
Updated environment test to use `mock` instead of `flexmock`.  Also, set development requirements in `dev_requirements.txt`
