### PR TITLE
Added ignored context manager with usage examples

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -13,6 +13,7 @@ import salt.crypt
 import salt.utils
 import salt.utils.event
 from salt.utils.event import tagify
+from salt.utils.contextmanagers import ignored
 
 class KeyCLI(object):
     '''
@@ -390,7 +391,7 @@ class Key(object):
         matches = self.name_match(match)
         if 'minions_pre' in matches:
             for key in matches['minions_pre']:
-                try:
+                with ignored(IOError, OSError):
                     shutil.move(
                             os.path.join(
                                 self.opts['pki_dir'],
@@ -405,8 +406,6 @@ class Key(object):
                              'act': 'accept',
                              'id': key}
                     self.event.fire_event(eload, tagify(prefix='key'))
-                except (IOError, OSError):
-                    pass
         return self.name_match(match)
 
     def accept_all(self):
@@ -415,7 +414,7 @@ class Key(object):
         '''
         keys = self.list_keys()
         for key in keys['minions_pre']:
-            try:
+            with ignored(IOError, OSError):
                 shutil.move(
                         os.path.join(
                             self.opts['pki_dir'],
@@ -430,8 +429,6 @@ class Key(object):
                          'act': 'accept',
                          'id': key}
                 self.event.fire_event(eload, tagify(prefix='key'))
-            except (IOError, OSError):
-                pass
         return self.list_keys()
 
     def delete_key(self, match):
@@ -440,14 +437,12 @@ class Key(object):
         '''
         for status, keys in self.name_match(match).items():
             for key in keys:
-                try:
+                with ignored(OSError, IOError):
                     os.remove(os.path.join(self.opts['pki_dir'], status, key))
                     eload = {'result': True,
                              'act': 'delete',
                              'id': key}
                     self.event.fire_event(eload, tagify(prefix='key'))
-                except (OSError, IOError):
-                    pass
         self.check_minion_cache()
         salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
@@ -458,14 +453,12 @@ class Key(object):
         '''
         for status, keys in self.list_keys().items():
             for key in keys:
-                try:
+                with ignored(OSError, IOError):
                     os.remove(os.path.join(self.opts['pki_dir'], status, key))
                     eload = {'result': True,
                              'act': 'delete',
                              'id': key}
                     self.event.fire_event(eload, tagify(prefix='key'))
-                except (OSError, IOError):
-                    pass
         self.check_minion_cache()
         salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
@@ -477,7 +470,7 @@ class Key(object):
         matches = self.name_match(match)
         if 'minions_pre' in matches:
             for key in matches['minions_pre']:
-                try:
+                with ignored(IOError, OSError):
                     shutil.move(
                             os.path.join(
                                 self.opts['pki_dir'],
@@ -492,8 +485,6 @@ class Key(object):
                              'act': 'reject',
                              'id': key}
                     self.event.fire_event(eload, tagify(prefix='key'))
-                except (IOError, OSError):
-                    pass
         self.check_minion_cache()
         salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.name_match(match)
@@ -504,7 +495,7 @@ class Key(object):
         '''
         keys = self.list_keys()
         for key in keys['minions_pre']:
-            try:
+            with ignored(IOError, OSError):
                 shutil.move(
                         os.path.join(
                             self.opts['pki_dir'],
@@ -519,8 +510,6 @@ class Key(object):
                          'act': 'reject',
                          'id': key}
                 self.event.fire_event(eload, tagify(prefix='key'))
-            except (IOError, OSError):
-                pass
         self.check_minion_cache()
         salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()

--- a/salt/utils/contextmanagers.py
+++ b/salt/utils/contextmanagers.py
@@ -1,0 +1,21 @@
+'''
+Some useful context managers used by salt
+'''
+
+from contextlib import contextmanager
+
+
+# This context manager have been added to python3.4
+# Probably, it will be backported to python2
+@contextmanager
+def ignored(*exceptions):
+    '''
+    Context manager to ignore specified exceptions
+
+    with ignored(OSError):
+        os.remove(somefile)
+    '''
+    try:
+        yield
+    except exceptions:
+        pass


### PR DESCRIPTION
I think, this

```
with ignore(Exception1, Exception2):
    # some code
```

is way more readable than

```
try:
    # some code
except (Exception1, Exception2):
    pass
```

Especially when the nested block is huge.

I've also included two examples.

For more information you can read http://bugs.python.org/issue15806 this discussion.
