### PR TITLE
Fix return statement in supervisord.running state

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -75,7 +75,7 @@ def running(name,
         ret['comment'] = (
             'Service {0} is set to be {1}{2}'.format(
                 name, _msg, _update))
-        return
+        return ret
 
     changes = []
     just_updated = False


### PR DESCRIPTION
When test=True is used, this state builts the return dict, and then runs
"return" instead of returning the dict, causing a traceback. This commit
fixes #6053 by fixing that return statement.
