### PR TITLE
Allow pkg.purged to purge partially removed packages

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -48,7 +48,7 @@ def _tap(tap, runas=None):
     return True
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
@@ -59,6 +59,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -202,7 +202,7 @@ def porttree_matches(name):
                 if x.endswith('/' + str(name))]
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
@@ -213,6 +213,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -139,7 +139,7 @@ def refresh_db():
     return {}
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -150,6 +150,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -24,7 +24,7 @@ def __virtual__():
     return False
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -34,6 +34,11 @@ def list_pkgs(versions_as_list=False):
 
         salt '*' pkg.list_pkgs
     '''
+    versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
+
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:
             return __context__['pkg.list_pkgs']

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -116,7 +116,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -127,6 +127,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -131,7 +131,7 @@ def refresh_db():
     return {}
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -142,6 +142,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     pkgin = _check_pkgin()
     if pkgin:

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -101,7 +101,7 @@ def upgrade(refresh=True, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -113,6 +113,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs versions_as_list=True
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -61,7 +61,7 @@ def _write_adminfile(kwargs):
     return adminfile
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -72,6 +72,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -192,7 +192,7 @@ def version(*names, **kwargs):
     return ret
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
         List the packages currently installed in a dict::
 
@@ -204,6 +204,9 @@ def list_pkgs(versions_as_list=False):
             salt '*' pkg.list_pkgs versions_as_list=True
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -238,7 +238,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
@@ -249,6 +249,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -177,7 +177,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed in a dict::
 
@@ -188,6 +188,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -133,7 +133,7 @@ def version(*names, **kwargs):
     return __salt__['pkg_resource.version'](*names, **kwargs)
 
 
-def list_pkgs(versions_as_list=False):
+def list_pkgs(versions_as_list=False, **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -144,6 +144,9 @@ def list_pkgs(versions_as_list=False):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
+    # 'removed' not yet implemented or not applicable
+    if salt.utils.is_true(kwargs.get('removed')):
+        return {}
 
     if 'pkg.list_pkgs' in __context__:
         if versions_as_list:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -105,10 +105,11 @@ def _find_install_targets(name=None, version=None, pkgs=None, sources=None):
         if salt.utils.is_windows():
             pkginfo = _get_package_info(name)
             if not pkginfo:
-                return {'name':name,
-                        'changes':{},
-                        'result':False,
-                        'comment':('Package {0} not found in the repository.'.format(name))}
+                return {'name': name,
+                        'changes': {},
+                        'result': False,
+                        'comment': 'Package {0} not found in the '
+                                   'repository.'.format(name)}
             if version is None:
                 version = _get_latest_pkg_version(pkginfo)
             name = pkginfo[version]['full_name']
@@ -654,7 +655,11 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
     old = __salt__['pkg.list_pkgs'](versions_as_list=True)
     if not salt.utils.is_windows():
-        targets = sorted([x for x in pkg_params if x in old])
+        targets = [x for x in pkg_params if x in old]
+        if action == 'purge':
+            old_removed = __salt__['pkg.list_pkgs'](versions_as_list=True,
+                                                    removed=True)
+            targets.extend([x for x in pkg_params if x in old_removed])
     else:
         targets = []
         for item in pkg_params:
@@ -665,7 +670,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
                 version_num = _get_latest_pkg_version(pkginfo)
             if pkginfo[version_num]['full_name'] in old:
                 targets.append(pkginfo[version_num]['full_name'])
-    targets = sorted(targets)
+    targets.sort()
 
     if not targets:
         return {'name': name,
@@ -683,6 +688,11 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     changes = __salt__['pkg.{0}'.format(action)](name, pkgs=pkgs, **kwargs)
     new = __salt__['pkg.list_pkgs'](versions_as_list=True)
     failed = [x for x in pkg_params if x in new]
+    if action == 'purge':
+        new_removed = __salt__['pkg.list_pkgs'](versions_as_list=True,
+                                                removed=True)
+        failed.extend([x for x in pkg_params if x in new_removed])
+    failed.sort()
 
     if failed:
         return {'name': name,


### PR DESCRIPTION
This commit fixes #4972 by adding a check in apt.py for packages that were removed but not purged, thus allowing the **pkg.purge** execution function and the **pkg.purged** state to purge partially-removed packages.
