### PR TITLE
Collect 'with_communicate' value in consistent and concise way

### DIFF
--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -17,10 +17,7 @@ class TimedProc(object):
             # Translate a newline submitted as '\n' on the CLI to an actual
             # newline character.
             self.stdin = self.stdin.replace('\\n', '\n')
-        self.with_communicate = True
-        if 'with_communicate' in kwargs:
-            self.with_communicate = kwargs['with_communicate']
-            del kwargs['with_communicate']
+        self.with_communicate = kwargs.pop('with_communicate', True)
 
         self.process = subprocess.Popen(args, **kwargs)
 


### PR DESCRIPTION
Just happened to be reviewing this code to see what it does...

There was a pop for stdin, but very verbose test for with_communicate.  Did not test this.
