### PR TITLE
Pass minion_id to ext_pillar

### DIFF
--- a/salt/pillar/cmd_json.py
+++ b/salt/pillar/cmd_json.py
@@ -11,7 +11,7 @@ import json
 log = logging.getLogger(__name__)
 
 
-def ext_pillar(pillar, command):
+def ext_pillar(minion_id, pillar, command):
     '''
     Execute a command and read the output as JSON
     '''

--- a/salt/pillar/cmd_yaml.py
+++ b/salt/pillar/cmd_yaml.py
@@ -13,7 +13,7 @@ import yaml
 log = logging.getLogger(__name__)
 
 
-def ext_pillar(pillar, command):
+def ext_pillar(minion_id, pillar, command):
     '''
     Execute a command and read the output as YAML
     '''

--- a/salt/pillar/cobbler.py
+++ b/salt/pillar/cobbler.py
@@ -41,7 +41,7 @@ __opts__ = {'cobbler.url': 'http://localhost/cobbler_api',
 log = logging.getLogger(__name__)
 
 
-def ext_pillar(pillar, key=None, only=()):
+def ext_pillar(minion_id, pillar, key=None, only=()):
     '''
     Read pillar data from Cobbler via its API.
     '''
@@ -49,7 +49,6 @@ def ext_pillar(pillar, key=None, only=()):
     user = __opts__['cobbler.user']
     password = __opts__['cobbler.password']
 
-    minion_id = __opts__['id']
     log.info("Querying cobbler at %r for information for %r", url, minion_id)
     try:
         server = xmlrpclib.Server(url, allow_none=True)

--- a/salt/pillar/hiera.py
+++ b/salt/pillar/hiera.py
@@ -25,7 +25,7 @@ def __virtual__():
     return 'hiera' if salt.utils.which('hiera') else False
 
 
-def ext_pillar(pillar, conf):
+def ext_pillar(minion_id, pillar, conf):
     '''
     Execute hiera and return the data
     '''

--- a/salt/pillar/libvirt.py
+++ b/salt/pillar/libvirt.py
@@ -11,14 +11,14 @@ import subprocess
 import salt.utils
 
 
-def ext_pillar(pillar, command):
+def ext_pillar(minion_id, pillar, command):
     '''
     Read in the generated libvirt keys
     '''
     key_dir = os.path.join(
             __opts__['pki_dir'],
             'libvirt',
-            __grains__['id'])
+            minion_id)
     cacert = os.path.join(__opts__['pki_dir'],
             'libvirt',
             'cacert.pem')
@@ -65,7 +65,7 @@ def gen_hyper_keys(
         cmd = ('certtool --generate-self-signed --load-privkey {0} '
                '--template {1} --outfile {2}').format(cakey, cainfo, cacert)
         subprocess.call(cmd, shell=True)
-    sub_dir = os.path.join(key_dir, __grains__['id'])
+    sub_dir = os.path.join(key_dir, minion_id)
     if not os.path.isdir(sub_dir):
         os.makedirs(sub_dir)
     priv = os.path.join(sub_dir, 'serverkey.pem')

--- a/salt/pillar/mongo.py
+++ b/salt/pillar/mongo.py
@@ -80,8 +80,8 @@ def __virtual__():
 log = logging.getLogger(__name__)
 
 
-def ext_pillar(pillar, collection='pillar', id_field='_id', re_pattern=None,
-               re_replace='', fields=None):
+def ext_pillar(minion_id, pillar, collection='pillar', id_field='_id',
+               re_pattern=None, re_replace='', fields=None):
     '''
     Connect to a mongo database and read per-node pillar information.
 
@@ -121,7 +121,6 @@ def ext_pillar(pillar, collection='pillar', id_field='_id', re_pattern=None,
         mdb.authenticate(user, password)
 
     # Do the regex string replacement on the minion id
-    minion_id = __opts__['id']
     if re_pattern:
         minion_id = re.sub(re_pattern, re_replace, minion_id)
 

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -145,7 +145,7 @@ def _do_search(conf):
     return result
 
 
-def ext_pillar(pillar, config_file):
+def ext_pillar(minion_id, pillar, config_file):
     '''
     Execute LDAP searches and return the aggregated data
     '''

--- a/salt/pillar/puppet.py
+++ b/salt/pillar/puppet.py
@@ -12,12 +12,12 @@ import yaml
 # Set up logging
 log = logging.getLogger(__name__)
 
-def ext_pillar(pillar, command):
+def ext_pillar(minion_id, pillar, command):
     '''
     Execute an unmodified puppet_node_classifier and read the output as YAML
     '''
     try:
-        data = yaml.safe_load(__salt__['cmd.run']('{0}'.format(command + ' ' + __grains__.get('nodename'))))
+        data = yaml.safe_load(__salt__['cmd.run']('{0} {1}'.format(command, minion_id)))
         data = data['parameters']
         return data
     except Exception:

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -45,13 +45,11 @@ except ImportError:
 
 from salt.exceptions import SaltInvocationError
 
-def ext_pillar(pillar, **kwargs):
+def ext_pillar(minion_id, pillar, **kwargs):
     try:
         # I purposely do not pass any of __opts__ or __salt__ or __grains__
         # to reclass, as I consider those to be Salt-internal and reclass
-        # should not make any assumptions about it. Reclass only needs to know
-        # what minion we are talking about, so:
-        minion_id = __opts__['id']
+        # should not make any assumptions about it.
         return reclass_ext_pillar(minion_id, pillar, **kwargs)
 
     except TypeError, e:


### PR DESCRIPTION
Pillar data is always targetted at a minion, so it makes sense to
actually pass the minion ID via the ext_pillar interface, rather than
expecting plugins to obtain it from **opts**.

While this patch also changes all existing plugins, it concedes that
there are going to be plugins outside of the tree, continuing to use the
old interface. Such plugins will trigger a warning written to the master
log. This warning can later be made critical as part of proper
deprecation.

Signed-off-by: martin f. krafft madduck@madduck.net
