### PR TITLE
Fix query mysql module

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -192,7 +192,7 @@ def query(database, query, **connection_args):
 
     connection_args.update({'connection_db': database, 'connection_conv': conv})
     dbc = _connect(**connection_args)
-    if dbc is not None:
+    if dbc is None:
         return {}
     cur = dbc.cursor()
     start = time.time()

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -190,8 +190,8 @@ def query(database, query, **connection_args):
     conv_iter = iter(orig_conv)
     conv = dict(zip(conv_iter, [str] * len(orig_conv.keys())))
 
-    dbc = _connect(**(connection_args.update({
-        'connection_db': database, 'connection_conv': conv})))
+    connection_args.update({'connection_db': database, 'connection_conv': conv})
+    dbc = _connect(**connection_args)
     if dbc is not None:
         return {}
     cur = dbc.cursor()


### PR DESCRIPTION
The query() function in modules/mysql.py was throwing the following error:

```
...
File "/usr/lib/pymodules/python2.7/salt/modules/mysql.py", line 194, in query
    dbc = _connect(**(connection_args.update({'connection_db': database, 'connection_conv': conv})))
TypeError: _connect() argument after ** must be a mapping, not NoneType
```

Moved connection_args.update() to a separate line since it returns None.

Also fixed backwards logic for checking dbc
