### PR TITLE
Bugfix: NPM module and state (support for JSON Arrays)

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -84,15 +84,9 @@ def install(pkg=None,
 
     lines = result['stdout'].splitlines()
 
-    while ' -> ' in lines[0]:
-        lines = lines[1:]
-
     # Strip all lines until JSON output starts
-    for i in lines:
-        if i.startswith('{'):
-            break
-        else:
-            lines = lines[1:]
+    while not lines[0].startswith("{") and not lines[0].startswith("["):
+        lines = lines[1:]
 
     try:
         return json.loads(''.join(lines))

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -58,7 +58,7 @@ def installed(name,
         ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
         return ret
 
-    if call:
+    if call or isinstance(call, list) or isinstance(call, dict):
         ret['result'] = True
         version = call[0]['version']
         pkg_name = call[0]['name']


### PR DESCRIPTION
NPM may return JSON arrays which were not supported by the NPM module and the NPM state. If you try to install an already existing NPM package the state fails.
