### PR TITLE
New output changes

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -358,6 +358,7 @@ The state_output setting changes if the output is the full multi line
 output for each changed state if set to 'full', but if set to 'terse'
 the output will be shortened to a single line.  If set to 'mixed', the output
 will be terse unless a state failed, in which case that output will be full.
+If set to 'changes', the output will be fill unless the state didn't change.
 
 .. code-block:: yaml
 

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -86,6 +86,13 @@ def output(data):
                         msg = _format_terse(tcolor, comps, ret, colors)
                         hstrs.append(msg)
                         continue
+                elif __opts__.get('state_output', 'full').lower() == 'changes':
+                    # Print terse if no error and no changes, otherwise, be
+                    # verbose
+                    if ret['result'] is not False and not ret['changes']:
+                        msg = _format_terse(tcolor, comps, ret, colors)
+                        hstrs.append(msg)
+                        continue
                 hstrs.append(('{0}----------\n    State: - {1}{2[ENDC]}'
                               .format(tcolor, comps[0], colors)))
                 hstrs.append('    {0}Name:      {1}{2[ENDC]}'.format(

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -77,25 +77,13 @@ def output(data):
                 if __opts__.get('state_output', 'full').lower() == 'terse':
                     # Print this chunk in a terse way and continue in the
                     # loop
-                    msg = (' {0}Name: {1} - Function: {2}.{3} - '
-                           'Result: {4}{5}').format(tcolor,
-                                                    comps[2],
-                                                    comps[0],
-                                                    comps[-1],
-                                                    str(ret['result']),
-                                                    colors['ENDC'])
+                    msg = _format_terse(tcolor, comps, ret, colors)
                     hstrs.append(msg)
                     continue
                 elif __opts__.get('state_output', 'full').lower() == 'mixed':
                     # Print terse unless it failed
                     if ret['result'] is not False:
-                        msg = (' {0}Name: {1} - Function: {2}.{3} - '
-                               'Result: {4}{5}').format(tcolor,
-                                                        comps[2],
-                                                        comps[0],
-                                                        comps[-1],
-                                                        str(ret['result']),
-                                                        colors['ENDC'])
+                        msg = _format_terse(tcolor, comps, ret, colors)
                         hstrs.append(msg)
                         continue
                 hstrs.append(('{0}----------\n    State: - {1}{2[ENDC]}'
@@ -159,3 +147,18 @@ def _strip_clean(returns):
     for tag in rm_tags:
         returns.pop(tag)
     return returns
+
+
+def _format_terse(tcolor, comps, ret, colors):
+    '''
+    Terse formatting of a message.
+    '''
+    msg = (' {0}Name: {1} - Function: {2}.{3} - '
+           'Result: {4}{5}').format(tcolor,
+                                    comps[2],
+                                    comps[0],
+                                    comps[-1],
+                                    str(ret['result']),
+                                    colors['ENDC'])
+
+    return msg


### PR DESCRIPTION
It displays states result in 'full' mode unless nothing changed, in which case it displays results in 'terse' mode.

This is a proposed fix for #5516

I would happily update the changelog as well if I knew which file to modify.
