### PR TITLE
Fix exception caught when mtime_map parent dir does not exist

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -159,7 +159,7 @@ def update():
                         '{0}'.format(exc))
         try:
             os.remove(lk_fn)
-        except (OSError, IOError):
+        except (IOError, OSError):
             pass
 
     # if there is a change, fire an event
@@ -170,7 +170,7 @@ def update():
             os.path.join(__opts__['cachedir'], 'gitfs/hash'),
             find_file
         )
-    except os.error:
+    except (IOError, OSError):
         # Hash file won't exist if no files have yet been served up
         pass
 

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -62,6 +62,7 @@ log = logging.getLogger(__name__)
 _s3_cache_expire = 30  # cache for 30 seconds
 _s3_sync_on_update = True  # sync cache on update rather than jit
 
+
 def envs():
     '''
     Return a list of directories within the bucket that can be
@@ -71,6 +72,7 @@ def envs():
     # update and grab the envs from the metadata keys
     metadata = _init()
     return metadata.keys()
+
 
 def update():
     '''
@@ -94,6 +96,7 @@ def update():
                     _get_file_from_s3(metadata, env, bucket, file_path, cached_file_path)
 
         log.info('Sync local cache from S3 completed.')
+
 
 def find_file(path, env='base', **kwargs):
     '''
@@ -130,6 +133,7 @@ def find_file(path, env='base', **kwargs):
 
     return fnd
 
+
 def file_hash(load, fnd):
     '''
     Return an MD5 file hash
@@ -153,6 +157,7 @@ def file_hash(load, fnd):
         ret['hash_type'] = 'md5'
 
     return ret
+
 
 def serve_file(load, fnd):
     '''
@@ -187,6 +192,7 @@ def serve_file(load, fnd):
         ret['data'] = data
     return ret
 
+
 def file_list(load):
     '''
     Return a list of all files on the file server in a specified environment
@@ -209,6 +215,7 @@ def file_list(load):
 
     return ret
 
+
 def file_list_emptydirs(load):
     '''
     Return a list of all empty directories on the master
@@ -217,6 +224,7 @@ def file_list_emptydirs(load):
     _init()
 
     return []
+
 
 def dir_list(load):
     '''
@@ -243,6 +251,7 @@ def dir_list(load):
 
     return ret
 
+
 def _get_s3_key():
     '''
     Get AWS keys from pillar or config
@@ -252,6 +261,7 @@ def _get_s3_key():
     keyid = __opts__['s3.keyid'] if 's3.keyid' in __opts__ else None
 
     return key, keyid
+
 
 def _init():
     '''
@@ -269,6 +279,7 @@ def _init():
         # bucket files cache expired
         return _refresh_buckets_cache_file(cache_file)
 
+
 def _get_cache_dir():
     '''
     Return the path to the s3cache dir
@@ -276,6 +287,7 @@ def _get_cache_dir():
 
     # Or is that making too many assumptions?
     return os.path.join(__opts__['cachedir'], 's3cache')
+
 
 def _get_cached_file_name(bucket_name, env, path):
     '''
@@ -290,6 +302,7 @@ def _get_cached_file_name(bucket_name, env, path):
 
     return file_path
 
+
 def _get_buckets_cache_filename():
     '''
     Return the filename of the cache for bucket contents.
@@ -301,6 +314,7 @@ def _get_buckets_cache_filename():
         os.makedirs(cache_dir)
 
     return os.path.join(cache_dir, 'buckets_files.cache')
+
 
 def _refresh_buckets_cache_file(cache_file):
     '''
@@ -375,6 +389,7 @@ def _refresh_buckets_cache_file(cache_file):
 
     return metadata
 
+
 def _read_buckets_cache_file(cache_file):
     '''
     Return the contents of the buckets cache file
@@ -386,6 +401,7 @@ def _read_buckets_cache_file(cache_file):
         data = pickle.load(fp_)
 
     return data
+
 
 def _find_files(metadata, dirs_only=False):
     '''
@@ -405,6 +421,7 @@ def _find_files(metadata, dirs_only=False):
 
     return ret
 
+
 def _find_file_meta(metadata, bucket_name, env, path):
     '''
     Looks for a file's metadata in the S3 bucket cache file
@@ -418,12 +435,14 @@ def _find_file_meta(metadata, bucket_name, env, path):
         if 'Key' in item_meta and item_meta['Key'] == path:
             return item_meta
 
+
 def _get_buckets():
     '''
     Return the configuration buckets
     '''
 
     return __opts__['s3.buckets'] if 's3.buckets' in __opts__ else {}
+
 
 def _get_file_from_s3(metadata, env, bucket_name, path, cached_file_path):
     '''
@@ -453,6 +472,7 @@ def _get_file_from_s3(metadata, env, bucket_name, path, cached_file_path):
             path=urllib.quote(path),
             local_file=cached_file_path)
 
+
 def _trim_env_off_path(paths, env, trim_slash=False):
     '''
     Return a list of file paths with the env directory removed
@@ -461,6 +481,7 @@ def _trim_env_off_path(paths, env, trim_slash=False):
     slash_len = -1 if trim_slash else None
 
     return map(lambda d: d[env_len:slash_len], paths)
+
 
 def _is_env_per_bucket():
     '''


### PR DESCRIPTION
This fixes an exception that was introduced in 342a6ae. Also, using
os.error does not catch IOError execeptions, so this has been changed as
well.
