### PR TITLE
Fix for issue #7121 - Changed py renderer global variables to be consistent with pydsl

### DIFF
--- a/salt/renderers/py.py
+++ b/salt/renderers/py.py
@@ -26,12 +26,12 @@ def render(template, env='', sls='', tmplpath=None, **kws):
     tmp_data = salt.utils.templates.py(
             template,
             True,
-            salt=__salt__,
-            grains=__grains__,
-            opts=__opts__,
-            pillar=__pillar__,
-            env=env,
-            sls=sls,
+            __salt__=__salt__,
+            __grains__=__grains__,
+            __opts__=__opts__,
+            __pillar__=__pillar__,
+            __env__=env,
+            __sls__=sls,
             **kws)
     if not tmp_data.get('result', False):
         raise SaltRenderError(tmp_data.get('data',


### PR DESCRIPTION
As per issue #7121 - this PR changes the global variable names salt, grains, opts, pillar, env and sls to be **salt**, **grains**, **opts**, **pillar**, **env** and **sls** to restore consistency between the py and pydsl renderers.

Simple change, but it will break compatibility with existing py rendered states/pillars that utilise the old global variable names.
