### PR TITLE
Fix docstring in alternatives module

### DIFF
--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -1,14 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
-    salt.modules.alternatives
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+Support for Alternatives system
 
-    Support for Alternatives system
-
-    :codeauthor: Radek Rada <radek.rada@gmail.com>
-    :copyright: © 2012 by the SaltStack Team, see AUTHORS for more details.
-    :license: Apache 2.0, see LICENSE for more details.
-
+:codeauthor: Radek Rada <radek.rada@gmail.com>
+:copyright: © 2012 by the SaltStack Team, see AUTHORS for more details.
+:license: Apache 2.0, see LICENSE for more details.
 '''
 
 # Import python libs

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -1,6 +1,5 @@
 '''
-Service support for Debian systems - uses update-rc.d and service to modify the
-system
+Service support for Debian systems (uses update-rc.d and /sbin/service)
 '''
 
 # Import python libs

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -1,7 +1,5 @@
 '''
-Support for eselect_, Gentoo's configuration and management tool.
-
-.. _eselect: http://wiki.gentoo.org/wiki/Project:Eselect/User_guide
+Support for eselect, Gentoo's configuration and management tool.
 '''
 
 # Import salt libs

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -1,7 +1,7 @@
 '''
-.. _eselect: http://wiki.gentoo.org/wiki/Project:Eselect/User_guide
-
 Support for eselect_, Gentoo's configuration and management tool.
+
+.. _eselect: http://wiki.gentoo.org/wiki/Project:Eselect/User_guide
 '''
 
 # Import salt libs

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -1,6 +1,5 @@
 '''
-Top level package command wrapper, used to translate the os detected by the
-grains to the correct service manager
+Top level package command wrapper, used to translate the os detected by grains to the correct service manager
 '''
 
 

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -1,6 +1,5 @@
 '''
-The match module allows for match routines to be run and determine target
-specs.
+The match module allows for match routines to be run and determine target specs
 '''
 
 # Import python libs

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -1,6 +1,5 @@
 '''
-The function cache system allows for data to be stored on the master so it
-can be easily read by other minions
+The function cache system allows for data to be stored on the master so it can be easily read by other minions
 '''
 
 # Import python libs

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -1,5 +1,5 @@
 '''
-Package support for pkgin based systems, inspired from freebsdpkg.py
+Package support for pkgin based systems, inspired from freebsdpkg module
 '''
 
 # Import python libs

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -1,3 +1,7 @@
+'''
+Configure ``portage(5)``
+'''
+
 # Import python libs
 import os
 import shutil

--- a/salt/modules/ret.py
+++ b/salt/modules/ret.py
@@ -1,6 +1,5 @@
 '''
-Module to integrate with the returner system and retrieve data sent to a salt
-returner.
+Module to integrate with the returner system and retrieve data sent to a salt returner
 '''
 
 # Import salt libs

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -1,7 +1,5 @@
 '''
-Service support for RHEL-based systems. This interface uses the service and
-chkconfig commands, and for upstart support uses helper functions from the
-upstart module, as well as the ``start``, ``stop``, and ``status`` commands.
+Service support for RHEL-based systems, including support for both upstart and sysvinit
 '''
 
 # Import python libs

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1,6 +1,5 @@
 '''
-The Saltutil module is used to manage the state of the salt minion itself. It
-is used to manage minion modules as well as automate updates to the salt minion
+The Saltutil module is used to manage the state of the salt minion itself. It is used to manage minion modules as well as automate updates to the salt minion.
 
 :depends:   - esky Python module for update functionality
 '''

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -1,6 +1,5 @@
 '''
-The sys module provides information about the available functions on the
-minion.
+The sys module provides information about the available functions on the minion
 '''
 
 # Import python libs


### PR DESCRIPTION
This makes the autosummary in http://docs.saltstack.com/ref/modules/all/
have a proper summary text. Resolves #7250. Also resolves #7249.
