### PR TITLE
Report on cache failures for cmd.script states

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -694,11 +694,23 @@ def script(
         path = salt.utils.mkstemp(dir=cwd)
     else:
         path = __salt__['cp.cache_file'](source, env)
+        if not path:
+            return {'pid': 0,
+                    'retcode': 1,
+                    'stdout': '',
+                    'stderr': '',
+                    'cache_error': True}
     if template:
         __salt__['cp.get_template'](source, path, template, env, **kwargs)
     else:
         if not salt.utils.is_windows():
             fn_ = __salt__['cp.cache_file'](source, env)
+            if not fn_:
+                return {'pid': 0,
+                        'retcode': 1,
+                        'stdout': '',
+                        'stderr': '',
+                        'cache_error': True}
             shutil.copyfile(fn_, path)
     if not salt.utils.is_windows():
         os.chmod(path, 320)

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -641,7 +641,7 @@ def script(name,
         # Wow, we passed the test, run this sucker!
         try:
             cmd_all = __salt__['cmd.script'](source, **cmd_kwargs)
-        except CommandExecutionError as err:
+        except (CommandExecutionError, IOError) as err:
             ret['comment'] = str(err)
             return ret
 
@@ -650,7 +650,11 @@ def script(name,
             ret['result'] = not bool(cmd_all)
         else:
             ret['result'] = not bool(cmd_all['retcode'])
-        ret['comment'] = 'Command "{0}" run'.format(name)
+        if ret.get('changes', {}).get('cache_error'):
+            ret['comment'] = 'Unable to cache script {0} from env ' \
+                             '\'{1}\''.format(source, env)
+        else:
+            ret['comment'] = 'Command "{0}" run'.format(name)
         return _reinterpreted_state(ret) if stateful else ret
 
     finally:


### PR DESCRIPTION
This commit will report that the source script failed to cache, rather
than misreporting that the script was run when it couldn't possibly
have run.

Fixes #6230
