### PR TITLE
comply w/ pep8 E203+E241 (aligning operators w/ whitespace)

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -100,7 +100,7 @@ def find_file(path, env='base', **kwargs):
     '''
 
     fnd = {'bucket': None,
-            'path' : None}
+           'path': None}
 
     metadata = _init()
     if not metadata or env not in metadata:

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -98,17 +98,17 @@ def inodeusage(args=None):
             if __grains__['kernel'] == 'OpenBSD':
                 ret[comps[8]] = {
                     'inodes': int(comps[5]) + int(comps[6]),
-                    'used':   comps[5],
-                    'free':   comps[6],
-                    'use':    comps[7],
+                    'used': comps[5],
+                    'free': comps[6],
+                    'use': comps[7],
                     'filesystem': comps[0],
                 }
             else:
                 ret[comps[5]] = {
                     'inodes': comps[1],
-                    'used':   comps[2],
-                    'free':   comps[3],
-                    'use':    comps[4],
+                    'used': comps[2],
+                    'free': comps[3],
+                    'use': comps[4],
                     'filesystem': comps[0],
                 }
         except (IndexError, ValueError):

--- a/salt/modules/powerpath.py
+++ b/salt/modules/powerpath.py
@@ -10,14 +10,14 @@ import os
 import re
 
 POLICY_MAP_DICT = {
-    'Adaptive':     'ad',
-    'CLAROpt':      'co',
-    'LeastBlocks':  'lb',
-    'LeastIos':     'li',
-    'REquest':      're',
-    'RoundRobin':   'rr',
-    'StreamIo':     'si',
-    'SymmOpt':      'so',
+    'Adaptive': 'ad',
+    'CLAROpt': 'co',
+    'LeastBlocks': 'lb',
+    'LeastIos': 'li',
+    'REquest': 're',
+    'RoundRobin': 'rr',
+    'StreamIo': 'si',
+    'SymmOpt': 'so',
 }
 
 POLICY_RE = re.compile('.*policy=([^;]+)')

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -34,8 +34,8 @@ class Registry(object):
     '''
     def __init__(self):
         self.hkeys = {
-            "HKEY_USERS":         _winreg.HKEY_USERS,
-            "HKEY_CURRENT_USER":  _winreg.HKEY_CURRENT_USER,
+            "HKEY_USERS": _winreg.HKEY_USERS,
+            "HKEY_CURRENT_USER": _winreg.HKEY_CURRENT_USER,
             "HKEY_LOCAL_MACHINE": _winreg.HKEY_LOCAL_MACHINE,
             }
     def __getattr__(self, k):

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -595,11 +595,11 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
                     _raise_error_iface(iface, opts[opt], valid)
         if bypassfirewall:
             __salt__['sysctl.persist']('net.bridge.bridge-nf-call-ip6tables', '0')
-            __salt__['sysctl.persist']('net.bridge.bridge-nf-call-iptables',  '0')
+            __salt__['sysctl.persist']('net.bridge.bridge-nf-call-iptables', '0')
             __salt__['sysctl.persist']('net.bridge.bridge-nf-call-arptables', '0')
         else:
             __salt__['sysctl.persist']('net.bridge.bridge-nf-call-ip6tables', '1')
-            __salt__['sysctl.persist']('net.bridge.bridge-nf-call-iptables',  '1')
+            __salt__['sysctl.persist']('net.bridge.bridge-nf-call-iptables', '1')
             __salt__['sysctl.persist']('net.bridge.bridge-nf-call-arptables', '1')
     else:
         if 'bridge' in opts:

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -125,8 +125,8 @@ def loadavg():
         salt '*' status.loadavg
     '''
     load_avg = os.getloadavg()
-    return {'1-min':  load_avg[0],
-            '5-min':  load_avg[1],
+    return {'1-min': load_avg[0],
+            '5-min': load_avg[1],
             '15-min': load_avg[2]}
 
 

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1068,14 +1068,14 @@ def vm_netstats(vm_=None):
         dom = _get_dom(vm_)
         nics = get_nics(vm_)
         ret = {
-                'rx_bytes'  : 0,
+                'rx_bytes': 0,
                 'rx_packets': 0,
-                'rx_errs'   : 0,
-                'rx_drop'   : 0,
-                'tx_bytes'  : 0,
+                'rx_errs': 0,
+                'rx_drop': 0,
+                'tx_bytes': 0,
                 'tx_packets': 0,
-                'tx_errs'   : 0,
-                'tx_drop'   : 0
+                'tx_errs': 0,
+                'tx_drop': 0
                }
         for attrs in nics.values():
             if 'target' in attrs:
@@ -1137,19 +1137,19 @@ def vm_diskstats(vm_=None):
         # and unsuitable for any sort of real time statistics
         disks = get_disk_devs(vm_)
         ret = {
-                'rd_req'  : 0,
+                'rd_req': 0,
                 'rd_bytes': 0,
-                'wr_req'  : 0,
+                'wr_req': 0,
                 'wr_bytes': 0,
-                'errs'    : 0
+                'errs': 0
                }
         for disk in disks:
             stats = dom.blockStats(disk)
-            ret['rd_req']   += stats[0]
+            ret['rd_req'] += stats[0]
             ret['rd_bytes'] += stats[1]
-            ret['wr_req']   += stats[2]
+            ret['wr_req'] += stats[2]
             ret['wr_bytes'] += stats[3]
-            ret['errs']     += stats[4]
+            ret['errs'] += stats[4]
 
         return ret
     info = {}


### PR DESCRIPTION
Relevant parts of PEP 8:

> #### Whitespace in Expressions and Statements
> ##### Pet Peeves
> 
> Avoid extraneous whitespace in the following situations:
> - Immediately before a comma, semicolon, or colon
> - More than one space around an assignment (or other) operator to align it with another.

I couldn't find anything contradictory in the Salt Coding Style guide, but I'll understand if there's an unwritten Salt convention about this.
