### PR TITLE
enable the quiet argument in cmd state and module

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -302,9 +302,9 @@ def _run(cmd,
 
     # Setting stdout to None seems to cause the Process to fail.
     # See bug #2640 for more info
-    if retcode:
+    #if retcode:
         #kwargs['stdout'] = None
-        kwargs['stderr'] = None
+        #kwargs['stderr'] = None
 
     # This is where the magic happens
     proc = subprocess.Popen(cmd, **kwargs)
@@ -373,7 +373,8 @@ def run(cmd,
         env=(),
         template=None,
         rstrip=True,
-        umask=None):
+        umask=None,
+        quiet=False):
     '''
     Execute the passed command and return the output as a string
 
@@ -396,8 +397,10 @@ def run(cmd,
                env=env,
                template=template,
                rstrip=rstrip,
-               umask=umask)['stdout']
-    log.debug('output: {0}'.format(out))
+               umask=umask,
+               quiet=quiet)['stdout']
+    if not quiet:
+        log.debug('output: {0}'.format(out))
     return out
 
 
@@ -408,7 +411,8 @@ def run_stdout(cmd,
                env=(),
                template=None,
                rstrip=True,
-               umask=None):
+               umask=None,
+               quiet=False):
     '''
     Execute a command, and only return the standard out
 
@@ -430,8 +434,10 @@ def run_stdout(cmd,
                   env=env,
                   template=template,
                   rstrip=rstrip,
-                  umask=umask)["stdout"]
-    log.debug('stdout: {0}'.format(stdout))
+                  umask=umask,
+                  quiet=quiet)["stdout"]
+    if not quiet:
+        log.debug('stdout: {0}'.format(stdout))
     return stdout
 
 
@@ -442,7 +448,8 @@ def run_stderr(cmd,
                env=(),
                template=None,
                rstrip=True,
-               umask=None):
+               umask=None,
+               quiet=False):
     '''
     Execute a command and only return the standard error
 
@@ -464,8 +471,10 @@ def run_stderr(cmd,
                   env=env,
                   template=template,
                   rstrip=rstrip,
-                  umask=umask)["stderr"]
-    log.debug('stderr: {0}'.format(stderr))
+                  umask=umask,
+                  quiet=quiet)["stderr"]
+    if not quiet:
+        log.debug('stderr: {0}'.format(stderr))
     return stderr
 
 
@@ -476,7 +485,8 @@ def run_all(cmd,
             env=(),
             template=None,
             rstrip=True,
-            umask=None):
+            umask=None,
+            quiet=False):
     '''
     Execute the passed command and return a dict of return data
 
@@ -498,23 +508,25 @@ def run_all(cmd,
                env=env,
                template=template,
                rstrip=rstrip,
-               umask=umask)
+               umask=umask,
+               quiet=quiet)
 
-    if ret['retcode'] != 0:
-        rcode = ret['retcode']
-        msg = 'Command \'{0}\' failed with return code: {1}'
-        log.error(msg.format(cmd, rcode))
-        # Don't log a blank line if there is no stderr or stdout
-        if ret['stdout']:
-            log.error('stdout: {0}'.format(ret['stdout']))
-        if ret['stderr']:
-            log.error('stderr: {0}'.format(ret['stderr']))
-    else:
-        # No need to always log output on success to the logs
-        if ret['stdout']:
-            log.debug('stdout: {0}'.format(ret['stdout']))
-        if ret['stderr']:
-            log.debug('stderr: {0}'.format(ret['stderr']))
+    if not quiet:
+        if ret['retcode'] != 0:
+            rcode = ret['retcode']
+            msg = 'Command \'{0}\' failed with return code: {1}'
+            log.error(msg.format(cmd, rcode))
+            # Don't log a blank line if there is no stderr or stdout
+            if ret['stdout']:
+                log.error('stdout: {0}'.format(ret['stdout']))
+            if ret['stderr']:
+                log.error('stderr: {0}'.format(ret['stderr']))
+        else:
+            # No need to always log output on success to the logs
+            if ret['stdout']:
+                log.debug('stdout: {0}'.format(ret['stdout']))
+            if ret['stderr']:
+                log.debug('stderr: {0}'.format(ret['stderr']))
     return ret
 
 
@@ -524,7 +536,8 @@ def retcode(cmd,
             shell=DEFAULT_SHELL,
             env=(),
             template=None,
-            umask=None):
+            umask=None,
+            quiet=False):
     '''
     Execute a shell command and return the command's return code.
 
@@ -547,8 +560,8 @@ def retcode(cmd,
             env=env,
             retcode=True,
             template=template,
-            umask=umask
-            )['retcode']
+            umask=umask,
+            quiet=quiet)['retcode']
 
 
 def script(

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -358,6 +358,7 @@ def run(name,
         env=(),
         stateful=False,
         umask=None,
+        quiet=False,
         **kwargs):
     '''
     Run a command if certain circumstances are met
@@ -392,7 +393,11 @@ def run(name,
         environments are defined in the master config file.
 
     umask
-         The umask (in octal) to use when running the command.
+        The umask (in octal) to use when running the command.
+
+    quiet
+        The command will be executed quietly, meaning no log entries of the
+        actual command or its return data
 
     stateful
         The command being executed is expected to return data about executing
@@ -456,7 +461,8 @@ def run(name,
                   'runas': user,
                   'shell': shell or __grains__['shell'],
                   'env': env,
-                  'umask': umask}
+                  'umask': umask,
+                  'quiet': quiet}
 
     try:
         cret = _run_check(cmd_kwargs, onlyif, unless, cwd, user, group, shell)


### PR DESCRIPTION
In a continue to the thread https://groups.google.com/forum/#!topic/salt-users/lWxeOJOUVnA

I've added the quiet argument to the module and state.

Couple of notes:
- note the change I've made in line 305-307 in the cmd module, without it strerr will be output to the log file.
- while executing the cmd.run state from some reason there are still log entries, what am I missing ?

```
(UTC)[root@app ~ :) ]$ salt-call state.single cmd.run name='ls' quiet=True         
[INFO    ] Loaded configuration file: /etc/salt/minion
[INFO    ] Executing command 'ps -efH' in directory '/root'
[INFO    ] Loading fresh modules for state activity
[INFO    ] Executing state cmd.run for ls
[INFO    ] {'pid': 24319, 'retcode': 0, 'stderr': '', 'stdout': 'cdrom\ncmd.py\ncmdmod.py'}
local:
----------
    State: - cmd
    Name:      ls
    Function:  run
        Result:    True
        Comment:   Command "ls" run
        Changes:   pid: 24319
                   retcode: 0
                   stderr: 
                   stdout: cdrom
cmd.py
cmdmod.py

(UTC)[root@app ~ :) ]$ salt-call state.single cmd.run name='ls'            
[INFO    ] Loaded configuration file: /etc/salt/minion
[INFO    ] Executing command 'ps -efH' in directory '/root'
[INFO    ] Loading fresh modules for state activity
[INFO    ] Executing state cmd.run for ls
[INFO    ] Executing command 'ls' in directory '/root'
[INFO    ] {'pid': 24350, 'retcode': 0, 'stderr': '', 'stdout': 'cdrom\ncmd.py\ncmdmod.py'}
local:
----------
    State: - cmd
    Name:      ls
    Function:  run
        Result:    True
        Comment:   Command "ls" run
        Changes:   pid: 24350
                   retcode: 0
                   stderr: 
                   stdout: cdrom
cmd.py
cmdmod.py

```
