### PR TITLE
Replace _parse_yum function, add yum-utils dep for RPM

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -36,6 +36,7 @@ Requires: dmidecode
 %endif
 
 Requires: pciutils
+Requires: yum-utils
 
 %if 0%{?with_python26}
 BuildRequires: python26-zmq


### PR DESCRIPTION
This commit fixes #4998 by getting rid of the parsing of yum output and replacing it with calls to repoquery. It also adds a dependency on yum-utils to the spec file. yum-utils is in RHEL/CentOS base but does not appear to be a default package (at least, not when installing CentOS from the minimal install ISO). Nevertheless, it requires no additional deps be packaged, so it is a painless addition to the spec file.
