### PR TITLE
Fix useradd handling of home directories

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -72,14 +72,15 @@ def add(name,
         uid=None,
         gid=None,
         groups=None,
-        home=True,
+        home=None,
         shell=None,
         unique=True,
         system=False,
         fullname='',
         roomnumber='',
         workphone='',
-        homephone=''):
+        homephone='',
+        createhome=True):
     '''
     Add a user to the minion
 
@@ -107,17 +108,14 @@ def add(name,
             return retval
         if usergroups():
             cmd += '-g {0} '.format(__salt__['file.group_to_gid'](name))
-    if home:
-        if system:
-            if home is not True:
-                cmd += '-m -d {0} '.format(home)
-            else:
-                cmd += '-d {0} '.format(home)
+    if home is None:
+        if createhome:
+            cmd += '-m '
+    else:
+        if createhome:
+            cmd += '-m -d {0} '.format(home)
         else:
-            if home is not True:
-                cmd += '-m -d {0} '.format(home)
-            else:
-                cmd += '-m '
+            cmd += '-d {0} '.format(home)   
     if not unique:
         cmd += '-o '
     if system:

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -36,7 +36,7 @@ def _changes(name,
              groups=None,
              optional_groups=None,
              remove_groups=True,
-             home=True,
+             home=None,
              password=None,
              enforce_password=True,
              shell=None,
@@ -90,8 +90,7 @@ def _changes(name,
                     change['groups'].append(wanted_group)
     if home:
         if lusr['home'] != home:
-            if home is not True:
-                change['home'] = home
+            change['home'] = home
     if shell:
         if lusr['shell'] != shell:
             change['shell'] = shell
@@ -121,7 +120,8 @@ def present(name,
             groups=None,
             optional_groups=None,
             remove_groups=True,
-            home=True,
+            home=None,
+            createhome=True,
             password=None,
             enforce_password=True,
             shell=None,
@@ -168,6 +168,11 @@ def present(name,
 
     home
         The location of the home directory to manage
+
+    createhome
+        If True, the home directory will be created if it doesn't exist.
+        Please note that directories leading up to the home directory
+        will NOT be created.
 
     password
         A password hash to set for the user
@@ -338,7 +343,8 @@ def present(name,
                                 fullname=fullname,
                                 roomnumber=roomnumber,
                                 workphone=workphone,
-                                homephone=homephone):
+                                homephone=homephone,
+                                createhome=createhome):
             ret['comment'] = 'New user {0} created'.format(name)
             ret['changes'] = __salt__['user.info'](name)
             if password:


### PR DESCRIPTION
Fix modules.useradd so that `home` isn't overloaded with multiple meanings
and allow states.user to support `createhome` as an alternative to
the multiple meanings of `home`.

This also fixes the edge-case that useradd would under specific
circumstances create a home directory called "True".

Setting createhome to `True` by default will preserve a certain amount of backwards
compatibility. This change especially solves my personal problem of having states
that choke on the skeleton files that get copied when useradd gets the `-m` 
parameter.
