### PR TITLE
output: fix typo introduced in 5f473b

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -358,7 +358,7 @@ The state_output setting changes if the output is the full multi line
 output for each changed state if set to 'full', but if set to 'terse'
 the output will be shortened to a single line.  If set to 'mixed', the output
 will be terse unless a state failed, in which case that output will be full.
-If set to 'changes', the output will be fill unless the state didn't change.
+If set to 'changes', the output will be full unless the state didn't change.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
Reported in https://github.com/saltstack/salt/commit/5f473bb17e1a940441c354b6db333b296dbdf991#commitcomment-3438710
