### PR TITLE
Rename network.hwaddr to network.hw_addr

### DIFF
--- a/doc/topics/tutorials/states_pt3.rst
+++ b/doc/topics/tutorials/states_pt3.rst
@@ -95,10 +95,10 @@ The Salt module functions are also made available in the template context as
 Note that for the above example to work, ``some_group_that_exists`` must exist
 before the state file is processed by the templating engine.
 
-Below is an example that uses the ``network.hwaddr`` function to retrieve the
+Below is an example that uses the ``network.hw_addr`` function to retrieve the
 MAC address for eth0::
 
-    salt['network.hwaddr']('eth0')
+    salt['network.hw_addr']('eth0')
 
 Advanced SLS module syntax
 ==========================

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -171,15 +171,18 @@ def interfaces():
     return salt.utils.network.interfaces()
 
 
-def hwaddr(iface):
+def hw_addr(iface):
     '''
     Return the hardware address (a.k.a. MAC address) for a given interface
 
     CLI Example::
 
-        salt '*' network.hwaddr eth0
+        salt '*' network.hw_addr eth0
     '''
-    return salt.utils.network.hwaddr(iface)
+    return salt.utils.network.hw_addr(iface)
+
+# Alias hwaddr to preserve backward compat
+hwaddr = hw_addr
 
 
 def subnets():
@@ -217,6 +220,8 @@ def ip_addrs(interface=None, include_loopback=False):
     return salt.utils.network.ip_addrs(interface=interface,
                                        include_loopback=include_loopback)
 
+ipaddrs = ip_addrs
+
 
 def ip_addrs6(interface=None, include_loopback=False):
     '''
@@ -230,3 +235,5 @@ def ip_addrs6(interface=None, include_loopback=False):
     '''
     return salt.utils.network.ip_addrs6(interface=interface,
                                         include_loopback=include_loopback)
+
+ipaddrs6 = ip_addrs6

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -178,15 +178,18 @@ def interfaces():
     return salt.utils.network.interfaces()
 
 
-def hwaddr(iface):
+def hw_addr(iface):
     '''
     Return the hardware address (a.k.a. MAC address) for a given interface
 
     CLI Example::
 
-        salt '*' network.hwaddr eth0
+        salt '*' network.hw_addr 'Wireless Connection #1'
     '''
-    return salt.utils.network.hwaddr(iface)
+    return salt.utils.network.hw_addr(iface)
+
+# Alias hwaddr to preserve backward compat
+hwaddr = hw_addr
 
 
 def subnets():
@@ -224,6 +227,8 @@ def ip_addrs(interface=None, include_loopback=False):
     return salt.utils.network.ip_addrs(interface=interface,
                                        include_loopback=include_loopback)
 
+ipaddrs = ip_addrs
+
 
 def ip_addrs6(interface=None, include_loopback=False):
     '''
@@ -237,3 +242,5 @@ def ip_addrs6(interface=None, include_loopback=False):
     '''
     return salt.utils.network.ip_addrs6(interface=interface,
                                         include_loopback=include_loopback)
+
+ipaddrs6 = ip_addrs6

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -443,7 +443,7 @@ def _ipv4_to_bits(ipaddr):
     return ''.join([bin(int(x))[2:].rjust(8, '0') for x in ipaddr.split('.')])
 
 
-def hwaddr(iface):
+def hw_addr(iface):
     '''
     Return the hardware address (a.k.a. MAC address) for a given interface
     '''


### PR DESCRIPTION
This also adds the aliases network.hwaddr, as well as network.ipaddrs
and network.ipaddrs6. Fixes #5061.
