### PR TITLE
Fix some unsafe imports in tests

### DIFF
--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -9,7 +9,7 @@ try:
     has_mock = True
 except ImportError:
     has_mock = False
-    patch = lambda x: pass
+    patch = lambda x: x
 
 
 @skipIf(has_mock is False, "mock python module is unavailable")

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -23,19 +23,21 @@ class CMDModuleTest(integration.ModuleCase):
         shell = os.environ['SHELL']
         self.assertTrue(self.run_function('cmd.run', ['echo $SHELL']))
         self.assertEqual(
-                self.run_function('cmd.run',
-                    ['echo $SHELL', 'shell={0}'.format(shell)]).rstrip(),
-                shell)
+            self.run_function('cmd.run',
+                              ['echo $SHELL',
+                               'shell={0}'.format(shell)]).rstrip(),
+            shell)
 
     @patch('pwd.getpwnam')
     @patch('subprocess.Popen')
     @patch('json.loads')
     def test_os_environment_remains_intact(self, *mocks):
         '''
-        make sure the OS environment is not tainted after running a command that specifies runas.
+        Make sure the OS environment is not tainted after running a command
+        that specifies runas.
         '''
         environment = os.environ.copy()
-    loads_mock, popen_mock, getpwnam_mock = mocks
+        loads_mock, popen_mock, getpwnam_mock = mocks
 
         popen_mock.return_value = Mock(
             communicate=lambda *args, **kwags: ['hi', None],
@@ -47,36 +49,37 @@ class CMDModuleTest(integration.ModuleCase):
 
         from salt.modules import cmdmod
 
-    cmdmod.__grains__ = {'os': 'darwin'}
-    try:
-        ret = cmdmod._run('ls', cwd=tempfile.gettempdir(), runas='foobar', shell='/bin/bash')
+        cmdmod.__grains__ = {'os': 'darwin'}
+        try:
+            cmdmod._run('ls',
+                        cwd=tempfile.gettempdir(),
+                        runas='foobar',
+                        shell='/bin/bash')
 
-        environment2 = os.environ.copy()
+            environment2 = os.environ.copy()
 
-        self.assertEquals(environment, environment2)
+            self.assertEquals(environment, environment2)
 
-        getpwnam_mock.assert_called_with('foobar')
-        loads_mock.assert_called_with('hi')
-    finally:
-        delattr(cmdmod, '__grains__')
+            getpwnam_mock.assert_called_with('foobar')
+            loads_mock.assert_called_with('hi')
+        finally:
+            delattr(cmdmod, '__grains__')
 
     def test_stdout(self):
         '''
         cmd.run_stdout
         '''
-        self.assertEqual(
-                self.run_function('cmd.run_stdout',
-                    ['echo "cheese"']).rstrip(),
-                'cheese')
+        self.assertEqual(self.run_function('cmd.run_stdout',
+                                           ['echo "cheese"']).rstrip(),
+                         'cheese')
 
     def test_stderr(self):
         '''
         cmd.run_stderr
         '''
-        self.assertEqual(
-                self.run_function('cmd.run_stderr',
-                    ['echo "cheese" 1>&2']).rstrip(),
-                'cheese')
+        self.assertEqual(self.run_function('cmd.run_stderr',
+                                           ['echo "cheese" 1>&2']).rstrip(),
+                         'cheese')
 
     def test_run_all(self):
         '''
@@ -105,19 +108,16 @@ class CMDModuleTest(integration.ModuleCase):
         '''
         cmd.which
         '''
-        self.assertEqual(
-                self.run_function('cmd.which', ['cat']).rstrip(),
-                self.run_function('cmd.run', ['which cat']).rstrip())
+        self.assertEqual(self.run_function('cmd.which', ['cat']).rstrip(),
+                         self.run_function('cmd.run', ['which cat']).rstrip())
 
     def test_has_exec(self):
         '''
         cmd.has_exec
         '''
         self.assertTrue(self.run_function('cmd.has_exec', ['python']))
-        self.assertFalse(self.run_function(
-            'cmd.has_exec',
-            ['alllfsdfnwieulrrh9123857ygf']
-            ))
+        self.assertFalse(self.run_function('cmd.has_exec',
+                                           ['alllfsdfnwieulrrh9123857ygf']))
 
     def test_exec_code(self):
         '''
@@ -127,10 +127,9 @@ class CMDModuleTest(integration.ModuleCase):
 import sys
 sys.stdout.write('cheese')
         '''
-        self.assertEqual(
-                self.run_function('cmd.exec_code', ['python', code]).rstrip(),
-                'cheese'
-                )
+        self.assertEqual(self.run_function('cmd.exec_code',
+                                           ['python', code]).rstrip(),
+                         'cheese')
 
     def test_quotes(self):
         '''
@@ -149,11 +148,11 @@ sys.stdout.write('cheese')
         expected_result = 'SELECT * FROM foo WHERE bar="baz"'
 
         try:
-            runas=os.getlogin()
+            runas = os.getlogin()
         except:
             # On some distros (notably Gentoo) os.getlogin() fails
             import pwd
-            runas=pwd.getpwuid(os.getuid())[0]
+            runas = pwd.getpwuid(os.getuid())[0]
 
         result = self.run_function('cmd.run_stdout', [cmd],
                                    runas=runas).strip()

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -35,7 +35,7 @@ class CMDModuleTest(integration.ModuleCase):
         make sure the OS environment is not tainted after running a command that specifies runas.
         '''
         environment = os.environ.copy()
-	loads_mock, popen_mock, getpwnam_mock = mocks
+    loads_mock, popen_mock, getpwnam_mock = mocks
 
         popen_mock.return_value = Mock(
             communicate=lambda *args, **kwags: ['hi', None],
@@ -47,18 +47,18 @@ class CMDModuleTest(integration.ModuleCase):
 
         from salt.modules import cmdmod
 
-	cmdmod.__grains__ = {'os': 'darwin'}
-	try:
-            ret = cmdmod._run('ls', cwd=tempfile.gettempdir(), runas='foobar', shell='/bin/bash')
-    
-            environment2 = os.environ.copy()
-    
-            self.assertEquals(environment, environment2)
-    
-            getpwnam_mock.assert_called_with('foobar')
-            loads_mock.assert_called_with('hi')
-        finally:
-            delattr(cmdmod, '__grains__')
+    cmdmod.__grains__ = {'os': 'darwin'}
+    try:
+        ret = cmdmod._run('ls', cwd=tempfile.gettempdir(), runas='foobar', shell='/bin/bash')
+
+        environment2 = os.environ.copy()
+
+        self.assertEquals(environment, environment2)
+
+        getpwnam_mock.assert_called_with('foobar')
+        loads_mock.assert_called_with('hi')
+    finally:
+        delattr(cmdmod, '__grains__')
 
     def test_stdout(self):
         '''

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -9,7 +9,7 @@ try:
     has_mock = True
 except ImportError:
     has_mock = False
-    patch = lambda x: lambda: None
+    patch = lambda x: lambda y: None
 
 
 @skipIf(has_mock is False, "mock python module is unavailable")

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -9,7 +9,7 @@ try:
     has_mock = True
 except ImportError:
     has_mock = False
-    patch = lambda x: x
+    patch = lambda x: lambda: None
 
 
 @skipIf(has_mock is False, "mock python module is unavailable")

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -9,6 +9,7 @@ try:
     has_mock = True
 except ImportError:
     has_mock = False
+    patch = lambda x: pass
 
 
 @skipIf(has_mock is False, "mock python module is unavailable")

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -2,9 +2,16 @@ import os
 import integration
 import tempfile
 
-from mock import Mock, patch
+from saltunittest import skipIf
+
+try:
+    from mock import Mock, patch
+    has_mock = True
+except ImportError:
+    has_mock = False
 
 
+@skipIf(has_mock is False, "mock python module is unavailable")
 class CMDModuleTest(integration.ModuleCase):
     '''
     Validate the cmd module

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -6,7 +6,7 @@ except ImportError:
     has_mock = False
     patch = lambda x: lambda: None
 
-from saltunittest import TestCase, TestLoader, TextTestRunner
+from saltunittest import TestCase, TestLoader, TextTestRunner, skipIf
 
 from salt.modules import postgres
 postgres.__grains__ = None  # in order to stub it w/patch below
@@ -18,6 +18,7 @@ SALT_STUB = {
 }
 
 
+@skipIf(has_mock is False, "mock python module is unavailable")
 class PostgresTestCase(TestCase):
     @patch.multiple(postgres, __grains__={'os_family': 'FreeBSD'})
     def test_get_runas_bsd(self):

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -12,10 +12,13 @@ from salt.modules import postgres
 postgres.__grains__ = None  # in order to stub it w/patch below
 postgres.__salt__ = None  # in order to stub it w/patch below
 
-SALT_STUB = {
-    'config.option': Mock(),
-    'cmd.run_all': Mock(),
-}
+if has_mock:
+    SALT_STUB = {
+        'config.option': Mock(),
+        'cmd.run_all': Mock(),
+    }
+else:
+    SALT_STUB = {}
 
 
 @skipIf(has_mock is False, "mock python module is unavailable")

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -5,9 +5,9 @@ try:
 except ImportError:
     has_mock = False
     patch = lambda x: lambda y: None
-    def patchmultiple(x, y, z=None):
-        return None
-    patch.multiple = lambda x: patchmultiple
+    def patchmultiple(x, __grains__, __salt__=None):
+        return lambda y: None
+    patch.multiple = patchmultiple
 
 from saltunittest import TestCase, TestLoader, TextTestRunner, skipIf
 

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -4,7 +4,10 @@ try:
     has_mock = True
 except ImportError:
     has_mock = False
-    patch = lambda x: lambda: None
+    patch = lambda x: lambda y: None
+    def patchmultiple(x, y, z=None):
+        return None
+    patch.multiple = lambda x: patchmultiple
 
 from saltunittest import TestCase, TestLoader, TextTestRunner, skipIf
 

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -9,8 +9,8 @@ except ImportError:
 from saltunittest import TestCase, TestLoader, TextTestRunner
 
 from salt.modules import postgres
-postgres.__grains__ = None # in order to stub it w/patch below
-postgres.__salt__ = None # in order to stub it w/patch below
+postgres.__grains__ = None  # in order to stub it w/patch below
+postgres.__salt__ = None  # in order to stub it w/patch below
 
 SALT_STUB = {
     'config.option': Mock(),
@@ -19,18 +19,20 @@ SALT_STUB = {
 
 
 class PostgresTestCase(TestCase):
-    @patch.multiple(postgres, __grains__={ 'os_family': 'FreeBSD' })
+    @patch.multiple(postgres, __grains__={'os_family': 'FreeBSD'})
     def test_get_runas_bsd(self):
         self.assertEqual('pgsql', postgres._get_runas())
 
-    @patch.multiple(postgres, __grains__={ 'os_family': 'Linux' })
+    @patch.multiple(postgres, __grains__={'os_family': 'Linux'})
     def test_get_runas_other(self):
         self.assertEqual('postgres', postgres._get_runas())
 
-    @patch.multiple(postgres, __grains__={ 'os_family': 'Linux' }, __salt__=SALT_STUB)
+    @patch.multiple(postgres,
+                    __grains__={'os_family': 'Linux'},
+                    __salt__=SALT_STUB)
     def test_run_psql(self):
         postgres._run_psql('echo "hi"')
-        cmd = SALT_STUB['cmd.run_all'] 
+        cmd = SALT_STUB['cmd.run_all']
 
         self.assertEquals('postgres', cmd.call_args[1]['runas'])
 

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -1,4 +1,10 @@
-from mock import Mock, patch
+
+try:
+    from mock import Mock, patch
+    has_mock = True
+except ImportError:
+    has_mock = False
+    patch = lambda x: lambda: None
 
 from saltunittest import TestCase, TestLoader, TextTestRunner
 


### PR DESCRIPTION
`mock` was imported in an unsafe manner in both `integration/modules/cmdmod.py` and `unit/modules/postgres_test.py`.

@rca, please keep in mind for future tests that we should never just import modules which are not direct dependencies for salt.  Rather, we want to wrap them and skip the tests if that module is not available (as I've done here)

Sorry for so many extra commits -- decorators are evaluated at import-time, and apparently I completely forgot how they work as I tried to fix them.  =P

Also, I have not actually tested these tests -- this pull req only makes it so if `mock` isn't installed, these tests are skipped.
