### PR TITLE
Use versionadded directive to denote new features

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -403,6 +403,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -429,6 +431,9 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -140,6 +140,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -465,6 +465,8 @@ def remove(name=None, slot=None, pkgs=None, **kwargs):
         Uninstall multiple packages. ``slot`` argument is ignored if this
         argument is present. Must be passed as a python list.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -510,6 +512,8 @@ def purge(name=None, slot=None, pkgs=None, **kwargs):
     pkgs
         Uninstall multiple packages. ``slot`` argument is ignored if this
         argument is present. Must be passed as a python list.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -318,6 +318,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -360,6 +362,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -164,7 +164,16 @@ def remove(name=None, pkgs=None, **kwargs):
     '''
     Remove a single package with pkg_delete
 
-    Returns a list containing the removed packages.
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
@@ -200,6 +209,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -353,6 +353,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -379,6 +381,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -324,23 +324,26 @@ def upgrade():
 
 def remove(name=None, pkgs=None, **kwargs):
     '''
-    Remove a single package.
-
-    name : None
+    name
         The name of the package to be deleted.
 
-    pkgs : None
-        A list of packages to delete. Must be passed as a python list.
 
-        CLI Example::
+    Multiple Package Options:
 
-            salt '*' pkg.remove pkgs='["foo","bar"]'
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
+
 
     Returns a list containing the removed packages.
 
     CLI Example::
 
         salt '*' pkg.remove <package name>
+        salt '*' pkg.remove <package1>,<package2>,<package3>
+        salt '*' pkg.remove pkgs='["foo", "bar"]'
     '''
     pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](name, pkgs)
     if not pkg_params:
@@ -376,17 +379,33 @@ def remove(name=None, pkgs=None, **kwargs):
     return __salt__['pkg_resource.find_changes'](old, new)
 
 
-def purge(name, **kwargs):
+def purge(name=None, pkgs=None, **kwargs):
     '''
-    Remove a single package with pkg_delete
+    Package purges are not supported, this function is identical to
+    ``remove()``.
 
-    Returns a list containing the removed packages.
+    name
+        The name of the package to be deleted.
+
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to delete. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
+
+
+    Returns a dict containing the changes.
 
     CLI Example::
 
         salt '*' pkg.purge <package name>
+        salt '*' pkg.purge <package1>,<package2>,<package3>
+        salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
-    return remove(name)
+    return remove(name=name, pkgs=pkgs)
 
 
 def rehash():

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -248,6 +248,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -283,6 +285,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -342,6 +342,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -417,6 +419,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -530,6 +530,8 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -596,6 +598,8 @@ def purge(name=None, pkgs=None, version=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -596,6 +596,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -652,6 +654,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -446,6 +446,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -481,6 +483,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -378,6 +378,8 @@ def remove(name=None, pkgs=None, **kwargs):
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
 
+    .. versionadded:: 0.16.0
+
 
     Returns a dict containing the changes.
 
@@ -404,6 +406,8 @@ def purge(name=None, pkgs=None, **kwargs):
     pkgs
         A list of packages to delete. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
 
 
     Returns a dict containing the changes.

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -32,11 +32,14 @@ Is changed to this:
 Then the existing cron will be updated, but if the cron command is changed,
 then a new cron job will be added to the user's crontab.
 
+
 Additionally, the temporal parameters (minute, hour, etc.) can be randomized
 by using ``random`` instead of using a specific value. However, please note
 that if a cron job already has a numeric value (in other words, not ``*``),
 changing the value to ``random`` will not modify this field. Otherwise, the
 value would be modified every time the state was applied.
+
+.. versionadded:: 0.16.0
 '''
 
 # Import python libs

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -735,6 +735,8 @@ def removed(name, pkgs=None, **kwargs):
     pkgs
         A list of packages to remove. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
     '''
     return _uninstall(action='remove', name=name, pkgs=pkgs, **kwargs)
 
@@ -753,6 +755,8 @@ def purged(name, pkgs=None, **kwargs):
     pkgs
         A list of packages to purge. Must be passed as a python list. The
         ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: 0.16.0
     '''
     return _uninstall(action='purge', name=name, pkgs=pkgs, **kwargs)
 


### PR DESCRIPTION
This commit adds the `versionadded` directive for a couple recent features, as well as corrects a minor bug in the **pkgin** module.
