### PR TITLE
added password parameter to support authenticated SVN commands

### DIFF
--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -29,7 +29,7 @@ def _check_svn():
     utils.check_or_die('svn')
 
 
-def _run_svn(cmd, cwd, user, username, opts, **kwargs):
+def _run_svn(cmd, cwd, user, username, password, opts, **kwargs):
     '''
     Execute svn
     return the output of the command
@@ -46,6 +46,9 @@ def _run_svn(cmd, cwd, user, username, opts, **kwargs):
     username
         Connect to the Subversion server as another user
 
+    password
+        Connect to the Subversion server with this password
+
     opts
         Any additional options to add to the command line
 
@@ -55,6 +58,8 @@ def _run_svn(cmd, cwd, user, username, opts, **kwargs):
     cmd = 'svn --non-interactive {0} '.format(cmd)
     if username:
         opts += ('--username', username)
+    if password:
+        opts += ('--password', password)
     if opts:
         cmd += subprocess.list2cmdline(opts)
 
@@ -68,7 +73,7 @@ def _run_svn(cmd, cwd, user, username, opts, **kwargs):
         raise exceptions.CommandExecutionError(result['stderr'] + '\n\n' + cmd)
 
 
-def info(cwd, targets=None, user=None, username=None, fmt='str'):
+def info(cwd, targets=None, user=None, username=None, password=None, fmt='str'):
     '''
     Display the Subversion information from the checkout.
 
@@ -85,6 +90,9 @@ def info(cwd, targets=None, user=None, username=None, fmt='str'):
     username : None
         Connect to the Subversion server as another user
 
+    password : None
+        Connect to the Subversion server with this password
+
     fmt : str
         How to fmt the output from info.
         (str, xml, list, dict)
@@ -98,7 +106,7 @@ def info(cwd, targets=None, user=None, username=None, fmt='str'):
         opts.append('--xml')
     if targets:
         opts += shlex.split(targets)
-    infos = _run_svn('info', cwd, user, username, opts)
+    infos = _run_svn('info', cwd, user, username, password, opts)
 
     if fmt in ('str', 'xml'):
         return infos
@@ -113,7 +121,7 @@ def info(cwd, targets=None, user=None, username=None, fmt='str'):
         return [dict(tmp) for tmp in info_list]
 
 
-def checkout(cwd, remote, target=None, user=None, username=None, *opts):
+def checkout(cwd, remote, target=None, user=None, username=None, password=None, *opts):
     '''
     Download a working copy of the remote Subversion repository
     directory or file
@@ -134,6 +142,9 @@ def checkout(cwd, remote, target=None, user=None, username=None, *opts):
     username : None
         Connect to the Subversion server as another user
 
+    password : None
+        Connect to the Subversion server with this password
+
     CLI Example::
 
         salt '*' svn.checkout /path/to/repo svn://remote/repo
@@ -141,10 +152,10 @@ def checkout(cwd, remote, target=None, user=None, username=None, *opts):
     opts += (remote,)
     if target:
         opts += (target,)
-    return _run_svn('checkout', cwd, user, username, opts)
+    return _run_svn('checkout', cwd, user, username, password, opts)
 
 
-def update(cwd, targets=None, user=None, *opts):
+def update(cwd, targets=None, user=None, username=None, password=None, *opts):
     '''
     Update the current directory, files, or directories from
     the remote Subversion repository
@@ -159,6 +170,9 @@ def update(cwd, targets=None, user=None, *opts):
     user : None
         Run svn as a user other than what the minion runs as
 
+    password : None
+        Connect to the Subversion server with this password
+
     username : None
         Connect to the Subversion server as another user
 
@@ -168,10 +182,10 @@ def update(cwd, targets=None, user=None, *opts):
     '''
     if targets:
         opts += tuple(shlex.split(targets))
-    return _run_svn('update', cwd, user, None, opts)
+    return _run_svn('update', cwd, user, username, password, opts)
 
 
-def diff(cwd, targets=None, user=None, username=None, *opts):
+def diff(cwd, targets=None, user=None, username=None, password=None, *opts):
     '''
     Return the diff of the current directory, files, or directories from
     the remote Subversion repository
@@ -189,6 +203,9 @@ def diff(cwd, targets=None, user=None, username=None, *opts):
     username : None
         Connect to the Subversion server as another user
 
+    password : None
+        Connect to the Subversion server with this password
+
     CLI Example::
 
         salt '*' svn.diff /path/to/repo
@@ -198,7 +215,7 @@ def diff(cwd, targets=None, user=None, username=None, *opts):
     return _run_svn('diff', cwd, user, username, opts)
 
 
-def commit(cwd, targets=None, msg=None, user=None, username=None, *opts):
+def commit(cwd, targets=None, msg=None, user=None, username=None, password=None, *opts):
     '''
     Commit the current directory, files, or directories to
     the remote Subversion repository
@@ -219,6 +236,9 @@ def commit(cwd, targets=None, msg=None, user=None, username=None, *opts):
     username : None
         Connect to the Subversion server as another user
 
+    password : None
+        Connect to the Subversion server with this password
+
     CLI Example::
 
         salt '*' svn.commit /path/to/repo
@@ -227,10 +247,10 @@ def commit(cwd, targets=None, msg=None, user=None, username=None, *opts):
         opts += ('-m', msg)
     if targets:
         opts += tuple(shlex.split(targets))
-    return _run_svn('commit', cwd, user, username, opts)
+    return _run_svn('commit', cwd, user, username, password, opts)
 
 
-def add(cwd, targets, user=None, *opts):
+def add(cwd, targets, user=None, username=None, password=None, *opts):
     '''
     Add files to be tracked by the Subversion working-copy checkout
 
@@ -243,16 +263,22 @@ def add(cwd, targets, user=None, *opts):
     user : None
         Run svn as a user other than what the minion runs as
 
+    username : None
+        Connect to the Subversion server as another user
+
+    password : None
+        Connect to the Subversion server with this password
+
     CLI Example::
 
         salt '*' svn.add /path/to/repo /path/to/new/file
     '''
     if targets:
         opts += tuple(shlex.split(targets))
-    return _run_svn('add', cwd, user, None, opts)
+    return _run_svn('add', cwd, user, username, password, opts)
 
 
-def remove(cwd, targets, msg=None, user=None, username=None, *opts):
+def remove(cwd, targets, msg=None, user=None, username=None, password=None, *opts):
     '''
     Remove files and directories from the Subversion repository
 
@@ -271,6 +297,9 @@ def remove(cwd, targets, msg=None, user=None, username=None, *opts):
     username : None
         Connect to the Subversion server as another user
 
+    password : None
+        Connect to the Subversion server with this password
+
     CLI Example::
 
         salt '*' svn.remove /path/to/repo /path/to/repo/remove
@@ -279,10 +308,10 @@ def remove(cwd, targets, msg=None, user=None, username=None, *opts):
         opts += ('-m', msg)
     if targets:
         opts += tuple(shlex.split(targets))
-    return _run_svn('remove', cwd, user, username, opts)
+    return _run_svn('remove', cwd, user, username, password, opts)
 
 
-def status(cwd, targets=None, user=None, username=None, *opts):
+def status(cwd, targets=None, user=None, username=None, password=None *opts):
     '''
     Display the status of the current directory, files, or
     directories in the Subversion repository
@@ -300,10 +329,13 @@ def status(cwd, targets=None, user=None, username=None, *opts):
     username : None
         Connect to the Subversion server as another user
 
+    password : None
+        Connect to the Subversion server with this password
+
     CLI Example::
 
         salt '*' svn.status /path/to/repo
     '''
     if targets:
         opts += tuple(shlex.split(targets))
-    return _run_svn('status', cwd, user, username, opts)
+    return _run_svn('status', cwd, user, username, password, opts)


### PR DESCRIPTION
Merging this does modify existing usage of the salt.svn.\* commands.  

In response to this issue: https://github.com/saltstack/salt/issues/6763
