### PR TITLE
Added more NetBSD support to grains/core.py and called pkgin with full path

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -298,6 +298,8 @@ def _memdata(osdata):
         sysctl = salt.utils.which('sysctl')
         if sysctl:
             mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
+            if (osdata['kernel'] == 'NetBSD' and mem.startswith('-')):
+                mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
             grains['mem_total'] = str(int(mem) / 1024 / 1024)
     elif osdata['kernel'] == 'SunOS':
         prtconf = '/usr/sbin/prtconf 2>/dev/null'

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -171,6 +171,35 @@ def _linux_gpu_data():
     return grains
 
 
+def _netbsd_gpu_data(osdata):
+    '''
+    num_gpus: int
+    gpus:
+      - vendor: nvidia|amd|ati|...
+        model: string
+    '''
+    # dominant gpu vendors to search for (MUST be lowercase for matching below)
+    known_vendors = ['nvidia', 'amd', 'ati', 'intel', 'cirrus logic', 'vmware']
+
+    gpus = []
+    try:
+        pcictl_out = __salt__['cmd.run']('pcictl pci0 list')
+
+        for line in pcictl_out.splitlines():
+            for vendor in known_vendors:
+                m = re.match("[0-9:]+ ({0}) (.+) \(VGA .+\)"
+                            .format(vendor), line, re.IGNORECASE)
+                if m:
+                    gpus.append({'vendor': m.group(1), 'model': m.group(2)})
+    except OSError:
+        pass
+
+    grains = {}
+    grains['num_gpus'] = len(gpus)
+    grains['gpus'] = gpus
+    return grains
+
+
 def _bsd_cpudata(osdata):
     '''
     Return CPU information for BSD-like systems
@@ -190,11 +219,20 @@ def _bsd_cpudata(osdata):
             'cpuarch': '{0} -n hw.machine'.format(sysctl),
             'cpu_model': '{0} -n hw.model'.format(sysctl),
         })
+
     if arch and osdata['kernel'] == 'OpenBSD':
         cmds['cpuarch'] = '{0} -s'.format(arch)
 
     grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
     grains['cpu_flags'] = []
+
+    if osdata['kernel'] == 'NetBSD':
+        for line in __salt__['cmd.run']('cpuctl identify 0').splitlines():
+            m = re.match('cpu[0-9]:\ features[0-9]?\ .+<(.+)>', line)
+            if m:
+                flag = m.group(1).split(',')
+                grains['cpu_flags'].extend(flag)
+
     if osdata['kernel'] == 'FreeBSD' and os.path.isfile('/var/run/dmesg.boot'):
         # TODO: at least it needs to be tested for BSD other then FreeBSD
         with salt.utils.fopen('/var/run/dmesg.boot', 'r') as _fp:
@@ -256,7 +294,7 @@ def _memdata(osdata):
                         continue
                     if comps[0].strip() == 'MemTotal':
                         grains['mem_total'] = int(comps[1].split()[0]) / 1024
-    elif osdata['kernel'] in ('FreeBSD', 'OpenBSD'):
+    elif osdata['kernel'] in ('FreeBSD', 'OpenBSD', 'NetBSD'):
         sysctl = salt.utils.which('sysctl')
         if sysctl:
             mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
@@ -360,6 +398,7 @@ def _virtual(osdata):
 
     choices = ('Linux', 'OpenBSD', 'HP-UX')
     isdir = os.path.isdir
+    sysctl = salt.utils.which('sysctl')
     if osdata['kernel'] in choices:
         if isdir('/proc/vz'):
             if os.path.isfile('/proc/vz/version'):
@@ -400,7 +439,6 @@ def _virtual(osdata):
             if 'QEMU Virtual CPU' in salt.utils.fopen('/proc/cpuinfo', 'r').read():
                 grains['virtual'] = 'kvm'
     elif osdata['kernel'] == 'FreeBSD':
-        sysctl = salt.utils.which('sysctl')
         kenv = salt.utils.which('kenv')
         if kenv:
             product = __salt__['cmd.run']('{0} smbios.system.product'.format(kenv))
@@ -423,6 +461,22 @@ def _virtual(osdata):
         # Check if it's a branded zone (i.e. Solaris 8/9 zone)
         if isdir('/.SUNWnative'):
             grains['virtual'] = 'zone'
+    elif osdata['kernel'] == 'NetBSD':
+        if sysctl:
+            model = __salt__['cmd.run']('{0} -n machdep.cpu_brand'
+                                        .format(sysctl))
+            xendomu = __salt__['cmd.run']('{0} -n machdep.xen.suspend'
+                                        .format(sysctl))
+            vmware = __salt__['cmd.run']('{0} -n machdep.dmi.system-vendor'
+                                        .format(sysctl))
+
+            if 'QEMU Virtual CPU' in model:
+                grains['virtual'] = 'kvm'
+            if not 'invalid' in xendomu:
+                grains['virtual'] = 'Xen PV DomU'
+            if 'VMware' in vmware:
+                grains['virtual'] = 'VMware'
+
     return grains
 
 
@@ -692,9 +746,11 @@ def os_data():
         grains.update(_bsd_cpudata(grains))
     else:
         grains['os'] = grains['kernel']
-    if grains['kernel'] in ('FreeBSD', 'OpenBSD'):
+    if grains['kernel'] in ('FreeBSD', 'OpenBSD', 'NetBSD'):
         grains.update(_bsd_cpudata(grains))
         grains['osrelease'] = grains['kernelrelease'].split('-')[0]
+        if grains['kernel'] == 'NetBSD':
+            grains.update(_netbsd_gpu_data(grains))
     if not grains['os']:
         grains['os'] = 'Unknown {0}'.format(grains['kernel'])
         grains['os_family'] = 'Unknown'
@@ -945,3 +1001,4 @@ def get_master():
     #   master
     return {'master': __opts__.get('master', '')}
 
+# vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -32,13 +32,14 @@ def __virtual__():
 
 
 def _splitpkg(name):
+    # name is in the format foobar-1.0nb1, already space-splitted
     if name[0].isalnum() and name != 'No': # avoid < > = and 'No result'
         return name.rsplit('-', 1)
 
 
 def search(pkg_name):
     '''
-    Use `pkgin search`
+    Searches for an exact match using pkgin ^package$
 
     CLI Example::
 
@@ -89,6 +90,7 @@ def latest_version(*names, **kwargs):
 
     if len(names) == 1 and pkglist :
         return pkglist[names[0]]
+
     return pkglist
 
 
@@ -119,7 +121,7 @@ def refresh_db():
         salt '*' pkg.refresh_db
     '''
     if _check_pkgin():
-        __salt__['cmd.run']('{0} up'.format('pkgin'))
+        __salt__['cmd.run']('pkgin up')
 
     return {}
 
@@ -136,9 +138,9 @@ def list_pkgs(versions_as_list=False):
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
     if _check_pkgin():
-        pkg_command = '{0} ls'.format('pkgin')
+        pkg_command = 'pkgin ls'
     else:
-        pkg_command = '{0}'.format('pkg_info')
+        pkg_command = 'pkg_info'
 
     ret = {}
 

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -12,11 +12,12 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+@salt.utils.memoize
 def _check_pkgin():
     '''
-    Looks to see if pkgin is present on the system
+    Looks to see if pkgin is present on the system, return full path
     '''
-    return os.path.isfile(salt.utils.which('pkgin'))
+    return salt.utils.which('pkgin')
 
 
 def __virtual__():
@@ -47,9 +48,10 @@ def search(pkg_name):
     '''
 
     pkglist = {}
+    pkgin = _check_pkgin()
 
-    if _check_pkgin():
-        for p in  __salt__['cmd.run']('pkgin se ^{0}$'.format(pkg_name)
+    if pkgin:
+        for p in  __salt__['cmd.run']('{0} se ^{1}$'.format(pkgin, pkg_name)
                                      ).splitlines():
             if p:
                 s = _splitpkg(p.split()[0])
@@ -74,10 +76,11 @@ def latest_version(*names, **kwargs):
     '''
 
     pkglist = {}
+    pkgin = _check_pkgin()
 
     for name in names:
-        if _check_pkgin():
-            for line in __salt__['cmd.run']('pkgin se ^{0}$'.format(name)
+        if pkgin:
+            for line in __salt__['cmd.run']('{0} se ^{1}$'.format(pkgin, name)
                                            ).splitlines():
                 p = line.split() # pkgname-version status
                 if p:
@@ -120,8 +123,11 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
-    if _check_pkgin():
-        __salt__['cmd.run']('pkgin up')
+
+    pkgin = _check_pkgin()
+
+    if pkgin:
+        __salt__['cmd.run']('{0} up'.format(pkgin))
 
     return {}
 
@@ -137,8 +143,10 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
-    if _check_pkgin():
-        pkg_command = 'pkgin ls'
+
+    pkgin = _check_pkgin()
+    if pkgin:
+        pkg_command = '{0} ls'.format(pkgin)
     else:
         pkg_command = 'pkg_info'
 
@@ -213,8 +221,9 @@ def install(name=None, refresh=False, fromrepo=None,
 
     env = []
     args = []
-    if _check_pkgin():
-        cmd = 'pkgin'
+    pkgin = _check_pkgin()
+    if pkgin:
+        cmd = pkgin
         if fromrepo:
             log.info('Setting PKG_REPOS={0}'.format(fromrepo))
             env.append(('PKG_REPOS', fromrepo))
@@ -227,7 +236,7 @@ def install(name=None, refresh=False, fromrepo=None,
     if pkg_type == 'file':
         cmd = 'pkg_add'
     elif pkg_type == 'repository':
-        if _check_pkgin():
+        if pkgin:
             if refresh:
                 args.append('-f')  # update repo db
             args.extend(('-y', 'in'))  # Assume yes when asked
@@ -256,12 +265,13 @@ def upgrade():
         salt '*' pkg.upgrade
     '''
 
-    if not _check_pkgin():
+    pkgin = _check_pkgin()
+    if not pkgin:
         # There is not easy way to upgrade packages with old package system
         return {}
 
     old = list_pkgs()
-    __salt__['cmd.retcode']('pkgin -y fug')
+    __salt__['cmd.retcode']('{0} -y fug'.format(pkgin))
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 
@@ -308,8 +318,9 @@ def remove(name=None, pkgs=None, **kwargs):
 
     for_remove = ' '.join(args)
 
-    if _check_pkgin():
-        cmd = 'pkgin -y remove {0}'.format(for_remove)
+    pkgin = _check_pkgin()
+    if pkgin:
+        cmd = '{0} -y remove {1}'.format(pkgin, for_remove)
     else:
         cmd = 'pkg_remove {0}'.format(for_remove)
 


### PR DESCRIPTION
Now NetBSD grains have gpudata, virtual informations, cpu_flags and accurate memdata.
pkgin.py now calls pkgin using salt.utils.which to avoid troubles why upgrading
