### PR TITLE
Better fix for 'pip' detection in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,11 @@ if setup_dirname != '':
     os.chdir(setup_dirname)
 
 # Use setuptools only if the user opts-in by setting the USE_SETUPTOOLS env var
+# Or if setuptools was previously imported (which is the case when using 'distribute')
 # This ensures consistent behavior but allows for advanced usage with
 # virtualenv, buildout, and others.
 with_setuptools = False
-if 'USE_SETUPTOOLS' in os.environ or 'pip' in __file__:
+if 'USE_SETUPTOOLS' in os.environ or 'setuptools' in sys.modules:
     try:
         from setuptools import setup
         from setuptools.command.install import install


### PR DESCRIPTION
We're using 'distribute', and current setup.py doesn't work with our packaging.
This fixes the problem on our end, and should be a better way of detecting whether 'pip' is being used.
This is related to this commit: https://github.com/saltstack/salt/commit/512d9adb8be4d754ab72fc0aa4f92ae69920cda1
