### PR TITLE
standardize to modern 'except FooError as err:' syntax (Final Part 4)

### DIFF
--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -146,10 +146,9 @@ def render(input, env='', sls='', argline='', **kws):
 
             # We must extract no matter what so extending a stateconf sls file works!
             extract_state_confs(data)
-
-        except Exception, err:
-            if isinstance(err, SaltRenderError):
-                raise
+        except SaltRenderError:
+            raise
+        except Exception as err:
             log.exception(
                 'Error found while pre-processing the salt file, '
                 '{0}.\n'.format(sls)
@@ -195,7 +194,7 @@ def render(input, env='', sls='', argline='', **kws):
                     )
             name, rt_argline = (args[1] + ' ').split(' ', 1)
             render_template = renderers[name]  # eg, the mako renderer
-        except KeyError, err:
+        except KeyError as err:
             raise SaltRenderError('Renderer: {0} is not available!'.format(err))
         except IndexError:
             raise INVALID_USAGE_ERROR

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -56,13 +56,13 @@ def returner(ret):
                 secret_key=pillar_data['raven']['secret_key'],
                 project=pillar_data['raven']['project'],
             )
-        except KeyError, missing_key:
+        except KeyError as missing_key:
             logger.error("Sentry returner need config '%s' in pillar",
                          missing_key)
         else:
             try:
                 client.captureMessage(ret['comment'], extra=sentry_data)
-            except Exception, err:
+            except Exception as err:
                 logger.error("Can't send message to sentry: %s", err,
                              exc_info=True)
 
@@ -80,5 +80,5 @@ def returner(ret):
                     if not ret['return'][state]['result'] and \
                        ret['return'][state]['comment'] != requisite_error:
                         connect_sentry(state, ret['return'][state])
-    except Exception, err:
+    except Exception as err:
         logger.error("Can't run connect_sentry: %s", err, exc_info=True)

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -214,7 +214,7 @@ def managed(name, **kwargs):
         return ret
     try:
         __salt__['pkg.mod_repo'](**repokwargs)
-    except Exception, e:
+    except Exception as e:
         # This is another way to pass information back from the mod_repo
         # function.
         ret['result'] = False
@@ -235,7 +235,7 @@ def managed(name, **kwargs):
 
         ret['result'] = True
         ret['comment'] = 'Configured package repo {0}'.format(name)
-    except Exception, e:
+    except Exception as e:
         ret['result'] = False
         ret['comment'] = 'Failed to confirm config of repo {0}: {1}'.format(
             name, str(e))


### PR DESCRIPTION
This completes standardization to said syntax.
