### PR TITLE
Use an unicode aware context in the jinja render call. Refs #3436

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -95,7 +95,8 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     if not env:
         if tmplpath:
             # ie, the template is from a file outside the state tree
-            loader = jinja2.FileSystemLoader(context, os.path.dirname(tmplpath))
+            loader = jinja2.FileSystemLoader(
+                context, os.path.dirname(tmplpath))
     else:
         loader = JinjaSaltCacheLoader(opts, context['env'])
     env_args = {'extensions': [], 'loader': loader}
@@ -112,8 +113,19 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     else:
         jinja_env = jinja2.Environment(
                         undefined=jinja2.StrictUndefined, **env_args)
+
+    unicode_context = {}
+    for key, value in context.iteritems():
+        # Let's try UTF-8 and fail if this still fails, that's why this is not
+        # wrapped in a try/except
+        unicode_context[unicode(key, 'utf-8')] = unicode(value, 'utf-8')
+
     try:
-        output = jinja_env.from_string(tmplstr).render(**context)
+        output = jinja_env.from_string(tmplstr).render(**unicode_context)
+        if isinstance(output, unicode):
+            # Let's encode the output back to utf-8 since that's what's assumed
+            # in salt
+            output = output.encode('utf-8')
     except jinja2.exceptions.TemplateSyntaxError as exc:
         error = '{0}; line {1} in template'.format(
                 exc,

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -116,9 +116,13 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     unicode_context = {}
     for key, value in context.iteritems():
+        if not isinstance(value, basestring):
+            unicode_context[key] = value
+            continue
+
         # Let's try UTF-8 and fail if this still fails, that's why this is not
         # wrapped in a try/except
-        unicode_context[unicode(key, 'utf-8')] = unicode(value, 'utf-8')
+        unicode_context[key] = unicode(value, 'utf-8')
 
     try:
         output = jinja_env.from_string(tmplstr).render(**unicode_context)

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -1,9 +1,11 @@
+# -*- coding: utf-8 -*-
+
 # Import python libs
 import os
 import tempfile
 
 # Import Salt Testing libs
-from salttesting import skipIf, TestCase
+from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
@@ -154,6 +156,20 @@ class TestGetTemplate(TestCase):
                 dict(opts={'cachedir': TEMPLATES_DIR, 'file_client': 'remote'},
                      a='Hi', b='Salt', env='test'))
         self.assertEqual(out, 'Hey world !Hi Salt !\n')
+        self.assertEqual(fc.requests[0]['path'], 'salt://macro')
+        SaltCacheLoader.file_client = _fc
+
+    def test_non_ascii_encoding(self):
+        fc = MockFileClient()
+        # monkey patch file client
+        _fc = SaltCacheLoader.file_client
+        SaltCacheLoader.file_client = lambda loader: fc
+        filename = os.path.join(TEMPLATES_DIR, 'files', 'test', 'hello_import')
+        out = render_jinja_tmpl(
+                salt.utils.fopen(filename).read(),
+                dict(opts={'cachedir': TEMPLATES_DIR, 'file_client': 'remote'},
+                     a='Hi', b='Sàlt', env='test'))
+        self.assertEqual(out, 'Hey world !Hi Sàlt !\n')
         self.assertEqual(fc.requests[0]['path'], 'salt://macro')
         SaltCacheLoader.file_client = _fc
 


### PR DESCRIPTION
This is a proposed quick fix to the new comment on #3436.

Should we start using unicode in salt internally?
