### PR TITLE
make it more obvious that salt runners execute on the master

### DIFF
--- a/doc/ref/runners/index.rst
+++ b/doc/ref/runners/index.rst
@@ -5,6 +5,8 @@ Salt Runners
 .. seealso:: :ref:`The full list of runners <all-salt.runners>`
 
 Salt runners are convenience applications executed with the salt-run command.
+Where as salt modules are sent out to minions for execution, salt runners are
+executed on the salt master.
 
 A Salt runner can be a simple client call, or a complex application.
 


### PR DESCRIPTION
feel free to reject this if you feel the existing docs are sufficient, I didn't and would propose this change.
