### PR TITLE
Fix file.rename so it works with files, dirs, and links

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1830,7 +1830,11 @@ def rename(name, source, force=False, makedirs=False):
                 'The target directory {0} is not present'.format(dname))
     # All tests pass, move the file into place
     try:
-        shutil.move(source, name)
+        if os.path.islink(source):
+            linkto = os.readlink(source)
+            os.symlink(linkto, name)
+        else:
+            shutil.move(source, name)
     except (IOError, OSError):
         return _error(
             ret, 'Failed to move "{0}" to "{1}"'.format(source, name))

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1833,6 +1833,7 @@ def rename(name, source, force=False, makedirs=False):
         if os.path.islink(source):
             linkto = os.readlink(source)
             os.symlink(linkto, name)
+            os.unlink(source)
         else:
             shutil.move(source, name)
     except (IOError, OSError):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1787,12 +1787,12 @@ def rename(name, source, force=False, makedirs=False):
         return _error(
             ret, 'Specified file {0} is not an absolute path'.format(name))
 
-    if not os.path.exists(source):
+    if not os.path.lexists(source):
         ret['comment'] = ('Source file "{0}" has already been moved out of '
                           'place').format(source)
         return ret
 
-    if os.path.exists(source) and os.path.exists(name):
+    if os.path.lexists(source) and os.path.lexists(name):
         if not force:
             ret['comment'] = ('The target file "{0}" exists and will not be '
                               'overwritten').format(name)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1787,16 +1787,30 @@ def rename(name, source, force=False, makedirs=False):
         return _error(
             ret, 'Specified file {0} is not an absolute path'.format(name))
 
-    if not os.path.isfile(source):
+    if not os.path.exists(source):
         ret['comment'] = ('Source file "{0}" has already been moved out of '
                           'place').format(source)
         return ret
 
-    if os.path.isfile(source) and os.path.isfile(name) and not force:
-        ret['comment'] = ('The target file "{0}" exists and will not be '
-                          'overwritten').format(name)
-        ret['result'] = False
-        return ret
+    if os.path.exists(source) and os.path.exists(name):
+        if not force:
+            ret['comment'] = ('The target file "{0}" exists and will not be '
+                              'overwritten').format(name)
+            ret['result'] = False
+            return ret
+        elif not __opts__['test']:
+            # Remove the destination to prevent problems later
+            try:
+                if os.path.islink(name):
+                    os.unlink(name)
+                elif os.path.isfile(name):
+                    os.remove(name)
+                else:
+                    shutil.rmtree(name)
+            except (IOError, OSError):
+                return _error(
+                    ret, ('Failed to delete "{0}" in preparation for '
+                          'forced move').format(name))
 
     if __opts__['test']:
         ret['comment'] = 'File "{0}" is set to be moved to "{1}"'.format(


### PR DESCRIPTION
Fixes #4079

The `file.rename` state should now work properly with files, directories, or symlinks.  When symlinks are moved, the old link is removed, and a new link is created pointing to the same location, rather than moving the files it links to.
