### PR TITLE
Use os.getloadavg output directly

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -124,11 +124,10 @@ def loadavg():
     
         salt '*' status.loadavg
     '''
-    comps = "%.2f %.2f %.2f" % os.getloadavg()
-    load_avg = comps.split()
-    return {'1-min':  _number(load_avg[0]),
-            '5-min':  _number(load_avg[1]),
-            '15-min': _number(load_avg[2])}
+    load_avg = os.getloadavg()
+    return {'1-min':  load_avg[0],
+            '5-min':  load_avg[1],
+            '15-min': load_avg[2]}
 
 
 def cpustats():


### PR DESCRIPTION
Small cleanup: directly use os.getloadavg()
