### PR TITLE
Added correct path for Gentoo iptables config file.

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -29,6 +29,8 @@ def _conf():
         return '/etc/sysconfig/iptables'
     elif __grains__['os_family'] == 'Arch':
         return '/etc/iptables/iptables.rules'
+    elif __grains__['os'] == 'Gentoo':
+        return '/var/lib/iptables/rules-save'
     else:
         return False
 


### PR DESCRIPTION
Gentoo also have a service to enforce iptables rules, maybe you can consider to handle it in some way.
I would have done that by myself, but this module looks to be still under heavy development and I don't want to create new issues.
