### PR TITLE
Checks if groups is none before extending it

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -302,7 +302,10 @@ def present(name,
             ret['result'] = None
             ret['comment'] = 'User {0} set to be added'.format(name)
             return ret
-        groups.extend(present_optgroups)
+        if groups:
+            groups.extend(present_optgroups)
+        elif present_optgroups:
+            groups = present_optgroups[:]
         if __salt__['user.add'](name,
                                 uid=uid,
                                 gid=gid,


### PR DESCRIPTION
This prevents getting an AttributeError when trying to create a new user when groups is None:

---

   State: - user
   Name:      git
   Function:  present
       Result:    False
       Comment:   An exception occured in this state: Traceback (most recent call last):
 File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1205, in call
   ret = self.states[cdata['full']](*cdata['args'])
 File "/usr/lib/python2.7/dist-packages/salt/states/user.py", line 305, in present
   groups.extend(present_optgroups)
AttributeError: 'NoneType' object has no attribute 'extend'
