### PR TITLE
Clarify the documentation for "random" cron timing feature

### DIFF
--- a/doc/topics/releases/0.16.0.rst
+++ b/doc/topics/releases/0.16.0.rst
@@ -44,8 +44,22 @@ Random Times in Cron States
 
 The temporal parameters in :mod:`cron.present <salt.states.cron.present>`
 states (minute, hour, etc.) can now be randomized by using ``random`` instead
-of a specific value. However, please note that if a cron job already has a
-numeric value (in other words, not ``*``), changing the value to ``random``
-will not modify this field in the crontab. Otherwise, the value would be
-modified every time the state was applied.
+of a specific value. For example, by using the ``random`` keyword in the
+``minute`` parameter of a cron state, the same cron job can be pushed to
+hundreds or thousands of hosts, and they would each use a randomly-generated
+minute. This can be helpful when the cron job accesses a network resource, and
+it is not desirable for all hosts to run the job concurrently.
 
+.. code-block:: yaml
+
+    /path/to/cron/script:
+      cron.present:
+        - user: root
+        - minute: random
+        - hour: 2
+
+Since Salt assumes a value of ``*`` for unspecified temporal parameters, adding
+a parameter to the state and setting it to ``random`` will change that value
+from ``*`` to a randomized numeric value. However, if the cron entry contains a
+numeric value on the minion, then using the ``random`` keyword will not modify
+this field.

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -33,13 +33,29 @@ Then the existing cron will be updated, but if the cron command is changed,
 then a new cron job will be added to the user's crontab.
 
 
-Additionally, the temporal parameters (minute, hour, etc.) can be randomized
-by using ``random`` instead of using a specific value. However, please note
-that if a cron job already has a numeric value (in other words, not ``*``),
-changing the value to ``random`` will not modify this field. Otherwise, the
-value would be modified every time the state was applied.
+Additionally, the temporal parameters (minute, hour, etc.) can be randomized by
+using ``random`` instead of using a specific value. For example, by using the
+``random`` keyword in the ``minute`` parameter of a cron state, the same cron
+job can be pushed to hundreds or thousands of hosts, and they would each use a
+randomly-generated minute. This can be helpful when the cron job accesses a
+network resource, and it is not desirable for all hosts to run the job
+concurrently.
+
+.. code-block:: yaml
+
+    /path/to/cron/script:
+      cron.present:
+        - user: root
+        - minute: random
+        - hour: 2
 
 .. versionadded:: 0.16.0
+
+Since Salt assumes a value of ``*`` for unspecified temporal parameters, adding
+a parameter to the state and setting it to ``random`` will change that value
+from ``*`` to a randomized numeric value. However, if the cron entry contains a
+numeric value on the minion, then using the ``random`` keyword will not modify
+this field.
 '''
 
 # Import python libs


### PR DESCRIPTION
This commit improves the explanation of this new feature, both in the
cron state's docstring and in the 0.16.0 release notes.
