### PR TITLE
replace "disable-msg" with "disable" per DeprecationWarning

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -20,7 +20,7 @@ if PY3:
 else:
     MAX_SIZE = sys.maxint
 
-# pylint: disable-msg=C0103
+# pylint: disable=C0103
 if PY3:
     string_types = str,
     integer_types = int,

--- a/salt/log.py
+++ b/salt/log.py
@@ -78,7 +78,7 @@ if sys.version_info < (2, 7):
         def emit(self, record):
             pass
 
-        def createLock(self):  # pylint: disable-msg=C0103
+        def createLock(self):  # pylint: disable=C0103
             self.lock = None
 
     logging.NullHandler = NullHandler
@@ -202,7 +202,7 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS):
             pass
         return instance
 
-    # pylint: disable-msg=C0103
+    # pylint: disable=C0103
     def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None,
                    extra=None):
         # Let's try to make every logging message unicode
@@ -243,7 +243,7 @@ if logging.getLoggerClass() is not SaltLoggingClass:
         logging.getLogger().addHandler(LOGGING_NULL_HANDLER)
 
 
-def getLogger(name):  # pylint: disable-msg=C0103
+def getLogger(name):  # pylint: disable=C0103
     '''
     This function is just a helper, an alias to:
         logging.getLogger(name)

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -169,7 +169,7 @@ def atrm(*args):
     return ret
 
 
-def at(*args, **kwargs):  # pylint: disable-msg=C0103
+def at(*args, **kwargs):  # pylint: disable=C0103
     '''
     Add a job to the queue.
 

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -190,7 +190,7 @@ def remove(path):
     return ret
 
 
-def ls(path):  # pylint: disable-msg=C0103
+def ls(path):  # pylint: disable=C0103
     '''
     List the direct children of a node
 

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -180,7 +180,7 @@ def list_tab(user):
     return ret
 
 # For consistency's sake
-ls = list_tab  # pylint: disable-msg=C0103
+ls = list_tab  # pylint: disable=C0103
 
 
 def set_special(user, special, cmd):
@@ -342,7 +342,7 @@ def rm_job(user,
         return comdat['stderr']
     return ret
 
-rm = rm_job  # pylint: disable-msg=C0103
+rm = rm_job  # pylint: disable=C0103
 
 
 def set_env(user, name, value=None):

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -106,8 +106,8 @@ def get_disabled():
     return sorted(set(all_) - set(en_))
 
 
-def _switch(name,                   # pylint: disable-msg=C0103
-            on,                     # pylint: disable-msg=C0103
+def _switch(name,                   # pylint: disable=C0103
+            on,                     # pylint: disable=C0103
             **kwargs):
     '''
     Switch on/off service start at boot.

--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -25,12 +25,12 @@ def _gem(command, ruby=None, runas=None):
         return False
 
 
-def install(gems,           # pylint: disable-msg=C0103
+def install(gems,           # pylint: disable=C0103
             ruby=None,
             runas=None,
             version=None,
             rdoc=False,
-            ri=False):      # pylint: disable-msg=C0103
+            ri=False):      # pylint: disable=C0103
     '''
     Installs one or several gems.
 

--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -76,7 +76,7 @@ def image_create(**kwargs):
     return {newimage['name']: newimage}
 
 
-def image_delete(id=None, name=None):  # pylint: disable-msg=C0103
+def image_delete(id=None, name=None):  # pylint: disable=C0103
     '''
     Delete an image (glance image-delete)
 
@@ -90,7 +90,7 @@ def image_delete(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for image in nt_ks.images.list():
             if image.name == name:
-                id = image.id  # pylint: disable-msg=C0103
+                id = image.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve image id'}
@@ -101,7 +101,7 @@ def image_delete(id=None, name=None):  # pylint: disable-msg=C0103
     return ret
 
 
-def image_show(id=None, name=None):  # pylint: disable-msg=C0103
+def image_show(id=None, name=None):  # pylint: disable=C0103
     '''
     Return details about a specific image (glance image-show)
 
@@ -114,7 +114,7 @@ def image_show(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for image in nt_ks.images.list():
             if image.name == name:
-                id = image.id  # pylint: disable-msg=C0103
+                id = image.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve image id'}
@@ -139,7 +139,7 @@ def image_show(id=None, name=None):  # pylint: disable-msg=C0103
     return ret
 
 
-def image_list(id=None):  # pylint: disable-msg=C0103
+def image_list(id=None):  # pylint: disable=C0103
     '''
     Return a list of available images (glance image-list)
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -167,7 +167,7 @@ def setval(key, val):
     return {key: val}
 
 
-def ls():  # pylint: disable-msg=C0103
+def ls():  # pylint: disable=C0103
     '''
     Return a list of all available grains
 

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -10,7 +10,7 @@ import salt.utils
 import salt.utils.odict as odict
 
 
-# pylint: disable-msg=C0103
+# pylint: disable=C0103
 def __get_hosts_filename():
     '''
     Return the path to the appropriate hosts file

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -72,9 +72,9 @@ def auth():
     return client.Client(**kwargs)
 
 
-def ec2_credentials_get(id=None,       # pylint: disable-msg=C0103
+def ec2_credentials_get(id=None,       # pylint: disable=C0103
                         name=None,
-                        access=None):  # pylint: disable-msg=C0103
+                        access=None):  # pylint: disable=C0103
     '''
     Return ec2_credentials for a user (keystone ec2-credentials-get)
 
@@ -89,7 +89,7 @@ def ec2_credentials_get(id=None,       # pylint: disable-msg=C0103
     if name:
         for user in kstone.users.list():
             if user.name == name:
-                id = user.id  # pylint: disable-msg=C0103
+                id = user.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve user id'}
@@ -105,7 +105,7 @@ def ec2_credentials_get(id=None,       # pylint: disable-msg=C0103
     return ret
 
 
-def ec2_credentials_list(id=None, name=None):  # pylint: disable-msg=C0103
+def ec2_credentials_list(id=None, name=None):  # pylint: disable=C0103
     '''
     Return a list of ec2_credentials for a specific user (keystone ec2-credentials-list)
 
@@ -120,7 +120,7 @@ def ec2_credentials_list(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for user in kstone.users.list():
             if user.name == name:
-                id = user.id  # pylint: disable-msg=C0103
+                id = user.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve user id'}
@@ -168,7 +168,7 @@ def endpoint_list():
     return ret
 
 
-def role_get(id=None, name=None):  # pylint: disable-msg=C0103
+def role_get(id=None, name=None):  # pylint: disable=C0103
     '''
     Return a specific roles (keystone role-get)
 
@@ -183,7 +183,7 @@ def role_get(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for role in kstone.roles.list():
             if role.name == name:
-                id = role.id  # pylint: disable-msg=C0103
+                id = role.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve role id'}
@@ -213,7 +213,7 @@ def role_list():
     return ret
 
 
-def service_get(id=None, name=None):  # pylint: disable-msg=C0103
+def service_get(id=None, name=None):  # pylint: disable=C0103
     '''
     Return a specific services (keystone service-get)
 
@@ -228,7 +228,7 @@ def service_get(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for service in kstone.services.list():
             if service.name == name:
-                id = service.id  # pylint: disable-msg=C0103
+                id = service.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve service id'}
@@ -262,7 +262,7 @@ def service_list():
     return ret
 
 
-def tenant_get(id=None, name=None):  # pylint: disable-msg=C0103
+def tenant_get(id=None, name=None):  # pylint: disable=C0103
     '''
     Return a specific tenants (keystone tenant-get)
 
@@ -277,7 +277,7 @@ def tenant_get(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for tenant in kstone.tenants.list():
             if tenant.name == name:
-                id = tenant.id  # pylint: disable-msg=C0103
+                id = tenant.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve tenant id'}
@@ -350,7 +350,7 @@ def user_list():
     return ret
 
 
-def user_get(id=None, name=None):  # pylint: disable-msg=C0103
+def user_get(id=None, name=None):  # pylint: disable=C0103
     '''
     Return a specific users (keystone user-get)
 
@@ -365,7 +365,7 @@ def user_get(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for user in kstone.users.list():
             if user.name == name:
-                id = user.id  # pylint: disable-msg=C0103
+                id = user.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve user id'}
@@ -399,7 +399,7 @@ def user_create(name, password, email, tenant_id=None, enabled=True):
     return user_get(item.id)
 
 
-def user_delete(id=None, name=None):  # pylint: disable-msg=C0103
+def user_delete(id=None, name=None):  # pylint: disable=C0103
     '''
     Delete a user (keystone user-delete)
 
@@ -413,7 +413,7 @@ def user_delete(id=None, name=None):  # pylint: disable-msg=C0103
     if name:
         for user in kstone.users.list():
             if user.name == name:
-                id = user.id  # pylint: disable-msg=C0103
+                id = user.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve user id'}
@@ -424,10 +424,10 @@ def user_delete(id=None, name=None):  # pylint: disable-msg=C0103
     return ret
 
 
-def user_update(id=None,        # pylint: disable-msg=C0103
+def user_update(id=None,        # pylint: disable=C0103
                 name=None,
                 email=None,
-                enabled=None):  # pylint: disable-msg=C0103
+                enabled=None):  # pylint: disable=C0103
     '''
     Update a user's information (keystone user-update)
     The following fields may be updated: name, email, enabled.
@@ -446,9 +446,9 @@ def user_update(id=None,        # pylint: disable-msg=C0103
     return ret
 
 
-def user_password_update(id=None,         # pylint: disable-msg=C0103
+def user_password_update(id=None,         # pylint: disable=C0103
                          name=None,
-                         password=None):  # pylint: disable-msg=C0103
+                         password=None):  # pylint: disable=C0103
     '''
     Update a user's password (keystone user-password-update)
 
@@ -462,7 +462,7 @@ def user_password_update(id=None,         # pylint: disable-msg=C0103
     if name:
         for user in kstone.users.list():
             if user.name == name:
-                id = user.id  # pylint: disable-msg=C0103
+                id = user.id  # pylint: disable=C0103
                 continue
     if not id:
         return {'Error': 'Unable to resolve user id'}

--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -86,8 +86,8 @@ def _connect(**kwargs):
     return _LDAPConnection(**connargs).ldap
 
 
-def search(filter,      # pylint: disable-msg=C0103
-           dn=None,     # pylint: disable-msg=C0103
+def search(filter,      # pylint: disable=C0103
+           dn=None,     # pylint: disable=C0103
            scope=None,
            attrs=None,
            **kwargs):
@@ -114,7 +114,7 @@ def search(filter,      # pylint: disable-msg=C0103
 
     '''
     if not dn:
-        dn = _config('dn', 'basedn')  # pylint: disable-msg=C0103
+        dn = _config('dn', 'basedn')  # pylint: disable=C0103
     if not scope:
         scope = _config('scope')
     if attrs == '':  # Allow command line 'return all' attr override

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -81,8 +81,8 @@ def flavor_list():
     return ret
 
 
-def flavor_create(name,      # pylint: disable-msg=C0103
-                  id=0,      # pylint: disable-msg=C0103
+def flavor_create(name,      # pylint: disable=C0103
+                  id=0,      # pylint: disable=C0103
                   ram=0,
                   disk=0,
                   vcpus=1):
@@ -111,7 +111,7 @@ def flavor_create(name,      # pylint: disable-msg=C0103
             'vcpus': vcpus}
 
 
-def flavor_delete(id):  # pylint: disable-msg=C0103
+def flavor_delete(id):  # pylint: disable=C0103
     '''
     Delete a flavor from nova by id (nova flavor-delete)
 
@@ -209,7 +209,7 @@ def image_list(name=None):
     return ret
 
 
-def image_meta_set(id=None, name=None, **kwargs):  # pylint: disable-msg=C0103
+def image_meta_set(id=None, name=None, **kwargs):  # pylint: disable=C0103
     '''
     Sets a key=value pair in the metadata for an image (nova image-meta set)
 
@@ -222,14 +222,14 @@ def image_meta_set(id=None, name=None, **kwargs):  # pylint: disable-msg=C0103
     if name:
         for image in nt_ks.images.list():
             if image.name == name:
-                id = image.id  # pylint: disable-msg=C0103
+                id = image.id  # pylint: disable=C0103
     if not id:
         return {'Error': 'A valid image name or id was not specified'}
     nt_ks.images.set_meta(id, kwargs)
     return {id: kwargs}
 
 
-def image_meta_delete(id=None,     # pylint: disable-msg=C0103
+def image_meta_delete(id=None,     # pylint: disable=C0103
                       name=None,
                       keys=None):
     '''
@@ -244,7 +244,7 @@ def image_meta_delete(id=None,     # pylint: disable-msg=C0103
     if name:
         for image in nt_ks.images.list():
             if image.name == name:
-                id = image.id  # pylint: disable-msg=C0103
+                id = image.id  # pylint: disable=C0103
     pairs = keys.split(',')
     if not id:
         return {'Error': 'A valid image name or id was not specified'}

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -139,7 +139,7 @@ def check(device, minor):
     return out
 
 
-def cp(device, from_minor, to_minor):  # pylint: disable-msg=C0103
+def cp(device, from_minor, to_minor):  # pylint: disable=C0103
     '''
     partition.check device from_minor to_minor
 
@@ -330,7 +330,7 @@ def resize(device, minor, start, end):
     return out.splitlines()
 
 
-def rm(device, minor):  # pylint: disable-msg=C0103
+def rm(device, minor):  # pylint: disable=C0103
     '''
     partition.rm device minor
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -16,7 +16,7 @@ from salt.exceptions import CommandExecutionError, CommandNotFoundError
 # pip can be installed on a virtualenv anywhere on the filesystem, there's no
 # definite way to tell if pip is installed on not.
 
-logger = logging.getLogger(__name__)  # pylint: disable-msg=C0103
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 # Don't shadow built-in's.
 __func_alias__ = {

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -276,7 +276,7 @@ def _parse_settings_bond_0(opts, iface, bond_def):
         if isinstance(opts['arp_ip_target'], list):
             if 1 <= len(opts['arp_ip_target']) <= 16:
                 bond.update({'arp_ip_target': []})
-                for ip in opts['arp_ip_target']:  # pylint: disable-msg=C0103
+                for ip in opts['arp_ip_target']:  # pylint: disable=C0103
                     bond['arp_ip_target'].append(ip)
             else:
                 _raise_error_iface(iface, 'arp_ip_target', valid)
@@ -349,7 +349,7 @@ def _parse_settings_bond_2(opts, iface, bond_def):
         if isinstance(opts['arp_ip_target'], list):
             if 1 <= len(opts['arp_ip_target']) <= 16:
                 bond.update({'arp_ip_target': []})
-                for ip in opts['arp_ip_target']:  # pylint: disable-msg=C0103
+                for ip in opts['arp_ip_target']:  # pylint: disable=C0103
                     bond['arp_ip_target'].append(ip)
             else:
                 _raise_error_iface(iface, 'arp_ip_target', valid)
@@ -944,7 +944,7 @@ def get_interface(iface):
     return _read_file(path)
 
 
-def up(iface, iface_type):  # pylint: disable-msg=C0103
+def up(iface, iface_type):  # pylint: disable=C0103
     '''
     Start up a network interface
 

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -328,7 +328,7 @@ def gemset_list_all(runas=None):
     return gemsets
 
 
-def do(ruby, command, runas=None):  # pylint: disable-msg=C0103
+def do(ruby, command, runas=None):  # pylint: disable=C0103
     '''
     Execute a command in an RVM controlled environment.
 

--- a/salt/modules/sqlite3.py
+++ b/salt/modules/sqlite3.py
@@ -11,7 +11,7 @@ except ImportError:
     HAS_SQLITE3 = False
 
 
-# pylint: disable-msg=C0103
+# pylint: disable=C0103
 def __virtual__():
     if not HAS_SQLITE3:
         return False

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -412,7 +412,7 @@ def netdev():
     return ret
 
 
-def w():  # pylint: disable-msg=C0103
+def w():  # pylint: disable=C0103
     '''
     Return a list of logged in users for this minion, using the w command
 

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -10,7 +10,7 @@ or use Self-Signed certificates.
         ca.cert_base_path: '/etc/pki'
 '''
 
-# pylint: disable-msg=C0103
+# pylint: disable=C0103
 
 # Import python libs
 import os

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -242,7 +242,7 @@ def has_names_decls(data):
             return sid
 
 
-def rewrite_single_shorthand_state_decl(data):  # pylint: disable-msg=C0103
+def rewrite_single_shorthand_state_decl(data):  # pylint: disable=C0103
     '''
     Rewrite all state declarations that look like this::
 
@@ -401,7 +401,7 @@ from itertools import chain
 #   explicit require_in/watch_in can only contain states after it
 def add_implicit_requires(data):
 
-    def T(sid, state):  # pylint: disable-msg=C0103
+    def T(sid, state):  # pylint: disable=C0103
         return '{0}:{1}'.format(sid, state_name(state))
 
     states_before = set()

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -25,7 +25,7 @@ Options:
 ''')
         raise
     if ('-o', '') in opts:
-        def Loader(*args):  # pylint: disable-msg=C0103
+        def Loader(*args):  # pylint: disable=C0103
             return CustomLoader(*args, dictclass=OrderedDict)
         return Loader
     return CustomLoader

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -79,7 +79,7 @@ def down():
     return ret
 
 
-def up():  # pylint: disable-msg=C0103
+def up():  # pylint: disable=C0103
     '''
     Print a list of all of the minions that are up
     '''

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -22,12 +22,12 @@ def __virtual__():
     return 'gem' if 'gem.list' in __salt__ else False
 
 
-def installed(name,          # pylint: disable-msg=C0103
+def installed(name,          # pylint: disable=C0103
               ruby=None,
               runas=None,
               version=None,
               rdoc=False,
-              ri=False):     # pylint: disable-msg=C0103
+              ri=False):     # pylint: disable=C0103
     '''
     Make sure that a gem is installed.
 

--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -27,7 +27,7 @@ update to remove the old entry.
 '''
 
 
-def present(name, ip):  # pylint: disable-msg=C0103
+def present(name, ip):  # pylint: disable=C0103
     '''
     Ensures that the named host is present with the given ip
 
@@ -59,7 +59,7 @@ def present(name, ip):  # pylint: disable-msg=C0103
         return ret
 
 
-def absent(name, ip):  # pylint: disable-msg=C0103
+def absent(name, ip):  # pylint: disable=C0103
     '''
     Ensure that the named host is absent
 

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -157,4 +157,4 @@ def run(name, **kwargs):
         ret['result'] = False
     return ret
 
-mod_watch = run  # pylint: disable-msg=C0103
+mod_watch = run  # pylint: disable=C0103

--- a/salt/states/stateconf.py
+++ b/salt/states/stateconf.py
@@ -14,4 +14,4 @@ def _no_op(name, **kwargs):
     '''
     return dict(name=name, result=True, changes={}, comment='')
 
-set = context = _no_op  # pylint: disable-msg=C0103
+set = context = _no_op  # pylint: disable=C0103

--- a/salt/states/virtualenv.py
+++ b/salt/states/virtualenv.py
@@ -161,4 +161,4 @@ def managed(name,
                 'old': old if old else ''}
     return ret
 
-manage = managed  # pylint: disable-msg=C0103
+manage = managed  # pylint: disable=C0103

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -710,7 +710,7 @@ def istextfile(fp_, blocksize=512):
     If more than 30% of the chars in the block are non-text, or there
     are NUL ('\x00') bytes in the block, assume this is a binary file.
     '''
-    PY3 = sys.version_info[0] == 3  # pylint: disable-msg=C0103
+    PY3 = sys.version_info[0] == 3  # pylint: disable=C0103
     int2byte = (lambda x: bytes((x,))) if PY3 else chr
     text_characters = (
         b''.join(int2byte(i) for i in range(32, 127)) +
@@ -824,9 +824,9 @@ def fopen(*args, **kwargs):
         # modify the file descriptor on systems with fcntl
         # unix and unix-like systems only
         try:
-            FD_CLOEXEC = fcntl.FD_CLOEXEC   # pylint: disable-msg=C0103
+            FD_CLOEXEC = fcntl.FD_CLOEXEC   # pylint: disable=C0103
         except AttributeError:
-            FD_CLOEXEC = 1                  # pylint: disable-msg=C0103
+            FD_CLOEXEC = 1                  # pylint: disable=C0103
         old_flags = fcntl.fcntl(fhandle.fileno(), fcntl.F_GETFD)
         fcntl.fcntl(fhandle.fileno(), fcntl.F_SETFD, old_flags | FD_CLOEXEC)
     return fhandle

--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -14,15 +14,15 @@ import random
 
 CAN_RENAME_OPEN_FILE = False
 if os.name == 'nt':  # pragma: no cover
-    _rename = lambda src, dst: False            # pylint: disable-msg=C0103
-    _rename_atomic = lambda src, dst: False     # pylint: disable-msg=C0103
+    _rename = lambda src, dst: False            # pylint: disable=C0103
+    _rename_atomic = lambda src, dst: False     # pylint: disable=C0103
 
     try:
         import ctypes
 
         _MOVEFILE_REPLACE_EXISTING = 0x1
         _MOVEFILE_WRITE_THROUGH = 0x8
-        _MoveFileEx = ctypes.windll.kernel32.MoveFileExW  # pylint: disable-msg=C0103
+        _MoveFileEx = ctypes.windll.kernel32.MoveFileExW  # pylint: disable=C0103
 
         def _rename(src, dst):
             if not isinstance(src, unicode):
@@ -42,7 +42,7 @@ if os.name == 'nt':  # pragma: no cover
             return rval
 
         # new in Vista and Windows Server 2008
-        # pylint: disable-msg=C0103
+        # pylint: disable=C0103
         _CreateTransaction = ctypes.windll.ktmw32.CreateTransaction
         _CommitTransaction = ctypes.windll.ktmw32.CommitTransaction
         _MoveFileTransacted = ctypes.windll.kernel32.MoveFileTransactedW
@@ -91,7 +91,7 @@ if os.name == 'nt':  # pragma: no cover
             except Exception:
                 pass
 else:
-    atomic_rename = os.rename  # pylint: disable-msg=C0103
+    atomic_rename = os.rename  # pylint: disable=C0103
     CAN_RENAME_OPEN_FILE = True
 
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -23,7 +23,7 @@ import salt.utils
 log = logging.getLogger(__name__)
 
 
-# pylint: disable-msg=C0103
+# pylint: disable=C0103
 
 
 def sanitize_host(host):
@@ -102,7 +102,7 @@ def _cidr_to_ipv4_netmask(cidr_bits):
     return netmask
 
 
-def _number_of_set_bits_to_ipv4_netmask(set_bits):  # pylint: disable-msg=C0103
+def _number_of_set_bits_to_ipv4_netmask(set_bits):  # pylint: disable=C0103
     '''
     Returns an IPv4 netmask from the integer representation of that mask.
 
@@ -111,7 +111,7 @@ def _number_of_set_bits_to_ipv4_netmask(set_bits):  # pylint: disable-msg=C0103
     return _cidr_to_ipv4_netmask(_number_of_set_bits(set_bits))
 
 
-# pylint: disable-msg=C0103
+# pylint: disable=C0103
 def _number_of_set_bits(x):
     '''
     Returns the number of bits that are set in a 32bit int
@@ -141,9 +141,9 @@ def _interfaces_ip(out):
         '''
         brd = None
         if '/' in value:  # we have a CIDR in this address
-            ip, cidr = value.split('/')  # pylint: disable-msg=C0103
+            ip, cidr = value.split('/')  # pylint: disable=C0103
         else:
-            ip = value  # pylint: disable-msg=C0103
+            ip = value  # pylint: disable=C0103
             cidr = 32
 
         if type_ == 'inet':

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -176,7 +176,7 @@ def render_wempy_tmpl(tmplstr, context, tmplpath=None):
     return Template(tmplstr).render(**context)
 
 
-def py(sfn, string=False, **kwargs):  # pylint: disable-msg=C0103
+def py(sfn, string=False, **kwargs):  # pylint: disable=C0103
     '''
     Render a template from a python source file
 

--- a/salt/utils/winservice.py
+++ b/salt/utils/winservice.py
@@ -28,7 +28,7 @@ class Service(win32serviceutil.ServiceFramework):
     def sleep(self, sec):
         win32api.Sleep(sec * 1000, True)
 
-    def SvcDoRun(self):  # pylint: disable-msg=C0103
+    def SvcDoRun(self):  # pylint: disable=C0103
         self.ReportServiceStatus(win32service.SERVICE_START_PENDING)
         try:
             self.ReportServiceStatus(win32service.SERVICE_RUNNING)
@@ -42,7 +42,7 @@ class Service(win32serviceutil.ServiceFramework):
             self.log('Exception: {0}'.format(err))
             self.SvcStop()
 
-    def SvcStop(self):  # pylint: disable-msg=C0103
+    def SvcStop(self):  # pylint: disable=C0103
         self.ReportServiceStatus(win32service.SERVICE_STOP_PENDING)
         self.log('stopping')
         self.stop()

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -16,7 +16,7 @@ except Exception:
 # accepts a custom loader, and every time this function is used in Salt
 # the custom loader defined below is used. This should be altered though to
 # not require the custom loader to be explicitly added.
-load = yaml.load  # pylint: disable-msg=C0103
+load = yaml.load  # pylint: disable=C0103
 
 
 class DuplicateKeyWarning(RuntimeWarning):


### PR DESCRIPTION
Fixes "DeprecationWarning: disable-msg is deprecated, replace it with disable" when running pylint.
This commit only modifies comments, not any actual operative code.
