### PR TITLE
rm unused imports reported by pyflakes

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -8,7 +8,6 @@ import os
 import re
 import socket
 import logging
-import urllib2
 import urlparse
 
 # import third party libs

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -8,7 +8,6 @@ import glob
 import re
 
 # Import salt libs
-import salt.utils
 from .systemd import _sd_booted
 
 

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -3,9 +3,6 @@ Top level package command wrapper, used to translate the os detected by the
 grains to the correct service manager
 '''
 
-# Import salt libs
-import salt.utils
-
 def __virtual__():
     '''
     Only work on systems which default to systemd

--- a/salt/modules/munin.py
+++ b/salt/modules/munin.py
@@ -9,7 +9,6 @@ import stat
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import SaltException
 from salt._compat import string_types
 
 PLUGINDIR = '/etc/munin/plugins/'

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -5,9 +5,6 @@ The service module for OpenBSD
 # Import python libs
 import os
 
-# Import salt libs
-import salt.utils
-
 # XXX enable/disable support would be nice
 
 

--- a/salt/modules/qemu_nbd.py
+++ b/salt/modules/qemu_nbd.py
@@ -11,7 +11,6 @@ import os
 import glob
 import tempfile
 import time
-import shutil
 
 # Import third party tools
 import yaml

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -25,12 +25,6 @@ Connection module for Amazon S3
 '''
 
 # Import Python libs
-import hmac
-import hashlib
-import binascii
-import datetime
-import urllib
-import urllib2
 import logging
 
 # Import Salt libs

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -6,9 +6,6 @@ to this basic module
 # Import python libs
 import os
 
-# Import salt libs
-import salt.utils
-
 
 GRAINMAP = {
            'Arch': '/etc/rc.d',

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -5,9 +5,6 @@ Provide the service module for systemd
 import os
 import re
 
-# Import salt libs
-import salt.utils
-
 LOCAL_CONFIG_PATH = '/etc/systemd/system'
 VALID_UNIT_TYPES = ['service', 'socket', 'device', 'mount', 'automount',
                     'swap', 'target', 'path', 'timer']

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -8,7 +8,6 @@ import warnings
 # Import salt libs
 from salt.utils.yamlloader import CustomLoader, load
 from salt.utils.odict import OrderedDict
-from salt.exceptions import SaltRenderError
 
 log = logging.getLogger(__name__)
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -3,8 +3,6 @@ General management functions for salt, tools like seeing what hosts are up
 and what hosts are down
 '''
 
-import distutils.version
-
 # Import salt libs
 import salt.key
 import salt.client

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -2,10 +2,6 @@
 Control virtual machines via Salt
 '''
 
-# Import python libs
-import os
-import subprocess
-
 # Import Salt libs
 import salt.client
 import salt.output

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -2,9 +2,6 @@
 Various XML utilities
 '''
 
-# Import python libs
-import xml.etree.ElementTree as ET
-
 def to_dict(xmltree):
     ''' 
     Convert an XML tree into a dict. The tree that is passed in must be an

--- a/tests/eventlisten.py
+++ b/tests/eventlisten.py
@@ -6,7 +6,6 @@ This script is a generic tool to test event output
 '''
 
 # Import Python libs
-import os
 import optparse
 import pprint
 import time

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -2,7 +2,6 @@ import tempfile
 
 from saltunittest import TestCase, TestLoader, TextTestRunner
 
-from salt import config as sconfig
 from salt.modules import file as filemod
 from salt.modules import cmdmod
 

--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -1,6 +1,5 @@
 # Import Python libs
 import os
-import sys
 import shutil
 import tempfile
 from cStringIO import StringIO
@@ -9,7 +8,7 @@ from cStringIO import StringIO
 from saltunittest import TestCase
 import salt.loader
 import salt.config
-from salt.state import State, HighState
+from salt.state import HighState
 from salt.utils.pydsl import PyDslError
 
 REQUISITES = ['require', 'require_in', 'use', 'use_in', 'watch', 'watch_in']

--- a/tests/unit/stateconf_test.py
+++ b/tests/unit/stateconf_test.py
@@ -1,5 +1,4 @@
 # Import Python libs
-import sys
 from cStringIO import StringIO
 
 # Import Salt libs


### PR DESCRIPTION
Tried to aggressively avoid false-positives, so there are some remaining unused imports beyond these that could probably be removed safely; in particular, there are some in a few Windows-related modules, which I did not look at.
