### PR TITLE
Change re to shlex

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -5,7 +5,7 @@ Support for iptables
 # Import python libs
 import os
 import sys
-import re
+import shlex
 
 # Import salt libs
 import salt.utils
@@ -264,10 +264,10 @@ def _parse_conf(conf_file=None, in_mem=False):
             parser = _parser()
             parsed_args = []
             if sys.version.startswith('2.6'):
-                (opts, args) = parser.parse_args(list(map(str.strip,re.split('(\-[\w-]+) ',line)[1:])))
+                (opts, args) = parser.parse_args(shlex.split(line))
                 parsed_args = vars(opts)
             else:
-                parsed_args = vars(parser.parse_args(list(map(str.strip,re.split('(\-[\w-]+) ',line)[1:]))))
+                parsed_args = vars(parser.parse_args(shlex.split(line)))
             ret_args = {}
             chain = parsed_args['append']
             for arg in parsed_args:


### PR DESCRIPTION
Using re in Python is a losing proposition. Let's use the tools that Python excels in.
