### PR TITLE
bsd_shadow: rm unused `salt` import

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -8,9 +8,6 @@ try:
 except ImportError:
     pass
 
-# Import salt libs
-import salt.utils
-
 
 def __virtual__():
     return 'shadow' if 'BSD' in __grains__.get('os', '') else False


### PR DESCRIPTION
```
************* Module salt.modules.bsd_shadow
W0611: 12,0: Unused import salt
```
