### PR TITLE
returners/sentry_return.py: fix indents & spacing

### DIFF
--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -63,11 +63,11 @@ def returner(ret):
         }
         tags = {}
         if pillar_data['raven'].has_key('tags'):
-           for tag  in pillar_data['raven']['tags']:
-               tags[tag] = grains[tag]
+            for tag  in pillar_data['raven']['tags']:
+                tags[tag] = grains[tag]
          
         if ret['return']:
-           data['level']='info'
+            data['level'] = 'info'
 
         servers = []
         try:


### PR DESCRIPTION
This was caught by Travis! https://travis-ci.org/saltstack/salt/jobs/9017807

```
************* Module salt.returners.sentry_return
W0311: 66,0: Bad indentation. Found 11 spaces, expected 12
W0311: 67,0: Bad indentation. Found 15 spaces, expected 16
W0311: 70,0: Bad indentation. Found 11 spaces, expected 12
C0322: 70,11:returner.connect_sentry: Operator not preceded by a space
           data['level']='info'
```
