### PR TITLE
Display message for unresponsive minions

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -69,7 +69,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 'tgt': self.config['tgt'],
                 'fun': self.config['fun'],
                 'arg': self.config['arg'],
-                'timeout': self.options.timeout}
+                'timeout': self.options.timeout,
+                'show_timeout': self.options.show_timeout}
 
             if 'token' in self.config:
                 kwargs['token'] = self.config['token']

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -677,6 +677,7 @@ class LocalClient(object):
                             or tgt_type in ('glob', 'pcre', 'list'):
                         if len(found.intersection(minions)) >= len(minions):
                             fail = sorted(list(minions.difference(found)))
+                            print fail
                             for minion in fail:
                                 yield({
                                     minion: {
@@ -972,6 +973,7 @@ class LocalClient(object):
             tgt='*',
             tgt_type='glob',
             verbose=False,
+            show_timeout=False,
             **kwargs):
         '''
         Get the returns for the command line interface via the event system
@@ -1054,6 +1056,8 @@ class LocalClient(object):
                 if verbose:
                     if self.opts.get('minion_data_cache', False) \
                             or tgt_type in ('glob', 'pcre', 'list'):
+                if verbose or show_timeout:
+                    if tgt_type in ('glob', 'pcre', 'list'):
                         if len(found) < len(minions):
                             fail = sorted(list(minions.difference(found)))
                             for minion in fail:

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -677,7 +677,6 @@ class LocalClient(object):
                             or tgt_type in ('glob', 'pcre', 'list'):
                         if len(found.intersection(minions)) >= len(minions):
                             fail = sorted(list(minions.difference(found)))
-                            print fail
                             for minion in fail:
                                 yield({
                                     minion: {
@@ -1053,11 +1052,9 @@ class LocalClient(object):
                 if more_time:
                     timeout += inc_timeout
                     continue
-                if verbose:
+                if verbose or show_timeout:
                     if self.opts.get('minion_data_cache', False) \
                             or tgt_type in ('glob', 'pcre', 'list'):
-                if verbose or show_timeout:
-                    if tgt_type in ('glob', 'pcre', 'list'):
                         if len(found) < len(minions):
                             fail = sorted(list(minions.difference(found)))
                             for minion in fail:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -986,6 +986,12 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'queries')
         )
         self.add_option(
+           '--show-timeout',
+           default=False,
+           action='store_true',
+           help=('Display minions that timeout')
+       )
+        self.add_option(
             '-b', '--batch',
             '--batch-size',
             default='',


### PR DESCRIPTION
In response to Issue #7084 which wanted a way to show unresponsive minions without the overhead of --verbose.  This might be a start.  It adds a --show-timeout option (which I am happy to rename if we think of something better. show_unresponsive is one alternative.)

 I only changed the get_cli_event_returns function in the client.  Two other very similar looking functions, get_cli_returns and get_cli_static_event_returns, may also need to be changed but I wasn't sure.  
