### PR TITLE
salt.utils.network: fix regex

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -162,7 +162,7 @@ def _interfaces_ip(out):
         for line in group.splitlines():
             if not ' ' in line:
                 continue
-            match = re.match(r'^\d*:\s+([\w.]+)(?:@)?(\w+)?:\s+<(.+)>', line)
+            match = re.match(r'^\d*:\s+([\w.]+)(?:@)?([\w.]+)?:\s+<(.+)>', line)
             if match:
                 iface, parent, attrs = match.groups()
                 if 'UP' in attrs.split(','):


### PR DESCRIPTION
Periods should be allowed on the right side of @ in iface definition. E.g., mvlan100@eth0.100
