### PR TITLE
Fix functions in match module

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1393,28 +1393,28 @@ class Matcher(object):
             tgt = tgt.split(',')
         return bool(self.opts['id'] in tgt)
 
-    def grain_match(self, tgt):
+    def grain_match(self, tgt, delim=':'):
         '''
         Reads in the grains glob match
         '''
         log.debug('grains target: {0}'.format(tgt))
-        if ':' not in tgt:
+        if delim not in tgt:
             log.error('Got insufficient arguments for grains match '
                       'statement from master')
             return False
-        return salt.utils.subdict_match(self.opts['grains'], tgt, delim=':')
+        return salt.utils.subdict_match(self.opts['grains'], tgt, delim=delim)
 
-    def grain_pcre_match(self, tgt):
+    def grain_pcre_match(self, tgt, delim=':'):
         '''
         Matches a grain based on regex
         '''
         log.debug('grains pcre target: {0}'.format(tgt))
-        if ':' not in tgt:
+        if delim not in tgt:
             log.error('Got insufficient arguments for grains pcre match '
                       'statement from master')
             return False
         return salt.utils.subdict_match(self.opts['grains'], tgt,
-                                        delim=':', regex_match=True)
+                                        delim=delim, regex_match=True)
 
     def data_match(self, tgt):
         '''
@@ -1450,16 +1450,16 @@ class Matcher(object):
             return False
         return(self.functions[tgt]())
 
-    def pillar_match(self, tgt):
+    def pillar_match(self, tgt, delim=':'):
         '''
         Reads in the pillar glob match
         '''
         log.debug('pillar target: {0}'.format(tgt))
-        if ':' not in tgt:
+        if delim not in tgt:
             log.error('Got insufficient arguments for pillar match '
                       'statement from master')
             return False
-        return salt.utils.subdict_match(self.opts['pillar'], tgt, delim=':')
+        return salt.utils.subdict_match(self.opts['pillar'], tgt, delim=delim)
 
     def ipcidr_match(self, tgt):
         '''

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -58,7 +58,7 @@ def pillar(tgt, delim=':'):
         salt '*' match.pillar 'cheese:foo'
         salt '*' match.pillar 'clone_url|https://github.com/saltstack/salt.git' delim='|'
 
-    ..versionchanged:: 0.16.4
+    .. versionchanged:: 0.16.4
         ``delim`` argument added
     '''
     matcher = salt.minion.Matcher({'pillar': __pillar__}, __salt__)
@@ -95,7 +95,7 @@ def grain_pcre(tgt, delim=':'):
         salt '*' match.grain_pcre 'os:Fedo.*'
         salt '*' match.grain_pcre 'ipv6|2001:.*' delim='|'
 
-    ..versionchanged:: 0.16.4
+    .. versionchanged:: 0.16.4
         ``delim`` argument added
     '''
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
@@ -116,7 +116,7 @@ def grain(tgt, delim=':'):
         salt '*' match.grain 'os:Ubuntu'
         salt '*' match.grain_pcre 'ipv6|2001:db8::ff00:42:8329' delim='|'
 
-    ..versionchanged:: 0.16.4
+    .. versionchanged:: 0.16.4
         ``delim`` argument added
     '''
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -3,11 +3,18 @@ The match module allows for match routines to be run and determine target
 specs.
 '''
 
+# Import python libs
+import logging
+
+# Import salt libs
 import salt.minion
 
 __func_alias__ = {
     'list_': 'list'
 }
+
+log = logging.getLogger(__name__)
+
 
 def compound(tgt):
     '''
@@ -20,7 +27,8 @@ def compound(tgt):
     matcher = salt.minion.Matcher(__opts__, __salt__)
     try:
         return matcher.compound_match(tgt)
-    except Exception:
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
@@ -32,25 +40,32 @@ def ipcidr(tgt):
 
         salt '*' match.ipcidr '192.168.44.0/24'
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
         return matcher.ipcidr_match(tgt)
-    except Exception:
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
-def pillar(tgt):
+def pillar(tgt, delim=':'):
     '''
-    Return True if the minion matches the given pillar target
+    Return True if the minion matches the given pillar target. The
+    ``delim`` argument can be used to specify a different delimiter.
 
     CLI Example::
 
         salt '*' match.pillar 'cheese:foo'
+        salt '*' match.pillar 'clone_url|https://github.com/saltstack/salt.git' delim='|'
+
+    ..versionchanged:: 0.16.4
+        ``delim`` argument added
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    matcher = salt.minion.Matcher({'pillar': __pillar__}, __salt__)
     try:
-        return matcher.pillar_match(tgt)
-    except Exception:
+        return matcher.pillar_match(tgt, delim=delim)
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
@@ -65,37 +80,50 @@ def data(tgt):
     matcher = salt.minion.Matcher(__opts__, __salt__)
     try:
         return matcher.data_match(tgt)
-    except Exception:
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
-def grain_pcre(tgt):
+def grain_pcre(tgt, delim=':'):
     '''
-    Return True if the minion matches the given grain_pcre target
+    Return True if the minion matches the given grain_pcre target. The
+    ``delim`` argument can be used to specify a different delimiter.
 
     CLI Example::
 
         salt '*' match.grain_pcre 'os:Fedo.*'
+        salt '*' match.grain_pcre 'ipv6|2001:.*' delim='|'
+
+    ..versionchanged:: 0.16.4
+        ``delim`` argument added
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
-        return matcher.grain_pcre_match(tgt)
-    except Exception:
+        return matcher.grain_pcre_match(tgt, delim=delim)
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
-def grain(tgt):
+def grain(tgt, delim=':'):
     '''
-    Return True if the minion matches the given grain target
+    Return True if the minion matches the given grain target. The ``delim``
+    argument can be used to specify a different delimiter.
 
     CLI Example::
 
         salt '*' match.grain 'os:Ubuntu'
+        salt '*' match.grain_pcre 'ipv6|2001:db8::ff00:42:8329' delim='|'
+
+    ..versionchanged:: 0.16.4
+        ``delim`` argument added
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
-        return matcher.grain_match(tgt)
-    except Exception:
+        return matcher.grain_match(tgt, delim=delim)
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
@@ -110,7 +138,8 @@ def list_(tgt):
     matcher = salt.minion.Matcher(__opts__, __salt__)
     try:
         return matcher.list_match(tgt)
-    except Exception:
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
@@ -125,7 +154,8 @@ def pcre(tgt):
     matcher = salt.minion.Matcher(__opts__, __salt__)
     try:
         return matcher.pcre_match(tgt)
-    except Exception:
+    except Exception as exc:
+        log.exception(exc)
         return False
 
 
@@ -140,5 +170,6 @@ def glob(tgt):
     matcher = salt.minion.Matcher(__opts__, __salt__)
     try:
         return matcher.glob_match(tgt)
-    except Exception:
+    except Exception as exc:
+        log.exception(exc)
         return False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -869,8 +869,8 @@ def subdict_match(data, expr, delim=':', regex_match=False):
         splits = expr.split(delim)
         key = delim.join(splits[:idx])
         matchstr = delim.join(splits[idx:])
-        log.debug('Attempting to match \'{0}\' in '
-                    '\'{1}\''.format(matchstr, key))
+        log.debug('Attempting to match \'{0}\' in \'{1}\' using delimiter '
+                  '\'{2}\''.format(matchstr, key, delim))
         match = traverse_dict(data, key, {}, delim=delim)
         if match == {}:
             continue


### PR DESCRIPTION
This pull request fixes #6745, and in the process adds the ability to override the delimiter when calling functions that use subdict parsing.
