### PR TITLE
Handle cases where _gem() returns False

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -201,4 +201,5 @@ def sources_list(ruby=None, runas=None):
 
         salt '*' gem.sources_list
     '''
-    return _gem('sources', ruby, runas=runas).splitlines()[2:]
+    ret = _gem('sources', ruby, runas=runas).splitlines()[2:]
+    return '' if ret is False else ret


### PR DESCRIPTION
This prevents a traceback when _gem() returns False due to a problem
running the gem command. Fixes #5886.
