### PR TITLE
Don't prompt user for auth credentials if token is already loaded

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -68,7 +68,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if getattr(self.options, 'return'):
                 kwargs['ret'] = getattr(self.options, 'return')
 
-            if self.options.eauth:
+            # If using eauth and a token hasn't already been loaded into
+            # kwargs, prompt the user to enter auth credentials
+            if not 'token' in kwargs and self.options.eauth:
                 resolver = salt.auth.Resolver(self.config)
                 res = resolver.cli(self.options.eauth)
                 if self.options.mktoken and res:


### PR DESCRIPTION
@thatch45, how/when does the CLI delete or regenerate the ~/.salt_token file once the token expires? This fix will output an auth error when the token goes bad and the user will have to delete the file manually.
