### PR TITLE
Initial addition of hash caching in the roots filserver plugin

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -20,14 +20,6 @@ def reap_fileserver_cache_dir(cache_base, find_func):
 
     cache_base -> env -> relpath
     '''
-    print 'running reap_fileserver_cache_dir'
-    print find_func
-    print
-    print
-    print
-    print
-    print
-    open('/export/apps/salt/cache/gitfs/testout', 'a+').write(cache_base + '\n')
     for env in os.listdir(cache_base):
         env_base = os.path.join(cache_base, env)
         for root, dirs, files in os.walk(env_base):
@@ -45,7 +37,6 @@ def reap_fileserver_cache_dir(cache_base, find_func):
                 ret = find_func(filename, env=env)
                 # if we don't actually have the file, lets clean up the cache object
                 if ret['path'] == '':
-                    print 'removing cache for file {0}'.format(file_path)
                     os.unlink(file_path)
 
 def is_file_ignored(opts, fname):

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -14,6 +14,39 @@ import salt.loader
 
 log = logging.getLogger(__name__)
 
+def reap_fileserver_cache_dir(cache_base, find_func):
+    '''
+    Remove unused cache items assuming the cache directory follows a directory convention:
+
+    cache_base -> env -> relpath
+    '''
+    print 'running reap_fileserver_cache_dir'
+    print find_func
+    print
+    print
+    print
+    print
+    print
+    open('/export/apps/salt/cache/gitfs/testout', 'a+').write(cache_base + '\n')
+    for env in os.listdir(cache_base):
+        env_base = os.path.join(cache_base, env)
+        for root, dirs, files in os.walk(env_base):
+            # if we have an empty directory, lets cleanup
+            # This will only remove the directory on the second time "_reap_cache" is called (which is intentional)
+            if len(dirs) == 0 and len (files) == 0:
+                os.rmdir(root)
+                continue
+            # if not, lets check the files in the directory
+            for file_ in files:
+                file_path = os.path.join(root, file_)
+                file_rel_path = os.path.relpath(file_path, env_base)
+                filename, _, hash_type = file_rel_path.rsplit('.', 2)
+                # do we have the file?
+                ret = find_func(filename, env=env)
+                # if we don't actually have the file, lets clean up the cache object
+                if ret['path'] == '':
+                    print 'removing cache for file {0}'.format(file_path)
+                    os.unlink(file_path)
 
 def is_file_ignored(opts, fname):
     '''

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -153,6 +153,7 @@ def update():
         except (OSError, IOError):
             pass
 
+    salt.fileserver.reap_fileserver_cache_dir(os.path.join(__opts__['cachedir'], 'gitfs/hash'), find_file)
 
 def envs():
     '''

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -125,31 +125,6 @@ def file_hash(load, fnd):
 
     return ret
 
-def _reap_cache():
-    '''
-    Remove unused cache items
-    '''
-    cache_base = os.path.join(__opts__['cachedir'], 'roots/hash')
-    for env in os.listdir(cache_base):
-        env_base = os.path.join(cache_base, env)
-        for root, dirs, files in os.walk(env_base):
-            # if we have an empty directory, lets cleanup
-            # This will only remove the directory on the second time "_reap_cache" is called (which is intentional)
-            if len(dirs) == 0 and len (files) == 0:
-                os.rmdir(root)
-                continue
-            # if not, lets check the files in the directory
-            for file_ in files:
-                file_path = os.path.join(root, file_)
-                file_rel_path = os.path.relpath(file_path, env_base)
-                filename, _, hash_type = file_rel_path.rsplit('.', 2)
-                # do we have the file?
-                ret = find_file(filename, env=env)
-                # if we don't actually have the file, lets clean up the cache object
-                if ret['path'] == '':
-                    print 'removing cache for file {0}'.format(file_path)
-                    os.unlink(file_path)
-
 def file_list(load):
     '''
     Return a list of all files on the file server in a specified

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -79,7 +79,7 @@ def update():
     '''
     When we are asked to update (regular interval) lets reap the cache
     '''
-    _reap_cache()
+    salt.fileserver.reap_fileserver_cache_dir(os.path.join(__opts__['cachedir'], 'roots/hash'), find_file)
 
 def file_hash(load, fnd):
     '''


### PR DESCRIPTION
This will cache the hash/mtime of files on disk in the cache dir so we don't have to re-calculate the hashes on every request.
This includes a function _reap_cache which will reap all the hash caches that the real files no longer exist
