### PR TITLE
Check /etc/hostname to derive minion id

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -91,7 +91,7 @@ This directory is prepended to the following options: :conf_minion:`pki_dir`,
 ``pki_dir``
 -----------
 
-Default: :file:`/etc/salt/pki`
+Default: ``/etc/salt/pki``
 
 The directory used to store the minion's public and private keys.
 
@@ -104,8 +104,12 @@ The directory used to store the minion's public and private keys.
 ``id``
 ------
 
-Default: the system's hostname (as returned by the Python function 
-``socket.getfqdn()``)
+Default: the system's hostname
+
+.. seealso:: :ref:`Salt Walkthrough <minion-id-generation>`
+
+    The :strong:`Setting up a Salt Minion` section contains detailed
+    information on how the hostname is determined.
 
 Explicitly declare the id for this minion to use. Since Salt uses detached ids
 it is possible to run multiple minions on the same machine but with different
@@ -135,7 +139,7 @@ FQDN (for instance, Solaris).
 ``cachedir``
 ------------
 
-Default: :file:`/var/cache/salt`
+Default: ``/var/cache/salt``
 
 The location for minion cache data.
 

--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -162,6 +162,31 @@ Now that the minion is started it will generate cryptographic keys and attempt
 to connect to the master. The next step is to venture back to the master server
 and accept the new minion's public key.
 
+.. _minion-id-generation:
+
+When the minion is started, it will generate an ``id`` value. This is the name
+by which the minion will attempt to authenticate to the master. The following
+steps are attempted, in order to try to find a value that is not ``localhost``:
+
+1. ``/etc/hostname`` is checked (non-Windows only)
+2. The Python function ``socket.getfqdn()`` is run
+3. ``/etc/hosts`` is checked for hostnames that map to anything within
+   :strong:`127.0.0.0/8`. (non-Windows only)
+4. ``%WINDIR%\system32\drivers\etc\hosts`` is checked (Windows only)
+
+If none of the above are able to produce an id which is not ``localhost``, then
+a sorted list of IP addresses on the minion (excluding any within
+:strong:`127.0.0.0/8`) is inspected. The first publicly-routable IP address is
+used, if there is one. Otherwise, the first privately-routable IP address is
+used.
+
+If all else fails, then ``localhost`` is used as a fallback.
+
+.. note:: Overriding the ``id``
+
+    The minion id can be manually specified using the :conf_minion:`id`
+    parameter in the minion config file.
+
 
 Using salt-key
 ~~~~~~~~~~~~~~

--- a/salt/config.py
+++ b/salt/config.py
@@ -661,7 +661,7 @@ def get_id():
     try:
         with salt.utils.fopen('/etc/hostname') as hfl:
             name = hfl.read().strip()
-        if re.search('\s', name):
+        if re.search(r'\s', name):
             log.warning('Whitespace character detected in /etc/hostname. '
                         'This file should not contain any whitespace.')
         else:

--- a/salt/config.py
+++ b/salt/config.py
@@ -643,17 +643,36 @@ def get_id():
     '''
     Guess the id of the minion.
 
+    - Check /etc/hostname for a value other than localhost
     - If socket.getfqdn() returns us something other than localhost, use it
     - Check /etc/hosts for something that isn't localhost that maps to 127.*
     - Look for a routeable / public IP
     - A private IP is better than a loopback IP
     - localhost may be better than killing the minion
+
+    Returns two values: the detected ID, and a boolean value noting whether or
+    not an IP address is being used for the ID.
     '''
 
     log.debug('Guessing ID. The id can be explicitly in set {0}'
               .format('/etc/salt/minion'))
+
+    # Check /etc/hostname
+    try:
+        with salt.utils.fopen('/etc/hostname') as hfl:
+            name = hfl.read().strip()
+        if re.search('\s', name):
+            log.warning('Whitespace character detected in /etc/hostname. '
+                        'This file should not contain any whitespace.')
+        else:
+            if name != 'localhost':
+                return name, False
+    except Exception:
+        pass
+
+    # Nothing in /etc/hostname or /etc/hostname not found
     fqdn = socket.getfqdn()
-    if 'localhost' != fqdn:
+    if fqdn != 'localhost':
         log.info('Found minion id from getfqdn(): {0}'.format(fqdn))
         return fqdn, False
 


### PR DESCRIPTION
This pull request fixes #6645 by making salt look at /etc/hostname first before running `socket.getfqdn()`. This fixes ID generation for distros like Arch Linux which respect the Linux FHS and require that the hostname be placed in /etc/hostname.

In addition, this pull request also adds documentation on how the minion id is derived to the walkthrough, and also x-refs the minion config file documentation for the `id` parameter.
