### PR TITLE
Punctuation fix in pillar docs

### DIFF
--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -220,8 +220,8 @@ locally. This is done with the ``saltutil.refresh_pillar`` function.
 
     salt '*' saltutil.refresh_pillar
 
-This function triggers the minion to asynchronously refresh the pillar and will always return
-``None``
+This function triggers the minion to asynchronously refresh the pillar and will
+always return ``None``.
 
 Targeting with Pillar
 =====================


### PR DESCRIPTION
Sentence is missing a period at the end.
