### PR TITLE
Use localectl to set keyboard layout on Arch Linux

### DIFF
--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -12,10 +12,8 @@ def __virtual__():
     '''
     Only work on posix-like systems
     '''
-    # Disable on these platorms, specific service modules exist:
-    disable = [
-        'Windows',
-        ]
+    # Disable on these platorms
+    disable = ('Windows',)
     if __grains__['os'] in disable:
         return False
     return 'keyboard'
@@ -52,7 +50,7 @@ def set_sys(layout):
         salt '*' keyboard.set_sys dvorak
     '''
     if 'Arch' in __grains__['os_family']:
-        __salt__['file.sed']('/etc/rc.conf', '^KEYMAP=.*', 'KEYMAP={0}'.format(layout))
+        __salt__['cmd.run']('localectl set-keymap {0}'.format(layout))
     elif 'RedHat' in __grains__['os_family']:
         __salt__['file.sed']('/etc/sysconfig/keyboard', '^LAYOUT=.*', 'LAYOUT={0}'.format(layout))
     elif 'Debian' in __grains__['os_family']:
@@ -86,4 +84,3 @@ def set_x(layout):
     cmd = 'setxkbmap {0}'.format(layout)
     __salt__['cmd.run'](cmd)
     return layout
-


### PR DESCRIPTION
Fixes #4062.
