### PR TITLE
Make systemd>=207 hosts use /etc/sysctl.d/99-salt.conf

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -4,14 +4,17 @@ Module for viewing and modifying sysctl parameters
 '''
 
 # Import python libs
-import re
+import logging
 import os
+import re
 
 # Import salt libs
 import salt.utils
 from salt._compat import string_types
 from salt.exceptions import CommandExecutionError
+from salt.modules.systemd import _sd_booted
 
+log = logging.getLogger(__name__)
 
 # TODO: Add unpersist() to remove either a sysctl or sysctl/value combo from
 # the config
@@ -21,7 +24,43 @@ def __virtual__():
     '''
     Only run on Linux systems
     '''
-    return 'sysctl' if __grains__['kernel'] == 'Linux' else False
+    if __grains__['kernel'] != 'Linux':
+        return False
+    global _sd_booted
+    _sd_booted = salt.utils.namespaced_function(_sd_booted, globals())
+    return 'sysctl'
+
+
+def default_config():
+    '''
+    Linux hosts using systemd 207 or later ignore ``/etc/sysctl.conf`` and only
+    load from ``/etc/sysctl.d/*.conf``. This function will do the proper checks
+    and return a default config file which will be valid for the Minion. Hosts
+    running systemd >= 207 will use ``/etc/sysctl.d/99-salt.conf``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt -G 'kernel:Linux' sysctl.default_config
+    '''
+    if _sd_booted():
+        for line in __salt__['cmd.run_stdout'](
+            'systemctl --version'
+        ).splitlines():
+            if line.startswith('systemd '):
+                version = line.split()[-1]
+                try:
+                    if int(version) >= 207:
+                        return '/etc/sysctl.d/99-salt.conf'
+                except ValueError:
+                    log.error(
+                        'Unexpected non-numeric systemd version {0!r} '
+                        'detected'.format(version)
+                    )
+                break
+
+    return '/etc/sysctl.conf'
 
 
 def show():
@@ -95,9 +134,11 @@ def assign(name, value):
     return ret
 
 
-def persist(name, value, config='/etc/sysctl.conf'):
+def persist(name, value, config=None):
     '''
-    Assign and persist a simple sysctl parameter for this minion
+    Assign and persist a simple sysctl parameter for this minion. If ``config``
+    is not specified, a sensible default will be chosen using
+    :mod:`sysctl.default_config <salt.modules.linux_sysctl.default_config>`.
 
     CLI Example:
 
@@ -105,6 +146,8 @@ def persist(name, value, config='/etc/sysctl.conf'):
 
         salt '*' sysctl.persist net.ipv4.ip_forward 1
     '''
+    if config is None:
+        config = default_config()
     running = show()
     edited = False
     # If the sysctl.conf is not present, add it

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -15,7 +15,15 @@ Control the kernel sysctl system
 # Import python libs
 import re
 
-def present(name, value, config='/etc/sysctl.conf'):
+
+def __virtual__():
+    '''
+    This state is only available on Minions which support sysctl
+    '''
+    return 'sysctl' if 'sysctl.show' in __salt__ else False
+
+
+def present(name, value, config=None):
     '''
     Ensure that the named sysctl value is set in memory and persisted to the
     named configuration file. The default sysctl configuration file is
@@ -28,12 +36,21 @@ def present(name, value, config='/etc/sysctl.conf'):
         The sysctl value to apply
 
     config
-        The location of the sysctl configuration file
+        The location of the sysctl configuration file. If not specified, the
+        proper location will be detected based on platform.
     '''
     ret = {'name': name,
            'result': True,
            'changes': {},
            'comment': ''}
+
+    if config is None:
+        # Certain linux systems will ignore /etc/sysctl.conf, get the right
+        # default configuration file.
+        if 'sysctl.default_config' in __salt__:
+            config = __salt__['sysctl.default_config']()
+        else:
+            config = '/etc/sysctl.conf'
 
     current = __salt__['sysctl.show']()
     if __opts__['test']:


### PR DESCRIPTION
As of systemd 207, /etc/sysctl.conf is now ignored, and
/etc/sysctl.d/*.conf are used. This commit makes linux hosts check to
see if they are running systemd, and for new enough versions it uses
/etc/sysctl.d/99-salt.conf for the default config file.

Resolves #7351.
