### PR TITLE
Fix traceback in sys.doc, sys.list_functions

### DIFF
--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -20,7 +20,7 @@ def __virtual__():
     return 'sys'
 
 
-def doc(module=''):
+def doc(*args, **kwargs):
     '''
     Return the docstrings for all modules. Optionally, specify a module or a
     function to narrow the selection.
@@ -28,43 +28,53 @@ def doc(module=''):
     The strings are aggregated into a single document on the master for easy
     reading.
 
+    Multiple modules/functions can be specified.
+
     CLI Example::
 
         salt '*' sys.doc
         salt '*' sys.doc sys
         salt '*' sys.doc sys.doc
+        salt '*' sys.doc network.traceroute user.info
     '''
+    ### NOTE: **kwargs is used here to prevent a traceback when garbage
+    ###       arguments are tacked on to the end.
     docs = {}
-    if module:
-        # allow both "sys" and "sys." to match sys, without also matching
-        # sysctl
-        target_mod = module + '.' if not module.endswith('.') else module
-    else:
-        target_mod = ''
-    for fun in __salt__:
-        if fun == module or fun.startswith(target_mod):
-            docs[fun] = __salt__[fun].__doc__
+    for module in args:
+        if module:
+            # allow both "sys" and "sys." to match sys, without also matching
+            # sysctl
+            target_mod = module + '.' if not module.endswith('.') else module
+        else:
+            target_mod = ''
+        for fun in __salt__:
+            if fun == module or fun.startswith(target_mod):
+                docs[fun] = __salt__[fun].__doc__
     return docs
 
 
-def list_functions(module=''):
+def list_functions(*args, **kwargs):
     '''
-    List the functions for all modules. Optionally, specify a module to list
-    from.
+    List the functions for all modules. Optionally, specify a module or modules
+    from which to list.
 
     CLI Example::
 
         salt '*' sys.list_functions
         salt '*' sys.list_functions sys
+        salt '*' sys.list_functions sys user
     '''
+    ### NOTE: **kwargs is used here to prevent a traceback when garbage
+    ###       arguments are tacked on to the end.
     names = set()
-    if module:
-        # allow both "sys" and "sys." to match sys, without also matching
-        # sysctl
-        module = module + '.' if not module.endswith('.') else module
-    for func in __salt__:
-        if func.startswith(module):
-            names.add(func)
+    for module in args:
+        if module:
+            # allow both "sys" and "sys." to match sys, without also matching
+            # sysctl
+            module = module + '.' if not module.endswith('.') else module
+        for func in __salt__:
+            if func.startswith(module):
+                names.add(func)
     return sorted(names)
 
 
@@ -96,6 +106,7 @@ def reload_modules():
     # This is handled inside the minion.py file, the function is caught before
     # it ever gets here
     return True
+
 
 def argspec(module=''):
     '''


### PR DESCRIPTION
This fixes #5779. In addition, it adds support for an arbitrary number
of positional arguments.
