### PR TITLE
Fix salt.modules.mount for FreeBSD

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -287,9 +287,10 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults'):
     if not os.path.exists(name) and mkmnt:
         os.makedirs(name)
     lopts = ','.join(opts)
-    cmd = 'mount -o {0} {1} {2} '.format(lopts, device, name)
+    args = '-o {0}'.format(lopts)
     if fstype:
-        cmd += ' -t {0}'.format(fstype)
+        args += ' -t {0}'.format(fstype)
+    cmd = 'mount {0} {1} {2} '.format(args, device, name)
     out = __salt__['cmd.run_all'](cmd)
     if out['retcode']:
         return out['stderr']

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -314,9 +314,10 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults'):
         if 'remount' not in opts:
             opts.append('remount')
         lopts = ','.join(opts)
-        cmd = 'mount -o {0} {1} {2} '.format(lopts, device, name)
+        args = '-o {0}'.format(lopts)
         if fstype:
-            cmd += ' -t {0}'.format(fstype)
+            args += ' -t {0}'.format(fstype)
+        cmd = 'mount {0} {1} {2} '.format(args, device, name)
         out = __salt__['cmd.run_all'](cmd)
         if out['retcode']:
             return out['stderr']


### PR DESCRIPTION
I've changed the way in which the mount.active function worked to use the `mount -p` command on FreeBSD as it doesn't support either of the `/proc/self` methods currently implemented.

I've also changed the way in which the `mount` arguments in mount and remount functions are created to ensure that flags/switches are passed first before the plain arguments as this was causing an invocation error when calling `mount` on FreeBSD.

The argument changes should be fine to pull, the mount.active I'm less sure about. I don't know if its better to look at the grains 'os' or to add another try/except block but I'm not a fan of having them too deeply nested.
