### PR TITLE
Add reauth delay

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -106,7 +106,6 @@
 # 0 and the defined value.
 #random_reauth_delay: 60
 
-
 # The loop_interval sets how long in seconds the minion will wait between
 # evaluating the scheduler and running cleanup tasks. This defaults to a
 # sane 60 seconds, but if the minion scheduler needs to be evaluated more

--- a/conf/minion
+++ b/conf/minion
@@ -98,6 +98,15 @@
 # seconds, between those reconnection attempts.
 #acceptance_wait_time: 10
 
+# When the master-key changes, the minion will try to re-auth itself to
+# receive the new master key. In larger environments this can cause a 
+# syn-flood on the master because all minions try to re-auth immediately. 
+# To prevent this and have a minion wait for a random amount of time, 
+# specify a value here. The wait-time will be chosen in seconds between
+# 0 and the defined value.
+#random_reauth_delay: 60
+
+
 # The loop_interval sets how long in seconds the minion will wait between
 # evaluating the scheduler and running cleanup tasks. This defaults to a
 # sane 60 seconds, but if the minion scheduler needs to be evaluated more

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -530,7 +530,7 @@ class Minion(object):
             # random seconds if set in config with random_reauth_delay
             if 'random_reauth_delay' in self.opts:
                 reauth_delay = randint(0, int(self.opts['random_reauth_delay']) )
-                log.debug("Waiting {0} seconds to re-authenticate".format(random_reauth_delay))
+                log.debug("Waiting {0} seconds to re-authenticate".format(reauth_delay))
                 time.sleep(reauth_delay)
 
             self.authenticate()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -529,7 +529,7 @@ class Minion(object):
             # random seconds if set in config with random_reauth_delay
             if 'random_reauth_delay' in self.opts:
                 reauth_delay = randint(0, int(self.opts['random_reauth_delay']) )
-                log.debug("Waiting {0} seconds to re-authenticate".format(reauth_delay))
+                log.debug("Waiting {0} seconds to re-authenticate".format(random_reauth_delay))
                 time.sleep(reauth_delay)
 
             self.authenticate()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -529,7 +529,7 @@ class Minion(object):
             # random seconds if set in config with random_reauth_delay
             if 'random_reauth_delay' in self.opts:
                 reauth_delay = randint(0, int(self.opts['random_reauth_delay']) )
-                log.debug("Wait {0} seconds to re-authenticate".format(reauth_delay))
+                log.debug("Waiting {0} seconds to re-authenticate".format(reauth_delay))
                 time.sleep(reauth_delay)
 
             self.authenticate()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -17,6 +17,7 @@ import time
 import traceback
 import sys
 import signal
+from random import randint
 
 # Import third party libs
 try:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -525,6 +525,13 @@ class Minion(object):
         try:
             data = self.crypticle.loads(load)
         except AuthenticationError:
+            # decryption of the payload failed, try to re-auth but wait
+            # random seconds if set in config with random_reauth_delay
+            if 'random_reauth_delay' in self.opts:
+                reauth_delay = randint(0, int(self.opts['random_reauth_delay']) )
+                log.debug("Wait {0} seconds to re-authenticate".format(reauth_delay))
+                time.sleep(reauth_delay)
+
             self.authenticate()
             data = self.crypticle.loads(load)
         # Verify that the publication is valid


### PR DESCRIPTION
When a minion fails to decrypt the masters message after a masters restart, it immediately trys to re-authenticate. In larger environments this can cause a syn-flood on the master if all minions try to reconnect at once. This adds a random integer value between 0 and the set mount of seconds that the minion waits before trying to re-authenticate. If the setting is not set, nothing changes.
