### PR TITLE
Add ability to set passwordless login (mysql_user)

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -471,7 +471,7 @@ def user_exists(user,
     ``password_hash``, and using ``passwordless=True``.
 
     .. note::
-        The ``passwordless`` option will be available in version 0.16.1
+        The ``passwordless`` option will be available in version 0.16.1.
 
     CLI Example::
 
@@ -568,7 +568,7 @@ def user_create(user,
         set to ``None``) to permit a passwordless login.
 
     .. note::
-        The ``allow_passwordless`` option will be available in version 0.16.1
+        The ``allow_passwordless`` option will be available in version 0.16.1.
 
     CLI Examples::
 
@@ -649,7 +649,7 @@ def user_chpass(user,
         set to ``None``) to permit a passwordless login.
 
     .. note::
-        The ``allow_passwordless`` option will be available in version 0.16.1
+        The ``allow_passwordless`` option will be available in version 0.16.1.
 
     CLI Examples::
 

--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -96,7 +96,7 @@ def present(name,
         permit a passwordless login.
 
     .. note::
-        The ``allow_passwordless`` option will be available in version 0.16.1
+        The ``allow_passwordless`` option will be available in version 0.16.1.
     '''
     ret = {'name': name,
            'changes': {},

--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -2,11 +2,10 @@
 Management of MySQL users.
 ==========================
 
-NOTE: This module requires the MySQLdb python module and the proper
-settings in the minion config file.
-See salt.modules.mysql for more information.
-
-The mysql_user module is used to manage MySQL users.
+:strong:`NOTE:` These states require the MySQLdb python module be installed on
+the minion, and additional settings added to the minion config file. See the
+documentation for the :mod:`mysql <salt.modules.mysql>` module for more
+information.
 
 .. code-block:: yaml
 
@@ -14,7 +13,31 @@ The mysql_user module is used to manage MySQL users.
       mysql_user.present:
         - host: localhost
         - password: bobcat
+
+
+The MySQL authentication information specified in the minion config file can be
+overidden in states using the following arguments: ``connection_host``,
+``connection_port``, ``connection_user``, ``connection_pass``,
+``connection_db``, ``connection_unix_socket``, and ``connection_default_file``.
+
+.. code-block:: yaml
+
+    frank:
+      mysql_user.present:
+        - host: localhost
+        - password: bobcat
+        - connection_user: someuser
+        - connection_pass: somepass
+
+.. note::
+    Authentication overrides will be available in version 0.16.1.
 '''
+
+# Import python libs
+import sys
+
+# Import salt libs
+import salt.utils
 
 
 def __virtual__():
@@ -24,68 +47,168 @@ def __virtual__():
     return 'mysql_user' if 'mysql.user_create' in __salt__ else False
 
 
+def _get_mysql_error():
+    '''
+    Look in module context for a MySQL error. Eventually we should make a less
+    ugly way of doing this.
+    '''
+    return sys.modules[
+        __salt__['test.ping'].__module__
+    ].__context__.pop('mysql.error', None)
+
+
 def present(name,
             host='localhost',
             password=None,
             password_hash=None,
+            allow_passwordless=False,
             **connection_args):
     '''
-    Ensure that the named user is present with the specified properties
+    Ensure that the named user is present with the specified properties. A
+    passwordless user can be configured by omitting ``password`` and
+    ``password_hash``, and setting ``allow_passwordless`` to ``True``.
 
     name
         The name of the user to manage
 
+    host
+        Host for which this user/password combo applies
+
     password
-        The password
+        The password to use for this user. Will take precedence over the
+        ``password_hash`` option if both are specified.
 
     password_hash
-        The password in hashed form. Be sure to quote the password because
-        YAML doesn't like the ``*``::
+        The password in hashed form. Be sure to quote the password because YAML
+        doesn't like the ``*``. A password hash can be obtained from the mysql
+        command-line client like so::
 
-            SELECT PASSWORD('mypass') ==> *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4
+            mysql> SELECT PASSWORD('mypass');
+            +-------------------------------------------+
+            | PASSWORD('mypass')                        |
+            +-------------------------------------------+
+            | *6C8989366EAF75BB670AD8EA7A7FC1176A95CEF4 |
+            +-------------------------------------------+
+            1 row in set (0.00 sec)
+
+    allow_passwordless
+        If ``True``, then ``password`` and ``password_hash`` can be omitted to
+        permit a passwordless login.
+
+    .. note::
+        The ``allow_passwordless`` option will be available in version 0.16.1
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': 'User {0}@{1} is already present'.format(name, host)}
 
-    # check if user exists with the same password
-    if __salt__['mysql.user_exists'](name, host, password, password_hash, **connection_args):
-        return ret
+    passwordless = not any((password, password_hash))
+
+    # check if user exists with the same password (or passwordless login)
+    if passwordless:
+        if not salt.utils.is_true(allow_passwordless):
+            ret['comment'] = 'Either password or password_hash must be ' \
+                             'specified, unless allow_passwordless is True'
+            ret['result'] = False
+            return ret
+        else:
+            if __salt__['mysql.user_exists'](name, host, passwordless=True,
+                                             **connection_args):
+                ret['comment'] += ' with passwordless login'
+                return ret
+            else:
+                err = _get_mysql_error()
+                if err is not None:
+                    ret['comment'] = err
+                    ret['result'] = False
+                    return ret
+    else:
+        if __salt__['mysql.user_exists'](name, host, password, password_hash,
+                                         **connection_args):
+            ret['comment'] += ' with the desired password'
+            if password_hash and not password:
+                ret['comment'] += ' hash'
+            return ret
+        else:
+            err = _get_mysql_error()
+            if err is not None:
+                ret['comment'] = err
+                ret['result'] = False
+                return ret
 
     # check if user exists with a different password
     if __salt__['mysql.user_exists'](name, host, **connection_args):
 
         # The user is present, change the password
         if __opts__['test']:
+            ret['comment'] = \
+                'Password for user {0}@{1} is set to be '.format(name, host)
             ret['result'] = None
-            ret['comment'] = ('Password for user {0}@{1} is set '
-                              'to be changed'.format(name, host))
+            if passwordless:
+                ret['comment'] += 'cleared'
+                if not salt.utils.is_true(allow_passwordless):
+                    ret['comment'] += ', but allow_passwordless != True'
+                    ret['result'] = False
+            else:
+                ret['comment'] += 'changed'
             return ret
 
-        if __salt__['mysql.user_chpass'](
-                name, host, password, password_hash, **connection_args):
-            ret['comment'] = ('Password for user {0}@{1} has '
-                              'been changed'.format(name, host))
+        if __salt__['mysql.user_chpass'](name, host,
+                                         password, password_hash,
+                                         allow_passwordless,
+                                         **connection_args):
+            ret['comment'] = \
+                'Password for user {0}@{1} has been ' \
+                '{2}'.format(name, host,
+                             'cleared' if passwordless else 'changed')
             ret['changes'][name] = 'Updated'
         else:
-            ret['comment'] = ('Failed to change password for '
-                              'user {0}@{1}'.format(name, host))
+            ret['comment'] = \
+                'Failed to {0} password for user ' \
+                '{1}@{2}'.format('clear' if passwordless else 'change',
+                                 name, host)
+            err = _get_mysql_error()
+            if err is not None:
+                ret['comment'] += ' ({0})'.format(err)
+            if passwordless and not salt.utils.is_true(allow_passwordless):
+                ret['comment'] += '. Note: allow_passwordless must be True ' \
+                                  'to permit passwordless login.'
             ret['result'] = False
     else:
 
-        # The user is not present, make it!
-        if __opts__['test']:
-            ret['result'] = None
-            ret['comment'] = 'User {0}@{1} is set to be added'.format(name, host)
+        err = _get_mysql_error()
+        if err is not None:
+            ret['comment'] = err
+            ret['result'] = False
             return ret
 
-        if __salt__['mysql.user_create'](
-                name, host, password, password_hash, **connection_args):
-            ret['comment'] = 'The user {0}@{1} has been added'.format(name, host)
+        # The user is not present, make it!
+        if __opts__['test']:
+            ret['comment'] = \
+                'User {0}@{1} is set to be added'.format(name, host)
+            ret['result'] = None
+            if passwordless:
+                ret['comment'] += ' with passwordless login'
+                if not salt.utils.is_true(allow_passwordless):
+                    ret['comment'] += ', but allow_passwordless != True'
+                    ret['result'] = False
+            return ret
+
+        if __salt__['mysql.user_create'](name, host,
+                                         password, password_hash,
+                                         allow_passwordless,
+                                         **connection_args):
+            ret['comment'] = \
+                'The user {0}@{1} has been added'.format(name, host)
+            if passwordless:
+                ret['comment'] += ' with passwordless login'
             ret['changes'][name] = 'Present'
         else:
             ret['comment'] = 'Failed to create user {0}@{1}'.format(name, host)
+            err = _get_mysql_error()
+            if err is not None:
+                ret['comment'] += ' ({0})'.format(err)
             ret['result'] = False
 
     return ret
@@ -105,7 +228,7 @@ def absent(name,
            'result': True,
            'comment': ''}
 
-    #check if db exists and remove it
+    # Check if user exists, and if so, remove it
     if __salt__['mysql.user_exists'](name, host, **connection_args):
         if __opts__['test']:
             ret['result'] = None
@@ -116,6 +239,17 @@ def absent(name,
         if __salt__['mysql.user_remove'](name, host, **connection_args):
             ret['comment'] = 'User {0}@{1} has been removed'.format(name, host)
             ret['changes'][name] = 'Absent'
+            return ret
+        else:
+            if err is not None:
+                ret['comment'] = err
+                ret['result'] = False
+                return ret
+    else:
+        err = _get_mysql_error()
+        if err is not None:
+            ret['comment'] = err
+            ret['result'] = False
             return ret
 
     # fallback


### PR DESCRIPTION
This commit adds the ability to set a passwordless login. This
functionality requires a new keyword argument (allow_passwordless) be
True.

Fixes #5550.
