### PR TITLE
Updating the output format for ping calls

### DIFF
--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -143,16 +143,21 @@ the ``test.ping`` remote command. ::
 
 
    [root@master ~]# salt 'alpha' test.ping
-   {'alpha': True}
+   alpha:
+       True
 
 Communication between the Master and all Minions may be tested in a
 similar way. ::
 
    [root@master ~]# salt '*' test.ping
-   {'alpha': True}
-   {'bravo': True}
-   {'charlie': True}
-   {'delta': True}
+   alpha:
+       True
+   bravo:
+       True
+   charlie:
+       True
+   delta:
+       True
 
 Each of the Minions should send a "True" response as shown above.
 


### PR DESCRIPTION
A default installation no longer has JSON-style output
