### PR TITLE
Return empty string instead of False

### DIFF
--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -24,7 +24,7 @@ def _pecl(command):
     if ret['retcode'] == 0:
         return ret['stdout']
     else:
-        return False
+        return ''
 
 
 def install(pecls):

--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -24,6 +24,7 @@ def _pecl(command):
     if ret['retcode'] == 0:
         return ret['stdout']
     else:
+        log.error('Problem running pecl. Is php-pear installed?')
         return ''
 
 


### PR DESCRIPTION
This fixes #5603. The return data from _pecl() is meant to be parsed
line by line, and you can't spilt a bool.
