### PR TITLE
Temporary directories should respect `integration.SYS_TMP_DIR`

### DIFF
--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -11,6 +11,7 @@ from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../')
 
 # Import Salt libs
+import integration
 import salt.loader
 import salt.config
 from salt.state import HighState
@@ -231,7 +232,13 @@ state('B').file.managed(source='/a/b/c')
         self.assertEqual(result['B']['file'][1]['require'][0]['cmd'], 'C')
 
     def test_pipe_through_stateconf(self):
-        dirpath = tempfile.mkdtemp()
+        dirpath = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        if not os.path.isdir(dirpath):
+            self.skipTest(
+                'The temporary directory {0!r} was not created'.format(
+                    dirpath
+                )
+            )
         output = os.path.join(dirpath, 'output')
         try:
             write_to(os.path.join(dirpath, 'xxx.sls'),
@@ -284,7 +291,13 @@ state('.C').cmd.run('echo C >> {2}', cwd='/')
             shutil.rmtree(dirpath, ignore_errors=True)
 
     def test_rendering_includes(self):
-        dirpath = tempfile.mkdtemp()
+        dirpath = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        if not os.path.isdir(dirpath):
+            self.skipTest(
+                'The temporary directory {0!r} was not created'.format(
+                    dirpath
+                )
+            )
         output = os.path.join(dirpath, 'output')
         try:
             write_to(os.path.join(dirpath, 'aaa.sls'),
@@ -371,8 +384,13 @@ hello blue 3
             shutil.rmtree(dirpath, ignore_errors=True)
 
     def test_compile_time_state_execution(self):
-        dirpath = tempfile.mkdtemp()
-        output = os.path.join(dirpath, 'output')
+        dirpath = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        if not os.path.isdir(dirpath):
+            self.skipTest(
+                'The temporary directory {0!r} was not created'.format(
+                    dirpath
+                )
+            )
         try:
             write_to(os.path.join(dirpath, 'aaa.sls'),
 '''#!pydsl
@@ -399,7 +417,13 @@ A()
             shutil.rmtree(dirpath, ignore_errors=True)
 
     def test_nested_high_state_execution(self):
-        dirpath = tempfile.mkdtemp()
+        dirpath = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        if not os.path.isdir(dirpath):
+            self.skipTest(
+                'The temporary directory {0!r} was not created'.format(
+                    dirpath
+                )
+            )
         output = os.path.join(dirpath, 'output')
         try:
             write_to(os.path.join(dirpath, 'aaa.sls'),


### PR DESCRIPTION
Also, skip if the directory was not actually created.
