### PR TITLE
Added some lines to the docs explaining how to use Powershell as an alte...

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -393,6 +393,10 @@ def run(cmd,
 
         salt '*' cmd.run template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
+    Specify an alternate shell with the shell parameter::
+
+        salt '*' cmd.run "Get-ChildItem C:\ " shell='powershell'
+
     '''
     out = _run(cmd,
                runas=runas,
@@ -606,6 +610,7 @@ def script(
 
         salt '*' cmd.script salt://scripts/runme.sh
         salt '*' cmd.script salt://scripts/runme.sh 'arg1 arg2 "arg 3"'
+        salt '*' cmd.script salt://scripts/windows_task.ps1 args=' -Input c:\tmp\infile.txt' shell='powershell'
     '''
     if not salt.utils.is_windows():
         path = salt.utils.mkstemp(dir=cwd)


### PR DESCRIPTION
(Hopefully) simple doc additions showing how to use cmd.script() and cmd.run() while specifying shell='powershell'. 

Related to Issue #5532
