### PR TITLE
Fix `file.sed` state to use sed to check 'before' pattern

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -520,6 +520,33 @@ def sed(path, before, after, limit='', backup='.bak', options='-r -e',
     return __salt__['cmd.run'](cmd)
 
 
+def sed_contains(path, text, limit='', flags='g'):
+    '''
+    Return True if the file at ``path`` contains ``text``. Utilizes sed to
+    perform the search (line-wise search).
+
+    Note: the ``p`` flag will be added to any flags you pass in.
+
+    Usage::
+
+        salt '*' file.contains /etc/crontab 'mymaintenance.sh'
+    '''
+    # Largely inspired by Fabric's contrib.files.contains()
+
+    if not os.path.exists(path):
+        return False
+
+    result = __salt__['file.sed'](path,
+                                  text,
+                                  '&',
+                                  limit=limit,
+                                  backup='',
+                                  options='-n -r -e',
+                                  flags='p{0}'.format(flags))
+
+    return bool(result)
+
+
 def psed(path, before, after, limit='', backup='.bak', flags='gMS',
          escape_all=False, multi=False):
     '''

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1355,7 +1355,10 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
     after = str(after)
 
     # Look for the pattern before attempting the edit
-    if not __salt__['file.contains_regex'](name, before):
+    if not __salt__['file.sed_contains'](name,
+                                         before,
+                                         limit=limit,
+                                         flags=flags):
         # Pattern not found; don't try to guess why, just tell the user there
         # were no changes made, as the changes should only be made once anyway.
         # This makes it so users can use backreferences without the state


### PR DESCRIPTION
Fixes #4425
Fixes #3342

Added the `file.sed_contains` function to the `file` module (courtesy of @whiteinge).  The `file.sed` state now uses this function to check for the `before` pattern.  This makes it so the `file.sed` state now should support basically any sed syntax, including named backreferences, the ignore case `i` flag, and uses the `limit` argument when checking the `before` pattern.

Should fix most of the outstanding issues around the `file.sed` state.
