### PR TITLE
return after exception is caught.

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -141,6 +141,7 @@ def run(name, **kwargs):
     except Exception:
         ret['comment'] = 'Module function {0} threw an exception'.format(name)
         ret['result'] = False
+        return ret
     else:
         if mret:
             ret['changes']['ret'] = mret


### PR DESCRIPTION
Otherwise, it is overwritten after 'returner' is evaluated and set result to True ... which is inaccurate.
