### PR TITLE
Feature: Show verbose error message if cron file update failed

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -66,6 +66,17 @@ def write_cron_file(user, path):
     return __salt__['cmd.retcode'](_get_cron_cmdstr(user, path)) == 0
 
 
+def write_cron_file_verbose(user, path):
+    '''
+    Writes the contents of a file to a user's crontab and return error message on error
+
+    CLI Example::
+
+        salt '*' cron.write_cron_file_verbose root /tmp/new_cron
+    '''
+    return __salt__['cmd.run_all'](_get_cron_cmdstr(user, path))
+
+
 def _write_cron_lines(user, lines):
     '''
     Takes a list of lines to be committed to a user's crontab and writes it

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -383,8 +383,12 @@ def file(name,
     elif ret['result']:
         ret['comment'] = 'Crontab for user {0} is in the correct ' \
                          'state'.format(user)
-    if not __salt__['cron.write_cron_file'](user, cron_path):
-        ret['comment'] = 'Unable to update user {0} crontab'.format(user)
+
+    cron_ret = __salt__['cron.write_cron_file_verbose'](user, cron_path)
+    if cron_ret['retcode']:
+        ret['comment'] = 'Unable to update user {0} crontab {1}.' \
+                         ' Error: {2}'.format(user, cron_path, cron_ret['stderr'])
         ret['result'] = False
+
     os.unlink(cron_path)
     return ret


### PR DESCRIPTION
I've added small changes to the states/cron module:
Return verbose error message if states/cron can not apply new crontab file

Module states/cron use function "write_cron_file" from modules/cron which return only boolean value,  but not error message. Since this function is public and can be used by customers I can not change its interface so  I've created new function "write_cron_file_verbose".  

I think this small change is useful because you can make typo in your cron tab file and when you try to apply changes you will only get response:
"Unable to update user  crontab" - without any additional information. 
Error message from crontab is not even written to the minion log - so you can only debug salt code to find out whats wrong with your crontab file. 
