### PR TITLE
Don't memoize user.list_groups, Fix #5154

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -439,12 +439,7 @@ def list_groups(name):
         # it does not exist
         pass
 
-    # If we already grabbed the group list, it's overkill to grab it again
-    if 'user.getgrall' in __context__:
-        groups = __context__['user.getgrall']
-    else:
-        groups = grp.getgrall()
-        __context__['user.getgrall'] = groups
+    groups = grp.getgrall()
 
     # Now, all other groups the user belongs to
     for group in groups:


### PR DESCRIPTION
The memoization here was causing incorrect group reports when creating a new user in `user.present.`  Rather than trying to pop the `__context__` under certain conditions, I removed the memoization.  I figure if you're querying a user's group list, you want up-to-date information.  (Also it's not an intensive call to figure out a user's groups, so the optimization is negligible)
