### PR TITLE
Start powerpath support module and state

### DIFF
--- a/salt/modules/powerpath.py
+++ b/salt/modules/powerpath.py
@@ -1,0 +1,122 @@
+'''
+powerpath support.
+
+Assumes RedHat
+
+'''
+
+# Import python libs
+import os
+import re
+
+POLICY_MAP_DICT = {
+    'Adaptive':     'ad',
+    'CLAROpt':      'co',
+    'LeastBlocks':  'lb',
+    'LeastIos':     'li',
+    'REquest':      're',
+    'RoundRobin':   'rr',
+    'StreamIo':     'si',
+    'SymmOpt':      'so',
+}
+
+POLICY_RE = re.compile('.*policy=([^;]+)')
+
+def __virtual__():
+    '''
+    Provide this only on Linux systems until proven to
+    work elsewhere.
+    '''
+    try:
+        kernel_grain = __grains__['kernel']
+    except Exception:
+        return False
+
+    # We don't bother to check if powerpath is installed
+    # because it's possible that the package is about to
+    # be installed before a key is installed.  Checking
+    # for powerpath here would require two highstate runs
+    # for everything to happen.
+
+    if kernel_grain == 'Linux':
+        return 'powerpath'
+
+    return False
+
+def has_powerpath():
+    if os.path.exists('/sbin/emcpreg'):
+        return True
+
+    return False
+
+def list_licenses():
+    '''
+    returns a list of applied powerpath license keys
+    '''
+    KEY_PATTERN = re.compile('Key (.*)')
+
+    keys = []
+    out = __salt__['cmd.run']('/sbin/emcpreg -list')
+    for line in out.splitlines():
+        match = KEY_PATTERN.match(line)
+
+        if not match:
+            continue
+
+        keys.append({'key': match.group(1)})
+
+    return keys
+
+def add_license(key):
+    '''
+    Add a license
+    '''
+    result = {
+        'result': False,
+        'retcode': -1,
+        'output': ''
+    }
+
+    if not has_powerpath():
+        result['output'] = "PowerPath is not installed"
+        return result
+
+    cmd = '/sbin/emcpreg -add {0}'.format(key)
+    ret = __salt__['cmd.run_all'](cmd)
+
+    result['retcode'] = ret['retcode']
+
+    if ret['retcode'] != 0:
+        result['output'] = ret['stderr']
+    else:
+        result['output'] = ret['stdout']
+        result['result'] = True
+
+    return result
+
+def remove_license(key):
+    '''
+    Remove a license
+    '''
+    result = {
+        'result': False,
+        'retcode': -1,
+        'output': ''
+    }
+
+    if not has_powerpath():
+        result['output'] = "PowerPath is not installed"
+        return result
+
+    cmd = '/sbin/emcpreg -remove {0}'.format(key)
+    ret = __salt__['cmd.run_all'](cmd)
+
+    result['retcode'] = ret['retcode']
+
+    if ret['retcode'] != 0:
+        result['output'] = ret['stderr']
+    else:
+        result['output'] = ret['stdout']
+        result['result'] = True
+
+    return result

--- a/salt/states/powerpath.py
+++ b/salt/states/powerpath.py
@@ -1,0 +1,98 @@
+'''
+Powerpath configuration support
+===============================
+
+Allows configuration of EMC Powerpath.  Currently
+only addition/deletion of licenses is supported.
+
+.. code-block:: yaml
+
+    key:
+      powerpath:
+        - license_present
+'''
+
+
+def license_present(name):
+    '''
+    Ensures that the specified PowerPath license key is present
+    on the host.
+
+    name
+        The licnese key to ensure is present
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if not __salt__['powerpath.has_powerpath']():
+        ret['result'] = False
+        ret['comment'] = 'PowerPath is not installed.'
+        return ret
+
+    licenses = [ l['key'] for l in __salt__['powerpath.list_licenses']() ]
+
+    if name in licenses:
+        ret['result'] = True
+        ret['comment'] = 'License key {0} already present'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'License key {0} is set to be added'.format(name)
+        return ret
+
+    data = __salt__['powerpath.add_license'](name)
+    if data['result']:
+        ret['changes'] = {name: 'added'}
+        ret['result'] = True
+        ret['comment'] = data['output']
+        return ret
+    else:
+        ret['result'] = False
+        ret['comment'] = data['output']
+        return ret
+
+
+def license_absent(name):
+    '''
+    Ensures that the specified PowerPath license key is absent
+    on the host.
+
+    name
+        The licnese key to ensure is absent
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
+
+    if not __salt__['powerpath.has_powerpath']():
+        ret['result'] = False
+        ret['comment'] = 'PowerPath is not installed.'
+        return ret
+
+    licenses = [ l['key'] for l in __salt__['powerpath.list_licenses']() ]
+
+    if name not in licenses:
+        ret['result'] = True
+        ret['comment'] = 'License key {0} not present'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'License key {0} is set to be removed'.format(name)
+        return ret
+
+    data = __salt__['powerpath.remove_license'](name)
+    if data['result']:
+        ret['changes'] = {name: 'removed'}
+        ret['result'] = True
+        ret['comment'] = data['output']
+        return ret
+    else:
+        ret['result'] = False
+        ret['comment'] = data['output']
+        return ret
+


### PR DESCRIPTION
I had to create this module a while back to automate adding powerpath licenses to some of my minions.  I thought others might find this useful.  Currently the module supports listing, adding, or removing license keys, and the state supports making sure a license key is either present or absent.
