### PR TITLE
Skip these tests if svn is not available.

### DIFF
--- a/tests/integration/states/svn.py
+++ b/tests/integration/states/svn.py
@@ -15,6 +15,9 @@ class SvnTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
     def setUp(self):
         super(SvnTest, self).setUp()
 
+        if not self.run_function('cmd.has_exec', ['svn']):
+            self.skipTest("The executable 'svn' is not available.")
+
         self.__domain = 'svn.apache.org'
         try:
             if hasattr(socket, 'setdefaulttimeout'):


### PR DESCRIPTION
Addresses an issue raised in the original pull request #4123 where the tests failed if Subversion was not installed. Added logic to skip the tests if `svn` cannot be found.
