### PR TITLE
Update rvm.py

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -19,7 +19,7 @@ def _get_rvm_location(runas=None):
 def _rvm(command, arguments='', runas=None):
     if not runas:
         runas = __salt__['config.option']('rvm.runas')
-    if not is_installed():
+    if not is_installed(runas):
         return False
 
     ret = __salt__['cmd.run_all'](


### PR DESCRIPTION
there is a bug in the code that causes _rvm to return False when rvm is not installed on the root account.
this commit passes runas to is_installed so it queries the correct user

i'm a total n00b with python, so please excuse me for not writing a test case for this.  hope it helps.

steps to duplicate the bad behaviour before this patch:

> [root@saltstack]# salt slave02* rvm.list runas=myuser
>     slave02.XXXXXXX:
>         Traceback (most recent call last):
>           File "/usr/lib/python2.6/site-packages/salt/minion.py", line 418, in _thread_return
>             ret['return'] = func(_args, *_kwargs)
>           File "/usr/lib/python2.6/site-packages/salt/modules/rvm.py", line 118, in list
>             for line in _rvm('list', '', runas=runas).splitlines():
>         AttributeError: 'bool' object has no attribute 'splitlines'
> # install rvm globally
> 
> ```
> [root@saltstack]# salt slave02\* rvm.install
> slave02.XXXXXXX:
> ```
> 
>     True
>     [root@saltstack]# salt slave02* rvm.list runas=myuser
>     slave02.XXXXXXX:

now that it's installed under the root user, _rvm returns a non-boolean
