### PR TITLE
add osarch grain and fix debian32 on x86_64

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -910,6 +910,15 @@ def os_data():
         grains['os_family'] = _OS_FAMILY_MAP.get(grains['os'],
                                                  grains['os'])
 
+    # Build the osarch grain. This grain will be used for platform-specific
+    # considerations such as package management. Fall back to the CPU
+    # architecture.
+    if grains.get('os_family') == 'Debian':
+        osarch = __salt__['cmd.run']('dpkg --print-architecture').strip()
+    else:
+        osarch = grains['cpuarch']
+    grains['osarch'] = osarch
+
     grains.update(_memdata(grains))
 
     # Get the hardware and bios data

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -526,8 +526,8 @@ def list_pkgs(versions_as_list=False, removed=False):
 
     out = __salt__['cmd.run_all'](cmd).get('stdout', '')
     # Typical lines of output:
-    # install ok installed zsh 4.3.17-1ubuntu1
-    # deinstall ok config-files mc 3:4.8.1-2ubuntu1
+    # install ok installed zsh 4.3.17-1ubuntu1 amd64
+    # deinstall ok config-files mc 3:4.8.1-2ubuntu1 amd64
     for line in out.splitlines():
         cols = line.split()
         try:
@@ -535,9 +535,10 @@ def list_pkgs(versions_as_list=False, removed=False):
                 [cols[x] for x in (0, 2, 3, 4, 5)]
         except ValueError:
             continue
-        if __grains__.get('cpuarch', '') == 'x86_64' \
-                and re.match(r'i\d86', arch):
-            name += ':{0}'.format(arch)
+        if __grains__.get('cpuarch', '') == 'x86_64':
+            osarch = __grains__.get('osarch', '')
+            if arch != 'all' and osarch == 'amd64' and osarch != arch:
+                name += ':{0}'.format(arch)
         if len(cols):
             if ('install' in linetype or 'hold' in linetype) and \
                     'installed' in status:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -67,6 +67,9 @@ def _parse_pkg_meta(path):
         cpuarch = sys.modules[
             __salt__['test.ping'].__module__
         ].__grains__.get('cpuarch', '')
+        osarch = sys.modules[
+            __salt__['test.ping'].__module__
+        ].__grains__.get('osarch', '')
 
         result = __salt__['cmd.run_all']('dpkg-deb -I "{0}"'.format(path))
         if result['retcode'] == 0:
@@ -95,8 +98,8 @@ def _parse_pkg_meta(path):
                         ).group(1)
                     except AttributeError:
                         continue
-        if arch:
-            if cpuarch == 'x86_64' and arch not in ('amd64', 'all'):
+        if arch and cpuarch == 'x86_64':
+            if arch != 'all' and osarch == 'amd64' and osarch != arch:
                 name += ':{0}'.format(arch)
         return name, version
 


### PR DESCRIPTION
This pull request adds a new grain, `osarch`, which can be used to detect 32-bit linux installed on 64-bit platform. `platform.uname()` returns `x86_64` for debian32 when installed on 64-bit hardware, causing 32-bit packages to be improperly identified by salt with a trailing `:i386`.

See #6607 for more information.
