### PR TITLE
Work around built-in shadowing not taken into account in 5f71be3

### DIFF
--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -18,7 +18,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms
-    disable = set(('Windows',))
+    # set() need to used like this because the module defines a set function
+    # which shadows the set() built-in.
+    disable = __builtins__['set'](('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'logrotate'

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -25,9 +25,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = set((
-        'Windows',
-        ))
+    # set() need to used like this because the module defines a set function
+    # which shadows the set() built-in.
+    disable = __builtins__['set'](('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'partition'
@@ -50,7 +50,7 @@ def probe(device=''):
 def part_list(device, unit=None):
     '''
     partition.part_list device unit
-    
+
     Prints partition information of given <device>
 
     CLI Examples::

--- a/salt/modules/quota.py
+++ b/salt/modules/quota.py
@@ -13,9 +13,9 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    disable = set((
-        'Windows',
-        ))
+    # set() need to used like this because the module defines a set function
+    # which shadows the set() built-in.
+    disable = __builtins__['set'](('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'quota'


### PR DESCRIPTION
Work around built-in shadowing not taken into account in 5f71be39a5b9bebe32b87c868416abe0fc548211
