### PR TITLE
Fixed "Failed to load ext_pillar git: 'branch_name'"

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -143,7 +143,7 @@ def ext_pillar(minion_id, pillar, repo_string):
 
     # Don't recurse forever-- the Pillar object will re-call the ext_pillar
     # function
-    if __opts__['pillar_roots'][branch_env] == [repo.working_dir]:
+    if __opts__['pillar_roots'].get(branch_env, []) == [repo.working_dir]:
         return {}
 
     opts = deepcopy(__opts__)


### PR DESCRIPTION
If there is something like the following in the master file:

```
ext_pillar:
  - git: master file:///root/salt/pillar
  - git: branch_name file:///root/salt/pillar
```

master branch will be checked out and assigned to pillar_roots:
`__opts__['pillar_roots']: {'base': ['/var/cache/salt/master/pillar_gitfs/0']}`

But when trying to get branch_name branch, it will fail:

```
[ERROR   ] Failed to load ext_pillar git: 'branch_name'
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/pillar/__init__.py", line 410, in ext_pillar
    ext = self.ext_pillars[key](self.opts['id'], pillar, val)
  File "/usr/lib/python2.6/site-packages/salt/pillar/git_pillar.py", line 151, in ext_pillar
    if __opts__['pillar_roots'][branch_env] == [repo.working_dir]:
KeyError: 'branch_name'
```
