### PR TITLE
Adding versionadd's for salt cli ref and salt.states.file 

### DIFF
--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -44,6 +44,8 @@ Options
 
 .. option:: --state-output=STATE_OUTPUT
 
+    .. versionadded:: 0.17
+    
     Override the configured state_output value for minion output.  Default: 
     full
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -920,6 +920,8 @@ def managed(name,
         file of any kind.  Ignores hashes and does not use a templating engine.
 
     contents_pillar
+        .. versionadded:: 0.17
+        
         Operates like ``contents``, but draws from a value stored in pillar,
         using the pillar path syntax used in :mod:`pillar.get
         <salt.modules.pillar.get>`. This is useful when the pillar value


### PR DESCRIPTION
Making note of some new 0.17 features in the docs so to not confuse people who are still on 0.16
