### PR TITLE
Fix traceback in salt-call --local

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -52,7 +52,10 @@ class Caller(object):
         ret = {}
         fun = self.opts['fun']
         ret['jid'] = '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
-        proc_fn = os.path.join(self.opts['cachedir'], 'proc', ret['jid'])
+        proc_fn = os.path.join(
+            salt.minion.get_proc_dir(self.opts['cachedir']),
+            ret['jid']
+        )
         if fun not in self.minion.functions:
             sys.stderr.write('Function {0} is not available\n'.format(fun))
             sys.exit(-1)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -109,10 +109,6 @@ def get_proc_dir(cachedir):
     if not os.path.isdir(fn_):
         # proc_dir is not present, create it
         os.makedirs(fn_)
-    else:
-        # proc_dir is present, clean out old proc files
-        for proc_fn in os.listdir(fn_):
-            os.remove(os.path.join(fn_, proc_fn))
     return fn_
 
 


### PR DESCRIPTION
This fixes #6502 by reverting 83c2e61 and removing the lines in
salt.minion.get_proc_dir that clear out the proc dir, since this is not
the desired behavior.
