### PR TITLE
displaying secondary ip addresses in the ip_interface grain.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -915,6 +915,9 @@ def ip_interfaces():
         for inet in ifaces[face].get('inet', []):
             if 'address' in inet:
                 iface_ips.append(inet['address'])
+        for secondary in ifaces[face].get('secondary', []):
+            if 'address' in secondary:
+                iface_ips.append(secondary['address'])
         ret[face] = iface_ips
     return {'ip_interfaces': ret}
 


### PR DESCRIPTION
Hello.

I needed to have the secondary IP addresses displayed in the grains to use them in templates.

Here are the modifications I did in the salt/grains/core.py file.

Thanks.
