### PR TITLE
Don't try to load git_pillar if not enabled in master config

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -40,7 +40,7 @@ def __virtual__():
         return False
     if not HAS_GIT:
         log.error('Git fileserver backend is enabled in configuration but '
-                  'could not be loaded, is gitpython installed?')
+                  'could not be loaded, is GitPython installed?')
         return False
     if not git.__version__ > '0.3.0':
         return False

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -34,6 +34,9 @@ def __virtual__():
     '''
     Only load if gitpython is available
     '''
+    ext_pillar_sources = [x for x in __opts__.get('ext_pillar', [])]
+    if not any(['git' in x for x in ext_pillar_sources]):
+        return False
     if not HAS_GIT:
         log.error('Git fileserver backend is enabled in configuration but '
                   'could not be loaded, is gitpython installed?')
@@ -147,6 +150,7 @@ def update(branch, repo_location):
     except (OSError, IOError):
         pass
     return True
+
 
 def envs(branch, repo_location):
     '''

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -38,8 +38,8 @@ def __virtual__():
     if not any(['git' in x for x in ext_pillar_sources]):
         return False
     if not HAS_GIT:
-        log.error('Git fileserver backend is enabled in configuration but '
-                  'could not be loaded, is gitpython installed?')
+        log.error('Git-based ext_pillar is enabled in configuration but '
+                  'could not be loaded, is GitPython installed?')
         return False
     if not git.__version__ > '0.3.0':
         return False


### PR DESCRIPTION
This fixes #6052 by doing a check for git-based external pillars in the
master config, and returning False when there are none. This suppresses
an error later on in the `__virtual__()` function which complains that the
git fileserver backend is configured (when it clearly is not).
