### PR TITLE
Add suse enterprise to rh_service

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -43,6 +43,7 @@ def __virtual__():
         'Fedora',
         'ALT',
         'OEL',
+        'SUSE  Enterprise Server',
     ]
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':


### PR DESCRIPTION
Suse linux enterprise uses the same service files as redhat.
/sbin/service is available as /sbin/chkconfig.

tested it on SLES 11 SP2
