### PR TITLE
Don't refer to deleted branch in environments list

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -147,11 +147,15 @@ def envs():
     ret = set()
     repos = init()
     for repo in repos:
+        remote = repo.remote()
         for ref in repo.refs:
-            if isinstance(ref, git.Head) or isinstance(ref, git.Tag):
-                short = os.path.basename(ref.name)
+            short = os.path.basename(ref.name)
+            if isinstance(ref, git.Head):
                 if short == 'master':
                     short = 'base'
+                if ref not in remote.stale_refs:
+                    ret.add(short)
+            elif isinstance(ref, git.Tag):
                 ret.add(short)
     return list(ret)
 


### PR DESCRIPTION
Using gitfs if you create a branch and push. `salt.fileserver.gitfs.update` will get it on next loop iteration.
But if you eventually delete that branch on the repository, it still appears in the list of environments.

This check if a ref is in remote stalled list.

I couldn't find a way to remove deleted tags.
