### PR TITLE
By enforcing absolute imports, there's no need for module name aliases.

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -29,7 +29,7 @@ Full list of builtin execution modules
     bridge
     bsd_shadow
     cassandra
-    cmdmod
+    cmd
     config
     cp
     cron

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -163,7 +163,7 @@ Full list of builtin execution modules
     upstart
     useradd
     virt
-    virtualenv_mod
+    virtualenv
     win_disk
     win_file
     win_groupadd

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -37,7 +37,7 @@ Full list of builtin execution modules
     darwin_sysctl
     data
     ddns
-    debconfmod
+    debconf
     debian_service
     dig
     disk

--- a/doc/ref/modules/all/salt.modules.cmd.rst
+++ b/doc/ref/modules/all/salt.modules.cmd.rst
@@ -1,0 +1,6 @@
+===================
+salt.modules.cmd
+===================
+
+.. automodule:: salt.modules.cmd
+    :members:

--- a/doc/ref/modules/all/salt.modules.cmdmod.rst
+++ b/doc/ref/modules/all/salt.modules.cmdmod.rst
@@ -1,0 +1,1 @@
+Please see :doc:`salt.modules.cmd`.

--- a/doc/ref/modules/all/salt.modules.cmdmod.rst
+++ b/doc/ref/modules/all/salt.modules.cmdmod.rst
@@ -1,6 +1,0 @@
-===================
-salt.modules.cmdmod
-===================
-
-.. automodule:: salt.modules.cmdmod
-    :members:

--- a/doc/ref/modules/all/salt.modules.debconf.rst
+++ b/doc/ref/modules/all/salt.modules.debconf.rst
@@ -1,0 +1,6 @@
+====================
+salt.modules.debconf
+====================
+
+.. automodule:: salt.modules.debconf
+    :members:

--- a/doc/ref/modules/all/salt.modules.debconfmod.rst
+++ b/doc/ref/modules/all/salt.modules.debconfmod.rst
@@ -1,6 +1,1 @@
-=======================
-salt.modules.debconfmod
-=======================
-
-.. automodule:: salt.modules.debconfmod
-    :members:
+Please see :doc:`salt.modules.debconf`.

--- a/doc/ref/modules/all/salt.modules.virtualenv.rst
+++ b/doc/ref/modules/all/salt.modules.virtualenv.rst
@@ -2,5 +2,5 @@
 salt.modules.virtualenv
 =======================
 
-.. automodule:: salt.modules.virtualenv_mod
+.. automodule:: salt.modules.virtualenv
     :members:

--- a/doc/ref/modules/all/salt.modules.virtualenv_mod.rst
+++ b/doc/ref/modules/all/salt.modules.virtualenv_mod.rst
@@ -1,0 +1,1 @@
+Please see :doc:`salt.modules.virtualenv`.

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -68,4 +68,4 @@ Full list of builtin state modules
     timezone
     tomcat
     user
-    virtualenv_mod
+    virtualenv

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -14,7 +14,7 @@ Full list of builtin state modules
     alternatives
     cmd
     cron
-    debconfmod
+    debconf
     disk
     eselect
     file

--- a/doc/ref/states/all/salt.states.debconf.rst
+++ b/doc/ref/states/all/salt.states.debconf.rst
@@ -1,0 +1,6 @@
+===================
+salt.states.debconf
+===================
+
+.. automodule:: salt.states.debconf
+    :members:

--- a/doc/ref/states/all/salt.states.debconfmod.rst
+++ b/doc/ref/states/all/salt.states.debconfmod.rst
@@ -1,6 +1,1 @@
-======================
-salt.states.debconfmod
-======================
-
-.. automodule:: salt.states.debconfmod
-    :members:
+Please see :doc:`salt.states.debconf`.

--- a/doc/ref/states/all/salt.states.virtualenv.rst
+++ b/doc/ref/states/all/salt.states.virtualenv.rst
@@ -2,6 +2,6 @@
 salt.states.virtualenv
 ======================
 
-.. automodule:: salt.states.virtualenv_mod
+.. automodule:: salt.states.virtualenv
     :members:
     :exclude-members: manage

--- a/doc/ref/states/all/salt.states.virtualenv_mod.rst
+++ b/doc/ref/states/all/salt.states.virtualenv_mod.rst
@@ -1,0 +1,1 @@
+Please see :doc:`salt.states.virtualenv`.

--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -314,10 +314,10 @@ of Salt.
 Helpful Functions to Know
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :doc:`cmd </ref/modules/all/salt.modules.cmdmod>` module contains
+The :doc:`cmd </ref/modules/all/salt.modules.cmd>` module contains
 functions to shell out on minions, such as :mod:`cmd.run
-<salt.modules.cmdmod.run>` and :mod:`cmd.run_all
-<salt.modules.cmdmod.run_all>`:
+<salt.modules.cmd.run>` and :mod:`cmd.run_all
+<salt.modules.cmd.run_all>`:
 
 .. code-block:: bash
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -31,11 +31,11 @@ import salt.utils.network
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
-import salt.modules.cmdmod
+import salt.modules.cmd
 
 __salt__ = {
-    'cmd.run': salt.modules.cmdmod._run_quiet,
-    'cmd.run_all': salt.modules.cmdmod._run_all_quiet
+    'cmd.run': salt.modules.cmd._run_quiet,
+    'cmd.run_all': salt.modules.cmd._run_all_quiet
 }
 
 log = logging.getLogger(__name__)

--- a/salt/modules/cmd.py
+++ b/salt/modules/cmd.py
@@ -6,6 +6,7 @@ access to the master root execution access to all salt minions
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
 import os
 import shutil
@@ -43,7 +44,7 @@ def __virtual__():
     Overwriting the cmd python module makes debugging modules
     with pdb a bit harder so lets do it this way instead.
     '''
-    return 'cmd'
+    return True
 
 
 def _chugid(runas):
@@ -53,14 +54,14 @@ def _chugid(runas):
 
     # No logging can happen on this function
     #
-    # 08:46:32,161 [salt.loaded.int.module.cmdmod:276 ][DEBUG   ] stderr: Traceback (most recent call last):
+    # 08:46:32,161 [salt.loaded.int.module.cmd:276 ][DEBUG   ] stderr: Traceback (most recent call last):
     #   File "/usr/lib/python2.7/logging/__init__.py", line 870, in emit
     #     self.flush()
     #   File "/usr/lib/python2.7/logging/__init__.py", line 832, in flush
     #     self.stream.flush()
     # IOError: [Errno 9] Bad file descriptor
-    # Logged from file cmdmod.py, line 59
-    # 08:46:17,481 [salt.loaded.int.module.cmdmod:59  ][DEBUG   ] Switching user 0 -> 1008 and group 0 -> 1012 if needed
+    # Logged from file cmd.py, line 59
+    # 08:46:17,481 [salt.loaded.int.module.cmd:59  ][DEBUG   ] Switching user 0 -> 1008 and group 0 -> 1012 if needed
     #
     # apparently because we closed fd's on Popen, though if not closed, output
     # would also go to its stderr

--- a/salt/modules/debconf.py
+++ b/salt/modules/debconf.py
@@ -3,6 +3,7 @@ Support for Debconf
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
 import os
 import re
@@ -29,7 +30,7 @@ def __virtual__():
         log.info('Package debconf-utils is not installed.')
         return False
 
-    return 'debconf'
+    return True
 
 
 def _unpack_lines(out):

--- a/salt/modules/virtualenv.py
+++ b/salt/modules/virtualenv.py
@@ -3,6 +3,7 @@ Create virtualenv environments
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import glob
 import shutil
 import logging

--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -29,8 +29,9 @@ except ImportError:
     HAS_IMPORTLIB = False
 
 # Import salt libs
-from salt.exceptions import CommandExecutionError
 import salt.utils
+import salt.modules.cmd
+from salt.exceptions import CommandExecutionError
 
 
 # This module has only been tested on Debian GNU/Linux and NetBSD, it
@@ -42,7 +43,7 @@ def _check_xenapi():
         debian_xen_version = '/usr/lib/xen-common/bin/xen-version'
         if os.path.isfile(debian_xen_version):
             # __salt__ is not available in __virtual__
-            xenversion = salt.modules.cmdmod._run_quiet(debian_xen_version)
+            xenversion = salt.modules.cmd._run_quiet(debian_xen_version)
             xapipath = '/usr/lib/xen-{0}/lib/python'.format(xenversion)
             if os.path.isdir(xapipath):
                 sys.path.append(xapipath)

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -12,7 +12,7 @@ import sys
 # Import Salt libs
 import salt.utils
 import salt.utils.decorators as decorators
-import salt.modules.cmdmod as salt_cmd
+import salt.modules.cmd as salt_cmd
 
 log = logging.getLogger(__name__)
 
@@ -42,8 +42,8 @@ def _available_commands():
     # Note that we append '|| :' as a unix hack to force return code to be 0.
     res = salt_cmd.run_all('{0} help || :'.format(zfs_path))
 
-    # This bit is dependent on specific output from `zfs help` - any major changes
-    # in how this works upstream will require a change.
+    # This bit is dependent on specific output from `zfs help` - any major
+    # changes in how this works upstream will require a change.
     for line in res['stderr'].splitlines():
         if re.match('	[a-zA-Z]', line):
             cmds = line.split(' ')[0].split('|')
@@ -61,7 +61,7 @@ def _exit_status(retcode):
     ret = {0: 'Successful completion.',
            1: 'An error occurred.',
            2: 'Usage error.'
-          }[retcode]
+           }[retcode]
     return ret
 
 
@@ -73,10 +73,12 @@ def __virtual__():
         return 'zfs'
     return False
 
+
 def _add_doc(func, doc, prefix='\n\n    '):
     if not func.__doc__:
         func.__doc__ = ''
     func.__doc__ += '{0}{1}'.format(prefix, doc)
+
 
 def _make_function(cmd_name, doc):
     '''

--- a/salt/states/debconf.py
+++ b/salt/states/debconf.py
@@ -36,6 +36,9 @@ set_file
     dict must be indented four spaces instead of two.
 '''
 
+# Import python libs
+from __future__ import absolute_import
+
 
 def __virtual__():
     '''
@@ -43,11 +46,12 @@ def __virtual__():
     '''
     if __grains__['os_family'] != 'Debian':
         return False
+
     # Check that debconf was loaded
     if 'debconf.show' not in __salt__:
         return False
 
-    return 'debconf'
+    return True
 
 
 def set_file(name, source, **kwargs):

--- a/salt/states/virtualenv.py
+++ b/salt/states/virtualenv.py
@@ -5,6 +5,7 @@ Setup of Python virtualenv sandboxes.
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
 import os
 import salt.utils

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -494,9 +494,6 @@ def check_or_die(command):
     '''
     Simple convenience function for modules to use for gracefully blowing up
     if a required tool is not available in the system path.
-
-    Lazily import `salt.modules.cmdmod` to avoid any sort of circular
-    dependencies.
     '''
     if command is None:
         raise CommandNotFoundError('\'None\' is not a valid command.')

--- a/tests/integration/modules/cmd.py
+++ b/tests/integration/modules/cmd.py
@@ -59,16 +59,16 @@ class CMDModuleTest(integration.ModuleCase):
 
         loads_mock.return_value = {'data': {'USER': 'foo'}}
 
-        from salt.modules import cmdmod
+        from salt.modules import cmd
 
-        cmdmod.__grains__ = {'os': 'darwin'}
+        cmd.__grains__ = {'os': 'darwin'}
         if sys.platform.startswith('freebsd'):
             shell = '/bin/sh'
         else:
             shell = '/bin/bash'
 
         try:
-            cmdmod._run('ls',
+            cmd._run('ls',
                         cwd=tempfile.gettempdir(),
                         runas='foobar',
                         shell=shell)
@@ -80,7 +80,7 @@ class CMDModuleTest(integration.ModuleCase):
             getpwnam_mock.assert_called_with('foobar')
             loads_mock.assert_called_with('{}')
         finally:
-            delattr(cmdmod, '__grains__')
+            delattr(cmd, '__grains__')
 
     def test_stdout(self):
         '''

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -9,11 +9,11 @@ ensure_in_syspath('../../')
 
 # Import Salt libs
 from salt.modules import file as filemod
-from salt.modules import cmdmod
+from salt.modules import cmd
 
 filemod.__salt__ = {
-    'cmd.run': cmdmod.run,
-    'cmd.run_all': cmdmod.run_all
+    'cmd.run': cmd.run,
+    'cmd.run_all': cmd.run_all
 }
 
 SED_CONTENT = """test

--- a/tests/unit/modules/virtualenv_test.py
+++ b/tests/unit/modules/virtualenv_test.py
@@ -30,10 +30,10 @@ except ImportError:
 
 
 # Import salt libs
-from salt.modules import virtualenv_mod
+from salt.modules import virtualenv
 from salt.exceptions import CommandExecutionError
 
-virtualenv_mod.__salt__ = {}
+virtualenv.__salt__ = {}
 
 base_virtualenv_mock = MagicMock()
 base_virtualenv_mock.__version__ = '1.9.1'
@@ -47,15 +47,15 @@ class VirtualenvTestCase(TestCase):
     def test_issue_6029_deprecated_distribute(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
 
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod._install_script = MagicMock(
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv._install_script = MagicMock(
                 return_value={
                     'retcode': 0,
                     'stdout': 'Installed script!',
                     'stderr': ''
                 }
             )
-            virtualenv_mod.create(
+            virtualenv.create(
                 '/tmp/foo', system_site_packages=True, distribute=True
             )
             mock.assert_called_once_with(
@@ -68,10 +68,10 @@ class VirtualenvTestCase(TestCase):
             virtualenv_mock = MagicMock()
             virtualenv_mock.__version__ = '1.10rc1'
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-            with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
                 with patch.dict('sys.modules',
                                 {'virtualenv': virtualenv_mock}):
-                    virtualenv_mod.create(
+                    virtualenv.create(
                         '/tmp/foo', system_site_packages=True, distribute=True
                     )
                     mock.assert_called_once_with(
@@ -91,8 +91,8 @@ class VirtualenvTestCase(TestCase):
     def test_issue_6030_deprecated_never_download(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
 
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create(
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create(
                 '/tmp/foo', never_download=True
             )
             mock.assert_called_once_with(
@@ -105,10 +105,10 @@ class VirtualenvTestCase(TestCase):
             # Let's fake a higher virtualenv version
             virtualenv_mock = MagicMock()
             virtualenv_mock.__version__ = '1.10rc1'
-            with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
                 with patch.dict('sys.modules',
                                 {'virtualenv': virtualenv_mock}):
-                    virtualenv_mod.create(
+                    virtualenv.create(
                         '/tmp/foo', never_download=True
                     )
                     mock.assert_called_once_with('virtualenv /tmp/foo',
@@ -132,8 +132,8 @@ class VirtualenvTestCase(TestCase):
 
         # Passing extra_search_dirs as a list
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create(
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create(
                 '/tmp/foo', extra_search_dir=extra_search_dirs
             )
             mock.assert_called_once_with(
@@ -147,8 +147,8 @@ class VirtualenvTestCase(TestCase):
 
         # Passing extra_search_dirs as comma separated list
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create(
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create(
                 '/tmp/foo', extra_search_dir=','.join(extra_search_dirs)
             )
             mock.assert_called_once_with(
@@ -162,10 +162,10 @@ class VirtualenvTestCase(TestCase):
 
     def test_system_site_packages_and_no_site_packages_mutual_exclusion(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 no_site_packages=True,
                 system_site_packages=True
@@ -177,9 +177,9 @@ class VirtualenvTestCase(TestCase):
         warnings.filterwarnings('always', '', DeprecationWarning, __name__)
 
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             with warnings.catch_warnings(record=True) as w:
-                virtualenv_mod.create(
+                virtualenv.create(
                     '/tmp/foo', no_site_packages=True
                 )
                 self.assertEqual(
@@ -192,20 +192,20 @@ class VirtualenvTestCase(TestCase):
     def test_unapplicable_options(self):
         # ----- Virtualenv using pyvenv options ----------------------------->
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='virtualenv',
                 upgrade=True
             )
 
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='virtualenv',
                 symlinks=True
@@ -213,49 +213,49 @@ class VirtualenvTestCase(TestCase):
         # <---- Virtualenv using pyvenv options ------------------------------
 
         # ----- pyvenv using virtualenv options ----------------------------->
-        virtualenv_mod.__salt__ = {'cmd.which_bin': lambda _: 'pyvenv'}
+        virtualenv.__salt__ = {'cmd.which_bin': lambda _: 'pyvenv'}
 
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='pyvenv',
                 no_site_packages=True
             )
 
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='pyvenv',
                 python='python2.7'
             )
 
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='pyvenv',
                 prompt='PY Prompt'
             )
 
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='pyvenv',
                 never_download=True
             )
 
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
             self.assertRaises(
                 CommandExecutionError,
-                virtualenv_mod.create,
+                virtualenv.create,
                 '/tmp/foo',
                 venv_bin='pyvenv',
                 extra_search_dir='/tmp/bar'
@@ -267,10 +267,10 @@ class VirtualenvTestCase(TestCase):
 
             # ----- virtualenv binary not available ------------------------->
             mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-            with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
                 self.assertRaises(
                     CommandExecutionError,
-                    virtualenv_mod.create,
+                    virtualenv.create,
                     '/tmp/foo',
                 )
             # <---- virtualenv binary not available --------------------------
@@ -280,10 +280,10 @@ class VirtualenvTestCase(TestCase):
                 {'retcode': 1, 'stdout': '', 'stderr': 'This is an error'},
                 {'retcode': 0, 'stdout': ''}
             ])
-            with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
+            with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
                 self.assertRaises(
                     CommandExecutionError,
-                    virtualenv_mod.create,
+                    virtualenv.create,
                     '/tmp/foo',
                     venv_bin='virtualenv',
                 )
@@ -294,8 +294,8 @@ class VirtualenvTestCase(TestCase):
                 {'retcode': 0, 'stdout': '1.9.1'},
                 {'retcode': 0, 'stdout': ''}
             ])
-            with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-                virtualenv_mod.create(
+            with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+                virtualenv.create(
                     '/tmp/foo', never_download=True
                 )
                 mock.assert_called_with(
@@ -309,8 +309,8 @@ class VirtualenvTestCase(TestCase):
                 {'retcode': 0, 'stdout': '1.10rc1'},
                 {'retcode': 0, 'stdout': ''}
             ])
-            with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-                virtualenv_mod.create(
+            with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+                virtualenv.create(
                     '/tmp/foo', never_download=True
                 )
                 mock.assert_called_with(
@@ -321,8 +321,8 @@ class VirtualenvTestCase(TestCase):
 
     def test_python_argument(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create(
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create(
                 '/tmp/foo', python='/usr/bin/python2.7',
             )
             mock.assert_called_once_with(
@@ -332,8 +332,8 @@ class VirtualenvTestCase(TestCase):
 
     def test_prompt_argument(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create('/tmp/foo', prompt='PY Prompt')
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create('/tmp/foo', prompt='PY Prompt')
             mock.assert_called_once_with(
                 'virtualenv --prompt=\'PY Prompt\' /tmp/foo',
                 runas=None
@@ -341,16 +341,16 @@ class VirtualenvTestCase(TestCase):
 
         # Now with some quotes on the mix
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create('/tmp/foo', prompt='\'PY\' Prompt')
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create('/tmp/foo', prompt='\'PY\' Prompt')
             mock.assert_called_once_with(
                 'virtualenv --prompt="\'PY\' Prompt" /tmp/foo',
                 runas=None
             )
 
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create('/tmp/foo', prompt='"PY" Prompt')
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create('/tmp/foo', prompt='"PY" Prompt')
             mock.assert_called_once_with(
                 'virtualenv --prompt=\'"PY" Prompt\' /tmp/foo',
                 runas=None
@@ -358,8 +358,8 @@ class VirtualenvTestCase(TestCase):
 
     def test_clear_argument(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create('/tmp/foo', clear=True)
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create('/tmp/foo', clear=True)
             mock.assert_called_once_with(
                 'virtualenv --clear /tmp/foo', runas=None
             )
@@ -368,8 +368,8 @@ class VirtualenvTestCase(TestCase):
         # We test for pyvenv only because with virtualenv this is un
         # unsupported option.
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create('/tmp/foo', venv_bin='pyvenv', upgrade=True)
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create('/tmp/foo', venv_bin='pyvenv', upgrade=True)
             mock.assert_called_once_with(
                 'pyvenv --upgrade /tmp/foo', runas=None
             )
@@ -378,8 +378,8 @@ class VirtualenvTestCase(TestCase):
         # We test for pyvenv only because with virtualenv this is un
         # unsupported option.
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            virtualenv_mod.create('/tmp/foo', venv_bin='pyvenv', symlinks=True)
+        with patch.dict(virtualenv.__salt__, {'cmd.run_all': mock}):
+            virtualenv.create('/tmp/foo', venv_bin='pyvenv', symlinks=True)
             mock.assert_called_once_with(
                 'pyvenv --symlinks /tmp/foo', runas=None
             )


### PR DESCRIPTION
@thatch45 is there a reason why we should not enforce absolute imports?
