### PR TITLE
img.seed: check result from mount_image

### DIFF
--- a/salt/modules/img.py
+++ b/salt/modules/img.py
@@ -58,6 +58,8 @@ def seed(location, id_='', config=None):
     if config is None:
         config = {}
     mpt = mount_image(location)
+    if not mpt:
+        return False
     mpt_tmp = os.path.join(mpt, 'tmp')
     __salt__['mount.mount'](
             os.path.join(mpt, 'dev'),


### PR DESCRIPTION
mount_image returns '' if it fails to mount the image. Without catching this, seed will mess with files on the hyper's filesystem instead of on the image.
