### PR TITLE
states/service.py: rm unused import of `sys`

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -35,9 +35,6 @@ service, then set the reload value to True:
           - pkg: redis
 '''
 
-# Import python libs
-import sys
-
 
 def __virtual__():
     '''


### PR DESCRIPTION
```
************* Module salt.states.service
W0611: 39,0: Unused import sys
```
