### PR TITLE
Formatting fixes

### DIFF
--- a/doc/ref/cli/index.rst
+++ b/doc/ref/cli/index.rst
@@ -34,7 +34,7 @@ glob:
 
 .. code-block:: bash
 
-    salt \*foo.com sys.doc
+    salt '*foo.com' sys.doc
 
 
 Salt can also define the target minions with regular expressions:

--- a/doc/ref/states/testing.rst
+++ b/doc/ref/states/testing.rst
@@ -11,23 +11,23 @@ interface can be invoked on any of the major state run functions:
 
 .. code-block:: bash
 
-    # salt \* state.highstate test=True
-    # salt \* state.sls test=True
-    # salt \* state.single test=True
+    salt '*' state.highstate test=True
+    salt '*' state.sls test=True
+    salt '*' state.single test=True
 
 The test run is mandated by adding the ``test=True`` option to the states. The
 return information will show states that will be applied in yellow and the
-result is reported as `None`.
+result is reported as ``None``.
 
 Default Test
 ============
 
-If the value `test` is set to True in the minion configuration file then states
-will default to being executed in test mode. If this value is set then states
-can still be run by calling test=False:
+If the value ``test`` is set to ``True`` in the minion configuration file then
+states will default to being executed in test mode. If this value is set then
+states can still be run by calling test=False:
 
 .. code-block:: bash
 
-    # salt \* state.highstate test=False
-    # salt \* state.sls test=False
-    # salt \* state.single test=False
+    salt '*' state.highstate test=False
+    salt '*' state.sls test=False
+    salt '*' state.single test=False

--- a/doc/ref/windows-package-manager.rst
+++ b/doc/ref/windows-package-manager.rst
@@ -6,11 +6,11 @@ The Salt Windows Software Repository provides a package manager and software
 repository similar to what is provided by yum and apt on Linux.
 
 By default, the Windows software repository is found at ``/srv/salt/win/repo``
-This can be changed in the master config file (default location is ``/etc/salt/master``)
-by modifying the  ``win_repo`` variable.
-Each piece of software should have its own directory which contains the
-installers and a package definition file. This package definition file is a
-YAML file named ``init.sls``.
+This can be changed in the master config file (default location is
+``/etc/salt/master``) by modifying the  ``win_repo`` variable.  Each piece of
+software should have its own directory which contains the installers and a
+package definition file. This package definition file is a YAML file named
+``init.sls``.
 
 The package definition file should look similar to this example for Firefox:
 ``/srv/salt/win/repo/firefox/init.sls``
@@ -52,7 +52,7 @@ even if they don't match which can make this hard to troubleshoot.
 
 .. code-block:: bash
 
-    $ salt 'test-2008' pkg.list_pkgs
+    salt 'test-2008' pkg.list_pkgs
     test-2008
         ----------
         7-Zip 9.20 (x64 edition):
@@ -132,13 +132,13 @@ Once the sls file has been created, generate the repository cache file with the 
 
 .. code-block:: bash
 
-    $ salt-run winrepo.genrepo
+    salt-run winrepo.genrepo
 
 Then update the repository cache file on your minions, exactly how it's done for the Linux package managers:
 
 .. code-block:: bash
 
-    $ salt '*' pkg.refresh_db
+    salt '*' pkg.refresh_db
 
 
 Install Windows Software
@@ -148,7 +148,7 @@ Now you can query the available version of Firefox using the Salt pkg module.
 
 .. code-block:: bash
 
-    $ salt \* pkg.available_version firefox
+    salt '*' pkg.available_version firefox
 
     {'davewindows': {'15.0.1': 'Mozilla Firefox 15.0.1 (x86 en-US)',
                      '16.0.2': 'Mozilla Firefox 16.0.2 (x86 en-US)',
@@ -158,13 +158,13 @@ As you can see, there are three versions of Firefox available for installation.
 
 .. code-block:: bash
 
-    $ salt \* pkg.install firefox
+    salt '*' pkg.install firefox
 
 The above line will install the latest version of Firefox.
 
 .. code-block:: bash
 
-    $ salt \* pkg.install firefox version=16.0.2
+    salt '*' pkg.install firefox version=16.0.2
 
 The above line will install version 16.0.2 of Firefox.
 
@@ -180,9 +180,9 @@ Uninstall software using the pkg module:
 
 .. code-block:: bash
 
-    $ salt \* pkg.remove firefox
+    salt '*' pkg.remove firefox
 
-    $ salt \* pkg.purge firefox
+    salt '*' pkg.purge firefox
 
 ``pkg.purge`` just executes ``pkg.remove`` on Windows. At some point in the
 future ``pkg.purge`` may direct the installer to remove all configs and
@@ -196,7 +196,8 @@ Standalone Minion Salt Windows Repo Module
 In order to facilitate managing a Salt Windows software repo with Salt on a
 Standalone Minion on Windows, a new module named winrepo has been added to
 Salt. wirepo matches what is available in the salt runner and allows you to
-manage the Windows software repo contents. Example:  salt \* winrepo.genrepo
+manage the Windows software repo contents. Example: ``salt '*'
+winrepo.genrepo``
 
 Git Hosted Repo
 ===============
@@ -218,9 +219,8 @@ cache and then refresh each minion's package cache:
 
 .. code-block:: bash
 
-    $ salt-run winrepo.update_git_repos
-    $ salt-run winrepo.genrepo
-    $ salt \* pkg.refresh_db
-
+    salt-run winrepo.update_git_repos
+    salt-run winrepo.genrepo
+    salt '*' pkg.refresh_db
 
 .. _wiki: http://wpkg.org/Category:Silent_Installers

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -23,10 +23,10 @@ event bus is an open system used for sending information notifying Salt and
 other systems about operations.
 
 The event system fires events with a very specific criteria. Every event has a
-`tag` which is comprised of a maximum of 20 characters. Event tags allow for
-fast top level filtering of events. In addition to the tag, an event has a data
-structure. This data structure is a dict containing information about the
-event.
+:strong:`tag` which is comprised of a maximum of 20 characters. Event tags
+allow for fast top level filtering of events. In addition to the tag, an event
+has a data structure. This data structure is a dict containing information
+about the event.
 
 Mapping Events to Reactor SLS Files
 ===================================
@@ -47,9 +47,10 @@ with lists of reactor sls formulas (globs can be used for matching):
 When an event with a tag of auth is fired the reactor will catch the event and
 render the two listed files. The rendered files are standard sls files, so by
 default they are yaml + Jinja. The Jinja is packed with a few data structures
-similar to state and pillar sls files. The data available is found in the `tag`
-and `data` variables. The `tag` variable is just the tag in the fired event
-and the `data` variable is the event's data dict. Here is a simple reactor sls:
+similar to state and pillar sls files. The data available is found in the
+``tag`` and ``data`` variables. The ``tag`` variable is just the tag in the
+fired event and the ``data`` variable is the event's data dict. Here is a
+simple reactor sls:
 
 .. code-block:: yaml
 
@@ -60,12 +61,13 @@ and the `data` variable is the event's data dict. Here is a simple reactor sls:
     {% endif %}
 
 This simple reactor file uses Jinja to further refine the reaction to be made.
-If the `id` in the event data is mysql1 (if the name of the minion is mysql1) then
-the following reaction is defined. The same data structure and compiler used
-for the state system is used for the reactor system. The only difference is that the
-data is matched up to the salt command API and the runner system. In this
-example a command is published to the mysql1 minion with a function of
-state.highstate. Similarly, a runner can be called:
+If the ``id`` in the event data is ``mysql1`` (in other words, if the name of
+the minion is ``mysql1``) then the following reaction is defined.  The same
+data structure and compiler used for the state system is used for the reactor
+system. The only difference is that the data is matched up to the salt command
+API and the runner system.  In this example a command is published to the
+mysql1 minion with a function of ``state.highstate``. Similarly, a runner can
+be called:
 
 .. code-block:: yaml
 
@@ -81,14 +83,15 @@ Understanding the Structure of Reactor Formulas
 ===============================================
 
 While the reactor system uses the same data structure as the state system, this
-data does not translate the same way to operations. In state formulas 
+data does not translate the same way to operations. In state formulas
 information is mapped to the state functions, but in the reactor system
 information is mapped to a number of available subsystems on the master. These
-systems are the `LocalClient` and the `Runners`. The `state declaration` field
-takes a reference to the function to call in each interface. So to trigger a
-salt-run call the `state declaration` field will start with `runner`, followed
-by the runner function to call. This means that a call to what would be on the
-command line `salt-run manage.up` will be `runner.manage.up`. An example of
+systems are the :strong:`LocalClient` and the :strong:`Runners`. The
+:strong:`state declaration` field takes a reference to the function to call in
+each interface. So to trigger a salt-run call the :strong:`state declaration`
+field will start with :strong:`runner`, followed by the runner function to
+call. This means that a call to what would be on the command line
+:strong:`salt-run manage.up` will be :strong:`runner.manage.up`. An example of
 this in a reactor formula would look like this:
 
 .. code-block:: yaml
@@ -104,12 +107,13 @@ If the runner takes arguments then they can be specified as well:
       runner.state.over:
         - env: dev
 
-Executing remote commands maps to the `LocalClient` interface which is used by
-the `salt` command. This interface more specifically maps to the `cmd_async`
-method inside of the `LocalClient` class. This means that the arguments passed
-are being passed to the `cmd_async` method, not the remote method. The field
-starts with `cmd` to use the `LocalClient` subsystem. The result is that to
-execute a remote command it looks like this:
+Executing remote commands maps to the :strong:`LocalClient` interface which is
+used by the :strong:`salt` command. This interface more specifically maps to
+the :strong:`cmd_async` method inside of the :strong:`LocalClient` class. This
+means that the arguments passed are being passed to the :strong:`cmd_async`
+method, not the remote method. The field starts with :strong:`cmd` to use the
+:strong:`LocalClient` subsystem. The result is that to execute a remote command
+it looks like this:
 
 .. code-block:: yaml
 
@@ -119,13 +123,15 @@ execute a remote command it looks like this:
         - arg:
           - rm -rf /tmp/*
 
-The `arg` option takes a list of arguments as they would be presented on the
+The ``arg`` option takes a list of arguments as they would be presented on the
 command line, so the above declaration is the same as running this salt
-command::
+command:
 
-    salt \* cmd.run 'rm -rf /tmp/*'
+.. code-block:: bash
 
-Use the `expr_form` argument to specify a matcher
+    salt '*' cmd.run 'rm -rf /tmp/*'
+
+Use the ``expr_form`` argument to specify a matcher:
 
 .. code-block:: yaml
 

--- a/doc/topics/releases/0.11.0.rst
+++ b/doc/topics/releases/0.11.0.rst
@@ -53,7 +53,7 @@ Multiple Package Management
 
 A long desired feature has been added to package management. By definition Salt
 States have always installed packages one at a time. On most platforms this is
-not the fastest way to install packages. Erik Johnson, aka archtaku, has
+not the fastest way to install packages. Erik Johnson, aka terminalmage, has
 modified the package modules for many providers and added new capabilities to
 install groups of packages. These package groups can be defined as a list of
 packages available in repository servers:
@@ -103,7 +103,7 @@ master and a minion on the same systems. 0.11.0 changes the defaults to be
 separate directories. Salt will also attempt to migrate all of the old key data
 into the correct new directories, but if it is not successful it may need to be
 done manually. If your keys exhibit issues after updating make sure that they
-have been moved from `/etc/salt/pki` to `/etc/salt/pki/{master,minion}`.
+have been moved from ``/etc/salt/pki`` to ``/etc/salt/pki/{master,minion}``.
 
 The old setup will look like this:
 
@@ -121,8 +121,8 @@ The old setup will look like this:
     |-- minions_pre
     `-- minions_rejected
 
-With the accepted minion keys in /etc/salt/pki/minions, the new setup places the
-accepted minion keys in /etc/salt/pki/master/minions
+With the accepted minion keys in ``/etc/salt/pki/minions``, the new setup
+places the accepted minion keys in ``/etc/salt/pki/master/minions``.
 
 .. code-block:: raw
 

--- a/doc/topics/releases/0.13.0.rst
+++ b/doc/topics/releases/0.13.0.rst
@@ -48,10 +48,12 @@ and ``state.highstate``. This allows for on the fly changes or settings to
 pillar and makes parameterizing state formulas even easier. This is done via
 the keyword argument:
 
-    salt \* state.highstate pillar='{"cheese": "spam"}'
+.. code-block:: bash
 
-The above example will extend the existing pillar to hold the `cheese` key
-with a value of `spam`. If the `cheese` key is already specified in the
+    salt '*' state.highstate pillar='{"cheese": "spam"}'
+
+The above example will extend the existing pillar to hold the ``cheese`` key
+with a value of ``spam``. If the ``cheese`` key is already specified in the
 minion's pillar then it will be overwritten.
 
 CLI Notifications

--- a/doc/topics/releases/0.9.5.rst
+++ b/doc/topics/releases/0.9.5.rst
@@ -184,7 +184,9 @@ previous versions the desired minions could only be targeted via a single
 specific target type, but now many target specifications can be declared.
 
 These targets can also be separated by and/or operators, so certain properties
-can be used to omit a node::
+can be used to omit a node:
+
+.. code-block:: bash
 
     salt -C 'webserv* and G@os:Debian or E@db.*' test.ping
 
@@ -199,13 +201,17 @@ Node Groups
 Often the convenience of having a predefined group of minions to execute
 targets on is desired. This can be accomplished with the new nodegroups
 feature. Nodegroups allow for predefined compound targets to be declared in
-the master configuration file::
+the master configuration file:
+
+.. code-block:: yaml
 
     nodegroups:
       group1: 'L@foo.domain.com,bar.domain.com,baz.domain.com and bl*.domain.com'
       group2: 'G@os:Debian and foo.domain.com'
 
-And then used via the ``-N`` option::
+And then used via the ``-N`` option:
+
+.. code-block:: bash
 
     salt -N group1 test.ping
 

--- a/doc/topics/releases/0.9.8.rst
+++ b/doc/topics/releases/0.9.8.rst
@@ -302,7 +302,7 @@ take a percentage or a finite number:
 
 .. code-block:: bash
 
-    salt \* -b 10 test.ping
+    salt '*' -b 10 test.ping
 
     salt -G 'os:RedHat' --batch-size 25% apache.signal restart
 

--- a/doc/topics/releases/0.9.9.rst
+++ b/doc/topics/releases/0.9.9.rst
@@ -33,7 +33,7 @@ on those changes.
 
 .. code-block:: bash
 
-    # salt \* state.highstate test=True
+    salt '*' state.highstate test=True
 
 Now states that would have made changes report them back in yellow.
 
@@ -230,14 +230,14 @@ testing out the behavior of single states:
 
 .. code-block:: bash
 
-    # salt \* state.single user.present name=wade uid=2000
+    salt '*' state.single user.present name=wade uid=2000
 
 The test interface functions here as well, so changes can also be tested
 against as:
 
 .. code-block:: bash
 
-    # salt \* state.single user.present name=wade uid=2000 test=True
+    salt '*' state.single user.present name=wade uid=2000 test=True
 
 New Tests
 =========
@@ -267,7 +267,7 @@ than your hardware can handle!
 
 .. code-block:: bash
 
-    # python minionswarm.py -m 20 --master salt-master
+    python minionswarm.py -m 20 --master salt-master
 
 
 Shell Tests

--- a/doc/topics/targeting/batch.rst
+++ b/doc/topics/targeting/batch.rst
@@ -7,7 +7,7 @@ supported.
 
 .. code-block:: bash
 
-    salt \* -b 10 test.ping
+    salt '*' -b 10 test.ping
 
     salt -G 'os:RedHat' --batch-size 25% apache.signal restart
 

--- a/doc/topics/targeting/globbing.rst
+++ b/doc/topics/targeting/globbing.rst
@@ -31,25 +31,35 @@ in the :term:`top file`.
     You must wrap :command:`salt` calls that use globbing in single-quotes to
     prevent the shell from expanding the globs before Salt is invoked.
 
-Match all minions::
+Match all minions:
+
+.. code-block:: bash
 
     salt '*' test.ping
 
-Match all minions in the example.net domain or any of the example domains::
+Match all minions in the example.net domain or any of the example domains:
+
+.. code-block:: bash
 
     salt '*.example.net' test.ping
     salt '*.example.*' test.ping
 
-Match all the ``webN`` minions in the example.net domain
-(``web1.example.net``, ``web2.example.net`` … ``webN.example.net``)::
+Match all the ``webN`` minions in the example.net domain (``web1.example.net``,
+``web2.example.net`` … ``webN.example.net``):
+
+.. code-block:: bash
 
     salt 'web?.example.net' test.ping
 
-Match the ``web1`` through ``web5`` minions::
+Match the ``web1`` through ``web5`` minions:
+
+.. code-block:: bash
 
     salt 'web[1-5]' test.ping
 
-Match the ``web-x``, ``web-y``, and ``web-z`` minions::
+Match the ``web-x``, ``web-y``, and ``web-z`` minions:
+
+.. code-block:: bash
 
     salt 'web-[x-z]' test.ping
 
@@ -60,7 +70,9 @@ Regular Expressions
 Minions can be matched using Perl-compatible :py:mod:`regular expressions
 <python2:re>` (which is globbing on steroids and a ton of caffeine).
 
-Match both ``web1-prod`` and ``web1-devel`` minions::
+Match both ``web1-prod`` and ``web1-devel`` minions:
+
+.. code-block:: bash
 
     salt -E 'web1-(prod|devel)' test.ping
 
@@ -79,6 +91,8 @@ the matcher as the first option. The following example executes the contents of
 Lists
 =====
 
-At the most basic level, you can specify a flat list of minion IDs::
+At the most basic level, you can specify a flat list of minion IDs:
+
+.. code-block:: bash
 
     salt -L 'web1,web2,web3' test.ping

--- a/doc/topics/tutorials/bootstrap_ec2.rst
+++ b/doc/topics/tutorials/bootstrap_ec2.rst
@@ -16,7 +16,9 @@ rc.local. The bootstrap script needs to:
 #. Install `Salt`_ with dependencies
 #. Point the minion to the master
 
-Here is a sample script::
+Here is a sample script:
+
+.. code-block:: bash
 
     #!/bin/bash
 
@@ -44,7 +46,9 @@ Used With Boto
 
 `Boto <https://github.com/boto/boto>`_ will accept a string for user data
 which can be used to pass our bootstrap script. If the script is saved to
-a file, you can read it into a string::
+a file, you can read it into a string:
+
+.. code-block:: python
 
     import boto
 
@@ -60,9 +64,10 @@ a file, you can read it into a string::
 Additional Notes
 ----------------
 
-Sometime in the future the ppa will include and install an upstart file. In the 
-meantime, you can use the bootstrap to `build one <https://gist.github.com/1617054>`_.
+Sometime in the future the ppa will include and install an upstart file. In the
+meantime, you can use the bootstrap to `build one
+<https://gist.github.com/1617054>`_.
 
 It may also be useful to set the node's role during this phase. One option
-would be saving the node's role to a file and then using a custom Grain
-to select it.
+would be saving the node's role to a file and then using a custom Grain to
+select it.

--- a/doc/topics/tutorials/cloud_controller.rst
+++ b/doc/topics/tutorials/cloud_controller.rst
@@ -4,7 +4,7 @@ Salt as a Cloud Controller
 
 In Salt 0.14.0 advanced cloud control systems were introduced, allowing for
 private cloud vms to be managed directly with Salt. This system is generally
-referred to as "Salt Virt".
+referred to as :strong:`Salt Virt`.
 
 The Salt Virt system already exists and is installed within Salt itself, this
 means that beyond setting up Salt no additional salt code needs to be deployed.
@@ -58,9 +58,9 @@ Network Setup
 
 Salt virt comes with a system to model the network interfaces used by the
 deployed virtual machines, by default a single interface is created for the
-deployed virtual machine and is bridged to `br0`. To get going with the default
-networking setup ensure that the bridge interface named `br0` exists on the
-hypervisor and is bridged to an active network device.
+deployed virtual machine and is bridged to ``br0``. To get going with the
+default networking setup ensure that the bridge interface named ``br0`` exists
+on the hypervisor and is bridged to an active network device.
 
 .. note::
 

--- a/doc/topics/tutorials/firewall.rst
+++ b/doc/topics/tutorials/firewall.rst
@@ -20,14 +20,18 @@ iptables firewall ports very simple via the command line. Just be careful
 to not lock out access to the server by neglecting to open the ssh
 port.
 
-**lokkit example** ::
+**lokkit example**:
+
+.. code-block:: bash
 
    lokkit -p 22:tcp -p 4505:tcp -p 4506:tcp
 
 The system-config-firewall-tui command provides a text-based interface to modifying
 the firewall.
 
-**system-config-firewall-tui** ::
+**system-config-firewall-tui**:
+
+.. code-block:: bash
 
    system-config-firewall-tui
 
@@ -39,11 +43,15 @@ Different Linux distributions store their `iptables`_ rules in different places,
 which makes it difficult to standardize firewall documentation. Included are
 some of the more common locations, but your mileage may vary.
 
-**Fedora / RHEL / CentOS** ::
+**Fedora / RHEL / CentOS**:
+
+.. code-block:: bash
 
     /etc/sysconfig/iptables
 
-**Arch Linux** ::
+**Arch Linux**:
+
+.. code-block:: bash
 
     /etc/iptables/iptables.rules
 
@@ -54,7 +62,7 @@ Follow these instructions: http://wiki.debian.org/iptables
 Once you've found your firewall rules, you'll need to add the two lines below
 to allow traffic on ``tcp/4505`` and ``tcp/4506``:
 
-::
+.. code-block:: bash
 
     -A INPUT -m state --state new -m tcp -p tcp --dport 4505 -j ACCEPT
     -A INPUT -m state --state new -m tcp -p tcp --dport 4506 -j ACCEPT
@@ -62,7 +70,9 @@ to allow traffic on ``tcp/4505`` and ``tcp/4506``:
 **Ubuntu**
 
 Salt installs firewall rules in :blob:`/etc/ufw/applications.d/salt.ufw
-<pkg/salt.ufw>`. Enable with::
+<pkg/salt.ufw>`. Enable with:
+
+.. code-block:: bash
 
     ufw allow salt
 
@@ -76,7 +86,7 @@ The BSD-family of operating systems uses `packet filter (pf)`_. The following
 example describes the additions to ``pf.conf`` needed to access the Salt
 master.
 
-::
+.. code-block:: bash
 
     pass in on $int_if proto tcp from any to $int_if port 4505
     pass in on $int_if proto tcp from any to $int_if port 4506
@@ -88,5 +98,4 @@ be reloaded. This can be done using the ``pfctl`` command.
 
     pfctl -vf /etc/pf.conf
 
-    
 .. _`packet filter (pf)`: http://openbsd.org/faq/pf/

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -11,13 +11,8 @@ from a git repository and serve them to minions.
 
 .. note::
 
-    This walkthrough assumes basic knowledge of Salt:
-
-        :doc:`Walkthrough </topics/tutorials/walkthrough>`
-
-    And a basic knowledge of file roots:
-
-        :doc:`File Roots </ref/file_server/file_roots>`
+    This walkthrough assumes basic knowledge of Salt. To get up to speed, check
+    out the :doc:`walkthrough </topics/tutorials/walkthrough>`.
 
 The gitfs backend hooks into any number of remote git repositories and caches
 the data from the repository on the master. This makes distributing a state
@@ -33,7 +28,8 @@ Simple Configuration
 ====================
 
 To use the gitfs backend only two configuration changes are required on the
-master. The ``fileserver_backend`` option needs to be set with `git`:
+master. The ``fileserver_backend`` option needs to be set with a value of
+``git``:
 
 .. code-block:: yaml
 
@@ -50,8 +46,8 @@ Now the gitfs system needs to be configured with a remote:
       - git://github.com/saltstack/salt-states.git
 
 These changes require a restart of the master, then the git repo will be cached
-on the master and new requests for the `salt://` protocol will send files found
-in the remote git repository via the master.
+on the master and new requests for the ``salt://`` protocol will send files
+found in the remote git repository via the master.
 
 .. note::
 
@@ -83,35 +79,37 @@ Assuming that the ``gitfs_remotes`` option specifies three remotes:
 
 .. note::
 
-    The ``file://`` prefix denotes a git repository in a local directory.
-    However, it will still use the given ``file://`` URL as a remote, rather
-    than copying the git repo to the salt cache.  This means that any refs you
-    want accessible must exist as *local* refs in the specified repo.
+    The :strong:`file://` prefix denotes a git repository in a local directory.
+    However, it will still use the given :strong:`file://` URL as a remote,
+    rather than copying the git repo to the salt cache.  This means that any
+    refs you want accessible must exist as *local* refs in the specified repo.
 
 Assume that each repository contains some files:
 
-first.git:
-    top.sls
-    edit/vim.sls
-    edit/vimrc
-    nginx/init.sls
+.. code-block:: yaml
 
-second.git:
-    edit/dev_vimrc
-    haproxy/init.sls
+    first.git:
+        top.sls
+        edit/vim.sls
+        edit/vimrc
+        nginx/init.sls
 
-third:
-    haproxy/haproxy.conf
-    edit/dev_vimrc
+    second.git:
+        edit/dev_vimrc
+        haproxy/init.sls
+
+    third:
+        haproxy/haproxy.conf
+        edit/dev_vimrc
 
 The repositories will be searched for files by the master in the order in which
 they are defined in the configuration, Therefore the remote
-`git://github.com/example/first.git` will be searched first, if the requested
-file is found then it is served and no further searching is executed. This
-means that if the file `salt://haproxy/init.sls` is requested then it will be
-pulled from the `git://github.com/example/second.git` git repo. If
-`salt://haproxy/haproxy.conf` is requested then it will be pulled from the
-third repo.
+:strong:`git://github.com/example/first.git` will be searched first, if the
+requested file is found then it is served and no further searching is executed.
+This means that if the file :strong:`salt://haproxy/init.sls` is requested then
+it will be pulled from the :strong:`git://github.com/example/second.git` git
+repo. If :strong:`salt://haproxy/haproxy.conf` is requested then it will be
+pulled from the third repo.
 
 Multiple Backends
 =================
@@ -129,8 +127,8 @@ the ``fileserver_backend`` option contains multiple backends:
       - roots
       - git
 
-Then the `roots` backend (the default backend of files in /srv/salt) will be
-searched first for the requested file, then if it is not found on the master
+Then the ``roots`` backend (the default backend of files in ``/srv/salt``) will
+be searched first for the requested file, then if it is not found on the master
 the git remotes will be searched.
 
 GitFS Remotes over SSH

--- a/doc/topics/tutorials/modules.rst
+++ b/doc/topics/tutorials/modules.rst
@@ -9,7 +9,9 @@ Order your minions around
 
 Now that you have a :term:`master` and at least one :term:`minion`
 communicating with each other you can perform commands on the minion via the
-:command:`salt` command. Salt calls are comprised of three main components::
+:command:`salt` command. Salt calls are comprised of three main components:
+
+.. code-block:: bash
 
     salt '<target>' <function> [arguments]
 
@@ -19,28 +21,38 @@ target
 ------
 
 The target component allows you to filter which minions should run the
-following function. The default filter is a glob on the minion id. For example::
+following function. The default filter is a glob on the minion id. For example:
 
-    # salt '*' test.ping
-    # salt '*.example.org' test.ping
+.. code-block:: bash
 
-Targets can be based on minion system information using the Grains system::
+    salt '*' test.ping
+    salt '*.example.org' test.ping
 
-    # salt -G 'os:Ubuntu' test.ping
+Targets can be based on minion system information using the Grains system:
+
+.. code-block:: bash
+
+    salt -G 'os:Ubuntu' test.ping
 
 .. seealso:: :doc:`Grains system </topics/targeting/grains>`
 
-Targets can be filtered by regular expression::
+Targets can be filtered by regular expression:
 
-    # salt -E 'virtmach[0-9]' test.ping
+.. code-block:: bash
 
-Targets can be explicitly specified in a list::
+    salt -E 'virtmach[0-9]' test.ping
 
-    # salt -L 'foo,bar,baz,quo' test.ping
+Targets can be explicitly specified in a list:
 
-Or Multiple target types can be combined in one command::
-    
-    # salt -C 'G@os:Ubuntu and webser* or E@database.*' test.ping
+.. code-block:: bash
+
+    salt -L 'foo,bar,baz,quo' test.ping
+
+Or Multiple target types can be combined in one command:
+
+.. code-block:: bash
+
+    salt -C 'G@os:Ubuntu and webser* or E@database.*' test.ping
 
 
 function
@@ -48,31 +60,41 @@ function
 
 A function is some functionality provided by a module. Salt ships with a large
 collection of available functions. List all available functions on your
-minions::
+minions:
 
-    # salt '*' sys.doc
+.. code-block:: bash
+
+    salt '*' sys.doc
 
 Here are some examples:
 
-Show all currently available minions::
+Show all currently available minions:
 
-    # salt '*' test.ping
+.. code-block:: bash
 
-Run an arbitrary shell command::
+    salt '*' test.ping
 
-    # salt '*' cmd.run 'uname -a'
+Run an arbitrary shell command:
+
+.. code-block:: bash
+
+    salt '*' cmd.run 'uname -a'
 
 .. seealso:: :doc:`the full list of modules </ref/modules/index>`
 
 arguments
 ---------
 
-Space-delimited arguments to the function::
+Space-delimited arguments to the function:
 
-    # salt '*' cmd.exec_code python 'import sys; print sys.version'
+.. code-block:: bash
 
-Optional, keyword arguments are also supported::
+    salt '*' cmd.exec_code python 'import sys; print sys.version'
 
-    # salt '*' pip.install salt timeout=5 upgrade=True
+Optional, keyword arguments are also supported:
+
+.. code-block:: bash
+
+    salt '*' pip.install salt timeout=5 upgrade=True
 
 They are always in the form of ``kwarg=argument``.

--- a/doc/topics/tutorials/multimaster.rst
+++ b/doc/topics/tutorials/multimaster.rst
@@ -8,9 +8,10 @@ masters and facilitates multiple points of communication out to minions. When
 using a multi-master setup, all masters are running hot, and any active master
 can be used to send commands out to the minions.
 
-In 0.16.0, the masters do not share any information, keys need to be accepted on
-both masters, and shared files need to be shared manually or use tools like the
-git fileserver backend to ensure that the ``file_roots`` are kept consistent.
+In 0.16.0, the masters do not share any information, keys need to be accepted
+on both masters, and shared files need to be shared manually or use tools like
+the git fileserver backend to ensure that the :conf_master:`file_roots` are
+kept consistent.
 
 Summary of Steps
 ----------------
@@ -29,7 +30,7 @@ The first task is to prepare the redundant master. There is only one
 requirement when preparing a redundant master, which is that masters share the
 same private key. When the first master was created, the master's identifying
 key was generated and placed in the master's ``pki_dir``. The default location
-of the key is `/etc/salt/pki/master/master.pem`. Take this key and copy it to
+of the key is ``/etc/salt/pki/master/master.pem``. Take this key and copy it to
 the same location on the redundant master. Assuming that no minions have yet
 been connected to the new redundant master, it is safe to delete any existing
 key in this location and replace it.
@@ -67,25 +68,25 @@ files should be shared or sharing of these files should be strongly considered.
 Minion Keys
 ```````````
 
-Minion keys can be accepted the normal way using `salt-key` on both masters.
-Keys accepted, deleted, or rejected on one master will NOT be automatically
-managed on redundant masters; this needs to be taken care of by running
-salt-key on both masters or sharing the
-`/etc/salt/pki/master/{minions,minions_pre,minions_rejected}` directories
+Minion keys can be accepted the normal way using :strong:`salt-key` on both
+masters.  Keys accepted, deleted, or rejected on one master will NOT be
+automatically managed on redundant masters; this needs to be taken care of by
+running salt-key on both masters or sharing the
+``/etc/salt/pki/master/{minions,minions_pre,minions_rejected}`` directories
 between masters.
 
 .. note::
 
-    While sharing the `/etc/salt/pki/master` directory will work, it is
-    strongly discouraged, since allowing access to the `master.pem` key outside
-    of Salt creates are *SERIOUS* security risk.
+    While sharing the :strong:`/etc/salt/pki/master` directory will work, it is
+    strongly discouraged, since allowing access to the :strong:`master.pem` key
+    outside of Salt creates a *SERIOUS* security risk.
 
 File_Roots
 ``````````
 
-The `file_roots` contents should be kept consistent between masters. Otherwise
-state runs will not always be consistent on minions since instructions managed
-by one master will not agree with other masters.
+The :conf_master:`file_roots` contents should be kept consistent between
+masters. Otherwise state runs will not always be consistent on minions since
+instructions managed by one master will not agree with other masters.
 
 The recommended way to sync these is to use a fileserver backend like gitfs or
 to keep these files on shared storage.
@@ -93,7 +94,8 @@ to keep these files on shared storage.
 Pillar_Roots
 ````````````
 
-Pillar roots should be given the same considerations as `file_roots`.
+Pillar roots should be given the same considerations as
+:conf_master:`file_roots`.
 
 Master Configurations
 `````````````````````
@@ -105,7 +107,7 @@ reason otherwise exists to keep them inconsistent.
 
 These access control options include but are not limited to:
 
-1. `external_auth`
-2. `client_acl`
-3. `peer`
-4. `peer_run`
+- external_auth
+- client_acl
+- peer
+- peer_run

--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -5,9 +5,7 @@ Pillar Walkthrough
 .. note::
 
     This walkthrough assumes that the reader has already completed the initial
-    Salt Stack walkthrough:
-
-        :doc:`Walkthrough </topics/tutorials/walkthrough>`
+    Salt Stack :doc:`walkthrough </topics/tutorials/walkthrough>`.
 
 The pillar interface inside of Salt is one of the most important components
 of a Salt deployment. Pillar is the interface used to generate arbitrary data
@@ -41,7 +39,9 @@ Setting Up Pillar
 The pillar is already running in Salt by default. The data in the minion's
 pillars can be seen via the following command:
 
-    # salt '*' pillar.items
+.. code-block:: bash
+
+    salt '*' pillar.items
 
 .. note::
     Prior to version 0.16.2, this function is named ``pillar.data``. This
@@ -63,7 +63,9 @@ location for the pillar is in /srv/pillar.
 
 To start setting up the pillar, the /srv/pillar directory needs to be present:
 
-    # mkdir /srv/pillar
+.. code-block:: bash
+
+    mkdir /srv/pillar
 
 Now a simple top file, following the same format as the top file used for
 states needs to be created:
@@ -87,18 +89,20 @@ This top file associates the data.sls file to all minions. Now the
 
 Now that the file has been saved the minions' pillars will be updated:
 
-    # salt '*' pillar.items
+.. code-block:: bash
 
-The key `info` should now appear in the returned pillar data.
+    salt '*' pillar.items
+
+The key ``info`` should now appear in the returned pillar data.
 
 More Complex Data
 ~~~~~~~~~~~~~~~~~
 
 Pillar files are sls files, just like states, but unlike states they do not
-need to define `formulas`, the data can be arbitrary, this example for
+need to define :strong:`formulas`, the data can be arbitrary, this example for
 instance sets up user data with a UID:
 
-`/srv/pillar/users/init.sls`
+``/srv/pillar/users/init.sls``:
 
 .. code-block:: yaml
 
@@ -111,11 +115,12 @@ instance sets up user data with a UID:
 .. note::
 
     The same directory lookups that exist in states exist in pillar, so the
-    file users/init.sls can be referenced with `users` in the top file
+    file ``users/init.sls`` can be referenced with ``users`` in the :term:`top
+    file`.
 
 The top file will need to be updated to include this sls file:
 
-`/srv/pillar/top.sls`
+``/srv/pillar/top.sls``:
 
 .. code-block:: yaml
 
@@ -127,7 +132,7 @@ The top file will need to be updated to include this sls file:
 Now the data will be available to the minions. To use the pillar data in a
 state just access the pillar via Jinja:
 
-`/srv/salt/users/init.sls`
+``/srv/salt/users/init.sls``
 
 .. code-block:: jinja
 
@@ -154,7 +159,7 @@ can be directly parameterized without needing to refactor the state tree.
 A simple example is to set up a mapping of package names in pillar for
 separate Linux distributions:
 
-`/srv/pillar/pkg/init.sls`
+``/srv/pillar/pkg/init.sls``:
 
 .. code-block:: jinja
 
@@ -170,9 +175,9 @@ separate Linux distributions:
       vim: vim
       {% endif %}
 
-The new `pkg` sls needs to be added to the top file:
+The new ``pkg`` sls needs to be added to the top file:
 
-`/srv/pillar/top.sls`
+``/srv/pillar/top.sls``:
 
 .. code-block:: yaml
 
@@ -185,7 +190,7 @@ The new `pkg` sls needs to be added to the top file:
 Now the minions will auto map values based on respective operating systems
 inside of the pillar, so sls files can be safely parameterized:
 
-`/srv/salt/apache/init.sls`
+``/srv/salt/apache/init.sls``:
 
 .. code-block:: jinja
 
@@ -200,7 +205,7 @@ Or, if no pillar is available a default can be set as well:
     The function ``pillar.get`` used in this example was added to Salt in
     version 0.14.0
 
-`/srv/salt/apache/init.sls`
+``/srv/salt/apache/init.sls``:
 
 .. code-block:: jinja
 
@@ -208,10 +213,10 @@ Or, if no pillar is available a default can be set as well:
       pkg.installed:
         - name: {{ salt['pillar.get']('pkgs:apache', 'httpd') }}
 
-In the above example, if the pillar value `pillar['pkgs']['apache']` is not
-set in the minion's pillar, then the default of 'httpd' will be used.
+In the above example, if the pillar value ``pillar['pkgs']['apache']`` is not
+set in the minion's pillar, then the default of ``httpd`` will be used.
 
-.. note
+.. note::
 
     Under the hood, pillar is just a python dict, so python dict methods such
     as `get` and `items` can be used.
@@ -224,7 +229,7 @@ into more flexible formulas without refactoring or complicating the states.
 
 A simple formula:
 
-`/srv/salt/edit/vim.sls`
+``/srv/salt/edit/vim.sls``:
 
 .. code-block:: yaml
 
@@ -243,7 +248,7 @@ A simple formula:
 
 Can be easily transformed into a powerful, parameterized formula:
 
-`/srv/salt/edit/vim.sls`
+``/srv/salt/edit/vim.sls``:
 
 .. code-block:: jinja
 
@@ -263,7 +268,7 @@ Can be easily transformed into a powerful, parameterized formula:
 
 Where the vimrc source location can now be changed via pillar:
 
-`/srv/pillar/edit/vim.sls`
+``/srv/pillar/edit/vim.sls``:
 
 .. code-block:: jinja
 

--- a/doc/topics/tutorials/preseed_key.rst
+++ b/doc/topics/tutorials/preseed_key.rst
@@ -9,13 +9,17 @@ developers provision new development machines on the fly.
 
 There is a general four step process to do this:
 
-1. Generate the keys on the master::
+1. Generate the keys on the master:
+
+.. code-block:: bash
 
     root@saltmaster# salt-key --gen-keys=[key_name]
 
 Pick a name for the key, such as the minion's id.
 
-2. Add the public key to the accepted minion folder:: 
+2. Add the public key to the accepted minion folder:
+
+.. code-block:: bash
 
     root@saltmaster# cp key_name.pub /etc/salt/pki/master/minions/[minion_id]
 
@@ -26,9 +30,10 @@ master config file.
 
 3. Distribute the minion keys.
 
-There is no single method to get the keypair to your minion. If you are 
-spooling up minions on EC2, you could pass them in using user_data or a 
-cloud-init script. If you are handing them off to a team of developers for provisioning dev machines, you will need a secure file transfer.
+There is no single method to get the keypair to your minion. If you are
+spooling up minions on EC2, you could pass them in using user_data or a
+cloud-init script. If you are handing them off to a team of developers for
+provisioning dev machines, you will need a secure file transfer.
 
 .. admonition:: Security Warning
 
@@ -38,7 +43,9 @@ cloud-init script. If you are handing them off to a team of developers for provi
 
 4. Preseed the Minion with the keys
 
-You will want to place the minion keys before starting the salt-minion daemon::
+You will want to place the minion keys before starting the salt-minion daemon:
+
+.. code-block:: bash
 
     /etc/salt/pki/minion/minion.pem
     /etc/salt/pki/minion/minion.pub

--- a/doc/topics/tutorials/quickstart.rst
+++ b/doc/topics/tutorials/quickstart.rst
@@ -11,7 +11,9 @@ for a single machine. It is also useful for testing out state trees before
 deploying to a production setup.
 
 The only real difference in using a standalone minion is that instead of issuing 
-commands with ``salt``, we use the ``salt-call`` command, like this::
+commands with ``salt``, we use the ``salt-call`` command, like this:
+
+.. code-block:: bash
 
     salt-call --local state.highstate
 
@@ -19,7 +21,9 @@ Bootstrap Salt Minion
 =====================
 
 First we need to install the salt minion. The `salt-bootstrap`_ script makes
-this incredibly easy for any OS with a Bourne shell. You can use it like this::
+this incredibly easy for any OS with a Bourne shell. You can use it like this:
+
+.. code-block:: bash
 
     wget -O - http://bootstrap.saltstack.org | sudo sh
 
@@ -30,33 +34,39 @@ provision the VM for you.
 Create State Tree
 =================
 
-Now we build an example state tree. This is where the configuration 
-is defined. For more in depth directions, see the `tutorial <http://docs.saltstack.org/en/latest/topics/tutorials/states_pt1.html>`_. 
+Now we build an example state tree. This is where the configuration is defined.
+For more in depth directions, see the `tutorial
+<http://docs.saltstack.org/en/latest/topics/tutorials/states_pt1.html>`_. 
 
-1. Create the top.sls file
-::
+1. Create the top.sls file:
 
-  # /srv/salt/top.sls
-  base:
-    '*':
-      - webserver
+``/srv/salt/top.sls:``
 
-2. Create our webserver state tree
-::
+.. code-block:: yaml
 
-  # /srv/salt/webserver.sls
-  apache:                 # ID declaration
-    pkg:                  # state declaration
-      - installed         # function declaration
+    base:
+      '*':
+        - webserver
+
+2. Create our webserver state tree:
+
+``/srv/salt/webserver.sls:``
+
+.. code-block:: yaml
+
+    apache:               # ID declaration
+      pkg:                # state declaration
+        - installed       # function declaration
 
 The only thing left is to provision our minion using the highstate command.
-Salt-call also gives us an easy way to give us verbose output::
+Salt-call also gives us an easy way to give us verbose output:
+
+.. code-block:: bash
 
     salt-call --local state.highstate -l debug
 
-The ``--local`` flag tells the salt-minion to look for the state tree in the local file system.
-Normally the minion copies the state tree from the master and executes it from there.
+The ``--local`` flag tells the salt-minion to look for the state tree in the
+local file system.  Normally the minion copies the state tree from the master
+and executes it from there.
 
 That's it, good luck!
-
-

--- a/doc/topics/tutorials/standalone_minion.rst
+++ b/doc/topics/tutorials/standalone_minion.rst
@@ -61,11 +61,15 @@ This makes it easy to "script" deployments with Salt states without having to
 set up a master, and allows for these SLS modules to be easily moved into a
 Salt master as the deployment grows.
 
-Now the declared state can now be executed with::
-    
-    # salt-call state.highstate
+Now the declared state can now be executed with:
 
-Or the salt-call command can be executed with the `--local` flag, this makes it
-unnecessary to change the configuration file::
+.. code-block:: bash
 
-    # salt-call state.highstate --local
+    salt-call state.highstate
+
+Or the salt-call command can be executed with the ``--local`` flag, this makes
+it unnecessary to change the configuration file:
+
+.. code-block:: bash
+
+    salt-call state.highstate --local

--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -60,7 +60,6 @@ A typical SLS file will often look like this in YAML:
     is later in the tutorial.
 
 .. code-block:: yaml
-   :linenos:
 
     apache:
       pkg:
@@ -101,7 +100,6 @@ need to be added. The Apache configuration file will most likely be managed,
 and a user and group may need to be set up.
 
 .. code-block:: yaml
-   :linenos:
 
     apache:
       pkg:
@@ -164,7 +162,7 @@ The SLS files are laid out in a directory structure on the Salt master; an
 SLS is just a file and files to download are just files.
 
 The Apache example would be laid out in the root of the Salt file server like
-this: ::
+this::
 
     apache/init.sls
     apache/httpd.conf
@@ -178,7 +176,6 @@ the toolkit. Consider this SSH example:
 ``ssh/init.sls:``
 
 .. code-block:: yaml
-   :linenos:
 
     openssh-client:
       pkg.installed
@@ -195,7 +192,6 @@ the toolkit. Consider this SSH example:
 ``ssh/server.sls:``
 
 .. code-block:: yaml
-   :linenos:
 
     include:
       - ssh
@@ -240,7 +236,7 @@ the toolkit. Consider this SSH example:
     produce an identical result; the first way -- using `file.managed` --
     is merely a shortcut.
 
-Now our State Tree looks like this: ::
+Now our State Tree looks like this::
 
     apache/init.sls
     apache/httpd.conf
@@ -276,7 +272,6 @@ add more watchers to apache to include mod_python.
 ``ssh/custom-server.sls:``
 
 .. code-block:: yaml
-   :linenos:
 
     include:
       - ssh.server
@@ -289,7 +284,6 @@ add more watchers to apache to include mod_python.
 ``python/mod_python.sls:``
 
 .. code-block:: yaml
-   :linenos:
 
     include:
       - apache
@@ -365,7 +359,6 @@ for the Grains to be accessed from within the template. A few examples:
 ``apache/init.sls:``
 
 .. code-block:: yaml
-   :linenos:
 
     apache:
       pkg.installed:
@@ -410,7 +403,6 @@ a MooseFS distributed filesystem chunkserver:
 ``moosefs/chunk.sls:``
 
 .. code-block:: yaml
-   :linenos:
 
     include:
       - moosefs
@@ -483,7 +475,6 @@ This example shows a very basic Python SLS file:
 ``python/django.sls:``
 
 .. code-block:: python
-   :linenos:
 
     #!py
 
@@ -506,7 +497,6 @@ renderer, the above example can be written more succinctly as:
 ``python/django.sls:``
 
 .. code-block:: python
-   :linenos:
 
     #!pydsl
 
@@ -517,7 +507,6 @@ renderer, the above example can be written more succinctly as:
 This Python examples would look like this if they were written in YAML:
 
 .. code-block:: yaml
-   :linenos:
 
     include:
       - python
@@ -535,7 +524,7 @@ Running and debugging salt states.
 Once the rules in an SLS are ready, they should be tested to ensure they
 work properly. To invoke these rules, simply execute 
 ``salt '*' state.highstate`` on the command line. If you get back only 
-hostnames with a `':'` after, but no return, chances are there is a problem with 
+hostnames with a ``:`` after, but no return, chances are there is a problem with 
 one or more of the sls files. On the minion, use the ``salt-call`` command: 
 ``salt-call state.highstate -l debug`` to examine the output for errors. 
 This should help troubleshoot the issue. The minions can also be started in 

--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -37,8 +37,8 @@ Restart the Salt master in order to pick up this change:
 
 .. code-block:: bash
 
-    % pkill salt-master
-    % salt-master -d
+    pkill salt-master
+    salt-master -d
 
 Preparing the Top File
 ======================
@@ -62,7 +62,9 @@ minion matches is defined; for now simply specify all hosts (``*``).
 
     The expressions can use any of the targeting mechanisms used by Salt —
     minions can be matched by glob, PCRE regular expression, or by :doc:`grains
-    </topics/targeting/grains>`. For example::
+    </topics/targeting/grains>`. For example:
+
+    .. code-block:: yaml
 
         base:
           'os:Fedora':
@@ -76,7 +78,6 @@ In the same directory as the :term:`top file`, create an empty file named
 ``webserver.sls``, containing the following:
 
 .. code-block:: yaml
-    :linenos:
 
     apache:                 # ID declaration
       pkg:                  # state declaration
@@ -156,22 +157,30 @@ and all changes made.
 
     Turn up logging
         Salt can be quite chatty when you change the logging setting to
-        ``debug``::
+        ``debug``:
+
+        .. code-block:: bash
 
             salt-minion -l debug
 
     Run the minion in the foreground
         By not starting the minion in daemon mode (:option:`-d <salt-minion
-        -d>`) one can view any output from the minion as it works::
+        -d>`) one can view any output from the minion as it works:
+
+        .. code-block:: bash
 
             salt-minion &
 
     Increase the default timeout value when running :command:`salt`. For
-    example, to change the default timeout to 60 seconds::
+    example, to change the default timeout to 60 seconds:
+
+    .. code-block:: bash
 
         salt -t 60
 
-    For best results, combine all three::
+    For best results, combine all three:
+
+    .. code-block:: bash
 
         salt-minion -l debug &          # On the minion
         salt '*' state.highstate -t 60  # On the master

--- a/doc/topics/tutorials/states_pt2.rst
+++ b/doc/topics/tutorials/states_pt2.rst
@@ -40,9 +40,7 @@ As you have seen, SLS modules are appended with the file extension ``.sls`` and
 are referenced by name starting at the root of the state tree. An SLS module
 can be also defined as a directory. Demonstrate that now by creating a
 directory named ``webserver`` and moving and renaming ``webserver.sls`` to
-``webserver/init.sls``. Your state directory should now resemble:
-
-::
+``webserver/init.sls``. Your state directory should now look like this::
 
     |- top.sls
     `- webserver/
@@ -123,7 +121,9 @@ directory:
 
 Last, call :func:`state.highstate <salt.modules.state.highstate>` again and the
 minion will fetch and execute the highstate as well as our HTML file from the
-master using Salt's File Server::
+master using Salt's File Server:
+
+.. code-block:: bash
 
     salt '*' state.highstate
 

--- a/doc/topics/tutorials/states_pt3.rst
+++ b/doc/topics/tutorials/states_pt3.rst
@@ -24,7 +24,7 @@ All states are passed through a templating system when they are initially read.
 To make use of the templating system, simply add some templating markup.
 An example of an sls module with templating markup may look like this:
 
-.. code-block:: yaml
+.. code-block:: jinja
 
     {% for usr in 'moe','larry','curly' %}
     {{ usr }}:
@@ -44,7 +44,7 @@ This templated sls file once generated will look like this:
 
 Here's a more complex example:
 
-.. code-blocK:: yaml
+.. code-blocK:: jinja
 
     {% for usr in 'moe','larry','curly' %}
     {{ usr }}:
@@ -64,7 +64,7 @@ Often times a state will need to behave differently on different systems.
 :doc:`Salt grains </topics/targeting/grains>` objects are made available
 in the template context. The `grains` can be used from within sls modules:
 
-.. code-block:: yaml
+.. code-block:: jinja
 
     apache:
       pkg.installed:
@@ -83,11 +83,11 @@ system. It also allows for shell commands to be run easily from within the sls
 modules.
 
 The Salt module functions are also made available in the template context as
-``salt``:
+``salt:``
 
-.. code-block:: yaml
+.. code-block:: jinja
 
-    basepi:
+    moe:
       user:
         - present
         - gid: {{ salt['file.group_to_gid']('some_group_that_exists') }}
@@ -96,7 +96,9 @@ Note that for the above example to work, ``some_group_that_exists`` must exist
 before the state file is processed by the templating engine.
 
 Below is an example that uses the ``network.hw_addr`` function to retrieve the
-MAC address for eth0::
+MAC address for eth0:
+
+.. code-block:: python
 
     salt['network.hw_addr']('eth0')
 
@@ -113,14 +115,14 @@ A previous example showed how to spread a Salt tree across several files.
 Similarly, :doc:`requisites </ref/states/requisites>` span multiple files by
 using an :term:`include declaration`. For example:
 
-``python/python-libs.sls``:
+``python/python-libs.sls:``
 
 .. code-block:: yaml
 
     python-dateutil:
       pkg.installed
 
-``python/django.sls``:
+``python/django.sls:``
 
 .. code-block:: yaml
 
@@ -139,14 +141,14 @@ You can modify previous declarations by using an :term:`extend declaration`. For
 example the following modifies the Apache tree to also restart Apache when the
 vhosts file is changed:
 
-``apache/apache.sls``:
+``apache/apache.sls:``
 
 .. code-block:: yaml
 
     apache:
       pkg.installed
 
-``apache/mywebsite.sls``:
+``apache/mywebsite.sls:``
 
 .. code-block:: yaml
 
@@ -173,7 +175,7 @@ You can override the :term:`ID declaration` by using a :term:`name
 declaration`. For example, the previous example is a bit more maintainable if
 rewritten as follows:
 
-``apache/mywebsite.sls``:
+``apache/mywebsite.sls:``
 
 .. code-block:: yaml
     :emphasize-lines: 8,10,12

--- a/doc/topics/tutorials/states_pt4.rst
+++ b/doc/topics/tutorials/states_pt4.rst
@@ -141,28 +141,36 @@ Given the above SLS, the source for the website should initially be placed in
 ``/srv/salt/dev/webserver/src/foobarcom``.
 
 First, let's deploy to dev. Given the configuration in the top file, this can
-be done using :mod:`state.highstate <salt.modules.state.highstate>`::
+be done using :mod:`state.highstate <salt.modules.state.highstate>`:
 
-    # salt --pillar 'webserver_role:dev' state.highstate
+.. code-block:: bash
+
+    salt --pillar 'webserver_role:dev' state.highstate
 
 However, in the event that it is not desirable to apply all states configured
 in the top file (which could be likely in more complex setups), it is possible
 to apply just the states for the ``foobarcom`` website, using :mod:`state.sls
-<salt.modules.state.sls>`::
+<salt.modules.state.sls>`:
 
-    # salt --pillar 'webserver_role:dev' state.sls webserver.foobarcom
+.. code-block:: bash
+
+    salt --pillar 'webserver_role:dev' state.sls webserver.foobarcom
 
 Once the site has been tested in dev, then the files can be moved from
 ``/srv/salt/dev/webserver/src/foobarcom`` to
-``/srv/salt/qa/webserver/src/foobarcom``, and deployed using the following::
+``/srv/salt/qa/webserver/src/foobarcom``, and deployed using the following:
 
-    # salt --pillar 'webserver_role:qa' state.sls webserver.foobarcom
+.. code-block:: bash
+
+    salt --pillar 'webserver_role:qa' state.sls webserver.foobarcom
 
 Finally, once the site has been tested in qa, then the files can be moved from
 ``/srv/salt/qa/webserver/src/foobarcom`` to
-``/srv/salt/prod/webserver/src/foobarcom``, and deployed using the following::
+``/srv/salt/prod/webserver/src/foobarcom``, and deployed using the following:
 
-    # salt --pillar 'webserver_role:prod' state.sls webserver.foobarcom
+.. code-block:: bash
+
+    salt --pillar 'webserver_role:prod' state.sls webserver.foobarcom
 
 Thanks to Salt's fileserver inheritance, even though the files have been moved
 to within ``/srv/salt/prod``, they are still available from the same

--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -77,26 +77,36 @@ Turning on the Salt Master is easy, just turn it on! The default configuration
 is suitable for the vast majority of installations. The Salt master can be
 controlled by the local Linux/Unix service manager:
 
-On Systemd based platforms (OpenSuse, Fedora)::
+On Systemd based platforms (OpenSuse, Fedora):
 
-    # systemctl start salt-master
+.. code-block:: bash
 
-On Upstart based systems (Ubuntu, older Fedora/RHEL)::
+    systemctl start salt-master
 
-    # service salt-master start
+On Upstart based systems (Ubuntu, older Fedora/RHEL):
 
-On SysV Init systems (Debian, Gentoo etc.)::
+.. code-block:: bash
 
-    # /etc/init.d/salt-master start
+    service salt-master start
 
-Or the master can be started directly on the command line::
+On SysV Init systems (Debian, Gentoo etc.):
 
-    # salt-master -d
+.. code-block:: bash
+
+    /etc/init.d/salt-master start
+
+Or the master can be started directly on the command line:
+
+.. code-block:: bash
+
+    salt-master -d
 
 The Salt Master can also be started in the foreground in debug mode, thus
-greatly increasing the command output::
+greatly increasing the command output:
 
-    # salt-master -l debug
+.. code-block:: bash
+
+    salt-master -l debug
 
 The Salt Master needs to bind to 2 TCP network ports on the system, these ports
 are 4505 and 4506. For more in depth information on firewalling these ports,
@@ -136,13 +146,17 @@ configuration file will need to be edited, edit the configuration option
 Now that the master can be found, start the minion in the same way as the
 master; with the platform init system, or via the command line directly:
 
-As a daemon::
+As a daemon:
 
-    # salt-minion -d
+.. code-block:: bash
 
-In the foreground in debug mode::
+    salt-minion -d
 
-    # salt-minion -l debug
+In the foreground in debug mode:
+
+.. code-block:: bash
+
+    salt-minion -l debug
 
 Now that the minion is started it will generate cryptographic keys and attempt
 to connect to the master. The next step is to venture back to the master server
@@ -155,14 +169,18 @@ Using salt-key
 Salt authenticates minions using public key encryption and authentication. For
 a minion to start accepting commands from the master the minion keys need to be
 accepted. The ``salt-key`` command is used to manage all of the keys on the
-master. To list the keys that are on the master run a salt-key list command::
+master. To list the keys that are on the master run a salt-key list command:
 
-    # salt-key -L
+.. code-block:: bash
+
+    salt-key -L
 
 The keys that have been rejected, accepted and pending acceptance are listed.
-The easiest way to accept the minion key is to accept all pending keys::
+The easiest way to accept the minion key is to accept all pending keys:
 
-    # salt-key -A
+.. code-block:: bash
+
+    salt-key -A
 
 .. note::
 
@@ -220,9 +238,11 @@ the command is also very usable, and easy to understand.
 
 The ``salt`` command is comprised of command options, target specification,
 the function to execute, and arguments to the function. A simple command to
-start with looks like this::
+start with looks like this:
 
-    # salt '*' test.ping
+.. code-block:: bash
+
+    salt '*' test.ping
 
 The ``*`` is the target, which specifies all minions, and ``test.ping`` tells
 the minion to run the :py:func:`test.ping <salt.modules.test.ping>` function.
@@ -245,9 +265,11 @@ Getting to Know the Functions
 
 Salt comes with a vast library of functions available for execution, and Salt
 functions are self documenting. To see what functions are available on the
-minions execute the :py:func:`sys.doc <salt.modules.sys.doc>` function::
+minions execute the :py:func:`sys.doc <salt.modules.sys.doc>` function:
 
-    # salt '*' sys.doc
+.. code-block:: bash
+
+    salt '*' sys.doc
 
 This will display a very large list of available functions and documentation on
 them, this documentation is also available :doc:`here
@@ -271,21 +293,27 @@ Helpful Functions to Know
 The :doc:`cmd </ref/modules/all/salt.modules.cmdmod>` module contains
 functions to shell out on minions, such as :mod:`cmd.run
 <salt.modules.cmdmod.run>` and :mod:`cmd.run_all
-<salt.modules.cmdmod.run_all>`::
+<salt.modules.cmdmod.run_all>`:
 
-    # salt '*' cmd.run 'ls -l /etc'
+.. code-block:: bash
+
+    salt '*' cmd.run 'ls -l /etc'
 
 The ``pkg`` functions automatically map local system package managers to the
 same salt functions. This means that ``pkg.install`` will install packages via
-yum on Red Hat based systems, apt on Debian systems, etc.::
+yum on Red Hat based systems, apt on Debian systems, etc.:
 
-    # salt '*' pkg.install vim
+.. code-block:: bash
+
+    salt '*' pkg.install vim
 
 The :mod:`network.interfaces <salt.modules.network.interfaces>` function will
 list all interfaces on a minion, along with their IP addresses, netmasks, MAC
-addresses, etc::
+addresses, etc:
 
-    # salt '*' network.interfaces
+.. code-block:: bash
+
+    salt '*' network.interfaces
 
 
 Grains
@@ -346,16 +374,20 @@ Passing in Arguments
 ~~~~~~~~~~~~~~~~~~~~
 
 Many of the functions available accept arguments, these arguments can be
-passed in on the command line::
+passed in on the command line:
 
-    # salt '*' pkg.install vim
+.. code-block:: bash
+
+    salt '*' pkg.install vim
 
 This example passes the argument ``vim`` to the pkg.install function, since
 many functions can accept more complex input then just a string the arguments
 are parsed through YAML, allowing for more complex data to be sent on the
-command line::
+command line:
 
-    # salt '*' test.echo 'foo: bar'
+.. code-block:: bash
+
+    salt '*' test.echo 'foo: bar'
 
 In this case Salt translates the string 'foo: bar' into the dictionary
 "{'foo': 'bar'}"
@@ -410,9 +442,11 @@ under /srv/salt named vim.sls and get vim installed:
     vim:
       pkg.installed
 
-Now install vim on the minions by calling the sls directly::
+Now install vim on the minions by calling the sls directly:
 
-    # salt '*' state.sls vim
+.. code-block:: bash
+
+    salt '*' state.sls vim
 
 This command will invoke the state system and run the named sls which was just
 created, ``vim``.
@@ -482,9 +516,11 @@ results in success.
 
 Now this new sls formula has a special name, ``init.sls``, when an sls formula is
 named ``init.sls`` it inherits the name of the directory path that contains it,
-so this formula can be referenced via the following command::
+so this formula can be referenced via the following command:
 
-    # salt '*' state.sls nginx
+.. code-block:: bash
+
+    salt '*' state.sls nginx
 
 Now that subdirectories can be used the vim.sls formula can be cleaned up, but
 to make things more flexible (and to illustrate another point of course), move

--- a/doc/topics/virt/index.rst
+++ b/doc/topics/virt/index.rst
@@ -7,26 +7,25 @@ The Salt Virt cloud controller capability was initial added to Salt in version
 
 The initial Salt Virt system supports core cloud operations:
 
-* Virtual machine deployment
-* Inspection of deployed VMs
-* Virtual machine migration
-* Network profiling
-* Automatic VM integration with all aspects of Salt
-* Image Pre-seeding
+- Virtual machine deployment
+- Inspection of deployed VMs
+- Virtual machine migration
+- Network profiling
+- Automatic VM integration with all aspects of Salt
+- Image Pre-seeding
 
 Many features are currently under development to enhance the capabilities of
 the Salt Virt systems.
 
 .. note::
 
-        It is noteworthy that Salt was originally developed with the intent of
-        using the Salt communication system as the backbone to a cloud
-        controller. This means that the Salt Virt system is not an
-        afterthought, simply a system that took the back seat to other
-        development. The original attempt to develop the cloud control aspects
-        of Salt was a project called butter. This project never took off, but
-        was functional and proves the early viability of Salt to be a cloud
-        controller.
+    It is noteworthy that Salt was originally developed with the intent of
+    using the Salt communication system as the backbone to a cloud controller.
+    This means that the Salt Virt system is not an afterthought, simply a
+    system that took the back seat to other development. The original attempt
+    to develop the cloud control aspects of Salt was a project called butter.
+    This project never took off, but was functional and proves the early
+    viability of Salt to be a cloud controller.
 
 Salt Virt Tutorial
 ==================
@@ -39,9 +38,9 @@ tutorial section:
 The Salt Virt Runner
 ====================
 
-The point of interaction with the cloud controller is the `virt` runner. The
-`virt` runner comes with routines to execute specific virtual machine
-routines.
+The point of interaction with the cloud controller is the :strong:`virt`
+runner. The :strong:`virt` runner comes with routines to execute specific
+virtual machine routines.
 
 Reference documentation for the virt runner is available with the runner
 module documentation:
@@ -55,4 +54,3 @@ The Salt Virt system is based on using Salt to query live data about
 hypervisors and then using the data gathered to make decisions about cloud
 operations. This means that no external resources are required to run Salt
 Virt, and that the information gathered about the cloud is live and accurate.
-

--- a/doc/topics/virt/nic.rst
+++ b/doc/topics/virt/nic.rst
@@ -8,7 +8,7 @@ read from the ``config.option`` function, meaning that the configuration can be
 stored in the minion config file, the master config file, or the minion's
 pillar.
 
-This configuration option is called `virt.nic`. By default the `virt.nic`
+This configuration option is called ``virt.nic``. By default the ``virt.nic``
 option is empty but defaults to a data structure which looks like this:
 
 .. code-block:: yaml
@@ -23,13 +23,13 @@ option is empty but defaults to a data structure which looks like this:
 
     The model does not need to be defined, Salt will default to the optimal
     model used by the underlying hypervisor, in the case of kvm this model
-    is `virtio`
+    is :strong:`virtio`
 
 This configuration sets up a network profile called default. The default
-profile creates a single Ethernet device on the virtual machine that is
-bridged to the hypervisor's `br0` interface. This default setup does not
-require setting up the `virt.nic` configuration, and is the reason why
-a default install only requires setting up the `br0` bridge device on the
+profile creates a single Ethernet device on the virtual machine that is bridged
+to the hypervisor's :strong:`br0` interface. This default setup does not
+require setting up the ``virt.nic`` configuration, and is the reason why a
+default install only requires setting up the :strong:`br0` bridge device on the
 hypervisor.
 
 Define More Profiles


### PR DESCRIPTION
This completes the documentation audit begun in cf365f7, using proper
backticks and :strong: tags to emphasize text, converting groups of
shell commands to bash code-block sections, etc. This also replaces the
use of * with the easier-to-grok '*', which will hopefully reduce
confusion among new users.
