### PR TITLE
Added name spaced event tags to runner

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -88,9 +88,10 @@ SALT = 'salt' #base prefix for all salt. events
 TAGS = \
 {
     'auth': 'auth', # prefix for all .auth events
-    'job': 'job', # prefix for all .job events
+    'job': 'job', # prefix for all .job events (minion jobs)
     'key': 'key', # prefix for all .key events
-    'minion': 'minion', # prefix for all .minion events
+    'minion': 'minion', # prefix for all .minion events (minion sourced events)
+    'run': 'run', #prefis for all .run events (salt runners)
 }
 
 def tagify(suffix='', prefix='', base=SALT):


### PR DESCRIPTION
runner now emits a new event at start of runner and ret event at end
uses name spaced tag
salt.run.jid
adds jid and tag to low structure passed to runner so in the future runners can emit progress events with same
tag
