### PR TITLE
Remove unused `path` args from list_env, Fixes #4847

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -501,7 +501,7 @@ class LocalClient(Client):
         ret['hash_type'] = self.opts['hash_type']
         return ret
 
-    def list_env(self, path, env='base'):
+    def list_env(self, env='base'):
         '''
         Return a list of the files in the file server's specified environment
         '''
@@ -716,7 +716,7 @@ class RemoteClient(Client):
         except SaltReqTimeoutError:
             return ''
 
-    def list_env(self, path, env='base'):
+    def list_env(self, env='base'):
         '''
         Return a list of the files in the file server's specified environment
         '''


### PR DESCRIPTION
I checked for calls which used the path arg.  As of right now, these functions don't seem to be called anywhere, or passed around in any way.  I suppose they are there for future use?
