### PR TITLE
Teach module.run state function to handle varargs

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -116,6 +116,17 @@ def run(name, **kwargs):
         ret['result'] = False
         return ret
 
+    if aspec[1] and aspec[1] in kwargs:
+        varargs = kwargs.pop(aspec[1])
+
+        if type(varargs) is not list:
+            msg = "'{0}' must be a list."
+            ret['comment'] = msg.format(aspec[1])
+            ret['result'] = False
+            return ret
+
+        args.extend(varargs)
+
     try:
         if aspec[2]:
             mret = __salt__[name](*args, **kwargs)


### PR DESCRIPTION
This is a fix for #4472, although I wound up implementing it a bit differently than I described in that issue.  I originally proposed we used a fixed argument called 'args' to specify the extra arguments.  This required additionally creating the special m_args to account for a function that had a "normal" argument called 'args'.  I decided this was not optimal.

The change I wound up doing detects the name of the vararg argument in the function definition and then allows you to just use that name.  For example:

``` python
def func(*args):
    pass
```

you'd do the module.run state like this:

``` yaml
test:
  module.run:
    - name: augeas.setvalue
    - args:
      - arg1
      - arg2
```

For this function:

``` python
def func(*stuff):
    pass
```

You'd do:

``` yaml
test:
  module.run:
    - name: augeas.setvalue
    - stuff:
      - arg1
      - arg2
```

This eliminates the need for the m_ special argument because there is no longer a corner case.  It also winds up being less code (11 lines vs 21).
