### PR TITLE
harmonize at.BAD & system.UNSUPPORTED => disable

### DIFF
--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -19,15 +19,15 @@ import salt.utils
 # Tested on OpenBSD 5.0
 BSD = ('OpenBSD', 'FreeBSD')
 
-# Known not to work
-BAD = ('Windows',)
-
 
 def __virtual__():
     '''
     Most everything has the ability to support at(1)
     '''
-    if __grains__['os'] in BAD or not salt.utils.which('at'):
+    disable = set((
+        'Windows',
+        ))
+    if __grains__['os'] in disable or not salt.utils.which('at'):
         return False
     return 'at'
 

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -4,13 +4,14 @@ Support for reboot, shutdown, etc
 
 import salt.utils
 
-UNSUPPORTED = ('Windows')
-
 def __virtual__():
     '''
     Only supported on POSIX-like systems
     '''
-    if __grains__['os'] in UNSUPPORTED or not salt.utils.which('shutdown'):
+    disable = set((
+        'Windows',
+        ))
+    if __grains__['os'] in disable or not salt.utils.which('shutdown'):
         return False
     return 'system'
 


### PR DESCRIPTION
These seem to be the odd modules out in not using `disable` for this.
