### PR TITLE
pkg/smartos : add compatible manifests for the SmartOS platform

### DIFF
--- a/pkg/smartos/salt-master.xml
+++ b/pkg/smartos/salt-master.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-master">
+    <service name="network/salt-master" type="service" version="1">
+
+      <create_default_instance enabled="false"/>
+
+      <single_instance/>
+
+      <dependency name="config-file"
+                  grouping="require_all"
+                  restart_on="none"
+                  type="path">
+          <service_fmri value='file:///opt/local/etc/salt/master'/>
+      </dependency>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="/opt/local/bin/salt-master"
+                   timeout_seconds="60"/>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <property_group name="application" type="application">
+        <propval name="config_file" type="astring" value="/opt/local/etc/salt/master"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt Master</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.org"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>
+

--- a/pkg/smartos/salt-minion.xml
+++ b/pkg/smartos/salt-minion.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-minion">
+    <service name="network/salt-minion" type="service" version="1">
+
+      <create_default_instance enabled="true"/>
+
+      <single_instance/>
+
+      <dependency name="config-file"
+                  grouping="require_all"
+                  restart_on="none"
+                  type="path">
+          <service_fmri value='file:///opt/local/etc/salt/minion'/>
+      </dependency>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="/opt/local/bin/salt-minion"
+                   timeout_seconds="60"/>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <property_group name="application" type="application">
+        <propval name="config_file" type="astring" value="/opt/local/etc/salt/minion"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt Minion</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.org"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>
+

--- a/pkg/smartos/salt-syndic.xml
+++ b/pkg/smartos/salt-syndic.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-syndic">
+    <service name="network/salt-syndic" type="service" version="1">
+
+      <create_default_instance enabled="false"/>
+
+      <single_instance/>
+
+      <dependency name="config-file"
+                  grouping="require_all"
+                  restart_on="none"
+                  type="path">
+          <service_fmri value='file:///opt/local/etc/salt/minion'/>
+      </dependency>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="/opt/local/bin/salt-syndic"
+                   timeout_seconds="60"/>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <property_group name="application" type="application">
+        <propval name="config_file" type="astring" value="/opt/local/etc/salt/master"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt Syndic</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.org"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>
+


### PR DESCRIPTION
Manifests in pkg/solaris are using /etc/salt which is innapropriate
for SmartOS design (/etc is removed @reboot). I suggest to add a
new directory in order to preserve existing Solaris installations
(and SmartOS one which are based on those manifests).
