### PR TITLE
call dict.__init__() in OrderedDict.__init__()

### DIFF
--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -53,6 +53,7 @@ except ImportError:
                 because their insertion order is arbitrary.
 
                 '''
+                super(OrderedDict, self).__init__()
                 if len(args) > 1:
                     raise TypeError('expected at most 1 arguments, got %d' % len(args))
                 try:


### PR DESCRIPTION
Best-practice; squelches a pylint warning. Did this before in #4716, but that seems to have been lost during the switch to a different `OrderedDict` recipe.

```
************* Module salt.utils.odict
W0231: 50,12:OrderedDict.__init__: __init__ method from base class 'dict' is not called
```
