### PR TITLE
Set permissions on Salt dir

### DIFF
--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -130,6 +130,7 @@ Section "MainSection" SEC01
   SetOverwrite try
   CreateDirectory $INSTDIR\conf\pki\minion
   File /r "..\buildenv\"
+  Exec 'icacls c:\salt /inheritance:r /grant:r "BUILTIN\Administrators":(OI)(CI)F /grant:r "NT AUTHORITY\SYSTEM":(OI)(CI)F' 
 
 SectionEnd
 


### PR DESCRIPTION
Only allow Administrator's group and System user access to
c:\salt

Fixes #6361
