### PR TITLE
Complete the work started on the sprint for `salt.modules.archive`

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -138,27 +138,28 @@ def unzip(zipfile, dest, excludes=None, template=None):
 
 
 @decorators.which('rar')
-def rar(rarfile, template=None, *sources):
+def rar(rarfile, sources, template=None):
     '''
     Uses the rar command to create rar files
     Uses rar for Linux from http://www.rarlab.com/
 
     CLI Example::
 
-        salt '*' archive.rar /tmp/rarfile.rar /tmp/sourcefile1 /tmp/sourcefile2
+        salt '*' archive.rar /tmp/rarfile.rar /tmp/sourcefile1,/tmp/sourcefile2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' archive.rar template=jinja /tmp/rarfile.rar /tmp/sourcefile1 /tmp/{{grains.id}}.txt
+        salt '*' archive.rar template=jinja /tmp/rarfile.rar \
+                /tmp/sourcefile1,/tmp/{{grains.id}}.txt
 
 
     '''
-    # TODO: Check that len(sources) >= 1
-    sourcefiles = ' '.join(sources)
-    cmd = 'rar a -idp {0} {1}'.format(rarfile, sourcefiles)
-    out = __salt__['cmd.run'](cmd, template=template).splitlines()
+    if isinstance(sources, salt._compat.string_types):
+        sources = [s.strip() for s in sources.split(',')]
+    cmd = 'rar a -idp {0} {1}'.format(rarfile, ' '.join(sources))
+    return __salt__['cmd.run'](cmd, template=template).splitlines()
     return out
 
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -111,27 +111,30 @@ def zip_(zipfile, sources, template=None):
 
 
 @decorators.which('unzip')
-def unzip(zipfile, dest, template=None, *xfiles):
+def unzip(zipfile, dest, excludes=None, template=None):
     '''
     Uses the unzip command to unpack zip files
 
     CLI Example::
 
-        salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ file_1 file_2
+        salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ \
+                excludes=file_1,file_2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' archive.unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ file_1 file_2
+        salt '*' archive.unzip template=jinja /tmp/zipfile.zip \
+                /tmp/{{grains.id}}/ excludes=file_1,file_2
 
     '''
-    xfileslist = ' '.join(xfiles)
+    if isinstance(excludes, salt._compat.string_types):
+        excludes = [entry.strip() for entry in excludes.split(',')]
+
     cmd = 'unzip {0} -d {1}'.format(zipfile, dest)
-    if xfileslist:
-        cmd = cmd + ' -x {0}'.format(xfiles)
-    out = __salt__['cmd.run'](cmd, template=template).splitlines()
-    return out
+    if excludes is not None:
+        cmd += ' -x {0}'.format(' '.join(excludes))
+    return __salt__['cmd.run'](cmd, template=template).splitlines()
 
 
 @decorators.which('rar')

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -36,7 +36,8 @@ def tar(options, tarfile, sources, cwd=None, template=None):
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' archive.tar template=jinja cjvf /tmp/salt.tar.bz2 {{grains.saltpath}}
+        salt '*' archive.tar template=jinja cjvf /tmp/salt.tar.bz2 \
+                {{grains.saltpath}}
 
     '''
     if isinstance(sources, salt._compat.string_types):
@@ -63,8 +64,7 @@ def gzip(sourcefile, template=None):
 
     '''
     cmd = 'gzip {0}'.format(sourcefile)
-    out = __salt__['cmd.run'](cmd, template=template).splitlines()
-    return out
+    return __salt__['cmd.run'](cmd, template=template).splitlines()
 
 
 @decorators.which('gunzip')
@@ -84,30 +84,30 @@ def gunzip(gzipfile, template=None):
 
     '''
     cmd = 'gunzip {0}'.format(gzipfile)
-    out = __salt__['cmd.run'](cmd, template=template).splitlines()
-    return out
+    return __salt__['cmd.run'](cmd, template=template).splitlines()
 
 
 @decorators.which('zip')
-def zip_(zipfile, template=None, *sources):
+def zip_(zipfile, sources, template=None):
     '''
     Uses the zip command to create zip files
 
     CLI Example::
 
-        salt '*' archive.zip /tmp/zipfile.zip /tmp/sourcefile1 /tmp/sourcefile2
+        salt '*' archive.zip /tmp/zipfile.zip /tmp/sourcefile1,/tmp/sourcefile2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
     For example::
 
-        salt '*' archive.zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1 /tmp/{{grains.id}}.txt
+        salt '*' archive.zip template=jinja /tmp/zipfile.zip \
+                /tmp/sourcefile1,/tmp/{{grains.id}}.txt
 
     '''
-    sourcefiles = ' '.join(sources)
-    cmd = 'zip {0} {1}'.format(zipfile, sourcefiles)
-    out = __salt__['cmd.run'](cmd, template=template).splitlines()
-    return out
+    if isinstance(sources, salt._compat.string_types):
+        sources = [s.strip() for s in sources.split(',')]
+    cmd = 'zip {0} {1}'.format(zipfile, ' '.join(sources))
+    return __salt__['cmd.run'](cmd, template=template).splitlines()
 
 
 @decorators.which('unzip')

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -160,7 +160,6 @@ def rar(rarfile, sources, template=None):
         sources = [s.strip() for s in sources.split(',')]
     cmd = 'rar a -idp {0} {1}'.format(rarfile, ' '.join(sources))
     return __salt__['cmd.run'](cmd, template=template).splitlines()
-    return out
 
 
 @decorators.which_bin(('unrar', 'rar'))

--- a/salt/utils/decorators.py
+++ b/salt/utils/decorators.py
@@ -132,6 +132,25 @@ def which(exe):
     return wrapper
 
 
+def which_bin(exes):
+    '''
+    Decorator wrapper for salt.utils.which_bin
+    '''
+    def wrapper(function):
+        def wrapped(*args, **kwargs):
+            if salt.utils.which_bin(exes) is None:
+                raise CommandNotFoundError(
+                    'None of provided binaries({0}) was not found '
+                    'in $PATH.'.format(
+                        ['{0!r}'.format(exe) for exe in exes]
+                    )
+                )
+            return function(*args, **kwargs)
+        return identical_signature_wrapper(function, wrapped)
+    return wrapper
+
+
+
 def identical_signature_wrapper(original_function, wrapped_function):
     '''
     Return a function with identical signature as ``original_function``'s which

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -137,6 +137,20 @@ class ArchiveTestCase(TestCase):
                 template='jinja'
             )
 
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.zip_(
+                '/tmp/salt.{{grains.id}}.zip',
+                ['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
+                template='jinja'
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'zip /tmp/salt.{{grains.id}}.zip '
+                '/tmp/tmpePe8yO /tmp/tmpLeSw1A',
+                template='jinja'
+            )
+
     @patch('salt.utils.which', lambda exe: None)
     def test_zip_raises_exception_if_not_found(self):
         mock = MagicMock(return_value='salt')

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -150,6 +150,37 @@ class ArchiveTestCase(TestCase):
             )
             self.assertFalse(mock.called)
 
+    @patch('salt.utils.which', lambda exe: exe)
+    def test_unzip(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.unzip(
+                '/tmp/salt.{{grains.id}}.zip',
+                '/tmp/dest',
+                excludes='/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
+                template='jinja'
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'unzip /tmp/salt.{{grains.id}}.zip -d /tmp/dest '
+                '-x /tmp/tmpePe8yO /tmp/tmpLeSw1A',
+                template='jinja'
+            )
+
+    @patch('salt.utils.which', lambda exe: None)
+    def test_unzip_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.unzip,
+                '/tmp/salt.{{grains.id}}.zip',
+                '/tmp/dest',
+                excludes='/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
+                template='jinja',
+            )
+            self.assertFalse(mock.called)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -15,6 +15,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 from salt.modules import archive
+from salt.exceptions import CommandNotFoundError
 
 # Import 3rd party libs
 try:
@@ -27,8 +28,9 @@ archive.__salt__ = {}
 
 
 @skipIf(HAS_MOCK is False, 'mock python module is unavailable')
-@patch('salt.utils.which', lambda exe: exe)
 class ArchiveTestCase(TestCase):
+
+    @patch('salt.utils.which', lambda exe: exe)
     def test_tar(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
@@ -61,6 +63,21 @@ class ArchiveTestCase(TestCase):
                 template=None
             )
 
+    @patch('salt.utils.which', lambda exe: None)
+    def test_tar_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.tar,
+                'zxvf',
+                'foo.tar',
+                '/tmp/something-to-compress'
+            )
+            self.assertFalse(mock.called)
+
+
+    @patch('salt.utils.which', lambda exe: exe)
     def test_gzip(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
@@ -71,6 +88,18 @@ class ArchiveTestCase(TestCase):
                 template=None
             )
 
+    @patch('salt.utils.which', lambda exe: None)
+    def test_gzip_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.gzip, '/tmp/something-to-compress'
+            )
+            self.assertFalse(mock.called)
+
+
+    @patch('salt.utils.which', lambda exe: exe)
     def test_gunzip(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
@@ -80,6 +109,17 @@ class ArchiveTestCase(TestCase):
                 'gunzip /tmp/something-to-decompress.tar.gz',
                 template=None
             )
+
+    @patch('salt.utils.which', lambda exe: None)
+    def test_gunzip_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.gunzip,
+                '/tmp/something-to-decompress.tar.gz'
+            )
+            self.assertFalse(mock.called)
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -76,7 +76,6 @@ class ArchiveTestCase(TestCase):
             )
             self.assertFalse(mock.called)
 
-
     @patch('salt.utils.which', lambda exe: exe)
     def test_gzip(self):
         mock = MagicMock(return_value='salt')
@@ -247,6 +246,48 @@ class ArchiveTestCase(TestCase):
                 archive.rar,
                 '/tmp/rarfile.rar',
                 '/tmp/sourcefile1,/tmp/sourcefile2'
+            )
+            self.assertFalse(mock.called)
+
+    @patch('salt.utils.which_bin', lambda exe: exe)
+    def test_unrar(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.unrar(
+                '/tmp/rarfile.rar',
+                '/home/strongbad/',
+                excludes='file_1,file_2'
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'rar a -idp /tmp/rarfile.rar '
+                '/tmp/sourcefile1 /tmp/sourcefile2',
+                template=None
+            )
+
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.unrar(
+                '/tmp/rarfile.rar',
+                '/home/strongbad/',
+                excludes=['file_1', 'file_2']
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'rar a -idp /tmp/rarfile.rar '
+                '/tmp/sourcefile1 /tmp/sourcefile2',
+                template=None
+            )
+
+    @patch('salt.utils.which_bin', lambda exe: None)
+    def test_unrar_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.unrar,
+                '/tmp/rarfile.rar',
+                '/home/strongbad/',
             )
             self.assertFalse(mock.called)
 

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -167,6 +167,21 @@ class ArchiveTestCase(TestCase):
                 template='jinja'
             )
 
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.unzip(
+                '/tmp/salt.{{grains.id}}.zip',
+                '/tmp/dest',
+                excludes=['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
+                template='jinja'
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'unzip /tmp/salt.{{grains.id}}.zip -d /tmp/dest '
+                '-x /tmp/tmpePe8yO /tmp/tmpLeSw1A',
+                template='jinja'
+            )
+
     @patch('salt.utils.which', lambda exe: None)
     def test_unzip_raises_exception_if_not_found(self):
         mock = MagicMock(return_value='salt')

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -181,6 +181,46 @@ class ArchiveTestCase(TestCase):
             )
             self.assertFalse(mock.called)
 
+    @patch('salt.utils.which', lambda exe: exe)
+    def test_rar(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.rar(
+                '/tmp/rarfile.rar',
+                '/tmp/sourcefile1,/tmp/sourcefile2'
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'rar a -idp /tmp/rarfile.rar '
+                '/tmp/sourcefile1 /tmp/sourcefile2',
+                template=None
+            )
+
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.rar(
+                '/tmp/rarfile.rar',
+                ['/tmp/sourcefile1', '/tmp/sourcefile2']
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'rar a -idp /tmp/rarfile.rar '
+                '/tmp/sourcefile1 /tmp/sourcefile2',
+                template=None
+            )
+
+    @patch('salt.utils.which', lambda exe: None)
+    def test_rar_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.rar,
+                '/tmp/rarfile.rar',
+                '/tmp/sourcefile1,/tmp/sourcefile2'
+            )
+            self.assertFalse(mock.called)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -121,6 +121,35 @@ class ArchiveTestCase(TestCase):
             )
             self.assertFalse(mock.called)
 
+    @patch('salt.utils.which', lambda exe: exe)
+    def test_zip(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            ret = archive.zip_(
+                '/tmp/salt.{{grains.id}}.zip',
+                '/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
+                template='jinja'
+            )
+            self.assertEqual(['salt'], ret)
+            mock.assert_called_once_with(
+                'zip /tmp/salt.{{grains.id}}.zip '
+                '/tmp/tmpePe8yO /tmp/tmpLeSw1A',
+                template='jinja'
+            )
+
+    @patch('salt.utils.which', lambda exe: None)
+    def test_zip_raises_exception_if_not_found(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(archive.__salt__, {'cmd.run': mock}):
+            self.assertRaises(
+                CommandNotFoundError,
+                archive.zip_,
+                '/tmp/salt.{{grains.id}}.zip',
+                '/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
+                template='jinja',
+            )
+            self.assertFalse(mock.called)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -249,6 +249,7 @@ class ArchiveTestCase(TestCase):
             )
             self.assertFalse(mock.called)
 
+    @patch('salt.utils.which', lambda exe: exe)
     @patch('salt.utils.which_bin', lambda exe: exe)
     def test_unrar(self):
         mock = MagicMock(return_value='salt')
@@ -260,8 +261,8 @@ class ArchiveTestCase(TestCase):
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(
-                'rar a -idp /tmp/rarfile.rar '
-                '/tmp/sourcefile1 /tmp/sourcefile2',
+                'unrar x -idp /tmp/rarfile.rar '
+                '-x file_1 -x file_2 /home/strongbad/',
                 template=None
             )
 
@@ -274,8 +275,8 @@ class ArchiveTestCase(TestCase):
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(
-                'rar a -idp /tmp/rarfile.rar '
-                '/tmp/sourcefile1 /tmp/sourcefile2',
+                'unrar x -idp /tmp/rarfile.rar '
+                '-x file_1 -x file_2 /home/strongbad/',
                 template=None
             )
 


### PR DESCRIPTION
Code coverage for `salt.modules.archive` is now 98% -> https://coveralls.io/files/31807366
