### PR TITLE
config.syndic_config(): rm unused `defaults` parameter

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -555,7 +555,6 @@ def syndic_config(master_config_path,
                   minion_config_path,
                   master_env_var='SALT_MASTER_CONFIG',
                   minion_env_var='SALT_MINION_CONFIG',
-                  defaults=None,
                   **kwargs):
     opts = {}
     master_opts = master_config(master_config_path, master_env_var)


### PR DESCRIPTION
None of its call sites seem to use it either.

```
************* Module salt.config
W0613:559,18:syndic_config: Unused argument 'defaults'
```
