### PR TITLE
'changes' output more verbose on changed states with test=True

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -93,7 +93,7 @@ def output(data):
                 elif __opts__.get('state_output', 'full').lower() == 'changes':
                     # Print terse if no error and no changes, otherwise, be
                     # verbose
-                    if ret['result'] is not False and not ret['changes']:
+                    if ret['result'] and not ret['changes']:
                         msg = _format_terse(tcolor, comps, ret, colors)
                         hstrs.append(msg)
                         continue


### PR DESCRIPTION
The `changes` output was always terse when using `test=True` when running highstates.

It now displays fuller informations if some states require changes, as it does when running highstate not in test mode.
