### PR TITLE
salt.states.mysql_grants: Fix grant_option behavior.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -978,7 +978,10 @@ def user_grants(user,
     ret = []
     results = cur.fetchall()
     for grant in results:
-        ret.append(grant[0].split(' IDENTIFIED BY')[0])
+        tmp = grant[0].split(' IDENTIFIED BY')[0]
+        if 'WITH GRANT OPTION' in grant[0]:
+            tmp = '{} WITH GRANT OPTION'.format(tmp)
+        ret.append(tmp)
     log.debug(ret)
     return ret
 


### PR DESCRIPTION
When grant_option=True, then this state is never succeed as 'WITH GRANT
OPTION' is cut off while checking for user grants. But actual grants are
set properly.
Fixed.
