### PR TITLE
Optimize comparison in _parse_pkg_meta

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -96,7 +96,7 @@ def _parse_pkg_meta(path):
                     except AttributeError:
                         continue
         if arch:
-            if cpuarch == 'x86_64' and arch != 'amd64' and arch != 'all':
+            if cpuarch == 'x86_64' and arch not in ('amd64', 'all'):
                 name += ':{0}'.format(arch)
         return name, version
 


### PR DESCRIPTION
This uses a more efficient method of checking if the package arch for
debian packages is one of two different arches. Inspired by a
conversation here:

https://github.com/saltstack/salt/pull/6587#issuecomment-22365073
