### PR TITLE
Update hacking

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -80,9 +80,66 @@ Clone the repository using::
 
         git fetch --tags
 
-    Fetching tags is done with the git 'fetch' utility::
+Preparing your system
+~~~~~~~~~~~~~~~~~~~~~
 
-        git fetch --tags upstream
+In order to install Salt's requirements, you'll need a system with a compiler
+and Python's development libraries.
+
+Debian-based systems
+````````````````````
+
+On Debian and derivative systems such as Ubuntu, system requirements can be
+installed by running::
+
+    apt-get install -y build-essential libssl-dev python-dev python-m2crypto
+    python-pip python-virtualenv swig virtualenvwrapper
+
+RedHat-based systems
+````````````````````
+
+If you are developing on a RedHat variant, be advised that the package provider
+for newer Redhat-based systems (:doc:`yumpkg.py
+<../ref/modules/all/salt.modules.yumpkg>`) relies on RedHat's python interface
+for yum. The variants that use this module to provide package support include
+the following:
+
+  * `RHEL`_ and `CentOS`_ releases 6 and later
+  * `Fedora Linux`_ releases 11 and later
+  * `Amazon Linux`_
+
+If you are developing using one of these releases, you will want to create your
+virtualenv using the ``--system-site-packages`` option so that these modules
+are available in the virtualenv.
+
+M2Crypto also supplies a fedora_setup.sh script you may use as well if you get
+the following error::
+
+    This openssl-devel package does not work your architecture?. Use the -cpperraswarn option to continue swig processing.
+
+You can use it doing the following::
+
+    cd <path-to-your-venv>/build/M2Crypto
+    chmod u+x fedora_setup.sh
+    ./fedora_setup.sh build
+    ./fedora_setup.sh install
+
+.. _`RHEL`: https://www.redhat.com/products/enterprise-linux/
+.. _`CentOS`: http://centos.org/
+.. _`Fedora Linux`: http://fedoraproject.org/
+.. _`Amazon Linux`: https://aws.amazon.com/amazon-linux-ami/
+
+Installing dependencies on OS X
+```````````````````````````````
+
+One simple way to get all needed dependencies on OS X is to use homebrew,
+and install the following packages::
+
+    brew install swig
+    brew install zmq
+
+Afterward the pip commands should run without a hitch. Also be sure to set
+max_open_files to 2048 (see below).
 
 Create a new `virtualenv`_::
 
@@ -92,6 +149,12 @@ Create a new `virtualenv`_::
 
 On Arch Linux, where Python 3 is the default installation of Python, use the
 ``virtualenv2`` command instead of ``virtualenv``.
+
+Debian, Ubuntu, and the RedHat systems mentioned above, you should use
+``--system-site-packages`` when creating the virtualenv, to pull in the
+M2Crypto installed using apt::
+
+    virtualenv --system-site-packages /path/to/your/virtualenv
 
 .. note:: Using your system Python modules in the virtualenv
 
@@ -109,9 +172,9 @@ Activate the virtualenv::
 
 Install Salt (and dependencies) into the virtualenv::
 
-    pip install M2Crypto    # Don't install on Debian/Ubuntu (see below)
-    pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil
-    pip install -e ./salt   # the path to the salt git clone from above (or . if you're already in that directory)
+    pip install -r requirements.txt
+    pip install psutil
+    pip install -e .
 
 .. note:: Installing M2Crypto
 
@@ -121,60 +184,6 @@ Install Salt (and dependencies) into the virtualenv::
 
         env SWIG_FEATURES="-cpperraswarn -includeall -D__`uname -m`__ -I/usr/include/openssl" pip install M2Crypto
 
-    Debian and Ubuntu systems have modified openssl libraries and mandate that
-    a patched version of M2Crypto be installed. This means that M2Crypto
-    needs to be installed via apt:
-
-        apt-get install python-m2crypto
-
-    This also means that you should use ``--system-site-packages`` when
-    creating the virtualenv, to pull in the M2Crypto installed using apt.
-
-
-.. note:: Important note for those developing using RedHat variants
-
-    If you are developing on a RedHat variant, be advised that the package
-    provider for newer Redhat-based systems (:doc:`yumpkg.py
-    <../ref/modules/all/salt.modules.yumpkg>`) relies on RedHat's python
-    interface for yum. The variants that use this module to provide package
-    support include the following:
-
-    * `RHEL`_ and `CentOS`_ releases 6 and later
-    * `Fedora Linux`_ releases 11 and later
-    * `Amazon Linux`_
-
-    If you are developing using one of these releases, you will want to create
-    your virtualenv using the ``--system-site-packages`` option so that these
-    modules are available in the virtualenv.
-
-    M2Crypto also supplies a fedora_setup.sh script you may use as well if you
-    get the following error:
-
-        This openssl-devel package does not work your architecture?. Use the -cpperraswarn option to continue swig processing.
-
-    You can use it doing the following:
-
-        cd <path-to-your-venv>/build/M2Crypto
-        chmod u+x fedora_setup.sh
-        ./fedora_setup.sh build
-        ./fedora_setup.sh install
-
-
-.. _`RHEL`: https://www.redhat.com/products/enterprise-linux/
-.. _`CentOS`: http://centos.org/
-.. _`Fedora Linux`: http://fedoraproject.org/
-.. _`Amazon Linux`: https://aws.amazon.com/amazon-linux-ami/
-
-.. note:: Installing dependencies on OS X.
-
-One simple way to get all needed dependencies on OS X is to use homebrew,
-and install the following packages::
-
-    brew install swig
-    brew install zmq
-
-Afterward the pip commands should run without a hitch. Also be sure to set
-max_open_files to 2048 (see below).
 
 Running a self-contained development version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -282,13 +282,9 @@ If it is less than 2047, you should increase it with::
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
-You will need ``mock`` to run the tests::
+For running tests, you'll also need to install ``dev_requirements.txt``::
 
-    pip install mock
-
-If you are on Python < 2.7 then you will also need unittest2::
-
-    pip install unittest2
+    pip install -r dev_requirements.txt
 
 Finally you use setup.py to run the tests with the following command::
 

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -69,15 +69,16 @@ Installing Salt for development
 Clone the repository using::
 
     git clone https://github.com/saltstack/salt
+    cd salt
 
 .. note:: tags
 
     Just cloning the repository is enough to work with Salt and make
     contributions. However, you must fetch additional tags into your clone to
-    have Salt report the correct version for itself. To do this you must first
-    add the git repository as an upstream source.::
+    have Salt report the correct version for itself. To do this, fetch the tags
+    with the command::
 
-        git remote add upstream http://github.com/saltstack/salt
+        git fetch --tags
 
     Fetching tags is done with the git 'fetch' utility::
 

--- a/HACKING.rst
+++ b/HACKING.rst
@@ -141,6 +141,9 @@ and install the following packages::
 Afterward the pip commands should run without a hitch. Also be sure to set
 max_open_files to 2048 (see below).
 
+Create a virtual environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Create a new `virtualenv`_::
 
     virtualenv /path/to/your/virtualenv
@@ -165,6 +168,9 @@ M2Crypto installed using apt::
     the pip command below that installs the dependencies (pyzmq, M2Crypto,
     etc.), assuming that the listed modules are all installed in your system
     PYTHONPATH at the time you create your virtualenv.
+
+Configure your virtual environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Activate the virtualenv::
 


### PR DESCRIPTION
Attempt to clean up hacking docs.  Reordered documentation, added some instructions specific to Debian/Ubuntu, and updated docs to use `requirements.txt` files.

I noticed that `psutil` is not in `requirements.txt`.  Is this a development requirement or is it not needed at all?
