### PR TITLE
Potential fix for issue #5637

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -44,7 +44,6 @@ import salt.utils.schedule
 from salt.state import _getargs
 from salt._compat import string_types
 from salt.utils.debug import enable_sigusr1_handler
-from salt.utils import enable_ctrl_logoff_handler
 
 log = logging.getLogger(__name__)
 
@@ -987,7 +986,7 @@ class Minion(object):
         enable_sigusr1_handler()
 
         # Make sure to gracefully handle CTRL_LOGOFF_EVENT
-        enable_ctrl_logoff_handler()
+        salt.utils.enable_ctrl_logoff_handler()
         
         # On first startup execute a state run if configured to do so
         self._state_run()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -44,6 +44,7 @@ import salt.utils.schedule
 from salt.state import _getargs
 from salt._compat import string_types
 from salt.utils.debug import enable_sigusr1_handler
+from salt.utils import enable_ctrl_logoff_handler
 
 log = logging.getLogger(__name__)
 
@@ -984,6 +985,10 @@ class Minion(object):
 
         # Make sure to gracefully handle SIGUSR1
         enable_sigusr1_handler()
+
+        # Make sure to gracefully handle CTRL_LOGOFF_EVENT
+        enable_ctrl_logoff_handler()
+        
         # On first startup execute a state run if configured to do so
         self._state_run()
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -34,6 +34,12 @@ except ImportError:
     # fcntl is not available on windows
     HAS_FNCTL = False
 
+try:
+    import win32api
+    HAS_WIN32API = True
+except ImportError:
+    HAS_WIN32API = False
+
 # Import salt libs
 import salt.log
 import salt.minion
@@ -1186,3 +1192,13 @@ def parse_kwarg(string):
         return match.groups()
     else:
         return None, None
+
+def _win_console_event_handler(event):
+    if event == 5:
+        # Do nothing on CTRL_LOGOFF_EVENT
+        return True
+    return False
+
+def enable_ctrl_logoff_handler():
+    if HAS_WIN32API:
+        win32api.SetConsoleCtrlHandler(_win_console_event_handler, 1)

--- a/salt/utils/saltminionservice.py
+++ b/salt/utils/saltminionservice.py
@@ -6,6 +6,7 @@ import salt
 import win32serviceutil
 import win32service
 import winerror
+import win32api
 
 # Import python libs
 import sys
@@ -27,8 +28,14 @@ class MinionService(Service):
         self.runflag = False
         self.log("Shutting down the Salt Minion")
 
+def console_event_handler(event):
+    if event == 5:
+        # Do nothing on CTRL_LOGOFF_EVENT
+        return True
+    return False
 
 def _main():
+    win32api.SetConsoleCtrlHandler(console_event_handler, 1)
     servicename = 'salt-minion'
     try:
         status = win32serviceutil.QueryServiceStatus(servicename)

--- a/salt/utils/saltminionservice.py
+++ b/salt/utils/saltminionservice.py
@@ -6,7 +6,6 @@ import salt
 import win32serviceutil
 import win32service
 import winerror
-import win32api
 
 # Import python libs
 import sys
@@ -28,14 +27,8 @@ class MinionService(Service):
         self.runflag = False
         self.log("Shutting down the Salt Minion")
 
-def console_event_handler(event):
-    if event == 5:
-        # Do nothing on CTRL_LOGOFF_EVENT
-        return True
-    return False
 
 def _main():
-    win32api.SetConsoleCtrlHandler(console_event_handler, 1)
     servicename = 'salt-minion'
     try:
         status = win32serviceutil.QueryServiceStatus(servicename)


### PR DESCRIPTION
Potential fix for issue #5637:
Create a null handler for CTRL_LOGOFF_EVENT. This event is not being sent on Windows 7 so I can't verify that it works but I can verify that the handler is active by adding a log statement.
