### PR TITLE
Clear minion cache data on master

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -940,6 +940,26 @@ class AESFuncs(object):
                 fp_.write(self.serial.dumps(load['data']))
         return True
 
+    def _mine_flush(self, load):
+        '''
+        Allow the minion to delete all of its own mine contents
+        '''
+        if 'id' not in load:
+            return False
+        if not salt.utils.verify.valid_id(self.opts, load['id']):
+            return False
+        if self.opts.get('minion_data_cache', False) or self.opts.get('enforce_mine_cache', False):
+            cdir = os.path.join(self.opts['cachedir'], 'minions', load['id'])
+            if not os.path.isdir(cdir):
+                return True
+            datap = os.path.join(cdir, 'mine.p')
+            if os.path.isfile(datap):
+                try:
+                    os.remove(datap)
+                except OSError:
+                    return False
+        return True
+
     def _file_recv(self, load):
         '''
         Allows minions to send files to the master, files are sent to the

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -154,3 +154,23 @@ def get(tgt, fun, expr_form='glob'):
     sreq = salt.payload.SREQ(__opts__['master_uri'])
     ret = sreq.send('aes', auth.crypticle.dumps(load))
     return auth.crypticle.loads(ret)
+
+
+def flush():
+    '''
+    Remove all mine contents of minion. Returns True on success.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mine.flush
+    '''
+    auth = _auth()
+    load = {
+            'cmd': '_mine_flush',
+            'id': __opts__['id'],
+    }
+    sreq = salt.payload.SREQ(__opts__['master_uri'])
+    ret = sreq.send('aes', auth.crypticle.dumps(load))
+    return auth.crypticle.loads(ret)

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -73,3 +73,52 @@ def pillar(tgt=None, expr_form='glob', **kwargs):
     cached_pillar = pillar_util.get_minion_pillar()
     salt.output.display_output(cached_pillar, None, __opts__)
     return cached_pillar
+
+
+def _clear_cache(tgt=None,
+                 expr_form='glob',
+                 clear_pillar=False,
+                 clear_grains=False,
+                 clear_mine=False):
+    '''
+    Clear the cached data/files for the targeted minions.
+    '''
+    if tgt is None:
+        return False
+    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
+                                            use_cached_grains=True,
+                                            grains_fallback=False,
+                                            use_cached_pillar=True,
+                                            pillar_fallback=False,
+                                            opts=__opts__)
+    return pillar_util.clear_cached_minion_data(clear_pillar=clear_pillar,
+                                                clear_grains=clear_grains,
+                                                clear_mine=clear_mine)
+
+def clear_pillar(tgt, expr_form='glob'):
+    '''
+    Clear the cached pillar data of the targeted minions
+    '''
+    return _clear_cache(tgt, expr_form, clear_pillar=True)
+
+def clear_grains(tgt=None, expr_form='glob'):
+    '''
+    Clear the cached grains data of the targeted minions
+    '''
+    return _clear_cache(tgt, expr_form, clear_grains=True)
+
+def clear_mine(tgt=None, expr_form='glob'):
+    '''
+    Clear the cached mine data of the targeted minions
+    '''
+    return _clear_cache(tgt, expr_form, clear_mine=True)
+
+def clear_all(tgt=None, expr_form='glob'):
+    '''
+    Clear the cached pillar, grains, and mine data of the targeted minions
+    '''
+    return _clear_cache(tgt,
+                        expr_form,
+                        clear_pillar=True,
+                        clear_grains=True,
+                        clear_mine=True)

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -98,24 +98,48 @@ def _clear_cache(tgt=None,
 def clear_pillar(tgt, expr_form='glob'):
     '''
     Clear the cached pillar data of the targeted minions
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.clear_pillar
     '''
     return _clear_cache(tgt, expr_form, clear_pillar=True)
 
 def clear_grains(tgt=None, expr_form='glob'):
     '''
     Clear the cached grains data of the targeted minions
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.clear_grains
     '''
     return _clear_cache(tgt, expr_form, clear_grains=True)
 
 def clear_mine(tgt=None, expr_form='glob'):
     '''
     Clear the cached mine data of the targeted minions
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.clear_mine
     '''
     return _clear_cache(tgt, expr_form, clear_mine=True)
 
 def clear_all(tgt=None, expr_form='glob'):
     '''
     Clear the cached pillar, grains, and mine data of the targeted minions
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.clear_all
     '''
     return _clear_cache(tgt,
                         expr_form,

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -11,11 +11,6 @@
 import os
 import logging
 
-# As of 2013/8/15:
-# Import inspect for sole purpose of determining if salt.utils.valid_id
-# takes one or two args. git develop it takes two, in 16.3 it takes one
-import inspect
-
 # Import salt libs
 import salt.log
 import salt.client
@@ -87,17 +82,10 @@ class MasterPillarUtil(object):
             return grains, pillars
         serial = salt.payload.Serial(self.opts)
         mdir = os.path.join(self.opts['cachedir'], 'minions')
-        # salt.utils.verify.valid_id has changed in git development to require opts arg
-        valid_id_args = inspect.getargspec(salt.utils.verify.valid_id).args
-        log.debug('salt.utils.verify.valid_id accepts args: {0}'.format(valid_id_args))
         try:
             for minion_id in minion_ids:
-                if 'opts' in valid_id_args:
-                    if not salt.utils.verify.valid_id(self.opts, minion_id):
-                        continue
-                else:
-                    if not salt.utils.verify.valid_id(self.opts, minion_id):
-                        continue
+                if not salt.utils.verify.valid_id(self.opts, minion_id):
+                    continue
                 path = os.path.join(mdir, minion_id, 'data.p')
                 if os.path.isfile(path):
                     with salt.utils.fopen(path) as fp_:


### PR DESCRIPTION
Add functions for clearing cached minion pillar, grains, and mine data on the master. Also add functions to the cache.py runner.
