### PR TITLE
Fixed compound commands parsing: do not split arguments

### DIFF
--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -189,3 +189,16 @@ arguments, then there needs to be a placeholder for the absent arguments. This
 is why in the above example, there are two commas right next to each other.
 ``test.ping`` takes no arguments, so we need to add another comma, otherwise
 Salt would attempt to pass "foo" to ``test.ping``.
+
+If you need to pass arguments that include commas, then make sure you add
+spaces around the commas that separate arguments. For example:
+
+.. code-block:: bash
+
+    salt '*' cmd.run,test.ping,test.echo 'echo "1,2,3"' , , foo
+
+You may change the arguments separator using the ``args-separator`` option:
+
+.. code-block:: bash
+
+    salt --arg-separator=::: '*' some.fun,test.echo params with comma , ::: foo

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -869,9 +869,19 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         # Detect compound command and set up the data for it
         if ',' in self.args[1]:
             self.config['fun'] = self.args[1].split(',')
-            self.config['arg'] = []
-            for comp in ' '.join(self.args[2:]).split(','):
-                self.config['arg'].append(comp.split())
+            self.config['arg'] = [[]]
+            command_index = 0
+            for arg in self.args[2:]:
+                if ',' in arg:
+                    sub_args = arg.split(",")
+                    for sub_arg_index, sub_arg in enumerate(sub_args):
+                        if sub_arg:
+                            self.config['arg'][command_index].append(sub_arg)
+                        if sub_arg_index != len(sub_args) - 1:
+                            command_index += 1
+                            self.config['arg'].append([])
+                else:
+                    self.config['arg'][command_index].append(arg)
             if len(self.config['fun']) != len(self.config['arg']):
                 self.exit(42, 'Cannot execute compound command without '
                               'defining all arguments.')

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -843,6 +843,15 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help=('Return the documentation for the specified module or for '
                   'all modules if none are specified.')
         )
+        self.add_option(
+            '--args-separator',
+            dest='args_separator',
+            default=',',
+            help=('Set the special argument used as a delimiter between '
+                  'command arguments of compound commands. This is useful '
+                  'when one wants to pass commas as arguments to '
+                  'some of the commands in a compound command.')
+        )
 
     def _mixin_after_parsed(self):
         # Catch invalid invocations of salt such as: salt run
@@ -870,21 +879,32 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         if ',' in self.args[1]:
             self.config['fun'] = self.args[1].split(',')
             self.config['arg'] = [[]]
-            command_index = 0
-            for arg in self.args[2:]:
-                if ',' in arg:
-                    sub_args = arg.split(",")
-                    for sub_arg_index, sub_arg in enumerate(sub_args):
-                        if sub_arg:
-                            self.config['arg'][command_index].append(sub_arg)
-                        if sub_arg_index != len(sub_args) - 1:
-                            command_index += 1
-                            self.config['arg'].append([])
-                else:
-                    self.config['arg'][command_index].append(arg)
-            if len(self.config['fun']) != len(self.config['arg']):
-                self.exit(42, 'Cannot execute compound command without '
-                              'defining all arguments.')
+            cmd_index = 0
+            if (self.args[2:].count(self.options.args_separator) ==
+                len(self.config['fun']) - 1):
+                # new style parsing: standalone argument separator
+                for arg in self.args[2:]:
+                    if arg == self.options.args_separator:
+                        cmd_index += 1
+                        self.config['arg'].append([])
+                    else:
+                        self.config['arg'][cmd_index].append(arg)
+            else:
+                # old style parsing: argument separator can be inside args
+                for arg in self.args[2:]:
+                    if self.options.args_separator in arg:
+                        sub_args = arg.split(self.options.args_separator)
+                        for sub_arg_index, sub_arg in enumerate(sub_args):
+                            if sub_arg:
+                                self.config['arg'][cmd_index].append(sub_arg)
+                            if sub_arg_index != len(sub_args) - 1:
+                                cmd_index += 1
+                                self.config['arg'].append([])
+                    else:
+                        self.config['arg'][cmd_index].append(arg)
+                if len(self.config['fun']) != len(self.config['arg']):
+                    self.exit(42, 'Cannot execute compound command without '
+                                  'defining all arguments.')
         else:
             self.config['fun'] = self.args[1]
             self.config['arg'] = self.args[2:]


### PR DESCRIPTION
This fixes the compound commands parsing, by not joining and splitting existing arguments.

For example, this would bomb:

```
salt '*' cmd.run,some.func 'echo "hello world"',a b c
```

The previous code would join all arguments into a single string `echo "hello world",a b c` then split it on commas: `[["echo", '"hello', 'world"'], ["a", "b", "c"]]`.

This pull request leaves arguments intact, except the ones that contain commas (they are split on commas).  So the previous command would chop arguments as you would expect, into `[['echo "hello world"'], ["a", "b", "c"]]`.

It also fixes another issue: empty strings could not be passed as arguments.  For example:

```
salt '*' some.func1,some.func2 one 1 two 2, three 3 empty "" four 4
```

This command would split arguments like this: `[["one", "1", "two", "2"], ["three", "3", "empty", "four", "4"]]`.  The empty string disappeared.

This pull request fixes this empty strings bug and splits arguments like this: `[["one", "1", "two", "2"], ["three", "3", "empty", "", "four", "4"]]`.
