### PR TITLE
Also reload python's `site` module which handles `site-packages`.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -17,7 +17,6 @@ import time
 import traceback
 import sys
 import signal
-import site
 from random import randint
 
 # Import third party libs
@@ -490,10 +489,6 @@ class Minion(object):
         Return the functions and the returners loaded up from the loader
         module
         '''
-        # In case a package has been installed into the current python
-        # process 'site-packages', the 'site' module needs to be reloaded in
-        # order for the newly installed package to be importable.
-        reload(site)
         self.opts['grains'] = salt.loader.grains(self.opts)
         functions = salt.loader.minion_mods(self.opts)
         returners = salt.loader.returners(self.opts, functions)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -17,6 +17,7 @@ import time
 import traceback
 import sys
 import signal
+import site
 from random import randint
 
 # Import third party libs
@@ -489,6 +490,10 @@ class Minion(object):
         Return the functions and the returners loaded up from the loader
         module
         '''
+        # In case a package has been installed into the current python
+        # process 'site-packages', the 'site' module needs to be reloaded in
+        # order for the newly installed package to be importable.
+        reload(site)
         self.opts['grains'] = salt.loader.grains(self.opts)
         functions = salt.loader.minion_mods(self.opts)
         returners = salt.loader.returners(self.opts, functions)

--- a/salt/state.py
+++ b/salt/state.py
@@ -15,6 +15,7 @@ The data sent to the state calls is as follows:
 import os
 import sys
 import copy
+import site
 import fnmatch
 import logging
 import collections
@@ -539,6 +540,10 @@ class State(object):
         Refresh all the modules
         '''
         log.debug('Refreshing modules...')
+        # In case a package has been installed into the current python
+        # process 'site-packages', the 'site' module needs to be reloaded in
+        # order for the newly installed package to be importable.
+        reload(site)
         self.load_modules()
         self.functions['saltutil.refresh_modules']()
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -538,6 +538,7 @@ class State(object):
         '''
         Refresh all the modules
         '''
+        log.debug('Refreshing modules...')
         self.load_modules()
         self.functions['saltutil.refresh_modules']()
 


### PR DESCRIPTION
In case a package has been installed into the current python process 'site-packages', the 'site' module needs to be reloaded in order for the newly installed package to be importable.
