### PR TITLE
Fix pkg.version on Windows.

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -138,7 +138,38 @@ def version(*names, **kwargs):
 
         salt '*' pkg.version <package name>
     '''
-    return __salt__['pkg_resource.version'](*names, **kwargs)
+    win_names = []
+    ret = {}
+    if len(names) == 1:
+        versions = _get_package_info(names[0])
+        if versions:
+            for version, val in versions.iteritems():
+                if 'full_name' in val and len(val.get('full_name', '')) > 0:
+                    win_names.append(val.get('full_name', ''))
+        nums = __salt__['pkg_resource.version'](*win_names, **kwargs)
+        if len(nums):
+            for num, val in nums.iteritems():
+                if len(val) > 0:
+                    return val
+        return ''
+    if len(names) > 1:
+        reverse_dict = {}
+        for name in names:
+            ret[name] = ''
+            versions = _get_package_info(name)
+            if versions:
+                for version, val in versions.iteritems():
+                    if 'full_name' in val and len(val.get('full_name', '')) > 0:
+                        reverse_dict[val.get('full_name', '')] = name
+                        win_names.append(val.get('full_name', ''))
+        nums = __salt__['pkg_resource.version'](*win_names, **kwargs)
+        if len(nums):
+            for num, val in nums.iteritems():
+                if len(val) > 0:
+                    ret[reverse_dict[num]] = val
+            return ret
+        return ''
+    return ret
 
 
 def list_pkgs(*args, **kwargs):


### PR DESCRIPTION
Fixes #4492

Makes pkg.version conform to pkg standards better.
