### PR TITLE
If not passing a `hostname`, use `None` in `getaddrinfo`.

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -95,8 +95,9 @@ def lookup_family(hostname):
     # If lookups fail, fall back to AF_INET sockets (and v4 addresses).
     fallback = socket.AF_INET
     try:
-        hostnames = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC,
-                                       socket.SOCK_STREAM)
+        hostnames = socket.getaddrinfo(
+            hostname or None, None, socket.AF_UNSPEC, socket.SOCK_STREAM
+        )
         if not hostnames:
             return fallback
         h = hostnames[0]


### PR DESCRIPTION
On my machine, passing an empty string to `getaddrinfo` raises errno 2, "No such file or directory". Use `None` if `hostname` is a string.
