### PR TITLE
Correcting exec for salt-minion on OpenBSD

### DIFF
--- a/pkg/openbsd/salt-minion.rc-d
+++ b/pkg/openbsd/salt-minion.rc-d
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-daemon="/usr/local/bin/salt-master"
+daemon="/usr/local/bin/salt-minion"
 daemon_flags="-d"
 
 . /etc/rc.d/rc.subr


### PR DESCRIPTION
I screwed up my original PR for this. The daemon name was wrong. Changing it to 'salt-minion' rather than 'salt-master'.
