### PR TITLE
Make user.info return an empty dict when user not present

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -360,17 +360,7 @@ def info(name):
         ret['workphone'] = gecos_field[2]
         ret['homephone'] = gecos_field[3]
     except KeyError:
-        ret['gid'] = ''
-        ret['groups'] = []
-        ret['home'] = ''
-        ret['name'] = ''
-        ret['passwd'] = ''
-        ret['shell'] = ''
-        ret['uid'] = ''
-        ret['fullname'] = ''
-        ret['roomnumber'] = ''
-        ret['workphone'] = ''
-        ret['homephone'] = ''
+        return {}
     return ret
 
 

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -378,17 +378,7 @@ def info(name):
         ret['workphone'] = gecos_field[2]
         ret['homephone'] = gecos_field[3]
     except KeyError:
-        ret['gid'] = ''
-        ret['groups'] = []
-        ret['home'] = ''
-        ret['name'] = ''
-        ret['passwd'] = ''
-        ret['shell'] = ''
-        ret['uid'] = ''
-        ret['fullname'] = ''
-        ret['roomnumber'] = ''
-        ret['workphone'] = ''
-        ret['homephone'] = ''
+        return {}
     return ret
 
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -390,18 +390,7 @@ def info(name):
     try:
         data = pwd.getpwnam(name)
     except KeyError:
-        ret['gid'] = ''
-        ret['groups'] = []
-        ret['home'] = ''
-        ret['name'] = ''
-        ret['passwd'] = ''
-        ret['shell'] = ''
-        ret['uid'] = ''
-        ret['fullname'] = ''
-        ret['roomnumber'] = ''
-        ret['workphone'] = ''
-        ret['homephone'] = ''
-        return ret
+        return {}
     else:
         return _format_info(data)
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -176,7 +176,7 @@ def info(name):
     lines = __salt__['cmd.run'](cmd).splitlines()
     for line in lines:
         if 'name could not be found' in line:
-            return False
+            return {}
         if 'successfully' not in line:
             comps = line.split('    ', 1)
             if not len(comps) > 1:


### PR DESCRIPTION
These commits update the user providers so that user.info returns an empty dict when the user is not present. This makes change detection much simpler in the user.present state and also makes `__salt__['user.info']('foo')` return a value that evaluates to `False` if the user **foo** does not exist.

Refs to the `user.info` function have been updated as well, where appropriate.
