### PR TITLE
Add file append template support - Fix typo and pylint errors

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -581,11 +581,17 @@ def _test_owner(kwargs, user=None):
 
 
 def _unify_sources_and_hashes(source=None, source_hash=None, 
-                              sources=[], source_hashes=[]):
+                              sources=None, source_hashes=None):
     '''
     Silly lil function to give us a standard tuple list for sources and 
     source_hashes
     '''
+    if sources is None:
+        sources = []
+        
+    if source_hashes is None:
+        source_hashes = []
+        
     if ( source and sources ):
         return (False, 
                 "source and sources are mutally exclusive", [] )
@@ -600,7 +606,7 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
     # Make a nice neat list of tuples exactly len(sources) long..
     return (True, '', map(None, sources, source_hashes[:len(sources)]) )
 
-def _get_template_texts(source_list = [], template='jinja', defaults = None, 
+def _get_template_texts(source_list = None, template='jinja', defaults = None, 
                         context = None, env = 'base', **kwargs):
     '''
     Iterate a list of sources and process them as templates.
@@ -609,8 +615,8 @@ def _get_template_texts(source_list = [], template='jinja', defaults = None,
 
     ret = {'name': '_get_template_texts', 'changes': {}, 
            'result': True, 'comment': '', 'data': []}
-
-    if not source_list:
+           
+    if source_list is None:
         return _error(ret, 
                       '_get_template_texts called with empty source_list')
   
@@ -1931,8 +1937,8 @@ def append(name,
            source_hash=None,
            __env__='base',
            template = 'jinja',
-           sources=[],
-           source_hashes=[],
+           sources=None,
+           source_hashes=None,
            defaults = None,
            context = None):
     '''
@@ -1973,6 +1979,12 @@ def append(name,
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
+    if sources is None:
+        sources = []
+        
+    if source_hashes is None:
+        source_hashes = []
+        
     # Add sources and source_hashes with template support
     # NOTE: FIX 'text' and any 'source' are mutally exclusive as 'text' 
     #       is re-assigned in the original code.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -621,20 +621,20 @@ def _get_template_texts(source_list = [], template='jinja', defaults = None,
         tmpctx = defaults if defaults else {}
         if context:
             tmpctx.update(context)
-        rndrd_templ_fn = __salt__['cp.get_template'](source,'',
+        rndrd_templ_fn = __salt__['cp.get_template'](source, '', 
                                   template=template, env=env, 
                                   context = tmpctx, **kwargs )
         msg = 'cp.get_template returned {0} (Called with: {1})'
-        log.debug(msg.format(rndrd_templ_fn,source))
+        log.debug(msg.format(rndrd_templ_fn, source))
         if rndrd_templ_fn:
             tmplines = None
             with salt.utils.fopen(rndrd_templ_fn, 'rb') as fp_:
                 tmplines = fp_.readlines()
             if not tmplines:
                 msg = 'Failed to read rendered template file {0} ({1})'
-                log.debug( msg.format(rndrd_templ_fn,source))
+                log.debug( msg.format(rndrd_templ_fn, source))
                 ret['name'] = source
-                return _error(ret, msg.format( rndrd_templ_fn,source) )
+                return _error(ret, msg.format( rndrd_templ_fn, source) )
             txtl.append( ''.join(tmplines))
         else:
             msg = 'Failed to load template file {0}'.format(source)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -595,7 +595,7 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
                 "source_hash and source_hashes are mutally exclusive", [] )
 
     if ( source ): 
-        return (True, '', [ (source,source_hash) ] )
+        return (True, '', [ (source, source_hash) ] )
 
     # Make a nice neat list of tuples exactly len(sources) long..
     return (True, '', map(None, sources, source_hashes[:len(sources)]) )

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -580,8 +580,8 @@ def _test_owner(kwargs, user=None):
     return user
 
 
-def _unify_sources_and_hashes(source=None,source_hash=None,
-                              sources=[],source_hashes=[]):
+def _unify_sources_and_hashes(source=None, source_hash=None, 
+                              sources=[], source_hashes=[]):
     '''
     Silly lil function to give us a standard tuple list for sources and 
     source_hashes
@@ -590,12 +590,12 @@ def _unify_sources_and_hashes(source=None,source_hash=None,
         return (False, 
                 "source and sources are mutally exclusive", [] )
 
-    if ( source_hash and sources_hash ):
+    if ( source_hash and source_hashes ):
         return (False, 
                 "source_hash and source_hashes are mutally exclusive", [] )
 
     if ( source ): 
-        return (True,'', [ (source,source_hash) ] )
+        return (True, '', [ (source,source_hash) ] )
 
     # Make a nice neat list of tuples exactly len(sources) long..
     return (True, '', map(None, sources, source_hashes[:len(sources)]) )


### PR DESCRIPTION
Ok - This fixes the typo in the var name, and I think it fixes all the pylint errors.
