### PR TITLE
Fix issue with cp.get_dir copying more than intended

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -284,6 +284,13 @@ class Client(object):
         # Copy files from master
         for fn_ in self.file_list(env):
             if fn_.startswith(path):
+                # Prevent files in "salt://foobar/" (or salt://foo.sh) from
+                # matching a path of "salt://foo"
+                try:
+                    if fn_[len(path)] != '/':
+                        continue
+                except IndexError:
+                    continue
                 # Remove the leading directories from path to derive
                 # the relative path on the minion.
                 minion_relpath = string.lstrip(fn_[len(prefix):], '/')
@@ -297,6 +304,13 @@ class Client(object):
         # Replicate empty dirs from master
         for fn_ in self.file_list_emptydirs(env):
             if fn_.startswith(path):
+                # Prevent an empty dir "salt://foobar/" from matching a path of
+                # "salt://foo"
+                try:
+                    if fn_[len(path)] != '/':
+                        continue
+                except IndexError:
+                    continue
                 # Remove the leading directories from path to derive
                 # the relative path on the minion.
                 minion_relpath = string.lstrip(fn_[len(prefix):], '/')


### PR DESCRIPTION
The get_dir member function of the salt fileclient was doing a simple
check to see if the path of a target file (or empty dir) started with
the specified salt:// path. As a result, salt://foo would match files
like salt://foo.sh or files within the directory salt://foobar/.

This commit adds a check to ensure that these undesired files/dirs are
not considered a match by the fileclient, and thus do not get
copied/replicated on the minion.

Fixes #6048.
