### PR TITLE
Don't yaml-ify args with newlines

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -397,7 +397,8 @@ class Minion(object):
         ret = {}
         for ind in range(0, len(data['arg'])):
             try:
-                arg = yaml.safe_load(data['arg'][ind])
+                if '\n' not in data['arg'][ind]:
+                    arg = yaml.safe_load(data['arg'][ind])
                 if isinstance(arg, bool):
                     data['arg'][ind] = str(data['arg'][ind])
                 elif isinstance(arg, (dict, int, list, string_types)):
@@ -477,7 +478,8 @@ class Minion(object):
         for ind in range(0, len(data['fun'])):
             for index in range(0, len(data['arg'][ind])):
                 try:
-                    arg = yaml.safe_load(data['arg'][ind][index])
+                    if '\n' not in data['arg'][ind]:
+                        arg = yaml.safe_load(data['arg'][ind][index])
                     if isinstance(arg, bool):
                         data['arg'][ind][index] = str(data['arg'][ind][index])
                     elif isinstance(arg, (dict, int, list, string_types)):


### PR DESCRIPTION
We replaced the eval() with yaml calls, which parse args that shouldn't be parsed.  However, that made it so we parsed arguments that were template strings.  So if there's a newline in the arg, don't parse it.
