### PR TITLE
Fix missing import

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -14,6 +14,10 @@ from salt.utils import namespaced_function as _namespaced_function
 from salt.modules.yumpkg import (mod_repo, _parse_repo_file, list_repos,
                                  get_repo, expand_repo_def, del_repo)
 
+# Import libs required by functions imported from yumpkg
+# DO NOT REMOVE THESE, ON PAIN OF DEATH
+import os
+
 log = logging.getLogger(__name__)
 
 # This is imported in salt.modules.pkg_resource._parse_pkg_meta. Don't change


### PR DESCRIPTION
This fixes #7203 by importing the 'os' module, required by some of the
functions imported from salt.modules.yumpkg. I also checked the other
re-namespaced functions in yumpkg5 and made sure additional modules did
not need to be imported here.
