### PR TITLE
Fix/update RPM packaging files

### DIFF
--- a/pkg/rpm/salt-master
+++ b/pkg/rpm/salt-master
@@ -35,15 +35,23 @@ else
     . /etc/rc.d/init.d/functions
 fi
 
+# Default values, can be overridden below in /etc/default/salt
+SALTMASTER=/usr/bin/salt-master
+PYTHON=/usr/bin/python
+
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt
-else
-    SALTMASTER=/usr/bin/salt-master
-    PYTHON=/usr/bin/python
 fi
 
 # Sanity checks.
-[ -x $SALTMASTER ] || exit 0
+if [ ! -x "$SALTMASTER" ]; then
+    echo "Unable to execute $SALTMASTER!"
+    exit 2
+fi
+if [ ! -x "$PYTHON" ]; then
+    echo "$PYTHON does not exist or is not executable"
+    exit 2
+fi
 
 SERVICE=salt-master
 PROCESS=salt-master

--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -36,15 +36,23 @@ else
     . /etc/rc.d/init.d/functions
 fi
 
+# Default values, can be overridden below in /etc/default/salt
+SALTMINION=/usr/bin/salt-minion
+PYTHON=/usr/bin/python
+
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt
-else
-    SALTMINION=/usr/bin/salt-minion
-    PYTHON=/usr/bin/python
 fi
 
 # Sanity checks.
-[ -x $SALTMINION ] || exit 0
+if [ ! -x "$SALTMINION" ]; then
+    echo "Unable to execute $SALTMINION!"
+    exit 2
+fi
+if [ ! -x "$PYTHON" ]; then
+    echo "$PYTHON does not exist or is not executable"
+    exit 2
+fi
 
 SERVICE=salt-minion
 PROCESS=salt-minion

--- a/pkg/rpm/salt-syndic
+++ b/pkg/rpm/salt-syndic
@@ -36,15 +36,23 @@ else
     . /etc/rc.d/init.d/functions
 fi
 
+# Default values, can be overridden below in /etc/default/salt
+SALTSYNDIC=/usr/bin/salt-syndic
+PYTHON=/usr/bin/python
+
 if [ -f /etc/default/salt ]; then
     . /etc/default/salt
-else
-    SALTSYNDIC=/usr/bin/salt-syndic
-    PYTHON=/usr/bin/python
 fi
 
 # Sanity checks.
-[ -x $SALTSYNDIC ] || exit 0
+if [ ! -x "$SALTSYNDIC" ]; then
+    echo "Unable to execute $SALTSYNDIC!"
+    exit 2
+fi
+if [ ! -x "$PYTHON" ]; then
+    echo "$PYTHON does not exist or is not executable"
+    exit 2
+fi
 
 SERVICE=salt-syndic
 PROCESS=salt-syndic

--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -11,7 +11,7 @@
 %{!?python_sitearch: %global python_sitearch %(%{__python} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib(1))")}
 
 Name: salt
-Version: 0.16.3
+Version: 0.16.4
 Release: 1%{?dist}
 Summary: A parallel remote execution system
 
@@ -310,6 +310,9 @@ rm -rf $RPM_BUILD_ROOT
 %changelog
 * Wed Sep 11 2013 David Anderson <dave@dubkat.com>
 - Change sourcing order of init functions and salt default file
+
+* Sat Sep 07 2013 Erik Johnson <erik@saltstack.com> - 0.16.4-1
+- Update to patch release 0.16.4
 
 * Sun Aug 25 2013 Florian La Roche <Florian.LaRoche@gmx.net>
 - fixed preun/postun scripts for salt-minion


### PR DESCRIPTION
This updates the spec to include the info on 0.16.4-1 (I didn't commit this when I built the package, d'oh). It also makes some fixes to the sourcing of the default file that would cause needed variables not to be created if they didn't exist (or were commented out) in the default file. Finally, the sanity checks have been fixed so that the initscript doesn't simply exit silently if the path to the master/minion/syndic is unset or set to an invalid path.
