### PR TITLE
Feauture: Salt runner jobs.py add user to active and printed jobs.

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -31,7 +31,8 @@ def active():
                                    'Function': job['fun'],
                                    'Arguments': list(job['arg']),
                                    'Target': job['tgt'],
-                                   'Target-type': job['tgt_type']}
+                                   'Target-type': job['tgt_type'],
+                                   'User': load.get('user', 'root')}
             else:
                 ret[job['jid']]['Running'].append({minion: job['pid']})
     for jid in ret:
@@ -142,6 +143,7 @@ def print_job(job_id):
                                     'Arguments': list(load['arg']),
                                     'Target': load['tgt'],
                                     'Target-type': load['tgt_type'],
+                                    'User': load.get('user', 'root'),
                                     'Result': hosts_return}
                         salt.output.display_output(ret, 'yaml', __opts__)
     return ret


### PR DESCRIPTION
If you want to know which jobs are active, you also
want to know who has started them.

And after a job has finished and you want to audit this,
it is handy to know who has started the job.

This will make jobs.py better for auditing salt jobs.
