### PR TITLE
Introduce `no_chown` option to pip-related functions

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -69,6 +69,7 @@ def install(pkgs=None,
             no_download=False,
             install_options=None,
             runas=None,
+            no_chown=False,
             cwd=None,
             __env__='base'):
     '''
@@ -147,6 +148,9 @@ def install(pkgs=None,
         path, be sure to use absolute path.
     runas
         User to run pip as
+    no_chown
+        When runas is given, do not attempt to copy and chown
+        a requirements file
     cwd
         Current working directory to run pip from
 
@@ -215,7 +219,7 @@ def install(pkgs=None,
 
             requirements = cached_requirements
 
-        if runas:
+        if runas and not no_chown:
             # Need to make a temporary copy since the runas user will, most
             # likely, not have the right permissions to read the file
             treq = salt.utils.mkstemp()

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -42,6 +42,7 @@ def installed(name,
               no_download=False,
               install_options=None,
               user=None,
+              no_chown=False,
               cwd=None,
               __env__='base'):
     '''
@@ -126,6 +127,7 @@ def installed(name,
         no_download=no_download,
         install_options=install_options,
         runas=user,
+        no_chown=no_chown,
         cwd=cwd,
         __env__=__env__
     )

--- a/salt/states/virtualenv.py
+++ b/salt/states/virtualenv.py
@@ -24,6 +24,7 @@ def managed(name,
             prompt='',
             __env__='base',
             runas=None,
+            no_chown=False,
             cwd=None,
             index_url=None,
             extra_index_url=None):
@@ -130,6 +131,7 @@ def managed(name,
             requirements=requirements, bin_env=name, runas=runas, cwd=cwd,
             index_url=index_url,
             extra_index_url=extra_index_url,
+            no_chown=no_chown,
             __env__=__env__
         )
         ret['result'] &= _ret['retcode'] == 0

--- a/tests/integration/modules/pip.py
+++ b/tests/integration/modules/pip.py
@@ -10,6 +10,7 @@
 
 # Import python libs
 import os
+import pwd
 import shutil
 import tempfile
 
@@ -48,6 +49,23 @@ class PipModuleTest(integration.ModuleCase):
                 'Command required for \'{0}\' not found: Could not find '
                 'a `pip` binary'.format(func)
             )
+
+    def test_issue_4805_nested_requirements_runas_no_chown(self):
+        self.run_function('virtualenv.create', [self.venv_dir])
+
+        # Create a requirements file that depends on another one.
+        req1_filename = os.path.join(self.venv_dir, 'requirements.txt')
+        req2_filename = os.path.join(self.venv_dir, 'requirements2.txt')
+        with open(req1_filename, 'wb') as f:
+            f.write('-r requirements2.txt')
+        with open(req2_filename, 'wb') as f:
+            f.write('pep8')
+
+        this_user = pwd.getpwuid(os.getuid())[0]
+        ret = self.run_function('pip.install', requirements=req1_filename,
+                                runas=this_user, no_chown=True)
+        self.assertEqual(ret['retcode'], 0)
+        self.assertIn('installed pep8', ret['stdout'])
 
     def test_pip_uninstall(self):
         # Let's create the testing virtualenv


### PR DESCRIPTION
See #4805

Affected functions:
- `pip.install`
- `pip.installed`
- `virtualenv.managed`

When using `runas` in conjunction with a local-filesystem `requirements` file with these functions, `pip.install` will create a temporary copy of the requirements file, then change ownership of that file to the `runas` user.

The purpose of this is to avoid file permission errors when accessing the original requirements file. However, this breaks when that file has a "-r otherfile.txt" line.

In these cases, set `no_chown` to `True`. The original path to the requirements file will be kept, and other requirements files included from the top-level file will be correctly found.
