### PR TITLE
updates to puppet.py for additional examples, and a fixed comma in cmd.py

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -124,6 +124,7 @@ def run(*args, **kwargs):
 
         salt '*' puppet.run
         salt '*' puppet.run tags=basefiles::edit,apache::server
+        salt '*' puppet.run agent onetime no-daemonize no-usecacheonfailure no-splay ignorecache
         salt '*' puppet.run debug
         salt '*' puppet.run apply /a/b/manifest.pp modulepath=/a/b/modules tags=basefiles::edit,apache::server
     '''

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -660,7 +660,7 @@ def script(name,
                        'cwd': cwd,
                        'template': template,
                        'umask': umask,
-                       'timeout': timeout
+                       'timeout': timeout,
                        '__env__': __env__})
 
     run_check_cmd_kwargs = {


### PR DESCRIPTION
Updated puppet.py with an example that has more than one argument, also added missing comma on line 663 that was causing cmd.py to fail
