### PR TITLE
nesting for pillar includes

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -296,6 +296,8 @@ class Pillar(object):
                                 sub_sls, v = sub_sls.iteritems().next()
                                 defaults = v.get('defaults', {})
                                 key = v.get('key', None)
+                            else:
+                                key = None
                             if sub_sls not in mods:
                                 nstate, mods, err = self.render_pstate(
                                         sub_sls,

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -295,7 +295,7 @@ class Pillar(object):
                             if isinstance(sub_sls, dict):
                                 sub_sls, v = sub_sls.iteritems().next()
                                 defaults = v.get('defaults', {})
-                                key = v.get('key', {})
+                                key = v.get('key', None)
                             if sub_sls not in mods:
                                 nstate, mods, err = self.render_pstate(
                                         sub_sls,

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -295,6 +295,7 @@ class Pillar(object):
                             if isinstance(sub_sls, dict):
                                 sub_sls, v = sub_sls.iteritems().next()
                                 defaults = v.get('defaults', {})
+                                key = v.get('key', {})
                             if sub_sls not in mods:
                                 nstate, mods, err = self.render_pstate(
                                         sub_sls,
@@ -303,7 +304,10 @@ class Pillar(object):
                                         defaults
                                         )
                             if nstate:
-                                state.update(nstate)
+                                if key:
+                                    state[key] = nstate
+                                else:
+                                    state.update(nstate)
                             if err:
                                 errors += err
         return state, mods, errors


### PR DESCRIPTION
Support for the following syntax:

``` yaml
include:
  - foo:
      key: bar
```

Which will render the pillar data from foo.sls into pillar's 'bar' key. Recursion is supported.
