### PR TITLE
version needs to be 0.15.2 for salt.spec

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -11,7 +11,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name: salt
-Version: 0.15.1
+Version: 0.15.2
 Release: 1%{?dist}
 Summary: A parallel remote execution system
 


### PR DESCRIPTION
Missed this one.
