### PR TITLE
Add error handling to Windows package management

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -141,6 +141,8 @@ def list_available(*names):
         versions = {}
         for name in names:
             pkginfo = _get_package_info(name)
+            if not pkginfo:
+                continue
             versions[name] = pkginfo.keys() if pkginfo else []
     return versions
 
@@ -421,6 +423,8 @@ def install(name=None, refresh=False, **kwargs):
         refresh_db()
     old = list_pkgs()
     pkginfo = _get_package_info(name)
+    if not pkginfo:
+        return 'Error: Unable to locate package {0}'.format(name)
     for pkg in pkginfo.keys():
         if pkginfo[pkg]['full_name'] in old:
             return '{0} already installed'.format(pkginfo[pkg]['full_name'])
@@ -428,7 +432,9 @@ def install(name=None, refresh=False, **kwargs):
         version_num = kwargs['version']
     else:
         version_num = _get_latest_pkg_version(pkginfo)
-    installer = pkginfo[version_num]['installer']
+    installer = pkginfo[version_num].get('installer')
+    if not installer:
+	return 'Error: No installer configured for package {0}'.format(name)
     if installer.startswith('salt:') or installer.startswith('http:') or installer.startswith('https:') or installer.startswith('ftp:'):
         cached_pkg = __salt__['cp.is_cached'](installer)
         if not cached_pkg:
@@ -505,21 +511,26 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
         if not version:
             version = _get_latest_pkg_version(pkginfo)
 
-        if pkginfo[version]['uninstaller'].startswith('salt:'):
+        uninstaller = pkginfo[version].get('uninstaller')
+        if not uninstaller:
+	    uninstaller = pkginfo[version].get('installer')
+        if not uninstaller:
+            return 'Error: No installer or uninstaller configured for package {0}'.format(name)
+        if uninstaller.startswith('salt:'):
             cached_pkg = \
-                __salt__['cp.is_cached'](pkginfo[version]['uninstaller'])
+                __salt__['cp.is_cached'](uninstaller)
             if not cached_pkg:
                 # It's not cached. Cache it, mate.
                 cached_pkg = \
-                    __salt__['cp.cache_file'](pkginfo[version]['uninstaller'])
+                    __salt__['cp.cache_file'](uninstaller)
         else:
-            cached_pkg = pkginfo[version]['uninstaller']
+            cached_pkg = uninstaller
         cached_pkg = cached_pkg.replace('/', '\\')
         if not os.path.exists(os.path.expandvars(cached_pkg)) \
                 and '(x86)' in cached_pkg:
             cached_pkg = cached_pkg.replace('(x86)', '')
         cmd = '"' + str(os.path.expandvars(
-            cached_pkg)) + '"' + str(pkginfo[version]['uninstall_flags'])
+            cached_pkg)) + '"' + str(pkginfo[version].get('uninstall_flags', ''))
         if pkginfo[version].get('msiexec'):
             cmd = 'msiexec /x ' + cmd
         __salt__['cmd.run_all'](cmd)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -434,7 +434,7 @@ def install(name=None, refresh=False, **kwargs):
         version_num = _get_latest_pkg_version(pkginfo)
     installer = pkginfo[version_num].get('installer')
     if not installer:
-	return 'Error: No installer configured for package {0}'.format(name)
+        return 'Error: No installer configured for package {0}'.format(name)
     if installer.startswith('salt:') or installer.startswith('http:') or installer.startswith('https:') or installer.startswith('ftp:'):
         cached_pkg = __salt__['cp.is_cached'](installer)
         if not cached_pkg:
@@ -513,7 +513,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
 
         uninstaller = pkginfo[version].get('uninstaller')
         if not uninstaller:
-	    uninstaller = pkginfo[version].get('installer')
+            uninstaller = pkginfo[version].get('installer')
         if not uninstaller:
             return 'Error: No installer or uninstaller configured for package {0}'.format(name)
         if uninstaller.startswith('salt:'):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -104,6 +104,11 @@ def _find_install_targets(name=None, version=None, pkgs=None, sources=None):
     else:
         if salt.utils.is_windows():
             pkginfo = _get_package_info(name)
+            if not pkginfo:
+                return {'name':name,
+                        'changes':{},
+                        'result':False,
+                        'comment':('Package {0} not found in the repository.'.format(name))}
             if version is None:
                 version = _get_latest_pkg_version(pkginfo)
             name = pkginfo[version]['full_name']


### PR DESCRIPTION
Check the output of _get_package_info before trying to treat it as a map; fallback on installer if the repo doesn't have uninstaller configured; tolerate absence of uninstall_flags; fail gracefully when asked to install something that doesn't exist in the repo.
