### PR TITLE
Allows specifying version ranges in NPM states

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -73,7 +73,7 @@ def install(pkg=None,
         cmd += ' --global'
 
     if pkg:
-        cmd += ' ' + pkg
+        cmd += ' "%s"' % pkg
 
     result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas)
 
@@ -134,7 +134,7 @@ def uninstall(pkg,
     if dir is None:
         cmd += ' --global'
 
-    cmd += ' ' + pkg
+    cmd += ' "%s"' % pkg
 
     result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas)
 
@@ -173,7 +173,7 @@ def list_(pkg=None,
         cmd += ' --global'
 
     if pkg:
-        cmd += ' ' + pkg
+        cmd += ' "%s"' % pkg
 
     result = __salt__['cmd.run_all'](cmd, cwd=dir)
 


### PR DESCRIPTION
Allows specifying version ranges in NPM states, so that e.g. npm.install "coffee-script@<1.6.0" will install the latest matching version and the npm.installed state will only install if the current version does not match.
