### PR TITLE
Adding an option to queue state commands instead of failing immediately

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -7,6 +7,7 @@ import os
 import json
 import copy
 import shutil
+import time
 import logging
 import tarfile
 import tempfile
@@ -60,6 +61,14 @@ def _check_pillar(kwargs):
     return True
 
 
+def _wait(jid):
+    """ Wait for all previously started state jobs to finish running """
+    states = _prior_running_states(jid)
+    while states:
+        time.sleep(1)
+        states = _prior_running_states(jid)
+
+
 def running():
     '''
     Return a dict of state return data if a state function is already running.
@@ -88,7 +97,21 @@ def running():
     return ret
 
 
-def low(data):
+def _prior_running_states(jid):
+    """
+    Return a list of dicts of prior calls to state functions.  This function is
+    used to queue state calls so only one is run at a time.
+    """
+
+    ret = []
+    active = __salt__['saltutil.is_running']('state.*')
+    for data in active:
+        if int(data['jid']) < int(jid):
+            ret.append(data)
+    return ret
+
+
+def low(data, queue=False, **kwargs):
     '''
     Execute a single low data call
     This function is mostly intended for testing the state system
@@ -99,10 +122,13 @@ def low(data):
 
         salt '*' state.low '{"state": "pkg", "fun": "installed", "name": "vi"}'
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.State(__opts__)
     err = st_.verify_data(data)
     if err:
@@ -116,7 +142,7 @@ def low(data):
     return ret
 
 
-def high(data):
+def high(data, queue=False, **kwargs):
     '''
     Execute the compound calls stored in a single set of high data
     This function is mostly intended for testing the state system
@@ -127,17 +153,20 @@ def high(data):
 
         salt '*' state.high '{"vim": {"pkg": ["installed"]}}'
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.State(__opts__)
     ret = st_.call_high(data)
     _set_retcode(ret)
     return ret
 
 
-def template(tem):
+def template(tem, queue=False, **kwargs):
     '''
     Execute the information stored in a template file on the minion
 
@@ -147,17 +176,20 @@ def template(tem):
 
         salt '*' state.template '<Path to template on the minion>'
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.State(__opts__)
     ret = st_.call_template(tem)
     _set_retcode(ret)
     return ret
 
 
-def template_str(tem):
+def template_str(tem, queue=False, **kwargs):
     '''
     Execute the information stored in a string from an sls template
 
@@ -167,17 +199,20 @@ def template_str(tem):
 
         salt '*' state.template_str '<Template String>'
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.State(__opts__)
     ret = st_.call_template_str(tem)
     _set_retcode(ret)
     return ret
 
 
-def highstate(test=None, **kwargs):
+def highstate(test=None, queue=False, **kwargs):
     '''
     Retrieve the state data from the salt master for this minion and execute it
 
@@ -190,10 +225,13 @@ def highstate(test=None, **kwargs):
         salt '*' state.highstate exclude=sls_to_exclude
         salt '*' state.highstate exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     if not _check_pillar(kwargs):
         __context__['retcode'] = 5
         err = ['Pillar failed to render with the following messages:']
@@ -242,7 +280,7 @@ def highstate(test=None, **kwargs):
     return ret
 
 
-def sls(mods, env='base', test=None, exclude=None, **kwargs):
+def sls(mods, env='base', test=None, exclude=None, queue=False, **kwargs):
     '''
     Execute a set list of state modules from an environment, default
     environment is base
@@ -255,10 +293,13 @@ def sls(mods, env='base', test=None, exclude=None, **kwargs):
         salt '*' state.sls core exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"
     '''
 
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     if not _check_pillar(kwargs):
         __context__['retcode'] = 5
         err = ['Pillar failed to render with the following messages:']
@@ -329,7 +370,7 @@ def sls(mods, env='base', test=None, exclude=None, **kwargs):
     return ret
 
 
-def top(topfn, test=None, **kwargs):
+def top(topfn, test=None, queue=False, **kwargs):
     '''
     Execute a specific top file instead of the default
 
@@ -341,10 +382,13 @@ def top(topfn, test=None, **kwargs):
         salt '*' state.top reverse_top.sls exclude=sls_to_exclude
         salt '*' state.top reverse_top.sls exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     if not _check_pillar(kwargs):
         __context__['retcode'] = 5
         err = ['Pillar failed to render with the following messages:']
@@ -369,7 +413,7 @@ def top(topfn, test=None, **kwargs):
     return ret
 
 
-def show_highstate():
+def show_highstate(queue=False, **kwargs):
     '''
     Retrieve the highstate data from the salt master and display it
 
@@ -379,10 +423,13 @@ def show_highstate():
 
         salt '*' state.show_highstate
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.HighState(__opts__)
     st_.push_active()
     try:
@@ -394,7 +441,7 @@ def show_highstate():
     return ret
 
 
-def show_lowstate():
+def show_lowstate(queue=False, **kwargs):
     '''
     List out the low data that will be applied to this minion
 
@@ -404,10 +451,13 @@ def show_lowstate():
 
         salt '*' state.show_lowstate
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.HighState(__opts__)
     st_.push_active()
     try:
@@ -417,7 +467,7 @@ def show_lowstate():
     return ret
 
 
-def show_sls(mods, env='base', test=None, **kwargs):
+def show_sls(mods, env='base', test=None, queue=False, **kwargs):
     '''
     Display the state data from a specific sls or list of sls files on the
     master
@@ -428,10 +478,13 @@ def show_sls(mods, env='base', test=None, **kwargs):
 
         salt '*' state.show_sls core,edit.vim dev
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     opts = copy.copy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
@@ -452,7 +505,7 @@ def show_sls(mods, env='base', test=None, **kwargs):
     return high_
 
 
-def show_top():
+def show_top(queue=False, **kwargs):
     '''
     Return the top data that the minion will use for a highstate
 
@@ -462,10 +515,13 @@ def show_top():
 
         salt '*' state.show_top
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     st_ = salt.state.HighState(__opts__)
     errors = []
     top_ = st_.get_top()
@@ -491,7 +547,7 @@ def show_top():
 #    return st_.compile_master()
 
 
-def single(fun, name, test=None, **kwargs):
+def single(fun, name, test=None, queue=False, **kwargs):
     '''
     Execute a single state function with the named kwargs, returns False if
     insufficient data is sent to the command
@@ -508,10 +564,13 @@ def single(fun, name, test=None, **kwargs):
         salt '*' state.single pkg.installed name=vim
 
     '''
-    conflict = running()
-    if conflict:
-        __context__['retcode'] = 1
-        return conflict
+    if queue:
+        _wait(kwargs['__pub_jid'])
+    else:
+        conflict = running()
+        if conflict:
+            __context__['retcode'] = 1
+            return conflict
     comps = fun.split('.')
     if len(comps) < 2:
         __context__['retcode'] = 1


### PR DESCRIPTION
This pull request adds a feature to state commands. Currently any state command will fail if any other state command is already running. Now there is an option to add `queue=True` and the second state will wait for the first state instead of failing immediately.

This pull request came out of [this discussion on the mailing list](https://groups.google.com/forum/#!topic/salt-users/hXMtNLP6jwA)

The order the states are run in is determined by the jid. This could _potentially_ cause issues if there are state commands coming down from multiple masters whose clocks are not synced.
