### PR TITLE
Fix pip module for python 3

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -36,7 +36,7 @@ def _get_pip_bin(bin_env):
         which_result = __salt__['cmd.which_bin'](['pip2', 'pip', 'pip-python'])
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
-        return which_result
+        return which_result, 'base'
 
     # try to get pip bin from env
     if os.path.isdir(bin_env):
@@ -45,13 +45,13 @@ def _get_pip_bin(bin_env):
         else:
             pip_bin = os.path.join(bin_env, 'bin', 'pip')
         if os.path.isfile(pip_bin):
-            return pip_bin
+            return pip_bin, {'VIRTUAL_ENV': bin_env}
         raise CommandNotFoundError('Could not find a `pip` binary')
 
-    return bin_env
+    return bin_env, 'base'
 
 
-def _get_cached_requirements(requirements):
+def _get_cached_requirements(requirements, __env__):
     '''Get the location of a cached requirements file; caching if necessary.'''
     cached_requirements = __salt__['cp.is_cached'](
         requirements, __env__
@@ -114,8 +114,7 @@ def install(pkgs=None,
             runas=None,
             no_chown=False,
             cwd=None,
-            activate=False,
-            __env__='base'):
+            activate=False):
     '''
     Install packages with pip
 
@@ -229,7 +228,8 @@ def install(pkgs=None,
     if env and not bin_env:
         bin_env = env
 
-    cmd = [_get_pip_bin(bin_env), 'install']
+    pip_bin, __env__ = _get_pip_bin(bin_env)
+    cmd = [pip_bin, 'install']
 
     if activate and bin_env:
         if not salt.utils.is_windows():
@@ -272,7 +272,7 @@ def install(pkgs=None,
     treq = None
     if requirements:
         if requirements.startswith('salt://'):
-            cached_requirements = _get_cached_requirements(requirements)
+            cached_requirements = _get_cached_requirements(requirements, __env__)
             if not cached_requirements:
                 return {
                     'result': False,
@@ -414,7 +414,7 @@ def install(pkgs=None,
             cmd.append('--install-option={0}'.format(opt))
 
     try:
-        return __salt__['cmd.run_all'](' '.join(cmd), runas=runas, cwd=cwd)
+        return __salt__['cmd.run_all'](' '.join(cmd), runas=runas, cwd=cwd, env=__env__)
     finally:
         if treq is not None:
             try:
@@ -430,8 +430,7 @@ def uninstall(pkgs=None,
               proxy=None,
               timeout=None,
               runas=None,
-              cwd=None,
-              __env__='base'):
+              cwd=None):
     '''
     Uninstall packages with pip
 
@@ -475,7 +474,8 @@ def uninstall(pkgs=None,
         salt '*' pip.uninstall <package name> bin_env=/path/to/pip_bin
 
     '''
-    cmd = [_get_pip_bin(bin_env), 'uninstall', '-y']
+    pip_bin, __env__ = _get_pip_bin(bin_env)
+    cmd = [pip_bin, 'uninstall', '-y']
 
     if pkgs:
         if isinstance(pkgs, basestring):
@@ -514,7 +514,7 @@ def uninstall(pkgs=None,
             )
         cmd.append('--timeout={0}'.format(timeout))
 
-    result = __salt__['cmd.run_all'](' '.join(cmd), runas=runas, cwd=cwd)
+    result = __salt__['cmd.run_all'](' '.join(cmd), runas=runas, cwd=cwd, env=__env__)
 
     if treq and requirements.startswith('salt://'):
         try:
@@ -547,10 +547,10 @@ def freeze(bin_env=None,
 
         salt '*' pip.freeze /home/code/path/to/virtualenv/
     '''
+    pip_bin, __env__ = _get_pip_bin(bin_env)
+    cmd = '{0} freeze'.format(pip_bin)
 
-    cmd = '{0} freeze'.format(_get_pip_bin(bin_env))
-
-    result = __salt__['cmd.run_all'](cmd, runas=runas, cwd=cwd)
+    result = __salt__['cmd.run_all'](cmd, runas=runas, cwd=cwd, env=__env__)
 
     if result['retcode'] > 0:
         raise CommandExecutionError(result['stderr'])
@@ -572,9 +572,10 @@ def list_(prefix='',
     '''
     packages = {}
 
-    cmd = '{0} freeze'.format(_get_pip_bin(bin_env))
+    pip_bin, __env__ = _get_pip_bin(bin_env)
+    cmd = '{0} freeze'.format(pip_bin)
 
-    result = __salt__['cmd.run_all'](cmd, runas=runas, cwd=cwd)
+    result = __salt__['cmd.run_all'](cmd, runas=runas, cwd=cwd, env=__env__)
     if result['retcode'] > 0:
         raise CommandExecutionError(result['stderr'])
 


### PR DESCRIPTION
Pip module now sets VIRTUAL_ENV environment before calling pip. Otherwise pip doesn't work in pyvenv-created environments.

Prerequisite for #5494.
