### PR TITLE
Add support for a module to define function names aliases

### DIFF
--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -13,14 +13,18 @@ log = logging.getLogger(__name__)
 default_conf = '/etc/logrotate.conf'
 
 
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
 def __virtual__():
     '''
     Only work on POSIX-like systems
     '''
     # Disable on these platforms
-    # set() need to used like this because the module defines a set function
-    # which shadows the set() built-in.
-    disable = __builtins__['set'](('Windows',))
+    disable = set(('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'logrotate'
@@ -94,7 +98,7 @@ def show_conf(conf_file=default_conf):
     return _parse_conf(conf_file)
 
 
-def set(key, value, setting=None, conf_file=default_conf):
+def set_(key, value, setting=None, conf_file=default_conf):
     '''
     Set a new value for a specific configuration line
 
@@ -124,8 +128,10 @@ def set(key, value, setting=None, conf_file=default_conf):
             conf_file = os.path.join(conf['include'], include)
 
     if isinstance(conf[key], dict) and not setting:
-        return ('Error: {0} includes a dict, and a specific setting inside the '
-                'dict was not declared'.format(key))
+        return (
+            'Error: {0} includes a dict, and a specific setting inside the '
+            'dict was not declared'.format(key)
+        )
 
     if setting:
         if isinstance(conf[key], str):
@@ -172,4 +178,3 @@ def _dict_to_stanza(key, stanza):
             stanza[skey] = ''
         ret += '    {0} {1}\n'.format(skey, stanza[skey])
     return '{0} {{\n{1}}}'.format(key, ret)
-

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -20,14 +20,18 @@ import logging
 log = logging.getLogger(__name__)
 
 
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
 def __virtual__():
     '''
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    # set() need to used like this because the module defines a set function
-    # which shadows the set() built-in.
-    disable = __builtins__['set'](('Windows',))
+    disable = set(('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'partition'
@@ -105,7 +109,9 @@ def align_check(device, part_type, partition):
 
         salt '*' partition.align_check /dev/sda minimal 1
     '''
-    cmd = 'parted -m -s {0} align-check {1} {2}'.format(device, part_type, partition)
+    cmd = 'parted -m -s {0} align-check {1} {2}'.format(
+        device, part_type, partition
+    )
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 
@@ -233,7 +239,9 @@ def mkpart(device, part_type, fs_type, start, end):
 
         salt '*' partition.mkpart /dev/sda primary fat32 0 639
     '''
-    cmd = 'parted -m -s -- {0} mkpart {1} {2} {3} {4}'.format(device, part_type, fs_type, start, end)
+    cmd = 'parted -m -s -- {0} mkpart {1} {2} {3} {4}'.format(
+        device, part_type, fs_type, start, end
+    )
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 
@@ -252,7 +260,9 @@ def mkpartfs(device, part_type, fs_type, start, end):
 
         salt '*' partition.mkpartfs /dev/sda logical ext2 440 670
     '''
-    cmd = 'parted -m -s -- {0} mkpart {1} {2} {3} {4}'.format(device, part_type, fs_type, start, end)
+    cmd = 'parted -m -s -- {0} mkpart {1} {2} {3} {4}'.format(
+        device, part_type, fs_type, start, end
+    )
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 
@@ -305,7 +315,9 @@ def resize(device, minor, start, end):
         salt '*' partition.resize /dev/sda 3 200 850
     '''
     out = __salt__['cmd.run'](
-        'parted -m -s -- {0} resize {1} {2} {3}'.format(device, minor, start, end)
+        'parted -m -s -- {0} resize {1} {2} {3}'.format(
+            device, minor, start, end
+        )
     )
     return out.splitlines()
 
@@ -325,7 +337,7 @@ def rm(device, minor):  # pylint: disable-msg=C0103
     return out
 
 
-def set(device, minor, flag, state):
+def set_(device, minor, flag, state):
     '''
     partition.set device  minor flag state
 
@@ -355,4 +367,3 @@ def toggle(device, partition, flag):
     cmd = 'parted -m -s {0} toggle {1} {2} {3}'.format(device, partition, flag)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
-

--- a/salt/modules/quota.py
+++ b/salt/modules/quota.py
@@ -8,14 +8,18 @@ import logging
 log = logging.getLogger(__name__)
 
 
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
 def __virtual__():
     '''
     Only work on POSIX-like systems
     '''
     # Disable on these platforms, specific service modules exist:
-    # set() need to used like this because the module defines a set function
-    # which shadows the set() built-in.
-    disable = __builtins__['set'](('Windows',))
+    disable = set(('Windows',))
     if __grains__['os'] in disable:
         return False
     return 'quota'
@@ -80,7 +84,7 @@ def _parse_quota(mount, opts):
     return ret
 
 
-def set(device, **kwargs):
+def set_(device, **kwargs):
     '''
     Calls out to setquota, for a specific user or group
 
@@ -127,7 +131,8 @@ def set(device, **kwargs):
                                         current['file-soft-limit'],
                                         current['file-hard-limit'],
                                         device)
-    out = __salt__['cmd.run'](cmd).splitlines()
+
+    __salt__['cmd.run'](cmd).splitlines()
 
     return {ret: current}
 
@@ -208,4 +213,3 @@ def get_mode(device):
             }
         ret[comps[3]][comps[0]] = comps[6]
     return ret
-


### PR DESCRIPTION
If the module has the `__func_alias__` attribute, it must be a dictionary mapping in the form of(key -> value):

```
    <real-func-name> -> <desired-func-name>
```

It default's of course to the found callable attribute name if no alias is defined.
