### PR TITLE
Make winrepo package names work for pkg states

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -657,8 +657,8 @@ def get_repo_data():
 
         salt '*' pkg.get_repo_data
     '''
-    if 'winrepo.data' in __context__:
-        return __context__['winrepo.data']
+    #if 'winrepo.data' in __context__:
+    #    return __context__['winrepo.data']
     repocache = __opts__['win_repo_cachefile']
     cached_repo = __salt__['cp.is_cached'](repocache)
     if not cached_repo:
@@ -667,7 +667,7 @@ def get_repo_data():
         with salt.utils.fopen(cached_repo, 'r') as repofile:
             try:
                 repodata = msgpack.loads(repofile.read()) or {}
-                __context__['winrepo.data'] = repodata
+                #__context__['winrepo.data'] = repodata
                 return repodata
             except Exception as exc:
                 log.exception(exc)

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -125,7 +125,7 @@ def list_upgrades(refresh=True):
         refresh_db()
 
     ret = {}
-    for name, data in _get_repo_data().items():
+    for name, data in get_repo_data().items():
         if version(name):
             latest = latest_version(name)
             if latest:
@@ -231,10 +231,15 @@ def list_pkgs(versions_as_list=False, **kwargs):
             return ret
 
     ret = {}
+    name_map = _get_name_map()
     with salt.utils.winapi.Com():
         for key, val in _get_reg_software().iteritems():
+            if key in name_map:
+                key = name_map[key]
             __salt__['pkg_resource.add_pkg'](ret, key, val)
         for key, val in _get_msi_software().iteritems():
+            if key in name_map:
+                key = name_map[key]
             __salt__['pkg_resource.add_pkg'](ret, key, val)
 
     __salt__['pkg_resource.sort_pkglist'](ret)
@@ -427,6 +432,7 @@ def refresh_db():
 
         salt '*' pkg.refresh_db
     '''
+    __context__.pop('winrepo.data', None)
     repocache = __opts__['win_repo_cachefile']
     cached_repo = __salt__['cp.is_cached'](repocache)
     if not cached_repo:
@@ -643,7 +649,16 @@ def purge(name=None, pkgs=None, version=None, **kwargs):
     return remove(name=name, pkgs=pkgs, version=version, **kwargs)
 
 
-def _get_repo_data():
+def get_repo_data():
+    '''
+    Returns the cached winrepo data
+
+    CLI Example::
+
+        salt '*' pkg.get_repo_data
+    '''
+    if 'winrepo.data' in __context__:
+        return __context__['winrepo.data']
     repocache = __opts__['win_repo_cachefile']
     cached_repo = __salt__['cp.is_cached'](repocache)
     if not cached_repo:
@@ -652,12 +667,22 @@ def _get_repo_data():
         with salt.utils.fopen(cached_repo, 'r') as repofile:
             try:
                 repodata = msgpack.loads(repofile.read()) or {}
+                __context__['winrepo.data'] = repodata
                 return repodata
-            except Exception:
-                return ''
-    except IOError:
-        log.debug('Not able to read repo file')
-        return ''
+            except Exception as exc:
+                log.exception(exc)
+                return {}
+    except IOError as exc:
+        log.error('Not able to read repo file')
+        log.exception(exc)
+        return {}
+
+
+def _get_name_map():
+    '''
+    Return a reverse map of full pkg names to the names recognized by winrepo.
+    '''
+    return get_repo_data().get('name_map', {})
 
 
 def _get_package_info(name):
@@ -666,12 +691,7 @@ def _get_package_info(name):
     Returns empty map if package not available
     TODO: Add option for version
     '''
-    repodata = _get_repo_data()
-    if not repodata:
-        return ''
-    if name in repodata:
-        return repodata[name]
-    return ''
+    return get_repo_data().get('repo', {}).get(name, {})
 
 
 def _reverse_cmp_pkg_versions(pkg1, pkg2):

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -41,7 +41,12 @@ def genrepo():
                                   '{0}: {1}'.format(os.path.join(root, name), exc))
                         print 'Failed to compile {0}: {1}'.format(os.path.join(root, name), exc)
                 if config:
-                    ret.update(config)
+                    ret.setdefault('repo', {}).update(config)
+                    revmap = {}
+                    for pkgname, versions in config.iteritems():
+                        for repodata in versions.values():
+                            revmap[repodata['full_name']] = pkgname
+                    ret.setdefault('name_map', {}).update(revmap)
     with salt.utils.fopen(os.path.join(repo, winrepo), 'w') as repo:
         repo.write(msgpack.dumps(ret))
     salt.output.display_output(ret, 'pprint', __opts__)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -43,11 +43,11 @@ import salt.utils
 if salt.utils.is_windows():
     from salt.utils import namespaced_function
     from salt.modules.win_pkg import _get_package_info
-    from salt.modules.win_pkg import _get_repo_data
+    from salt.modules.win_pkg import get_repo_data
     from salt.modules.win_pkg import _get_latest_pkg_version
     from salt.modules.win_pkg import _reverse_cmp_pkg_versions
     _get_package_info = namespaced_function(_get_package_info, globals())
-    _get_repo_data = namespaced_function(_get_repo_data, globals())
+    get_repo_data = namespaced_function(get_repo_data, globals())
     _get_latest_pkg_version = namespaced_function(_get_latest_pkg_version, globals())
     _reverse_cmp_pkg_versions = namespaced_function(_reverse_cmp_pkg_versions, globals())
     # The following imports are used by the namespaced win_pkg funcs
@@ -114,7 +114,6 @@ def _find_install_targets(name=None, version=None, pkgs=None, sources=None):
                                    'repository.'.format(name)}
             if version is None:
                 version = _get_latest_pkg_version(pkginfo)
-            name = pkginfo[version]['full_name']
         desired = {name: version}
 
         cver = cur_pkgs.get(name, [])
@@ -656,22 +655,11 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
 
     pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
     old = __salt__['pkg.list_pkgs'](versions_as_list=True)
-    if not salt.utils.is_windows():
-        targets = [x for x in pkg_params if x in old]
-        if action == 'purge':
-            old_removed = __salt__['pkg.list_pkgs'](versions_as_list=True,
-                                                    removed=True)
-            targets.extend([x for x in pkg_params if x in old_removed])
-    else:
-        targets = []
-        for item in pkg_params:
-            pkginfo = _get_package_info(item)
-            if kwargs.get('version') is not None:
-                version_num = kwargs['version']
-            else:
-                version_num = _get_latest_pkg_version(pkginfo)
-            if pkginfo[version_num]['full_name'] in old:
-                targets.append(pkginfo[version_num]['full_name'])
+    targets = [x for x in pkg_params if x in old]
+    if action == 'purge':
+        old_removed = __salt__['pkg.list_pkgs'](versions_as_list=True,
+                                                removed=True)
+        targets.extend([x for x in pkg_params if x in old_removed])
     targets.sort()
 
     if not targets:


### PR DESCRIPTION
This adds a reverse name map to the repo data that is created by the
winrepo.genrepo runner, and removes some windows-specific code from the
pkg state since we no longer have to work around the fact that winrepo
packages are discovered with their full names.
