### PR TITLE
Update ubuntu.rst

### DIFF
--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -16,9 +16,9 @@ key in one step:
 .. admonition:: add-apt-repository: command not found?
 
     The add-apt-repository command is not always present on Ubuntu systems.
-    This can be fixed by installing `python-software-properties`::
+    This can be fixed by installing `software-properties-common`::
 
-        sudo apt-get install python-software-properties
+        sudo apt-get install software-properties-common
 
 Alternately, manually add the repository and import the PPA key with these commands:
 


### PR DESCRIPTION
The `software-properties-common` package is required to be able to do `add-apt-repository` and not the mentioned `python-software-properties`.
