### PR TITLE
renderers.yaml: rm unused import of getopt

### DIFF
--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import
 
 # Import python libs
-import getopt
 import logging
 import warnings
 


### PR DESCRIPTION
```
************* Module salt.renderers.yaml
W0611:  4,0: Unused import getopt
```
