### PR TITLE
Run refresh_db in latest_version

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -137,6 +137,11 @@ def latest_version(*names, **kwargs):
     fromrepo = _get_repo(**kwargs)
     repo = ' -o APT::Default-Release="{0}"'.format(fromrepo) \
         if fromrepo else ''
+
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     for name in names:
         cmd = 'apt-cache -q policy {0}{1} | grep Candidate'.format(name, repo)
         out = __salt__['cmd.run_all'](cmd)

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -98,6 +98,11 @@ def latest_version(*names, **kwargs):
     '''
     if len(names) == 0:
         return ''
+
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     ret = {}
     # Initialize the dict with empty strings
     for name in names:
@@ -399,7 +404,7 @@ def update(pkg, slot=None, refresh=False):
 
         salt '*' pkg.update <package name>
     '''
-    if(refresh):
+    if salt.utils.is_true(refresh):
         refresh_db()
 
     if slot is not None:

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -65,6 +65,10 @@ def latest_version(*names, **kwargs):
 
     ret = {}
 
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     if _check_pkgng():
         for line in __salt__['cmd.run_stdout']('{0} upgrade -nq'.format(
             _cmd('pkg'))

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -44,7 +44,11 @@ def latest_version(*names, **kwargs):
     '''
     if len(names) == 0:
         return ''
-    refresh_db()
+
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     ret = {}
     # Initialize the dict with empty strings
     for name in names:

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -112,6 +112,10 @@ def latest_version(*names, **kwargs):
     if not pkgin:
         return pkglist
 
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     for name in names:
         if _supports_regex():
             name = '^{0}$'.format(name)

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -165,6 +165,10 @@ def latest_version(name, **kwargs):
 
         salt '*' pkgutil.latest_version CSWpython
     '''
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     cmd = '/opt/csw/bin/pkgutil -a --parse {0}'.format(name)
     namever = __salt__['cmd.run_stdout'](cmd).split()[2].strip()
     if namever:

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -59,6 +59,11 @@ def latest_version(*names, **kwargs):
     '''
     if len(names) == 0:
         return ''
+
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     ret = {}
     pkgs = list_pkgs()
     for name in names:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -185,6 +185,10 @@ def latest_version(*names, **kwargs):
     for name in names:
         ret[name] = ''
 
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     yumbase = yum.YumBase()
     error = _set_repo_options(yumbase, **kwargs)
     if error:

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -150,6 +150,10 @@ def latest_version(*names, **kwargs):
     for name in names:
         ret[name] = ''
 
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     # Get updates for specified package(s)
     repo_arg = _get_repo_options(**kwargs)
     updates = _repoquery('{0} --pkgnarrow=available --queryformat "{1}" '

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -76,6 +76,10 @@ def latest_version(*names, **kwargs):
     for name in names:
         ret[name] = ''
 
+    # Refresh before looking for the latest version available
+    if salt.utils.is_true(kwargs.get('refresh', True)):
+        refresh_db()
+
     cmd = 'zypper info -t package {0}'.format(' '.join(names))
     output = __salt__['cmd.run_all'](cmd).get('stdout', '')
     output = re.split('Information for package \\S+:\n', output)


### PR DESCRIPTION
This ensures that we are getting the latest package data available.
Without this, some pkg.latest states might mistakenly report as
up-to-date when the package really does have an upgrade available.
