### PR TITLE
Force autosign regex to match entire string, Fix #4851

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1430,7 +1430,7 @@ class ClearFuncs(object):
                 if fnmatch.fnmatch(keyid, line):
                     return True
                 try:
-                    if re.match(line, keyid):
+                    if re.match(r'\A{0}\z'.format(line), keyid):
                         return True
                 except re.error:
                     log.warn(


### PR DESCRIPTION
According to the [docs](http://docs.python.org/2/library/re.html), the `\A` matches the beginning of the string and the `\z` matches the end of the string.  Adding these forces a whole-string match, fixing this issue.
