### PR TITLE
Convert OrderedDicts inside of lists

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -5,7 +5,7 @@ in here
 '''
 
 # Import python libs
-import sys
+#import sys  # Use of sys is commented out below
 
 # Import salt libs
 import salt.log

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -131,6 +131,11 @@ class Serial(object):
                         for key, value in obj.copy().iteritems():
                             obj[key] = odict_encoder(value)
                         return dict(obj)
+                    elif isinstance(obj, (list, tuple)):
+                        obj = list(obj)
+                        for idx, entry in enumerate(obj):
+                            obj[idx] = odict_encoder(entry)
+                        return obj
                     return obj
 
                 if isinstance(msg, dict):


### PR DESCRIPTION
If a dict was contained inside of a list in pillar, the recursive conversion of OrderedDicts to dicts for msgpack would fail.  Recurse through lists as well as dicts.

This should fix a lot of pillar-related issues, not least of which is setting up the scheduler inside of pillar.
