### PR TITLE
PKGBUILD-git updated to make use of pacman 4.1 vcs additions

### DIFF
--- a/pkg/arch/PKGBUILD-git
+++ b/pkg/arch/PKGBUILD-git
@@ -1,6 +1,7 @@
 # Maintainer: Christer Edwards <christer.edwards@gmail.com>
 pkgname=salt-git
-pkgver=20120324
+_gitname="salt"
+pkgver=v0.14.0.504.g6fc4ee2
 pkgrel=1
 pkgdesc="A remote execution and communication system built on zeromq"
 arch=('any')
@@ -9,8 +10,8 @@ license=('APACHE')
 groups=()
 depends=('python2'
          'python2-yaml'
-         'python2-pyzmq'
          'python2-jinja'
+         'python2-pyzmq'
          'python2-crypto'
          'python2-psutil'
          'python2-msgpack'
@@ -20,51 +21,53 @@ backup=('etc/salt/master'
         'etc/salt/minion')
 
 makedepends=('git')
-optdepends=()
-options=()
 conflicts=('salt')
 provides=('salt')
 
-source=("salt-master.service"
-        "salt-minion.service"
-        "salt-syndic.service")
+# makepkg 4.1 knows about git and will pull main branch
+source=("git://github.com/saltstack/salt.git")
 
-md5sums=('3a2b032ec37077363c049969105b128e'
-         '833d31ebee69f5c0e2c0b6c8d345b6d7'
-         'e4c6adce5087e947c26c5c9d9fc3c9bb')
+# makepkg knows it's a git repo because the url starts with 'git'
+# it then knows to checkout the branch upon cloning, expediating versioning.
+#branch="develop"
+#source=("git://github.com/saltstack/salt.git#branch=$branch")
 
-_gitroot="https://github.com/saltstack/salt.git"
-_gitname="salt"
+# makepkg also knows about tags
+#tags="v0.14.1"
+#source=("git://github.com/saltstack/salt.git#tag=$tag")
 
-build() {
-  cd ${srcdir}
-  msg "Connecting to GIT server...."
+# because the sources are not static, skip checksums
+md5sums=('SKIP')
 
-  if [ -d ${_gitname} ] ; then
-    cd ${_gitname} && git pull origin
-    msg "The local files are updated."
-  else
-    git clone ${_gitroot} ${_gitname}
-  fi
-
-  msg "GIT checkout done or server timeout"
-  msg "Starting make..."
-
-  rm -rf ${srcdir}/${_gitname}-build
-  git clone ${srcdir}/${_gitname} ${srcdir}/${_gitname}-build
-
+pkgver() {
+  cd "$srcdir/$_gitname"
+  echo $(git describe --always | sed 's/-/./g')
+  # for git, if the repo has no tags, comment out the above and uncomment the next line:
+  #echo "0.$(git rev-list --count $branch).$(git describe --always)"
+  # This will give you a count of the total commits and the hash of the commit you are on.
+  # Useful if you're making a repository with git packages so that they can have sequential
+  # version numbers. (Else a pacman -Syu may not update the package)
 }
 
-package() {
-  cd ${srcdir}/${_gitname}-build
+#build() {
+#  cd "${srcdir}/${_gitname}"
+#  python2 setup.py build 
+   # no need to build setup.py install will do this
+#}
 
+package() {
+  cd "${srcdir}/${_gitname}"
+  
   python2 setup.py install --root=${pkgdir}/ --optimize=1
 
-  install -Dm644 ${srcdir}/salt/pkg/salt-master.service ${pkgdir}/usr/lib/systemd/system/salt-master.service
-  install -Dm644 ${srcdir}/salt/pkg/salt-syndic.service ${pkgdir}/usr/lib/systemd/system/salt-syndic.service
-  install -Dm644 ${srcdir}/salt/pkg/salt-minion.service ${pkgdir}/usr/lib/systemd/system/salt-minion.service
+  install -Dm644 ${srcdir}/salt/pkg/arch/salt-master.service ${pkgdir}/usr/lib/systemd/system/salt-master.service
+  install -Dm644 ${srcdir}/salt/pkg/arch/salt-syndic.service ${pkgdir}/usr/lib/systemd/system/salt-syndic.service
+  install -Dm644 ${srcdir}/salt/pkg/arch/salt-minion.service ${pkgdir}/usr/lib/systemd/system/salt-minion.service
 
   mkdir -p ${pkgdir}/etc/salt/
-  cp ${srcdir}/salt-build/conf/master ${pkgdir}/etc/salt/
-  cp ${srcdir}/salt-build/conf/minion ${pkgdir}/etc/salt/
+  cp ${srcdir}/salt/conf/master ${pkgdir}/etc/salt/
+  cp ${srcdir}/salt/conf/minion ${pkgdir}/etc/salt/
+
+  # remove vcs leftovers
+  find "$pkgdir" -type d -name .git -exec rm -r '{}' +
 }


### PR DESCRIPTION
- pkgver() function -> this will make package version sane again,
  no more date as package version.
  pkg version will reflect salts internal version
- sample vcs supported branch/tags added
- removed old sources/md5sums not needed
