### PR TITLE
Add workaround for https://github.com/saltstack/salt-api/issues/61

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -13,9 +13,10 @@ Implemented using ctypes, so no compilation is necessary.
 '''
 
 # Import python libs
-from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
+from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof, addressof, ArgumentError
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
 from ctypes.util import find_library
+import logging
 
 LIBPAM = CDLL(find_library('pam'))
 LIBC = CDLL(find_library('c'))
@@ -33,7 +34,9 @@ PAM_PROMPT_ECHO_OFF = 1
 PAM_PROMPT_ECHO_ON = 2
 PAM_ERROR_MSG = 3
 PAM_TEXT_INFO = 4
+NUM_RETRIES = 3 
 
+log = logging.getLogger(__name__)
 
 class PamHandle(Structure):
     '''
@@ -119,7 +122,7 @@ def authenticate(username, password, service='login'):
         '''
         # Create an array of n_messages response objects
         addr = CALLOC(n_messages, sizeof(PamResponse))
-        p_response[0] = cast(addr, POINTER(PamResponse))
+        p_response[0] = cast(addr, type(p_response[0]))
         for i in range(n_messages):
             if messages[i].contents.msg_style == PAM_PROMPT_ECHO_OFF:
                 pw_copy = STRDUP(str(password))
@@ -129,14 +132,20 @@ def authenticate(username, password, service='login'):
 
     handle = PamHandle()
     conv = PamConv(my_conv, 0)
-    retval = PAM_START(service, username, pointer(conv), pointer(handle))
-
+    
+    # Workaround for https://github.com/saltstack/salt-api/issues/61 
+    tmpHandle = cast(addressof(handle), PAM_START.argtypes[3]).contents
+    tmpConv = cast(addressof(conv), PAM_START.argtypes[2]).contents
+    retval = PAM_START(service, username, tmpConv , tmpHandle)
+    
     if retval != 0:
         # TODO: This is not an authentication error, something
         # has gone wrong starting up PAM
         return False
 
-    retval = PAM_AUTHENTICATE(handle, 0)
+    # Workaround for https://github.com/saltstack/salt-api/issues/61
+    tmpHandle = cast(addressof(handle), POINTER(PAM_AUTHENTICATE.argtypes[0])).contents
+    retval = PAM_AUTHENTICATE(tmpHandle, 0)
     return retval == 0
 
 
@@ -144,4 +153,15 @@ def auth(username, password, **kwargs):
     '''
     Authenticate via pam
     '''
-    return authenticate(username, password, kwargs.get('service', 'login'))
+    
+    # Retries are extra insurance for https://github.com/saltstack/salt-api/issues/61
+    for i in range(NUM_RETRIES):
+        try:
+            log.debug("Attempting pam authentication")
+            return authenticate(username, password, kwargs.get('service', 'login'))
+        except ArgumentError, e:
+            if i < NUM_RETRIES: 
+                log.warn("Failed pam authentication with {0}".format(e))
+                continue
+            else:
+                raise


### PR DESCRIPTION
This is a workaround for https://github.com/saltstack/salt-api/issues/61 which seems to be resolved simply by casting the instances to the type passed into the function declaration rather than creating a new type via POINTER().
