### PR TITLE
Assign ips first.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -739,6 +739,7 @@ def ip4():
     '''
     Return a list of ipv4 addrs
     '''
+    ips = ''
     if salt.utils.is_windows():
         # TODO: Add windows ip addrs here
         pass


### PR DESCRIPTION
This was broken on Windows since ips was referenced in the return
but was never created
