### PR TITLE
Looks like double-quotes are necessary as single quotes aren't escaped t...

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -136,7 +136,7 @@ def setval(key, val):
     .. code-block:: bash
 
         salt '*' grains.setval key val
-        salt '*' grains.setval key '{"sub-key": "val", "sub-key2": "val2"}'
+        salt '*' grains.setval key "{'sub-key': 'val', 'sub-key2': 'val2'}"
     '''
     grains = {}
     if os.path.isfile(__opts__['conf_file']):


### PR DESCRIPTION
...o insure dict assignment instead of string.
