### PR TITLE
suse init files add -d to start salt in daemon mode

### DIFF
--- a/pkg/suse/salt-master
+++ b/pkg/suse/salt-master
@@ -167,7 +167,7 @@ case "$1" in
 	echo -n "Starting salt-master daemon: "
 	## Start daemon with startproc(8). If this fails
 	## the return value is set appropriately by startproc.
-	/sbin/startproc $SALTMASTER
+	/sbin/startproc $SALTMASTER -d
 	
 	# Remember status and be verbose
 	rc_status -v

--- a/pkg/suse/salt-minion
+++ b/pkg/suse/salt-minion
@@ -167,7 +167,7 @@ case "$1" in
 	echo -n "Starting salt-minion daemon: "
 	## Start daemon with startproc(8). If this fails
 	## the return value is set appropriately by startproc.
-	/sbin/startproc $SALTMINION
+	/sbin/startproc $SALTMINION -d
 	
 	# Remember status and be verbose
 	rc_status -v

--- a/pkg/suse/salt-syndic
+++ b/pkg/suse/salt-syndic
@@ -167,7 +167,7 @@ case "$1" in
 	echo -n "Starting salt-syndic daemon: "
 	## Start daemon with startproc(8). If this fails
 	## the return value is set appropriately by startproc.
-	/sbin/startproc $SALTSYNDIC
+	/sbin/startproc $SALTSYNDIC -d
 	
 	# Remember status and be verbose
 	rc_status -v


### PR DESCRIPTION
fixes stdout in cli environments when starting salt with:
/etc/init.d/salt-(master/minion) start
