### PR TITLE
Small update salt/modules/mongodb.py

### DIFF
--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -5,7 +5,7 @@ Module to provide MongoDB functionality to Salt
     parameters as well as configuration settings::
 
         mongodb.host: 'localhost'
-        mongodb.port: '27017'
+        mongodb.port: 27017
         mongodb.user: ''
         mongodb.password: ''
 


### PR DESCRIPTION
Rectification of 'TypeError: port must be an instance of int' if using default settings specified in docs for MongoDB module. Error is raised if port value is specified as string instead of integer.
