### PR TITLE
Allow user to set password to default hash

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -13,6 +13,13 @@ def __virtual__():
     return 'shadow' if 'BSD' in __grains__.get('os', '') else False
 
 
+def empty_password():
+    '''
+    Returns the BSD flavor-specific hash used for unset/empty passwords
+    '''
+    return '*' if __grains__['os'].lower() == 'freebsd' else '*************'
+
+
 def info(name):
     '''
     Return information for the specified user
@@ -25,7 +32,7 @@ def info(name):
         data = pwd.getpwnam(name)
         ret = {
             'name': data.pw_name,
-            'passwd': data.pw_passwd if data.pw_passwd.strip('*') else ''}
+            'passwd': data.pw_passwd}
     except KeyError:
         return {
             'name': '',

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -17,6 +17,13 @@ def __virtual__():
     return 'shadow' if __grains__.get('kernel', '') == 'Linux' else False
 
 
+def empty_password():
+    '''
+    Returns the hash used for unset/empty passwords
+    '''
+    return '!'
+
+
 def info(name):
     '''
     Return information for the specified user
@@ -29,7 +36,7 @@ def info(name):
         data = spwd.getspnam(name)
         ret = {
             'name': data.sp_nam,
-            'passwd': data.sp_pwd if data.sp_pwd != '!' else '',
+            'passwd': data.sp_pwd,
             'lstchg': data.sp_lstchg,
             'min': data.sp_min,
             'max': data.sp_max,

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -13,7 +13,7 @@ except ImportError:
     try:
         import pwd
     except ImportError:
-        pass # We're most likely on a Windows machine.
+        pass  # We're most likely on a Windows machine.
 
 # Import salt libs
 import salt.utils
@@ -24,6 +24,13 @@ def __virtual__():
     Only work on POSIX-like systems
     '''
     return 'shadow' if __grains__.get('kernel', '') == 'SunOS' else False
+
+
+def empty_password():
+    '''
+    Returns the hash used in Solaris for an unset/empty passwords
+    '''
+    return '!'
 
 
 def info(name):
@@ -39,7 +46,7 @@ def info(name):
             data = spwd.getspnam(name)
             ret = {
                 'name': data.sp_nam,
-                'passwd': data.sp_pwd if data.sp_pwd != '!' else '',
+                'passwd': data.sp_pwd,
                 'lstchg': data.sp_lstchg,
                 'min': data.sp_min,
                 'max': data.sp_max,

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -25,7 +25,7 @@ def info(name):
     '''
     ret = {
             'name': name,
-            'pwd': '',
+            'passwd': '',
             'lstchg': '',
             'min': '',
             'max': '',

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -27,15 +27,16 @@ as either absent or present
 import logging
 import sys
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
 def _shadow_supported():
-    supported_os = ('FreeBSD', 'NetBSD', 'OpenBSD')
-    supported_kernel = ('Linux', 'SunOS')
-    return True if __grains__.get('os', '') in supported_os \
-        or __grains__.get('kernel', '') in supported_kernel \
-        else False
+    if salt.utils.is_windows():
+        return False
+    return 'shadow.info' in __salt__
 
 
 def _changes(name,
@@ -104,7 +105,9 @@ def _changes(name,
             change['shell'] = shell
     if password:
         if _shadow_supported():
-            if not lshad['passwd'] or lshad['passwd'] and enforce_password:
+            empty_password = __salt__['shadow.empty_password']()
+            if lshad['passwd'] == empty_password \
+                    or lshad['passwd'] != empty_password and enforce_password:
                 if lshad['passwd'] != password:
                     change['passwd'] = password
     # GECOS fields

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -186,7 +186,7 @@ def present(name,
 
     password
         A password hash to set for the user. This field is only supported on
-        Linux, FreeBSD, NetBSD, OpenBSD, and Solaris
+        Linux, FreeBSD, NetBSD, OpenBSD, and Solaris.
 
     .. versionchanged:: 0.16.0
        BSD support added.


### PR DESCRIPTION
The passwd field in the output from shadow.info was normalized in
508d816 and 6239136 to make it easier for states to manage users, but
this prevents users from setting the password to the default password
hash. This commit fixes that regression.

Fixes #6085.
