### PR TITLE
add support for a2ensite,a2dissite

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -251,7 +251,7 @@ def userdel(pwfile, user):
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
 
-def checkSiteEnabled(site):
+def check_site_enabled(site):
   '''
   Checks to see if the specific Site symlink is in /etc/apache2/sites-enabled
   '''

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -5,9 +5,12 @@ Support for Apache
 # Import python libs
 import os
 import re
+import logging
 
 # Import salt libs
 import salt.utils
+
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -247,3 +250,61 @@ def userdel(pwfile, user):
     cmd = 'htpasswd -D {0} {1}'.format(pwfile, user)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
+
+def checkSiteEnabled(site):
+  '''
+  Checks to see if the specific Site symlink is in /etc/apache2/sites-enabled
+  '''
+  if os.path.islink('/etc/apache2/sites-enabled/{0}'.format(site)):
+    return True
+  elif (site == 'default' and os.path.islink('/etc/apache2/sites-enabled/000-{0}'.format(site))):
+    return True
+  else:
+    return False
+
+def a2ensite(site):
+  '''  Runs a2ensite for the given site '''
+
+  ret = {}
+  command = 'a2ensite {0}'.format(site)
+
+  try:
+    status = os.system(command)
+  except Exception as e:
+    return e
+
+  ret['Name'] = 'Apache2 Enable Site'
+  ret['Site'] = site
+
+  if status == 1:
+    ret['Status'] = 'Site {0} Not found'.format(site)
+  elif status == 0:
+    ret['Status'] = 'Site {0} enabled'.format(site)
+  else:
+    ret['Status'] = status
+
+  return ret
+
+def a2dissite(site):
+  ''' Runs a2dissite for the given site '''
+
+  ret = {}
+  command = 'a2dissite {0}'.format(site)
+
+  try:
+    status = os.system(command)
+  except Exception as e:
+    return e
+
+
+  ret['Name'] = 'Apache2 Disable Site'
+  ret['Site'] = site
+
+  if status == 256:
+    ret['Status'] = 'Site {0} Not found'.format(site)
+  elif status == 0:
+    ret['Status'] = 'Site {0} disabled'.format(site)
+  else:
+    ret['Status'] = status
+
+  return ret

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -269,7 +269,7 @@ def a2ensite(site):
   command = 'a2ensite {0}'.format(site)
 
   try:
-    status = os.system(command)
+    status = __salt__['cmd.run'](command)
   except Exception as e:
     return e
 
@@ -292,7 +292,7 @@ def a2dissite(site):
   command = 'a2dissite {0}'.format(site)
 
   try:
-    status = os.system(command)
+    status = __salt__['cmd.run'](command)
   except Exception as e:
     return e
 


### PR DESCRIPTION
Adds the ability for people to enable and disable sites using standard apache2 tools (a2ensite/a2dissite). 

This also adds a check to see if a particular site(symlink) exists. This will be used for a state to be added soon.
