### PR TITLE
if showsid doesn't work, just return true

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -187,10 +187,16 @@ def status(name, sig=None):
     statuses = __salt__['cmd.run'](cmd).splitlines()
     for line in statuses:
         if 'RUNNING' in line:
-            return getsid(name)
+            try:
+                return getsid(name)
+            except Exception:
+                return True
         elif 'PENDING' in line:
-            return getsid(name)
-    return ''
+            try:
+                return getsid(name)
+            except Exception:
+                return True
+    return False
 
 
 def getsid(name):

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -187,15 +187,9 @@ def status(name, sig=None):
     statuses = __salt__['cmd.run'](cmd).splitlines()
     for line in statuses:
         if 'RUNNING' in line:
-            try:
-                return getsid(name)
-            except Exception:
-                return True
+            return True
         elif 'PENDING' in line:
-            try:
-                return getsid(name)
-            except Exception:
-                return True
+            return True
     return False
 
 


### PR DESCRIPTION
The regular service.py returns true if it can't get the pid.
We'll do the same here if we can't get the sid

Fixes #6666
