### PR TITLE
add missing salt.utils import to modules.openbsdpkg

### DIFF
--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -7,6 +7,9 @@ import copy
 import re
 import logging
 
+# Import Salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
```
************* Module salt.modules.openbsdpkg
E0602: 37,23:list_pkgs: Undefined variable 'salt'
E0602: 39,7:list_pkgs: Undefined variable 'salt'
```
