### PR TITLE
Two changes for a more robust user.present state

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -71,6 +71,12 @@ def _changes(
             # comparison purposes
             if __salt__['file.gid_to_group'](gid or lusr['gid']) in lusr['groups']:
                 lusr['groups'].remove(__salt__['file.gid_to_group'](gid or lusr['gid']))
+            # remove default group from wanted_groups, as this requirement is
+            # already met
+            if __salt__['file.gid_to_group'](gid or lusr['gid']) in \
+                    wanted_groups:
+                wanted_groups.remove(
+                    __salt__['file.gid_to_group'](gid or lusr['gid']))
             if groups is not None or wanted_groups:
                 if lusr['groups'] != wanted_groups:
                     change['groups'] = wanted_groups
@@ -88,13 +94,13 @@ def _changes(
                         if lshad['pwd'] != password:
                             change['passwd'] = password
             # GECOS fields
-            if lusr['fullname'] != fullname:
+            if fullname and lusr['fullname'] != fullname:
                 change['fullname'] = fullname
-            if lusr['roomnumber'] != roomnumber:
+            if roomnumber and lusr['roomnumber'] != roomnumber:
                 change['roomnumber'] = roomnumber
-            if lusr['workphone'] != workphone:
+            if workphone and lusr['workphone'] != workphone:
                 change['workphone'] = workphone
-            if lusr['homephone'] != homephone:
+            if homephone and lusr['homephone'] != homephone:
                 change['homephone'] = homephone
 
     if not found:
@@ -115,10 +121,10 @@ def present(
         shell=None,
         unique=True,
         system=False,
-        fullname='',
-        roomnumber='',
-        workphone='',
-        homephone=''):
+        fullname=None,
+        roomnumber=None,
+        workphone=None,
+        homephone=None):
     '''
     Ensure that the named user is present with the specified properties
 
@@ -219,15 +225,6 @@ def present(
         for isected in set(groups).intersection(optional_groups):
             log.warning('Group "{0}" specified in both groups and '
                         'optional_groups for user {1}'.format(isected, name))
-
-    if fullname is None:
-        fullname = ''
-    if roomnumber is None:
-        roomnumber = ''
-    if workphone is None:
-        workphone = ''
-    if homephone is None:
-        homephone = ''
 
     if gid_from_name:
         gid = __salt__['file.group_to_gid'](name)


### PR DESCRIPTION
Two changes I found necessary:
1. In my opinion, requiring a user to be present and belong to a group should validate to true whether the group is the default group or not.
If I happen to specify the default group explicitly by name (not gid), then it should also be removed from wanted_groups, as it is already fulfilled by being the default group.
1. If the state declaration does not require GECOS info, it should not be set to empty strings, but be allowed to remain in any state it is currently in.
