### PR TITLE
Lots of docs on salt fileserver environments

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,6 +54,7 @@ States - Configuration Management with Salt:
     - :doc:`Basic config management <topics/tutorials/states_pt1>`
     - :doc:`Less basic config management <topics/tutorials/states_pt2>`
     - :doc:`Advanced techniques <topics/tutorials/states_pt3>`
+    - :doc:`Salt Fileserver Path Inheritance <topics/tutorials/states_pt4>`
 
 Masterless Quickstart:
     :doc:`Salt Quickstart </topics/tutorials/quickstart>`

--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -123,14 +123,15 @@ to a system, as in this example, a shorthand is also available:
 .. note::
 
     The top files from all defined environments will be compiled into a single
-    top file for all states.  Top files are environment agnostic.
+    top file for all states. Top files are environment agnostic.
 
 Remember, that since everything is a file in Salt, the environments are
 primarily file server environments, this means that environments that have
 nothing to do with states can be defined and used to distribute other files.
 
-A clean and recommended setup for multiple environments would look like this:
+.. _states-top-file_roots:
 
+A clean and recommended setup for multiple environments would look like this:
 
 .. code-block:: yaml
 
@@ -224,4 +225,126 @@ minion with a pillar named ``somekey``, having a value of ``abc`` will receive
 the xyz state.  Finally, minions with ids matching the nag1* glob or with a
 grain named ``role`` equal to ``monitoring`` will receive the nagios.server
 state.
+
+How Top Files Are Compiled
+==========================
+
+As mentioned earlier, the top files in the different environments are compiled
+into a single set of data. The way in which this is done follows a few rules,
+which are important to understand when arranging top files in different
+environments. The examples below all assume that the :conf_master:`file_roots`
+are set as in the :ref:`above multi-environment example
+<states-top-file_roots>`.
+
+
+1. The ``base`` environment's top file is processed first. Any environment which
+   is defined in the ``base`` top.sls as well as another environment's top file,
+   will use the states configured in ``base`` and ignore all other instances.
+   In other words, the ``base`` top file is authoritative. Therefore, in the
+   example below, the ``dev`` section in ``/srv/salt/dev/top.sls`` would be
+   completely ignored.
+
+``/srv/salt/base/top.sls:``
+
+.. code-block:: yaml
+
+    base:
+      '*':
+        - common
+    dev:
+      'webserver*dev*':
+        - webserver
+      'db*dev*':
+        - db
+
+``/srv/salt/dev/top.sls:``
+
+.. code-block:: yaml
+
+    dev:
+      '10.10.100.0/24':
+        - match: ipcidr
+        - deployments.dev.site1
+      '10.10.101.0/24':
+        - match: ipcidr
+        - deployments.dev.site2
+
+.. note::
+    The rules below assume that the environments being discussed were not
+    defined in the ``base`` top file.
+
+2. If, for some reason, the ``base`` environment is not configured in the
+   ``base`` environment's top file, then the other environments will be checked
+   in alphabetical order. The first top file found to contain a section for the
+   ``base`` environment wins, and the other top files' ``base`` sections are
+   ignored. So, provided there is no ``base`` section in the ``base`` top file,
+   with the below two top files the ``dev`` environment would win out, and the
+   ``common.centos`` SLS would not be applied to CentOS hosts.
+
+``/srv/salt/dev/top.sls:``
+
+.. code-block:: yaml
+
+    base:
+      'os:Ubuntu':
+        - common.ubuntu
+    dev:
+      'webserver*dev*':
+        - webserver
+      'db*dev*':
+        - db
+
+``/srv/salt/qa/topsls:``
+
+.. code-block:: yaml
+
+    base:
+      'os:Ubuntu':
+        - common.ubuntu
+      'os:CentOS':
+        - common.centos
+    qa:
+      'webserver*qa*':
+        - webserver
+      'db*qa*':
+        - db
+
+3. For environments other than ``base``, the top file in a given environment
+   will be checked for a section matching the environment's name. If one is
+   found, then it is used. Otherwise, the remaining (non-``base``) environments
+   will be checked in alphabetical order. In the below example, the ``qa``
+   section in ``/srv/salt/dev/top.sls`` will be ignored, but if
+   ``/srv/salt/qa/top.sls`` were cleared or removed, then the states configured
+   for the ``qa`` environment in ``/srv/salt/dev/top.sls`` will be applied.
+
+``/srv/salt/dev/top.sls:``
+
+.. code-block:: yaml
+
+    dev:
+      'webserver*dev*':
+        - webserver
+      'db*dev*':
+        - db
+    qa:
+      '10.10.200.0/24':
+        - match: ipcidr
+        - deployments.qa.site1
+      '10.10.201.0/24':
+        - match: ipcidr
+        - deployments.qa.site2
+
+``/srv/salt/qa/top.sls:``
+
+.. code-block:: yaml
+
+    qa:
+      'webserver*qa*':
+        - webserver
+      'db*qa*':
+        - db
+
+.. note::
+    When in doubt, the simplest way to configure your states is with a single
+    top.sls in the ``base`` environment.
 

--- a/doc/topics/tutorials/states_pt2.rst
+++ b/doc/topics/tutorials/states_pt2.rst
@@ -4,8 +4,8 @@ States tutorial, part 2
 
 .. note:: 
 
-  This tutorial builds on the topic covered in :doc:`part 1 <states_pt1>`.
-  It is recommended that you begin there.
+  This tutorial builds on topics covered in :doc:`part 1 <states_pt1>`. It is
+  recommended that you begin there.
 
 In the :doc:`last part <states_pt1>` of the Salt States tutorial we covered
 the basics of installing a package. We will now modify our ``webserver.sls``

--- a/doc/topics/tutorials/states_pt3.rst
+++ b/doc/topics/tutorials/states_pt3.rst
@@ -4,7 +4,7 @@ States tutorial, part 3
 
 .. note::
 
-  This tutorial builds on the topic covered in :doc:`part1 <states_pt1>` and
+  This tutorial builds on topics covered in :doc:`part 1 <states_pt1>` and
   :doc:`part 2 <states_pt2>`. It is recommended that you begin there.
 
 This part of the tutorial will cover more advanced templating and
@@ -210,16 +210,9 @@ can be rewritten without the loop:
           - larry
           - curly
 
-Continue learning
-=================
+Next steps
+==========
 
-The best way to continue learning about Salt States is to read through the
-:doc:`reference documentation </ref/states/index>` and to look through examples
-of existing :term:`state trees <state tree>`. You can find examples in the
-`salt-states repository`_ and please send a pull-request on GitHub with any
-state trees that you build and want to share!
-
-.. _`salt-states repository`: https://github.com/saltstack/salt-states
-
-If you have any questions, suggestions, or just want to chat with other people
-who are using Salt we have an :doc:`active community </topics/community>`.
+In :doc:`part 4 <states_pt4>` we will discuss how to use salt's
+:conf_master:`file_roots` to set up a workflow in which states can be
+"promoted" from dev, to QA, to production.

--- a/doc/topics/tutorials/states_pt4.rst
+++ b/doc/topics/tutorials/states_pt4.rst
@@ -1,5 +1,5 @@
 =======================
-States tutorial, part 3
+States tutorial, part 4
 =======================
 
 .. note::
@@ -24,7 +24,7 @@ location shared to the salt master via NFS:
     # In the master config file (/etc/salt/master)
     file_roots:
       base:
-        - /srv/salt/base
+        - /srv/salt
         - /mnt/salt-nfs/base
 
 Salt's fileserver collapses the list of root directories into a single virtual
@@ -40,18 +40,18 @@ Configure a multiple-environment setup like so:
 
 .. code-block:: yaml
 
-file_roots:
-  base:
-    - /srv/salt/base
-  dev:
-    - /srv/salt/dev
-    - /srv/salt/qa
-    - /srv/salt/base
-  qa:
-    - /srv/salt/qa
-    - /srv/salt/base
+    file_roots:
+      base:
+        - /srv/salt/prod
+      qa:
+        - /srv/salt/qa
+        - /srv/salt/prod
+      dev:
+        - /srv/salt/dev
+        - /srv/salt/qa
+        - /srv/salt/prod
 
-Given the path inheritance described above, files within ``/srv/salt/base``
+Given the path inheritance described above, files within ``/srv/salt/prod``
 would be available in all environments. Files within ``/srv/salt/qa`` would be
 available in both ``qa``, and ``dev``. Finally, the files within
 ``/srv/salt/dev`` would only be available within the ``dev`` environment.
@@ -63,8 +63,110 @@ Those files/states can then be moved to the same relative path within
 ``/srv/salt/qa``, and they are now available only in the ``dev`` and ``qa``
 environments, allowing them to be pushed to QA hosts and tested.
 
-Finally, if moved to the same relative path within ``/srv/salt/base``, the
+Finally, if moved to the same relative path within ``/srv/salt/prod``, the
 files are now available in all three environments.
+
+Practical Example
+=================
+
+As an example, consider a simple website, installed to ``/var/www/foobarcom``.
+Below is a top.sls that can be used to deploy the website:
+
+``/srv/salt/prod/top.sls:``
+
+.. code-block:: yaml
+
+    base:
+      'web*prod*':
+        - webserver.foobarcom
+    qa:
+      'web*qa*':
+        - webserver.foobarcom
+    dev:
+      'web*dev*':
+        - webserver.foobarcom
+
+
+Using pillar, roles can be assigned to the hosts:
+
+``/srv/pillar/top.sls:``
+
+.. code-block:: yaml
+
+    base:
+      'web*prod*':
+        - webserver.prod
+      'web*qa*':
+        - webserver.qa
+      'web*dev*':
+        - webserver.dev
+
+``/srv/pillar/webserver/prod.sls:``
+
+.. code-block:: yaml
+
+    webserver_role: prod
+
+``/srv/pillar/webserver/qa.sls:``
+
+.. code-block:: yaml
+
+    webserver_role: qa
+
+``/srv/pillar/webserver/dev.sls:``
+
+.. code-block:: yaml
+
+    webserver_role: dev
+
+
+And finally, the SLS to deploy the website:
+
+``/srv/salt/prod/webserver/foobarcom.sls:``
+
+.. code-block:: yaml
+
+    {% if pillar.get('webserver_role', '') %}
+    /var/www/foobarcom:
+      file.recurse:
+        - source: salt://webserver/src/foobarcom
+        - env: {{ pillar['webserver_role'] }}
+        - user: www
+        - group: www
+        - dir_mode: 755
+        - file_mode: 644
+    {% endif %}
+
+Given the above SLS, the source for the website should initially be placed in
+``/srv/salt/dev/webserver/src/foobarcom``.
+
+First, let's deploy to dev. Given the configuration in the top file, this can
+be done using :mod:`state.highstate <salt.modules.state.highstate>`::
+
+    # salt --pillar 'webserver_role:dev' state.highstate
+
+However, in the event that it is not desirable to apply all states configured
+in the top file (which could be likely in more complex setups), it is possible
+to apply just the states for the ``foobarcom`` website, using :mod:`state.sls
+<salt.modules.state.sls>`::
+
+    # salt --pillar 'webserver_role:dev' state.sls webserver.foobarcom
+
+Once the site has been tested in dev, then the files can be moved from
+``/srv/salt/dev/webserver/src/foobarcom`` to
+``/srv/salt/qa/webserver/src/foobarcom``, and deployed using the following::
+
+    # salt --pillar 'webserver_role:qa' state.sls webserver.foobarcom
+
+Finally, once the site has been tested in qa, then the files can be moved from
+``/srv/salt/qa/webserver/src/foobarcom`` to
+``/srv/salt/prod/webserver/src/foobarcom``, and deployed using the following::
+
+    # salt --pillar 'webserver_role:prod' state.sls webserver.foobarcom
+
+Thanks to Salt's fileserver inheritance, even though the files have been moved
+to within ``/srv/salt/prod``, they are still available from the same
+``salt://`` URI in both the qa and dev environments.
 
 
 Continue learning

--- a/doc/topics/tutorials/states_pt4.rst
+++ b/doc/topics/tutorials/states_pt4.rst
@@ -1,0 +1,82 @@
+=======================
+States tutorial, part 3
+=======================
+
+.. note::
+
+  This tutorial builds on topics covered in :doc:`part 1 <states_pt1>`,
+  :doc:`part 2 <states_pt2>` and :doc:`part 3 <states_pt3>`. It is recommended
+  that you begin there.
+
+This part of the tutorial will show how to use salt's :conf_master:`file_roots`
+to set up a workflow in which states can be "promoted" from dev, to QA, to
+production.
+
+Salt fileserver path inheritance
+================================
+
+Salt's fileserver allows for more than one root directory per environment, like
+in the below example, which uses both a local directory and a secondary
+location shared to the salt master via NFS:
+
+.. code-block:: yaml
+
+    # In the master config file (/etc/salt/master)
+    file_roots:
+      base:
+        - /srv/salt/base
+        - /mnt/salt-nfs/base
+
+Salt's fileserver collapses the list of root directories into a single virtual
+environment containing all files from each root. If the same file exists at the
+same relative path in more than one root, then the top-most match "wins". For
+example, if ``/srv/salt/foo.txt`` and ``/mnt/salt-nfs/base/foo.txt`` both
+exist, then ``salt://foo.txt`` will point to ``/srv/salt/foo.txt``.
+
+Environment configuration
+=========================
+
+Configure a multiple-environment setup like so:
+
+.. code-block:: yaml
+
+file_roots:
+  base:
+    - /srv/salt/base
+  dev:
+    - /srv/salt/dev
+    - /srv/salt/qa
+    - /srv/salt/base
+  qa:
+    - /srv/salt/qa
+    - /srv/salt/base
+
+Given the path inheritance described above, files within ``/srv/salt/base``
+would be available in all environments. Files within ``/srv/salt/qa`` would be
+available in both ``qa``, and ``dev``. Finally, the files within
+``/srv/salt/dev`` would only be available within the ``dev`` environment.
+
+Based on the order in which the roots are defined, new files/states can be
+placed within ``/srv/salt/dev``, and pushed out to the dev hosts for testing.
+
+Those files/states can then be moved to the same relative path within
+``/srv/salt/qa``, and they are now available only in the ``dev`` and ``qa``
+environments, allowing them to be pushed to QA hosts and tested.
+
+Finally, if moved to the same relative path within ``/srv/salt/base``, the
+files are now available in all three environments.
+
+
+Continue learning
+=================
+
+The best way to continue learning about Salt States is to read through the
+:doc:`reference documentation </ref/states/index>` and to look through examples
+of existing :term:`state trees <state tree>`. Many pre-configured state trees
+can be found on Github in the `saltstack-formulas`_ collection of repositories.
+
+.. _`saltstack-formulas`: https://github.com/saltstack-formulas
+
+If you have any questions, suggestions, or just want to chat with other people
+who are using Salt, we have a very :doc:`active community </topics/community>`
+and we'd love to hear from you.


### PR DESCRIPTION
This adds a detailed explanation of how the top file is compiled, which clears up both #4409 and #6102. It also adds a "step 4" to the states walkthrough, giving an in-depth explanation of how the salt fileserver combines files from multiple root directories in a single environment, and how this path inheritance can be used to promote states from dev -> QA -> prod (satisfying #6284).
