### PR TITLE
Fixed typo

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -168,7 +168,7 @@ def list_pkgs(*args, **kwargs):
 
     __salt__['pkg_resource.sort_pkglist'](pkgs)
     if not versions_as_list:
-        __salt__['pkg_resource.stringify'](ret)
+        __salt__['pkg_resource.stringify'](pkgs)
     return pkgs
 
 


### PR DESCRIPTION
some issues remain - may only be with windows installer build though.

Get this exception AFTER this fix:

<Sacro>     AttributeError: 'module' object has no attribute 'is_true
<Sacro> line 155

I'm not sure if this is because the windows build is a little behind or something else
