### PR TITLE
yumpkg5: Comment indicates this is used on python >= 2.6 instead of < 2....

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -17,7 +17,7 @@ def __virtual__():
     '''
     Confine this module to yum based systems
     '''
-    # Work only on RHEL/Fedora based distros with python 2.6 or greater
+    # Work only on RHEL/Fedora based distros with python 2.5 and below
     try:
         os_grain = __grains__['os']
         os_family = __grains__['os_family']


### PR DESCRIPTION
...6
