### PR TITLE
handle gracefully -f (--find-links) in "pip freeze" and report error in ...

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -560,7 +560,7 @@ def list_(prefix='',
         raise CommandExecutionError(result['stderr'])
 
     for line in result['stdout'].splitlines():
-        if not line.startswith('-f'):
+        if line.startswith('-f'):
             # ignore -f line as it contains --find-links directory
             continue
         elif line.startswith('-e'):

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -560,12 +560,18 @@ def list_(prefix='',
         raise CommandExecutionError(result['stderr'])
 
     for line in result['stdout'].splitlines():
-        if line.startswith('-e'):
+        if not line.startswith('-f'):
+            # ignore -f line as it contains --find-links directory
+            continue
+        elif line.startswith('-e'):
             line = line.split('-e ')[1]
             version, name = line.split('#egg=')
         elif len(line.split('==')) >= 2:
             name = line.split('==')[0]
             version = line.split('==')[1]
+        else:
+            logger.error("Can't parse line '%s'", line)
+            continue
 
         if prefix:
             if name.lower().startswith(prefix.lower()):


### PR DESCRIPTION
...output

this bug had been introduced in 0.16

pip freeze can return more then `-e` and `==`.

the if/elif logic caused this:

```
   File "/usr/lib/pymodules/python2.6/salt/modules/pip.py", line 574, in list_
     packages[name] = version
UnboundLocalError: local variable 'version' referenced before assignment
```

when pip freeze output isn't handled, it log it as an error. but I think this should make pip.list fail.
what is the best to do in salt modules that don't return a dict `{'result': False, ...}` ?
