### PR TITLE
Fix indentation in the minion config template

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -89,7 +89,7 @@
 # /etc/ssh/sshd_config:
 #   file.managed:
 #     - source: salt://ssh/sshd_config
-#       - backup: minion
+#     - backup: minion
 #
 #backup_mode: minion
 


### PR DESCRIPTION
The example for the 'backup' param in the minion config file template is
indented one level further than it should. This commit fixes that.
