### PR TITLE
Fix for #6464

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -104,11 +104,11 @@ def run(name, **kwargs):
             rarg = 'm_fun'
         else:
             rarg = arg
-        if rarg not in kwargs and rarg not in defaults:
+        if rarg not in kwargs and arg not in defaults:
             missing.add(rarg)
             continue
-        if rarg in defaults:
-            args.append(defaults[rarg])
+        if arg in defaults:
+            args.append(defaults[arg])
         else:
             args.append(kwargs.pop(rarg))
     if missing:


### PR DESCRIPTION
When checking the defaults dict the keys "m_name" and "m_fun" are already renamed to "name" and "fun" earlier in the code so use arg (="name") instead of rarg (="m_name")

This solves #6464

This is my first contribution so I certainly need some adult supervision...

On a side note:
As of python 2.6 inspect.getargspec returns a named tuple
http://docs.python.org/2.6/library/inspect.html#inspect.getargspec

Would it be ok if I in another branch and pull request changed:
aspec[0] -> aspec.args
aspec[1] -> aspec.varargs
aspec[2] -> aspec.keywords
aspec[3] -> aspec.defaults
To get a more readable code?
I might be getting old, but it hurt my brains trying to remember which index refers to which argument when trying to figure out what the code does.
