### PR TITLE
Fix traceback in mount.mounted state

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -112,7 +112,7 @@ def mounted(name,
                                   'be set to be made persistent').format(name)
                 return ret
 
-        if ret['changes']['mount']:
+        if ret['changes'].get('mount'):
             out = __salt__['mount.set_fstab'](name,
                                               device,
                                               fstype,


### PR DESCRIPTION
This fixes a traceback introduced in 0c9bcab3.

Fixes #6522.
