### PR TITLE
no *mod.py modules / use absolute imports

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -107,7 +107,20 @@ release = '0.16.3'
 
 master_doc = 'contents'
 templates_path = ['_templates']
-exclude_patterns = ['_build', '_incl/*', 'ref/cli/_includes/*.rst']
+exclude_patterns = [
+    '_build',
+    '_incl/*',
+    'ref/cli/_includes/*.rst',
+    # The references below are just for documents which contain redirect links
+    # and are not present in any doctree.
+    'ref/modules/all/salt.modules.cmdmod.rst',
+    'ref/modules/all/salt.modules.debconfmod.rst',
+    'ref/modules/all/salt.modules.djangomod.rst',
+    'ref/modules/all/salt.modules.virtualenv_mod.rst',
+    'ref/states/all/salt.states.debconfmod.rst',
+    'ref/states/all/salt.states.virtualenv_mod.rst',
+    'ref/modules/all/salt.modules.gentoolkitmod.rst'
+]
 
 extensions = [
     'saltdocs',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -119,7 +119,8 @@ exclude_patterns = [
     'ref/modules/all/salt.modules.virtualenv_mod.rst',
     'ref/states/all/salt.states.debconfmod.rst',
     'ref/states/all/salt.states.virtualenv_mod.rst',
-    'ref/modules/all/salt.modules.gentoolkitmod.rst'
+    'ref/modules/all/salt.modules.gentoolkitmod.rst',
+    'ref/modules/all/salt.modules.ldapmod.rst'
 ]
 
 extensions = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -111,17 +111,6 @@ exclude_patterns = [
     '_build',
     '_incl/*',
     'ref/cli/_includes/*.rst',
-    # The references below are just for documents which contain redirect links
-    # and are not present in any doctree.
-    'ref/modules/all/salt.modules.cmdmod.rst',
-    'ref/modules/all/salt.modules.debconfmod.rst',
-    'ref/modules/all/salt.modules.djangomod.rst',
-    'ref/modules/all/salt.modules.virtualenv_mod.rst',
-    'ref/states/all/salt.states.debconfmod.rst',
-    'ref/states/all/salt.states.virtualenv_mod.rst',
-    'ref/modules/all/salt.modules.gentoolkitmod.rst',
-    'ref/modules/all/salt.modules.ldapmod.rst',
-    'ref/modules/all/salt.modules.localemod.rst'
 ]
 
 extensions = [

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -120,7 +120,8 @@ exclude_patterns = [
     'ref/states/all/salt.states.debconfmod.rst',
     'ref/states/all/salt.states.virtualenv_mod.rst',
     'ref/modules/all/salt.modules.gentoolkitmod.rst',
-    'ref/modules/all/salt.modules.ldapmod.rst'
+    'ref/modules/all/salt.modules.ldapmod.rst',
+    'ref/modules/all/salt.modules.localemod.rst'
 ]
 
 extensions = [

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -41,7 +41,7 @@ Full list of builtin execution modules
     debian_service
     dig
     disk
-    djangomod
+    django
     dnsmasq
     dnsutil
     dpkg

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -75,7 +75,7 @@ Full list of builtin execution modules
     kmod
     launchctl
     layman
-    ldapmod
+    ldap
     linux_acl
     linux_lvm
     linux_sysctl

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -57,7 +57,7 @@ Full list of builtin execution modules
     freebsdservice
     freebsd_sysctl
     gem
-    gentoolkitmod
+    gentoolkit
     gentoo_service
     git
     glance

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -79,7 +79,7 @@ Full list of builtin execution modules
     linux_acl
     linux_lvm
     linux_sysctl
-    localemod
+    locale
     locate
     logrotate
     makeconf

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -9,7 +9,7 @@ Full list of builtin execution modules
     .. toctree::
 
         salt.modules.pkg
-        salt.modules.sys
+        salt.modules.virtual-sys
 
 
 .. currentmodule:: salt.modules
@@ -154,7 +154,7 @@ Full list of builtin execution modules
     supervisord
     svn
     sysbench
-    sysmod
+    sys
     system
     systemd
     test
@@ -198,3 +198,4 @@ Full list of builtin execution modules
         salt.modules.gentoolkitmod
         salt.modules.ldapmod
         salt.modules.localemod
+        salt.modules.sysmod

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -11,6 +11,7 @@ Full list of builtin execution modules
         salt.modules.pkg
         salt.modules.sys
 
+
 .. currentmodule:: salt.modules
 
 .. autosummary::
@@ -51,14 +52,14 @@ Full list of builtin execution modules
     event
     extfs
     file
+    freebsd_sysctl
     freebsdjail
     freebsdkmod
     freebsdpkg
     freebsdservice
-    freebsd_sysctl
     gem
-    gentoolkit
     gentoo_service
+    gentoolkit
     git
     glance
     grains
@@ -69,8 +70,8 @@ Full list of builtin execution modules
     hosts
     img
     iptables
-    keyboard
     key
+    keyboard
     keystone
     kmod
     launchctl
@@ -93,8 +94,8 @@ Full list of builtin execution modules
     mount
     munin
     mysql
-    netbsdservice
     netbsd_sysctl
+    netbsdservice
     network
     nfs3
     nginx
@@ -110,9 +111,9 @@ Full list of builtin execution modules
     pecl
     pillar
     pip
+    pkg_resource
     pkgin
     pkgng
-    pkg_resource
     pkgutil
     portage_config
     postgres
@@ -142,9 +143,9 @@ Full list of builtin execution modules
     smartos_vmadm
     smf
     solaris_group
-    solarispkg
     solaris_shadow
     solaris_user
+    solarispkg
     solr
     sqlite3
     ssh
@@ -154,8 +155,8 @@ Full list of builtin execution modules
     svn
     sysbench
     sysmod
-    systemd
     system
+    systemd
     test
     timezone
     tls
@@ -175,8 +176,25 @@ Full list of builtin execution modules
     win_system
     win_useradd
     xapi
-    yumpkg5
     yumpkg
+    yumpkg5
     zfs
     zpool
     zypper
+
+
+.. admonition:: Renamed modules
+
+    The following modules were renamed but the renaming itself is only 
+    important from a developers perspective. They do not change the regular 
+    user's work-flow.
+
+    .. toctree::
+
+        salt.modules.cmdmod
+        salt.modules.debconfmod
+        salt.modules.djangomod
+        salt.modules.virtualenv_mod
+        salt.modules.gentoolkitmod
+        salt.modules.ldapmod
+        salt.modules.localemod

--- a/doc/ref/modules/all/salt.modules.cmdmod.rst
+++ b/doc/ref/modules/all/salt.modules.cmdmod.rst
@@ -1,1 +1,4 @@
+salt.modules.cmdmod -> salt.modules.cmd
+---------------------------------------
+
 Please see :doc:`salt.modules.cmd`.

--- a/doc/ref/modules/all/salt.modules.debconfmod.rst
+++ b/doc/ref/modules/all/salt.modules.debconfmod.rst
@@ -1,1 +1,4 @@
+salt.modules.debconfmod -> salt.modules.debconf
+-----------------------------------------------
+
 Please see :doc:`salt.modules.debconf`.

--- a/doc/ref/modules/all/salt.modules.django.rst
+++ b/doc/ref/modules/all/salt.modules.django.rst
@@ -1,0 +1,6 @@
+===================
+salt.modules.django
+===================
+
+.. automodule:: salt.modules.django
+    :members:

--- a/doc/ref/modules/all/salt.modules.djangomod.rst
+++ b/doc/ref/modules/all/salt.modules.djangomod.rst
@@ -1,1 +1,5 @@
+=============================================
+salt.modules.djangomod -> salt.modules.django
+=============================================
+
 Please see :doc:`salt.modules.django`.

--- a/doc/ref/modules/all/salt.modules.djangomod.rst
+++ b/doc/ref/modules/all/salt.modules.djangomod.rst
@@ -1,6 +1,1 @@
-======================
-salt.modules.djangomod
-======================
-
-.. automodule:: salt.modules.djangomod
-    :members:
+Please see :doc:`salt.modules.django`.

--- a/doc/ref/modules/all/salt.modules.gentoolkit.rst
+++ b/doc/ref/modules/all/salt.modules.gentoolkit.rst
@@ -1,0 +1,6 @@
+=======================
+salt.modules.gentoolkit
+=======================
+
+.. automodule:: salt.modules.gentoolkit
+    :members:

--- a/doc/ref/modules/all/salt.modules.gentoolkitmod.rst
+++ b/doc/ref/modules/all/salt.modules.gentoolkitmod.rst
@@ -1,6 +1,1 @@
-==========================
-salt.modules.gentoolkitmod
-==========================
-
-.. automodule:: salt.modules.gentoolkitmod
-    :members:
+Please see :doc:`salt.modules.gentoolkit`.

--- a/doc/ref/modules/all/salt.modules.gentoolkitmod.rst
+++ b/doc/ref/modules/all/salt.modules.gentoolkitmod.rst
@@ -1,1 +1,4 @@
+salt.modules.gentoolkitmod -> salt.modules.gentoolkit
+-----------------------------------------------------
+
 Please see :doc:`salt.modules.gentoolkit`.

--- a/doc/ref/modules/all/salt.modules.ldap.rst
+++ b/doc/ref/modules/all/salt.modules.ldap.rst
@@ -1,0 +1,6 @@
+====================
+salt.modules.ldapmod
+====================
+
+.. automodule:: salt.modules.ldapmod
+    :members:

--- a/doc/ref/modules/all/salt.modules.ldap.rst
+++ b/doc/ref/modules/all/salt.modules.ldap.rst
@@ -1,6 +1,6 @@
-====================
-salt.modules.ldapmod
-====================
+=================
+salt.modules.ldap
+=================
 
-.. automodule:: salt.modules.ldapmod
+.. automodule:: salt.modules.ldap
     :members:

--- a/doc/ref/modules/all/salt.modules.ldapmod.rst
+++ b/doc/ref/modules/all/salt.modules.ldapmod.rst
@@ -1,6 +1,1 @@
-====================
-salt.modules.ldapmod
-====================
-
-.. automodule:: salt.modules.ldapmod
-    :members:
+Please see :doc:`salt.modules.ldap`.

--- a/doc/ref/modules/all/salt.modules.ldapmod.rst
+++ b/doc/ref/modules/all/salt.modules.ldapmod.rst
@@ -1,1 +1,4 @@
+salt.modules.ldapmod -> salt.modules.ldap
+-----------------------------------------
+
 Please see :doc:`salt.modules.ldap`.

--- a/doc/ref/modules/all/salt.modules.locale.rst
+++ b/doc/ref/modules/all/salt.modules.locale.rst
@@ -1,0 +1,6 @@
+===================
+salt.modules.locale
+===================
+
+.. automodule:: salt.modules.locale
+    :members:

--- a/doc/ref/modules/all/salt.modules.localemod.rst
+++ b/doc/ref/modules/all/salt.modules.localemod.rst
@@ -1,6 +1,1 @@
-======================
-salt.modules.localemod
-======================
-
-.. automodule:: salt.modules.localemod
-    :members:
+Please see :doc:`salt.modules.locale`.

--- a/doc/ref/modules/all/salt.modules.localemod.rst
+++ b/doc/ref/modules/all/salt.modules.localemod.rst
@@ -1,1 +1,4 @@
+salt.modules.localemod -> salt.modules.locale
+---------------------------------------------
+
 Please see :doc:`salt.modules.locale`.

--- a/doc/ref/modules/all/salt.modules.sys.rst
+++ b/doc/ref/modules/all/salt.modules.sys.rst
@@ -2,32 +2,5 @@
 salt.modules.sys
 ================
 
-The regular salt modules execute in a separate context from the salt minion
-and manipulating the actual salt modules needs to happen in a higher level
-context within the minion process. This is where the sys pseudo module is
-used.
-
-The sys pseudo module comes with a few functions that return data about the
-available functions on the minion or allows for the minion modules to be
-refreshed. These functions are as follows:
-
-.. py:module:: salt.modules.sys
-
-.. py:function:: doc([module[, module.function]])
-
-    Display the inline documentation for all available modules, or for the
-    specified module or function.
-
-.. py:function:: reload_modules
-
-    Instruct the minion to reload all available modules in memory. This
-    function can be called if the modules need to be re-evaluated for
-    availability or new modules have been made available to the minion.
-
-.. py:function:: list_modules
-
-    List all available (loaded) modules.
-
-.. py:function:: list_functions
-
-    List all known functions that are in available (loaded) modules.
+.. automodule:: salt.modules.sys
+    :members:

--- a/doc/ref/modules/all/salt.modules.sysmod.rst
+++ b/doc/ref/modules/all/salt.modules.sysmod.rst
@@ -1,6 +1,4 @@
-===================
-salt.modules.sysmod
-===================
+salt.modules.sysmod -> salt.modules.sys
+---------------------------------------
 
-.. automodule:: salt.modules.sysmod
-    :members:
+Please see :doc:`salt.modules.sys`.

--- a/doc/ref/modules/all/salt.modules.virtual-sys.rst
+++ b/doc/ref/modules/all/salt.modules.virtual-sys.rst
@@ -1,0 +1,38 @@
+================
+salt.modules.sys
+================
+
+The regular salt modules execute in a separate context from the salt minion
+and manipulating the actual salt modules needs to happen in a higher level
+context within the minion process. This is where the sys pseudo module is
+used.
+
+The sys pseudo module comes with a few functions that return data about the
+available functions on the minion or allows for the minion modules to be
+refreshed. These functions are as follows:
+
+.. py:module:: salt.modules.sys
+    :noindex:
+
+.. py:function:: doc([module[, module.function]])
+    :noindex:
+
+    Display the inline documentation for all available modules, or for the
+    specified module or function.
+
+.. py:function:: reload_modules
+    :noindex:
+
+    Instruct the minion to reload all available modules in memory. This
+    function can be called if the modules need to be re-evaluated for
+    availability or new modules have been made available to the minion.
+
+.. py:function:: list_modules
+    :noindex:
+
+    List all available (loaded) modules.
+
+.. py:function:: list_functions
+    :noindex:
+
+    List all known functions that are in available (loaded) modules.

--- a/doc/ref/modules/all/salt.modules.virtualenv_mod.rst
+++ b/doc/ref/modules/all/salt.modules.virtualenv_mod.rst
@@ -1,1 +1,4 @@
+salt.modules.virtualenv_mod -> salt.modules.virtualenv
+------------------------------------------------------
+
 Please see :doc:`salt.modules.virtualenv`.

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -33,8 +33,8 @@ Full list of builtin state modules
     lvm
     makeconf
     mdadm
-    module
     modjk_worker
+    module
     mongodb_database
     mongodb_user
     mount
@@ -45,8 +45,8 @@ Full list of builtin state modules
     npm
     pecl
     pip
-    pkgng
     pkg
+    pkgng
     pkgrepo
     portage_config
     postgres_database
@@ -69,3 +69,16 @@ Full list of builtin state modules
     tomcat
     user
     virtualenv
+
+
+
+.. admonition:: Renamed modules
+
+    The following state modules were renamed but the renaming itself is only 
+    important from a developers perspective. They do not change the regular 
+    user's work-flow.
+
+    .. toctree::
+
+        salt.states.debconfmod
+        salt.states.virtualenv_mod

--- a/doc/ref/states/all/salt.states.debconfmod.rst
+++ b/doc/ref/states/all/salt.states.debconfmod.rst
@@ -1,1 +1,4 @@
+salt.states.debconfmod -> salt.states.debconf
+---------------------------------------------
+
 Please see :doc:`salt.states.debconf`.

--- a/doc/ref/states/all/salt.states.virtualenv_mod.rst
+++ b/doc/ref/states/all/salt.states.virtualenv_mod.rst
@@ -1,1 +1,4 @@
+salt.states.virtualenv_mod -> salt.states.virtualenv
+----------------------------------------------------
+
 Please see :doc:`salt.states.virtualenv`.

--- a/salt/modules/django.py
+++ b/salt/modules/django.py
@@ -3,11 +3,12 @@ Manage Django sites
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import os
 
 
 def __virtual__():
-    return 'django'
+    return True
 
 
 def _get_django_admin(bin_env):
@@ -83,7 +84,7 @@ def syncdb(settings_module,
         args.append('noinput')
 
     return command(settings_module,
-                  'syncdb',
+                   'syncdb',
                    bin_env,
                    pythonpath,
                    env,

--- a/salt/modules/gentoolkit.py
+++ b/salt/modules/gentoolkit.py
@@ -3,16 +3,16 @@ Support for Gentoolkit
 
 '''
 
+# Import python libs
+from __future__ import absolute_import
 import os
-
-HAS_GENTOOLKIT = False
 
 # Import third party libs
 try:
     from gentoolkit.eclean import search, clean, cli, exclude as excludemod
     HAS_GENTOOLKIT = True
 except ImportError:
-    pass
+    HAS_GENTOOLKIT = False
 
 
 def __virtual__():
@@ -20,7 +20,7 @@ def __virtual__():
     Only work on Gentoo systems with gentoolkit installed
     '''
     if __grains__['os'] == 'Gentoo' and HAS_GENTOOLKIT:
-        return 'gentoolkit'
+        return True
     return False
 
 
@@ -122,8 +122,8 @@ def eclean_dist(destructive=False, package_names=False, size_limit=0,
     else:
         try:
             exclude = _parse_exclude(exclude_file)
-        except excludemod.ParseExcludeFileException as e:
-            ret = {e: 'Invalid exclusion file: {0}'.format(exclude_file)}
+        except excludemod.ParseExcludeFileException as exc:
+            ret = {exc: 'Invalid exclusion file: {0}'.format(exclude_file)}
             return ret
 
     if time_limit != 0:
@@ -194,8 +194,8 @@ def eclean_pkg(destructive=False, package_names=False, time_limit=0,
     else:
         try:
             exclude = _parse_exclude(exclude_file)
-        except excludemod.ParseExcludeFileException as e:
-            ret = {e: 'Invalid exclusion file: {0}'.format(exclude_file)}
+        except excludemod.ParseExcludeFileException as exc:
+            ret = {exc: 'Invalid exclusion file: {0}'.format(exclude_file)}
             return ret
 
     if time_limit != 0:

--- a/salt/modules/ldap.py
+++ b/salt/modules/ldap.py
@@ -31,6 +31,7 @@ Salt interface to LDAP commands
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import time
 import logging
 
@@ -50,12 +51,9 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
-    Only load this module if the ldap config is set
+    Load the module if the ldap package is installed
     '''
-    # These config items must be set in the minion config
-    if HAS_LDAP:
-        return 'ldap'
-    return False
+    return HAS_LDAP
 
 
 def _config(name, key=None, **kwargs):

--- a/salt/modules/locale.py
+++ b/salt/modules/locale.py
@@ -3,6 +3,7 @@ Module for managing locales on POSIX-like systems.
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
 import re
 
@@ -18,7 +19,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'locale'
+    return True
 
 
 def _parse_localectl():
@@ -34,7 +35,7 @@ def _parse_localectl():
             try:
                 key, val = re.match('^([A-Z_]+)=(.*)$', cols[0]).groups()
             except AttributeError:
-                log.error('Odd locale parameter "{0}" detected in localectl '
+                log.error('Odd locale parameter {0!r} detected in localectl '
                           'output. This should not happen. localectl should '
                           'catch this. You should probably investigate what '
                           'caused this.'.format(cols[0]))

--- a/salt/modules/sys.py
+++ b/salt/modules/sys.py
@@ -4,6 +4,7 @@ minion.
 '''
 
 # Import python libs
+from __future__ import absolute_import
 import logging
 
 # Import salt libs
@@ -16,7 +17,7 @@ def __virtual__():
     '''
     Return as sys
     '''
-    return 'sys'
+    return True
 
 
 def doc(*args, **kwargs):

--- a/tests/integration/modules/django.py
+++ b/tests/integration/modules/django.py
@@ -8,7 +8,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
-from salt.modules import djangomod as django
+from salt.modules import django
 
 try:
     from mock import MagicMock, patch


### PR DESCRIPTION
This should finish up the absolute imports changes.

I've made separate commits in order to revert back if need be. :smile: 
