### PR TITLE
Catch jinja2.exceptions.UndefinedError

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -20,11 +20,18 @@ which makes use of the jinja templating system would look like this:
         - group: root
         - mode: 644
         - template: jinja
-        - context:
-            custom_var: "override"
         - defaults:
             custom_var: "default value"
             other_var: 123
+    {% if grains['os'] = 'Ubuntu' %}
+        - context:
+            custom_var: "override"
+    {% endif %}
+
+If using a template, any user-defined template variables in the file defined in
+``source`` must be passed in using the ``defaults`` and/or ``context``
+arguments. The general best practice is to place default values in
+``defaults``, with conditional overrides going into ``context``, as seen above.
 
 The ``source`` parameter can be specified as a list. If this is done, then the
 first file to be matched will be the one that is used. This allows you to have
@@ -2203,8 +2210,8 @@ def serialize(name,
     return __salt__['file.manage_file'](name=name,
                                         sfn='',
                                         ret=ret,
-                                        source = None,
-                                        source_sum = {},
+                                        source=None,
+                                        source_sum={},
                                         user=user,
                                         group=group,
                                         mode=mode,

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -139,6 +139,11 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
                 traceback.extract_tb(sys.exc_info()[2])[-1][1]
         )
         raise SaltTemplateRenderError(error)
+    except jinja2.exceptions.UndefinedError:
+        error = 'Undefined jinja variable; line {0} in template'.format(
+                traceback.extract_tb(sys.exc_info()[2])[-1][1]
+        )
+        raise SaltTemplateRenderError(error)
 
     # Workaround a bug in Jinja that removes the final newline
     # (https://github.com/mitsuhiko/jinja2/issues/75)


### PR DESCRIPTION
This commit suppresses a traceback that occurs when there is an
undefined jinja variable used in a template. Unfortunately, it does not
seem that this exception class captures the name of the undefined
variable, which would be useful information, so a mention of the line
number in which the exception was found will have to be sufficient.
