### PR TITLE
Refresh modules for certain file.symlink states

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -565,6 +565,9 @@ class State(object):
                     self.module_refresh()
             elif data['fun'] == 'recurse':
                 self.module_refresh()
+            elif data['fun'] == 'symlink':
+                if 'bin' in data['name']:
+                    self.module_refresh()
         elif data['state'] == 'pkg':
             self.module_refresh()
 


### PR DESCRIPTION
This commit refreshes modules when there are changes in a file.symlink
state with 'bin' in the name. Making this distinction keeps refreshes
from being done for all symlinks, reducing the amount of overhead this
change would introduce. A symlink with 'bin' in the name is likely to
change the available commands on the minion, and thus might make
available certain states/modules which rely on the existence of a given
command in the user's PATH. Without a refresh, these states/module
function calls would fail despite the needed shell command technically
being available.
