### PR TITLE
Serialize dataset into file states and jinja templates

### DIFF
--- a/doc/ref/renderers/all/salt.renderers.jinja.rst
+++ b/doc/ref/renderers/all/salt.renderers.jinja.rst
@@ -99,6 +99,33 @@ the context into the included file is required:
 
 .. _imports: http://jinja.pocoo.org/docs/templates/#import
 
+Variable Serializers
+====================
+
+Salt allows to serialize any variable into **json** or **yaml**. For example this
+variable::
+
+    data:
+      foo: True
+      bar: 42
+      baz:
+        - 1
+        - 2
+        - 3
+      qux: 2.0
+
+with this template::
+
+    yaml -> {{ data|yaml }}
+
+    json -> {{ data|json }}
+
+will be rendered has::
+
+    yaml -> {bar: 42, baz: [1, 2, 3], foo: true, qux: 2.0}
+
+    json -> {"baz": [1, 2, 3], "foo": true, "bar": 42, "qux": 2.0}
+
 Template Inheritance
 ====================
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -132,6 +132,10 @@ import logging
 import copy
 import re
 import fnmatch
+import json
+
+# Import third party libs
+import yaml
 
 # Import salt libs
 import salt.utils
@@ -2096,3 +2100,87 @@ def accumulated(name, filename, text, **kwargs):
             ret['comment'] = ('Accumulator {0} for file {1} '
                               'was charged by text'.format(name, filename))
     return ret
+
+
+def serialize(name,
+            dataset,
+            user=None,
+            group=None,
+            mode=None,
+            env=None,
+            backup='',
+            show_diff=True,
+            create=True,
+            **kwargs):
+    """
+    Manages files which contents is serialized dataset.
+
+    name
+        The location of the symlink to create
+
+    dataset
+        the dataset that will be serialized
+
+    formatter
+        the formatter, currently only yaml and json are supported
+
+    user
+        The user to own the directory, this defaults to the user salt is
+        running as on the minion
+
+    group
+        The group ownership set for the directory, this defaults to the group
+        salt is running as on the minion
+
+    mode
+        The permissions to set on this file, aka 644, 0775, 4664
+
+    backup
+        Overrides the default backup mode for this specific file.
+
+    show_diff
+        If set to False, the diff will not be shown.
+
+    create
+        Default is True, if create is set to False then the file will only be
+        managed if the file already exists on the system.
+
+    """
+    ret = {'changes': {},
+           'comment': '',
+           'name': name,
+           'result': True}
+
+    if not create:
+        if not os.path.isfile(name):
+            # Don't create a file that is not already present
+            ret['comment'] = ('File {0} is not present and is not set for '
+                              'creation').format(name)
+            return ret
+
+    formatter = kwargs.pop('formatter', 'yaml').lower()
+    if formatter == 'yaml':
+        contents = yaml.dump(dataset, default_flow_style=False)
+    elif formatter == 'json':
+        contents = json.dumps(dataset, ent=4, separators=(',', ': '))
+    else:
+        return {'changes': {},
+                'comment': '{0} format is not supported'.format(
+                    formatter.capitalized()),
+                'name': name,
+                'result': False
+               }
+
+    return __salt__['file.manage_file'](name=name,
+                                        sfn='',
+                                        ret=ret,
+                                        source = None,
+                                        source_sum = {},
+                                        user=user,
+                                        group=group,
+                                        mode=mode,
+                                        env=env,
+                                        backup=backup,
+                                        template=None,
+                                        show_diff=show_diff,
+                                        contents=contents)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1975,11 +1975,11 @@ def rename(name, source, force=False, makedirs=False):
     source
         The location of the file to move to the location specified with name
 
-    force:
+    force
         If the target location is present then the file will not be moved,
         specify "force: True" to overwrite the target file
 
-    makedirs:
+    makedirs
         If the target subdirectories don't exist create them
 
     '''
@@ -2113,7 +2113,8 @@ def serialize(name,
             create=True,
             **kwargs):
     """
-    Manages files which contents is serialized dataset.
+    Serializes dataset and store it into managed file. Useful for sharing
+    simple configuration files.
 
     name
         The location of the symlink to create
@@ -2145,7 +2146,35 @@ def serialize(name,
         Default is True, if create is set to False then the file will only be
         managed if the file already exists on the system.
 
+
+    For example, this state::
+
+        /etc/dummy/package.json:
+          file.serialize:
+            - dataset:
+                name: naive
+                description: A package using naive versioning
+                author: A confused individual <iam@confused.com>
+                dependencies:
+                    express: >= 1.2.0
+                    optimist: >= 0.1.0
+                engine: node 0.4.1
+            - formatter: json
+
+    will manages the file ``/etc/dummy/package.json``::
+
+        {
+          "author": "A confused individual <iam@confused.com>",
+          "dependencies": {
+            "express": ">= 1.2.0",
+            "optimist": ">= 0.1.0"
+          },
+          "description": "A package using naive versioning",
+          "engine": "node 0.4.1"
+          "name": "naive",
+        }
     """
+
     ret = {'changes': {},
            'comment': '',
            'name': name,
@@ -2162,7 +2191,7 @@ def serialize(name,
     if formatter == 'yaml':
         contents = yaml.dump(dataset, default_flow_style=False)
     elif formatter == 'json':
-        contents = json.dumps(dataset, indent=4, separators=(',', ': '))
+        contents = json.dumps(dataset, indent=2, separators=(',', ': '), sort_keys=True)
     else:
         return {'changes': {},
                 'comment': '{0} format is not supported'.format(

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2162,7 +2162,7 @@ def serialize(name,
     if formatter == 'yaml':
         contents = yaml.dump(dataset, default_flow_style=False)
     elif formatter == 'json':
-        contents = json.dumps(dataset, ent=4, separators=(',', ': '))
+        contents = json.dumps(dataset, indent=4, separators=(',', ': '))
     else:
         return {'changes': {},
                 'comment': '{0} format is not supported'.format(

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -133,7 +133,7 @@ class SerializerExtension(Extension):
 
     def format(self, value, formatter, *args, **kwargs):
         if formatter == "json":
-            return Markup(json.dumps(value))
+            return Markup(json.dumps(value, sort_keys=True))
         elif formatter == "yaml":
             return Markup(yaml.dump(value, default_flow_style=True))
         raise ValueError("Serializer {} is not implemented".format(formatter))

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -5,10 +5,13 @@ Jinja loading utils to enable a more powerful backend for jinja templates
 # Import python libs
 from os import path
 import logging
+from functools import partial
+import json
 
 # Import third party libs
-from jinja2 import BaseLoader
-from jinja2.exceptions import TemplateNotFound
+from jinja2 import BaseLoader, Markup, TemplateNotFound
+from jinja2.ext import Extension
+import yaml
 
 # Import salt libs
 import salt
@@ -16,6 +19,10 @@ import salt.fileclient
 
 log = logging.getLogger(__name__)
 
+__all__ = [
+    'SaltCacheLoader',
+    'SerializerExtension'
+]
 
 class SaltCacheLoader(BaseLoader):
     '''
@@ -88,3 +95,45 @@ class SaltCacheLoader(BaseLoader):
                 continue
         # there is no template file within searchpaths
         raise TemplateNotFound(template)
+
+
+class SerializerExtension(Extension):
+    """
+    Serializes variables.
+
+    For example, this dataset:
+
+    .. code-block:: python
+
+        data = {
+            "foo": True,
+            "bar": 42,
+            "baz": [1, 2, 3],
+            "qux": 2.0
+        }
+
+    .. code-block:: jinja
+
+        yaml = {{ data|yaml }}
+        json = {{ data|json }}
+
+    will be rendered has::
+
+        yaml = {bar: 42, baz: [1, 2, 3], foo: true, qux: 2.0}
+        json = {"baz": [1, 2, 3], "foo": true, "bar": 42, "qux": 2.0}
+
+    """
+
+    def __init__(self, environment):
+        self.environment = environment
+        environment.filters.update({
+            'yaml': partial(self.format, formatter='yaml'),
+            'json': partial(self.format, formatter='json')
+        })
+
+    def format(self, value, formatter, *args, **kwargs):
+        if formatter == "json":
+            return Markup(json.dumps(value))
+        elif formatter == "yaml":
+            return Markup(yaml.dump(value, default_flow_style=True))
+        raise ValueError("Serializer {} is not implemented".format(formatter))

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -108,7 +108,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         env_args['extensions'].append('jinja2.ext.do')
     if hasattr(jinja2.ext, 'loopcontrols'):
         env_args['extensions'].append('jinja2.ext.loopcontrols')
-    jinja_env.add_extension(JinjaSerializerExtension)
+    env_args['extensions'].append(JinjaSerializerExtension)
 
     if opts.get('allow_undefined', False):
         jinja_env = jinja2.Environment(**env_args)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -21,6 +21,7 @@ import jinja2.ext
 import salt.utils
 import salt.exceptions
 from salt.utils.jinja import SaltCacheLoader as JinjaSaltCacheLoader
+from salt.utils.jinja import SerializerExtension as JinjaSerializerExtension
 
 log = logging.getLogger(__name__)
 
@@ -107,6 +108,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         env_args['extensions'].append('jinja2.ext.do')
     if hasattr(jinja2.ext, 'loopcontrols'):
         env_args['extensions'].append('jinja2.ext.loopcontrols')
+    jinja_env.add_extension(JinjaSerializerExtension)
 
     if opts.get('allow_undefined', False):
         jinja_env = jinja2.Environment(**env_args)

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -1,0 +1,57 @@
+# Import python libs
+import json
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import third party libs
+import yaml
+
+try:
+    from mock import MagicMock, patch
+    has_mock = True
+except ImportError:
+    has_mock = False
+
+if has_mock:
+    import salt.states.file as filestate
+    filestate.__salt__ = {
+        'file.manage_file': False
+    }
+    filestate.__opts__ = {'test': False}
+
+
+@skipIf(has_mock is False, 'mock python module is unavailable')
+class TestFileState(TestCase):
+
+    def test_serialize(self):
+        def returner(contents, *args, **kwargs):
+            returner.returned = contents
+        returner.returned = None
+
+
+        filestate.__salt__ = {
+            'file.manage_file': returner
+        }
+
+        dataset = {
+            "foo": True,
+            "bar": 42,
+            "baz": [1, 2, 3],
+            "qux": 2.0
+        }
+
+        filestate.serialize('/tmp', dataset)
+        self.assertEquals(yaml.load(returner.returned), dataset)
+
+        filestate.serialize('/tmp', dataset, formatter="yaml")
+        self.assertEquals(yaml.load(returner.returned), dataset)
+
+        filestate.serialize('/tmp', dataset, formatter="json")
+        self.assertEquals(json.loads(returner.returned), dataset)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(TestFileState, needs_daemon=False)


### PR DESCRIPTION
Writing some simple managed configuration files can be a real pain, so I've added 2 news features:
- 2 jinja templates filters in order to serialize any variable in JSON or YAML.
- `file.serialize` state which allow to create JSON or YAML files without the need of a complexe template.

See the docs for more details.
Review and suggestions are welcome.
