### PR TITLE
Only write minion key to disk if you don't already have it

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1703,8 +1703,10 @@ class ClearFuncs(object):
                     'load': {'ret': False}}
 
         log.info('Authentication accepted from {id}'.format(**load))
-        with salt.utils.fopen(pubfn, 'w+') as fp_:
-            fp_.write(load['pub'])
+        # only write to disk if you are adding the file
+        if not os.path.isfile(pubfn):
+            with salt.utils.fopen(pubfn, 'w+') as fp_:
+                fp_.write(load['pub'])
         pub = None
 
         # The key payload may sometimes be corrupt when using auto-accept


### PR DESCRIPTION
I've noticed on our salt-masters that there is a LOT of disk activity writing keys to disk if you have auto_accept on-- this is because there is no checking if we already have it or not

As far as I can tell this won't break anything-- and the unit tests don't break (any more than they are currently on develop)
