### PR TITLE
states.alternatives: avoid shadowing set() built-in type

### DIFF
--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -27,6 +27,12 @@ Control the alternatives system
 
 '''
 
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
 def install(name, link, path, priority):
     '''
     Install new alternative for defined <name>
@@ -149,7 +155,7 @@ def auto(name):
     return ret
 
 
-def set(name, path):
+def set_(name, path):
     '''
     Removes installed alternative for defined <name> and <path>
     or fallback to default alternative, if some defined before.


### PR DESCRIPTION
```
************* Module salt.states.alternatives
salt/states/alternatives.py:152: [W0622(redefined-builtin), set] Redefining built-in 'set'
```
