### PR TITLE
Add contents arg for file.managed, Fixes #3516

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1349,8 +1349,7 @@ def check_managed(
             env,
             context,
             defaults,
-            **kwargs
-            )
+            **kwargs)
     if comment:
         __clean_tmp(sfn)
         return False, comment
@@ -1476,6 +1475,7 @@ def manage_file(name,
                'changes': {},
                'comment': '',
                'result': True}
+
     # Check changes if the target file exists
     if os.path.isfile(name):
         # Only test the checksums on files with managed contents
@@ -1499,8 +1499,7 @@ def manage_file(name,
                                       ).format(
                                               name,
                                               source_sum['hsum'],
-                                              dl_sum
-                                              )
+                                              dl_sum)
                     ret['result'] = False
                     return ret
 
@@ -1508,8 +1507,9 @@ def manage_file(name,
             if _is_bin(sfn) or _is_bin(name):
                 ret['changes']['diff'] = 'Replace binary file'
             else:
-                with contextlib.nested(salt.utils.fopen(sfn, 'rb'),
-                            salt.utils.fopen(name, 'rb')) as (src, name_):
+                with contextlib.nested(
+                        salt.utils.fopen(sfn, 'rb'),
+                        salt.utils.fopen(name, 'rb')) as (src, name_):
                     slines = src.readlines()
                     nlines = name_.readlines()
                     # Print a diff equivalent to diff -u old new
@@ -1519,8 +1519,7 @@ def manage_file(name,
                         ret['changes']['diff'] = '<show_diff=False>'
                     else:
                         ret['changes']['diff'] = (
-                                ''.join(difflib.unified_diff(nlines, slines))
-                                )
+                                ''.join(difflib.unified_diff(nlines, slines)))
             # Pre requisites are met, and the file needs to be replaced, do it
             try:
                 salt.utils.copyfile(
@@ -1563,8 +1562,7 @@ def manage_file(name,
                                       ).format(
                                               name,
                                               source_sum['hsum'],
-                                              dl_sum
-                                              )
+                                              dl_sum)
                     ret['result'] = False
                     return ret
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1326,7 +1326,7 @@ def check_managed(
         context,
         defaults,
         env,
-        static_contents=None,
+        contents=None,
         **kwargs):
     '''
     Check to see what changes need to be made for a file
@@ -1340,7 +1340,7 @@ def check_managed(
 
     sfn, source_sum, comment = '', None, ''
 
-    if static_contents is None:
+    if contents is None:
         # Gather the source file from the server
         sfn, source_sum, comment = get_managed(
                 name,
@@ -1358,7 +1358,7 @@ def check_managed(
             __clean_tmp(sfn)
             return False, comment
     changes = check_file_meta(name, sfn, source, source_sum, user,
-                              group, mode, env, template, static_contents)
+                              group, mode, env, template, contents)
     __clean_tmp(sfn)
     if changes:
         comment = 'The following values are set to be changed:\n'
@@ -1378,7 +1378,7 @@ def check_file_meta(
         mode,
         env,
         template=None,
-        static_contents=None):
+        contents=None):
     '''
     Check for the changes in the file metadata.
 
@@ -1412,11 +1412,11 @@ def check_file_meta(
                             ''.join(difflib.unified_diff(nlines, slines)))
             else:
                 changes['sum'] = 'Checksum differs'
-    if not static_contents is None:
+    if not contents is None:
         # Write a tempfile with the static contents
         tmp = salt.utils.mkstemp(text=True)
         with salt.utils.fopen(tmp, 'w') as tmp_:
-            tmp_.write(static_contents)
+            tmp_.write(contents)
         # Compare the static contents with the named file
         with contextlib.nested(
                 salt.utils.fopen(tmp, 'rb'),
@@ -1486,7 +1486,7 @@ def manage_file(name,
                 backup,
                 template=None,
                 show_diff=True,
-                static_contents=None):
+                contents=None):
     '''
     Checks the destination against what was retrieved with get_managed and
     makes the appropriate modifications (if necessary).
@@ -1557,11 +1557,11 @@ def manage_file(name,
                 return _error(
                     ret, 'Failed to commit change, permission error')
 
-        if not static_contents is None:
+        if not contents is None:
             # Write the static contents to a temporary file
             tmp = salt.utils.mkstemp(text=True)
             with salt.utils.fopen(tmp, 'w') as tmp_:
-                tmp_.write(static_contents)
+                tmp_.write(contents)
 
             # Compare contents of files to know if we need to replace
             with contextlib.nested(
@@ -1647,7 +1647,7 @@ def manage_file(name,
                 current_umask = os.umask(63)
 
             # Create a new file when test is False and source is None
-            if static_contents is None:
+            if contents is None:
                 if not __opts__['test']:
                     if __salt__['file.touch'](name):
                         ret['changes']['new'] = 'file {0} created'.format(name)
@@ -1668,11 +1668,11 @@ def manage_file(name,
             if mode:
                 os.umask(current_umask)
 
-        if not static_contents is None:
+        if not contents is None:
             # Write the static contents to a temporary file
             tmp = salt.utils.mkstemp(text=True)
             with salt.utils.fopen(tmp, 'w') as tmp_:
-                tmp_.write(static_contents)
+                tmp_.write(contents)
             # Copy into place
             salt.utils.copyfile(
                     tmp,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -612,6 +612,7 @@ def managed(name,
             backup='',
             show_diff=True,
             create=True,
+            static_contents=None,
             **kwargs):
     '''
     Manage a given file, this function allows for a file to be downloaded from
@@ -748,18 +749,19 @@ def managed(name,
 
     if __opts__['test']:
         ret['result'], ret['comment'] = __salt__['file.check_managed'](
-            name,
-            source,
-            source_hash,
-            user,
-            group,
-            mode,
-            template,
-            makedirs,
-            context,
-            defaults,
-            env,
-            **kwargs
+                name,
+                source,
+                source_hash,
+                user,
+                group,
+                mode,
+                template,
+                makedirs,
+                context,
+                defaults,
+                env,
+                static_contents,
+                **kwargs
         )
         return ret
 
@@ -784,21 +786,22 @@ def managed(name,
         defaults,
         **kwargs
     )
-    if comment:
+    if comment and not static_contents is None:
         return _error(ret, comment)
-
-    return __salt__['file.manage_file'](name,
-                                        sfn,
-                                        ret,
-                                        source,
-                                        source_sum,
-                                        user,
-                                        group,
-                                        mode,
-                                        env,
-                                        backup,
-                                        template,
-                                        show_diff)
+    else:
+        return __salt__['file.manage_file'](name,
+                                            sfn,
+                                            ret,
+                                            source,
+                                            source_sum,
+                                            user,
+                                            group,
+                                            mode,
+                                            env,
+                                            backup,
+                                            template,
+                                            show_diff,
+                                            static_contents)
 
 
 def directory(name,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -612,7 +612,7 @@ def managed(name,
             backup='',
             show_diff=True,
             create=True,
-            static_contents=None,
+            contents=None,
             **kwargs):
     '''
     Manage a given file, this function allows for a file to be downloaded from
@@ -690,6 +690,11 @@ def managed(name,
     create
         Default is True, if create is set to False then the file will only be
         managed if the file already exists on the system.
+
+    contents
+        Default is None.  If specified, will use the given string as the
+        contents of the file.  Should not be used in conjunction with a source
+        file of any kind.  Ignores hashes and does not use a templating engine.
     '''
     user = _test_owner(kwargs, user=user)
     # Initial set up
@@ -760,7 +765,7 @@ def managed(name,
                 context,
                 defaults,
                 env,
-                static_contents,
+                contents,
                 **kwargs
         )
         return ret
@@ -786,7 +791,7 @@ def managed(name,
         defaults,
         **kwargs
     )
-    if comment and not static_contents is None:
+    if comment and not contents is None:
         return _error(ret, comment)
     else:
         return __salt__['file.manage_file'](name,
@@ -801,7 +806,7 @@ def managed(name,
                                             backup,
                                             template,
                                             show_diff,
-                                            static_contents)
+                                            contents)
 
 
 def directory(name,


### PR DESCRIPTION
Can now use `contents` kwarg in `file.managed` to specify static file contents.

"Oh, I think I can add static file contents to file.managed without too much difficulty!"  <----famous last words

In any case, I think I've managed it.  There was probably a more elegant way to do this, but it's working, I've tested both with and without `test=True`.

Keep me posted if you see anything that needs to be changed.
