### PR TITLE
Sort 'comps' and 'line' when comparing Debian repos, Fix #5517

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -211,9 +211,9 @@ def managed(name, **kwargs):
             elif kwarg == 'line' and __grains__['os_family'] == 'Debian':
                 # split the line and sort everything after the URL
                 sanitizedsplit = sanitizedkwargs[kwarg].split()
-                sanitizedsplit[2:] = sorted(sanitizedsplit[2:])
+                sanitizedsplit[3:] = sorted(sanitizedsplit[3:])
                 reposplit = repo[kwarg].split()
-                reposplit[2:] = sorted(reposplit[2:])
+                reposplit[3:] = sorted(reposplit[3:])
                 if sanitizedsplit != reposplit:
                     notset = True
             else:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -202,9 +202,17 @@ def managed(name, **kwargs):
         notset = False
         for kwarg in sanitizedkwargs:
             if kwarg == 'repo':
-                continue
-            if kwarg not in repo.keys():
+                pass
+            elif kwarg not in repo.keys():
                 notset = True
+            elif kwarg == 'comps':
+                if sorted(sanitizedkwargs[kwarg]) != sorted(repo[kwarg]):
+                    notset = True
+            elif kwarg == 'line' and __grains__['os_family'] == 'Debian':
+                sanitizedsplit = sorted(sanitizedkwargs[kwarg].split())
+                reposplit = sorted(repo[kwarg].split())
+                if sanitizedsplit != reposplit:
+                    notset = True
             else:
                 if str(sanitizedkwargs[kwarg]) != str(repo[kwarg]):
                     notset = True

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -209,8 +209,11 @@ def managed(name, **kwargs):
                 if sorted(sanitizedkwargs[kwarg]) != sorted(repo[kwarg]):
                     notset = True
             elif kwarg == 'line' and __grains__['os_family'] == 'Debian':
-                sanitizedsplit = sorted(sanitizedkwargs[kwarg].split())
-                reposplit = sorted(repo[kwarg].split())
+                # split the line and sort everything after the URL
+                sanitizedsplit = sanitizedkwargs[kwarg].split()
+                sanitizedsplit[2:] = sorted(sanitizedsplit[2:])
+                reposplit = repo[kwarg].split()
+                reposplit[2:] = sorted(reposplit[2:])
                 if sanitizedsplit != reposplit:
                     notset = True
             else:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -188,7 +188,7 @@ def managed(name, **kwargs):
         repo = __salt__['pkg.get_repo'](
                 repokwargs['repo'],
                 ppa_auth=repokwargs.get('ppa_auth', None)
-                )
+        )
     except Exception:
         pass
 
@@ -226,7 +226,8 @@ def managed(name, **kwargs):
         return ret
     try:
         repodict = __salt__['pkg.get_repo'](repokwargs['repo'],
-                                            ppa_auth=repokwargs.get('ppa_auth', None))
+                                            ppa_auth=repokwargs.get('ppa_auth',
+                                                                    None))
         if repo:
             for kwarg in sanitizedkwargs:
                 if repodict.get(kwarg) != repo.get(kwarg):
@@ -278,7 +279,8 @@ def absent(name, **kwargs):
         kwargs['name'] = kwargs.pop('ppa')
 
     try:
-        repo = __salt__['pkg.get_repo'](name, ppa_auth=kwargs.get('ppa_auth', None))
+        repo = __salt__['pkg.get_repo'](name,
+                                        ppa_auth=kwargs.get('ppa_auth', None))
     except Exception:
         pass
     if not repo:


### PR DESCRIPTION
This is a really hacky fix.  Basically, both 'comps' (a list) and 'line' (a string) can end up out of order from your state args, so even though the repo is fully configured, the state reports it as needing to be configured.

So I'm sorting 'comps' and splitting and then sorting 'line' and comparing them.

I'm open to better ways of accomplishing this.  I don't like this code.
