### PR TITLE
Bugfix for interacting with yum -- bug seen on CentOS 6.4, with Python 2...

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -10,6 +10,7 @@ import pprint
 import re
 import sys
 import yaml
+import collections # needed by _parse_pkginfo -- there might be a better way to make it work
 
 # Import salt libs
 import salt.utils


### PR DESCRIPTION
....6 using pkg.installed.sources.
