### PR TITLE
modify content error, "vm.swappines" to "vm.swappiness"

### DIFF
--- a/doc/cheatsheet/salt.tex
+++ b/doc/cheatsheet/salt.tex
@@ -265,7 +265,7 @@ Mounting of filesystems.
 Configuration of the Linux kernel using sysctrl.
 
 \begin{verbatim}
-vm.swappines:
+vm.swappiness:
   sysctl.present:
     - value: 20
 \end{verbatim}

--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -34642,7 +34642,7 @@ Control the kernel sysctl system
 .sp
 .nf
 .ft C
-vm.swappines:
+vm.swappiness:
   sysctl.present:
     \- value: 20
 .ft P


### PR DESCRIPTION
In linux, "vm.swappiness" is correct
