### PR TITLE
ddns module: fix pylint warnings & docstring typo

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -5,9 +5,6 @@ Requires dnspython module.
 # Import python libs
 import logging
 
-# Import salt libs
-import salt.utils
-
 
 log = logging.getLogger(__name__)
 
@@ -32,7 +29,7 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False)
     '''
     Add, replace, or update a DNS record.
     nameserver must be an IP address and the minion running this module
-    must have update priviledges on that server.
+    must have update privileges on that server.
     If replace is true, first deletes all records for this name and type.
 
     CLI Example::
@@ -59,12 +56,12 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False)
             is_update = True
             break
 
-    update = dns.update.Update(zone)
+    dns_update = dns.update.Update(zone)
     if is_update:
-        update.replace(name, ttl, rdata)
+        dns_update.replace(name, ttl, rdata)
     else:
-        update.add(name, ttl, rdata)
-    answer = dns.query.udp(update, nameserver)
+        dns_update.add(name, ttl, rdata)
+    answer = dns.query.udp(dns_update, nameserver)
     if answer.rcode() > 0:
         return False
     return True
@@ -85,19 +82,19 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1'):
     if not answer.answer:
         return None
 
-    update = dns.update.Update(zone)
+    dns_update = dns.update.Update(zone)
 
     if rdtype:
         rdtype = dns.rdatatype.from_text(rdtype)
         if data:
             rdata = dns.rdata.from_text(dns.rdataclass.IN, rdtype, data)
-            update.delete(name, rdata)
+            dns_update.delete(name, rdata)
         else:
-            update.delete(name, rdtype)
+            dns_update.delete(name, rdtype)
     else:
-        update.delete(name)
+        dns_update.delete(name)
 
-    answer = dns.query.udp(update, nameserver)
+    answer = dns.query.udp(dns_update, nameserver)
     if answer.rcode() > 0:
         return False
     return True


### PR DESCRIPTION
```
************* Module salt.modules.ddns
W0621: 62,4:update: Redefining name 'update' from outer scope (line 31)
W0621: 88,4:delete: Redefining name 'update' from outer scope (line 31)
W0611:  9,0: Unused import salt
```
