### PR TITLE
subprocess.Popen takes a PIPE for stdin

### DIFF
--- a/salt/utils/timed_subprocess.py
+++ b/salt/utils/timed_subprocess.py
@@ -17,6 +17,7 @@ class TimedProc(object):
             # Translate a newline submitted as '\n' on the CLI to an actual
             # newline character.
             self.stdin = self.stdin.replace('\\n', '\n')
+            kwargs['stdin'] = subprocess.PIPE
         self.with_communicate = kwargs.pop('with_communicate', True)
 
         self.process = subprocess.Popen(args, **kwargs)


### PR DESCRIPTION
http://docs.python.org/2/library/subprocess.html#subprocess.Popen.communicate

   Note that if you want to send data to the process’s stdin, you need to
   create the Popen object with stdin=PIPE.
