### PR TITLE
Historical coverage stats

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+branch = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,16 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig rabbitmq-server ruby
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
-  - pip install mock --use-mirrors --mirrors=http://testpypi.python.org/pypi
+  - pip install coveralls mock --use-mirrors --mirrors=http://testpypi.python.org/pypi
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://testpypi.python.org/pypi unittest2 ordereddict; fi"
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
 script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo -v'"
+
+after_success:
+  - coveralls
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,10 @@ before_install:
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
-#script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo --coverage -v'"
-
 script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/coverage run setup.py test --runtests-opts='--run-destructive --sysinfo -v'"
 
-after_success:
-  - coveralls --verbose
+after_script:
+  - coveralls
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ before_install:
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
-script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo --coverage -v'"
+#script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo --coverage -v'"
+
+script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/coverage run setup.py test --runtests-opts='--run-destructive --sysinfo -v'"
 
 after_success:
   - coveralls --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,9 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig rabbitmq-server ruby
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
-  - pip install coveralls mock --use-mirrors --mirrors=http://testpypi.python.org/pypi
+  - pip install mock --use-mirrors --mirrors=http://testpypi.python.org/pypi
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
+  - pip install python-coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://testpypi.python.org/pypi unittest2 ordereddict; fi"
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,14 @@ before_install:
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
   - pip install python-coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://testpypi.python.org/pypi unittest2 ordereddict; fi"
+  - cd -
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
 script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo --coverage -v'"
 
 after_success:
+  - cd -
   - coveralls
 
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
-script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo -v'"
+script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo --coverage -v'"
 
 after_success:
   - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,17 +10,15 @@ before_install:
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
   - pip install mock --use-mirrors --mirrors=http://testpypi.python.org/pypi
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
-  - pip install python-coveralls
+  - pip install coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://testpypi.python.org/pypi unittest2 ordereddict; fi"
-  - cd -
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://testpypi.python.org/pypi
 
 script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo --coverage -v'"
 
 after_success:
-  - cd -
-  - coveralls
+  - coveralls --verbose
 
 notifications:
   irc:

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -460,11 +460,6 @@ if __name__ == '__main__':
         code_coverage.save()
         print('Current Directory: {0}'.format(os.getcwd()))
         print('Coverage data file exists? {0}'.format(os.path.isfile('.coverage')))
-        import subprocess
-        subprocess.call(['ls', '-lah'])
-        if os.path.isfile('.coverage'):
-            import cPickle
-            print(cPickle.load(open('.coverage')))
 
         report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
         print(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -460,6 +460,8 @@ if __name__ == '__main__':
         code_coverage.save()
         print('Current Directory: {0}'.format(os.getcwd()))
         print('Coverage data file exists? {0}'.format(os.path.isfile('.coverage')))
+        import subprocess
+        subprocess.call(['ls', '-lah'])
 
         report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
         print(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -345,6 +345,7 @@ def parse_opts():
     logging.root.setLevel(logging.DEBUG)
 
     print_header('Logging tests on {0}'.format(logfile), bottom=False)
+    print('Current Directory: {0}'.format(os.getcwd()))
     print_header(
         'Test suite is running under PID {0}'.format(os.getpid()), bottom=False
     )

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -458,6 +458,8 @@ if __name__ == '__main__':
         print('Stopping and saving coverage info')
         code_coverage.stop()
         code_coverage.save()
+        print('Current Directory: {0}'.format(os.getcwd()))
+        print('Coverage data file exists? {0}'.format(os.path.isfile('.coverage'))
 
         report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
         print(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -462,6 +462,9 @@ if __name__ == '__main__':
         print('Coverage data file exists? {0}'.format(os.path.isfile('.coverage')))
         import subprocess
         subprocess.call(['ls', '-lah'])
+        if os.path.isfile('.coverage'):
+            import cPickle
+            print(cPickle.load(open('.coverage')))
 
         report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
         print(

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -459,7 +459,7 @@ if __name__ == '__main__':
         code_coverage.stop()
         code_coverage.save()
         print('Current Directory: {0}'.format(os.getcwd()))
-        print('Coverage data file exists? {0}'.format(os.path.isfile('.coverage'))
+        print('Coverage data file exists? {0}'.format(os.path.isfile('.coverage')))
 
         report_dir = os.path.join(os.path.dirname(__file__), 'coverage-report')
         print(


### PR DESCRIPTION
The reason for this pull request can be seen [here](https://coveralls.io/r/s0undt3ch/salt).

An idea:
![coverage](https://f.cloud.github.com/assets/300048/590237/f51adef6-c9da-11e2-8e72-797cc4b78328.png)

It's already enabled for Salt Stack's salt repository.
At least it will allows up to get a notion of our test suite coverage.

Of course, the coverage **will never** be accurate since we would need to merge the coverage data from multiple distributions :smile: 
