### PR TITLE
ssh: add missing import, fix typo

### DIFF
--- a/salt/ssh/__init__.py
+++ b/salt/ssh/__init__.py
@@ -7,6 +7,7 @@ import tarfile
 import tempfile
 import json
 import getpass
+import shutil
 
 # Import salt libs
 import salt.ssh.shell
@@ -436,7 +437,7 @@ def prep_trans_tar(opts, chunks, file_refs):
     file_client = salt.fileclient.LocalClient(fnopts)
     lowfn = os.path.join(gendir, 'lowstate.json')
     with open(lowfn, 'w+') as fp_:
-        fp_.write(json.dumpd(lowfn))
+        fp_.write(json.dumps(lowfn))
     for env in file_refs:
         c_files = file_client.list_env(env)
         for ref in file_refs[env]:

--- a/salt/ssh/__init__.py
+++ b/salt/ssh/__init__.py
@@ -8,6 +8,7 @@ import tempfile
 import json
 import getpass
 import shutil
+import copy
 
 # Import salt libs
 import salt.ssh.shell


### PR DESCRIPTION
```
************* Module salt.ssh
E1101:439,18:prep_trans_tar: Module 'json' has no 'dumpd' member
E0602:454,4:prep_trans_tar: Undefined variable 'shutil'
```
