### PR TITLE
Run git fetch after init

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -125,6 +125,7 @@ def init(branch, repo_location):
             repo.create_remote('origin', repo_location)
         except Exception:
             pass
+    repo.git.fetch()
     return repo
 
 


### PR DESCRIPTION
I was unable to use git ext pillar without this patch.
It looks like the flow it was using is
- git init
- add remote origin
- git checkout master
- git pull

This is problematic, because you can not switch a branch in git before you know which branches exist. Then the process stops at the checkout step and the git pull never runs.

Maybe this got missed if the author of this module never tested on a clean install, or maybe I missed something.

If the code runs a "git fetch" after the adding of the remote, the checkout will work and the pull will work.

I'm not sure the flow is 100% correct still, but this was the least intrusive change I had to do to get it to work for me at all.
