### PR TITLE
Fixes issue 5058: Fix a bug in linux GPU vendor searches. With Intel integrated graphics, ...

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -155,12 +155,12 @@ def _linux_gpu_data():
 
     gpus = []
     for gpu in devs:
-        vendor_str_lower = gpu['Vendor'].lower()
+        vendor_strings = gpu['Vendor'].lower().split()
         # default vendor to 'unknown', overwrite if we match a known one
         vendor = 'unknown'
         for name in known_vendors:
-            # search for an 'expected' vendor name in the string
-            if name in vendor_str_lower:
+            # search for an 'expected' vendor name in the list of strings
+            if name in vendor_strings:
                 vendor = name
                 break
         gpus.append({'vendor': vendor, 'model': gpu['Device']})


### PR DESCRIPTION
...this function would return 'ati' as the vendor name because 'ati' was in the string Intel Corporation. Change the search to look at a list of strings to match a vendor name. This should work with any of the known vendors at this point in time.

https://github.com/saltstack/salt/issues/5058
