### PR TITLE
Fix traceback in peer publish system

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -534,7 +534,8 @@ class Minion(object):
         # Verify that the publication applies to this minion
         if 'tgt_type' in data:
             if not getattr(self.matcher,
-                           '{0}_match'.format(data['tgt_type']))(data['tgt']):
+                           '{0}_match'.format(data['tgt_type']))(data['tgt'],
+                           False):
                 return
         else:
             if not self.matcher.glob_match(data['tgt']):


### PR DESCRIPTION
This fixes #5958 by adding a default value for the call to getattr().
