### PR TITLE
Make the freebsdservice.status function honor the sig argument.

### DIFF
--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -306,6 +306,8 @@ def status(name, sig=None):
 
         salt '*' service.status <service name>
     '''
+    if sig:
+        return bool(__salt__['status.pid'](sig))
     cmd = '{0} {1} onestatus'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
 


### PR DESCRIPTION
Some services on FreeBSD don't return the "right" value.  This is where the 'sig' argument comes in handy.  Unfortunately, the freebsdservice module current does nothing with that argument.  This patch resolves that.
