### PR TITLE
Add success flag to LocalClient.get_full_return()

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -818,6 +818,7 @@ class LocalClient(object):
                     continue
                 found.add(raw['id'])
                 ret[raw['id']] = {'ret': raw['return']}
+                ret[raw['id']]['success'] = raw.get('success', False)
                 if 'out' in raw:
                     ret[raw['id']]['out'] = raw['out']
                 if len(found.intersection(minions)) >= len(minions):

--- a/tests/integration/client/standard.py
+++ b/tests/integration/client/standard.py
@@ -55,7 +55,15 @@ class StdTest(integration.ModuleCase):
                 'minion',
                 'test.ping',
                 )
-        self.assertTrue(ret['minion'])
+        self.assertIn('minion', ret)
+        self.assertEqual(ret['minion'], {'ret': True, 'success': True})
+        
+        ret = self.client.cmd_full_return(
+                'minion',
+                'test.pong',
+                )
+        self.assertIn('minion', ret)
+        self.assertEqual(ret['minion'], {'ret': '"test.pong" is not available.', 'success': False})
 
 if __name__ == "__main__":
     loader = TestLoader()


### PR DESCRIPTION
The success flag is available on the master but currently not passed through via the API.  This changes the return structure from `get_full_return()`  from

```
 { 'ret': <module return value or error string>, 'out': 'outputter' }
```

to

```
{ 'ret' <module return value or error string>, 'out': 'outputter', 'success': True|False }
```

I also noticed that `get_full_return()` uses `get_cli_static_event_returns()` instead of `get_full_returns()` which is used by nothing as far as I can see so this module may need some cleanup at some point - I'm happy to do it if required...
