### PR TITLE
Use __context__ to reduce calls to chkconfig/runlevel

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -113,6 +113,9 @@ def _services():
     Return a dict of services and their types (sysv or upstart), as well
     as whether or not the service is enabled.
     '''
+    if 'service.all' in __context__:
+        return __context__['service.all']
+
     # First, parse sysvinit services from chkconfig
     rlevel = _runlevel()
     ret = {}
@@ -133,6 +136,7 @@ def _services():
                 continue
             ret.setdefault(name, {})['type'] = 'upstart'
             ret[name]['enabled'] = _upstart_is_enabled(name)
+    __context__['service.all'] = ret
     return ret
 
 

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -35,6 +35,9 @@ service then set the reload value to True:
           - pkg: redis
 '''
 
+# Import python libs
+import sys
+
 
 def __virtual__():
     '''
@@ -265,6 +268,11 @@ def running(name, enable=None, sig=None, **kwargs):
         ret['comment'] = 'Service {0} is set to start'.format(name)
         return ret
 
+    # Clear cached service info
+    sys.modules[
+        __salt__['service.status'].__module__
+    ].__context__.pop('service.all', None)
+
     changes = {name: __salt__['service.start'](name)}
 
     if not changes[name]:
@@ -325,6 +333,11 @@ def dead(name, enable=None, sig=None, **kwargs):
         ret['result'] = None
         ret['comment'] = 'Service {0} is set to be killed'.format(name)
         return ret
+
+    # Clear cached service info
+    sys.modules[
+        __salt__['service.status'].__module__
+    ].__context__.pop('service.all', None)
 
     changes = {name: __salt__['service.stop'](name)}
 


### PR DESCRIPTION
This commit uses the **context** dict to keep
salt.modules.rh_service._services() from running chkconfig --list and
runlevel every time it is called (which is often). The service.running
and service.dead states will clear the context data before trying to
detect changes.

This fixes #4295.
