### PR TITLE
Check perms for file.directory test=True, Fix #5573

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1327,7 +1327,7 @@ def check_perms(name, ret, user, group, mode):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])
-    if __opts__['test'] is True:
+    if __opts__['test'] is True and ret['changes']:
         ret['result'] = None
     return ret, perms
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1272,15 +1272,18 @@ def check_perms(name, ret, user, group, mode):
     # Mode changes if needed
     if mode:
         if str(mode) != perms['lmode']:
-            if not __opts__['test']:
-                __salt__['file.set_mode'](name, mode)
-            if str(mode) != str(__salt__['file.get_mode'](name)).lstrip('0'):
-                ret['result'] = False
-                ret['comment'].append(
-                    'Failed to change mode to {0}'.format(mode)
-                )
-            else:
+            if __opts__['test'] is True:
                 ret['changes']['mode'] = mode
+            else:
+                __salt__['file.set_mode'](name, mode)
+                if (str(mode) !=
+                        str(__salt__['file.get_mode'](name)).lstrip('0')):
+                    ret['result'] = False
+                    ret['comment'].append(
+                        'Failed to change mode to {0}'.format(mode)
+                    )
+                else:
+                    ret['changes']['mode'] = mode
     # user/group changes if needed, then check if it worked
     if user:
         if user != perms['luser']:
@@ -1301,15 +1304,22 @@ def check_perms(name, ret, user, group, mode):
 
     if user:
         if user != __salt__['file.get_user'](name):
-            ret['result'] = False
-            ret['comment'].append('Failed to change user to {0}'.format(user))
+            if __opts__['test'] is True:
+                ret['changes']['user'] = user
+            else:
+                ret['result'] = False
+                ret['comment'].append('Failed to change user to {0}'
+                                      .format(user))
         elif 'cuser' in perms:
             ret['changes']['user'] = user
     if group:
         if group != __salt__['file.get_group'](name):
-            ret['result'] = False
-            ret['comment'].append('Failed to change group to {0}'
-                               .format(group))
+            if __opts__['test'] is True:
+                ret['changes']['group'] = group
+            else:
+                ret['result'] = False
+                ret['comment'].append('Failed to change group to {0}'
+                                      .format(group))
         elif 'cgroup' in perms:
             ret['changes']['group'] = group
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1327,6 +1327,8 @@ def check_perms(name, ret, user, group, mode):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])
+    if __opts__['test'] is True:
+        ret['result'] = None
     return ret, perms
 
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -299,6 +299,13 @@ def _check_directory(name,
                 fchange = _check_dir_meta(path, user, group, mode)
                 if fchange:
                     changes[path] = fchange
+    else:
+        ret, perms = __salt__['file.check_perms'](name,
+                                                  None,
+                                                  user,
+                                                  group,
+                                                  mode)
+        changes[name] = ret['changes']
     if clean:
         keep = _gen_keep_files(name, require)
         for root, dirs, files in os.walk(name):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -301,7 +301,7 @@ def _check_directory(name,
                     changes[path] = fchange
     else:
         ret, perms = __salt__['file.check_perms'](name,
-                                                  None,
+                                                  {},
                                                   user,
                                                   group,
                                                   mode)


### PR DESCRIPTION
Previously it did not check for perms unless `recurse: True` was set.

Had to modify the half-done `test=True` logic for the `file.check_perms` directory -- now works much better
