### PR TITLE
Sensible runas default for postgres_* states = postgres?

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -36,12 +36,25 @@ def __virtual__():
     return False
 
 
+def _get_runas(runas=None):
+    '''
+    Returns the default runas user for this platform
+    '''
+    if runas is not None:
+        return runas
+
+    if 'FreeBSD' in __grains__['os_family']:
+        return 'pgsql'
+    else:
+        return 'postgres'
+
+
 def _run_psql(cmd, runas=None, password=None, run_cmd="cmd.run_all"):
     '''
     Helper function to call psql, because the password requirement
     makes this too much code to be repeated in each function below
     '''
-    kwargs = {"runas": runas}
+    kwargs = {"runas": _get_runas(runas)}
 
     if not password:
         password = __salt__['config.option']('postgres.pass')

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -1,0 +1,34 @@
+from mock import Mock, patch
+
+from saltunittest import TestCase, TestLoader, TextTestRunner
+
+from salt.modules import postgres
+postgres.__grains__ = None # in order to stub it w/patch below
+postgres.__salt__ = None # in order to stub it w/patch below
+
+SALT_STUB = {
+    'config.option': Mock(),
+    'cmd.run_all': Mock(),
+}
+
+
+class PostgresTestCase(TestCase):
+    @patch.multiple(postgres, __grains__={ 'os_family': 'FreeBSD' })
+    def test_get_runas_bsd(self):
+	self.assertEqual('pgsql', postgres._get_runas())
+
+    @patch.multiple(postgres, __grains__={ 'os_family': 'Linux' })
+    def test_get_runas_other(self):
+	self.assertEqual('postgres', postgres._get_runas())
+
+    @patch.multiple(postgres, __grains__={ 'os_family': 'Linux' }, __salt__=SALT_STUB)
+    def test_run_psql(self):
+        postgres._run_psql('echo "hi"')
+        cmd = SALT_STUB['cmd.run_all'] 
+
+        self.assertEquals('postgres', cmd.call_args[1]['runas'])
+
+if __name__ == "__main__":
+    loader = TestLoader()
+    tests = loader.loadTestsFromTestCase(PostgresTestCase)
+    TextTestRunner(verbosity=1).run(tests)

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -15,11 +15,11 @@ SALT_STUB = {
 class PostgresTestCase(TestCase):
     @patch.multiple(postgres, __grains__={ 'os_family': 'FreeBSD' })
     def test_get_runas_bsd(self):
-	self.assertEqual('pgsql', postgres._get_runas())
+        self.assertEqual('pgsql', postgres._get_runas())
 
     @patch.multiple(postgres, __grains__={ 'os_family': 'Linux' })
     def test_get_runas_other(self):
-	self.assertEqual('postgres', postgres._get_runas())
+        self.assertEqual('postgres', postgres._get_runas())
 
     @patch.multiple(postgres, __grains__={ 'os_family': 'Linux' }, __salt__=SALT_STUB)
     def test_run_psql(self):


### PR DESCRIPTION
I created a user and database in Postgres and was surprised that the default `runas` user is `root`.  Please share your thoughts on making the default `runas` user for postgres-related functions the user `postgres`.

Thanks!
