### PR TITLE
Check for existance of git-python before checking it's version attribute

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -38,11 +38,11 @@ def __virtual__():
         return False
     if not 'git' in __opts__['fileserver_backend']:
         return False
-    if not git.__version__ > '0.3.0':
-        return False
     if not HAS_GIT:
         log.error('Git fileserver backend is enabled in configuration but '
                   'could not be loaded, is git-python installed?')
+        return False
+    if not git.__version__ > '0.3.0':
         return False
     return 'git'
 


### PR DESCRIPTION
Otherwise, we get these unfriendly stack traces:
[ERROR   ] Failed to read the virtual function for fileserver: gitfs
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/salt/loader.py", line 686, in gen_functions
    virtual = mod.**virtual**()
  File "/usr/lib/pymodules/python2.7/salt/fileserver/gitfs.py", line 41, in **virtual**
    if not git.**version** > '0.3.0':
NameError: global name 'git' is not defined
