### PR TITLE
fixed a typo

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -568,7 +568,7 @@ def _role_update(name,
         sub_cmd = '{0} CREATEUSER'.format(sub_cmd, )
     if encrypted:
         sub_cmd = '{0} ENCRYPTED'.format(sub_cmd, )
-    if encrypted:
+    if replication:
         sub_cmd = '{0} REPLICATION'.format(sub_cmd, )
 
     if sub_cmd.endswith('WITH'):


### PR DESCRIPTION
`encrypted=True` won't work with `_role_update` because `encrypted` is used in place of `replication` in the function implementation.

I believe this is just a typo.
