### PR TITLE
Use package name instead of full package name

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -174,14 +174,7 @@ def version(*names, **kwargs):
     win_names = []
     ret = {}
     if len(names) == 1:
-        versions = _get_package_info(names[0])
-        if versions:
-            for val in versions.itervalues():
-                if 'full_name' in val and len(val.get('full_name', '')) > 0:
-                    win_names.append(val.get('full_name', ''))
-        else:
-            win_names.append(names[0])
-        val = __salt__['pkg_resource.version'](win_names[0], **kwargs)
+        val = __salt__['pkg_resource.version'](*names, **kwargs)
         if len(val):
             return val
         return ''


### PR DESCRIPTION
Fixes #6078
Using the package name instead of the full package name allows
for proper comparison.

This fixes pkg.version and pkg.latest on Windows
