### PR TITLE
Convert shell command examples to bash code-block

### DIFF
--- a/doc/topics/configuration.rst
+++ b/doc/topics/configuration.rst
@@ -66,14 +66,18 @@ Running Salt
 ============
 
 1.  Start the master in the foreground (to daemonize the process, pass the
-    :option:`-d flag <salt-master -d>`)::
+    :option:`-d flag <salt-master -d>`):
 
-        # salt-master
+    .. code-block:: bash
+
+        salt-master
 
 2.  Start the minion in the foreground (to daemonize the process, pass the
-    :option:`-d flag <salt-minion -d>`)::
+    :option:`-d flag <salt-minion -d>`):
 
-        # salt-minion
+    .. code-block:: bash
+
+        salt-minion
 
 .. admonition:: Having trouble?
 
@@ -139,15 +143,18 @@ Sending Commands
 ================
 
 Communication between the Master and a Minion may be verified by running
-the ``test.ping`` remote command. ::
+the ``test.ping`` command:
 
+.. code-block:: bash
 
-   [root@master ~]# salt 'alpha' test.ping
+   [root@master ~]# salt alpha test.ping
    alpha:
        True
 
 Communication between the Master and all Minions may be tested in a
-similar way. ::
+similar way:
+
+.. code-block:: bash
 
    [root@master ~]# salt '*' test.ping
    alpha:
@@ -159,12 +166,13 @@ similar way. ::
    delta:
        True
 
-Each of the Minions should send a "True" response as shown above.
+Each of the Minions should send a ``True`` response as shown above.
 
 What's Next?
 ============
 
-Depending on the primary way you want to manage your machines you may
-either want to visit the section regarding Salt States, or the section
-on Modules.
+Understanding :doc:`targeting <targeting/index>` is important. From there,
+depending on the way you wish to use Salt, you should also proceed to learn
+about :doc:`States <tutorials/starting_states>` and :doc:`Execution Modules
+</ref/modules/index>`.
 

--- a/doc/topics/development/modular_systems.rst
+++ b/doc/topics/development/modular_systems.rst
@@ -24,13 +24,11 @@ detecting information about the system. The only restraint in execution
 modules is that the defined functions always return a JSON serializable
 object.
 
-For a list of all built in execution modules:
+For a list of all built in execution modules, click :doc:`here
+</ref/modules/all/index>`
 
-:doc:`Full List of built in execution modules </ref/modules/all/index>`
-
-For information on writing execution modules, see this document:
-
-:doc:`Execution module development </ref/modules/index>`
+For information on writing execution modules, see :doc:`this page
+</ref/modules/index>`.
 
 State Modules
 =============

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -21,7 +21,9 @@ sending a pull request for a GitHub repository.
 First, make a local clone of your GitHub fork of the salt GitHub repo and make
 edits and changes locally.
 
-Then, create a new branch on your clone by entering the following commands::
+Then, create a new branch on your clone by entering the following commands:
+
+.. code-block:: bash
 
     git checkout -b fixed-broken-thing
 
@@ -29,12 +31,24 @@ Then, create a new branch on your clone by entering the following commands::
 
 Choose a name for your branch that describes its purpose.  
 
-Now commit your changes to this new branch with the following command::
+Now commit your changes to this new branch with the following command:
 
-    #add and commit all changes at once
-    git commit -a -m 'description of my fixes for the broken thing'
+.. code-block:: bash
 
-And then push your locally committed changes back up to GitHub::
+    git commit -am 'description of my fixes for the broken thing'
+
+.. note::
+
+    Using ``git commit -am``, followed by a quoted string, both stages and
+    commits all modified files in a single command. Depending on the nature of
+    your changes, you may wish to stage and commit them separately. Also, note
+    that if you wish to add newly-tracked files as part of your commit, they
+    will not be caught using ``git commit -am`` and will need to be added using
+    ``git add`` before committing.
+
+Push your locally-committed changes back up to GitHub:
+
+.. code-block:: bash
 
     git push --set-upstream origin fixed-broken-thing
     
@@ -42,27 +56,33 @@ Now go look at your fork of the salt repo on the GitHub website. The new
 branch will now be listed under the "Source" tab where it says "Switch Branches".
 Select the new branch from this list, and then click the "Pull request" button.
 
-Put in a descriptive comment, and include links to any project issues related to the pull request.
+Put in a descriptive comment, and include links to any project issues related
+to the pull request.
 
-The repo managers will be notified of your pull request and it will
-be reviewed. If a reviewer asks for changes, just make the changes locally in the 
-same local feature branch, push them to GitHub, then add a comment to the 
+The repo managers will be notified of your pull request and it will be
+reviewed. If a reviewer asks for changes, just make the changes locally in the
+same local feature branch, push them to GitHub, then add a comment to the
 discussion section of the pull request. 
 
 .. note:: Travis-CI
 
-    To make reviewing pull requests easier for the maintainers, please enable Travis-CI on 
-    the fork. Salt is already configured, so simply follow the first 
-    2 steps on the Travis-CI `Getting Started Doc`_.
+    To make reviewing pull requests easier for the maintainers, please enable
+    Travis-CI on your fork. Salt is already configured, so simply follow the
+    first 2 steps on the Travis-CI `Getting Started Doc`_.
 
 .. _`Getting Started Doc`: http://about.travis-ci.org/docs/user/getting-started
 
 Keeping Salt Forks in Sync
 --------------------------
 
-Salt is advancing quickly. It is therefore critical to pull upstream changes from master into forks on a regular basis. Nothing is worse than putting in a days of hard work into a pull request only to have it rejected because it has diverged too far from master. 
+Salt is advancing quickly. It is therefore critical to pull upstream changes
+from master into forks on a regular basis. Nothing is worse than putting in a
+days of hard work into a pull request only to have it rejected because it has
+diverged too far from master. 
 
-To pull in upstream changes::
+To pull in upstream changes:
+
+.. code-block:: bash
 
     # For ssh github
     git remote add upstream git@github.com:saltstack/salt.git
@@ -73,15 +93,21 @@ To pull in upstream changes::
     git fetch upstream
 
 
-To check the log to be sure that you actually want the changes, run this before merging::
+To check the log to be sure that you actually want the changes, run the
+following before merging:
+
+.. code-block:: bash
 
     git log upstream/develop
 
-Then to accept the changes and merge into the current branch::
+Then to accept the changes and merge into the current branch:
+
+.. code-block:: bash
 
     git merge upstream/develop
 
-For more info, see `GitHub Fork a Repo Guide`_ or `Open Comparison Contributing Docs`_
+For more info, see `GitHub Fork a Repo Guide`_ or `Open Comparison Contributing
+Docs`_
 
 .. _`GitHub Fork a Repo Guide`: http://help.github.com/fork-a-repo/
 .. _`Open Comparison Contributing Docs`: http://opencomparison.readthedocs.org/en/latest/contributing.html
@@ -89,16 +115,19 @@ For more info, see `GitHub Fork a Repo Guide`_ or `Open Comparison Contributing 
 Posting patches to the mailing list
 -----------------------------------
 
-Patches will also be accepted by email. Format patches using `git format-patch`_
-and send them to the Salt users mailing list. The contributor will then get credit 
-for the patch, and the Salt community will have an archive of the patch and a place for discussion.
+Patches will also be accepted by email. Format patches using `git
+format-patch`_ and send them to the Salt users mailing list. The contributor
+will then get credit for the patch, and the Salt community will have an archive
+of the patch and a place for discussion.
 
 .. _`git format-patch`: http://www.kernel.org/pub/software/scm/git/docs/git-format-patch.html
 
 Installing Salt for development
 -------------------------------
 
-Clone the repository using::
+Clone the repository using:
+
+.. code-block:: bash
 
     git clone https://github.com/saltstack/salt
 
@@ -107,15 +136,21 @@ Clone the repository using::
     Just cloning the repository is enough to work with Salt and make
     contributions. However, fetching additional tags from git is required to
     have Salt report the correct version for itself. To do this, first
-    add the git repository as an upstream source::
+    add the git repository as an upstream source:
+
+    .. code-block:: bash
 
         git remote add upstream http://github.com/saltstack/salt
 
-    Fetching tags is done with the git 'fetch' utility::
+    Fetching tags is done with the git 'fetch' utility:
+
+    .. code-block:: bash
 
         git fetch --tags upstream
 
-Create a new `virtualenv`_::
+Create a new `virtualenv`_:
+
+.. code-block:: bash
 
     virtualenv /path/to/your/virtualenv
 
@@ -132,11 +167,15 @@ On Arch Linux, where Python 3 is the default installation of Python, use the
     again, although it does assume that the listed modules are all installed in the
     system PYTHONPATH at the time of virtualenv creation.
 
-Activate the virtualenv::
+Activate the virtualenv:
+
+.. code-block:: bash
 
     source /path/to/your/virtualenv/bin/activate
 
-Install Salt (and dependencies) into the virtualenv::
+Install Salt (and dependencies) into the virtualenv:
+
+.. code-block:: bash
 
     pip install M2Crypto    # Don't install on Debian/Ubuntu (see below)
     pip install pyzmq PyYAML pycrypto msgpack-python jinja2 psutil
@@ -146,13 +185,17 @@ Install Salt (and dependencies) into the virtualenv::
 
     ``swig`` and ``libssl-dev`` are required to build M2Crypto. To fix
     the error ``command 'swig' failed with exit status 1`` while installing M2Crypto, 
-    try installing it with the following command::
+    try installing it with the following command:
+
+    .. code-block:: bash
 
         env SWIG_FEATURES="-cpperraswarn -includeall -D__`uname -m`__ -I/usr/include/openssl" pip install M2Crypto
 
     Debian and Ubuntu systems have modified openssl libraries and mandate that
     a patched version of M2Crypto be installed. This means that M2Crypto
-    needs to be installed via apt::
+    needs to be installed via apt:
+
+    .. code-block:: bash
 
         apt-get install python-m2crypto
 
@@ -200,7 +243,9 @@ During development it is easiest to be able to run the Salt master and minion
 that are installed in the virtualenv you created above, and also to have all
 the configuration, log, and cache files contained in the virtualenv as well.
 
-Copy the master and minion config files into your virtualenv::
+Copy the master and minion config files into your virtualenv:
+
+.. code-block:: bash
 
     mkdir -p /path/to/your/virtualenv/etc/salt
     cp ./salt/conf/master /path/to/your/virtualenv/etc/salt/master
@@ -238,7 +283,9 @@ Edit the minion config file:
     `/etc/salt`.
 
 Start the master and minion, accept the minion's key, and verify your local Salt
-installation is working::
+installation is working:
+
+.. code-block:: bash
 
     cd /path/to/your/virtualenv
     salt-master -c ./etc/salt -d
@@ -270,7 +317,9 @@ and 103 characters on BSD-based systems.
 
 .. note:: File descriptor limits
 
-    Ensure that the system open file limit is raised to at least 2047::
+    Ensure that the system open file limit is raised to at least 2047:
+
+    .. code-block:: bash
 
         # check your current limit
         ulimit -n
@@ -279,7 +328,8 @@ and 103 characters on BSD-based systems.
         # use 'limit descriptors 2047' for c-shell
         ulimit -n 2047
 
-    To set file descriptors on OSX, refer to the :doc:`OS X Installation </topics/installation/osx>` instructions.
+    To set file descriptors on OSX, refer to the :doc:`OS X Installation
+    </topics/installation/osx>` instructions.
 
 
 Using easy_install to Install Salt
@@ -287,26 +337,36 @@ Using easy_install to Install Salt
 
 If you are installing using ``easy_install``, you will need to define a
 :strong:`USE_SETUPTOOLS` environment variable, otherwise dependencies will not
-be installed::
+be installed:
 
-    $ USE_SETUPTOOLS=1 easy_install salt
+.. code-block:: bash
+
+    USE_SETUPTOOLS=1 easy_install salt
 
 Running the tests
 ~~~~~~~~~~~~~~~~~
 
-You will need ``mock`` to run the tests::
+You will need ``mock`` to run the tests:
+
+.. code-block:: bash
 
     pip install mock
 
-If you are on Python < 2.7 then you will also need unittest2::
+If you are on Python < 2.7 then you will also need unittest2:
+
+.. code-block:: bash
 
     pip install unittest2
 
-Finally you use setup.py to run the tests with the following command::
+Finally you use setup.py to run the tests with the following command:
+
+.. code-block:: bash
 
     ./setup.py test
 
-For greater control while running the tests, please try::
+For greater control while running the tests, please try:
+
+.. code-block:: bash
 
     ./tests/runtests.py -h
 
@@ -316,11 +376,15 @@ Editing and previewing the documentation
 
 You need ``sphinx-build`` command to build the docs. In Debian/Ubuntu this is
 provided in the ``python-sphinx`` package. Sphinx can also be installed
-to a virtualenv using pip::
+to a virtualenv using pip:
+
+.. code-block:: bash
 
     pip install Sphinx
 
-Change to salt documentation directory, then::
+Change to salt documentation directory, then:
+
+.. code-block:: bash
 
     cd doc; make html
 
@@ -336,11 +400,15 @@ Change to salt documentation directory, then::
 
 - To build the docs on Arch Linux, the :strong:`python2-sphinx` package is
   required. Additionally, it is necessary to tell :strong:`make` where to find
-  the proper :strong:`sphinx-build` binary, like so::
+  the proper :strong:`sphinx-build` binary, like so:
+
+.. code-block:: bash
 
     make SPHINXBUILD=sphinx-build2 html
 
 - To build the docs on RHEL/CentOS 6, the :strong:`python-sphinx10` package
-  must be installed from EPEL, and the following make command must be used::
+  must be installed from EPEL, and the following make command must be used:
+
+.. code-block:: bash
 
     make SPHINXBUILD=sphinx-1.0-build html

--- a/doc/topics/installation/debian.rst
+++ b/doc/topics/installation/debian.rst
@@ -88,7 +88,7 @@ may be given at a time:
 Post-installation tasks
 -----------------------
 
-Now go to the :doc:`Configuring Salt</topics/configuration>` page.
+Now, go to the :doc:`Configuring Salt </topics/configuration>` page.
 
 
 Notes
@@ -108,6 +108,3 @@ upgrade paths between debian versions.
 
 If you have any questions regarding these, please email the mailing
 list or look for joehh on irc.
-
-
-

--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -15,9 +15,12 @@ goals of Salt.
 Quick Install
 -------------
 
-Many popular distributions will be able to install the salt minion by executing the bootstrap script::
+Many popular distributions will be able to install the salt minion by executing
+the bootstrap script:
 
-  wget -O - http://bootstrap.saltstack.org | sudo sh
+.. code-block:: bash
+
+    wget -O - http://bootstrap.saltstack.org | sudo sh
 
 The script should also make it simple to install a salt master, if desired.
 
@@ -72,7 +75,8 @@ Salt should run on any Unix-like platform so long as the dependencies are met.
 Optional Dependencies
 ---------------------
 
-* `mako`_ - an optional parser for Salt States (configurable in the master settings)
+* `mako`_ - an optional parser for Salt States (configurable in the master
+  settings)
 * gcc - dynamic `Cython`_ module compiling
 
 .. _`Python 2.6`: http://python.org/download/

--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -25,7 +25,8 @@ key in one step:
     install. Thus, ``add-apt-repository`` should be able to be used
     out-of-the-box to add the PPA.
 
-Alternately, manually add the repository and import the PPA key with these commands:
+Alternately, manually add the repository and import the PPA key with these
+commands:
 
 .. code-block:: bash
 

--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -28,8 +28,8 @@ minions based on matchers in a top file which is laid out in the same way
 as the state top file. Salt pillars can use the same matcher types as the
 standard top file.
 
-The configuration for the ``pillar_roots`` in the master config is identical in
-behavior and function as the ``file_roots`` configuration:
+The configuration for the :conf_master:`pillar_roots` in the master config file
+is identical in behavior and function as :conf_master:`file_roots`:
 
 .. code-block:: yaml
 
@@ -50,8 +50,8 @@ file used for States, and has the same structure:
         - packages
 
 This further example shows how to use other standard top matching types (grain
-matching is used in this example) to deliver specific salt pillar data to minions
-with different 'os' grains:
+matching is used in this example) to deliver specific salt pillar data to
+minions with different ``os`` grains:
 
 .. code-block:: yaml
 
@@ -97,7 +97,7 @@ Pillar namespace flattened
 ==========================
 
 The separate pillar files all share the same namespace. Given 
-a ``top.sls`` of
+a ``top.sls`` of:
 
 .. code-block:: yaml
 
@@ -118,9 +118,9 @@ and a services.sls file of:
 
     bind: named
 
-Then a pillar request for pillar['bind'] will only return "named", the
-'bind9' value is not available. It's better to structure your pillar 
-files with more heirarchy. For example your package files could look like:
+Then a request for the ``bind`` pillar will only return 'named'; the 'bind9'
+value is not available. It is better to structure your pillar files with more
+hierarchy. For example your package files could look like:
 
 .. code-block:: yaml
 
@@ -170,7 +170,7 @@ will return a freshly reloaded pillar and :mod:`pillar.raw
 
 .. code-block:: bash
 
-    # salt '*' pillar.items
+    salt '*' pillar.items
 
 .. note::
     Prior to version 0.16.2, this function is named ``pillar.data``. This
@@ -239,7 +239,9 @@ Like with :doc:`Grains <../targeting/grains>`, it is possible to use globbing
 as well as match nested values in Pillar, by adding colons for each level that
 is being traversed. The below example would match minions with a pillar named
 ``foo``, which is a dict containing a key ``bar``, with a value beginning with
-``baz``::
+``baz``:
+
+.. code-block:: bash
 
     salt -I 'foo:bar:baz*'
 

--- a/doc/topics/targeting/batch.rst
+++ b/doc/topics/targeting/batch.rst
@@ -1,9 +1,9 @@
 Batch Size
 ----------
 
-The batch size option allows commands to be executed while maintaining that
-only so many hosts are executing the command at one time. This option can
-take a percentage or a finite number:
+The ``-b`` (or ``--batch-size``) option allows commands to be executed on only
+a specifed number of minions at a time. Both percentages and finite numbers are
+supported.
 
 .. code-block:: bash
 

--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -8,42 +8,47 @@ Compound matchers
         A combination of many target definitions that can be combined with
         boolean operators.
 
-Compound matchers allow very granular minion targeting using any of the
-previously discussed matchers. The default matcher is a :mod:`glob <python2:fnmatch>`, as
-usual. For matching via anything other than glob, preface it with the letter denoting
-the match type. The currently implemented "letters" are:
+Compound matchers allow very granular minion targeting using any of Salt's
+matchers. The default matcher is a :mod:`glob <python2:fnmatch>` match, just as
+with CLI and :term:`top file` matching. To match using anything other than a
+glob, prefix the match string with the appropriate letter from the table below,
+followed by an ``@`` sign.
 
 ====== ==================== ===============================================================
-Letter Meaning              Example
+Letter Match Type           Example
 ====== ==================== ===============================================================
-G      Grains glob match    ``G@os:Ubuntu``
-E      PCRE Minion id match ``E@web\d+\.(dev|qa|prod)\.loc``
-P      Grains PCRE match    ``P@os:(RedHat|Fedora|CentOS)``
+G      Grains glob          ``G@os:Ubuntu``
+E      PCRE Minion ID       ``E@web\d+\.(dev|qa|prod)\.loc``
+P      Grains PCRE          ``P@os:(RedHat|Fedora|CentOS)``
 L      List of minions      ``L@minion1.example.com,minion3.domain.com or bl*.domain.com``
-I      Pillar glob match    ``I@pdata:foobar``
-S      Subnet/IP addr match ``S@192.168.1.0/24`` or ``S@192.168.1.100``
-R      Range cluster match  ``R@%foo.bar``
-D      Minion Data match    ``D@key:value``
+I      Pillar glob          ``I@pdata:foobar``
+S      Subnet/IP address    ``S@192.168.1.0/24`` or ``S@192.168.1.100``
+R      Range cluster        ``R@%foo.bar``
+D      Minion Data          ``D@key:value``
 ====== ==================== ===============================================================
 
-Matchers can be joined using boolean ``and``, ``or``, and ``not`` operators.
+| Matchers can be joined using boolean ``and``, ``or``, and ``not`` operators.
 
-For example, the following command matches all minions that have a hostname
-that begins with "webserv" and that are running Debian or it matches any
-minions that have a hostname that matches the :mod:`regular
-expression <python2:re>`
-``web-dc1-srv.*``::
+For example, the following string matches all Debian minions with a hostname
+that begins with ``webserv``, as well as any minions that have a hostname which
+matches the :mod:`regular expression <python2:re>` ``web-dc1-srv.*``:
+
+.. code-block:: bash
 
     salt -C 'webserv* and G@os:Debian or E@web-dc1-srv.*' test.ping
 
-That same example expressed in a :term:`top file` looks like the following::
+That same example expressed in a :term:`top file` looks like the following:
+
+.. code-block:: yaml
 
     base:
       'webserv* and G@os:Debian or E@web-dc1-srv.*':
         - match: compound
         - webserver
 
-Note that you cannot have a leading ``not`` in a command.  Instead you must do
-something like the following::
+Note that a leading ``not`` is not supported in compound matches. Instead,
+something like the following must be done:
+
+.. code-block:: bash
 
     salt -C '* and not G@kernel:Darwin' test.ping

--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -22,11 +22,16 @@ information in grains is unchanging, therefore the nature of the data is
 static. So grains information are things like the running kernel, or the
 operating system.
 
-Match all CentOS minions::
+Match all CentOS minions:
+
+.. code-block:: bash
 
     salt -G 'os:CentOS' test.ping
 
-Match all minions with 64-bit CPUs and return number of available cores::
+Match all minions with 64-bit CPUs, and return number of CPU cores for each
+matching minion:
+
+.. code-block:: bash
 
     salt -G 'cpuarch:x86_64' grains.item num_cpus
 
@@ -35,7 +40,9 @@ a :ref:`dictionary <python2:typesmapping>` can be matched by adding a colon for
 each level that is traversed. For example, the following will match hosts that
 have a grain called ``ec2_tags``, which itself is a
 :ref:`dict <python2:typesmapping>` with a key named ``environment``, which
-has a value that contains the word ``production``::
+has a value that contains the word ``production``:
+
+.. code-block:: bash
 
     salt -G 'ec2_tags:environment:*production*'
 
@@ -43,11 +50,15 @@ has a value that contains the word ``production``::
 Listing Grains
 ==============
 
-Available grains can be listed by using the 'grains.ls' module::
+Available grains can be listed by using the 'grains.ls' module:
+
+.. code-block:: bash
 
     salt '*' grains.ls
 
-Grains data can be listed by using the 'grains.items' module::
+Grains data can be listed by using the 'grains.items' module:
+
+.. code-block:: bash
 
     salt '*' grains.items
 
@@ -166,5 +177,7 @@ Syncing Grains
 --------------
 
 Syncing grains can be done a number of ways, they are automatically synced when
-state.highstate is called, or the grains can be synced and reloaded by calling
-the saltutil.sync_grains or saltutil.sync_all functions.
+:mod:`state.highstate <salt.modules.state.highstate>` is called, or (as noted
+above) the grains can be manually synced and reloaded by calling the
+:mod:`saltutil.sync_grains <salt.modules.saltutil.sync_grains>` or
+:mod:`saltutil.sync_all <salt.modules.saltutil.sync_all>` functions.

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -9,21 +9,27 @@ Node groups
         :conf_master:`nodegroups` setting as a compound target.
 
 Nodegroups are declared using a compound target specification. The compound
-target documentation can be found here:
+target documentation can be found :doc:`here <compound>`.
 
-:doc:`Compound Matchers <compound>`
+The :conf_master:`nodegroups` master config file parameter is used to define
+nodegroups. Here's an example nodegroup configuration:
 
-For example, in the master config file :conf_master:`nodegroups` setting::
+.. code-block:: yaml
 
     nodegroups:
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com or bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
 
-Specify a nodegroup via the ``-N`` option at the command-line::
+To match a nodegroup on the CLI, use the ``-N`` command-line option:
+
+.. code-block:: bash
 
     salt -N group1 test.ping
 
-Specify a nodegroup with ``- match: nodegroup`` in a :term:`top file`::
+To match in your :term:`top file`, make sure to put ``- match: nodegroup`` on
+the line directly following the nodegroup name.
+
+.. code-block:: yaml
 
     base:
       group1:


### PR DESCRIPTION
This commit modifes a number of files which have command-line examples
so that the code-block directive is used. This provides more
visually-appealing syntax highlighting.

More commits like this will follow, this commit is part of an overall
documentation audit that I am performing.
