### PR TITLE
XCP <= 1.6 should use yumpkg5

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -528,6 +528,7 @@ _OS_FAMILY_MAP = {
     'CloudLinux': 'RedHat',
     'OVS': 'RedHat',
     'OEL': 'RedHat',
+    'XCP': 'RedHat',
     'Mandrake': 'Mandriva',
     'ESXi': 'VMWare',
     'Mint': 'Debian',

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -46,6 +46,9 @@ def __virtual__():
         # Fedora <= 10 used Python 2.5 and below
         if os_major >= 11:
             return 'pkg'
+    elif os_grain == 'XCP':
+        if os_major >= 2:
+            return 'pkg'
     elif os_family == 'RedHat' and os_major >= 6:
         return 'pkg'
     return False

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -31,6 +31,11 @@ def __virtual__():
         # RHEL <= 5 and all variants need to use this module
         if os_family == 'RedHat' and os_major_version <= 5:
             return 'pkg'
+        # XCP <= 1.6 needs to use this module
+        if os_family == 'XCP':
+            os_minor_version = int(__grains__['osrelease'].split('.')[1])
+            if os_major_version == 1 and os_minor_version <= 6:
+                return 'pkg'
     return False
 
 

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -27,15 +27,13 @@ def __virtual__():
     # Fedora <= 10 need to use this module
     if os_grain == 'Fedora' and os_major_version < 11:
         return 'pkg'
+    # XCP == 1.x needs to use this module
+    elif os_grain == 'XCP' and os_major_version == 1:
+        return 'pkg'
     else:
         # RHEL <= 5 and all variants need to use this module
         if os_family == 'RedHat' and os_major_version <= 5:
             return 'pkg'
-        # XCP <= 1.6 needs to use this module
-        if os_family == 'XCP':
-            os_minor_version = int(__grains__['osrelease'].split('.')[1])
-            if os_major_version == 1 and os_minor_version <= 6:
-                return 'pkg'
     return False
 
 


### PR DESCRIPTION
Configure yumpkg5 as the virtual package for pkg on XCP <= 1.6.  Per http://wiki.xen.org/wiki/Xen_/_XCP_/_XCP_on_Linux_Overview, Xen 1.6 uses a CentOS 5 base.  Additional cases for selection of yumpkg vs. yumpkg5 may need to be added in the future.
