### PR TITLE
Move import to make it less confusing

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -10,7 +10,6 @@ import pprint
 import re
 import sys
 import yaml
-import collections # needed by _parse_pkginfo -- there might be a better way to make it work
 
 # Import salt libs
 import salt.utils
@@ -25,6 +24,7 @@ def _parse_pkg_meta(path):
     '''
     def parse_rpm(path):
         try:
+            import collections  # needed by _parse_pkginfo, DO NOT REMOVE
             from salt.modules.yumpkg5 import __QUERYFORMAT, _parse_pkginfo
             from salt.utils import namespaced_function as _namespaced_function
             _parse_pkginfo = _namespaced_function(_parse_pkginfo, globals())


### PR DESCRIPTION
An imported function, _parse_pkginfo(), requires the collections module.
It has been removed a couple times, causing regressions each time. Since
it is needed in just one place, this commit moves the import to where it is
needed and includes a warning not to remove it.

See https://github.com/saltstack/salt/pull/7017#issuecomment-23757320 for more info.
