### PR TITLE
Add function config.is_true

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -78,11 +78,11 @@ def manage_mode(mode):
 def is_true(value=None):
     '''
     Returns a boolean value representing the "truth" of the value passed. The
-    rules for what is a True value are:
+    rules for what is a ``True`` value are:
 
-        1. Numeric values greater than 0
-        2. The string values ``True`` and ``true``
-        3. Any object for which bool(obj) returns True
+        1. Numeric values greater than :strong:`0`
+        2. The string values :strong:`True` and :strong:`true`
+        3. Any object for which ``bool(obj)`` returns ``True``
     '''
     if isinstance(value, (int, float)):
         return value > 0

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -75,6 +75,23 @@ def manage_mode(mode):
     return mode
 
 
+def is_true(value=None):
+    '''
+    Returns a boolean value representing the "truth" of the value passed. The
+    rules for what is a True value are:
+
+        1. Numeric values greater than 0
+        2. The string values "True" and "true"
+        3. Any object for which bool(obj) returns True
+    '''
+    if isinstance(value, (int, float)):
+        return value > 0
+    elif isinstance(value, basestring):
+        return str(value).lower() == 'true'
+    else:
+        return bool(value)
+
+
 def valid_fileproto(uri):
     '''
     Returns a boolean value based on whether or not the URI passed has a valid

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -81,7 +81,7 @@ def is_true(value=None):
     rules for what is a True value are:
 
         1. Numeric values greater than 0
-        2. The string values "True" and "true"
+        2. The string values ``True`` and ``true``
         3. Any object for which bool(obj) returns True
     '''
     if isinstance(value, (int, float)):


### PR DESCRIPTION
This function will provide a common interface for determining truth, so
that module functions can properly determine the truthiness of a value
passed in via the CLI.

This will allow some code in the package providers to be a little less
ugly, and will also come in handy when #3363 is implemented.
