### PR TITLE
This fixes Issue #4488 suse (sles) service status problems

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -42,6 +42,8 @@ def __virtual__():
                'Arch',
                'Arch ARM',
                'ALT',
+               'SUSE  Enterprise Server',
+               'openSUSE',
                'OEL',
               ]
     if __grains__['os'] in disable:


### PR DESCRIPTION
Issue #4488 fixed:
Suse Linux Enterprise uses the same service module as redhat.
so don't rely on service.py but rh_service.py.

This also updates opensuse which uses systemd as service module
like archlinux.
