### PR TITLE
Implement master-side pillar, ipcidr, and compound matching

### DIFF
--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -24,7 +24,6 @@ L      List of minions      ``L@minion1.example.com,minion3.domain.com or bl*.do
 I      Pillar glob          ``I@pdata:foobar``
 S      Subnet/IP address    ``S@192.168.1.0/24`` or ``S@192.168.1.100``
 R      Range cluster        ``R@%foo.bar``
-D      Minion Data          ``D@key:value``
 ====== ==================== ===============================================================
 
 | Matchers can be joined using boolean ``and``, ``or``, and ``not`` operators.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -673,16 +673,15 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if tgt_type in ('glob', 'pcre', 'list'):
-                        if len(found.intersection(minions)) >= len(minions):
-                            fail = sorted(list(minions.difference(found)))
-                            for minion in fail:
-                                yield({
-                                    minion: {
-                                        'out': 'no_return',
-                                        'ret': 'Minion did not return'
-                                    }
-                                })
+                    if len(found.intersection(minions)) >= len(minions):
+                        fail = sorted(list(minions.difference(found)))
+                        for minion in fail:
+                            yield({
+                                minion: {
+                                    'out': 'no_return',
+                                    'ret': 'Minion did not return'
+                                }
+                            })
                 break
             time.sleep(0.01)
 
@@ -950,14 +949,13 @@ class LocalClient(object):
                 continue
             if int(time.time()) > start + timeout:
                 if verbose:
-                    if tgt_type in ('glob', 'pcre', 'list'):
-                        if len(found) < len(minions):
-                            fail = sorted(list(minions.difference(found)))
-                            for minion in fail:
-                                ret[minion] = {
-                                    'out': 'no_return',
-                                    'ret': 'Minion did not return'
-                                }
+                    if len(found) < len(minions):
+                        fail = sorted(list(minions.difference(found)))
+                        for minion in fail:
+                            ret[minion] = {
+                                'out': 'no_return',
+                                'ret': 'Minion did not return'
+                            }
                 break
             time.sleep(0.01)
         return ret
@@ -1050,16 +1048,15 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if tgt_type in ('glob', 'pcre', 'list'):
-                        if len(found) < len(minions):
-                            fail = sorted(list(minions.difference(found)))
-                            for minion in fail:
-                                yield({
-                                    minion: {
-                                        'out': 'no_return',
-                                        'ret': 'Minion did not return'
-                                    }
-                                })
+                    if len(found) < len(minions):
+                        fail = sorted(list(minions.difference(found)))
+                        for minion in fail:
+                            yield({
+                                minion: {
+                                    'out': 'no_return',
+                                    'ret': 'Minion did not return'
+                                }
+                            })
                 break
             time.sleep(0.01)
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -673,15 +673,17 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if len(found.intersection(minions)) >= len(minions):
-                        fail = sorted(list(minions.difference(found)))
-                        for minion in fail:
-                            yield({
-                                minion: {
-                                    'out': 'no_return',
-                                    'ret': 'Minion did not return'
-                                }
-                            })
+                    if self.opts.get('minion_data_cache', False) \
+                            or tgt_type in ('glob', 'pcre', 'list'):
+                        if len(found.intersection(minions)) >= len(minions):
+                            fail = sorted(list(minions.difference(found)))
+                            for minion in fail:
+                                yield({
+                                    minion: {
+                                        'out': 'no_return',
+                                        'ret': 'Minion did not return'
+                                    }
+                                })
                 break
             time.sleep(0.01)
 
@@ -949,13 +951,15 @@ class LocalClient(object):
                 continue
             if int(time.time()) > start + timeout:
                 if verbose:
-                    if len(found) < len(minions):
-                        fail = sorted(list(minions.difference(found)))
-                        for minion in fail:
-                            ret[minion] = {
-                                'out': 'no_return',
-                                'ret': 'Minion did not return'
-                            }
+                    if self.opts.get('minion_data_cache', False) \
+                            or tgt_type in ('glob', 'pcre', 'list'):
+                        if len(found) < len(minions):
+                            fail = sorted(list(minions.difference(found)))
+                            for minion in fail:
+                                ret[minion] = {
+                                    'out': 'no_return',
+                                    'ret': 'Minion did not return'
+                                }
                 break
             time.sleep(0.01)
         return ret
@@ -1048,15 +1052,17 @@ class LocalClient(object):
                     timeout += inc_timeout
                     continue
                 if verbose:
-                    if len(found) < len(minions):
-                        fail = sorted(list(minions.difference(found)))
-                        for minion in fail:
-                            yield({
-                                minion: {
-                                    'out': 'no_return',
-                                    'ret': 'Minion did not return'
-                                }
-                            })
+                    if self.opts.get('minion_data_cache', False) \
+                            or tgt_type in ('glob', 'pcre', 'list'):
+                        if len(found) < len(minions):
+                            fail = sorted(list(minions.difference(found)))
+                            for minion in fail:
+                                yield({
+                                    minion: {
+                                        'out': 'no_return',
+                                        'ret': 'Minion did not return'
+                                    }
+                                })
                 break
             time.sleep(0.01)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1542,12 +1542,10 @@ class Matcher(object):
             return False
         ref = {'G': 'grain',
                'P': 'grain_pcre',
-               'X': 'exsel',
                'I': 'pillar',
                'L': 'list',
                'S': 'ipcidr',
-               'E': 'pcre',
-               'D': 'data'}
+               'E': 'pcre'}
         if HAS_RANGE:
             ref['R'] = 'range'
         results = []

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -259,6 +259,9 @@ class CkMinions(object):
                                 return []
                             results.append(match)
                             unmatched.pop()
+                            if unmatched and unmatched[-1] == '-':
+                                results.append(')')
+                                unmatched.pop()
                         else:  # Won't get here, unless oper is added
                             log.error('Unhandled oper in compound expr: {0}'
                                       .format(expr))
@@ -280,6 +283,8 @@ class CkMinions(object):
                     else:
                         results.append(
                                 str(set(self._check_glob_minions(match))))
+            for token in unmatched:
+                results.append(')')
             results = ' '.join(results)
             try:
                 return list(eval(results))

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -79,7 +79,7 @@ class CkMinions(object):
 
     def _check_grain_minions(self, expr):
         '''
-        Return the minions found by looking via a list
+        Return the minions found by looking via grains
         '''
         minions = set(
             os.listdir(os.path.join(self.opts['pki_dir'], 'minions'))
@@ -103,7 +103,7 @@ class CkMinions(object):
 
     def _check_grain_pcre_minions(self, expr):
         '''
-        Return the minions found by looking via a list
+        Return the minions found by looking via grains with PCRE
         '''
         minions = set(os.listdir(os.path.join(self.opts['pki_dir'], 'minions')))
         if self.opts.get('minion_data_cache', False):
@@ -122,6 +122,24 @@ class CkMinions(object):
                 if not salt.utils.subdict_match(grains, expr,
                                                 delim=':', regex_match=True):
                     minions.remove(id_)
+        return list(minions)
+
+    def _check_pillar_minions(self, expr):
+        '''
+        Return the minions found by looking via pillar
+        '''
+        minions = set(
+            os.listdir(os.path.join(self.opts['pki_dir'], 'minions'))
+        )
+        return list(minions)
+
+    def _check_compound_minions(self, expr):
+        '''
+        Return the minions found by looking via compound matcher
+        '''
+        minions = set(
+            os.listdir(os.path.join(self.opts['pki_dir'], 'minions'))
+        )
         return list(minions)
 
     def _all_minions(self, expr=None):
@@ -143,9 +161,8 @@ class CkMinions(object):
                        'list': self._check_list_minions,
                        'grain': self._check_grain_minions,
                        'grain_pcre': self._check_grain_pcre_minions,
-                       'exsel': self._all_minions,
-                       'pillar': self._all_minions,
-                       'compound': self._all_minions,
+                       'pillar': self._check_pillar_minions,
+                       'compound': self._check_compound_minions,
                       }[expr_form](expr)
         except Exception:
             log.exception(('Failed matching available minions with {0} pattern: {1}'

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -105,7 +105,9 @@ class CkMinions(object):
         '''
         Return the minions found by looking via grains with PCRE
         '''
-        minions = set(os.listdir(os.path.join(self.opts['pki_dir'], 'minions')))
+        minions = set(
+            os.listdir(os.path.join(self.opts['pki_dir'], 'minions'))
+        )
         if self.opts.get('minion_data_cache', False):
             cdir = os.path.join(self.opts['cachedir'], 'minions')
             if not os.path.isdir(cdir):
@@ -163,10 +165,11 @@ class CkMinions(object):
                        'grain_pcre': self._check_grain_pcre_minions,
                        'pillar': self._check_pillar_minions,
                        'compound': self._check_compound_minions,
-                      }[expr_form](expr)
+                       }[expr_form](expr)
         except Exception:
-            log.exception(('Failed matching available minions with {0} pattern: {1}'
-                           ).format(expr_form, expr))
+            log.exception(
+                    'Failed matching available minions with {0} pattern: {1}'
+                    .format(expr_form, expr))
             minions = expr
         return minions
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -286,6 +286,8 @@ class CkMinions(object):
             for token in unmatched:
                 results.append(')')
             results = ' '.join(results)
+            log.debug('Evaluating final compound matching expr: {0}'
+                      .format(results))
             try:
                 return list(eval(results))
             except Exception:

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -133,6 +133,21 @@ class CkMinions(object):
         minions = set(
             os.listdir(os.path.join(self.opts['pki_dir'], 'minions'))
         )
+        if self.opts.get('minion_data_cache', False):
+            cdir = os.path.join(self.opts['cachedir'], 'minions')
+            if not os.path.isdir(cdir):
+                return list(minions)
+            for id_ in os.listdir(cdir):
+                if id_ not in minions:
+                    continue
+                datap = os.path.join(cdir, id_, 'data.p')
+                if not os.path.isfile(datap):
+                    continue
+                pillar = self.serial.load(
+                    salt.utils.fopen(datap)
+                ).get('pillar')
+                if not salt.utils.subdict_match(pillar, expr):
+                    minions.remove(id_)
         return list(minions)
 
     def _check_compound_minions(self, expr):


### PR DESCRIPTION
@thatch45 should probably be the one to merge this.

Fixes #4831
Fixes #4957
Paves the way for #5505

Probably some other issue resolved or ready to be addressed now as well.

I have not tested this with extremely complex compound matches, as I my minions are not very varied.  I did test some basic compound matches, including parenthesis, `not`, and as many edge cases as I could think of.  Pillar matching is working.

The compound matcher on the master takes advantage of set theory and the set shortcuts (`&`, `|`, `-`).  I _think_ the `eval()` is still safe, because we carefully evaluate everything in the original expression and only add things to `results` that we have generated.  No way an attacker could inject code there.

The compound matcher was a beast to write and reason about, so I would love any input anyone can give.  I'd also be happy to walk anyone through the logic -- I couldn't find a good way to document inline without writing a novel.

Anyone who can help test the compound matcher more thoroughly before 0.17 would be a great help.
