### PR TITLE
fixes to modules.mongodb.db_exists

### DIFF
--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -16,6 +16,9 @@ Module to provide MongoDB functionality to Salt
 # Import python libs
 import logging
 
+# Import salt libs
+from salt._compat import string_types
+
 # Import third party libs
 try:
     import pymongo
@@ -76,17 +79,16 @@ def db_list(user=None, password=None, host=None, port=None):
         return err.message
 
 
-def db_exists(name, user=None, password=None, host=None, port=None,
-              database='admin'):
+def db_exists(name, user=None, password=None, host=None, port=None):
     '''
     Checks if a database exists in Mongodb
     '''
     dbs = db_list(user, password, host, port)
-    for mdb in dbs:
-        if name == mdb:
-            return True
 
-    return False
+    if isinstance(dbs, string_types):
+        return False
+
+    return name in dbs
 
 
 def db_remove(name, user=None, password=None, host=None, port=None):


### PR DESCRIPTION
- `database` argument was redundant to `name`
- `db_list` returns an error message string when an error happens; handle this case
- the mongodb Python API docs explicitly say that a list is returned, so we can just use `in`
