### PR TITLE
Adding file:// URL support for salt mako template lookup and mine_get acl support (Issue#5467)

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -389,6 +389,28 @@
 #     - manage.up
 
 
+#####         Mine settings     #####
+###########################################
+# Restrict mine.get access from minions. By default any minion has a full access
+# to get all mine data from master cache. In acl definion below, only pcre matches
+# are allowed.
+#
+# mine_get:
+#   .*:
+#     - .*
+#
+# Example below enables minion foo.example.com to get  'network.interfaces' mine data only
+# , minions web* to get all network.* and disk.* mine data and all other minions won't get
+# any mine data.
+#
+# mine_get:
+#   foo.example.com:
+#     - network.inetrfaces
+#   web.*:
+#     - network.*
+#     - disk.*
+
+
 #####         Logging settings       #####
 ##########################################
 # The location of the master log file

--- a/salt/master.py
+++ b/salt/master.py
@@ -802,6 +802,21 @@ class AESFuncs(object):
         '''
         if any(key not in load for key in ('id', 'tgt', 'fun')):
             return {}
+        if 'mine_get' in self.opts:
+            # If master side acl defined.
+            if not isinstance(self.opts['mine_get'],dict):
+                return {}
+            perms = set()
+            for match in self.opts['mine_get']:
+                if re.match(match, load['id']):
+                    if isinstance(self.opts['mine_get'][match], list):
+                            perms.update(self.opts['mine_get'][match])
+            good = False
+            for perm in perms:
+                if re.match(perm, load['fun']):
+                    good = True
+            if not good:
+                return {}
         ret = {}
         if not salt.utils.verify.valid_id(load['id']):
             return ret

--- a/salt/utils/mako.py
+++ b/salt/utils/mako.py
@@ -12,37 +12,42 @@ import salt.fileclient
 
 class SaltMakoTemplateLookup(TemplateCollection):
     """
-    Look up Mako template files on Salt master via salt://... URLs.
+    Look up Mako template files using file:// or salt:// URLs with <%include/>
+    or <%namespace/>.
 
-    If URL is a relative path(without an URL scheme) then assume it's relative
-    to the directory of the salt file that's doing the lookup(with <%include/>
-    or <%namespace/>).
+    (1) Look up mako template files on local file system via files://... URL.
+        Make sure mako template file is present locally on minion beforehand.
 
-    If URL is an absolute path then it's treated as if it has been prefixed
-    with salt://.
+      Examples:
+        <%include   file="file:///etc/salt/lib/templates/sls-parts.mako"/>
+        <%namespace file="file:///etc/salt/lib/templates/utils.mako" import="helper"/>
 
-    Examples::
+    (2) Look up mako template files on Salt master via salt://... URL. 
+        If URL is a relative  path (without an URL scheme) then assume it's relative
+        to the directory of the salt file that's doing the lookup. If URL is an absolute 
+        path then it's treated as if it has been prefixed with salt://.
 
-       <%include file="templates/sls-parts.mako"/>
-       <%namespace file="salt://lib/templates/utils.mako" import="helper"/>
+       Examples::
+         <%include   file="templates/sls-parts.mako"/>
+         <%include   file="salt://lib/templates/sls-parts.mako"/>
+         <%include   file="/lib/templates/sls-parts.mako"/>                 ##-- treated as salt://
+
+         <%namespace file="templates/utils.mako"/>
+         <%namespace file="salt://lib/templates/utils.mako" import="helper"/>
+         <%namespace file="/lib/templates/utils.mako" import="helper"/>     ##-- treated as salt://      
 
     """
 
     def __init__(self, opts, env='base'):
         self.opts = opts
         self.env = env
-        if opts['file_client'] == 'local':
-            searchpath = opts['file_roots'][env]
-        else:
-            searchpath = [os.path.join(opts['cachedir'], 'files', env)]
-        self.lookup = TemplateLookup(directories=searchpath)
-
+        self.lookup = TemplateLookup(directories='/')
         self.file_client = salt.fileclient.get_file_client(self.opts)
         self.cache = {}
-        
+
     def adjust_uri(self, uri, filename):
         scheme = urlparse.urlparse(uri).scheme
-        if scheme == 'salt':
+        if scheme in ('salt','file'):
             return uri
         elif scheme:
             raise ValueError("Unsupported URL scheme(%s) in %s" % \
@@ -52,11 +57,22 @@ class SaltMakoTemplateLookup(TemplateCollection):
 
 
     def get_template(self, uri):
-        prefix = "salt://"
-        salt_uri = uri if uri.startswith(prefix) else prefix+uri
-        self.cache_file(salt_uri)
-        return self.lookup.get_template(salt_uri[len(prefix):])
+        if uri.startswith("file://"):
+            prefix = "file://"
+            searchpath = "/"
+            salt_uri = uri
+        else:
+            prefix = "salt://"
+            if self.opts['file_client'] == 'local':
+                searchpath = self.opts['file_roots'][self.env]
+            else:
+                searchpath = [os.path.join(self.opts['cachedir'], 'files', self.env)]
+            salt_uri = uri if uri.startswith(prefix) else (prefix + uri)
+            self.cache_file(salt_uri)
 
+        self.lookup = TemplateLookup(directories=searchpath)
+        
+        return self.lookup.get_template(salt_uri[len(prefix):])
 
     def cache_file(self, fpath):
         if fpath not in self.cache:


### PR DESCRIPTION
(1) Adding file:// URL support to lookup mako templates on local file system...
If mako templates are already present on a local file system on a
minion, it can use file:// URL to lookup a local copy. This  in addition
to salt:// url support that is already present, which fetches a copy
from a salt server.

(2) Issue#5467 :    Adding master side acl support for mine.get

Not sure if you accept two different commits per pull request. If not then I will try to create separate pull requests. 
