### PR TITLE
Allow execution to continue if missing SLS, Fix #5430

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1987,7 +1987,7 @@ class BaseHighState(object):
                 statefiles = fnmatch.filter(self.avail[env], sls_match)
                 if not statefiles:
                     # No matching sls file was found!  Output an error
-                    all_errors.append(
+                    log.error(
                             'No matching sls found for \'{0}\' in env \'{1}\''
                             .format(sls_match, env)
                     )
@@ -2247,4 +2247,3 @@ class RemoteHighState(object):
                     72000))
         except SaltReqTimeoutError:
             return {}
-


### PR DESCRIPTION
Now it logs to ERROR rather than actually _raising_ an error.

In the future, we might add a master config option which tells whether we should allow for missing SLS files or not.  Or maybe add an option on state.highstate.  But for now, this should allow us to see these errors, but doesn't break "generic states" as described in #5430
