### PR TITLE
Fix userdel 12 exit code

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -97,9 +97,9 @@ def add(name,
     if shell:
         cmd.extend(['-s', shell])
     if uid not in (None, ''):
-        cmd.extend(['-u', uid])
+        cmd.extend(['-u', str(uid)])
     if gid not in (None, ''):
-        cmd.extend(['-g', gid])
+        cmd.extend(['-g', str(gid)])
     elif groups is not None and name in groups:
         try:
             for line in salt.utils.fopen('/etc/login.defs'):
@@ -107,7 +107,9 @@ def add(name,
                     continue
 
                 if 'yes' in line:
-                    cmd.extend(['-g', __salt__['file.group_to_gid'](name)])
+                    cmd.extend([
+                        '-g', str(__salt__['file.group_to_gid'](name))
+                    ])
 
                 # We found what we wanted, let's break out of the loop
                 break

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -184,7 +184,7 @@ def delete(name, remove=False, force=False):
         # There's a known bug in Debian based distributions, at least, that
         # makes the command exit with 12, see:
         #  https://bugs.launchpad.net/ubuntu/+source/shadow/+bug/1023509
-        if __grains__['os_familiy'] not in ('Debian',):
+        if __grains__['os_family'] not in ('Debian',):
             return False
 
         if RETCODE_12_ERROR_REGEX.match(ret['stderr']) is not None:

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -16,7 +16,7 @@ import copy
 
 # Import salt libs
 import salt.utils
-from salt._compat import callable, string_types
+from salt._compat import string_types, callable as _callable
 
 log = logging.getLogger(__name__)
 RETCODE_12_ERROR_REGEX = re.compile(
@@ -37,7 +37,7 @@ def __virtual__():
         # Functionality on OS X needs to be limited
         mod = sys.modules[__name__]
         for attr in dir(mod):
-            if callable(getattr(mod, attr)):
+            if _callable(getattr(mod, attr)):
                 if not attr in ('_format_info', 'getent', 'info',
                                 'list_groups', 'list_users', '__virtual__'):
                     delattr(mod, attr)


### PR DESCRIPTION
- Simplify the logic in `__virtual__`
- Only catch `OSError`, replace unneeded function with it's loop and break out of the loop as soon as we're done with it
- Use a list for command arguments building and simplify logic with the command `retcode`
- When the command's exit code is 12 and it's from a Debian based distribution, let's match it to a know error and if matched, log and don't return as an error.
