### PR TITLE
states/iptables.py: rm unused imports

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -20,9 +20,6 @@ at some point be deprecated in favor of a more generic `firewall` state.
         - sport: 1025:65535
 '''
 
-import sys
-import pprint
-
 
 def __virtual__():
     '''


### PR DESCRIPTION
```
************* Module salt.states.iptables
W0611: 23,0: Unused import sys
W0611: 24,0: Unused import pprint
```
