### PR TITLE
Don't allow npm state to be used if npm module not available

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -6,6 +6,13 @@ A state module to manage installed NPM packages.
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
+def __virtual__():
+    '''
+    Only load if the npm module is available in __salt__
+    '''
+    return 'npm' if 'npm.list' in __salt__ else False
+
+
 def installed(name,
               dir=None,
               runas=None,


### PR DESCRIPTION
This prevents a traceback (as seen in #5934) when one tries to run an
npm state when the npm module is not available, by preventing the npm
state from loading using the `__virtual__()` function.
