### PR TITLE
Allow pip to install pre-release versions

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -116,6 +116,7 @@ def install(pkgs=None,
             no_chown=False,
             cwd=None,
             activate=False,
+            pre_releases=False,
             __env__='base'):
     '''
     Install packages with pip
@@ -207,6 +208,8 @@ def install(pkgs=None,
     activate
         Activates the virtual environment, if given via bin_env,
         before running install.
+    pre_releases
+        Include pre-releases in the available versions
 
 
     CLI Example::
@@ -382,6 +385,9 @@ def install(pkgs=None,
 
     if no_download:
         cmd.append('--no-download')
+
+    if pre_releases:
+        cmd.append('--pre')
 
     if global_options:
         if isinstance(global_options, string_types):

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -62,6 +62,7 @@ def installed(name,
               user=None,
               no_chown=False,
               cwd=None,
+              pre_releases=False,
               __env__='base'):
     '''
     Make sure the package is installed
@@ -156,6 +157,7 @@ def installed(name,
         runas=user,
         no_chown=no_chown,
         cwd=cwd,
+        pre_releases=pre_releases,
         __env__=__env__
     )
 


### PR DESCRIPTION
As of version 1.4 of pip, you have to specify a "--pre" flag to install pre-release versions. This is notably a problem for the `pytz` package, which has non-standard version numbering.

This patch adds support for "--pre" to salt.

https://github.com/pypa/pip/commit/4d5c5f8f977d55f84ac6d7ea97c213ed91ca081d
