### PR TITLE
add a new method salt.wheel.key.list to list keys under a named status

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -331,6 +331,31 @@ class Key(object):
         keys.update(self.local_keys())
         return keys
 
+    def list_status(self, match):
+        '''
+        Return a dict of managed keys under a named status
+        '''
+        acc, pre, rej = self._check_minions_directories()
+        ret = {}
+        if match.startswith('acc'):
+            ret[os.path.basename(acc)] = []
+            for fn_ in salt.utils.isorted(os.listdir(acc)):
+                if os.path.isfile(os.path.join(acc, fn_)):
+                    ret[os.path.basename(acc)].append(fn_)
+        elif match.startswith('pre') or match.startswith('un'):
+            ret[os.path.basename(pre)] = []
+            for fn_ in salt.utils.isorted(os.listdir(pre)):
+                if os.path.isfile(os.path.join(pre, fn_)):
+                    ret[os.path.basename(pre)].append(fn_)
+        elif match.startswith('rej'):
+            ret[os.path.basename(rej)] = []
+            for fn_ in salt.utils.isorted(os.listdir(rej)):
+                if os.path.isfile(os.path.join(rej, fn_)):
+                    ret[os.path.basename(rej)].append(fn_)
+        elif match.startswith('all'):
+            return self.all_keys()
+        return ret
+
     def key_str(self, match):
         '''
         Return the specified public key or keys based on a glob

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -5,10 +5,16 @@ Wheel system wrapper for key system
 # Import salt libs
 import salt.key
 
+def list(match):
+    '''
+    List all the keys under a named status
+    '''
+    skey = salt.key.Key(__opts__)
+    return skey.list_status(match)
 
 def list_all():
     '''
-    List the keys under a named status
+    List all the keys
     '''
     skey = salt.key.Key(__opts__)
     return skey.all_keys()


### PR DESCRIPTION
Added a new method to allow listing keys via their status when using salt-api.
