### PR TITLE
salt.crypt: fix pylint W0702 "No exception type(s) specified"

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -17,7 +17,7 @@ import logging
 try:
     from M2Crypto import RSA
     from Crypto.Cipher import AES
-except:
+except ImportError:
     # No need for crypt in local mode
     pass
 


### PR DESCRIPTION
```
************* Module salt.crypt
W0702: 20,0: No exception type(s) specified
```
