### PR TITLE
Fixed pedantic spelling errors picked up by lintian

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -112,7 +112,7 @@
 #random_reauth_delay: 60
 
 
-# If you dont have any problems with syn-floods, dont bother with the
+# If you don't have any problems with syn-floods, dont bother with the
 # three recon_* settings described below, just leave the defaults!
 #
 # The ZeroMQ pull-socket that binds to the masters publishing interface tries

--- a/doc/ref/configuration/logging/index.rst
+++ b/doc/ref/configuration/logging/index.rst
@@ -24,7 +24,7 @@ Remote logging works best when configured to use rsyslogd(8) (e.g.: ``file:///de
 with rsyslogd(8) configured for network logging.  The format for remote addresses is:
 ``<file|udp|tcp>://<host|socketpath>:<port-if-required>/<log-facility>``.
 
-Default: Dependant of the binary being executed, for example, for ``salt-master``,
+Default: Dependent of the binary being executed, for example, for ``salt-master``,
 ``/var/log/salt/master``.
 
 

--- a/doc/ref/renderers/all/salt.renderers.jinja.rst
+++ b/doc/ref/renderers/all/salt.renderers.jinja.rst
@@ -102,7 +102,7 @@ the context into the included file is required:
 Variable and block Serializers
 ==============================
 
-Salt allows to serialize any variable into **json** or **yaml**. For example
+Salt allows one to serialize any variable into **json** or **yaml**. For example
 this variable::
 
     data:
@@ -128,7 +128,7 @@ will be rendered has::
 
 
 Strings and variables can be deserialized with **load_yaml** and **load_json**
-tags and filters. It allows to manipulate data directly in templates, easily:
+tags and filters. It allows one to manipulate data directly in templates, easily:
 
 .. code-block:: yaml
 

--- a/doc/ref/windows-package-manager.rst
+++ b/doc/ref/windows-package-manager.rst
@@ -90,7 +90,7 @@ More examples can be found here: https://github.com/saltstack/salt-winrepo
 
 The version number and ``full_name`` need to match the output from ``pkg.list_pkgs``
 so that the status can be verfied when running highstate.
-Note: It is still possible to succesfully install packages using ``pkg.install``
+Note: It is still possible to successfully install packages using ``pkg.install``
 even if they don't match which can make this hard to troubleshoot.
 
 .. code-block:: bash
@@ -300,5 +300,5 @@ Packages management under Windows 2003
 
 On windows server 2003, you need to install optional windows component 
 "wmi windows installer provider" to have full list of installed packages.
-If you don't have this, salt-minion can't report some installed softwares.
+If you don't have this, salt-minion can't report some installed sotware.
 

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -83,8 +83,8 @@ standard ``salt``. The intent is that Salt Formulas defined for standard
 The standard Salt States walkthroughs function by simply replacing ``salt``
 commands with ``salt-ssh``.
 
-Targetting with Salt SSH
-========================
+Targeting with Salt SSH
+=======================
 
 Due to the fact that the targeting approach differs in salt-ssh, only glob
 and regex targets are supported as of this writing, the remaining target

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -5,7 +5,7 @@ Salt Rosters
 Salt rosters are plugable systems added in Salt 0.17.0 to facilitate the
 ``salt-ssh`` system.
 The roster system was created because ``salt-ssh`` needs a means to
-identify which systems need to be targetted for execution.
+identify which systems need to be targeted for execution.
 
 .. note::
     The Roster System is not needed or used in standard Salt because the

--- a/doc/topics/targeting/batch.rst
+++ b/doc/topics/targeting/batch.rst
@@ -2,7 +2,7 @@ Batch Size
 ----------
 
 The ``-b`` (or ``--batch-size``) option allows commands to be executed on only
-a specifed number of minions at a time. Both percentages and finite numbers are
+a specified number of minions at a time. Both percentages and finite numbers are
 supported.
 
 .. code-block:: bash

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -270,7 +270,7 @@ class LocalClient(object):
             cli=False,
             **kwargs):
         '''
-        Execute a command on a random subset of the targetted systems, pass
+        Execute a command on a random subset of the targeted systems, pass
         in the subset via the sub option to signify the number of systems to
         execute on.
         '''

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -48,7 +48,7 @@ class Shell(object):
 
     def get_error(self, errstr):
         '''
-        Parse out an error and return a targetted error string
+        Parse out an error and return a targeted error string
         '''
         for line in errstr.split('\n'):
             if line.startswith('ssh:'):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2583,7 +2583,7 @@ def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
     (deleted). This is logically in place as a safety measure because you can really shoot
     yourself in the foot here and it is the behavior of 'nix mknod. It is also important to
     note that not just anyone can create special devices. Usually this is only done as root.
-    If the state is executed as none other than root on a minion, you may recieve a permission
+    If the state is executed as none other than root on a minion, you may receive a permission
     error.
 
     name


### PR DESCRIPTION
Fixed typos picked up by lintian - it would be good to get these into 0.17.0 and develop.

Details of lintian run below (note this is not a complete spell check, just a list of common miss-spellings):

joe@unstable-builder:~/salt_017rc/salt$ lintian -I ../*.deb
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz softwares software - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz specifed specified - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz Targetting Targeting - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz targetted targeted - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz Dependant Dependent - done
I: salt-common: FSSTND-dir-in-manual-page usr/share/man/man7/salt.7.gz:57301 /var/named/ - not done - example
I: salt-common: FSSTND-dir-in-manual-page usr/share/man/man7/salt.7.gz:57320 /var/named/ - not done - example
I: salt-common: FSSTND-dir-in-manual-page usr/share/man/man7/salt.7.gz:57339 /var/named/ - not done - example
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz recieve receive - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz allows to allows one to - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz allows to allows one to - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz dont don't - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz succesfully successfully - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz softwares software - done
I: salt-common: spelling-error-in-manpage usr/share/man/man7/salt.7.gz These package This package - not done - legitimate
