### PR TITLE
We can't use `getCanonArch()` after all.

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -122,7 +122,7 @@ def list_upgrades(refresh=True):
                 pkglist, [pkg]
             )
             for pkg in exactmatch:
-                if pkg.arch == rpmUtils.arch.getCanonArch() \
+                if pkg.arch in rpmUtils.arch.legitMultiArchesInSameLib() \
                         or pkg.arch == 'noarch':
                     versions_list[pkg['name']] = '-'.join(
                         [pkg['version'], pkg['release']]
@@ -200,7 +200,7 @@ def latest_version(*names, **kwargs):
         )
         for pkg in exactmatch:
             if pkg.name in ret \
-                    and (pkg.arch == rpmUtils.arch.getCanonArch()
+                    and (pkg.arch in rpmUtils.arch.legitMultiArchesInSameLib()
                          or pkg.arch == 'noarch'):
                 ret[pkg.name] = '-'.join([pkg.version, pkg.release])
 


### PR DESCRIPTION
Under a Fedora 18 machine for which the `cpuarch` grain reports `x86_64`:

``` python
>>> import rpmUtils.arch
>>> rpmUtils.arch.getCanonArch()
'ia32e'
>>> rpmUtils.arch.legitMultiArchesInSameLib()
['x86_64', 'amd64', 'ia32e']
>>> rpmUtils.arch.getBaseArch()
'x86_64'
>>>
```

Under a CentOS 6.4 for which the `cpuarch` grain reports `i686`:

``` python
>>> import rpmUtils.arch
>>> rpmUtils.arch.getCanonArch()
'i686'
>>> rpmUtils.arch.legitMultiArchesInSameLib()
['i686']
>>> rpmUtils.arch.getBaseArch()
'i386'
>>>
```

The only common recipe seems to be using `legitMultiArchesInSameLib()`
