### PR TITLE
Complete cli tools logging

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -226,7 +226,6 @@ class SaltKey(parsers.SaltKeyOptionParser):
                     os.path.join(self.config['pki_dir'], 'minions'),
                     os.path.join(self.config['pki_dir'], 'minions_pre'),
                     os.path.join(self.config['pki_dir'], 'minions_rejected'),
-                    os.path.dirname(self.config['key_logfile'])
                 ])
 
             verify_env(
@@ -235,6 +234,14 @@ class SaltKey(parsers.SaltKeyOptionParser):
                 permissive=self.config['permissive_pki_access'],
                 pki_dir=self.config['pki_dir'],
             )
+            if (not self.config['key_logfile'].startswith('tcp://') or
+                    not self.config['key_logfile'].startswith('udp://') or
+                    not self.config['key_logfile'].startswith('file://')):
+                # Logfile is not using Syslog, verify
+                verify_files(
+                    [self.config['key_logfile']],
+                    self.config['user']
+                )
 
         self.setup_logfile_logger()
 
@@ -263,8 +270,8 @@ class SaltCall(parsers.SaltCallOptionParser):
                 pki_dir=self.config['pki_dir'],
             )
             if (not self.config['log_file'].startswith('tcp://') or
-                not self.config['log_file'].startswith('udp://') or
-                not self.config['log_file'].startswith('file://')):
+                    not self.config['log_file'].startswith('udp://') or
+                    not self.config['log_file'].startswith('file://')):
                 # Logfile is not using Syslog, verify
                 verify_files(
                     [self.config['log_file']],

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -188,6 +188,19 @@ class SaltCP(parsers.SaltCPOptionParser):
         Execute salt-cp
         '''
         self.parse_args()
+
+        if (not self.config['log_file'].startswith('tcp://') or
+                not self.config['log_file'].startswith('udp://') or
+                not self.config['log_file'].startswith('file://')):
+            # Logfile is not using Syslog, verify
+            verify_files(
+                [self.config['log_file']],
+                self.config['user']
+            )
+
+        # Setup file logging!
+        self.setup_logfile_logger()
+
         cp_ = salt.cli.cp.SaltCP(self.config)
         cp_.run()
 

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -36,6 +36,18 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         '''
         self.parse_args()
 
+        if (not self.config['log_file'].startswith('tcp://') or
+                not self.config['log_file'].startswith('udp://') or
+                not self.config['log_file'].startswith('file://')):
+            # Logfile is not using Syslog, verify
+            verify_files(
+                [self.config['log_file']],
+                self.config['user']
+            )
+
+        # Setup file logging!
+        self.setup_logfile_logger()
+
         try:
             local = salt.client.LocalClient(self.get_config_file_path())
         except SaltClientError as exc:

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -36,14 +36,15 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         '''
         self.parse_args()
 
-        if (not self.config['log_file'].startswith('tcp://') or
-                not self.config['log_file'].startswith('udp://') or
-                not self.config['log_file'].startswith('file://')):
-            # Logfile is not using Syslog, verify
-            verify_files(
-                [self.config['log_file']],
-                self.config['user']
-            )
+        if self.config['verify_env']:
+            if (not self.config['log_file'].startswith('tcp://') or
+                    not self.config['log_file'].startswith('udp://') or
+                    not self.config['log_file'].startswith('file://')):
+                # Logfile is not using Syslog, verify
+                verify_files(
+                    [self.config['log_file']],
+                    self.config['user']
+                )
 
         # Setup file logging!
         self.setup_logfile_logger()
@@ -189,14 +190,15 @@ class SaltCP(parsers.SaltCPOptionParser):
         '''
         self.parse_args()
 
-        if (not self.config['log_file'].startswith('tcp://') or
-                not self.config['log_file'].startswith('udp://') or
-                not self.config['log_file'].startswith('file://')):
-            # Logfile is not using Syslog, verify
-            verify_files(
-                [self.config['log_file']],
-                self.config['user']
-            )
+        if self.config['verify_env']:
+            if (not self.config['log_file'].startswith('tcp://') or
+                    not self.config['log_file'].startswith('udp://') or
+                    not self.config['log_file'].startswith('file://')):
+                # Logfile is not using Syslog, verify
+                verify_files(
+                    [self.config['log_file']],
+                    self.config['user']
+                )
 
         # Setup file logging!
         self.setup_logfile_logger()

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1111,7 +1111,7 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 
 class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
-                         TimeoutMixIn, TargetOptionsMixIn):
+                         TimeoutMixIn, TargetOptionsMixIn, LogLevelMixIn):
     __metaclass__ = OptionParserMeta
 
     description = (
@@ -1126,8 +1126,11 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
+
     # LogLevelMixIn attributes
+    _default_logging_level_ = 'warning'
     _default_logging_logfile_ = '/var/log/salt/master'
+
 
     def _mixin_after_parsed(self):
         # salt-cp needs arguments

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -297,7 +297,8 @@ class LogLevelMixIn(object):
     _default_logging_level_ = 'warning'
     _default_logging_logfile_ = None
     _logfile_config_setting_name_ = 'log_file'
-    _loglevel_config_setting_name_ = 'log_level_logfile'
+    _loglevel_config_setting_name_ = 'log_level'
+    _logfile_loglevel_config_setting_name_ = 'log_level_logfile'
     _skip_console_logging_config_ = False
 
     def _mixin_setup(self):
@@ -337,7 +338,7 @@ class LogLevelMixIn(object):
 
         group.add_option(
             '--log-file-level',
-            dest=self._loglevel_config_setting_name_,
+            dest=self._logfile_loglevel_config_setting_name_,
             choices=list(log.LOG_LEVELS),
             help='Logfile logging log level. One of {0}. '
                  'Default: \'{1}\'.'.format(
@@ -353,8 +354,10 @@ class LogLevelMixIn(object):
             )
             if self.config.get(cli_log_level, None) is not None:
                 self.options.log_level = self.config.get(cli_log_level)
-            elif self.config.get('log_level', None) is not None:
-                self.options.log_level = self.config.get('log_level')
+            elif self.config.get(self._loglevel_config_setting_name_, None):
+                self.options.log_level = self.config.get(
+                    self._loglevel_config_setting_name_
+                )
             else:
                 self.options.log_level = self._default_logging_level_
         # Setup the console as the last _mixin_after_parsed_func to run
@@ -389,10 +392,11 @@ class LogLevelMixIn(object):
                 # logging level, ie, `key_log_file_level` if the cli tool is
                 # `salt-key`
                 self.options.log_file_level = self.config.get(cli_setting_name)
-            elif self.config.get(self._loglevel_config_setting_name_, None):
+            elif self.config.get(
+                    self._logfile_loglevel_config_setting_name_, None):
                 # Is the regular log file level setting set?
                 self.options.log_file_level = self.config.get(
-                    self._loglevel_config_setting_name_
+                    self._logfile_loglevel_config_setting_name_
                 )
             else:
                 # Nothing is set on the configuration? Let's use the cli tool
@@ -400,16 +404,16 @@ class LogLevelMixIn(object):
                 self.options.log_level = self._default_logging_level_
 
     def setup_logfile_logger(self):
-        if self._loglevel_config_setting_name_ in self.config and not \
-                self.config.get(self._loglevel_config_setting_name_):
+        if self._logfile_loglevel_config_setting_name_ in self.config and not \
+                self.config.get(self._logfile_loglevel_config_setting_name_):
             # Remove it from config so it inherits from log_level
-            self.config.pop(self._loglevel_config_setting_name_)
+            self.config.pop(self._logfile_loglevel_config_setting_name_)
 
         loglevel = self.config.get(
-            self._loglevel_config_setting_name_,
+            self._logfile_loglevel_config_setting_name_,
             self.config.get(
                 # From the config setting
-                'log_level_logfile',
+                self._loglevel_config_setting_name_,
                 # From the console setting
                 self.config['log_level']
             )
@@ -967,6 +971,7 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
     # LogLevelMixIn attributes
     _default_logging_level_ = 'warning'
     _default_logging_logfile_ = '/var/log/salt/master'
+    _loglevel_config_setting_name_ = 'cli_salt_log_file'
 
     def _mixin_setup(self):
         self.add_option(
@@ -1130,7 +1135,7 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
     # LogLevelMixIn attributes
     _default_logging_level_ = 'warning'
     _default_logging_logfile_ = '/var/log/salt/master'
-
+    _loglevel_config_setting_name_ = 'cli_salt_cp_log_file'
 
     def _mixin_after_parsed(self):
         # salt-cp needs arguments

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -953,7 +953,7 @@ class SyndicOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                           TimeoutMixIn, ExtendedTargetOptionsMixIn,
-                          OutputOptionsMixIn):
+                          OutputOptionsMixIn, LogLevelMixIn):
 
     __metaclass__ = OptionParserMeta
 
@@ -963,7 +963,9 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     # ConfigDirMixIn config filename attribute
     _config_filename_ = 'master'
+
     # LogLevelMixIn attributes
+    _default_logging_level_ = 'warning'
     _default_logging_logfile_ = '/var/log/salt/master'
 
     def _mixin_setup(self):


### PR DESCRIPTION
This pull request enables ALL, correct me if wrong and I'll fix it, `cli` tools to be logging tweakable from the console.

Tools that originally were not supposed to have any console logging output, `salt`, `salt-cp`, etc, explicitly ignore the `log_level` setting from their configuration file which was originally used to configure the master and/or the minion.

To tweak the cli log level setting on the configuration files there's `cli_<underscored_cli_tool_name>_log_level` and some other settings too, see #5647
