### PR TITLE
Fix traceback with malformed requisites

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -45,6 +45,7 @@ def split_low_tag(tag):
             'name': name,
             'fun': fun}
 
+
 def _gen_tag(low):
     '''
     Generate the running dict tag string from the low data structure
@@ -1318,6 +1319,8 @@ class State(object):
                     for chunk in chunks:
                         req_key = next(iter(req))
                         req_val = req[req_key]
+                        if req_val is None:
+                            continue
                         if (fnmatch.fnmatch(chunk['name'], req_val) or
                             fnmatch.fnmatch(chunk['__id__'], req_val)):
                             if chunk['state'] == req_key:
@@ -1394,6 +1397,8 @@ class State(object):
                     for chunk in chunks:
                         req_key = next(iter(req))
                         req_val = req[req_key]
+                        if req_val is None:
+                            continue
                         if (fnmatch.fnmatch(chunk['name'], req_val) or
                             fnmatch.fnmatch(chunk['__id__'], req_val)):
                             if chunk['state'] == req_key:
@@ -1413,10 +1418,15 @@ class State(object):
             if lost['require'] or lost['watch'] or lost['prereq'] or lost.get('prerequired'):
                 comment = 'The following requisites were not found:\n'
                 for requisite, lreqs in lost.items():
+                    if not lreqs:
+                        continue
+                    comment += \
+                        '{0}{1}:\n'.format(' ' * 19, requisite)
                     for lreq in lreqs:
-                        comment += '{0}{1}: {2}\n'.format(' ' * 19,
-                                requisite,
-                                lreq)
+                        req_key = next(iter(lreq))
+                        req_val = lreq[req_key]
+                        comment += \
+                            '{0}{1}: {2}\n'.format(' ' * 23, req_key, req_val)
                 running[tag] = {'changes': {},
                                 'result': False,
                                 'comment': comment,
@@ -2273,7 +2283,8 @@ class HighState(BaseHighState):
     compound state derived from a group of template files stored on the
     salt master or in the local cache.
     '''
-    stack = [] # a stack of active HighState objects during a state.highstate run.
+    # a stack of active HighState objects during a state.highstate run
+    stack = []
 
     def __init__(self, opts, pillar=None):
         self.client = salt.fileclient.get_file_client(opts)


### PR DESCRIPTION
This fixes #6521 by skipping any requisites that have a value of None.
Additionally, the state output for failed requisites has been cleaned up
a bit. See the following link for an example:

https://github.com/saltstack/salt/issues/6521#issuecomment-22146254
