### PR TITLE
Fix cmd.script on Windows.

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -579,14 +579,14 @@ def script(
     '''
     if not salt.utils.is_windows():
         path = salt.utils.mkstemp(dir=cwd)
+    else:
+        path = __salt__['cp.cache_file'](source, env)
     if template:
         __salt__['cp.get_template'](source, path, template, env, **kwargs)
     else:
-        fn_ = __salt__['cp.cache_file'](source, env)
         if not salt.utils.is_windows():
+            fn_ = __salt__['cp.cache_file'](source, env)
             shutil.copyfile(fn_, path)
-        else:
-            path = fn_
     if not salt.utils.is_windows():
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -577,12 +577,16 @@ def script(
         salt '*' cmd.script salt://scripts/runme.sh
         salt '*' cmd.script salt://scripts/runme.sh 'arg1 arg2 "arg 3"'
     '''
-    path = salt.utils.mkstemp(dir=cwd)
+    if not salt.utils.is_windows():
+        path = salt.utils.mkstemp(dir=cwd)
     if template:
         __salt__['cp.get_template'](source, path, template, env, **kwargs)
     else:
         fn_ = __salt__['cp.cache_file'](source, env)
-        shutil.copyfile(fn_, path)
+        if not salt.utils.is_windows():
+            shutil.copyfile(fn_, path)
+        else:
+            path = fn_
     if not salt.utils.is_windows():
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)


### PR DESCRIPTION
Fixes #2972

Was previously creating a temp file on Windows, which couldn't be executed.
Just cache the file and run it when on Windows.
