### PR TITLE
Fix issue 6800. cwd=target was being passed to _run_check which blew up ...

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -91,8 +91,7 @@ def latest(name,
     if not target:
         return _fail(ret, '"target" option is required')
 
-    run_check_cmd_kwargs = {'cwd': target,
-                            'runas': runas}
+    run_check_cmd_kwargs = {'runas': runas}
 
     # check if git.latest should be applied
     cret = _run_check(

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -88,6 +88,28 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    def test_latest_unless_no_cwd_issue_6800(self):
+        '''
+        cwd=target was being passed to _run_check which blew up if
+        target dir did not already exist.
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        if os.path.isdir(name):
+            shutil.rmtree(name)
+        try:
+            ret = self.run_state(
+                'git.latest',
+                name='https://{0}/saltstack/salt-bootstrap.git'.format(self.__domain),
+                rev='develop',
+                target=name,
+                unless='test -e {0}'.format(name),
+                submodules=True
+            )
+            self.assertSaltTrueReturn(ret)
+            self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
+        finally:
+            shutil.rmtree(name, ignore_errors=True)
+
     def test_present(self):
         '''
         git.present


### PR DESCRIPTION
...if target dir did not already exist.

There's no reason to assume we should run the unless and onlyif tests in the target dir, so don't force cwd=target for run_check_cmd_kwargs.
