### PR TITLE
have modjk.workers() honor `profile` arg

### DIFF
--- a/salt/modules/modjk.py
+++ b/salt/modules/modjk.py
@@ -203,7 +203,7 @@ def workers(profile='default'):
         salt '*' modjk.workers other-profile
     '''
 
-    config = get_running()
+    config = get_running(profile)
     lbn = config['worker.list'].split(',')
     worker_list = []
     ret = {}


### PR DESCRIPTION
```
salt/modules/modjk.py:194: [W0613(unused-argument), workers] Unused argument 'profile'
```
