### PR TITLE
Add tests for states.svn. Ensure svn.latest includes changes in return

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -91,7 +91,7 @@ def latest(name,
                 ret,
                 ('{0}').format(out))
     try:
-        __salt__['svn.info'](cwd, target, user=user)
+        current_info = __salt__['svn.info'](cwd, target, user=user, fmt='dict')
         svn_cmd = 'svn.update'
     except exceptions.CommandExecutionError:
         pass
@@ -107,8 +107,25 @@ def latest(name,
 
     if svn_cmd == 'svn.update':
         out = __salt__[svn_cmd](cwd, basename, user, *opts)
+
+        current_rev = current_info[0]['Revision']
+        new_rev = __salt__['svn.info'](cwd=target,
+                                       targets=None,
+                                       user=user,
+                                       username=username,
+                                       fmt='dict')[0]['Revision']
+        if current_rev != new_rev:
+            ret['changes']['revision'] = "{0} => {1}".format(current_rev, new_rev)
     else:
         out = __salt__[svn_cmd](cwd, name, basename, user, username, *opts)
+
+        ret['changes']['new'] = name
+        ret['changes']['revision'] = __salt__['svn.info'](cwd=target,
+                                                          targets=None,
+                                                          user=user,
+                                                          username=username,
+                                                          fmt='dict')[0]['Revision']
+
     ret['comment'] = out
     return ret
 

--- a/tests/integration/states/svn.py
+++ b/tests/integration/states/svn.py
@@ -1,0 +1,130 @@
+'''
+Tests for the SVN state
+'''
+import os
+import shutil
+import socket
+import integration
+
+
+class SvnTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
+    '''
+    Validate the svn state
+    '''
+
+    def setUp(self):
+        super(SvnTest, self).setUp()
+
+        self.__domain = 'svn.apache.org'
+        try:
+            if hasattr(socket, 'setdefaulttimeout'):
+                # 10 second dns timeout
+                socket.setdefaulttimeout(10)
+            socket.gethostbyname(self.__domain)
+        except socket.error:
+            msg = 'error resolving {0}, possible network issue?'
+            self.skipTest(msg.format(self.__domain))
+
+        self.target = os.path.join(integration.TMP, 'apache_http_test_repo')
+        self.name = 'http://{0}/repos/asf/httpd/httpd/trunk/test/'.format(self.__domain)
+        self.new_rev = '1456987'
+
+    def tearDown(self):
+        shutil.rmtree(self.target, ignore_errors=True)
+
+    def test_latest(self):
+        '''
+        svn.latest
+        '''
+        ret = self.run_state(
+            'svn.latest',
+            name=self.name,
+            rev=self.new_rev,
+            target=self.target,
+        )
+        self.assertSaltTrueReturn(ret)
+        self.assertTrue(os.path.isdir(os.path.join(self.target, '.svn')))
+        self.assertSaltStateChangesEqual(
+            ret, self.name, keys=['new']
+        )
+        self.assertSaltStateChangesEqual(
+            ret, self.new_rev, keys=['revision']
+        )
+
+    def test_latest_failure(self):
+        '''
+        svn.latest
+        '''
+        ret = self.run_state(
+            'svn.latest',
+            name='https://youSpelledApacheWrong.com/repos/asf/httpd/httpd/trunk/test/',
+            rev=self.new_rev,
+            target=self.target,
+        )
+        self.assertSaltFalseReturn(ret)
+        self.assertFalse(os.path.isdir(os.path.join(self.target, '.svn')))
+
+    def test_latest_empty_dir(self):
+        '''
+        svn.latest
+        '''
+        if not os.path.isdir(self.target):
+            os.mkdir(self.target)
+        ret = self.run_state(
+            'svn.latest',
+            name=self.name,
+            rev=self.new_rev,
+            target=self.target,
+        )
+        self.assertSaltTrueReturn(ret)
+        self.assertTrue(os.path.isdir(os.path.join(self.target, '.svn')))
+
+    def test_latest_existing_repo(self):
+        '''
+        svn.latest againt existing repository
+        '''
+        current_rev = '1442865'
+        cwd, basename = os.path.split(self.target)
+        opts = ('-r', current_rev)
+
+        out = self.run_function('svn.checkout',
+                                [cwd, self.name, basename, None, None, opts])
+        assert out
+
+        ret = self.run_state(
+            'svn.latest',
+            name=self.name,
+            rev=self.new_rev,
+            target=self.target,
+        )
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(
+            ret,
+            "{0} => {1}".format(current_rev, self.new_rev),
+            keys=['revision']
+        )
+        self.assertTrue(os.path.isdir(os.path.join(self.target, '.svn')))
+
+    def test_latest_existing_repo_no_rev_change(self):
+        '''
+        svn.latest againt existing repository
+        '''
+        current_rev = self.new_rev
+        cwd, basename = os.path.split(self.target)
+        opts = ('-r', current_rev)
+        out = self.run_function('svn.checkout',
+                                [cwd, self.name, basename, None, None, opts])
+        assert out
+        ret = self.run_state(
+            'svn.latest',
+            name=self.name,
+            rev=self.new_rev,
+            target=self.target,
+        )
+        self.assertSaltTrueReturn(ret)
+        self.assertSaltStateChangesEqual(ret, {})
+        self.assertTrue(os.path.isdir(os.path.join(self.target, '.svn')))
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(SvnTest)


### PR DESCRIPTION
This pull request addresses issue #4064. It includes changes in the dictionary returned from `svn.latest`, essentially mirroring the format of changes returned by `git.latest`. 

A few notes:
- There were no integration tests for `states.svn`, so I wrote a test class for it, again largely mimicking the structure of the integration tests for `git.latest`.
- For the test SVN repository, I somewhat arbitrarily chose the test subfolder of the Apache Foundation's httpd library. I figured this has a good chance of sticking around at that location  over the long haul.

This is my first contribution to this project, so let me know if I did anything wrong or you need anything else etc.

I'm working on a deployment against an active SVN repository right now, so I'd really like to have proper changes behavior in `svn.latest`!
