### PR TITLE
Fix syntax error caused by unicode character

### DIFF
--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -28,7 +28,7 @@ able to define the `__virtual__` function. You will hence either have to
 install reclass to `PYTHONPATH`, or extend `PYTHONPATH` when running the
 master, e.g.:
 
-    PYTHONPATH=~/code/reclass:$PYTHONPATH salt-master …
+    PYTHONPATH=~/code/reclass:$PYTHONPATH salt-master ...
 '''
 # This file cannot be called reclass.py, because then the module import would
 # not work. Thanks to the __virtual__ function, however, the plugin still


### PR DESCRIPTION
in 20302cd, a unicode ellipsis character was introduced in a docstring,
causing a SyntaxError traceback. This commit fixes that.
