### PR TITLE
Always seek() to beginning of StringIO obj, Fix #5062

### DIFF
--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -49,5 +49,5 @@ def render(yaml_data, env='', sls='', argline='', **kws):
                     warn=item.message, sls=sls, env=env))
         if not data:
             data = {}
-        log.trace('Results of YAML rendering: \n{0}'.format(data))
+        log.debug('Results of YAML rendering: \n{0}'.format(data))
         return data

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -47,4 +47,7 @@ def render(yaml_data, env='', sls='', argline='', **kws):
                 log.warn(
                     '{warn} found in salt://{sls} environment={env}'.format(
                     warn=item.message, sls=sls, env=env))
-        return data if data else {}
+        if not data:
+            data = {}
+        log.trace('Results of YAML rendering: \n{0}'.format(data))
+        return data

--- a/salt/template.py
+++ b/salt/template.py
@@ -57,7 +57,10 @@ def compile_template(template, renderers, default, env='', sls='', **kwargs):
 
     input_data = string_io(input_data)
     for render, argline in render_pipe:
-        input_data.seek(0)
+        try:
+            input_data.seek(0)
+        except Exception as e:
+            pass
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)
         if argline:

--- a/salt/template.py
+++ b/salt/template.py
@@ -57,6 +57,7 @@ def compile_template(template, renderers, default, env='', sls='', **kwargs):
 
     input_data = string_io(input_data)
     for render, argline in render_pipe:
+        input_data.seek(0)
         render_kwargs = dict(renderers=renderers, tmplpath=template)
         render_kwargs.update(kwargs)
         if argline:


### PR DESCRIPTION
Very small pull req for the amount of time it took to track it down.  =)

It seems that non-ascii characters _are_ supported by both msgpack and YAML.  But somehow (possibly in the logging try-except at the bottom of the for loop where the change was made) the StringIO was getting read, but not reset.

I also added a log for the results of the YAML renderer while I was there, because we need to work on making it easier to debug YAML and other errors.
