### PR TITLE
% => .format(); avoids pylint W1201

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -42,7 +42,7 @@ def _tap(tap, runas=None):
 
     cmd = 'brew tap {0}'.format(tap)
     if __salt__['cmd.retcode'](cmd, runas=runas):
-        log.error("Failed to tap '%s'" % tap)
+        log.error('Failed to tap "{0}"'.format(tap))
         return False
 
     return True

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -84,12 +84,12 @@ def returner(ret):
     options = _get_options()
 
     # Create a connection to the server.
-    server = couchdb.client.Server(options["url"])
+    server = couchdb.client.Server(options['url'])
 
     # Create the database if the configuration calls for it.
-    if options["db"] not in server:
-        log.debug("Creating database %s" % options["db"])
-        server.create(options["db"])
+    if options['db'] not in server:
+        log.debug('Creating database "{0}"'.format(options['db']))
+        server.create(options['db'])
 
     # Save the document that comes out of _generate_doc.
-    server[options["db"]].save(_generate_doc(ret, options))
+    server[options['db']].save(_generate_doc(ret, options))

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -43,7 +43,7 @@ def _retry_get_url(url, num_retries=10, timeout=5):
         except Exception:
             pass
 
-        log.warning('Caught exception reading from URL. Retry no. %s'%(i))
+        log.warning('Caught exception reading from URL. Retry no. {0}'.format(i))
         time.sleep(2 ** i)
     log.error('Failed to read from URL for {0} times. Giving up.'.format(num_retries))
     return ''


### PR DESCRIPTION
Per Salt house style.
Also remove some double-quoting in the vicinity.
