### PR TITLE
Rename pkg.available_version to pkg.latest_version

### DIFF
--- a/doc/ref/modules/all/salt.modules.apt.rst
+++ b/doc/ref/modules/all/salt.modules.apt.rst
@@ -4,3 +4,4 @@ salt.modules.apt
 
 .. automodule:: salt.modules.apt
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.brew.rst
+++ b/doc/ref/modules/all/salt.modules.brew.rst
@@ -4,3 +4,4 @@ salt.modules.brew
 
 .. automodule:: salt.modules.brew
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.ebuild.rst
+++ b/doc/ref/modules/all/salt.modules.ebuild.rst
@@ -4,3 +4,4 @@ salt.modules.ebuild
 
 .. automodule:: salt.modules.ebuild
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.freebsdpkg.rst
+++ b/doc/ref/modules/all/salt.modules.freebsdpkg.rst
@@ -4,3 +4,4 @@ salt.modules.freebsdpkg
 
 .. automodule:: salt.modules.freebsdpkg
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.openbsdpkg.rst
+++ b/doc/ref/modules/all/salt.modules.openbsdpkg.rst
@@ -4,3 +4,4 @@ salt.modules.openbsdpkg
 
 .. automodule:: salt.modules.openbsdpkg
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.pacman.rst
+++ b/doc/ref/modules/all/salt.modules.pacman.rst
@@ -4,3 +4,4 @@ salt.modules.pacman
 
 .. automodule:: salt.modules.pacman
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.pkgng.rst
+++ b/doc/ref/modules/all/salt.modules.pkgng.rst
@@ -4,3 +4,4 @@ salt.modules.pkgng
 
 .. automodule:: salt.modules.pkgng
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.pkgutil.rst
+++ b/doc/ref/modules/all/salt.modules.pkgutil.rst
@@ -4,3 +4,4 @@ salt.modules.pkgutil
 
 .. automodule:: salt.modules.pkgutil
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.solarispkg.rst
+++ b/doc/ref/modules/all/salt.modules.solarispkg.rst
@@ -4,3 +4,4 @@ salt.modules.solarispkg
 
 .. automodule:: salt.modules.solarispkg
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.win_pkg.rst
+++ b/doc/ref/modules/all/salt.modules.win_pkg.rst
@@ -4,3 +4,4 @@ salt.modules.win_pkg
 
 .. automodule:: salt.modules.win_pkg
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.yumpkg.rst
+++ b/doc/ref/modules/all/salt.modules.yumpkg.rst
@@ -9,3 +9,4 @@ salt.modules.yumpkg
 
 .. automodule:: salt.modules.yumpkg
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.yumpkg5.rst
+++ b/doc/ref/modules/all/salt.modules.yumpkg5.rst
@@ -4,3 +4,4 @@ salt.modules.yumpkg5
 
 .. automodule:: salt.modules.yumpkg5
     :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.zypper.rst
+++ b/doc/ref/modules/all/salt.modules.zypper.rst
@@ -4,4 +4,4 @@ salt.modules.zypper
 
 .. automodule:: salt.modules.zypper
     :members:
-    :exclude-members: list_updates
+    :exclude-members: list_updates, available_version

--- a/doc/topics/development/package_providers.rst
+++ b/doc/topics/development/package_providers.rst
@@ -45,8 +45,8 @@ data:
          'bar': '5.6.7-8'}
 
 
-available_version
-^^^^^^^^^^^^^^^^^
+latest_version
+^^^^^^^^^^^^^^
 
 Accepts an arbitrary number of arguments. Each argument is a package name. The
 return value for a package will be an empty string if the package is not found
@@ -69,7 +69,7 @@ still work, to preserve backwards compatibility with older versions of Salt.
 version
 ^^^^^^^
 
-Like ``available_version``, accepts an arbitrary number of arguments and
+Like ``latest_version``, accepts an arbitrary number of arguments and
 returns a string if a single package name was passed, or a dict of name/value
 pairs if more than one was passed. The only difference is that the return
 values are the currently-installed versions of whatever packages are passed. If
@@ -83,7 +83,7 @@ Deprecated and destined to be removed. For now, should just do the following:
 
 .. code-block:: python
 
-        return __salt__['pkg.available_version'](name) != ''
+        return __salt__['pkg.latest_version'](name) != ''
 
 
 install

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -103,7 +103,7 @@ def _get_repo(**kwargs):
     return ''
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -116,9 +116,9 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package name> fromrepo=unstable
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package name> fromrepo=unstable
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
     if len(names) == 0:
         return ''
@@ -155,6 +155,9 @@ def available_version(*names, **kwargs):
     if len(names) == 1:
         return ret[names[0]]
     return ret
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def version(*names, **kwargs):
@@ -573,7 +576,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def perform_cmp(pkg1='', pkg2=''):

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -56,7 +56,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation
@@ -66,8 +66,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3>
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3>
     '''
     if len(names) <= 1:
         return ''
@@ -76,6 +76,9 @@ def available_version(*names, **kwargs):
         for name in names:
             ret[name] = ''
         return ret
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def remove(pkgs, **kwargs):

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -59,7 +59,7 @@ def _cpv_to_version(cpv):
     return str(cpv[len(_cpv_to_name(cpv) + '-'):])
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -70,8 +70,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
     if len(names) == 0:
         return ''
@@ -89,6 +89,9 @@ def available_version(*names, **kwargs):
     if len(names) == 1:
         return ret[names[0]]
     return ret
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def _get_upgradable():
@@ -142,7 +145,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def version(*names, **kwargs):

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -48,7 +48,7 @@ def search(pkg_name):
         return {"Results": res}
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -59,8 +59,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
 
     ret = {}
@@ -105,6 +105,9 @@ def available_version(*names, **kwargs):
         return ret.values()[0]
 
     return ret
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def version(*names, **kwargs):

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -81,13 +81,13 @@ def list_pkgs(versions_as_list=False):
     return _format_pkgs(_get_pkgs(), versions_as_list=versions_as_list)
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     The available version of the package in the repository
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
+        salt '*' pkg.latest_version <package name>
     '''
     ret = {}
     # Initialize the dict with empty strings
@@ -103,6 +103,9 @@ def available_version(*names, **kwargs):
     if len(names) == 1:
         return ret[names[0]]
     return ret
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def version(*names, **kwargs):

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -28,7 +28,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -39,8 +39,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
     if len(names) == 0:
         return ''
@@ -67,6 +67,9 @@ def available_version(*names, **kwargs):
         return ret[names[0]]
     return ret
 
+# available_version is being deprecated
+available_version = latest_version
+
 
 def upgrade_available(name):
     '''
@@ -76,7 +79,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def list_upgrades():

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -56,18 +56,21 @@ def version():
     return __salt__['cmd.run'](cmd)
 
 
-def available_version(pkg_name, **kwargs):
+def latest_version(pkg_name, **kwargs):
     '''
     The available version of the package in the repository
 
     CLI Example::
 
-        salt '*' pkgng.available_version <package name>
+        salt '*' pkgng.latest_version <package name>
     '''
 
     cmd = 'pkg info {0}'.format(pkg_name)
     out = __salt__['cmd.run'](cmd).split()
     return out[0]
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def update_package_site(new_url):

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -153,19 +153,22 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def available_version(name, **kwargs):
+def latest_version(name, **kwargs):
     '''
     The available version of the package in the repository
 
     CLI Example::
 
-        salt '*' pkgutil.available_version CSWpython
+        salt '*' pkgutil.latest_version CSWpython
     '''
     cmd = '/opt/csw/bin/pkgutil -a --parse {0}'.format(name)
     namever = __salt__['cmd.run_stdout'](cmd).split()[2].strip()
     if namever:
         return namever
     return ''
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def install(name, refresh=False, version=None, **kwargs):

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -102,7 +102,7 @@ def list_pkgs(versions_as_list=False):
     return ret
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -113,8 +113,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
 
     NOTE: As package repositories are not presently supported for Solaris
     pkgadd, this function will always return an empty string for a given
@@ -131,6 +131,9 @@ def available_version(*names, **kwargs):
         return ret[names[0]]
     return ret
 
+# available_version is being deprecated
+available_version = latest_version
+
 
 def upgrade_available(name):
     '''
@@ -140,7 +143,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def version(*names, **kwargs):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -47,7 +47,7 @@ def _list_removed(old, new):
     return pkgs
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -58,8 +58,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
 
     '''
     if len(names) == 0:
@@ -94,6 +94,9 @@ def available_version(*names, **kwargs):
                                                 str(version)) > 0:
             ret[name] = candidate
     return ret
+
+# available_version is being deprecated
+available_version = latest_version
 
 
 def upgrade_available(name):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -162,7 +162,7 @@ def _set_repo_options(yumbase, **kwargs):
         return e
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -175,9 +175,9 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package name> fromrepo=epel-testing
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package name> fromrepo=epel-testing
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
     if len(names) == 0:
         return ''
@@ -210,6 +210,9 @@ def available_version(*names, **kwargs):
         return ret[names[0]]
     return ret
 
+# available_version is being deprecated
+available_version = latest_version
+
 
 def upgrade_available(name):
     '''
@@ -219,7 +222,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def version(*names, **kwargs):

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -92,7 +92,7 @@ def _get_repo_options(**kwargs):
     return repo_arg
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -105,9 +105,9 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package name> fromrepo=epel-testing
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package name> fromrepo=epel-testing
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
     if len(names) == 0:
         return ''
@@ -127,6 +127,9 @@ def available_version(*names, **kwargs):
         return ret[names[0]]
     return ret
 
+# available_version is being deprecated
+available_version = latest_version
+
 
 def upgrade_available(name):
     '''
@@ -136,7 +139,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def version(*names, **kwargs):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -65,7 +65,7 @@ def list_upgrades(refresh=True):
 list_updates = list_upgrades
 
 
-def available_version(*names, **kwargs):
+def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or
     installation. If more than one package name is specified, a dict of
@@ -76,8 +76,8 @@ def available_version(*names, **kwargs):
 
     CLI Example::
 
-        salt '*' pkg.available_version <package name>
-        salt '*' pkg.available_version <package1> <package2> <package3> ...
+        salt '*' pkg.latest_version <package name>
+        salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
     if len(names) == 0:
         return ''
@@ -91,6 +91,9 @@ def available_version(*names, **kwargs):
         return ret[names[0]]
     return ret
 
+# available_version is being deprecated
+available_version = latest_version
+
 
 def upgrade_available(name):
     '''
@@ -100,7 +103,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return available_version(name) != ''
+    return latest_version(name) != ''
 
 
 def version(*names, **kwargs):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -466,9 +466,9 @@ def latest(
         desired_pkgs = [name]
 
     cur = __salt__['pkg.version'](*desired_pkgs)
-    avail = __salt__['pkg.available_version'](*desired_pkgs,
-                                              fromrepo=fromrepo,
-                                              **kwargs)
+    avail = __salt__['pkg.latest_version'](*desired_pkgs,
+                                           fromrepo=fromrepo,
+                                           **kwargs)
 
     # Repack the cur/avail data if only a single package is being checked
     if isinstance(cur, basestring):


### PR DESCRIPTION
See https://github.com/saltstack/salt/issues/4163#issuecomment-15211619

All refs have been updated, and each pkg provider now has
available_version as a function reference pointing to latest_version.

Sphinx docs also updated so that the available_version function
reference is hidden in the docs.
