### PR TITLE
fix handling of fromrepo parameter in salt.states.yumpkg.install

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -378,7 +378,6 @@ def group_install(name=None,
 
 def install(name=None,
             refresh=False,
-            fromrepo=None,
             skip_verify=False,
             pkgs=None,
             sources=None,


### PR DESCRIPTION
This fixes Issue #4572.  The `fromrepo` parameter was not getting collected into `kwargs` and getting passed to `_set_repo_options`.
