### PR TITLE
Used a safer method to get proc_fn

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -52,9 +52,7 @@ class Caller(object):
         ret = {}
         fun = self.opts['fun']
         ret['jid'] = '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
-        proc_fn = os.path.join(
-                salt.minion.get_proc_dir(self.opts['cachedir']),
-                ret['jid'])
+        proc_fn = os.path.join(self.opts['cachedir'], 'proc', ret['jid'])
         if fun not in self.minion.functions:
             sys.stderr.write('Function {0} is not available\n'.format(fun))
             sys.exit(-1)


### PR DESCRIPTION
Previously, this called get_proc_dir(), which clears the contents of the
specified directory, resulting in issue #6238.
