### PR TITLE
Non existent key in data store returns key error when using data.getval

### DIFF
--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -105,7 +105,8 @@ def getval(key):
         salt '*' data.getval <key>
     '''
     store = load()
-    return store[key]
+    if key in store:
+      return store[key]
 
 
 def getvals(*keys):


### PR DESCRIPTION
Check if the key exists before returning, if the key does not exist, getval will return None instead of a key error.
