### PR TITLE
Import salt.utils.winapi

### DIFF
--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -6,7 +6,7 @@ Module for gathering and managing network information
 import re
 
 # Import salt libs
-import salt.utils
+import salt.utils.winapi
 from salt.utils.socket_util import sanitize_host
 
 # Import 3rd party libraries


### PR DESCRIPTION
On line 223, salt.utils.winapi is used but was not imported.
