### PR TITLE
Change hardcoded padding numbers to M2Crypto's exposed constant

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -183,7 +183,7 @@ class Auth(object):
             pub = RSA.load_pub_key(
                 os.path.join(self.opts['pki_dir'], self.mpub)
             )
-            payload['load']['token'] = pub.public_encrypt(self.token, 4)
+            payload['load']['token'] = pub.public_encrypt(self.token, RSA.pkcs1_oaep_padding)
         except Exception:
             pass
         with salt.utils.fopen(tmp_pub, 'r') as fp_:
@@ -202,7 +202,7 @@ class Auth(object):
         '''
         log.debug('Decrypting the current master AES key')
         key = self.get_keys()
-        key_str = key.private_decrypt(payload['aes'], 4)
+        key_str = key.private_decrypt(payload['aes'], RSA.pkcs1_oaep_padding)
         if 'sig' in payload:
             m_path = os.path.join(self.opts['pki_dir'], self.mpub)
             if os.path.exists(m_path):
@@ -220,7 +220,7 @@ class Auth(object):
             return key_str.split('_|-')
         else:
             if 'token' in payload:
-                token = key.private_decrypt(payload['token'], 4)
+                token = key.private_decrypt(payload['token'], RSA.pkcs1_oaep_padding)
                 return key_str, token
             elif not master_pub:
                 return key_str, ''


### PR DESCRIPTION
As defined here:

https://github.com/eventbrite/m2crypto/blob/master/SWIG/_rsa.i#L27

https://github.com/openssl/openssl/blob/master/crypto/rsa/rsa.h#L297

In addition this line should use an explicit constant as well, but I wasn't able to track down what it stands for:

https://github.com/saltstack/salt/blob/develop/salt/crypt.py#L214
