### PR TITLE
bridge module: avoid bare `except:`

### DIFF
--- a/salt/modules/bridge.py
+++ b/salt/modules/bridge.py
@@ -284,7 +284,7 @@ def find_interfaces(*args):
             try: # a bridge may not contain interfaces
                 if iface in brs[br]['interfaces']:
                     iflist[iface] = br
-            except:
+            except Exception:
                 pass
 
     return iflist


### PR DESCRIPTION
```
************* Module salt.modules.bridge
W0702:287,12:find_interfaces: No exception type(s) specified
```
