### PR TITLE
Add options parameter to brew module.

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -181,7 +181,9 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
     options
         Options to pass to brew. Only applies to inital install. Due to how brew
         works, modifying chosen options requires a full uninstall followed by a
-        fresh install.
+        fresh install. Note that if "pkgs" is used, all options will be passed
+        to all packages. Unreconized options for a package will be silently
+        ignored by brew.
 
         CLI Example::
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -166,12 +166,14 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         ignored if "pkgs" is passed.
 
         CLI Example::
+
             salt '*' pkg.install <package name>
 
     taps
         Unofficial Github repos to use when updating and installing formulas.
 
         CLI Example::
+
             salt '*' pkg.install <package name> tap='<tap>'
             salt '*' pkg.install zlib taps='homebrew/dupes'
             salt '*' pkg.install php54 taps='["josegonzalez/php", "homebrew/dupes"]'
@@ -182,6 +184,7 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         fresh install.
 
         CLI Example::
+
             salt '*' pkg.install <package name> tap='<tap>'
             salt '*' pkg.install php54 taps='["josegonzalez/php", "homebrew/dupes"]' options='["--with-fpm"]'
 
@@ -191,6 +194,7 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         A list of formulas to install. Must be passed as a python list.
 
         CLI Example::
+
             salt '*' pkg.install pkgs='["foo","bar"]'
 
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -157,7 +157,7 @@ def remove(name=None, pkgs=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def install(name=None, pkgs=None, taps=None, **kwargs):
+def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
     '''
     Install the passed package(s) with ``brew install``
 
@@ -175,6 +175,15 @@ def install(name=None, pkgs=None, taps=None, **kwargs):
             salt '*' pkg.install <package name> tap='<tap>'
             salt '*' pkg.install zlib taps='homebrew/dupes'
             salt '*' pkg.install php54 taps='["josegonzalez/php", "homebrew/dupes"]'
+
+    options
+        Options to pass to brew. Only applies to inital install. Due to how brew
+        works, modifying chosen options requires a full uninstall followed by a
+        fresh install.
+
+        CLI Example::
+            salt '*' pkg.install <package name> tap='<tap>'
+            salt '*' pkg.install php54 taps='["josegonzalez/php", "homebrew/dupes"]' options='["--with-fpm"]'
 
     Multiple Package Installation Options:
 
@@ -219,7 +228,11 @@ def install(name=None, pkgs=None, taps=None, **kwargs):
             else:
                 _tap(tap)
 
-    cmd = 'brew install {0}'.format(formulas)
+    if options:
+        cmd = 'brew install {0} {1}'.format(formulas, ' '.join(options))
+    else:
+        cmd = 'brew install {0}'.format(formulas)
+
     if user != __opts__['user']:
         __salt__['cmd.run'](cmd, runas=user)
     else:


### PR DESCRIPTION
Adds additional support for the many brew packages that can be installed with options. Brew itself however does not handle the reinstall process if you want to change the options after install. Brew currently forces you to do an uninstall followed by a install.

I imagine that we could automate the updating of options as the `brew info <pkg name>` command does contain info about what the last install options were. However parsing that and comparing to the state options is a bit much for me to take on right now.
