### PR TITLE
OpenVZ Hardware Node process list fix

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -538,7 +538,7 @@ def _ps(osdata):
     elif osdata['os'] == 'Windows':
         grains['ps'] = 'tasklist.exe'
     elif osdata.get('virtual', '') == 'openvzhn':
-        grains['ps'] = 'vzps -E 0 -efH|cut -b 6-'
+        grains['ps'] = 'ps -fH -p $(grep -l \"^envID:[[:space:]]*0\\$\" /proc/[0-9]*/status | sed -e \"s=/proc/\\([0-9]*\\)/.*=\\1=\")  | awk \'{ $7=\"\"; print }\''
     else:
         grains['ps'] = 'ps -efH'
     return grains


### PR DESCRIPTION
Detected a bug with OpenVZ Hardware Node (virtual:openvzhn) using a missing `vzps` command, not an official OpenVZ tool anymore

In this example, `saltutil.find_job` is pooling for the running job and fails, this cause salt to stop waiting:

```
[root@labs ~]# salt -v 'host*' state.highstate
Executing job with jid 20130713073519858443
-------------------------------------------

host1:
    Minion did not return
host2:
    Minion did not return

[root@host1 ~]# grep vzps -B2 -A2 /var/log/salt/minion
2013-07-13 07:35:28,090 [salt.minion                  ] [INFO ] User root Executing command saltutil.find_job with jid 20130713073528087785
2013-07-13 07:35:28,091 [salt.minion                  ] [DEBUG] Command details {'tgt_type': 'glob', 'jid': '20130713073528087785', 'tgt': 'host*0*', 'ret': '', 'user': 'root', 'arg': ['20130713073519858443'], 'fun': 'saltutil.find_job'}
2013-07-13 07:35:28,098 [salt.loaded.int.module.cmdmod] [INFO ] Executing command 'vzps -E 0 -efH|cut -b 6-' in directory '/root'
2013-07-13 07:35:28,121 [salt.loaded.int.module.cmdmod] [DEBUG] output: /bin/sh: vzps: command not found
2013-07-13 07:35:28,122 [salt.minion                  ] [INFO ] Returning information for job: 20130713073528087785
```

The proposed fix: 

Use OpenVZ's recommended solution to obtain the list of processes running on hardware node and format to looks like regular `ps -efH` for salt

See: http://openvz.org/Processes_scope_and_visibility

```
ps -fH -p $(grep -l "^envID:[[:space:]]*0$" /proc/[0-9]*/status | sed -e "s=/proc/\([0-9]*\)/.*=\1=")  | awk '{ $7=""; print }'
```

Results with the fix:

```
[root@labs ~]# salt -v 'host*0*' state.highstate
Executing job with jid 20130713080107687405
-------------------------------------------

Execution is still running on host2
Execution is still running on host1
Execution is still running on host2
Execution is still running on host1

[ Command successful ]


[root@host1 ~]# grep "ps -fH" -B2 -A10 /var/log/salt/minion
2013-07-13 08:01:26,256 [salt.minion                   ][INFO ] User root Executing command saltutil.find_job with jid 20130713080126252779
2013-07-13 08:01:26,257 [salt.minion                   ][DEBUG] Command details {'tgt_type': 'glob', 'jid': '20130713080126252779', 'tgt': 'host*0*', 'ret': '', 'user': 'root', 'arg': ['20130713080107687405'], 'fun': 'saltutil.find_job'}
2013-07-13 08:01:26,265 [salt.loaded.int.module.cmdmod ][INFO ] Executing command 'ps -fH -p $(grep -l "^envID:[[:space:]]*0\\$" /proc/[0-9]*/status | sed -e "s=/proc/\\([0-9]*\\)/.*=\\1=")  | awk \'{ $7=""; print }\'' in directory '/root'
root 1 0 0 Jul12 ?  0:01 /sbin/init
root 2 1 0 Jul12 ?  0:00 [kthreadd]
root 3 2 0 Jul12 ?  0:01 [migration/0]
root 4 2 0 Jul12 ?  0:04 [ksoftirqd/0]
root 5 2 0 Jul12 ?  0:00 [migration/0]
root 6 2 0 Jul12 ?  0:00 [watchdog/0]
root 7 2 0 Jul12 ?  0:00 [migration/1]
root 8 2 0 Jul12 ?  0:00 [migration/1]
..
..
..
2013-07-13 08:01:26,372 [salt.minion                   ][INFO ] Returning information for job: 20130713080126252779
```
