### PR TITLE
pip: deprecate runas param

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -606,8 +606,7 @@ def uninstall(pkgs=None,
 def freeze(bin_env=None,
            user=None,
            runas=None,
-           cwd=None,
-           **kwargs):
+           cwd=None):
     '''
     Return a list of installed packages either globally or in the specified
     virtualenv
@@ -655,8 +654,7 @@ def list_(prefix=None,
           bin_env=None,
           user=None,
           runas=None,
-          cwd=None,
-          **kwargs):
+          cwd=None):
     '''
     Filter list of installed apps from ``freeze`` and check to see if
     ``prefix`` exists in the list of packages installed.

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -117,7 +117,8 @@ def install(pkgs=None,
             cwd=None,
             activate=False,
             pre_releases=False,
-            __env__='base'):
+            __env__='base',
+            **kwargs):
     '''
     Install packages with pip
 
@@ -199,7 +200,7 @@ def install(pkgs=None,
         Extra global options to be supplied to the setup.py call before the
         install command.
     runas
-        User to run pip as
+        The user under which to run pip
     no_chown
         When runas is given, do not attempt to copy and chown
         a requirements file
@@ -235,6 +236,10 @@ def install(pkgs=None,
     # the `bin_env` argument and we'll take care of the rest.
     if env and not bin_env:
         bin_env = env
+
+    # Support "user" if "runas" not used (will need to unify this for 0.17)
+    if not runas and 'user' in kwargs:
+        runas = str(kwargs['user'])
 
     cmd = [_get_pip_bin(bin_env), 'install']
 
@@ -453,7 +458,8 @@ def uninstall(pkgs=None,
               runas=None,
               no_chown=False,
               cwd=None,
-              __env__='base'):
+              __env__='base',
+              **kwargs):
     '''
     Uninstall packages with pip
 
@@ -482,7 +488,7 @@ def uninstall(pkgs=None,
     timeout
         Set the socket timeout (default 15 seconds)
     runas
-        User to run pip as
+        The user under which to run pip
     no_chown
         When runas is given, do not attempt to copy and chown
         a requirements file
@@ -501,6 +507,10 @@ def uninstall(pkgs=None,
 
     '''
     cmd = [_get_pip_bin(bin_env), 'uninstall', '-y']
+
+    # Support "user" if "runas" not used (will need to unify this for 0.17)
+    if not runas and 'user' in kwargs:
+        runas = str(kwargs['user'])
 
     cleanup_requirements = []
     if requirements is not None:
@@ -579,7 +589,8 @@ def uninstall(pkgs=None,
 
 def freeze(bin_env=None,
            runas=None,
-           cwd=None):
+           cwd=None,
+           **kwargs):
     '''
     Return a list of installed packages either globally or in the specified
     virtualenv
@@ -591,7 +602,7 @@ def freeze(bin_env=None,
         If uninstalling from a virtualenv, just use the path to the virtualenv
         (/home/code/path/to/virtualenv/)
     runas
-        User to run pip as
+        The user under which to run pip
     cwd
         Current working directory to run pip from
 
@@ -599,6 +610,9 @@ def freeze(bin_env=None,
 
         salt '*' pip.freeze /home/code/path/to/virtualenv/
     '''
+    # Support "user" if "runas" not used (will need to unify this for 0.17)
+    if not runas and 'user' in kwargs:
+        runas = str(kwargs['user'])
 
     cmd = [_get_pip_bin(bin_env), 'freeze']
     cmd_kwargs = dict(runas=runas, cwd=cwd)
@@ -615,7 +629,8 @@ def freeze(bin_env=None,
 def list_(prefix=None,
           bin_env=None,
           runas=None,
-          cwd=None):
+          cwd=None,
+          **kwargs):
     '''
     Filter list of installed apps from ``freeze`` and check to see if
     ``prefix`` exists in the list of packages installed.
@@ -627,6 +642,10 @@ def list_(prefix=None,
     packages = {}
 
     cmd = [_get_pip_bin(bin_env), 'freeze']
+
+    # Support "user" if "runas" not used (will need to unify this for 0.17)
+    if not runas and 'user' in kwargs:
+        runas = str(kwargs['user'])
 
     cmd_kwargs = dict(runas=runas, cwd=cwd)
     if bin_env and os.path.isdir(bin_env):

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -7,17 +7,11 @@ import os
 import re
 import logging
 import shutil
-import warnings
 
 # Import salt libs
 import salt.utils
 from salt._compat import string_types
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
-
-# runas warnings filter to force deprecation warning exhibition once
-warnings.filterwarnings(
-    'once', '(.*)runas(.*)', DeprecationWarning, __name__
-)
 
 # It would be cool if we could use __virtual__() in this module, though, since
 # pip can be installed on a virtualenv anywhere on the filesystem, there's no
@@ -249,10 +243,10 @@ def install(pkgs=None,
     # Support deprecated 'runas' arg
     if not user and runas is not None:
         user = str(runas)
-        warnings.warn('The \'runas\' argument to pip.install is deprecated, '
-                      'and will be removed in 0.18.0. Please use \'user\' '
-                      'instead.',
-                      DeprecationWarning
+        salt.utils.warn_until(
+            (0, 18),
+            'The \'runas\' argument to pip.install is deprecated, and will be '
+            'removed in 0.18.0. Please use \'user\' instead.'
         )
 
     cmd = [_get_pip_bin(bin_env), 'install']
@@ -528,10 +522,10 @@ def uninstall(pkgs=None,
     # Support deprecated 'runas' arg
     if not user and runas is not None:
         user = str(runas)
-        warnings.warn('The \'runas\' argument to pip.uninstall is deprecated, '
-                      'and will be removed in 0.18.0. Please use \'user\' '
-                      'instead.',
-                      DeprecationWarning
+        salt.utils.warn_until(
+            (0, 18),
+            'The \'runas\' argument to pip.install is deprecated, and will be '
+            'removed in 0.18.0. Please use \'user\' instead.'
         )
 
     cleanup_requirements = []
@@ -639,10 +633,10 @@ def freeze(bin_env=None,
     # Support deprecated 'runas' arg
     if not user and runas is not None:
         user = str(runas)
-        warnings.warn('The \'runas\' argument to pip.freeze is deprecated, '
-                      'and will be removed in 0.18.0. Please use \'user\' '
-                      'instead.',
-                      DeprecationWarning
+        salt.utils.warn_until(
+            (0, 18),
+            'The \'runas\' argument to pip.install is deprecated, and will be '
+            'removed in 0.18.0. Please use \'user\' instead.'
         )
 
     cmd = [_get_pip_bin(bin_env), 'freeze']
@@ -678,10 +672,10 @@ def list_(prefix=None,
     # Support deprecated 'runas' arg
     if not user and runas is not None:
         user = str(runas)
-        warnings.warn('The \'runas\' argument to pip.freeze is deprecated, '
-                      'and will be removed in 0.18.0. Please use \'user\' '
-                      'instead.',
-                      DeprecationWarning
+        salt.utils.warn_until(
+            (0, 18),
+            'The \'runas\' argument to pip.install is deprecated, and will be '
+            'removed in 0.18.0. Please use \'user\' instead.'
         )
 
     cmd_kwargs = dict(runas=user, cwd=cwd)

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -63,8 +63,7 @@ def installed(name,
               no_chown=False,
               cwd=None,
               pre_releases=False,
-              __env__='base',
-              **kwargs):
+              __env__='base'):
     '''
     Make sure the package is installed
 
@@ -85,10 +84,6 @@ def installed(name,
     elif env and not bin_env:
         bin_env = env
 
-    # Support "runas" if "user" not used (will need to unify this for 0.17)
-    if not user and 'runas' in kwargs:
-        user = str(kwargs['runas'])
-
     scheme, netloc, path, query, fragment = urlparse.urlsplit(name)
     if scheme and netloc:
         # parse as VCS url
@@ -101,7 +96,7 @@ def installed(name,
 
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     try:
-        pip_list = __salt__['pip.list'](prefix, bin_env, runas=user, cwd=cwd)
+        pip_list = __salt__['pip.list'](prefix, bin_env, user=user, cwd=cwd)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
@@ -161,7 +156,7 @@ def installed(name,
         no_install=no_install,
         no_download=no_download,
         install_options=install_options,
-        runas=user,
+        user=user,
         no_chown=no_chown,
         cwd=cwd,
         pre_releases=pre_releases,
@@ -171,7 +166,7 @@ def installed(name,
     if pip_install_call and (pip_install_call['retcode'] == 0):
         ret['result'] = True
 
-        pkg_list = __salt__['pip.list'](prefix, bin_env, runas=user, cwd=cwd)
+        pkg_list = __salt__['pip.list'](prefix, bin_env, user=user, cwd=cwd)
         if not pkg_list:
             ret['comment'] = (
                 'There was no error installing package \'{0}\' although '
@@ -205,8 +200,7 @@ def removed(name,
             timeout=None,
             user=None,
             cwd=None,
-            __env__='base',
-            **kwargs):
+            __env__='base'):
     '''
     Make sure that a package is not installed.
 
@@ -217,14 +211,10 @@ def removed(name,
     bin_env : None
         the pip executable or virtualenenv to use
     '''
-    # Support "runas" if "user" not used (will need to unify this for 0.17)
-    if not user and 'runas' in kwargs:
-        user = str(kwargs['runas'])
-
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
     try:
-        pip_list = __salt__['pip.list'](bin_env=bin_env, runas=user, cwd=cwd)
+        pip_list = __salt__['pip.list'](bin_env=bin_env, user=user, cwd=cwd)
     except (CommandExecutionError, CommandNotFoundError) as err:
         ret['result'] = False
         ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)
@@ -246,7 +236,7 @@ def removed(name,
                                  log=log,
                                  proxy=proxy,
                                  timeout=timeout,
-                                 runas=user,
+                                 user=user,
                                  cwd=cwd,
                                  __env__='base'):
         ret['result'] = True

--- a/salt/states/pip.py
+++ b/salt/states/pip.py
@@ -63,12 +63,15 @@ def installed(name,
               no_chown=False,
               cwd=None,
               pre_releases=False,
-              __env__='base'):
+              __env__='base',
+              **kwargs):
     '''
     Make sure the package is installed
 
     name
         The name of the python package to install
+    user
+        The user under which to run pip
     pip_bin : None
         Deprecated, use bin_env
     env : None
@@ -81,6 +84,10 @@ def installed(name,
         bin_env = pip_bin
     elif env and not bin_env:
         bin_env = env
+
+    # Support "runas" if "user" not used (will need to unify this for 0.17)
+    if not user and 'runas' in kwargs:
+        user = str(kwargs['runas'])
 
     scheme, netloc, path, query, fragment = urlparse.urlsplit(name)
     if scheme and netloc:
@@ -198,15 +205,21 @@ def removed(name,
             timeout=None,
             user=None,
             cwd=None,
-            __env__='base'):
+            __env__='base',
+            **kwargs):
     '''
     Make sure that a package is not installed.
 
     name
         The name of the package to uninstall
+    user
+        The user under which to run pip
     bin_env : None
         the pip executable or virtualenenv to use
     '''
+    # Support "runas" if "user" not used (will need to unify this for 0.17)
+    if not user and 'runas' in kwargs:
+        user = str(kwargs['runas'])
 
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 


### PR DESCRIPTION
The pip state uses "user", while the module uses "runas".  This needs to
be unified in 0.17.0, but until then this commit makes these arguments
interchangeable.
