### PR TITLE
Added basic EC2 IAM metadata support for S3

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -3,14 +3,16 @@ Connection library for Amazon S3
 '''
 
 # Import Python libs
-import xml.etree.ElementTree as ET
-import hmac
-import hashlib
 import binascii
 import datetime
+import hashlib
+import hmac
+import json
+import logging
+import time
 import urllib
 import urllib2
-import logging
+import xml.etree.ElementTree as ET
 
 # Import Salt libs
 import salt.utils
@@ -18,6 +20,74 @@ import salt.utils.xmlutil as xml
 
 log = logging.getLogger(__name__)
 
+def _retry_get_url(url, num_retries=10, timeout=5):
+    '''
+    Retry grabbing a URL.
+    Based heavily on boto.utils.retry_url
+    '''
+    for i in range(0, num_retries):
+        try:
+            # disable any environmental proxy settings
+            proxy_handler = urllib2.ProxyHandler({})
+            opener = urllib2.build_opener(proxy_handler)
+
+            req = urllib2.Request(url)
+
+            # timeout only in > 2.6
+            r = opener.open(req, timeout=timeout)
+            return r.read()
+        except urllib2.HTTPError:
+            return ''
+        except urllib2.URLError:
+            pass
+        except Exception:
+            pass
+
+        log.warning('Caught exception reading from url. Retry no. %s'%(i))
+        time.sleep(2 ** i)
+    log.error('Failed to read from url for {0} times. Giving up.'.format(num_retries))
+    return ''
+
+def _convert_key_to_str(key):
+    '''
+    Stolen completely from boto.providers
+    '''
+    if isinstance(key, unicode):
+        # the secret key must be bytes and not unicode to work
+        #  properly with hmac.new (see http://bugs.python.org/issue5285)
+        return str(key)
+    return key
+
+def get_iam_metadata(version='latest', url='http://169.254.169.254',
+        timeout=None, num_retries=5):
+    '''
+    Grabs the first IAM role from this instances metadata if it exists.
+    '''
+    iam_url = '{0}/{1}/meta-data/iam/security-credentials/'.format(url, version)
+    roles = _retry_get_url(iam_url, num_retries).splitlines()
+
+    credentials = {
+                'access_key': None,
+                'secret_key': None,
+                'expires_at': None,
+                'security_token': None
+            }
+
+    try:
+        data = _retry_get_url(iam_url + roles[0], num_retries)
+        meta = json.loads(data)
+
+    except (ValueError, TypeError, IndexError):
+        log.error('Failed to read metadata. Giving up on IAM credentials.')
+        pass # json failed to decode so just pass no credentials back
+
+    else:
+        credentials['access_key'] = meta['AccessKeyId']
+        credentials['secret_key'] = _convert_key_to_str(meta['SecretAccessKey'])
+        credentials['expires_at'] =  meta['Expiration']
+        credentials['security_token'] = meta['Token']
+
+    return credentials
 
 def query(key, keyid, method='GET', params=None, headers=None,
           requesturl=None, return_url=False, bucket=None, service_url=None,
@@ -59,12 +129,17 @@ def query(key, keyid, method='GET', params=None, headers=None,
     else:
         endpoint = service_url
 
+    # Try grabbing the credentials from the EC2 instance IAM metadata if available
+    token = None
+    if not key or not keyid:
+        iam_creds = get_iam_metadata()
+        key = iam_creds['secret_key']
+        keyid = iam_creds['access_key']
+        token = iam_creds['security_token']
+
     if not requesturl:
-        timestamp = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
         x_amz_date = datetime.datetime.utcnow().strftime('%a, %d %b %Y %H:%M:%S GMT')
         content_type = 'text/plain'
-        content_md5 = ''
-        date = datetime.datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ')
         if method == 'GET':
             if bucket:
                 can_resource = '/{0}/{1}'.format(bucket, path)
@@ -84,6 +159,8 @@ def query(key, keyid, method='GET', params=None, headers=None,
         headers['Host'] = endpoint
         headers['Content-type'] = content_type
         headers['Date'] = x_amz_date
+        if token:
+            headers['x-amz-security-token'] = token
 
         string_to_sign = '{0}\n'.format(method)
 
@@ -93,7 +170,6 @@ def query(key, keyid, method='GET', params=None, headers=None,
                 log.debug(header.lower())
                 new_headers.append('{0}:{1}'.format(header.lower(),
                                                     headers[header]))
-                string_to_sign += '{0}\n'.format(headers[header])
         can_headers = '\n'.join(new_headers)
         log.debug('CanonicalizedAmzHeaders: {0}'.format(can_headers))
 


### PR DESCRIPTION
Hi all,

Here is a small patch to add basic support for getting the AWS credentials from the instance metadata using IAM roles. This will allow the minion's IAM role to control what it can access in S3 and salt doesn't have to worry about credentials at all.

Please let me know if there are any things that aren't to style or function. I also removed a few lines of un-used code (nothing major).

Thanks,
-A. 
