### PR TITLE
remove _pkgname_without_arch (and refs)

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -87,20 +87,6 @@ def _reconstruct_ppa_name(owner_name, ppa_name):
     return 'ppa:{0}/{1}'.format(owner_name, ppa_name)
 
 
-def _pkgname_without_arch(name):
-    '''
-    Check for ':arch' appended to pkg name (i.e. 32 bit installed on 64 bit
-    machine is ':i386')
-    '''
-    ret = name.rsplit(':', 1)[0]
-    if not ret:
-        # Prevent any parsing weirdness from completely breaking list_pkgs()
-        # in the future by bailing if the resultant string was empty.
-        log.error('Problem stripping arch from pkgname. This is likely a bug.')
-        return name
-    return ret
-
-
 def _get_repo(**kwargs):
     '''
     Check the kwargs for either 'fromrepo' or 'repo' and return the value.
@@ -535,7 +521,6 @@ def list_pkgs(versions_as_list=False, removed=False):
                 [cols[x] for x in (0, 2, 3, 4)]
         except ValueError:
             continue
-        name = _pkgname_without_arch(name)
         if len(cols):
             if ('install' in linetype or 'hold' in linetype) and \
                     'installed' in status:


### PR DESCRIPTION
This function is old code that is unneeded due to changes in how salt
manages packages. It also represents a bug in which trying to use a
pkg.removed state using the pkgname:i386 format used by apt for 32-bit
packages on 64-bit systems always fails, because the package is
identified as pkgname, not pkgname:i386.  Additionally, using just
"pkgname" in your pkg.removed state would fail, because running "apt-get
remove pkgname" would fail for pkgname:i386.
