### PR TITLE
Making tests runnable on OSX

### DIFF
--- a/doc/topics/tests/index.rst
+++ b/doc/topics/tests/index.rst
@@ -1,3 +1,14 @@
+Running The Tests
+=================
+
+To run the tests, use ``tests/runtests.py``, see ``--help`` for more info.
+
+Examples:
+To run all tests: ``sudo ./tests/runtests.py``
+Run unit tests only: ``sudo ./tests/runtests.py --unit-tests``
+
+You will need 'mock' (https://pypi.python.org/pypi/mock) in addition to salt requirements in order to run the tests.
+
 =============
 Writing Tests
 =============

--- a/salt/master.py
+++ b/salt/master.py
@@ -228,6 +228,10 @@ class Master(SMaster):
     def __set_max_open_files(self):
         # Let's check to see how our max open files(ulimit -n) setting is
         mof_s, mof_h = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if mof_h == resource.RLIM_INFINITY:
+          # Unclear what to do with infinity... OSX reports RLIM_INFINITY as hard limit,
+          # but raising to anything above soft limit fails...
+          mof_h = mof_s
         log.info(
             'Current values for max open files soft/hard setting: '
             '{0}/{1}'.format(


### PR DESCRIPTION
Added a paragraph in the docs on how to run the tests (didn't see it in the doc, may be inaccurate though, found out by reading the code)

On OSX, tests couldn't start the background daemons at all due to resource.setrlimit() failing. With this change, the daemons are started properly, I believe other platforms shouldn't be impacted (only ones reporting infinity as hard limit...).
This also should fix this open issue: https://github.com/saltstack/salt/issues/3711

Not all tests are passing for me on OSX, but at least now they can get started :)

Setting up Salt daemons to execute tests

```
 * Waiting at most 0:02:00 for minions(minion, sub_minion) to connect back
   * minion connected.                                                                                                                                                                                                             
   * sub_minion connected.                                                                                                                                                                                                         
 * Syncing minion's modules (saltutil.sync_modules)
   * Synced minion modules: modules.runtests_helpers                                                                                                                                                                               
   * Synced sub_minion modules: modules.runtests_helpers
```
