### PR TITLE
No fstab change for failed mount

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ pkg/arch/*.tar.xz
 doc/_build
 dist
 MANIFEST
+*~
+*#
 
 # virtualenv
 # - ignores directories of a virtualenv when you create it right on

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -87,13 +87,15 @@ def mounted(name,
             return ret
         out = __salt__['mount.mount'](name, device, mkmnt, fstype, opts)
         if isinstance(out, string_types):
-            # Failed to remount, the state has failed!
+            # Failed to (re)mount, the state has failed!
             ret['comment'] = out
             ret['result'] = False
+            mounted = False
         elif out is True:
-            # Remount worked!
+            # (Re)mount worked!
             ret['comment'] = 'Target was successfully mounted'
             ret['changes']['mount'] = True
+            mounted = True
     else:
         ret['comment'] = 'Target was already mounted'
 
@@ -106,15 +108,18 @@ def mounted(name,
                                   'be set to be made persistent').format(name)
                 return ret
 
-        # present, new, change, bad config
-        # Make sure the entry is in the fstab
-        out = __salt__['mount.set_fstab'](name,
-                                          device,
-                                          fstype,
-                                          opts,
-                                          dump,
-                                          pass_num,
-                                          config)
+        if mounted:
+            # Make sure the entry is in the fstab
+            out = __salt__['mount.set_fstab'](name,
+                                              device,
+                                              fstype,
+                                              opts,
+                                              dump,
+                                              pass_num,
+                                              config)
+        else:
+            out == 'bad mount'
+
         if out == 'present':
             return ret
         if out == 'new':
@@ -129,6 +134,9 @@ def mounted(name,
             ret['result'] = False
             ret['comment'] += '. However, the fstab was not found.'
             return ret
+        if out == 'bad mount':
+            ret['result'] == False
+            ret['comment'] += '. Unfortunately the file system didn\'t exist.'
 
     return ret
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -90,12 +90,10 @@ def mounted(name,
             # Failed to (re)mount, the state has failed!
             ret['comment'] = out
             ret['result'] = False
-            mounted = False
         elif out is True:
             # (Re)mount worked!
             ret['comment'] = 'Target was successfully mounted'
             ret['changes']['mount'] = True
-            mounted = True
     else:
         ret['comment'] = 'Target was already mounted'
 
@@ -108,8 +106,7 @@ def mounted(name,
                                   'be set to be made persistent').format(name)
                 return ret
 
-        if mounted:
-            # Make sure the entry is in the fstab
+        if ret['changes']['mount']:
             out = __salt__['mount.set_fstab'](name,
                                               device,
                                               fstype,


### PR DESCRIPTION
Currently a failed mount will update fstab which is A Bad Thing.

fstab should be the source of truthiness for what a machine can mount _and_ in a position that applying it right away will work.

Allowing the input of garbage, in the context of failed mounts, is bad. This addresses that.

Travis tests [here](https://travis-ci.org/jspc/salt)
