### PR TITLE
Add versions_as_list kwarg to version, list_pkgs

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -16,7 +16,7 @@ def __virtual__():
     return False
 
 
-def list_pkgs(*args):
+def list_pkgs(versions_as_list=False):
     '''
     List the packages currently installed in a dict::
 
@@ -26,18 +26,23 @@ def list_pkgs(*args):
 
         salt '*' pkg.list_pkgs
     '''
+    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    ret = {}
     cmd = 'brew list --versions {0}'.format(' '.join(args))
-
-    result_dict = {}
-
     for line in __salt__['cmd.run'](cmd).splitlines():
-        (pkg, version) = line.split(' ')[0:2]
-        result_dict[pkg] = version
+        try:
+            name, version = line.split(' ')[0:2]
+        except ValueError:
+            continue
+        __salt__['pkg_resource.add_pkg'](ret, name, version)
 
-    return result_dict
+    __salt__['pkg_resource.sort_pkglist'](ret)
+    if not versions_as_list:
+        __salt__['pkg_resource.stringify'](ret)
+    return ret
 
 
-def version(*names):
+def version(*names, **kwargs):
     '''
     Returns a string representing the package version or an empty string if not
     installed. If more than one package name is specified, a dict of
@@ -48,16 +53,7 @@ def version(*names):
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3>
     '''
-    pkgs = list_pkgs()
-    if len(names) == 0:
-        return ''
-    elif len(names) == 1:
-        return pkgs.get(names[0], '')
-    else:
-        ret = {}
-        for name in names:
-            ret[name] = pkgs.get(name, '')
-        return ret
+    return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
 def available_version(*names, **kwargs):

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -129,8 +129,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    # Catch both boolean input from state and string input from CLI
-    if refresh is True or str(refresh).lower() == 'true':
+    if __salt__['config.is_true'](refresh):
         refresh_db()
     return _get_upgradable()
 
@@ -146,7 +145,7 @@ def upgrade_available(name):
     return available_version(name) != ''
 
 
-def version(*names):
+def version(*names, **kwargs):
     '''
     Returns a string representing the package version or an empty string if not
     installed. If more than one package name is specified, a dict of
@@ -157,16 +156,7 @@ def version(*names):
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
-    if len(names) == 0:
-        return ''
-    ret = {}
-    for name in names:
-        ret[name] = _cpv_to_version(_vartree().dep_bestmatch(name))
-
-    # Return a string if only one package name passed
-    if len(names) == 1:
-        return ret[names[0]]
-    return ret
+    return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
 def porttree_matches(name):
@@ -183,7 +173,7 @@ def porttree_matches(name):
                 if x.endswith('/' + str(name))]
 
 
-def list_pkgs():
+def list_pkgs(versions_as_list=False):
     '''
     List the packages currently installed in a dict::
 
@@ -193,14 +183,16 @@ def list_pkgs():
 
         salt '*' pkg.list_pkgs
     '''
+    versions_as_list = __salt__['config.is_true'](versions_as_list)
     ret = {}
     pkgs = _vartree().dbapi.cpv_all()
     for cpv in pkgs:
-        ret[_cpv_to_name(cpv)] = _cpv_to_version(cpv)
         __salt__['pkg_resource.add_pkg'](ret,
                                          _cpv_to_name(cpv),
                                          _cpv_to_version(cpv))
     __salt__['pkg_resource.sort_pkglist'](ret)
+    if not versions_as_list:
+        __salt__['pkg_resource.stringify'](ret)
     return ret
 
 
@@ -286,8 +278,7 @@ def install(name=None,
             'kwargs': kwargs
         }
     ))
-    # Catch both boolean input from state and string input from CLI
-    if refresh is True or str(refresh).lower() == 'true':
+    if __salt__['config.is_true'](refresh):
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -395,8 +386,7 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
-    # Catch both boolean input from state and string input from CLI
-    if refresh is True or str(refresh).lower() == 'true':
+    if __salt__['config.is_true'](refresh):
         refresh_db()
 
     ret_pkgs = {}

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -107,7 +107,7 @@ def available_version(*names, **kwargs):
     return ret
 
 
-def version(*names):
+def version(*names, **kwargs):
     '''
     Returns a string representing the package version or an empty string if not
     installed. If more than one package name is specified, a dict of
@@ -118,18 +118,7 @@ def version(*names):
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
-    if not names:
-        return ''
-
-    ret = {}
-    installed = list_pkgs()
-    for name in names:
-        ret[name] = installed.get(name, '')
-
-    if len(names) == 1:
-        return ret[names[0]]
-    else:
-        return ret
+    return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
 def refresh_db():
@@ -147,7 +136,7 @@ def refresh_db():
     return {}
 
 
-def list_pkgs():
+def list_pkgs(versions_as_list=True):
     '''
     List the packages currently installed as a dict::
 
@@ -157,6 +146,7 @@ def list_pkgs():
 
         salt '*' pkg.list_pkgs
     '''
+    versions_as_list = __salt__['config.is_true'](versions_as_list)
     if _check_pkgng():
         pkg_command = '{0} info'.format(_cmd('pkg'))
     else:
@@ -167,7 +157,10 @@ def list_pkgs():
             continue
         pkg, ver = line.split(' ')[0].rsplit('-', 1)
         __salt__['pkg_resource.add_pkg'](ret, pkg, ver)
-        __salt__['pkg_resource.sort_pkglist'](ret)
+
+    __salt__['pkg_resource.sort_pkglist'](ret)
+    if not versions_as_list:
+        __salt__['pkg_resource.stringify'](ret)
     return ret
 
 

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -136,7 +136,7 @@ def refresh_db():
     return {}
 
 
-def list_pkgs(versions_as_list=True):
+def list_pkgs(versions_as_list=False):
     '''
     List the packages currently installed as a dict::
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -99,7 +99,7 @@ def list_upgrades():
     return upgrades
 
 
-def version(*names):
+def version(*names, **kwargs):
     '''
     Returns a string representing the package version or an empty string if not
     installed. If more than one package name is specified, a dict of
@@ -110,19 +110,10 @@ def version(*names):
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
-    pkgs = list_pkgs()
-    if len(names) == 0:
-        return ''
-    elif len(names) == 1:
-        return pkgs.get(names[0], '')
-    else:
-        ret = {}
-        for name in names:
-            ret[name] = pkgs.get(name, '')
-        return ret
+    return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs():
+def list_pkgs(versions_as_list=False):
     '''
     List the packages currently installed as a dict::
 
@@ -132,6 +123,7 @@ def list_pkgs():
 
         salt '*' pkg.list_pkgs
     '''
+    versions_as_list = __salt__['config.is_true'](versions_as_list)
     cmd = 'pacman -Q'
     ret = {}
     out = __salt__['cmd.run'](cmd).splitlines()
@@ -145,7 +137,10 @@ def list_pkgs():
                       'line: "{0}"'.format(line))
         else:
             __salt__['pkg_resource.add_pkg'](ret, name, version)
+
     __salt__['pkg_resource.sort_pkglist'](ret)
+    if not versions_as_list:
+        __salt__['pkg_resource.stringify'](ret)
     return ret
 
 
@@ -269,8 +264,7 @@ def install(name=None,
                 log.error(problem)
             return {}
 
-        # Catch both boolean input from state and string input from CLI
-        if refresh is True or str(refresh).lower() == 'true':
+        if __salt__['config.is_true'](refresh):
             cmd = 'pacman -Syu --noprogressbar --noconfirm ' \
                   '"{0}"'.format('" "'.join(targets))
         else:
@@ -426,5 +420,3 @@ def file_dict(*packages):
                 ret[comps[0]] = []
             ret[comps[0]].append((' '.join(comps[1:])))
     return {'errors': errors, 'packages': ret}
-
-

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -131,9 +131,9 @@ def list_pkgs(versions_as_list=False):
     lines = __salt__['cmd.run'](cmd).splitlines()
     for index in range(0, len(lines)):
         if index % 2 == 0:
-            namever = lines[index].split()[0].strip()
+            name = lines[index].split()[0].strip()
         if index % 2 == 1:
-            ret[namever] = lines[index].split()[1].strip()
+            version = lines[index].split()[1].strip()
             __salt__['pkg_resource.add_pkg'](ret, name, version)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
@@ -142,7 +142,7 @@ def list_pkgs(versions_as_list=False):
     return ret
 
 
-def version(name):
+def version(*names, **kwargs):
     '''
     Returns a version if the package is installed, else returns an empty string
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -111,7 +111,7 @@ def upgrade(refresh=True, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def list_pkgs(versions_as_list=True):
+def list_pkgs(versions_as_list=False):
     '''
     List the packages currently installed as a dict::
 

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -71,7 +71,7 @@ def _write_adminfile(kwargs):
     return adminfile
 
 
-def list_pkgs(versions_as_list=True):
+def list_pkgs(versions_as_list=False):
     '''
     List the packages currently installed as a dict::
 

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -71,7 +71,7 @@ def _write_adminfile(kwargs):
     return adminfile
 
 
-def list_pkgs():
+def list_pkgs(versions_as_list=True):
     '''
     List the packages currently installed as a dict::
 
@@ -81,17 +81,25 @@ def list_pkgs():
 
         salt '*' pkg.list_pkgs
     '''
-    pkg = {}
+    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    ret = {}
     cmd = '/usr/bin/pkginfo -x'
 
-    line_count = 0
-    for line in __salt__['cmd.run'](cmd).splitlines():
-        if line_count % 2 == 0:
-            namever = line.split()[0].strip()
-        if line_count % 2 == 1:
-            pkg[namever] = line.split()[1].strip()
-        line_count = line_count + 1
-    return pkg
+    # Package information returned two lines per package. On even-offset
+    # lines, the package name is in the first column. On odd-offset lines, the
+    # package version is in the second column.
+    lines = __salt__['cmd.run'](cmd).splitlines()
+    for index in range(0, len(lines)):
+        if index % 2 == 0:
+            name = lines[index].split()[0].strip()
+        if index % 2 == 1:
+            version = lines[index].split()[1].strip()
+            __salt__['pkg_resource.add_pkg'](ret, name, version)
+
+    __salt__['pkg_resource.sort_pkglist'](ret)
+    if not versions_as_list:
+        __salt__['pkg_resource.stringify'](ret)
+    return ret
 
 
 def available_version(*names, **kwargs):
@@ -135,7 +143,7 @@ def upgrade_available(name):
     return available_version(name) != ''
 
 
-def version(*names):
+def version(*names, **kwargs):
     '''
     Returns a string representing the package version or an empty string if not
     installed. If more than one package name is specified, a dict of
@@ -146,16 +154,7 @@ def version(*names):
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
-    pkgs = list_pkgs()
-    if len(names) == 0:
-        return ''
-    elif len(names) == 1:
-        return pkgs.get(names[0], '')
-    else:
-        ret = {}
-        for name in names:
-            ret[name] = pkgs.get(name, '')
-        return ret
+    return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
 def install(name=None, refresh=False, sources=None, **kwargs):
@@ -259,8 +258,10 @@ def install(name=None, refresh=False, sources=None, **kwargs):
     "sources" parameter.
     '''
 
-    pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name, kwargs.get('pkgs'), sources)
+    pkg_params, pkg_type = \
+        __salt__['pkg_resource.parse_targets'](name,
+                                               kwargs.get('pkgs'),
+                                               sources)
     if pkg_params is None or len(pkg_params) == 0:
         return {}
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -120,13 +120,12 @@ def list_upgrades(refresh=True):
 
     # Uncomment the below once pkg.list_upgrades has been implemented
 
-    # Catch both boolean input from state and string input from CLI
-    #if refresh is True or str(refresh).lower() == 'true':
+    #if __salt__['config.is_true'](refresh):
     #    refresh_db()
     return {}
 
 
-def version(name):
+def version(*names, **kwargs):
     '''
     Returns a version if the package is installed, else returns an empty string
 
@@ -134,14 +133,10 @@ def version(name):
 
         salt '*' pkg.version <package name>
     '''
-    pkgs = list_pkgs()
-    if name in pkgs:
-        return pkgs[name]
-    else:
-        return ''
+    return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs(*args):
+def list_pkgs(*args, **kwargs):
     '''
         List the packages currently installed in a dict::
 
@@ -151,6 +146,8 @@ def list_pkgs(*args):
 
             salt '*' pkg.list_pkgs
     '''
+    versions_as_list = \
+        __salt__['config.is_true'](kwargs.get('versions_as_list'))
     pkgs = {}
     with salt.utils.winapi.Com():
         if len(args) == 0:
@@ -163,7 +160,10 @@ def list_pkgs(*args):
             for arg in args:
                 for key, val in _search_software(arg).iteritems():
                     __salt__['pkg_resource.add_pkg'](pkgs, key, val)
+
     __salt__['pkg_resource.sort_pkglist'](pkgs)
+    if not versions_as_list:
+        __salt__['pkg_resource.stringify'](ret)
     return pkgs
 
 
@@ -404,8 +404,7 @@ def upgrade(refresh=True):
 
     # Uncomment the below once pkg.upgrade has been implemented
 
-    # Catch both boolean input from state and string input from CLI
-    #if refresh is True or str(refresh).lower() == 'true':
+    #if __salt__['config.is_true'](refresh):
     #    refresh_db()
     return {}
 


### PR DESCRIPTION
This commit adds the ability to optionally get the version information
as a list of strings, as opposed to a string. All package providers have
been updated with this (even though very few providers actually support
multiple versions of the same package), so as not to break pkg states.

Reference: https://github.com/saltstack/salt/issues/2783#issuecomment-14011820
