### PR TITLE
Set pub_hwm to 1000 by default, Fix #7211

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -247,7 +247,7 @@ DEFAULT_MINION_OPTS = {
 DEFAULT_MASTER_OPTS = {
     'interface': '0.0.0.0',
     'publish_port': '4505',
-    'pub_hwm': 1,
+    'pub_hwm': 1000,
     'auth_mode': 1,
     'user': 'root',
     'worker_threads': 5,


### PR DESCRIPTION
@thatch45 should probably be the one to merge this.

@olliewalsh pointed out in #7211 that a HWM of 1 means that you can't have any pubs queued on the wire, which is a problem for concurrent CLI clients or salt API.  We obviously don't want no HWM, but it makes sense to default this a little higher than 1, unless I'm missing something.
