### PR TITLE
payload.py: rm now-unused import of OrderedDict

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -12,7 +12,6 @@ import salt.log
 import salt.crypt
 from salt.exceptions import SaltReqTimeoutError
 from salt._compat import pickle
-from salt.utils.odict import OrderedDict
 
 # Import third party libs
 try:


### PR DESCRIPTION
```
************* Module salt.payload
W0611: 15,0: Unused import OrderedDict
```
