### PR TITLE
Remove ref to salt/modules in module writing docs

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -12,10 +12,9 @@ Modules Are Easy to Write!
 ==========================
 
 Salt modules are amazingly simple to write. Just write a regular Python module
-or a regular `Cython`_ module and place it in the ``salt/modules`` directory.
-You can also place them in a directory called ``_modules/`` within the
-:conf_master:`file_roots` specified by the master config file, and they will be
-synced to the minions when :mod:`state.highstate
+or a regular `Cython`_ module and place it a directory called ``_modules/``
+within the :conf_master:`file_roots` specified by the master config file, and
+they will be synced to the minions when :mod:`state.highstate
 <salt.modules.state.highstate>` is run, or by executing the
 :mod:`saltutil.sync_modules <salt.modules.saltutil.sync_modules>` or
 :mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>` functions.

--- a/doc/ref/tops/all/salt.tops.reclass_adapter.rst
+++ b/doc/ref/tops/all/salt.tops.reclass_adapter.rst
@@ -1,0 +1,6 @@
+=========================
+salt.tops.reclass_adapter
+=========================
+
+.. automodule:: salt.tops.reclass_adapter
+    :members:


### PR DESCRIPTION
A beginner is not going to know what this means, so don't muddy the
waters with this info. Besides, new modules should only go in
salt/modules once they are accepted into salt proper. Custom modules
should pretty much always go into _modules.
