### PR TITLE
Adds force_checkout option to git state.

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -36,6 +36,7 @@ def latest(name,
            target=None,
            runas=None,
            force=None,
+           force_checkout=False,
            submodules=False,
            mirror=False,
            bare=False,
@@ -56,6 +57,9 @@ def latest(name,
         Name of the user performing repository management operations
     force
         Force git to clone into pre-existing directories (deletes contents)
+    force_checkout
+        Force a checkout even if there might be overwritten changes
+        (Default: False)
     submodules
         Update submodules on clone or branch change (Default: False)
     mirror
@@ -134,7 +138,10 @@ def latest(name,
                                               user=runas,
                                               identity=identity)
 
-                    __salt__['git.checkout'](target, rev, user=runas)
+                    __salt__['git.checkout'](target,
+                                             rev,
+                                             force=force_checkout,
+                                             user=runas)
 
                 # check if we are on a branch to merge changes
                 cmd = "git symbolic-ref -q HEAD > /dev/null"


### PR DESCRIPTION
I clone the homebrew repo to /usr/local/homebrew and on occasion changes will occur to the one or more files in the repo during the typical usage of brew. Most times it is just permissions, but no matter the changes, if I'm running state.highstate I'm expecting the repo that is managed via git.latest to be up to date after the salt run if I've passed enough options to allow git.latest to be destructive.
