### PR TITLE
Rename build_whitepace_splited_regex to build_whitespace_split_regex

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1702,7 +1702,7 @@ def append(name,
     for chunk in text:
 
         if __salt__['file.contains_regex_multiline'](
-                name, salt.utils.build_whitepace_splited_regex(chunk)):
+                name, salt.utils.build_whitespace_split_regex(chunk)):
             continue
 
         try:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -22,6 +22,7 @@ import platform
 import tempfile
 import subprocess
 import types
+import warnings
 import zmq
 from calendar import month_abbr as months
 import salt._compat
@@ -572,7 +573,7 @@ def pem_finger(path, sum_type='md5'):
     return finger.rstrip(':')
 
 
-def build_whitepace_splited_regex(text):
+def build_whitespace_split_regex(text):
     '''
     Create a regular expression at runtime which should match ignoring the
     addition or deletion of white space or line breaks, unless between commas
@@ -581,7 +582,7 @@ def build_whitepace_splited_regex(text):
 
     >>> import re
     >>> from salt.utils import *
-    >>> regex = build_whitepace_splited_regex(
+    >>> regex = build_whitespace_split_regex(
     ...     """if [ -z "$debian_chroot" ] && [ -r /etc/debian_chroot ]; then"""
     ... )
 
@@ -614,6 +615,13 @@ def build_whitepace_splited_regex(text):
         parts = [re.escape(s) for s in __build_parts(line)]
         regex += r'(?:[\s]+)?{0}(?:[\s]+)?'.format(r'(?:[\s]+)?'.join(parts))
     return r'(?m)^{0}$'.format(regex)
+
+
+def build_whitepace_splited_regex(text):
+    warnings.warn("The build_whitepace_splited_regex function is deprecated,"
+                  " please use build_whitespace_split_regex instead.",
+                  DeprecationWarning)
+    build_whitespace_split_regex(text)
 
 
 def format_call(fun, data):

--- a/tests/unit/utils/runtime_whitespace_regex_test.py
+++ b/tests/unit/utils/runtime_whitespace_regex_test.py
@@ -13,7 +13,7 @@ import re
 
 # Import salt libs
 from saltunittest import TestCase, TestLoader, TextTestRunner
-from salt.utils import build_whitepace_splited_regex
+from salt.utils import build_whitespace_split_regex
 
 
 DOUBLE_TXT = """\
@@ -84,19 +84,19 @@ fi
 class TestRuntimeWhitespaceRegex(TestCase):
 
     def test_single_quotes(self):
-        regex = build_whitepace_splited_regex(SINGLE_TXT)
+        regex = build_whitespace_split_regex(SINGLE_TXT)
         self.assertTrue(re.search(regex, MATCH))
 
     def test_double_quotes(self):
-        regex = build_whitepace_splited_regex(DOUBLE_TXT)
+        regex = build_whitespace_split_regex(DOUBLE_TXT)
         self.assertTrue(re.search(regex, MATCH))
 
     def test_single_and_double_quotes(self):
-        regex = build_whitepace_splited_regex(SINGLE_DOUBLE_TXT)
+        regex = build_whitespace_split_regex(SINGLE_DOUBLE_TXT)
         self.assertTrue(re.search(regex, MATCH))
 
     def test_issue_2227(self):
-        regex = build_whitepace_splited_regex(SINGLE_DOUBLE_SAME_LINE_TXT)
+        regex = build_whitespace_split_regex(SINGLE_DOUBLE_SAME_LINE_TXT)
         self.assertTrue(re.search(regex, MATCH))
 
 


### PR DESCRIPTION
This function has multiple typos in its name so I renamed it but retained backwards compatibility.
