### PR TITLE
Correcting npm.bootstrap so that it returns success on repeat runs

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -145,12 +145,13 @@ def bootstrap(
         ret['comment'] = 'Error Bootstrapping \'{0}\': {1}'.format(name, err)
         return ret
 
-    if call:
+    # npm.install will return a string if it can't parse a JSON result
+    if isinstance(call, str):
+        ret['result'] = False
+        ret['comment'] = 'Could not bootstrap directory'
+    else:
         ret['result'] = True
         ret['changes'] = name, 'Bootstrapped'
         ret['comment'] = 'Directory was successfully bootstrapped'
-    else:
-        ret['result'] = False
-        ret['comment'] = 'Could not bootstrap directory'
 
     return ret


### PR DESCRIPTION
State npm.bootstrap returns a failure if it has already been run once. Repeated runs simply return an empty JSON result if there are no modules to update and that doesn't seem like it should be a failure.
