### PR TITLE
Setup logging on salt's runner `CLI` access. Fixes #5706.

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -805,9 +805,9 @@ class OutputOptionsMixIn(object):
         )
         group.add_option(
             '--force-color', '--force-colour',
-        	  default=False,
-        	  action='store_true',
-        	  help='Force colored output'
+            default=False,
+            action='store_true',
+            help='Force colored output'
         )
 
         for option in self.output_options_group.option_list:
@@ -1446,7 +1446,7 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 
 class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
-                          TimeoutMixIn):
+                          TimeoutMixIn, LogLevelMixIn):
     __metaclass__ = OptionParserMeta
 
     default_timeout = 1
@@ -1455,7 +1455,9 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
+
     # LogLevelMixIn attributes
+    _default_logging_level_ = 'warning'
     _default_logging_logfile_ = '/var/log/salt/master'
 
     def _mixin_setup(self):


### PR DESCRIPTION
Default log level is `warning`, though, since the master configuration file is shared, whatever the `log_level` defined on the master configuration file that's the value that will be used. To tweak the `salt-run` log level on the configuration file, independently from the master, you can use `cli_salt_run_log_level`(See #5609).
