### PR TITLE
Pillar.render_pstate: avoid mutable default argument value (pylint W0102)

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -261,10 +261,12 @@ class Pillar(object):
                             matches[env].append(item)
         return matches
 
-    def render_pstate(self, sls, env, mods, defaults={}):
+    def render_pstate(self, sls, env, mods, defaults=None):
         '''
         Collect a single pillar sls file and render it
         '''
+        if defaults is None:
+            defaults = {}
         err = ''
         errors = []
         fn_ = self.client.get_state(sls, env).get('dest', False)


### PR DESCRIPTION
```
************* Module salt.pillar
W0102:264,4:Pillar.render_pstate: Dangerous default value {} as argument
```
