### PR TITLE
Reclass plugins for ext_pillar and master_tops

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -565,6 +565,8 @@ Default:: ``None``
     ext_pillar:
       - hiera: /etc/hiera.yaml
       - cmd_yaml: cat /etc/salt/yaml
+      - reclass:
+          inventory_base_uri: /etc/reclass
 
 There are additional details at :ref:`salt-pillars`
 

--- a/doc/ref/pillar/all/index.rst
+++ b/doc/ref/pillar/all/index.rst
@@ -18,3 +18,4 @@ Full list of builtin pillar modules
     mongo
     pillar_ldap
     puppet
+    reclass

--- a/doc/ref/pillar/all/salt.pillar.reclass.rst
+++ b/doc/ref/pillar/all/salt.pillar.reclass.rst
@@ -1,0 +1,6 @@
+===================
+salt.pillar.reclass
+===================
+
+.. automodule:: salt.pillar.reclass
+    :members:

--- a/doc/ref/tops/all/index.rst
+++ b/doc/ref/tops/all/index.rst
@@ -13,3 +13,4 @@ Full list of builtin master tops modules
     ext_nodes
     cobbler
     mongo
+    reclass

--- a/doc/ref/tops/all/salt.tops.reclass.rst
+++ b/doc/ref/tops/all/salt.tops.reclass.rst
@@ -1,0 +1,6 @@
+=================
+salt.tops.reclass
+=================
+
+.. automodule:: salt.tops.reclass
+    :members:

--- a/doc/topics/master_tops/index.rst
+++ b/doc/topics/master_tops/index.rst
@@ -18,3 +18,12 @@ Using the new `master_tops` option is simple:
 
     master_tops:
       ext_nodes: cobbler-external-nodes
+
+or:
+
+.. code-block:: yaml
+
+    master_tops:
+      reclass:
+        inventory_base_uri: /etc/reclass
+        classes_uri: roles

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -1,21 +1,60 @@
 '''
-Adapter for reclass.
+ext_pillar adapter for reclass.
 
-This file cannot be called reclass.py, because then the module import would
-not work. Thanks to the __virtual__ function, however, the plugin still
-responds to the name 'reclass'.
+Please refer to the file `README.Salt` in the reclass source for more
+information on how to use these. In a nutshell, you'll just add the plugin to
+the ext_pillar hash in the master config and tell reclass by way of a few
+options how and where to find the inventory:
+
+    ---
+    ext_pillar:
+        - reclass:
+            storage_type: yaml_fs
+            base_inventory_uri: /srv/salt
+
+This would cause reclass to read the inventory from YAML files in
+`/srv/salt/nodes` and `/srv/salt/classes`.
 
 More information about reclass: http://github.com/madduck/reclass
 
-It would be desirable to specify the location of reclass in the master config
-file. Unfortunately, __opts__ is only made available to the ext_pillar
-function, not to the module, so that the import cannot make use of these data,
-at least not at the module level, which is needed to set __virtual__
-accordingly.
+There is currently no way to avoid having to specify the same configuration
+for `ext_pillar` and `master_tops`.
+
+Unfortunately, there is currently no way to specify the location of the
+reclass source in the master config, because Salt provides no way to access
+the configuration file data at the module scope (`__opts__` is injected by the
+Salt loader), where we need to know about whether reclass is import-able to be
+able to define the `__virtual__` function. You will hence either have to
+install reclass to `PYTHONPATH`, or extend `PYTHONPATH` when running the
+master, e.g.:
+
+    PYTHONPATH=~/code/reclass:$PYTHONPATH salt-master …
 '''
+# This file cannot be called reclass.py, because then the module import would
+# not work. Thanks to the __virtual__ function, however, the plugin still
+# responds to the name 'reclass'.
+
 try:
-    from reclass.adapters.saltstack import ext_pillar
+    from reclass.adapters.salt import ext_pillar as reclass_ext_pillar
+    from reclass.errors import ReclassException
     __virtual__ = lambda: 'reclass'
 
 except ImportError:
     __virtual__ = lambda: False
+
+from salt.exceptions import SaltInvocationError
+
+def ext_pillar(pillar, **kwargs):
+    try:
+        return reclass_ext_pillar(__opts__, __salt__, __grains__, pillar, **kwargs)
+
+    except TypeError, e:
+        if e.message.find('unexpected keyword argument') > -1:
+            arg = e.message.split()[-1]
+            raise SaltInvocationError('pillar.reclass: unexpected option: ' + arg)
+
+        else:
+            raise
+
+    except ReclassException, e:
+        raise SaltInvocationError('pillar.reclass: ' + e.message)

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -1,0 +1,21 @@
+'''
+Adapter for reclass.
+
+This file cannot be called reclass.py, because then the module import would
+not work. Thanks to the __virtual__ function, however, the plugin still
+responds to the name 'reclass'.
+
+More information about reclass: http://github.com/madduck/reclass
+
+It would be desirable to specify the location of reclass in the master config
+file. Unfortunately, __opts__ is only made available to the ext_pillar
+function, not to the module, so that the import cannot make use of these data,
+at least not at the module level, which is needed to set __virtual__
+accordingly.
+'''
+try:
+    from reclass.adapters.saltstack import ext_pillar
+    __virtual__ = lambda: 'reclass'
+
+except ImportError:
+    __virtual__ = lambda: False

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -1,20 +1,60 @@
 '''
-Adapter for reclass.
+master_tops adapter for reclass.
 
-This file cannot be called reclass.py, because then the module import would
-not work. Thanks to the __virtual__ function, however, the plugin still
-responds to the name 'reclass'.
+Please refer to the file `README.Salt` in the reclass source for more
+information on how to use these. In a nutshell, you'll just add the plugin to
+the master_tops hash in the master config and tell reclass by way of a few
+options how and where to find the inventory:
+
+    ---
+    master_tops:
+        reclass:
+            storage_type: yaml_fs
+            base_inventory_uri: /srv/salt
+
+This would cause reclass to read the inventory from YAML files in
+`/srv/salt/nodes` and `/srv/salt/classes`.
 
 More information about reclass: http://github.com/madduck/reclass
 
-It would be desirable to specify the location of reclass in the master config
-file. Unfortunately, __opts__ is only made available to the tops function, not
-to the module, so that the import cannot make use of these data, at least not
-at the module level, which is needed to set __virtual__ accordingly.
+There is currently no way to avoid having to specify the same configuration
+for `ext_pillar` and `master_tops`.
+
+Unfortunately, there is currently no way to specify the location of the
+reclass source in the master config, because Salt provides no way to access
+the configuration file data at the module scope (`__opts__` is injected by the
+Salt loader), where we need to know about whether reclass is import-able to be
+able to define the `__virtual__` function. You will hence either have to
+install reclass to `PYTHONPATH`, or extend `PYTHONPATH` when running the
+master, e.g.:
+
+    PYTHONPATH=~/code/reclass:$PYTHONPATH salt-master …
 '''
+# This file cannot be called reclass.py, because then the module import would
+# not work. Thanks to the __virtual__ function, however, the plugin still
+# responds to the name 'reclass'.
+
 try:
-    from reclass.adapters.saltstack import tops
+    from reclass.adapters.salt import top as reclass_top
+    from reclass.errors import ReclassException
     __virtual__ = lambda: 'reclass'
 
 except ImportError:
     __virtual__ = lambda: False
+
+from salt.exceptions import SaltInvocationError
+
+def top(**kwargs):
+    try:
+        return reclass_top(__opts__, __salt__, __grains__, **kwargs)
+
+    except TypeError, e:
+        if e.message.find('unexpected keyword argument') > -1:
+            arg = e.message.split()[-1]
+            raise SaltInvocationError('master_tops.reclass: unexpected option: ' + arg)
+
+        else:
+            raise
+
+    except ReclassException, e:
+        raise SaltInvocationError('master_tops.reclass: ' + e.message)

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -1,0 +1,20 @@
+'''
+Adapter for reclass.
+
+This file cannot be called reclass.py, because then the module import would
+not work. Thanks to the __virtual__ function, however, the plugin still
+responds to the name 'reclass'.
+
+More information about reclass: http://github.com/madduck/reclass
+
+It would be desirable to specify the location of reclass in the master config
+file. Unfortunately, __opts__ is only made available to the tops function, not
+to the module, so that the import cannot make use of these data, at least not
+at the module level, which is needed to set __virtual__ accordingly.
+'''
+try:
+    from reclass.adapters.saltstack import tops
+    __virtual__ = lambda: 'reclass'
+
+except ImportError:
+    __virtual__ = lambda: False


### PR DESCRIPTION
This series of commits adds `ext_pillar` and `master_tops` plugins for [reclass](http://github.com/madduck/reclass).

The idea is not to take over any work that `reclass` does, and also not to expose too much of Salt internals. As such, `__opts__` and `__salt__` are _not_ passed along, but only the data extract that are needed by `reclass`. This means that if `reclass` changes its requirements, Salt will get a patch, but it's just cleaner that way and a nice, natural separation.

Note that `reclass` must be in `PYTHONPATH` for these to work. It would definitely be better if a path-to-source could be defined in the master config, but I couldn't figure out how to get at it… `__opts__` is not available at the module scope, unfortunately.

I kept a bit of history of evolution in the series of commits. Let me know if you prefer a squash.
