### PR TITLE
Suse package updated to 0.16.4

### DIFF
--- a/pkg/suse/salt.changes
+++ b/pkg/suse/salt.changes
@@ -1,4 +1,27 @@
 -------------------------------------------------------------------
+Sat Sep  7 22:44:41 UTC 2013 - aboe76@gmail.com
+
+- Update 0.16.4 bugfix release:
+  - Multiple documentation improvements/additions
+  - Added the osfinger and osarch grains
+  - Fix bug in :mod:`hg.latest <salt.states.hg.latest>` state 
+  that would erroneously delete directories (:issue:`6661`)
+  - Fix bug related to pid not existing for 
+  :mod:`ps.top <salt.modules.ps.top>` (:issue:`6679`)
+  - Fix regression in :mod:`MySQL returner <salt.returners.mysql>` 
+  (:issue:`6695`)
+  - Fix IP addresses grains (ipv4 and ipv6) to include all addresses
+  (:issue:`6656`)
+  - Fix regression preventing authenticated FTP (:issue:`6733`)
+  - Fix :mod:`file.contains <salt.modules.file.contains>` on values 
+  YAML parses as non-string (:issue:`6817`)
+  - Fix :mod:`file.get_gid <salt.modules.file.get_gid>`, 
+  :mod:`file.get_uid <salt.modules.file.get_uid>`, and 
+  :mod:`file.chown <salt.modules.file.chown>` for broken symlinks 
+  (:issue:`6826`)
+  - Fix comment for service reloads in service state (:issue:`6851`)
+  
+-------------------------------------------------------------------
 Fri Aug  9 18:08:12 UTC 2013 - aboe76@gmail.com
 
 - Update 0.16.3 bugfix release:

--- a/pkg/suse/salt.spec
+++ b/pkg/suse/salt.spec
@@ -15,9 +15,8 @@
 # Please submit bugfixes or comments via http://bugs.opensuse.org/
 #
 
-
 Name:           salt
-Version:        0.16.3
+Version:        0.16.4
 Release:        0
 Summary:        A parallel remote execution system
 License:        Apache-2.0
@@ -44,6 +43,9 @@ BuildRequires:  python-PyYAML
 BuildRequires:  python-msgpack-python
 BuildRequires:  python-pycrypto
 BuildRequires:  python-pyzmq >= 2.1.9
+BuildRequires:  unzip
+# Disabled for now when salt-testing and salt 0.17 is available.
+#BuildRequires:  salt-testing
 Requires:       logrotate
 Requires:       python-Jinja2
 Requires:       python-M2Crypto
@@ -51,6 +53,7 @@ Requires:       python-PyYAML
 Requires:       python-msgpack-python
 Requires:       python-pycrypto
 Requires:       python-pyzmq >= 2.1.9
+Requires:		python-GitPython
 Requires(pre): %fillup_prereq
 Requires(pre): %insserv_prereq
 %if 0%{?suse_version} >= 1210
@@ -68,6 +71,16 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %else
 BuildArch:      noarch
 %endif
+
+# Disabled for now when salt-testing and salt 0.17 is available.
+#%if 0%{?suse_version} != 1220 && 0%{?suse_version} != 1230
+BuildRequires: python-unittest2
+# this BR causes windows tests to happen
+# clearly, that's not desired
+# https://github.com/saltstack/salt/issues/3749
+BuildRequires: python-mock
+BuildRequires: git
+#%endif
 
 %description
 Salt is a distributed remote execution system used to execute commands and
@@ -154,6 +167,13 @@ install -Dpm 0644  %{SOURCE7} %{buildroot}%{_sysconfdir}/logrotate.d/salt
 #
 ##SuSEfirewall2 file
 install -Dpm 0644  %{SOURCE8} %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/salt
+
+# Disabled for now when salt-testing and salt 0.17 is available.
+#%if 0%{?suse_version} != 1220 && 0%{?suse_version} != 1230
+#%check
+#export only_local_network=False
+#%{__python} setup.py test --runtests-opts=-u
+#%endif
 
 %preun -n salt-syndic
 %stop_on_removal salt-syndic
@@ -243,6 +263,8 @@ install -Dpm 0644  %{SOURCE8} %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2
 %{_bindir}/salt-cp
 %{_bindir}/salt-key
 %{_bindir}/salt-run
+# Salt-ssh only available in salt 0.17
+#%{_bindir}/salt-ssh
 %{_mandir}/man1/salt-master.1.*
 %{_mandir}/man1/salt.1.*
 %{_mandir}/man1/salt-cp.1.*


### PR DESCRIPTION
The spec file is future ready for salt 0.17, this is commented
I have tested it on sles 11 sp3 and opensuse 12.3 vm.
