### PR TITLE
Fix FTP authentication in the salt fileclient

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -347,7 +347,8 @@ class Client(object):
             destdir = os.path.dirname(dest)
             if not os.path.isdir(destdir):
                 os.makedirs(destdir)
-        if url_data.username is not None:
+        if url_data.username is not None \
+                and url_data.scheme in ('http', 'https'):
             _, netloc = url_data.netloc.split('@', 1)
             fixed_url = urlunparse((url_data.scheme, netloc, url_data.path,
                 url_data.params, url_data.query, url_data.fragment))


### PR DESCRIPTION
4f36393 inadvertently broke FTP authentication by stripping the username
and password from URIs and trying to use an HTTP authenticator. This
commit restricts that behavior to http(s) URIs. Fixes #6733.
