### PR TITLE
log warning if MySQLdb python module is missing when the mysql_database ...

### DIFF
--- a/salt/states/mysql_database.py
+++ b/salt/states/mysql_database.py
@@ -15,12 +15,21 @@ Databases can be set as either absent or present.
       mysql_database.present
 '''
 
+import logging
+log = logging.getLogger(__name__)
+
 
 def __virtual__():
     '''
     Only load if the mysql module is available in __salt__
     '''
-    return 'mysql_database' if 'mysql.db_exists' in __salt__ else False
+    if 'mysql.db_exists' in __salt__:
+        return 'mysql_database'
+    else:
+        log.warn("The mysql_database state module will not work unless"
+                 " the MySQLdb python module is installed. You can install"
+                 " MySQLdb by running: 'pip install mysql-python'")
+        return False
 
 
 def present(name):


### PR DESCRIPTION
...state module is used

I was learning how to install and setup MySQL with Salt, and at one point couldn't figure out why I couldn't get Salt to create a database in a very simple test.

After spending a bunch of time trying to debug things, I finally caught this important note right at the top of http://docs.saltstack.com/ref/states/all/salt.states.mysql_database.html::

```
This module requires the MySQLdb python module
```

I think some sort of log message would have helped me figure out what I was missing pretty quickly, and that's what this pull request tries to do...!
