### PR TITLE
pylint pragmas: `enable-msg` is deprecated, replace it with `enable`

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -146,4 +146,4 @@ if PY3:
     from io import StringIO
 else:
     from StringIO import StringIO
-# pylint: enable-msg=C0103
+# pylint: enable=C0103

--- a/salt/log.py
+++ b/salt/log.py
@@ -222,7 +222,7 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS):
         return LOGGING_LOGGER_CLASS.makeRecord(
             self, name, level, fn, lno, msg, args, exc_info, func, extra
         )
-    # pylint: enable-msg=C0103
+    # pylint: enable=C0103
 
 
 # Override the python's logging logger class as soon as this module is imported

--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -47,7 +47,7 @@ if os.name == 'nt':  # pragma: no cover
         _CommitTransaction = ctypes.windll.ktmw32.CommitTransaction
         _MoveFileTransacted = ctypes.windll.kernel32.MoveFileTransactedW
         _CloseHandle = ctypes.windll.kernel32.CloseHandle
-        # pylint: enable-msg=C0103
+        # pylint: enable=C0103
         CAN_RENAME_OPEN_FILE = True
 
         def _rename_atomic(src, dst):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -82,7 +82,7 @@ def ip_to_host(ip):
         hostname = None
     return hostname
 
-# pylint: enable-msg=C0103
+# pylint: enable=C0103
 
 
 def _cidr_to_ipv4_netmask(cidr_bits):
@@ -124,7 +124,7 @@ def _number_of_set_bits(x):
     x += x >> 16
     return x & 0x0000003f
 
-# pylint: enable-msg=C0103
+# pylint: enable=C0103
 
 
 def _interfaces_ip(out):


### PR DESCRIPTION
Squelches pylint runtime `DeprecationWarning: enable-msg is deprecated, replace it with enable` messages.
Parallels PR #5931.
