### PR TITLE
Properly deprecate `check_dns`

### DIFF
--- a/doc/topics/development/deprecations.rst
+++ b/doc/topics/development/deprecations.rst
@@ -1,0 +1,49 @@
+================
+Deprecating Code
+================
+
+Salt should remain backwards compatible, though sometimes, this backwards 
+compatibility needs to be broken because a specific feature and/or solution is 
+no longer necessary or required.  At first one might think, let me change this 
+code, it seems that it's not used anywhere else so it should be safe to remove. 
+Then, once there's a new release, users complain about functionality which was 
+removed and they where using it, etc. This should, at all costs, be avoided, 
+and, in these cases, *that* specific code should be deprecated.
+
+Depending on the complexity and usage of a specific piece of code, the 
+deprecation time frame should be properly evaluated. As an example, a 
+deprecation warning which is shown for 2 major releases, for example `0.17.0` 
+and `0.18.0`, gives users enough time to stop using the deprecated code and 
+adapt to the new one.
+
+For example, if you're deprecating the usage of a keyword argument to a 
+function, that specific keyword argument should remain in place for the full 
+deprecation time frame and if that keyword argument is used, a deprecation 
+warning should be shown to the user.
+
+To help in this deprecation task, salt provides :func:`salt.utils.warn_until 
+<salt.utils.warn_until>`. The idea behind this helper function is to show the 
+deprecation warning until salt reaches the provided version. Once that provided 
+version is equaled :func:`salt.utils.warn_until <salt.utils.warn_until>` will 
+raise a :py:exc:`RuntimeError` making salt stop it's execution. This stoppage 
+is unpleasant and will remind the developer that the deprecation limit has been 
+reached and that the code can then be safely removed.
+
+Consider the following example:
+
+.. code-block:: python
+
+    def some_function(bar=False, foo=None):
+        if foo is not None:
+            salt.utils.warn_until(
+                (0, 18),
+                'The \'foo\' argument has been deprecated and it\'s '
+                'functionality removed, as such, it\'s usage is no longer '
+                'required.'
+            )
+
+Consider that the current salt release is ``0.16.0``. Whenever ``foo`` is 
+passed a value different from ``None`` that warning will be shown to the user.  
+This will happen in versions ``0.16.1`` to ``0.18.0``, after which a 
+:py:exc:`RuntimeError` will be raised making us aware that the deprecated code 
+should now be removed.

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -311,56 +311,6 @@ For greater control while running the tests, please try::
     ./tests/runtests.py -h
 
 
-Deprecating Code
-----------------
-
-Salt should remain backwards compatible, though sometimes, this backwards 
-compatibility needs to be broken because a specific feature and/or solution is 
-no longer necessary or required.  At first one might think, let me change this 
-code, it seems that it's not used anywhere else so it should be safe to remove. 
-Then, once there's a new release, users complain about functionality which was 
-removed and they where using it, etc. This should, at all costs, be avoided, 
-and, in these cases, *that* specific code should be deprecated.
-
-Depending on the complexity and usage of a specific piece of code, the 
-deprecation time frame should be properly evaluated. As an example, a 
-deprecation warning which is shown for 2 major releases, for example `0.17.0` 
-and `0.18.0`, gives users enough time to stop using the deprecated code and 
-adapt to the new one.
-
-For example, if you're deprecating the usage of a keyword argument to a 
-function, that specific keyword argument should remain in place for the full 
-deprecation time frame and if that keyword argument is used, a deprecation 
-warning should be shown to the user.
-
-To help in this deprecation task, salt provides :func:`warn_until 
-<salt.utils.warn_until>`. The idea behind this helper function is to show the 
-deprecation warning until salt reaches the provided version. Once that provided 
-version is equaled :func:`warn_until <salt.utils.warn_until>` will raise a 
-:py:exc:`RuntimeError` making salt stop it's execution. This stoppage is 
-unpleasant and will remind the developer that the deprecation limit has been 
-reached and that the code can then be safely removed.
-
-Consider the following example:
-
-.. code-block:: python
-
-    def some_function(bar=False, foo=None):
-        if foo is not None:
-            salt.utils.warn_until(
-                (0, 18),
-                'The \'foo\' argument has been deprecated and it\'s '
-                'functionality removed, as such, it's usage is no longer '
-                'required.'
-            )
-
-Consider that the current salt release is ``0.16.0``. Whenever ``foo`` is 
-passed a value different from ``None`` that warning will be shown to the user.  
-This will happen in versions ``0.16.1`` to ``0.18.0``, after which a 
-:py:exc:`RuntimeError` will be raised making us aware that the deprecated code 
-should now be removed.
-
-
 Editing and previewing the documentation
 ----------------------------------------
 
@@ -370,7 +320,7 @@ to a virtualenv using pip::
 
     pip install Sphinx
 
-Change to salt documention directory, then::
+Change to salt documentation directory, then::
 
     cd doc; make html
 

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -310,8 +310,59 @@ For greater control while running the tests, please try::
 
     ./tests/runtests.py -h
 
-Editing and previewing the documention
---------------------------------------
+
+Deprecating Code
+----------------
+
+Salt should remain backwards compatible, though sometimes, this backwards 
+compatibility needs to be broken because a specific feature and/or solution is 
+no longer necessary or required.  At first one might think, let me change this 
+code, it seems that it's not used anywhere else so it should be safe to remove. 
+Then, once there's a new release, users complain about functionality which was 
+removed and they where using it, etc. This should, at all costs, be avoided, 
+and, in these cases, *that* specific code should be deprecated.
+
+Depending on the complexity and usage of a specific piece of code, the 
+deprecation time frame should be properly evaluated. As an example, a 
+deprecation warning which is shown for 2 major releases, for example `0.17.0` 
+and `0.18.0`, gives users enough time to stop using the deprecated code and 
+adapt to the new one.
+
+For example, if you're deprecating the usage of a keyword argument to a 
+function, that specific keyword argument should remain in place for the full 
+deprecation time frame and if that keyword argument is used, a deprecation 
+warning should be shown to the user.
+
+To help in this deprecation task, salt provides :func:`warn_until 
+<salt.utils.warn_until>`. The idea behind this helper function is to show the 
+deprecation warning until salt reaches the provided version. Once that provided 
+version is equaled :func:`warn_until <salt.utils.warn_until>` will raise a 
+:py:exc:`RuntimeError` making salt stop it's execution. This stoppage is 
+unpleasant and will remind the developer that the deprecation limit has been 
+reached and that the code can then be safely removed.
+
+Consider the following example:
+
+.. code-block:: python
+
+    def some_function(bar=False, foo=None):
+        if foo is not None:
+            salt.utils.warn_until(
+                (0, 18),
+                'The \'foo\' argument has been deprecated and it\'s '
+                'functionality removed, as such, it's usage is no longer '
+                'required.'
+            )
+
+Consider that the current salt release is ``0.16.0``. Whenever ``foo`` is 
+passed a value different from ``None`` that warning will be shown to the user.  
+This will happen in versions ``0.16.1`` to ``0.18.0``, after which a 
+:py:exc:`RuntimeError` will be raised making us aware that the deprecated code 
+should now be removed.
+
+
+Editing and previewing the documentation
+----------------------------------------
 
 You need ``sphinx-build`` command to build the docs. In Debian/Ubuntu this is
 provided in the ``python-sphinx`` package. Sphinx can also be installed

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -6,6 +6,15 @@ Make me some salt!
 import os
 import sys
 import logging
+import warnings
+
+# All salt related deprecation warnings should be shown once each!
+warnings.filterwarnings(
+    'once',                 # Show once
+    '',                     # No deprecation message match
+    DeprecationWarning,     # This filter is for DeprecationWarnings
+    r'^(salt|salt\.(.*))$'  # Match module(s) 'salt' and 'salt.<whatever>'
+)
 
 # Import salt libs
 # We import log ASAP because we NEED to make sure that any logger instance salt

--- a/salt/config.py
+++ b/salt/config.py
@@ -9,6 +9,7 @@ import re
 import socket
 import logging
 import urlparse
+import warnings
 
 # import third party libs
 import yaml
@@ -24,6 +25,11 @@ import salt.loader
 import salt.utils
 import salt.utils.network
 import salt.pillar
+
+# check_dns warnings filter to force deprecation warning exhibition once
+warnings.filterwarnings(
+    'once', '(.*)check_dns(.*)', DeprecationWarning, __name__
+)
 
 log = logging.getLogger(__name__)
 
@@ -531,10 +537,25 @@ def prepend_root_dir(opts, path_options):
 def minion_config(path,
                   env_var='SALT_MINION_CONFIG',
                   defaults=None,
-                  **kwargs):
+                  check_dns=None):
     '''
     Reads in the minion configuration file and sets up special options
     '''
+    if check_dns is not None:
+        # All use of the `check_dns` arg was removed in `598d715`. The keyword
+        # argument was then removed in `9d893e4` and `**kwargs` was then added
+        # in `5d60f77` in order not to break backwards compatibility.
+        #
+        # Showing a deprecation for 0.17.0 and 0.18.0 should be enough for any
+        # api calls to be updated in order to stop it's use.
+        #
+        # XXX: Remove deprecation warning message on 0.19.0
+        warnings.warn(
+            'The functionality behind the \'check_dns\' keyword argument is '
+            'no longer required, as such, it became unnecessary and is now '
+            'deprecated. \'check_dns\' will be removed in salt > 0.18.0',
+            DeprecationWarning
+        )
     if defaults is None:
         defaults = DEFAULT_MINION_OPTS
 
@@ -672,10 +693,26 @@ def get_id():
     return 'localhost', False
 
 
-def apply_minion_config(overrides=None, defaults=None, **kwargs):
+def apply_minion_config(overrides=None, defaults=None, check_dns=None):
     '''
     Returns minion configurations dict.
     '''
+    if check_dns is not None:
+        # All use of the `check_dns` arg was removed in `598d715`. The keyword
+        # argument was then removed in `9d893e4` and `**kwargs` was then added
+        # in `5d60f77` in order not to break backwards compatibility.
+        #
+        # Showing a deprecation for 0.17.0 and 0.18.0 should be enough for any
+        # api calls to be updated in order to stop it's use.
+        #
+        # XXX: Remove deprecation warning message on 0.19.0
+        warnings.warn(
+            'The functionality behind the \'check_dns\' keyword argument is '
+            'no longer required, as such, it became unnecessary and is now '
+            'deprecated. \'check_dns\' will be removed in salt > 0.18.0',
+            DeprecationWarning
+        )
+
     if defaults is None:
         defaults = DEFAULT_MINION_OPTS
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -26,11 +26,6 @@ import salt.utils
 import salt.utils.network
 import salt.pillar
 
-# check_dns warnings filter to force deprecation warning exhibition once
-warnings.filterwarnings(
-    'once', '(.*)check_dns(.*)', DeprecationWarning, __name__
-)
-
 log = logging.getLogger(__name__)
 
 _DFLT_LOG_DATEFMT = '%H:%M:%S'

--- a/salt/config.py
+++ b/salt/config.py
@@ -9,7 +9,6 @@ import re
 import socket
 import logging
 import urlparse
-import warnings
 
 # import third party libs
 import yaml
@@ -543,13 +542,11 @@ def minion_config(path,
         #
         # Showing a deprecation for 0.17.0 and 0.18.0 should be enough for any
         # api calls to be updated in order to stop it's use.
-        #
-        # XXX: Remove deprecation warning message on 0.19.0
-        warnings.warn(
+        salt.utils.warn_until(
+            (0, 19),
             'The functionality behind the \'check_dns\' keyword argument is '
             'no longer required, as such, it became unnecessary and is now '
-            'deprecated. \'check_dns\' will be removed in salt > 0.18.0',
-            DeprecationWarning
+            'deprecated. \'check_dns\' will be removed in salt > 0.18.0'
         )
     if defaults is None:
         defaults = DEFAULT_MINION_OPTS
@@ -699,13 +696,11 @@ def apply_minion_config(overrides=None, defaults=None, check_dns=None):
         #
         # Showing a deprecation for 0.17.0 and 0.18.0 should be enough for any
         # api calls to be updated in order to stop it's use.
-        #
-        # XXX: Remove deprecation warning message on 0.19.0
-        warnings.warn(
+        salt.utils.warn_until(
+            (0, 19),
             'The functionality behind the \'check_dns\' keyword argument is '
             'no longer required, as such, it became unnecessary and is now '
-            'deprecated. \'check_dns\' will be removed in salt > 0.18.0',
-            DeprecationWarning
+            'deprecated. \'check_dns\' will be removed in salt > 0.18.0'
         )
 
     if defaults is None:

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -86,9 +86,6 @@ def create(path,
     if no_site_packages is not None:
         # Show a deprecation warning
         # XXX: Remove deprecation warning message on 0.18.0
-        warnings.filterwarnings(
-            'once', '', DeprecationWarning, __name__
-        )
         warnings.warn(
             '\'no_site_packages\' has been deprecated. Please start using '
             '\'system_site_packages=False\' which means exactly the same '

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -7,7 +7,6 @@ import glob
 import shutil
 import logging
 import os.path
-import warnings
 
 # Import salt libs
 import salt.utils
@@ -56,7 +55,8 @@ def create(path,
     distribute : False
         Passthrough argument given to virtualenv
     pip : False
-        Install pip after creating a virtual environment, implies distribute=True
+        Install pip after creating a virtual environment,
+        implies distribute=True
     clear : False
         Passthrough argument given to virtualenv or pyvenv
     python : None (default)
@@ -85,12 +85,11 @@ def create(path,
 
     if no_site_packages is not None:
         # Show a deprecation warning
-        # XXX: Remove deprecation warning message on 0.18.0
-        warnings.warn(
+        salt.utils.warn_until(
+            (0, 19),
             '\'no_site_packages\' has been deprecated. Please start using '
             '\'system_site_packages=False\' which means exactly the same '
-            'as \'no_site_packages=True\'',
-            DeprecationWarning
+            'as \'no_site_packages=True\''
         )
 
     if no_site_packages is True and system_site_packages is True:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -64,6 +64,7 @@ import salt._compat
 import salt.log
 import salt.minion
 import salt.payload
+import salt.version
 from salt.exceptions import (
     SaltClientError, CommandNotFoundError, SaltSystemExit
 )
@@ -1330,3 +1331,46 @@ def date_format(date=None, format="%Y-%m-%d"):
     'Dec 25, 2002'
     '''
     return date_cast(date).strftime(format)
+
+
+def warn_until(version_info, message,
+               category=DeprecationWarning, stacklevel=None):
+    '''
+    Helper function to raise a warning, by default, a ``DeprecationWarning``,
+    until the provided ``version_info``, after which, a ``RuntimeError`` will
+    be raised to remember the developers to remove the warning because the
+    version defined has matched.
+
+    :param version_info: The version info after which the warning becomes a
+                         ``RuntimeError``. For example ``(0, 17)``.
+    :param message: The warning message to be displayed.
+    :param category: The warning class to be thrown, by default
+                     ``DeprecationWarning``
+    :param stacklevel: There should be no need to set the value of
+                       ``stacklevel`` salt should be able to do the right thing
+    '''
+
+    if not isinstance(version_info, tuple):
+        raise RuntimeError(
+            'The \'version_info\' argument should be passed as a tuple.'
+        )
+
+    if stacklevel is None:
+        # Show the warning a triggered from the calling function not warn_until
+        stacklevel = 2
+
+    if salt.version.__version_info__ >= version_info:
+        caller = inspect.getframeinfo(sys._getframe(stacklevel-1))
+        raise RuntimeError(
+            'The warning triggered on filename {filename!r}, line number '
+            '{lineno}, is supposed to be shown until salt {until_version!r} '
+            'is released. Salt version is now {salt_version!r}. Please '
+            'remove the warning.'.format(
+                filename=caller.filename,
+                lineno=caller.lineno,
+                until_version='.'.join(map(str, version_info)),
+                salt_version='.'.join(map(str, salt.version.__version_info__))
+            ),
+        )
+
+    warnings.warn(message, category, stacklevel=stacklevel)

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1333,8 +1333,11 @@ def date_format(date=None, format="%Y-%m-%d"):
     return date_cast(date).strftime(format)
 
 
-def warn_until(version_info, message,
-               category=DeprecationWarning, stacklevel=None):
+def warn_until(version_info,
+               message,
+               category=DeprecationWarning,
+               stacklevel=None,
+               _dont_call_warnings=False):
     '''
     Helper function to raise a warning, by default, a ``DeprecationWarning``,
     until the provided ``version_info``, after which, a ``RuntimeError`` will
@@ -1348,8 +1351,11 @@ def warn_until(version_info, message,
                      ``DeprecationWarning``
     :param stacklevel: There should be no need to set the value of
                        ``stacklevel`` salt should be able to do the right thing
+    :param _dont_call_warnings: This parameter is used just to get the
+                                functionality until the actual error is to be
+                                issued. When we're only after the salt version
+                                checks to raise a ``RuntimeError``.
     '''
-
     if not isinstance(version_info, tuple):
         raise RuntimeError(
             'The \'version_info\' argument should be passed as a tuple.'
@@ -1360,7 +1366,7 @@ def warn_until(version_info, message,
         stacklevel = 2
 
     if salt.version.__version_info__ >= version_info:
-        caller = inspect.getframeinfo(sys._getframe(stacklevel-1))
+        caller = inspect.getframeinfo(sys._getframe(stacklevel - 1))
         raise RuntimeError(
             'The warning triggered on filename {filename!r}, line number '
             '{lineno}, is supposed to be shown until salt {until_version!r} '
@@ -1373,4 +1379,5 @@ def warn_until(version_info, message,
             ),
         )
 
-    warnings.warn(message, category, stacklevel=stacklevel)
+    if _dont_call_warnings is False:
+        warnings.warn(message, category, stacklevel=stacklevel)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -852,11 +852,6 @@ class OutputOptionsWithTextMixIn(OutputOptionsMixIn):
 
     def __new__(cls, *args, **kwargs):
         instance = super(OutputOptionsWithTextMixIn, cls).__new__(cls, *args, **kwargs)
-        # Let the next warning show up at least once since DeprecationWarning's
-        # are, by default, ignored by python default filters
-        warnings.filterwarnings(
-            'once', '', DeprecationWarning, 'salt.utils.parsers'
-        )
         warnings.warn(
             '\'OutputOptionsWithTextMixIn\' has been deprecated. Please '
             'start using \'OutputOptionsMixIn\', your code should not need '

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -851,12 +851,14 @@ class OutputOptionsWithTextMixIn(OutputOptionsMixIn):
     _include_text_out_ = True
 
     def __new__(cls, *args, **kwargs):
-        instance = super(OutputOptionsWithTextMixIn, cls).__new__(cls, *args, **kwargs)
-        warnings.warn(
+        instance = super(OutputOptionsWithTextMixIn, cls).__new__(
+            cls, *args, **kwargs
+        )
+        utils.warn_until(
+            (0, 19),
             '\'OutputOptionsWithTextMixIn\' has been deprecated. Please '
             'start using \'OutputOptionsMixIn\', your code should not need '
-            'any more change.',
-            DeprecationWarning,
+            'any more change.'
         )
         return instance
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -15,7 +15,6 @@ import os
 import sys
 import logging
 import optparse
-import warnings
 import traceback
 from functools import partial
 
@@ -1137,6 +1136,7 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
     def _mixin_setup(self):
         # XXX: Remove '--key-logfile' support in 0.18.0
+        utils.warn_until((0, 18), '', _dont_call_warnings=True)
         self.logging_options_group.add_option(
             '--key-logfile',
             default=None,
@@ -1312,6 +1312,7 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         if self.options.key_logfile:
             # XXX: Remove '--key-logfile' support in 0.18.0
             # In < 0.18.0 error out
+            utils.warn_until((0, 18), '', _dont_call_warnings=True)
             self.error(
                 'The \'--key-logfile\' option has been deprecated in favour '
                 'of \'--log-file\''

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -12,6 +12,7 @@
 import os
 import shutil
 import tempfile
+import warnings
 
 # Import Salt Testing libs
 from salttesting import TestCase
@@ -23,7 +24,7 @@ ensure_in_syspath('../')
 import salt.minion
 import salt.utils
 import integration
-from salt import config as sconfig
+from salt import config as sconfig, version as salt_version
 
 
 class ConfigTestCase(TestCase):
@@ -294,6 +295,60 @@ class ConfigTestCase(TestCase):
         # are not merged with syndic ones
         self.assertEquals(syndic_opts['_master_conf_file'], minion_config_path)
         self.assertEquals(syndic_opts['_minion_conf_file'], syndic_conf_path)
+
+    def test_check_dns_deprecation_warning(self):
+        if salt_version.__version_info__ >= (0, 19):
+            raise AssertionError(
+                'Failing this test on purpose! Please delete this test case, '
+                'the \'check_dns\' keyword argument and the deprecation '
+                'warnings in `salt.config.minion_config` and '
+                'salt.config.apply_minion_config`'
+            )
+
+        # Let's force the warning to always be thrown
+        warnings.resetwarnings()
+        warnings.filterwarnings(
+            'always', '(.*)check_dns(.*)', DeprecationWarning, 'salt.config'
+        )
+        with warnings.catch_warnings(record=True) as w:
+            sconfig.minion_config(None, None, check_dns=True)
+            self.assertEqual(
+                'The functionality behind the \'check_dns\' keyword argument '
+                'is no longer required, as such, it became unnecessary and is '
+                'now deprecated. \'check_dns\' will be removed in salt > '
+                '0.18.0', str(w[-1].message)
+            )
+
+        with warnings.catch_warnings(record=True) as w:
+            sconfig.apply_minion_config(
+                overrides=None, defaults=None, check_dns=True
+            )
+            self.assertEqual(
+                'The functionality behind the \'check_dns\' keyword argument '
+                'is no longer required, as such, it became unnecessary and is '
+                'now deprecated. \'check_dns\' will be removed in salt > '
+                '0.18.0', str(w[-1].message)
+            )
+
+        with warnings.catch_warnings(record=True) as w:
+            sconfig.minion_config(None, None, check_dns=False)
+            self.assertEqual(
+                'The functionality behind the \'check_dns\' keyword argument '
+                'is no longer required, as such, it became unnecessary and is '
+                'now deprecated. \'check_dns\' will be removed in salt > '
+                '0.18.0', str(w[-1].message)
+            )
+
+        with warnings.catch_warnings(record=True) as w:
+            sconfig.apply_minion_config(
+                overrides=None, defaults=None, check_dns=False
+            )
+            self.assertEqual(
+                'The functionality behind the \'check_dns\' keyword argument '
+                'is no longer required, as such, it became unnecessary and is '
+                'now deprecated. \'check_dns\' will be removed in salt > '
+                '0.18.0', str(w[-1].message)
+            )
 
 
 if __name__ == '__main__':

--- a/tests/unit/highstateconf_test.py
+++ b/tests/unit/highstateconf_test.py
@@ -10,7 +10,7 @@ import salt.config
 from salt.state import HighState
 
 
-OPTS = salt.config.minion_config(None, check_dns=False)
+OPTS = salt.config.minion_config(None)
 OPTS['id'] = 'match'
 OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/tmp'])

--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -18,7 +18,7 @@ from salt.utils.pydsl import PyDslError
 
 REQUISITES = ['require', 'require_in', 'use', 'use_in', 'watch', 'watch_in']
 
-OPTS = salt.config.minion_config(None, check_dns=False)
+OPTS = salt.config.minion_config(None)
 OPTS['id'] = 'whatever'
 OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/tmp'])

--- a/tests/unit/stateconf_test.py
+++ b/tests/unit/stateconf_test.py
@@ -15,7 +15,7 @@ import salt.config
 
 REQUISITES = ['require', 'require_in', 'use', 'use_in', 'watch', 'watch_in']
 
-OPTS = salt.config.minion_config(None, check_dns=False)
+OPTS = salt.config.minion_config(None)
 OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/'])
 

--- a/tests/unit/utils/warnings_test.py
+++ b/tests/unit/utils/warnings_test.py
@@ -52,6 +52,14 @@ class WarnUntilTestCase(TestCase):
                 'Deprecation Message!', str(recorded_warnings[0].message)
             )
 
+        # the deprecation warning is not issued because we passed
+        # _dont_call_warning
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            warn_until(
+                (0, 17), 'Foo', _dont_call_warnings=True
+            )
+            self.assertEqual(0, len(recorded_warnings))
+
         # Let's set version info to (0, 17), a RuntimeError should be raised
         salt_version_mock.__version_info__ = (0, 17)
         with self.assertRaisesRegexp(
@@ -61,6 +69,18 @@ class WarnUntilTestCase(TestCase):
                 r'\'0.17\' is released. Salt version is now \'0.17\'. Please '
                 r'remove the warning.'):
             raise_warning()
+
+        # Even though we're calling warn_until, we pass _dont_call_warnings
+        # because we're only after the RuntimeError
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                r'The warning triggered on filename \'(.*)warnings_test.py\', '
+                r'line number ([\d]+), is supposed to be shown until salt '
+                r'\'0.17\' is released. Salt version is now \'0.17\'. Please '
+                r'remove the warning.'):
+            warn_until(
+                (0, 17), 'Foo', _dont_call_warnings=True
+            )
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/warnings_test.py
+++ b/tests/unit/utils/warnings_test.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.utils.warnings_test
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test ``salt.utils.warn_until``
+
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+'''
+
+# Import python libs
+import warnings
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+from salt.utils import warn_until
+
+# Import 3rd party libs
+try:
+    from mock import patch
+    HAS_MOCK = True
+except ImportError:
+    HAS_MOCK = False
+
+
+@skipIf(HAS_MOCK is False, 'mock python module is unavailable')
+class WarnUntilTestCase(TestCase):
+
+    @patch('salt.version')
+    def test_warning_raised(self, salt_version_mock):
+        # We *always* want *all* warnings thrown on this module
+        warnings.filterwarnings('always', '', DeprecationWarning, __name__)
+
+        # Define a salt version info
+        salt_version_mock.__version_info__ = (0, 16)
+
+        def raise_warning():
+            warn_until(
+                (0, 17), 'Deprecation Message!'
+            )
+
+        # raise_warning should show warning until version info is >= (0, 17)
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            raise_warning()
+            self.assertEqual(
+                'Deprecation Message!', str(recorded_warnings[0].message)
+            )
+
+        # Let's set version info to (0, 17), a RuntimeError should be raised
+        salt_version_mock.__version_info__ = (0, 17)
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                r'The warning triggered on filename \'(.*)warnings_test.py\', '
+                r'line number ([\d]+), is supposed to be shown until salt '
+                r'\'0.17\' is released. Salt version is now \'0.17\'. Please '
+                r'remove the warning.'):
+            raise_warning()
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(WarnUntilTestCase, needs_daemon=False)


### PR DESCRIPTION
Instead of having to leave `**kwargs` "forever" in `salt.config.minion_config` and `salt.config.apply_minion_config` in order to support API access to those which still passes `check_dns`. Support the argument but show a deprecation warning once. Leave the deprecation warning for 2 major releases. Then, finally, and properly, remove `check_dns` for good.
