### PR TITLE
update spec to 0.15.0

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -11,7 +11,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name: salt
-Version: 0.14.1
+Version: 0.15.0
 Release: 1%{?dist}
 Summary: A parallel remote execution system
 
@@ -309,6 +309,9 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Sat May 4 2013 Clint Savage <herlo1@gmail.com> - 0.15.0-1
+- Update to upstream feature release 0.15.0
+
 * Fri Apr 19 2013 Clint Savage <herlo1@gmail.com> - 0.14.1-1
 - Update to upstream patch release 0.14.1
 


### PR DESCRIPTION
This is the new spec for 0.15.0, which currently fails to build because of tests.
