### PR TITLE
Import distutils.version instead of just distutils

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -14,7 +14,7 @@ import os
 import time
 import hashlib
 import logging
-import distutils
+import distutils.version
 
 # Import third party libs
 HAS_GIT = False


### PR DESCRIPTION
This fixes an `AttributeError` since `distutils.version` is in a separate module.
