### PR TITLE
Remove usage of now nonexistent args in brew module

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -28,7 +28,7 @@ def list_pkgs(versions_as_list=False):
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
     ret = {}
-    cmd = 'brew list --versions {0}'.format(' '.join(args))
+    cmd = 'brew list --versions'
     for line in __salt__['cmd.run'](cmd).splitlines():
         try:
             name, version = line.split(' ')[0:2]


### PR DESCRIPTION
I believe this fixes the issue I encountered with the brew module when moving from v0.13.3 to v0.14.0.
