### PR TITLE
Added logic to failback to python os.getloadavg if procfs does not exist

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -119,15 +119,16 @@ def uptime():
 def loadavg():
     '''
     Return the load averages for this minion
-
+    
     CLI Example::
-
+    
         salt '*' status.loadavg
     '''
     procf = '/proc/loadavg'
     if not os.path.isfile(procf):
-        return {}
-    comps = salt.utils.fopen(procf, 'r').read().strip()
+        comps = "%.2f %.2f %.2f" % os.getloadavg()
+    else:
+        comps = salt.utils.fopen(procf, 'r').read().strip()
     load_avg = comps.split()
     return {'1-min':  _number(load_avg[0]),
             '5-min':  _number(load_avg[1]),


### PR DESCRIPTION
Such as in FreeBSD for load averages.

Currently FreeBSD status.loadavg returns ---------- instead of the load averages.
