### PR TITLE
Use win32 newlines in templated files on windows

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -56,6 +56,10 @@ def wrap_tmpl_func(render_str):
             tmplsrc.close()
         try:
             output = render_str(tmplstr, context, tmplpath)
+            if salt.utils.is_windows():
+                # Write out with Windows newlines
+                output = os.linesep.join(output.splitlines())
+
         except SaltTemplateRenderError as exc:
             return dict(result=False, data=str(exc))
         except Exception:


### PR DESCRIPTION
Fixes #4355
