### PR TITLE
Add timeout to salt.state.cmd.* functions

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -83,6 +83,11 @@ class SaltReqTimeoutError(SaltException):
     Thrown when a salt master request call fails to return within the timeout
     '''
 
+class TimedProcTimeoutError(SaltException):
+    '''
+    Thrown when a timed subprocess does not terminate within the timeout,
+    or if the specified timeout is not an int or a float
+    '''
 
 class EauthAuthenticationError(SaltException):
     '''

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -365,6 +365,7 @@ def run(name,
         stateful=False,
         umask=None,
         quiet=False,
+        timeout=None,
         **kwargs):
     '''
     Run a command if certain circumstances are met
@@ -398,6 +399,10 @@ def run(name,
         Pass in a list or dict of environment variables to be applied to the
         command upon execution
 
+    stateful
+        The command being executed is expected to return data about executing
+        a state
+
     umask
         The umask (in octal) to use when running the command.
 
@@ -405,9 +410,9 @@ def run(name,
         The command will be executed quietly, meaning no log entries of the
         actual command or its return data
 
-    stateful
-        The command being executed is expected to return data about executing
-        a state
+    timeout
+        If the command has not terminated after timeout seconds, send the
+        subprocess sigterm, and if sigterm is ignored, follow up with sigkill
     '''
     ret = {'name': name,
            'changes': {},
@@ -479,7 +484,7 @@ def run(name,
         # Wow, we passed the test, run this sucker!
         if not __opts__['test']:
             try:
-                cmd_all = __salt__['cmd.run_all'](name, **cmd_kwargs)
+                cmd_all = __salt__['cmd.run_all'](name, timeout=timeout, **cmd_kwargs)
             except CommandExecutionError as err:
                 ret['comment'] = str(err)
                 return ret
@@ -509,6 +514,7 @@ def script(name,
            env=None,
            stateful=False,
            umask=None,
+           timeout=None,
            **kwargs):
     '''
     Download a script from a remote source and execute it. The name can be the
@@ -560,6 +566,11 @@ def script(name,
     stateful
         The command being executed is expected to return data about executing
         a state
+
+    timeout
+        If the command has not terminated after timeout seconds, send the
+        subprocess sigterm, and if sigterm is ignored, follow up with sigkill
+
     '''
     ret = {'changes': {},
            'comment': '',
@@ -586,7 +597,8 @@ def script(name,
                        'group': group,
                        'cwd': cwd,
                        'template': template,
-                       'umask': umask})
+                       'umask': umask,
+                       'timeout': timeout})
 
     run_check_cmd_kwargs = {
         'cwd': cwd,
@@ -597,11 +609,11 @@ def script(name,
     # Change the source to be the name arg if it is not specified
     if source is None:
         source = name
- 
+
     # If script args present split from name and define args
     if len(name.split()) > 1:
         cmd_kwargs.update({'args': name.split(' ', 1)[1]})
-    
+
     try:
         cret = _run_check(
             run_check_cmd_kwargs, onlyif, unless, group

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -1,0 +1,45 @@
+"""For running command line executables with a timeout"""
+
+import subprocess
+import threading
+import salt.exceptions
+
+class TimedProc(object):
+    '''
+    Create a TimedProc object, calls subprocess.Popen with passed args and **kwargs
+    '''
+    def __init__(self, args, **kwargs):
+
+        self.command = args
+        self.process = subprocess.Popen(args, **kwargs)
+
+    def wait(self, timeout=None):
+        '''
+        wait for subprocess to terminate and return subprocess' return code.
+        If timeout is reached, throw TimedProcTimeoutError
+        '''
+        def receive():
+            (self.stdout, self.stderr) = self.process.communicate()
+
+        if timeout:
+            if not isinstance(timeout, (int,float)):
+                raise salt.exceptions.TimedProcTimeoutError('Error: timeout must be a number')
+            rt = threading.Thread(target=receive)
+            rt.start()
+            rt.join(timeout)
+            if rt.isAlive():
+                # Subprocess cleanup (best effort)
+                self.process.kill()
+
+                def terminate():
+                    if rt.isAlive():
+                        self.process.terminate()
+                threading.Timer(10, terminate)
+                raise salt.exceptions.TimedProcTimeoutError('%s : Timed out after %s seconds' % (
+                    self.command,
+                    str(timeout),
+                ))
+        else:
+            receive()
+        return self.process.returncode
+

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -180,6 +180,17 @@ sys.stdout.write('cheese')
                                    runas=runas).strip()
         self.assertEqual(result, expected_result)
 
+    def test_timeout(self):
+        '''
+        cmd.run trigger timeout
+        '''
+        self.assertTrue('Timed out' in self.run_function('cmd.run', ['sleep 2 && echo hello', 'timeout=1']))
+
+    def test_timeout_success(self):
+        '''
+        cmd.run sufficient timeout to succeed
+        '''
+        self.assertTrue('hello' == self.run_function('cmd.run', ['sleep 1 && echo hello', 'timeout=2']))
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Add ability to specify timeouts for arbitrary commands.
If timeout is reached, subprocess is sent sigterm, and later sigkill
if it still exists. Issue #5322
