### PR TITLE
Fix windows

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -30,7 +30,7 @@ from salt.modules.file import (check_hash, check_managed, check_perms, # pylint:
         patch, remove, source_list, sed_contains, touch, append, contains,
         contains_regex, contains_regex_multiline, contains_glob, patch,
         uncomment, sed, find, psed, get_sum, check_hash, get_hash, comment,
-        manage_file, file_exists, get_diff, get_managed, __clean_tmp, _is_bin,
+        manage_file, file_exists, get_diff, get_managed, __clean_tmp,
         check_managed, check_file_meta, contains_regex)
 
 from salt.utils import namespaced_function
@@ -45,7 +45,7 @@ def __virtual__():
     if salt.utils.is_windows():
         if HAS_WINDOWS_MODULES:
             global check_perms, get_managed, makedirs_perms, manage_file
-            global source_list, mkdir, __clean_tmp, makedirs, _is_bin
+            global source_list, mkdir, __clean_tmp, makedirs, 
 
             check_perms = namespaced_function(check_perms, globals())
             get_managed = namespaced_function(get_managed, globals())
@@ -55,7 +55,6 @@ def __virtual__():
             source_list = namespaced_function(source_list, globals())
             mkdir = namespaced_function(mkdir, globals())
             __clean_tmp = namespaced_function(__clean_tmp, globals())
-            _is_bin = namespaced_function(_is_bin, globals())
             
             return 'file'
         log.warn(salt.utils.required_modules_error(__file__, __doc__))

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -295,7 +295,7 @@ def _get_reg_software():
                    'SchedulingAgent',
                    'WIC'
                    ]
-    encoding = locale.get_locale()
+    encoding = locale.getpreferredencoding()
 
     #attempt to corral the wild west of the multiple ways to install
     #software in windows


### PR DESCRIPTION
modules/win_pkg.py:
locale.get_locale() doesn't exists. locale.getlocale() does but returns (None, None) on windows. locale.getpreferredencoding() appears to be correct.

modules/win_file.py:
_is_bin appears to have been removed form modules/file.py
