### PR TITLE
Fix ssh_auth.absent to check only the key, not the whole key line

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -231,7 +231,7 @@ def absent(name, user, config='.ssh/authorized_keys'):
                 [],
                 config)
         if check == 'update' or check == 'exists':
-            ret['return'] = None
+            ret['result'] = None
             ret['comment'] = 'Key {0} is set for removal'.format(name)
             return ret
         else:

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -219,6 +219,9 @@ def absent(name, user, config='.ssh/authorized_keys'):
            'result': True,
            'comment': ''}
 
+    # Get just the key
+    name = name.split(' ')[0]
+
     if __opts__['test']:
         check = __salt__['ssh.check_key'](
                 user,


### PR DESCRIPTION
Fixes #4170

Previously was searching for the whole line, and ssh.rm_auth_key and ssh.check_key were both expecting just the key part.
