### PR TITLE
__NewStyleClassMixIn => _NewStyleClassMixIn

### DIFF
--- a/salt/log.py
+++ b/salt/log.py
@@ -138,7 +138,7 @@ class LoggingMixInMeta(type):
         )
 
 
-class __NewStyleClassMixIn(object):
+class _NewStyleClassMixIn(object):
     '''
     Simple new style class to make pylint shut up!
     This is required because SaltLoggingClass can't subclass object directly:
@@ -147,7 +147,7 @@ class __NewStyleClassMixIn(object):
     '''
 
 
-class SaltLoggingClass(LOGGING_LOGGER_CLASS, __NewStyleClassMixIn):
+class SaltLoggingClass(LOGGING_LOGGER_CLASS, _NewStyleClassMixIn):
     __metaclass__ = LoggingMixInMeta
 
     def __new__(cls, logger_name):


### PR DESCRIPTION
One underscore is sufficient to indicate that the class is "private". Unlike a method or attribute, double-underscore in a class name doesn't result in name mangling.

```
************* Module salt.log
C0103:141,0:__NewStyleClassMixIn: Invalid name "__NewStyleClassMixIn" for type class (should match [A-Z_][a-zA-Z0-9]+$)
```
