### PR TITLE
cmd state: add space after comma

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -613,7 +613,7 @@ def script(name,
  
     # If script args present split from name and define args
     if len(name.split()) > 1:
-        cmd_kwargs.update({'args': name.split(' ',1)[1]})
+        cmd_kwargs.update({'args': name.split(' ', 1)[1]})
     
     try:
         cret = _run_check(


### PR DESCRIPTION
```
************* Module salt.states.cmd
C0324:616,8:script: Comma not followed by a space
        cmd_kwargs.update({'args': name.split(' ',1)[1]})
                                                 ^^
```
