### PR TITLE
Handle args that were previously parsed into lists, Fix #5031

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -490,7 +490,10 @@ def single(fun, name, test=None, kwval_as='yaml', **kwargs):
 
     for key, value in kwargs.iteritems():
         if not key.startswith('__pub_'):
-            kwargs[key] = parse_kwval(value)
+            if not isinstance(value, list):
+                kwargs[key] = parse_kwval(value)
+            else:
+                kwargs[key] = value
 
     ret = {'{0[state]}_|-{0[__id__]}_|-{0[name]}_|-{0[fun]}'.format(kwargs):
             st_.call(kwargs)}


### PR DESCRIPTION
I've only added lists at this point, because I think that's all that's needed -- however, exceptions for dicts or similar will be easy if use cases pop up for those.
