### PR TITLE
states.file: avoid the `copy` module; conflicts w/ new copy() func

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -136,7 +136,6 @@ import os
 import shutil
 import difflib
 import logging
-import copy
 import re
 import fnmatch
 import json
@@ -1034,7 +1033,7 @@ def directory(name,
             ret['comment'] = 'Types for "recurse" limited to "user", ' \
                              '"group" and "mode"'
         else:
-            targets = copy.copy(recurse)
+            targets = recurse[:]
             if 'user' in targets:
                 if user:
                     uid = __salt__['file.user_to_uid'](user)


### PR DESCRIPTION
```
************* Module salt.states.file
E0102:1992,0:copy: function already defined line 139
```
