### PR TITLE
Fixing issue with node returning non JSON data

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -57,7 +57,7 @@ def install(pkg=None,
     if not _valid_version():
         return '"{0}" is not available.'.format('npm.install')
 
-    cmd = 'npm install --silent --json'
+    cmd = 'npm install'
 
     if dir is None:
         cmd += ' --global'
@@ -71,18 +71,7 @@ def install(pkg=None,
         raise CommandExecutionError(result['stderr'])
 
     lines = result['stdout'].splitlines()
-
-    while ' -> ' in lines[0]:
-        lines = lines[1:]
-
-    # Strip all lines until JSON output starts
-    for i in lines:
-        if i.startswith("{"):
-            break
-        else:
-            lines = lines[1:]        
-
-    return json.loads(''.join(lines))
+    return str(lines)
 
 def uninstall(pkg,
               dir=None,


### PR DESCRIPTION
This will now just dump the output of npm install as a return,

This won't over-pollute the logs however as once npm install is run once, it will not output anything subsequent times (unless there are changes)
