### PR TITLE
support comparisons for IPv4Address

### DIFF
--- a/salt/utils/socket_util.py
+++ b/salt/utils/socket_util.py
@@ -337,6 +337,9 @@ class IPv4Address(object):
     def __repr__(self):
         return 'IPv4Address("{0}")'.format(str(self))
 
+    def __cmp__(self, other):
+        return cmp(self.dotted_quad, other.dotted_quad)
+
     @property
     def is_private(self):
         '''


### PR DESCRIPTION
2 line addition to support comparisons between IPv4Address objects. First step towards testing membership in subnets.
