### PR TITLE
Added show_diff kwarg to file.managed.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1285,7 +1285,8 @@ def manage_file(name,
         mode,
         env,
         backup,
-        template=None):
+        template=None,
+        show_diff=True):
     '''
     Checks the destination against what was retrieved with get_managed and
     makes the appropriate modifications (if necessary).
@@ -1338,6 +1339,8 @@ def manage_file(name,
                     # Print a diff equivalent to diff -u old new
                     if __salt__['config.option']('obfuscate_templates'):
                         ret['changes']['diff'] = '<Obfuscated Template>'
+                    elif not show_diff:
+                        ret['changes']['diff'] = '<show_diff=False>'
                     else:
                         ret['changes']['diff'] = (
                                 ''.join(difflib.unified_diff(nlines, slines))

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -592,6 +592,7 @@ def managed(name,
             defaults=None,
             env=None,
             backup='',
+            show_diff=True,
             **kwargs):
     '''
     Manage a given file, this function allows for a file to be downloaded from
@@ -662,6 +663,9 @@ def managed(name,
 
     backup
         Overrides the default backup mode for this specific file
+
+    show_diff
+        If set to false, the diff will not be shown.
     '''
     user = _test_owner(kwargs, user=user)
     # Initial set up
@@ -759,7 +763,8 @@ def managed(name,
                                             mode,
                                             env,
                                             backup,
-                                            template)
+                                            template,
+                                            show_diff)
 
 
 def directory(name,

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -115,6 +115,21 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         self.assertSaltNoneReturn(ret)
         self.assertFalse(os.path.isfile(name))
 
+    def test_managed_show_diff_false(self):
+        '''
+        file.managed test interface
+        '''
+        name = os.path.join(integration.TMP, 'grail_not_scene33')
+        with open(name, 'wb') as fp_:
+            fp_.write('test_managed_show_diff_false\n')
+
+        ret = self.run_state(
+            'file.managed', name=name, source='salt://grail/scene33', show_diff=False
+        )
+
+        changes = ret.values()[0]['changes']
+        self.assertEquals('<show_diff=False>', changes['diff'])
+
     def test_directory(self):
         '''
         file.directory


### PR DESCRIPTION
I have a use-case where I don't want a managed file's diff to show in the logs.  This patch provides a `show_diff` arg that can be set to `False` to suppress the diff from being added to the log.
