### PR TITLE
Add "pkgs" support for pkg.purged, pkg.removed states

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -145,10 +145,7 @@ def latest_version(*names, **kwargs):
         if fromrepo else ''
     for name in names:
         cmd = 'apt-cache -q policy {0}{1} | grep Candidate'.format(name, repo)
-        out = __salt__['cmd.run_all'](cmd, **kwargs)
-        if out['retcode'] != 0:
-            msg = 'Error:  ' + out['stderr']
-            log.error(msg)
+        out = __salt__['cmd.run_all'](cmd)
         candidate = out['stdout'].split()
         if len(candidate) >= 2:
             candidate = candidate[-1]
@@ -203,11 +200,7 @@ def refresh_db():
     '''
     ret = {}
     cmd = 'apt-get -q update'
-    out = __salt__['cmd.run_all'](cmd)
-    if out['retcode'] != 0:
-        msg = 'Error:  ' + out['stderr']
-        log.error(msg)
-    out = out['stdout']
+    out = __salt__['cmd.run_all'](cmd).get('stdout', '')
 
     lines = out.splitlines()
     for line in lines:
@@ -525,12 +518,7 @@ def _get_upgradable():
     '''
 
     cmd = 'apt-get --just-print dist-upgrade'
-    out = __salt__['cmd.run_all'](cmd)
-    if out['retcode'] != 0:
-        msg = 'Error:  ' + out['stderr']
-        log.error(msg)
-
-    out = out['stdout']
+    out = __salt__['cmd.run_all'](cmd).get('stdout', '')
 
     # rexp parses lines that look like the following:
     # Conf libxfont1 (1:1.4.5-1 Debian:testing [i386])

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -302,7 +302,7 @@ def parse_targets(name=None, pkgs=None, sources=None):
         return [x[2] for x in srcinfo], 'file'
 
     elif name and __grains__['os_family'] != 'Solaris':
-        return {name: None}, 'repository'
+        return dict([(x, None) for x in name.split(',')]), 'repository'
 
     else:
         log.error('No package sources passed to pkg.install.')

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -235,27 +235,14 @@ def parse_targets(name=None, pkgs=None, sources=None):
 
         salt '*' pkg_resource.parse_targets
     '''
-
-    # For Solaris, there is no repository, and only the "sources" param can be
-    # used. Warn if "name" or "pkgs" is provided, and require that "sources" is
-    # present.
-    if __grains__['os_family'] == 'Solaris':
-        if name:
-            log.warning('Parameter "name" ignored on Solaris hosts.')
-        if pkgs:
-            log.warning('Parameter "pkgs" ignored on Solaris hosts.')
-        if not sources:
-            log.error('"sources" option required with Solaris pkg installs')
-            return None, None
-    elif __grains__['os'] == 'MacOS' and sources:
+    if __grains__['os'] == 'MacOS' and sources:
         log.warning('Parameter "sources" ignored on MacOS hosts.')
 
-    # "pkgs" is always ignored on Solaris.
-    if pkgs and sources and __grains__['os_family'] != 'Solaris':
+    if pkgs and sources:
         log.error('Only one of "pkgs" and "sources" can be used.')
         return None, None
 
-    elif pkgs and __grains__['os_family'] != 'Solaris':
+    elif pkgs:
         if name:
             log.warning('"name" parameter will be ignored in favor of "pkgs"')
         pkgs = pack_pkgs(pkgs)
@@ -266,7 +253,7 @@ def parse_targets(name=None, pkgs=None, sources=None):
 
     elif sources and __grains__['os'] != 'MacOS':
         # No need to warn for Solaris, warning taken care of above.
-        if name and __grains__['os_family'] != 'Solaris':
+        if name:
             log.warning('"name" parameter will be ignored in favor of '
                         '"sources".')
         sources = pack_sources(sources)
@@ -301,7 +288,7 @@ def parse_targets(name=None, pkgs=None, sources=None):
         # the package path (3rd element of tuple).
         return [x[2] for x in srcinfo], 'file'
 
-    elif name and __grains__['os_family'] != 'Solaris':
+    elif name:
         return dict([(x, None) for x in name.split(',')]), 'repository'
 
     else:

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -304,7 +304,7 @@ def install(pkg_name, orphan=False, force=False, glob=False, local=False,
 
 
 def delete(pkg_name, all_installed=False, force=False, glob=False,
-            dryrun=False, recurse=False, regex=False, pcre=False):
+           dryrun=False, recurse=False, regex=False, pcre=False):
     '''
     Delete a package from the database and system
 
@@ -470,7 +470,6 @@ def upgrade(force=False, local=False, dryrun=False):
 
                 salt '*' pkgng.update dryrun=True
     '''
-
     opts = ''
     if force:
         opts += 'f'
@@ -503,19 +502,16 @@ def clean():
 def autoremove(dryrun=False):
     '''
     Delete packages which were automatically installed as dependencies and are
-    not required anymore
-
-    CLI Example::
-
-	    salt '*' pkgng.autoremove
+    not required anymore.
 
         dryrun
             Dry-run mode. The list of changes to packages is always printed,
             but no changes are actually made.
 
-            CLI Example::
+    CLI Example::
 
-                salt '*' pkgng.autoremove dryrun=True
+         salt '*' pkgng.autoremove
+         salt '*' pkgng.autoremove dryrun=True
     '''
 
     opts = ''
@@ -606,8 +602,8 @@ def which(file_name, origin=False, quiet=False):
 
 
 def search(pkg_name, exact=False, glob=False, regex=False, pcre=False,
-            comment=False, desc=False, full=False, depends=False,
-            size=False, quiet=False, origin=False, prefix=False, ):
+           comment=False, desc=False, full=False, depends=False,
+           size=False, quiet=False, origin=False, prefix=False):
     '''
     Searches in remote package repositories
 
@@ -734,7 +730,7 @@ def search(pkg_name, exact=False, glob=False, regex=False, pcre=False,
 
 
 def fetch(pkg_name, all=False, quiet=False, reponame=None, glob=True,
-            regex=False, pcre=False, local=False, depends=False):
+          regex=False, pcre=False, local=False, depends=False):
     '''
     Fetches remote packages
 

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -2,6 +2,9 @@
 Pkgutil support for Solaris
 '''
 
+# Import python libs
+import copy
+
 # Import salt libs
 import salt.utils
 
@@ -13,17 +16,6 @@ def __virtual__():
     if __grains__['os'] == 'Solaris':
         return 'pkgutil'
     return False
-
-
-def _list_removed(old, new):
-    '''
-    List the packages which have been removed between the two package objects
-    '''
-    pkgs = []
-    for pkg in old:
-        if pkg not in new:
-            pkgs.append(pkg)
-    return pkgs
 
 
 def refresh_db():
@@ -86,7 +78,7 @@ def upgrade(refresh=True, **kwargs):
     '''
     Upgrade all of the packages to the latest available version.
 
-    Returns a dict containing the new package names and versions::
+    Returns a dict containing the changes::
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
@@ -98,19 +90,14 @@ def upgrade(refresh=True, **kwargs):
     if salt.utils.is_true(refresh):
         refresh_db()
 
-    # Get a list of the packages before install so we can diff after to see
-    # what got installed.
     old = list_pkgs()
 
     # Install or upgrade the package
     # If package is already installed
     cmd = '/opt/csw/bin/pkgutil -yu'
-    __salt__['cmd.run'](cmd)
-
-    # Get a list of the packages again, including newly installed ones.
+    __salt__['cmd.run_all'](cmd)
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-
-    # Return a list of the new package installed.
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
@@ -122,9 +109,19 @@ def list_pkgs(versions_as_list=False):
 
     CLI Example::
 
-        salt '*' pkgutil.list_pkgs
+        salt '*' pkg.list_pkgs
+        salt '*' pkg.list_pkgs versions_as_list=True
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+
+    if 'pkg.list_pkgs' in __context__:
+        if versions_as_list:
+            return __context__['pkg.list_pkgs']
+        else:
+            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
+            __salt__['pkg_resource.stringify'](ret)
+            return ret
+
     ret = {}
     cmd = '/usr/bin/pkginfo -x'
 
@@ -140,6 +137,7 @@ def list_pkgs(versions_as_list=False):
             __salt__['pkg_resource.add_pkg'](ret, name, version)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
+    __context__['pkg.list_pkgs'] = ret
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
     return ret
@@ -174,90 +172,119 @@ def latest_version(name, **kwargs):
 available_version = latest_version
 
 
-def install(name, refresh=False, version=None, **kwargs):
+def install(name=None, refresh=False, version=None, pkgs=None, **kwargs):
     '''
-    Install the named package using the pkgutil tool.
+    Install packages using the pkgutil tool.
+
+    CLI Example::
+
+        salt '*' pkg.install <package_name>
+        salt '*' pkg.install SMClgcc346
+
+
+    Multiple Package Installation Options:
+
+    pkgs
+        A list of packages to install from OpenCSW. Must be passed as a python
+        list.
+
+        CLI Example::
+            salt '*' pkg.install pkgs='["foo", "bar"]'
+            salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3"}]'
+
 
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
-
-    CLI Example::
-
-        salt '*' pkgutil.install <package_name>
-        salt '*' pkgutil.install SMClgcc346
     '''
-
     if refresh:
         refresh_db()
 
-    if version:
-        pkg = "{0}-{1}".format(name, version)
-    else:
-        pkg = "{0}".format(name)
+    # Ignore 'sources' argument
+    pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
 
-    cmd = '/opt/csw/bin/pkgutil -yu '
+    if pkg_params is None or len(pkg_params) == 0:
+        return {}
 
-    # Get a list of the packages before install so we can diff after to see
-    # what got installed.
+    if pkgs is None and version and len(pkg_params) == 1:
+        pkg_params = {name: version}
+    targets = []
+    for param, pkgver in pkg_params.iteritems():
+        if pkgver is None:
+            targets.append(param)
+        else:
+            targets.append('{0}-{1}'.format(param, pkgver))
+
+    cmd = '/opt/csw/bin/pkgutil -yu {0}'.format(' '.join(targets))
     old = list_pkgs()
-
-    # Install or upgrade the package
-    # If package is already installed
-    cmd += '{0}'.format(pkg)
-    __salt__['cmd.run'](cmd)
-
-    # Get a list of the packages again, including newly installed ones.
+    __salt__['cmd.run_all'](cmd)
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-
-    # Return a list of the new package installed.
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def remove(name, **kwargs):
+def remove(name=None, pkgs=None, **kwargs):
     '''
     Remove a package and all its dependencies which are not in use by other
     packages.
 
-    Returns a list containing the removed packages.
+    name
+        The name of the package to be deleted.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
-        salt '*' pkgutil.remove <package name>
-        salt '*' pkgutil.remove SMCliconv
+        salt '*' pkg.remove <package name>
+        salt '*' pkg.remove <package1>,<package2>,<package3>
+        salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
-
-    # Check to see if the package is installed before we proceed
-    if version(name) == '':
-        return ''
-
-    # Get a list of the currently installed pkgs.
+    pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
     old = list_pkgs()
-
-    # Remove the package
-    cmd = '/opt/csw/bin/pkgutil -yr {0}'.format(name)
-    __salt__['cmd.run'](cmd)
-
-    # Get a list of the packages after the uninstall
+    targets = [x for x in pkg_params if x in old]
+    if not targets:
+        return {}
+    cmd = '/opt/csw/bin/pkgutil -yr {0}'.format(' '.join(targets))
+    __salt__['cmd.run_all'](cmd)
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-
-    # Compare the pre and post remove package objects and report the uninstalled pkgs.
-    return _list_removed(old, new)
+    return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name, **kwargs):
+def purge(name=None, pkgs=None, **kwargs):
     '''
-    Remove a package and all its dependencies which are not in use by other
-    packages.
+    Package purges are not supported, this function is identical to
+    ``remove()``.
 
-    Returns a list containing the removed packages.
+    name
+        The name of the package to be deleted.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
-        salt '*' pkgutil.purge <package name>
+        salt '*' pkg.purge <package name>
+        salt '*' pkg.purge <package1>,<package2>,<package3>
+        salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
-    return remove(name, **kwargs)
+    return remove(name=name, pkgs=pkgs)
 
 
 def perform_cmp(pkg1='', pkg2=''):

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -260,12 +260,16 @@ def install(name=None, refresh=False, sources=None, **kwargs):
     Note: the ID declaration is ignored, as the package name is read from the
     "sources" parameter.
     '''
-
     pkg_params, pkg_type = \
         __salt__['pkg_resource.parse_targets'](name,
                                                kwargs.get('pkgs'),
                                                sources)
+
     if pkg_params is None or len(pkg_params) == 0:
+        return {}
+
+    if not sources:
+        log.error('"sources" param required for solaris pkg_add installs')
         return {}
 
     if 'admin_source' in kwargs:

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -3,6 +3,7 @@ Package support for Solaris
 '''
 
 # Import python libs
+import copy
 import os
 import logging
 
@@ -20,17 +21,6 @@ def __virtual__():
     if __grains__['os'] == 'Solaris':
         return 'pkg'
     return False
-
-
-def _list_removed(old, new):
-    '''
-    List the packages which have been removed between the two package objects
-    '''
-    pkgs = []
-    for pkg in old:
-        if pkg not in new:
-            pkgs.append(pkg)
-    return pkgs
 
 
 def _write_adminfile(kwargs):
@@ -82,6 +72,15 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+
+    if 'pkg.list_pkgs' in __context__:
+        if versions_as_list:
+            return __context__['pkg.list_pkgs']
+        else:
+            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
+            __salt__['pkg_resource.stringify'](ret)
+            return ret
+
     ret = {}
     cmd = '/usr/bin/pkginfo -x'
 
@@ -97,6 +96,7 @@ def list_pkgs(versions_as_list=False):
             __salt__['pkg_resource.add_pkg'](ret, name, version)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
+    __context__['pkg.list_pkgs'] = ret
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
     return ret
@@ -273,10 +273,7 @@ def install(name=None, refresh=False, sources=None, **kwargs):
     else:
         adminfile = _write_adminfile(kwargs)
 
-    # Get a list of the packages before install so we can diff after to see
-    # what got installed.
     old = list_pkgs()
-
     cmd = '/usr/sbin/pkgadd -n -a {0} '.format(adminfile)
 
     # Only makes sense in a global zone but works fine in non-globals.
@@ -286,11 +283,9 @@ def install(name=None, refresh=False, sources=None, **kwargs):
     for pkg in pkg_params:
         temp_cmd = cmd + '-d {0} "all"'.format(pkg)
         # Install the package{s}
-        stderr = __salt__['cmd.run_all'](temp_cmd).get('stderr', '')
-        if stderr:
-            log.error(stderr)
+        __salt__['cmd.run_all'](temp_cmd)
 
-    # Get a list of the packages again, including newly installed ones.
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
 
     # Remove the temp adminfile
@@ -300,9 +295,12 @@ def install(name=None, refresh=False, sources=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def remove(name, **kwargs):
+def remove(name=None, pkgs=None, **kwargs):
     '''
-    Remove a single package with pkgrm
+    Remove packages with pkgrm
+
+    name
+        The name of the package to be deleted.
 
     By default salt automatically provides an adminfile, to automate package
     removal, with these options set::
@@ -329,15 +327,28 @@ def remove(name, **kwargs):
 
         man -s 4 admin
 
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
+
     CLI Example::
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove SUNWgit
+        salt '*' pkg.remove <package1>,<package2>,<package3>
+        salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
-
-    # Check to see if the package is installed before we proceed
-    if version(name) == '':
-        return ''
+    pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
+    old = list_pkgs()
+    targets = [x for x in pkg_params if x in old]
+    if not targets:
+        return {}
 
     if 'admin_source' in kwargs:
         adminfile = __salt__['cp.cache_file'](kwargs['admin_source'])
@@ -372,36 +383,43 @@ def remove(name, **kwargs):
         os.write(fd_, 'basedir={0}\n'.format(basedir))
         os.close(fd_)
 
-    # Get a list of the currently installed pkgs.
-    old = list_pkgs()
-
     # Remove the package
-    cmd = '/usr/sbin/pkgrm -n -a {0} {1}'.format(adminfile, name)
-    __salt__['cmd.retcode'](cmd)
-
+    cmd = '/usr/sbin/pkgrm -n -a {0} {1}'.format(adminfile,
+                                                 ' '.join(targets))
+    __salt__['cmd.run_all'](cmd)
     # Remove the temp adminfile
     if not 'admin_source' in kwargs:
         os.unlink(adminfile)
-
-    # Get a list of the packages after the uninstall
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-
-    # Compare the pre and post remove package objects and report the
-    # uninstalled pkgs.
-    return _list_removed(old, new)
+    return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name, **kwargs):
+def purge(name=None, pkgs=None, **kwargs):
     '''
-    Remove a single package with pkgrm
+    Package purges are not supported, this function is identical to
+    ``remove()``.
 
-    Returns a list containing the removed packages.
+    name
+        The name of the package to be deleted.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
         salt '*' pkg.purge <package name>
+        salt '*' pkg.purge <package1>,<package2>,<package3>
+        salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
-    return remove(name, **kwargs)
+    return remove(name=name, pkgs=pkgs, **kwargs)
 
 
 def perform_cmp(pkg1='', pkg2=''):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -18,6 +18,7 @@ except ImportError:
     HAS_DEPENDENCIES = False
 
 # Import python libs
+import copy
 import logging
 import msgpack
 import os
@@ -36,17 +37,6 @@ def __virtual__():
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
         return 'pkg'
     return False
-
-
-def _list_removed(old, new):
-    '''
-    List the packages which have been removed between the two package objects
-    '''
-    pkgs = []
-    for pkg in old:
-        if pkg not in new:
-            pkgs.append(pkg)
-    return pkgs
 
 
 def latest_version(*names, **kwargs):
@@ -208,22 +198,32 @@ def list_pkgs(*args, **kwargs):
     '''
     versions_as_list = \
         salt.utils.is_true(kwargs.get('versions_as_list'))
-    pkgs = {}
+
+    if 'pkg.list_pkgs' in __context__:
+        if versions_as_list:
+            return __context__['pkg.list_pkgs']
+        else:
+            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
+            __salt__['pkg_resource.stringify'](ret)
+            return ret
+
+    ret = {}
     with salt.utils.winapi.Com():
         if len(args) == 0:
             for key, val in _get_reg_software().iteritems():
-                __salt__['pkg_resource.add_pkg'](pkgs, key, val)
+                __salt__['pkg_resource.add_pkg'](ret, key, val)
             for key, val in _get_msi_software().iteritems():
-                __salt__['pkg_resource.add_pkg'](pkgs, key, val)
+                __salt__['pkg_resource.add_pkg'](ret, key, val)
         else:
             # get package version for each package in *args
             for arg in args:
                 for key, val in _search_software(arg).iteritems():
-                    __salt__['pkg_resource.add_pkg'](pkgs, key, val)
+                    __salt__['pkg_resource.add_pkg'](ret, key, val)
 
-    __salt__['pkg_resource.sort_pkglist'](pkgs)
+    __salt__['pkg_resource.sort_pkglist'](ret)
+    __context__['pkg.list_pkgs'] = ret
     if not versions_as_list:
-        __salt__['pkg_resource.stringify'](pkgs)
+        __salt__['pkg_resource.stringify'](ret)
     return pkgs
 
 
@@ -431,18 +431,16 @@ def install(name=None, refresh=False, **kwargs):
         cached_pkg = __salt__['cp.is_cached'](pkginfo[version]['installer'])
         if not cached_pkg:
             # It's not cached. Cache it, mate.
-            cached_pkg = __salt__['cp.cache_file'](pkginfo[
-                                                   version]['installer'])
+            cached_pkg = \
+                __salt__['cp.cache_file'](pkginfo[version]['installer'])
     else:
         cached_pkg = pkginfo[version]['installer']
     cached_pkg = cached_pkg.replace('/', '\\')
     cmd = '"' + str(cached_pkg) + '"' + str(pkginfo[version]['install_flags'])
-    if 'msiexec' in pkginfo[version]:
-        if pkginfo[version]['msiexec']:
-            cmd = 'msiexec /i ' + cmd
-    stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
-    if stderr:
-        log.error(stderr)
+    if pkginfo[version].get('msiexec'):
+        cmd = 'msiexec /i ' + cmd
+    __salt__['cmd.run_all'](cmd)
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 
@@ -469,56 +467,98 @@ def upgrade(refresh=True):
     return {}
 
 
-def remove(name, version=None, **kwargs):
+def remove(name=None, pkgs=None, version=None, **kwargs):
     '''
-    Remove a single package
+    Remove packages.
 
-    Return a list containing the removed packages.
+    name
+        The name of the package to be deleted.
+
+    version
+        The version of the package to be deleted. If this option is used in
+        combination with the ``pkgs`` option below, then this version will be
+        applied to all targeted packages.
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
         salt '*' pkg.remove <package name>
+        salt '*' pkg.remove <package1>,<package2>,<package3>
+        salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
+    pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
     old = list_pkgs()
-    pkginfo = _get_package_info(name)
-    if not version:
-        version = _get_latest_pkg_version(pkginfo)
+    targets = [x for x in pkg_params if x in old]
+    if not targets:
+        return {}
 
-    if pkginfo[version]['uninstaller'].startswith('salt:'):
-        cached_pkg = __salt__['cp.is_cached'](pkginfo[version]['uninstaller'])
-        if not cached_pkg:
-            # It's not cached. Cache it, mate.
-            cached_pkg = __salt__['cp.cache_file'](pkginfo[
-                                                   version]['uninstaller'])
-    else:
-        cached_pkg = pkginfo[version]['uninstaller']
-    cached_pkg = cached_pkg.replace('/', '\\')
-    if not os.path.exists(os.path.expandvars(cached_pkg)) and '(x86)' in cached_pkg:
-        cached_pkg = cached_pkg.replace('(x86)', '')
-    cmd = '"' + str(os.path.expandvars(
-        cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
-    if 'msiexec'in pkginfo[version]:
-        if pkginfo[version]['msiexec']:
+    for target in targets:
+        pkginfo = _get_package_info(target)
+        if not version:
+            version = _get_latest_pkg_version(pkginfo)
+
+        if pkginfo[version]['uninstaller'].startswith('salt:'):
+            cached_pkg = \
+                __salt__['cp.is_cached'](pkginfo[version]['uninstaller'])
+            if not cached_pkg:
+                # It's not cached. Cache it, mate.
+                cached_pkg = \
+                    __salt__['cp.cache_file'](pkginfo[version]['uninstaller'])
+        else:
+            cached_pkg = pkginfo[version]['uninstaller']
+        cached_pkg = cached_pkg.replace('/', '\\')
+        if not os.path.exists(os.path.expandvars(cached_pkg)) \
+                and '(x86)' in cached_pkg:
+            cached_pkg = cached_pkg.replace('(x86)', '')
+        cmd = '"' + str(os.path.expandvars(
+            cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
+        if pkginfo[version].get('msiexec'):
             cmd = 'msiexec /x ' + cmd
-    stderr = __salt__['cmd.run_all'](cmd).get('stderr', '')
-    if stderr:
-        log.error(stderr)
+        __salt__['cmd.run_all'](cmd)
+
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name, version=None, **kwargs):
+def purge(name=None, pkgs=None, version=None, **kwargs):
     '''
-    Recursively remove a package and all dependencies which were installed
-    with it
+    Package purges are not supported, this function is identical to
+    ``remove()``.
 
-    Return a list containing the removed packages.
+    name
+        The name of the package to be deleted.
+
+    version
+        The version of the package to be deleted. If this option is used in
+        combination with the ``pkgs`` option below, then this version will be
+        applied to all targeted packages.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
         salt '*' pkg.purge <package name>
+        salt '*' pkg.purge <package1>,<package2>,<package3>
+        salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
-    return remove(name, version, **kwargs)
+    return remove(name=name, pkgs=pkgs, version=version, **kwargs)
 
 
 def _get_package_info(name):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -99,17 +99,6 @@ class _YumErrorLogger(object):
         self.messages[package] = msgs
 
 
-def _list_removed(old, new):
-    '''
-    List the packages which have been removed between the two package objects
-    '''
-    pkgs = []
-    for pkg in old:
-        if pkg not in new:
-            pkgs.append(pkg)
-    return pkgs
-
-
 def list_upgrades(refresh=True):
     '''
     Check whether or not an upgrade is available for all packages
@@ -259,6 +248,15 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+
+    if 'pkg.list_pkgs' in __context__:
+        if versions_as_list:
+            return __context__['pkg.list_pkgs']
+        else:
+            ret = copy.deepcopy(__context__['pkg.list_pkgs'])
+            __salt__['pkg_resource.stringify'](ret)
+            return ret
+
     ret = {}
     yb = yum.YumBase()
     for p in yb.rpmdb:
@@ -271,6 +269,7 @@ def list_pkgs(versions_as_list=False):
         __salt__['pkg_resource.add_pkg'](ret, name, pkgver)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
+    __context__['pkg.list_pkgs'] = ret
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
     return ret
@@ -528,6 +527,7 @@ def install(name=None,
     except Exception as e:
         log.error('Install failed: {0}'.format(e))
 
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 
@@ -568,35 +568,53 @@ def upgrade(refresh=True):
     except Exception as e:
         log.error('Upgrade failed: {0}'.format(e))
 
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def remove(pkgs, **kwargs):
+def remove(name=None, pkgs=None, **kwargs):
     '''
-    Removes packages with yum remove
+    Removes packages using python API for yum.
 
-    Return a list containing the removed packages:
+    name
+        The name of the package to be deleted.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
-        salt '*' pkg.remove <package,package,package>
+        salt '*' pkg.remove <package name>
+        salt '*' pkg.remove <package1>,<package2>,<package3>
+        salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
+
+    pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
+    old = list_pkgs()
+    targets = [x for x in pkg_params if x in old]
+    if not targets:
+        return {}
 
     yumbase = yum.YumBase()
     setattr(yumbase.conf, 'assumeyes', True)
-    pkgs = pkgs.split(',')
-    old = list_pkgs()
 
     # same comments as in upgrade for remove.
-    for pkg in pkgs:
+    for target in targets:
         if __grains__.get('cpuarch', '') == 'x86_64' \
-                and pkg.endswith('.i686'):
-            pkg = pkg[:-5]
+                and target.endswith('.i686'):
+            target = target[:-5]
             arch = 'i686'
         else:
             arch = None
-        yumbase.remove(name=pkg, arch=arch)
+        yumbase.remove(name=target, arch=arch)
 
     log.info('Resolving dependencies')
     yumbase.resolveDeps()
@@ -606,22 +624,36 @@ def remove(pkgs, **kwargs):
     yumlogger.log_accumulated_errors()
     yumbase.closeRpmDB()
 
+    __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+    return __salt__['pkg_resource.find_changes'](old, new)
 
-    return _list_removed(old, new)
 
-
-def purge(pkgs, **kwargs):
+def purge(name=None, pkgs=None, **kwargs):
     '''
-    Yum does not have a purge, this function calls remove
+    Package purges are not supported by yum, this function is identical to
+    ``remove()``.
 
-    Return a list containing the removed packages:
+    name
+        The name of the package to be deleted.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
         salt '*' pkg.purge <package name>
+        salt '*' pkg.purge <package1>,<package2>,<package3>
+        salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
-    return remove(pkgs)
+    return remove(name=name, pkgs=pkgs)
 
 
 def verify(*package):


### PR DESCRIPTION
In addition to adding support for the `pkgs` argument (a la `pkg.installed`), this commit also adds use of the `__context__` dict to the `list_pkgs` function, which should noticeably improve the speed of pkg states.

This is a pretty substantial pull. I've tested the following providers:

```
apt
freebsdpkg
openbsdpkg
pacman
pkgutil
solarispkg
yumpkg
yumpkg5
zypper
```

The following remain to be tested:

```
brew
ebuild
win_pkg
```
