### PR TITLE
Support parted 2.x for partition.part_list

### DIFF
--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -76,6 +76,10 @@ def part_list(device, unit=None):
             continue
         comps = line.replace(';', '').split(':')
         if mode == 'info':
+            # Older parted (2.x) doesn't support disk flags, and will return a
+            # 7-column output for the info line.
+            if len(comps) == 7:
+                comps.append('(not supported)')
             if len(comps) == 8:
                 ret['info'] = {
                     'disk': comps[0],

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -76,11 +76,7 @@ def part_list(device, unit=None):
             continue
         comps = line.replace(';', '').split(':')
         if mode == 'info':
-            # Older parted (2.x) doesn't show disk flags in the 'print' output,
-            # and will return a 7-column output for the info line.
-            if len(comps) == 7:
-                comps.append('(not supported)')
-            if len(comps) == 8:
+            if 7 <= len(comps) <= 8:
                 ret['info'] = {
                     'disk': comps[0],
                     'size': comps[1],
@@ -88,8 +84,15 @@ def part_list(device, unit=None):
                     'logical sector': comps[3],
                     'physical sector': comps[4],
                     'partition table': comps[5],
-                    'model': comps[6],
-                    'disk flags': comps[7]}
+                    'model': comps[6]}
+                try:
+                    ret['info']['disk flags'] = comps[7]
+                except IndexError:
+                    # Older parted (2.x) doesn't show disk flags in the 'print'
+                    # output, and will return a 7-column output for the info
+                    # line. In these cases we just leave this field out of the
+                    # return dict.
+                    pass
                 mode = 'partitions'
         else:
             ret['partitions'][comps[0]] = {

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -76,8 +76,8 @@ def part_list(device, unit=None):
             continue
         comps = line.replace(';', '').split(':')
         if mode == 'info':
-            # Older parted (2.x) doesn't support disk flags, and will return a
-            # 7-column output for the info line.
+            # Older parted (2.x) doesn't show disk flags in the 'print' output,
+            # and will return a 7-column output for the info line.
             if len(comps) == 7:
                 comps.append('(not supported)')
             if len(comps) == 8:


### PR DESCRIPTION
Older parted (2.x) doesn't return info on disk flags. This commit checks
to see if the disk flags field is present in the output, and if not,
inserts the value '(not supported)' for this field, allowing
partition.part_list to return successfully on systems using parted 2.x.

Fixes #5616.
