### PR TITLE
Integrate pylint into Travis build process

### DIFF
--- a/.travis.pylintrc
+++ b/.travis.pylintrc
@@ -1,0 +1,136 @@
+[MASTER]
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+init-hook="
+  exec 'aW1wb3J0IG9zLCBzeXMKCmlmICdWSVJUVUFMX0VOVicgaW4gb3MuZW52aXJvbjoKCiAgICB2ZV9k \
+  aXIgPSBvcy5lbnZpcm9uWydWSVJUVUFMX0VOViddCiAgICB2ZV9kaXIgaW4gc3lzLnBhdGggb3Ig \
+  c3lzLnBhdGguaW5zZXJ0KDAsIHZlX2RpcikKICAgIGFjdGl2YXRlX3RoaXMgPSBvcy5wYXRoLmpv \
+  aW4ob3MucGF0aC5qb2luKHZlX2RpciwgJ2JpbicpLCAnYWN0aXZhdGVfdGhpcy5weScpCgogICAg \
+  IyBGaXggZm9yIHdpbmRvd3MKICAgIGlmIG5vdCBvcy5wYXRoLmV4aXN0cyhhY3RpdmF0ZV90aGlz \
+  KToKICAgICAgICBhY3RpdmF0ZV90aGlzID0gb3MucGF0aC5qb2luKG9zLnBhdGguam9pbih2ZV9k \
+  aXIsICdTY3JpcHRzJyksICdhY3RpdmF0ZV90aGlzLnB5JykKCiAgICBleGVjZmlsZShhY3RpdmF0 \
+  ZV90aGlzLCBkaWN0KF9fZmlsZV9fPWFjdGl2YXRlX3RoaXMpKQo='.decode('base64')"
+# Pickle collected data for later comparisons.
+persistent=no
+
+
+[MESSAGES CONTROL]
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time. See also the "--disable" option for examples.
+#enable=E0001,E0100,E0101,E0102,E0103,E0104,E0105,E0106,E0107,E0108,E0202,E0203,E0211,E0213,E0221,E0222,E0601,E0602,E0603,E0604,E0701,E0702,E0710,E0711,E1001,E1002,E1003,E1102,E1111,E1120,E1121,E1122,E1123,E1124,E1200,E1201,E1205,E1206,E1300,E1301,E1302,E1303,E1304,E1305,E1306,E1310,C0112,C0121,C0202,C0321,C0322,C0323,C0324,W0101,W0102,W0104,W0105,W0106,W0107,W0108,W0109,W0120,W0141,W0150,W0199,W0211,W0221,W0222,W0223,W0231,W0232,W0233,W0301,W0311,W0312,W0331,W0332,W0333,W0401,W0402,W0403,W0406,W0410,W0601,W0602,W0604,W0614,W0623,W0701,W0702,W0703,W0710,W0711,W1001,W1111,W1201,W1300,W1301,W1401,W1402,F0202
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=R,
+  I0011,
+  E1101,
+  E1103,
+  C0102,
+  C0103,
+  C0111,
+  C0203,
+  C0204,
+  C0301,
+  C0302,
+  W0110,
+  W0122,
+  W0142,
+  W0201,
+  W0212,
+  W0404,
+  W0511,
+  W0603,
+  W0611,
+  W0612,
+  W0613,
+  W0621,
+  W0622,
+  W0631,
+  W0704,
+  F0220,
+  F0401
+
+# Disabled:
+# R* [refactoring suggestions & reports]
+# I0011 (locally-disabling)
+# E1101 (no-member) [pylint isn't smart enough]
+# E1103 (maybe-no-member)
+# C0102 (blacklisted-name) [because it activates C0103 too]
+# C0103 (invalid-name)
+# C0111 (missing-docstring)
+# C0203 (bad-mcs-method-argument)
+# C0204 (bad-mcs-classmethod-argument)
+# C0301 (line-too-long)
+# C0302 (too-many-lines)
+# W0110 (deprecated-lambda)
+# W0122 (exec-statement)
+# W0142 (star-args)
+# W0201 (attribute-defined-outside-init) [done in several places in the codebase]
+# W0212 (protected-access)
+# W0404 (reimported) [done intentionally for legit reasons]
+# W0511 (fixme) [several outstanding instances currently in the codebase]
+# W0603 (global-statement)
+# W0611 (unused-import) [used to check for module availability]
+# W0612 (unused-variable) [unused return values]
+# W0613 (unused-argument)
+# W0621 (redefined-outer-name)
+# W0622 (redefined-builtin) [many parameter names shadow builtins]
+# W0631 (undefined-loop-variable) [~3 instances, seem to be okay]
+# W0704 (pointless-except) [misnomer; "ignores the exception" rather than "pointless"]
+# F0220 (unresolved-interface)
+# F0401 (import-error)
+
+
+[REPORTS]
+
+# Include message's id in output
+include-ids=yes
+
+# Include symbolic ids of messages in output
+symbols=no
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+
+[BASIC]
+
+# List of builtins function names that should not be used, separated by a comma
+bad-functions=apply,input
+
+
+[FORMAT]
+
+# String used as indentation unit. This is usually " " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__
+
+
+[IMPORTS]
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,TERMIOS,Bastion,rexec
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=BaseException

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,14 @@ before_install:
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
   - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io mock
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
-  - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io coveralls
+  - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io pylint coveralls
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io unittest2 ordereddict; fi"
   - pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
 
 install: pip install -r requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io
 
-script: "sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo -v --coverage --no-coverage-report'"
+script: "pylint --rcfile=.travis.pylintrc salt/ && \
+        sudo -E /home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/python setup.py test --runtests-opts='--run-destructive --sysinfo -v --coverage --no-coverage-report'"
 
 after_script:
   - coveralls

--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -111,6 +111,7 @@ Python 2: If ``s`` is an instance of ``text_type``, return
 '''
 
 if PY3:
+    # pylint: disable=E0611
     from urllib.parse import urlparse
     from urllib.error import URLError
     import http.server as BaseHTTPServer

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -5,7 +5,7 @@ Manage and query NPM packages.
 # Import python libs
 import json
 import logging
-import distutils.version
+import distutils.version  # pylint: disable=E0611
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -9,7 +9,7 @@ import re
 import yaml
 import pprint
 import logging
-import distutils.version
+import distutils.version  # pylint: disable=E0611
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -25,7 +25,7 @@ import logging
 import msgpack
 import os
 import locale
-from distutils.version import LooseVersion
+from distutils.version import LooseVersion  # pylint: disable=E0611
 
 # Import salt libs
 import salt.utils

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -53,7 +53,7 @@ if salt.utils.is_windows():
     # The following imports are used by the namespaced win_pkg funcs
     # and need to be included in their globals.
     import msgpack
-    from distutils.version import LooseVersion
+    from distutils.version import LooseVersion  # pylint: disable=E0611
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/atomicfile.py
+++ b/salt/utils/atomicfile.py
@@ -24,7 +24,7 @@ if os.name == 'nt':  # pragma: no cover
         _MOVEFILE_WRITE_THROUGH = 0x8
         _MoveFileEx = ctypes.windll.kernel32.MoveFileExW  # pylint: disable=C0103
 
-        def _rename(src, dst):
+        def _rename(src, dst):  # pylint: disable=E0102
             if not isinstance(src, unicode):
                 src = unicode(src, sys.getfilesystemencoding())
             if not isinstance(dst, unicode):
@@ -50,7 +50,7 @@ if os.name == 'nt':  # pragma: no cover
         # pylint: enable=C0103
         CAN_RENAME_OPEN_FILE = True
 
-        def _rename_atomic(src, dst):
+        def _rename_atomic(src, dst):  # pylint: disable=E0102
             tra = _CreateTransaction(None, 0, 0, 0, 0, 1000, 'Atomic rename')
             if tra == -1:
                 return False

--- a/salt/utils/filebuffer.py
+++ b/salt/utils/filebuffer.py
@@ -105,7 +105,7 @@ def _main():
 
         breader = BufferedReader(fpath, max_size, chunk_size)
         for chunk in breader:
-            chunk
+            chunk  # pylint: disable=W0104
         return
 
     def sizeof_fmt(num):

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -53,7 +53,7 @@ except ImportError:
                 because their insertion order is arbitrary.
 
                 '''
-                super(OrderedDict, self).__init__()
+                super(OrderedDict, self).__init__()  # pylint: disable=E1003
                 if len(args) > 1:
                     raise TypeError('expected at most 1 arguments, got %d' % len(args))
                 try:

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -47,7 +47,7 @@ except ImportError:
             # The sentinel element never gets deleted (this simplifies the algorithm).
             # Each link is stored as a list of length three:  [PREV, NEXT, KEY].
 
-            def __init__(self, *args, **kwds):
+            def __init__(self, *args, **kwds):  # pylint: disable=E1003
                 '''Initialize an ordered dictionary.  Signature is the same as for
                 regular dictionaries, but keyword arguments are not recommended
                 because their insertion order is arbitrary.

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -16,7 +16,7 @@
 '''
 
 try:
-    from collections import OrderedDict
+    from collections import OrderedDict  # pylint: disable=E0611
 except ImportError:
     try:
         from ordereddict import OrderedDict

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -217,7 +217,7 @@ except ImportError:
                 self[key] = default
                 return default
 
-            def __repr__(self, _repr_running={}):
+            def __repr__(self, _repr_running={}):  # pylint: disable=W0102
                 'od.__repr__() <==> repr(od)'
                 call_key = id(self), _get_ident()
                 if call_key in _repr_running:

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -162,7 +162,7 @@ except ImportError:
                 for k in self:
                     yield (k, self[k])
 
-            def update(*args, **kwds):
+            def update(*args, **kwds):  # pylint: disable=E0211
                 '''od.update(E, **F) -> None.  Update od from dict/iterable E and F.
 
                 If E is a dict instance, does:           for k in E: od[k] = E[k]

--- a/salt/version.py
+++ b/salt/version.py
@@ -22,7 +22,7 @@ def __get_version(version, version_info):
     '''
     try:
         # Try to import the version information provided at install time
-        from salt._version import __version__, __version_info__
+        from salt._version import __version__, __version_info__  # pylint: disable=E0611
         return __version__, __version_info__
     except ImportError:
         pass


### PR DESCRIPTION
So, I'm finally starting to tire of making lots of pull requests to fix the relatively easy/simple/obvious issues that pylint reports. Hence, this pull request :stuck_out_tongue_winking_eye:

This pull request adds a pylint step to Salt's Travis build. The configuration has been painstakingly tweaked to avoid checks that are prone to false positives or with which the codebase does not already almost completely comply.

This PR also adds a select few pragma comments to manually ignore outstanding instances of a few high-value checks (it's several commits for ease of future auditing, but it adds up to only 14 Python lines changed in total).

With this configuration, pylint currently reports [only 5 violations](https://travis-ci.org/cvrebert/salt/jobs/8983127); these are due exclusively to issues #4681 and #5865.
