### PR TITLE
Strftime formatter

### DIFF
--- a/doc/ref/renderers/all/salt.renderers.jinja.rst
+++ b/doc/ref/renderers/all/salt.renderers.jinja.rst
@@ -173,6 +173,26 @@ breaks, using `whitespace control`_.
 .. _`macro`: http://jinja.pocoo.org/docs/templates/#macros
 .. _`whitespace control`: http://jinja.pocoo.org/docs/templates/#whitespace-control
 
+Filters
+=======
+
+Saltstack extends `builtin filters`_ with his custom filters:
+
+strftime
+  Converts any time related object into a time based string. It requires a
+  valid `strftime directives`_. An `exhaustive list`_ can be found in the
+  official Python documentation.
+
+  .. code-block:: yaml
+
+      {{ "2002/12/25"|strftime("%y") }}
+      {{ "1040814000"|strftime("%Y-%m-%d") }}
+      {{ datetime|strftime("%u") }}
+
+.. _`builtin filters`: http://jinja.pocoo.org/docs/templates/##builtin-filters
+.. _`strftime directives`: http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+.. _`exhaustive list`: http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+
 Jinja in Files
 ==============
 

--- a/doc/ref/renderers/all/salt.renderers.jinja.rst
+++ b/doc/ref/renderers/all/salt.renderers.jinja.rst
@@ -181,17 +181,20 @@ Saltstack extends `builtin filters`_ with his custom filters:
 strftime
   Converts any time related object into a time based string. It requires a
   valid `strftime directives`_. An `exhaustive list`_ can be found in the
-  official Python documentation.
+  official Python documentation. Fuzzy dates are parsed by `timelib`_ python
+  module. Some exemples are available on this pages.
 
   .. code-block:: yaml
 
       {{ "2002/12/25"|strftime("%y") }}
       {{ "1040814000"|strftime("%Y-%m-%d") }}
       {{ datetime|strftime("%u") }}
+      {{ "now"|strftime }}
 
 .. _`builtin filters`: http://jinja.pocoo.org/docs/templates/##builtin-filters
 .. _`strftime directives`: http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
 .. _`exhaustive list`: http://docs.python.org/2/library/datetime.html#strftime-and-strptime-behavior
+.. _`timelib`: https://github.com/pediapress/timelib/
 
 Jinja in Files
 ==============

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ msgpack-python
 pycrypto
 PyYAML
 pyzmq >= 2.1.9
-dateutils >= 0.6.6
+timelib >= 0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ msgpack-python
 pycrypto
 PyYAML
 pyzmq >= 2.1.9
+dateutils >= 0.6.6

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -5,7 +5,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import datetime
-from decimal import Decimal
 import fnmatch
 import hashlib
 import imp

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -115,7 +115,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     else:
         jinja_env = jinja2.Environment(
                         undefined=jinja2.StrictUndefined, **env_args)
-    jinja_env.filters['strftime'] = salt.utils.format_strftime
+    jinja_env.filters['strftime'] = salt.utils.date_format
 
     unicode_context = {}
     for key, value in context.iteritems():

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -115,6 +115,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     else:
         jinja_env = jinja2.Environment(
                         undefined=jinja2.StrictUndefined, **env_args)
+    jinja_env.filters['strftime'] = salt.utils.format_strftime
 
     unicode_context = {}
     for key, value in context.iteritems():

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -178,7 +178,7 @@ class TestGetTemplate(TestCase):
 
 
     def test_strftime(self):
-        response = render_jinja_tmpl('{{ "2002/12/25"|strftime("%Y-%m-%d") }}',
+        response = render_jinja_tmpl('{{ "2002/12/25"|strftime }}',
                 dict(opts=self.local_opts, env='other'))
         self.assertEqual(response, '2002-12-25')
 
@@ -191,6 +191,10 @@ class TestGetTemplate(TestCase):
 
         for object in objects:
             response = render_jinja_tmpl('{{ object|strftime }}',
+                    dict(object=object, opts=self.local_opts, env='other'))
+            self.assertEqual(response, '2002-12-25')
+
+            response = render_jinja_tmpl('{{ object|strftime("%b %d, %Y") }}',
                     dict(object=object, opts=self.local_opts, env='other'))
             self.assertEqual(response, 'Dec 25, 2002')
 

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -4,6 +4,7 @@
 import os
 import tempfile
 import json
+import datetime
 
 # Import Salt Testing libs
 from salttesting import TestCase
@@ -175,6 +176,29 @@ class TestGetTemplate(TestCase):
         self.assertEqual(fc.requests[0]['path'], 'salt://macro')
         SaltCacheLoader.file_client = _fc
 
+
+    def test_strftime(self):
+        response = render_jinja_tmpl('{{ "2002/12/25"|strftime("%Y-%m-%d") }}',
+                dict(opts=self.local_opts, env='other'))
+        self.assertEqual(response, '2002-12-25')
+
+        objects = (
+            datetime.datetime(2002, 12, 25, 12, 00, 00, 00),
+            '2002/12/25',
+            1040814000,
+            '1040814000'
+        )
+
+        for object in objects:
+            response = render_jinja_tmpl('{{ object|strftime }}',
+                    dict(object=object, opts=self.local_opts, env='other'))
+            self.assertEqual(response, 'Dec 25, 2002')
+
+            response = render_jinja_tmpl('{{ object|strftime("%y") }}',
+                    dict(object=object, opts=self.local_opts, env='other'))
+            self.assertEqual(response, '02')
+
+
 class TestCustomExtensions(TestCase):
     def test_serialize(self):
         dataset = {
@@ -189,6 +213,7 @@ class TestCustomExtensions(TestCase):
 
         rendered = env.from_string('{{ dataset|json }}').render(dataset=dataset)
         self.assertEquals(dataset, json.loads(rendered))
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Implements a new jinja "strftime" filter, in order to resolve saltstack/salt#6088:
- add 2 new utils functions for casting & formating with time related objects.
- add 1 jinja filter for formatting.
- add 1 new dependency to https://github.com/pediapress/timelib/ in order to parse fuzzy dates.
