### PR TITLE
For @thatch45 to review. Remove the `tty` logic left from 0d6ff2e.

### DIFF
--- a/salt/ssh/shell.py
+++ b/salt/ssh/shell.py
@@ -146,8 +146,5 @@ class Shell(object):
         cmd = '{0} {1}:{2}'.format(local, self.host, remote)
         if self.sudo:
             cmd = 'sudo {0}'.format(cmd)
-            tty = True
-        else:
-            tty = False
-        cmd = self._cmd_str(cmd, ssh='scp', tty=tty)
+        cmd = self._cmd_str(cmd, ssh='scp')
         return self._run_cmd(cmd)


### PR DESCRIPTION
@thatch45 special attention here, I just removed the `tty` keyword argument and the unneeded logic, though, I'm not sure if for some commands you want to temporarily override the value of `self.tty` or not.
