### PR TITLE
Properly detect changes to groups made by user states

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -83,14 +83,13 @@ def getent():
 
         salt '*' group.getent
     '''
-    if 'groupadd_getent' in __context__:
-      return __context__['groupadd_getent']
+    if 'group.getent' in __context__:
+        return __context__['group.getent']
 
     ret = []
     for grinfo in grp.getgrall():
         ret.append(_format_info(grinfo))
-    __context__['groupadd_getent'] = ret
-
+    __context__['group.getent'] = ret
     return ret
 
 

--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -72,9 +72,13 @@ def getent():
 
         salt '*' group.getent
     '''
+    if 'group.getent' in __context__:
+        return __context__['group.getent']
+
     ret = []
     for grinfo in grp.getgrall():
         ret.append(info(grinfo.gr_name))
+    __context__['group.getent'] = ret
     return ret
 
 

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -118,7 +118,7 @@ def delete(name, remove=False, force=False):
     return not ret['retcode']
 
 
-def getent(user=None):
+def getent():
     '''
     Return the list of all info for all users
 
@@ -126,14 +126,13 @@ def getent(user=None):
 
         salt '*' user.getent
     '''
+    if 'user.getent' in __context__:
+        return __context__['user.getent']
+
     ret = []
     for data in pwd.getpwall():
         ret.append(info(data.pw_name))
-    if user:
-        try:
-            return [x for x in ret if x.get('name', '') == user][0]
-        except IndexError:
-            return {}
+    __context__['user.getent'] = ret
     return ret
 
 
@@ -391,8 +390,16 @@ def list_groups(name):
         # The user's applied default group is undefined on the system, so
         # it does not exist
         pass
+
+    # If we already grabbed the group list, it's overkill to grab it again
+    if 'user.getgrall' in __context__:
+        groups = __context__['user.getgrall']
+    else:
+        groups = grp.getgrall()
+        __context__['user.getgrall'] = groups
+
     # Now, all other groups the user belongs to
-    for group in grp.getgrall():
+    for group in groups:
         if name in group.gr_mem:
             ugrp.add(group.gr_name)
     return sorted(list(ugrp))

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -74,9 +74,14 @@ def getent():
 
         salt '*' group.getent
     '''
+    if 'group.getent' in __context__:
+        return __context__['group.getent']
+
     ret = []
     for grinfo in grp.getgrall():
         ret.append(info(grinfo.gr_name))
+
+    __context__['group.getent'] = ret
     return ret
 
 

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -136,7 +136,7 @@ def delete(name, remove=False, force=False):
     return not ret['retcode']
 
 
-def getent(user=None):
+def getent():
     '''
     Return the list of all info for all users
 
@@ -144,14 +144,13 @@ def getent(user=None):
 
         salt '*' user.getent
     '''
+    if 'user.getent' in __context__:
+        return __context__['user.getent']
+
     ret = []
     for data in pwd.getpwall():
         ret.append(info(data.pw_name))
-    if user:
-        try:
-            ret = [x for x in ret if x.get('name', '') == user][0]
-        except IndexError:
-            ret = {}
+    __context__['user.getent'] = ret
     return ret
 
 
@@ -404,8 +403,16 @@ def list_groups(name):
     ugrp = set()
     # Add the primary user's group
     ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
+
+    # If we already grabbed the group list, it's overkill to grab it again
+    if 'user.getgrall' in __context__:
+        groups = __context__['user.getgrall']
+    else:
+        groups = grp.getgrall()
+        __context__['user.getgrall'] = groups
+
     # Now, all other groups the user belongs to
-    for group in grp.getgrall():
+    for group in groups:
         if name in group.gr_mem:
             ugrp.add(group.gr_name)
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -163,7 +163,7 @@ def delete(name, remove=False, force=False):
     return not ret['retcode']
 
 
-def getent(user=None):
+def getent():
     '''
     Return the list of all info for all users
 
@@ -171,17 +171,13 @@ def getent(user=None):
 
         salt '*' user.getent
     '''
-    if 'useradd_getent' in __context__:
-        return __context__['useradd_getent']
+    if 'user.getent' in __context__:
+        return __context__['user.getent']
 
     ret = []
     for data in pwd.getpwall():
         ret.append(_format_info(data))
-    if user:
-        try:
-            ret = [x for x in ret if x.get('name', '') == user][0]
-        except IndexError:
-            ret = {}
+    __context__['user.getent'] = ret
     return ret
 
 
@@ -421,7 +417,7 @@ def _format_info(data):
         gecos_field.append('')
 
     return {'gid': data.pw_gid,
-            'groups': list_groups(data.pw_name,),
+            'groups': list_groups(data.pw_name),
             'home': data.pw_dir,
             'name': data.pw_name,
             'passwd': data.pw_passwd,
@@ -452,11 +448,11 @@ def list_groups(name):
         pass
 
     # If we already grabbed the group list, it's overkill to grab it again
-    if 'useradd_getgrall' in __context__:
-        groups = __context__['useradd_getgrall']
+    if 'user.getgrall' in __context__:
+        groups = __context__['user.getgrall']
     else:
         groups = grp.getgrall()
-        __context__['useradd_getgrall'] = groups
+        __context__['user.getgrall'] = groups
 
     # Now, all other groups the user belongs to
     for group in groups:

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -76,6 +76,9 @@ def getent():
 
         salt '*' group.getent
     '''
+    if 'group.getent' in __context__:
+        return __context__['group.getent']
+
     ret = []
     ret2 = []
     lines = __salt__['cmd.run']('net localgroup').splitlines()
@@ -104,4 +107,6 @@ def getent():
                 'name': item,
                 'passwd': 'x'}
         ret2.append(group)
+
+    __context__['group.getent'] = ret2
     return ret2

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -220,7 +220,7 @@ def list_groups(name):
     return sorted(list(ugrp))
 
 
-def getent(user=None):
+def getent():
     '''
     Return the list of all info for all users
 
@@ -228,6 +228,9 @@ def getent(user=None):
 
         salt '*' user.getent
     '''
+    if 'user.getent' in __context__:
+        return __context__['user.getent']
+
     ret = []
     users = []
     startusers = False
@@ -260,9 +263,5 @@ def getent(user=None):
 
         ret.append(stuff)
 
-    if user:
-        try:
-            ret = [x for x in ret if x.get('name', '') == user][0]
-        except IndexError:
-            ret = {}
+    __context__['user.getent'] = ret
     return ret


### PR DESCRIPTION
This pull contains some changes to both the user and group providers that normalizes the use of the `__context__` dict. In addition, the user state now clears the value in `__context__` (if present) which is used by `user.list_groups`.

This allows for changes to group membership to be properly detected by the `user.present` state. Fixes #4336 and also #4351.
