### PR TITLE
Error on completely invalid kwd args; follow-up to #6093

### DIFF
--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -33,8 +33,10 @@ def add(name, gid=None, **kwargs):
 
         salt '*' group.add foo 3456
     '''
-    if salt.utils.is_true(kwargs.get('system')):
+    if salt.utils.is_true(kwargs.pop('system', False)):
         log.warning('pw_group module does not support the \'system\' argument')
+    if kwargs:
+        raise TypeError('Invalid keyword argument(s): {}'.format(kwargs))
 
     cmd = 'pw groupadd '
     if gid:

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -73,8 +73,10 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
-    if salt.utils.is_true(kwargs.get('system')):
+    if salt.utils.is_true(kwargs.pop('system', False)):
         log.warning('pw_user module does not support the \'system\' argument')
+    if kwargs:
+        raise TypeError('Invalid keyword argument(s): {}'.format(kwargs))
 
     if isinstance(groups, string_types):
         groups = groups.split(',')

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -33,9 +33,11 @@ def add(name, gid=None, **kwargs):
 
         salt '*' group.add foo 3456
     '''
-    if salt.utils.is_true(kwargs.get('system')):
+    if salt.utils.is_true(kwargs.pop('system', False)):
         log.warning('solaris_group module does not support the \'system\' '
                     'argument')
+    if kwargs:
+        raise TypeError('Invalid keyword argument(s): {}'.format(kwargs))
 
     cmd = 'groupadd '
     if gid:

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -74,9 +74,11 @@ def add(name,
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
-    if salt.utils.is_true(kwargs.get('system')):
+    if salt.utils.is_true(kwargs.pop('system', False)):
         log.warning('solaris_user module does not support the \'system\' '
                     'argument')
+    if kwargs:
+        raise TypeError('Invalid keyword argument(s): {}'.format(kwargs))
 
     if isinstance(groups, string_types):
         groups = groups.split(',')


### PR DESCRIPTION
Solves the `frobscottle=True` (i.e. wrong keyword args) problem.
Follow-up to #6093.
