### PR TITLE
Change "empty_password" to "default_hash"

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -13,9 +13,13 @@ def __virtual__():
     return 'shadow' if 'BSD' in __grains__.get('os', '') else False
 
 
-def empty_password():
+def default_hash():
     '''
-    Returns the BSD flavor-specific hash used for unset/empty passwords
+    Returns the default hash used for unset passwords
+
+    CLI Example::
+
+        salt '*' shadow.default_hash
     '''
     return '*' if __grains__['os'].lower() == 'freebsd' else '*************'
 

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -17,9 +17,13 @@ def __virtual__():
     return 'shadow' if __grains__.get('kernel', '') == 'Linux' else False
 
 
-def empty_password():
+def default_hash():
     '''
-    Returns the hash used for unset/empty passwords
+    Returns the default hash used for unset passwords
+
+    CLI Example::
+
+        salt '*' shadow.default_hash
     '''
     return '!'
 

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -26,9 +26,13 @@ def __virtual__():
     return 'shadow' if __grains__.get('kernel', '') == 'SunOS' else False
 
 
-def empty_password():
+def default_hash():
     '''
-    Returns the hash used in Solaris for an unset/empty passwords
+    Returns the default hash used for unset passwords
+
+    CLI Example::
+
+        salt '*' shadow.default_hash
     '''
     return '!'
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -105,9 +105,9 @@ def _changes(name,
             change['shell'] = shell
     if password:
         if _shadow_supported():
-            empty_password = __salt__['shadow.empty_password']()
-            if lshad['passwd'] == empty_password \
-                    or lshad['passwd'] != empty_password and enforce_password:
+            default_hash = __salt__['shadow.default_hash']()
+            if lshad['passwd'] == default_hash \
+                    or lshad['passwd'] != default_hash and enforce_password:
                 if lshad['passwd'] != password:
                     change['passwd'] = password
     # GECOS fields


### PR DESCRIPTION
Since the function doesn't really return an empty password, but rather
the default hash, this change makes the naming more accurate, especially
since this function is exposed to the user.
