### PR TITLE
Add note about new mount.unmounted state

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -220,6 +220,9 @@ def unmounted(name,
               config='/etc/fstab',
               persist=False):
     '''
+    .. note::
+        This state will be available in verion 0.17.0.
+
     Verify that a device is mounted
 
     name


### PR DESCRIPTION
This state will not be available until 0.17.0, adding this note so the
docs reflect that.
