### PR TITLE
Don't call apt-get update when there were no changes in repo structure

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -931,7 +931,9 @@ def mod_repo(repo, **kwargs):
             # implementation via apt-add-repository.  The code path for
             # secure PPAs should be the same as urllib method
             if ppa_format_support and 'ppa_auth' not in kwargs:
-                if not get_repo(repo):
+                try:
+                  get_repo(repo)
+                except:
                     if float(__grains__['osrelease']) < 12.04:
                         cmd = 'apt-add-repository {0}'.format(repo)
                     else:

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -932,7 +932,7 @@ def mod_repo(repo, **kwargs):
             # secure PPAs should be the same as urllib method
             if ppa_format_support and 'ppa_auth' not in kwargs:
                 try:
-                  get_repo(repo)
+                    get_repo(repo)
                 except:
                     if float(__grains__['osrelease']) < 12.04:
                         cmd = 'apt-add-repository {0}'.format(repo)

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -933,7 +933,8 @@ def mod_repo(repo, **kwargs):
             if ppa_format_support and 'ppa_auth' not in kwargs:
                 try:
                     get_repo(repo)
-                except:
+                    return {repo: ''}
+                except Exception:
                     if float(__grains__['osrelease']) < 12.04:
                         cmd = 'apt-add-repository {0}'.format(repo)
                     else:

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -779,7 +779,9 @@ def get_repo(repo, **kwargs):
         for source in repos.values():
             for sub in source:
                 if (sub['type'] == repo_type and
-                    sub['uri'] == repo_uri and
+                    # strip trailing '/' from repo_uri, it's valid in definition
+                    # but not valid when compared to persisted source
+                    sub['uri'] == repo_uri.rstrip('/') and
                         sub['dist'] == repo_dist):
                     if not repo_comps:
                         return sub
@@ -929,14 +931,15 @@ def mod_repo(repo, **kwargs):
             # implementation via apt-add-repository.  The code path for
             # secure PPAs should be the same as urllib method
             if ppa_format_support and 'ppa_auth' not in kwargs:
-                if float(__grains__['osrelease']) < 12.04:
-                    cmd = 'apt-add-repository {0}'.format(repo)
-                else:
-                    cmd = 'apt-add-repository -y {0}'.format(repo)
-                out = __salt__['cmd.run_stdout'](cmd, **kwargs)
-                # explicit refresh when a repo is modified.
-                refresh_db()
-                return {repo: out}
+                if not get_repo(repo):
+                    if float(__grains__['osrelease']) < 12.04:
+                        cmd = 'apt-add-repository {0}'.format(repo)
+                    else:
+                        cmd = 'apt-add-repository -y {0}'.format(repo)
+                    out = __salt__['cmd.run_stdout'](cmd, **kwargs)
+                    # explicit refresh when a repo is modified.
+                    refresh_db()
+                    return {repo: out}
             else:
                 if not ppa_format_support:
                     warning_str = 'Unable to use functions from ' \


### PR DESCRIPTION
This supports PPA repo definitions on Ubuntu only, but I suspect is the majority of use cases.  It's not obvious without quite a bit of work how to get a more general use case for mod_repo in apt.py to work (Debian or secure ppa_auth definitions).

Also, a small fix to make get_repo a little less finicky.  

This should fix issue 6866.
https://github.com/saltstack/salt/issues/6866
