### PR TITLE
On file.recurse don't recurse into directories that aren't direct descen...

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1507,6 +1507,8 @@ def recurse(name,
         # empty dir(if include_empty==true).
 
         relname = os.path.relpath(fn_, srcpath)
+        if relname.startswith('..'):
+            continue
 
         # Check for maxdepth of the relative path
         if maxdepth is not None:


### PR DESCRIPTION
...dants

When getting files as recurse candidates in the file.recurse state, directories that are not descendants of the recurse source folder but which are descendants of the root folder are being included as candidates for being copied as a part of the state.  With this change, once we have a relative filename, we check to see if the file is a descendant of the recurse root, and skip that file if that is true.
