### PR TITLE
Fix os major release check

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -56,7 +56,7 @@ def __virtual__():
     # Suse >=12.0 uses systemd
     if __grains__.get('os', '') == 'openSUSE':
         try:
-            if int(__grains__.get('os', '').split('.')[0]) >= 12:
+            if int(__grains__.get('osrelease', '').split('.')[0]) >= 12:
                 return False
         except ValueError:
             return False


### PR DESCRIPTION
The wrong grain ('os' vs 'osrelease') was used in 6256b1c. This commit fixes that.
