### PR TITLE
call superclass __init__ in dict subclasses

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -1034,6 +1034,7 @@ class FunctionWrapper(dict):
     minion when the salt functions dict is referenced.
     '''
     def __init__(self, opts, minion):
+        super(FunctionWrapper, self).__init__()
         self.opts = opts
         self.minion = minion
         self.local = LocalClient(self.opts['conf_file'])

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -72,6 +72,7 @@ class MasterKeys(dict):
     authentication by the master.
     '''
     def __init__(self, opts):
+        super(MasterKeys, self).__init__()
         self.opts = opts
         self.pub_path = os.path.join(self.opts['pki_dir'], 'master.pub')
         self.rsa_path = os.path.join(self.opts['pki_dir'], 'master.pem')


### PR DESCRIPTION
good practice, fixes a pylint warning
