### PR TITLE
Performance increase for large file.recurse directories

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -11941,7 +11941,7 @@ salt \(aq*\(aq cp.is_cached salt://path/to/file
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.cp.list_master(env=\(aqbase\(aq)
+.B salt.modules.cp.list_master(env=\(aqbase\(aq, prefix=\(aq\(aq)
 List all of the files stored on the master
 .sp
 CLI Example:
@@ -11954,7 +11954,7 @@ salt \(aq*\(aq cp.list_master
 .UNINDENT
 .INDENT 0.0
 .TP
-.B salt.modules.cp.list_master_dirs(env=\(aqbase\(aq)
+.B salt.modules.cp.list_master_dirs(env=\(aqbase\(aq, prefix=\(aq\(aq)
 List all of the directories stored on the master
 .sp
 CLI Example:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -464,6 +464,7 @@ class LocalClient(Client):
     def file_list(self, env='base', prefix=''):
         '''
         Return a list of files in the given environment
+        with optional relative prefix path to limit directory traversal
         '''
         ret = []
         if env not in self.opts['file_roots']:
@@ -484,6 +485,7 @@ class LocalClient(Client):
     def file_list_emptydirs(self, env='base', prefix=''):
         '''
         List the empty dirs in the file_roots
+        with optional relative prefix path to limit directory traversal
         '''
         ret = []
         if env not in self.opts['file_roots']:
@@ -499,6 +501,7 @@ class LocalClient(Client):
     def dir_list(self, env='base', prefix=''):
         '''
         List the dirs in the file_roots
+        with optional relative prefix path to limit directory traversal
         '''
         ret = []
         if env not in self.opts['file_roots']:

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -449,7 +449,7 @@ class LocalClient(Client):
             return ''
         return fnd['path']
 
-    def file_list(self, env='base'):
+    def file_list(self, env='base', prefix=''):
         '''
         Return a list of files in the given environment
         '''
@@ -457,6 +457,8 @@ class LocalClient(Client):
         if env not in self.opts['file_roots']:
             return ret
         for path in self.opts['file_roots'][env]:
+            if prefix:
+                path = os.path.join(path, prefix)
             for root, dirs, files in os.walk(path, followlinks=True):
                 for fname in files:
                     ret.append(
@@ -480,7 +482,7 @@ class LocalClient(Client):
                     ret.append(os.path.relpath(root, path))
         return ret
 
-    def dir_list(self, env='base'):
+    def dir_list(self, env='base', prefix=''):
         '''
         List the dirs in the file_roots
         '''
@@ -488,6 +490,8 @@ class LocalClient(Client):
         if env not in self.opts['file_roots']:
             return ret
         for path in self.opts['file_roots'][env]:
+            if prefix:
+                path = os.path.join(path, prefix)
             for root, dirs, files in os.walk(path, followlinks=True):
                 ret.append(os.path.relpath(root, path))
         return ret

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -99,10 +99,11 @@ def file_list(load):
         return ret
 
     for path in __opts__['file_roots'][load['env']]:
+        path = os.path.join(path, load['prefix'])
         for root, dirs, files in os.walk(path, followlinks=True):
             for fname in files:
                 rel_fn = os.path.relpath(
-                            os.path.join(root, fname),
+                            os.path.join(root, load['prefix'], fname),
                             path
                         )
                 if not salt.fileserver.is_file_ignored(__opts__, rel_fn):
@@ -118,11 +119,12 @@ def file_list_emptydirs(load):
     if load['env'] not in __opts__['file_roots']:
         return ret
     for path in __opts__['file_roots'][load['env']]:
+        path = os.path.join(path, load['prefix'])
         for root, dirs, files in os.walk(path, followlinks=True):
             if len(dirs) == 0 and len(files) == 0:
                 rel_fn = os.path.relpath(root, path)
                 if not salt.fileserver.is_file_ignored(__opts__, rel_fn):
-                    ret.append(rel_fn)
+                    ret.append(os.path.join(load['prefix'], rel_fn))
     return ret
 
 
@@ -134,6 +136,7 @@ def dir_list(load):
     if load['env'] not in __opts__['file_roots']:
         return ret
     for path in __opts__['file_roots'][load['env']]:
+        path = os.path.join(path, load['prefix'])
         for root, dirs, files in os.walk(path, followlinks=True):
-            ret.append(os.path.relpath(root, path))
+            ret.append(os.path.relpath(root, os.path.join(load['prefix'], path)))
     return ret

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -312,7 +312,7 @@ def list_states(env='base'):
     return __context__['cp.fileclient'].list_states(env)
 
 
-def list_master(env='base'):
+def list_master(env='base', prefix=''):
     '''
     List all of the files stored on the master
 
@@ -321,10 +321,10 @@ def list_master(env='base'):
         salt '*' cp.list_master
     '''
     _mk_client()
-    return __context__['cp.fileclient'].file_list(env)
+    return __context__['cp.fileclient'].file_list(env, prefix)
 
 
-def list_master_dirs(env='base'):
+def list_master_dirs(env='base', prefix=''):
     '''
     List all of the directories stored on the master
 
@@ -333,7 +333,7 @@ def list_master_dirs(env='base'):
         salt '*' cp.list_master_dirs
     '''
     _mk_client()
-    return __context__['cp.fileclient'].dir_list(env)
+    return __context__['cp.fileclient'].dir_list(env, prefix)
 
 
 def list_minion(env='base'):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1245,7 +1245,7 @@ def recurse(name,
 
     if not _src_path:
         pass
-    elif _src_path.strip('/') not in __salt__['cp.list_master_dirs'](env):
+    elif _src_path.strip('/') not in __salt__['cp.list_master_dirs'](env, srcpath):
         ret['result'] = False
         ret['comment'] = (
             'The source: {0} does not exist on the master'.format(source)
@@ -1357,10 +1357,8 @@ def recurse(name,
         #we're searching for things that start with this *directory*.
         # use '/' since #master only runs on POSIX
         srcpath = srcpath + '/'
-    for fn_ in __salt__['cp.list_master'](env):
+    for fn_ in __salt__['cp.list_master'](env, srcpath):
         if not fn_.strip():
-            continue
-        if not fn_.startswith(srcpath):
             continue
 
         # fn_ here is the absolute (from file_roots) source path of
@@ -1397,10 +1395,8 @@ def recurse(name,
         manage_file(dest, src)
 
     if include_empty:
-        mdirs = __salt__['cp.list_master_dirs'](env)
+        mdirs = __salt__['cp.list_master_dirs'](env, srcpath)
         for mdir in mdirs:
-            if not mdir.startswith(srcpath):
-                continue
             if not _check_include_exclude(os.path.relpath(mdir, srcpath),
                                           include_pat,
                                           exclude_pat):


### PR DESCRIPTION
As talked about in the news group at link below.  This will start the os.walk calls in the subdirectory when appropriate, otherwise default to previous behavior.

https://groups.google.com/forum/#!topic/salt-users/xHBMHP_A0zc
