### PR TITLE
Propagate ipv6 option to dns lookup function.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,3 @@ before_install:
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
 script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo -v'"
-
-notifications:
-  irc:
-    channels: "irc.freenode.org#salt-devel"
-    on_success: change
-    on_failure: change

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -246,7 +246,8 @@ class Auth(object):
         try:
             self.opts['master_ip'] = salt.utils.dns_check(
                     self.opts['master'],
-                    True
+                    True,
+                    self.opts['ipv6']
                     )
         except SaltClientError:
             return 'retry'

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -68,7 +68,7 @@ def resolve_dns(opts):
         # Because I import salt.log below I need to re-import salt.utils here
         import salt.utils
         try:
-            ret['master_ip'] = salt.utils.dns_check(opts['master'], True)
+            ret['master_ip'] = salt.utils.dns_check(opts['master'], True, opts['ipv6'])
         except SaltClientError:
             if opts['retry_dns']:
                 while True:
@@ -82,7 +82,7 @@ def resolve_dns(opts):
                     time.sleep(opts['retry_dns'])
                     try:
                         ret['master_ip'] = salt.utils.dns_check(
-                            opts['master'], True
+                            opts['master'], True, opts['ipv6']
                         )
                         break
                     except SaltClientError:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -314,7 +314,7 @@ def ip_bracket(addr):
     return addr
 
 
-def dns_check(addr, safe=False):
+def dns_check(addr, safe=False, ipv6=False):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an
     exception. Obeys system preference for IPv4/6 address resolution.
@@ -326,8 +326,13 @@ def dns_check(addr, safe=False):
         if not hostnames:
             error = True
         else:
-            h = hostnames[0]
-            addr = ip_bracket(h[4][0])
+            addr = False
+            for h in hostnames:
+                if h[0] == socket.AF_INET or (h[0] == socket.AF_INET6 and ipv6):
+                    addr = ip_bracket(h[4][0])
+                    break
+            if not addr:
+                error = True
     except socket.gaierror:
         error = True
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -728,7 +728,7 @@ class SyndicOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         # Some of the opts need to be changed to match the needed opts
         # in the minion class.
         opts['master'] = opts['syndic_master']
-        opts['master_ip'] = utils.dns_check(opts['master'])
+        opts['master_ip'] = utils.dns_check(opts['master'], ipv6=opts['ipv6'])
 
         opts['master_uri'] = 'tcp://{0}:{1}'.format(
             opts['master_ip'], str(opts['master_port'])


### PR DESCRIPTION
This change propagates the ipv6 enable/disable option to the dns lookup code, which should make ipv6 support be a noop when disabled in the config.

Ref: https://github.com/saltstack/salt/pull/4232#issuecomment-17154609
