### PR TITLE
Fix xinetd service name to not have appended : in service name.

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -124,7 +124,7 @@ def _services():
     for line in __salt__['cmd.run']('/sbin/chkconfig --list').splitlines():
         cols = line.split()
         try:
-            name = cols[0]
+            name = cols[0].strip(':')
         except IndexError:
             continue
         if name in ret:


### PR DESCRIPTION
The xinetd support was broken in the merge with upstart.  It would leave the appended : to the service name. As shown below:

```
myserver.example.com:
    - crond
    - eklogin:
    - ekrb5-telnet:
    - ip6tables
    - iptables
```

This patch strips the : from the service name.
