### PR TITLE
Fix 32-bit binary package installs on 64-bit OS

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -231,6 +231,10 @@ def install(name=None,
         software repository. To install a package file manually, use the
         "sources" option.
 
+        32-bit packages can be installed on 64-bit systems by appending the
+        architecture designation (``:i386``, etc.) to the end of the package
+        name.
+
         CLI Example::
             salt '*' pkg.install <package name>
 

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -269,6 +269,10 @@ def install(name=None,
         with the keys being package names, and the values being the source URI
         or local path to the package.
 
+        32-bit packages can be installed on 64-bit systems by appending the
+        architecture designation (``:i386``, etc.) to the end of the package
+        name.
+
         CLI Example::
             salt '*' pkg.install sources='[{"foo": "salt://foo.deb"},{"bar": "salt://bar.deb"}]'
 
@@ -509,7 +513,7 @@ def list_pkgs(versions_as_list=False, removed=False):
 
     ret = {'installed': {}, 'removed': {}}
     cmd = 'dpkg-query --showformat=\'${Status} ${Package} ' \
-          '${Version}\n\' -W'
+          '${Version} ${Architecture}\n\' -W'
 
     out = __salt__['cmd.run_all'](cmd).get('stdout', '')
     # Typical lines of output:
@@ -518,10 +522,13 @@ def list_pkgs(versions_as_list=False, removed=False):
     for line in out.splitlines():
         cols = line.split()
         try:
-            linetype, status, name, version_num = \
-                [cols[x] for x in (0, 2, 3, 4)]
+            linetype, status, name, version_num, arch = \
+                [cols[x] for x in (0, 2, 3, 4, 5)]
         except ValueError:
             continue
+        if __grains__.get('cpuarch', '') == 'x86_64' \
+                and re.match(r'i\d86', arch):
+            name += ':{0}'.format(arch)
         if len(cols):
             if ('install' in linetype or 'hold' in linetype) and \
                     'installed' in status:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -3,13 +3,15 @@ Resources needed by pkg providers
 '''
 
 # Import python libs
-import fnmatch
-import os
-import re
-import yaml
-import pprint
-import logging
+import collections
 import distutils.version  # pylint: disable=E0611
+import fnmatch
+import logging
+import os
+import pprint
+import re
+import sys
+import yaml
 
 # Import salt libs
 import salt.utils
@@ -23,30 +25,22 @@ def _parse_pkg_meta(path):
     version number.
     '''
     def parse_rpm(path):
-        name = ''
-        version = ''
-        rel = ''
-        result = __salt__['cmd.run_all']('rpm -qpi "{0}"'.format(path))
-        if result['retcode'] == 0:
-            for line in result['stdout'].splitlines():
-                if not name:
-                    match = re.match(r'^Name\s*:\s*(\S+)', line)
-                    if match:
-                        name = match.group(1)
-                        continue
-                if not version:
-                    match = re.match(r'^Version\s*:\s*(\S+)', line)
-                    if match:
-                        version = match.group(1)
-                        continue
-                if not rel:
-                    match = re.match(r'^Release\s*:\s*(\S+)', line)
-                    if match:
-                        rel = match.group(1)
-                        continue
-        if rel:
-            version += '-{0}'.format(rel)
-        return name, version
+        try:
+            from salt.modules.yumpkg5 import __QUERYFORMAT, _parse_pkginfo
+            from salt.utils import namespaced_function
+            _parse_pkginfo = namespaced_function(_parse_pkginfo, globals())
+        except ImportError:
+            log.critical('Error importing helper functions. This is almost '
+                         'certainly a bug.')
+            return '', ''
+        pkginfo = __salt__['cmd.run_all'](
+            'rpm -qp --queryformat {0!r} {1!r}'.format(__QUERYFORMAT, path)
+        ).get('stdout', '').strip()
+        pkginfo = _parse_pkginfo(pkginfo)
+        if pkginfo is None:
+            return '', ''
+        else:
+            return pkginfo.name, pkginfo.version
 
     def parse_pacman(path):
         name = ''
@@ -69,19 +63,42 @@ def _parse_pkg_meta(path):
     def parse_deb(path):
         name = ''
         version = ''
+        arch = ''
+        # This is ugly, will have to try to find a better way of accessing the
+        # __grains__ global.
+        cpuarch = sys.modules[
+            __salt__['test.ping'].__module__
+        ].__grains__.get('cpuarch', '')
+
         result = __salt__['cmd.run_all']('dpkg-deb -I "{0}"'.format(path))
         if result['retcode'] == 0:
             for line in result['stdout'].splitlines():
                 if not name:
-                    match = re.match(r'^\s*Package\s*:\s*(\S+)', line)
-                    if match:
-                        name = match.group(1)
+                    try:
+                        name = re.match(
+                            r'^\s*Package\s*:\s*(\S+)',
+                            line
+                        ).group(1)
+                    except AttributeError:
                         continue
                 if not version:
-                    match = re.match(r'^\s*Version\s*:\s*(\S+)', line)
-                    if match:
-                        version = match.group(1)
+                    try:
+                        version = re.match(
+                            r'^\s*Version\s*:\s*(\S+)',
+                            line
+                        ).group(1)
+                    except AttributeError:
                         continue
+                if cpuarch == 'x86_64' and not arch:
+                    try:
+                        arch = re.match(
+                            r'^\s*Architecture\s*:\s*(\S+)',
+                            line
+                        ).group(1)
+                    except AttributeError:
+                        continue
+        if arch:
+            name += ':{0}'.format(arch)
         return name, version
 
     if __grains__['os_family'] in ('Suse', 'RedHat', 'Mandriva'):
@@ -467,6 +484,7 @@ def version_clean(version):
         return __salt__['pkg.version_clean'](version)
 
     return version
+
 
 def check_extra_requirements(pkgname, pkgver):
     '''

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -16,6 +16,8 @@ from salt.modules.yumpkg import (mod_repo, _parse_repo_file, list_repos,
 
 log = logging.getLogger(__name__)
 
+# This is imported in salt.modules.pkg_resource._parse_pkg_meta. Don't change
+# it without considering its impact there.
 __QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}'
 
 
@@ -60,6 +62,8 @@ def __virtual__():
     return False
 
 
+# This is imported in salt.modules.pkg_resource._parse_pkg_meta. Don't change
+# it without considering its impact there.
 def _parse_pkginfo(line):
     '''
     A small helper to parse package information; returns a namedtuple


### PR DESCRIPTION
This fixes #6303. It also forces a change in SLS for apt-based systems,
to avoid a name collision with the 64-bit version of the package. 32-bit
binary packages must now be referred to using pkgname:arch, as they
appear in dpkg --list.
