### PR TITLE
Coerce output of file.get_mode to string

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1230,7 +1230,7 @@ def check_perms(name, ret, user, group, mode):
         if str(mode) != perms['lmode']:
             if not __opts__['test']:
                 __salt__['file.set_mode'](name, mode)
-            if str(mode) != __salt__['file.get_mode'](name).lstrip('0'):
+            if str(mode) != str(__salt__['file.get_mode'](name)).lstrip('0'):
                 ret['result'] = False
                 ret['comment'].append(
                     'Failed to change mode to {0}'.format(mode)


### PR DESCRIPTION
This is a quick fix for #4286. In the `file.check_perms` it's trying to call the `lstrip` method on the return value from `file.get_mode`, which could be an integer. When an integer is returned this throws an AttributeError.

Looking at the module, I found this bit of code a few lines up (1226):

``` python
    perms['lmode'] = str(__salt__['file.get_mode'](name)).lstrip('0')
```

There, the return value of get_mode is being correctly coerced to a string.

As a quick fix, I just applied the same fix to the line that was causing a problem.

(Normally, I'd write a test, but there were no tests for `check_perms()` and the fix was straightforward, so this seemed like the most expedient solution.)
