### PR TITLE
Add __virtual__ functions for pecl and pip states

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -1,5 +1,21 @@
 '''
-A state module to manage installed NPM packages.
+Installation of NPM Packages
+============================
+
+These states manage the installed packages for node.js using the Node Package
+Manager (npm). Note that npm must be installed for these states to be
+available, so npm states should include a requisite to a pkg.installed state
+for the package which provides npm (simply ``npm`` in most cases). Example:
+
+.. code-block:: yaml
+
+    npm:
+      pkg.installed
+
+    yaml:
+      npm.installed:
+        - require:
+          - pkg: npm
 '''
 
 # Import salt libs

--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -1,13 +1,21 @@
 '''
-Installation of PHP pecl extensions.
-==============================================
+Installation of PHP Extensions Using pecl
+=========================================
 
-A state module to manage php pecl extensions.
+These states manage the installed pecl extensions. Note that php-pear must be
+installed for these states to be available, so pecl states should include a
+requisite to a pkg.installed state for the package which provides pecl
+(``php-pear`` in most cases). Example:
 
 .. code-block:: yaml
 
+    php-pear:
+      pkg.installed
+
     mongo:
-      pecl.installed
+      pecl.installed:
+        - require:
+          - pkg: php-pear
 '''
 
 

--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -11,6 +11,13 @@ A state module to manage php pecl extensions.
 '''
 
 
+def __virtual__():
+    '''
+    Only load if the pecl module is available in __salt__
+    '''
+    return 'pecl' if 'pecl.list' in __salt__ else False
+
+
 def installed(name,
               version=None,
               defaults=False):

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -16,6 +16,13 @@ import urlparse
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 
+def __virtual__():
+    '''
+    Only load if the pip module is available in __salt__
+    '''
+    return 'pip' if 'pip.list' in __salt__ else False
+
+
 def installed(name,
               pip_bin=None,
               requirements=None,

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -1,13 +1,21 @@
 '''
-Installation of Python packages using pip.
-==========================================
+Installation of Python Packages Using pip
+=========================================
 
-A state module to manage system installed python packages
+These states manage system installed python packages. Note that pip must be
+installed for these states to be available, so pip states should include a
+requisite to a pkg.installed state for the package which provides pip
+(``python-pip`` in most cases). Example:
 
 .. code-block:: yaml
 
+    python-pip:
+      pkg.installed
+
     virtualenvwrapper:
-      pip.installed
+      pip.installed:
+        - require:
+          - pkg: python-pip
 '''
 
 import urlparse


### PR DESCRIPTION
Similar to what was recently done for npm, disable pecl and pip states
when the needed binary is not available. This prevents tracebacks when
one tries running these states without the required shell command
installed.
