### PR TITLE
Apt improve

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -1267,10 +1267,10 @@ def expand_repo_def(repokwargs):
 
 def hold(*packages):
     '''
-    Set dpkg to hold a list of packages. Not specifying any packages does
+    Set dpkg holds on a list of packages. Not specifying any packages does
     nothing and returns blank results.
 
-    Holds are set by dpkg and are respected by tools that use dpkg (apt-get,
+    Holds that are set by dpkg are respected by tools that use dpkg (apt-get,
     aptitude)
 
     CLI Examples:
@@ -1296,6 +1296,47 @@ def hold(*packages):
             ret.append({p: True})
             continue
         cmd = 'echo {0} hold | dpkg --set-selections'.format(p)
+        out = __salt__['cmd.run_all'](cmd)
+        if out['retcode'] != 0:
+            msg = 'Error:  ' + out['stderr']
+            log.error(msg)
+            return msg
+        ret.append({p: True})
+
+    return ret
+
+
+def unhold(*packages):
+    '''
+    Unset dpkg holds on a list of packages. Not specifying any packages does
+    nothing and returns blank results.
+
+    Holds that are set by dpkg are respected by tools that use dpkg (apt-get,
+    aptitude). Holds set by those tools may not be affected by this function.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.unhold grub-pc
+        salt '*' pkg.unhold grub-pc linux-image-generic
+    '''
+    if len(packages) == 0:
+        return []
+
+    ret =[]
+    out = __salt__['cmd.run_all']("dpkg --get-selections | awk '$2~/hold/'")
+    if out['retcode'] != 0:
+        msg = 'Error:  ' + out['stderr']
+        log.error(msg)
+        return msg
+    holds = out['stdout']
+
+    for p in packages:
+        if not re.search('\b{0}\b'.format(re.escape(p)), holds):
+            ret.append({p: True})
+            continue
+        cmd = 'echo {0} install | dpkg --set-selections'.format(p)
         out = __salt__['cmd.run_all'](cmd)
         if out['retcode'] != 0:
             msg = 'Error:  ' + out['stderr']

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -1264,3 +1264,43 @@ def expand_repo_def(repokwargs):
     sanitized['architectures'] = getattr(source_entry, 'architectures', [])
 
     return sanitized
+
+def hold(*packages):
+    '''
+    Set dpkg to hold a list of packages. Not specifying any packages does
+    nothing and returns blank results.
+
+    Holds are set by dpkg and are respected by tools that use dpkg (apt-get,
+    aptitude)
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.hold grub-pc
+        salt '*' pkg.hold grub-pc linux-image-generic
+    '''
+    if len(packages) == 0:
+        return []
+
+    ret =[]
+    out = __salt__['cmd.run_all']("dpkg --get-selections | awk '$2~/hold/'")
+    if out['retcode'] != 0:
+        msg = 'Error:  ' + out['stderr']
+        log.error(msg)
+        return msg
+    holds = out['stdout']
+
+    for p in packages:
+        if re.search('\b{0}\b'.format(re.escape(p)), holds):
+            ret.append({p: True})
+            continue
+        cmd = 'echo {0} hold | dpkg --set-selections'.format(p)
+        out = __salt__['cmd.run_all'](cmd)
+        if out['retcode'] != 0:
+            msg = 'Error:  ' + out['stderr']
+            log.error(msg)
+            return msg
+        ret.append({p: True})
+
+    return ret


### PR DESCRIPTION
I don't have an environment to test this in right now, but would find the features very helpful.

Can be tested with a simple sls like the following:

```
hold-us:
  pkg.hold:
    - grub-pc
    - linux-image-generic

```

It should return a list of `{ <package>: True }` dicts, or an error, or, if nothing was specified, an empty list.

After applying the state, they should be printed when the following command is run:

```
dpkg --get-selections | grep 'hold$' 
```

Changing `hold` to `unhold` in the sls should make the packages no longer show up in the shell command.

I'll update this req if I get the chance to test it.
