### PR TITLE
Add "defaults" option for pecl.installed state

### DIFF
--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -47,6 +47,7 @@ def install(pecls, defaults=False):
         Use default answers for extensions such as pecl_http which ask
         questions before installation. Without this option, the pecl.installed
         state will hang indefinitely when trying to install these extensions.
+        This option will be available in version 0.17.0.
 
     CLI Example::
 

--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -6,6 +6,8 @@ Manage PHP pecl extensions.
 import re
 import logging
 
+# Import salt libs
+import salt.utils
 
 __opts__ = {}
 __pillar__ = {}
@@ -17,11 +19,13 @@ __func_alias__ = {
 log = logging.getLogger(__name__)
 
 
-def _pecl(command):
+def _pecl(command, defaults=False):
     '''
     Execute the command passed with pecl
     '''
     cmdline = 'pecl {0}'.format(command)
+    if salt.utils.is_true(defaults):
+        cmdline = "printf '\n' | " + cmdline
 
     ret = __salt__['cmd.run_all'](cmdline)
 
@@ -32,18 +36,23 @@ def _pecl(command):
         return ''
 
 
-def install(pecls):
+def install(pecls, defaults=False):
     '''
     Installs one or several pecl extensions.
 
     pecls
         The pecl extensions to install.
 
+    defaults
+        Use default answers for extensions such as pecl_http which ask
+        questions before installation. Without this option, the pecl.installed
+        state will hang indefinitely when trying to install these extensions.
+
     CLI Example::
 
         salt '*' pecl.install fuse
     '''
-    return _pecl('install {0}'.format(pecls))
+    return _pecl('install {0}'.format(pecls), defaults=defaults)
 
 
 def uninstall(pecls):

--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -28,6 +28,7 @@ def installed(name,
         Use default answers for extensions such as pecl_http which ask
         questions before installation. Without this option, the pecl.installed
         state will hang indefinitely when trying to install these extensions.
+        This option will be available in version 0.17.0.
     '''
     # Check to see if we have a designated version
     if not isinstance(version, basestring) and version is not None:

--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -11,9 +11,9 @@ A state module to manage php pecl extensions.
 '''
 
 
-def installed(
-        name,
-        version=None):
+def installed(name,
+              version=None,
+              defaults=False):
     '''
     Make sure that a pecl extension is installed.
 
@@ -23,12 +23,20 @@ def installed(
     version
         The pecl extension version to install. This option may be
         ignored to install the latest stable version.
+
+    defaults
+        Use default answers for extensions such as pecl_http which ask
+        questions before installation. Without this option, the pecl.installed
+        state will hang indefinitely when trying to install these extensions.
     '''
     # Check to see if we have a designated version
     if not isinstance(version, basestring) and version is not None:
         version = str(version)
 
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name,
+           'result': None,
+           'comment': '',
+           'changes': {}}
 
     installed_pecls = __salt__['pecl.list']()
 
@@ -46,7 +54,7 @@ def installed(
     if __opts__['test']:
         ret['comment'] = 'Pecl extension {0} would have been installed'.format(name)
         return ret
-    if __salt__['pecl.install'](name):
+    if __salt__['pecl.install'](name, defaults=defaults):
         ret['result'] = True
         ret['changes'][name] = 'Installed'
         ret['comment'] = 'Pecl extension {0} was successfully installed'.format(name)


### PR DESCRIPTION
This commit adds a "defaults" option, which if True will pipe a newline
to the "pecl install" command, causing default answers to be used to
install extensions which ask questions and thus cannot be installed
unattended.

Fixes #5701.
