### PR TITLE
fix default name of pidfile for salt-syndic

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -717,6 +717,8 @@ class SyndicOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         opts.update(config.minion_config(self.get_config_file_path('minion')))
         # Override the user from the master config file
         opts['user'] = user
+        # Override the name of the PID file.
+        opts['pidfile'] = '/var/run/salt-syndic.pid'
 
         if 'syndic_master' not in opts:
             self.error(


### PR DESCRIPTION
This patch ensures we write to /var/run/salt-syndic.pid instead of /var/run/salt-minion.pid when we start the syndic.  Otherwise, conflicts will arise when using system init scripts to start with syndic and minion on the same host.
