### PR TITLE
Make shadow support work in FreeBSD, NetBSD

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -158,6 +158,7 @@ def _render_cmd(cmd, cwd, template):
 
 def _run(cmd,
          cwd=None,
+         stdin=None,
          stdout=subprocess.PIPE,
          stderr=subprocess.PIPE,
          quiet=False,
@@ -263,7 +264,7 @@ def _run(cmd,
             msg = 'Environment could not be retrieved for User \'{0}\''.format(runas)
             raise CommandExecutionError(msg)
 
-    if not quiet:
+    if not salt.utils.is_true(quiet):
         # Put the most common case first
         log.info(
             'Executing command {0!r} {1}in directory {2!r}'.format(
@@ -285,6 +286,7 @@ def _run(cmd,
     kwargs = {'cwd': cwd,
               'shell': True,
               'env': run_env,
+              'stdin': str(stdin) if stdin is not None else stdin,
               'stdout': stdout,
               'stderr': stderr}
 
@@ -340,6 +342,7 @@ def _run(cmd,
 
 def _run_quiet(cmd,
                cwd=None,
+               stdin=None,
                runas=None,
                shell=DEFAULT_SHELL,
                env=(),
@@ -352,6 +355,7 @@ def _run_quiet(cmd,
     return _run(cmd,
                 runas=runas,
                 cwd=cwd,
+                stdin=stdin,
                 stderr=subprocess.STDOUT,
                 quiet=True,
                 shell=shell,
@@ -363,6 +367,7 @@ def _run_quiet(cmd,
 
 def _run_all_quiet(cmd,
                    cwd=None,
+                   stdin=None,
                    runas=None,
                    shell=DEFAULT_SHELL,
                    env=(),
@@ -376,6 +381,7 @@ def _run_all_quiet(cmd,
     return _run(cmd,
                 runas=runas,
                 cwd=cwd,
+                stdin=stdin,
                 shell=shell,
                 env=env,
                 quiet=True,
@@ -386,6 +392,7 @@ def _run_all_quiet(cmd,
 
 def run(cmd,
         cwd=None,
+        stdin=None,
         runas=None,
         shell=DEFAULT_SHELL,
         env=(),
@@ -412,11 +419,17 @@ def run(cmd,
 
         salt '*' cmd.run "Get-ChildItem C:\\ " shell='powershell'
 
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.run "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     out = _run(cmd,
                runas=runas,
                shell=shell,
                cwd=cwd,
+               stdin=stdin,
                stderr=subprocess.STDOUT,
                env=env,
                template=template,
@@ -431,6 +444,7 @@ def run(cmd,
 
 def run_stdout(cmd,
                cwd=None,
+               stdin=None,
                runas=None,
                shell=DEFAULT_SHELL,
                env=(),
@@ -453,10 +467,16 @@ def run_stdout(cmd,
 
         salt '*' cmd.run_stdout template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.run_stdout "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     stdout = _run(cmd,
                   runas=runas,
                   cwd=cwd,
+                  stdin=stdin,
                   shell=shell,
                   env=env,
                   template=template,
@@ -471,6 +491,7 @@ def run_stdout(cmd,
 
 def run_stderr(cmd,
                cwd=None,
+               stdin=None,
                runas=None,
                shell=DEFAULT_SHELL,
                env=(),
@@ -493,10 +514,16 @@ def run_stderr(cmd,
 
         salt '*' cmd.run_stderr template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.run_stderr "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     stderr = _run(cmd,
                   runas=runas,
                   cwd=cwd,
+                  stdin=stdin,
                   shell=shell,
                   env=env,
                   template=template,
@@ -511,6 +538,7 @@ def run_stderr(cmd,
 
 def run_all(cmd,
             cwd=None,
+            stdin=None,
             runas=None,
             shell=DEFAULT_SHELL,
             env=(),
@@ -533,10 +561,16 @@ def run_all(cmd,
 
         salt '*' cmd.run_all template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.run_all "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     ret = _run(cmd,
                runas=runas,
                cwd=cwd,
+               stdin=stdin,
                shell=shell,
                env=env,
                template=template,
@@ -566,6 +600,7 @@ def run_all(cmd,
 
 def retcode(cmd,
             cwd=None,
+            stdin=None,
             runas=None,
             shell=DEFAULT_SHELL,
             env=(),
@@ -586,11 +621,17 @@ def retcode(cmd,
 
         salt '*' cmd.retcode template=jinja "file {{grains.pythonpath[0]}}/python"
 
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.retcode "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     return _run(
             cmd,
             runas=runas,
             cwd=cwd,
+            stdin=stdin,
             shell=shell,
             env=env,
             template=template,
@@ -603,6 +644,7 @@ def script(
         source,
         args=None,
         cwd=None,
+        stdin=None,
         runas=None,
         shell=DEFAULT_SHELL,
         env='base',
@@ -626,6 +668,12 @@ def script(
         salt '*' cmd.script salt://scripts/runme.sh
         salt '*' cmd.script salt://scripts/runme.sh 'arg1 arg2 "arg 3"'
         salt '*' cmd.script salt://scripts/windows_task.ps1 args=' -Input c:\\tmp\\infile.txt' shell='powershell'
+
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     if not salt.utils.is_windows():
         path = salt.utils.mkstemp(dir=cwd)
@@ -643,12 +691,12 @@ def script(
     ret = _run(
             path + ' ' + args if args else path,
             cwd=cwd,
+            stdin=stdin,
             quiet=kwargs.get('quiet', False),
             runas=runas,
             shell=shell,
             umask=umask,
-            timeout=timeout
-            )
+            timeout=timeout)
     os.remove(path)
     return ret
 
@@ -656,6 +704,7 @@ def script(
 def script_retcode(
         source,
         cwd=None,
+        stdin=None,
         runas=None,
         shell=DEFAULT_SHELL,
         env='base',
@@ -678,6 +727,12 @@ def script_retcode(
     CLI Example::
 
         salt '*' cmd.script_retcode salt://scripts/runme.sh
+
+    A string of standard input can be specified for the command to be run using
+    the ``stdin`` parameter. This can be useful in cases where sensitive
+    information must be read from standard input.::
+
+        salt '*' cmd.script_retcode salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
     return script(
             source,

--- a/salt/modules/freebsd_shadow.py
+++ b/salt/modules/freebsd_shadow.py
@@ -1,0 +1,75 @@
+'''
+Manage the password database on FreeBSD systems
+'''
+
+# Import python libs
+import os
+try:
+    import pwd
+except ImportError:
+    pass
+
+# Import salt libs
+import salt.utils
+
+
+def __virtual__():
+    return 'shadow' if __grains__.get('os', '') == 'FreeBSD' else False
+
+
+def info(name):
+    '''
+    Return information for the specified user
+
+    CLI Example::
+
+        salt '*' shadow.info root
+    '''
+    try:
+        data = pwd.getpwnam(name)
+        ret = {
+            'name': data.pw_name,
+            'passwd': data.pw_passwd if data.pw_passwd != '*' else '',
+            'change': '',
+            'expire': ''}
+    except KeyError:
+        return {
+            'name': '',
+            'passwd': '',
+            'change': '',
+            'expire': ''}
+
+    # Get password aging info
+    cmd = 'pw user show {0} | cut -f6,7 -d:'.format(name)
+    try:
+        change, expire = __salt__['cmd.run_all'](cmd)['stdout'].split(':')
+    except ValueError:
+        pass
+    else:
+        ret['change'] = change
+        ret['expire'] = expire
+
+    return ret
+
+
+def set_password(name, password):
+    '''
+    Set the password for a named user. The password must be a properly defined
+    hash. The password hash can be generated with this command:
+
+    ``python -c "import crypt; print crypt.crypt('password',
+    '$6$SALTsalt')"``
+
+    ``SALTsalt`` is the 8-character crpytographic salt. Valid characters in the
+    salt are ``.``, ``/``, and any alphanumeric character.
+
+    Keep in mind that the $6 represents a sha512 hash, if your OS is using a
+    different hashing algorithm this needs to be changed accordingly
+
+    CLI Example::
+
+        salt '*' shadow.set_password root '$1$UYCIxa628.9qXjpQCjM4a..'
+    '''
+    __salt__['cmd.run']('pw user mod {0} -H 0'.format(name), stdin=password)
+    uinfo = info(name)
+    return uinfo['passwd'] == password

--- a/salt/modules/netbsd_shadow.py
+++ b/salt/modules/netbsd_shadow.py
@@ -1,0 +1,69 @@
+'''
+Manage the password database on NetBSD systems
+'''
+
+# Import python libs
+import logging
+import os
+try:
+    import pwd
+except ImportError:
+    pass
+
+# Import salt libs
+import salt.utils
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return 'shadow' if __grains__.get('os', '') == 'NetBSD' else False
+
+
+def info(name):
+    '''
+    Return information for the specified user
+
+    CLI Example::
+
+        salt '*' shadow.info root
+    '''
+    try:
+        data = pwd.getpwnam(name)
+        ret = {
+            'name': data.pw_name,
+            'passwd': data.pw_passwd if data.pw_passwd != '*************'
+                else ''}
+    except KeyError:
+        return {
+            'name': '',
+            'passwd': ''}
+    return ret
+
+
+def set_password(name, password):
+    '''
+    Set the password for a named user. The password must be a properly defined
+    hash. The password hash can be generated with this command:
+
+    ``python -c "import crypt; print crypt.crypt('password',
+    '$sha1$numrounds$SALTsalt')"``
+
+    ``numrounds`` is the number of rounds. See ``man passwd.conf`` as this
+    option is not used for all ciphers.
+
+    ``SALTsalt`` is the 8-character crpytographic salt. Valid characters in the
+    salt are ``.``, ``/``, and any alphanumeric character.
+
+    CLI Example::
+
+        salt '*' shadow.set_password root
+        '$sha1$22295$f8s.YafO$eRQSGyI4BP98Kj/hIohuXCmatl7L'
+    '''
+    cmd = 'usermod -p \'{0}\' {1}'.format(password, name)
+    log.info('Setting password for user {0}'.format(name))
+    # Don't log this command, to keep hash out of the log
+    __salt__['cmd.run'](cmd, quiet=True)
+    uinfo = info(name)
+    return uinfo['passwd'] == password

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -14,16 +14,7 @@ import salt.utils
 
 
 def __virtual__():
-    '''
-    Only work on POSIX-like systems
-    '''
-
-    # Disable on Windows, a specific file module exists:
-    if salt.utils.is_windows() or __grains__['kernel'] in (
-                'SunOS', 'NetBSD'
-            ):
-        return False
-    return 'shadow'
+    return 'shadow' if __grains__.get('kernel', '') == 'Linux' else False
 
 
 def info(name):
@@ -38,7 +29,7 @@ def info(name):
         data = spwd.getspnam(name)
         ret = {
             'name': data.sp_nam,
-            'pwd': data.sp_pwd,
+            'passwd': data.sp_pwd if data.sp_pwd != '!' else '',
             'lstchg': data.sp_lstchg,
             'min': data.sp_min,
             'max': data.sp_max,
@@ -46,9 +37,9 @@ def info(name):
             'inact': data.sp_inact,
             'expire': data.sp_expire}
     except KeyError:
-        ret = {
+        return {
             'name': '',
-            'pwd': '',
+            'passwd': '',
             'lstchg': '',
             'min': '',
             'max': '',
@@ -118,16 +109,22 @@ def set_mindays(name, mindays):
 def set_password(name, password, use_usermod=False):
     '''
     Set the password for a named user. The password must be a properly defined
-    hash, the password hash can be generated with this command:
-    ``python -c "import crypt, getpass, pwd; print crypt.crypt('password', '\\$6\\$SALTsalt\\$')"``
+    hash. The password hash can be generated with this command:
+
+    ``python -c "import crypt; print crypt.crypt('password',
+    '$6$SALTsalt')"``
+
+    ``SALTsalt`` is the 8-character crpytographic salt. Valid characters in the
+    salt are ``.``, ``/``, and any alphanumeric character.
+
     Keep in mind that the $6 represents a sha512 hash, if your OS is using a
     different hashing algorithm this needs to be changed accordingly
 
     CLI Example::
 
-        salt '*' shadow.set_password root $1$UYCIxa628.9qXjpQCjM4a..
+        salt '*' shadow.set_password root '$1$UYCIxa628.9qXjpQCjM4a..'
     '''
-    if not use_usermod:
+    if not salt.utils.is_true(use_usermod):
         # Edit the shadow file directly
         s_file = '/etc/shadow'
         ret = {}
@@ -146,13 +143,13 @@ def set_password(name, password, use_usermod=False):
         with salt.utils.fopen(s_file, 'w+') as fp_:
             fp_.writelines(lines)
         uinfo = info(name)
-        return uinfo['pwd'] == password
+        return uinfo['passwd'] == password
     else:
         # Use usermod -p (less secure, but more feature-complete)
         cmd = 'usermod -p {0} {1}'.format(name, password)
         __salt__['cmd.run'](cmd)
         uinfo = info(name)
-        return uinfo['pwd'] == password
+        return uinfo['passwd'] == password
 
 
 def set_warndays(name, warndays):

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -1,5 +1,5 @@
 '''
-Manage the shadow file
+Manage the password database on Solaris systems
 '''
 
 # Import python libs
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Only work on POSIX-like systems
     '''
-    return 'shadow' if __grains__['kernel'] == 'SunOS' else False
+    return 'shadow' if __grains__.get('kernel', '') == 'SunOS' else False
 
 
 def info(name):
@@ -36,7 +36,7 @@ def info(name):
             data = spwd.getspnam(name)
             ret = {
                 'name': data.sp_nam,
-                'pwd': data.sp_pwd,
+                'passwd': data.sp_pwd if data.sp_pwd != '!' else '',
                 'lstchg': data.sp_lstchg,
                 'min': data.sp_min,
                 'max': data.sp_max,
@@ -46,7 +46,7 @@ def info(name):
         except KeyError:
             ret = {
                 'name': '',
-                'pwd': '',
+                'passwd': '',
                 'lstchg': '',
                 'min': '',
                 'max': '',
@@ -59,7 +59,7 @@ def info(name):
     # Return what we can know
     ret = {
         'name': '',
-        'pwd': '',
+        'passwd': '',
         'lstchg': '',
         'min': '',
         'max': '',
@@ -71,7 +71,7 @@ def info(name):
         data = pwd.getpwnam(name)
         ret.update({
             'name': name,
-            'pwd': data.pw_dir
+            'passwd': data.pw_dir
         })
     except KeyError:
         return ret
@@ -104,7 +104,7 @@ def info(name):
     #   buildbot L 05/09/2013 0 99999 7
     ret.update({
         'name': data.pw_name,
-        'pwd': data.pw_dir,
+        'passwd': data.pw_dir,
         'lstchg': fields[2],
         'min': int(fields[3]),
         'max': int(fields[4]),
@@ -180,7 +180,7 @@ def set_password(name, password):
     with salt.utils.fopen(s_file, 'w+') as ofile:
         ofile.writelines(lines)
     uinfo = info(name)
-    return uinfo['pwd'] == password
+    return uinfo['passwd'] == password
 
 
 def set_warndays(name, warndays):

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -31,8 +31,8 @@ log = logging.getLogger(__name__)
 
 
 def _shadow_supported():
-    supported_os = ('FreeBSD', 'NetBSD', 'SunOS')
-    supported_kernel = ('Linux',)
+    supported_os = ('FreeBSD', 'NetBSD')
+    supported_kernel = ('Linux', 'SunOS')
     return True if __grains__.get('os', '') in supported_os \
         or __grains__.get('kernel', '') in supported_kernel \
         else False

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -182,7 +182,8 @@ def present(name,
         will NOT be created.
 
     password
-        A password hash to set for the user
+        A password hash to set for the user. This field is only supported on
+        Linux, FreeBSD, NetBSD, and Solaris
 
     enforce_password
         Set to False to keep the password from being changed if it has already


### PR DESCRIPTION
These commits update the user state to support setting a password hash in FreeBSD and NetBSD. It also adds support for specifying a string of text to pass as standard input to commands run via the cmd module.

OpenBSD still needs to be audited, as does MacOS. This is a good step in the right direction, though.
