### PR TITLE
Allow alternate enc names to be used for ssh_auth states

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -262,6 +262,7 @@ def check_key(user, key, enc, comment, options, config='.ssh/authorized_keys'):
 
         salt '*' ssh.check_key <user> <key> <enc> <comment> <options>
     '''
+    enc = _refine_enc(enc)
     current = auth_keys(user, config)
     nline = _format_auth_line(key, enc, comment, options)
     if key in current:


### PR DESCRIPTION
If 'rsa' or 'dss', etc. are used as the 'enc' value in ssh_auth.present
states (rather than 'ssh-rsa' or 'ssh-dss'), the call to
salt.modules.ssh.check_key() will fail, which causes ssh_auth.present
states to mistakenly report the key as needing to be changed. This
commit adds a call to salt.modules.ssh._refine_enc(), which normalizes
the 'enc' param so that the call to ssh.check_key() does not fail.

Fixes #5374.
