### PR TITLE
/usr/bin/env python -> /usr/bin/python in scripts

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -13,3 +13,7 @@ SALT_BIN = common minion master syndic
 
 dh_override_auto_build:
 	python setup.py build
+
+override_dh_installdeb:
+	dh_installdeb
+	find . -type f -regex .*/usr/bin/.* -exec sed -i -e 's/^\(#!\/usr\/bin\/\)env \(python\)$$/\1\2/' {} \;


### PR DESCRIPTION
This is fix to change #!/usr/bin/env python to #!/usr/bin/python while building debian binary packages.
