### PR TITLE
rm duplicate import of `salt.utils` in fileclient

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -19,7 +19,6 @@ from salt.exceptions import MinionError, SaltReqTimeoutError
 import salt.client
 import salt.crypt
 import salt.loader
-import salt.utils
 import salt.payload
 import salt.utils
 import salt.utils.templates


### PR DESCRIPTION
It's imported again 2 lines later.
