### PR TITLE
Better way of emphasizing S, L, and S in docs

### DIFF
--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -8,10 +8,10 @@ Many of the most powerful and useful engineering solutions are founded on
 simple principles. The Salt SLS system strives to do just that. K.I.S.S. 
 (Keep It Stupidly Simple)
 
-The core of the Salt State system is the SLS, or the Salt State file. The SLS
-is a representation of the state in which a system should be in, and is set up
-to contain this data in a simple format. This is often called configuration 
-management.
+The core of the Salt State system is the SLS, or **S**\ a\ **L**\ t
+**S**\ tate file. The SLS is a representation of the state in which
+a system should be in, and is set up to contain this data in a simple format.
+This is often called configuration management.
 
 .. note::
 


### PR DESCRIPTION
Pull req #6972 negated a 100% intentional design decision, intended to
draw attention to the S, L, and S in "SaLt State file" to show why they
are called "SLS files". This commit reverts that change, and bolds the
S, L, and S so that this is more apparent.
