### PR TITLE
Fix a bug of pip.list

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -562,15 +562,14 @@ def list_(prefix='',
     for line in result['stdout'].splitlines():
         if line.startswith('-e'):
             line = line.split('-e ')[1]
-            line, name = line.split('#egg=')
-            packages[name] = line
-
+            version, name = line.split('#egg=')
         elif len(line.split('==')) >= 2:
             name = line.split('==')[0]
             version = line.split('==')[1]
-            if prefix:
-                if line.lower().startswith(prefix.lower()):
-                    packages[name] = version
-            else:
+
+        if prefix:
+            if name.lower().startswith(prefix.lower()):
                 packages[name] = version
+        else:
+            packages[name] = version
     return packages


### PR DESCRIPTION
Before:

```
$ salt-call pip.list tinypng
salt-dev:
    git+https://github.com/saltstack/salt.git@77e758c2e8142d92298aa26db08ed6af02506038
tinypng:
    1.2.0
```

After:

```
$ salt-call pip.list tinypng
tinypng:
    1.2.0
```
