### PR TITLE
Fix for non-string args being cast as strings

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -152,7 +152,7 @@ def yamlify_arg(arg):
     yaml.safe_load the arg unless it has a newline in it.
     '''
     try:
-        original_arg = str(arg)
+        original_arg = copy.copy(arg)
         if isinstance(arg, string_types):
             if '\n' not in arg:
                 arg = yaml.safe_load(arg)


### PR DESCRIPTION
If you passed down a boolean/None value this funciton casts it as a string then checks what type the object is-- where i'm sure the intent was to create a copy of the original arg (thats what the comment says)
