### PR TITLE
Fixed bug with parsing output of npm.install

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -57,7 +57,7 @@ def install(pkg=None,
     if not _valid_version():
         return '"{0}" is not available.'.format('npm.install')
 
-    cmd = 'npm install --json'
+    cmd = 'npm install --silent --json'
 
     if dir is None:
         cmd += ' --global'
@@ -74,6 +74,13 @@ def install(pkg=None,
 
     while ' -> ' in lines[0]:
         lines = lines[1:]
+        
+    ''' Strip all lines until JSON output starts ''' 
+    for i in lines:
+        if i.startswith("{"):
+            break
+        else:
+            lines = lines[1:]        
 
     return json.loads(''.join(lines))
 


### PR DESCRIPTION
When installing packages via "npm install --json" npm also helpfully pumps out the original output this causes an error to be thrown on (line 85) "return json.loads(''.join(lines))" as there will still be non json lines.

I added --silent to the npm command on line 60 for good measure, however this does not guarantee that only JSON will be outputted.

eg Running salt-call npm.install dir=./  on a directory with a package.json that contains an offending package like node-expat will result in the following error on many configurations:

vagrant@precise64:/vagrant/node-example-estore$ sudo salt-call npm.install dir=./  
[INFO    ] Loaded configuration file: /etc/salt/minion
[INFO    ] Executing command 'npm install --json' in directory './'
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/pymodules/python2.7/salt/scripts.py", line 76, in salt_call
    client.run()
  File "/usr/lib/pymodules/python2.7/salt/cli/**init**.py", line 255, in run
    caller.run()
  File "/usr/lib/pymodules/python2.7/salt/cli/caller.py", line 129, in run
    ret = self.call()
  File "/usr/lib/pymodules/python2.7/salt/cli/caller.py", line 71, in call
    ret['return'] = self.minion.functions[fun](*args, **kwargs)
  File "/usr/lib/pymodules/python2.7/salt/modules/npm.py", line 54, in install
    return json.loads(''.join(lines))
  File "/usr/lib/python2.7/json/**init**.py", line 326, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python2.7/json/decoder.py", line 366, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python2.7/json/decoder.py", line 384, in raw_decode
    raise ValueError("No JSON object could be decoded")
ValueError: No JSON object could be decoded
