### PR TITLE
Prioritize environmnt variable config location over default, Fix #5631

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -407,7 +407,7 @@ def load_config(path, env_var):
     if not env_path or not os.path.isfile(env_path):
         env_path = path
     # If non-default path from `-c`, use that over the env variable
-    if path != '/etc/salt/master':
+    if path != DEFAULT_MASTER_OPTS['conf_file']:
         env_path = path
     path = env_path
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -402,8 +402,12 @@ def load_config(path, env_var):
         # defaults, not actually loading the whole configuration.
         return {}
 
-    if not path or not os.path.isfile(path):
-        path = os.environ.get(env_var, path)
+    # Default to the environment variable path, if it exists
+    env_path = os.environ.get(env_var, path)
+    if not env_path or not os.path.isfile(env_path):
+        env_path = path
+    path = env_path
+
     # If the configuration file is missing, attempt to copy the template,
     # after removing the first header line.
     if not os.path.isfile(path):

--- a/salt/config.py
+++ b/salt/config.py
@@ -406,6 +406,9 @@ def load_config(path, env_var):
     env_path = os.environ.get(env_var, path)
     if not env_path or not os.path.isfile(env_path):
         env_path = path
+    # If non-default path from `-c`, use that over the env variable
+    if path != '/etc/salt/master':
+        env_path = path
     path = env_path
 
     # If the configuration file is missing, attempt to copy the template,


### PR DESCRIPTION
Except for the exception below, Salt will use the path passed in by `-c` if available, falling back first to the environment variable, and then to the default path if all else fails.

Exception:

If you define an environment variable like `SALT_MASTER_CONFIG=/root/master` and then try to use the default config location with `-c`:

```
salt-master -c /etc/salt
```

Then it still uses the environment variable.  This is because I only override the environment variable if the passed-in path is not the default path.  (See line 410 of the diff)  I'm not sure how else to detect if `-c` was passed in without passing around some sort of flag.  Any suggestions would be appreciated.
