### PR TITLE
Fix a regression where not specifying "mode" in a file.managed stanza was throwing an error.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1274,9 +1274,9 @@ def check_perms(name, ret, user, group, mode):
     perms['lgroup'] = get_group(name)
     perms['lmode'] = __salt__['config.manage_mode'](get_mode(name))
 
-    mode = __salt__['config.manage_mode'](mode)
     # Mode changes if needed
-    if mode:
+    if mode is not None:
+        mode = __salt__['config.manage_mode'](mode)
         if mode != perms['lmode']:
             if __opts__['test'] is True:
                 ret['changes']['mode'] = mode

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -744,7 +744,8 @@ def managed(name,
         file of any kind.  Ignores hashes and does not use a templating engine.
     '''
     # Make sure that leading zeros stripped by YAML loader are added back
-    mode = __salt__['config.manage_mode'](mode)
+    if mode is not None:
+        mode = __salt__['config.manage_mode'](mode)
 
     user = _test_owner(kwargs, user=user)
     ret = {'changes': {},


### PR DESCRIPTION
Not specifying a mode for a file was causing an error: "Failed to change mode to None"
