### PR TITLE
salt.payload: fix pylint W0702 "No exception type(s) specified"

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -17,7 +17,7 @@ from salt.utils.odict import OrderedDict
 # Import third party libs
 try:
     import zmq
-except:
+except ImportError:
     # No need for zeromq in local mode
     pass
 


### PR DESCRIPTION
```
************* Module salt.payload
W0702: 20,0: No exception type(s) specified
```
