### PR TITLE
grains/core : fix fqdn / domain return on SunOS systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -813,7 +813,10 @@ def hostname():
     #   domain
     grains = {}
     grains['localhost'] = socket.gethostname()
-    grains['fqdn'] = socket.getfqdn()
+    if (re.search("\.", socket.getfqdn())):
+        grains['fqdn'] = socket.getfqdn()
+    else :
+        grains['fqdn'] = grains['localhost']
     (grains['host'], grains['domain']) = grains['fqdn'].partition('.')[::2]
     return grains
 


### PR DESCRIPTION
getfqdn() on Solaris platforms returns the unqualified hostname. In
that case, using gethostname() could be a solution.

Tested on SmartOS / Solaris 11 / FreeBSD
