### PR TITLE
spelling: dependant ==> dependent

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -41,7 +41,7 @@ def _available_commands():
     # Note that we append '|| :' as a unix hack to force return code to be 0.
     res = salt_cmd.run_all('{0} help || :'.format(zfs_path))
 
-    # This bit is dependant on specific output from `zfs help` - any major changes
+    # This bit is dependent on specific output from `zfs help` - any major changes
     # in how this works upstream will require a change.
     for line in res['stderr'].splitlines():
         if re.match('	[a-zA-Z]', line):

--- a/salt/utils/decorators.py
+++ b/salt/utils/decorators.py
@@ -51,15 +51,15 @@ class Depends(object):
 
         It will modify the "functions" dict and remove/replace modules that are missing dependencies
         '''
-        for dependency, dependant_set in cls.dependency_dict.iteritems():
+        for dependency, dependent_set in cls.dependency_dict.iteritems():
             # check if dependency is loaded
-            for module, func, fallback_funcion in dependant_set:
+            for module, func, fallback_funcion in dependent_set:
                 # check if you have the dependency
                 if dependency in dir(module):
                     logging.debug('Dependency ({0}) already loaded inside {1}, skipping'.format(dependency, module.__name__.split('.')[-1]))
                     continue
                 logging.debug('Unloading {0}.{1} because dependency ({2}) is not imported'.format(module, func, dependency))
-                # if not, unload dependand_set
+                # if not, unload dependent_set
                 mod_key = '{0}.{1}'.format(module.__name__.split('.')[-1],
                                            func.__name__)
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -132,7 +132,7 @@ del __get_version
 
 def versions_information():
     '''
-    Report on all of the versions for dependant software
+    Report on all of the versions for dependent software
     '''
     libs = (
         ('Salt', None, __version__),


### PR DESCRIPTION
"dependant" is apparently valid as a noun in British English, but it's being used as an adjective here.
"dependent" is preferred for both the noun and adjective in American English.
And "dependancy" isn't valid anywhere, which makes "dependant"  kinda confusing anyway.
