### PR TITLE
Adds example to Using Peer Communication with a specified matcher

### DIFF
--- a/doc/ref/peer.rst
+++ b/doc/ref/peer.rst
@@ -110,3 +110,9 @@ To execute the manage.up runner:
 .. code-block:: bash
 
     # salt-call publish.runner manage.up
+    
+To match minions using other matchers, use ``expr_form``:
+
+.. code-block:: bash
+
+    # salt-call publish.publish 'webserv* and not G@os:Ubuntu' test.ping expr_form='compound'


### PR DESCRIPTION
It took me a while to figure out I could do this, thought I'd clarify with an example.

Should more examples (for other matchers) be added?
