### PR TITLE
Add kwargs_warn_until() function

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1341,7 +1341,7 @@ def warn_until(version_info,
     :param category: The warning class to be thrown, by default
                      ``DeprecationWarning``
     :param stacklevel: There should be no need to set the value of
-                       ``stacklevel`` salt should be able to do the right thing
+                       ``stacklevel``. Salt should be able to do the right thing.
     :param _version_info_: In order to reuse this function for other SaltStack
                            projects, they need to be able to provide the
                            version info to compare to.

--- a/tests/unit/utils/warnings_test.py
+++ b/tests/unit/utils/warnings_test.py
@@ -3,7 +3,7 @@
     tests.unit.utils.warnings_test
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Test ``salt.utils.warn_until``
+    Test ``salt.utils.warn_until`` and ``salt.utils.kwargs_warn_until``
 
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
     :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
@@ -20,13 +20,13 @@ from salttesting.mock import NO_MOCK, NO_MOCK_REASON, patch
 ensure_in_syspath('../../')
 
 # Import salt libs
-from salt.utils import warn_until
+from salt.utils import warn_until, kwargs_warn_until
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class WarnUntilTestCase(TestCase):
 
     @patch('salt.version')
-    def test_warning_raised(self, salt_version_mock):
+    def test_warn_until_warning_raised(self, salt_version_mock):
         # We *always* want *all* warnings thrown on this module
         warnings.filterwarnings('always', '', DeprecationWarning, __name__)
 
@@ -74,6 +74,54 @@ class WarnUntilTestCase(TestCase):
             warn_until(
                 (0, 17), 'Foo', _dont_call_warnings=True
             )
+
+    @patch('salt.version')
+    def test_kwargs_warn_until_warning_raised(self, salt_version_mock):
+        # We *always* want *all* warnings thrown on this module
+        warnings.filterwarnings('always', '', DeprecationWarning, __name__)
+
+        # Define a salt version info
+        salt_version_mock.__version_info__ = (0, 16)
+
+        def raise_warning(**kwargs):
+            kwargs_warn_until(
+                kwargs,
+                (0, 17),
+            )
+
+        # raise_warning({...}) should show warning until version info is >= (0, 17)
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            raise_warning(foo=42) # with a kwarg
+            self.assertEqual(
+                'The following parameter(s) have been deprecated and '
+                'will be removed in 0.17: \'foo\'.',
+                str(recorded_warnings[0].message)
+            )
+        # With no **kwargs, should not show warning until version info is >= (0, 17)
+        with warnings.catch_warnings(record=True) as recorded_warnings:
+            kwargs_warn_until(
+                {},  # no kwargs
+                (0, 17),
+            )
+            self.assertEqual(0, len(recorded_warnings))
+
+        # Let's set version info to (0, 17), a RuntimeError should be raised
+        # regardless of whether or not we pass any **kwargs.
+        salt_version_mock.__version_info__ = (0, 17)
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                r'The warning triggered on filename \'(.*)warnings_test.py\', '
+                r'line number ([\d]+), is supposed to be shown until version '
+                r'\'0.17\' is released. Current version is now \'0.17\'. Please '
+                r'remove the warning.'):
+            raise_warning()  # no kwargs
+        with self.assertRaisesRegexp(
+                RuntimeError,
+                r'The warning triggered on filename \'(.*)warnings_test.py\', '
+                r'line number ([\d]+), is supposed to be shown until version '
+                r'\'0.17\' is released. Current version is now \'0.17\'. Please '
+                r'remove the warning.'):
+            raise_warning(bar='baz', qux='quux')  # some kwargs
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds a `salt.utils.kwargs_warn_until()` function to be used as an aid in deprecating and removing the unused `**kwargs` present in many places in Salt. These `**kwargs` are allowing some typo mistakes in SLS files (and other places) to be silently ignored, which is bad.

Example use:

``` py
def some_state_function(user, flag, **kwargs):
    kwargs_warn_until(kwargs, (0, 19))  # or whatever the applicable version is
    # ...(doesn't use `kwargs`)...
```
