### PR TITLE
Adding startup scripts for salt-bootstrap to use on OpenBSD

### DIFF
--- a/pkg/openbsd/salt-master.rc-d
+++ b/pkg/openbsd/salt-master.rc-d
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+daemon="/usr/local/bin/salt-master"
+daemon_flags="-d"
+
+. /etc/rc.d/rc.subr
+
+pexp="/usr/local/bin/python2.7 $daemon"
+
+rc_cmd $1

--- a/pkg/openbsd/salt-minion.rc-d
+++ b/pkg/openbsd/salt-minion.rc-d
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+daemon="/usr/local/bin/salt-master"
+daemon_flags="-d"
+
+. /etc/rc.d/rc.subr
+
+pexp="/usr/local/bin/python2.7 $daemon"
+
+rc_cmd $1

--- a/pkg/openbsd/salt-syncdic.rc-d
+++ b/pkg/openbsd/salt-syncdic.rc-d
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+daemon="/usr/local/bin/salt-syncdic"
+daemon_flags="-d"
+
+. /etc/rc.d/rc.subr
+
+pexp="/usr/local/bin/python2.7 $daemon"
+
+rc_cmd $1


### PR DESCRIPTION
These are the scripts to start the services under OpenBSD. I'm currently working on adding OpenBSD support to the salt-bootstrap stuff. This is to match the way it is handled when doing an install via Git on Ubuntu (trying for consistency). The current OpenBSD stuff is at [my fork](https://github.com/kmwhite/salt-bootstrap/tree/feature-add_openbsd_installation_support)
