### PR TITLE
Error when persistent mount.unmounted state run does not change mountpoints.

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -287,7 +287,7 @@ def unmounted(name,
                                   'persistent').format(name, config)
                 return ret
 
-        if ret['changes']['umount']:
+        if ret['changes'].get('umount', False):
             out = __salt__['mount.rm_fstab'](name, config)
         else:
             out = 'bad mount'


### PR DESCRIPTION
`ret['changes']['umount']` is not always defined (only gets set to `True` when there was a change. never gets set to `False`).
We need to guard the code against `KeyError`s.
