### PR TITLE
Cleanup unused arguments

### DIFF
--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -15,7 +15,7 @@ def __virtual__():
     return 'group' if __grains__['kernel'] == 'FreeBSD' else False
 
 
-def add(name, gid=None, system=False):
+def add(name, gid=None, **kwargs):
     '''
     Add the specified group
 
@@ -23,6 +23,9 @@ def add(name, gid=None, system=False):
 
         salt '*' group.add foo 3456
     '''
+    if salt.utils.is_true(kwargs.get('system')):
+        log.warning('pw_group module does not support the \'system\' argument')
+
     cmd = 'pw groupadd '
     if gid:
         cmd += '-g {0} '.format(gid)

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -61,7 +61,6 @@ def add(name,
         home=True,
         shell=None,
         unique=True,
-        system=False,
         fullname='',
         roomnumber='',
         workphone='',
@@ -74,6 +73,9 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
+    if salt.utils.is_true(kwargs.get('system')):
+        log.warning('pw_user module does not support the \'system\' argument')
+
     if isinstance(groups, string_types):
         groups = groups.split(',')
     cmd = 'pw useradd '

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -16,7 +16,7 @@ def __virtual__():
     return 'group' if __grains__['kernel'] == 'SunOS' else False
 
 
-def add(name, gid=None, system=False):
+def add(name, gid=None, **kwargs):
     '''
     Add the specified group
 
@@ -24,6 +24,10 @@ def add(name, gid=None, system=False):
 
         salt '*' group.add foo 3456
     '''
+    if salt.utils.is_true(kwargs.get('system')):
+        log.warning('solaris_group module does not support the \'system\' '
+                    'argument')
+
     cmd = 'groupadd '
     if gid:
         cmd += '-g {0} '.format(gid)

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -61,12 +61,12 @@ def add(name,
         home=None,
         shell=None,
         unique=True,
-        system=False,
         fullname='',
         roomnumber='',
         workphone='',
         homephone='',
-        createhome=True):
+        createhome=True,
+        **kwargs):
     '''
     Add a user to the minion
 
@@ -74,6 +74,10 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
+    if salt.utils.is_true(kwargs.get('system')):
+        log.warning('solaris_user module does not support the \'system\' '
+                    'argument')
+
     if isinstance(groups, string_types):
         groups = groups.split(',')
     cmd = 'useradd '


### PR DESCRIPTION
This commit cleans up some unused arguments in user and group
management, storing them in **kwargs. Warnings are logged when the
arguments are used. Fixes #6070.
