### PR TITLE
pip state: despite the name, pkg_list is a dict; initialize accordingly

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -327,7 +327,7 @@ def installed(name,
             ret['comment'] = ' '.join(comments)
         else:
             if not prefix:
-                pkg_list = []
+                pkg_list = {}
             else:
                 pkg_list = __salt__['pip.list'](
                     prefix, bin_env, user=user, cwd=cwd


### PR DESCRIPTION
The other branch, which calls `pip.list()`, returns a dict.

Prompted by pylint:

```
salt/states/pip_state.py:344: [E1103(maybe-no-member), installed] Instance of 'list' has no 'values' member (but some types could not be inferred)
```
