### PR TITLE
file.restore_backup: FileNotFoundError is from Python 3; rm pointless 'pass'

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1967,8 +1967,7 @@ def restore_backup(path, backup_id):
     # Try to set proper ownership
     try:
         fstat = os.stat(path)
-    except (FileNotFoundError, IOError):
-        pass
+    except (OSError, IOError):
         ret['comment'] += ', but was unable to set ownership'
     else:
         os.chown(path, fstat.st_uid, fstat.st_gid)


### PR DESCRIPTION
```
************* Module salt.modules.file
E0602:1970,12:restore_backup: Undefined variable 'FileNotFoundError'
W0107:1971,8:restore_backup: Unnecessary pass statement
```
