### PR TITLE
reclass_adapter: extract minion_id and pass to top()

### DIFF
--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -93,11 +93,16 @@ def top(**kwargs):
         # file_roots of class 'base' (if that exists):
         set_inventory_base_uri_default(__opts__, kwargs)
 
+        # Salt expects the top data to be filtered by minion_id, so we better
+        # let it know which minion it is dealing with. Unfortunately, we must
+        # extract these data (see #6930):
+        minion_id = kwargs['opts']['id']
+
         # I purposely do not pass any of __opts__ or __salt__ or __grains__
         # to reclass, as I consider those to be Salt-internal and reclass
         # should not make any assumptions about it. Reclass only needs to know
         # how it's configured, so:
-        return reclass_top(**reclass_opts)
+        return reclass_top(minion_id, **reclass_opts)
 
     except ImportError as e:
         if 'reclass' in e.message:


### PR DESCRIPTION
Contrary to previous information, the master_tops interface _expects_
the data to be limited to states applicable to a specific minion.
Therefore, the minion ID needs to be provided to reclass. As the
minion_id is currently not part of the master_tops interface, it needs
to be extracted from kwargs, see Salt issue #6930.

Signed-off-by: martin f. krafft madduck@madduck.net
