### PR TITLE
Fix more(/all?) remaining instances of #4733 (`not X == Y` -> `X != Y`)

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -216,7 +216,7 @@ class Auth(object):
         m_pub_fn = os.path.join(self.opts['pki_dir'], self.mpub)
         if os.path.isfile(m_pub_fn) and not self.opts['open_mode']:
             local_master_pub = salt.utils.fopen(m_pub_fn).read()
-            if not payload['pub_key'] == local_master_pub:
+            if payload['pub_key'] != local_master_pub:
                 # This is not the last master we connected to
                 log.error('The master key has changed, the salt master could '
                           'have been subverted, verify salt master\'s public '

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -823,7 +823,7 @@ class Loader(object):
         grains = {}
         funcs = self.gen_functions()
         for key, fun in funcs.items():
-            if not key[key.index('.') + 1:] == 'core':
+            if key[key.index('.') + 1:] != 'core':
                 continue
             ret = fun()
             if not isinstance(ret, dict):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -744,7 +744,7 @@ class Minion(object):
         self.epub_sock.bind(epub_uri)
         self.epull_sock.bind(epull_uri)
         # Restrict access to the sockets
-        if not self.opts.get('ipc_mode', '') == 'tcp':
+        if self.opts.get('ipc_mode', '') != 'tcp':
             os.chmod(
                 epub_sock_path,
                 448

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -21,7 +21,7 @@ def _render_tab(lst):
     for pre in lst['pre']:
         ret.append('{0}\n'.format(pre))
     if len(ret):
-        if not ret[-1] == TAG:
+        if ret[-1] != TAG:
             ret.append(TAG)
     else:
         ret.append(TAG)

--- a/salt/modules/kvm_hyper.py
+++ b/salt/modules/kvm_hyper.py
@@ -233,7 +233,7 @@ def _get_image(image, vda):
         if not os.path.isabs(image) or not image.startswith('file://'):
             # The image is on a network resource
             env = 'base'
-            if not image.rindex(':') == 4:
+            if image.rindex(':') != 4:
                 env = image.split(':')[-1]
                 image = image[:image.rindex(':')]
             __salt__['cp.get_url'](image, vda, env)

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -148,7 +148,7 @@ def persist(name, value, config='/etc/sysctl.conf'):
             if str(comps[1]) == str(value):
                 # It is correct in the config, check if it is correct in /proc
                 if name in running:
-                    if not str(running[name]) == str(value):
+                    if str(running[name]) != str(value):
                         assign(name, value)
                         return 'Updated'
                 return 'Already set'

--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -18,7 +18,7 @@ def __virtual__():
     '''
     mdadm provides raid functions for Linux
     '''
-    if not __grains__['kernel'] == 'Linux':
+    if __grains__['kernel'] != 'Linux':
         return False
     if not salt.utils.which('mdadm'):
         return False

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -90,7 +90,7 @@ def fstab(config='/etc/fstab'):
                 # Blank line
                 continue
             comps = line.split()
-            if not len(comps) == 6:
+            if len(comps) != 6:
                 # Invalid entry
                 continue
             ret[comps[1]] = {'device': comps[0],
@@ -126,7 +126,7 @@ def rm_fstab(name, config='/etc/fstab'):
                     lines.append(line)
                     continue
                 comps = line.split()
-                if not len(comps) == 6:
+                if len(comps) != 6:
                     # Invalid entry
                     lines.append(line)
                     continue
@@ -186,7 +186,7 @@ def set_fstab(
                     lines.append(line)
                     continue
                 comps = line.split()
-                if not len(comps) == 6:
+                if len(comps) != 6:
                     # Invalid entry
                     lines.append(line)
                     continue

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -135,7 +135,7 @@ def set_password(name, password, use_usermod=False):
         with salt.utils.fopen(s_file, 'rb') as fp_:
             for line in fp_:
                 comps = line.strip().split(':')
-                if not comps[0] == name:
+                if comps[0] != name:
                     lines.append(line)
                     continue
                 comps[1] = password

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -108,7 +108,7 @@ def set_password(name, password):
     with salt.utils.fopen(s_file, 'rb') as ifile:
         for line in ifile:
             comps = line.strip().split(':')
-            if not comps[0] == name:
+            if comps[0] != name:
                 lines.append(line)
                 continue
             comps[1] = password

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -122,7 +122,7 @@ def _runlevel():
 
 
 def _is_symlink(name):
-    return not os.path.abspath(name) == os.path.realpath(name)
+    return os.path.abspath(name) != os.path.realpath(name)
 
 
 def _service_is_upstart(name):

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -834,8 +834,8 @@ def seed_non_shared_migrate(disks, force=False):
             pre = yaml.safe_load(subprocess.Popen('qemu-img info arch',
                 shell=True,
                 stdout=subprocess.PIPE).communicate()[0])
-            if not pre['file format'] == data['file format']\
-                    and not pre['virtual size'] == data['virtual size']:
+            if pre['file format'] != data['file format']\
+                    and pre['virtual size'] != data['virtual size']:
                 return False
         if not os.path.isdir(os.path.dirname(fn_)):
             os.makedirs(os.path.dirname(fn_))

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -47,11 +47,11 @@ def _check_cron(cmd, user, minute, hour, dom, month, dow):
     lst = __salt__['cron.list_tab'](user)
     for cron in lst['crons']:
         if cmd == cron['cmd']:
-            if not str(minute) == cron['min'] or \
-                    not str(hour) == cron['hour'] or \
-                    not str(dom) == cron['daymonth'] or \
-                    not str(month) == cron['month'] or \
-                    not str(dow) == cron['dayweek']:
+            if str(minute) != cron['min'] or \
+                    str(hour) != cron['hour'] or \
+                    str(dom) != cron['daymonth'] or \
+                    str(month) != cron['month'] or \
+                    str(dow) != cron['dayweek']:
                 return 'update'
             return 'present'
     return 'absent'

--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -24,7 +24,7 @@ def __virtual__():
     '''
     mdadm provides raid functions for Linux
     '''
-    if not __grains__['kernel'] == 'Linux':
+    if __grains__['kernel'] != 'Linux':
         return False
     if not salt.utils.which('mdadm'):
         return False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -271,7 +271,7 @@ def jid_to_time(jid):
     Convert a salt job id into the time when the job was invoked
     '''
     jid = str(jid)
-    if not len(jid) == 20:
+    if len(jid) != 20:
         return ''
     year = jid[:4]
     month = jid[4:6]
@@ -433,7 +433,7 @@ def is_jid(jid):
     '''
     if not isinstance(jid, basestring):
         return False
-    if not len(jid) == 20:
+    if len(jid) != 20:
         return False
     try:
         int(jid)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -368,7 +368,7 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         for ropt in react_map:
             if not isinstance(ropt, dict):
                 continue
-            if not len(ropt) == 1:
+            if len(ropt) != 1:
                 continue
             key = ropt.keys()[0]
             val = ropt[key]

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -208,7 +208,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
         # If starting the process as root, chown the new dirs
         if os.getuid() == 0:
             fmode = os.stat(dir_)
-            if not fmode.st_uid == uid or not fmode.st_gid == gid:
+            if fmode.st_uid != uid or fmode.st_gid != gid:
                 if permissive and fmode.st_gid in groups:
                     # Allow the directory to be owned by any group root
                     # belongs to if we say it's ok to be permissive
@@ -227,7 +227,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
                         fmode = os.stat(path)
                     except (IOError, OSError):
                         pass
-                    if not fmode.st_uid == uid or not fmode.st_gid == gid:
+                    if fmode.st_uid != uid or fmode.st_gid != gid:
                         if permissive and fmode.st_gid in groups:
                             pass
                         else:
@@ -236,7 +236,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
                 for name in dirs:
                     path = os.path.join(root, name)
                     fmode = os.stat(path)
-                    if not fmode.st_uid == uid or not fmode.st_gid == gid:
+                    if fmode.st_uid != uid or fmode.st_gid != gid:
                         if permissive and fmode.st_gid in groups:
                             pass
                         else:


### PR DESCRIPTION
When greping for instances in #4733, I had used an overly restrictive regex so that the list would have few enough false positives (and thus be short enough) to make manual review feasible.
This time, I used a looser regex to find all(?) remaining instances. The # of resulting hits was fortunately manageable!
