### PR TITLE
`cmd.mod_watch` does not check for required func paramter for `call`

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -770,7 +770,14 @@ def mod_watch(name, **kwargs):
         return script(name, **kwargs)
 
     elif kwargs['sfun'] == 'wait_call' or kwargs['sfun'] == 'call':
-        return call(name, **kwargs)
+        if kwargs.get('func'):
+            func = kwargs.pop('func')
+            return call(name, func, **kwargs)
+        else:
+            return {'name': name, 
+                    'changes': {},
+                    'comment': 'cmd.{0[sfun]} needs a named parameter func'.format(kwargs),
+                    'result': False}
 
     return {'name': name,
             'changes': {},


### PR DESCRIPTION
`cmd.call` and `cmd.wait_call` (used by the `pydsl` renderer) need two parameters – `name` and `func`. With this pull request, `mod_watch` now checks for the second required parameter `func` also and raises a bette error message when the user did not supply it.
