### PR TITLE
Automagically chkconfig --add custom initscripts

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -4,8 +4,14 @@ service command (so it is compatible with upstart systems) and the chkconfig
 command.
 '''
 
+# Import python libs
+import logging
+import os
+
 # Import salt libs
 import salt.utils
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -14,21 +20,22 @@ def __virtual__():
     '''
     # Disable on these platforms, specific service modules exist:
     enable = [
-               'RedHat',
-               'CentOS',
-               'Scientific',
-               'CloudLinux',
-               'Amazon',
-               'Fedora',
-               'ALT',
-               'OEL',
-              ]
+        'RedHat',
+        'CentOS',
+        'Scientific',
+        'CloudLinux',
+        'Amazon',
+        'Fedora',
+        'ALT',
+        'OEL',
+    ]
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':
             if __grains__['osrelease'] > 15:
                 return False
         return 'service'
     return False
+
 
 def _runlevel():
     '''
@@ -43,6 +50,27 @@ def _runlevel():
         return '3'
     else:
         return out.split()[1]
+
+
+def _add_custom_initscript(name):
+    '''
+    If the passed service name is not in the output from get_all(), runs a
+    'chkconfig --add' so that it is available.
+    '''
+    initscript_path = os.path.join('/etc/rc.d/init.d', name)
+    if name not in get_all() and __salt__['cmd.has_exec'](initscript_path):
+        cmd = '/sbin/chkconfig --add {0}'.format(name)
+        if __salt__['cmd.retcode'](cmd):
+            log.error('Unable to add initscript "{0}"'.format(name))
+        else:
+            log.info('Added initscript "{0}"'.format(name))
+            # Disable initscript by default. If a user wants it enabled, he/she
+            # can configure that in a state. Since we're adding the service
+            # automagically, we shouldn't also enable it, as the user may not
+            # be aware that the service was added to chkconfig and thus would
+            # not be expecting it to start on boot (which is the default).
+            cmd = '/sbin/chkconfig {0} off'.format(name)
+            __salt__['cmd.run'](cmd)
 
 
 def get_enabled():
@@ -67,6 +95,7 @@ def get_enabled():
             ret.add(comps[0].strip(':'))
     return sorted(ret)
 
+
 def get_disabled():
     '''
     Return the disabled services
@@ -87,6 +116,7 @@ def get_disabled():
             ret.add(comps[0])
     return sorted(ret)
 
+
 def get_all():
     '''
     Return all installed services
@@ -97,6 +127,7 @@ def get_all():
     '''
     return sorted(get_enabled() + get_disabled())
 
+
 def start(name):
     '''
     Start the specified service
@@ -105,6 +136,7 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
+    _add_custom_initscript(name)
     cmd = '/sbin/service {0} start'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
@@ -117,6 +149,7 @@ def stop(name):
 
         salt '*' service.stop <service name>
     '''
+    _add_custom_initscript(name)
     cmd = '/sbin/service {0} stop'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
@@ -129,6 +162,7 @@ def restart(name, **kwargs):
 
         salt '*' service.restart <service name>
     '''
+    _add_custom_initscript(name)
     cmd = '/sbin/service {0} restart'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
@@ -142,6 +176,7 @@ def status(name, sig=None):
 
         salt '*' service.status <service name>
     '''
+    _add_custom_initscript(name)
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = '/sbin/service {0} status'.format(name)
@@ -156,6 +191,7 @@ def enable(name, **kwargs):
 
         salt '*' service.enable <service name>
     '''
+    _add_custom_initscript(name)
     cmd = '/sbin/chkconfig {0} on'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
@@ -168,6 +204,7 @@ def disable(name, **kwargs):
 
         salt '*' service.disable <service name>
     '''
+    _add_custom_initscript(name)
     cmd = '/sbin/chkconfig {0} off'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
@@ -180,6 +217,7 @@ def enabled(name):
 
         salt '*' service.enabled <service name>
     '''
+    _add_custom_initscript(name)
     return name in get_enabled()
 
 
@@ -191,4 +229,5 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
+    _add_custom_initscript(name)
     return name in get_disabled()


### PR DESCRIPTION
If a custom initscript does not show in /sbin/chkconfig --list, add it
when running any function that checks on/modifies the status of a
service. Saves the user from having to add a cmd.run state for each
custom initscript they deploy.

Service is disabled upon being added so that it does not run unless the
user turns it on, to avoid confusion.

Fulfills #2908, though I'll probably look into this for other service
providers as well.
