### PR TITLE
Fix folder name for external pillars in docs

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -7696,9 +7696,9 @@ module.
 .sp
 Salt expects to find your ext_pillar module in the same location where it
 looks for other python modules. If the \fBextension_modules\fP option in your
-Salt master configuration is set, Salt will look for a \fBpillars\fP directory
+Salt master configuration is set, Salt will look for a \fBpillar\fP directory
 under there and load all the modules it finds. Otherwise, it will look in
-your Python site\-packages \fBsalt/pillars\fP directory.
+your Python site\-packages \fBsalt/pillar\fP directory.
 .SS Configuration
 .sp
 The external pillars that are called when a minion refreshes its pillars is

--- a/doc/topics/development/external_pillars.rst
+++ b/doc/topics/development/external_pillars.rst
@@ -9,11 +9,11 @@ module.
 Location
 --------
 
-Salt expects to find your ext_pillar module in the same location where it
+Salt expects to find your ``ext_pillar`` module in the same location where it
 looks for other python modules. If the ``extension_modules`` option in your
-Salt master configuration is set, Salt will look for a ``pillars`` directory
+Salt master configuration is set, Salt will look for a ``pillar`` directory
 under there and load all the modules it finds. Otherwise, it will look in
-your Python site-packages ``salt/pillars`` directory.
+your Python site-packages ``salt/pillar`` directory.
 
 Configuration
 -------------


### PR DESCRIPTION
Trying to get an external pillar to work, I realised that the folder containing the built-in external pillars are in `salt/pillar`, the docs explain, however, that it should be `pillars`. Is the difference between the names intentional? Or is this a typo in the documentation? 

In case it's the latter, I attached a PR with appropriate changes in the docs and the man page.
