### PR TITLE
Fix syntax error in jinja context examples

### DIFF
--- a/doc/ref/renderers/all/salt.renderers.jinja.rst
+++ b/doc/ref/renderers/all/salt.renderers.jinja.rst
@@ -67,10 +67,10 @@ template, using the ``defaults`` and ``context`` mappings of the
         - source: salt://motd
         - template: jinja
         - defaults:
-          message: 'Foo'
+            message: 'Foo'
         {% if grains['os'] == 'FreeBSD' %}
         - context:
-          message: 'Bar'
+            message: 'Bar'
         {% endif %}
 
 The template will receive a variable ``message``, which would be accessed in the


### PR DESCRIPTION
Bad indentation meant it would pass in the pieces of context as part of
the **kwargs, rather than as part of the context kwarg.
