### PR TITLE
Fix for issue #6188

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -122,8 +122,11 @@ class SMaster(object):
             )
             cumask = os.umask(191)
             if user not in users:
-                log.error('ACL user {0} is not available'.format(user))
-                continue
+                try:
+                    founduser = pwd.getpwnam(user)
+                except KeyError:
+                    log.error('ACL user {0} is not available'.format(user))
+                    continue
             keyfile = os.path.join(
                 self.opts['cachedir'], '.{0}_key'.format(user)
             )


### PR DESCRIPTION
added code to master.py to check for users if they do't show up in pwd.getpwall. This can happen on LDAP-enabled user systems. You can see the
user not show up, but still be visible if you query for them directly.

Issue #6188 shows a problem when users ar ein LDAP but don't show up in pwd.getpwall. This change still allows the master.py process to create the key and accept the user if a direct lookup yields a result.
