### PR TITLE
Added pillar:// scheme to file.managed.

### DIFF
--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -52,6 +52,66 @@ class TestFileState(TestCase):
         filestate.serialize('/tmp', dataset, formatter="json")
         self.assertEquals(json.loads(returner.returned), dataset)
 
+    def test_contents_and_contents_pillar(self):
+        def returner(contents, *args, **kwargs):
+            returner.returned = contents
+        returner.returned = None
+
+        filestate.__salt__ = {
+            'file.manage_file': returner
+        }
+
+        manage_mode_mock = MagicMock()
+        filestate.__salt__['config.manage_mode'] = manage_mode_mock
+
+        ret = filestate.managed('/tmp/foo', contents='hi', contents_pillar='foo:bar')
+        self.assertEquals(False, ret['result'])
+
+    def test_contents_pillar_adds_newline(self):
+        # make sure the newline
+        pillar_value = 'i am the pillar value'
+        expected = '{}\n'.format(pillar_value)
+
+        self.run_contents_pillar(pillar_value, expected)
+
+    def test_contents_pillar_doesnt_add_more_newlines(self):
+        # make sure the newline
+        pillar_value = 'i am the pillar value\n'
+
+        self.run_contents_pillar(pillar_value, expected=pillar_value)
+
+    def run_contents_pillar(self, pillar_value, expected):
+        def returner(contents, *args, **kwargs):
+            returner.returned = (contents, args, kwargs)
+        returner.returned = None
+
+        filestate.__salt__ = {
+            'file.manage_file': returner
+        }
+
+        path = '/tmp/foo'
+        pillar_path = 'foo:bar'
+
+        # the values don't matter here
+        filestate.__salt__['config.manage_mode'] = MagicMock()
+        filestate.__salt__['file.source_list'] = MagicMock(return_value=[None, None])
+        filestate.__salt__['file.get_managed'] = MagicMock(return_value=[None, None, None])
+
+        # pillar.get should return the pillar_value
+        pillar_mock = MagicMock(return_value=pillar_value)
+        filestate.__salt__['pillar.get'] = pillar_mock
+
+        ret = filestate.managed(path, contents_pillar=pillar_path)
+
+        # make sure the pillar_mock is called with the given path
+        pillar_mock.assert_called_once_with(pillar_path)
+
+        # make sure no errors are returned
+        self.assertEquals(None, ret)
+
+        # make sure the value is correct
+        self.assertEquals(expected, returner.returned[1][-1])
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(TestFileState, needs_daemon=False)


### PR DESCRIPTION
It's very difficult to use the `contents` option in `file.managed` with pillar data and I came up with a quick way to get this functionality into `file.managed` by passing in a `source` with the `pillar://` scheme followed by a path usable by `pillar.get`.  This works amazingly well and looks to me like a natural fit to the way `file.managed` operates.  For example:

```
/etc/myservice.conf:
  file.managed:
    - source: pillar://services:myservice:conf
```

Please share your thoughts and if there is a better place to check for the pillar scheme.  The current implementation is a bit hacked in and needs tests.

Thanks.
