### PR TITLE
Provide the master's version in pillar.data

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -15,6 +15,7 @@ import salt.crypt
 from salt._compat import string_types
 from salt.template import compile_template
 from salt.utils.dictupdate import update
+from salt.version import __version__
 
 log = logging.getLogger(__name__)
 
@@ -347,6 +348,7 @@ class Pillar(object):
                 mopts.pop('grains')
             if 'aes' in mopts:
                 mopts.pop('aes')
+            mopts['saltversion'] = __version__
             pillar['master'] = mopts
         if errors:
             for error in errors:


### PR DESCRIPTION
This allows you to make decisions based on the minion version and
master version, for example, running pkg.install only if the
salt-minion is out of date

Grains would have the minion's version
Pillar would have the master's version
{% if grains['saltversion'] != pillar['master']['saltversion'] %}
