### PR TITLE
Only load module if windows required imports are available.

### DIFF
--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -7,23 +7,25 @@ import re
 
 # Import salt libs
 import salt.utils
-import salt.utils.winapi
 from salt.utils.socket_util import sanitize_host
+try:
+    import salt.utils.winapi
+    HAS_DEPENDENCIES = True
+except ImportError:
+    HAS_DEPENDENCIES = False
 
 # Import 3rd party libraries
-HAS_WMI = False
 try:
     import wmi
-    HAS_WMI = True
 except ImportError:
-    pass
+    HAS_DEPENDENCIES = False
 
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if salt.utils.is_windows():
+    if salt.utils.is_windows() and HAS_DEPENDENCIES is True:
         return 'network'
     return False
 


### PR DESCRIPTION
Seems the way to do it and also stops an import traceback to be logged on Linux when importing `salt.utils.winapi`.
