### PR TITLE
state.py: rm unused import of callable()

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -27,7 +27,7 @@ import salt.minion
 import salt.pillar
 import salt.fileclient
 import salt.utils.event
-from salt._compat import string_types, callable
+from salt._compat import string_types
 from salt.template import compile_template, compile_template_str
 from salt.exceptions import SaltReqTimeoutError, SaltException
 


### PR DESCRIPTION
```
************* Module salt.state
W0611: 30,0: Unused import callable
```
