### PR TITLE
Fix batch timeout and infinite while-loop in batch-mode

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -128,6 +128,7 @@ class Batch(object):
                 if self.opts.get('raw'):
                     yield data
                 else:
+		    ret[minion] = data['ret']
                     yield {minion: data['ret']}
                 if not self.quiet:
                     ret[minion] = data['ret']

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -29,7 +29,7 @@ class Batch(object):
         args = [self.opts['tgt'],
                 'test.ping',
                 [],
-                1,
+                5,
                 ]
 
         selected_target_option = self.opts.get('selected_target_option', None)


### PR DESCRIPTION
A 1 second timeout to detect minions for a batch run is fairly optimistic for larger networks that span over large distances. Here it repeatedly resulted in not all minions being detected and the batch-run to be only run on about 75-90% of the minions. Im not sure that 5 seconds is fine for you, but it works here and seems alright for me on larger networks. Maybe make it configurable in the future?

The second change is a fix for the while loop on line 84 which would essentially never brake due to 'ret' not being updated in line 130/131.
