### PR TITLE
Fix traceback on non-yum systems

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -27,6 +27,71 @@ try:
     import yum
     import rpmUtils.arch
     HAS_YUMDEPS = True
+
+    class _YumLogger(yum.rpmtrans.RPMBaseCallback):
+        '''
+        A YUM callback handler that logs failed packages with their associated
+        script output to the minion log, and logs install/remove/update/etc.
+        activity to the yum log (usually /var/log/yum.log).
+
+        See yum.rpmtrans.NoOutputCallBack in the yum package for base
+        implementation.
+        '''
+        def __init__(self):
+            self.messages = {}
+            self.failed = []
+            self.action = {
+                yum.constants.TS_UPDATE: yum._('Updating'),
+                yum.constants.TS_ERASE: yum._('Erasing'),
+                yum.constants.TS_INSTALL: yum._('Installing'),
+                yum.constants.TS_TRUEINSTALL: yum._('Installing'),
+                yum.constants.TS_OBSOLETED: yum._('Obsoleted'),
+                yum.constants.TS_OBSOLETING: yum._('Installing'),
+                yum.constants.TS_UPDATED: yum._('Cleanup'),
+                'repackaging': yum._('Repackaging')
+            }
+            # The fileaction are not translated, most sane IMHO / Tim
+            self.fileaction = {
+                yum.constants.TS_UPDATE: 'Updated',
+                yum.constants.TS_ERASE: 'Erased',
+                yum.constants.TS_INSTALL: 'Installed',
+                yum.constants.TS_TRUEINSTALL: 'Installed',
+                yum.constants.TS_OBSOLETED: 'Obsoleted',
+                yum.constants.TS_OBSOLETING: 'Installed',
+                yum.constants.TS_UPDATED: 'Cleanup'
+            }
+            self.logger = logging.getLogger('yum.filelogging.RPMInstallCallback')
+
+        def event(self, package, action, te_current, te_total, ts_current, ts_total):
+            # This would be used for a progress counter according to Yum docs
+            pass
+
+        def log_accumulated_errors(self):
+            '''
+            Convenience method for logging all messages from failed packages
+            '''
+            for pkg in self.failed:
+                log.error('{0} {1}'.format(pkg, self.messages[pkg]))
+
+        def errorlog(self, msg):
+            # Log any error we receive
+            log.error(msg)
+
+        def filelog(self, package, action):
+            if action == yum.constants.TS_FAILED:
+                self.failed.append(package)
+            else:
+                if action in self.fileaction:
+                    msg = '{0}: {1}'.format(self.fileaction[action], package)
+                else:
+                    msg = '{0}: {1}'.format(package, action)
+                self.logger.info(msg)
+
+        def scriptout(self, package, msgs):
+            # This handler covers ancillary messages coming from the RPM script
+            # Will sometimes contain more detailed error messages.
+            self.messages[package] = msgs
+
 except (ImportError, AttributeError):
     HAS_YUMDEPS = False
 
@@ -64,76 +129,6 @@ def __virtual__():
     elif os_family == 'RedHat' and os_major >= 6:
         return 'pkg'
     return False
-
-
-class _YumLogger(yum.rpmtrans.RPMBaseCallback):
-    '''
-    A YUM callback handler that logs failed packages with their associated
-    script output to the minion log, and logs install/remove/update/etc.
-    activity to the yum log (usually /var/log/yum.log).
-
-    See yum.rpmtrans.NoOutputCallBack in the yum package for base
-    implementation.
-    '''
-    def __init__(self):
-        self.messages = {}
-        self.failed = []
-        self.action = {
-            yum.constants.TS_UPDATE: yum._('Updating'),
-            yum.constants.TS_ERASE: yum._('Erasing'),
-            yum.constants.TS_INSTALL: yum._('Installing'),
-            yum.constants.TS_TRUEINSTALL: yum._('Installing'),
-            yum.constants.TS_OBSOLETED: yum._('Obsoleted'),
-            yum.constants.TS_OBSOLETING: yum._('Installing'),
-            yum.constants.TS_UPDATED: yum._('Cleanup'),
-            'repackaging': yum._('Repackaging')
-        }
-        # The fileaction are not translated, most sane IMHO / Tim
-        self.fileaction = {
-            yum.constants.TS_UPDATE: 'Updated',
-            yum.constants.TS_ERASE: 'Erased',
-            yum.constants.TS_INSTALL: 'Installed',
-            yum.constants.TS_TRUEINSTALL: 'Installed',
-            yum.constants.TS_OBSOLETED: 'Obsoleted',
-            yum.constants.TS_OBSOLETING: 'Installed',
-            yum.constants.TS_UPDATED: 'Cleanup'
-        }
-        self.logger = logging.getLogger('yum.filelogging.RPMInstallCallback')
-
-    def event(self, package, action, te_current, te_total, ts_current, ts_total):
-        # This would be used for a progress counter according to Yum docs
-        pass
-
-    def log_accumulated_errors(self):
-        '''
-        Convenience method for logging all messages from failed packages
-        '''
-        for pkg in self.failed:
-            log.error('{0} {1}'.format(pkg, self.messages[pkg]))
-
-    def errorlog(self, msg):
-        # Log any error we receive
-        log.error(msg)
-
-    def filelog(self, package, action):
-        # TODO: extend this for more conclusive transaction handling for
-        # installs and removes VS. the pkg list compare method used now.
-        #
-        # See yum.constants and yum.rpmtrans.RPMBaseCallback in the yum
-        # package for more information about the received actions.
-        if action == yum.constants.TS_FAILED:
-            self.failed.append(package)
-        else:
-            if action in self.fileaction:
-                msg = '{0}: {1}'.format(self.fileaction[action], package)
-            else:
-                msg = '{0}: {1}'.format(package, action)
-            self.logger.info(msg)
-
-    def scriptout(self, package, msgs):
-        # This handler covers ancillary messages coming from the RPM script
-        # Will sometimes contain more detailed error messages.
-        self.messages[package] = msgs
 
 
 def list_upgrades(refresh=True):


### PR DESCRIPTION
3b8b6de added yum.rpmtrans.RPMBaseCallback as a base class for
the _YumLogger class, which causes tracebacks on non-yum systems. This
commit fixes that by only creating this class if the yum python
interface is successfully imported.
