### PR TITLE
pillar: specify explicit exception type in `except` clause

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -331,7 +331,7 @@ class Pillar(object):
                 if pstate:
                     try:
                         pillar.update(pstate)
-                    except:
+                    except Exception:
                         pass
                 if err:
                     errors += err


### PR DESCRIPTION
```
************* Module salt.pillar
W0702:334,20:Pillar.render_pillar: No exception type(s) specified
```
