### PR TITLE
Improve file.directory for clean=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -267,7 +267,8 @@ def _check_directory(name,
                      recurse,
                      mode,
                      clean,
-                     require):
+                     require,
+                     exclude_pat):
     '''
     Check what changes need to be made on a directory
     '''
@@ -305,12 +306,18 @@ def _check_directory(name,
                 fchange = {}
                 path = os.path.join(root, fname)
                 if path not in keep:
+                    if not _check_include_exclude(path[len(name) + 1:], None,
+                                                  exclude_pat):
+                        continue
                     fchange['removed'] = 'Removed due to clean'
                     changes[path] = fchange
             for name_ in dirs:
                 fchange = {}
                 path = os.path.join(root, name_)
                 if path not in keep:
+                    if not _check_include_exclude(path[len(name) + 1:], None,
+                                                  exclude_pat):
+                        continue
                     fchange['removed'] = 'Removed due to clean'
                     changes[path] = fchange
 
@@ -923,7 +930,8 @@ def directory(name,
             recurse or [],
             dir_mode,
             clean,
-            require)
+            require,
+            exclude_pat)
         return ret
 
     if not os.path.isdir(name):
@@ -1670,7 +1678,7 @@ def append(name,
         if not __salt__['file.directory_exists'](dirname):
             __salt__['file.makedirs'](name)
             check_res, check_msg = _check_directory(
-                dirname, None, None, False, None, False, False
+                dirname, None, None, False, None, False, False, None
             )
             if not check_res:
                 return _error(ret, check_msg)


### PR DESCRIPTION
This change improves the behaviour of something like this:

``` yaml
/etc/dhcp:
    file.directory:
        - clean: yes
        - exclude_pat: 'dhclient*'
```

Originally, when running highstate with test=True, exclude_pat would be ignored and the comment would say that all files were to be deleted. With that change, exclude_pat is correctly taken into account.

I also added some tests to verify the behavior of file.directory with the clean option.

edit: the test cases pass, however there seems to be some other issue in develop branch which causes travis to report test failure.
