### PR TITLE
djangomod commands take env= argument

### DIFF
--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -27,6 +27,7 @@ def command(settings_module,
             command,
             bin_env=None,
             pythonpath=None,
+            env=None,
             *args, **kwargs):
     '''
     Run arbitrary django management command
@@ -47,7 +48,7 @@ def command(settings_module,
     for key, value in kwargs.items():
         if not key.startswith('__'):
             cmd = '{0} --{1}={2}'.format(cmd, key, value)
-    return __salt__['cmd.run'](cmd)
+    return __salt__['cmd.run'](cmd, env=env)
 
 
 def syncdb(settings_module,
@@ -55,6 +56,7 @@ def syncdb(settings_module,
            migrate=False,
            database=None,
            pythonpath=None,
+           env=None,
            noinput=True):
     '''
     Run syncdb
@@ -80,6 +82,7 @@ def syncdb(settings_module,
                   'syncdb',
                    bin_env,
                    pythonpath,
+                   env,
                    *args, **kwargs)
 
 
@@ -88,7 +91,8 @@ def createsuperuser(settings_module,
                     email,
                     bin_env=None,
                     database=None,
-                    pythonpath=None):
+                    pythonpath=None,
+                    env=None):
     '''
     Create a super user for the database.
     This function defaults to use the ``--noinput`` flag which prevents the
@@ -109,6 +113,7 @@ def createsuperuser(settings_module,
                    'createsuperuser',
                    bin_env,
                    pythonpath,
+                   env,
                    *args, **kwargs)
 
 
@@ -116,7 +121,8 @@ def loaddata(settings_module,
              fixtures,
              bin_env=None,
              database=None,
-             pythonpath=None):
+             pythonpath=None,
+             env=None):
     '''
     Load fixture data
 
@@ -146,7 +152,8 @@ def collectstatic(settings_module,
                   clear=False,
                   link=False,
                   no_default_ignore=False,
-                  pythonpath=None):
+                  pythonpath=None,
+                  env=None):
     '''
     Collect static files from each of your applications into a single location
     that can easily be served in production.
@@ -174,4 +181,5 @@ def collectstatic(settings_module,
                    'collectstatic',
                    bin_env,
                    pythonpath,
+                   env,
                    *args, **kwargs)

--- a/tests/integration/modules/django.py
+++ b/tests/integration/modules/django.py
@@ -26,7 +26,8 @@ class DjangoModuleTest(integration.ModuleCase):
                         {'cmd.run': mock}):
             django.command('settings.py', 'runserver')
             mock.assert_called_once_with(
-                'django-admin.py runserver --settings=settings.py'
+                'django-admin.py runserver --settings=settings.py',
+                env=None
             )
 
     def test_command_with_args(self):
@@ -38,12 +39,14 @@ class DjangoModuleTest(integration.ModuleCase):
                 'runserver',
                 None,
                 None,
+                None,
                 'noinput',
                 'somethingelse'
             )
             mock.assert_called_once_with(
                 'django-admin.py runserver --settings=settings.py '
-                '--noinput --somethingelse'
+                '--noinput --somethingelse',
+                env=None
             )
 
     def test_command_with_kwargs(self):
@@ -59,7 +62,8 @@ class DjangoModuleTest(integration.ModuleCase):
             )
             mock.assert_called_once_with(
                 'django-admin.py runserver --settings=settings.py '
-                '--database=something'
+                '--database=something',
+                env=None
             )
 
     def test_command_with_kwargs_ignore_dunder(self):
@@ -70,7 +74,8 @@ class DjangoModuleTest(integration.ModuleCase):
                 'settings.py', 'runserver', None, None, __ignore='something'
             )
             mock.assert_called_once_with(
-                'django-admin.py runserver --settings=settings.py'
+                'django-admin.py runserver --settings=settings.py',
+                env=None
             )
 
     def test_syncdb(self):
@@ -79,7 +84,8 @@ class DjangoModuleTest(integration.ModuleCase):
                         {'cmd.run': mock}):
             django.syncdb('settings.py')
             mock.assert_called_once_with(
-                'django-admin.py syncdb --settings=settings.py --noinput'
+                'django-admin.py syncdb --settings=settings.py --noinput',
+                env=None
             )
 
     def test_syncdb_migrate(self):
@@ -89,7 +95,8 @@ class DjangoModuleTest(integration.ModuleCase):
             django.syncdb('settings.py', migrate=True)
             mock.assert_called_once_with(
                 'django-admin.py syncdb --settings=settings.py --migrate '
-                '--noinput'
+                '--noinput',
+                env=None
             )
 
     def test_createsuperuser(self):
@@ -101,7 +108,8 @@ class DjangoModuleTest(integration.ModuleCase):
             )
             mock.assert_called_once_with(
                 'django-admin.py createsuperuser --settings=settings.py '
-                '--noinput --username=testuser --email=user@example.com'
+                '--noinput --username=testuser --email=user@example.com',
+                env=None
             )
 
     def test_loaddata(self):
@@ -110,7 +118,8 @@ class DjangoModuleTest(integration.ModuleCase):
                         {'cmd.run': mock}):
             django.loaddata('settings.py', 'app1,app2')
             mock.assert_called_once_with(
-                'django-admin.py loaddata --settings=settings.py app1 app2'
+                'django-admin.py loaddata --settings=settings.py app1 app2',
+                env=None
             )
 
     def test_collectstatic(self):
@@ -123,7 +132,7 @@ class DjangoModuleTest(integration.ModuleCase):
             mock.assert_called_once_with(
                 'django-admin.py collectstatic --settings=settings.py '
                 '--noinput --no-post-process --dry-run --clear --link '
-                '--no-default-ignore --ignore=something'
+                '--no-default-ignore --ignore=something', env=None
             )
 
 


### PR DESCRIPTION
When using django-configurations (http://django-configurations.readthedocs.org/en/latest/) one needs to invoke `collectstatic` with an extra environment variable (e.g. `export DJANGO_CONFIGURATION=Dev`) so it will find the correct configuration.
