### PR TITLE
Compare sorted supplemental groups

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -73,7 +73,7 @@ def _chugid(runas):
             )
 
     # Set supplemental groups
-    if os.getgroups() != supgroups:
+    if sorted(os.getgroups()) != sorted(supgroups):
         try:
             os.setgroups(supgroups)
         except OSError, err:


### PR DESCRIPTION
Makes the `if` statement a little more useful, without arbitrarily running `setgroups()` every time.
