### PR TITLE
Added support for (Net|Open)BSD's ethernet addresses and netmasks

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -178,7 +178,6 @@ def _netbsd_gpu_data(osdata):
       - vendor: nvidia|amd|ati|...
         model: string
     '''
-    # dominant gpu vendors to search for (MUST be lowercase for matching below)
     known_vendors = ['nvidia', 'amd', 'ati', 'intel', 'cirrus logic', 'vmware']
 
     gpus = []

--- a/salt/utils/socket_util.py
+++ b/salt/utils/socket_util.py
@@ -215,10 +215,10 @@ def _interfaces_ifconfig(out):
     ret = dict()
 
     piface = re.compile(r'^([^\s:]+)')
-    pmac = re.compile('.*?(?:HWaddr|ether) ([0-9a-fA-F:]+)')
+    pmac = re.compile('.*?(?:HWaddr|ether|address:|lladdr) ([0-9a-fA-F:]+)')
     pip = re.compile(r'.*?(?:inet addr:|inet )(.*?)\s')
     pip6 = re.compile('.*?(?:inet6 addr: (.*?)/|inet6 )([0-9a-fA-F:]+)')
-    pmask = re.compile(r'.*?(?:Mask:|netmask )(?:([0-9a-fA-F]{8})|([\d\.]+))')
+    pmask = re.compile(r'.*?(?:Mask:|netmask )(?:((?:0x)?[0-9a-fA-F]{8})|([\d\.]+))')
     pmask6 = re.compile(r'.*?(?:inet6 addr: [0-9a-fA-F:]+/(\d+)|prefixlen (\d+)).*')
     pupdown = re.compile('UP')
     pbcast = re.compile(r'.*?(?:Bcast:|broadcast )([\d\.]+)')


### PR DESCRIPTION
NetBSD's ifconfig output prints hardware address after the keyword "address:", OpenBSD uses the "lladdr" keyword.
