### PR TITLE
Populate __context__ with retcode; Fixes issue #5518

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -337,6 +337,11 @@ def _run(cmd,
     ret['stderr'] = err
     ret['pid'] = proc.process.pid
     ret['retcode'] = proc.process.returncode
+    try:
+        __context__['retcode'] = ret['retcode']
+    except NameError:
+        # Ignore the context error during grain generation
+        pass 
     return ret
 
 


### PR DESCRIPTION
Returns the proper retcode when running something like "salt-call cmd.run lsdfds --return local":

`{'fun': 'cmd.run', 'jid': '20130727172909251080', 'return': '/bin/bash: lsdfds: command not found', 'retcode': 127, 'id': 'Helios'}`

Previously `__context__` did not have `retcode` defined, and defaulted to 0 (in line 70 of salt/cli/caller).
