### PR TITLE
Command to change the ownership of all relations in a database

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -805,7 +805,7 @@ def owner_to(dbname,
          ),
         # sequences
         (
-         'alter sequence %{n}s owner to %{owner}s;',
+         'alter sequence %(n)s owner to %(owner)s;',
          "select quote_ident(sequence_schema)||'.'||quote_ident(sequence_name) as n from information_schema.sequences;"
         )
     )


### PR DESCRIPTION
This pull request implements a new command to change the ownership of all tables, views, sequences, functions, aggregates and schemata in a database at once.

This is useful when creating new databases from a template and setting the correct ownerships for the new user.
