### PR TITLE
Added Scientific Linux OS Name and Family Mappings

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -691,7 +691,8 @@ _OS_NAME_MAP = {
     'alt': 'ALT',
     'oracleserv': 'OEL',
     'cloudserve': 'CloudLinux',
-    'pidora': 'Fedora'
+    'pidora': 'Fedora',
+    'scientific': 'ScientificLinux'
 }
 
 # Map the 'os' grain to the 'os_family' grain
@@ -730,7 +731,8 @@ _OS_FAMILY_MAP = {
     'Trisquel': 'Debian',
     'GCEL': 'Debian',
     'Linaro': 'Debian',
-    'elementary OS': 'Debian'
+    'elementary OS': 'Debian',
+    'ScientificLinux': 'RedHat'
 }
 
 


### PR DESCRIPTION
"ScientificLinux" has been added to _OS_NAME_MAP and map "ScientificLinux" to "RedHat" in _OS_FAMILY_MAP
tested on Scientific Linux CERN SLC release 5.9 (Boron)
it will be displayed like this and module 'pkg' will be work fine

```
# salt-call grains.items| grep ^os -A 1
os:
    ScientificLinux
os_family:
    RedHat
osarch:
    x86_64
oscodename:
    Boron
osfinger:
    Scientific Linux CERN SLC-5
osfullname:
    Scientific Linux CERN SLC
osmajorrelease:
    - 5
--
osrelease:
    5.9
```

instead of

```
# salt-call grains.items| grep ^os -A 1
os:
    Scientific  CERN SLC
os_family:
    Scientific  CERN SLC
oscodename:
    Boron
osfullname:
    Scientific Linux CERN SLC
osrelease:
    5.9
```
