### PR TITLE
Correct docstring for salt.modules.dnsutil.hosts_remove

### DIFF
--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -89,8 +89,8 @@ def hosts_remove(hostsfile='/etc/hosts', entries=None):
 
     .. code-block:: bash
 
-        salt '*' dnsutil.hosts_delete /etc/hosts ad1.yuk.co
-        salt '*' dnsutil.hosts_delete /etc/hosts ad2.yuk.co,ad1.yuk.co
+        salt '*' dnsutil.hosts_remove /etc/hosts ad1.yuk.co
+        salt '*' dnsutil.hosts_remove /etc/hosts ad2.yuk.co,ad1.yuk.co
     '''
     with salt.utils.fopen(hostsfile, 'r') as fp_:
         hosts = fp_.read()


### PR DESCRIPTION
It looks like this function might have changed names at one point and
the docstring was never updated, or the docstring was just incorrect to
begin. This fixes CLI example to match the correct function name.

Resolves #7255.
