### PR TITLE
updated troubleshooting index to add selinux commands for CentOS/RHEL 6.

### DIFF
--- a/doc/topics/troubleshooting/index.rst
+++ b/doc/topics/troubleshooting/index.rst
@@ -159,8 +159,13 @@ to this issue is to set the execution context of ``salt-call`` and
 
 .. code-block:: bash
 
+    # CentOS 5 and RHEL 5:
     # chcon -t system_u:system_r:rpm_exec_t:s0 /usr/bin/salt-minion
     # chcon -t system_u:system_r:rpm_exec_t:s0 /usr/bin/salt-call
+
+    # CentOS 6 and RHEL 6:
+    # chcon system_u:object_r:rpm_exec_t:s0 /usr/bin/salt-minion
+    # chcon system_u:object_r:rpm_exec_t:s0 /usr/bin/salt-call
 
 This works well, because the ``rpm_exec_t`` context has very broad control over
 other types.


### PR DESCRIPTION
Merge to update troubleshooting index to resolve issues with the selinux commands as they differ on CentOS/RHEL 5 and 6. I confirmed functionality on a CentOS VM. that were brought up in https://github.com/saltstack/salt/issues/7185 .
