### PR TITLE
Timezone gethwclock deb fix

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -158,12 +158,18 @@ def get_hwclock():
         cmd = 'tail -n 1 /etc/adjtime'
         return __salt__['cmd.run'](cmd)
     elif 'Debian' in __grains__['os_family']:
+        #Original way to look up hwclock on Debian-based systems
         cmd = 'grep "UTC=" /etc/default/rcS | grep -vE "^#"'
         out = __salt__['cmd.run'](cmd).split('=')
-        if len(out) > 1 and out[1] == 'yes':
-            return 'UTC'
+        if len(out) > 1:
+            if out[1] == 'yes':
+                return 'UTC'
+            else:
+                return 'localtime'
         else:
-            return 'localtime'
+            #Since Wheezy
+            cmd = 'tail -n 1 /etc/adjtime'
+            return __salt__['cmd.run'](cmd)
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'grep "^clock=" /etc/conf.d/hwclock | grep -vE "^#"'
         out = __salt__['cmd.run'](cmd).split('=')

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -160,7 +160,7 @@ def get_hwclock():
     elif 'Debian' in __grains__['os_family']:
         cmd = 'grep "UTC=" /etc/default/rcS | grep -vE "^#"'
         out = __salt__['cmd.run'](cmd).split('=')
-        if out[1] == 'yes':
+        if len(out) > 1 and out[1] == 'yes':
             return 'UTC'
         else:
             return 'localtime'


### PR DESCRIPTION
On Debian-based systems, Salt previously looked at /etc/default/rcS to determine if hardware clock was running UTC or localtime. Since Wheezy release, value is now located in /etc/adjtime like most other distros.
