### PR TITLE
Remove check_dns arg from minion_config, Fixes #4811

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -59,10 +59,10 @@ DEFAULT_MINION_OPTS = {
     'file_client': 'remote',
     'file_roots': {
         'base': ['/srv/salt'],
-        },
+    },
     'pillar_roots': {
         'base': ['/srv/pillar'],
-        },
+    },
     'hash_type': 'md5',
     'external_nodes': '',
     'disable_modules': [],
@@ -130,13 +130,13 @@ DEFAULT_MASTER_OPTS = {
     'cachedir': '/var/cache/salt/master',
     'file_roots': {
         'base': ['/srv/salt'],
-        },
+    },
     'master_roots': {
         'base': ['/srv/salt-master'],
-        },
+    },
     'pillar_roots': {
         'base': ['/srv/pillar'],
-        },
+    },
     'gitfs_remotes': [],
     'ext_pillar': [],
     'pillar_version': 2,
@@ -379,9 +379,8 @@ def get_id():
     - localhost may be better than killing the minion
     '''
 
-    log.debug('Guessing ID. The id can be explicitly in set {0}'.format(
-            '/etc/salt/minion')
-            )
+    log.debug('Guessing ID. The id can be explicitly in set {0}'
+              .format('/etc/salt/minion'))
     fqdn = socket.getfqdn()
     if 'localhost' != fqdn:
         log.info('Found minion id from getfqdn(): {0}'.format(fqdn))
@@ -398,8 +397,8 @@ def get_id():
                 if ip.startswith('127.'):
                     for name in names:
                         if name != 'localhost':
-                            log.info(('Found minion id in hosts file: {0}'
-                                ).format(name))
+                            log.info('Found minion id in hosts file: {0}'
+                                     .format(name))
                             return name, False
                 line = f.readline()
     except Exception:
@@ -476,8 +475,8 @@ def apply_minion_config(overrides=None, check_dns=True, defaults=None):
                 {
                     'function': 'mine.update',
                     'minutes': opts['mine_interval']
-                    }
-                })
+                }
+        })
     return opts
 
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -348,7 +348,6 @@ def prepend_root_dir(opts, path_options):
 
 
 def minion_config(path,
-                  check_dns=True,
                   env_var='SALT_MINION_CONFIG',
                   defaults=None):
     '''
@@ -365,7 +364,7 @@ def minion_config(path,
     overrides.update(include_config(default_include, path, verbose=False))
     overrides.update(include_config(include, path, verbose=True))
 
-    return apply_minion_config(overrides, check_dns, defaults)
+    return apply_minion_config(overrides, defaults)
 
 
 def get_id():
@@ -423,7 +422,7 @@ def get_id():
     return 'localhost', False
 
 
-def apply_minion_config(overrides=None, check_dns=True, defaults=None):
+def apply_minion_config(overrides=None, defaults=None):
     '''
     Returns minion configurations dict.
     '''

--- a/salt/config.py
+++ b/salt/config.py
@@ -349,7 +349,8 @@ def prepend_root_dir(opts, path_options):
 
 def minion_config(path,
                   env_var='SALT_MINION_CONFIG',
-                  defaults=None):
+                  defaults=None,
+                  **kwargs):
     '''
     Reads in the minion configuration file and sets up special options
     '''
@@ -422,7 +423,7 @@ def get_id():
     return 'localhost', False
 
 
-def apply_minion_config(overrides=None, defaults=None):
+def apply_minion_config(overrides=None, defaults=None, **kwargs):
     '''
     Returns minion configurations dict.
     '''

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -46,7 +46,10 @@ class MixInMeta(type):
 
 class OptionParserMeta(MixInMeta):
     def __new__(cls, name, bases, attrs):
-        instance = super(OptionParserMeta, cls).__new__(cls, name, bases, attrs)
+        instance = super(OptionParserMeta, cls).__new__(cls,
+                                                        name,
+                                                        bases,
+                                                        attrs)
         if not hasattr(instance, '_mixin_setup_funcs'):
             instance._mixin_setup_funcs = []
         if not hasattr(instance, '_mixin_process_funcs'):
@@ -72,7 +75,9 @@ class OptionParserMeta(MixInMeta):
                 if getattr(func, '_mixin_prio_', None) is not None:
                     # Function already has the attribute set, don't override it
                     continue
-                func.__func__._mixin_prio_ = getattr(base, '_mixin_prio_', 1000)
+                func.__func__._mixin_prio_ = getattr(base,
+                                                     '_mixin_prio_',
+                                                     1000)
 
         return instance
 
@@ -470,9 +475,9 @@ class TargetOptionsMixIn(object):
         if len(group_options_selected) > 1:
             self.error(
                 "The options {0} are mutually exclusive. Please only choose "
-                "one of them".format('/'.join([
-                    option.get_opt_string() for option in group_options_selected
-                ]))
+                "one of them".format('/'.join(
+                    [option.get_opt_string()
+                     for option in group_options_selected]))
             )
         self.config['selected_target_option'] = self.selected_target_option
 
@@ -485,12 +490,12 @@ class ExtendedTargetOptionsMixIn(TargetOptionsMixIn):
             '-C', '--compound',
             default=False,
             action='store_true',
-            help=('The compound target option allows for multiple target types '
-                  'to be evaluated, allowing for greater granularity in target '
-                  'matching. The compound target is space delimited, targets '
-                  'other than globs are preceded with an identifier matching '
-                  'the specific targets argument type: salt \'G@os:RedHat and '
-                  'webser* or E@database.*\'')
+            help=('The compound target option allows for multiple target '
+                  'types to be evaluated, allowing for greater granularity in '
+                  'target matching. The compound target is space delimited, '
+                  'targets other than globs are preceded with an identifier '
+                  'matching the specific targets argument type: salt '
+                  '\'G@os:RedHat and webser* or E@database.*\'')
         )
         group.add_option(
             '-X', '--exsel',
@@ -1009,7 +1014,8 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help='Answer Yes to all questions presented, defaults to False'
         )
 
-        key_options_group = optparse.OptionGroup(self, "Key Generation Options")
+        key_options_group = optparse.OptionGroup(self,
+                                                 "Key Generation Options")
         self.add_option_group(key_options_group)
         key_options_group.add_option(
             '--gen-keys',
@@ -1157,7 +1163,8 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                 self.config.setdefault('module_dirs', []).extend(
                     os.path.abspath(x) for x in module_dir.split(','))
                 continue
-            self.config.setdefault('module_dirs', []).append(os.path.abspath(module_dir))
+            self.config.setdefault('module_dirs',
+                                   []).append(os.path.abspath(module_dir))
 
 
 class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -592,7 +592,7 @@ class OutputOptionsMixIn(object):
             )
 
         outputters = loader.outputters(
-            config.minion_config(None, check_dns=False)
+            config.minion_config(None)
         )
 
         group.add_option(
@@ -1150,10 +1150,7 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             self.config['arg'] = self.args[1:]
 
     def setup_config(self):
-        return config.minion_config(
-            self.get_config_file_path(),
-            check_dns=not self.options.local
-        )
+        return config.minion_config(self.get_config_file_path())
 
     def process_module_dirs(self):
         for module_dir in self.options.module_dirs:


### PR DESCRIPTION
All use of the check_dns arg was removed in
598d715d28b15202cdba87b6882ef96c90d4f075.  No longer needed.

Arg was removed from both apply_minion_config and minion_config in
config.py, as well as all their call points.
