### PR TITLE
Removed unnecessary os_family mapping for pidora

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -729,8 +729,7 @@ _OS_FAMILY_MAP = {
     'ALT': 'RedHat',
     'Trisquel': 'Debian',
     'GCEL': 'Debian',
-    'Linaro': 'Debian',
-    'Pidora': 'RedHat'
+    'Linaro': 'Debian'
 }
 
 


### PR DESCRIPTION
Just realized that the pidora os_family mapping did not need to be modified since the os name map is already going to be mapping pidora to fedora. So I removed the os_family mapping for pidora.  This was my original commit for pidora: https://github.com/saltstack/salt/pull/6596
