### PR TITLE
Adding "Depends" decorator to salt.utils

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -13,6 +13,7 @@ import tempfile
 # Import salt libs
 from salt.exceptions import LoaderError
 from salt.template import check_render_pipe_str
+from salt.utils.decorators import Depends
 
 log = logging.getLogger(__name__)
 
@@ -99,6 +100,9 @@ def minion_mods(opts, context=None, whitelist=None):
         pack,
         whitelist=whitelist
     )
+    # Enforce dependancies of module functions from "functions"
+    Depends.enforce_dependancies(functions)
+
     if opts.get('providers', False):
         if isinstance(opts['providers'], dict):
             for mod, provider in opts['providers'].items():

--- a/salt/utils/decorators.py
+++ b/salt/utils/decorators.py
@@ -1,0 +1,112 @@
+'''
+Helpful decorators module writing
+'''
+
+import logging
+from collections import defaultdict
+import inspect
+
+class Depends(object):
+    '''
+    This decorator will check the module when it is loaded and check that the dependancies passed in
+        are in the globals of the module. If not, it will cause the function to be unloaded (or replaced)
+    '''
+    # Dependancy -> list of things that depend on it
+    dependancy_dict = defaultdict(set)
+    def __init__(self, *dependancies, **kwargs):
+        '''
+        The decorator is instantiated with a list of dependancies (string of global name)
+
+            an example use of this would be:
+
+            @depends('modulename')
+            def test():
+                return 'foo'
+
+            OR
+
+            @depends('modulename', fallback_funcion=function)
+            def test():
+                return 'foo'
+        '''
+        logging.debug('Depends decorator instantiated with dep list of {0}'.format(dependancies))
+        self.depencancies = dependancies
+        self.fallback_funcion = kwargs.get('fallback_funcion')
+
+    def __call__(self, function):
+        '''
+        The decorator is "__call__"d with the function, we take that function and
+            determine which module and function name it is to store in the class wide
+            depandancy_dict
+        '''
+        module = inspect.getmodule(inspect.stack()[1][0])
+        for dep in self.depencancies:
+            self.dependancy_dict[dep].add((module, function, self.fallback_funcion))
+        return function
+
+    @classmethod
+    def enforce_dependancies(self, functions):
+        '''
+        This is a class global method to enforce the dependancies that you currently know about
+
+        It will modify the "functions" dict and remove/replace modules that are missing dependancies
+        '''
+        for dependancy, dependant_set in self.dependancy_dict.iteritems():
+            # check if dependancy is loaded
+            for module, func, fallback_funcion in dependant_set:
+                # check if you have the dependancy
+                if dependancy in dir(module):
+                    logging.debug('Dependancy ({0}) already loaded, skipping'.format(dependancy))
+                    continue
+                logging.debug('Unloading {0}.{1} because dependancy ({2}) is not imported'.format(module, func, dependancy))
+                # if not, unload dependand_set
+                print
+                mod_key = '{0}.{1}'.format(module.__name__.split('.')[-1],
+                                           func.__name__)
+
+                # if we don't have this module loaded, skip it!
+                if mod_key not in functions:
+                    continue
+
+                try:
+                    if fallback_funcion is not None:
+                        functions[mod_key] = fallback_funcion
+                    else:
+                        del(functions[mod_key])
+                except AttributeError:
+                    # we already did???
+                    logging.debug('{0} already removed, skipping'.format(mod_key))
+                    continue
+
+    @classmethod
+    def old_enforce_dependancies(self):
+        '''
+        This is a class global method to enforce the dependancies that you currently know about
+        '''
+        for dependancy, dependant_set in self.dependancy_dict.iteritems():
+            # check if dependancy is loaded
+            for module, func, fallback_funcion in dependant_set:
+                # check if you have the dependancy
+                if dependancy in dir(module):
+                    logging.debug('Dependancy ({0}) already loaded, skipping'.format(dependancy))
+                    continue
+                logging.debug('Unloading {0}.{1} because dependancy ({2}) is not imported'.format(module, func, dependancy))
+                # if not, unload dependand_set
+
+
+                try:
+                    if fallback_funcion is not None:
+                        setattr(module, func.__name__, fallback_funcion)
+                    else:
+                        delattr(module, func.__name__)
+                except AttributeError:
+                    # we already did???
+                    logging.debug('{0}.{1} already removed, skipping'.format(module, func.__name__))
+                    continue
+
+class depends(Depends):
+    '''
+    Wrapper of Depends for capitalization
+    '''
+    pass
+

--- a/tests/integration/files/file/base/_modules/runtests_decorators.py
+++ b/tests/integration/files/file/base/_modules/runtests_decorators.py
@@ -1,0 +1,25 @@
+import salt.utils.decorators
+import time
+
+def _fallbackfunc():
+    return False, 'fallback'
+
+
+def working_function():
+    return True
+
+@salt.utils.decorators.depends('time')
+def depends():
+    return True, time.time()
+
+@salt.utils.decorators.depends('time123')
+def missing_depends():
+    return True, time.time()
+
+@salt.utils.decorators.depends('time', fallback_funcion=_fallbackfunc)
+def depends_will_fallback():
+    return True, time.time()
+
+@salt.utils.decorators.depends('time123', fallback_funcion=_fallbackfunc)
+def missing_depends_will_fallback():
+    return True, time.time()

--- a/tests/integration/modules/decorators.py
+++ b/tests/integration/modules/decorators.py
@@ -1,0 +1,23 @@
+import integration
+
+
+class DecoratorTest(integration.ModuleCase):
+    def test_module(self):
+        self.assertTrue(self.run_function('runtests_decorators.working_function'))
+
+    def test_depends(self):
+        ret_val, time = self.run_function('runtests_decorators.depends')
+        self.assertTrue(ret_val)
+        self.assertTrue(type(time) == float)
+
+    def test_missing_depends(self):
+        self.assertTrue('is not available' in self.run_function('runtests_decorators.missing_depends'))
+
+    def test_depends_will_fallback(self):
+        ret_val, time = self.run_function('runtests_decorators.depends_will_fallback')
+        self.assertTrue(ret_val)
+        self.assertTrue(type(time) == float)
+
+    def test_missing_depends(self):
+        self.assertTrue('fallback' in self.run_function('runtests_decorators.missing_depends_will_fallback'))
+


### PR DESCRIPTION
The Depends decorator allows you to optionally remove functions if sepecific globals/modules don't exist. This is particuarly helpful in larger scale deployments where some functions of the module work everywhere, but others require (for example) a service to be installed. This way you can avoid having to try/except all over the module to only load certain functions etc.
