### PR TITLE
Add option to allow SVN to trust server identity.

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -130,7 +130,7 @@ def latest(name,
             ret['changes']['revision'] = "{0} => {1}".format(current_rev, new_rev)
     
     else:
-        out = __salt__[svn_cmd](cwd, name, basename, user, username, password, trus, *opts)
+        out = __salt__[svn_cmd](cwd, name, basename, user, username, password, *opts)
 
         ret['changes']['new'] = name
         ret['changes']['revision'] = __salt__['svn.info'](cwd=target,

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -38,7 +38,8 @@ def latest(name,
            username=None,
            password=None,
            force=False,
-           externals=True):
+           externals=True,
+           trust=False):
     '''
     Checkout or update the working directory to the latest revision from the
     remote repository.
@@ -69,6 +70,9 @@ def latest(name,
 
     externals : True
         Change to False to not checkout or update externals
+
+    trust : False
+        Automatically trust the remote server. SVN's --trust-server-cert
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if not target:
@@ -109,6 +113,9 @@ def latest(name,
     if externals is False:
         opts += ('--ignore-externals',)
 
+    if trust:
+        opts += ('--trust-server-cert',)
+
     if svn_cmd == 'svn.update':
         out = __salt__[svn_cmd](cwd, basename, user, username, password, *opts)
 
@@ -121,8 +128,9 @@ def latest(name,
                                        fmt='dict')[0]['Revision']
         if current_rev != new_rev:
             ret['changes']['revision'] = "{0} => {1}".format(current_rev, new_rev)
+    
     else:
-        out = __salt__[svn_cmd](cwd, name, basename, user, username, password, *opts)
+        out = __salt__[svn_cmd](cwd, name, basename, user, username, password, trus, *opts)
 
         ret['changes']['new'] = name
         ret['changes']['revision'] = __salt__['svn.info'](cwd=target,


### PR DESCRIPTION
This is helpful if you've generated your own SSL certificates and for an initial checkout and deployment I suppose.
