### PR TITLE
[patch] More reliably fetch locale LANG env

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -88,9 +88,9 @@ def get_locale():
     if 'Arch' in __grains__['os_family']:
         return _localectl_get()
     elif 'RedHat' in __grains__['os_family']:
-        cmd = 'grep LANG /etc/sysconfig/i18n | grep -vE "^#"'
+        cmd = 'grep "^LANG=" /etc/sysconfig/i18n'
     elif 'Debian' in __grains__['os_family']:
-        cmd = 'grep LANG /etc/default/locale | grep -vE "^#"'
+        cmd = 'grep "^LANG=" /etc/default/locale'
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'eselect --brief locale show'
         return __salt__['cmd.run'](cmd).strip()


### PR DESCRIPTION
On a clean Debian wheezy install, my /etc/default/locale file looks as follows:

<pre>
#  File generated by update-locale
LANG="en_AU.UTF-8"
LANGUAGE="en_AU:en"
</pre>


As part of my state.highstate, I call salt.states.locale.system, but this always prints output of the locale module run in blue (instead of green) - indicating that it was changed during the execution. It actually does change /etc/default/locale.bak, which would annoyingly appear on an AIDE report.

Currently, the localemod.py calls <pre>grep LANG /etc/default/locale | grep -vE "#"</pre> to check if a change is required. That doesn't sufficiently narrow down the required line though - it captures both LANG and LANGUAGE variables (and also calls grep twice unnecessarily). This later causes the test in states/locale.py to fail, which then causes set_locale to execute on every run.

Interestingly, set_locale does a similar test with grep, but invokes the command more accurately such that it doesn't fail. Hence, my patch below makes sure get_locale does the same thing. After applying, Debian wheezy works as it should. I also made a similar change to RedHat for consistency.
