### PR TITLE
added service refresh function to Solaris SMF

### DIFF
--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -114,6 +114,18 @@ def restart(name):
     return not __salt__['cmd.retcode'](cmd)
 
 
+def reload(name):
+    '''
+    Reload the named service
+
+    CLI Example::
+
+        salt '*' service.reload <service name>
+    '''
+    cmd = '/usr/sbin/svcadm refresh {0}'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
+
+
 def status(name, sig=None):
     '''
     Return the status for a service, returns a bool whether the service is


### PR DESCRIPTION
Added reload function to Solaris service management facility.
CLI usage example:
salt <target> service.reload ssh
- or
  salt <target> service.reload network/ssh

CFG usage example:
ssh:
  service:
- running
- reload: True
- watch:
  - file: /etc/ssh/sshd_config
