### PR TITLE
Allow slashes in gitfs envs, Fix #5007

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -53,7 +53,9 @@ def _get_ref(repo, short):
     '''
     for ref in repo.refs:
         if isinstance(ref, git.RemoteReference):
-            if short == os.path.basename(ref.name):
+            parted = ref.name.partition('/')
+            refname = parted[2] if parted[2] else parted[0]
+            if short == refname:
                 return ref
     return False
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -152,7 +152,8 @@ def envs():
     for repo in repos:
         remote = repo.remote()
         for ref in repo.refs:
-            short = os.path.basename(ref.name)
+            parted = ref.name.partition('/')
+            short = parted[2] if parted[2] else parted[0]
             if isinstance(ref, git.Head):
                 if short == 'master':
                     short = 'base'


### PR DESCRIPTION
Previously, we were using os.path.basename to get the last part of the "path", which we assumed was the branch (origin/master, for example).  However, if you have an env (branch) with slashes in it, it shows up as origin/dev/network or similar, and so basename was just returning network, not dev/network.

Using the string partition method, we just pull off the remote (which we assume doesn't have slashes in it), and return the rest as the env.
