### PR TITLE
Render errors are critical

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -309,7 +309,7 @@ class Pillar(object):
             msg = 'Rendering SLS {0!r} failed, render error:\n{1}'.format(
                 sls, exc
             )
-            log.error(msg)
+            log.critical(msg)
             errors.append(msg)
         mods.add(sls)
         nstate = None

--- a/salt/state.py
+++ b/salt/state.py
@@ -1932,7 +1932,7 @@ class BaseHighState(object):
             msg = 'Rendering SLS {0} failed, render error: {1}'.format(
                 sls, exc
             )
-            log.error(
+            log.critical(
                 msg,
                 # Show the traceback if the debug logging level is enabled
                 exc_info=log.isEnabledFor(logging.DEBUG)
@@ -2019,7 +2019,7 @@ class BaseHighState(object):
                                    ).format(env_key,
                                             inc_sls,
                                             ', '.join(resolved_envs))
-                        log.error(msg)
+                        log.critical(msg)
                         if self.opts['failhard']:
                             errors.append(msg)
                 self._handle_iorder(state)


### PR DESCRIPTION
Currently, some render errors are logged at critical and some are logged at error. This makes all render error logging consistent by logging them all at critical.
