### PR TITLE
Allow pip paths to use the file:// protocol and allow local files or directories in find_links.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -24,7 +24,7 @@ __func_alias__ = {
     'list_': 'list'
 }
 
-VALID_PROTOS = ['http', 'https', 'ftp']
+VALID_PROTOS = ['http', 'https', 'ftp', 'file']
 
 
 def _get_pip_bin(bin_env):
@@ -300,9 +300,9 @@ def install(pkgs=None,
             find_links = [l.strip() for l in find_links.split(',')]
 
         for link in find_links:
-            if not salt.utils.valid_url(link, VALID_PROTOS):
+            if not salt.utils.valid_url(link, VALID_PROTOS) or os.path.exists(link):
                 raise CommandExecutionError(
-                    '{0!r} must be a valid URL'.format(link)
+                    '{0!r} must be a valid URL or path'.format(link)
                 )
             cmd.append('--find-links={0}'.format(link))
 


### PR DESCRIPTION
The current pip module is a bit too restrictive with the paths that it will accept (only http/https/ftp), which specifically prevents me from using a local directory of downloading packages for offline installs (http://www.pip-installer.org/en/latest/cookbook.html#fast-local-installs).

I'm not sure if os.path.exists(...) is quite the check you'd prefer to use, but it seems in line with other parts of the module.

Thanks!
