### PR TITLE
Fix grammar, spelling, formatting in 0.16.2 release notes

### DIFF
--- a/doc/topics/releases/0.16.2.rst
+++ b/doc/topics/releases/0.16.2.rst
@@ -18,7 +18,8 @@ Grains
 ------
 - Fixed detection of ``virtual`` grain on OpenVZ hardware nodes
 - Gracefully handle lsb_release data when it is enclosed in quotes
-- LSB-Grains are prefixed with ``lsb_distrib_`` instead of ``lsb_``. This renameing is not backward compatible!
+- LSB grains are now prefixed with ``lsb_distrib_`` instead of simply ``lsb_``.
+  The old naming is not preserved, so SLS may be affected.
 - Improved grains detection on MacOS
 
 Pillar


### PR DESCRIPTION
55d9586 introduced some errors that needed to be corrected, this commit
corrects them.
