### PR TITLE
Fix tmpfile cleanup for windows (itertools not supported), Fix #6209

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -54,8 +54,11 @@ def __clean_tmp(sfn):
     '''
     if sfn.startswith(tempfile.gettempdir()):
         # Don't remove if it exists in file_roots (any env)
-        all_roots = itertools.chain.from_iterable(__opts__['file_roots'].itervalues())
-        in_roots = any(sfn.startswith(root) for root in all_roots)
+        for env in __opts__['file_roots'].itervalues():
+            for root in env:
+                if sfn.startswith(root):
+                    in_roots = True
+                    break
         # Only clean up files that exist
         if os.path.exists(sfn) and not in_roots:
             os.remove(sfn)


### PR DESCRIPTION
Rather than continue the list comprehensions that have given trouble
previously, I just did it with an easy-to-follow nested loop.

@cvrebert I'd be happy to make any changes you suggest.  I've tested this, and it seems to work beautifully, and should work on Windows.
