### PR TITLE
cmd_iter_no_block did not pass on tgt to get_iter_returns(). That makes ...

### DIFF
--- a/salt/client.py
+++ b/salt/client.py
@@ -447,6 +447,7 @@ class LocalClient(object):
             for fn_ret in self.get_iter_returns(pub_data['jid'],
                                                 pub_data['minions'],
                                                 timeout,
+                                                tgt,
                                                 **kwargs):
                 yield fn_ret
 


### PR DESCRIPTION
salt.Client.LocalClient.cmd_iter_no_block() does not pass on the tgt-variable to salt.Client.LocalClient.get_iter_returns(). In get_iter_returns() tgt defaults to tgt='*' so the saltmaster always queries ALL minions with saltutil.find_job in line 660 while waiting for results to return.

While this might not be a problem in smaller setups, asking thousands if minions for a job which only targeted a single minion is not optimal.
