### PR TITLE
Revert 439c736, 29798a8

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -342,6 +342,8 @@ def installed(
               - baz: ftp://someothersite.org/baz.rpm
               - qux: /minion/path/to/qux.rpm
     '''
+    rtag = __gen_rtag()
+
     if not isinstance(version, basestring) and version is not None:
         version = str(version)
 
@@ -492,6 +494,8 @@ def latest(
               - bar
               - baz
     '''
+    rtag = __gen_rtag()
+
     if kwargs.get('sources'):
         return {'name': name,
                 'changes': {},


### PR DESCRIPTION
This puts back the call to __gen_rtag(). Its removal was a
misunderstanding of how the rtag works. mod_init creates the file,
__gen_rtag() just returns the path to the file so that it can be checked
to see if the file exists.
