### PR TITLE
Reclass adapter improvements

### DIFF
--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -17,36 +17,66 @@ This would cause reclass to read the inventory from YAML files in
 
 More information about reclass: http://github.com/madduck/reclass
 
-There is currently no way to avoid having to specify the same configuration
-for ``ext_pillar`` and ``master_tops``.
+If you are also using master_tops and you want to avoid having to specify the
+same information for both, use YAML anchors:
 
-Unfortunately, there is currently no way to specify the location of the
-reclass source in the master config, because Salt provides no way to access
-the configuration file data at the module scope (``__opts__`` is injected by
-the Salt loader), where we need to know about whether reclass is import-able to
-be able to define the ``__virtual__`` function. You will hence either have to
-install reclass to ``PYTHONPATH``, or extend ``PYTHONPATH`` when running the
-master, e.g.::
+    ---
+    reclass: &reclass
+        storage_type: yaml_fs
+        base_inventory_uri: /srv/salt
+        reclass_source_path: ~/code/reclass
 
-    PYTHONPATH=~/code/reclass:$PYTHONPATH salt-master <args>
+    ext_pillar:
+        - reclass: *reclass
 
+    master_tops:
+        reclass: *reclass
+
+If you want to run reclass from source, rather than installing it, you can
+either let the master know via the ``PYTHONPATH`` environment variable, or by
+setting the configuration option, like in the example above.
 '''
 # This file cannot be called reclass.py, because then the module import would
 # not work. Thanks to the __virtual__ function, however, the plugin still
 # responds to the name 'reclass'.
 
-try:
-    from reclass.adapters.salt import ext_pillar as reclass_ext_pillar
-    from reclass.errors import ReclassException
-    __virtual__ = lambda: 'reclass'
+from salt.utils.reclass import prepend_reclass_source_path, \
+        filter_out_source_path_option
 
-except ImportError:
-    __virtual__ = lambda: False
+def __virtual__(retry=False):
+    try:
+        import reclass
+        return 'reclass'
+
+    except ImportError as e:
+        if retry:
+            return False
+
+        for pillar in __opts__.get('ext_pillar', []):
+            if 'reclass' not in pillar.keys():
+                continue
+
+            # each pillar entry is a single-key hash of name -> options
+            opts = pillar.values()[0]
+            prepend_reclass_source_path(opts)
+            break
+
+        return __virtual__(retry=True)
+
 
 from salt.exceptions import SaltInvocationError
 
 def ext_pillar(minion_id, pillar, **kwargs):
+    # If reclass is installed, __virtual__ put it onto the search path, so we
+    # don't need to protect against ImportError:
+    from reclass.adapters.salt import ext_pillar as reclass_ext_pillar
+    from reclass.errors import ReclassException
+
     try:
+        # the source path we used above isn't something reclass needs to care
+        # about, so filter it:
+        filter_out_source_path_option(kwargs)
+
         # I purposely do not pass any of __opts__ or __salt__ or __grains__
         # to reclass, as I consider those to be Salt-internal and reclass
         # should not make any assumptions about it.

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -55,17 +55,17 @@ def ext_pillar(minion_id, pillar, **kwargs):
     except TypeError as e:
         if e.message.find('unexpected keyword argument') > -1:
             arg = e.message.split()[-1]
-            raise SaltInvocationError('pillar.reclass: unexpected option: '\
+            raise SaltInvocationError('ext_pillar.reclass: unexpected option: '\
                                       + arg)
         else:
             raise
 
     except KeyError as e:
         if e.message.find('id') > -1:
-            raise SaltInvocationError('pillar.reclass: __opts__ does not '\
+            raise SaltInvocationError('ext_pillar.reclass: __opts__ does not '\
                                       'define minion ID')
         else:
             raise
 
     except ReclassException as e:
-        raise SaltInvocationError('pillar.reclass: ' + e.message)
+        raise SaltInvocationError('ext_pillar.reclass: ' + e.message)

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -41,7 +41,7 @@ setting the configuration option, like in the example above.
 # responds to the name 'reclass'.
 
 from salt.utils.reclass import prepend_reclass_source_path, \
-        filter_out_source_path_option
+        filter_out_source_path_option, set_inventory_base_uri_default
 
 def __virtual__(retry=False):
     try:
@@ -76,6 +76,10 @@ def ext_pillar(minion_id, pillar, **kwargs):
         # the source path we used above isn't something reclass needs to care
         # about, so filter it:
         filter_out_source_path_option(kwargs)
+
+        # if no inventory_base_uri was specified, initialise it to the first
+        # file_roots of class 'base' (if that exists):
+        set_inventory_base_uri_default(__opts__, kwargs)
 
         # I purposely do not pass any of __opts__ or __salt__ or __grains__
         # to reclass, as I consider those to be Salt-internal and reclass

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -41,7 +41,7 @@ setting the configuration option, like in the example above.
 # responds to the name 'reclass'.
 
 from salt.utils.reclass import prepend_reclass_source_path, \
-        filter_out_source_path_option
+        filter_out_source_path_option, set_inventory_base_uri_default
 
 def __virtual__(retry=False):
     try:
@@ -73,6 +73,10 @@ def top(**kwargs):
         # the source path we used above isn't something reclass needs to care
         # about, so filter it:
         filter_out_source_path_option(reclass_opts)
+
+        # if no inventory_base_uri was specified, initialise it to the first
+        # file_roots of class 'base' (if that exists):
+        set_inventory_base_uri_default(__opts__, kwargs)
 
         # I purposely do not pass any of __opts__ or __salt__ or __grains__
         # to reclass, as I consider those to be Salt-internal and reclass

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -17,34 +17,52 @@ This would cause reclass to read the inventory from YAML files in
 
 More information about reclass: http://github.com/madduck/reclass
 
-There is currently no way to avoid having to specify the same configuration
-for ``ext_pillar`` and ``master_tops``.
+If you are also using ext_pillar and you want to avoid having to specify the
+same information for both, use YAML anchors:
 
-Unfortunately, there is currently no way to specify the location of the
-reclass source in the master config, because Salt provides no way to access
-the configuration file data at the module scope (``__opts__`` is injected by
-the Salt loader), where we need to know about whether reclass is import-able to
-be able to define the ``__virtual__`` function. You will hence either have to
-install reclass to ``PYTHONPATH``, or extend ``PYTHONPATH`` when running the
-master, e.g.::
+    ---
+    reclass: &reclass
+        storage_type: yaml_fs
+        base_inventory_uri: /srv/salt
+        reclass_source_path: ~/code/reclass
 
-    PYTHONPATH=~/code/reclass:$PYTHONPATH salt-master ...
+    ext_pillar:
+        - reclass: *reclass
+
+    master_tops:
+        reclass: *reclass
+
+If you want to run reclass from source, rather than installing it, you can
+either let the master know via the ``PYTHONPATH`` environment variable, or by
+setting the configuration option, like in the example above.
 '''
 # This file cannot be called reclass.py, because then the module import would
 # not work. Thanks to the __virtual__ function, however, the plugin still
 # responds to the name 'reclass'.
 
-try:
-    from reclass.adapters.salt import top as reclass_top
-    from reclass.errors import ReclassException
-    __virtual__ = lambda: 'reclass'
+from salt.utils.reclass import prepend_reclass_source_path, \
+        filter_out_source_path_option
 
-except ImportError:
-    __virtual__ = lambda: False
+def __virtual__(retry=False):
+    try:
+        import reclass
+        return 'reclass'
+    except ImportError:
+        if retry:
+            return False
+
+        opts = __opts__.get('master_tops', {}).get('reclass', {})
+        prepend_reclass_source_path(opts)
+        return __virtual__(retry=True)
 
 from salt.exceptions import SaltInvocationError
 
 def top(**kwargs):
+    # If reclass is installed, __virtual__ put it onto the search path, so we
+    # don't need to protect against ImportError:
+    from reclass.adapters.salt import top as reclass_top
+    from reclass.errors import ReclassException
+
     try:
         # Salt's top interface is inconsistent with ext_pillar (see #5786) and
         # one is expected to extract the arguments to the master_tops plugin
@@ -52,11 +70,22 @@ def top(**kwargs):
         # to hide this internality.
         reclass_opts = __opts__['master_tops']['reclass']
 
+        # the source path we used above isn't something reclass needs to care
+        # about, so filter it:
+        filter_out_source_path_option(reclass_opts)
+
         # I purposely do not pass any of __opts__ or __salt__ or __grains__
         # to reclass, as I consider those to be Salt-internal and reclass
         # should not make any assumptions about it. Reclass only needs to know
         # how it's configured, so:
         return reclass_top(**reclass_opts)
+
+    except ImportError as e:
+        if e.message.find('reclass') > -1:
+            raise SaltInvocationError('master_tops.reclass: cannot find reclass '\
+                                      'module in ' + sys.path)
+        else:
+            raise
 
     except TypeError as e:
         if e.message.find('unexpected keyword argument') > -1:

--- a/salt/utils/reclass.py
+++ b/salt/utils/reclass.py
@@ -1,0 +1,15 @@
+'''
+Common utility functions for the reclass adapters
+'''
+import os, sys
+
+def prepend_reclass_source_path(opts):
+    source_path = opts.get('reclass_source_path')
+    if source_path:
+        source_path = os.path.abspath(os.path.expanduser(source_path))
+        sys.path.insert(0, source_path)
+
+def filter_out_source_path_option(opts):
+    if 'reclass_source_path' in opts:
+        del opts['reclass_source_path']
+    # no return required, object was passed by reference

--- a/salt/utils/reclass.py
+++ b/salt/utils/reclass.py
@@ -13,3 +13,11 @@ def filter_out_source_path_option(opts):
     if 'reclass_source_path' in opts:
         del opts['reclass_source_path']
     # no return required, object was passed by reference
+
+def set_inventory_base_uri_default(config, opts):
+    if 'inventory_base_uri' in opts:
+        return
+
+    base_roots = config.get('file_roots', {}).get('base', [])
+    if len(base_roots) > 0:
+        opts['inventory_base_uri'] = base_roots[0]


### PR DESCRIPTION
These three commits improve the reclass adapters in backwards-compatible ways.
1. Logging messages are amended;
2. It is not possible to specify the path to a reclass source checkout in the Salt master configuration file, if reclass isn't properly installed;
3. reclass is made to default to looking for its inventory in the first 'file_roots' or class 'base' (this isn't yet working due to Salt issue #5951).
