### PR TITLE
Audit module documentation (A to D)

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -36,6 +36,7 @@ Full list of builtin execution modules
     daemontools
     darwin_sysctl
     data
+    ddns
     debconfmod
     debian_service
     dig

--- a/doc/ref/modules/all/salt.modules.ddns.rst
+++ b/doc/ref/modules/all/salt.modules.ddns.rst
@@ -1,0 +1,6 @@
+=================
+salt.modules.ddns
+=================
+
+.. automodule:: salt.modules.ddns
+    :members:

--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -98,9 +98,11 @@ def list_aliases():
     '''
     Return the aliases found in the aliases file in this format::
 
-        {'<alias>': '<target>'}
+        {'alias': 'target'}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' aliases.list_aliases
     '''
@@ -112,9 +114,11 @@ def get_target(alias):
     '''
     Return the target associated with an alias
 
-    CLI Example::
+    CLI Example:
 
-        salt '*' aliases.get_target <alias>
+    .. code-block:: bash
+
+        salt '*' aliases.get_target alias
     '''
     aliases = list_aliases()
     if alias in aliases:
@@ -126,9 +130,11 @@ def has_target(alias, target):
     '''
     Return true if the alias/target is set
 
-    CLI Example::
+    CLI Example:
 
-        salt '*' aliases.has_target <alias> <target>
+    .. code-block:: bash
+
+        salt '*' aliases.has_target alias target
     '''
     aliases = list_aliases()
     return alias in aliases and target == aliases[alias]
@@ -140,9 +146,11 @@ def set_target(alias, target):
     any previous entry for the given alias or create a new one if it does not
     exist.
 
-    CLI Example::
+    CLI Example:
 
-        salt '*' aliases.set_target <alias> <target>
+    .. code-block:: bash
+
+        salt '*' aliases.set_target alias target
     '''
 
     if get_target(alias) == target:
@@ -169,9 +177,11 @@ def rm_alias(alias):
     '''
     Remove an entry from the aliases file
 
-    CLI Example::
+    CLI Example:
 
-        salt '*' aliases.rm_alias <alias>
+    .. code-block:: bash
+
+        salt '*' aliases.rm_alias alias
     '''
     if not get_target(alias):
         return True

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -46,7 +46,9 @@ def display(name):
     '''
     Display alternatives settings for defined command name
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' alternatives.display editor
     '''
@@ -63,7 +65,9 @@ def show_current(name):
     Display the current highest-priority alternative for a given alternatives
     link
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' alternatives.show_current editor
     '''
@@ -82,7 +86,9 @@ def check_installed(name, path):
     Check if the current highest-priority match for a given alternatives link
     is set to the desired path
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' alternatives.check_installed name path
     '''
@@ -93,7 +99,9 @@ def install(name, link, path, priority):
     '''
     Install symbolic links determining default commands
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' alternatives.install editor /usr/bin/editor /usr/bin/emacs23 50
     '''
@@ -110,7 +118,9 @@ def remove(name, path):
     '''
     Remove symbolic links determining the default commands.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' alternatives.remove name path
     '''

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -41,7 +41,9 @@ def version():
     '''
     Return server version from apachectl -v
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' apache.version
     '''
@@ -55,7 +57,9 @@ def fullversion():
     '''
     Return server version from apachectl -V
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' apache.fullversion
     '''
@@ -82,7 +86,9 @@ def modules():
     '''
     Return list of static and shared modules from apachectl -M
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' apache.modules
     '''
@@ -106,7 +112,9 @@ def servermods():
     '''
     Return list of modules compiled into the server (apachectl -l)
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' apache.servermods
     '''
@@ -126,7 +134,9 @@ def directives():
     Return list of directives together with expected arguments
     and places where the directive is valid (``apachectl -L``)
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' apache.directives
     '''
@@ -150,7 +160,9 @@ def vhosts():
     Because each additional virtual host adds to the execution
     time, this command may require a long timeout be specified.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt -t 10 '*' apache.vhosts
     '''
@@ -182,7 +194,9 @@ def signal(signal=None):
     '''
     Signals httpd to start, restart, or stop.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' apache.signal restart
     '''
@@ -224,7 +238,9 @@ def useradd(pwfile, user, password, opts=''):
         p  Do not encrypt the password (plaintext).
         s  Force SHA encryption of the password.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' apache.useradd /etc/httpd/htpasswd larry badpassword
         salt '*' apache.useradd /etc/httpd/htpasswd larry badpass opts=ns
@@ -241,7 +257,9 @@ def userdel(pwfile, user):
     '''
     Delete an HTTP user from the specified htpasswd file.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' apache.userdel /etc/httpd/htpasswd larry
     '''
@@ -260,7 +278,9 @@ def check_site_enabled(site):
     This will only be functional on Debian-based operating systems (Ubuntu,
     Mint, etc).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' apache.check_site_enabled example.com
     '''
@@ -279,7 +299,9 @@ def a2ensite(site):
     This will only be functional on Debian-based operating systems (Ubuntu,
     Mint, etc).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' apache.a2ensite example.com
     '''
@@ -311,7 +333,9 @@ def a2dissite(site):
     This will only be functional on Debian-based operating systems (Ubuntu,
     Mint, etc).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' apache.a2dissite example.com
     '''
@@ -357,7 +381,9 @@ def server_status(profile='default'):
         'realm': 'authentication realm for digest passwords'
         'timeout': 5
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' apache.server_status
         salt '*' apache.server_status other-profile

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -111,7 +111,9 @@ def latest_version(*names, **kwargs):
 
     A specific repo can be requested using the ``fromrepo`` keyword argument.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package name> fromrepo=unstable
@@ -174,7 +176,9 @@ def version(*names, **kwargs):
     installed. If more than one package name is specified, a dict of
     name/version pairs is returned.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
@@ -189,11 +193,13 @@ def refresh_db():
     Returns a dict, with the keys being package databases and the values being
     the result of the update attempt. Values can be one of the following:
 
-        ``True``: Database updated successfully
-        ``False``: Problem updating database
-        ``None``: Database already up-to-date
+    - ``True``: Database updated successfully
+    - ``False``: Problem updating database
+    - ``None``: Database already up-to-date
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.refresh_db
     '''
@@ -240,7 +246,10 @@ def install(name=None,
         architecture designation (``:i386``, etc.) to the end of the package
         name.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install <package name>
 
     refresh
@@ -269,7 +278,10 @@ def install(name=None,
         A list of packages to install from a software repository. Must be
         passed as a python list.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install pkgs='["foo", "bar"]'
             salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-0ubuntu0"}]'
 
@@ -282,7 +294,10 @@ def install(name=None,
         architecture designation (``:i386``, etc.) to the end of the package
         name.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install sources='[{"foo": "salt://foo.deb"},{"bar": "salt://bar.deb"}]'
 
 
@@ -411,7 +426,9 @@ def remove(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove <package1>,<package2>,<package3>
@@ -440,7 +457,9 @@ def purge(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.purge <package name>
         salt '*' pkg.purge <package1>,<package2>,<package3>
@@ -458,7 +477,9 @@ def upgrade(refresh=True, **kwargs):
         {'<package>':  {'old': '<old-version>',
                         'new': '<new-version>'}}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade
     '''
@@ -503,7 +524,9 @@ def list_pkgs(versions_as_list=False, removed=False):
         Virtual package resolution requires dctrl-tools.
         Without dctrl-tools virtual packages will be reported as not installed.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_pkgs
         salt '*' pkg.list_pkgs versions_as_list=True
@@ -615,7 +638,9 @@ def list_upgrades(refresh=True):
     '''
     List all available package upgrades.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_upgrades
     '''
@@ -628,7 +653,9 @@ def upgrade_available(name):
     '''
     Check whether or not an upgrade is available for a given package
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade_available <package name>
     '''
@@ -641,7 +668,9 @@ def version_cmp(pkg1, pkg2):
     pkg1 == pkg2, and 1 if pkg1 > pkg2. Return None if there was a problem
     making the comparison.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version_cmp '0.2.4-0ubuntu1' '0.2.4.1-0ubuntu1'
     '''
@@ -699,7 +728,9 @@ def list_repos():
     '''
     Lists all repos in the sources.list (and sources.lists.d) files
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
        salt '*' pkg.list_repos
        salt '*' pkg.list_repos disabled=True
@@ -733,7 +764,9 @@ def get_repo(repo, **kwargs):
 
     The repo passwd in needs to be a complete repo entry.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.get_repo "myrepo definition"
     '''
@@ -802,7 +835,9 @@ def del_repo(repo, **kwargs):
     The repo passed in must be a fully formed repository definition
     string.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.del_repo "myrepo definition"
     '''
@@ -914,7 +949,9 @@ def mod_repo(repo, **kwargs):
                 at the same time.  Keys should be properly added on initial
                 configuration.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.mod_repo 'myrepo definition' uri=http://new/uri
         salt '*' pkg.mod_repo 'myrepo definition' comps=main,universe
@@ -1149,7 +1186,9 @@ def file_list(*packages):
     return a list of _every_ file on the system's package database (not
     generally recommended).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.file_list httpd
         salt '*' pkg.file_list httpd postfix
@@ -1164,7 +1203,9 @@ def file_dict(*packages):
     specifying any packages will return a list of _every_ file on the system's
     package database (not generally recommended).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.file_list httpd
         salt '*' pkg.file_list httpd postfix

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -28,16 +28,19 @@ def tar(options, tarfile, sources, cwd=None, template=None):
     '''
     Uses the tar command to pack, unpack, etc tar files
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' archive.tar cjvf /tmp/tarfile.tar.bz2 /tmp/file_1,/tmp/file_2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
+    For example:
 
-        salt '*' archive.tar template=jinja cjvf /tmp/salt.tar.bz2 \
-                {{grains.saltpath}}
+    .. code-block:: bash
+
+        salt '*' archive.tar template=jinja cjvf /tmp/salt.tar.bz2 {{grains.saltpath}}
 
     '''
     if isinstance(sources, salt._compat.string_types):
@@ -52,13 +55,18 @@ def gzip(sourcefile, template=None):
     '''
     Uses the gzip command to create gzip files
 
-    CLI Example to create ``/tmp/sourcefile.txt.gz``::
+    CLI Example to create ``/tmp/sourcefile.txt.gz``:
+
+    .. code-block:: bash
 
         salt '*' archive.gzip /tmp/sourcefile.txt
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    CLI Example::
+
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' archive.gzip template=jinja /tmp/{{grains.id}}.txt
 
@@ -72,13 +80,18 @@ def gunzip(gzipfile, template=None):
     '''
     Uses the gunzip command to unpack gzip files
 
-    CLI Example to create ``/tmp/sourcefile.txt``::
+    CLI Example to create ``/tmp/sourcefile.txt``:
+
+    .. code-block:: bash
 
         salt '*' archive.gunzip /tmp/sourcefile.txt.gz
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    CLI Example::
+
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' archive.gunzip template=jinja /tmp/{{grains.id}}.txt.gz
 
@@ -92,16 +105,20 @@ def zip_(zipfile, sources, template=None):
     '''
     Uses the zip command to create zip files
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' archive.zip /tmp/zipfile.zip /tmp/sourcefile1,/tmp/sourcefile2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
 
-        salt '*' archive.zip template=jinja /tmp/zipfile.zip \
-                /tmp/sourcefile1,/tmp/{{grains.id}}.txt
+    For example:
+
+    .. code-block:: bash
+
+        salt '*' archive.zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1,/tmp/{{grains.id}}.txt
 
     '''
     if isinstance(sources, salt._compat.string_types):
@@ -115,17 +132,20 @@ def unzip(zipfile, dest, excludes=None, template=None):
     '''
     Uses the unzip command to unpack zip files
 
-    CLI Example::
+    CLI Example:
 
-        salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ \
-                excludes=file_1,file_2
+    .. code-block:: bash
+
+        salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
 
-        salt '*' archive.unzip template=jinja /tmp/zipfile.zip \
-                /tmp/{{grains.id}}/ excludes=file_1,file_2
+    For example:
+
+    .. code-block:: bash
+
+        salt '*' archive.unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
 
     '''
     if isinstance(excludes, salt._compat.string_types):
@@ -143,16 +163,20 @@ def rar(rarfile, sources, template=None):
     Uses the rar command to create rar files
     Uses rar for Linux from http://www.rarlab.com/
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' archive.rar /tmp/rarfile.rar /tmp/sourcefile1,/tmp/sourcefile2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
 
-        salt '*' archive.rar template=jinja /tmp/rarfile.rar \
-                /tmp/sourcefile1,/tmp/{{grains.id}}.txt
+    For example:
+
+    .. code-block:: bash
+
+        salt '*' archive.rar template=jinja /tmp/rarfile.rar /tmp/sourcefile1,/tmp/{{grains.id}}.txt
 
 
     '''
@@ -168,17 +192,20 @@ def unrar(rarfile, dest, excludes=None, template=None):
     Uses the unrar command to unpack rar files
     Uses rar for Linux from http://www.rarlab.com/
 
-    CLI Example::
+    CLI Example:
 
-        salt '*' archive.unrar /tmp/rarfile.rar /home/strongbad/ \
-                excludes=file_1,file_2
+    .. code-block:: bash
+
+        salt '*' archive.unrar /tmp/rarfile.rar /home/strongbad/ excludes=file_1,file_2
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
 
-        salt '*' archive.unrar template=jinja /tmp/rarfile.rar \
-                /tmp/{{grains.id}}/ excludes=file_1,file_2
+    For example:
+
+    .. code-block:: bash
+
+        salt '*' archive.unrar template=jinja /tmp/rarfile.rar /tmp/{{grains.id}}/ excludes=file_1,file_2
 
     '''
     if isinstance(excludes, salt._compat.string_types):

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -45,7 +45,9 @@ def atq(tag=None):
     List all queued and running jobs or only those with
     an optional 'tag'.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' at.atq
         salt '*' at.atq [tag]
@@ -134,7 +136,9 @@ def atrm(*args):
     '''
     Remove jobs from the queue.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' at.atrm <jobid> <jobid> .. <jobid>
         salt '*' at.atrm all
@@ -176,7 +180,9 @@ def at(*args, **kwargs):  # pylint: disable=C0103
     The 'timespec' follows the format documented in the
     at(1) manpage.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' at.at <timespec> <cmd> [tag=<tag>] [runas=<user>]
         salt '*' at.at 12:05am '/sbin/reboot' tag=reboot
@@ -236,7 +242,9 @@ def atc(jobid):
     id. This is mostly for debugging so the output will
     just be text.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' at.atc <jobid>
     '''

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -56,7 +56,9 @@ def get(path, value=''):
     '''
     Get a value for a specific augeas path
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.get /files/etc/hosts/1/ ipaddr
     '''
@@ -84,20 +86,26 @@ def setvalue(*args):
     '''
     Set a value for a specific augeas path
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.setvalue /files/etc/hosts/1/canonical localhost
 
     This will set the first entry in /etc/hosts to localhost
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.setvalue /files/etc/hosts/01/ipaddr 192.168.1.1 \\
                                  /files/etc/hosts/01/canonical test
 
     Adds a new host to /etc/hosts the ip address 192.168.1.1 and hostname test
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.setvalue prefix=/files/etc/sudoers/ \\
                  "spec[user = '%wheel']/user" "%wheel" \\
@@ -145,7 +153,9 @@ def match(path, value=''):
     '''
     Get matches for path expression
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.match /files/etc/services/service-name ssh
     '''
@@ -169,7 +179,9 @@ def remove(path):
     '''
     Get matches for path expression
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.remove /files/etc/sysctl.conf/net.ipv4.conf.all.log_martians
     '''
@@ -194,7 +206,9 @@ def ls(path):  # pylint: disable=C0103
     '''
     List the direct children of a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.ls /files/etc/passwd
     '''
@@ -231,7 +245,9 @@ def tree(path):
     '''
     Returns recursively the complete tree of a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' augeas.tree /files/etc/
     '''

--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -42,7 +42,9 @@ def version():
     '''
     Return Bluez version from bluetoothd -v
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetoothd.version
     '''
@@ -61,7 +63,9 @@ def address_():
     '''
     Get the many addresses of the Bluetooth adapter
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.address
     '''
@@ -91,7 +95,9 @@ def power(dev, mode):
     '''
     Power a bluetooth device on or off
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.power hci0 on
         salt '*' bluetooth.power hci0 off
@@ -114,7 +120,9 @@ def discoverable(dev):
     '''
     Enable this bluetooth device to be discovrable.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.discoverable hci0
     '''
@@ -131,7 +139,9 @@ def noscan(dev):
     '''
     Turn off scanning modes on this device.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.noscan hci0
     '''
@@ -148,7 +158,9 @@ def scan():
     '''
     Scan for bluetooth devices in the area
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.scan
     '''
@@ -163,7 +175,9 @@ def block(bdaddr):
     '''
     Block a specific bluetooth device by BD Address
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.block DE:AD:BE:EF:CA:FE
     '''
@@ -175,7 +189,9 @@ def unblock(bdaddr):
     '''
     Unblock a specific bluetooth device by BD Address
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.unblock DE:AD:BE:EF:CA:FE
     '''
@@ -187,7 +203,9 @@ def pair(address, key):
     '''
     Pair the bluetooth adapter with a device
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.pair DE:AD:BE:EF:CA:FE 1234
 
@@ -209,7 +227,9 @@ def unpair(address):
     '''
     Unpair the bluetooth adapter from a device
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.unpair DE:AD:BE:EF:CA:FE
 
@@ -227,7 +247,9 @@ def start():
     '''
     Start the bluetooth service.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.start
     '''
@@ -239,7 +261,9 @@ def stop():
     '''
     Stop the bluetooth service.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bluetooth.stop
     '''

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -54,7 +54,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
         {'<package_name>': '<version>'}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_pkgs
     '''
@@ -93,7 +95,9 @@ def version(*names, **kwargs):
     installed. If more than one package name is specified, a dict of
     name/version pairs is returned.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3>
@@ -109,7 +113,9 @@ def latest_version(*names, **kwargs):
     Note that this currently not fully implemented but needs to return
     something to avoid a traceback when calling pkg.latest.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3>
@@ -145,7 +151,9 @@ def remove(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove <package1>,<package2>,<package3>
@@ -173,14 +181,18 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         The name of the formula to be installed. Note that this parameter is
         ignored if "pkgs" is passed.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
 
             salt '*' pkg.install <package name>
 
     taps
         Unofficial Github repos to use when updating and installing formulas.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
 
             salt '*' pkg.install <package name> tap='<tap>'
             salt '*' pkg.install zlib taps='homebrew/dupes'
@@ -193,7 +205,9 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         to all packages. Unreconized options for a package will be silently
         ignored by brew.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
 
             salt '*' pkg.install <package name> tap='<tap>'
             salt '*' pkg.install php54 taps='["josegonzalez/php", "homebrew/dupes"]' options='["--with-fpm"]'
@@ -203,7 +217,9 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
     pkgs
         A list of formulas to install. Must be passed as a python list.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
 
             salt '*' pkg.install pkgs='["foo","bar"]'
 
@@ -213,7 +229,9 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.install 'package package package'
     '''
@@ -260,7 +278,9 @@ def list_upgrades():
     '''
     Check whether or not an upgrade is available for all packages
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_upgrades
     '''
@@ -273,7 +293,9 @@ def upgrade_available(pkg):
     '''
     Check whether or not an upgrade is available for a given package
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade_available <package name>
     '''

--- a/salt/modules/bridge.py
+++ b/salt/modules/bridge.py
@@ -11,6 +11,7 @@ __func_alias__ = {
     'list_': 'list'
 }
 
+
 def __virtual__():
     '''
     Confirm this module is supported by the OS and the system has
@@ -233,7 +234,9 @@ def show(br=None):
     no interface is given, all bridges are shown, else only the specified
     bridge values are returned.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.show
         salt '*' bridge.show br0
@@ -245,7 +248,9 @@ def list_():
     '''
     Returns the machine's bridges list
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.list
     '''
@@ -263,7 +268,9 @@ def interfaces(br=None):
     '''
     Returns interfaces attached to a bridge
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.interfaces br0
     '''
@@ -279,7 +286,9 @@ def find_interfaces(*args):
     '''
     Returns the bridge to which the interfaces are bond to
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.find_interfaces eth0 [eth1...]
     '''
@@ -304,7 +313,9 @@ def add(br=None):
     '''
     Creates a bridge
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.add br0
     '''
@@ -315,7 +326,9 @@ def delete(br=None):
     '''
     Deletes a bridge
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.delete br0
     '''
@@ -326,7 +339,9 @@ def addif(br=None, iface=None):
     '''
     Adds an interface to a bridge
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.addif br0 eth0
     '''
@@ -337,7 +352,9 @@ def delif(br=None, iface=None):
     '''
     Removes an interface from a bridge
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.delif br0 eth0
     '''
@@ -348,7 +365,9 @@ def stp(br=None, state='disable', iface=None):
     '''
     Sets Spanning Tree Protocol state for a bridge
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.stp br0 enable
         salt '*' bridge.stp br0 disable
@@ -356,7 +375,9 @@ def stp(br=None, state='disable', iface=None):
     For the NetBSD operating system, it is required to add the interface on
     which to enable the STP.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' bridge.stp bridge0 enable fxp0
         salt '*' bridge.stp bridge0 disable fxp0

--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -17,7 +17,9 @@ def default_hash():
     '''
     Returns the default hash used for unset passwords
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' shadow.default_hash
     '''
@@ -28,7 +30,9 @@ def info(name):
     '''
     Return information for the specified user
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' shadow.info someuser
     '''
@@ -78,7 +82,9 @@ def set_password(name, password):
 
     It is important to make sure that a supported cipher is used.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' shadow.set_password someuser '$1$UYCIxa628.9qXjpQCjM4a..'
     '''

--- a/salt/modules/cassandra.py
+++ b/salt/modules/cassandra.py
@@ -61,7 +61,9 @@ def compactionstats():
     '''
     Return compactionstats info
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.compactionstats
     '''
@@ -72,7 +74,9 @@ def version():
     '''
     Return the cassandra version
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.version
     '''
@@ -83,7 +87,9 @@ def netstats():
     '''
     Return netstats info
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.netstats
     '''
@@ -94,7 +100,9 @@ def tpstats():
     '''
     Return tpstats info
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.tpstats
     '''
@@ -105,7 +113,9 @@ def info():
     '''
     Return cassandra node info
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.info
     '''
@@ -116,7 +126,9 @@ def ring():
     '''
     Return cassandra ring info
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.ring
     '''
@@ -127,7 +139,9 @@ def keyspaces():
     '''
     Return existing keyspaces
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.keyspaces
     '''
@@ -140,7 +154,9 @@ def column_families(keyspace=None):
     Return existing column families for all keyspaces
     or just the provided one.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.column_families
         salt '*' cassandra.column_families <keyspace>
@@ -166,7 +182,9 @@ def column_family_definition(keyspace=None, column_family=None):
     Return a dictionary of column family definitions for the given
     keyspace/column_family
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cassandra.column_family_definition <keyspace> <column_family>
 

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -420,23 +420,31 @@ def run(cmd,
     Note that ``env`` represents the environment variables for the command, and
     should be formatted as a dict, or a YAML string which resolves to a dict.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run "ls -l | awk '/foo/{print \\$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
+    For example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
-    Specify an alternate shell with the shell parameter::
+    Specify an alternate shell with the shell parameter:
+
+    .. code-block:: bash
 
         salt '*' cmd.run "Get-ChildItem C:\\ " shell='powershell'
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.run "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -477,19 +485,25 @@ def run_stdout(cmd,
     Note that ``env`` represents the environment variables for the command, and
     should be formatted as a dict, or a YAML string which resolves to a dict.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_stdout "ls -l | awk '/foo/{print \\$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
+    For example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_stdout template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_stdout "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -529,19 +543,25 @@ def run_stderr(cmd,
     Note that ``env`` represents the environment variables for the command, and
     should be formatted as a dict, or a YAML string which resolves to a dict.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_stderr "ls -l | awk '/foo/{print \\$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
+    For example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_stderr template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_stderr "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -581,19 +601,25 @@ def run_all(cmd,
     Note that ``env`` represents the environment variables for the command, and
     should be formatted as a dict, or a YAML string which resolves to a dict.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_all "ls -l | awk '/foo/{print \\$2}'"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
+    For example:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_all template=jinja "ls -l /tmp/{{grains.id}} | awk '/foo/{print \\$2}'"
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.run_all "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -646,19 +672,25 @@ def retcode(cmd,
     Note that ``env`` represents the environment variables for the command, and
     should be formatted as a dict, or a YAML string which resolves to a dict.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.retcode "file /bin/bash"
 
     The template arg can be set to 'jinja' or another supported template
     engine to render the command arguments before execution.
-    For example::
+    For example:
+
+    .. code-block:: bash
 
         salt '*' cmd.retcode template=jinja "file {{grains.pythonpath[0]}}/python"
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.retcode "grep f" stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -699,7 +731,9 @@ def script(
     The script can also be formated as a template, the default is jinja.
     Arguments for the script can be specified as well.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.script salt://scripts/runme.sh
         salt '*' cmd.script salt://scripts/runme.sh 'arg1 arg2 "arg 3"'
@@ -707,7 +741,9 @@ def script(
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.script salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -772,13 +808,17 @@ def script_retcode(
 
     Only evaluate the script return code and do not block for terminal output
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.script_retcode salt://scripts/runme.sh
 
     A string of standard input can be specified for the command to be run using
     the ``stdin`` parameter. This can be useful in cases where sensitive
-    information must be read from standard input.::
+    information must be read from standard input.:
+
+    .. code-block:: bash
 
         salt '*' cmd.script_retcode salt://scripts/runme.sh stdin='one\\ntwo\\nthree\\nfour\\nfive\\n'
     '''
@@ -799,7 +839,9 @@ def which(cmd):
     '''
     Returns the path of an executable available on the minion, None otherwise
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.which cat
     '''
@@ -810,7 +852,9 @@ def which_bin(cmds):
     '''
     Returns the first command found in a list of commands
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.which_bin '[pip2, pip, pip-python]'
     '''
@@ -821,7 +865,9 @@ def has_exec(cmd):
     '''
     Returns true if the executable is available on the minion, false otherwise
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.has_exec cat
     '''
@@ -834,7 +880,9 @@ def exec_code(lang, code, cwd=None):
     python2, python3, ruby, perl, lua, etc. the second string containing
     the code you wish to execute. The stdout and stderr will be returned
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cmd.exec_code ruby 'puts "cheese"'
     '''

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -52,7 +52,9 @@ def backup_mode(backup=''):
     '''
     Return the backup mode
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.backup_mode
     '''
@@ -65,7 +67,9 @@ def manage_mode(mode):
     '''
     Return a mode value, normalized to a string
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.manage_mode
     '''
@@ -79,7 +83,9 @@ def valid_fileproto(uri):
     Returns a boolean value based on whether or not the URI passed has a valid
     remote file protocol designation
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.valid_fileproto salt://path/to/file
     '''
@@ -98,7 +104,9 @@ def option(
     '''
     Pass in a generic option and receive the value that will be assigned
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.option redis.host
     '''
@@ -127,7 +135,9 @@ def merge(value,
     Same as ``option()`` except that it merges all matches, rather than taking
     the first match.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.merge schedule
     '''
@@ -177,23 +187,25 @@ def get(key, default=''):
     The default return is an empty string.
 
     The value can also represent a value in a nested dict using a ":" delimiter
-    for the dict. This means that if a dict looks like this:
+    for the dict. This means that if a dict looks like this::
 
-    {'pkg': {'apache': 'httpd'}}
+        {'pkg': {'apache': 'httpd'}}
 
     To retrieve the value associated with the apache key in the pkg dict this
-    key can be passed:
+    key can be passed::
 
-    pkg:apache
+        pkg:apache
 
     This routine traverses these data stores in this order:
 
-        Local minion config (opts)
-        Minion's grains
-        Minion's pillar
-        Master config
+    - Local minion config (opts)
+    - Minion's grains
+    - Minion's pillar
+    - Master config
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.get pkg:apache
     '''
@@ -217,7 +229,9 @@ def dot_vals(value):
     Pass in a configuration value that should be preceded by the module name
     and a dot, this will return a list of all read key/value pairs
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' config.dot_vals host
     '''
@@ -236,7 +250,9 @@ def gather_bootstrap_script(replace=False):
     Download the salt-bootstrap script, set replace to True to refresh the
     script if it has already been downloaded
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' qemu.gather_bootstrap_script True
     '''

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -29,15 +29,12 @@ def recv(files, dest):
     '''
     Used with salt-cp, pass the files dict, and the destination.
 
-    This function receives small fast copy files from the master via salt-cp
-
-    CLI Example::
-
-        This function does not work via the CLI
+    This function receives small fast copy files from the master via salt-cp.
+    It does not work via the CLI.
     '''
     ret = {}
     for path, data in files.items():
-        if os.path.basename(path) == os.path.basename(dest)\
+        if os.path.basename(path) == os.path.basename(dest) \
                 and not os.path.isdir(dest):
             final = dest
         elif os.path.isdir(dest):
@@ -113,12 +110,16 @@ def get_file(path, dest, env='base', makedirs=False, template=None, gzip=None):
     '''
     Used to get a single file from the salt master
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.get_file salt://path/to/file /minion/dest
 
     Template rendering can be enabled on both the source and destination file
-    names like so::
+    names like so:
+
+    .. code-block:: bash
 
         salt '*' cp.get_file "salt://{{grains.os}}/vimrc" /etc/vimrc template=jinja
 
@@ -152,7 +153,9 @@ def get_template(path, dest, template='jinja', env='base', **kwargs):
     '''
     Render a file as a template before setting it down
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.get_template salt://path/to/template /minion/dest
     '''
@@ -178,7 +181,9 @@ def get_dir(path, dest, env='base', template=None, gzip=None):
     '''
     Used to recursively copy a directory from the salt master
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.get_dir salt://path/to/dir/ /minion/dest
 
@@ -194,7 +199,9 @@ def get_url(path, dest, env='base'):
     '''
     Used to get a single file from a URL.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.get_url salt://my/file /tmp/mine
         salt '*' cp.get_url http://www.slashdot.org /tmp/index.html
@@ -207,7 +214,9 @@ def get_file_str(path, env='base'):
     '''
     Return the contents of a file from a URL
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.get_file_str salt://my/file
     '''
@@ -221,7 +230,9 @@ def cache_file(path, env='base'):
     '''
     Used to cache a single file in the local salt-master file cache.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.cache_file salt://path/to/file
     '''
@@ -242,7 +253,9 @@ def cache_files(paths, env='base'):
     saved in the minion cachedir reflective to the paths retrieved from the
     master.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.cache_files salt://pathto/file1,salt://pathto/file1
     '''
@@ -254,7 +267,9 @@ def cache_dir(path, env='base', include_empty=False):
     '''
     Download and cache everything under a directory from the master
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.cache_dir salt://path/to/dir
     '''
@@ -266,7 +281,9 @@ def cache_master(env='base'):
     '''
     Retrieve all of the files on the master and cache them locally
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.cache_master
     '''
@@ -278,7 +295,9 @@ def cache_local_file(path):
     '''
     Cache a local file on the minion in the localfiles cache
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.cache_local_file /etc/hosts
     '''
@@ -304,7 +323,9 @@ def list_states(env='base'):
     '''
     List all of the available state modules in an environment
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.list_states
     '''
@@ -316,7 +337,9 @@ def list_master(env='base', prefix=''):
     '''
     List all of the files stored on the master
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.list_master
     '''
@@ -328,7 +351,9 @@ def list_master_dirs(env='base', prefix=''):
     '''
     List all of the directories stored on the master
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.list_master_dirs
     '''
@@ -340,7 +365,9 @@ def list_minion(env='base'):
     '''
     List all of the files cached on the minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.list_minion
     '''
@@ -353,7 +380,9 @@ def is_cached(path, env='base'):
     Return a boolean if the given path on the master has been cached on the
     minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.is_cached salt://path/to/file
     '''
@@ -367,7 +396,9 @@ def hash_file(path, env='base'):
     salt master file server prepend the path with salt://<file on server>
     otherwise, prepend the file with / for a local file.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.hash_file salt://path/to/file
     '''
@@ -386,7 +417,9 @@ def push(path):
     ``file_recv`` to ``True`` in the master configuration file, and restart the
     master.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cp.push /etc/fstab
     '''

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -71,7 +71,9 @@ def write_cron_file(user, path):
     '''
     Writes the contents of a file to a user's crontab
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.write_cron_file root /tmp/new_cron
     '''
@@ -82,7 +84,9 @@ def write_cron_file_verbose(user, path):
     '''
     Writes the contents of a file to a user's crontab and return error message on error
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.write_cron_file_verbose root /tmp/new_cron
     '''
@@ -117,7 +121,9 @@ def raw_cron(user):
     '''
     Return the contents of the user's crontab
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.raw_cron root
     '''
@@ -132,7 +138,9 @@ def list_tab(user):
     '''
     Return the contents of the specified user's crontab
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.list_tab root
     '''
@@ -187,7 +195,9 @@ def set_special(user, special, cmd):
     '''
     Set up a special command in the crontab.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.set_special @hourly 'echo foobar'
     '''
@@ -247,7 +257,9 @@ def set_job(user, minute, hour, daymonth, month, dayweek, cmd):
     '''
     Sets a cron job up for a specified user.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.set_job root '*' '*' '*' '*' 1 /usr/local/weekly
     '''
@@ -309,7 +321,9 @@ def rm_job(user,
     Remove a cron job for a specified user. If any of the day/time params are
     specified, the job will only be removed if the specified params match.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.rm_job root /usr/local/weekly
         salt '*' cron.rm_job root /usr/bin/foo dayweek=1
@@ -349,7 +363,9 @@ def set_env(user, name, value=None):
     '''
     Set up an environment variable in the crontab.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.set_env root MAILTO user@example.com
     '''
@@ -378,7 +394,9 @@ def rm_env(user, name):
     '''
     Remove cron environment variable for a specified user.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' cron.rm_env root MAILTO
     '''

--- a/salt/modules/cytest.pyx
+++ b/salt/modules/cytest.pyx
@@ -10,7 +10,10 @@ def echo(text):
     Return a string - used for testing the connection
 
     CLI Example:
-    salt '*' test.echo 'foo bar baz quo qux'
+
+    .. code-block:: bash
+
+        salt '*' test.echo 'foo bar baz quo qux'
     '''
     return text
 
@@ -21,7 +24,10 @@ def ping():
     Return True
 
     CLI Example:
-    salt '*' test.ping
+
+    .. code-block:: bash
+
+        salt '*' test.ping
     '''
     return True
 
@@ -32,7 +38,8 @@ def fib(long num):
     to compute in seconds. Used for performance tests
 
     CLI Example:
-    salt '*' test.fib 3
+
+        salt '*' test.fib 3
     '''
     cdef float start = time.time()
     cdef long a = 0
@@ -51,7 +58,10 @@ def collatz(long start):
     the sequence and the time it took to compute. Used for performance tests.
 
     CLI Example:
-    salt '*' test.collatz 3
+
+    .. code-block:: bash
+
+        salt '*' test.collatz 3
     '''
     cdef float begin = time.time()
     steps = []

--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -45,7 +45,9 @@ def start(name):
     '''
     Starts service via daemontools
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.start <service name>
     '''
@@ -59,7 +61,9 @@ def stop(name):
     '''
     Stops service via daemontools
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.stop <service name>
     '''
@@ -72,7 +76,9 @@ def term(name):
     '''
     Send a TERM to service via daemontools
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.term <service name>
     '''
@@ -85,7 +91,9 @@ def reload_(name):
     '''
     Wrapper for term()
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.reload <service name>
     '''
@@ -97,7 +105,9 @@ def restart(name):
     '''
     Restart service via daemontools. This will stop/start service
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.restart <service name>
     '''
@@ -112,7 +122,9 @@ def full_restart(name):
     '''
     Calls daemontools.restart() function
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.full_restart <service name>
     '''
@@ -124,7 +136,9 @@ def status(name, sig=None):
     '''
     Return the status for a service via daemontools, return pid if running
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.status <service name>
     '''
@@ -142,7 +156,9 @@ def get_all():
     '''
     Return a list of all available services
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' daemontools.get_all
     '''

--- a/salt/modules/darwin_sysctl.py
+++ b/salt/modules/darwin_sysctl.py
@@ -21,7 +21,9 @@ def show():
     '''
     Return a list of sysctl parameters for this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' sysctl.show
     '''
@@ -70,7 +72,9 @@ def get(name):
     '''
     Return a single sysctl parameter for this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' sysctl.get hw.physmem
     '''
@@ -83,7 +87,9 @@ def assign(name, value):
     '''
     Assign a single sysctl parameter for this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' sysctl.assign net.inet.icmp.icmplim 50
     '''
@@ -103,7 +109,9 @@ def persist(name, value, config='/etc/sysctl.conf'):
     '''
     Assign and persist a simple sysctl parameter for this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' sysctl.persist net.inet.icmp.icmplim 50
         salt '*' sysctl.persist coretemp_load NO config=/etc/sysctl.conf

--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -17,7 +17,9 @@ def clear():
     Clear out all of the data in the minion datastore, this function is
     destructive!
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.clear
     '''
@@ -32,7 +34,9 @@ def load():
     '''
     Return all of the data in the minion datastore
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.load
     '''
@@ -50,7 +54,9 @@ def dump(new_data):
     '''
     Replace the entire datastore with a passed data structure
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.dump '{'eggs': 'spam'}'
     '''
@@ -76,7 +82,9 @@ def update(key, value):
     '''
     Update a key with a value in the minion datastore
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.update <key> <value>
     '''
@@ -90,7 +98,9 @@ def getval(key):
     '''
     Get a value from the minion datastore
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.getval <key>
     '''
@@ -102,7 +112,9 @@ def getvals(*keys):
     '''
     Get values from the minion datastore
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.getvals <key> [<key> ...]
     '''
@@ -113,11 +125,14 @@ def getvals(*keys):
             ret.append(store[key])
     return ret
 
+
 def cas(key, value, old_value):
     '''
     Check and set a value in the minion datastore
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' data.cas <key> <value> <old_value>
     '''

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -16,6 +16,7 @@ try:
 except ImportError as e:
     dns_support = False
 
+
 def __virtual__():
     '''
     Confirm dnspython is available.
@@ -29,7 +30,9 @@ def add_host(zone, name, ttl, ip, nameserver='127.0.0.1', replace=True):
     '''
     Add, replace, or update the A and PTR (reverse) records for a host.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 ddns.add_host example.com host1 60 10.1.1.1
     '''
@@ -60,7 +63,9 @@ def delete_host(zone, name, nameserver='127.0.0.1'):
 
     Returns true if any records are deleted.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 ddns.delete_host example.com host1
     '''
@@ -99,7 +104,9 @@ def update(zone, name, ttl, rdtype, data, nameserver='127.0.0.1', replace=False)
     must have update privileges on that server.
     If replace is true, first deletes all records for this name and type.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 ddns.update example.com host1 60 A 10.0.0.1
     '''
@@ -139,7 +146,9 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1'):
     '''
     Delete a DNS record.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 ddns.delete example.com host1 A
     '''

--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -51,7 +51,9 @@ def get_selections(fetchempty=True):
 
         {'package': [['question', 'type', 'value'], ...]}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' debconf.get_selections
     '''
@@ -80,7 +82,9 @@ def show(name):
 
     If debconf doesn't know about a package, we return None.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' debconf.show <package name>
     '''
@@ -103,7 +107,9 @@ def set_(package, question, type, value, *extra):
     '''
     Set answers to debconf questions for a package.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' debconf.set <package> <question> <type> <value> [<value> ...]
     '''
@@ -128,7 +134,9 @@ def set_file(path, **kwargs):
     '''
     Set answers to debconf questions from a file.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' debconf.set_file salt://pathto/pkg.selections
     '''

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -14,6 +14,7 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+
 def __virtual__():
     '''
     Only work on Debian and when systemd isn't running
@@ -34,7 +35,9 @@ def get_enabled():
     '''
     Return a list of service that are enabled on boot
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.get_enabled
     '''
@@ -50,7 +53,9 @@ def get_disabled():
     '''
     Return a set of services that are installed but disabled
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.get_disabled
     '''
@@ -61,7 +66,9 @@ def get_all():
     '''
     Return all available boot services
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.get_all
     '''
@@ -79,7 +86,9 @@ def start(name):
     '''
     Start the specified service
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.start <service name>
     '''
@@ -91,7 +100,9 @@ def stop(name):
     '''
     Stop the specified service
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.stop <service name>
     '''
@@ -103,7 +114,9 @@ def restart(name, **kwargs):
     '''
     Restart the named service
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.restart <service name>
     '''
@@ -115,7 +128,9 @@ def reload_(name):
     '''
     Reload the named service
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.reload <service name>
     '''
@@ -127,7 +142,9 @@ def force_reload(name):
     '''
     Force-reload the named service
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.force_reload <service name>
     '''
@@ -140,7 +157,9 @@ def status(name, sig=None):
     Return the status for a service, pass a signature to use to find
     the service via ps
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.status <service name>
     '''
@@ -154,7 +173,9 @@ def enable(name, **kwargs):
     '''
     Enable the named service to start at boot
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.enable <service name>
     '''
@@ -169,7 +190,9 @@ def disable(name, **kwargs):
     '''
     Disable the named service to start at boot
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.disable <service name>
     '''
@@ -181,7 +204,9 @@ def enabled(name):
     '''
     Return True if the named service is enabled, false otherwise
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.enabled <service name>
     '''
@@ -192,7 +217,9 @@ def disabled(name):
     '''
     Return True if the named service is enabled, false otherwise
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' service.disabled <service name>
     '''

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -25,7 +25,9 @@ def check_ip(x):
     '''
     Check that string x is a valid IP
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.check_ip 127.0.0.1
     '''
@@ -40,11 +42,13 @@ def check_ip(x):
 
 def A(host, nameserver=None):
     '''
-    Return the A record for 'host'.
+    Return the A record for ``host``.
 
     Always returns a list.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.A www.google.com
     '''
@@ -70,11 +74,13 @@ def A(host, nameserver=None):
 
 def NS(domain, resolve=True, nameserver=None):
     '''
-    Return a list of IPs of the nameservers for 'domain'
+    Return a list of IPs of the nameservers for ``domain``
 
-    If 'resolve' is False, don't resolve names.
+    If ``resolve`` is False, don't resolve names.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.NS google.com
     '''
@@ -106,13 +112,15 @@ def NS(domain, resolve=True, nameserver=None):
 
 def SPF(domain, record='SPF', nameserver=None):
     '''
-    Return the allowed IPv4 ranges in the SPF record for 'domain'.
+    Return the allowed IPv4 ranges in the SPF record for ``domain``.
 
-    If record is 'SPF' and the SPF record is empty, the TXT record will be
+    If record is ``SPF`` and the SPF record is empty, the TXT record will be
     searched automatically. If you know the domain uses TXT and not SPF,
     specifying that will save a lookup.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.SPF google.com
     '''
@@ -157,19 +165,18 @@ def SPF(domain, record='SPF', nameserver=None):
 
 def MX(domain, resolve=False, nameserver=None):
     '''
-    Return a list of lists for the MX of 'domain'. Example:
+    Return a list of lists for the MX of ``domain``.
 
-    >>> dig.MX('saltstack.org')
-    [ [10, 'mx01.1and1.com.'], [10, 'mx00.1and1.com.'] ]
-
-    If the 'resolve' argument is True, resolve IPs for the servers.
+    If the ``resolve`` argument is True, resolve IPs for the servers.
 
     It's limited to one IP, because although in practice it's very rarely a
     round robin, it is an acceptable configuration and pulling just one IP lets
     the data be similar to the non-resolved version. If you think an MX has
     multiple IPs, don't use the resolver here, resolve them in a separate step.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.MX google.com
     '''

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -24,7 +24,9 @@ def usage(args=None):
     '''
     Return usage information for volumes mounted on this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' disk.usage
     '''
@@ -77,7 +79,9 @@ def inodeusage(args=None):
     '''
     Return inode usage information for volumes mounted on this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' disk.inodeusage
     '''

--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -32,7 +32,9 @@ def command(settings_module,
     '''
     Run arbitrary django management command
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' django.command <settings_module> <command>
     '''
@@ -65,7 +67,9 @@ def syncdb(settings_module,
     minion the ``migrate`` option can be passed as ``True`` calling the
     migrations to run after the syncdb completes
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' django.syncdb <settings_module>
     '''
@@ -98,7 +102,9 @@ def createsuperuser(settings_module,
     This function defaults to use the ``--noinput`` flag which prevents the
     creation of a password for the superuser.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' django.createsuperuser <settings_module> user user@example.com
     '''
@@ -129,7 +135,9 @@ def loaddata(settings_module,
     Fixtures:
         comma separated list of fixtures to load
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' django.loaddata <settings_module> <comma delimited list of fixtures>
 
@@ -147,6 +155,7 @@ def loaddata(settings_module,
                    *fixtures.split(','),
                    **kwargs)
 
+
 def collectstatic(settings_module,
                   bin_env=None,
                   no_post_process=False,
@@ -161,7 +170,9 @@ def collectstatic(settings_module,
     Collect static files from each of your applications into a single location
     that can easily be served in production.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' django.collectstatic <settings_module>
     '''

--- a/salt/modules/dnsmasq.py
+++ b/salt/modules/dnsmasq.py
@@ -25,7 +25,9 @@ def version():
     '''
     Shows installed version of dnsmasq
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' dnsmasq.version
     '''
@@ -39,7 +41,9 @@ def fullversion():
     '''
     Shows installed version of dnsmasq, and compile options
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' dnsmasq.version
     '''
@@ -65,7 +69,9 @@ def set_config(config_file='/etc/dnsmasq.conf', follow=True, **kwargs):
     to the end of the main config file (and not to any includes). If you need
     an option added to a specific include file, specify it as the config_file.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' dnsmasq.set_config domain=mydomain.com
         salt '*' dnsmasq.set_config follow=False domain=mydomain.com
@@ -104,7 +110,9 @@ def get_config(config_file='/etc/dnsmasq.conf'):
     '''
     Dumps all options from the config file
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' dnsmasq.get_config
         salt '*' dnsmasq.get_config file=/etc/dnsmasq.conf

--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -24,7 +24,9 @@ def parse_hosts(hostsfile='/etc/hosts', hosts=None):
     '''
     Parse /etc/hosts file.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' dnsutil.parse_hosts
     '''
@@ -53,7 +55,9 @@ def hosts_append(hostsfile='/etc/hosts', ip_addr=None, entries=None):
     '''
     Append a single line to the /etc/hosts file.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' dnsutil.hosts_append /etc/hosts 127.0.0.1 ad1.yuk.co,ad2.yuk.co
     '''
@@ -74,13 +78,16 @@ def hosts_append(hostsfile='/etc/hosts', ip_addr=None, entries=None):
     return 'The following line was added to {0}:{1}'.format(hostsfile,
                                                             append_line)
 
+
 def hosts_remove(hostsfile='/etc/hosts', entries=None):
     '''
     Remove a host from the /etc/hosts file. If doing so will leave a line
     containing only an IP address, then the line will be deleted. This function
     will leave comments and blank lines intact.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' dnsutil.hosts_delete /etc/hosts ad1.yuk.co
         salt '*' dnsutil.hosts_delete /etc/hosts ad2.yuk.co,ad1.yuk.co
@@ -109,7 +116,9 @@ def parse_zone(zonefile=None, zone=None):
     '''
     Parses a zone file. Can be passed raw zone data on the API level.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dnsutil.parse_zone /var/lib/named/example.com.zone
     '''
@@ -213,7 +222,9 @@ def check_ip(ip_addr):
     '''
     Check that string ip_addr is a valid IP
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.check_ip 127.0.0.1
     '''
@@ -229,7 +240,9 @@ def A(host, nameserver=None):
 
     Always returns a list.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.A www.google.com
     '''
@@ -248,11 +261,13 @@ def A(host, nameserver=None):
 
 def NS(domain, resolve=True, nameserver=None):
     '''
-    Return a list of IPs of the nameservers for 'domain'
+    Return a list of IPs of the nameservers for ``domain``
 
     If 'resolve' is False, don't resolve names.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.NS google.com
 
@@ -265,13 +280,15 @@ def NS(domain, resolve=True, nameserver=None):
 
 def SPF(domain, record='SPF', nameserver=None):
     '''
-    Return the allowed IPv4 ranges in the SPF record for 'domain'.
+    Return the allowed IPv4 ranges in the SPF record for ``domain``.
 
-    If record is 'SPF' and the SPF record is empty, the TXT record will be
+    If record is ``SPF`` and the SPF record is empty, the TXT record will be
     searched automatically. If you know the domain uses TXT and not SPF,
     specifying that will save a lookup.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.SPF google.com
     '''
@@ -283,10 +300,7 @@ def SPF(domain, record='SPF', nameserver=None):
 
 def MX(domain, resolve=False, nameserver=None):
     '''
-    Return a list of lists for the MX of 'domain'. Example:
-
-    >>> dig.MX('saltstack.org')
-    [ [10, 'mx01.1and1.com.'], [10, 'mx00.1and1.com.'] ]
+    Return a list of lists for the MX of ``domain``.
 
     If the 'resolve' argument is True, resolve IPs for the servers.
 
@@ -295,7 +309,9 @@ def MX(domain, resolve=False, nameserver=None):
     the data be similar to the non-resolved version. If you think an MX has
     multiple IPs, don't use the resolver here, resolve them in a separate step.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt ns1 dig.MX google.com
     '''

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -27,7 +27,9 @@ def list_pkgs(*packages):
         Virtual package resolution requires aptitude. Because this function
         uses dpkg, virtual packages will be reported as not installed.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' lowpkg.list_pkgs
         salt '*' lowpkg.list_pkgs httpd
@@ -54,7 +56,9 @@ def file_list(*packages):
     return a list of _every_ file on the system's package database (not
     generally recommended).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' lowpkg.file_list httpd
         salt '*' lowpkg.file_list httpd postfix
@@ -94,7 +98,9 @@ def file_dict(*packages):
     specifying any packages will return a list of _every_ file on the system's
     package database (not generally recommended).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' lowpkg.file_list httpd
         salt '*' lowpkg.file_list httpd postfix

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -66,7 +66,7 @@ class SysModuleTest(integration.ModuleCase):
                 continue
             if not isinstance(docs[fun], basestring):
                 nodoc.add(fun)
-            elif not re.search(r'([E|e]xample(?:s)?)+(?:.*)::', docs[fun]):
+            elif not re.search(r'([E|e]xample(?:s)?)+(?:.*)::?', docs[fun]):
                 noexample.add(fun)
 
         if not nodoc and not noexample:

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -53,6 +53,7 @@ class SysModuleTest(integration.ModuleCase):
         nodoc = set()
         noexample = set()
         allow_failure = (
+                'cp.recv',
                 'pkg.expand_repo_def',
                 'runtests_decorators.depends',
                 'runtests_decorators.depends_will_fallback',


### PR DESCRIPTION
This commit formats shell examples using bash code-block directives, so
that they get syntax highlighting. It also adds missing doc pages for
the ddns module.
