### PR TITLE
Fix issue 4598

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -463,6 +463,7 @@ class Minion(object):
             self.opts,
             self.functions,
             self.returners)
+        signal.signal(signal.SIGTERM, self.clean_die)
 
     def __getstate__(self):
         # Minion instance must be picklable for multiprocessing on windows
@@ -477,7 +478,10 @@ class Minion(object):
                      'poller', 
                      'epull_sock',
                      'context']:
-            del picklable_state[attr]
+            try:
+                del picklable_state[attr]
+            except KeyError:
+                pass
 
         return picklable_state
 
@@ -900,8 +904,6 @@ class Minion(object):
                 ),
                 exc_info=err
             )
-        if threading.current_thread() == 'MainThread':
-            signal.signal(signal.SIGTERM, self.clean_die)
         log.debug('Minion "{0}" trying to tune in'.format(self.opts['id']))
         self.context = zmq.Context()
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -464,6 +464,23 @@ class Minion(object):
             self.functions,
             self.returners)
 
+    def __getstate__(self):
+        # Minion instance must be picklable for multiprocessing on windows
+        # Strip the unpicklable attributes and recreate on the other side
+        picklable_state = copy.copy(self.__dict__)
+        del picklable_state['functions']
+        del picklable_state['returners']
+        del picklable_state['schedule']
+        return picklable_state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.functions, self.returners = self.__load_modules()
+        self.schedule = salt.utils.schedule.Schedule(
+            self.opts,
+            self.functions,
+            self.returners)
+
     def __prep_mod_opts(self):
         '''
         Returns a copy of the opts with key bits stripped out
@@ -574,53 +591,44 @@ class Minion(object):
                 self.functions, self.returners = self.__load_modules()
                 self.schedule.functions = self.functions
                 self.schedule.returners = self.returners
+        instance = self
         if isinstance(data['fun'], tuple) or isinstance(data['fun'], list):
-            target = Minion._thread_multi_return
+            target = self._thread_multi_return
         else:
-            target = Minion._thread_return
+            target = self._thread_return
         # We stash an instance references to allow for the socket
         # communication in Windows. You can't pickle functions, and thus
         # python needs to be able to reconstruct the reference on the other
         # side.
-        instance = self
         if self.opts['multiprocessing']:
-            if sys.platform.startswith('win'):
-                # let python reconstruct the minion on the other side if we're
-                # running on windows
-                instance = None
             process = multiprocessing.Process(
-                target=target, args=(instance, self.opts, data)
+                target=target, args=(data,)
             )
         else:
             process = threading.Thread(
-                target=target, args=(instance, self.opts, data)
+                target=target, args=(data,)
             )
         process.start()
         process.join()
 
-    @classmethod
-    def _thread_return(cls, minion_instance, opts, data):
+    def _thread_return(self, data):
         '''
         This method should be used as a threading target, start the actual
         minion side execution.
         '''
-        # this seems awkward at first, but it's a workaround for Windows
-        # multiprocessing communication.
-        if not minion_instance:
-            minion_instance = cls(opts)
-        if opts['multiprocessing']:
-            fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
-            salt.utils.daemonize_if(opts)
+        if self.opts['multiprocessing']:
+            fn_ = os.path.join(self.proc_dir, data['jid'])
+            salt.utils.daemonize_if(self.opts)
             sdata = {'pid': os.getpid()}
             sdata.update(data)
             with salt.utils.fopen(fn_, 'w+') as fp_:
-                fp_.write(minion_instance.serial.dumps(sdata))
+                fp_.write(self.serial.dumps(sdata))
         ret = {}
         function_name = data['fun']
-        if function_name in minion_instance.functions:
+        if function_name in self.functions:
             ret['success'] = False
             try:
-                func = minion_instance.functions[data['fun']]
+                func = self.functions[data['fun']]
                 args, kwargs = parse_args_and_kwargs(func, data['arg'], data)
                 sys.modules[func.__module__].__context__['retcode'] = 0
                 ret['return'] = func(*args, **kwargs)
@@ -645,7 +653,7 @@ class Minion(object):
                 )
             except TypeError as exc:
                 trb = traceback.format_exc()
-                aspec = _getargs(minion_instance.functions[data['fun']])
+                aspec = _getargs(self.functions[data['fun']])
                 log.warning(('TypeError encountered executing {0}. See debug '
                              'log for more info.  Possibly a missing '
                              'arguments issue:  {1}').format(function_name,
@@ -669,12 +677,12 @@ class Minion(object):
 
         ret['jid'] = data['jid']
         ret['fun'] = data['fun']
-        minion_instance._return_pub(ret)
+        self._return_pub(ret)
         if data['ret']:
             for returner in set(data['ret'].split(',')):
-                ret['id'] = opts['id']
+                ret['id'] = self.opts['id']
                 try:
-                    minion_instance.returners['{0}.returner'.format(
+                    self.returners['{0}.returner'.format(
                         returner
                     )](ret)
                 except Exception as exc:
@@ -685,16 +693,11 @@ class Minion(object):
                         )
                     )
 
-    @classmethod
-    def _thread_multi_return(cls, minion_instance, opts, data):
+    def _thread_multi_return(self, data):
         '''
         This method should be used as a threading target, start the actual
         minion side execution.
         '''
-        # this seems awkward at first, but it's a workaround for Windows
-        # multiprocessing communication.
-        if not minion_instance:
-            minion_instance = cls(opts)
         ret = {
             'return': {},
             'success': {},
@@ -702,7 +705,7 @@ class Minion(object):
         for ind in range(0, len(data['fun'])):
             ret['success'][data['fun'][ind]] = False
             try:
-                func = minion_instance.functions[data['fun'][ind]]
+                func = self.functions[data['fun'][ind]]
                 args, kwargs = parse_args_and_kwargs(func, data['arg'][ind], data)
                 ret['return'][data['fun'][ind]] = func(*args, **kwargs)
                 ret['success'][data['fun'][ind]] = True
@@ -715,12 +718,12 @@ class Minion(object):
                 )
                 ret['return'][data['fun'][ind]] = trb
             ret['jid'] = data['jid']
-        minion_instance._return_pub(ret)
+        self._return_pub(ret)
         if data['ret']:
             for returner in set(data['ret'].split(',')):
-                ret['id'] = opts['id']
+                ret['id'] = self.opts['id']
                 try:
-                    minion_instance.returners['{0}.returner'.format(
+                    self.returners['{0}.returner'.format(
                         returner
                     )](ret)
                 except Exception as exc:
@@ -1300,6 +1303,17 @@ class Matcher(object):
         if functions is None:
             functions = salt.loader.minion_mods(self.opts)
         self.functions = functions
+
+    def __getstate__(self):
+        # Schedule instance must be picklable for multiprocessing on windows
+        # Strip the unpicklable attributes and recreate on the other side
+        picklable_state = copy.copy(self.__dict__)
+        del picklable_state['functions']
+        return picklable_state
+
+    def __setstate__(self, state):
+        self.__dict__.update(state)
+        self.functions = salt.loader.minion_mods(self.opts)
 
     def confirm_top(self, match, data, nodegroups=None):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -468,9 +468,17 @@ class Minion(object):
         # Minion instance must be picklable for multiprocessing on windows
         # Strip the unpicklable attributes and recreate on the other side
         picklable_state = copy.copy(self.__dict__)
-        del picklable_state['functions']
-        del picklable_state['returners']
-        del picklable_state['schedule']
+        for attr in ['functions', 
+                     'returners',
+                     'schedule',
+                     'epoller', 
+                     'socket', 
+                     'epub_sock',
+                     'poller', 
+                     'epull_sock',
+                     'context']:
+            del picklable_state[attr]
+
         return picklable_state
 
     def __setstate__(self, state):
@@ -892,7 +900,8 @@ class Minion(object):
                 ),
                 exc_info=err
             )
-        signal.signal(signal.SIGTERM, self.clean_die)
+        if threading.current_thread() == 'MainThread':
+            signal.signal(signal.SIGTERM, self.clean_die)
         log.debug('Minion "{0}" trying to tune in'.format(self.opts['id']))
         self.context = zmq.Context()
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -463,7 +463,6 @@ class Minion(object):
             self.opts,
             self.functions,
             self.returners)
-        signal.signal(signal.SIGTERM, self.clean_die)
 
     def __getstate__(self):
         # Minion instance must be picklable for multiprocessing on windows
@@ -904,6 +903,7 @@ class Minion(object):
                 ),
                 exc_info=err
             )
+        signal.signal(signal.SIGTERM, self.clean_die)
         log.debug('Minion "{0}" trying to tune in'.format(self.opts['id']))
         self.context = zmq.Context()
 

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -8,9 +8,9 @@ from multiprocessing import freeze_support
 
 
 if __name__ == '__main__':
-	if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
-		# If it's not a frozen build then the main module must have a .py ext on windows
-		raise RuntimeError('Run {0}.py on windows for multiprocessing support'.format(__file__))
+    if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
+        # If it's not a frozen build then the main module must have a .py ext on windows
+        raise RuntimeError('Run {0}.py on windows for multiprocessing support'.format(__file__))
     # This handles the bootstrapping code that is included with frozen
     # scripts. It is a no-op on unfrozen code.
     freeze_support()

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -3,12 +3,15 @@
 This script is used to kick off a salt minion daemon
 '''
 
+import sys
 from salt.scripts import salt_minion
 from multiprocessing import freeze_support
 
 
 if __name__ == '__main__':
-    if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
+    if sys.platform == 'win32' \
+       and not getattr(sys, 'frozen', False) \
+       and not __file__.endswith('.py'):
         # If it's not a frozen build then the main module must have a .py ext on windows
         raise RuntimeError('Run {0}.py on windows for multiprocessing support'.format(__file__))
     # This handles the bootstrapping code that is included with frozen

--- a/scripts/salt-minion
+++ b/scripts/salt-minion
@@ -8,6 +8,9 @@ from multiprocessing import freeze_support
 
 
 if __name__ == '__main__':
+	if sys.platform == 'win32' and not getattr(sys, 'frozen', False):
+		# If it's not a frozen build then the main module must have a .py ext on windows
+		raise RuntimeError('Run {0}.py on windows for multiprocessing support'.format(__file__))
     # This handles the bootstrapping code that is included with frozen
     # scripts. It is a no-op on unfrozen code.
     freeze_support()

--- a/scripts/salt-minion.py
+++ b/scripts/salt-minion.py
@@ -1,0 +1,4 @@
+#!/usr/bin/env python
+
+execfile(__file__[0:-3])
+

--- a/setup.py
+++ b/setup.py
@@ -299,6 +299,8 @@ if with_setuptools:
                             'salt = salt.scripts:salt_main'
                             ],
     }
+    if os.name == 'nt':
+        setup_kwargs['entry_points']['console_scripts'].append('salt-minion.py = salt.scripts:salt_minion.py')
 else:
     setup_kwargs['scripts'] = ['scripts/salt-master',
                                'scripts/salt-minion',
@@ -308,6 +310,8 @@ else:
                                'scripts/salt-call',
                                'scripts/salt-run',
                                'scripts/salt']
+    if os.name == 'nt':
+        setup_kwargs['scripts'].append('scripts/salt-minion.py')
 
 if __name__ == '__main__':
     setup(**setup_kwargs)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -15,6 +15,7 @@ import time
 import signal
 import subprocess
 import pickle
+import threading
 from hashlib import md5
 from subprocess import PIPE, Popen
 from datetime import datetime, timedelta
@@ -1065,9 +1066,13 @@ class MultiprocessingTest(ShellCase):
             os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
         )
         minion = salt.minion.Minion(minion_opts)
+        process = threading.Thread(target=minion.tune_in)
+        process.daemon=True
+        process.start()
+        time.sleep(5)
         try:
             pickle.dumps(minion)
-        except pickle.PicklingError as e:
+        except:
             if hasattr(minion, '__getstate__'):
                 state = minion.__getstate__()
             else:
@@ -1076,7 +1081,7 @@ class MultiprocessingTest(ShellCase):
             for k, v in state.items():
                 try:
                     pickle.dumps(v)
-                except pickle.PicklingError:
+                except:
                     failed_attrs.append(k)
             self.fail('Minion instance attrs are not picklable: {0}'.format(failed_attrs))
 
@@ -1088,9 +1093,10 @@ class MultiprocessingTest(ShellCase):
             os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
         )
         minion = salt.minion.Minion(minion_opts)
+        
         try:
             pickle.dumps(minion.schedule)
-        except pickle.PicklingError as e:
+        except:
             if hasattr(minion.schedule, '__getstate__'):
                 state = minion.schedule.__getstate__()
             else:
@@ -1099,7 +1105,7 @@ class MultiprocessingTest(ShellCase):
             for k, v in state.items():
                 try:
                     pickle.dumps(v)
-                except pickle.PicklingError:
+                except:
                     failed_attrs.append(k)
             self.fail('Schedule instance attrs are not picklable: {0}'.format(failed_attrs))
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -14,8 +14,6 @@ import logging
 import time
 import signal
 import subprocess
-import pickle
-import threading
 from hashlib import md5
 from subprocess import PIPE, Popen
 from datetime import datetime, timedelta
@@ -1052,91 +1050,4 @@ class SaltReturnAssertsMixIn(object):
         return self.assertNotEqual(
             self.__getWithinSaltReturn(ret, keys), comparison
         )
-
-
-class MultiprocessingTest(ShellCase):
-    '''
-    Test multiprocessing windows requirements are satisfied
-    '''
-    def test_minion_pickle(self):
-        '''
-        Test minion instance can be pickled
-        '''
-        minion_opts = salt.config.minion_config(
-            os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
-        )
-        minion = salt.minion.Minion(minion_opts)
-        process = threading.Thread(target=minion.tune_in)
-        process.daemon=True
-        process.start()
-        time.sleep(5)
-        try:
-            pickle.dumps(minion)
-        except:
-            if hasattr(minion, '__getstate__'):
-                state = minion.__getstate__()
-            else:
-                state = minion.__dict__
-            failed_attrs=[]
-            for k, v in state.items():
-                try:
-                    pickle.dumps(v)
-                except:
-                    failed_attrs.append(k)
-            self.fail('Minion instance attrs are not picklable: {0}'.format(failed_attrs))
-
-    def test_minion_schedule_pickle(self):
-        '''
-        Test minion schedule instance can be pickled
-        '''
-        minion_opts = salt.config.minion_config(
-            os.path.join(INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
-        )
-        minion = salt.minion.Minion(minion_opts)
-        
-        try:
-            pickle.dumps(minion.schedule)
-        except:
-            if hasattr(minion.schedule, '__getstate__'):
-                state = minion.schedule.__getstate__()
-            else:
-                state = minion.schedule.__dict__
-            failed_attrs=[]
-            for k, v in state.items():
-                try:
-                    pickle.dumps(v)
-                except:
-                    failed_attrs.append(k)
-            self.fail('Schedule instance attrs are not picklable: {0}'.format(failed_attrs))
-
-    def test_minion_main_import(self):
-        '''
-        Test minion salt-minion.py is importable
-        '''
-        module = 'salt-minion'
-        script = '{0}.py'.format(module)
-        path = os.path.join(SCRIPT_DIR, script)
-        if not os.path.isfile(path):
-            self.fail('{0} not found'.format(script))
-
-        ppath = 'PYTHONPATH={0}:{1}:{2}'.format(SCRIPT_DIR, CODE_DIR, ':'.join(sys.path[1:]))
-        cmd = '{0} {1} -m {2} --version'.format(ppath, PYEXEC, module)
-
-        popen_kwargs = {
-            'shell': True,
-            'stdout': PIPE
-        }
-        if not sys.platform.lower().startswith('win'):
-            popen_kwargs['close_fds'] = True
-
-
-        if not sys.platform.lower().startswith('win'):
-            popen_kwargs['close_fds'] = True
-
-        process = Popen(cmd, **popen_kwargs)
-        data = process.communicate()[0].splitlines()
-
-        expected = self.run_script('salt-minion', '--version')
-
-        self.assertEqual(data[0].split()[1:], expected[0].split()[1:])
 

--- a/tests/integration/wincompat/minion.py
+++ b/tests/integration/wincompat/minion.py
@@ -4,6 +4,7 @@ import threading
 import time
 import pickle
 import subprocess
+import copy
 
 import integration
 
@@ -21,11 +22,12 @@ class MultiprocessingTest(integration.ShellCase):
         minion_opts = salt.config.minion_config(
             os.path.join(integration.INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
         )
-        minion = salt.minion.Minion(minion_opts)
-        process = threading.Thread(target=minion.tune_in)
-        process.daemon=True
+        my_opts=copy.copy(minion_opts)
+        my_opts['id']='test_minion_pickle'
+        minion = salt.minion.Minion(my_opts)
+        process = threading.Thread(target=minion.tune_in_no_block)
         process.start()
-        time.sleep(5)
+        process.join()
         try:
             pickle.dumps(minion)
         except:
@@ -48,7 +50,12 @@ class MultiprocessingTest(integration.ShellCase):
         minion_opts = salt.config.minion_config(
             os.path.join(integration.INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
         )
-        minion = salt.minion.Minion(minion_opts)
+        my_opts=copy.copy(minion_opts)
+        my_opts['id']='test_minion_schedule_pickle'
+        minion = salt.minion.Minion(my_opts)
+        process = threading.Thread(target=minion.tune_in_no_block)
+        process.start()
+        process.join()
         
         try:
             pickle.dumps(minion.schedule)

--- a/tests/integration/wincompat/minion.py
+++ b/tests/integration/wincompat/minion.py
@@ -28,6 +28,7 @@ class MultiprocessingTest(integration.ShellCase):
         process = threading.Thread(target=minion.tune_in_no_block)
         process.start()
         process.join()
+        self.run_key('-y -d test_minion_pickle')
         try:
             pickle.dumps(minion)
         except:
@@ -56,7 +57,7 @@ class MultiprocessingTest(integration.ShellCase):
         process = threading.Thread(target=minion.tune_in_no_block)
         process.start()
         process.join()
-        
+        self.run_key('-y -d test_minion_schedule_pickle')
         try:
             pickle.dumps(minion.schedule)
         except:

--- a/tests/integration/wincompat/minion.py
+++ b/tests/integration/wincompat/minion.py
@@ -1,0 +1,98 @@
+import os
+import sys
+import threading
+import time
+import pickle
+import subprocess
+
+import integration
+
+import salt.config
+import salt.minion
+
+class MultiprocessingTest(integration.ShellCase):
+    '''
+    Test multiprocessing windows requirements are satisfied
+    '''
+    def test_minion_pickle(self):
+        '''
+        Test minion instance can be pickled
+        '''
+        minion_opts = salt.config.minion_config(
+            os.path.join(integration.INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
+        )
+        minion = salt.minion.Minion(minion_opts)
+        process = threading.Thread(target=minion.tune_in)
+        process.daemon=True
+        process.start()
+        time.sleep(5)
+        try:
+            pickle.dumps(minion)
+        except:
+            if hasattr(minion, '__getstate__'):
+                state = minion.__getstate__()
+            else:
+                state = minion.__dict__
+            failed_attrs=[]
+            for k, v in state.items():
+                try:
+                    pickle.dumps(v)
+                except:
+                    failed_attrs.append(k)
+            self.fail('Minion instance attrs are not picklable: {0}'.format(failed_attrs))
+
+    def test_minion_schedule_pickle(self):
+        '''
+        Test minion schedule instance can be pickled
+        '''
+        minion_opts = salt.config.minion_config(
+            os.path.join(integration.INTEGRATION_TEST_DIR, 'files', 'conf', 'minion')
+        )
+        minion = salt.minion.Minion(minion_opts)
+        
+        try:
+            pickle.dumps(minion.schedule)
+        except:
+            if hasattr(minion.schedule, '__getstate__'):
+                state = minion.schedule.__getstate__()
+            else:
+                state = minion.schedule.__dict__
+            failed_attrs=[]
+            for k, v in state.items():
+                try:
+                    pickle.dumps(v)
+                except:
+                    failed_attrs.append(k)
+            self.fail('Schedule instance attrs are not picklable: {0}'.format(failed_attrs))
+
+    def test_minion_main_import(self):
+        '''
+        Test minion salt-minion.py is importable
+        '''
+        module = 'salt-minion'
+        script = '{0}.py'.format(module)
+        path = os.path.join(integration.SCRIPT_DIR, script)
+        if not os.path.isfile(path):
+            self.fail('{0} not found'.format(script))
+
+        ppath = 'PYTHONPATH={0}:{1}:{2}'.format(integration.SCRIPT_DIR, integration.CODE_DIR, ':'.join(sys.path[1:]))
+        cmd = '{0} {1} -m {2} --version'.format(ppath, integration.PYEXEC, module)
+
+        popen_kwargs = {
+            'shell': True,
+            'stdout': subprocess.PIPE
+        }
+        if not sys.platform.lower().startswith('win'):
+            popen_kwargs['close_fds'] = True
+
+
+        if not sys.platform.lower().startswith('win'):
+            popen_kwargs['close_fds'] = True
+
+        process = subprocess.Popen(cmd, **popen_kwargs)
+        data = process.communicate()[0].splitlines()
+
+        expected = self.run_script('salt-minion', '--version')
+
+        self.assertEqual(data[0].split()[1:], expected[0].split()[1:])
+


### PR DESCRIPTION
Fix issue #4598.

It's really two issues: on windows the main module must be importable and the minion instance must be picklable.

The installed version has no issues with importing the main module but running python salt-minion will fail as it lacks a .py extension. I've created a dummy .py script for this that execs the real script and added a check in the real script so that it refuses to run unless it's frozen.
I've always included the dummy script on windows for now - it probably should be omitted for certain build/install/develop targets.

Making minion/schedule/matcher instances picklable is relatively straightforward - anything in the `__dict__` that isn't picklable is removed and recreated on the other side if necessary. This also removes the need for the windows multiprocessing hacks in thread_return.
While it might be possible to make the minion functions/returners picklable this would not work for cython modules so I think the only option is to reload for every process.

Tests added for both issues too which should catch obvious problems on travis ci.

NB until issue #5395 is fixed this will be very prone to timeouts
