### PR TITLE
fix indentation in states.selinux

### DIFF
--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -30,7 +30,7 @@ def _refine_mode(mode):
     if any([mode.startswith('p'),
             mode == '0',
             mode == 'off']):
-            return 'Permissive'
+        return 'Permissive'
     return 'unknown'
 
 


### PR DESCRIPTION
```
************* Module salt.states.selinux
W0311: 33,0: Bad indentation. Found 12 spaces, expected 8
```
