### PR TITLE
Added the 'master' grain to give the minion its master

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -931,3 +931,13 @@ def get_server_id():
     # Provides:
     #   server_id
     return {'server_id': abs(hash(__opts__.get('id', '')) % (2 ** 31))}
+
+def get_master():
+    '''
+    Provides the minion with the name of it's master.
+    This is useful in states to target other services running on the master.
+    '''
+    # Provides:
+    #   master
+    return {'master': __opts__.get('master', '')}
+

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -934,7 +934,7 @@ def get_server_id():
 
 def get_master():
     '''
-    Provides the minion with the name of it's master.
+    Provides the minion with the name of its master.
     This is useful in states to target other services running on the master.
     '''
     # Provides:


### PR DESCRIPTION
Hey guys.

Simple addition to grains to allow a minion to know its master. I'm using this to allow additional services running on the master to be targeted in state files.
