### PR TITLE
Adding default value for range_server in minion config

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -106,6 +106,7 @@ DEFAULT_MINION_OPTS = {
     'recon_max': 5000,
     'win_repo_cachefile': 'salt://win/repo/winrepo.p',
     'pidfile': '/var/run/salt-minion.pid',
+    'range_server': 'range:80',
     'tcp_keepalive': True,
     'tcp_keepalive_idle': 300,
     'tcp_keepalive_cnt': -1,


### PR DESCRIPTION
this is for the range compound matcher, and any other range usage in the minion
