### PR TITLE
[#6428] Fixing CommandExecutionError warnings

### DIFF
--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -23,6 +23,7 @@ VALID_SERVICE_DIRS = [
     '/service',
     '/var/service',
     '/etc/service',
+    '/etc/init.d',
 ]
 SERVICE_DIR = None
 for service_dir in VALID_SERVICE_DIRS:


### PR DESCRIPTION
Adding a service directory to suppress the CmdExecError warnings.
