### PR TITLE
Fix stop/start and add plist support to launchctl module.

### DIFF
--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -5,8 +5,11 @@ Module for the management of MacOS systems that use launchd/launchctl
 '''
 
 # Import python libs
+import os
 import plistlib
 
+# Import salt libs
+import salt.utils
 
 def __virtual__():
     '''
@@ -15,6 +18,72 @@ def __virtual__():
     if __grains__['os'] == 'MacOS':
         return 'service'
     return False
+
+
+def _launchd_paths():
+    '''
+    Paths where launchd services can be found
+    '''
+    return [
+        '/Library/LaunchAgents',
+        '/Library/LaunchDaemons',
+        '/System/Library/LaunchAgents',
+        '/System/Library/LaunchDaemons',
+    ]
+
+
+@salt.utils.memoize
+def _available_services():
+    '''
+    Return a dictionary of all available services on the system
+    '''
+    available_services = dict()
+    for launch_dir in _launchd_paths():
+        for root, sub_folders, files in os.walk(launch_dir):
+            for filename in files:
+                file_path = os.path.join(root, filename)
+
+                try:
+                    # This assumes most of the plist files will be already in XML format
+                    plist = plistlib.readPlist(file_path)
+                except:
+                    # If plistlib is unable to read the file we'll need to use
+                    # the system provided plutil program to do the conversion
+                    cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(file_path)
+                    plist_xml = __salt__['cmd.run_all'](cmd)['stdout']
+                    plist = plistlib.readPlistFromString(plist_xml)
+
+                available_services[plist.Label.lower()] = {
+                    'filename': filename,
+                    'file_path': file_path,
+                    'plist': plist,
+                }
+
+    return available_services
+
+
+def _service_by_name(name):
+    '''
+    Return the service info for a service by label, filename or path
+    '''
+    services = _available_services()
+    name = name.lower()
+
+    if name in services:
+        # Match on label
+        return services[name]
+
+    for key, service in services.items():
+        if service['file_path'].lower() == name:
+            # Match on full path
+            return service
+        basename, ext = os.path.splitext(service['filename'])
+        if basename.lower() == name:
+            # Match on basename
+            return service
+
+    return False
+
 
 
 def get_all():
@@ -32,15 +101,39 @@ def get_all():
         if not line.startswith('PID')
     ]
 
-    return sorted([line.split("\t")[2] for line in service_lines])
+    service_labels_from_list = [
+        line.split("\t")[2] for line in service_lines
+    ]
+    service_labels_from_services = [
+        key for key, value in _available_services().items()
+    ]
+
+    return sorted(set(service_labels_from_list + service_labels_from_services))
 
 
-def get_launchctl_data(job_label, runas=None):
+def _get_launchctl_data(job_label, runas=None):
     cmd = 'launchctl list -x {0}'.format(job_label)
 
-    launchctl_xml = __salt__['cmd.run_all'](cmd, runas=runas)['stderr']
+    launchctl_xml = __salt__['cmd.run_all'](cmd, runas=runas)
 
-    return dict(plistlib.readPlistFromString(launchctl_xml))
+    if launchctl_xml['stderr'] == 'launchctl list returned unknown response':
+        # The service is not loaded, further, it might not even exist
+        # in either case we didn't get XML to parse, so return an empty
+        # dict
+        return dict()
+
+    return dict(plistlib.readPlistFromString(launchctl_xml['stdout']))
+
+
+def available(job_label, runas=None):
+    '''
+    Check that the given service is available.
+
+    CLI Example::
+
+        salt '*' service.available com.openssh.sshd
+    '''
+    return True if _service_by_name(job_label) else False
 
 
 def status(job_label, runas=None):
@@ -50,12 +143,14 @@ def status(job_label, runas=None):
 
     CLI Example::
 
-        salt '*' service.status <service name>
+        salt '*' service.status <service label>
     '''
-    launchctl_data = get_launchctl_data(job_label, runas=runas)
+    service = _service_by_name(job_label)
+
+    lookup_name = service['plist']['Label'] if service else job_label
+    launchctl_data = _get_launchctl_data(lookup_name, runas=runas)
 
     return 'PID' in launchctl_data
-
 
 def stop(job_label, runas=None):
     '''
@@ -63,11 +158,16 @@ def stop(job_label, runas=None):
 
     CLI Example::
 
-        salt '*' service.stop <service name>
+        salt '*' service.stop <service label>
+        salt '*' service.stop org.ntp.ntpd
+        salt '*' service.stop /System/Library/LaunchDaemons/org.ntp.ntpd.plist
     '''
-    cmd = 'launchctl stop {0}'.format(job_label)
+    service = _service_by_name(job_label)
+    if service:
+        cmd = 'launchctl unload -w {0}'.format(service['file_path'], runas=runas)
+        return not __salt__['cmd.retcode'](cmd, runas=runas)
 
-    return __salt__['cmd.run'](cmd, runas=runas)
+    return False
 
 
 def start(job_label, runas=None):
@@ -76,11 +176,16 @@ def start(job_label, runas=None):
 
     CLI Example::
 
-        salt '*' service.start <service name>
+        salt '*' service.start <service label>
+        salt '*' service.start org.ntp.ntpd
+        salt '*' service.start /System/Library/LaunchDaemons/org.ntp.ntpd.plist
     '''
-    cmd = 'launchctl start {0}'.format(job_label, runas=runas)
+    service = _service_by_name(job_label)
+    if service:
+        cmd = 'launchctl load -w {0}'.format(service['file_path'], runas=runas)
+        return not __salt__['cmd.retcode'](cmd, runas=runas)
 
-    return __salt__['cmd.run'](cmd, runas=runas)
+    return False
 
 
 def restart(job_label, runas=None):
@@ -89,7 +194,7 @@ def restart(job_label, runas=None):
 
     CLI Example::
 
-        salt '*' service.restart <service name>
+        salt '*' service.restart <service label>
     '''
     stop(job_label, runas=runas)
     return start(job_label, runas=runas)


### PR DESCRIPTION
Currently the launchctl module is unable to manage a service that is not already loaded, nor does it start and stop a service correctly. In order to support unloaded plists, all plists have to be read on first access to most methods in the launchctl module. This is because we don't know if all label in each plist file matches its filename. Usually they do, however it's not guaranteed. Also, not all plist files are XML, some are binary or JSON. Thankfully we have the `plutil` tool provided by the system for doing conversions.

Launchctl `stop` is not the same as stop on most systems. It will kill the process, however most services will start up again as it's very common for a service to have both `RunAtLoad` and `KeepAlive` set in the services plist file.

Similarly, `start` start will only start a service that has previously been loaded without the `RunAtLoad` key in the service plist. The man page for `launchctl` also notes that expected usage of `start` is for debugging and testing.

These changes do not find per-user `~/Library/LaunchAgents` services at the current time.
