### PR TITLE
fix salt-syndic Fixes #5954.

### DIFF
--- a/pkg/suse/salt-syndic
+++ b/pkg/suse/salt-syndic
@@ -126,7 +126,7 @@ case "$1" in
    reload)
         echo "can't reload configuration, you have to restart it"
         if [ -f $SUSE_RELEASE ]; then
-        	rc status -v
+        	rc_status -v
         else
         	RETVAL=$?
         fi


### PR DESCRIPTION
missed salt-syndic init script rc_status is the right command
