### PR TITLE
jinja2 templates: Enable the 'do' and 'loopcontrols' extensions

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -87,8 +87,14 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     else:
         loader = JinjaSaltCacheLoader(opts, context['env'])
     env_args = {'extensions': [], 'loader': loader}
+
     if hasattr(jinja2.ext, 'with_'):
         env_args['extensions'].append('jinja2.ext.with_')
+    if hasattr(jinja2.ext, 'do'):
+        env_args['extensions'].append('jinja2.ext.do')
+    if hasattr(jinja2.ext, 'loopcontrols'):
+        env_args['extensions'].append('jinja2.ext.loopcontrols')
+
     if opts.get('allow_undefined', False):
         jinja_env = jinja2.Environment(**env_args)
     else:


### PR DESCRIPTION
As discussed in https://github.com/saltstack/salt/pull/3186#issuecomment-17097427

This commit enables 2 extensions in jinja2 that then provide 3 very useful constructs:
- do
- break
- continue

While the intention of jinja2 is generally to encourage more code and logic in the app and less in the template, I believe in salt's case where the user is just writing templates, opening these up is a good idea.
