### PR TITLE
Use the running user and default group for symlink ownership

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -534,8 +534,8 @@ def symlink(
         target,
         force=False,
         makedirs=False,
-        user='root',
-        group='root',
+        user=None,
+        group=None,
         mode=None,
         **kwargs):
     '''
@@ -571,6 +571,14 @@ def symlink(
            'changes': {},
            'result': True,
            'comment': ''}
+
+    if user is None:
+        user = __opts__['user']
+
+    if group is None:
+        group = __salt__['file.gid_to_group'](
+            __salt__['user.info'](user).get('gid', 0)
+        )
 
     preflight_errors = []
     uid = __salt__['file.user_to_uid'](user)


### PR DESCRIPTION
This commit modifies the work done in 77b749d. Instead of using
root:root for the default symlink ownership if no user/group is
specified, the user under which the salt-minion is running is used when
'user' is not sspecified, and the default group of whatever is assigned
to 'user' is used (whether specified directly or derived using the
aforementioned method).
