### PR TITLE
Include secondary IP addresses in ip_addrs{,6}

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -506,7 +506,7 @@ def ip_addrs(interface=None, include_loopback=False):
     ignored, unless 'include_loopback=True' is indicated. If 'interface' is
     provided, then only IP addresses from that interface will be returned.
     '''
-    ret = []
+    ret = set()
     ifaces = interfaces()
     if interface is None:
         target_ifaces = ifaces
@@ -520,8 +520,15 @@ def ip_addrs(interface=None, include_loopback=False):
             if include_loopback \
                     or (not include_loopback
                         and ipv4['address'] != '127.0.0.1'):
-                ret.append(ipv4['address'])
-    return ret
+                ret.add(ipv4['address'])
+        for secondary in ipv4_info.get('secondary', []):
+            addr = secondary.get('address')
+            if addr and secondary.get('type') == 'inet':
+                if include_loopback \
+                        or (not include_loopback
+                            and address != '127.0.0.1'):
+                    ret.add(addr)
+    return sorted(list(ret))
 
 
 def ip_addrs6(interface=None, include_loopback=False):
@@ -530,7 +537,7 @@ def ip_addrs6(interface=None, include_loopback=False):
     unless 'include_loopback=True' is indicated. If 'interface' is provided,
     then only IP addresses from that interface will be returned.
     '''
-    ret = []
+    ret = set()
     ifaces = interfaces()
     if interface is None:
         target_ifaces = ifaces
@@ -543,8 +550,14 @@ def ip_addrs6(interface=None, include_loopback=False):
         for ipv6 in ipv6_info.get('inet6', []):
             if include_loopback \
                     or (not include_loopback and ipv6['address'] != '::1'):
-                ret.append(ipv6['address'])
-    return ret
+                ret.add(ipv6['address'])
+        for secondary in ipv6_info.get('secondary', []):
+            addr = secondary.get('address')
+            if addr and secondary.get('type') == 'inet6':
+                if include_loopback \
+                        or (not include_loopback and address != '::1'):
+                    ret.add(addr)
+    return sorted(list(ret))
 
 
 def hex2ip(hex_ip):


### PR DESCRIPTION
These functions were not iterating over the list of secondary IP
addresses, causing grains['ipv4'] and grains['ipv6'], as well as the
module execution functions network.ip_addrs and network.ip_addrs6 to
fail to include these IPs. This commit fixes that oversight.

Fixes #6656.
