### PR TITLE
Add docs on installing w/easy_install

### DIFF
--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -281,6 +281,16 @@ and 103 characters on BSD-based systems.
 
     To set file descriptors on OSX, refer to the :doc:`OS X Installation </topics/installation/osx>` instructions.
 
+
+Using easy_install to Install Salt
+----------------------------------
+
+If you are installing using ``easy_install``, you will need to define a
+:strong:`USE_SETUPTOOLS` environment variable, otherwise dependencies will not
+be installed.
+
+    $ USE_SETUPTOOLS=1 easy_install salt
+
 Running the tests
 ~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
If you'd rather this be in `doc/topics/installation/index.rst`, let me know and I'll make the change.

See: https://github.com/saltstack/salt/issues/3196
