### PR TITLE
salt.states.group.present system arg undocumented

### DIFF
--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -24,6 +24,11 @@ def present(name, gid=None, system=False):
     gid
         The group id to assign to the named group; if left empty, then the next
         available group id will be assigned
+
+    system 
+        Whether or not the named group is a system group.  This is essentially
+        the '-r' option of 'groupadd'.
+
     '''
     ret = {'name': name,
            'changes': {},


### PR DESCRIPTION
I was learning how to add a group in a state file, and noticed the example for "cheese:" here http://docs.saltstack.com/ref/states/all/salt.states.group.html had a "- system: True",  but wasn't described or listed in the argument list etc etc
