### PR TITLE
Add a friendly error message if python-mysqldb isn't installed

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -45,6 +45,8 @@ def __virtual__():
     '''
     if HAS_MYSQLDB:
         return 'mysql'
+    else:
+        log.error("No python module found for mysqldb connections.")
     return False
 
 


### PR DESCRIPTION
Because the error

```
"mysql.version" is not available.
```

doesn't mean much.
