### PR TITLE
djangomod.command: allow non-"--"-options

### DIFF
--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -28,7 +28,8 @@ def command(settings_module,
             bin_env=None,
             pythonpath=None,
             env=None,
-            *args, **kwargs):
+            args=None,
+            *options, **kwargs):
     '''
     Run arbitrary django management command
 
@@ -42,12 +43,16 @@ def command(settings_module,
     if pythonpath:
         cmd = '{0} --pythonpath={1}'.format(cmd, pythonpath)
 
-    for arg in args:
-        cmd = '{0} --{1}'.format(cmd, arg)
+    for option in options:
+        cmd = '{0} --{1}'.format(cmd, option)
 
     for key, value in kwargs.items():
         if not key.startswith('__'):
             cmd = '{0} --{1}={2}'.format(cmd, key, value)
+
+    if args:
+        cmd = '{0} {1}'.format(cmd, " ".join(args))
+
     return __salt__['cmd.run'](cmd, env=env)
 
 
@@ -145,7 +150,7 @@ def loaddata(settings_module,
                    bin_env,
                    pythonpath,
                    env,
-                   *fixtures.split(','),
+                   args=fixtures.split(','),
                    **kwargs)
 
 def collectstatic(settings_module,


### PR DESCRIPTION
**Please don't merge yet**
_Travis won't run on my fork, so I need to see if this fixes all the issues once travis ran the tests. So, this is rebase-land ;)_

Makes djangomod more consistent with django-admin.py's usage:

```
$ django-admin.py --help
Usage: django-admin.py subcommand [options] [args]
```

(also fixes failing loaddata test)
