### PR TITLE
fix typos of salt.utils in modules.win_disk

### DIFF
--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -9,7 +9,7 @@ import ctypes
 import string
 
 # Import salt libs
-import salt.util
+import salt.utils
 
 try:
     import win32api
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Only works on Windows systems
     '''
-    if salt.util.is_windows():
+    if salt.utils.is_windows():
         return 'disk'
     return False
 


### PR DESCRIPTION
```
************* Module salt.modules.win_disk
E0611: 12,0: No name 'util' in module 'salt'
E1101: 23,7:__virtual__: Module 'salt' has no 'util' member
```
