### PR TITLE
Stop pacman from doing a system upgrade during package updates.

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -286,7 +286,7 @@ def install(name=None,
             return {}
 
         if salt.utils.is_true(refresh):
-            cmd = 'pacman -Syu --noprogressbar --noconfirm ' \
+            cmd = 'pacman -Sy --noprogressbar --noconfirm ' \
                   '"{0}"'.format('" "'.join(targets))
         else:
             cmd = 'pacman -S --noprogressbar --noconfirm ' \


### PR DESCRIPTION
The pacman command for installing packages included a full system
upgrade - this has been removed.
