### PR TITLE
While handling `iorder` on states, skip non string entries.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2019,9 +2019,15 @@ class BaseHighState(object):
                     if not isinstance(s_dec, string_types):
                         # PyDSL OrderedDict?
                         continue
+
+                    if not isinstance(state[name], dict):
+                        # Include's or excludes as lists?
+                        continue
+
                     found = False
                     if s_dec.startswith('_'):
                         continue
+
                     for arg in state[name][s_dec]:
                         if isinstance(arg, dict):
                             if len(arg) > 0:

--- a/salt/state.py
+++ b/salt/state.py
@@ -2016,6 +2016,9 @@ class BaseHighState(object):
         if self.opts['state_auto_order']:
             for name in state:
                 for s_dec in state[name]:
+                    if not isinstance(s_dec, string_types):
+                        # PyDSL OrderedDict?
+                        continue
                     found = False
                     if s_dec.startswith('_'):
                         continue


### PR DESCRIPTION
@kjkuan this fixes the issue which I emailed you about, ie, the failing pydsl tests. Can you confirm this is the best approach to the problem please?
