### PR TITLE
Add confirmation step for salt-key -a/-A

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -59,6 +59,16 @@ class KeyCLI(object):
         '''
         Accept the keys matched
         '''
+        def _print_accepted(matches, after_match):
+            if 'minions_pre' in after_match:
+                accepted = set(matches['minions_pre']).difference(
+                        set(after_match['minions_pre'])
+                        )
+            else:
+                accepted = matches['minions_pre']
+            for key in accepted:
+                print('Key for minion {0} accepted.'.format(key))
+
         matches = self.key.name_match(match)
         if not matches.get('minions_pre', False):
             print(
@@ -67,15 +77,25 @@ class KeyCLI(object):
                     )
                 )
             return
-        after_match = self.key.accept(match)
-        if 'minions_pre' in after_match:
-            accepted = set(matches['minions_pre']).difference(
-                    set(after_match['minions_pre'])
-                    )
+        if not self.opts.get('yes', False):
+            print('The following keys are going to be accepted:')
+            salt.output.display_output(
+                    {'minions_pre': matches['minions_pre']},
+                    'key',
+                    self.opts)
+            try:
+                veri = raw_input('Proceed? [n/Y] ')
+            except KeyboardInterrupt:
+                raise SystemExit("\nExiting on CTRL-c")
+            if not veri or veri.lower().startswith('y'):
+                _print_accepted(matches, self.key.accept(match))
         else:
-            accepted = matches['minions_pre']
-        for key in accepted:
-            print('Key for minion {0} accepted.'.format(key))
+            print('The following keys are going to be accepted:')
+            salt.output.display_output(
+                    {'minions_pre': matches['minions_pre']},
+                    'key',
+                    self.opts)
+            _print_accepted(matches, self.key.accept(match))
 
     def accept_all(self):
         '''


### PR DESCRIPTION
This implements #3495, adding a confirmation dialog (which can be skipped using -y/--yes) when accepting keys.
