### PR TITLE
Add test.versions_information(). Fix stray print() call in version.py.

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -9,6 +9,8 @@ import time
 import random
 
 # Import Salt libs
+import salt
+import salt.version
 import salt.loader
 
 
@@ -69,7 +71,6 @@ def version():
 
         salt '*' test.version
     '''
-    import salt
     return salt.__version__
 
 
@@ -81,7 +82,6 @@ def versions_information():
 
         salt '*' test.versions_information
     '''
-    import salt.version
     return dict(salt.version.versions_information())
 
 
@@ -93,7 +93,6 @@ def versions_report():
 
         salt '*' test.versions_report
     '''
-    import salt.version
     return '\n'.join(salt.version.versions_report())
 
 

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -73,6 +73,18 @@ def version():
     return salt.__version__
 
 
+def versions_information():
+    '''
+    Returns versions of components used by salt as a dict
+
+    CLI Example::
+
+        salt '*' test.versions_information
+    '''
+    import salt.version
+    return dict(salt.version.versions_information())
+
+
 def versions_report():
     '''
     Returns versions of components used by salt

--- a/salt/version.py
+++ b/salt/version.py
@@ -148,7 +148,6 @@ def versions_report():
     '''
     Yield each library properly formatted for a console clean output.
     '''
-    print dict(versions_information())
     libs = list(versions_information())
 
     padding = len(max([lib[0] for lib in libs], key=len)) + 1


### PR DESCRIPTION
This patch adds an entry point for version.versions_information() in the test module.
Also removes a stray print() left behind in the version.versions_report().
