### PR TITLE
Don't return False on `file.sed` if no changes, check retcode instead

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -543,7 +543,7 @@ def sed_contains(path, text, limit='', flags='g'):
         options = options.replace('-r', '-E')
 
     cmd = r"sed {options} '{limit}s/{before}/$/{flags}' {path}".format(
-            options='-n -r -e',
+            options=options,
             limit='/{0}/ '.format(limit) if limit else '',
             before=before,
             flags='p{0}'.format(flags),

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -517,7 +517,7 @@ def sed(path, before, after, limit='', backup='.bak', options='-r -e',
             flags=flags,
             path=path)
 
-    return __salt__['cmd.run'](cmd)
+    return __salt__['cmd.run_all'](cmd)
 
 
 def sed_contains(path, text, limit='', flags='g'):

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -29,7 +29,7 @@ import salt.utils
 from salt.exceptions import SaltInvocationError
 from file import check_hash, check_managed, check_perms, contains_regex,\
         directory_exists, get_managed, makedirs, makedirs_perms, manage_file,\
-        patch, remove, source_list
+        patch, remove, source_list, sed_contains
 
 
 log = logging.getLogger(__name__)
@@ -374,11 +374,16 @@ def find(path, **kwargs):
     return ret
 
 
-def _sed_esc(string):
+def _sed_esc(string, escape_all=False):
     '''
     Escape single quotes and forward slashes
     '''
-    return '{0}'.format(string).replace("'", "'\"'\"'").replace("/", "\/")
+    special_chars = "^.[$()|*+?{"
+    string = string.replace("'", "'\"'\"'").replace("/", "\/")
+    if escape_all is True:
+        for char in special_chars:
+            string = string.replace(char, "\\" + char)
+    return string
 
 
 def sed(path, before, after, limit='', backup='.bak', options='-r -e',

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -526,13 +526,21 @@ def contains(path, text, limit=''):
 
     .. versionadded:: 0.9.5
     '''
-    # Largely inspired by Fabric's contrib.files.contains()
-
     if not os.path.exists(path):
         return False
 
-    result = __salt__['file.sed'](path, text, '&', limit=limit, backup='',
-            options='-n -r -e', flags='gp')
+    before = _sed_esc(str(text), False)
+    limit = _sed_esc(str(limit), False)
+    options = '-n -r -e'
+
+    cmd = r"sed {options} '{limit}s/{before}/$/{flags}' {path}".format(
+            options=options,
+            limit='/{0}/ '.format(limit) if limit else '',
+            before=before,
+            flags='p{0}'.format(flags),
+            path=path)
+
+    result = __salt__['cmd.run'](cmd)
 
     return bool(result)
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1390,7 +1390,7 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
         ret['result'] = True
         ret['comment'] = 'sed ran without error'
     else:
-        ret['result'] = False
+        ret['result'] = True
         ret['comment'] = 'sed ran without error, but no changes were made'
 
     return ret

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1376,7 +1376,19 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
         slines = fp_.readlines()
 
     # should be ok now; perform the edit
-    __salt__['file.sed'](name, before, after, limit, backup, options, flags)
+    retcode = __salt__['file.sed'](name,
+                                   before,
+                                   after,
+                                   limit,
+                                   backup,
+                                   options,
+                                   flags)['retcode']
+
+    if retcode != 0:
+        ret['result'] = False
+        ret['comment'] = ('There was an error running sed.  '
+                          'Return code {0}').format(retcode)
+        return ret
 
     with salt.utils.fopen(name, 'rb') as fp_:
         nlines = fp_.readlines()


### PR DESCRIPTION
Issue #4481 gives a completely valid use case for `sed` which results in
the `begin` pattern always being present.  `sed` should not return False
in this case.

We now check the retcode for `sed` to see if there was any problem.  A non-zero retcode is now the only way the `file.sed` state will return False.

I also did a few small fixes to win_file.py, as I was going through making sure that changing the `file.sed` module function to use `cmd.run_all` wouldn't hurt anything.
