### PR TITLE
Issue #4948 - add state_output argument to allow override of value configured in master

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -953,6 +953,14 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help=('Run the salt command but don\'t wait for a reply')
         )
         self.add_option(
+            '--state_output',
+            default='full',
+            dest='state_output',
+            type=str,
+            help=('Override the configured state_output value for minion output'
+                  '. Default: full')
+        )
+        self.add_option(
             '--subset',
             default=0,
             dest='subset',


### PR DESCRIPTION
Adds new parameter to cli:

salt '_' state.highstate --state_output=terse
salt '_' state.highstate --state_output=full
