### PR TITLE
Add libzmq version to --versions-report output.

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -124,6 +124,7 @@ def versions_report():
         ('pycrypto', 'Crypto', '__version__'),
         ('PyYAML', 'yaml', '__version__'),
         ('PyZMQ', 'zmq', '__version__'),
+        ('ZMQ', 'zmq', 'zmq_version'),
     )
 
     padding = len(max([lib[0] for lib in libs], key=len)) + 1
@@ -140,14 +141,13 @@ def versions_report():
         try:
             imp = __import__(imp)
             version = getattr(imp, attr)
-            if not isinstance(version, basestring):
+            if callable(version):
+                version = version()
+            if isinstance(version, (tuple, list)):
                 version = '.'.join(map(str, version))
             yield fmt.format(name, version, pad=padding)
         except ImportError:
             yield fmt.format(name, 'not installed', pad=padding)
-
-    from zmq import zmq_version
-    yield fmt.format('libzmq', zmq_version(), pad=padding)
 
 
 if __name__ == '__main__':

--- a/salt/version.py
+++ b/salt/version.py
@@ -146,6 +146,9 @@ def versions_report():
         except ImportError:
             yield fmt.format(name, 'not installed', pad=padding)
 
+    from zmq import zmq_version
+    yield fmt.format('libzmq', zmq_version(), pad=padding)
+
 
 if __name__ == '__main__':
     print(__version__)


### PR DESCRIPTION
When debugging we often need output from "salt --versions-report", but currently the version of the zmq library itself is not included (PyZMQ is included, but not libzmq). This patch remedies that.
