### PR TITLE
xapi mod: add comma after space

### DIFF
--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -719,7 +719,7 @@ def vm_netstats(vm_=None):
                 return False
             for vif in vm_rec['VIFs']:
                 vif_rec = _get_record(xapi, 'VIF', vif)
-                ret[vif_rec['device']] = _get_metrics_record(xapi,'VIF',
+                ret[vif_rec['device']] = _get_metrics_record(xapi, 'VIF',
                                                             vif_rec)
                 del ret[vif_rec['device']]['last_updated']
     


### PR DESCRIPTION
```
************* Module salt.modules.xapi
C0324:722,16:vm_netstats._info: Comma not followed by a space
                ret[vif_rec['device']] = _get_metrics_record(xapi,'VIF',
                                                                 ^^
                                                            vif_rec)
```
