### PR TITLE
standardize to modern 'except FooError as err:' syntax in test files

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -773,7 +773,7 @@ class ShellCase(TestCase):
             finally:
                 try:
                     process.terminate()
-                except OSError, err:
+                except OSError as err:
                     # process already terminated
                     pass
 
@@ -785,7 +785,7 @@ class ShellCase(TestCase):
         finally:
             try:
                 process.terminate()
-            except OSError, err:
+            except OSError as err:
                 # process already terminated
                 pass
 

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -59,7 +59,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             )
         try:
             os.makedirs(ographite)
-        except OSError, err:
+        except OSError as err:
             if err.errno == 13:
                 # Permission denied
                 self.skipTest(

--- a/tests/integration/states/ssh.py
+++ b/tests/integration/states/ssh.py
@@ -39,7 +39,7 @@ class SSHKnownHostsStateTest(integration.ModuleCase,
         ret = self.run_state('ssh_known_hosts.present', **kwargs)
         try:
             self.assertSaltTrueReturn(ret)
-        except AssertionError, err:
+        except AssertionError as err:
             try:
                 self.assertInSaltComment(
                     ret, 'Unable to receive remote host key'

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -95,7 +95,7 @@ def run_integration_tests(opts):
                 resource.RLIMIT_NOFILE,
                 (REQUIRED_OPEN_FILES, hmax_open_files)
             )
-        except Exception, err:
+        except Exception as err:
             print('ERROR: Failed to raise the max open files setting -> {0}'.format(err))
             print('Please issue the following command on your console:')
             print('  ulimit -n {0}'.format(REQUIRED_OPEN_FILES))

--- a/tests/unit/log_test.py
+++ b/tests/unit/log_test.py
@@ -36,7 +36,7 @@ class TestLog(TestCase):
             # calculations.
             try:
                 saltlog.SaltLoggingClass('{0}.with_digits'.format(__name__))
-            except Exception, err:
+            except Exception as err:
                 raise AssertionError(
                     'No exception should have been raised: {0}'.format(err)
                 )
@@ -55,7 +55,7 @@ class TestLog(TestCase):
             # calculations.
             try:
                 saltlog.SaltLoggingClass('{0}.without_digits'.format(__name__))
-            except Exception, err:
+            except Exception as err:
                 raise AssertionError(
                     'No exception should have been raised: {0}'.format(err)
                 )

--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -176,7 +176,7 @@ class TestVerify(TestCase):
                     handler.messages
                 )
                 handler.clear()
-            except IOError, err:
+            except IOError as err:
                 if err.errno == 24:
                     # Too many open files
                     self.skipTest('We\'ve hit the max open files setting')


### PR DESCRIPTION
Step 1 of this standardization.
