### PR TITLE
Further debian doc changes

### DIFF
--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -126,39 +126,3 @@ list or look for joehh on irc.
 
 
 
-Packages from Source
---------------------
-
-To build your own salt Debian packages on squeeze use:
-
-.. code-block:: bash
-
-    cat <<EOF | sudo tee /etc/apt/sources.list.d/backports.list
-    deb http://backports.debian.org/debian-backports squeeze-backports main
-    EOF
-    apt-get update
-    apt-get install build-essential fakeroot
-    apt-get install python-argparse python-zmq
-    apt-get -t squeeze-backports install debhelper python-sphinx
-
-After installing the necessary dependencies build the packages with:
-
-.. code-block:: bash
-
-    git clone https://github.com/saltstack/salt.git
-    cd salt
-    fakeroot debian/rules binary
-
-You will need to install the salt-common package along with the salt-minion or
-salt-master packages. For example:
-
-.. code-block:: bash
-
-   dpkg -i salt-common_<version>.deb salt-minion<version>.deb
-   apt-get -f install
-
-The last command pulls in the required dependencies for your salt packages.
-
-For more information how to use debian-backports see
-http://backports-master.debian.org/Instructions/
-

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -25,15 +25,6 @@ following to ``/etc/apt/sources.list`` or a file in
 
 
 
-
-The packages have been signed with a key available from http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key
-
-This can be imported with::
-
-  wget -O - http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key|apt-key add -
-
-
-
 Wheezy (Testing)
 ~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Deletions for clarity.

Also deleted the part on rolling your own packaging as this is likely to cause confusion if people try and mix and match package sources.
