### PR TITLE
postgres.pass setting enabled and some bug fixes for salt.module.postgres

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -19152,7 +19152,7 @@ overwrite options passed into pillar
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.db_create(name, user=None, host=None, port=None, tablespace=None, encoding=None, locale=None, lc_collate=None, lc_ctype=None, owner=None, template=None, runas=None)
+.B salt.modules.postgres.db_create(name, user=None, host=None, port=None, db=None, password=None, tablespace=None, encoding=None, locale=None, lc_collate=None, lc_ctype=None, owner=None, template=None, runas=None)
 Adds a databases to the Postgres server.
 .sp
 CLI Example:
@@ -19167,7 +19167,7 @@ salt \(aq*\(aq postgres.db_create \(aqdbname\(aq template=template_postgis
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.db_exists(name, user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.db_exists(name, user=None, host=None, port=None, db=None, password=None, runas=None)
 Checks if a database exists on the Postgres server.
 .sp
 CLI Example:
@@ -19180,7 +19180,7 @@ salt \(aq*\(aq postgres.db_exists \(aqdbname\(aq
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.db_list(user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.db_list(user=None, host=None, port=None, db=None, password=None, runas=None)
 Return a list of databases of a Postgres server using the output
 from the \fBpsql \-l\fP query.
 .sp
@@ -19194,7 +19194,7 @@ salt \(aq*\(aq postgres.db_list
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.db_remove(name, user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.db_remove(name, user=None, host=None, port=None, db=None, password=None, runas=None)
 Removes a databases from the Postgres server.
 .sp
 CLI Example:
@@ -19207,7 +19207,7 @@ salt \(aq*\(aq postgres.db_remove \(aqdbname\(aq
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.group_create(groupname, user=None, host=None, port=None, createdb=False, createuser=False, encrypted=False, superuser=False, replication=False, password=None, groups=None, runas=None)
+.B salt.modules.postgres.group_create(groupname, user=None, host=None, port=None, db=None, password=None, createdb=False, createuser=False, encrypted=False, superuser=False, replication=False, rolepassword=None, groups=None, runas=None)
 Creates a Postgres group. A group is postgres is similar to a user, but
 cannot login.
 .sp
@@ -19215,13 +19215,13 @@ CLI Example:
 .sp
 .nf
 .ft C
-salt \(aq*\(aq postgres.group_create \(aqgroupname\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq password=\(aqpassword\(aq
+salt \(aq*\(aq postgres.group_create \(aqgroupname\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq rolepassword=\(aqpassword\(aq
 .ft P
 .fi
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.group_remove(groupname, user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.group_remove(groupname, user=None, host=None, port=None, db=None, password=None, runas=None)
 Removes a group from the Postgres server.
 .sp
 CLI Example:
@@ -19234,33 +19234,33 @@ salt \(aq*\(aq postgres.group_remove \(aqgroupname\(aq
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.group_update(groupname, user=None, host=None, port=None, createdb=False, createuser=False, encrypted=False, replication=False, password=None, groups=None, runas=None)
+.B salt.modules.postgres.group_update(groupname, user=None, host=None, port=None, db=None, password=None, createdb=False, createuser=False, encrypted=False, replication=False, rolepassword=None, groups=None, runas=None)
 Updated a postgres group
 .sp
 CLI Examples:
 .sp
 .nf
 .ft C
-salt \(aq*\(aq postgres.group_update \(aqusername\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq password=\(aqpassword\(aq
+salt \(aq*\(aq postgres.group_update \(aqusername\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq rolepassword=\(aqpassword\(aq
 .ft P
 .fi
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.user_create(username, user=None, host=None, port=None, createdb=False, createuser=False, encrypted=False, superuser=False, replication=False, password=None, groups=None, runas=None)
+.B salt.modules.postgres.user_create(username, user=None, host=None, port=None, db=None, password=None, createdb=False, createuser=False, encrypted=False, superuser=False, replication=False, rolepassword=None, groups=None, runas=None)
 Creates a Postgres user.
 .sp
 CLI Examples:
 .sp
 .nf
 .ft C
-salt \(aq*\(aq postgres.user_create \(aqusername\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq password=\(aqpassword\(aq
+salt \(aq*\(aq postgres.user_create \(aqusername\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq rolepassword=\(aqpassword\(aq
 .ft P
 .fi
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.user_exists(name, user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.user_exists(name, user=None, host=None, port=None, db=None, password=None, runas=None)
 Checks if a user exists on the Postgres server.
 .sp
 CLI Example:
@@ -19273,7 +19273,7 @@ salt \(aq*\(aq postgres.user_exists \(aqusername\(aq
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.user_list(user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.user_list(user=None, host=None, port=None, db=None, password=password, runas=None)
 Return a list of users of a Postgres server.
 .sp
 CLI Example:
@@ -19286,7 +19286,7 @@ salt \(aq*\(aq postgres.user_list
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.user_remove(username, user=None, host=None, port=None, runas=None)
+.B salt.modules.postgres.user_remove(username, user=None, host=None, port=None, db=None, password=None, runas=None)
 Removes a user from the Postgres server.
 .sp
 CLI Example:
@@ -19299,14 +19299,14 @@ salt \(aq*\(aq postgres.user_remove \(aqusername\(aq
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.postgres.user_update(username, user=None, host=None, port=None, createdb=False, createuser=False, encrypted=False, replication=False, password=None, groups=None, runas=None)
+.B salt.modules.postgres.user_update(username, user=None, host=None, port=None, db=None, password=None, createdb=False, createuser=False, encrypted=False, replication=False, rolepassword=None, groups=None, runas=None)
 Creates a Postgres user.
 .sp
 CLI Examples:
 .sp
 .nf
 .ft C
-salt \(aq*\(aq postgres.user_create \(aqusername\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq password=\(aqpassword\(aq
+salt \(aq*\(aq postgres.user_create \(aqusername\(aq user=\(aquser\(aq host=\(aqhostname\(aq port=\(aqport\(aq rolepassword=\(aqpassword\(aq
 .ft P
 .fi
 .UNINDENT

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -46,15 +46,13 @@ def _run_psql(cmd, runas=None, password=None, run_cmd="cmd.run_all"):
     if not password:
         password = __salt__['config.option']('postgres.pass')
     if password:
-        import os
-        env = os.environ.copy()
-        env["PGPASSWORD"] = password
+        kwargs["env"] = {"PGPASSWORD": password}
         # PGPASSWORD has been deprecated, supposedly leading to
         # protests. Currently, this seems the simplest way to solve
         # this. If needed in the future, a tempfile could also be
         # written and the filename set to the PGPASSFILE variable. see
         # http://www.postgresql.org/docs/8.4/static/libpq-pgpass.html
-        kwargs["env"] = env
+
     return __salt__[run_cmd](cmd, **kwargs)
 
 

--- a/salt/states/postgres_group.py
+++ b/salt/states/postgres_group.py
@@ -70,7 +70,7 @@ def present(name,
                                          encrypted=encrypted,
                                          superuser=superuser,
                                          replication=replication,
-                                         password=password,
+                                         rolepassword=password,
                                          groups=groups,
                                          runas=runas):
         ret['comment'] = 'The group {0} has been created'.format(name)

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -70,7 +70,7 @@ def present(name,
                                         encrypted=encrypted,
                                         superuser=superuser,
                                         replication=replication,
-                                        password=password,
+                                        rolepassword=password,
                                         groups=groups,
                                         runas=runas):
         ret['comment'] = 'The user {0} has been created'.format(name)


### PR DESCRIPTION
The postgres.pass option mentioned in the documentation was actually defunct. I enabled it using the environment variable method.
This required a change to be made to the password argument for the postgres module.
I decided to rename the password of created or amended roles to rolepassword. However, I am happy to change that if anyone has a better suggestion.

Also a couple of bugs were fixed:
- the version check did not convert strings to integers and did not check correctly
- pg_authid is a protected table that holds passwords. I replaced it with pg_roles, the public table. (http://www.postgresql.org/docs/9.1/static/catalog-pg-authid.html)
