### PR TITLE
Debian Package Architechture

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -96,7 +96,7 @@ def _parse_pkg_meta(path):
                     except AttributeError:
                         continue
         if arch:
-            if cpuarch == 'x86_64' and arch != 'amd64':
+            if cpuarch == 'x86_64' and arch != 'amd64' and arch != 'all':
                 name += ':{0}'.format(arch)
         return name, version
 


### PR DESCRIPTION
Debian packages are allowed to designate the package as
architecture-independent by specifying the value 'all' in the
Architecture field of debian/control. Update
salt.modules.apt.install (via
salt.modules.pkg_resource._parse_pkg_meta) to respect this and not
require ':all' appended to a package name in order to install it on a
64bit machine.

While it was certainly possible to use pkg.install, prior to this change, to install such a package by, as mentioned, adding ':all' to the end of the package name, when trying to use the pkg.installed state, it would fail because the package that gets installed does not have the ':all' attached and therefor, salt thinks the state failed because it doesn't find '<pacakge>:all' in the changes. This, in a round about way fixes that problem, which is my real problem. What that means is that the real problem still exists when trying to install a 32bit package on 64bit machine as you'd have to say '<package>:i386' in the pkg.installed state and it'd fail for the same reasons. All of this was discovered using the 'sources' argument to pkg.installed and pkg.install.

Hope all this makes sense...thanks for the great software. 
