### PR TITLE
Rename file.contains_regex to file.contains_regex_multiline

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -760,16 +760,13 @@ def contains(path, text):
         return False
 
 
-def contains_regex_multiline(path, regex, lchar=''):
+def contains_regex_multiline(path, regex):
     '''
     Return True if the given regular expression matches anything in the text
     of a given file
 
     Traverses multiple lines at a time, via the salt BufferedReader (reads in
     chunks)
-
-    `lchar` is ignored (as it's not relevant if we're not dealing with lines).
-    We would remove it, but it might break existing code.
 
     CLI Example::
 
@@ -781,8 +778,6 @@ def contains_regex_multiline(path, regex, lchar=''):
     try:
         with salt.utils.filebuffer.BufferedReader(path) as breader:
             for chunk in breader:
-                if lchar:
-                    chunk = chunk.lstrip(lchar)
                 if re.search(regex, chunk, re.MULTILINE):
                     return True
             return False

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -776,7 +776,7 @@ def contains_regex(path, regex, lchar=''):
         return False
 
     try:
-        with open(path, 'r') as target:
+        with salt.utils.fopen(path, 'r') as target:
             for line in target:
                 if lchar:
                     line = line.lstrip(lchar)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -760,6 +760,33 @@ def contains(path, text):
         return False
 
 
+def contains_regex(path, regex, lchar=''):
+    '''
+    Return True if the given regular expression matches on any line in the text
+    of a given file.
+
+    If the lchar argument (leading char) is specified, it
+    will strip `lchar` from the left side of each line before trying to match
+
+    CLI Examples:
+
+        salt '*' file.contains_regex /etc/crontab
+    '''
+    if not os.path.exists(path):
+        return False
+
+    try:
+        with open(path, 'r') as target:
+            for line in target:
+                if lchar:
+                    line = line.lstrip(lchar)
+                if re.search(regex, line):
+                    return True
+            return False
+    except (IOError, OSError):
+        return False
+
+
 def contains_regex_multiline(path, regex):
     '''
     Return True if the given regular expression matches anything in the text

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -760,14 +760,20 @@ def contains(path, text):
         return False
 
 
-def contains_regex(path, regex, lchar=''):
+def contains_regex_multiline(path, regex, lchar=''):
     '''
     Return True if the given regular expression matches anything in the text
     of a given file
 
+    Traverses multiple lines at a time, via the salt BufferedReader (reads in
+    chunks)
+
+    `lchar` is ignored (as it's not relevant if we're not dealing with lines).
+    We would remove it, but it might break existing code.
+
     CLI Example::
 
-        salt '*' file.contains_regex /etc/crontab '^maint'
+        salt '*' file.contains_regex_multiline /etc/crontab '^maint'
     '''
     if not os.path.exists(path):
         return False

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -79,7 +79,7 @@ def _set_persistent_module(mod):
         return set()
     escape_mod = re.escape(mod)
     ## If module is commented only uncomment it
-    if __salt__['file.contains_regex'](conf, "^#[\t ]*{}[\t ]*$".format(escape_mod)):
+    if __salt__['file.contains_regex_multiline'](conf, "^#[\t ]*{}[\t ]*$".format(escape_mod)):
         __salt__['file.uncomment'](conf, escape_mod)
     else:
         __salt__['file.append'](conf, mod)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1314,7 +1314,7 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
     after = str(after)
 
     # Look for the pattern before attempting the edit
-    if not __salt__['file.contains_regex'](name, before):
+    if not __salt__['file.contains_regex_multiline'](name, before):
         # Pattern not found; try to guess why
         if __salt__['file.contains'](name, after):
             ret['comment'] = 'Edit already performed'
@@ -1336,7 +1336,7 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
         nlines = fp_.readlines()
 
     # check the result
-    ret['result'] = __salt__['file.contains_regex'](name, after)
+    ret['result'] = __salt__['file.contains_regex_multiline'](name, after)
     if slines != nlines:
         # Changes happened, add them
         ret['changes']['diff'] = ''.join(difflib.unified_diff(slines, nlines))
@@ -1395,8 +1395,8 @@ def comment(name, regex, char='#', backup='.bak'):
     unanchor_regex = regex.lstrip('^').rstrip('$')
 
     # Make sure the pattern appears in the file before continuing
-    if not __salt__['file.contains_regex'](name, regex):
-        if __salt__['file.contains_regex'](name, unanchor_regex):
+    if not __salt__['file.contains_regex_multiline'](name, regex):
+        if __salt__['file.contains_regex_multiline'](name, unanchor_regex):
             ret['comment'] = 'Pattern already commented'
             ret['result'] = True
             return ret
@@ -1416,7 +1416,7 @@ def comment(name, regex, char='#', backup='.bak'):
         nlines = fp_.readlines()
 
     # Check the result
-    ret['result'] = __salt__['file.contains_regex'](name, unanchor_regex)
+    ret['result'] = __salt__['file.contains_regex_multiline'](name, unanchor_regex)
 
     if slines != nlines:
         # Changes happened, add them
@@ -1467,11 +1467,11 @@ def uncomment(name, regex, char='#', backup='.bak'):
         return _error(ret, check_msg)
 
     # Make sure the pattern appears in the file
-    if __salt__['file.contains_regex'](name, '^[ \t]*' + regex.lstrip('^')):
+    if __salt__['file.contains_regex_multiline'](name, '^[ \t]*' + regex.lstrip('^')):
         ret['comment'] = 'Pattern already uncommented'
         ret['result'] = True
         return ret
-    elif __salt__['file.contains_regex'](name,
+    elif __salt__['file.contains_regex_multiline'](name,
                                          char + '[ \t]*' + regex.lstrip('^')):
         # Line exists and is commented
         pass
@@ -1494,7 +1494,7 @@ def uncomment(name, regex, char='#', backup='.bak'):
 
     # Check the result
     ret['result'] = \
-        __salt__['file.contains_regex'](name, '^[ \t]*' + regex.lstrip('^'))
+        __salt__['file.contains_regex_multiline'](name, '^[ \t]*' + regex.lstrip('^'))
 
     if slines != nlines:
         # Changes happened, add them
@@ -1591,7 +1591,7 @@ def append(name,
 
     for chunk in text:
 
-        if __salt__['file.contains_regex'](
+        if __salt__['file.contains_regex_multiline'](
                 name, salt.utils.build_whitepace_splited_regex(chunk)):
             continue
 


### PR DESCRIPTION
Renamed `file.contains_regex` to `file.contains_regex_multiline`, as that's how it's written to behave, and it it more intuitively names this way.  I also refactored every instance of `file.contains_regex` to `file.contains_regex_multiline` to keep existing behavior, even though some of the instances probably _should_ be `file.contains_regex`

I added a new `file.contains_regex` that operates on single lines.  This is probably the version most people will want to use.

@s0undt3ch, everything look good?  IIRC, you wrote the original `contains_regex`.
