### PR TITLE
Fix IndexError

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -118,8 +118,11 @@ def _services():
     ret = {}
     for line in __salt__['cmd.run']('/sbin/chkconfig --list').splitlines():
         cols = line.split()
-        name = cols[0]
-        if not cols or name in ret:
+        try:
+            name = cols[0]
+        except IndexError:
+            continue
+        if name in ret:
             continue
         ret.setdefault(name, {})['type'] = 'sysvinit'
         ret[name]['enabled'] = _sysv_is_enabled(cols, rlevel)


### PR DESCRIPTION
Running str.split() on a whitespace-only string results in an empty
list. Enclose variable assignment in a try/except block and skip to
parsing next line of output if an IndexError is detected.

This fixes #4315.
