### PR TITLE
rm **kwargs from modules.upstart.full_restart()

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -293,7 +293,7 @@ def restart(name, **kwargs):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def full_restart(name, **kwargs):
+def full_restart(name):
     '''
     Do a full restart (stop/start) of the named service
 


### PR DESCRIPTION
- `upstart.full_restart()` already ignores its kwargs
- `daemontools` is the only other service module to implement `full_restart`, and its version doesn't accept arbitrary kwargs
- [According to my research](https://docs.google.com/spreadsheet/ccc?key=0AtlcnvZE4HSKdDMzZGRxWEdVMzBkSVFvRWZwOWM4akE&usp=sharing), no other service module's `restart()` uses its kwargs, and not all of them even accept kwargs in the first place.

So it's neither useful on its own, nor for API conformance/compatibility purposes.
