### PR TITLE
Add missing 'createhome' option

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -39,7 +39,8 @@ def add(name,
         fullname=False,
         roomnumber=False,
         workphone=False,
-        homephone=False
+        homephone=False,
+        createhome=False
         # pylint: enable=W0613
         ):
     '''


### PR DESCRIPTION
Fixes #6641

This allows for the creating of the user, but reveals another bug regarding setting the password and with groups.
