### PR TITLE
Fixed get_event and runner low

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ dist
 MANIFEST
 *~
 *#
+*.wpr
+*.wpu
 
 # virtualenv
 # - ignores directories of a virtualenv when you create it right on

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -51,6 +51,7 @@ class RunnerClient(object):
         '''
         Pass in the runner function name and the low data structure
         '''
+        self._verify_fun(fun)
         l_fun = self.functions[fun]
         f_call = salt.utils.format_call(l_fun, low)
         ret = l_fun(*f_call.get('args', ()), **f_call.get('kwargs', {}))

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -139,28 +139,28 @@ class SaltEvent(object):
 
     def get_event(self, wait=5, tag='', full=False):
         '''
-        Get a single publication
+        Get a single publication.
+        IF no publication available THEN block for upto wait seconds
+        AND either return publication OR None IF no publication available.
+        
+        IF wait is 0 then block forever.
+        
         '''
-        end_time = time.time() + wait
-        wait = wait * 1000
-
         self.subscribe(tag)
-        while True:
-            if time.time() >= end_time:
+        socks = dict(self.poller.poll(wait * 1000)) #convert to milliseconds
+        if self.sub in socks and socks[self.sub] == zmq.POLLIN:
+            raw = self.sub.recv()
+            # Double check the tag
+            if not raw[:20].rstrip('|').startswith(tag):
                 return None
-            socks = dict(self.poller.poll(wait))
-            if self.sub in socks and socks[self.sub] == zmq.POLLIN:
-                raw = self.sub.recv()
-                # Double check the tag
-                if not raw[:20].rstrip('|').startswith(tag):
-                    continue
-                data = self.serial.loads(raw[20:])
-                if full:
-                    ret = {'data': data,
-                           'tag': raw[:20].rstrip('|')}
-                    return ret
-                return data
-            return None
+            data = self.serial.loads(raw[20:])
+            if full:
+                ret = {'data': data,
+                        'tag': raw[:20].rstrip('|')}
+                return ret
+            return data
+        return None
+
 
     def iter_events(self, tag='', full=False):
         '''


### PR DESCRIPTION
Fixed get_event
    Removed spurious while loop on timer.
    This did not perform any useful function since poll already blocks and then released on
    the provided timeout.
    Also the while loop had a bug in that if the wait time was 0 then get_event would return
    immediately without even polling once.

Also
  Added self.verify_fun call to low method in runner

Sorry about 2 changes in this pull requrest forgot to do them separately
