### PR TITLE
adding modjk modules

### DIFF
--- a/salt/modules/modjk.py
+++ b/salt/modules/modjk.py
@@ -1,0 +1,356 @@
+'''
+Control Modjk via the Status worker
+http://tomcat.apache.org/connectors-doc/reference/status.html
+
+The following configuration needs to exists in pillar/grains
+each entry nested in modjk is a profile of the loadbalancer in question
+this would give support to multiple modjk balancers in different hosts/vhosts
+
+modjk:
+  'default':
+    'url': http://localhost/jkstatus
+    'user': modjk
+    'pass': secret
+    'realm': 'authentication realm for digest passwords'
+    'timeout': 5
+  'otherVhost:
+    'url': http://otherVhost/jkstatus
+    'user': modjk
+    'pass': secret2
+    'realm': 'authentication realm2 for digest passwords'
+    'timeout': 600
+'''
+
+# Python libs
+import urllib
+import urllib2
+
+
+def __virtual__():
+    '''
+    Always load
+    '''
+    
+    return 'modjk'
+
+
+def _auth(url, user, passwd, realm):
+    '''
+    returns a authentication handler.
+    '''
+
+    basic = urllib2.HTTPBasicAuthHandler()
+    basic.add_password(realm=realm, uri=url, user=user, passwd=passwd)
+    digest = urllib2.HTTPDigestAuthHandler()
+    digest.add_password(realm=realm, uri=url, user=user, passwd=passwd)
+    return urllib2.build_opener(basic, digest)
+
+
+def _do_http(opts, profile='default'):
+    '''
+    Make the http request and return the data
+    '''
+    
+    ret = {}
+    
+    url = __salt__['config.get']('modjk:'+profile+':url', '')
+    user = __salt__['config.get']('modjk:'+profile+':user', '')
+    passwd = __salt__['config.get']('modjk:'+profile+':pass', '')
+    realm = __salt__['config.get']('modjk:'+profile+':realm', '')
+    timeout = __salt__['config.get']('modjk:'+profile+':timeout', 5)
+    
+    if not url:
+        raise Exception('missing url in profile {0}'.format(profile))
+    
+    if user and passwd:
+        auth = _auth(url, realm, user, passwd)
+        urllib2.install_opener(auth)
+    
+    url += '?{0}'.format(urllib.urlencode(opts))
+    
+    for line in urllib2.urlopen(url, timeout=timeout).read().splitlines():
+        splt = line.split('=', 1)
+        ret[splt[0]] = splt[1]
+    
+    return ret
+
+   
+def _workerCtl(worker, lb, vwa, profile='default'):
+    '''
+    enable/disable/stop a worker
+    '''
+    
+    cmd = {
+        'cmd': 'update',
+        'mime': 'prop',
+        'w': lb,
+        'sw': worker,
+        'vwa': vwa,
+    }
+    return _do_http(cmd, profile)['worker.result.type'] == 'OK'
+
+
+###############
+### General ###
+###############
+
+
+def version(profile='default'):
+    '''
+    Return the modjk version
+    
+    CLI Examples::
+
+        salt '*' modjk.version
+        salt '*' modjk.version other-profile
+    '''
+    
+    cmd = {
+        'cmd': 'version',
+        'mime': 'prop',
+    }
+    return _do_http(cmd, profile)['worker.jk_version'].split('/')[-1]
+
+
+def get_running(profile='default'):
+    '''
+    Get the current running config (not from disk)
+    
+    CLI Examples::
+
+        salt '*' modjk.get_running
+        salt '*' modjk.get_running other-profile
+    '''
+    
+    cmd = {
+        'cmd': 'list',
+        'mime': 'prop',
+    }
+    return _do_http(cmd, profile)
+
+
+def dump_config(profile='default'):
+    '''
+    Dump the original configuration that was loaded from disk
+    
+    CLI Examples::
+
+        salt '*' modjk.dump_config
+        salt '*' modjk.dump_config other-profile
+    '''
+    
+    cmd = {
+        'cmd': 'dump',
+        'mime': 'prop',
+    }
+    return _do_http(cmd, profile)
+
+
+####################
+### LB Functoins ###
+####################
+
+
+def list_configured_members(lb, profile='default'):
+    '''
+    Return a list of member workers from the configuration files
+    
+    CLI Examples::
+
+        salt '*' modjk.list_configured_members loadbalancer1
+        salt '*' modjk.list_configured_members loadbalancer1 other-profile
+    '''
+    
+    config = dump_config(profile)
+    
+    try:
+        ret = config['worker.{0}.balance_workers'.format(lb)].strip().split(',')
+    except KeyError:
+        return []
+    
+    return filter(None, ret)
+
+
+def list_running_members(lb, profile='default'):
+    '''
+    Return a list of member workers
+    
+    CLI Examples::
+
+        salt '*' modjk.list_running_members loadbalancer1
+        salt '*' modjk.list_running_members loadbalancer1 other-profile
+    '''
+    
+    config = get_running()
+    try:
+        return config['worker.{0}.balance_workers'.format(lb)].split(',')
+    except KeyError:
+        return []
+
+
+def recover_all(lb, profile='default'):
+    '''
+    Set the all the workers in lb to recover and activate them if they are not
+    
+    CLI Examples::
+
+        salt '*' modjk.recover_all loadbalancer1
+        salt '*' modjk.recover_all loadbalancer1 other-profile
+    '''
+    
+    ret = {}
+    
+    workers = list_running_members(lb, profile)
+    for worker in workers:
+        curr_state = worker_status(worker, profile)
+        if curr_state['activation'] != 'ACT':
+            worker_activate(worker, lb, profile)
+        if not curr_state['state'].startswith('OK'):
+            worker_recover(worker, lb, profile)
+        ret[worker] = worker_status(worker, profile)
+    
+    return ret
+
+
+def reset_stats(lb, profile='default'):
+    '''
+    Reset all runtime statistics for the load balancer
+    
+    CLI Examples::
+
+        salt '*' modjk.reset_stats loadbalancer1
+        salt '*' modjk.reset_stats loadbalancer1 other-profile
+    '''
+    
+    cmd = {
+        'cmd': 'reset',
+        'mime': 'prop',
+        'w': lb,
+    }
+    return _do_http(cmd, profile)['worker.result.type'] == 'OK'
+
+
+def lb_edit(lb, settings, profile='default'):
+    '''
+    Edit the loadbalancer settings
+    
+    Note: http://tomcat.apache.org/connectors-doc/reference/status.html
+    Data Parameters for the standard Update Action
+    
+    CLI Examples::
+
+        salt '*' modjk.lb_edit loadbalancer1 "{'vlr': 1, 'vlt': 60}"
+        salt '*' modjk.lb_edit loadbalancer1 "{'vlr': 1, 'vlt': 60}" other-profile
+    '''
+    
+    settings['cmd'] = 'update'
+    settings['mime'] = 'prop'
+    settings['w'] = lb
+    
+    return _do_http(settings, profile)['worker.result.type'] == 'OK'    
+
+
+########################
+### Worker Functions ###
+########################
+
+
+def worker_status(worker, profile='default'):
+    '''
+    Return the state of the worker
+    
+    CLI Examples::
+
+        salt '*' modjk.worker_status node1
+        salt '*' modjk.worker_status node1 other-profile
+    '''
+    
+    config = get_running(profile)
+    try:
+        return {
+            'activation': config['worker.{0}.activation'.format(worker)],
+            'state': config['worker.{0}.state'.format(worker)],
+        }
+    except KeyError:
+        return False
+
+
+def worker_recover(worker, lb, profile='default'):
+    '''
+    Set the worker to recover
+    this module will fail if it is in OK state
+    
+    CLI Examples::
+
+        salt '*' modjk.worker_recover node1 loadbalancer1
+        salt '*' modjk.worker_recover node1 loadbalancer1 other-profile
+    '''
+    
+    cmd = {
+        'cmd': 'recover',
+        'mime': 'prop',
+        'w': lb,
+        'sw': worker,
+    }
+    return _do_http(cmd, profile)
+
+
+def worker_disable(worker, lb, profile='default'):
+    '''
+    Set the worker to disable state in the lb load balancer
+    
+    CLI Examples::
+
+        salt '*' modjk.worker_disable node1 loadbalancer1
+        salt '*' modjk.worker_disable node1 loadbalancer1 other-profile
+    '''
+    
+    return _workerCtl(worker, lb, 'd', profile)
+
+
+def worker_activate(worker, lb, profile='default'):
+    '''
+    Set the worker to activate state in the lb load balancer
+    
+    CLI Examples::
+
+        salt '*' modjk.worker_activate node1 loadbalancer1
+        salt '*' modjk.worker_activate node1 loadbalancer1 other-profile
+    '''
+    
+    return _workerCtl(worker, lb, 'a', profile)
+
+
+def worker_stop(worker, lb, profile='default'):
+    '''
+    Set the worker to stopped state in the lb load balancer
+    
+    CLI Examples::
+
+        salt '*' modjk.worker_activate node1 loadbalancer1
+        salt '*' modjk.worker_activate node1 loadbalancer1 other-profile
+    '''
+    
+    return _workerCtl(worker, lb, 's', profile)
+
+
+def worker_edit(worker, lb, settings, profile='default'):
+    '''
+    Edit the worker settings
+    
+    Note: http://tomcat.apache.org/connectors-doc/reference/status.html
+    Data Parameters for the standard Update Action
+    
+    CLI Examples::
+
+        salt '*' modjk.lb_edit node1 loadbalancer1 "{'vwf': 500, 'vwd': 60}"
+        salt '*' modjk.lb_edit node1 loadbalancer1 "{'vwf': 500, 'vwd': 60}" other-profile
+    '''
+    
+    settings['cmd'] = 'update'
+    settings['mime'] = 'prop'
+    settings['w'] = lb
+    settings['sw'] = worker
+    
+    return _do_http(settings, profile)['worker.result.type'] == 'OK'
+

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -1,0 +1,195 @@
+'''
+Send commands to a modjk loadbalancer via the peer system
+
+This module is usefull with the prereq feature to remove/add the worker
+from the loadbalancer before deploying/restarting service
+http://docs.saltstack.com/ref/states/requisites.html#prereq
+
+Mandatory Settings:
+    - The minion needs to have a peer permission to publish the modjk.* functions !
+    - The modjk loadbalncer needs to be configured as stated in the modjk module !
+'''
+
+def __virtual__():
+    '''
+    Check if we have peer access ?
+    '''
+    
+    return 'modjk_worker'
+
+
+def _send_command(cmd, worker, lb, target, profile='default', expr_form='glob'):
+    '''
+    Send a command to the modjk loadbalancer
+    The minion need to be able to publish the commands to the load balancer
+    
+    cmd:
+        worker_stop - won't get any traffic from the lb
+        worker_activate - activate the worker
+        worker_disable - will get traffic only for current sessions
+    '''
+    
+    ret = {
+        'code': False,
+        'msg': 'OK',
+        'minions': [],
+    }
+    
+    # Send the command to target
+    func = 'modjk.{0}'.format(cmd)
+    args = [worker, lb, profile]
+    response = __salt__['publish.publish'](target, func, args, expr_form)
+    
+    # Get errors and list of affeced minions
+    errors = []
+    minions = []
+    for minion in response:
+        minions.append(minion)
+        if not response[minion]:
+            errors.append(minion)
+    
+    # parse response
+    if not response:
+        ret['msg'] = 'no servers answered the published command {0}'.format(cmd)
+        return ret
+    elif len(errors) > 0:
+        ret['msg'] = 'the following minions return False'
+        ret['minions'] = errors
+        return ret
+    else:
+        ret['code'] = True
+        ret['msg'] = 'the commad was published successfully'
+        ret['minions'] = minions
+        return ret
+
+
+def _worker_status(target, worker, activation, profile='default', expr_form='glob'):
+    '''
+    Check if the worker is in `activation` state in the targeted load balancers
+    
+    The function will return the following dictionary:
+        result - False if no server returned from the published command
+        errors - list of servers that couldn't find the worker
+        wrong_state - list of servers that the worker was in the wrong state (not activation)
+    '''
+    
+    ret = {
+        'result': True,
+        'errors': [],
+        'wrong_state': [],
+    }
+    
+    args = [worker, profile]
+    status = __salt__['publish.publish'](target, 'modjk.worker_status', args, expr_form)
+    
+    # Did we got any respone from someone ?
+    if not status:
+        ret['result'] = False
+        return ret
+    
+    # Search for errors & status
+    for balancer in status:
+        if not status[balancer]:
+            ret['errors'].append(balancer)
+        elif status[balancer]['activation'] != activation:
+            ret['wrong_state'].append(balancer)
+    
+    return ret
+
+
+def _talk2modjk(name, lb, target, action, profile='default', expr_form='glob'):
+    '''
+    Wrapper function for the stop/disable/activate functions
+    '''
+    
+    ret = {'name': name,
+           'result': True,
+           'changes': {},
+           'comment': ''}
+    
+    action_map = {
+        'worker_stop': 'STP',
+        'worker_disable': 'DIS',
+        'worker_activate': 'ACT',
+    }
+    
+    # Check what needs to be done
+    status = _worker_status(target, name, action_map[action], profile, expr_form)
+    if not status['result']:
+        ret['result'] = False
+        ret['comment'] = 'no servers answered the published command modjk.worker_status'
+        return ret
+    if status['errors']:
+        ret['result'] = False
+        ret['comment'] = 'the following balancers could not find the worker {0}: {1}'.format(name, status['errors'])
+        return ret
+    if not status['wrong_state']:
+        ret['comment'] = 'the worker is in the desired activation state on all the balancers'
+        return ret
+    else:
+        ret['comment'] = 'the action {0} will be sent to the balancers {1}'.format(action, status['wrong_state'])
+        ret['changes'] = {action: status['wrong_state']}
+    
+    if __opts__['test']:
+        ret['result'] = None
+        return ret
+    
+    # Send the action command to target
+    response = _send_command(action, name, lb, target, profile, expr_form)
+    ret['comment'] = response['msg']
+    ret['result'] = response['code']
+    return ret
+
+
+def stop(name, lb, target, profile='default', expr_form='glob'):
+    '''
+    Stop the named worker from the lb load balancers at the targeted minions
+    The worker won't get any traffic from the lb
+    
+    Example::
+    
+        disable-before-deploy:
+          modjk_worker.stop:
+            - name: {{ grains['id'] }}
+            - lb: application
+            - target: 'roles:balancer'
+            - expr_form: grain
+    '''
+    
+    return _talk2modjk(name, lb, target, 'worker_stop', profile, expr_form)
+
+
+def activate(name, lb, target, profile='default', expr_form='glob'):
+    '''
+    Activate the named worker from the lb load balancers at the targeted minions
+    
+    Example::
+    
+        disable-before-deploy:
+          modjk_worker.activate:
+            - name: {{ grains['id'] }}
+            - lb: application
+            - target: 'roles:balancer'
+            - expr_form: grain
+    '''
+    
+    return _talk2modjk(name, lb, target, 'worker_activate', profile, expr_form)
+
+
+def disable(name, lb, target, profile='default', expr_form='glob'):
+    '''
+    Disable the named worker from the lb load balancers at the targeted minions
+    The worker will get traffic only for current sessions and won't get new ones
+    
+    Example::
+    
+        disable-before-deploy:
+          modjk_worker.disable:
+            - name: {{ grains['id'] }}
+            - lb: application
+            - target: 'roles:balancer'
+            - expr_form: grain
+    '''
+    
+    return _talk2modjk(name, lb, target, 'worker_disable', profile, expr_form)
+


### PR DESCRIPTION
**modjk module**
A wrapper module to the modjk http api

**modjk_worker state**
A state module that allows a minion to remove/add it-self from/a modjk load balancer
with the help of the peer system and the modjk module above at the load balancer side

I find these modules very useful with using prereq states which makes continues deployment very easy...
The only problem I've encountered is how to determine if I want to load these modules so for now they are loaded by-default

for example:

```
tomcat:
  service.running:
    - enable: True

wait-4-tomcat:
  tomcat.wait:
    - timeout: 600
    - require:
      - service: tomcat

remove-from-jk:
  modjk_worker.stop:
    - name: {{ grains['id'] }}
    - lb: load balancer name
    - target: 'roles:loadbalancer'
    - expr_form: grain
    - prereq:
      - tomcat: /webapp

/webapp:
  tomcat.war_deployed:
    - war: salt://wars/webapp-1.0.war
    - require:
      - tomcat: wait-4-tomcat

add-to-jk:
  modjk_worker.activate:
    - name: {{ grains['id'] }}
    - lb: load balancer name
    - target: 'roles:loadbalancer'
    - expr_form: grain
    - require:
      - tomcat: /webapp
```
