### PR TITLE
cmd: force use of a known working shell.

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -186,9 +186,9 @@ def _run(cmd,
         try:
             # Getting the environment for the runas user
             # There must be a better way to do this.
-            env_cmd = ('su - {0} -c "{1} -c \'import os, json;'
+            env_cmd = ('su -s {0} - {1} -c "{2} -c \'import os, json;'
                        'print(json.dumps(os.environ.__dict__))\'"').format(
-                               runas, sys.executable)
+                               shell, runas, sys.executable)
             env = json.loads(
                     subprocess.Popen(
                         env_cmd,


### PR DESCRIPTION
Users may have an odd shell: for example `/bin/false` is often used for system accounts. Currently the su call used by cmd to determine a users environment fails on those accounts. This pull request fixes that by explicitly asking su to use a known working shell.
