### PR TITLE
Fix bug in suse initscripts

### DIFF
--- a/pkg/suse/salt-master
+++ b/pkg/suse/salt-master
@@ -130,7 +130,7 @@ case "$1" in
     reload)
         echo "can't reload configuration, you have to restart it"
         if [ -f $SUSE_RELEASE ]; then
-        	rc status -v
+        	rc_status -v
         else
         	RETVAL=$?
         fi

--- a/pkg/suse/salt-minion
+++ b/pkg/suse/salt-minion
@@ -134,7 +134,7 @@ case "$1" in
     reload)
         echo "can't reload configuration, you have to restart it"
         if [ -f $SUSE_RELEASE ]; then
-        	rc status -v
+        	rc_status -v
         else
         	RETVAL=$?
         fi


### PR DESCRIPTION
'rc status' is not valid for suse initscripts, 'rc_status' must be used
instead. Fixes #5954.
