### PR TITLE
wrap match name in quote to make sure it work

### DIFF
--- a/doc/ref/states/overstate.rst
+++ b/doc/ref/states/overstate.rst
@@ -28,12 +28,12 @@ or to execute a state.highstate.
 .. code-block:: yaml
 
     mysql:
-      match: db*
+      match: 'db*'
       sls:
         - mysql.server
         - drbd
     webservers:
-      match: web*
+      match: 'web*'
       require:
         - mysql
     all:
@@ -76,7 +76,7 @@ Executing the Over State
 
 The over state can be executed from the salt-run command, calling the
 state.over runner function. The function will by default look in the base
-environment for the overstate.sls file:
+environment for the `overstate.sls` file:
 
 .. code-block:: bash
 


### PR DESCRIPTION
This maybe problem in code but I just fix document since that worked.

I got throwed in to this Exception
https://github.com/saltstack/salt/blob/develop/salt/overstate.py#L45
and had no idea why. 
It's better to see the error than catch Exception.

I tried to debug the code, then figured out that because I used match: *word

``` yaml
master:
  match: *master
  sls:
    - postgresql.server.master

standby:
  match: *standby
  sls:
    - postgresql.server.standby
  require:
    - master
```

After wrap _master => '_master' , same for *standby, it worked
