### PR TITLE
Add XenServer to grains and set proper virtual pkg

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -529,6 +529,7 @@ _OS_FAMILY_MAP = {
     'OVS': 'RedHat',
     'OEL': 'RedHat',
     'XCP': 'RedHat',
+    'XenServer': 'RedHat',
     'Mandrake': 'Mandriva',
     'ESXi': 'VMWare',
     'Mint': 'Debian',

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -49,6 +49,9 @@ def __virtual__():
     elif os_grain == 'XCP':
         if os_major >= 2:
             return 'pkg'
+    elif os_grain == 'XenServer':
+        if os_major > 6:
+            return 'pkg'
     elif os_family == 'RedHat' and os_major >= 6:
         return 'pkg'
     return False

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -27,9 +27,14 @@ def __virtual__():
     # Fedora <= 10 need to use this module
     if os_grain == 'Fedora' and os_major_version < 11:
         return 'pkg'
-    # XCP == 1.x needs to use this module
-    elif os_grain == 'XCP' and os_major_version == 1:
-        return 'pkg'
+    # XCP == 1.x uses a CentOS 5 base
+    elif os_grain == 'XCP':
+        if os_major_version == 1:
+            return 'pkg'
+    # XenServer 6 and earlier uses a CentOS 5 base
+    elif os_grain == 'XenServer':
+        if os_major_version <= 6:
+            return 'pkg'
     else:
         # RHEL <= 5 and all variants need to use this module
         if os_family == 'RedHat' and os_major_version <= 5:


### PR DESCRIPTION
Add XenServer to _OS_FAMILY and set usage of yumpk5 for XenServer 6 and below.  This is very similar to #4277.

Relavent grains from XenServer 6 (after this patch):
 'os': 'XenServer',
 'os_family': 'RedHat',
 'oscodename': 'xenenterprise',
 'osfullname': 'XenServer',
 'osrelease': '6.0.0',
 'virtual': 'xen',
 'virtual_subtype': 'Xen Dom0'
