### PR TITLE
git.latest should not touch the repo on an up-to-date branch

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -110,6 +110,16 @@ def _check_git():
     utils.check_or_die('git')
 
 
+def current_branch(cwd, user=None):
+    '''
+    Returns the current branch name, if on a branch.
+    '''
+    cmd = 'git branch --list | grep "^*\ " | cut -d " " -f 2 | ' + \
+        'grep -v "(detached"'
+
+    return __salt__['cmd.run_stdout'](cmd, cwd=cwd, runas=user)
+
+
 def revision(cwd, rev='HEAD', short=False, user=None):
     '''
     Returns the long hash of a given identifier (hash, branch, tag, HEAD, etc)

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -113,6 +113,10 @@ def latest(name,
         try:
             current_rev = __salt__['git.revision'](target, user=runas)
 
+            branch = __salt__['git.current_branch'](target, user=runas)
+            if len(branch) > 0:
+                current_rev = branch
+
             #only do something, if the specified rev differs from the
             #current_rev
             if rev == current_rev:


### PR DESCRIPTION
I'm using git.latest that specifies a branch. Something like:

```
git@github.com:boltronics/myrepo.git:
  git.latest:
    - rev: master
    - target: /var/www/myrepo
    - identity: salt://some/path
    - force_checkout: True
    - submodules: True
    - require:
       ...
```

As part of my salt state, I'm also watching the above and run some post-configuration on the code-base via script execution. Unfortunately when I re-run the state, even when the repo is already up-to-date on master (same hash), Salt will happily report that nothing was executed - but it nukes all the customisations and breaks the application!

We do want force_checkout - we need to clobber the changes when we do need to deploy a new git hash (which is fine since the post-deploy script will kick in and put it back into a good state).

The attached patch basically allows the above to work as expected. Could do with a little less Bash, but at least it solves the problem and stops destroying my production environment every time highstate is ran. :)

I also see that the latest develop commits have `onlyif` and `unless` support for git.latest now (so another work-around can more easily be implemented), but I still think the current behaviour without these patches is unexpected and quite frustrating. Thanks in advance.
