### PR TITLE
Audit module documentation (X to Z + new mac modules)

### DIFF
--- a/salt/modules/mac_group.py
+++ b/salt/modules/mac_group.py
@@ -29,7 +29,9 @@ def add(name, gid=None, **kwargs):
     '''
     Add the specified group
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' group.add foo 3456
     '''
@@ -57,7 +59,9 @@ def delete(name):
     '''
     Remove the named group
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' group.delete foo
     '''
@@ -77,7 +81,9 @@ def info(name):
     '''
     Return information about a group
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' group.info foo
     '''
@@ -106,7 +112,9 @@ def getent(refresh=False):
     '''
     Return info on all groups
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' group.getent
     '''
@@ -125,7 +133,9 @@ def chgid(name, gid):
     '''
     Change the gid for a named group
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' group.chgid foo 4376
     '''

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -75,7 +75,9 @@ def add(name,
     '''
     Add a user to the minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.add name <uid> <gid> <groups> <home> <shell>
     '''
@@ -126,7 +128,9 @@ def delete(name, *args):
     '''
     Remove a user from the minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.delete foo
     '''
@@ -147,7 +151,9 @@ def getent():
     '''
     Return the list of all info for all users
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.getent
     '''
@@ -165,7 +171,9 @@ def chuid(name, uid):
     '''
     Change the uid for a named user
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.chuid foo 4376
     '''
@@ -190,7 +198,9 @@ def chgid(name, gid):
     '''
     Change the default group of the user
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.chgid foo 4376
     '''
@@ -217,7 +227,9 @@ def chshell(name, shell):
     '''
     Change the default shell of the user
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.chshell foo /bin/zsh
     '''
@@ -242,7 +254,9 @@ def chhome(name, home):
     '''
     Change the home directory of the user
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.chhome foo /Users/foo
     '''
@@ -267,7 +281,9 @@ def chfullname(name, fullname):
     '''
     Change the user's Full Name
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.chfullname foo 'Foo Bar'
     '''
@@ -304,7 +320,9 @@ def chgroups(name, groups, append=False):
         Instead of removing user from groups not included in the ``groups``
         parameter, just add user to any groups for which they are not members
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.chgroups foo wheel,root
     '''
@@ -349,7 +367,9 @@ def info(name):
     '''
     Return user information
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.info root
     '''
@@ -378,7 +398,9 @@ def list_groups(name):
     '''
     Return a list of groups the named user belongs to
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.list_groups foo
     '''
@@ -406,7 +428,9 @@ def list_users():
     '''
     Return a list of all users
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' user.list_users
     '''

--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -169,7 +169,9 @@ def list_vms():
     '''
     Return a list of virtual machine names on the minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.list_vms
     '''
@@ -191,7 +193,9 @@ def vm_info(vm_=None):
     If you pass a VM name in as an argument then it will return info
     for just the named VM, otherwise it will return all VMs.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.vm_info
     '''
@@ -232,7 +236,9 @@ def vm_state(vm_=None):
     If you pass a VM name in as an argument then it will return info
     for just the named VM, otherwise it will return all VMs.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.vm_state <vm name>
     '''
@@ -252,7 +258,9 @@ def node_info():
     '''
     Return a dict with information about this node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.node_info
     '''
@@ -335,7 +343,9 @@ def get_nics(vm_):
     '''
     Return info about the network interfaces of a named vm
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.get_nics <vm name>
     '''
@@ -360,7 +370,9 @@ def get_macs(vm_):
     '''
     Return a list off MAC addresses from the named vm
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.get_macs <vm name>
     '''
@@ -378,7 +390,9 @@ def get_disks(vm_):
     '''
     Return the disks of a named vm
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.get_disks <vm name>
     '''
@@ -409,7 +423,9 @@ def setmem(vm_, memory):
 
     Memory is to be specified in MB
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.setmem myvm 768
     '''
@@ -433,7 +449,9 @@ def setvcpus(vm_, vcpus):
 
     vcpus is an int representing the number to be assigned
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.setvcpus myvm 2
     '''
@@ -452,7 +470,9 @@ def vcpu_pin(vm_, vcpu, cpus):
     '''
     Set which CPUs a VCPU can use.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt 'foo' virt.vcpu_pin domU-id 2 1
         salt 'foo' virt.vcpu_pin domU-id 2 2-6
@@ -505,7 +525,9 @@ def freemem():
     Return an int representing the amount of memory that has not been given
     to virtual machines on this node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.freemem
     '''
@@ -517,7 +539,9 @@ def freecpu():
     Return an int representing the number of unallocated cpus on this
     hypervisor
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.freecpu
     '''
@@ -528,7 +552,9 @@ def full_info():
     '''
     Return the node_info, vm_info and freemem
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.full_info
     '''
@@ -539,7 +565,9 @@ def shutdown(vm_):
     '''
     Send a soft shutdown signal to the named vm
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.shutdown <vm name>
     '''
@@ -558,7 +586,9 @@ def pause(vm_):
     '''
     Pause the named vm
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.pause <vm name>
     '''
@@ -577,7 +607,9 @@ def resume(vm_):
     '''
     Resume the named vm
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.resume <vm name>
     '''
@@ -601,7 +633,9 @@ def create(config_):
     '''
     Start a defined domain
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.create <path to Xen cfg file>
     '''
@@ -612,7 +646,9 @@ def start(config_):
     '''
     Alias for the obscurely named 'create' function
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.start <path to Xen cfg file>
     '''
@@ -623,7 +659,9 @@ def reboot(vm_):
     '''
     Reboot a domain via ACPI request
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.reboot <vm name>
     '''
@@ -642,7 +680,9 @@ def reset(vm_):
     '''
     Reset a VM by emulating the reset button on a physical machine
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.reset <vm name>
     '''
@@ -662,16 +702,24 @@ def migrate(vm_, target,
     '''
     Migrates the virtual machine to another hypervisor
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.migrate <vm name> <target hypervisor> [live] [port] [node] [ssl] [change_home_server]
 
     Optional values:
-        - live, use live migration
-        - port, use a specified port
-        - node, use specified NUMA node on target
-        - ssl, use ssl connection for migration
-        - change_home_server, change home server for managed domains
+
+    live
+        Use live migration
+    port
+        Use a specified port
+    node
+        Use specified NUMA node on target
+    ssl
+        use ssl connection for migration
+    change_home_server
+        change home server for managed domains
     '''
     with _get_xapi_session() as xapi:
         vm_uuid = _get_label_uuid(xapi, 'VM', vm_)
@@ -695,7 +743,9 @@ def destroy(vm_):
     Hard power down the virtual machine, this is equivalent to pulling the
     power
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.destroy <vm name>
     '''
@@ -714,7 +764,9 @@ def is_hyper():
     '''
     Returns a bool whether or not this node is a hypervisor of any kind
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.is_hyper
     '''
@@ -736,7 +788,9 @@ def is_hyper():
 def vm_cputime(vm_=None):
     '''
     Return cputime used by the vms on this hyper in a
-    list of dicts::
+    list of dicts:
+
+    .. code-block:: python
 
         [
             'your-vm': {
@@ -749,7 +803,9 @@ def vm_cputime(vm_=None):
     If you pass a VM name in as an argument then it will return info
     for just the named VM, otherwise it will return all VMs.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.vm_cputime
     '''
@@ -782,7 +838,9 @@ def vm_cputime(vm_=None):
 def vm_netstats(vm_=None):
     '''
     Return combined network counters used by the vms on this hyper in a
-    list of dicts::
+    list of dicts:
+
+    .. code-block:: python
 
         [
             'your-vm': {
@@ -797,7 +855,9 @@ def vm_netstats(vm_=None):
     If you pass a VM name in as an argument then it will return info
     for just the named VM, otherwise it will return all VMs.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.vm_netstats
     '''
@@ -827,7 +887,9 @@ def vm_netstats(vm_=None):
 def vm_diskstats(vm_=None):
     '''
     Return disk usage counters used by the vms on this hyper in a
-    list of dicts::
+    list of dicts:
+
+    .. code-block:: python
 
         [
             'your-vm': {
@@ -840,7 +902,9 @@ def vm_diskstats(vm_=None):
     If you pass a VM name in as an argument then it will return info
     for just the named VM, otherwise it will return all VMs.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.vm_diskstats
     '''

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -139,7 +139,9 @@ def list_upgrades(refresh=True):
     '''
     Check whether or not an upgrade is available for all packages
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_upgrades
     '''
@@ -207,7 +209,9 @@ def latest_version(*names, **kwargs):
 
     A specific repo can be requested using the ``fromrepo`` keyword argument.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package name> fromrepo=epel-testing
@@ -261,7 +265,9 @@ def upgrade_available(name):
     '''
     Check whether or not an upgrade is available for a given package
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade_available <package name>
     '''
@@ -274,7 +280,9 @@ def version(*names, **kwargs):
     installed. If more than one package name is specified, a dict of
     name/version pairs is returned.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
@@ -288,7 +296,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
         {'<package_name>': '<version>'}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_pkgs
     '''
@@ -373,7 +383,9 @@ def refresh_db():
     Since yum refreshes the database automatically, this runs a yum clean,
     so that the next yum operation will have a clean database
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.refresh_db
     '''
@@ -386,7 +398,9 @@ def clean_metadata():
     '''
     Cleans local yum metadata.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.clean_metadata
     '''
@@ -411,7 +425,9 @@ def group_install(name=None,
     groups
         The names of multiple packages which are to be installed.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
 
             salt '*' pkg.group_install groups='["Group 1", "Group 2"]'
 
@@ -420,7 +436,9 @@ def group_install(name=None,
         installed by the package group ("default" packages), which should not
         be installed.
 
-        CLI Examples::
+        CLI Examples:
+
+        .. code-block:: bash
 
             salt '*' pkg.group_install 'My Group' skip='["foo", "bar"]'
 
@@ -430,7 +448,9 @@ def group_install(name=None,
         this will nor enforce group membership; if you include packages which
         are not members of the specified groups, they will still be installed.
 
-        CLI Examples::
+        CLI Examples:
+
+        .. code-block:: bash
 
             salt '*' pkg.group_install 'My Group' include='["foo", "bar"]'
 
@@ -489,7 +509,9 @@ def install(name=None,
         architecture designation (``.i686``, ``.i586``, etc.) to the end of the
         package name.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
             salt '*' pkg.install <package name>
 
     refresh
@@ -526,7 +548,10 @@ def install(name=None,
         by using a single-element dict representing the package and its
         version.
 
-        CLI Examples::
+        CLI Examples:
+
+        .. code-block:: bash
+
             salt '*' pkg.install pkgs='["foo", "bar"]'
             salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-4.el6"}]'
 
@@ -535,7 +560,10 @@ def install(name=None,
         with the keys being package names, and the values being the source URI
         or local path to the package.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install sources='[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
 
 
@@ -639,7 +667,9 @@ def upgrade(refresh=True):
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade
     '''
@@ -690,7 +720,9 @@ def remove(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove <package1>,<package2>,<package3>
@@ -754,7 +786,9 @@ def purge(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.purge <package name>
         salt '*' pkg.purge <package1>,<package2>,<package3>
@@ -767,7 +801,9 @@ def verify(*package):
     '''
     Runs an rpm -Va on a system, and returns the results in a dict
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.verify
     '''
@@ -778,7 +814,9 @@ def group_list():
     '''
     Lists all groups known by yum on this system
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.group_list
     '''
@@ -801,7 +839,9 @@ def group_info(groupname):
     '''
     Lists packages belonging to a certain group
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.group_info 'Perl Support'
     '''
@@ -820,7 +860,9 @@ def group_diff(groupname):
     '''
     Lists packages belonging to a certain group, and which are installed
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.group_diff 'Perl Support'
     '''
@@ -862,7 +904,9 @@ def list_repos(basedir='/etc/yum.repos.d'):
     '''
     Lists all repos in <basedir> (default: /etc/yum.repos.d/).
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_repos
     '''
@@ -883,7 +927,9 @@ def get_repo(repo, basedir='/etc/yum.repos.d', **kwargs):
     '''
     Display a repo from <basedir> (default basedir: /etc/yum.repos.d).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.get_repo myrepo
         salt '*' pkg.get_repo myrepo basedir=/path/to/dir
@@ -910,7 +956,9 @@ def del_repo(repo, basedir='/etc/yum.repos.d', **kwargs):
     If the .repo file that the repo exists in does not contain any other repo
     configuration, the file itself will be deleted.
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.del_repo myrepo
         salt '*' pkg.del_repo myrepo basedir=/path/to/dir
@@ -965,17 +1013,23 @@ def del_repo(repo, basedir='/etc/yum.repos.d', **kwargs):
 def mod_repo(repo, basedir=None, **kwargs):
     '''
     Modify one or more values for a repo. If the repo does not exist, it will
-    be created, so long as the following values are specified::
+    be created, so long as the following values are specified:
 
-        repo (name by which the yum refers to the repo)
-        name (a human-readable name for the repo)
-        baseurl or mirrorlist (the URL for yum to reference)
+    repo
+        name by which the yum refers to the repo
+    name
+        a human-readable name for the repo
+    baseurl
+    mirrorlist
+        the URL for yum to reference
 
     Key/Value pairs may also be removed from a repo's configuration by setting
     a key to a blank value. Bear in mind that a name cannot be deleted, and a
     baseurl can only be deleted if a mirrorlist is specified (or vice versa).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.mod_repo reponame enabled=1 gpgcheck=1
         salt '*' pkg.mod_repo reponame basedir=/path/to/dir enabled=1
@@ -1095,7 +1149,9 @@ def file_list(*packages):
     return a list of _every_ file on the system's rpm database (not generally
     recommended).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.file_list httpd
         salt '*' pkg.file_list httpd postfix
@@ -1110,7 +1166,9 @@ def file_dict(*packages):
     specifying any packages will return a list of _every_ file on the system's
     rpm database (not generally recommended).
 
-    CLI Examples::
+    CLI Examples:
+
+    .. code-block:: bash
 
         salt '*' pkg.file_list httpd
         salt '*' pkg.file_list httpd postfix

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -151,7 +151,9 @@ def latest_version(*names, **kwargs):
 
     A specific repo can be requested using the ``fromrepo`` keyword argument.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package name> fromrepo=epel-testing
@@ -194,7 +196,9 @@ def upgrade_available(name):
     '''
     Check whether or not an upgrade is available for a given package
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade_available <package name>
     '''
@@ -207,7 +211,9 @@ def version(*names, **kwargs):
     installed. If more than one package name is specified, a dict of
     name/version pairs is returned.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
@@ -221,7 +227,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
         {'<package_name>': '<version>'}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_pkgs
     '''
@@ -257,7 +265,9 @@ def list_upgrades(refresh=True, **kwargs):
     '''
     Check whether or not an upgrade is available for all packages
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_upgrades
     '''
@@ -318,7 +328,9 @@ def refresh_db():
     Since yum refreshes the database automatically, this runs a yum clean,
     so that the next yum operation will have a clean database
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.refresh_db
     '''
@@ -349,7 +361,10 @@ def install(name=None,
         architecture designation (``.i686``, ``.i586``, etc.) to the end of the
         package name.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install <package name>
 
     refresh
@@ -386,7 +401,10 @@ def install(name=None,
         by using a single-element dict representing the package and its
         version.
 
-        CLI Examples::
+        CLI Examples:
+
+        .. code-block:: bash
+
             salt '*' pkg.install pkgs='["foo", "bar"]'
             salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-4.el5"}]'
 
@@ -395,7 +413,10 @@ def install(name=None,
         with the keys being package names, and the values being the source URI
         or local path to the package.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install sources='[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
 
 
@@ -484,7 +505,9 @@ def upgrade(refresh=True):
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade
     '''
@@ -517,7 +540,9 @@ def remove(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove <package1>,<package2>,<package3>
@@ -555,7 +580,9 @@ def purge(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.purge <package name>
         salt '*' pkg.purge <package1>,<package2>,<package3>

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -73,10 +73,12 @@ def __virtual__():
         return 'zfs'
     return False
 
+
 def _add_doc(func, doc, prefix='\n\n    '):
     if not func.__doc__:
         func.__doc__ = ''
     func.__doc__ += '{0}{1}'.format(prefix, doc)
+
 
 def _make_function(cmd_name, doc):
     '''
@@ -107,7 +109,7 @@ def _make_function(cmd_name, doc):
 
     _add_doc(_cmd, 'This function is dynamically generated.', '\n    ')
     _add_doc(_cmd, doc)
-    _add_doc(_cmd, '\n    CLI Example::\n')
+    _add_doc(_cmd, '\n    CLI Example:\n\n')
     _add_doc(_cmd, '\n        salt \'*\' zfs.{0} <args>'.format(cmd_name))
 
     # At this point return the function we've just defined.

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -42,7 +42,9 @@ def status(name=''):
     '''
     Return the status of the named zpool
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.status
     '''
@@ -56,7 +58,9 @@ def iostat(name=''):
     '''
     Display I/O statistics for the given pools
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.iostat
     '''
@@ -70,7 +74,9 @@ def zpool_list():
     '''
     Return a list of all pools in the system with health status and space usage
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.zpool_list
     '''
@@ -84,7 +90,9 @@ def exists(pool_name):
     '''
     Check if a ZFS storage pool is active
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.exists myzpool
     '''
@@ -99,7 +107,9 @@ def destroy(pool_name):
     '''
     Destroys a storage pool
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.destroy myzpool
     '''
@@ -119,7 +129,9 @@ def scrub(pool_name=None):
     '''
     Begin a scrub
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.scrub myzpool
     '''
@@ -141,7 +153,9 @@ def create(pool_name, *vdevs):
     '''
     Create a new storage pool
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.create myzpool /path/to/vdev1 [/path/to/vdev2] [...]
     '''
@@ -183,7 +197,9 @@ def add(pool_name, vdev):
     '''
     Add the specified vdev to the given pool
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.add myzpool /path/to/vdev
     '''
@@ -214,7 +230,9 @@ def replace(pool_name, old, new):
     '''
     Replaces old device with new device.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.replace myzpool /path/to/vdev1 /path/to/vdev2
     '''
@@ -253,7 +271,9 @@ def create_file_vdev(size, *vdevs):
 
     ``*vdevs`` is a list of full paths for mkfile to create
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' zpool.create_file_vdev 7g /path/to/vdev1 [/path/to/vdev2] [...]
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -29,7 +29,9 @@ def list_upgrades(refresh=True):
     '''
     List all available package upgrades on this system
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_upgrades
     '''
@@ -64,7 +66,9 @@ def latest_version(*names, **kwargs):
     If the latest version of a given package is already installed, an empty
     string will be returned for that package.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.latest_version <package name>
         salt '*' pkg.latest_version <package1> <package2> <package3> ...
@@ -120,7 +124,9 @@ def upgrade_available(name):
     '''
     Check whether or not an upgrade is available for a given package
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade_available <package name>
     '''
@@ -133,7 +139,9 @@ def version(*names, **kwargs):
     installed. If more than one package name is specified, a dict of
     name/version pairs is returned.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
@@ -147,7 +155,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
         {'<package_name>': '<version>'}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.list_pkgs
     '''
@@ -185,7 +195,9 @@ def refresh_db():
 
         {'<database name>': Bool}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.refresh_db
     '''
@@ -222,7 +234,10 @@ def install(name=None,
         software repository. To install a package file manually, use the
         "sources" option.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install <package name>
 
     refresh
@@ -243,7 +258,10 @@ def install(name=None,
         version. As with the ``version`` parameter above, comparison operators
         can be used to target a specific version of a package.
 
-        CLI Examples::
+        CLI Examples:
+
+        .. code-block:: bash
+
             salt '*' pkg.install pkgs='["foo", "bar"]'
             salt '*' pkg.install pkgs='["foo", {"bar": "1.2.3-4"}]'
             salt '*' pkg.install pkgs='["foo", {"bar": "<1.2.3-4"}]'
@@ -253,7 +271,10 @@ def install(name=None,
         with the keys being package names, and the values being the source URI
         or local path to the package.
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
+
             salt '*' pkg.install sources='[{"foo": "salt://foo.rpm"},{"bar": "salt://bar.rpm"}]'
 
 
@@ -336,7 +357,9 @@ def upgrade(refresh=True):
         {'<package>': {'old': '<old-version>',
                        'new': '<new-version>'}}
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.upgrade
     '''
@@ -387,7 +410,9 @@ def remove(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.remove <package name>
         salt '*' pkg.remove <package1>,<package2>,<package3>
@@ -416,7 +441,9 @@ def purge(name=None, pkgs=None, **kwargs):
 
     Returns a dict containing the changes.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' pkg.purge <package name>
         salt '*' pkg.purge <package1>,<package2>,<package3>


### PR DESCRIPTION
This commit completes the work started in 7d4739d, putting CLI examples
in bash code-blocks to give them syntax highlighting on
docs.saltstack.com. Combined with 5094719, this both improves the
documentation on the website, as well as the messages seen when using
sys.doc.
