### PR TITLE
Add BSD shadow support to release notes.

### DIFF
--- a/doc/topics/releases/0.16.0.rst
+++ b/doc/topics/releases/0.16.0.rst
@@ -125,3 +125,9 @@ When accepting new keys with ``salt-key -a minion-id`` or ``salt-key -A``,
 there is now a prompt that will show the affected keys and ask for confirmation
 before proceeding. This prompt can be bypassed using the ``-y`` or ``--yes``
 command line argument, as with other ``salt-key`` commands.
+
+Support for Setting Password Hashes on BSD Minions
+--------------------------------------------------
+
+FreeBSD, NetBSD, and OpenBSD all now support setting passwords in
+:mod:`user.present <salt.states.user.present>` states. 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -185,6 +185,9 @@ def present(name,
         A password hash to set for the user. This field is only supported on
         Linux, FreeBSD, NetBSD, OpenBSD, and Solaris
 
+    .. versionchanged:: 0.16.0
+       BSD support added.
+
     enforce_password
         Set to False to keep the password from being changed if it has already
         been set and the password hash differs from what is specified in the


### PR DESCRIPTION
Also added a versionchanged directive to the docstring for the user
state to denote when shadow support was added for BSD.
