### PR TITLE
Add with_retcode option to ShellCase.run_call().

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -706,19 +706,19 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
     _script_dir_ = SCRIPT_DIR
     _python_executable_ = PYEXEC
 
-    def run_salt(self, arg_str):
+    def run_salt(self, arg_str, with_retcode=False):
         '''
         Execute salt
         '''
         arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt', arg_str)
+        return self.run_script('salt', arg_str, with_retcode=with_retcode)
 
-    def run_run(self, arg_str):
+    def run_run(self, arg_str, with_retcode=False):
         '''
         Execute salt-run
         '''
         arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-run', arg_str)
+        return self.run_script('salt-run', arg_str, with_retcode=with_retcode)
 
     def run_run_plus(self, fun, options='', *arg):
         '''
@@ -738,19 +738,24 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
             ret['fun'] = runner.run()
         return ret
 
-    def run_key(self, arg_str, catch_stderr=False):
+    def run_key(self, arg_str, catch_stderr=False, with_retcode=False):
         '''
         Execute salt-key
         '''
         arg_str = '-c {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-key', arg_str, catch_stderr=catch_stderr)
+        return self.run_script(
+            'salt-key',
+            arg_str,
+            catch_stderr=catch_stderr,
+            with_retcode=with_retcode
+        )
 
-    def run_cp(self, arg_str):
+    def run_cp(self, arg_str, with_retcode=False):
         '''
         Execute salt-cp
         '''
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-cp', arg_str)
+        return self.run_script('salt-cp', arg_str, with_retcode=with_retcode)
 
     def run_call(self, arg_str, with_retcode=False):
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -752,9 +752,9 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
         return self.run_script('salt-cp', arg_str)
 
-    def run_call(self, arg_str):
+    def run_call(self, arg_str, with_retcode=False):
         arg_str = '--config-dir {0} {1}'.format(self.get_config_dir(), arg_str)
-        return self.run_script('salt-call', arg_str)
+        return self.run_script('salt-call', arg_str, with_retcode=with_retcode)
 
 
 class ShellCaseCommonTestsMixIn(CheckShellBinaryNameAndVersionMixIn):

--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -11,6 +11,7 @@
 # Import python libs
 import os
 import sys
+import shutil
 import yaml
 from datetime import datetime
 
@@ -54,6 +55,29 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             'salt \'*\' user.delete name remove=True force=True',
             ''.join(ret)
         )
+
+    def test_issue_6973_state_highstate_exit_code(self):
+        '''
+        If there is no tops/master_tops or state file matches
+        for this minion, salt-call should exit non-zero if invoked with
+        option --retcode-passthrough
+        '''
+        src = os.path.join(integration.FILES, 'file/base/top.sls')
+        dst = os.path.join(integration.FILES, 'file/base/top.sls.bak')
+        shutil.move(src, dst)
+        expected_tag = 'no_|-states_|-states_|-None'
+        expected_comment = 'No Top file or external nodes data matches found'
+        try:
+            stdout, retcode = self.run_call(
+                '-l quiet --retcode-passthrough state.highstate',
+                with_retcode=True
+            )
+        finally:
+            pass
+            shutil.move(dst, src)
+        self.assertIn(expected_tag, ''.join(stdout))
+        self.assertIn(expected_comment, ''.join(stdout))
+        self.assertNotEqual(0, retcode)
 
     @skipIf(sys.platform.startswith('win'), 'This test does not apply on Win')
     def test_issue_2731_masterless(self):


### PR DESCRIPTION
Also adds a test case for https://github.com/saltstack/salt/issues/6973 - expect a non-zero exit code when running "salt-call --retcode-passthrough state.highstate"

**Depends on salt-testing pull req https://github.com/saltstack/salt-testing/pull/3**
