### PR TITLE
Audited network state and rh_ip module

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -752,7 +752,7 @@ def _read_temp(data):
     return output
 
 
-def build_bond(iface, settings):
+def build_bond(iface, **settings):
     '''
     Create a bond script in /etc/modprobe.d with the passed settings
     and load the bonding kernel module.
@@ -788,7 +788,7 @@ def build_bond(iface, settings):
     return _read_file(path)
 
 
-def build_interface(iface, iface_type, enabled, settings):
+def build_interface(iface, iface_type, enabled, **settings):
     '''
     Build an interface script for a network interface.
 
@@ -842,7 +842,7 @@ def build_interface(iface, iface_type, enabled, settings):
     return _read_file(path)
 
 
-def down(iface, iface_type, opts):
+def down(iface, iface_type):
     '''
     Shutdown a network interface
 
@@ -880,7 +880,7 @@ def get_interface(iface):
     return _read_file(path)
 
 
-def up(iface, iface_type, opts):  # pylint: disable-msg=C0103
+def up(iface, iface_type):  # pylint: disable-msg=C0103
     '''
     Start up a network interface
 
@@ -905,7 +905,7 @@ def get_network_settings():
     return _read_file(_RH_NETWORK_FILE)
 
 
-def apply_network_settings(opts):
+def apply_network_settings(**settings):
     '''
     Apply global network configuration.
 
@@ -913,10 +913,10 @@ def apply_network_settings(opts):
 
         salt '*' ip.apply_network_settings
     '''
-    if not 'require_reboot' in opts:
-        opts['require_reboot'] = False
+    if not 'require_reboot' in settings:
+        settings['require_reboot'] = False
 
-    if opts['require_reboot'] in _CONFIG_TRUE:
+    if settings['require_reboot'] in _CONFIG_TRUE:
         log.warning(
             'The network state sls is requiring a reboot of the system to '
             'properly apply network configuration.'
@@ -926,7 +926,7 @@ def apply_network_settings(opts):
         return __salt__['service.restart']('network')
 
 
-def build_network_settings(settings):
+def build_network_settings(**settings):
     '''
     Build the global network script.
 

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -172,17 +172,19 @@ def managed(name, type, enabled=True, **kwargs):
     # Build interface
     try:
         old = __salt__['ip.get_interface'](name)
-        new = __salt__['ip.build_interface'](name, type, enabled, kwargs)
+        new = __salt__['ip.build_interface'](name, type, enabled, **kwargs)
         if __opts__['test']:
             if old == new:
                 pass
             if not old and new:
                 ret['result'] = None
-                ret['comment'] = 'Interface {0} is set to be added.'.format(name)
+                ret['comment'] = 'Interface {0} is set to be ' \
+                                 'added.'.format(name)
             elif old != new:
                 diff = difflib.unified_diff(old, new)
                 ret['result'] = None
-                ret['comment'] = 'Interface {0} is set to be updated.'.format(name)
+                ret['comment'] = 'Interface {0} is set to be ' \
+                                 'updated.'.format(name)
                 ret['changes']['interface'] = ''.join(diff)
         else:
             if not old and new:
@@ -199,17 +201,19 @@ def managed(name, type, enabled=True, **kwargs):
     if type == 'bond':
         try:
             old = __salt__['ip.get_bond'](name)
-            new = __salt__['ip.build_bond'](name, kwargs)
+            new = __salt__['ip.build_bond'](name, **kwargs)
             if __opts__['test']:
                 if old == new:
                     pass
                 if not old and new:
                     ret['result'] = None
-                    ret['comment'] = 'Bond interface {0} is set to be added.'.format(name)
+                    ret['comment'] = 'Bond interface {0} is set to be ' \
+                                     'added.'.format(name)
                 elif old != new:
                     diff = difflib.unified_diff(old, new)
                     ret['result'] = None
-                    ret['comment'] = 'Bond interface {0} is set to be updated.'.format(name)
+                    ret['comment'] = 'Bond interface {0} is set to be ' \
+                                     'updated.'.format(name)
                     ret['changes']['bond'] = ''.join(diff)
             else:
                 if not old and new:
@@ -226,12 +230,12 @@ def managed(name, type, enabled=True, **kwargs):
     if __opts__['test']:
         return ret
 
-    #Bring up/shutdown interface
+    # Bring up/shutdown interface
     try:
         if enabled:
-            __salt__['ip.up'](name, type, kwargs)
+            __salt__['ip.up'](name, type)
         else:
-            __salt__['ip.down'](name, type, kwargs)
+            __salt__['ip.down'](name, type)
     except Exception as error:
         ret['result'] = False
         ret['comment'] = error.message
@@ -263,7 +267,7 @@ def system(name, **kwargs):
     # Build global network settings
     try:
         old = __salt__['ip.get_network_settings']()
-        new = __salt__['ip.build_network_settings'](kwargs)
+        new = __salt__['ip.build_network_settings'](**kwargs)
         if __opts__['test']:
             if old == new:
                 return ret
@@ -292,7 +296,7 @@ def system(name, **kwargs):
     # Apply global network settings
     if apply_net_settings:
         try:
-            __salt__['ip.apply_network_settings'](kwargs)
+            __salt__['ip.apply_network_settings'](**kwargs)
         except AttributeError as error:
             ret['result'] = False
             ret['comment'] = error.message


### PR DESCRIPTION
This fixes #5129 by removing the unnecessary passing of the kwargs.

Also, the kwargs were not being passed (and received by the execution
modules) using double-asterisk. Fixed this as well.
