### PR TITLE
.now() is a classmethod, not a module function

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1273,7 +1273,7 @@ def date_cast(date):
       any datetime, time string representation...
     '''
     if date is None:
-        return datetime.now()
+        return datetime.datetime.now()
     elif isinstance(date, datetime.datetime):
         return date
 


### PR DESCRIPTION
Not caught by Travis because it's one of the pylint checks that gives too many false positives for salt.
Fixup to #6124.

```
************* Module salt.utils
E1101:1276,15:date_cast: Module 'datetime' has no 'now' member
```
