### PR TITLE
salt/modules/omapi.py: rm unused imports

### DIFF
--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -13,10 +13,6 @@ config or pillar:
 # Import python libs
 import logging
 import struct
-import base64
-
-# Import salt libs
-import salt.utils
 
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
```
************* Module salt.modules.omapi
W0611: 16,0: Unused import base64
W0611: 19,0: Unused import salt
```
