### PR TITLE
pkgrepo.managed should return True if repo is already configured

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -138,6 +138,7 @@ def managed(name, **kwargs):
                 if repokwargs[kwarg] != repo[kwarg]:
                     notset = True
         if notset is False:
+            ret['result'] = True
             ret['comment'] = 'Package repo {0} already configured'.format(name)
             return ret
     if __opts__['test']:


### PR DESCRIPTION
Currently when configuring a repo, the output will be the following on a first (successful) run

```
----------
    State: - pkgrepo
    Name:      deb http://ceph.com/debian-cuttlefish/ raring main
    Function:  managed
        Result:    True
        Comment:   Configured package repo deb http://ceph.com/debian-cuttlefish/ raring main
        Changes:   repo: deb http://ceph.com/debian-cuttlefish/ raring main
```

However on subsequent runs, the output will have a `Result: none`

```
----------
    State: - pkgrepo
    Name:      deb http://ceph.com/debian-cuttlefish/ raring main
    Function:  managed
        Result:    None
        Comment:   Package repo deb http://ceph.com/debian-cuttlefish/ raring main already configured
        Changes:   
```

I believe that we want to return `Result: True` when the repo is already configured to indicate that the state is in a good state.

I have included a pull request. This has been tested on `Ubuntu 13.04` only.
