### PR TITLE
Fix #7154 - cmd.* should fail when cwd does not exist

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -210,6 +210,11 @@ def _run(cmd,
     # munge the cmd and cwd through the template
     (cmd, cwd) = _render_cmd(cmd, cwd, template)
 
+    if not os.path.isdir(cwd):
+      # cwd is not a directory - fatal error
+      msg = 'Working directory {0!r} does not exist'
+      raise CommandExecutionError(msg.format(cwd))
+
     ret = {}
 
     if not env:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -211,9 +211,9 @@ def _run(cmd,
     (cmd, cwd) = _render_cmd(cmd, cwd, template)
 
     if not os.path.isdir(cwd):
-      # cwd is not a directory - fatal error
-      msg = 'Working directory {0!r} does not exist'
-      raise CommandExecutionError(msg.format(cwd))
+        # cwd is not a directory - fatal error
+        msg = 'Working directory {0!r} does not exist'
+        raise CommandExecutionError(msg.format(cwd))
 
     ret = {}
 

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -202,7 +202,8 @@ sys.stdout.write('cheese')
 
     def test_run_cwd_doesnt_exist_issue_7154(self):
         '''
-        cmd.run should fail and return ENOENT if the cwd dir does not
+        cmd.run should fail and raise
+        salt.exceptions.CommandExecutionError if the cwd dir does not
         exist
         '''
         from salt.exceptions import CommandExecutionError

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -200,6 +200,21 @@ sys.stdout.write('cheese')
             'hello' == self.run_function(
                 'cmd.run', ['sleep 1 && echo hello', 'timeout=2']))
 
+    def test_run_cwd_doesnt_exist_issue_7154(self):
+        '''
+        cmd.run should fail and return ENOENT if the cwd dir does not
+        exist
+        '''
+        from salt.exceptions import CommandExecutionError
+        import salt.modules.cmdmod as cmdmod
+        cmd = 'echo OHAI'
+        cwd = '/path/to/nowhere'
+        try:
+            cmdmod.run_all(cmd, cwd=cwd)
+        except CommandExecutionError:
+            pass
+        else:
+            raise RuntimeError
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Fixes issue [#7154](https://github.com/saltstack/salt/issues/7154)
