### PR TITLE
Change comment for pkg.purged state

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -678,7 +678,9 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
         return {'name': name,
                 'changes': {},
                 'result': True,
-                'comment': 'None of the targeted packages are installed'}
+                'comment': 'None of the targeted packages are installed'
+                           '{0}'.format(' or partially installed'
+                                        if action == 'purge' else '')}
 
     if __opts__['test']:
         return {'name': name,


### PR DESCRIPTION
This commit only affects states for packages which are already purged.
It adds "or partially installed" to the normal comment that would eb
seen for pkg.removed states, "None of the targeted packages are
installed". This makes the state output more descriptive for pkg.purged
states.
