### PR TITLE
pecl docstring tweak

### DIFF
--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -47,7 +47,9 @@ def install(pecls, defaults=False):
         Use default answers for extensions such as pecl_http which ask
         questions before installation. Without this option, the pecl.installed
         state will hang indefinitely when trying to install these extensions.
-        This option will be available in version 0.17.0.
+
+    .. note::
+        The ``defaults`` option will be available in version 0.17.0.
 
     CLI Example::
 

--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -43,7 +43,9 @@ def installed(name,
         Use default answers for extensions such as pecl_http which ask
         questions before installation. Without this option, the pecl.installed
         state will hang indefinitely when trying to install these extensions.
-        This option will be available in version 0.17.0.
+
+    .. note::
+        The ``defaults`` option will be available in version 0.17.0.
     '''
     # Check to see if we have a designated version
     if not isinstance(version, basestring) and version is not None:


### PR DESCRIPTION
This moves the notice that the new "defaults" argument will be available
in 0.17.0 to a "note" section for greater emphasis.
