### PR TITLE
Enforce a timeout (#3431) even if you get an event every time you look

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -13,6 +13,7 @@ Manage events
 # to read is the same module to fire off events.
 
 # Import python libs
+import time
 import os
 import fnmatch
 import glob
@@ -129,10 +130,13 @@ class SaltEvent(object):
         '''
         Get a single publication
         '''
+        end_time = time.time() + wait
         wait = wait * 1000
 
         self.subscribe(tag)
         while True:
+            if time.time() >= end_time:
+                return None
             socks = dict(self.poller.poll(wait))
             if self.sub in socks and socks[self.sub] == zmq.POLLIN:
                 raw = self.sub.recv()


### PR DESCRIPTION
If you have a fairly busy event system (lots of minions) you will always get an event ever time that you look. This causes the tag check to catch it and do a continue, so you (effectively) get stuck reading all the messages on the event bus indefinetly-- which causes the timeout to never be enforced
