### PR TITLE
Fix salt.states.selinux._refine_value()

### DIFF
--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -20,35 +20,30 @@ booleans can be set.
 
 def _refine_mode(mode):
     '''
-    Return a mode value that is completely predictable
+    Return a mode value that is predictable
     '''
-    if any([
-        str(mode).startswith('e'),
-        str(mode) == '1',
-        str(mode).startswith('E'),
-        str(mode) == 'on']):
+    mode = str(mode).lower()
+    if any([mode.startswith('e'),
+            mode == '1',
+            mode == 'on']):
         return 'Enforcing'
-    if any([
-        str(mode).startswith('p'),
-        str(mode) == '0',
-        str(mode).startswith('P'),
-        str(mode) == 'off']):
-        return 'Permissive'
+    if any([mode.startswith('p'),
+            mode == '0',
+            mode == 'off']):
+            return 'Permissive'
     return 'unknown'
 
 
 def _refine_value(value):
     '''
-    Return a value that is completely predictable
+    Return a yes/no value, or None if the input is invalid
     '''
-    if any([
-        str(value) == '1',
-        str(value) == 'on']):
+    value = str(value).lower()
+    if value in ('1', 'on', 'yes', 'true'):
         return 'on'
-    if any([
-        str(value) == '0',
-        str(value) == 'off']):
+    if value in ('0', 'off', 'no', 'false'):
         return 'off'
+    return None
 
 
 def mode(name):
@@ -111,9 +106,14 @@ def boolean(name, value, persist=False):
         ret['comment'] = 'Boolean {0} is not available'.format(name)
         ret['result'] = False
         return ret
-    value = _refine_value(value)
-    state = bools[name]['State'] == value
-    default = bools[name]['Default'] == value
+    rvalue = _refine_value(value)
+    if rvalue is None:
+        ret['comment'] = '{0} is not a valid value for the ' \
+                         'boolean'.format(value)
+        ret['result'] = False
+        return ret
+    state = bools[name]['State'] == rvalue
+    default = bools[name]['Default'] == rvalue
     if persist:
         if state and default:
             ret['comment'] = 'Boolean is in the correct state'
@@ -125,11 +125,11 @@ def boolean(name, value, persist=False):
     if __opts__['test']:
         ret['result'] = None
         ret['comment'] = 'Boolean {0} is set to be changed to {1}'.format(
-                name, value)
+                name, rvalue)
         return ret
 
-    if __salt__['selinux.setsebool'](name, value, persist):
-        ret['comment'] = 'Boolean {0} has been set to {1}'.format(name, value)
+    if __salt__['selinux.setsebool'](name, rvalue, persist):
+        ret['comment'] = 'Boolean {0} has been set to {1}'.format(name, rvalue)
         return ret
-    ret['comment'] = 'Failed to set the boolean {0} to {1}'.format(name, value)
+    ret['comment'] = 'Failed to set the boolean {0} to {1}'.format(name, rvalue)
     return ret


### PR DESCRIPTION
This function was not properly handling True/False values, causing the
state not to work when one of these values is used. This makes the
example in the docstring fail.

Also cleaned up/simplified _refine_mode.

Fixes #5912.
