### PR TITLE
[ATTENTION 0.16 commit] Fix memoize decorator for 0.16(same fix as in #6685)

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -26,6 +26,7 @@ import types
 import warnings
 import zmq
 from calendar import month_abbr as months
+from functools import wraps
 import salt._compat
 
 try:
@@ -806,6 +807,7 @@ def memoize(func):
     '''
     cache = {}
 
+    @wraps(func)
     def _memoize(*args):
         if args not in cache:
             cache[args] = func(*args)


### PR DESCRIPTION
Instead of cherry-picking all the commits from #6685, which also pulls unrelated code, we just fix the decorator and don't move it like in salt's develop.

This is the easiest solution to my cherry picking comments on #6685.

@basepi, @thatch45 is this acceptable? Committing directly to 0.16?
