### PR TITLE
Issue #6427 fix : Choose Package Provider on CentOS Boxes with Custom /etc/centos-release Content

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -803,6 +803,22 @@ def os_data():
                             grains['lsb_distrib_release'] = comps[2]
                             grains['lsb_distrib_codename'] = \
                                 comps[3].replace('(', '').replace(')', '')
+            elif os.path.isfile('/etc/centos-release'):
+                # CentOS Linux
+                grains['lsb_distrib_id'] = 'CentOS'
+                with salt.utils.fopen('/etc/centos-release') as ifile:
+                    for line in ifile:
+                        # Need to pull out the version and codename
+                        # in the case of custom content in /etc/centos-release
+                        find_release = re.compile('\d+\.\d+')
+                        find_codename = re.compile('(?<=\()(.*?)(?=\))')
+                        release = find_release.search(line)
+                        codename = find_codename.search(line)
+                        if release is not None:
+                            grains['lsb_distrib_release'] = release.group()
+                        if codename is not None:
+                            grains['lsb_distrib_codename'] = codename.group()
+
         # Use the already intelligent platform module to get distro info
         # (though apparently it's not intelligent enough to strip quotes)
         (osname, osrelease, oscodename) = \


### PR DESCRIPTION
Added conditional block to grains/core.py to address CentOS boxes that may have custom content within /etc/centos-release.

I encountered this after I transferred my configs to a CentOS box from getting Salt to work locally with Vagrant. None of the "usual" packages would install through Salt, but I could install them through yum.

As it turned out, our company uses custom CentOS spins with one of the changes being custom text in /etc/centos-release. The custom text was being added as the osname grain. That custom text didn't have a mapping in _OS_NAME_MAP, which resulted in os_family not being defined properly...and so on. Basically, this threw off Salt's package provider logic, thus packages couldn't be installed on CentOS (potentially, and on a custom spin), despite being able to do so directly with yum.
