### PR TITLE
Add __virtual__ function to new apt state module

### DIFF
--- a/salt/states/apt.py
+++ b/salt/states/apt.py
@@ -7,6 +7,13 @@ import salt.utils
 log = logging.getLogger(__name__)
 
 
+def __virtual__():
+    '''
+    Only work on apt-based platforms with pkg.get_selections
+    '''
+    return 'apt' if 'pkg.get_selections' in __salt__ else False
+
+
 def held(name):
     '''
     Set package in 'hold' state, meaning it will not be upgraded.


### PR DESCRIPTION
I was waiting on this change from @holmboe before I merged #7085. Since
it has now been merged, here is the `__virtual__` function to which I was
referring.
