### PR TITLE
Fixed multiple pep8 errors in salt-run code

### DIFF
--- a/salt/runners/doc.py
+++ b/salt/runners/doc.py
@@ -15,6 +15,7 @@ import salt.wheel
 def __virtual__():
     return 'doc'
 
+
 def runner():
     '''
     Return all inline documetation for runner modules
@@ -24,6 +25,7 @@ def runner():
     salt.output.display_output(ret, '', __opts__)
     return ret
 
+
 def wheel():
     '''
     Return all inline documentation for wheel modules
@@ -32,6 +34,7 @@ def wheel():
     ret = client.get_docs()
     salt.output.display_output(ret, '', __opts__)
     return ret
+
 
 def execution():
     '''
@@ -49,6 +52,7 @@ def execution():
 
     salt.output.display_output(ret, '', __opts__)
     return ret
+
 
 # Still need to modify some of the backend for auth checks to make this work
 def __list_functions(user=None):

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -39,8 +39,7 @@ def active():
         jid_dir = salt.utils.jid_dir(
                 jid,
                 __opts__['cachedir'],
-                __opts__['hash_type']
-                )
+                __opts__['hash_type'])
         if not os.path.isdir(jid_dir):
             continue
         for minion in os.listdir(jid_dir):

--- a/salt/runners/launchd.py
+++ b/salt/runners/launchd.py
@@ -32,7 +32,7 @@ def write_launchd_plist(program):
     if program not in supported_programs:
         sys.stderr.write("Supported programs: %r\n" % supported_programs)
         sys.exit(-1)
-    
+
     sys.stdout.write(
         plist_sample_text.format(
             program=program,

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -46,13 +46,15 @@ def _find_vm(name, data, quiet=False):
             return ret
     return {}
 
+
 def query(hyper=None, quiet=False):
     '''
     Query the virtual machines
     '''
     ret = {}
     client = salt.client.LocalClient(__opts__['conf_file'])
-    for info in client.cmd_iter('virtual:physical', 'virt.full_info', expr_form='grain'):
+    for info in client.cmd_iter('virtual:physical',
+                                'virt.full_info', expr_form='grain'):
         if not info:
             continue
         if not isinstance(info, dict):
@@ -113,7 +115,7 @@ def init(name, cpu, mem, image, hyper=None, seed=True, nic='default'):
             return 'fail'
     else:
         hyper = _determine_hyper(data)
-    
+
     client = salt.client.LocalClient(__opts__['conf_file'])
 
     print('Creating VM {0} on hypervisor {1}'.format(name, hyper))
@@ -307,4 +309,6 @@ def migrate(name, target=''):
         print('Target hypervisor {0} not found'.format(origin_data))
         return ''
     client.cmd(target, 'virt.seed_non_shared_migrate', [disks, True])
-    print client.cmd_async(origin_hyper, 'virt.migrate_non_shared', [name, target])
+    print client.cmd_async(origin_hyper,
+                           'virt.migrate_non_shared',
+                           [name, target])

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -35,10 +35,10 @@ def genrepo():
                         config = yaml.safe_load(slsfile.read()) or {}
                     except yaml.parser.ParserError as exc:
                         # log.debug doesn't seem to be working
-                        # delete the following print statement 
+                        # delete the following print statement
                         # when log.debug works
                         log.debug('Failed to compile'
-                                '{0}: {1}'.format(os.path.join(root, name), exc))
+                                  '{0}: {1}'.format(os.path.join(root, name), exc))
                         print 'Failed to compile {0}: {1}'.format(os.path.join(root, name), exc)
                 if config:
                     ret.update(config)
@@ -46,6 +46,7 @@ def genrepo():
         repo.write(msgpack.dumps(ret))
     salt.output.display_output(ret, 'pprint', __opts__)
     return ret
+
 
 def update_git_repos():
     '''
@@ -61,7 +62,9 @@ def update_git_repos():
         else:
             targetname = gitrepo
         gittarget = os.path.join(repo, targetname)
-        result = mminion.states['git.latest'](gitrepo, target=gittarget, force=True)
+        result = mminion.states['git.latest'](gitrepo,
+                                              target=gittarget,
+                                              force=True)
         ret[result['name']] = result['result']
     salt.output.display_output(ret, 'pprint', __opts__)
     return ret


### PR DESCRIPTION
fixed errors

```
doc.py:18:1: E302 expected 2 blank lines, found 1
doc.py:27:1: E302 expected 2 blank lines, found 1
doc.py:36:1: E302 expected 2 blank lines, found 1
doc.py:54:1: E302 expected 2 blank lines, found 1
jobs.py:43:17: E123 closing bracket does not match indentation of opening bracket's line
launchd.py:35:1: W293 blank line contains whitespace
virt.py:49:1: E302 expected 2 blank lines, found 1
virt.py:55:80: E501 line too long (89 > 79 characters)
virt.py:116:1: W293 blank line contains whitespace
virt.py:310:80: E501 line too long (83 > 79 characters)
winrepo.py:38:63: W291 trailing whitespace
winrepo.py:41:33: E128 continuation line under-indented for visual indent
winrepo.py:50:1: E302 expected 2 blank lines, found 1
winrepo.py:64:80: E501 line too long (84 > 79 characters)
```

after refactor: no errors

```
doc.py
jobs.py
virt.py
```

after refacter:pep8 errors left:

```
launchd.py:12:80: E501 line too long (102 > 79 characters)
winrepo.py:33:80: E501 line too long (80 > 79 characters)
winrepo.py:41:80: E501 line too long (83 > 79 characters)
winrepo.py:42:80: E501 line too long (96 > 79 characters)
```
