### PR TITLE
Replace `rpmUtils.arch.getBaseArch()` with `rpmUtils.arch.getCanonArch()`

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -122,7 +122,7 @@ def list_upgrades(refresh=True):
                 pkglist, [pkg]
             )
             for pkg in exactmatch:
-                if pkg.arch == rpmUtils.arch.getBaseArch() \
+                if pkg.arch == rpmUtils.arch.getCanonArch() \
                         or pkg.arch == 'noarch':
                     versions_list[pkg['name']] = '-'.join(
                         [pkg['version'], pkg['release']]
@@ -200,7 +200,7 @@ def latest_version(*names, **kwargs):
         )
         for pkg in exactmatch:
             if pkg.name in ret \
-                    and (pkg.arch == rpmUtils.arch.getBaseArch()
+                    and (pkg.arch == rpmUtils.arch.getCanonArch()
                          or pkg.arch == 'noarch'):
                 ret[pkg.name] = '-'.join([pkg.version, pkg.release])
 


### PR DESCRIPTION
According to the `rpmUtils.arch` source code, when [no argument](http://yum.baseurl.org/gitweb?p=yum.git;a=blob;f=rpmUtils/arch.py;h=72cba605ce8af2a72ebe624175e9914cf03e430a;hb=30c993c19b8b85f44e7cec436484862ab55a6961#l353) is passed to `rpmUtils.arch.getBaseArch()`, the result should be the same as `rpmUtils.arch.getCanonArch()`[[look here](http://yum.baseurl.org/gitweb?p=yum.git;a=blob;f=rpmUtils/arch.py;h=72cba605ce8af2a72ebe624175e9914cf03e430a;hb=30c993c19b8b85f44e7cec436484862ab55a6961#l320)]. However, in CentOS 6.4 with yum-3.2.29-40.el6.centos.noarch:

``` python
>>> import rpmUtils.arch
>>> rpmUtils.arch.getBaseArch()
'i386'
>>> rpmUtils.arch.getBaseArch(None)
'i386'
>>> rpmUtils.arch.getCanonArch()
'i686'
>>>
```

This little thing made the `pkg.latest` state fail, and also the `pkg.latest_version` module function.

@terminalmage, I need your input on this. Is this the right approach?
