### PR TITLE
Properly handle pecl extension versions

### DIFF
--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -11,18 +11,36 @@ A state module to manage php pecl extensions.
 '''
 
 
-def installed(name):
+def installed(
+        name,
+        version=None):
     '''
     Make sure that a pecl extension is installed.
 
     name
         The pecl extension name to install
+
+    version
+        The pecl extension version to install. This option may be 
+        ignored to install the latest stable version.
     '''
+    # Check to see if we have a designated version
+    if not isinstance(version, basestring) and version is not None:
+        version = str(version)
+
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
-    if name in __salt__['pecl.list']():
-        ret['result'] = True
-        ret['comment'] = 'Pecl is already installed.'
-        return ret
+
+    installed_pecls = __salt__['pecl.list']()
+
+    if name in installed_pecls:
+        # The package is only installed if version is absent or matches
+        if version is None or installed_pecls[name][0] == version:
+            ret['result'] = True
+            ret['comment'] = 'Pecl is already installed.'
+            return ret
+        else:
+            # Modify the name to include the version and proceed.
+            name = '{0}-{1}'.format(name, version)
 
     if __opts__['test']:
         ret['comment'] = 'The pecl {0} would have been installed'.format(name)


### PR DESCRIPTION
If you force pecl to install a specific version (e.g. memcache-3.0.6), then the state gets a non-zero exit code on every subsequent check. This change makes the pecl state accept an option version that will be honored and checked correctly.

Example of bad behavior:

```
$ salt web1* cmd.run 'pecl list'
web1:
    INSTALLED PACKAGES, CHANNEL PECL.PHP.NET:
    =========================================
    PACKAGE  VERSION STATE
    memcache 3.0.6   beta
$ salt web1* state.single pecl.installed name=memcache test=True
web1:
----------
    State: - pecl
    Name:      memcache
    Function:  installed
        Result:    True
        Comment:   Pecl is already installed.
        Changes:
$ salt web1* state.single pecl.installed name=memcache-3.0.6 test=True
web1:
----------
    State: - pecl
    Name:      memcache-3.0.6
    Function:  installed
        Result:    None
        Comment:   The pecl memcache-3.0.6 would have been installed
        Changes:
```
