### PR TITLE
Fixed formatting in doc/topics/tests/index.rst

### DIFF
--- a/doc/topics/tests/index.rst
+++ b/doc/topics/tests/index.rst
@@ -4,8 +4,8 @@ Running The Tests
 To run the tests, use ``tests/runtests.py``, see ``--help`` for more info.
 
 Examples:
-To run all tests: ``sudo ./tests/runtests.py``
-Run unit tests only: ``sudo ./tests/runtests.py --unit-tests``
+* To run all tests: ``sudo ./tests/runtests.py``
+* Run unit tests only: ``sudo ./tests/runtests.py --unit-tests``
 
 You will need 'mock' (https://pypi.python.org/pypi/mock) in addition to salt requirements in order to run the tests.
 


### PR DESCRIPTION
Didn't realize that my doc contribution was poorly formatted, see https://salt.readthedocs.org/en/latest/topics/tests/index.html
Sorry about that, this fixes the formatting.
