### PR TITLE
Fix cpu_model output on OS X

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -247,6 +247,9 @@ def _bsd_cpudata(osdata):
     if arch and osdata['kernel'] == 'OpenBSD':
         cmds['cpuarch'] = '{0} -s'.format(arch)
 
+    if osdata['kernel'] == 'Darwin':
+        cmds['cpu_model'] = '{0} -n machdep.cpu.brand_string'.format(sysctl)
+
     grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
     grains['cpu_flags'] = []
 


### PR DESCRIPTION
On test system, old behavior:
{'cpu_model': 'MacBookAir4,1'}
With this patch:
{'cpu_model': 'Intel(R) Core(TM) i7-2677M CPU @ 1.80GHz'}
