### PR TITLE
Fix regression in binary package installation

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -97,7 +97,8 @@ def _parse_pkg_meta(path):
                     except AttributeError:
                         continue
         if arch:
-            name += ':{0}'.format(arch)
+            if cpuarch == 'x86_64' and arch != 'amd64':
+                name += ':{0}'.format(arch)
         return name, version
 
     if __grains__['os_family'] in ('Suse', 'RedHat', 'Mandriva'):


### PR DESCRIPTION
Pull #6461 caused a regression in which binary package installs of
64-bit packages broke on 64-bit systems. This commit fixes that
regression.
