### PR TITLE
module.pip: added doc for new option "use_wheel"

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -138,6 +138,8 @@ def install(pkgs=None,
         (/home/code/path/to/virtualenv/)
     env
         deprecated, use bin_env now
+    use_wheel
+        Prefer wheel archives (requires pip>=1.4)        
     log
         Log file where a complete (maximum verbosity) record will be kept
     proxy


### PR DESCRIPTION
pip state and module got new option for pip>=1.4 called "use_wheel". State got properly updated doc for this change, but module not. This commit adds two lines of doc for pip module too.
