### PR TITLE
Mirror salt.utils.pydsl.StateDeclaration.__getattr__ as __getitem__

### DIFF
--- a/salt/utils/pydsl.py
+++ b/salt/utils/pydsl.py
@@ -261,6 +261,8 @@ class StateDeclaration(object):
             self._mods.append(m)
             return m
 
+    __getitem__ = __getattr__
+
     def __str__(self):
         return self._id
 


### PR DESCRIPTION
This is helpful e.g. in top.sls files where non-keyword like attributes
of the state('base') object often get accessed. This little patch allows
to write things like:

  state('base')['*'].foo
