### PR TITLE
Fix file.recurse:   - clean: True   on Windows minions.

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -28,7 +28,7 @@ except ImportError:
 import salt.utils
 from salt.exceptions import SaltInvocationError
 from file import check_hash, check_managed, check_perms, contains_regex,\
-        directory_exists, get_managed, makedirs, makedirs_perms, manage_file,\
+        directory_exists, get_managed, mkdir, makedirs, makedirs_perms, manage_file,\
         patch, remove, source_list, sed_contains
 
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -198,7 +198,7 @@ def _clean_dir(root, keep, exclude_pat):
             while True:
                 fn_ = os.path.dirname(fn_)
                 real_keep.add(fn_)
-                if fn_ == '/':
+                if fn_ in ['/', ''.join([os.path.splitdrive(fn_)[0], '\\'])]:
                     break
 
     for roots, dirs, files in os.walk(root):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -908,7 +908,7 @@ def directory(name,
             # The parent directory does not exist, create them
             if makedirs:
                 __salt__['file.makedirs'](
-                    name, user=user, group=group, mode=dir_mode, makedirs=True
+                    name, user=user, group=group, mode=dir_mode
                 )
             else:
                 return _error(


### PR DESCRIPTION
Fixes #4452

Once again, this was an issue dealing with the cross-platform differences in paths.
This was tricky to sort out.
