### PR TITLE
Change behavior of apt._clean_pkglist

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -463,16 +463,17 @@ def upgrade(refresh=True, **kwargs):
 
 def _clean_pkglist(pkgs):
     '''
-    Go through package list and, if any packages have a mix of actual versions
-    and virtual package markers, remove the virtual package markers.
+    Go through package list and, if any packages have more than one virtual
+    package marker and no actual package versions, remove all virtual package
+    markers. If there is a mix of actual package versions and virtual package
+    markers, remove the virtual package markers.
     '''
-    for key in pkgs.keys():
-        if '1' in pkgs[key] and len(pkgs[key]) > 1:
-            while True:
-                try:
-                    pkgs[key].remove('1')
-                except ValueError:
-                    break
+    for name, versions in pkgs.iteritems():
+        stripped = filter(lambda x: x != '1', versions)
+        if not stripped:
+            pkgs[name] = ['1']
+        elif versions != stripped:
+            pkgs[name] = stripped
 
 
 def list_pkgs(versions_as_list=False, removed=False):


### PR DESCRIPTION
The current behavior of this function will remove all instances of '1'
from the version list for a package. If the list only contains multiple
instances of '1', this will clear the list though, and that's not what
is wanted. The intention I had for this function when I wrote it was to
strip all virtual package markers if that package is both a real package
and virtual package, but also to take instances where more than one
target of a virtual package is installed, and make it so that only one
instance of '1' is in the version list for that package. This commit
adjusts the behavior to work that way.
