### PR TITLE
Fix handling of lsb_release info in Debian

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -686,7 +686,12 @@ def os_data():
             import lsb_release
             release = lsb_release.get_distro_information()
             for key, value in release.iteritems():
-                grains['lsb_{0}'.format(key.lower())] = value  # override /etc/lsb-release
+                key = key.lower()
+                lsb_param = 'lsb_{0}{1}'.format(
+                    '' if key.startswith('distrib_') else 'distrib_',
+                    key
+                )
+                grains[lsb_param] = value
         except ImportError:
             # if the python library isn't available, default to regex
             if os.path.isfile('/etc/lsb-release'):


### PR DESCRIPTION
Debian's `lsb_release.get_distro_information()` returns a dict with keys
missing the leading 'DISTRIB_' found in /etc/lsb-release. This causes
the values to be assigned to grains like `lsb_id`, `lsb_release`,
`lsb_codename`, etc. instead of `lsb_distrib_id`, `lsb_distrib_release`,
`lsb_distrib_codename` as the later grains code expects to find. As I am
not sure if this is a change in the return data for
`lsb_release.get_distro_information()`, this commit should preserve
backwards compatibility by only inserting 'distrib_' into the grain's
name if it was not already present.
