### PR TITLE
fixed: TypeError in pkg._find_install_targets when version is None

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -109,7 +109,7 @@ def _find_install_targets(name=None, version=None, pkgs=None, sources=None):
         desired = {name: version}
 
         cver = cur_pkgs.get(name, [])
-        if version in cver:
+        if version and version in cver:
             # The package is installed and is the correct version
             return {'name': name,
                     'changes': {},


### PR DESCRIPTION
here's an example traceback:

```
State: - pkg
Name:      libgeos-c1
Function:  installed
     Result:    False
     Comment:   An exception occurred in this state: Traceback (most recent call last):
File "/usr/lib/pymodules/python2.7/salt/state.py", line 1201, in call
 *cdata['args'], **cdata['kwargs'])
File "/usr/lib/pymodules/python2.7/salt/states/pkg.py", line 325, in installed
 result = _find_install_targets(name, version, pkgs, sources)
File "/usr/lib/pymodules/python2.7/salt/states/pkg.py", line 95, in _find_install_targets
 if version in cver:
TypeError: 'in <string>' requires string as left operand, not NoneType
```
