### PR TITLE
Improve TypeError reporting in minion.py, Fixes #5723

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -646,9 +646,10 @@ class Minion(object):
             except TypeError as exc:
                 trb = traceback.format_exc()
                 aspec = _getargs(minion_instance.functions[data['fun']])
-                log.warning(('TypeError encountered executing {0}. See debug '
-                             'log for more info.  Possibly a missing '
-                             'arguments issue:  {1}').format(function_name,
+                log.warning(('TypeError encountered executing {0}: {1}. See '
+                             'debug log for more info.  Possibly a missing '
+                             'arguments issue:  {2}').format(function_name,
+                                                             exc,
                                                              aspec))
                 log.debug(
                     'TypeError intercepted: {0}\n{1}'.format(exc, trb),

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -650,10 +650,6 @@ class Minion(object):
                              'log for more info.  Possibly a missing '
                              'arguments issue:  {1}').format(function_name,
                                                              aspec))
-                msg = 'Missing arguments executing "{0}": {1}'.format(
-                    function_name, aspec
-                )
-                log.warning(msg)
                 log.debug(
                     'TypeError intercepted: {0}\n{1}'.format(exc, trb),
                     exc_info=True


### PR DESCRIPTION
Removed an out-of-date log, and improved the new log with the actual exception text.
