### PR TITLE
add __func_alias__ for modules.smf.reload

### DIFF
--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -3,6 +3,10 @@ Service support for Solaris 10 and 11, should work with other systems
 that use SMF also. (e.g. SmartOS)
 '''
 
+__func_alias__ = {
+    'reload_': 'reload'
+}
+
 
 def __virtual__():
     '''
@@ -114,7 +118,7 @@ def restart(name):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def reload(name):
+def reload_(name):
     '''
     Reload the named service
 


### PR DESCRIPTION
Avoids a pylint warning.

```
************* Module salt.modules.smf
W0622:117,0:reload: Redefining built-in 'reload'
```
