### PR TITLE
Fix caching of 0-byte files

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -622,9 +622,8 @@ class RemoteClient(Client):
                     # This is a 0 byte file on the master
                     with self._cache_loc(data['dest'], env) as cache_dest:
                         dest = cache_dest
-                        if not os.path.exists(cache_dest):
-                            with salt.utils.fopen(cache_dest, 'wb+') as ofile:
-                                ofile.write(data['data'])
+                        with salt.utils.fopen(cache_dest, 'wb+') as ofile:
+                            ofile.write(data['data'])
                 if 'hsum' in data and d_tries < 3:
                     # Master has prompted a file verification, if the
                     # verification fails, redownload the file. Try 3 times


### PR DESCRIPTION
For some reason there was a check to see that the destination for the
cached file exists before writing an empty file. This prevented a 0-byte
file from overwriting a previously non-empty file in the cachedir. This
commit removes that check for the cache file's existence, allowing it to
be overwritten.

Fixes #6200.
