### PR TITLE
fileserver/gitfs.py: rm trailing whitespace

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -320,7 +320,7 @@ def file_hash(load, fnd):
     if __opts__['gitfs_root']:
         relpath = os.path.join(__opts__['gitfs_root'], relpath)
         path = os.path.join(__opts__['gitfs_root'], path)
-    
+
     hashdest = os.path.join(__opts__['cachedir'],
                             'gitfs/hash',
                             short,


### PR DESCRIPTION
```
salt/fileserver/gitfs.py:323: [C0303(trailing-whitespace), ] Trailing whitespace
```
