### PR TITLE
Don't ignore environment variables pointing to valid configuration files

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -3,15 +3,16 @@ Set up the Salt integration test suite
 '''
 
 # Import Python libs
-import multiprocessing
+
 import os
 import sys
+import time
 import shutil
 import pprint
-import tempfile
 import logging
-import time
+import tempfile
 import subprocess
+import multiprocessing
 from hashlib import md5
 from datetime import datetime, timedelta
 try:
@@ -25,13 +26,16 @@ INTEGRATION_TEST_DIR = os.path.dirname(
 )
 CODE_DIR = os.path.dirname(os.path.dirname(INTEGRATION_TEST_DIR))
 SALT_LIBS = os.path.dirname(CODE_DIR)
-SCRIPT_DIR = os.path.join(CODE_DIR, 'scripts')
-PYEXEC = 'python{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.case import ShellTestCase
+from salttesting.mixins import CheckShellBinaryNameAndVersionMixIn
+from salttesting.parser import PNUM, print_header, SaltTestcaseParser
+from salttesting.helpers import ensure_in_syspath, RedirectStdStreams
 
 # Update sys.path
-for dir_ in [CODE_DIR, SALT_LIBS]:
-    if not dir_ in sys.path:
-        sys.path.insert(0, dir_)
+ensure_in_syspath(CODE_DIR, SALT_LIBS)
 
 # Import Salt libs
 import salt
@@ -43,21 +47,14 @@ import salt.output
 from salt.utils import fopen, get_colors
 from salt.utils.verify import verify_env
 
-# Import Salt Testing libs
-from salttesting import TestCase
-from salttesting.case import ShellTestCase
-from salttesting.mixins import CheckShellBinaryNameAndVersionMixIn
-from salttesting.parser import PNUM, print_header, SaltTestcaseParser
-from salttesting.helpers import RedirectStdStreams
-
 # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
 SYS_TMP_DIR = os.environ.get('TMPDIR', tempfile.gettempdir())
-
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
+PYEXEC = 'python{0}.{1}'.format(sys.version_info[0], sys.version_info[1])
 MOCKBIN = os.path.join(INTEGRATION_TEST_DIR, 'mockbin')
+SCRIPT_DIR = os.path.join(CODE_DIR, 'scripts')
 TMP_STATE_TREE = os.path.join(SYS_TMP_DIR, 'salt-temp-state-tree')
-
 
 log = logging.getLogger(__name__)
 

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -27,28 +27,173 @@ from salt import config as sconfig
 class ConfigTestCase(TestCase):
     def test_proper_path_joining(self):
         fpath = tempfile.mktemp()
-        salt.utils.fopen(fpath, 'w').write(
-            "root_dir: /\n"
-            "key_logfile: key\n"
-        )
-        config = sconfig.master_config(fpath)
-        # os.path.join behaviour
-        self.assertEqual(config['key_logfile'], os.path.join('/', 'key'))
-        # os.sep.join behaviour
-        self.assertNotEqual(config['key_logfile'], '//key')
+        try:
+            salt.utils.fopen(fpath, 'w').write(
+                "root_dir: /\n"
+                "key_logfile: key\n"
+            )
+            config = sconfig.master_config(fpath)
+            # os.path.join behaviour
+            self.assertEqual(config['key_logfile'], os.path.join('/', 'key'))
+            # os.sep.join behaviour
+            self.assertNotEqual(config['key_logfile'], '//key')
+        finally:
+            if os.path.isfile(fpath):
+                os.unlink(fpath)
 
     def test_common_prefix_stripping(self):
         tempdir = tempfile.mkdtemp()
-        root_dir = os.path.join(tempdir, 'foo', 'bar')
-        os.makedirs(root_dir)
-        fpath = os.path.join(root_dir, 'config')
-        salt.utils.fopen(fpath, 'w').write(
-            'root_dir: {0}\n'
-            'log_file: {1}\n'.format(root_dir, fpath)
-        )
-        config = sconfig.master_config(fpath)
-        self.assertEqual(config['log_file'], fpath)
-        shutil.rmtree(tempdir)
+        try:
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            salt.utils.fopen(fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(root_dir, fpath)
+            )
+            config = sconfig.master_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_load_master_config_from_environ_var(self):
+        original_environ = os.environ.copy()
+
+        tempdir = tempfile.mkdtemp()
+        try:
+            env_root_dir = os.path.join(tempdir, 'foo', 'env')
+            os.makedirs(env_root_dir)
+            env_fpath = os.path.join(env_root_dir, 'config-env')
+
+            salt.utils.fopen(env_fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+            )
+
+            os.environ['SALT_MASTER_CONFIG'] = env_fpath
+            # Should load from env variable, not the default configuration file.
+            config = sconfig.master_config('/etc/salt/master')
+            self.assertEqual(config['log_file'], env_fpath)
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            salt.utils.fopen(fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(root_dir, fpath)
+            )
+            # Let's set the environment variable, yet, since the configuration
+            # file path is not the default one, ie, the user has passed an
+            # alternative configuration file form the CLI parser, the
+            # environment variable will be ignored.
+            os.environ['SALT_MASTER_CONFIG'] = env_fpath
+            config = sconfig.master_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_load_minion_config_from_environ_var(self):
+        original_environ = os.environ.copy()
+
+        tempdir = tempfile.mkdtemp()
+        try:
+            env_root_dir = os.path.join(tempdir, 'foo', 'env')
+            os.makedirs(env_root_dir)
+            env_fpath = os.path.join(env_root_dir, 'config-env')
+
+            salt.utils.fopen(env_fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+            )
+
+            os.environ['SALT_MINION_CONFIG'] = env_fpath
+            # Should load from env variable, not the default configuration file
+            config = sconfig.minion_config('/etc/salt/minion')
+            self.assertEqual(config['log_file'], env_fpath)
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            salt.utils.fopen(fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(root_dir, fpath)
+            )
+            # Let's set the environment variable, yet, since the configuration
+            # file path is not the default one, ie, the user has passed an
+            # alternative configuration file form the CLI parser, the
+            # environment variable will be ignored.
+            os.environ['SALT_MINION_CONFIG'] = env_fpath
+            config = sconfig.minion_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+            os.environ.clear()
+            os.environ.update(original_environ)
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_load_client_config_from_environ_var(self):
+        original_environ = os.environ.copy()
+        try:
+            tempdir = tempfile.mkdtemp()
+            env_root_dir = os.path.join(tempdir, 'foo', 'env')
+            os.makedirs(env_root_dir)
+
+            # Let's populate a master configuration file which should not get
+            # picked up since the client configuration tries to load the master
+            # configuration settings using the provided client configuration
+            # file
+            master_config = os.path.join(env_root_dir, 'master')
+            salt.utils.fopen(master_config, 'w').write(
+                'blah: true\n'
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(env_root_dir, master_config)
+            )
+            os.environ['SALT_MASTER_CONFIG'] = master_config
+
+            # Now the client configuration file
+            env_fpath = os.path.join(env_root_dir, 'config-env')
+            salt.utils.fopen(env_fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+            )
+
+            os.environ['SALT_CLIENT_CONFIG'] = env_fpath
+            # Should load from env variable, not the default configuration file
+            config = sconfig.client_config(os.path.expanduser('~/.salt'))
+            self.assertEqual(config['log_file'], env_fpath)
+            self.assertTrue('blah' not in config)
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            salt.utils.fopen(fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(root_dir, fpath)
+            )
+            # Let's set the environment variable, yet, since the configuration
+            # file path is not the default one, ie, the user has passed an
+            # alternative configuration file form the CLI parser, the
+            # environment variable will be ignored.
+            os.environ['SALT_MASTER_CONFIG'] = env_fpath
+            config = sconfig.master_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes saltstack/salt-cloud#661

`salt.config.load_config()` cannot be hard-coded to use only the master configuration file as the default configuration file path to know if the user has passed any configuration file in the CLI tool or not.
To fix this, `default_path` was added. This way, the minion config or client config or even the salt cloud config can say which is the expected default path of the configuration file and properly load config from environment variables.
