### PR TITLE
Salt name spaced events

### DIFF
--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -15,15 +15,15 @@ import salt.utils
 from salt.exceptions import SaltException, EauthAuthenticationError
 from salt.utils.event import tagify
 
-def tokenify(low, token=None):
+def tokenify(cmd, token=None):
     '''
-    If token is not None Then assign token to 'token' key of lowstate cmd dict
-        low and return low
-    Otherwise return low
+    If token is not None Then assign token to 'token' key of cmd dict
+        and return cmd
+    Otherwise return cmd
     '''
     if token is not None:
-        low['token'] = token
-    return low
+        cmd['token'] = token
+    return cmd
 
 
 class APIClient(object):

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -13,6 +13,7 @@ import salt.runner
 import salt.wheel
 import salt.utils
 from salt.exceptions import SaltException, EauthAuthenticationError
+from salt.utils.event import tagify
 
 def tokenify(low, token=None):
     '''
@@ -288,4 +289,4 @@ class APIClient(object):
         Need to convert this to a master call with appropriate authentication
         
         '''
-        return (self.event.fire_event(data, tag))    
+        return (self.event.fire_event(data, tagify(tag, 'wui')))    

--- a/salt/key.py
+++ b/salt/key.py
@@ -12,7 +12,7 @@ import fnmatch
 import salt.crypt
 import salt.utils
 import salt.utils.event
-
+from salt.utils.event import tagify
 
 class KeyCLI(object):
     '''
@@ -404,7 +404,7 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'accept',
                              'id': key}
-                    self.event.fire_event(eload, 'key')
+                    self.event.fire_event(eload, tagify(prefix='key'))
                 except (IOError, OSError):
                     pass
         return self.name_match(match)
@@ -429,7 +429,7 @@ class Key(object):
                 eload = {'result': True,
                          'act': 'accept',
                          'id': key}
-                self.event.fire_event(eload, 'key')
+                self.event.fire_event(eload, tagify(prefix='key'))
             except (IOError, OSError):
                 pass
         return self.list_keys()
@@ -445,7 +445,7 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'delete',
                              'id': key}
-                    self.event.fire_event(eload, 'key')
+                    self.event.fire_event(eload, tagify(prefix='key'))
                 except (OSError, IOError):
                     pass
         self.check_minion_cache()
@@ -463,7 +463,7 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'delete',
                              'id': key}
-                    self.event.fire_event(eload, 'key')
+                    self.event.fire_event(eload, tagify(prefix='key'))
                 except (OSError, IOError):
                     pass
         self.check_minion_cache()
@@ -491,7 +491,7 @@ class Key(object):
                     eload = {'result': True,
                              'act': 'reject',
                              'id': key}
-                    self.event.fire_event(eload, 'key')
+                    self.event.fire_event(eload, tagify(prefix='key'))
                 except (IOError, OSError):
                     pass
         self.check_minion_cache()
@@ -518,7 +518,7 @@ class Key(object):
                 eload = {'result': True,
                          'act': 'reject',
                          'id': key}
-                self.event.fire_event(eload, 'key')
+                self.event.fire_event(eload, tagify(prefix='key'))
             except (IOError, OSError):
                 pass
         self.check_minion_cache()

--- a/salt/master.py
+++ b/salt/master.py
@@ -51,6 +51,7 @@ import salt.utils.minions
 import salt.utils.gzip_util
 from salt.utils.debug import enable_sigusr1_handler
 from salt.exceptions import SaltMasterError, MasterExit
+from salt.utils.event import tagify
 
 log = logging.getLogger(__name__)
 
@@ -996,10 +997,12 @@ class AESFuncs(object):
             return False
         if 'events' in load:
             for event in load['events']:
-                self.event.fire_event(event, event['tag'])
+                self.event.fire_event(event, event['tag']) # old dup event
+                self.event.fire_event(event, tagify([load['id'], event['tag']], 'minion'))
         else:
             tag = load['tag']
-            self.event.fire_event(load, tag)
+            self.event.fire_event(load, tag) #old dup event
+            self.event.fire_event(load, tagify([load['id'], tag], 'minion'))
         return True
 
     def _return(self, load):
@@ -1018,7 +1021,8 @@ class AESFuncs(object):
                     self.opts['hash_type'],
                     load.get('nocache', False))
         log.info('Got return from {id} for job {jid}'.format(**load))
-        self.event.fire_event(load, load['jid'])
+        self.event.fire_event(load, load['jid']) # old dup event
+        self.event.fire_event(load, tagify([load['jid'], 'ret', load['id']], 'job'))
         self.event.fire_ret_load(load)
         if self.opts['master_ext_job_cache']:
             fstr = '{0}.returner'.format(self.opts['master_ext_job_cache'])
@@ -1593,7 +1597,7 @@ class ClearFuncs(object):
             eload = {'result': False,
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, 'auth')
+            self.event.fire_event(eload, tagify(prefix = 'auth')) 
             return ret
         elif os.path.isfile(pubfn):
             # The key has been accepted check it
@@ -1608,7 +1612,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, 'auth')
+                self.event.fire_event(eload, tagify(prefix = 'auth'))
                 return ret
         elif not os.path.isfile(pubfn_pend)\
                 and not self._check_autosign(load['id']):
@@ -1622,7 +1626,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, 'auth')
+                self.event.fire_event(eload, tagify(prefix = 'auth'))
                 return ret
             # This is a new key, stick it in pre
             log.info(
@@ -1636,7 +1640,7 @@ class ClearFuncs(object):
                      'act': 'pend',
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, 'auth')
+            self.event.fire_event(eload, tagify(prefix = 'auth'))
             return ret
         elif os.path.isfile(pubfn_pend)\
                 and not self._check_autosign(load['id']):
@@ -1651,7 +1655,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, 'auth')
+                self.event.fire_event(eload, tagify(prefix = 'auth'))
                 return {'enc': 'clear',
                         'load': {'ret': False}}
             else:
@@ -1664,7 +1668,7 @@ class ClearFuncs(object):
                          'act': 'pend',
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, 'auth')
+                self.event.fire_event(eload, tagify(prefix = 'auth'))
                 return {'enc': 'clear',
                         'load': {'ret': True}}
         elif os.path.isfile(pubfn_pend)\
@@ -1679,7 +1683,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, 'auth')
+                self.event.fire_event(eload, tagify(prefix = 'auth'))
                 return {'enc': 'clear',
                         'load': {'ret': False}}
             else:
@@ -1694,7 +1698,7 @@ class ClearFuncs(object):
             eload = {'result': False,
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, 'auth')
+            self.event.fire_event(eload, tagify(prefix = 'auth'))
             return {'enc': 'clear',
                     'load': {'ret': False}}
 
@@ -1750,7 +1754,7 @@ class ClearFuncs(object):
                  'act': 'accept',
                  'id': load['id'],
                  'pub': load['pub']}
-        self.event.fire_event(eload, 'auth')
+        self.event.fire_event(eload, tagify(prefix = 'auth'))
         return ret
 
     def runner(self, clear_load):
@@ -2173,11 +2177,13 @@ class ClearFuncs(object):
                 'ret': clear_load['ret'],
                 'user': clear_load['user'],
                 'fun': clear_load['fun'],
-                'arg': clear_load['arg']
+                'arg': clear_load['arg'],
+                'minions': minions,
             }
 
         # Announce the job on the event bus
-        self.event.fire_event(new_job_load, 'new_job')
+        self.event.fire_event(new_job_load, 'new_job') # old dup event
+        self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new_job'], 'job'))
 
         # Verify the jid dir
         if not os.path.isdir(jid_dir):

--- a/salt/master.py
+++ b/salt/master.py
@@ -2183,7 +2183,7 @@ class ClearFuncs(object):
 
         # Announce the job on the event bus
         self.event.fire_event(new_job_load, 'new_job') # old dup event
-        self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new_job'], 'job'))
+        self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new'], 'job'))
 
         # Verify the jid dir
         if not os.path.isdir(jid_dir):


### PR DESCRIPTION
Added support for name spaced events preliminary.
Added duplicate job events under salt.job.jid...
Changed auth events to salt.auth
changed key event to salt.key
Added duplicate minion events

CAUTION. 
This commit only changes the publication tag of events but does not change the subscribers to the events.
Because job events are duplicated it should not mess up job event subscribers but because key and auth events
were not duplicated it could mess those up.
