### PR TITLE
Fix alternatives.check_installed

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -13,6 +13,7 @@
 
 # Import python libs
 import os
+import logging
 
 __outputter__ = {
     'display': 'txt',
@@ -20,12 +21,14 @@ __outputter__ = {
     'remove': 'txt',
 }
 
+log = logging.getLogger(__name__)
+
 
 def __virtual__():
     '''
     Only if alternatives dir is available
     '''
-    if os.path.isdir("/etc/alternatives"):
+    if os.path.isdir('/etc/alternatives'):
         return 'alternatives'
     return False
 
@@ -42,59 +45,62 @@ def _get_cmd():
 
 def display(name):
     '''
-    Display alternatives settings for defined command name.
+    Display alternatives settings for defined command name
 
     CLI Example::
 
-        salt '*' alternatives.display <command name>
+        salt '*' alternatives.display editor
     '''
 
-    cmd = "{0} --display {1}".format(_get_cmd(), name)
+    cmd = '{0} --display {1}'.format(_get_cmd(), name)
     out = __salt__['cmd.run_all'](cmd)
     if out['retcode'] > 0 and out['stderr'] != '':
         return out['stderr']
     return out['stdout']
 
+
 def show_current(name):
     '''
-    Display the current alternatives for the given name
+    Display the current higest-priority alternative for a given alternatives
+    link
 
     CLI Example::
 
-        salt '*' alternatives.show_current emacs
+        salt '*' alternatives.show_current editor
     '''
     alt_link_path = '/etc/alternatives/{0}'.format(name)
-    if os.path.islink(alt_link_path):
-        path = os.path.realpath(alt_link_path)
-        return path
+    try:
+        return os.readlink(alt_link_path)
+    except OSError:
+        log.error(
+            'alternatives: path {0} does not exist'.format(alt_link_path)
+        )
     return False
 
 
 def check_installed(name, path):
     '''
-    Check if the alternatives link is set to desired path.
+    Check if the current highest-priority match for a given alternatives link
+    is set to the desired path
 
     CLI Example::
 
         salt '*' alternatives.check_installed name path
     '''
-
-    alt_link_path = '/etc/alternatives/{0}'.format(name)
-    if os.path.realpath(alt_link_path) == path:
-        return True
-    return False
+    return show_current(name) == path
 
 
 def install(name, link, path, priority):
     '''
-    Install symbolic links determining default commands.
+    Install symbolic links determining default commands
 
     CLI Example::
 
-        salt '*' alternatives.install name link path priority
+        salt '*' alternatives.install editor /usr/bin/editor /usr/bin/emacs23 50
     '''
 
-    cmd = "{0} --install {1} {2} {3} {4}".format(_get_cmd(), link, name, path, priority)
+    cmd = '{0} --install {1} {2} {3} {4}'.format(_get_cmd(), link, name,
+                                                 path, priority)
     out = __salt__['cmd.run_all'](cmd)
     if out['retcode'] > 0 and out['stderr'] != '':
         return out['stderr']
@@ -110,7 +116,7 @@ def remove(name, path):
         salt '*' alternatives.remove name path
     '''
 
-    cmd = "{0} --remove {1} {2}".format(_get_cmd(), name, path)
+    cmd = '{0} --remove {1} {2}'.format(_get_cmd(), name, path)
     out = __salt__['cmd.run_all'](cmd)
     if out['retcode'] > 0:
         return out['stderr']


### PR DESCRIPTION
This function used os.path.realpath(), which follows symlinks
recursively. This means that, when the path for the alternative is also
a symlink, alternatives.check_installed returns False since it follows
the symlinks all the way down to the actual binary.

Additionally, there was redundant code in check_installed() and
show_current(). This commit changes check_installed() so that it uses
show_current() to provide the redundant functionality, and makes
show_current() use os.readlink() instead, so that it only checks the
path to which the link points instead of recursively following symlinks

Fixes #6162.
