### PR TITLE
Fix TypeError in pkg.group_install

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -364,9 +364,9 @@ def group_install(name=None,
     pkgs = []
     for group in pkg_groups:
         group_detail = group_info(group)
-        for package in group_detail['mandatory packages'].keys():
+        for package in group_detail.get('mandatory packages', {}).keys():
             pkgs.append(package)
-        for package in group_detail['default packages'].keys():
+        for package in group_detail.get('default packages', {}).keys():
             if package not in skip_pkgs:
                 pkgs.append(package)
         for package in include:
@@ -670,7 +670,7 @@ def group_info(groupname):
     yumbase = yum.YumBase()
     (installed, available) = yumbase.doGroupLists()
     for group in installed + available:
-        if group.name == groupname:
+        if group.name.lower() == groupname.lower():
             return {'mandatory packages': group.mandatory_packages,
                     'optional packages': group.optional_packages,
                     'default packages': group.default_packages,


### PR DESCRIPTION
Package groups are case-insensitive, so convert the group names to
lowercase in group_info to ensure that matches are found.

However, if the group does not exist, this same traceback will happen.
Resolve this by using dict.get.

This fixes #4260.
