### PR TITLE
add missing initialization for syndic_wait in LocalClient.get_iter_returns

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -612,6 +612,7 @@ class LocalClient(object):
         if not os.path.isdir(jid_dir):
             yield {}
         # Wait for the hosts to check in
+        syndic_wait = 0
         while True:
             raw = self.event.get_event(timeout, jid)
             if raw is not None:


### PR DESCRIPTION
```
************ Module salt.client
E0601:636,27:LocalClient.get_iter_returns: Using variable 'syndic_wait' before assignment
```
