### PR TITLE
use sets for platform tests for enabling/disabling modules

### DIFF
--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -20,7 +20,7 @@ import salt.utils
 BSD = ('OpenBSD', 'FreeBSD')
 
 # Known not to work
-BAD = ('Windows',)
+BAD = set(('Windows',))
 
 
 def __virtual__():

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -13,9 +13,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'disk'

--- a/salt/modules/dnsmasq.py
+++ b/salt/modules/dnsmasq.py
@@ -17,9 +17,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'dnsmasq'

--- a/salt/modules/extfs.py
+++ b/salt/modules/extfs.py
@@ -13,9 +13,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'extfs'

--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -13,7 +13,7 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms
-    disable = ('Windows',)
+    disable = set(('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'keyboard'

--- a/salt/modules/locale.py
+++ b/salt/modules/locale.py
@@ -14,7 +14,7 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms
-    disable = ('Windows',)
+    disable = set(('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'locale'

--- a/salt/modules/locate.py
+++ b/salt/modules/locate.py
@@ -13,9 +13,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'locate'

--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -18,7 +18,7 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms
-    disable = ('Windows',)
+    disable = set(('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'logrotate'

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -25,9 +25,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'partition'

--- a/salt/modules/quota.py
+++ b/salt/modules/quota.py
@@ -13,9 +13,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'quota'

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -35,7 +35,7 @@ def __virtual__():
     Only work on systems which default to systemd
     '''
     # Enable on these platforms only.
-    enable = [
+    enable = set((
         'RedHat',
         'CentOS',
         'Scientific',
@@ -45,7 +45,7 @@ def __virtual__():
         'ALT',
         'OEL',
         'SUSE  Enterprise Server'
-    ]
+    ))
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':
             if __grains__.get('osrelease', 0) > 15:

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -29,7 +29,7 @@ def __virtual__():
     Only work on systems which default to systemd
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
                'RedHat',
                'CentOS',
                'Amazon',
@@ -45,7 +45,7 @@ def __virtual__():
                'SUSE  Enterprise Server',
                'openSUSE',
                'OEL',
-              ]
+              ))
     if __grains__['os'] in disable:
         return False
     # Disable on all non-Linux OSes as well

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -9,9 +9,9 @@ def __virtual__():
     Only work on systems which default to SMF
     '''
     # Don't let this work on Solaris 9 since SMF doesn't exist on it.
-    enable = [
+    enable = set((
                'Solaris',
-              ]
+              ))
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Solaris' and __grains__['kernelrelease'] == "5.9":
             return False

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -4,7 +4,7 @@ Support for reboot, shutdown, etc
 
 import salt.utils
 
-UNSUPPORTED = ('Windows')
+UNSUPPORTED = set(('Windows',))
 
 def __virtual__():
     '''

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -16,9 +16,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = [
+    disable = set((
         'Windows',
-        ]
+        ))
     if __grains__['os'] in disable:
         return False
     return 'timezone'


### PR DESCRIPTION
- Logically speaking, these are sets, not sequences.
- O(1) membership test, vs. O(n) for lists/tuples
