### PR TITLE
minion: fix pylint W0702 "No exception type(s) specified"

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -21,7 +21,7 @@ import signal
 # Import third party libs
 try:
     import zmq
-except:
+except ImportError:
     # Running in local, zmq not needed
     pass
 import yaml


### PR DESCRIPTION
```
************* Module salt.minion
W0702: 24,0: No exception type(s) specified
```
