### PR TITLE
rm unused 'osdata' params from grains.core funcs

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -183,7 +183,7 @@ def _linux_gpu_data():
     return grains
 
 
-def _netbsd_gpu_data(osdata):
+def _netbsd_gpu_data():
     '''
     num_gpus: int
     gpus:
@@ -269,7 +269,7 @@ def _bsd_cpudata(osdata):
     return grains
 
 
-def _sunos_cpudata(osdata):
+def _sunos_cpudata():
     '''
     Return the CPU information for Solaris-like systems
     '''
@@ -488,7 +488,7 @@ def _virtual(osdata):
             if zone != "global":
                 grains['virtual'] = 'zone'
                 if osdata['os'] == 'SmartOS':
-                    grains.update(_smartos_zone_data(grains))
+                    grains.update(_smartos_zone_data())
         # Check if it's a branded zone (i.e. Solaris 8/9 zone)
         if isdir('/.SUNWnative'):
             grains['virtual'] = 'zone'
@@ -531,7 +531,7 @@ def _ps(osdata):
     return grains
 
 
-def _windows_platform_data(osdata):
+def _windows_platform_data():
     '''
     Use the platform module for as much as we can.
     '''
@@ -663,7 +663,7 @@ def os_data():
         grains['os'] = 'Windows'
         grains['os_family'] = 'Windows'
         grains.update(_memdata(grains))
-        grains.update(_windows_platform_data(grains))
+        grains.update(_windows_platform_data())
         grains.update(_windows_cpudata())
         grains.update(_ps(grains))
         return grains
@@ -769,7 +769,7 @@ def os_data():
                         grains['os'] = osname
                         grains['osrelease'] = osrelease
 
-        grains.update(_sunos_cpudata(grains))
+        grains.update(_sunos_cpudata())
     elif grains['kernel'] == 'VMkernel':
         grains['os'] = 'ESXi'
     elif grains['kernel'] == 'Darwin':
@@ -781,7 +781,7 @@ def os_data():
         grains.update(_bsd_cpudata(grains))
         grains['osrelease'] = grains['kernelrelease'].split('-')[0]
         if grains['kernel'] == 'NetBSD':
-            grains.update(_netbsd_gpu_data(grains))
+            grains.update(_netbsd_gpu_data())
     if not grains['os']:
         grains['os'] = 'Unknown {0}'.format(grains['kernel'])
         grains['os_family'] = 'Unknown'
@@ -1054,7 +1054,7 @@ def _hw_data(osdata):
 
     return grains
 
-def _smartos_zone_data(osdata):
+def _smartos_zone_data():
     '''
     Return useful information from a SmartOS zone
     '''


### PR DESCRIPTION
Fixes pylint W0613 warnings.
