### PR TITLE
Make it possible to run a single unit test

### DIFF
--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -91,6 +91,8 @@ def run_integration_tests(opts):
     '''
     Execute the integration tests suite
     '''
+    if opts.unit:
+        return [True]
     smax_open_files, hmax_open_files = resource.getrlimit(resource.RLIMIT_NOFILE)
     if smax_open_files < REQUIRED_OPEN_FILES:
         print('~' * PNUM)
@@ -141,9 +143,14 @@ def run_unit_tests(opts):
     if not opts.unit:
         return [True]
     status = []
-    results = run_suite(
-        opts, os.path.join(TEST_DIR, 'unit'), 'Unit', '*_test.py')
-    status.append(results)
+    if opts.name:
+        for name in opts.name:
+            results = run_suite(opts, os.path.join(TEST_DIR, 'unit'), name)
+            status.append(results)
+    else:
+        results = run_suite(
+            opts, os.path.join(TEST_DIR, 'unit'), 'Unit', '*_test.py')
+        status.append(results)
     return status
 
 


### PR DESCRIPTION
Before, command like `./tests/runtests.py -u -n unit.modules.pip_test -vv` won't work, since it will start to run integration suite.

```
$ ./tests/runtests.py -u -n unit.modules.pip_test -vv
Logging tests on /tmp/salt-runtests.log
Current Directory: /salt-src
Test suite is running under PID 10098
Setting up Salt daemons to execute tests
15:19:53,951 [salt.crypt:102 ][INFO    ] Generating keys: /tmp/salttest/pki
15:19:56,129 [salt.master:120 ][INFO    ] Preparing the vagrant key for local communication
15:19:56,130 [salt.master:120 ][INFO    ] Preparing the root key for local communication
15:19:56,302 [salt.master                     :304 ][INFO    ] salt-master is starting as user 'vagrant'
...
```

After this fix, 

```
$ ./tests/runtests.py -u -n unit.modules.pip_test -vv
Logging tests on /tmp/salt-runtests.log
Current Directory: /salt-src
Test suite is running under PID 10510
Starting unit.modules.pip_test Tests
test_cached_requirements_used (unit.modules.pip_test.PipTestCase) ... ok
test_failed_cached_requirements (unit.modules.pip_test.PipTestCase) ... ok
test_fix4361 (unit.modules.pip_test.PipTestCase) ... ok
test_fix_activate_env (unit.modules.pip_test.PipTestCase) ... ok

----------------------------------------------------------------------
Ran 4 tests in 0.009s

OK
```
