### PR TITLE
Overhaul (most of) bluez.py to work with BlueZ 5.7

### DIFF
--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -96,21 +96,52 @@ def power(dev, mode):
         salt '*' bluetooth.power hci0 on
         salt '*' bluetooth.power hci0 off
     '''
-    log.debug('mode is {0}'.format(mode))
     if mode == 'on' or mode is True:
         state = 'up'
         mode = 'on'
     else:
         state = 'down'
         mode = 'off'
-    log.debug('state is {0}'.format(state))
     cmd = 'hciconfig {0} {1}'.format(dev, state)
-    out = __salt__['cmd.run'](cmd).splitlines()
+    __salt__['cmd.run'](cmd).splitlines()
     info = address_()
-    log.debug(info)
     if info[dev]['power'] == mode:
         return True
     return False
+
+
+def discoverable(dev):
+    '''
+    Enable this bluetooth device to be discovrable.
+
+    CLI Example::
+
+        salt '*' bluetooth.discoverable hci0
+    '''
+    cmd = 'hciconfig {0} iscan'.format(dev)
+    __salt__['cmd.run'](cmd).splitlines()
+    cmd = 'hciconfig {0}'.format(dev)
+    out = __salt__['cmd.run'](cmd)
+    if 'UP RUNNING ISCAN' in out:
+        return True
+    return False
+
+
+def noscan(dev):
+    '''
+    Turn off scanning modes on this device.
+
+    CLI Example::
+
+        salt '*' bluetooth.noscan hci0
+    '''
+    cmd = 'hciconfig {0} noscan'.format(dev)
+    __salt__['cmd.run'](cmd).splitlines()
+    cmd = 'hciconfig {0}'.format(dev)
+    out = __salt__['cmd.run'](cmd)
+    if 'SCAN' in out:
+        return False
+    return True
 
 
 def scan():

--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -96,12 +96,18 @@ def power(dev, mode):
         salt '*' bluetooth.power hci0 on
         salt '*' bluetooth.power hci0 off
     '''
-    state = 'down'
-    if mode == 'on':
+    log.debug('mode is {0}'.format(mode))
+    if mode == 'on' or mode is True:
         state = 'up'
-    cmd = 'hcitool {0} {1}'.format(dev, state)
+        mode = 'on'
+    else:
+        state = 'down'
+        mode = 'off'
+    log.debug('state is {0}'.format(state))
+    cmd = 'hciconfig {0} {1}'.format(dev, state)
     out = __salt__['cmd.run'](cmd).splitlines()
     info = address_()
+    log.debug(info)
     if info[dev]['power'] == mode:
         return True
     return False

--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -173,9 +173,9 @@ def pair(address, key):
     TODO: This function is currently broken, as the bluez-simple-agent program
     no longer ships with BlueZ >= 5.0. It needs to be refactored.
     '''
-    address = address()
+    addy = address_()
     cmd = 'echo "{0}" | bluez-simple-agent {1} {2}'.format(
-        address['devname'], address, key
+        addy['device'], address, key
     )
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
@@ -194,7 +194,6 @@ def unpair(address):
     TODO: This function is currently broken, as the bluez-simple-agent program
     no longer ships with BlueZ >= 5.0. It needs to be refactored.
     '''
-    address = address()
     cmd = 'bluez-test-device remove {0}'.format(address)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out


### PR DESCRIPTION
BlueZ 4.x was current when this module was originally written. BlueZ 5.x makes life much easier. Pairing and Unpairing are still b0rked, and possibly should be removed (pairing is pretty much irrelevant at this point; instead, just connect to the device). Also, the ability to turn the bluetooth radio (power) on and off has been added, and toggling inquiry (discoverable) scans. A future pull request will include more functionality that the new bluetoothctl has.

Ref: http://www.bluez.org/bluez-5-api-introduction-and-porting-guide/
