### PR TITLE
Only Syndic minions have .local; push .local cleanup down into Syndic class

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1122,8 +1122,6 @@ class Minion(object):
             self.socket.close()
         if hasattr(self, 'context') and self.context.closed is False:
             self.context.term()
-        if hasattr(self, 'local'):
-            del self.local
 
     def __del__(self):
         self.destroy()
@@ -1296,6 +1294,14 @@ class Syndic(Minion):
                     'An exception occurred while polling the syndic',
                     exc_info=True
                 )
+
+    def destroy(self):
+        '''
+        Tear down the syndic minion
+        '''
+        super(Syndic, self).destroy()
+        if hasattr(self, 'local'):
+            del self.local
 
 
 class Matcher(object):


### PR DESCRIPTION
```
************* Module salt.minion
E1101:1126,16:Minion.destroy: Instance of 'Minion' has no 'local' member
```
