### PR TITLE
Remove errant re-assignment of pillar['master']['file_roots']

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -94,7 +94,6 @@ class Pillar(object):
         The options need to be altered to conform to the file client
         '''
         opts = dict(opts_in)
-        opts['file_roots'] = opts['pillar_roots']
         opts['file_client'] = 'local'
         opts['grains'] = grains
         opts['id'] = id_


### PR DESCRIPTION
In 62a38a1, pillar['master']['flie_roots'] was set to the value of
pillar['master']['pillar_roots']. This causes the data in
pillar['master'] to be inaccurate. This commit removes that assignment
and thus corrects the pillar value.

This fixes #5449.
