### PR TITLE
add a mention of the include_empty option to file.recurse

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -31876,6 +31876,7 @@ something like this:
 /opt/code/flask:
   file.recurse:
     \- source: salt://code/flask
+    \- include_empty: True
 .ft P
 .fi
 .INDENT 0.0


### PR DESCRIPTION
The 'include_empty' option for file.recurse isn't currently mentioned anywhere in the documentation. 
