### PR TITLE
Useradd stability improvements

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -89,11 +89,17 @@ def add(name,
         cmd += '-g {0} '.format(gid)
     elif name in groups:
         def usergroups():
-            for line in open("/etc/login.defs"):
-                if "USERGROUPS_ENAB" in line[:15]:
-                    if "yes" in line:
-                        return True
-            return False
+            retval = False
+            try:
+                for line in open("/etc/login.defs"):
+                    if "USERGROUPS_ENAB" in line[:15]:
+                        if "yes" in line:
+                            retval = True
+            except Exception:
+                import traceback
+                log.debug("Error reading /etc/login.defs")
+                log.debug(traceback.format_exc())
+            return retval
         if usergroups():
             cmd += '-g {0} '.format(__salt__['file.group_to_gid'](name))
     if home:

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -87,6 +87,15 @@ def add(name,
         cmd += '-u {0} '.format(uid)
     if gid not in (None, ''):
         cmd += '-g {0} '.format(gid)
+    elif name in groups:
+        def usergroups():
+            for line in open("/etc/login.defs"):
+                if "USERGROUPS_ENAB" in line[:15]:
+                    if "yes" in line:
+                        return True
+            return False
+        if usergroups():
+            cmd += '-g {0} '.format(__salt__['file.group_to_gid'](name))
     if home:
         if system:
             if home is not True:

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -80,8 +80,6 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
-    if isinstance(groups, string_types):
-        groups = groups.split(',')
     cmd = 'useradd '
     if shell:
         cmd += '-s {0} '.format(shell)
@@ -89,8 +87,6 @@ def add(name,
         cmd += '-u {0} '.format(uid)
     if gid not in (None, ''):
         cmd += '-g {0} '.format(gid)
-    if groups:
-        cmd += '-G "{0}" '.format(','.join(groups))
     if home:
         if system:
             if home is not True:
@@ -119,6 +115,8 @@ def add(name,
         # to return False when the user was successfully created since A) the
         # user does exist, and B) running useradd again would result in a
         # nonzero exit status and be interpreted as a False result.
+        if groups:
+            chgroups(name, groups)
         if fullname:
             chfullname(name, fullname)
         if roomnumber:


### PR DESCRIPTION
Useradd and explicit group dependencies did not work under certain circumstances, as explained in https://github.com/saltstack/salt/issues/1406
I moved the group adding out of the first call of useradd and made it a modification of the user after useradd has been called.
I also test whether the system has usergroups enabled and set the default group in useradd to avoid errors.
