### PR TITLE
hosts module and state fix

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -215,10 +215,10 @@ def add_host(ip, alias):
 def _write_hosts(hosts):
     lines = []
     for ip, aliases in hosts.iteritems():
+        line = '{0}\t'.format(ip)
         for alias in aliases:
-            lines.append(
-                '{0}\t\t{1}'.format(ip, alias)
-            )
+            line = '{0}\t{1}'.format(line, alias)
+        lines.append(line)
 
     hfn = __get_hosts_filename()
     with salt.utils.fopen(hfn, 'w+') as ofile:

--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -22,7 +22,7 @@ Or using the "names:" directive, you can put several names for the same IP.
           - server1
           - florida
 
-NOTE: changing the IP or name(s) in the present() function does not cause an
+NOTE: changing the name(s) in the present() function does not cause an
 update to remove the old entry.
 '''
 


### PR DESCRIPTION
- a small doc fix in the host state
- changing the _write_hosts function to write the hosts file aliases in the same line

for example:

```
1.2.3.4  alias1 alias2
```

instead of

```
1.2.3.4 alias1
1.2.3.4 alias2
```
