### PR TITLE
added 'SUSE  Enterprise Server' to rh_service.py

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -43,6 +43,7 @@ def __virtual__():
         'Fedora',
         'ALT',
         'OEL',
+        'SUSE  Enterprise Server'
     ]
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':


### PR DESCRIPTION
SLES uses /sbin/service and /sbin/chkconfig too.
tested it on SLES 11 SP2 
