### PR TITLE
freeze numbers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -243,6 +243,7 @@ freezer_includes = [
     'difflib',
     'distutils',
     'distutils.version',
+    'numbers',
     'json',
 ]
 


### PR DESCRIPTION
the numbers module wasn't being included by default by bbfreeze.
