### PR TITLE
IPv6 support for master-minion communication

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -13,7 +13,7 @@ from salt.version import __version__  # pylint: disable-msg=W402
 from salt.utils import migrations
 
 try:
-    from salt.utils import parsers
+    from salt.utils import parsers, ip_bracket
     from salt.utils.verify import check_user, verify_env, verify_socket
     from salt.utils.verify import verify_files
 except ImportError as e:
@@ -77,6 +77,7 @@ class Master(parsers.MasterOptionParser):
                              self.config['publish_port'],
                              self.config['ret_port']):
             self.exit(4, 'The ports are not available to bind\n')
+        self.config['interface'] = ip_bracket(self.config['interface'])
         migrations.migrate_paths(self.config)
 
         # Late import so logging works correctly

--- a/salt/master.py
+++ b/salt/master.py
@@ -372,6 +372,9 @@ class Publisher(multiprocessing.Process):
         except AttributeError:
             pub_sock.setsockopt(zmq.SNDHWM, 1)
             pub_sock.setsockopt(zmq.RCVHWM, 1)
+        if hasattr(zmq, 'IPV4ONLY'):
+            # IPv6 sockets work for both IPv6 and IPv4 addresses
+            pub_sock.setsockopt(zmq.IPV4ONLY, 0)
         pub_uri = 'tcp://{interface}:{publish_port}'.format(**self.opts)
         # Prepare minion pull socket
         pull_sock = context.socket(zmq.PULL)
@@ -424,6 +427,9 @@ class ReqServer(object):
         # Prepare the zeromq sockets
         self.uri = 'tcp://{interface}:{ret_port}'.format(**self.opts)
         self.clients = self.context.socket(zmq.ROUTER)
+        if hasattr(zmq, 'IPV4ONLY'):
+            # IPv6 sockets work for both IPv6 and IPv4 addresses
+            self.clients.setsockopt(zmq.IPV4ONLY, 0)
         self.workers = self.context.socket(zmq.DEALER)
         self.w_uri = 'ipc://{0}'.format(
             os.path.join(self.opts['sock_dir'], 'workers.ipc')

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -737,6 +737,9 @@ class Minion(object):
         self.socket = self.context.socket(zmq.SUB)
         self.socket.setsockopt(zmq.SUBSCRIBE, '')
         self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
+        if hasattr(zmq, 'IPV4ONLY'):
+            # IPv6 sockets work for both IPv6 and IPv4 addresses
+            self.socket.setsockopt(zmq.IPV4ONLY, 0)
         if hasattr(zmq, 'RECONNECT_IVL_MAX'):
             self.socket.setsockopt(
                 zmq.RECONNECT_IVL_MAX, self.opts['recon_max']

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -129,6 +129,9 @@ class SREQ(object):
             self.socket.setsockopt(
                 zmq.RECONNECT_IVL_MAX, 5000
             )
+        if hasattr(zmq, 'IPV4ONLY'):
+            # IPv6 sockets work for both IPv6 and IPv4 addresses
+            self.socket.setsockopt(zmq.IPV4ONLY, 0)
         self.socket.linger = linger
         if id_:
             self.socket.setsockopt(zmq.IDENTITY, id_)

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -303,25 +303,12 @@ def gen_mac(prefix='52:54:'):
             mac += random.choice(src) + random.choice(src) + ':'
     return mac[:-1]
 
-def ip_ztop(addr):
+def ip_bracket(addr):
     '''
-    Convert IP address representation from ZMQ to Python format. ZMQ expects
-    brackets around IPv6 literals, while Python socket functions do not.
+    Convert IP address representation to ZMQ (url) format. ZMQ expects
+    brackets around IPv6 literals, since they are used in URLs.
     '''
-    if not addr:
-        return addr
-    if addr.startswith("["):
-        addr = addr[1:]
-    if addr.endswith("]"):
-        addr = addr[:-1]
-    return addr
-
-def ip_ptoz(addr):
-    '''
-    Convert IP address representation from Python to ZMQ format. ZMQ expects
-    brackets around IPv6 literals, while Python socket functions do not.
-    '''
-    if addr and addr.find(":") > -1:
+    if addr and addr.find(":") > -1 and not addr.startswith('['):
         return "[{0}]".format(addr)
     return addr
 
@@ -333,13 +320,13 @@ def dns_check(addr, safe=False):
     '''
     error = False
     try:
-        hostnames = socket.getaddrinfo(ip_ztop(addr), None, socket.AF_UNSPEC,
+        hostnames = socket.getaddrinfo(addr, None, socket.AF_UNSPEC,
                                        socket.SOCK_STREAM)
         if not hostnames:
             error = True
         else:
             h = hostnames[0]
-            addr = ip_ptoz(h[4][0])
+            addr = ip_bracket(h[4][0])
     except socket.gaierror:
         error = True
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -308,6 +308,8 @@ def ip_ztop(addr):
     Convert IP address representation from ZMQ to Python format. ZMQ expects
     brackets around IPv6 literals, while Python socket functions do not.
     '''
+    if not addr:
+        return addr
     if addr.startswith("["):
         addr = addr[1:]
     if addr.endswith("]"):
@@ -319,7 +321,7 @@ def ip_ptoz(addr):
     Convert IP address representation from Python to ZMQ format. ZMQ expects
     brackets around IPv6 literals, while Python socket functions do not.
     '''
-    if addr.find(":") > -1:
+    if addr and addr.find(":") > -1:
         return "[{0}]".format(addr)
     return addr
 

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -105,7 +105,6 @@ def verify_socket(interface, pub_port, ret_port):
     Attempt to bind to the sockets to verify that they are available
     '''
 
-    interface = salt.utils.ip_ztop(interface) # strip brackets from IPv6 addresses
     addr_family = lookup_family(interface)
     pubsock = socket.socket(addr_family, socket.SOCK_STREAM)
     retsock = socket.socket(addr_family, socket.SOCK_STREAM)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -83,13 +83,27 @@ def zmq_version():
             sys.stderr.write('CRITICAL {0}\n'.format(msg))
     return False
 
+def lookup_family(hostname):
+    '''
+    Lookup a hostname and determine its address family. The first address returned
+    will be AF_INET6 if the system is IPv6-enabled, and AF_INET otherwise.
+    '''
+    hostnames = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC,
+                                   socket.SOCK_STREAM)
+    if not hostnames:
+        raise RuntimeError("Found no hostnames on lookup of {0}".format(hostname))
+    h = hostnames[0]
+    return h[0]
 
 def verify_socket(interface, pub_port, ret_port):
     '''
     Attempt to bind to the sockets to verify that they are available
     '''
-    pubsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    retsock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+    interface = utils.ip_ztop(interface) # strip brackets from IPv6 addresses
+    addr_family = lookup_family(interface)
+    pubsock = socket.socket(addr_family, socket.SOCK_STREAM)
+    retsock = socket.socket(addr_family, socket.SOCK_STREAM)
     try:
         pubsock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         pubsock.bind((interface, int(pub_port)))

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -100,7 +100,7 @@ def verify_socket(interface, pub_port, ret_port):
     Attempt to bind to the sockets to verify that they are available
     '''
 
-    interface = utils.ip_ztop(interface) # strip brackets from IPv6 addresses
+    interface = salt.utils.ip_ztop(interface) # strip brackets from IPv6 addresses
     addr_family = lookup_family(interface)
     pubsock = socket.socket(addr_family, socket.SOCK_STREAM)
     retsock = socket.socket(addr_family, socket.SOCK_STREAM)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -88,12 +88,17 @@ def lookup_family(hostname):
     Lookup a hostname and determine its address family. The first address returned
     will be AF_INET6 if the system is IPv6-enabled, and AF_INET otherwise.
     '''
-    hostnames = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC,
-                                   socket.SOCK_STREAM)
-    if not hostnames:
-        raise RuntimeError("Found no hostnames on lookup of {0}".format(hostname))
-    h = hostnames[0]
-    return h[0]
+    # If lookups fail, fall back to AF_INET sockets (and v4 addresses).
+    fallback = socket.AF_INET
+    try:
+        hostnames = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC,
+                                       socket.SOCK_STREAM)
+        if not hostnames:
+            return fallback
+        h = hostnames[0]
+        return h[0]
+    except socket.gaierror:
+        return fallback
 
 def verify_socket(interface, pub_port, ret_port):
     '''

--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -10,6 +10,7 @@ import stat
 import shutil
 import resource
 import tempfile
+import socket
 
 # Import Salt libs
 import salt.utils
@@ -75,6 +76,10 @@ class TestVerify(TestCase):
 
     def test_verify_socket(self):
         self.assertTrue(verify_socket('', 18000, 18001))
+        if socket.has_ipv6:
+            # Only run if Python is built with IPv6 support; otherwise
+            # this will just fail.
+            self.assertTrue(verify_socket('[::]', 18000, 18001))
 
     @skipIf(os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None,
             'Travis environment does not like too many open files')

--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -79,7 +79,7 @@ class TestVerify(TestCase):
         if socket.has_ipv6:
             # Only run if Python is built with IPv6 support; otherwise
             # this will just fail.
-            self.assertTrue(verify_socket('[::]', 18000, 18001))
+            self.assertTrue(verify_socket('::', 18000, 18001))
 
     @skipIf(os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None,
             'Travis environment does not like too many open files')


### PR DESCRIPTION
These commits add proper IPv6 support to the minion-master communication path. The system hostname lookup mechanisms are used to determine whether v6 or v4 is preferred, which should prevent any detriment to IPv4-only setups.

I've tested these patches in an IPv6-only setup, an IPv4-only setup and a mixed setup, and the hosts seem to communicate fine in all cases.

When specifying an IPv6 listen address, it has to be quoted, since : interferes with YAML syntax. I'm using the following in my master config:

```
interface: '::'
```
