### PR TITLE
Properly detect Linaro (Ubuntu derivative)

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -711,7 +711,8 @@ _OS_FAMILY_MAP = {
     'Arch ARM': 'Arch',
     'ALT': 'RedHat',
     'Trisquel': 'Debian',
-    'GCEL': 'Debian'
+    'GCEL': 'Debian',
+    'Linaro': 'Debian'
 }
 
 

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -11,21 +11,22 @@ __func_alias__ = {
 }
 
 GRAINMAP = {
-           'Arch': '/etc/rc.d',
-           'Arch ARM': '/etc/rc.d',
-           'Debian': '/etc/init.d',
-           'Fedora': '/etc/init.d',
-           'RedHat': '/etc/init.d',
-           'Ubuntu': '/etc/init.d',
-           'Gentoo': '/etc/init.d',
-           'CentOS': '/etc/init.d',
-           'CloudLinux': '/etc/init.d',
-           'Amazon': '/etc/init.d',
-           'SunOS': '/etc/init.d',
-           'SUSE  Enterprise Server': '/etc/init.d',
-           'openSUSE': '/etc/init.d',
-           'OEL': '/etc/init.d',
-          }
+    'Arch': '/etc/rc.d',
+    'Arch ARM': '/etc/rc.d',
+    'Debian': '/etc/init.d',
+    'Fedora': '/etc/init.d',
+    'RedHat': '/etc/init.d',
+    'Ubuntu': '/etc/init.d',
+    'Gentoo': '/etc/init.d',
+    'CentOS': '/etc/init.d',
+    'CloudLinux': '/etc/init.d',
+    'Amazon': '/etc/init.d',
+    'SunOS': '/etc/init.d',
+    'SUSE  Enterprise Server': '/etc/init.d',
+    'openSUSE': '/etc/init.d',
+    'OEL': '/etc/init.d',
+}
+
 
 def __virtual__():
     '''
@@ -33,21 +34,22 @@ def __virtual__():
     '''
     # Disable on these platforms, specific service modules exist:
     disable = set((
-               'RedHat',
-               'CentOS',
-               'Amazon',
-               'Scientific',
-               'CloudLinux',
-               'Fedora',
-               'Gentoo',
-               'Ubuntu',
-               'Debian',
-               'Arch',
-               'Arch ARM',
-               'ALT',
-               'SUSE  Enterprise Server',
-               'OEL',
-              ))
+        'RedHat',
+        'CentOS',
+        'Amazon',
+        'Scientific',
+        'CloudLinux',
+        'Fedora',
+        'Gentoo',
+        'Ubuntu',
+        'Debian',
+        'Arch',
+        'Arch ARM',
+        'ALT',
+        'SUSE  Enterprise Server',
+        'OEL',
+        'Linaro',
+    ))
     if __grains__.get('os', '') in disable:
         return False
     # Disable on all non-Linux OSes as well

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -50,7 +50,7 @@ def __virtual__():
     Only work on Ubuntu
     '''
     # Disable on these platforms, specific service modules exist:
-    if __grains__['os'] == 'Ubuntu':
+    if __grains__['os'] in ('Ubuntu', 'Linaro'):
         return 'service'
     return False
 


### PR DESCRIPTION
This commit sets the os_family grain to `Debian`, thus enabling `apt` to
be detected as the `pkg` provider. In addition, it properly sets the
`service` provider to `upstart`.

Fixes #6496.
