### PR TITLE
fixed bug: script arg is int will not work

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -594,7 +594,7 @@ def script(
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)
     ret = _run(
-            path + ' ' + args if args else path,
+            path + ' ' + str(args) if args else path,
             cwd=cwd,
             quiet=kwargs.get('quiet', False),
             runas=runas,


### PR DESCRIPTION
salt 'minion1' cmd.script salt://scripts/test.sh '5156'

```
minion1:
    Missing arguments executing "cmd.script": ArgSpec(args=['source', 'args', 'cwd', 'runas', 'shell', 'env', 'template', 'umask'], varargs=None, keywords='kwargs', defaults=(None, None, None, '/bin/bash', 'base', 'jinja', None))
```

error like this:

```
Traceback (most recent call last):
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 232, in _bootstrap
    self.run()
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 88, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/lib/python2.6/site-packages/salt/minion.py", line 426, in _thread_return
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.6/site-packages/salt/modules/cmdmod.py", line 487, in script
    path + ' ' + args if args else path,
TypeError: cannot concatenate 'str' and 'int' objects
```
