### PR TITLE
Remove un-used `message` arg, Fixes #4824

### DIFF
--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -38,7 +38,7 @@ def returner(ret):
     '''
     If an error occurs, log it to sentry
     '''
-    def connect_sentry(message, result):
+    def connect_sentry(result):
         pillar_data = __salt__['pillar.raw']()
         sentry_data = {
             'result': result,


### PR DESCRIPTION
Don't know where it came from, but `ret` contains all the message we
need
