### PR TITLE
utils.jinja: rm unused import of salt._compat.string_types

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -17,7 +17,6 @@ import yaml
 # Import salt libs
 import salt
 import salt.fileclient
-from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
```
************* Module salt.utils.jinja
W0611: 20,0: Unused import string_types
```
