### PR TITLE
quickfix for IPv6, added basic documentation to the default configs

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -13,6 +13,10 @@
 # The address of the interface to bind to
 #interface: 0.0.0.0
 
+# Whether the master should listen for IPv6 connections. If this is set to True,
+# the interface option must be adjusted too (for example: "interface: '::'")
+#ipv6: False
+
 # The tcp port used by the publisher
 #publish_port: 4505
 

--- a/conf/minion
+++ b/conf/minion
@@ -10,6 +10,9 @@
 # resolved, then the minion will fail to start.
 #master: salt
 
+# Set whether the minion should connect to the master via IPv6
+#ipv6: False
+
 # Set the number of seconds to wait before attempting to resolve
 # the master hostname if name resolution fails. Defaults to 30 seconds.
 # Set to zero if the minion should shutdown and not retry.

--- a/salt/client.py
+++ b/salt/client.py
@@ -1080,7 +1080,9 @@ class LocalClient(object):
             payload_kwargs['to'] = timeout
 
         sreq = salt.payload.SREQ(
-            'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
+            #'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
+            'tcp://' + salt.utils.ip_bracket(self.opts['interface']) +
+            ':' + self.opts['ret_port'],
         )
         payload = sreq.send('clear', payload_kwargs)
 


### PR DESCRIPTION
I have added a workaround for #5590 and some basic documentation for salt's IPv6 capability in the default config files. I left the former parameter to SREQ as a comment for an easy revert to String.format(), because I feel an IPv6 adress should be written to self.opts with brackets already present.
But as I do not know the further implications of changing formats in opts, this puts IPv6 in a usable state for now.
