### PR TITLE
Corrected syntax error in include example for python-libs.

### DIFF
--- a/doc/topics/tutorials/states_pt3.rst
+++ b/doc/topics/tutorials/states_pt3.rst
@@ -113,7 +113,7 @@ files by using an :term:`include declaration`. For example:
 .. code-block:: yaml
 
     include:
-      - python-libs
+      - python.python-libs
 
     django:
       pkg.installed:


### PR DESCRIPTION
Changed

include:
- python-libs

to

include:
- python.python-libs
