### PR TITLE
Add rbenv module and states

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -1,3 +1,8 @@
+'''
+Manage ruby installations with rbenv.
+'''
+
+# Import python libs
 import os
 import re
 import logging

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -129,11 +129,14 @@ def install_ruby(ruby,runas=None):
     if __grains__['os'] in ('FreeBSD', 'NetBSD', 'OpenBSD'):
         env = 'MAKE=gmake'
 
-    result = _rbenv_exec('install', ruby, env=env, runas=runas)
-    if result == False:
+    ret = {}
+    _rbenv_exec('install', ruby, env=env, runas=runas, ret=ret)
+    if ret['retcode'] == 0:
+        return ret['stderr']
+    else:
         # Cleanup the failed installation so it doesn't list as installed
         _rbenv_exec('uninstall', ruby, runas=runas)
-    return result
+        return False
 
 def uninstall_ruby(ruby,runas=None):
     '''

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -128,7 +128,12 @@ def install_ruby(ruby,runas=None):
     env = None
     if __grains__['os'] in ('FreeBSD', 'NetBSD', 'OpenBSD'):
         env = 'MAKE=gmake'
-    return _rbenv_exec('install', ruby, env=env, runas=runas)
+
+    result = _rbenv_exec('install', ruby, env=env, runas=runas)
+    if result == False:
+        # Cleanup the failed installation so it doesn't list as installed
+        _rbenv_exec('uninstall', ruby, runas=runas)
+    return result
 
 def uninstall_ruby(ruby,runas=None):
     '''

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -125,8 +125,10 @@ def install_ruby(ruby,runas=None):
     if ruby.startswith('ruby-'):
         ruby = re.sub(r'^ruby-','',ruby)
 
-    # TODO: Add FreeBSD MAKE=gmake environment variable to this command
-    return _rbenv_exec('install', ruby, runas=runas)
+    env = None
+    if __grains__['os'] in ('FreeBSD', 'NetBSD', 'OpenBSD'):
+        env = 'MAKE=gmake'
+    return _rbenv_exec('install', ruby, env=env, runas=runas)
 
 def uninstall_ruby(ruby,runas=None):
     '''

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -1,5 +1,9 @@
 import os
 import re
+import logging
+
+# Set up logger
+log = logging.getLogger(__name__)
 
 __opts__ = {
     'rbenv.root': None,

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -135,7 +135,7 @@ def install_ruby(ruby,runas=None):
         return ret['stderr']
     else:
         # Cleanup the failed installation so it doesn't list as installed
-        _rbenv_exec('uninstall', ruby, runas=runas)
+        uninstall_ruby(ruby,runas=runas)
         return False
 
 def uninstall_ruby(ruby,runas=None):
@@ -154,7 +154,7 @@ def uninstall_ruby(ruby,runas=None):
     if ruby.startswith('ruby-'):
         ruby = re.sub(r'^ruby-','',ruby)
 
-    return _rbenv_exec('uninstall', ruby, runas=runas)
+    return _rbenv_exec('uninstall --force', ruby, runas=runas)
 
 def versions(runas=None):
     '''

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -1,0 +1,188 @@
+import os
+import re
+
+__opts__ = {
+    'rbenv.root': None,
+}
+
+def _rbenv_exec(command, args='', env=None, runas=None, ret=None):
+    if not is_installed(runas):
+        return False
+
+    bin = _rbenv_bin(runas)
+    if env:
+        bin = 'env {0} {1}'.format(env, bin)
+
+    ret = ret or {}
+    ret.update(__salt__['cmd.run_all'](
+        '{0} {1} {2}'.format(bin, command, args),
+        runas=runas
+    ))
+
+    if ret['retcode'] == 0:
+        return ret['stdout']
+    else:
+        return False
+
+def _rbenv_bin(runas=None):
+    path = _rbenv_path(runas)
+    return '{0}/bin/rbenv'.format(path)
+
+def _rbenv_path(runas=None):
+    path = None
+    if runas in (None, 'root'):
+        path = __salt__['config.option']('rbenv.root') or '/usr/local/rbenv'
+    else:
+        path = __salt__['config.option']('rbenv.root') or '~{0}/.rbenv'.format(runas)
+
+    return os.path.expanduser(path)
+
+def _install_rbenv(path,runas=None):
+    if os.path.isdir(path):
+        return True
+
+    return 0 == __salt__['cmd.retcode'](
+        'git clone https://github.com/sstephenson/rbenv.git {0}'.format(path), runas=runas)
+
+def _install_ruby_build(path,runas=None):
+    path = '{0}/plugins/ruby-build'.format(path)
+    if os.path.isdir(path):
+        return True
+
+    return 0 == __salt__['cmd.retcode'](
+        'git clone https://github.com/sstephenson/ruby-build.git {0}'.format(path), runas=runas)
+
+def _update_rbenv(path,runas=None):
+    if not os.path.isdir(path):
+        return False
+
+    return 0 == __salt__['cmd.retcode'](
+        'git pull --git-dir {0}'.format(path), runas=runas)
+
+def _update_ruby_build(path,runas=None):
+    path = '{0}/plugins/ruby-build'.format(path)
+    if not os.path.isdir(path):
+        return False
+
+    return 0 == __salt__['cmd.retcode'](
+        'git pull --git-dir {0}'.format(path), runas=runas)
+
+def install(runas=None,path=None):
+    '''
+    Install Rbenv systemwide
+
+    CLI Example::
+
+        salt '*' rbenv.install
+    '''
+
+    path = path or _rbenv_path(runas)
+    path = os.path.expanduser(path)
+    return (_install_rbenv(path, runas) and _install_ruby_build(path, runas))
+
+def update(runas=None,path=None):
+    '''
+    Updates the current versions of Rbenv and Ruby-Build
+
+    CLI Example::
+
+        salt '*' rbenv.update
+    '''
+
+    path = path or _rbenv_path(runas)
+    path = os.path.expanduser(path)
+
+    return (_update_rbenv(path, runas) and _update_ruby_build(path, runas))
+
+def is_installed(runas=None):
+    '''
+    Check if Rbenv is installed.
+
+    CLI Example::
+
+        salt '*' rbenv.is_installed
+    '''
+    return __salt__['cmd.has_exec'](_rbenv_bin(runas))
+
+def install_ruby(ruby,runas=None):
+    '''
+    Install a ruby implementation.
+
+    ruby
+        The version of Ruby to install, should match one of the
+        versions listed by rbenv.list
+
+    CLI Example::
+
+        salt '*' rbenv.install_ruby 2.0.0-p0
+    '''
+
+    if ruby.startswith('ruby-'):
+        ruby = re.sub(r'^ruby-','',ruby)
+
+    # TODO: Add FreeBSD MAKE=gmake environment variable to this command
+    return _rbenv_exec('install', ruby, runas=runas)
+
+def uninstall_ruby(ruby,runas=None):
+    '''
+    Uninstall a ruby implementation.
+
+    ruby
+        The version of ruby to uninstall. Should match one of
+        the versions listed by rbenv.versions
+
+    CLI Example::
+
+        salt '*' rbenv.uninstall_ruby 2.0.0-p0
+    '''
+
+    if ruby.startswith('ruby-'):
+        ruby = re.sub(r'^ruby-','',ruby)
+
+    return _rbenv_exec('uninstall', ruby, runas=runas)
+
+def versions(runas=None):
+    '''
+    List the installed versions of ruby.
+
+    CLI Example::
+
+        salt '*' rbenv.versions
+    '''
+
+    return _rbenv_exec('versions', '--bare', runas=runas).splitlines()
+
+def default(ruby=None,runas=None):
+    '''
+    Returns or sets the currently defined default ruby.
+
+    ruby=None
+        The version to set as the default. Should match one of
+        the versions listed by rbenv.versions.
+        Leave blank to return the current default.
+
+    CLI Example::
+
+        salt '*' rbenv.default
+        # 2.0.0-p0
+
+        salt '*' rbenv.default 2.0.0-p0
+    '''
+
+    return _rbenv_exec('global', ruby or '', runas=runas).strip()
+
+def list(runas=None):
+    '''
+    List the installable versions of ruby.
+
+    CLI Example::
+
+        salt '*' rbenv.list
+    '''
+
+    results = []
+    for line in _rbenv_exec('install', '--list', runas=runas).splitlines():
+        if line == 'Available versions:':
+            continue
+        results.append(line.strip())
+    return results

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -10,8 +10,13 @@ def _rbenv_exec(command, args='', env=None, runas=None, ret=None):
         return False
 
     bin = _rbenv_bin(runas)
+    path = _rbenv_path(runas)
+
     if env:
-        bin = 'env {0} {1}'.format(env, bin)
+        env = ' {0}'.format(env)
+    env = env or ''
+
+    bin = 'env RBENV_ROOT={0}{1} {2}'.format(path, env, bin)
 
     ret = ret or {}
     ret.update(__salt__['cmd.run_all'](

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -18,14 +18,17 @@ def _rbenv_exec(command, args='', env=None, runas=None, ret=None):
 
     bin = 'env RBENV_ROOT={0}{1} {2}'.format(path, env, bin)
 
-    ret = ret or {}
-    ret.update(__salt__['cmd.run_all'](
+    result = __salt__['cmd.run_all'](
         '{0} {1} {2}'.format(bin, command, args),
         runas=runas
-    ))
+    )
 
-    if ret['retcode'] == 0:
-        return ret['stdout']
+    if isinstance(ret, dict):
+        ret.update(result)
+        return ret
+
+    if result['retcode'] == 0:
+        return result['stdout']
     else:
         return False
 
@@ -130,7 +133,7 @@ def install_ruby(ruby,runas=None):
         env = 'MAKE=gmake'
 
     ret = {}
-    _rbenv_exec('install', ruby, env=env, runas=runas, ret=ret)
+    ret = _rbenv_exec('install', ruby, env=env, runas=runas, ret=ret)
     if ret['retcode'] == 0:
         return ret['stderr']
     else:

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -154,7 +154,9 @@ def uninstall_ruby(ruby,runas=None):
     if ruby.startswith('ruby-'):
         ruby = re.sub(r'^ruby-','',ruby)
 
-    return _rbenv_exec('uninstall --force', ruby, runas=runas)
+    args = '--force {0}'.format(ruby)
+    _rbenv_exec('uninstall', args, runas=runas)
+    return True
 
 def versions(runas=None):
     '''
@@ -184,7 +186,11 @@ def default(ruby=None,runas=None):
         salt '*' rbenv.default 2.0.0-p0
     '''
 
-    return _rbenv_exec('global', ruby or '', runas=runas).strip()
+    if ruby:
+        _rbenv_exec('global', ruby, runas=runas)
+        return True
+    else:
+        return _rbenv_exec('global', runas=runas).strip()
 
 def list(runas=None):
     '''

--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -1,0 +1,95 @@
+import re
+
+def _check_rbenv(ret,runas=None):
+    if not __salt__['rbenv.is_installed'](runas):
+        ret['result'] = False
+        ret['comment'] = 'Rbenv is not installed.'
+    return ret
+
+def _ruby_installed(ret, ruby, runas=None):
+    default = __salt__['rbenv.default'](runas=runas)
+    for version in __salt__['rbenv.versions'](runas):
+        if version == ruby:
+            ret['result'] = True
+            ret['comment'] = 'Requested ruby exists.'
+            ret['default'] = default == ruby
+            break
+
+    return ret
+
+def _check_and_install_ruby(ret, ruby, default=False, runas=None):
+    ret = _ruby_installed(ret, ruby, runas=runas)
+    if not ret['result']:
+        if __salt__['rbenv.install_ruby'](ruby, runas=runas):
+            ret['result'] = True
+            ret['changes'][ruby] = 'Installed'
+            ret['comment'] = 'Successfully installed ruby'
+            ret['default'] = default
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Could not install ruby.'
+            return ret
+
+    if default:
+        __salt__['rbenv.default'](ruby,runas=runas)
+
+    return ret
+
+def installed(name,default=False,runas=None):
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    if name.startswith('ruby-'):
+        name = re.sub(r'^ruby-','',name)
+
+    if __opts__['test']:
+        ret['comment'] = 'Ruby {0} is set to be installed'.format(name)
+        return ret
+
+    ret = _check_rbenv(ret, runas)
+    if ret['result'] == False:
+        if not __salt__['rbenv.install'](runas):
+            ret['comment'] = 'Rbenv failed to install'
+            return ret
+        else:
+            return _check_and_install_ruby(ret, name, default, runas=runas)
+    else:
+        return _check_and_install_ruby(ret, name, default, runas=runas)
+
+def _check_and_uninstall_ruby(ret, ruby, runas=None):
+    ret = _ruby_installed(ret, ruby, runas=runas)
+    if ret['result']:
+        if ret['default']:
+            __salt__['rbenv.default']('system', runas=runas)
+
+        if __salt__['rbenv.uninstall_ruby'](ruby, runas=runas):
+            ret['result'] = True
+            ret['changes'][ruby] = 'Uninstalled'
+            ret['comment'] = 'Successfully removed ruby'
+            return ret
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to uninstall ruby'
+            return ret
+    else:
+        ret['result'] = True
+        ret['comment'] = 'Ruby {0} is already absent'.format(ruby)
+
+    return ret
+
+def absent(name,runas=None):
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    if name.startswith('ruby-'):
+        name = re.sub(r'^ruby-','',name)
+
+    if __opts__['test']:
+        ret['comment'] = 'Ruby {0} is set to be uninstalled'.format(name)
+        return ret
+
+    ret = _check_rbenv(ret, runas)
+    if ret['result'] == False:
+        ret['result'] = True
+        ret['comment'] = 'Rbenv not installed, {0} not either'.format(name)
+        return ret
+    else:
+        return _check_and_uninstall_ruby(ret, name, runas=runas)

--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -1,12 +1,61 @@
+'''
+Managing Ruby installations with rbenv.
+========================================
+
+This module is used to install and manage ruby installations with rbenv.
+Different versions of ruby can be installed, and uninstalled. Rbenv will
+be installed automatically the first time it is needed and can be updated
+later. This module will *not* automatically install packages which rbenv
+will need to compile the versions of ruby.
+
+If rbenv is run as the root user then it will be installed to /usr/local/rbenv,
+otherwise it will be installed to the users ~/.rbenv directory. To make
+rbenv available in the shell you may need to add the rbenv/shims and rbenv/bin
+directories to the users PATH. If you are installing as root and want other
+users to be able to access rbenv then you will need to add RBENV_ROOT to
+their environment.
+
+This is how a state configuration could look like:
+
+.. code-block:: yaml
+
+    rbenv-deps:
+      pkg.installed:
+        - names:
+          - bash
+          - git
+          - openssl
+          - gmake
+          - curl
+
+    ruby-1.9.3-p392:
+      rbenv.absent:
+        - require:
+          - pkg: rbenv-deps
+
+    ruby-1.9.3-p429:
+      rvm.installed:
+        - default: True
+        - require:
+          - pkg: rbenv-deps
+'''
+
+# Import python libs
 import re
 
 def _check_rbenv(ret,runas=None):
+    '''
+    Check to see if rbenv is installed.
+    '''
     if not __salt__['rbenv.is_installed'](runas):
         ret['result'] = False
         ret['comment'] = 'Rbenv is not installed.'
     return ret
 
 def _ruby_installed(ret, ruby, runas=None):
+    '''
+    Check to see if given ruby is installed.
+    '''
     default = __salt__['rbenv.default'](runas=runas)
     for version in __salt__['rbenv.versions'](runas):
         if version == ruby:
@@ -18,6 +67,9 @@ def _ruby_installed(ret, ruby, runas=None):
     return ret
 
 def _check_and_install_ruby(ret, ruby, default=False, runas=None):
+    '''
+    Verify that ruby is installed, install if unavailable
+    '''
     ret = _ruby_installed(ret, ruby, runas=runas)
     if not ret['result']:
         if __salt__['rbenv.install_ruby'](ruby, runas=runas):
@@ -36,6 +88,17 @@ def _check_and_install_ruby(ret, ruby, default=False, runas=None):
     return ret
 
 def installed(name,default=False,runas=None):
+    '''
+    Verify that the specified ruby is installed with rbenv. Rbenv is
+    installed if necessary.
+
+    name
+        The version of ruby to install
+    default : False
+        Whether to make this ruby the default.
+    runas : None
+        The user to run rbenv as.
+    '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     if name.startswith('ruby-'):
@@ -56,6 +119,9 @@ def installed(name,default=False,runas=None):
         return _check_and_install_ruby(ret, name, default, runas=runas)
 
 def _check_and_uninstall_ruby(ret, ruby, runas=None):
+    '''
+    Verify that ruby is uninstalled
+    '''
     ret = _ruby_installed(ret, ruby, runas=runas)
     if ret['result']:
         if ret['default']:
@@ -77,6 +143,15 @@ def _check_and_uninstall_ruby(ret, ruby, runas=None):
     return ret
 
 def absent(name,runas=None):
+    '''
+    Verify that the specified ruby is not installed with rbenv. Rbenv
+    is installed if necessary.
+
+    name
+        The version of ruby to uninstall
+    runas : None
+        The user to run rbenv as.
+    '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     if name.startswith('ruby-'):


### PR DESCRIPTION
Adds support for using rbenv instead of rvm to manage additional rubies.

States and modules have been reasonably well tested for installation and uninstallation of ruby versions.

Let me know if theres anything I should tweak, still getting back into writing Python code.
