### PR TITLE
We're no longer leaking threads. Travis-CI should be OK with 10 worker threads

### DIFF
--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -1,6 +1,6 @@
 publish_port: 64505
 ret_port: 64506
-worker_threads: 3
+worker_threads: 10
 root_dir: /tmp/salttest
 pidfile: masterpid
 pki_dir: pki

--- a/tests/integration/files/conf/syndic_master
+++ b/tests/integration/files/conf/syndic_master
@@ -1,6 +1,6 @@
 publish_port: 54505
 ret_port: 54506
-worker_threads: 3
+worker_threads: 10
 root_dir: /tmp/saltsyndictest
 pidfile: syndicmasterpid
 pki_dir: pki


### PR DESCRIPTION
- We're no longer leaking threads. Travis-CI should be OK with 10 worker threads

@thatch45 should we add a check to the config to see if `worker_threads` are bellow 3? Which proved to be problematic on the test-suite?
