### PR TITLE
Quiet warning for missing default_path kwarg

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -245,7 +245,8 @@ def grains(opts):
     if 'conf_file' in opts:
         pre_opts = {}
         pre_opts.update(salt.config.load_config(
-            opts['conf_file'], 'SALT_MINION_CONFIG'
+            opts['conf_file'], 'SALT_MINION_CONFIG',
+            salt.config.DEFAULT_MINION_OPTS['conf_file']
         ))
         default_include = pre_opts.get(
             'default_include', opts['default_include']


### PR DESCRIPTION
This fixes #5956 by passing the default path for the minion config file,
as obtained from `salt.config.DEFAULT_MINION_OPTS['conf_file']`.
