### PR TITLE
Add cleaner explanation of environment mapping

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -156,6 +156,28 @@ Then the ``roots`` backend (the default backend of files in ``/srv/salt``) will
 be searched first for the requested file, then if it is not found on the master
 the git remotes will be searched.
 
+Branches, environments and top.sls files
+========================================
+
+As stated above, when using the ``gitfs`` backend, branches will be mapped
+to environments using the branch name as identifier.
+There is an exception to this rule thought: the ``master`` branch is implicitly
+mapped to the ``base`` environment.
+Therefore, for a typical ``base``, ``qa``, ``dev`` setup, you'll have to
+create the following branches:
+
+.. code-block:: yaml
+
+    master
+    qa
+    dev
+
+Also, ``top.sls`` files from different branches will be merged into one big
+file at runtime. Since this could lead to hardly manageable configurations,
+the recommended setup is to have the ``top.sls`` file only in your master branch,
+and use environment-specific branches for states definitions.
+
+
 GitFS Remotes over SSH
 ======================
 


### PR DESCRIPTION
Explicitely state that the 'master' branch is automagically mapped
to the 'base' environment.

Also mention the fact that top.sls files are merged from the different
branches, which suggests a setup where top.sls is only present in
the 'master' branch.

These bits of information where collected in IRC thanks to UtahDave
