### PR TITLE
Fix multiplication problem for #3431

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -979,7 +979,7 @@ class LocalClient(object):
         sreq = salt.payload.SREQ(
             'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
         )
-        payload = sreq.send('clear', payload_kwargs)
+        payload = sreq.send('clear', payload_kwargs, timeout=timeout)
 
         # We have the payload, let's get rid of SREQ fast(GC'ed faster)
         del(sreq)

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -146,7 +146,7 @@ class SREQ(object):
         self.poller.register(self.socket, zmq.POLLIN)
         tried = 0
         while True:
-            polled = self.poller.poll(timeout * 1000)
+            polled = self.poller.poll(timeout)
             tried += 1
             if polled:
                 break


### PR DESCRIPTION
The pyzmq bindings already do the conversion to milliseconds (https://github.com/zeromq/pyzmq/blob/master/zmq/eventloop/ioloop.py) So instead of sleeping 60 seconds, we are sleeping 60000 seconds (~16 hours) which is causing the cli to "never return"

In addition we aren't passing the timeout of the command from the client down to the zmq socket
