### PR TITLE
utils.verify.zmq_version: fix pylint W0702 "No exception type(s) specified

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -33,7 +33,7 @@ def zmq_version():
     '''
     try:
         import zmq
-    except:
+    except Exception:
         # Return True for local mode
         return True
     ver = zmq.__version__


### PR DESCRIPTION
```
************* Module salt.utils.verify
W0702: 36,4:zmq_version: No exception type(s) specified
```
