### PR TITLE
Switch to pkg.compare for version comparison

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -74,19 +74,20 @@ def latest_version(*names, **kwargs):
             ret[name] = ''
             if name in pkgs:
                 version_num = pkgs[name]
-            if __salt__['pkg_resource.perform_cmp'](str(candidate),
-                                                    str(version_num)) > 0:
+            if __salt__['pkg.compare'](pkg1=str(candidate), oper='>',
+                                       pkg2=str(version_num)):
                 ret[name] = candidate
             continue
         for ver in pkginfo.keys():
-            if __salt__['pkg_resource.perform_cmp'](str(ver), str(candidate)) > 0:
+            if __salt__['pkg.compare'](pkg1=str(ver), oper='>',
+                                       pkg2=str(candidate)):
                 candidate = ver
         name = pkginfo[candidate]['full_name']
         ret[name] = ''
         if name in pkgs:
             version_num = pkgs[name]
-        if __salt__['pkg_resource.perform_cmp'](str(candidate),
-                                                str(version_num)) > 0:
+        if __salt__['pkg.compare'](pkg1=str(candidate), oper='>',
+                                   pkg2=str(version_num)):
             ret[name] = candidate
     return ret
 
@@ -319,8 +320,10 @@ def _get_reg_software():
                     reg_hive,
                     prd_uninst_key,
                     "DisplayName")
-                try: prd_name=prd_name.decode(encoding)
-                except: pass
+                try:
+                    prd_name = prd_name.decode(encoding)
+                except:
+                    pass
                 prd_ver = _get_reg_value(
                     reg_hive,
                     prd_uninst_key,


### PR DESCRIPTION
perform_cmp is really only supposed to be used under-the-hood, while
pkg.compare makes for easier-to-read code.
