### PR TITLE
Fix indentation in mysql module.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -217,8 +217,8 @@ def query(database, query, **connection_args):
     select_query = False
     for keyword in select_keywords:
         if query.upper().strip().startswith(keyword):
-           select_query = True
-           break
+            select_query = True
+            break
     if select_query:
         ret['rows returned'] = affected
         columns = ()


### PR DESCRIPTION
Pylint flagged indentation not being a multiple of 4, this commit fixes
that.
