### PR TITLE
Improve logging logic in `salt/template.py`. Allow the test suite to set/handle more logging levels

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -67,7 +67,7 @@ def compile_template(template, renderers, default, env='', sls='', **kwargs):
             time.sleep(0.01)
             ret = render(input_data, env, sls, **render_kwargs)
         input_data = ret
-        if log.getEffectiveLevel() == 1:
+        if log.isEnabledFor(logging.GARBAGE):
             try:
                 log.debug('Rendered data from file: {0}:\n{1}'.format(
                     template,

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -346,14 +346,23 @@ def parse_opts():
         'Test suite is running under PID {0}'.format(os.getpid()), bottom=False
     )
 
-
     # With greater verbosity we can also log to the console
     if options.verbosity > 2:
         consolehandler = logging.StreamHandler(sys.stderr)
         consolehandler.setLevel(logging.INFO)       # -vv
         consolehandler.setFormatter(formatter)
+        handled_levels = {
+            3: logging.DEBUG,   # -vvv
+            4: logging.TRACE,   # -vvvv
+            5: logging.GARBAGE  # -vvvvv
+        }
         if options.verbosity > 3:
-            consolehandler.setLevel(logging.DEBUG)  # -vvv
+            consolehandler.setLevel(
+                handled_levels.get(
+                    options.verbosity,
+                    options.verbosity > 5 and 5 or 3
+                )
+            )
 
         logging.root.addHandler(consolehandler)
 


### PR DESCRIPTION
Improve logging logic in `salt/template.py`. Allow the test suite to set/handle more logging levels.

@thatch45, if only I knew what you were after, I'd get you the proper answer.
