### PR TITLE
fixd bug: not stdout when cmd error and not stderr

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -308,6 +308,8 @@ def _run(cmd,
     ret['stderr'] = err
     ret['pid'] = proc.pid
     ret['retcode'] = proc.returncode
+    if ret['retcode'] and (not ret['stderr']):
+        ret['stderr'] = False
     return ret
 
 


### PR DESCRIPTION
fixed bug like this:

```
[root@test ~]# cat test.sh
exit 123
[root@test ~]# sh test.sh
[root@test ~]# echo $?
123
```

```
[root@salt salt]# salt  'test' cmd.run_stderr './test.sh'
test:
```

after fixed:

```
[root@salt salt]# salt  'test' cmd.run_stderr './test.sh'
test:
    False
```
