### PR TITLE
Add single string shorthand for Top File

### DIFF
--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -103,7 +103,22 @@ suits your deployment:
         - db
 
 In this setup all systems will pull the global SLS from the base environment,
-as well as pull from their respective environments.
+as well as pull from their respective environments. If you assign only one SLS
+to a system, as in this example, a shorthand is also available::
+
+.. code-block:: yaml
+
+    base:
+      '*': global
+    dev:
+      'webserver*dev*': webserver
+      'db*dev*':        db
+    qa:
+      'webserver*qa*': webserver
+      'db*qa*':        db
+    prod:
+      'webserver*prod*': webserver
+      'db*prod*':        db
 
 .. note::
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -1829,6 +1829,8 @@ class BaseHighState(object):
                 if env != self.opts['environment']:
                     continue
             for match, data in body.items():
+                if isinstance(data, string_types):
+                    data = [data]
                 if self.matcher.confirm_top(
                         match,
                         data,

--- a/tests/unit/highstateconf_test.py
+++ b/tests/unit/highstateconf_test.py
@@ -1,0 +1,41 @@
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../')
+ensure_in_syspath('../../')
+
+# Import Salt libs
+import salt.config
+from salt.state import HighState
+
+
+OPTS = salt.config.minion_config(None, check_dns=False)
+OPTS['id'] = 'match'
+OPTS['file_client'] = 'local'
+OPTS['file_roots'] = dict(base=['/tmp'])
+OPTS['test'] = False
+OPTS['grains'] = salt.loader.grains(OPTS)
+
+
+class HighStateTestCase(TestCase):
+    def setUp(self):
+        self.highstate = HighState(OPTS)
+        self.highstate.push_active()
+
+    def tearDown(self):
+        self.highstate.pop_active()
+
+    def test_top_matches_with_list(self):
+        top = {'env': {'match': ['state1', 'state2'], 'nomatch': ['state3']}}
+        matches = self.highstate.top_matches(top)
+        self.assertEqual(matches, {'env': ['state1', 'state2']})
+
+    def test_top_matches_with_string(self):
+        top = {'env': {'match': 'state1', 'nomatch': 'state2'}}
+        matches = self.highstate.top_matches(top)
+        self.assertEqual(matches, {'env': ['state1']})
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(HighStateTestCase, needs_daemon=False)


### PR DESCRIPTION
As per issue #5804, this makes the following valid syntax for the `top.sls` file:

``` yaml
base:
  tommy.example.com:   webserver
  jerry.example.com:   dbserver
  alberon.example.com: mailserver

develop:
  saturn.example.com:  webserver
```

I added a test and documentation to the Top File reference.
