### PR TITLE
dctrl-tools belongs in depends, not build-depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,6 @@ Priority: optional
 Maintainer: Sean Channel <pentabular@gmail.com>
 Build-Depends: debhelper (>= 7.0.50),
                cython,
-               dctrl-tools,
                python | python-all | python-dev | python-all-dev,
                python-crypto,
                python-jinja2,
@@ -28,6 +27,7 @@ Depends: ${python:Depends}, ${misc:Depends}, ${shlibs:Depends},
          python-m2crypto,
          python-yaml,
          python-zmq,
+         dctrl-tools,
          msgpack-python
 Recommends: dmidecode, pciutils
 Description: Shared libraries that salt requires for all packages


### PR DESCRIPTION
Corrects slight debian packaging mistake from yesterday.
