### PR TITLE
PID file now written prior to Minion init

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -178,8 +178,8 @@ class Minion(parsers.MinionOptionParser):
         # the boot process waiting for a key to be accepted on the master.
         # This is the latest safe place to daemonize
         self.daemonize_if_required()
-        self.minion = salt.minion.Minion(self.config)
         self.set_pidfile()
+        self.minion = salt.minion.Minion(self.config)
 
     def start(self):
         '''


### PR DESCRIPTION
This pull request fixes #4251 by ensuring the PID file is written prior to Minion init.

This ensures that the PID file is written before any chance of the Minion init section entering the resolve_dns method and looping (minion.py) while the master is unavailable.
