### PR TITLE
Lint fixes

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -226,16 +226,19 @@ max-args=35
 ignored-argument-names=_.*
 
 # Maximum number of locals for function / method body
-max-locals=15
+# Let's have max-args + 5
+max-locals=40
 
 # Maximum number of return / yield for function / method body
 max-returns=6
 
 # Maximum number of branch for function / method body
-max-branchs=12
+# We create a lot of branches in salt, 4x the default value
+max-branchs=48
 
 # Maximum number of statements in function / method body
-max-statements=50
+# Again, we have LOTS in salt. Double default
+max-statements=100
 
 # Maximum number of parents for a class (see R0901).
 max-parents=7

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -125,7 +125,7 @@ def create(path,
         # Virtualenv package
         try:
             import virtualenv
-            VIRTUALENV_VERSION_INFO = tuple(
+            virtualenv_version_info = tuple(
                 [int(i) for i in
                  virtualenv.__version__.split('rc')[0].split('.')]
             )
@@ -138,7 +138,7 @@ def create(path,
                     'Unable to get the virtualenv version output using {0!r}. '
                     'Returned data: {1!r}'.format(version_cmd, ret)
                 )
-            VIRTUALENV_VERSION_INFO = tuple(
+            virtualenv_version_info = tuple(
                 [int(i) for i in
                  ret['stdout'].strip().split('rc')[0].split('.')]
             )
@@ -146,7 +146,7 @@ def create(path,
         if no_site_packages is True:
             cmd.append('--no-site-packages')
         if distribute:
-            if VIRTUALENV_VERSION_INFO >= (1, 10):
+            if virtualenv_version_info >= (1, 10):
                 log.info(
                     'The virtualenv \'--distribute\' option has been '
                     'deprecated in virtualenv(>=1.10), as such, the '
@@ -166,7 +166,7 @@ def create(path,
             for entry in extra_search_dir:
                 cmd.append('--extra-search-dir={0}'.format(entry))
         if never_download is True:
-            if VIRTUALENV_VERSION_INFO >= (1, 10):
+            if virtualenv_version_info >= (1, 10):
                 log.info(
                     'The virtualenv \'--never-download\' option has been '
                     'deprecated in virtualenv(>=1.10), as such, the '


### PR DESCRIPTION
Ignore the branch name where this is coming form :smiley: 
- Adapt `.pylintrc` design settings to Salt's reality.
- Local variables should not be uppercased.
