### PR TITLE
Link to 0.16.0 release notes from 0.16.2/0.16.3

### DIFF
--- a/doc/topics/releases/0.16.2.rst
+++ b/doc/topics/releases/0.16.2.rst
@@ -2,7 +2,8 @@
 Salt 0.16.2 Release Notes
 =========================
 
-Version 0.16.2 is a bugfix release for 0.16.0, and contains a number of fixes.
+Version 0.16.2 is a bugfix release for :doc:`0.16.0 </topics/releases/0.16.0>`,
+and contains a number of fixes.
 
 Windows
 -------

--- a/doc/topics/releases/0.16.3.rst
+++ b/doc/topics/releases/0.16.3.rst
@@ -2,7 +2,8 @@
 Salt 0.16.3 Release Notes
 =========================
 
-Version 0.16.3 is another bugfix release for 0.16.0. The changes include:
+Version 0.16.3 is another bugfix release for :doc:`0.16.0
+</topics/releases/0.16.0>`. The changes include:
 
 - Various documentation fixes
 - Fix proc directory regression (:issue:`6502`)


### PR DESCRIPTION
The release notes for these two versions make mention of 0.16.0, so this
commit makes those into links for easier navigation.
