### PR TITLE
Corrected typo in modules/rh_service.py

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -258,7 +258,7 @@ def status(name, sig=None):
     '''
     if _service_is_upstart(name):
         cmd = 'status {0}'.format(name)
-        return 'start/running' in __salt___['cmd.run'](cmd)
+        return 'start/running' in __salt__['cmd.run'](cmd)
     _add_custom_initscript(name)
     if sig:
         return bool(__salt__['status.pid'](sig))


### PR DESCRIPTION
At one point, `__salt___` is referenced rather than `__salt__`. Extra underscore. Makes some service runs fail.
