### PR TITLE
Add ip6 grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -871,6 +871,13 @@ def ip4():
     return {'ipv4': salt.utils.network.ip_addrs(include_loopback=True)}
 
 
+def ip6():
+    '''
+    Return a list of ipv6 addrs
+    '''
+    return {'ipv6': salt.utils.network.ip_addrs6(include_loopback=True)}
+
+
 def ip_interfaces():
     '''
     Provide a dict of the connected interfaces and their ip addresses


### PR DESCRIPTION
A trivial but useful grain made possible by the recent addition of IPv6 address functions in `utils/network.py`.

Two questions:
- Does this grain need docs other than the docstring?
- Does this grain need tests? Where would I add them?
