### PR TITLE
fix hosts file error in Travis

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -215,9 +215,10 @@ def add_host(ip, alias):
 def _write_hosts(hosts):
     lines = []
     for ip, aliases in hosts.iteritems():
-        line = '{0}\t'.format(ip)
-        for alias in aliases:
-            line = '{0}\t{1}'.format(line, alias)
+        line = '{0}\t\t{1}'.format(
+            ip,
+            '\t\t'.join(aliases)
+            )
         lines.append(line)
 
     hfn = __get_hosts_filename()

--- a/tests/integration/modules/hosts.py
+++ b/tests/integration/modules/hosts.py
@@ -208,13 +208,8 @@ class HostsModuleTest(integration.ModuleCase):
         lines = salt.utils.fopen(HFN, 'r').read().splitlines()
         self.assertEqual(lines, [
             '192.168.1.3\t\thost3.fqdn.com',
-            '192.168.1.1\t\thost1.fqdn.com',
-            '192.168.1.1\t\thost1',
-            '192.168.1.1\t\thost1-reorder',
-            '192.168.1.2\t\thost2.fqdn.com',
-            '192.168.1.2\t\thost2',
-            '192.168.1.2\t\toldhost2',
-            '192.168.1.2\t\thost2-reorder'
+            '192.168.1.1\t\thost1.fqdn.com\t\thost1\t\thost1-reorder',
+            '192.168.1.2\t\thost2.fqdn.com\t\thost2\t\toldhost2\t\thost2-reorder',
         ])
 
 


### PR DESCRIPTION
In a continue to [this error](https://github.com/saltstack/salt/commit/61573b1394c8835e8dccc91db44eeb2f7e843bd0#commitcomment-3967806)
- fixed the aliases loop
- try to fix Travis error - https://travis-ci.org/saltstack/salt/jobs/10730122#L2156

Please review the changes I've done in the tests/integration/modules/hosts.py file,
I'm not 100% sure this is ok.

Thanks
