### PR TITLE
Changed name spaced event tag separator from "." to "/' dot to slash

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -27,7 +27,7 @@ except ImportError:
 # Import salt libs
 import salt.utils
 import salt.fileserver
-
+from salt.utils.event import tagify
 
 log = logging.getLogger(__name__)
 
@@ -164,7 +164,7 @@ def update():
 
     # if there is a change, fire an event
     event = salt.utils.event.MasterEvent(__opts__['sock_dir'])
-    event.fire_event(data, 'salt.fileserver.gitfs.update ')
+    event.fire_event(data, tagify(['gitfs', 'update'], prefix='fileserver'))
     try:
         salt.fileserver.reap_fileserver_cache_dir(
             os.path.join(__opts__['cachedir'], 'gitfs/hash'),

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -11,7 +11,7 @@ import os
 # Import salt libs
 import salt.fileserver
 import salt.utils
-
+from salt.utils.event import tagify
 
 def find_file(path, env='base', **kwargs):
     '''
@@ -119,7 +119,7 @@ def update():
 
     # if there is a change, fire an event
     event = salt.utils.event.MasterEvent(__opts__['sock_dir'])
-    event.fire_event(data, 'salt.fileserver.roots.update')
+    event.fire_event(data, tagify(['roots', 'update'], prefix='fileserver'))
 
 
 def file_hash(load, fnd):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -82,16 +82,19 @@ SUB_EVENT = set([
             ])
 
 TAGEND = '\n\n'  # long tag delimeter
-TAGPARTER = '.'  # name spaced tag delimeter
-SALT = 'salt'  # base prefix for all salt. events
+TAGPARTER = '/'  # name spaced tag delimeter
+SALT = 'salt'  # base prefix for all salt/ events
 # dict map of namespaced base tag prefixes for salt events
 TAGS = {
-    'auth': 'auth',  # prefix for all .auth events
-    'job': 'job',  # prefix for all .job events (minion jobs)
-    'key': 'key',  # prefix for all .key events
-    'minion': 'minion',  # prefix for all .minion events (minion sourced events)
-    'syndic': 'syndic',  # prefix for all .syndic events (syndic minion sourced events)
-    'run': 'run',  # prefix for all .run events (salt runners)
+    'auth': 'auth',  # prefix for all salt/auth events
+    'job': 'job',  # prefix for all salt/job events (minion jobs)
+    'key': 'key',  # prefix for all salt/key events
+    'minion': 'minion',  # prefix for all salt/minion events (minion sourced events)
+    'syndic': 'syndic',  # prefix for all salt/syndic events (syndic minion sourced events)
+    'run': 'run',  # prefix for all salt/run events (salt runners)
+    'wheel': 'wheel', # prefix for all salt/wheel events
+    'cloud': 'cloud', # prefix for all salt/cloud events
+    'fileserver': 'fileserver', #prefix for all salt/fileserver events
 }
 
 


### PR DESCRIPTION
This change enables tags to include minion id which  commonly minon are domain names

Updated constant delimiter value
Also fixed fileserver tags that were not being created with tagify so that in the future
any changes are automatic.

In general users should use the tagify function to create tags to ensure
correct separators etc.
