### PR TITLE
Require aesfunc tokens

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -182,6 +182,22 @@
 # security purposes.
 #file_recv: False 
 
+# Require all minions to include a signed token for all commands sent to the
+# master. This enforces verification of the minion id on the master when
+# the master receives a command or return from a minion.
+# All minions will be required to provide signed tokens in 0.20.
+# See http://docs.saltstack.com/topics/releases/0.17.0.html for more info
+#
+# If set to True, all minions MUST be upgraded to version 0.17 or they will
+# not be able to send returns and certain commands to the master.
+# If set to False, allow minions older than 0.17 to continue to work with
+# master. Default False
+#require_aes_tokens: False
+
+# Log the deprecation warnings if require_aes_tokens is False or
+# not set. Default True
+#log_aes_tokens_warning: True
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded

--- a/conf/master
+++ b/conf/master
@@ -192,11 +192,11 @@
 # not be able to send returns and certain commands to the master.
 # If set to False, allow minions older than 0.17 to continue to work with
 # master. Default False
-#require_aes_tokens: False
+#require_cmd_auth_tokens: False
 
-# Log the deprecation warnings if require_aes_tokens is False or
+# Log the deprecation warnings if require_cmd_auth_tokens is False or
 # not set. Default True
-#log_aes_tokens_warning: True
+#log_cmd_auth_tokens_warning: True
 
 #####    Master Module Management    #####
 ##########################################

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -597,6 +597,7 @@ class RemoteClient(Client):
     def __init__(self, opts):
         Client.__init__(self, opts)
         self.auth = salt.crypt.SAuth(opts)
+        self.aes_cmd_tok = self.auth.gen_token('salt')
         self.sreq = salt.payload.SREQ(self.opts['master_uri'])
 
     def get_file(self, path, dest='', makedirs=False, env='base', gzip=None):
@@ -623,7 +624,9 @@ class RemoteClient(Client):
         log.debug('Fetching file ** attempting ** \'{0}\''.format(path))
         d_tries = 0
         path = self._check_proto(path)
-        load = {'path': path,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'path': path,
                 'env': env,
                 'cmd': '_serve_file'}
         if gzip:
@@ -697,7 +700,9 @@ class RemoteClient(Client):
         '''
         List the files on the master
         '''
-        load = {'env': env,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'env': env,
                 'prefix': prefix,
                 'cmd': '_file_list'}
         try:
@@ -714,7 +719,9 @@ class RemoteClient(Client):
         '''
         List the empty dirs on the master
         '''
-        load = {'env': env,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'env': env,
                 'prefix': prefix,
                 'cmd': '_file_list_emptydirs'}
         try:
@@ -731,7 +738,9 @@ class RemoteClient(Client):
         '''
         List the dirs on the master
         '''
-        load = {'env': env,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'env': env,
                 'prefix': prefix,
                 'cmd': '_dir_list'}
         try:
@@ -762,7 +771,9 @@ class RemoteClient(Client):
                 ret['hsum'] = salt.utils.get_hash(path, form='md5', chunk_size=4096)
                 ret['hash_type'] = 'md5'
                 return ret
-        load = {'path': path,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'path': path,
                 'env': env,
                 'cmd': '_file_hash'}
         try:
@@ -779,7 +790,9 @@ class RemoteClient(Client):
         '''
         Return a list of the files in the file server's specified environment
         '''
-        load = {'env': env,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'env': env,
                 'cmd': '_file_list'}
         try:
             return self.auth.crypticle.loads(
@@ -795,7 +808,10 @@ class RemoteClient(Client):
         '''
         Return the master opts data
         '''
-        load = {'cmd': '_master_opts'}
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'cmd': '_master_opts'
+                }
         try:
             return self.auth.crypticle.loads(
                 self.sreq.send('aes',
@@ -813,6 +829,7 @@ class RemoteClient(Client):
         '''
         load = {'cmd': '_ext_nodes',
                 'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
                 'opts': self.opts}
         try:
             return self.auth.crypticle.loads(

--- a/salt/master.py
+++ b/salt/master.py
@@ -53,6 +53,8 @@ import salt.utils.gzip_util
 from salt.utils.debug import enable_sigusr1_handler
 from salt.exceptions import SaltMasterError, MasterExit
 from salt.utils.event import tagify
+from salt.utils.master import verify_minion_rsa_token
+from salt.utils import warn_until
 
 # Import halite libs
 try:
@@ -651,10 +653,44 @@ class MWorker(multiprocessing.Process):
             data = self.crypticle.loads(load)
         except Exception:
             return ''
-        if 'cmd' not in data:
-            log.error('Received malformed command {0}'.format(data))
-            return {}
-        log.info('AES payload received with command {0}'.format(data['cmd']))
+        # Allow AES Functions to be called without a signed token
+        # until release 0.20.0. The option 'require_aes_tokens' in
+        # the master config file controls whether to allow functions
+        # to be called by minions without a signed token.
+        # Until 0.20, the require_aes_tokens option is optional.
+        # After 0.20 the require_aes_tokens option will be removed and
+        # all minions will be required to provide signed aes tokens.
+        if not self.opts.get('require_aes_tokens', False):
+            if self.opts.get('log_aes_tokens_warning', True):
+                warn_until(
+                    (0, 20),
+                    'Master option "require_aes_tokens" was not found in '
+                    'the master options. AES tokens will be REQUIRED in '
+                    'the 0.20 release. All minions MUST be upgraded to '
+                    'version 0.17 prior to the master running 0.20! '
+                    'Refer to '
+                    'http://docs.saltstack.com/topics/releases/0.17.0.html '
+                    'for more information.'
+                )
+            if 'cmd' not in data:
+                log.error('Received malformed command {0!r}'.format(data))
+                return {}
+        else:
+            if not all(key in data for key in ('id', 'tok', 'cmd')):
+                if 'id' in data and not 'tok' in data:
+                    log.error(
+                        'Received command without aes token: {0!r}'
+                        .format(data)
+                    )
+                    return {}
+                else:
+                    log.error('Received malformed command {0!r}'.format(data))
+                    return {}
+            if not verify_minion_rsa_token(self.opts, data['id'], data['tok']):
+                log.warn('Received command with bad token: {0!r}'.format(data))
+                return False
+        # End AES token check
+        log.info('AES payload received with command {0!r}'.format(data['cmd']))
         if data['cmd'].startswith('__'):
             return False
         return self.aes_funcs.run_func(data['cmd'], data)
@@ -733,38 +769,6 @@ class AESFuncs(object):
         self._dir_list = fs_.dir_list
         self._file_envs = fs_.envs
 
-    def __verify_minion(self, id_, token):
-        '''
-        Take a minion id and a string signed with the minion private key
-        The string needs to verify as 'salt' with the minion public key
-        '''
-        if not salt.utils.verify.valid_id(self.opts, id_):
-            return False
-        pub_path = os.path.join(self.opts['pki_dir'], 'minions', id_)
-        with salt.utils.fopen(pub_path, 'r') as fp_:
-            minion_pub = fp_.read()
-        tmp_pub = salt.utils.mkstemp()
-        with salt.utils.fopen(tmp_pub, 'w+') as fp_:
-            fp_.write(minion_pub)
-
-        pub = None
-        try:
-            pub = RSA.load_pub_key(tmp_pub)
-        except RSA.RSAError as err:
-            log.error('Unable to load temporary public key "{0}": {1}'
-                      .format(tmp_pub, err))
-        try:
-            os.remove(tmp_pub)
-            if pub.public_decrypt(token, 5) == 'salt':
-                return True
-        except RSA.RSAError as err:
-            log.error('Unable to decrypt token: {0}'.format(err))
-
-        log.error('Salt minion claiming to be {0} has attempted to'
-                  'communicate with the master and could not be verified'
-                  .format(id_))
-        return False
-
     def __verify_minion_publish(self, clear_load):
         '''
         Verify that the passed information authorized a minion to execute
@@ -780,7 +784,7 @@ class AESFuncs(object):
         if re.match('publish.*', clear_load['fun']):
             return False
         # Check the permissions for this minion
-        if not self.__verify_minion(clear_load['id'], clear_load['tok']):
+        if not verify_minion_rsa_token(self.opts, clear_load['id'], clear_load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
             log.warn(
@@ -1215,7 +1219,7 @@ class AESFuncs(object):
             return {}
         if any(key not in clear_load for key in ('fun', 'arg', 'id', 'tok')):
             return {}
-        if not self.__verify_minion(clear_load['id'], clear_load['tok']):
+        if not verify_minion_rsa_token(self.opts, clear_load['id'], clear_load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
             log.warn(
@@ -1253,7 +1257,7 @@ class AESFuncs(object):
         '''
         if any(key not in load for key in ('jid', 'id', 'tok')):
             return {}
-        if not self.__verify_minion(load['id'], load['tok']):
+        if not verify_minion_rsa_token(self.opts, load['id'], load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
             log.warn(
@@ -1409,7 +1413,7 @@ class AESFuncs(object):
         '''
         if 'id' not in load or 'tok' not in load:
             return False
-        if not self.__verify_minion(load['id'], load['tok']):
+        if not verify_minion_rsa_token(self.opts, load['id'], load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
             log.warn(

--- a/salt/master.py
+++ b/salt/master.py
@@ -53,7 +53,7 @@ import salt.utils.gzip_util
 from salt.utils.debug import enable_sigusr1_handler
 from salt.exceptions import SaltMasterError, MasterExit
 from salt.utils.event import tagify
-from salt.utils.master import verify_minion_rsa_token
+from salt.utils.master import verify_minion_auth_token
 from salt.utils import warn_until
 
 # Import halite libs
@@ -159,7 +159,6 @@ class SMaster(object):
                 pass
             keys[user] = key
         return keys
-
 
 class Master(SMaster):
     '''
@@ -287,6 +286,20 @@ class Master(SMaster):
                     )
                 )
 
+    def __check_cmd_auth_token_deprecation(self):
+        if not self.opts.get('require_cmd_auth_tokens', False):
+            if self.opts.get('log_cmd_auth_tokens_warning', True):
+                warn_until(
+                    (0, 20),
+                    'Master option "require_cmd_auth_tokens" was not found '
+                    'in the master options. Minion auth tokens will be '
+                    'required in the 0.20 release. All minions MUST be '
+                    'upgraded to version 0.17 prior to the master running '
+                    'version 0.20. Refer to '
+                    'http://docs.saltstack.com/topics/releases/0.17.0.html '
+                    'for more information.'
+                )
+
     def _pre_flight(self):
         '''
         Run pre flight checks, if anything in this method fails then the master
@@ -321,6 +334,7 @@ class Master(SMaster):
         enable_sigusr1_handler()
 
         self.__set_max_open_files()
+        self.__check_cmd_auth_token_deprecation()
         clear_old_jobs_proc = multiprocessing.Process(
             target=self._clear_old_jobs)
         clear_old_jobs_proc.start()
@@ -654,24 +668,13 @@ class MWorker(multiprocessing.Process):
         except Exception:
             return ''
         # Allow AES Functions to be called without a signed token
-        # until release 0.20.0. The option 'require_aes_tokens' in
+        # until release 0.20.0. The option 'require_cmd_auth_tokens' in
         # the master config file controls whether to allow functions
         # to be called by minions without a signed token.
-        # Until 0.20, the require_aes_tokens option is optional.
-        # After 0.20 the require_aes_tokens option will be removed and
-        # all minions will be required to provide signed aes tokens.
-        if not self.opts.get('require_aes_tokens', False):
-            if self.opts.get('log_aes_tokens_warning', True):
-                warn_until(
-                    (0, 20),
-                    'Master option "require_aes_tokens" was not found in '
-                    'the master options. AES tokens will be REQUIRED in '
-                    'the 0.20 release. All minions MUST be upgraded to '
-                    'version 0.17 prior to the master running 0.20! '
-                    'Refer to '
-                    'http://docs.saltstack.com/topics/releases/0.17.0.html '
-                    'for more information.'
-                )
+        # Until 0.20, the require_cmd_auth_tokens option is optional.
+        # After 0.20 the require_cmd_auth_tokens option will be removed and
+        # all minions will be required to provide signed auth tokens.
+        if not self.opts.get('require_cmd_auth_tokens', False):
             if 'cmd' not in data:
                 log.error('Received malformed command {0!r}'.format(data))
                 return {}
@@ -679,17 +682,17 @@ class MWorker(multiprocessing.Process):
             if not all(key in data for key in ('id', 'tok', 'cmd')):
                 if 'id' in data and not 'tok' in data:
                     log.error(
-                        'Received command without aes token: {0!r}'
+                        'Received command without auth token: {0!r}'
                         .format(data)
                     )
                     return {}
                 else:
                     log.error('Received malformed command {0!r}'.format(data))
                     return {}
-            if not verify_minion_rsa_token(self.opts, data['id'], data['tok']):
-                log.warn('Received command with bad token: {0!r}'.format(data))
+            if not verify_minion_auth_token(self.opts, data['id'], data['tok']):
+                log.warn('Received command with bad auth token: {0!r}'.format(data))
                 return False
-        # End AES token check
+        # End cmd auth token check
         log.info('AES payload received with command {0!r}'.format(data['cmd']))
         if data['cmd'].startswith('__'):
             return False

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -218,6 +218,8 @@ class SMinion(object):
                 self.gen_modules()
         else:
             self.gen_modules()
+        self.auth = salt.crypt.SAuth(self.opts)
+        self.aes_cmd_tok = self.auth.gen_token('salt')
 
     def gen_modules(self):
         '''
@@ -462,6 +464,8 @@ class Minion(object):
         opts.update(resolve_dns(opts))
         self.opts = opts
         self.authenticate(timeout, safe)
+        self.auth = salt.crypt.SAuth(opts)
+        self.aes_cmd_tok = self.auth.gen_token('salt')
         self.opts['pillar'] = salt.pillar.get_pillar(
             opts,
             opts['grains'],
@@ -504,6 +508,7 @@ class Minion(object):
         Fire an event on the master
         '''
         load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
                 'cmd': '_minion_event',
                 'pretag': pretag}
         if events:
@@ -787,6 +792,7 @@ class Minion(object):
         if ret_cmd == '_syndic_return':
             load = {'cmd': ret_cmd,
                     'id': self.opts['id'],
+                    'tok': self.aes_cmd_tok,
                     'jid': jid,
                     'fun': fun,
                     'load': ret.get('__load__')}
@@ -797,7 +803,8 @@ class Minion(object):
                 load['return'][key] = value
         else:
             load = {'cmd': ret_cmd,
-                    'id': self.opts['id']}
+                    'id': self.opts['id'],
+                    'tok': self.aes_cmd_tok}
             for key, value in ret.items():
                 load[key] = value
         try:

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -430,9 +430,11 @@ def push(path):
     if not os.path.isfile(path):
         return False
     auth = _auth()
+    tok = auth.gen_token('salt')
 
     load = {'cmd': '_file_recv',
             'id': __opts__['id'],
+            'tok': tok,
             'path': path.lstrip(os.sep)}
     sreq = salt.payload.SREQ(__opts__['master_uri'])
     with salt.utils.fopen(path) as fp_:

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -20,12 +20,14 @@ def fire_master(data, tag):
 
         salt '*' event.fire_master 'stuff to be in the event' 'tag'
     '''
+    sreq = salt.payload.SREQ(__opts__['master_uri'])
+    auth = salt.crypt.SAuth(__opts__)
+    tok = auth.gen_token('salt')
     load = {'id': __opts__['id'],
+            'tok': tok,
             'tag': tag,
             'data': data,
             'cmd': '_minion_event'}
-    auth = salt.crypt.SAuth(__opts__)
-    sreq = salt.payload.SREQ(__opts__['master_uri'])
     try:
         sreq.send('aes', auth.crypticle.dumps(load))
     except Exception:

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -64,14 +64,16 @@ def update(clear=False):
             log.error('Function {0} in mine_functions failed to execute'
                       .format(func))
             continue
-    load = {
-            'cmd': '_mine',
-            'data': data,
-            'id': __opts__['id'],
-            'clear': clear,
-    }
     sreq = salt.payload.SREQ(__opts__['master_uri'])
     auth = _auth()
+    tok = auth.gen_token('salt')
+    load = {
+        'cmd': '_mine',
+        'data': data,
+        'id': __opts__['id'],
+        'tok': tok,
+        'clear': clear,
+    }
     try:
         sreq.send('aes', auth.crypticle.dumps(load), 1, 0)
     except Exception:
@@ -110,13 +112,15 @@ def send(func, *args, **kwargs):
         log.error('Function {0} in mine.send failed to execute: {1}'
                   .format(func, exc))
         return False
-    load = {
-            'cmd': '_mine',
-            'data': data,
-            'id': __opts__['id'],
-    }
     sreq = salt.payload.SREQ(__opts__['master_uri'])
     auth = _auth()
+    tok = auth.gen_token('salt')
+    load = {
+        'cmd': '_mine',
+        'data': data,
+        'id': __opts__['id'],
+        'tok': tok
+    }
     try:
         sreq.send('aes', auth.crypticle.dumps(load), 1, 10)
     except Exception:
@@ -144,15 +148,17 @@ def get(tgt, fun, expr_form='glob'):
         salt '*' mine.get '*' network.interfaces
         salt '*' mine.get 'os:Fedora' network.interfaces grain
     '''
+    sreq = salt.payload.SREQ(__opts__['master_uri'])
     auth = _auth()
+    tok = auth.gen_token('salt')
     load = {
             'cmd': '_mine_get',
             'id': __opts__['id'],
+            'tok': tok,
             'tgt': tgt,
             'fun': fun,
             'expr_form': expr_form,
     }
-    sreq = salt.payload.SREQ(__opts__['master_uri'])
     ret = sreq.send('aes', auth.crypticle.dumps(load))
     return auth.crypticle.loads(ret)
 
@@ -166,13 +172,15 @@ def delete(fun):
 
         salt '*' mine.delete 'network.interfaces'
     '''
-    auth = _auth()
-    load = {
-            'cmd': '_mine_delete',
-            'id': __opts__['id'],
-            'fun': fun
-    }
     sreq = salt.payload.SREQ(__opts__['master_uri'])
+    auth = _auth()
+    tok = auth.gen_token('salt')
+    load = {
+        'cmd': '_mine_delete',
+        'id': __opts__['id'],
+        'tok': tok,
+        'fun': fun
+    }
     ret = sreq.send('aes', auth.crypticle.dumps(load))
     return auth.crypticle.loads(ret)
 
@@ -186,11 +194,13 @@ def flush():
 
         salt '*' mine.flush
     '''
-    auth = _auth()
-    load = {
-            'cmd': '_mine_flush',
-            'id': __opts__['id'],
-    }
     sreq = salt.payload.SREQ(__opts__['master_uri'])
+    auth = _auth()
+    tok = auth.gen_token('salt')
+    load = {
+        'cmd': '_mine_flush',
+        'id': __opts__['id'],
+        'tok': tok
+    }
     ret = sreq.send('aes', auth.crypticle.dumps(load))
     return auth.crypticle.loads(ret)

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -45,12 +45,14 @@ class RemotePillar(object):
         self.serial = salt.payload.Serial(self.opts)
         self.sreq = salt.payload.SREQ(self.opts['master_uri'])
         self.auth = salt.crypt.SAuth(opts)
+        self.aes_cmd_tok = self.auth.gen_token('salt')
 
     def compile_pillar(self):
         '''
         Return the pillar data from the master
         '''
         load = {'id': self.id_,
+                'tok': self.aes_cmd_tok,
                 'grains': self.grains,
                 'env': self.opts['environment'],
                 'ver': '2',

--- a/salt/state.py
+++ b/salt/state.py
@@ -2413,13 +2413,16 @@ class RemoteHighState(object):
         self.grains = grains
         self.serial = salt.payload.Serial(self.opts)
         self.auth = salt.crypt.SAuth(opts)
+        self.aes_cmd_tok = self.auth.gen_token('salt')
         self.sreq = salt.payload.SREQ(self.opts['master_uri'])
 
     def compile_master(self):
         '''
         Return the state data from the master
         '''
-        load = {'grains': self.grains,
+        load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
+                'grains': self.grains,
                 'opts': self.opts,
                 'cmd': '_master_state'}
         try:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -585,6 +585,7 @@ class StateFire(object):
             self.auth = salt.crypt.SAuth(self.opts)
         else:
             self.auth = auth
+        self.aes_cmd_tok = self.auth.gen_token('salt')
 
     def fire_master(self, data, tag):
         '''
@@ -595,6 +596,7 @@ class StateFire(object):
             salt '*' event.fire_master 'stuff to be in the event' 'tag'
         '''
         load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
                 'tag': tag,
                 'data': data,
                 'cmd': '_minion_event'}
@@ -614,6 +616,7 @@ class StateFire(object):
         this can be configured.
         '''
         load = {'id': self.opts['id'],
+                'tok': self.aes_cmd_tok,
                 'events': [],
                 'cmd': '_minion_event'}
         for stag in sorted(

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -25,7 +25,7 @@ from salt.exceptions import SaltException
 log = logging.getLogger(__name__)
 
 
-def verify_minion_rsa_token(master_opts, id_, token):
+def verify_minion_auth_token(master_opts, id_, token):
     '''
     Take a minion id and a string signed with the minion private key
     The string needs to verify as 'salt' with the minion public key

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -11,6 +11,9 @@
 import os
 import logging
 
+# Import third party libs
+from M2Crypto import RSA
+
 # Import salt libs
 import salt.log
 import salt.client
@@ -20,6 +23,34 @@ import salt.payload
 from salt.exceptions import SaltException
 
 log = logging.getLogger(__name__)
+
+
+def verify_minion_rsa_token(master_opts, id_, token):
+    '''
+    Take a minion id and a string signed with the minion private key
+    The string needs to verify as 'salt' with the minion public key
+    '''
+    if not salt.utils.verify.valid_id(master_opts, id_):
+        return False
+    pub_path = os.path.join(master_opts['pki_dir'], 'minions', id_)
+    with salt.utils.fopen(pub_path, 'r') as fp_:
+        minion_pub = fp_.read()
+    tmp_pub = salt.utils.mkstemp()
+    with salt.utils.fopen(tmp_pub, 'w+') as fp_:
+        fp_.write(minion_pub)
+    pub = None
+    try:
+        pub = RSA.load_pub_key(tmp_pub)
+    except RSA.RSAError as err:
+        log.error('Unable to load temporary public key "{0}": {1}'
+                  .format(tmp_pub, err))
+    try:
+        os.remove(tmp_pub)
+        if pub.public_decrypt(token, 5) == 'salt':
+            return True
+    except RSA.RSAError as err:
+        log.error('Unable to decrypt token: {0}'.format(err))
+    return False
 
 class MasterPillarUtil(object):
     '''

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -15,6 +15,7 @@ peer:
 log_file: master
 key_logfile: key
 token_file: /tmp/ksfjhdgiuebfgnkefvsikhfjdgvkjahcsidk
+require_aes_tokens: True
 
 file_buffer_size: 8192
 

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -15,7 +15,7 @@ peer:
 log_file: master
 key_logfile: key
 token_file: /tmp/ksfjhdgiuebfgnkefvsikhfjdgvkjahcsidk
-require_aes_tokens: True
+require_cmd_auth_tokens: True
 
 file_buffer_size: 8192
 

--- a/tests/integration/files/conf/syndic_master
+++ b/tests/integration/files/conf/syndic_master
@@ -9,3 +9,4 @@ timeout: 1
 sock_dir: .salt-unix-syndic
 open_mode: True
 order_masters: True
+require_aes_tokens: True

--- a/tests/integration/files/conf/syndic_master
+++ b/tests/integration/files/conf/syndic_master
@@ -9,4 +9,4 @@ timeout: 1
 sock_dir: .salt-unix-syndic
 open_mode: True
 order_masters: True
-require_aes_tokens: True
+require_cmd_auth_tokens: True


### PR DESCRIPTION
See also https://github.com/saltstack/salt/issues/7353

The master currently allows any minion with an accepted key to send commands to the master as any other minion. This pull request requires that commands sent from a minion to the master include a token encrypted with the minion's public key.

Unfortunately, requiring this token breaks backwards compatibility with all previous minion versions. I have added "require_aes_tokens: False" to the master config, and the master will allow old minions to send commands without a token unless require_aes_tokens is set to True. I gave it a warn_until version 0.20 to allow for salt admins to upgrade their minions to at least 0.17 (assuming this pull request gets included in 0.17)

I think salt should, by default, not trust the minions as much as possible. This greatly reduces the ability of evil minions to do nasty things.
