### PR TITLE
Add Debian/Ubuntu package compatible service dir to daemontools module

### DIFF
--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -11,15 +11,26 @@ service state via provider interface:
 import os
 import re
 
+# Import salt libs
+from salt.exceptions import CommandExecutionError
+
 # Function alias to not shadow built-ins.
 __func_alias__ = {
     'reload_': 'reload'
 }
 
-if os.path.exists('/service'):
-    SERVICE_DIR = "/service"
-elif os.path.exists('/var/service'):
-    SERVICE_DIR = "/var/service"
+VALID_SERVICE_DIRS = [
+    '/service',
+    '/var/service',
+    '/etc/service',
+]
+SERVICE_DIR = None
+for service_dir in VALID_SERVICE_DIRS:
+    if os.path.exists(service_dir):
+        SERVICE_DIR = service_dir
+        break
+if not SERVICE_DIR:
+    raise CommandExecutionError("Could not find service directory.")
 
 
 def _service_path(name):


### PR DESCRIPTION
The Debian/Ubuntu packaged version of daemontools relocates the service directory to /etc/service

This simple patch adds support for the relocated service directory to the daemontools module, and raises an exception if a service directory cannot be found.
