### PR TITLE
Upgrade kwargs parsing

### DIFF
--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -150,7 +150,26 @@ Optional, keyword arguments are also supported:
 
     salt '*' pip.install salt timeout=5 upgrade=True
 
-They are always in the form of ``kwarg=argument``. 
+They are always in the form of ``kwarg=argument``.
+
+Arguments are formatted as YAML:
+
+.. code-block:: bash
+
+    salt '*' cmd.run 'echo "Hello: $FIRST_NAME"' env='{FIRST_NAME: "Joe"}'
+
+Note: dictionaries must have curly braces around them (like the ``env``
+keyword argument above).  This was changed in 0.15.1: in the above example,
+the first argument used to be parsed as the dictionary
+``{'echo "Hello': '$FIRST_NAME"'}``. This was generally not the expected
+behavior.
+
+If you want to test what parameters are actually passed to a module, use the
+``test.arg_repr`` command:
+
+.. code-block:: bash
+
+    salt '*' test.arg_repr 'echo "Hello: $FIRST_NAME"' env='{FIRST_NAME: "Joe"}'
 
 Finding available minion functions
 ``````````````````````````````````
@@ -197,8 +216,8 @@ spaces around the commas that separate arguments. For example:
 
     salt '*' cmd.run,test.ping,test.echo 'echo "1,2,3"' , , foo
 
-You may change the arguments separator using the ``args-separator`` option:
+You may change the arguments separator using the ``--args-separator`` option:
 
 .. code-block:: bash
 
-    salt --arg-separator=::: '*' some.fun,test.echo params with comma , ::: foo
+    salt --args-separator=:: '*' some.fun,test.echo params with , comma :: foo

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -62,9 +62,8 @@ class Caller(object):
             sys.stderr.write('Function {0} is not available\n'.format(fun))
             sys.exit(-1)
         try:
-            args, kwargs = salt.minion.detect_kwargs(
+            args, kwargs = salt.minion.parse_args_and_kwargs(
                 self.minion.functions[fun], self.opts['arg'])
-            args, kwargs = self.parse_args(args, kwargs)
             sdata = {
                     'fun': fun,
                     'pid': os.getpid(),
@@ -107,34 +106,6 @@ class Caller(object):
                 except Exception:
                     pass
         return ret
-
-    def parse_arg(self, arg):
-        '''
-        Yaml-erize an argument
-        '''
-        try:
-            if '\n' not in arg:
-                arg = yaml.safe_load(arg)
-            if isinstance(arg, bool):
-                return str(arg)
-            return arg
-        except Exception:
-            return arg
-
-    def parse_args(self, args=None, kwargs=None):
-        '''
-        Read in the args and kwargs and return the structures with parsed
-        arguments
-        '''
-        r_args = []
-        r_kwargs = {}
-        if args:
-            for arg in args:
-                r_args.append(self.parse_arg(arg))
-        if kwargs:
-            for key, val in kwargs.items():
-                r_kwargs[key] = self.parse_arg(val)
-        return r_args, r_kwargs
 
     def print_docs(self):
         '''

--- a/salt/client.py
+++ b/salt/client.py
@@ -1149,5 +1149,5 @@ class Caller(object):
         Call a single salt function
         '''
         func = self.sminion.functions[fun]
-        args, kwargs = salt.minion.detect_kwargs(func, args, kwargs)
+        args, kwargs = salt.minion.parse_args_and_kwargs(func, args, kwargs)
         return func(*args, **kwargs)

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -142,10 +142,35 @@ def kwarg(**kwargs):
 
     CLI Example::
 
-        salt '*' test.kwarg
+        salt '*' test.kwarg num=1 txt="two" env='{a: 1, b: "hello"}'
     '''
     return kwargs
 
+def arg(*args, **kwargs):
+    '''
+    Print out the data passed into the function ``*args`` and ```kwargs``, this
+    is used to both test the publication data and cli argument passing, but
+    also to display the information available within the publication data.
+    Returns {"args": args, "kwargs": kwargs}.
+
+    CLI Example::
+
+        salt '*' test.arg 1 "two" 3.1 txt="hello" wow='{a: 1, b: "hello"}'
+    '''
+    return {"args": args, "kwargs": kwargs}
+
+def arg_repr(*args, **kwargs):
+    '''
+    Print out the data passed into the function ``*args`` and ```kwargs``, this
+    is used to both test the publication data and cli argument passing, but
+    also to display the information available within the publication data.
+    Returns {"args": repr(args), "kwargs": repr(kwargs)}.
+
+    CLI Example::
+
+        salt '*' test.arg_repr 1 "two" 3.1 txt="hello" wow='{a: 1, b: "hello"}'
+    '''
+    return {"args": repr(args), "kwargs": repr(kwargs)}
 
 def fib(num):
     '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -42,7 +42,7 @@ class RunnerClient(object):
         if not isinstance(kwarg, dict):
             kwarg = {}
         self._verify_fun(fun)
-        args, kwargs = salt.minion.detect_kwargs(
+        args, kwargs = salt.minion.parse_args_and_kwargs(
                 self.functions[fun],
                 arg,
                 kwarg)

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -65,6 +65,8 @@ DEFAULT_COLOR = '\033[00m'
 RED_BOLD = '\033[01;31m'
 ENDC = '\033[0m'
 
+#KWARG_REGEX = re.compile(r"^([^\d\W]\w*)=(.*)$", re.UNICODE) # python 3
+KWARG_REGEX = re.compile(r"^([^\d\W]\w*)=(.*)$")
 
 log = logging.getLogger(__name__)
 
@@ -1164,3 +1166,22 @@ def namespaced_function(function, global_dict, defaults=None):
     )
     new_namespaced_function.__dict__.update(function.__dict__)
     return new_namespaced_function
+
+def parse_kwarg(string):
+    '''
+    Parses the string and looks for the kwarg format:
+    "{argument name}={argument value}"
+    For example:
+    "my_message=Hello world"
+    The argument name must have a valid python identifier format (it should
+    match the following regular expression: [^\\d\\W]\\w*).
+    If the string matches, then this function returns the following tuple:
+    ({argument name}, {value})
+    Or else it returns:
+    (None, None)
+    '''
+    match = KWARG_REGEX.match(string)
+    if match:
+        return match.groups()
+    else:
+        return None, None


### PR DESCRIPTION
Hi,

Here's another set of commits meant to make salt command line arguments and keyword arguments simpler to use.

**Change 1: dictionaries in arguments and keyword argument values _must_ be formatted with curly brackets.**

I was frustrated with the fact that the following bombs:

```
salt '*' cmd.run 'echo "Hello: world"'
```

First, the master passes the argument string untouched to the minions as `'echo "Hello: world"'`. But then it is further parsed by the minions into a dictionary `{'echo "Hello': 'world"'}`.

Ouch.  Not at all what you would expect, don't you think?

With the existing argument parsing, you need to escape strings quite often, like this:

```
salt '*' cmd.run '"echo \"Hello: world\""'
```

Now if you add kwargs to the mix, it gets ugly:

```
salt '*' cmd.run '"echo \"Hello: $FIRST_NAME\""' '"env={FIRST_NAME: \"Joe\"}"'
```

This is really tough to get right. Unnecessarily so, I reckon.

The problem is mostly due to YAML: it considers almost anything as a dictionary when it sees a colon `:`.

So this pull request adds a new rule: all dictionaries in arguments and kwargs should be formatted with curly brackets.

This greatly simplifies a lot of commands.  The one above still works but it can be simplified into this:

```
salt '*' cmd.run 'echo "Hello: $FIRST_NAME"' 'env={FIRST_NAME: "Joe"}'
```

It might be a breaking change for some people, I'm afraid.  But how much so, I don't know: who actually passes dictionaries as arguments without curly braces (on purpose)? Here's code that won't work anymore:

```
salt '*' func.expects_dict 'Hello: world'
```

It should be replaced with this:

```
salt '*' func.expects_dict '{Hello: world}'
```

I really think this change will save people a lot of headaches, as colons creep up all over the place and yaml tends to think everything's a dictionary, which leads to escaping strings all the time, and that's just painful.

**Change 2: keyword argument names _must_ be valid python identifiers.**

The only constraint on the kwarg name today is that it should not include a space.  I made it a bit more strict by only allowing properly formatted python identifiers (take a look at the regex in `salt/utils/__init__.py`).  This will avoid bugs with this kind of calls:

```
salt '*' some.display hello ====== how are you?
```

The function would be passed the kwarg `{"=": "====="}`, most likely a bug.
Here's another similar bug:

```
salt '*' genius.solve_equation "cos(x)=0.5"
```

Instead of having argument `"cos(x)=0.5"`, we end up with kwarg `"cos(x)"` with value `0.5`.  Most likely not what you want.  So now in these two examples, all arguments will be understood as regular arguments (as strings), not kwargs.

Again, a breaking change... but really, even though it's _possible_, who would actually have used this "functionality" (I'd rather call it a parsing bug actually)?  I don't think changing this will actually break anyone's code.  Again, I may be wrong.

**Change 3 (implemented but not activated): Kwarg parsing _before_ YAML parsing**

Keyword argument parsing is currently done _after_ yamlifying the arguments.  This means that it is impossible to pass the string `"a=b"` as an argument to a function, like this:

```
salt '*' some.func '"a=b"'
```

The first round of yaml parsing results in removing the internal double-quotes, so when the kwarg parsing kicks in, it detects an kwarg `a`... not what's expected.

So I fixed this: there's just one round of parsing now, and kwargs detection is applied first, before yamlifying (yamlifying applies only to arguments and keyword argument-values, not kwarg names).  In the process, I removed a few redundancies in the code, so don't be surprised to see a `parse_arg` and `parse_args` disappear and `detect_kwargs` renamed.  I hope no-one used them elsewhere (they were purely internal code, from what I can see, not API, so it should be ok).

Yet again it's a breaking change, but this time a bit more severe. Let's go back to the example above:

```
salt '*' cmd.run '"echo \"Hello: $FIRST_NAME\""' '"env={FIRST_NAME: \"Joe\"}"'
```

This command will now call `cmd.run` with two string arguments, instead of one string and one `env` keyword argument dictionary.  Yet it used to work, and it was actually the only way to make it work.  So this change is fairly severe, people will have to fix a few commands. So for now I deactivated this change in the code: I put `YAMLIFY_ARGS_BEFORE_PARSING_KWARGS=True` at the beginning of `minions.py`.  Just set it to `False` to enjoy the new parsing.

This may need to be a config file option or something, I don't know yet.  Any ideas?

**Change 4: any argument can be passed as a kwarg**

I don't understand why the code limits keyword arguments to just the arguments that have default values.  This is not standard python behavior, so it's really confusing and error prone.  For example, say there's a function like this:

```
# some.py
def func(x, y, z=3):
    return (x, y, z)
```

This function can be called in the following ways:

```
salt '*' some.func 1 2 3        # x=1 y=2 z=3
salt '*' some.func 1 2 z=3      # x=1 y=2 z=3
salt '*' some.func 1 z=3 2      # x=1 y=2 z=3
salt '*' some.func z=3 1 2      # x=1 y=2 z=3
salt '*' some.func 1 2          # x=1 y=2 z=3
```

So far so good. But the following would not give the expected result:

```
salt '*' some.func x=1 y=2 z=3  # x="x=1" y="y=2" z=3 !!
```

This is really weird.  It took effort to code, so I'm guessing it might be useful for some reason, but I really don't see what.

So I changed this behavior (and it actually simplifies the code): now all arguments can be passed as keyword arguments, whether they have a default value or not.  It's more like python (although there are still a few differences, for example it's possible to pass regular args after kwargs).

**Change 5: added `test.arg` and `test.arg_repr`**

Lastly, to see what arguments are actually passed, I added `test.arg` and `test.arg_repr`.  The first one is output as yaml by default, which is pretty but not clear enough when you want to be absolutely sure whether a specific argument was passed as a string or an int, for example.  That's why I also added `arg_repr` which returns `{"args": repr(args), "kwargs": repr(kwargs)}`.

**Conclusion**

I have used the new parsing all day long, and it was really pleasant to use. :smile:  I hope I didn't go too far, though: how can we make sure that we don't break peoples existing code?
