### PR TITLE
Only split on basestring types

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -281,7 +281,7 @@ def _bsd_cpudata(osdata):
 
     grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
 
-    if 'cpu_flags' in grains and not isinstance(grains['cpu_flags'], list):
+    if 'cpu_flags' in grains and isinstance(grains['cpu_flags'], basestring):
         grains['cpu_flags'] = grains['cpu_flags'].split(' ')
 
     if osdata['kernel'] == 'NetBSD':


### PR DESCRIPTION
Ref #6413 and #6407

Just prevents errors down the road.  Credit goes to @SEJeff.  =)
