### PR TITLE
Provide a `saltversioninfo` grain.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1091,8 +1091,18 @@ def saltversion():
     '''
     # Provides:
     #   saltversion
-    from salt import __version__
+    from salt.version import __version__
     return {'saltversion': __version__}
+
+
+def saltversioninfo():
+    '''
+    Return the version_info of salt
+    '''
+    # Provides:
+    #   saltversioninfo
+    from salt.version import __version_info__
+    return {'saltversioninfo': __version_info__}
 
 
 # Relatively complex mini-algorithm to iterate over the various


### PR DESCRIPTION
This helps in version comparison on templates, for example:

``` python
(0, 17) > (0, 16, 3)
```
