### PR TITLE
Make file.sed return true even if `after` isn't found in file

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1346,6 +1346,10 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
     else:
         ret['comment'] = 'Expected edit does not appear in file'
 
+    # In this case, even if the `after` pattern doesn't appear in the file, we
+    # return True, as it's not necessarily an error
+    ret['result'] = True
+
     return ret
 
 


### PR DESCRIPTION
Fixes #4063

Now the `file.sed` state will return `True` even if the `after` pattern is not found in the file.  This way, it won't show up as an error in the cases of that pattern not appearing in the file, or in the case of using backreferences and such.

The issue is that `sed` is not a tool that's designed to handle state -- it's a stream editor, meant to process a file once.  Rather than removing a module that people seem to be using, however, we'll just hack it so it behaves better.  =P
