### PR TITLE
Provide a size aware buffer to be used in our non blocking `popen`.

### DIFF
--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -11,7 +11,6 @@
 '''
 
 # Import python libs
-import io
 import os
 import sys
 import fcntl


### PR DESCRIPTION
Contents are stored up to a specific size. If more is needed, the internal buffer gets switched by a temporary file.
