### PR TITLE
Some docs updates

### DIFF
--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -323,15 +323,23 @@ Change to salt documention directory, then::
 
     cd doc; make html
 
-- The docs then are built in the ``docs/_build/html/`` folder. If you make
-  changes and want to see the results, ``make html`` again.
+- This will build the HTML docs. Run ``make`` without any arguments to see the
+  available make targets, which include :strong:`html`, :strong:`man`, and
+  :strong:`text`.
+- The docs then are built within the :strong:`docs/_build/` folder. If you make
+  changes and want to see the results, run the ``make`` again.
 - The docs use `reStructuredText <http://sphinx-doc.org/rest.html>`_ for markup.
   See a live demo at http://rst.ninjs.org/.
 - The help information on each module or state is culled from the python code
   that runs for that piece. Find them in ``salt/modules/`` or ``salt/states/``.
-- If you are developing using Arch Linux (or any other distribution for which
-  Python 3 is the default Python installation), then ``sphinx-build`` may be
-  named ``sphinx-build2`` instead. If this is the case, then you will need to
-  run the following ``make`` command::
+
+- To build the docs on Arch Linux, you will need to install the
+  :strong:`python2-sphinx` package, and tell :strong:`make` where to find the
+  proper :strong:`sphinx-build` binary, like so::
 
     make SPHINXBUILD=sphinx-build2 html
+
+- To build the docs on RHEL/CentOS 6, you will need to install the
+  :strong:`python-sphinx10` package from EPEL, and use the following make command::
+
+    make SPHINXBUILD=sphinx-1.0-build html

--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -129,6 +129,14 @@ control and flexibility when targeting minions.
 
     salt -I 'somekey:specialvalue' test.ping
 
+Like with :doc:`Grains <../targeting/grains>`, you can use globbing as well as
+match nested values in Pillar, by adding colons for each level that you are
+traversing. The below example would match minions with a pillar named ``foo``,
+which is a dict containing a key ``bar``, with a value beginning with ``baz``::
+
+    salt -I 'foo:bar:baz*'
+
+
 Master Config In Pillar
 =======================
 

--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -30,6 +30,15 @@ Match all minions with 64-bit CPUs and return number of available cores::
 
     salt -G 'cpuarch:x86_64' grains.item num_cpus
 
+You can also use globbing, as well as match grains that are nested in a
+dictionary, by adding a colon for each level you are traversing. For example,
+the following will match hosts that have a grain called ``ec2_tags``, which
+itself is a dict with a key named ``environment``, which has a value that
+contains the word ``production``::
+
+    salt -G 'ec2_tags:environment:*production*'
+
+
 Listing Grains
 ==============
 


### PR DESCRIPTION
This adds some clarification on matching nested grains/pillars, as well as gives details on how to build the docs on RHEL/CentOS 6.
