### PR TITLE
Ddns

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -75,7 +75,8 @@ def delete_host(zone, name, nameserver='127.0.0.1'):
         ips = []
 
     res = delete(zone, name, nameserver=nameserver)
-    
+
+    fqdn = fqdn + '.' 
     for ip in ips:
         zone = 'in-addr.arpa.'
         parts = ip.split('.')
@@ -87,7 +88,7 @@ def delete_host(zone, name, nameserver='127.0.0.1'):
             popped.append(p)
             zone = '{0}.{1}'.format(p, zone)
             name = ip.replace('{0}.'.format('.'.join(popped)), '', 1)
-            ptr = delete(zone, name, 'PTR', nameserver=nameserver)
+            ptr = delete(zone, name, 'PTR', fqdn, nameserver=nameserver)
         if ptr:
             res = True
     return res

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -29,42 +29,37 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True):
     '''
     Add, replace, or update the A and PTR (reverse) records for a host.
 
-    Note: This function attempts to add reverse records to each
-    possible zone, beginning with the least specific.
-
     CLI Example::
         
         salt ns1 ddns.add_host example.com host1 60 10.1.1.1
     '''
 
-    a = update(zone, name, ttl, 'A', ip, nameserver, replace)
-    if a is False:
+    res = update(zone, name, ttl, 'A', ip, nameserver, replace)
+    if res is False:
         return False
     
     fqdn = '{0}.{1}.'.format(name, zone)
     zone = 'in-addr.arpa.'
     parts = ip.split('.')
-    ptr = False
+    popped = []
 
-    # Iterate over possible reverse zones, starting at the
-    # least specific.
+    # Iterate over possible reverse zones
     while len(parts) > 1:
-        zone = '{0}.{1}'.format(parts.pop(0), zone)
-        name = ip.replace('{0}.'.format('.'.join(parts)), '')
+        p = parts.pop(0)
+        popped.append(p)
+        zone = '{0}.{1}'.format(p, zone)
+        name = ip.replace('{0}.'.format('.'.join(popped)), '', 1)
         ptr = update(zone, name, ttl, 'PTR', fqdn, nameserver, replace)
         if ptr:
             return True
-        elif ptr is None:
-            return a
-    return False
+    return res
 
 
 def delete_host(zone, name, nameserver='127.0.0.1'):
     '''
-    Delete the A and PTR (reverse) records for a host.
+    Delete the forward and reverse records for a host.
 
-    Note: This attempts to delete reverse records from each
-    possible zone, beginning with the least specific.
+    Returns true if any records are deleted.
 
     CLI Example::
         
@@ -75,29 +70,27 @@ def delete_host(zone, name, nameserver='127.0.0.1'):
     request = dns.message.make_query(fqdn, 'A')
     answer = dns.query.udp(request, nameserver)
     try:
-        ip = answer.answer[0].items[0].address
+        ips = [i.address for i in answer.answer[0].items]
     except IndexError:
-        ip = None
+        ips = []
 
-    a = delete(zone, name, 'A', nameserver=nameserver)
-    if not ip:
-        return a
+    res = delete(zone, name, nameserver=nameserver)
+    
+    for ip in ips:
+        zone = 'in-addr.arpa.'
+        parts = ip.split('.')
+        popped = []
 
-    zone = 'in-addr.arpa.'
-    parts = ip.split('.')
-    ptr = False
-
-    # Iterate over possible reverse zones, starting at the
-    # least specific.
-    while len(parts) > 1:
-        zone = '{0}.{1}'.format(parts.pop(0), zone)
-        name = ip.replace('{0}.'.format('.'.join(parts)), '')
-        ptr = delete(zone, name, 'PTR', nameserver=nameserver)
+        # Iterate over possible reverse zones
+        while len(parts) > 1:
+            p = parts.pop(0)
+            popped.append(p)
+            zone = '{0}.{1}'.format(p, zone)
+            name = ip.replace('{0}.'.format('.'.join(popped)), '', 1)
+            ptr = delete(zone, name, 'PTR', nameserver=nameserver)
         if ptr:
-            return True
-        elif ptr is None:
-            return a
-    return False
+            res = True
+    return res
 
 
 def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False):


### PR DESCRIPTION
This commit fixes several bugs and inadequacies in the ddns execution module.

1) add_host and delete_host were not properly handling reverse records. Fixed.
2) delete_host was not handling reverse records when there were multiple A records. It now deletes all corresponding reverse records.
3) delete_host now deletes all matching (forward) records, not just A. E.g., TXT records (which are sometimes created by dhcp ddns updates) are now deleted along with the A and PTR records.
4) I've removed the note in the docstrings about how PTR records are added/deleted. I don't think this is necessary in the end user docs -- the comment within the code should be adequate.

Known remaining issue: add_host with replace=True will leave a hanging PTR record if the IP for the host is updated. I think the best solution is to simply call delete_host first when replace=True. I will fix that in an upcoming commit.
