### PR TITLE
SaltLoggingClass: Pass __init__ args thru to superclass' __new__

### DIFF
--- a/salt/log.py
+++ b/salt/log.py
@@ -162,7 +162,7 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS, _NewStyleClassMixIn):
             logging.getLogger(__name__)
 
         '''
-        instance = super(SaltLoggingClass, cls).__new__(cls)
+        instance = super(SaltLoggingClass, cls).__new__(cls, logger_name)
 
         try:
             max_logger_length = len(max(


### PR DESCRIPTION
```
************* Module salt.log
W0613:153,21:SaltLoggingClass.__new__: Unused argument 'logger_name'
```
