### PR TITLE
Add NetBSD groupadd/useradd

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -13,7 +13,10 @@ def __virtual__():
     '''
     Set the user module if the kernel is Linux or OpenBSD
     '''
-    return 'group' if __grains__['kernel'] in ('Linux', 'OpenBSD') else False
+    return (
+        'group' if __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD')
+        else False
+    )
 
 
 def add(name, gid=None, system=False):

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -19,7 +19,9 @@ def __virtual__():
     '''
 
     # Disable on Windows, a specific file module exists:
-    if salt.utils.is_windows() or __grains__['kernel'] == 'SunOS':
+    if salt.utils.is_windows() or __grains__['kernel'] in (
+                'SunOS', 'NetBSD'
+            ):
         return False
     return 'shadow'
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -34,7 +34,8 @@ def __virtual__():
                                 'list_groups', 'list_users', '__virtual__'):
                     delattr(mod, attr)
     return (
-        'user' if __grains__['kernel'] in ('Linux', 'Darwin', 'OpenBSD')
+        'user' if __grains__['kernel'] in ('Linux', 'Darwin', 'OpenBSD',
+                                           'NetBSD')
         else False
     )
 
@@ -120,7 +121,8 @@ def add(name,
     if not unique:
         cmd += '-o '
     if system:
-        cmd += '-r '
+        if not __grains__['kernel'] == 'NetBSD':
+            cmd += '-r '
     cmd += name
     ret = __salt__['cmd.run_all'](cmd)['retcode']
     if ret != 0:

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -49,7 +49,7 @@ def _changes(name,
     otherwise return False.
     '''
 
-    if __grains__['os'] not in ('FreeBSD', 'OpenBSD'):
+    if __grains__['os'] not in ('FreeBSD', 'OpenBSD', 'NetBSD'):
         lshad = __salt__['shadow.info'](name)
 
     lusr = __salt__['user.info'](name)
@@ -96,7 +96,7 @@ def _changes(name,
         if lusr['shell'] != shell:
             change['shell'] = shell
     if password:
-        if __grains__['os'] not in ('FreeBSD', 'OpenBSD'):
+        if __grains__['os'] not in ('FreeBSD', 'OpenBSD', 'NetBSD'):
             if lshad['pwd'] == '!' or \
                     lshad['pwd'] != '!' and enforce_password:
                 if lshad['pwd'] != password:
@@ -263,7 +263,7 @@ def present(name,
                 ret['comment'] += '{0}: {1}\n'.format(key, val)
             return ret
         # The user is present
-        if not __grains__['os'] in ('FreeBSD', 'OpenBSD'):
+        if not __grains__['os'] in ('FreeBSD', 'OpenBSD', 'NetBSD'):
             lshad = __salt__['shadow.info'](name)
         pre = __salt__['user.info'](name)
         for key, val in changes.items():
@@ -282,14 +282,14 @@ def present(name,
 
         post = __salt__['user.info'](name)
         spost = {}
-        if __grains__['os'] not in ('FreeBSD', 'OpenBSD'):
+        if __grains__['os'] not in ('FreeBSD', 'OpenBSD', 'NetBSD'):
             if lshad['pwd'] != password:
                 spost = __salt__['shadow.info'](name)
         # See if anything changed
         for key in post:
             if post[key] != pre[key]:
                 ret['changes'][key] = post[key]
-        if __grains__['os'] not in ('FreeBSD', 'OpenBSD'):
+        if __grains__['os'] not in ('FreeBSD', 'OpenBSD', 'NetBSD'):
             for key in spost:
                 if lshad[key] != spost[key]:
                     ret['changes'][key] = spost[key]


### PR DESCRIPTION
This adds netbsd support to the modules `useradd` and `groupadd`. The `user.info` salt module is currently missing on netbsd -- netbsd does support the `useradd` and `groupadd` commands, but not python's `spwd` module (similar to freebsd with #3321):

https://gist.github.com/agjohnson/5609511

The nbsd useradd command doesn't support the system (`-r`) flag. For now, this patch disregards the system flag, though I suppose forcing a low uid and `/sbin/nologin` shell would emulate a system user? If there is any input on this I can rework the patch to do something intelligent with the system flag.

Also, is it best to disable netbsd (freebsd, openbsd) on the `shadow` module with https://github.com/agjohnson/salt/commit/fd06ef830d580742cc5b4078db326ac697f43f09#L1R23?
