### PR TITLE
Mysql returner fix

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -99,7 +99,6 @@ def _get_serv(commit=False):
     '''
     _options = _get_options()
     conn = MySQLdb.connect(host=_options['host'], user=_options['user'], passwd=_options['pass'], db=_options['db'], port=_options['port'])
-    log.debug( "FOO" )
     cursor = conn.cursor()
     try:
         yield cursor
@@ -121,15 +120,11 @@ def returner(ret):
     '''
     Return data to a mysql server
     '''
-    log.debug( "Got to this point.." )
     with _get_serv(commit=True) as cur:
-        log.debug( "Didn't get here?" )
         sql = '''INSERT INTO `salt_returns`
                 (`fun`, `jid`, `return`, `id`, `success`, `full_ret` )
                 VALUES (%s, %s, %s, %s, %s, %s)'''
-        log.error( "got here" )
-        if len(ret['return']) == str(ret['return']).count("'result': True"):
-            ret['success'] = True
+
         cur.execute(sql, (ret['fun'], ret['jid'],
                             str(ret['return']), ret['id'],
                             ret['success'], json.dumps(ret)))


### PR DESCRIPTION
Split out the options so that defaults can be automatically set. Also removed obsolete line testing the `ret['return']` for the contents of `'result': True` to set `ret['success']` even though `ret['success']` is already set by the module.

See issue #6695
