### PR TITLE
Defaults to keeping old configuration, avoids hanging

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -306,7 +306,8 @@ def install(name=None,
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
-        cmd = 'dpkg -i {verify} {pkg}'.format(
+        cmd = 'dpkg -i {confold} {verify} {pkg}'.format(
+            confold='--force-confold',
             verify='--force-bad-verify' if skip_verify else '',
             pkg=' '.join(pkg_params),
         )


### PR DESCRIPTION
Using pkg.installed with a '.deb' source uses dpkg instead of apt-get. The package managers ask if you want to keep an old configuration file rather than create a new one, if an old one exists. apt-get already chooses to keep the old one as a default, but dpkg does not. I think this is a sensible default and added it to avoid hanging when installing from '.deb' sources.
