### PR TITLE
Added the 'ip_interfaces' grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -846,6 +846,21 @@ def ip4():
     ips = salt.utils.socket_util.ip4_addrs()
     return {'ipv4': ips}
 
+def ip_interfaces():
+    '''
+    Provide a dict of the connected interfaces and their ip addresses
+    '''
+    # Provides:
+    #   ip_interfaces
+    ret = {}
+    ifaces = salt.utils.socket_util.interfaces()
+    for face in ifaces:
+        iface_ips = []
+        for inet in ifaces[face].get('inet', []):
+            if 'address' in inet:
+                iface_ips.append(inet['address'])
+        ret[face] = iface_ips
+    return {'ip_interfaces': ret}
 
 def path():
     '''


### PR DESCRIPTION
This grain returns a dict of the interfaces and their ip address which
is handy when you want to build a config file with a specfic known
interface. The current 'ipv4' grain is useless for this.
