### PR TITLE
 Move config.is_true, make upstart work properly in rh_service.py

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -9,6 +9,9 @@ import logging
 import urllib2
 import json
 
+# Import salt libs
+import salt.utils
+
 try:
     from aptsources import sourceslist
     apt_support = True
@@ -279,7 +282,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     if debconf:
@@ -427,7 +430,7 @@ def upgrade(refresh=True, **kwargs):
 
         salt '*' pkg.upgrade
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     ret_pkgs = {}
@@ -472,7 +475,7 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
         salt '*' pkg.list_pkgs httpd
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     cmd = 'dpkg-query --showformat=\'${Status} ${Package} ' \
           '${Version}\n\' -W'
@@ -562,7 +565,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     return _get_upgradable()
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -3,7 +3,7 @@ Homebrew for Mac OS X
 '''
 
 # Import salt libs
-import salt
+import salt.utils
 
 
 def __virtual__():
@@ -26,7 +26,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     cmd = 'brew list --versions {0}'.format(' '.join(args))
     for line in __salt__['cmd.run'](cmd).splitlines():

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -75,27 +75,6 @@ def manage_mode(mode):
     return mode
 
 
-def is_true(value=None):
-    '''
-    Returns a boolean value representing the "truth" of the value passed. The
-    rules for what is a ``True`` value are:
-
-        1. Numeric values greater than :strong:`0`
-        2. The string values :strong:`True` and :strong:`true`
-        3. Any object for which ``bool(obj)`` returns ``True``
-
-    CLI Example::
-
-        salt '*' config.is_true true
-    '''
-    if isinstance(value, (int, float)):
-        return value > 0
-    elif isinstance(value, basestring):
-        return str(value).lower() == 'true'
-    else:
-        return bool(value)
-
-
 def valid_fileproto(uri):
     '''
     Returns a boolean value based on whether or not the URI passed has a valid

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -11,6 +11,9 @@ i.e. ``'vim'`` will not work, ``'app-editors/vim'`` will.
 import logging
 import re
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 HAS_PORTAGE = False
@@ -132,7 +135,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     return _get_upgradable()
 
@@ -186,7 +189,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     pkgs = _vartree().dbapi.cpv_all()
     for cpv in pkgs:
@@ -281,7 +284,7 @@ def install(name=None,
             'kwargs': kwargs
         }
     ))
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -389,7 +392,7 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     ret_pkgs = {}

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -5,8 +5,7 @@ Package support for FreeBSD
 # Import python libs
 import logging
 
-# Import python libs
-import os
+# Import salt libs
 import salt.utils
 
 
@@ -149,7 +148,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     if _check_pkgng():
         pkg_command = '{0} info'.format(_cmd('pkg'))
     else:

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -6,6 +6,9 @@ Package support for OpenBSD
 import re
 import logging
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -77,7 +80,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     return _format_pkgs(_get_pkgs(), versions_as_list=versions_as_list)
 
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -7,6 +7,9 @@ A module to wrap pacman calls, since Arch is the best
 import logging
 import re
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -126,7 +129,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     cmd = 'pacman -Q'
     ret = {}
     out = __salt__['cmd.run'](cmd).splitlines()
@@ -267,7 +270,7 @@ def install(name=None,
                 log.error(problem)
             return {}
 
-        if __salt__['config.is_true'](refresh):
+        if salt.utils.is_true(refresh):
             cmd = 'pacman -Syu --noprogressbar --noconfirm ' \
                   '"{0}"'.format('" "'.join(targets))
         else:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -10,6 +10,9 @@ import pprint
 import logging
 import distutils.version
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -315,7 +318,7 @@ def version(*names, **kwargs):
     '''
     ret = {}
     versions_as_list = \
-        __salt__['config.is_true'](kwargs.get('versions_as_list'))
+        salt.utils.is_true(kwargs.get('versions_as_list'))
     if len(names) != 0:
         pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True)
         for name in names:

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -2,6 +2,9 @@
 Pkgutil support for Solaris
 '''
 
+# Import salt libs
+import salt.utils
+
 
 def __virtual__():
     '''
@@ -64,7 +67,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkgutil.list_upgrades
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     upgrades = {}
     lines = __salt__['cmd.run_stdout'](
@@ -92,7 +95,7 @@ def upgrade(refresh=True, **kwargs):
 
         salt '*' pkgutil.upgrade
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     # Get a list of the packages before install so we can diff after to see
@@ -121,7 +124,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkgutil.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     cmd = '/usr/bin/pkginfo -x'
 

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -81,7 +81,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     cmd = '/usr/bin/pkginfo -x'
 

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -21,8 +21,10 @@ except ImportError:
 import logging
 import msgpack
 import os
-import salt.utils
 from distutils.version import LooseVersion
+
+# Import salt libs
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -123,7 +125,7 @@ def list_upgrades(refresh=True):
 
     # Uncomment the below once pkg.list_upgrades has been implemented
 
-    #if __salt__['config.is_true'](refresh):
+    #if salt.utils.is_true(refresh):
     #    refresh_db()
     return {}
 
@@ -150,7 +152,7 @@ def list_pkgs(*args, **kwargs):
             salt '*' pkg.list_pkgs
     '''
     versions_as_list = \
-        __salt__['config.is_true'](kwargs.get('versions_as_list'))
+        salt.utils.is_true(kwargs.get('versions_as_list'))
     pkgs = {}
     with salt.utils.winapi.Com():
         if len(args) == 0:
@@ -407,7 +409,7 @@ def upgrade(refresh=True):
 
     # Uncomment the below once pkg.upgrade has been implemented
 
-    #if __salt__['config.is_true'](refresh):
+    #if salt.utils.is_true(refresh):
     #    refresh_db()
     return {}
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -10,6 +10,9 @@ import yaml
 import os
 import logging
 
+# Import salt libs
+import salt.utils
+
 # Import third party libs
 try:
     import yum
@@ -109,7 +112,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     pkgs = list_pkgs()
@@ -249,7 +252,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     yb = yum.YumBase()
     for p in yb.rpmdb:
@@ -443,7 +446,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -537,7 +540,7 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     yumbase = yum.YumBase()

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -6,6 +6,9 @@ Support for YUM
 import logging
 import collections
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -166,7 +169,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
     cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-' \
           '%{ARCH}\n"'
@@ -199,7 +202,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     out = _parse_yum('check-update')
     return dict([(i.name, i.version) for i in out])
@@ -295,7 +298,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -374,7 +377,7 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     old = list_pkgs()
     cmd = 'yum -q -y upgrade'

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -43,7 +43,7 @@ def list_upgrades(refresh=True):
 
         salt '*' pkg.list_upgrades
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     ret = {}
     out = __salt__['cmd.run_stdout']('zypper list-updates').splitlines()
@@ -130,7 +130,7 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
-    versions_as_list = __salt__['config.is_true'](versions_as_list)
+    versions_as_list = salt.utils.is_true(versions_as_list)
     cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
     ret = {}
     for line in __salt__['cmd.run'](cmd).splitlines():
@@ -229,7 +229,7 @@ def install(name=None,
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name,
@@ -305,7 +305,7 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
-    if __salt__['config.is_true'](refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
     old = list_pkgs()
     cmd = 'zypper -n up -l'

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -837,6 +837,23 @@ def check_state_result(self, running):
     return True
 
 
+def is_true(value=None):
+    '''
+    Returns a boolean value representing the "truth" of the value passed. The
+    rules for what is a ``True`` value are:
+
+        1. Numeric values greater than :strong:`0`
+        2. The string values :strong:`True` and :strong:`true`
+        3. Any object for which ``bool(obj)`` returns ``True``
+    '''
+    if isinstance(value, (int, float)):
+        return value > 0
+    elif isinstance(value, basestring):
+        return str(value).lower() == 'true'
+    else:
+        return bool(value)
+
+
 def rm_rf(path):
     '''
     Platform-independent recursive delete. Includes code from


### PR DESCRIPTION
These commits do two things:
1. Move salt.modules.config.is_true to salt.utils. This function makes
   more sense there.
2. Fix #3183, making rh_service.py properly handle upstart-based
   services.
