### PR TITLE
 Ignoring multiple spaces or tabs, while checking for sysctl changes.

### DIFF
--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -11,6 +11,8 @@ Control the kernel sysctl system
       - value: 20
 '''
 
+# Import python libs
+import re
 
 def present(name, value, config='/etc/sysctl.conf'):
     '''
@@ -35,7 +37,7 @@ def present(name, value, config='/etc/sysctl.conf'):
     current = __salt__['sysctl.show']()
     if __opts__['test']:
         if name in current:
-            if current[name] != str(value):
+            if re.sub(' +|\t+',' ',current[name]) != re.sub(' +|\t+',' ',str(value)):
                 ret['result'] = None
                 ret['comment'] = (
                         'Sysctl option {0} set to be changed to {1}'


### PR DESCRIPTION
For states.sysctl() , test=True seems to always show a pending  (at least on CentOS platform). The original code under states.sysctl.present() checks for exact string match between sysctl parameters value coming from a state file and sysctl value read via sysctl -a (used by modules.sysctl.show() call, that always contains tab separated values).

This fix will ignore multiple spaces or tabs while comparing (by normalizing with single space)

e.g: mystate.sls

<pre>
net.ipv4.tcp_rmem:
  sysctl:
    - present
    - value: 4096 87380 16777216
</pre>


value: contains single space separated numerals, however after applying above state successfully, sysctl -a shows tab separated values (kernel presents it that way)  and subsequent  salt '*' state.sls mystate test=True always shows a pending update.
