### PR TITLE
Add functions to manage file backups

### DIFF
--- a/doc/ref/modules/all/salt.modules.file.rst
+++ b/doc/ref/modules/all/salt.modules.file.rst
@@ -4,3 +4,4 @@ salt.modules.file
 
 .. automodule:: salt.modules.file
     :members:
+    :exclude-members: list_backup

--- a/doc/ref/modules/all/salt.modules.file.rst
+++ b/doc/ref/modules/all/salt.modules.file.rst
@@ -4,4 +4,4 @@ salt.modules.file
 
 .. automodule:: salt.modules.file
     :members:
-    :exclude-members: list_backup
+    :exclude-members: list_backup, remove_backup

--- a/doc/ref/states/backup_mode.rst
+++ b/doc/ref/states/backup_mode.rst
@@ -1,5 +1,5 @@
 ==================
-State File Backups
+File State Backups
 ==================
 
 In 0.10.2 a new feature was added for backing up files that are replaced by
@@ -22,10 +22,102 @@ Or it can be set for each file:
         - source: salt://ssh/sshd_config
         - backup: minion
 
-Backed up Files
+Backed-up Files
 ===============
 
 The files will be saved in the minion cachedir under the directory named
 ``file_backup``. The files will be in the location relative to where they
 were under the root filesystem and be appended with a timestamp. This should
 make them easy to browse.
+
+Interacting with Backups
+========================
+
+Starting with version 0.17.0, it will be possible to list, restore, and delete
+previously-created backups.
+
+Listing
+-------
+
+The backups for a given file can be listed using :mod:`file.list_backups
+<salt.modules.file.list_backups>`::
+
+    # salt foo.bar.com file.list_backups /tmp/foo.txt
+    foo.bar.com:
+        ----------
+        0:
+            ----------
+            Backup Time:
+                Sat Jul 27 2013 17:48:41.738027
+            Location:
+                /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_17:48:41_738027_2013
+            Size:
+                13
+        1:
+            ----------
+            Backup Time:
+                Sat Jul 27 2013 17:48:28.369804
+            Location:
+                /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_17:48:28_369804_2013
+            Size:
+                35
+
+Restoring
+---------
+
+Restoring is easy using :mod:`file.restore_backup
+<salt.modules.file.restore_backup>`, just pass the path and the numeric id
+found with :mod:`file.list_backups <salt.modules.file.list_backups>`::
+
+    # salt foo.bar.com file.restore_backup /tmp/foo.txt 1
+    foo.bar.com:
+        ----------
+        comment:
+            Successfully restored /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_17:48:28_369804_2013 to /tmp/foo.txt
+        result:
+            True
+
+The existing file will be backed up, just in case, as can be seen if :mod:`file.list_backups
+<salt.modules.file.list_backups>` is run again::
+
+    # salt foo.bar.com file.list_backups /tmp/foo.txt
+    foo.bar.com:
+        ----------
+        0:
+            ----------
+            Backup Time:
+                Sat Jul 27 2013 18:00:19.822550
+            Location:
+                /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_18:00:19_822550_2013
+            Size:
+                53
+        1:
+            ----------
+            Backup Time:
+                Sat Jul 27 2013 17:48:41.738027
+            Location:
+                /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_17:48:41_738027_2013
+            Size:
+                13
+        2:
+            ----------
+            Backup Time:
+                Sat Jul 27 2013 17:48:28.369804
+            Location:
+                /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_17:48:28_369804_2013
+            Size:
+                35
+
+Deleting
+--------
+
+Deleting backups can be done using mod:`file.delete_backup
+<salt.modules.file.delete_backup>`::
+
+    # salt foo.bar.com file.delete_backup /tmp/foo.txt 0
+    foo.bar.com:
+        ----------
+        comment:
+            Successfully removed /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_18:00:19_822550_2013
+        result:
+            True

--- a/doc/ref/states/backup_mode.rst
+++ b/doc/ref/states/backup_mode.rst
@@ -77,8 +77,8 @@ found with :mod:`file.list_backups <salt.modules.file.list_backups>`::
         result:
             True
 
-The existing file will be backed up, just in case, as can be seen if :mod:`file.list_backups
-<salt.modules.file.list_backups>` is run again::
+The existing file will be backed up, just in case, as can be seen if
+:mod:`file.list_backups <salt.modules.file.list_backups>` is run again::
 
     # salt foo.bar.com file.list_backups /tmp/foo.txt
     foo.bar.com:
@@ -107,6 +107,11 @@ The existing file will be backed up, just in case, as can be seen if :mod:`file.
                 /var/cache/salt/minion/file_backup/tmp/foo.txt_Sat_Jul_27_17:48:28_369804_2013
             Size:
                 35
+
+.. note::
+    Since no state is being run, restoring a file will not trigger any watches
+    for the file. So, if you are restoring a config file for a service, it will
+    likely still be necessary to run a ``service.restart``.
 
 Deleting
 --------

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -9,20 +9,21 @@ data
 # Import python libs
 import contextlib  # For < 2.7 compat
 import datetime
-import os
-import re
-import time
-import shutil
-import stat
-import tempfile
-import sys
+import difflib
+import errno
+import fnmatch
 import getpass
 import hashlib
-import difflib
-import fnmatch
-import errno
-import logging
 import itertools
+import logging
+import os
+import re
+import shutil
+import stat
+import sys
+import tempfile
+import time
+
 try:
     import grp
     import pwd
@@ -88,6 +89,14 @@ def _binary_replace(old, new):
         elif new_isbin:
             return 'Replace text file with binary file'
     return ''
+
+
+def _get_bkroot():
+    '''
+    Get the location of the backup dir in the minion cache
+    '''
+    # Get the cachedir from the minion config
+    return os.path.join(__salt__['config.get']('cachedir'), 'file_backup')
 
 
 def gid_to_group(gid):
@@ -1854,7 +1863,7 @@ def makedirs_perms(name, user=None, group=None, mode='0755'):
                 int('{0}'.format(mode)) if mode else None)
 
 
-def list_backups(path):
+def list_backups(path, limit=None):
     '''
     .. note::
         This function will be available in version 0.17.0.
@@ -1862,19 +1871,31 @@ def list_backups(path):
     Lists the previous versions of a file backed up using Salt's :doc:`file
     state backup </ref/states/backup_mode>` system.
 
+    path
+        The path on the minion to check for backups
+    limit
+        Limit the number of results to the most recent N backups
+
     CLI Example::
 
         salt '*' file.list_backups /foo/bar/baz.txt
     '''
-    # Get the cachedir from the minion config
-    cachedir = __salt__['config.get']('cachedir')
+    try:
+        limit = int(limit)
+    except TypeError:
+        pass
+    except ValueError:
+        log.error('file.list_backups: \'limit\' value must be numeric')
+        limit = None
+
+    bkroot = _get_bkroot()
     parent_dir, basename = os.path.split(path)
     # Figure out full path of location of backup file in minion cache
-    cachedir = os.path.join(cachedir, 'file_backup', parent_dir.lstrip('/'))
+    bkdir = os.path.join(bkroot, parent_dir[1:])
 
     files = {}
-    for fn in [x for x in os.listdir(cachedir)
-               if os.path.isfile(os.path.join(cachedir, x))]:
+    for fn in [x for x in os.listdir(bkdir)
+               if os.path.isfile(os.path.join(bkdir, x))]:
         strpfmt = '{0}_%a_%b_%d_%H:%M:%S_%f_%Y'.format(basename)
         try:
             timestamp = datetime.datetime.strptime(fn, strpfmt)
@@ -1884,10 +1905,118 @@ def list_backups(path):
             continue
         files.setdefault(timestamp, {})['Backup Time'] = \
             timestamp.strftime('%a %b %d %Y %H:%M:%S.%f')
-        stats = os.stat(os.path.join(cachedir, fn))
+        stats = os.stat(os.path.join(bkdir, fn))
         files[timestamp]['Size'] = stats.st_size
-        files[timestamp]['Location'] = os.path.join(cachedir, fn)
+        files[timestamp]['Location'] = os.path.join(bkdir, fn)
 
-    return dict(zip(range(len(files)), [files[x] for x in sorted(files)]))
+    return dict(zip(
+        range(len(files)),
+        [files[x] for x in sorted(files, reverse=True)[:limit]]
+    ))
 
 list_backup = list_backups
+
+
+def restore_backup(path, backup_id):
+    '''
+    .. note::
+        This function will be available in version 0.17.0.
+
+    Restore a previous version of a file that was backed up using Salt's
+    :doc:`file state backup </ref/states/backup_mode>` system.
+
+    path
+        The path on the minion to check for backups
+    backup_id
+        The numeric id for the backup you wish to restore, as found using
+        :mod:`file.list_backups <salt.modules.file.list_backups>`
+
+    CLI Example::
+
+        salt '*' file.restore_backup /foo/bar/baz.txt 0
+    '''
+    # Note: This only supports minion backups, so this function will need to be
+    # modified if/when master backups are implemented.
+    ret = {'result': False,
+           'comment': 'Invalid backup_id \'{0}\''.format(backup_id)}
+    try:
+        if len(str(backup_id)) == len(str(int(backup_id))):
+            backup = list_backups(path)[int(backup_id)]
+        else:
+            return ret
+    except ValueError:
+        return ret
+    except KeyError:
+        ret['comment'] = 'backup_id \'{0}\' does not exist for ' \
+                         '{1}'.format(backup_id, path)
+        return ret
+
+    salt.utils.backup_minion(path, _get_bkroot())
+    try:
+        shutil.copyfile(backup['Location'], path)
+    except IOError as exc:
+        ret['comment'] = \
+            'Unable to restore {0} to {1}: ' \
+            '{2}'.format(backup['Location'], path, exc)
+        return ret
+    else:
+        ret['result'] = True
+        ret['comment'] = 'Successfully restored {0} to ' \
+                         '{1}'.format(backup['Location'], path)
+
+    # Try to set proper ownership
+    try:
+        fstat = os.stat(path)
+    except (FileNotFoundError, IOError):
+        pass
+        ret['comment'] += ', but was unable to set ownership'
+    else:
+        os.chown(path, fstat.st_uid, fstat.st_gid)
+
+    return ret
+
+
+def delete_backup(path, backup_id):
+    '''
+    .. note::
+        This function will be available in version 0.17.0.
+
+    Restore a previous version of a file that was backed up using Salt's
+    :doc:`file state backup </ref/states/backup_mode>` system.
+
+    path
+        The path on the minion to check for backups
+    backup_id
+        The numeric id for the backup you wish to delete, as found using
+        :mod:`file.list_backups <salt.modules.file.list_backups>`
+
+    CLI Example::
+
+        salt '*' file.restore_backup /foo/bar/baz.txt 0
+    '''
+    ret = {'result': False,
+           'comment': 'Invalid backup_id \'{0}\''.format(backup_id)}
+    try:
+        if len(str(backup_id)) == len(str(int(backup_id))):
+            backup = list_backups(path)[int(backup_id)]
+        else:
+            return ret
+    except ValueError:
+        return ret
+    except KeyError:
+        ret['comment'] = 'backup_id \'{0}\' does not exist for ' \
+                         '{1}'.format(backup_id, path)
+        return ret
+
+    try:
+        os.remove(backup['Location'])
+    except IOError as exc:
+        ret['comment'] = 'Unable to remove {0}: {1}'.format(backup['Location'],
+                                                            exc)
+    else:
+        ret['result'] = True
+        ret['comment'] = 'Successfully removed {0}'.format(backup['Location'])
+
+    return ret
+
+remove_backup = delete_backup

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -528,17 +528,7 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
         bkroot = os.path.join(cachedir, 'file_backup')
     if backup_mode == 'minion' or backup_mode == 'both' and bkroot:
         if os.path.exists(dest):
-            fstat = os.stat(dest)
-            msecs = str(int(time.time() * 1000000))[-6:]
-            stamp = time.asctime().replace(' ', '_')
-            stamp = '{0}{1}_{2}'.format(stamp[:-4], msecs, stamp[-4:])
-            bkpath = os.path.join(bkroot,
-                                  dname[1:],
-                                  '{0}_{1}'.format(bname, stamp))
-            if not os.path.isdir(os.path.dirname(bkpath)):
-                os.makedirs(os.path.dirname(bkpath))
-            shutil.copyfile(dest, bkpath)
-            os.chown(bkpath, fstat.st_uid, fstat.st_gid)
+            backup_minion(dest, bkroot)
     if backup_mode == 'master' or backup_mode == 'both' and bkroot:
         # TODO, backup to master
         pass
@@ -555,6 +545,24 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
             os.remove(tgt)
         except Exception:
             pass
+
+
+def backup_minion(path, bkroot):
+    '''
+    Backup a file on the minion
+    '''
+    dname, bname = os.path.split(path)
+    fstat = os.stat(path)
+    msecs = str(int(time.time() * 1000000))[-6:]
+    stamp = time.asctime().replace(' ', '_')
+    stamp = '{0}{1}_{2}'.format(stamp[:-4], msecs, stamp[-4:])
+    bkpath = os.path.join(bkroot,
+                          dname[1:],
+                          '{0}_{1}'.format(bname, stamp))
+    if not os.path.isdir(os.path.dirname(bkpath)):
+        os.makedirs(os.path.dirname(bkpath))
+    shutil.copyfile(path, bkpath)
+    os.chown(bkpath, fstat.st_uid, fstat.st_gid)
 
 
 def path_join(*parts):


### PR DESCRIPTION
This pull req adds three new functions to interact with files backed up by Salt: `file.list_backups`, `file.restore_backup`, and `file.delete_backup`. Documentation for this feature has also been added to the page describing how to use salt to backup files overwritten by file states.

Fixes #6322.
