### PR TITLE
yumpkg{,5}: add pkg suggestions for nonexistant packages

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -101,7 +101,7 @@ def _process_emerge_err(stderr):
     return ret
 
 
-def checkdb(*names):
+def check_db(*names, **kwargs):
     '''
     .. versionadded:: 0.17.0
 
@@ -120,12 +120,14 @@ def checkdb(*names):
 
     .. code-block:: bash
 
-        salt '*' pkg.checkdb <package1> <package2> <package3>
+        salt '*' pkg.check_db <package1> <package2> <package3>
     '''
+    ### NOTE: kwargs is not used here but needs to be present due to it being
+    ### required in the check_db function in other package providers.
     ret = {}
     for name in names:
         if name in ret:
-            log.warning('pkg.checkdb: Duplicate package name {0!r} '
+            log.warning('pkg.check_db: Duplicate package name {0!r} '
                         'submitted'.format(name))
             continue
         if '/' not in name:

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -58,6 +58,15 @@ def _p_to_cp(p):
     return None
 
 
+def _allnodes():
+    if 'portage._allnodes' in __context__:
+        return __context__['portage._allnodes']
+    else:
+        ret = _porttree().getallnodes()
+        __context__['portage._allnodes'] = ret
+        return ret
+
+
 def _cpv_to_cp(cpv):
     ret = portage.cpv_getkey(cpv)
     if ret:
@@ -89,6 +98,43 @@ def _process_emerge_err(stderr):
         elif 'The following mask changes' in section:
             changes['mask'] = rexp.findall(section)
     ret['changes'] = changes
+    return ret
+
+
+def checkdb(*names):
+    '''
+    .. versionadded:: 0.17.0
+
+    Returns a dict containing the following information for each specified
+    package:
+
+    1. A key ``found``, which will be a boolean value denoting if a match was
+       found in the package database.
+    2. If ``found`` is ``False``, then a second key called ``suggestions`` will
+       be present, which will contain a list of possible matches. This list
+       will be empty if the package name was specified in ``category/pkgname``
+       format, since the suggestions are only intended to disambiguate
+       ambiguous package names (ones submitted without a category).
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.checkdb <package1> <package2> <package3>
+    '''
+    ret = {}
+    for name in names:
+        if name in ret:
+            log.warning('pkg.checkdb: Duplicate package name {0!r} '
+                        'submitted'.format(name))
+            continue
+        if '/' not in name:
+            ret.setdefault(name, {})['found'] = False
+            ret[name]['suggestions'] = porttree_matches(name)
+        else:
+            ret.setdefault(name, {})['found'] = name in _allnodes()
+            if ret[name]['found'] is False:
+                ret[name]['suggestions'] = []
     return ret
 
 

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -219,38 +219,6 @@ def _verify_binary_pkg(srcinfo):
     return problems
 
 
-def check_desired(desired=None):
-    '''
-    Examines desired package names to make sure they were formatted properly.
-    Returns a list of problems encountered.
-
-    CLI Examples:
-
-    .. code-block:: bash
-
-        salt '*' pkg_resource.check_desired
-    '''
-    problems = []
-
-    # If minion is Gentoo-based, ensure packages are properly submitted as
-    # category/pkgname. For any package that does not follow this format, offer
-    # matches from the portage tree.
-    if __grains__['os_family'] == 'Gentoo':
-        for pkg in (desired or []):
-            if '/' not in pkg:
-                matches = __salt__['pkg.porttree_matches'](pkg)
-                if matches:
-                    msg = 'Package category missing for "{0}" (possible ' \
-                          'matches: {1}).'.format(pkg, ', '.join(matches))
-                else:
-                    msg = 'Package category missing for "{0}" and no match ' \
-                          'found in portage tree.'.format(pkg)
-                log.error(msg)
-                problems.append(msg)
-
-    return problems
-
-
 def parse_targets(name=None, pkgs=None, sources=None, **kwargs):
     '''
     Parses the input to pkg.install and returns back the package(s) to be


### PR DESCRIPTION
We've already been doing something like this for Gentoo for a while, but it was in pkg_resource.py. This pull request does the following:

1) Pulls the pkg target verification from pkg_resource.py into a function called `check_db` in ebuild.py, and changes the format of the output generated by this check (see the docstring for more information).
2) Modifies the `pkg.installed` state to use the return data generated by `pkg.check_db` and, if problems were encountered, to fail out of the state and notify the user of the suggested package names discovered by `pkg.check_db`. **NOTE: If `pkg.check_db` does not exist, then the pkg.installed state will not attempt to run this function, and will thus proceed without the possiblity of failing out on this step.**
3) Adds `check_db` functions to both yumpkg and yumpkg5, thereby adding the package suggestion capability to these providers.

This new framework for checking package targets before attempting an installation can now be easily extended to other providers. It is my hope that we can also use this to deprecate (and eventually drop) support of virtual packages in Ubuntu.
