### PR TITLE
Fix mine.send

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -4,6 +4,7 @@ can be easily read by other minions
 '''
 
 # Import python libs
+import copy
 import logging
 
 # Import salt libs
@@ -92,14 +93,13 @@ def send(func, *args, **kwargs):
         return False
     data = {}
     arg_data = salt.utils.arg_lookup(__salt__[func])
-    func_data = {}
+    func_data = copy.deepcopy(kwargs)
     for ind, _ in enumerate(arg_data.get('args', [])):
         try:
-            func_data[arg_data[ind]] = args[ind]
+            func_data[arg_data['args'][ind]] = args[ind]
         except IndexError:
             # Safe error, arg may be in kwargs
             pass
-    func_data.update(kwargs)
     f_call = salt.utils.format_call(__salt__[func], func_data)
     try:
         if 'kwargs' in f_call:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -672,12 +672,6 @@ def format_call(fun, data):
     ret = {}
     ret['args'] = []
     aspec = get_function_argspec(fun)
-    arglen = 0
-    deflen = 0
-    if isinstance(aspec.args, list):
-        arglen = len(aspec.args)
-    if isinstance(aspec.defaults, tuple):
-        deflen = len(aspec.defaults)
     if aspec.keywords:
         # This state accepts kwargs
         ret['kwargs'] = {}


### PR DESCRIPTION
DO NOT MERGE BLINDLY. THIS NEEDS REVIEW. SEE COMMENTS.

For functions that use arguments, mine.send is broken due to bugs in
salt.utils.arg_lookup() and salt.utils.format_call(). This commit
restores proper functionality.
