### PR TITLE
Pip amendments

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -412,7 +412,14 @@ def install(pkgs=None,
         cmd.append('--no-download')
 
     if pre_releases:
-        cmd.append('--pre')
+        # Check the locally installed pip version
+        pip_version_cmd = '{0} --version'.format(_get_pip_bin(bin_env))
+        output = __salt__['cmd.run_all'](pip_version_cmd).get('stdout', '')
+        pip_version = output.split()[1]
+
+        # From pip v1.4 the --pre flag is available
+        if salt.utils.compare_versions(ver1=pip_version, oper='>=', ver2='1.4'):
+            cmd.append('--pre')
 
     if global_options:
         if isinstance(global_options, string_types):

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -32,7 +32,8 @@ def managed(name,
             no_chown=False,
             cwd=None,
             index_url=None,
-            extra_index_url=None):
+            extra_index_url=None,
+            pre_releases=False):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -146,7 +147,8 @@ def managed(name,
             index_url=index_url,
             extra_index_url=extra_index_url,
             no_chown=no_chown,
-            __env__=__env__
+            __env__=__env__,
+            pre_releases=pre_releases
         )
         ret['result'] &= _ret['retcode'] == 0
         if _ret['retcode'] > 0:


### PR DESCRIPTION
- Support for the `pre_releases` parameter (`--pre` flag) in the `virtualenv.manage` state
- Added some local version checking of pip, since the `--pre` flag was added in 1.4 (the version check is localised to just the pre_release parameter for now, but someone can refactor it out later if they want to reuse it)
