### PR TITLE
Added output for package.unmask changes in ebuild. #5393

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -79,6 +79,8 @@ def _process_emerge_err(stderr):
             changes['license'] = rexp.findall(section)
         elif 'The following USE changes' in section:
             changes['use'] = rexp.findall(section)
+        elif 'The following mask changes' in section:
+            changes['mask'] = rexp.findall(section)
     ret['changes'] = changes
     return ret
 


### PR DESCRIPTION
If emerge fails due to mask issues, return the recommended changes.
