### PR TITLE
Documentation fix

### DIFF
--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -16,9 +16,9 @@ key in one step:
 .. admonition:: add-apt-repository: command not found?
 
     The add-apt-repository command is not always present on Ubuntu systems.
-    This can be fixed by installing `software-properties-common`::
+    This can be fixed by installing `python-software-properties`::
 
-        sudo apt-get install software-properties-common
+        sudo apt-get install python-software-properties
 
 Alternately, manually add the repository and import the PPA key with these commands:
 


### PR DESCRIPTION
This fixes #5827 by specifying the proper name for the software package
which provides add-apt-repository. It may have at one point been called
software-properties-common, but Ubuntu's package search page has
packages going back to 10.04 LTS showing add-apt-repository in the
python-software-properties package.
