### PR TITLE
pkg/solaris : fix typo on salt-master's manifest

### DIFF
--- a/pkg/solaris/salt-master.xml
+++ b/pkg/solaris/salt-master.xml
@@ -14,7 +14,7 @@
                   grouping="require_all"
                   restart_on="none"
                   type="path">
-          <service_fmri value='file:///etc/salt/minion'/>
+          <service_fmri value='file:///etc/salt/master'/>
       </dependency>
 
       <dependency name="network"


### PR DESCRIPTION
A typo on salt-master's manifest prevents its start without salt-minion
on SunOS/Solaris/SmartOS platform. Tested on SmartOS
joyent_20130405T010449Z.
