### PR TITLE
SuSE based distributions get the `gid` from `users` not the `gid` from it's name

### DIFF
--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -11,7 +11,11 @@ import grp
 
 # Import Salt Testing libs
 from salttesting import skipIf
-from salttesting.helpers import destructiveTest, ensure_in_syspath
+from salttesting.helpers import (
+    destructiveTest,
+    ensure_in_syspath,
+    requires_system_grains
+)
 ensure_in_syspath('../../')
 
 # Import salt libs
@@ -70,7 +74,8 @@ class UserTest(integration.ModuleCase,
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
-    def test_user_present_gid_from_name_default(self):
+    @requires_system_grains
+    def test_user_present_gid_from_name_default(self, grains=None):
         '''
         This is a DESTRUCTIVE TEST. It creates a new user on the on the minion.
         This is an integration test. Not all systems will automatically create
@@ -78,9 +83,6 @@ class UserTest(integration.ModuleCase,
         If you run the test and it fails, please fix the code it's testing to
         work on your operating system.
         '''
-        # Let's get this system's grains
-        grains = self.run_function('grains.items')
-
         ret = self.run_state('user.present', name='salt_test',
                              gid_from_name=True, home='/var/lib/salt_test')
         self.assertSaltTrueReturn(ret)

--- a/tests/integration/states/user.py
+++ b/tests/integration/states/user.py
@@ -78,6 +78,9 @@ class UserTest(integration.ModuleCase,
         If you run the test and it fails, please fix the code it's testing to
         work on your operating system.
         '''
+        # Let's get this system's grains
+        grains = self.run_function('grains.items')
+
         ret = self.run_state('user.present', name='salt_test',
                              gid_from_name=True, home='/var/lib/salt_test')
         self.assertSaltTrueReturn(ret)
@@ -87,7 +90,10 @@ class UserTest(integration.ModuleCase,
         group_name = grp.getgrgid(ret['gid']).gr_name
 
         self.assertTrue(os.path.isdir('/var/lib/salt_test'))
-        self.assertEqual(group_name, 'salt_test')
+        if grains['os_family'] in ('Suse',):
+            self.assertEqual(group_name, 'users')
+        else:
+            self.assertEqual(group_name, 'salt_test')
 
         ret = self.run_state('user.absent', name='salt_test')
         self.assertSaltTrueReturn(ret)


### PR DESCRIPTION
Fixes #7003.

Full explanation about why is this can be seen here:

  https://github.com/saltstack/salt/issues/7003#issuecomment-23813071
