### PR TITLE
Fix off-by-one error in module.run state function setting default arg values

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -79,7 +79,7 @@ def run(name, **kwargs):
                 continue
             defaults[key] = kwargs[key]
     # Match up the defaults with the respective args
-    for ind in range(arglen - 1, 0, -1):
+    for ind in range(arglen - 1, -1, -1):
         minus = arglen - ind
         if deflen - minus > -1:
             defaults[aspec[0][ind]] = aspec[3][-minus]


### PR DESCRIPTION
While iterating the list of arguments to fill in the default values, module.run stops too soon because the range() stops at 0 and not -1.  As a result, the following would fail:

The function:

``` python
def func(arg='default_value'):
    print arg
```

The state:

``` yaml
test:
  module.run:
    - name: func
```

It would fail saying that 'arg' was missing even though there is a default value.

I found this while testing my code for #4511, but is a completely separate change.
