### PR TITLE
Added puppet pillar and documentation

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -35975,6 +35975,12 @@ T}	T{
 This pillar module parses a config file (specified in the salt master config),
 T}
 _
+T{
+\fBpuppet\fP
+T}	T{
+Execute a puppet_node_classifier command and read the output as YAML. The YAML data is then directly
+T}
+_
 .TE
 .SS salt.pillar.cmd_json
 .sp
@@ -36105,6 +36111,15 @@ The final result set is merged with the pillar data.
 .TP
 .B salt.pillar.pillar_ldap.ext_pillar(pillar, config_file)
 Execute LDAP searches and return the aggregated data
+.UNINDENT
+.SS salt.pillar.puppet
+.sp
+Execute a puppet_node_classifier command and read the output as YAML.
+The YAML data is then directly overlaid onto the minion\(aqs pillar data
+.INDENT 0.0
+.TP
+.B salt.pillar.puppet.ext_pillar(pillar, command)
+Execute a puppet_node_classifier command and read the output as YAML
 .UNINDENT
 .SH MASTER TOPS
 .sp

--- a/doc/ref/pillar/all/index.rst
+++ b/doc/ref/pillar/all/index.rst
@@ -15,3 +15,4 @@ Full list of builtin pillar modules
     hiera
     mongo
     pillar_ldap
+    puppet

--- a/doc/ref/pillar/all/salt.pillar.puppet.rst
+++ b/doc/ref/pillar/all/salt.pillar.puppet.rst
@@ -1,0 +1,6 @@
+====================
+salt.pillar.puppet
+====================
+
+.. automodule:: salt.pillar.puppet
+    :members:

--- a/salt/pillar/puppet.py
+++ b/salt/pillar/puppet.py
@@ -1,0 +1,27 @@
+'''
+Execute an unmodified puppet_node_classifier and read the output as YAML.
+The YAML data is then directly overlaid onto the minion's pillar data.
+'''
+
+# Import python libs
+import logging
+
+# Import third party libs
+import yaml
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+def ext_pillar(pillar, command):
+    '''
+    Execute an unmodified puppet_node_classifier and read the output as YAML
+    '''
+    try:
+        data = yaml.safe_load(__salt__['cmd.run']('{0}'.format(command + ' ' + __grains__.get('nodename'))))
+        data = data['parameters']
+        return data
+    except Exception:
+        log.critical(
+                'YAML data from {0} failed to parse'.format(command)
+                )
+        return {}


### PR DESCRIPTION
Here is my puppet pillar. It passes the nodename grain to an unmodified puppet_node_classifier as specified in the master config file. I've added documentation as well, assuming this would go into the mainstream part of salt. The doco is worth reviewing for content and formatting correctness. Move it all to contrib/ or wherever you think it's best, as you see fit!
