### PR TITLE
Added new "osfinger" grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -916,8 +916,19 @@ def os_data():
     # Load the virtual machine info
     grains.update(_virtual(grains))
     grains.update(_ps(grains))
+
+    # Load additional OS family grains
     if grains['os_family'] == "RedHat":
         grains['osmajorrelease'] = grains['osrelease'].split('.', 1)
+
+        grains['osfinger'] = '{os}-{ver}'.format(
+                os=grains['osfullname'],
+                ver=grains['osrelease'].partition('.')[0])
+    elif grains['osfullname'] == 'Ubuntu':
+        grains['osfinger'] = '{os}-{ver}'.format(
+                os=grains['osfullname'],
+                ver=grains['osrelease'])
+
 
     return grains
 


### PR DESCRIPTION
This grain is a unique identifier for a given OS and OS version that can
also be used as the key in a dictionary. For example a fingerprint for
CentOS 5.9 would be "CentOS-5", a fingerprint for Precise would be
"Ubuntu-12.04".
