### PR TITLE
Clear cached service data at the beginning of service states

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -259,6 +259,11 @@ def running(name, enable=None, sig=None, **kwargs):
            'result': True,
            'comment': ''}
 
+    # Clear cached service info
+    sys.modules[
+        __salt__['service.status'].__module__
+    ].__context__.pop('service.all', None)
+
     # Check if the service is available
     ret = _available(name, ret)
     if not ret.pop('available', True):
@@ -327,6 +332,11 @@ def dead(name, enable=None, sig=None, **kwargs):
            'result': True,
            'comment': ''}
 
+    # Clear cached service info
+    sys.modules[
+        __salt__['service.status'].__module__
+    ].__context__.pop('service.all', None)
+
     # Check if the service is available
     ret = _available(name, ret)
     if not ret.pop('available', True):
@@ -384,6 +394,11 @@ def enabled(name, **kwargs):
     name
         The name of the init or rc script used to manage the service
     '''
+    # Clear cached service info
+    sys.modules[
+        __salt__['service.status'].__module__
+    ].__context__.pop('service.all', None)
+
     return _enable(name, None, **kwargs)
 
 
@@ -397,6 +412,11 @@ def disabled(name, **kwargs):
     name
         The name of the init or rc script used to manage the service
     '''
+    # Clear cached service info
+    sys.modules[
+        __salt__['service.status'].__module__
+    ].__context__.pop('service.all', None)
+
     return _disable(name, None, **kwargs)
 
 


### PR DESCRIPTION
This fixes an edge case where service data has already been discovered
in another service state within the same highstate run, causing the
cached service data to be stored in `__context__`. If a package is then
installed which also adds a service, and a service state is run for that
service name, the list of available services will return cached data,
and salt will think that the service does not exist. By clearing the
cache at the beginning of the service states, we ensure that the most
up-to-date service information is used for service states.
