### PR TITLE
Fixed bug in file.makedirs where the requested directory is never created

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1619,15 +1619,15 @@ def manage_file(name,
         return ret
 
 
-def makedirs(path, user=None, group=None, mode=None):
+def mkdir(dir_path, user=None, group=None, mode=None):
     '''
-    Ensure that the directory containing this path is available.
+    Ensure that a directory is available.
 
     CLI Example::
 
-        salt '*' file.makedirs /opt/code
+        salt '*' file.mkdir /opt/jetty/context
     '''
-    directory = os.path.normpath(path)
+    directory = os.path.normpath(dir_path)
 
     if not os.path.isdir(directory):
         # turn on the executable bits for user, group and others.
@@ -1640,6 +1640,17 @@ def makedirs(path, user=None, group=None, mode=None):
         # makedirs=True, make sure that any created dirs
         # are created with the same user  and  group  to
         # follow the principal of least surprise method.
+
+
+def makedirs(path, user=None, group=None, mode=None):
+    '''
+    Ensure that the directory containing this path is available.
+
+    CLI Example::
+
+        salt '*' file.makedirs /opt/code
+    '''
+    return mkdir(os.path.dirname(path), user=user, group=group, mode=mode)
 
 
 def makedirs_perms(name, user=None, group=None, mode='0755'):

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1627,7 +1627,7 @@ def makedirs(path, user=None, group=None, mode=None):
 
         salt '*' file.makedirs /opt/code
     '''
-    directory = os.path.dirname(os.path.normpath(path))
+    directory = os.path.normpath(path)
 
     if not os.path.isdir(directory):
         # turn on the executable bits for user, group and others.


### PR DESCRIPTION
Hi guys,

It seems illogical to me to have a function called makedirs assume the last thing on the given path is always removed. So for example:

salt "_" file.makedirs /srv/test/woo/ or salt "_" file.makedirs /srv/test/woo 

Would only create '/srv/test' not '/srv/test/woo/'

I'd assume it would function the same as 'mkdir' in that the path given is always just directories. eg. 'mkdir /srv/test/woo/foo.sh' would result in '/srv/test/woo/foo.sh/'

Is the current usage correct for this module function? If so, it seems broken to me.

Thanks,
-A.
