### PR TITLE
bridge mod: add spaces after commas

### DIFF
--- a/salt/modules/bridge.py
+++ b/salt/modules/bridge.py
@@ -208,8 +208,8 @@ def _os_dispatch(func, *args, **kwargs):
     '''
     Internal, dispatches functions by operating system
     '''
-    _os_func = getattr(sys.modules[__name__],'_{0}_{1}'.
-                            format(__grains__['kernel'].lower(),func))
+    _os_func = getattr(sys.modules[__name__], '_{0}_{1}'.
+                            format(__grains__['kernel'].lower(), func))
     if callable(_os_func):
         return _os_func(*args, **kwargs)
 


### PR DESCRIPTION
```
************* Module salt.modules.bridge
C0324:211,4:_os_dispatch: Comma not followed by a space
```
