### PR TITLE
"X is not 0" ==> "X != 0"

### DIFF
--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -144,7 +144,7 @@ def A(host, nameserver=None):
         dig.append('@{0}'.format(nameserver))
 
     cmd = __salt__['cmd.run_all'](' '.join(dig))
-    if cmd['retcode'] is not 0:
+    if cmd['retcode'] != 0:
         log.warn(
             'dig returned exit code \'{0}\'. Returning empty list as '
             'fallback.'.format(
@@ -169,7 +169,7 @@ def NS(domain, resolve=True, nameserver=None):
         dig.append('@{0}'.format(nameserver))
 
     cmd = __salt__['cmd.run_all'](' '.join(dig))
-    if cmd['retcode'] is not 0:
+    if cmd['retcode'] != 0:
         log.warn(
             'dig returned exit code \'{0}\'. Returning empty list as '
             'fallback.'.format(
@@ -212,7 +212,7 @@ def SPF(domain, record='SPF', nameserver=None):
         dig.append('@{0}'.format(nameserver))
 
     cmd = __salt__['cmd.run_all'](' '.join(dig))
-    if cmd['retcode'] is not 0:
+    if cmd['retcode'] != 0:
         log.warn(
             'dig returned exit code \'{0}\'. Returning empty list as '
             'fallback.'.format(
@@ -254,7 +254,7 @@ def MX(domain, resolve=False, nameserver=None):
         dig.append('@{0}'.format(nameserver))
 
     cmd = __salt__['cmd.run_all'](' '.join(dig))
-    if cmd['retcode'] is not 0:
+    if cmd['retcode'] != 0:
         log.warn(
             'dig returned exit code \'{0}\'. Returning empty list as '
             'fallback.'.format(

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -110,9 +110,9 @@ def eclean_dist(destructive=False, package_names=False, size_limit=0,
         if exclude_file is not None:
             exclude = _parse_exclude(exclude_file)
 
-        if time_limit is not 0:
+        if time_limit != 0:
             time_limit = cli.parseTime(time_limit)
-        if size_limit is not 0:
+        if size_limit != 0:
             size_limit = cli.parseSize(size_limit)
 
         clean_size=0
@@ -174,10 +174,10 @@ def eclean_pkg(destructive=False, package_names=False, time_limit=0,
         if exclude_file is not None:
             exclude = _parse_exclude(exclude_file)
 
-        if time_limit is not 0:
+        if time_limit != 0:
             time_limit = cli.parseTime(time_limit)
 
-        clean_size=0
+        clean_size = 0
         # findPackages requires one arg, but does nothing with it.
         # So we will just pass None in for the required arg
         clean_me = search.findPackages(None, destructive=destructive,


### PR DESCRIPTION
`is not` just happens to work for small integers due to CPython optimizations, but it's not good practice by any means. Checking the _object identity_ of ints is just weird; _equality_ is what really matters.
