### PR TITLE
Update debconfmod.py

### DIFF
--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -120,6 +120,20 @@ def set(name, data):
     current = __salt__['debconf.show'](name)
 
     for (key, args) in data.iteritems():
+        '''
+         For debconf data, valid booleans are 'true' and 'false';
+         But str()'ing the args['value'] will result in 'True' and 'False'
+         which will be ignored and overridden by a dpkg-reconfigure.
+
+         So we should manually set these values to lowercase ones, 
+         before any str() call is performed.
+        '''
+        if args['type'] == 'boolean':
+            if args['value']:
+                args['value'] = 'true'
+            else:
+                args['value'] = 'false'    	
+    	
         if current is not None and [key, args['type'], str(args['value'])] in current:
             if ret['comment'] is '':
                 ret['comment'] = 'Unchanged answers: '


### PR DESCRIPTION
Within the debconfmod state module, when boolean debconf data is set, the resulting 'True' and 'False' values are invalid which should be 'true' / 'false'. Invalid datas are overridden when a dpkg-reconfigure <package> command is non-interactively executed, resulting in broken states.

For example, the 'exim4-config' package in Debian requires 'exim4/dc_minimaldns' key; which is a boolean. This key, and any other boolean keys will be unavailable for debconf state module, without this fix.
