### PR TITLE
Bugs fixed for the test conditions for states.sysctl

### DIFF
--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -43,12 +43,14 @@ def present(name, value, config='/etc/sysctl.conf'):
                         'Sysctl option {0} set to be changed to {1}'
                         ).format(name, value)
                 return ret
+            else:
+                ret['comment'] = 'Sysctl value {0} = {1} is already set'.format(name,value)
+                return ret
         else:
-            ret['comment'] = 'Sysctl value {0} = {1} is already set'.format(
-                    name,
-                    value
-                    )
+            ret['result'] = None
+            ret['comment'] = 'Invalid sysctl option {0} = {1}'.format(name,value)
             return ret
+
 
     update = __salt__['sysctl.persist'](name, value, config)
 

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -51,7 +51,6 @@ def present(name, value, config='/etc/sysctl.conf'):
             ret['comment'] = 'Invalid sysctl option {0} = {1}'.format(name,value)
             return ret
 
-
     update = __salt__['sysctl.persist'](name, value, config)
 
     if update == 'Updated':


### PR DESCRIPTION
Bugs fixed for the test conditions for states.sysctl:
1. Corrected if-else logic, for already correct sysctl option setup before.
2. Added test logic: If state file is trying to setup invalid sysctl option, that is not supported by the minion's kernel.
