### PR TITLE
Fix state.show_top to return the exact data as used by state.highstate

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -443,20 +443,14 @@ def show_top():
         __context__['retcode'] = 1
         return conflict
     st_ = salt.state.HighState(__opts__)
-    ret = {}
-    static = st_.get_top()
-    ext = st_.client.ext_nodes()
-    for top_ in [static, ext]:
-        for env in top_:
-            if env not in ret:
-                ret[env] = top_[env]
-            else:
-                for match in top_[env]:
-                    if match not in ret[env]:
-                        ret[env][match] = top_[env][match]
-                    else:
-                        ret[env][match].extend(top_[env][match])
-    return ret
+    errors = []
+    top = st_.get_top()
+    errors += st_.verify_tops(top)
+    if errors:
+        __context__['retcode'] = 1
+        return errors
+    matches = st_.top_matches(top)
+    return matches
 
 # Just commenting out, someday I will get this working
 #def show_masterstate():


### PR DESCRIPTION
As @madduck discovered, the state.show_top function does not return accurate data. It currently returns all top data for all minions. The expected output is to return the exact data that is used for running a minion's state.highstate call.

state.show_top also breaks if both top.sls and master_tops are used. The expected result is to compile top.sls first, then merge the master_tops data.

This pull request fixes both issues.
