### PR TITLE
Fix traceback in publish module

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -69,7 +69,8 @@ def _publish(
         return '{0!r} publish timed out'.format(fun)
     if not peer_data:
         return {}
-    time.sleep(timeout)
+    # CLI args are passed as strings, re-cast to keep time.sleep happy
+    time.sleep(float(timeout))
     load = {'cmd': 'pub_ret',
             'id': __opts__['id'],
             'tok': tok,


### PR DESCRIPTION
This fixes #5959 by re-casting the timeout value so that it is of the
proper type to be passed to time.sleep. Salt CLI args are loaded as
strings, which time.sleep does not like.
