### PR TITLE
Don't show debconf passwords

### DIFF
--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -143,7 +143,10 @@ def set(name, data):
                 ret['changes'][key] = ('New value: {0}').format(args['value'])
             else:
                 if __salt__['debconf.set'](name, key, args['type'], args['value']):
-                    ret['changes'][key] = ('{0}').format(args['value'])
+                    if args['type'] == 'password':
+                        ret['changes'][key] = '(password hidden)'
+                    else:
+                        ret['changes'][key] = ('{0}').format(args['value'])
                 else:
                     ret['result'] = False
                     ret['comment'] = 'Some settings failed to be applied.'


### PR DESCRIPTION
Debconf options have a specific type for password, which prevents
revealing them by accident (readable only to root, stored separately,
marked explicitly as passwords). Salt shouldn't leave those values
available either. This applies to log files, console output, etc.
