### PR TITLE
Missing import and some formatting love to `salt.{modules,states}.eselect`

### DIFF
--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -2,6 +2,10 @@
 Support for eselect: the Gentoo's configuration and management tool.
 '''
 
+# Import salt libs
+import salt.utils
+
+
 def __virtual__():
     '''
     Only work on Gentoo systems with eselect installed
@@ -10,59 +14,71 @@ def __virtual__():
         return 'eselect'
     return False
 
-def exec_action(module,action,parameter='',state_only=False):
+
+def exec_action(module, action, parameter='', state_only=False):
     '''
     Execute an arbitrary action on a module.
-    
+
     CLI Example::
-    
+
         salt '*' eselect.exec_action <module name> <action> [parameter]
     '''
-    out = __salt__['cmd.run']("eselect --brief --colour=no {0} {1} {2}".format(module,action,parameter)).strip().split('\n')
+    out = __salt__['cmd.run'](
+        'eselect --brief --colour=no {0} {1} {2}'.format(
+            module, action, parameter
+        )
+    )
+    out = out.strip().split('\n')
+
     if out[0].startswith('!!! Error'):
         return False
-    elif state_only:
+
+    if state_only:
         return True
-    else:
-        return out
+
+    return out
+
 
 def get_modules():
     '''
     Get available modules list.
-    
+
     CLI Example::
-    
+
         salt '*' eselect.get_modules
     '''
-    return exec_action('modules','list')
+    return exec_action('modules', 'list')
+
 
 def get_target_list(module):
     '''
     Get available target for the given module.
-    
+
     CLI Example::
-    
+
         salt '*' eselect.get_target_list <module name>
     '''
-    return exec_action(module,'list')
+    return exec_action(module, 'list')
+
 
 def get_current_target(module):
     '''
     Get the currently selected target for the given module.
-    
+
     CLI Example::
-    
+
         salt '*' eselect.get_current_target <module name>
     '''
-    return exec_action(module,'show')[0]
+    return exec_action(module, 'show')[0]
 
-def set_target(module,target):
+
+def set_target(module, target):
     '''
     Set the target for the given module.
     Target can be specified by index or name.
-    
+
     CLI Example::
-    
+
         salt '*' eselect.set_target <module name> <target>
     '''
-    return exec_action(module,'set',target, state_only=True)
+    return exec_action(module, 'set', target, state_only=True)

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -11,13 +11,20 @@ A state module to manage Gentoo configuration via eselect
             target: hardened/linux/amd64
 '''
 
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
 def __virtual__():
     '''
     Only load if the eselect module is available in __salt__
     '''
     return 'eselect' if 'eselect.exec_action' in __salt__ else False
 
-def set(name, target):
+
+def set_(name, target):
     '''
     Verify that the given module is set to the given target
 
@@ -25,28 +32,40 @@ def set(name, target):
         The name of the module
     '''
     ret = {'changes': {},
-             'comment': '',
-             'name': name,
-             'result': True}
-    
+           'comment': '',
+           'name': name,
+           'result': True}
+
     old_target = __salt__['eselect.get_current_target'](name)
-    
+
     if target == old_target:
-        ret['comment'] = 'Target "{0}" is already set on "{1}" module.'.format(target,name)
+        ret['comment'] = 'Target {0!r} is already set on {1!r} module.'.format(
+            target, name
+        )
     elif target not in __salt__['eselect.get_target_list'](name):
-        ret['comment'] = 'Target "{0}" is not available for "{1}" module.'.format(target,name)
+        ret['comment'] = (
+            'Target {0!r} is not available for {1!r} module.'.format(
+                target, name
+            )
+        )
         ret['result'] = False
     elif __opts__['test']:
-        ret['comment'] = 'Target "{0}" will be set on "{1}" module.'.format(target,name)
+        ret['comment'] = 'Target {0!r} will be set on {1!r} module.'.format(
+            target, name
+        )
         ret['result'] = None
-        return ret
     else:
-        result = __salt__['eselect.set_target'](name,target)
+        result = __salt__['eselect.set_target'](name, target)
         if result:
-            ret['comment'] = 'Target "{0}" failed to be set on "{1}" module.'.format(target,name)
+            ret['comment'] = (
+                'Target {0!r} failed to be set on {1!r} module.'.format(
+                    target, name
+                )
+            )
             ret['result'] = False
         else:
-            ret['changes'][name] = {'old':old_target,'new':target}
-            ret['comment'] = 'Target "{0}" set on "{1}" module.'.format(target,name)
-    
+            ret['changes'][name] = {'old': old_target, 'new': target}
+            ret['comment'] = 'Target {0!r} set on {1!r} module.'.format(
+                target, name
+            )
     return ret


### PR DESCRIPTION
- Add missing import.
- Use function alias in order not to shadow `set`
- Simplify some reading logic
- PEP-8 and formatting fixes.
