### PR TITLE
Fix documentation bug in cmdmod.py (lacked an escape in code examples)

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -386,13 +386,13 @@ def run(cmd,
 
     CLI Example::
 
-        salt '*' cmd.run "ls -l | awk '/foo/{print $2}'"
+        salt '*' cmd.run "ls -l | awk '/foo/{print \$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' cmd.run template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print $2}'"
+        salt '*' cmd.run template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \$2}'"
 
     '''
     out = _run(cmd,
@@ -427,13 +427,13 @@ def run_stdout(cmd,
 
     CLI Example::
 
-        salt '*' cmd.run_stdout "ls -l | awk '/foo/{print $2}'"
+        salt '*' cmd.run_stdout "ls -l | awk '/foo/{print \$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' cmd.run_stdout template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print $2}'"
+        salt '*' cmd.run_stdout template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \$2}'"
 
     '''
     stdout = _run(cmd,
@@ -467,13 +467,13 @@ def run_stderr(cmd,
 
     CLI Example::
 
-        salt '*' cmd.run_stderr "ls -l | awk '/foo/{print $2}'"
+        salt '*' cmd.run_stderr "ls -l | awk '/foo/{print \$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' cmd.run_stderr template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print $2}'"
+        salt '*' cmd.run_stderr template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \$2}'"
 
     '''
     stderr = _run(cmd,
@@ -507,13 +507,13 @@ def run_all(cmd,
 
     CLI Example::
 
-        salt '*' cmd.run_all "ls -l | awk '/foo/{print $2}'"
+        salt '*' cmd.run_all "ls -l | awk '/foo/{print \$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' cmd.run_all template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print $2}'"
+        salt '*' cmd.run_all template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \$2}'"
 
     '''
     ret = _run(cmd,

--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -34,7 +34,7 @@ class TimedProc(object):
                 def terminate():
                     if rt.isAlive():
                         self.process.terminate()
-                threading.Timer(10, terminate)
+                threading.Timer(10, terminate).start()
                 raise salt.exceptions.TimedProcTimeoutError('%s : Timed out after %s seconds' % (
                     self.command,
                     str(timeout),


### PR DESCRIPTION
The examples were incorrect:

```
salt '*' cmd.run "ls -l | awk '/foo/{print $2}'"
```

The `$2` would be interpreted by the shell before being passed to the `salt` command.  So it would actually receive these parameters:

```
['*', 'cmd.run', "ls -l | awk '/foo/{print }'"]
```

Not what you would expect.

There are two possible solutions:

```
salt '*' cmd.run "ls -l | awk '/foo/{print \$2}'"
salt '*' cmd.run 'ls -l | awk "/foo/{print \$2}"'
```

I chose the former.
