### PR TITLE
fixed bug: cp.caches does not work

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -120,7 +120,7 @@ class Client(object):
         minion file cache
         '''
         ret = []
-        for path in paths:
+        for path in paths.split(','):
             ret.append(self.cache_file(path, env))
         return ret
 

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -112,6 +112,8 @@ def returner(ret):
         sql = '''INSERT INTO `salt_returns`
                 (`fun`, `jid`, `return`, `id`, `success`, `full_ret` )
                 VALUES (%s, %s, %s, %s, %s, %s)'''
+        if len(ret['return']) == str(ret['return']).count("'result': True"):
+            ret['success'] = True
         cur.execute(sql, (ret['fun'], ret['jid'],
                             str(ret['return']), ret['id'],
                             ret['success'], json.dumps(ret)))


### PR DESCRIPTION
https://github.com/halfss/salt/commit/5b1ecede5f3fb31fda6a4bba821fff5af4b96d20

salt 'minion1' cp.cache_files salt://kvm/qemu.conf,salt://kvm/init.sls

var paths is a str like 'salt://kvm/qemu.conf,salt://kvm/init.sls'

when loop it,got a str 's',not 'salt://kvm/qemu.conf'

got error:

```
[root@localhost _modules]# salt 'minion1' cp.cache_files salt://kvm/qemu.conf,salt://kvm/init.sls
minion1:
    Traceback (most recent call last):
      File "/usr/lib/python2.6/site-packages/salt/minion.py", line 426, in _thread_return
        ret['return'] = func(*args, **kwargs)
      File "/usr/lib/python2.6/site-packages/salt/modules/cp.py", line 240, in cache_files
        return __context__['cp.fileclient'].cache_files(paths, env)
      File "/usr/lib/python2.6/site-packages/salt/fileclient.py", line 126, in cache_files
        ret.append(self.cache_file(path, env))
      File "/usr/lib/python2.6/site-packages/salt/fileclient.py", line 116, in cache_file
        return self.get_url(path, '', True, env)
      File "/usr/lib/python2.6/site-packages/salt/fileclient.py", line 336, in get_url
        with contextlib.closing(url_open(url)) as srcfp:
      File "/usr/lib64/python2.6/urllib2.py", line 126, in urlopen
        return _opener.open(url, data, timeout)
      File "/usr/lib64/python2.6/urllib2.py", line 384, in open
        protocol = req.get_type()
      File "/usr/lib64/python2.6/urllib2.py", line 245, in get_type
        raise ValueError, "unknown url type: %s" % self.__original
    ValueError: unknown url type: s
```
