### PR TITLE
Hide _namespaced_function from salt's loader.

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -25,8 +25,8 @@ def _parse_pkg_meta(path):
     def parse_rpm(path):
         try:
             from salt.modules.yumpkg5 import __QUERYFORMAT, _parse_pkginfo
-            from salt.utils import namespaced_function
-            _parse_pkginfo = namespaced_function(_parse_pkginfo, globals())
+            from salt.utils import namespaced_function as _namespaced_function
+            _parse_pkginfo = _namespaced_function(_parse_pkginfo, globals())
         except ImportError:
             log.critical('Error importing helper functions. This is almost '
                          'certainly a bug.')


### PR DESCRIPTION
This is needed because in CentOS 5, under python 2.6 that function is flagged as not having a CLI example from the test suite.
