### PR TITLE
Add reclass adapters for master_tops and ext_pillar

### DIFF
--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -1,0 +1,21 @@
+'''
+Adapter for reclass.
+
+This file cannot be called reclass.py, because then the module import would
+not work. Thanks to the __virtual__ function, however, the plugin still
+responds to the name 'reclass'.
+
+More information about reclass: http://github.com/madduck/reclass
+
+It would be desirable to specify the location of reclass in the master config
+file. Unfortunately, __opts__ is only made available to the ext_pillar
+function, not to the module, so that the import cannot make use of these data,
+at least not at the module level, which is needed to set __virtual__
+accordingly.
+'''
+try:
+    from reclass.adapters.saltstack import ext_pillar
+    __virtual__ = lambda: 'reclass'
+
+except ImportError:
+    __virtual__ = lambda: False

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -1,0 +1,20 @@
+'''
+Adapter for reclass.
+
+This file cannot be called reclass.py, because then the module import would
+not work. Thanks to the __virtual__ function, however, the plugin still
+responds to the name 'reclass'.
+
+More information about reclass: http://github.com/madduck/reclass
+
+It would be desirable to specify the location of reclass in the master config
+file. Unfortunately, __opts__ is only made available to the tops function, not
+to the module, so that the import cannot make use of these data, at least not
+at the module level, which is needed to set __virtual__ accordingly.
+'''
+try:
+    from reclass.adapters.saltstack import tops
+    __virtual__ = lambda: 'reclass'
+
+except ImportError:
+    __virtual__ = lambda: False


### PR DESCRIPTION
These adapters really don't do anything but delegate to the
Salt-specific adapters in the reclass source. This should be quite
future-proof, allowing reclass to evolve without requiring Salt to be
patched.

Signed-off-by: martin f. krafft madduck@madduck.net
