### PR TITLE
use connection_args in modules.mysql.processlist()

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1129,7 +1129,7 @@ def processlist(**connection_args):
     '''
     ret = []
 
-    dbc = _connect()
+    dbc = _connect(**connection_args)
     cur = dbc.cursor()
     cur.execute('SHOW FULL PROCESSLIST')
     hdr = [c[0] for c in cur.description]


### PR DESCRIPTION
```
************* Module salt.modules.mysql
W0613:1107,0:processlist: Unused argument 'connection_args'
```
