### PR TITLE
Take into account default_include configuration when calling verify_env()

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -126,10 +126,18 @@ class Minion(parsers.MinionOptionParser):
 
         try:
             if self.config['verify_env']:
-                confd = os.path.join(
-                    os.path.dirname(self.config['conf_file']),
-                    'minion.d'
-                )
+                confd = self.config.get('default_include')
+                if confd:
+                  # If 'default_include' is specified in config, then use it
+                  if '*' in confd:
+                      # Value is of the form "minion.d/*.conf"
+                      confd = os.path.dirname(confd)
+                  if not os.path.isabs(confd):
+                      # If configured 'default_include' is not an absolute path,
+                      # consider it relative to folder of 'conf_file' (/etc/salt by default)
+                      confd = os.path.join(os.path.dirname(self.config['conf_file']), confd)
+                else:
+                    confd = os.path.join(os.path.dirname(self.config['conf_file']), 'minion.d')
                 verify_env(
                     [
                         self.config['pki_dir'],


### PR DESCRIPTION
salt-minion insists on /etc/salt/minion.d existing, even if one specifies a different default_include path in configuration

I'm trying to run without sudo (avoid using default /etc/salt) and ran across this.

[edit: incomplete sentence, forgot the "sudo" in my description "trying to run without sudo ..."]
