### PR TITLE
use urllib2 instead of urllib

### DIFF
--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -255,7 +255,7 @@ def gather_bootstrap_script(replace=False):
 
     .. code-block:: bash
 
-        salt '*' qemu.gather_bootstrap_script True
+        salt '*' config.gather_bootstrap_script True
     '''
     fn_ = os.path.join(__opts__['cachedir'], 'bootstrap.sh')
     if not replace and os.path.isfile(fn_):

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -5,7 +5,7 @@ Return config information
 # Import python libs
 import re
 import os
-import urllib
+import urllib2
 
 # Import salt libs
 import salt.utils
@@ -261,5 +261,5 @@ def gather_bootstrap_script(replace=False):
     if not replace and os.path.isfile(fn_):
         return fn_
     with salt.utils.fopen(fn_, 'w+') as fp_:
-        fp_.write(urllib.urlopen('http://bootstrap.saltstack.org').read())
+        fp_.write(urllib2.urlopen('http://bootstrap.saltstack.org').read())
     return fn_


### PR DESCRIPTION
urllib.urlopen has been deprecated since 2.6 in favor of the urllib2 version (available since Python 2.1) and does not support proxy CONNECT tunneling, which is necessary to access GitHub over a Squid proxy.
