### PR TITLE
Add Xen DomU detection for FreeBSD.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -455,8 +455,12 @@ def _virtual(osdata):
         kenv = salt.utils.which('kenv')
         if kenv:
             product = __salt__['cmd.run']('{0} smbios.system.product'.format(kenv))
+            maker = __salt__['cmd.run']('{0} smbios.system.maker'.format(kenv))
             if product.startswith('VMware'):
                 grains['virtual'] = 'VMware'
+            if maker.startswith('Xen'):
+                grains['virtual_subtype'] = '{0} {1}'.format(maker, product)
+                grains['virtual'] = 'xen'
         if sysctl:
             model = __salt__['cmd.run']('{0} hw.model'.format(sysctl))
             jail = __salt__['cmd.run']('{0} -n security.jail.jailed'.format(sysctl))


### PR DESCRIPTION
I think I've kept this consistent with the Linux 'virtual' detection results.
