### PR TITLE
fix debian/control to use python2.6

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -15,7 +15,7 @@ Build-Depends: debhelper (>= 7.0.50),
                msgpack-python
 Standards-Version: 3.9.3
 Homepage: http://saltstack.org
-#X-Python-Version: >= 2.6, <= 2.7
+XS-Python-Version: >= 2.6, <= 2.7
 
 
 Package: salt-common


### PR DESCRIPTION
Not sure why, but the line in the debian/control file that specifies the python version was misspelled and commented out. Should be XS-Python-Version, was X-Python-Version. Package builds on debian squeeze now.
