### PR TITLE
salt.utils: fix pylint W0702 "No exception type(s) specified"

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -40,7 +40,7 @@ except ImportError:
 
 try:
     import zmq
-except:
+except ImportError:
     # Running as purely local
     pass
 


### PR DESCRIPTION
```
************* Module salt.utils
W0702: 43,0: No exception type(s) specified
```
