### PR TITLE
Detect oVirt Virtualization as kvm and not physical

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -317,6 +317,10 @@ def _virtual(osdata):
                 grains['virtual'] = 'kvm'
             if 'Vendor: Bochs' in output:
                 grains['virtual'] = 'kvm'
+            # Product Name: (oVirt) www.ovirt.org
+            # Red Hat Community virtualization Project based on kvm 
+            elif 'Manufacturer: oVirt' in output:
+                grains['virtual'] = 'kvm'                
             elif 'VirtualBox' in output:
                 grains['virtual'] = 'VirtualBox'
             # Product Name: VMware Virtual Platform


### PR DESCRIPTION
Quick change to make grains detect oVirt virtualization (ovirt.org) as KVM and not physical host. 

First github pull request so let me know if I have done anything wrong
