### PR TITLE
Avoid tracebacks in certain caching edge cases

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -36,9 +36,9 @@ def get_file_client(opts):
     server
     '''
     return {
-            'remote': RemoteClient,
-            'local': LocalClient
-           }.get(opts['file_client'], RemoteClient)(opts)
+        'remote': RemoteClient,
+        'local': LocalClient
+    }.get(opts['file_client'], RemoteClient)(opts)
 
 
 class Client(object):
@@ -80,15 +80,17 @@ class Client(object):
         '''
         Return the local location to cache the file, cache dirs will be made
         '''
-        dest = os.path.join(
-            self.opts['cachedir'],
-            'files',
-            env,
-            path
-            )
+        dest = os.path.join(self.opts['cachedir'],
+                            'files',
+                            env,
+                            path)
         destdir = os.path.dirname(dest)
         cumask = os.umask(63)
         if not os.path.isdir(destdir):
+            # remove destdir if it is a regular file to avoid an OSError when
+            # running os.makedirs below
+            if os.path.isfile(destdir):
+                os.remove(destdir)
             os.makedirs(destdir)
         yield dest
         os.umask(cumask)
@@ -177,7 +179,7 @@ class Client(object):
         Cache a local file on the minion in the localfiles cache
         '''
         dest = os.path.join(self.opts['cachedir'], 'localfiles',
-                path.lstrip('/'))
+                            path.lstrip('/'))
         destdir = os.path.dirname(dest)
 
         if not os.path.isdir(destdir):
@@ -215,9 +217,9 @@ class Client(object):
         otherwise returns a blank string
         '''
         localsfilesdest = os.path.join(
-                self.opts['cachedir'], 'localfiles', path.lstrip('/'))
+            self.opts['cachedir'], 'localfiles', path.lstrip('/'))
         filesdest = os.path.join(
-                self.opts['cachedir'], 'files', env, path.lstrip('salt://'))
+            self.opts['cachedir'], 'files', env, path.lstrip('salt://'))
 
         if os.path.exists(filesdest):
             return filesdest
@@ -330,9 +332,9 @@ class Client(object):
             return dest
         except HTTPError as ex:
             raise MinionError('HTTP error {0} reading {1}: {3}'.format(
-                    ex.code,
-                    url,
-                    *BaseHTTPServer.BaseHTTPRequestHandler.responses[ex.code]))
+                ex.code,
+                url,
+                *BaseHTTPServer.BaseHTTPRequestHandler.responses[ex.code]))
         except URLError as ex:
             raise MinionError('Error reading {0}: {1}'.format(url, ex.reason))
 
@@ -354,9 +356,9 @@ class Client(object):
             return ''
         if template in salt.utils.templates.TEMPLATE_REGISTRY:
             data = salt.utils.templates.TEMPLATE_REGISTRY[template](
-                    sfn,
-                    **kwargs
-                    )
+                sfn,
+                **kwargs
+            )
         else:
             log.error('Attempted to render template with unavailable engine '
                       '{0}'.format(template))
@@ -436,13 +438,10 @@ class LocalClient(Client):
                 for fname in files:
                     ret.append(
                         os.path.relpath(
-                            os.path.join(
-                                root,
-                                fname
-                                ),
+                            os.path.join(root, fname),
                             path
-                            )
                         )
+                    )
         return ret
 
     def file_list_emptydirs(self, env='base'):
@@ -524,12 +523,11 @@ class LocalClient(Client):
                        '').format(self.opts['external_nodes']))
             return {}
         cmd = '{0} {1}'.format(self.opts['external_nodes'], self.opts['id'])
-        ndata = yaml.safe_load(
-                subprocess.Popen(
-                    cmd,
-                    shell=True,
-                    stdout=subprocess.PIPE
-                    ).communicate()[0])
+        ndata = yaml.safe_load(subprocess.Popen(
+                               cmd,
+                               shell=True,
+                               stdout=subprocess.PIPE
+                               ).communicate()[0])
         ret = {}
         if 'environment' in ndata:
             env = ndata['environment']
@@ -588,12 +586,11 @@ class RemoteClient(Client):
                 load['loc'] = fn_.tell()
             try:
                 data = self.auth.crypticle.loads(
-                        self.sreq.send(
-                            'aes',
-                            self.auth.crypticle.dumps(load),
-                            3,
-                            60)
-                        )
+                    self.sreq.send('aes',
+                                   self.auth.crypticle.dumps(load),
+                                   3,
+                                   60)
+                )
             except SaltReqTimeoutError:
                 return ''
 
@@ -611,19 +608,21 @@ class RemoteClient(Client):
                     d_tries += 1
                     with salt.utils.fopen(dest, 'rb') as fp_:
                         hsum = getattr(
-                                hashlib,
-                                data.get('hash_type', 'md5')
-                                )(fp_.read()).hexdigest()
+                            hashlib,
+                            data.get('hash_type', 'md5')
+                        )(fp_.read()).hexdigest()
                         if hsum != data['hsum']:
-                            log.warn(
-                                ('Bad download of file {0}, attempt {1} of 3'
-                                    ).format(path, d_tries)
-                                )
+                            log.warn('Bad download of file {0}, attempt {1} '
+                                     'of 3'.format(path, d_tries))
                             continue
                 break
             if not fn_:
                 with self._cache_loc(data['dest'], env) as cache_dest:
                     dest = cache_dest
+                    # If a directory was formerly cached at this path, then
+                    # remove it to avoid a traceback trying to write the file
+                    if os.path.isdir(dest):
+                        salt.utils.rm_rf(dest)
                     fn_ = salt.utils.fopen(dest, 'wb+')
             if data.get('gzip', None):
                 data = salt.utils.gzip_util.uncompress(data['data'])
@@ -642,12 +641,11 @@ class RemoteClient(Client):
                 'cmd': '_file_list'}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''
 
@@ -659,12 +657,11 @@ class RemoteClient(Client):
                 'cmd': '_file_list_emptydirs'}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''
 
@@ -676,12 +673,11 @@ class RemoteClient(Client):
                 'cmd': '_dir_list'}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''
 
@@ -709,12 +705,11 @@ class RemoteClient(Client):
                 'cmd': '_file_hash'}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''
 
@@ -726,12 +721,11 @@ class RemoteClient(Client):
                 'cmd': '_file_list'}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''
 
@@ -742,12 +736,11 @@ class RemoteClient(Client):
         load = {'cmd': '_master_opts'}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''
 
@@ -761,11 +754,10 @@ class RemoteClient(Client):
                 'opts': self.opts}
         try:
             return self.auth.crypticle.loads(
-                    self.sreq.send(
-                        'aes',
-                        self.auth.crypticle.dumps(load),
-                        3,
-                        60)
-                    )
+                self.sreq.send('aes',
+                               self.auth.crypticle.dumps(load),
+                               3,
+                               60)
+            )
         except SaltReqTimeoutError:
             return ''

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -34,7 +34,7 @@ except ImportError:
 import salt.minion
 import salt.payload
 from salt.exceptions import (
-        SaltClientError, CommandNotFoundError, SaltSystemExit
+    SaltClientError, CommandNotFoundError, SaltSystemExit
 )
 
 
@@ -109,26 +109,26 @@ def get_colors(use=True):
     as empty strings so that they will not be applied
     '''
     colors = {
-            'BLACK': '\033[0;30m',
-            'DARK_GRAY': '\033[1;30m',
-            'LIGHT_GRAY': '\033[0;37m',
-            'BLUE': '\033[0;34m',
-            'LIGHT_BLUE': '\033[1;34m',
-            'GREEN': '\033[0;32m',
-            'LIGHT_GREEN': '\033[1;32m',
-            'CYAN': '\033[0;36m',
-            'LIGHT_CYAN': '\033[1;36m',
-            'RED': '\033[0;31m',
-            'LIGHT_RED': '\033[1;31m',
-            'PURPLE': '\033[0;35m',
-            'LIGHT_PURPLE': '\033[1;35m',
-            'BROWN': '\033[0;33m',
-            'YELLOW': '\033[1;33m',
-            'WHITE': '\033[1;37m',
-            'DEFAULT_COLOR': '\033[00m',
-            'RED_BOLD': '\033[01;31m',
-            'ENDC': '\033[0m',
-            }
+        'BLACK': '\033[0;30m',
+        'DARK_GRAY': '\033[1;30m',
+        'LIGHT_GRAY': '\033[0;37m',
+        'BLUE': '\033[0;34m',
+        'LIGHT_BLUE': '\033[1;34m',
+        'GREEN': '\033[0;32m',
+        'LIGHT_GREEN': '\033[1;32m',
+        'CYAN': '\033[0;36m',
+        'LIGHT_CYAN': '\033[1;36m',
+        'RED': '\033[0;31m',
+        'LIGHT_RED': '\033[1;31m',
+        'PURPLE': '\033[0;35m',
+        'LIGHT_PURPLE': '\033[1;35m',
+        'BROWN': '\033[0;33m',
+        'YELLOW': '\033[1;33m',
+        'WHITE': '\033[1;37m',
+        'DEFAULT_COLOR': '\033[00m',
+        'RED_BOLD': '\033[01;31m',
+        'ENDC': '\033[0m',
+    }
 
     try:
         fileno = sys.stdout.fileno()
@@ -279,15 +279,13 @@ def jid_to_time(jid):
     second = jid[12:14]
     micro = jid[14:]
 
-    ret = '{0}, {1} {2} {3}:{4}:{5}.{6}'.format(
-            year,
-            months[int(month)],
-            day,
-            hour,
-            minute,
-            second,
-            micro
-            )
+    ret = '{0}, {1} {2} {3}:{4}:{5}.{6}'.format(year,
+                                                months[int(month)],
+                                                day,
+                                                hour,
+                                                minute,
+                                                second,
+                                                micro)
     return ret
 
 
@@ -421,12 +419,12 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     '''
     if not os.path.isfile(source):
         raise IOError(
-                '[Errno 2] No such file or directory: {0}'.format(source)
-                )
+            '[Errno 2] No such file or directory: {0}'.format(source)
+        )
     if not os.path.isdir(os.path.dirname(dest)):
         raise IOError(
-                '[Errno 2] No such file or directory: {0}'.format(source)
-                )
+            '[Errno 2] No such file or directory: {0}'.format(source)
+        )
     bname = os.path.basename(dest)
     dname = os.path.dirname(os.path.abspath(dest))
     tgt = mkstemp(prefix=bname, dir=dname)
@@ -443,11 +441,9 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
             msecs = str(int(time.time() * 1000000))[-6:]
             stamp = time.asctime().replace(' ', '_')
             stamp = '{0}{1}_{2}'.format(stamp[:-4], msecs, stamp[-4:])
-            bkpath = os.path.join(
-                    bkroot,
-                    dname[1:],
-                    '{0}_{1}'.format(bname, stamp)
-                    )
+            bkpath = os.path.join(bkroot,
+                                  dname[1:],
+                                  '{0}_{1}'.format(bname, stamp))
             if not os.path.isdir(os.path.dirname(bkpath)):
                 os.makedirs(os.path.dirname(bkpath))
             shutil.copyfile(dest, bkpath)
@@ -839,3 +835,30 @@ def check_state_result(self, running):
             if ret['result'] is False:
                 return False
     return True
+
+
+def rm_rf(path):
+    '''
+    Platform-independent recursive delete. Includes code from
+    http://stackoverflow.com/a/2656405
+    '''
+    def _onerror(func, path, exc_info):
+        """
+        Error handler for `shutil.rmtree`.
+
+        If the error is due to an access error (read only file)
+        it attempts to add write permission and then retries.
+
+        If the error is for another reason it re-raises the error.
+
+        Usage : `shutil.rmtree(path, onerror=onerror)`
+        """
+        if is_windows() and not os.access(path, os.W_OK):
+            import stat
+            # Is the error an access error ?
+            os.chmod(path, stat.S_IWUSR)
+            func(path)
+        else:
+            raise
+
+    shutil.rmtree(path, onerror=_onerror)


### PR DESCRIPTION
This fixes #4174.

When salt tries to cache a file and its cache destination already exists
(and is a directory), recursively remove the directory before caching
the file.

Inversely, when salt tries to cache a file/directory and a directory in
the cachedir that salt is trying to create exists (and is a file),
remove the cached file first before attempting to create the directory.

Also, made PEP8 fixes to keep pylint happy.
