### PR TITLE
fixing issues with passing env var to salt-minion,master,syndic

### DIFF
--- a/pkg/salt-master.upstart
+++ b/pkg/salt-master.upstart
@@ -7,5 +7,5 @@ stop on runlevel [!2345]
 limit nofile 100000 100000
 
 script
-exec salt-master
+exec su -c salt-master
 end script

--- a/pkg/salt-minion.upstart
+++ b/pkg/salt-minion.upstart
@@ -13,5 +13,5 @@ stop on runlevel [!2345]
 #respawn limit 10 5
 
 script
-exec salt-minion
+exec su -c salt-minion
 end script

--- a/pkg/salt-syndic.upstart
+++ b/pkg/salt-syndic.upstart
@@ -5,4 +5,4 @@ start on (net-device-up
           and runlevel [2345])
 stop on runlevel [!2345]
 
-exec salt-syndic
+exec su -c salt-syndic


### PR DESCRIPTION
Hi guys I have a problem with env variables (set in /etc/environment) as they are not passed when running salt-minion as a service (ubuntu)
I found that this post http://serverfault.com/questions/128605/have-upstart-read-environment-from-etc-environment-for-a-service and basically they advice to use exec su -c in upstart scripts, which pointed me to https://github.com/saltstack/salt/blob/develop/pkg/salt-minion.service and I think in this script there should be exec su -c salt-minion (at least I have tested that one with:
salt '*' cmd.exec_code python 'import os; print os.environ' (and /etc/environment variables are passed)
any comments appreciated
