### PR TITLE
added list_queues commands

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -298,3 +298,30 @@ def force_reset(runas=None):
         runas=runas)
 
     return res
+
+def list_queues(*kwargs):
+    '''
+    Returns queue details of the / virtual host
+
+    Example::
+
+        salt '*' rabbitmq.list_queues messages consumers
+    '''
+    res = __salt__['cmd.run'](
+        'rabbitmqctl list_queues {0}'.format(' '.join(list(kwargs))))
+    return res
+
+def list_queues_vhost(vhost, *kwargs):
+    '''
+    Returns queue details of specified virtual host.
+    This command will consider first parameter as the vhost name and rest will be treated as queueinfoitem.
+    Also rabbitmqctl's -p parameter will be passed by salt, it should not be provided by salt command
+    For getting details on vhost '/', use list_queues instead).
+
+    Example::
+
+        salt '*' rabbitmq.list_queues messages consumers
+    '''
+    res = __salt__['cmd.run'](
+        'rabbitmqctl list_queues -p {0} {1}'.format(vhost, ' '.join(list(kwargs))))
+    return res


### PR DESCRIPTION
rabbitmqctl has these list commands (list_queues, list_exchanges, list_bindings etc), which accepts vhost argument  with -p parameter (which is not mandatory, if not provided, command is executed on vhost '/' ).

Also these commands accept various number of arguments which defines the output of these commands.

But since we cannot provide -p on salt command line, I have split it in two separate salt commands. 

If this is ok, I can implement other commands in the similar format.

http://www.rabbitmq.com/man/rabbitmqctl.1.man.html
