### PR TITLE
allow matching on presence of a key when value is a dict

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -987,6 +987,9 @@ class Matcher(object):
             log.error('Targeted grain "{0}" not found'.format(comps[0]))
             return False
         if isinstance(match, dict):
+            if comps[1] == '*':
+                # We are just checking that the key exists
+                return True
             log.error('Targeted grain "{0}" must correspond to a list, '
                       'string, or numeric value'.format(comps[0]))
             return False
@@ -1009,6 +1012,9 @@ class Matcher(object):
         if comps[0] not in self.opts['grains']:
             log.error('Got unknown grain from master: {0}'.format(comps[0]))
             return False
+        if isinstance(self.opts['grains'][comps[0]], dict) and comps[1] == '*':
+            # We are just checking that the key exists
+            return True
         if isinstance(self.opts['grains'][comps[0]], list):
             # We are matching a single component to a single list member
             for member in self.opts['grains'][comps[0]]:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1067,6 +1067,9 @@ class Matcher(object):
             log.error('Targeted pillar "{0}" not found'.format(comps[0]))
             return False
         if isinstance(match, dict):
+            if comps[1] == '*':
+                # We are just checking that the key exists
+                return True
             log.error('Targeted pillar "{0}" must correspond to a list, '
                       'string, or numeric value'.format(comps[0]))
             return False

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -108,6 +108,9 @@ class CkMinions(object):
                     minions.remove(id_)
                     continue
                 if isinstance(match, dict):
+                    if comps[1] == '*':
+                        # We are just checking that the key exists
+                        continue 
                     minions.remove(id_)
                     continue
                 if isinstance(match, list):
@@ -155,6 +158,9 @@ class CkMinions(object):
                     continue
                 if comps[0] not in grains:
                     minions.remove(id_)
+                if isinstance(grains[comps[0]], dict) and comps[1] == '*':
+                    # We are just checking that the key exists
+                    continue
                 if isinstance(grains[comps[0]], list):
                     # We are matching a single component to a single list member
                     found = False


### PR DESCRIPTION
Not sure this is the best way to do this, but as far as I can tell, there is not currently a way to match on the presence of a key where the value is a dictionary. If this is accepted, it might need to also be applied in the case of grains.
