### PR TITLE
6079 add umount when device of mounted filesystem differs

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -78,6 +78,15 @@ def mounted(name,
 
     # Get the active data
     active = __salt__['mount.active']()
+    if name in active:
+	print "active!\n"
+        if active.__getitem__(name).__getitem__('device') != device:
+            # name matches but device doesn't - need to umount
+            out = __salt__['mount.umount'](name)
+            active = __salt__['mount.active']()
+        else:
+	    ret['comment'] = 'Target was already mounted'
+    # using a duplicate check so I can catch the results of a umount
     if name not in active:
         # The mount is not present! Mount it
         if __opts__['test']:
@@ -94,8 +103,6 @@ def mounted(name,
             # (Re)mount worked!
             ret['comment'] = 'Target was successfully mounted'
             ret['changes']['mount'] = True
-    else:
-        ret['comment'] = 'Target was already mounted'
 
     if persist:
         if __opts__['test']:

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -79,13 +79,12 @@ def mounted(name,
     # Get the active data
     active = __salt__['mount.active']()
     if name in active:
-	print "active!\n"
         if active.__getitem__(name).__getitem__('device') != device:
             # name matches but device doesn't - need to umount
             out = __salt__['mount.umount'](name)
             active = __salt__['mount.active']()
         else:
-	    ret['comment'] = 'Target was already mounted'
+            ret['comment'] = 'Target was already mounted'
     # using a duplicate check so I can catch the results of a umount
     if name not in active:
         # The mount is not present! Mount it


### PR DESCRIPTION
Working on https://github.com/saltstack/salt/issues/6079.. Added logic to umount a mounted filesystem if the mountpoint matches the one requested but the device name doesn't (meaning the mount is being changed). I added a redundant check of whether the filesystem is mounted so that I could umount it and let the existing logic mount it and send back the status codes. I also moved the 'Target was already mounted' message up to my new check because it seemed like a good place for it.
