### PR TITLE
extend git.latest state with remote handling

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -431,6 +431,7 @@ def submodule(cwd, init=True, opts=None, user=None):
     cmd = 'git submodule update {0} {1}'.format('--init' if init else '', opts)
     return _git_run(cmd, cwd=cwd, runas=user)
 
+
 def status(cwd, user=None):
     '''
     Return the status of the repository. The returned format uses the status
@@ -451,6 +452,7 @@ def status(cwd, user=None):
         if filename != '' and state != '':
             status.append((state, filename))
     return status
+
 
 def add(cwd, file_name, user=None, opts=None):
     '''
@@ -473,6 +475,7 @@ def add(cwd, file_name, user=None, opts=None):
         opts = ''
     cmd = 'git add {0} {1}'.format(file_name, opts)
     return _git_run(cmd, cwd=cwd, runas=user)
+
 
 def rm(cwd, file_name, user=None, opts=None):
     '''
@@ -547,3 +550,91 @@ def push(cwd, remote_name, branch='master', user=None, opts=None, identity=None)
         opts = ''
     cmd = 'git push {0} {1} {2}'.format(remote_name, branch, opts)
     return _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+
+
+def remotes(cwd, user=None, identity=None):
+    '''
+    Get remotes like git remote -v
+
+    cwd
+        The path to the Git repository
+
+    user : None
+        Run git as a user other than what the minion runs as
+
+    identity : None
+        A path to a private key to use over SSH
+
+    CLI Example::
+
+        salt '*' git.remotes /path/to/repo
+    '''
+    cmd = 'git remote'
+    ret = _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+    res = dict()
+    for remote_name in ret.splitlines():
+        remote = remote_name.strip()
+        res[remote] = remote_get(cwd, remote, user=user, identity=identity)
+    return res
+
+
+def remote_get(cwd, remote='origin', user=None, identity=None):
+    '''
+    get fetch und push url for a specified remote name
+
+    remote : origin
+        the remote name used to define the fetch and push url
+
+    user : None
+        Run git as a user other than what the minion runs as
+
+    identity : None
+        A path to a private key to use over SSH
+
+    CLI Example::
+
+        salt '*' git.remote_get /path/to/repo
+        salt '*' git.remote_get /path/to/repo upstream
+    '''
+    try:
+        cmd = 'git remote show -n {}'.format(remote)
+        ret = _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+        lines = ret.splitlines()
+        remote_fetch_url = lines[1].replace('Fetch URL: ', '').strip()
+        remote_push_url = lines[2].replace('Push  URL: ', '').strip()
+        if remote_fetch_url != remote and remote_push_url != remote:
+            res = (remote_fetch_url, remote_push_url)
+            return res
+        else:
+            return None
+    except exceptions.CommandExecutionError:
+        return None
+
+
+def remote_set(cwd, name='origin', url=None, user=None, opts=None, identity=None):
+    '''
+    sets a remote with name and url like git remote add <remote_name> <remote_url>
+
+    remote_name : origin
+        defines the remote name
+
+    remote_url : None
+        defines the remote url shut not be null!
+
+    user : None
+        Run git as a user other than what the minion runs as
+
+    identity : None
+        A path to a private key to use over SSH
+
+    CLI Example::
+
+        salt '*' git.remote_set /path/to/repo remote_url=git@github.com:saltstack/salt.git
+        salt '*' git.remote_set /path/to/repo origin git@github.com:saltstack/salt.git
+    '''
+    if remote_get(cwd, name):
+        cmd = 'git remote rm {}'.format(name)
+        _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+    cmd = 'git remote add {} {}'.format(name, url)
+    _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+    return remote_get(cwd=cwd, remote=name, user=None, identity=identity)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -552,7 +552,7 @@ def push(cwd, remote_name, branch='master', user=None, opts=None, identity=None)
     return _git_run(cmd, cwd=cwd, runas=user, identity=identity)
 
 
-def remotes(cwd, user=None, identity=None):
+def remotes(cwd, user=None):
     '''
     Get remotes like git remote -v
 
@@ -562,23 +562,20 @@ def remotes(cwd, user=None, identity=None):
     user : None
         Run git as a user other than what the minion runs as
 
-    identity : None
-        A path to a private key to use over SSH
-
     CLI Example::
 
         salt '*' git.remotes /path/to/repo
     '''
     cmd = 'git remote'
-    ret = _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+    ret = _git_run(cmd, cwd=cwd, runas=user)
     res = dict()
     for remote_name in ret.splitlines():
         remote = remote_name.strip()
-        res[remote] = remote_get(cwd, remote, user=user, identity=identity)
+        res[remote] = remote_get(cwd, remote, user=user)
     return res
 
 
-def remote_get(cwd, remote='origin', user=None, identity=None):
+def remote_get(cwd, remote='origin', user=None):
     '''
     get fetch und push url for a specified remote name
 
@@ -588,9 +585,6 @@ def remote_get(cwd, remote='origin', user=None, identity=None):
     user : None
         Run git as a user other than what the minion runs as
 
-    identity : None
-        A path to a private key to use over SSH
-
     CLI Example::
 
         salt '*' git.remote_get /path/to/repo
@@ -598,7 +592,7 @@ def remote_get(cwd, remote='origin', user=None, identity=None):
     '''
     try:
         cmd = 'git remote show -n {0}'.format(remote)
-        ret = _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+        ret = _git_run(cmd, cwd=cwd, runas=user)
         lines = ret.splitlines()
         remote_fetch_url = lines[1].replace('Fetch URL: ', '').strip()
         remote_push_url = lines[2].replace('Push  URL: ', '').strip()
@@ -611,7 +605,7 @@ def remote_get(cwd, remote='origin', user=None, identity=None):
         return None
 
 
-def remote_set(cwd, name='origin', url=None, user=None, opts=None, identity=None):
+def remote_set(cwd, name='origin', url=None, user=None):
     '''
     sets a remote with name and url like git remote add <remote_name> <remote_url>
 
@@ -624,9 +618,6 @@ def remote_set(cwd, name='origin', url=None, user=None, opts=None, identity=None
     user : None
         Run git as a user other than what the minion runs as
 
-    identity : None
-        A path to a private key to use over SSH
-
     CLI Example::
 
         salt '*' git.remote_set /path/to/repo remote_url=git@github.com:saltstack/salt.git
@@ -634,7 +625,7 @@ def remote_set(cwd, name='origin', url=None, user=None, opts=None, identity=None
     '''
     if remote_get(cwd, name):
         cmd = 'git remote rm {0}'.format(name)
-        _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+        _git_run(cmd, cwd=cwd, runas=user)
     cmd = 'git remote add {0} {1}'.format(name, url)
-    _git_run(cmd, cwd=cwd, runas=user, identity=identity)
-    return remote_get(cwd=cwd, remote=name, user=None, identity=identity)
+    _git_run(cmd, cwd=cwd, runas=user)
+    return remote_get(cwd=cwd, remote=name, user=None)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -597,7 +597,7 @@ def remote_get(cwd, remote='origin', user=None, identity=None):
         salt '*' git.remote_get /path/to/repo upstream
     '''
     try:
-        cmd = 'git remote show -n {}'.format(remote)
+        cmd = 'git remote show -n {0}'.format(remote)
         ret = _git_run(cmd, cwd=cwd, runas=user, identity=identity)
         lines = ret.splitlines()
         remote_fetch_url = lines[1].replace('Fetch URL: ', '').strip()
@@ -633,8 +633,8 @@ def remote_set(cwd, name='origin', url=None, user=None, opts=None, identity=None
         salt '*' git.remote_set /path/to/repo origin git@github.com:saltstack/salt.git
     '''
     if remote_get(cwd, name):
-        cmd = 'git remote rm {}'.format(name)
+        cmd = 'git remote rm {0}'.format(name)
         _git_run(cmd, cwd=cwd, runas=user, identity=identity)
-    cmd = 'git remote add {} {}'.format(name, url)
+    cmd = 'git remote add {0} {1}'.format(name, url)
     _git_run(cmd, cwd=cwd, runas=user, identity=identity)
     return remote_get(cwd=cwd, remote=name, user=None, identity=identity)

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -65,8 +65,9 @@ def latest(name,
         True if the repository is to be a bare clone of the remote repository.
         This is incompatible with rev, as nothing will be checked out.
     remote_name
-        default ist the well known origin you can also define a different name for the first clone
-        this given name is set to default, else it is just to a additional remote. (Default: 'origin')
+        defines a different remote name.
+        For the first clone the given name is set to the default remote,
+        else it is just a additional remote. (Default: 'origin')
     identity
         A path to a private key to use over SSH
     '''

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -115,7 +115,7 @@ def latest(name,
                                                remote_url=name,
                                                user=runas,
                                                identity=identity)
-                    ret['changes']['remote/{}'.format(remote_name)] = "{} => {}".format(str(remote), name)
+                    ret['changes']['remote/{0}'.format(remote_name)] = "{0} => {1}".format(str(remote), name)
 
                 # check if rev is already present in repo, git-fetch otherwise
                 if bare:
@@ -189,7 +189,7 @@ def latest(name,
             opts = '--mirror' if mirror else '--bare' if bare else ''
             # if remote_name is not origin add --origin <name> to opts
             if not remote_name == 'origin':
-                opts += ' --origin {}'.format(remote_name)
+                opts += ' --origin {0}'.format(remote_name)
             # do the clone
             __salt__['git.clone'](target,
                                   name,

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -107,14 +107,12 @@ def latest(name,
                 # check remote if fetch_url not == name set it
                 remote = __salt__['git.remote_get'](target,
                                                     remote=remote_name,
-                                                    user=runas,
-                                                    identity=identity)
+                                                    user=runas)
                 if remote == None or not remote[0] == name:
                     __salt__['git.remote_set'](target,
                                                remote_name=remote_name,
                                                remote_url=name,
-                                               user=runas,
-                                               identity=identity)
+                                               user=runas)
                     ret['changes']['remote/{0}'.format(remote_name)] = "{0} => {1}".format(str(remote), name)
 
                 # check if rev is already present in repo, git-fetch otherwise
@@ -125,10 +123,11 @@ def latest(name,
                                           identity=identity)
                 elif rev:
 
-                    cmd = "git rev-parse "+rev
+                    cmd = "git rev-parse " + rev
                     retcode = __salt__['cmd.retcode'](cmd,
                                                       cwd=target,
                                                       runas=runas)
+                    # there is a issues #3938 addressing this
                     if 0 != retcode:
                         __salt__['git.fetch'](target,
                                               opts=fetch_opts,
@@ -141,8 +140,10 @@ def latest(name,
                 cmd = "git symbolic-ref -q HEAD > /dev/null"
                 retcode = __salt__['cmd.retcode'](cmd, cwd=target, runas=runas)
                 if 0 == retcode:
-                    __salt__['git.fetch' if bare else 'git.pull'](
-                        target, user=runas, identity=identity)
+                    __salt__['git.fetch' if bare else 'git.pull'](target,
+                                                                  opts=fetch_opts,
+                                                                  user=runas,
+                                                                  identity=identity)
 
                 if submodules:
                     __salt__['git.submodule'](target, user=runas,


### PR DESCRIPTION
Because the name of git.latest is the repository where the target shut be based on.
I think it is important that this state does handle remotes correctly and forces them.
