### PR TITLE
Functions get_gid, get_uid and chown in modules/file.py do not work for broken symlinks

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -155,6 +155,11 @@ def get_gid(path):
         salt '*' file.get_gid /etc/passwd
     '''
     if not os.path.exists(path):
+        try:
+            # Broken symlinks will return false, but still have a uid and gid
+            return os.lstat(path).st_gid
+        except OSError:
+            pass
         return -1
     return os.stat(path).st_gid
 
@@ -220,6 +225,11 @@ def get_uid(path):
         salt '*' file.get_uid /etc/passwd
     '''
     if not os.path.exists(path):
+        try:
+            # Broken symlinks will return false, but still have a uid and gid
+            return os.lstat(path).st_uid
+        except OSError:
+            pass
         return False
     return os.stat(path).st_uid
 
@@ -304,6 +314,11 @@ def chown(path, user, group):
         else:
             gid = -1
     if not os.path.exists(path):
+        try:
+            # Broken symlinks will return false, but still need to be chowned
+            return os.lchown(path, uid, gid)
+        except OSError:
+            pass
         err += 'File not found'
     if err:
         return err


### PR DESCRIPTION
Addresses issue #6826

This issue can arise when you are recursively managing the group and user of a directory which contains a broken symlink -- symlink exists on disk, but file it's pointing to does not. This causes the state to fail, when in reality the symlink itself should have it's owner and group changed.

This requires changes to get_uid and get_gid as they too try to `stat` the file but since it is a symlink pointing to nothing, we need to not follow the link, so we use `lstat`. I'll try to put in some tests for this, but I figured I'd open the pull request now.
