### PR TITLE
Fix #4361 : pip's requirements option is partially broken in 0.14

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -184,29 +184,33 @@ def install(pkgs=None,
             cmd=cmd, pkg=pkg)
 
     treq = None
-    if requirements and requirements.startswith('salt://'):
-        cached_requirements = __salt__['cp.is_cached'](requirements, __env__)
-        if not cached_requirements:
-            # It's not cached, let's cache it.
-            cached_requirements = __salt__['cp.cache_file'](requirements, __env__)
-        # Check if the master version has changed.
-        if __salt__['cp.hash_file'](requirements, __env__) != \
-                __salt__['cp.hash_file'](cached_requirements, __env__):
-            cached_requirements = __salt__['cp.cache_file'](requirements, __env__)
-        if not cached_requirements:
-            return {
-                'result': False,
-                'comment': (
-                    'pip requirements file \'{0}\' not found'.format(
-                        requirements
+    if requirements:
+        if requirements.startswith('salt://'):
+            cached_requirements = __salt__['cp.is_cached'](requirements,
+                    __env__)
+            if not cached_requirements:
+                # It's not cached, let's cache it.
+                cached_requirements = __salt__['cp.cache_file'](requirements,
+                        __env__)
+            # Check if the master version has changed.
+            if __salt__['cp.hash_file'](requirements, __env__) != \
+                    __salt__['cp.hash_file'](cached_requirements, __env__):
+                cached_requirements = __salt__['cp.cache_file'](requirements,
+                        __env__)
+            if not cached_requirements:
+                return {
+                    'result': False,
+                    'comment': (
+                        'pip requirements file \'{0}\' not found'.format(
+                            requirements
+                        )
                     )
-                )
-            }
+                }
 
-            treq = salt.utils.mkstemp()
-            shutil.copyfile(req, treq)
-        else:
-            treq = requirements
+                treq = salt.utils.mkstemp()
+                shutil.copyfile(req, treq)
+            else:
+                treq = requirements
         cmd = '{cmd} --requirement "{requirements}" '.format(
             cmd=cmd, requirements=treq or requirements)
 

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -1,0 +1,19 @@
+try:
+    from mock import MagicMock, patch
+    has_mock = True
+except ImportError:
+    has_mock = False
+
+from saltunittest import TestCase, skipIf
+from salt.modules import pip
+
+pip.__salt__ = {"cmd.which_bin":lambda _:"pip"}
+
+@skipIf(has_mock is False, "mock python module is unavailable")
+class PipTestCase(TestCase):
+    def test_fix4361(self):
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        with patch.dict(pip.__salt__, {'cmd.run_all':mock}):
+            pip.install(requirements="requirements.txt")
+            expected_cmd = 'pip install --requirement "requirements.txt" '
+            mock.assert_called_once_with(expected_cmd, runas=None, cwd=None)


### PR DESCRIPTION
Move the conditions to the correct block.
Add a unittest on the requirements option.
