### PR TITLE
Rewrite "success" requirements for file.sed

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -54,6 +54,7 @@ log = logging.getLogger(__name__)
 # 5. connect to the publisher
 # 6. handle publications
 
+
 def resolve_dns(opts):
     '''
     Resolves the master_ip and master_uri options
@@ -92,7 +93,7 @@ def resolve_dns(opts):
         ret['master_ip'] = '127.0.0.1'
 
     ret['master_uri'] = 'tcp://{ip}:{port}'.format(ip=ret['master_ip'],
-                                                    port=opts['master_port'])
+                                                   port=opts['master_port'])
     return ret
 
 
@@ -417,7 +418,10 @@ class Minion(object):
                 args, kwargs = detect_kwargs(func, data['arg'], data)
                 sys.modules[func.__module__].__context__['retcode'] = 0
                 ret['return'] = func(*args, **kwargs)
-                ret['retcode'] = sys.modules[func.__module__].__context__.get('retcode', 0)
+                ret['retcode'] = sys.modules[func.__module__].__context__.get(
+                        'retcode',
+                        0
+                )
                 ret['success'] = True
             except CommandNotFoundError as exc:
                 msg = 'Command required for \'{0}\' not found: {1}'
@@ -853,7 +857,6 @@ class Syndic(Minion):
     '''
     def __init__(self, opts):
         interface = opts.get('interface')
-        sock_dir = opts['sock_dir']
         self._syndic = True
         opts['loop_interval'] = 1
         Minion.__init__(self, opts)
@@ -910,14 +913,13 @@ class Syndic(Minion):
         if 'tgt_type' not in data:
             data['tgt_type'] = 'glob'
         # Send out the publication
-        self.local.pub(
-            data['tgt'],
-            data['fun'],
-            data['arg'],
-            data['tgt_type'],
-            data['ret'],
-            data['jid'],
-            data['to'])
+        self.local.pub(data['tgt'],
+                       data['fun'],
+                       data['arg'],
+                       data['tgt_type'],
+                       data['ret'],
+                       data['jid'],
+                       data['to'])
 
     def tune_in(self):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -437,6 +437,8 @@ class Minion(object):
                 aspec = _getargs(minion_instance.functions[data['fun']])
                 msg = 'Missing arguments executing "{0}": {1}'
                 log.warning(msg.format(function_name, aspec))
+                dmsg = '"Missing args" caused by exc: {0}'.format(exc)
+                log.debug(dmsg)
                 ret['return'] = msg.format(function_name, aspec)
             except Exception:
                 trb = traceback.format_exc()

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1306,11 +1306,9 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
     '''
     Maintain a simple edit to a file
 
-    The file will be searched for the ``before`` pattern before making the edit
-    and then searched for the ``after`` pattern to verify the edit was
-    successful using :mod:`salt.modules.file.contains`. In general the
-    ``limit`` pattern should be as specific as possible and ``before`` and
-    ``after`` should contain the minimal text to be changed.
+    The file will be searched for the ``before`` pattern before making the
+    edit.  In general the ``limit`` pattern should be as specific as possible
+    and ``before`` and ``after`` should contain the minimal text to be changed.
 
     Usage::
 
@@ -1336,49 +1334,32 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
     if not check_res:
         return _error(ret, check_msg)
 
-    # sed returns no output if the edit matches anything or not so we'll have
-    # to look for ourselves
-
     # Mandate that before and after are strings
     before = str(before)
     after = str(after)
 
     # Look for the pattern before attempting the edit
-    if not __salt__['file.contains_regex_multiline'](name, before):
-        # Pattern not found; try to guess why
-        if __salt__['file.contains'](name, after):
-            ret['comment'] = 'Edit already performed'
-            ret['result'] = True
-            return ret
-        else:
-            ret['comment'] = 'Pattern not matched'
-            return ret
+    if not __salt__['file.contains_regex'](name, before):
+        # Pattern not found; don't try to guess why, just tell the user there
+        # were no changes made, as the changes should only be made once anyway.
+        # This makes it so users can use backreferences without the state
+        # coming back as failed all the time.
+        ret['comment'] = '"before" pattern not found, no changes made'
+        ret['result'] = True
+        return ret
 
     if __opts__['test']:
         ret['comment'] = 'File {0} is set to be updated'.format(name)
         ret['result'] = None
         return ret
-    with salt.utils.fopen(name, 'rb') as fp_:
-        slines = fp_.readlines()
     # should be ok now; perform the edit
     __salt__['file.sed'](name, before, after, limit, backup, options, flags)
-    with salt.utils.fopen(name, 'rb') as fp_:
-        nlines = fp_.readlines()
 
-    # check the result
-    ret['result'] = __salt__['file.contains_regex_multiline'](name, after)
-    if slines != nlines:
-        # Changes happened, add them
-        ret['changes']['diff'] = ''.join(difflib.unified_diff(slines, nlines))
-
-    if ret['result']:
-        ret['comment'] = 'File successfully edited'
-    else:
-        ret['comment'] = 'Expected edit does not appear in file'
-
-    # In this case, even if the `after` pattern doesn't appear in the file, we
-    # return True, as it's not necessarily an error
+    # Don't check the result -- sed is not designed to be able to check the
+    # result, because of backreferences and so forth.  Just report that sed
+    # was run, and assume it was successful (no error!)
     ret['result'] = True
+    ret['comment'] = 'sed ran without error'
 
     return ret
 


### PR DESCRIPTION
Fixes #4353

We no longer do any checking with regard to the `after` pattern.  If the `before` pattern is not present, then we return `True`, because we assume the edit has either been made previously, or does not need to be made.

If the `before` pattern is present, we run the `sed` command, creating a diff of the file before and after.  If the file changed, we return `True` and the diff.  If the file remained the same, we return `False`.

I'm still not completely on board with using `sed` to manage state, but this should make it much more reasonable/robust (backreferences work now!).
