### PR TITLE
pkg mods: latest_version: (1) always allow refresh arg (2) error on invalid kwargs

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -124,13 +124,8 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name> fromrepo=unstable
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
-    if len(names) == 0:
-        return ''
-    ret = {}
-    # Initialize the dict with empty strings
-    for name in names:
-        ret[name] = ''
-    pkgs = list_pkgs(versions_as_list=True)
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+
     if 'repo' in kwargs:
         # Remember to kill _get_repo() too when removing this warning.
         salt.utils.warn_until(
@@ -139,11 +134,24 @@ def latest_version(*names, **kwargs):
             'removed in 0.18.0. Please use \'fromrepo\' instead.'
         )
     fromrepo = _get_repo(**kwargs)
+    kwargs.pop('fromrepo', None)
+    kwargs.pop('repo', None)
+
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
+    if len(names) == 0:
+        return ''
+    ret = {}
+    # Initialize the dict with empty strings
+    for name in names:
+        ret[name] = ''
+    pkgs = list_pkgs(versions_as_list=True)
     repo = ' -o APT::Default-Release="{0}"'.format(fromrepo) \
         if fromrepo else ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     for name in names:

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -120,6 +120,10 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3>
     '''
+    kwargs.pop('refresh', True)
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if len(names) <= 1:
         return ''
     else:

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -170,11 +170,15 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if len(names) == 0:
         return ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     ret = {}

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -68,10 +68,14 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
 
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     ret = {}
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     if _check_pkgng():

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -80,6 +80,10 @@ def latest_version(*names, **kwargs):
 
         salt '*' pkg.latest_version <package name>
     '''
+    kwargs.pop('refresh', True)
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     pkgs = list_pkgs()
     ret = {}
     # Initialize the dict with empty strings

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -44,11 +44,15 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if len(names) == 0:
         return ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     ret = {}

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -112,13 +112,17 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package1> <package2> ...
     '''
 
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     pkglist = {}
     pkgin = _check_pkgin()
     if not pkgin:
         return pkglist
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     for name in names:

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -72,6 +72,10 @@ def latest_version(pkg_name, **kwargs):
         salt '*' pkgng.latest_version <package name>
     '''
 
+    kwargs.pop('refresh', True)
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     cmd = 'pkg info {0}'.format(pkg_name)
     out = __salt__['cmd.run'](cmd).split()
     return out[0]

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -185,6 +185,10 @@ def latest_version(*names, **kwargs):
         salt '*' pkgutil.latest_version CSWpython
         salt '*' pkgutil.latest_version <package1> <package2> <package3> ...
     '''
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if not names:
         return ''
     ret = {}
@@ -193,7 +197,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     pkgs = list_pkgs()

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -127,6 +127,10 @@ def latest_version(*names, **kwargs):
     pkgadd, this function will always return an empty string for a given
     package.
     '''
+    kwargs.pop('refresh', True)
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     ret = {}
     if not names:
         return ''

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -213,6 +213,11 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name> fromrepo=epel-testing
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    # FIXME: do stricter argument checking that somehow takes _get_repo_options() into account
+    # if kwargs:
+    #     raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if len(names) == 0:
         return ''
     ret = {}
@@ -221,7 +226,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     yumbase = yum.YumBase()

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -157,6 +157,11 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name> fromrepo=epel-testing
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    # FIXME: do stricter argument checking that somehow takes _get_repo_options() into account
+    # if kwargs:
+    #     raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if len(names) == 0:
         return ''
     ret = {}
@@ -165,7 +170,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     # Get updates for specified package(s)

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -69,6 +69,10 @@ def latest_version(*names, **kwargs):
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
     '''
+    refresh = salt.utils.is_true(kwargs.pop('refresh', True))
+    if kwargs:
+        raise TypeError('Got unexpected keyword argument(s): {0!r}'.format(kwargs))
+
     if len(names) == 0:
         return ''
 
@@ -77,7 +81,7 @@ def latest_version(*names, **kwargs):
         ret[name] = ''
 
     # Refresh before looking for the latest version available
-    if salt.utils.is_true(kwargs.get('refresh', True)):
+    if refresh:
         refresh_db()
 
     cmd = 'zypper info -t package {0}'.format(' '.join(names))


### PR DESCRIPTION
A majority of package manager modules support a `refresh` argument to `latest_version()`. For the sake of API uniformity, this commit adds explicit support for allowing `refresh` as a no-op argument to the remaining modules.

With that in place, this commit also adds (wherever easily possible) extra error checking for unsupported keyword arguments (so that typos will be reported instead of silently ignored).
# warOnKwargs
