### PR TITLE
S3 file server multi bucket and cache sync support

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -1,4 +1,3 @@
-# TODO - add the doc for working with buckets both ways.
 '''
 The backend for a fileserver based on Amazon S3 - see
 http://docs.saltstack.com/ref/file_server/index.html
@@ -67,7 +66,7 @@ def update():
 
     if _s3_sync_on_update:
         # sync the buckets to the local cache
-        # TODO - do something / not here?
+        # TODO - implement full S3 sync versus JIT file serving
         pass
 
 def find_file(path, env='base', **kwargs):
@@ -186,7 +185,6 @@ def file_list(load):
     for buckets in _find_files(resultset[env]).values():
         for env_path in buckets:
             if not salt.fileserver.is_file_ignored(__opts__, env_path):
-                # TODO - should this being a length check?
                 if env_path[env_len:]:
                     ret.append(env_path[env_len:])
 
@@ -199,12 +197,8 @@ def file_list_emptydirs(load):
     # TODO - implement this
 
     ret = []
-    env = load['env']
 
-    resultset = _init()
-
-    if not resultset or env not in resultset:
-        return ret
+    _init()
 
     return ret
 
@@ -227,7 +221,7 @@ def dir_list(load):
     # map and filter the dirs without the env
     for dirs in _find_files(resultset[env], dirs_only = True).values():
         filtered_dirs = map(lambda dir: dir[env_len:-1], dirs)
-        # TODO - this filter = ?
+        # TODO - filter out the empties
         ret += filter(lambda dir: dir, filtered_dirs)
 
     return ret
@@ -262,7 +256,6 @@ def _get_cache_dir():
     Return the path to the s3cache dir
     '''
 
-    # TODO - Should this be an absolute path in case of change in WD?
     # Or is that making too many assumptions?
     return os.path.join(__opts__['cachedir'], 's3cache')
 
@@ -281,7 +274,6 @@ def _get_cached_file_name(bucket_name, path):
     file_path = os.path.join(_get_cache_dir(), bucket_name, path)
 
     # make sure bucket and env directories exist
-    # TODO - should use file.makedirs maybe?
     if not os.path.exists(os.path.dirname(file_path)):
         os.makedirs(os.path.dirname(file_path))
 
@@ -305,7 +297,6 @@ def _refresh_buckets_cache_file(cache_file):
     cache file
     '''
 
-    # TODO - adjust this to only work with buckets for multiple environments
     log.debug('Refreshing buckets cache file')
 
     key, keyid = _get_s3_key()
@@ -458,7 +449,6 @@ def _is_env_per_bucket():
     s3://bucket1/staging/<files>
     etc
     '''
-    # TODO - document this configuration
 
     buckets = _get_buckets()
     if isinstance(buckets, dict):

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -49,11 +49,10 @@ import urllib
 import logging
 
 # Import salt libs
+import salt.filserver as fs
+import salt.modules
 import salt.utils
 import salt.utils.s3 as s3
-import salt.modules
-
-from salt.fileserver import is_file_ignored
 
 log = logging.getLogger(__name__)
 
@@ -114,7 +113,7 @@ def find_file(path, env='base', **kwargs):
 
     # look for the files and check if they're ignored globally
     for bucket_name, files in env_files.iteritems():
-        if path in files and not is_file_ignored(__opts__, path):
+        if path in files and not fs.is_file_ignored(__opts__, path):
             fnd['bucket'] = bucket_name
             fnd['path'] = path
 
@@ -202,7 +201,7 @@ def file_list(load):
         return ret
 
     for buckets in _find_files(metadata[env]).values():
-        files = filter(lambda f: not is_file_ignored(__opts__, f), buckets)
+        files = filter(lambda f: not fs.is_file_ignored(__opts__, f), buckets)
         ret += _trim_env_off_path(files, env)
 
     return ret
@@ -212,15 +211,9 @@ def file_list_emptydirs(load):
     Return a list of all empty directories on the master
     '''
     # TODO - implement this
-
-    log.error('### file_list_emptydirs')
-    log.error('### ' + str(load))
-
-    ret = []
-
     _init()
 
-    return ret
+    return []
 
 def dir_list(load):
     '''

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -16,17 +16,28 @@ config.
     Alternatively, if on EC2 these credentials can be automatically loaded from
     instance metadata.
 
-    s3.buckets in the salt master config should look like this:
+    This fileserver supports two modes of operation for the buckets:
 
+    - A single bucket per environment:
+    eg.
         s3.buckets:
-          - bucket1
-          - bucket2
+            production:
+                - bucket1
+                - bucket2
+            staging:
+                - bucket3
+                - bucket4
 
-    The buckets must contain the directory structure. For example:
+    - Or multiple environments per bucket
+    eg.
+        s3.buckets:
+            - bucket1
+            - bucket2
+            - bucket3
+            - bucket4
 
-        /bucket1/<env>/<files and dirs>
-
-        eg. /bucket1/prod/<files and dirs>
+    A multiple environment bucket must adhere to the following root directory structure:
+        s3://<bucket name>/<environment>/<files>
 '''
 
 # Import python libs
@@ -449,27 +460,8 @@ def _trim_env_off_path(paths, env, trim_slash=False):
 
 def _is_env_per_bucket():
     '''
-    Return the configuration mode, either buckets per environment
-    eg.
-        s3.buckets:
-            production:
-                - bucket1
-                - bucket2
-            staging:
-                - bucket3
-                - bucket4
-
-    or a list of buckets that have environment dirs in their root
-    eg.
-        s3.buckets:
-            - bucket1
-            - bucket2
-            - bucket3
-            - bucket4
-
-    s3://bucket1/production/<files>
-    s3://bucket1/staging/<files>
-    etc
+    Return the configuration mode, either buckets per environment or a list of
+    buckets that have environment dirs in their root
     '''
 
     buckets = _get_buckets()


### PR DESCRIPTION
Big refactor of the S3 file server. Now it supports:
- multiple buckets per environment (eg. `production = s3://myproduction`, `staging = s3://mystaging`) 
- a single bucket with directories per environment in the buckets root directory (eg. `s3://mybucket/{production,staging}`).
- also now syncs the local cache on 'update()' instead of just-in-time downloading.

Plus a bit of a clean up too.
