### PR TITLE
added service support for opensuse

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -22,6 +22,7 @@ GRAINMAP = {
            'Amazon': '/etc/init.d',
            'SunOS': '/etc/init.d',
            'SUSE  Enterprise Server': '/etc/init.d',
+           'openSUSE': '/etc/init.d',
            'OEL': '/etc/init.d',
           }
 


### PR DESCRIPTION
got this error previously:

 State: - service
    Name:      ntp
    Function:  running
        Result:    False
        Comment:   An exception occured in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/state.py", line 1214, in call
    _cdata['args'], *_cdata['kwargs'])
  File "/usr/lib/python2.7/site-packages/salt/states/service.py", line 258, in running
    ret = _available(name, ret)
  File "/usr/lib/python2.7/site-packages/salt/states/service.py", line 219, in _available
    ret['available'] = __salt__['service.available'](name)
  File "/usr/lib/python2.7/site-packages/salt/modules/service.py", line 141, in available
    return name in get_all()
  File "/usr/lib/python2.7/site-packages/salt/modules/service.py", line 128, in get_all
    if not os.path.isdir(GRAINMAP[**grains**['os']]):
KeyError: 'openSUSE'

```
    Changes:  
```
