### PR TITLE
Adding a reference to watch_in on the highstate reference

### DIFF
--- a/doc/ref/states/highstate.rst
+++ b/doc/ref/states/highstate.rst
@@ -109,6 +109,14 @@ declaration that will restart Apache whenever the Apache configuration file,
       file:
         - managed
 
+    .. seealso:: watch_in and require_in
+
+        Sometimes it is more convenient to use the :term:`watch_in` or 
+        :term:`require_in` syntax instead of extending another ``SLS``
+        file.
+
+        :doc:`State Requisites </ref/states/requisites>`
+
 State declaration
 -----------------
 


### PR DESCRIPTION
This is the first time I've ever submitted a documentation pull request, so please double check my syntax to make sure I did it correctly.

I've found using the watch_in syntax very helpful, but it's buried in the docs, so I think plugging it in highstate reference doc would help more people realize it's possible.
