### PR TITLE
utils.parsers: fix pylint W1401 (Anomalous backslash in string) problems

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -263,7 +263,7 @@ class ConfigDirMixIn(object):
     def _mixin_setup(self):
         default = '/etc/salt'
         if utils.is_windows():
-            default = 'c:\salt\conf'
+            default = 'c:\\salt\\conf'
         self.add_option(
             '-c', '--config-dir', default=default,
             help=('Pass in an alternative configuration directory. Default: '


### PR DESCRIPTION
Backslash has always been a rather unfortunate choice of directory separator.
