### PR TITLE
Add Trisquel to `_OS_FAMILY_MAP` as Debian since it's Ubuntu based

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -543,6 +543,7 @@ _OS_FAMILY_MAP = {
     'SmartOS': 'Solaris',
     'Arch ARM': 'Arch',
     'ALT': 'RedHat',
+    'Trisquel': 'Debian'
 }
 
 


### PR DESCRIPTION
See saltstack/salt-bootstrap#88.
