### PR TITLE
Fix case where setting file perms to 000 didn't work

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -69,13 +69,7 @@ def manage_mode(mode):
 
         salt '*' config.manage_mode
     '''
-    if mode:
-        mode = str(mode).lstrip('0')
-        if not mode:
-            return '0'
-        else:
-            return mode
-    return mode
+    return str(mode).lstrip('0').zfill(3)
 
 
 def valid_fileproto(uri):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -514,6 +514,9 @@ def symlink(
         then the state will fail, setting makedirs to True will allow Salt to
         create the parent directory
     '''
+    # Make sure that leading zeros stripped by YAML loader are added back
+    mode = __salt__['config.manage_mode'](mode)
+
     user = _test_owner(kwargs, user=user)
     ret = {'name': name,
            'changes': {},
@@ -740,9 +743,10 @@ def managed(name,
         contents of the file.  Should not be used in conjunction with a source
         file of any kind.  Ignores hashes and does not use a templating engine.
     '''
-    user = _test_owner(kwargs, user=user)
-    # Initial set up
+    # Make sure that leading zeros stripped by YAML loader are added back
     mode = __salt__['config.manage_mode'](mode)
+
+    user = _test_owner(kwargs, user=user)
     ret = {'changes': {},
            'comment': '',
            'name': name,
@@ -795,19 +799,19 @@ def managed(name,
 
     if __opts__['test']:
         ret['result'], ret['comment'] = __salt__['file.check_managed'](
-                name,
-                source,
-                source_hash,
-                user,
-                group,
-                mode,
-                template,
-                makedirs,
-                context,
-                defaults,
-                env,
-                contents,
-                **kwargs
+            name,
+            source,
+            source_hash,
+            user,
+            group,
+            mode,
+            template,
+            makedirs,
+            context,
+            defaults,
+            env,
+            contents,
+            **kwargs
         )
         return ret
 
@@ -924,6 +928,7 @@ def directory(name,
     if not file_mode:
         file_mode = dir_mode
 
+    # Make sure that leading zeros stripped by YAML loader are added back
     dir_mode = __salt__['config.manage_mode'](dir_mode)
     file_mode = __salt__['config.manage_mode'](file_mode)
 
@@ -1173,6 +1178,10 @@ def recurse(name,
             '\'file_mode\' and \'dir_mode\'.'
         )
         return ret
+
+    # Make sure that leading zeros stripped by YAML loader are added back
+    dir_mode = __salt__['config.manage_mode'](dir_mode)
+    file_mode = __salt__['config.manage_mode'](file_mode)
 
     u_check = _check_user(user, group)
     if u_check:

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -57,9 +57,11 @@ class CustomLoader(yaml.SafeLoader):
         Build the mapping for YAML
         '''
         if not isinstance(node, MappingNode):
-            raise ConstructorError(None, None,
-                    'expected a mapping node, but found {0}'.format(node.id),
-                    node.start_mark)
+            raise ConstructorError(
+                None,
+                None,
+                'expected a mapping node, but found {0}'.format(node.id),
+                node.start_mark)
 
         self.flatten_mapping(node)
 
@@ -90,4 +92,8 @@ class CustomLoader(yaml.SafeLoader):
             elif node.value.startswith('0') \
                     and not node.value.startswith(('0b', '0x')):
                 node.value = node.value.lstrip('0')
+                # If value was all zeros, node.value would have been reduced to
+                # an empty string. Change it to '0'.
+                if node.value == '':
+                    node.value = '0'
         return yaml.constructor.SafeConstructor.construct_scalar(self, node)


### PR DESCRIPTION
Due to how Salt handles leading zeros the YAML renderer (strips them), a
value of '000' becomes '', causing tracebacks in some states, as well as
a failure to properly compare the desired mode against the actual mode
of the file. This commit normalizes modes, zero-padding them to replace
zeros removed by the YAML renderer.

It also modifies the YAML renderer to properly handle an input
consisting of all zeros, keeping it from being reduced to an empty
string.

Fixes #5613.
