### PR TITLE
Don't try to get the `_fmt` attribute if there's no formatter. 

### DIFF
--- a/salt/log.py
+++ b/salt/log.py
@@ -166,6 +166,9 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS):
                 handler.acquire()
 
                 formatter = handler.formatter
+                if not formatter:
+                    continue
+
                 fmt = formatter._fmt.replace('%', '%%')
 
                 match = MODNAME_PATTERN.search(fmt)


### PR DESCRIPTION
Refs saltstack/salt-cloud#589
