### PR TITLE
Add support in test module for getting versions report from minions.

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -79,10 +79,10 @@ def versions_report():
 
     CLI Example::
 
-        salt '*' test.version
+        salt '*' test.versions_report
     '''
     import salt.version
-    return "\n".join(salt.version.versions_report())
+    return '\n'.join(salt.version.versions_report())
 
 
 def conf_test():

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -73,6 +73,18 @@ def version():
     return salt.__version__
 
 
+def versions_report():
+    '''
+    Returns versions of components used by salt
+
+    CLI Example::
+
+        salt '*' test.version
+    '''
+    import salt.version
+    return "\n".join(salt.version.versions_report())
+
+
 def conf_test():
     '''
     Return the value for test.foo in the minion configuration file, or return


### PR DESCRIPTION
This allows us to easily gather relevant version information from minions when debugging. 

For example, to see how many versions of 0MQ you have (and number of minons for each version) you could run:

```
salt '*' test.versions_report | grep " ZMQ:" | sort | uniq -c
```
