### PR TITLE
Updated salt-git package with new features

### DIFF
--- a/pkg/arch/git/PKGBUILD
+++ b/pkg/arch/git/PKGBUILD
@@ -1,0 +1,88 @@
+# Maintainer: Christer Edwards <christer.edwards@gmail.com>
+pkgname=salt-git
+_gitname="salt"
+pkgver=v0.15.0.786.g0a800ec
+pkgrel=1
+pkgdesc="A remote execution and communication system built on zeromq"
+arch=('any')
+url="https://github.com/saltstack/salt"
+license=('APACHE')
+groups=()
+depends=('python2'
+         'python2-yaml'
+         'python2-jinja'
+         'python2-pyzmq'
+         'python2-crypto'
+         'python2-psutil'
+         'python2-msgpack'
+         'python2-m2crypto'
+         'logrotate'
+         'bash-completion')
+
+backup=('etc/salt/master'
+        'etc/salt/minion')
+
+makedepends=('git')
+conflicts=('salt')
+provides=('salt' 'bash-completion-salt')
+install="salt.install"
+
+# makepkg 4.1 knows about git and will pull main branch
+source=("git://github.com/saltstack/salt.git")
+
+# makepkg knows it's a git repo because the url starts with 'git'
+# it then knows to checkout the branch upon cloning, expediating versioning.
+#branch="develop"
+#source=("git://github.com/saltstack/salt.git#branch=$branch")
+
+# makepkg also knows about tags
+#tags="v0.14.1"
+#source=("git://github.com/saltstack/salt.git#tag=$tag")
+
+# because the sources are not static, skip checksums
+md5sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/$_gitname"
+  echo $(git describe --always | sed 's/-/./g')
+  # for git, if the repo has no tags, comment out the above and uncomment the next line:
+  #echo "0.$(git rev-list --count $branch).$(git describe --always)"
+  # This will give you a count of the total commits and the hash of the commit you are on.
+  # Useful if you're making a repository with git packages so that they can have sequential
+  # version numbers. (Else a pacman -Syu may not update the package)
+}
+
+#build() {
+#  cd "${srcdir}/${_gitname}"
+#  python2 setup.py build 
+   # no need to build setup.py install will do this
+#}
+
+package() {
+  cd "${srcdir}/${_gitname}"
+
+  ## build salt
+  python2 setup.py install --root=${pkgdir}/ --optimize=1
+
+  ## install salt systemd service files
+  install -Dm644 ${srcdir}/salt/pkg/arch/salt-master.service ${pkgdir}/usr/lib/systemd/system/salt-master.service
+  install -Dm644 ${srcdir}/salt/pkg/arch/salt-syndic.service ${pkgdir}/usr/lib/systemd/system/salt-syndic.service
+  install -Dm644 ${srcdir}/salt/pkg/arch/salt-minion.service ${pkgdir}/usr/lib/systemd/system/salt-minion.service
+
+  ## install salt config files
+  mkdir -p ${pkgdir}/etc/salt/master.d
+  mkdir -p ${pkgdir}/etc/salt/minion.d
+  cp ${srcdir}/salt/conf/master ${pkgdir}/etc/salt/
+  cp ${srcdir}/salt/conf/minion ${pkgdir}/etc/salt/
+
+  ## install logrotate:
+  mkdir -p ${pkgdir}/etc/logrotate.d/
+  install -Dm644 ${srcdir}/salt/pkg/salt-common.logrotate ${pkgdir}/etc/logrotate.d/salt
+
+  ## install bash-completion
+  mkdir -p ${pkgdir}usr/share/bash-completion/completion/
+  install -Dm644 ${srcdir}/salt/pkg/salt.bash ${pkgdir}usr/share/bash-completion/completion/salt
+
+  # remove vcs leftovers
+  find "$pkgdir" -type d -name .git -exec rm -r '{}' +
+}

--- a/pkg/arch/git/salt.install
+++ b/pkg/arch/git/salt.install
@@ -1,0 +1,104 @@
+# Salt: Installer: Arch
+# Maintainer: Niels Abspoel
+
+pre_install(){
+  # create salt user
+  getent passwd salt &>/dev/null || \
+    echo "salt master user doesn't exist, creating..."; \
+    useradd -r -d /srv/salt -s /sbin/nologin -c "Salt" salt &>/dev/null || :
+}
+
+pre_upgrade () {
+  pre_install
+  salthomedir=`getent passwd salt | cut -d: -f6`
+  saltdir=/srv/salt/
+  if [[ $salthomedir != $saltdir ]]; then
+    echo "setting salt master user homedir to /srv/salt/"
+    usermod -d /srv/salt/ salt &>/dev/null || :
+  fi
+}
+
+post_install() {
+  # set user permissions on directories needed for salt
+  getent passwd salt &>/dev/null && chown -R salt /var/cache/salt
+  getent passwd salt &>/dev/null && chown -R salt /var/log/salt
+  getent passwd salt &>/dev/null && chown -R salt /etc/salt/pki
+  getent passwd salt &>/dev/null && chown -R salt /srv/salt
+
+  # set salt master user in config
+  # and verify environment
+  if [[ ! -f /etc/salt/master.d/salt-user.conf ]]; then
+    if [[ ! -d /etc/salt/master.d ]]; then
+      mkdir -p /etc/salt/master.d
+    fi
+    echo "configure salt-master to run as salt master user"
+    cat << EOF1 > /etc/salt/master.d/salt-user.conf
+user: salt
+verify_env: True
+EOF1
+  fi
+
+  # set salt user limits
+  if [[ ! -f /etc/security/limits.d/20-salt.conf ]]; then
+    echo "raising file limits for salt master user"
+    cat << EOF2 > /etc/security/limits.d/20-salt.conf
+salt  soft  nofile  100000
+salt  hard  nofile  100000
+EOF2
+  fi
+}
+
+post_upgrade () {
+  # if salt-master/salt-minion daemon is running reinitialise
+  if [[ -f /var/run/salt-master.pid ]]; then
+    if [ "`systemctl is-active salt-master`" == "active" ]; then
+      echo "salt-master is running system daemons are reloaded"
+      getent passwd salt &>/dev/null && systemctl daemon-reexec
+      getent passwd salt &>/dev/null && systemctl daemon-reload
+    fi
+  fi
+  if [[ -f /var/run/salt-minion.pid ]]; then
+    if [ "`systemctl is-active salt-minion`" == "active" ]; then
+      echo "salt-minion was running system daemons are reloaded"
+      getent passwd salt &>/dev/null && systemctl daemon-reexec
+      getent passwd salt &>/dev/null && systemctl daemon-reload
+    fi
+  fi
+}
+
+pre_remove (){
+  # Stop salt-master daemon and remove it
+  if [[ -f /var/run/salt-master.pid ]]; then
+    if [ "`systemctl is-active salt-master`" == "active" ]; then
+      echo "stopping salt-master and removing it"
+      systemctl stop salt-master
+      systemctl disable salt-master
+    fi
+  fi
+
+  # Stop salt-minion daemon and remove it
+  if [[ -f /var/run/salt-minion.pid ]]; then
+    if [ "`systemctl is-active salt-minion`" == "active" ]; then
+      echo "stopping salt-minion and removing it"
+      systemctl stop salt-minion
+      systemctl disable salt-minion
+    fi
+  fi
+}
+
+post_remove (){
+  # remove shared job cache and other runtime directories
+  rm -rf \
+    /var/cache/salt \
+    /var/log/salt \
+    2> /dev/null
+  echo "shared job cache and runtime directories removed"
+  # remove salt user and group but leave /srv/salt
+  getent passwd salt &>/dev/null && userdel salt && echo "salt master user removed"
+  echo "salt has been removed but /srv/salt is still available"
+}
+
+op=$1
+shift
+
+$op "$@"


### PR DESCRIPTION
feautures:
- during installation a salt system user is created
- Creation of '/etc/salt/master.d/' for enhanced configuration
- salt-master run under own user 'salt'
- salt-user.conf created to set salt-master up for using salt system user
- added logrotate config files in appropriate place
- added bash-completion config files in appropriate place.
- Check if salt-master/salt-minion is running when upgrading
  and use systemd reexec / reload accordingly
- Updated removal of salt package to remove 'cache' and 'log' dirs.
  and removal of salt system user.
- Made installation more verbose to communicate what happens.
