### PR TITLE
Add set and auto to alternatives

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -130,3 +130,41 @@ def remove(name, path):
     if out['retcode'] > 0:
         return out['stderr']
     return out['stdout']
+
+
+def auto(name):
+    '''
+    Trigger alternatives to set the path for <name> as
+    specified by priority.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' alternatives.auto name
+    '''
+
+    cmd = '{0} --auto {1}'.format(_get_cmd(), name)
+    out = __salt__['cmd.run_all'](cmd)
+    if out['retcode'] > 0:
+        return out['stderr']
+    return out['stdout']
+
+
+def set(name, path):
+    '''
+    Manually set the alternative <path> for <name>.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' alternatives.set name path
+    '''
+
+    cmd = '{0} --set {1} {2}'.format(_get_cmd(), name, path)
+    out = __salt__['cmd.run_all'](cmd)
+    if out['retcode'] > 0:
+        return out['stderr']
+    return out['stdout']
+


### PR DESCRIPTION
Add support to manually set the alternative
path for a name and to restore the name to
auto mode.

Change-Id: I36a816a7068ed8af8f60a6fbe3bdaf1bdca6c825
