### PR TITLE
Add new job event

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -2059,9 +2059,9 @@ class ClearFuncs(object):
                 self.opts['cachedir'],
                 self.opts['hash_type']
                 )
-	
-	# Announce the job on the event bus 
-	self.event.fire_event(clear_load, 'new_job')
+
+         # Announce the job on the event bus 
+         self.event.fire_event(clear_load, 'new_job')
 
         # Verify the jid dir
         if not os.path.isdir(jid_dir):

--- a/salt/master.py
+++ b/salt/master.py
@@ -2060,8 +2060,8 @@ class ClearFuncs(object):
                 self.opts['hash_type']
                 )
 
-         # Announce the job on the event bus 
-         self.event.fire_event(clear_load, 'new_job')
+        # Announce the job on the event bus 
+        self.event.fire_event(clear_load, 'new_job')
 
         # Verify the jid dir
         if not os.path.isdir(jid_dir):

--- a/salt/master.py
+++ b/salt/master.py
@@ -2059,6 +2059,10 @@ class ClearFuncs(object):
                 self.opts['cachedir'],
                 self.opts['hash_type']
                 )
+	
+	# Announce the job on the event bus 
+	self.event.fire_event(clear_load, 'new_job')
+
         # Verify the jid dir
         if not os.path.isdir(jid_dir):
             os.makedirs(jid_dir)


### PR DESCRIPTION
Right now its not possible, to have an external database which contains published jobs as well as the matching returns, because a new job is not announced on the event_bus, only the returns are.

There is a '_minions' event when a new job is announced, but i dont get (yet) whats its for.

Announcing a new job with an event seems reasonable for users (like me), who do not rely on the job-cache on the salt-master (too many minions) but who  listen on the event_bus to act on specific events/returns to put them into a database or any other external data-structure which will keep data for a longer period of time or as a job-archive.

I already have a "matching" daemon that does the above. Currently it listens on the event_bus and acts on events with 'new_job' or '\d{20}' as tag. If its of any interest to salt, please let me know. I'll polish it a little and contribute it.
