### PR TITLE
Pkg proposal

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -754,9 +754,13 @@ def mod_init(low):
     When originally setting up the mod_init for pkg a number of corner cases
     arose with different package managers and how they refresh package data.
     '''
+    ret = True
+    if 'pkg.ex_mod_init' in __salt__:
+        ret = __salt__['pkg.ex_mod_init'](low)
+
     if low['fun'] == 'installed' or low['fun'] == 'latest':
         rtag = __gen_rtag()
         if not os.path.exists(rtag):
             salt.utils.fopen(rtag, 'w+').write('')
-        return True
+        return ret
     return False


### PR DESCRIPTION
I want to allow the Gentoo users to set use flags and keywords directly in pkg.install, but to do this I need to enforce a specific environment. So I thought I'd add to pkg mod_init the ability to execute a special "ex_mod_init" function from the execution module. In this way the new ebuild.py will be able to do its checks. The others pkg modules will not need to be modified. What do you think about this?
