### PR TITLE
cli/caller.py: rm unused import of `yaml`

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -25,9 +25,6 @@ from salt.exceptions import (
     CommandExecutionError,
 )
 
-# Import third party libs
-import yaml
-
 
 class Caller(object):
     '''


### PR DESCRIPTION
```
************* Module salt.cli.caller
W0611: 29,0: Unused import yaml
```
