### PR TITLE
Added fall back to "webrsync" in case of failure of "rsync" Portage synchronization and GPG support.

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -223,8 +223,21 @@ def refresh_db():
     '''
     if 'eix.sync' in __salt__:
         return __salt__['eix.sync']()
-    return __salt__['cmd.retcode']('emerge --sync --ask n --quiet') == 0
 
+    if 'makeconf.features_contains'in __salt__ and __salt__['makeconf.features_contains']('webrsync-gpg'):
+        # GPG sign verify is supported only for "webrsync"
+        cmd='emerge-webrsync -q'
+        if salt.utils.which('emerge-delta-webrsync'): # We prefer 'delta-webrsync' to 'webrsync'
+            cmd='emerge-delta-webrsync -q'
+        return __salt__['cmd.retcode'](cmd) == 0
+    else:
+        if __salt__['cmd.retcode']('emerge --sync --ask n --quiet') == 0:
+            return True
+        # We fall back to "webrsync" if "rsync" fails for some reason
+        cmd='emerge-webrsync -q'
+        if salt.utils.which('emerge-delta-webrsync'): # We prefer 'delta-webrsync' to 'webrsync'
+            cmd='emerge-delta-webrsync -q'
+        return __salt__['cmd.retcode'](cmd) == 0
 
 def install(name=None,
             refresh=False,

--- a/salt/modules/eix.py
+++ b/salt/modules/eix.py
@@ -23,8 +23,22 @@ def sync():
         salt '*' eix.sync
     '''
     cmd = 'eix-sync -q'
-    return __salt__['cmd.retcode'](cmd) == 0
-
+    if 'makeconf.features_contains'in __salt__ and __salt__['makeconf.features_contains']('webrsync-gpg'):
+        # GPG sign verify is supported only for "webrsync"
+        if salt.utils.which('emerge-delta-webrsync'): # We prefer 'delta-webrsync' to 'webrsync'
+            cmd+=' -W'
+        else:
+            cmd+=' -w'
+        return __salt__['cmd.retcode'](cmd) == 0
+    else:
+        if __salt__['cmd.retcode'](cmd) == 0:
+            return True
+        # We fall back to "webrsync" if "rsync" fails for some reason
+        if salt.utils.which('emerge-delta-webrsync'): # We prefer 'delta-webrsync' to 'webrsync'
+            cmd+=' -W'
+        else:
+            cmd+=' -w'
+        return __salt__['cmd.retcode'](cmd) == 0
 
 def update():
     '''


### PR DESCRIPTION
Added fall back to "webrsync" in case of failure of "rsync" Portage synchronization.
Added support for GPG signed Portage snapshot ("webrsync-gpg" feature).
"emerge-delta-webrsync" is also supported and preferred.
This code require #5198
