### PR TITLE
properly pass along negate_match arg in file.sed state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1659,13 +1659,14 @@ def sed(name, before, after, limit='', backup='.bak', options='-r -e',
         slines = fp_.readlines()
 
     # should be ok now; perform the edit
-    retcode = __salt__['file.sed'](name,
-                                   before,
-                                   after,
-                                   limit,
-                                   backup,
-                                   options,
-                                   flags)['retcode']
+    retcode = __salt__['file.sed'](path=name,
+                                   before=before,
+                                   after=after,
+                                   limit=limit,
+                                   backup=backup,
+                                   options=options,
+                                   flags=flags,
+                                   negate_match=negate_match)['retcode']
 
     if retcode != 0:
         ret['result'] = False


### PR DESCRIPTION
Fixes pylint warning:

```
salt/states/file.py:1582: [W0613(unused-argument), sed] Unused argument 'negate_match'
```

Fixup for 487203d60e90edaf784ed7b4219186fd728a5b44.
Also, switches to using keyword arguments due to large number of arguments involved.
