### PR TITLE
Added Pidora OS Name and Family Mappings

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -691,6 +691,7 @@ _OS_NAME_MAP = {
     'alt': 'ALT',
     'oracleserv': 'OEL',
     'cloudserve': 'CloudLinux',
+    'pidora': 'Fedora'
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -728,7 +729,8 @@ _OS_FAMILY_MAP = {
     'ALT': 'RedHat',
     'Trisquel': 'Debian',
     'GCEL': 'Debian',
-    'Linaro': 'Debian'
+    'Linaro': 'Debian',
+    'Pidora': 'RedHat'
 }
 
 


### PR DESCRIPTION
Added correct mappings for os grain and os_family grain under Pidora.  Pidora is based on the Fedora Project compiled specifically for the ARMv6 architecture used on the Raspberry Pi.  Here is the [wiki](http://zenit.senecac.on.ca/wiki/index.php/Pidora).  

It will be displayed like this from grains:

``` bash
    os:
        Fedora
    os_family:
        RedHat
    oscodename:
        Raspberry Pi Fedora Remix
    osfullname:
        Pidora
    osmajorrelease:
        - 18
    osrelease:
        18
```
