### PR TITLE
client.py: fix punctuation typo

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -256,7 +256,7 @@ class LocalClient(object):
         '''
         group = self.cmd(tgt, 'sys.list_functions', expr_form=expr_form)
         f_tgt = []
-        for minion. ret in group.items():
+        for minion, ret in group.items():
             if len(f_tgt) >= sub:
                 break
             if fun in ret:


### PR DESCRIPTION
```
************* Module salt.client
E0602:259,12:LocalClient.cmd_subset: Undefined variable 'minion'
E0602:263,29:LocalClient.cmd_subset: Undefined variable 'minion'
```
