### PR TITLE
Remove unused locking code

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -58,49 +58,6 @@ def _get_ref(repo, short):
                 return ref
     return False
 
-
-def _wait_lock(lk_fn, dest):
-    '''
-    If the write lock is there, check to see if the file is actually being
-    written. If there is no change in the file size after a short sleep,
-    remove the lock and move forward.
-    '''
-    if not os.path.isfile(lk_fn):
-        return False
-    if not os.path.isfile(dest):
-        # The dest is not here, sleep for a bit, if the dest is not here yet
-        # kill the lockfile and start the write
-        time.sleep(1)
-        if not os.path.isfile(dest):
-            try:
-                os.remove(lk_fn)
-            except (OSError, IOError):
-                pass
-            return False
-    # There is a lock file, the dest is there, stat the dest, sleep and check
-    # that the dest is being written, if it is not being written kill the lock
-    # file and continue. Also check if the lock file is gone.
-    s_count = 0
-    s_size = os.stat(dest).st_size
-    while True:
-        time.sleep(1)
-        if not os.path.isfile(lk_fn):
-            return False
-        size = os.stat(dest).st_size
-        if size == s_size:
-            s_count += 1
-            if s_count >= 3:
-                # The file is not being written to, kill the lock and proceed
-                try:
-                    os.remove(lk_fn)
-                except (OSError, IOError):
-                    pass
-                return False
-        else:
-            s_size = size
-    return False
-
-
 def init(branch, repo_location):
     '''
     Return the git repo object for this session
@@ -141,14 +98,7 @@ def update(branch, repo_location):
     except git.exc.GitCommandError as e:
         logging.error('Unable to checkout branch {0}: {1}'.format(branch, e))
         return False
-    lk_fn = os.path.join(repo.working_dir, 'update.lk')
-    with salt.utils.fopen(lk_fn, 'w+') as fp_:
-        fp_.write(str(pid))
     repo.git.pull()
-    try:
-        os.remove(lk_fn)
-    except (OSError, IOError):
-        pass
     return True
 
 


### PR DESCRIPTION
Does the git_pillar module need locking? If it does then it should either use the code from the gitfs backend instead of copypaste or it should use the locking module from gitpython I think?

Anyway, it looks like it is not used so I removed it.
