### PR TITLE
Add append, remove, and delval to the grains module

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -162,6 +162,51 @@ def setval(key, val):
     return {key: val}
 
 
+def append(key, val):
+    '''
+    Append a value to a list in the grains config file
+
+    CLI Example::
+
+        salt '*' grains.append key val
+    '''
+    grains = get(key, [])
+    if not isinstance(grains, list):
+        return 'The key {0} is not a valid list'.format(key)
+    if val in grains:
+        return 'The val {0} was already in the list {1}'.format(val, key)
+    grains.append(val)
+    return setval(key, grains)
+
+
+def remove(key, val):
+    '''
+    Remove a value from a list in the grains config file
+
+    CLI Example:
+
+        salt '*' grains.remove key val
+    '''
+    grains = get(key, [])
+    if not isinstance(grains, list):
+        return 'The key {0} is not a valid list'.format(key)
+    if val not in grains:
+        return 'The val {0} was not in the list {1}'.format(val, key)
+    grains.remove(val)
+    return setval(key, grains)
+
+
+def delval(key):
+    '''
+    Delete a grain from the grains config file
+
+    CLI Example:
+
+        salt '*' grains.delval key
+    '''
+    setval(key, None)
+
+
 def ls():  # pylint: disable=C0103
     '''
     Return a list of all available grains


### PR DESCRIPTION
I wrote a similar module for internal use, but thought it might be useful for others. Pushing a draft to get some comments.

The basic usage is for matching from a list of items. For example.

```
# On the minion
salt-call grains.setval roles webserver
salt-call grains.setval roles databaseserver

# On the master
salt -G 'roles:webserver' test.ping

# in a top file
base:
  'roles:webserver':
    - match: grain
    - nginx
    - php
  'roles:databaseserver':
    - match: grain
    - mysql-server
```

The main questions I have are around the code in setval(). It seems like the code interacting with reading the grains file, should possibly be put in its own function, to allow for simpler usage from elsewhere. Would it be cleaner to set it as a private function in the grains module (_get ?) or in more of a utility module (salt.util.grains ?)
