### PR TITLE
Let's start checking PEP8 in Jenkins too

### DIFF
--- a/salt/_compat.py
+++ b/salt/_compat.py
@@ -143,9 +143,11 @@ else:
     from urllib2 import HTTPBasicAuthHandler as url_auth_handler
     from urllib2 import build_opener as url_build_opener
     from urllib2 import install_opener as url_install_opener
+
     def url_unquote_text(v, encoding='utf-8', errors='replace'):
         v = url_unquote(v)
         return v.decode(encoding, errors)
+
     def url_unquote_native(v, encoding='utf-8', errors='replace'):
         return native_(url_unquote_text(v, encoding, errors))
 

--- a/salt/auth/stormpath_mod.py
+++ b/salt/auth/stormpath_mod.py
@@ -33,6 +33,7 @@ def __virtual__():
     else:
         return False
 
+
 def auth(username, password):
     '''
     Try and authenticate

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -113,7 +113,7 @@ class APIClient(object):
             cmd['fun'] = '.'.join(funparts[1:]) #strip prefix
 
         if not ('token' in cmd  or
-                ('eauth' in cmd and 'password' in cmd and 'username' in cmd) ):
+                ('eauth' in cmd and 'password' in cmd and 'username' in cmd)):
             raise EauthAuthenticationError('No authentication credentials given')
 
         executor = getattr(self, '{0}_{1}'.format(client, mode))

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -18,6 +18,7 @@ import salt.syspaths as syspaths
 from salt.exceptions import SaltException, EauthAuthenticationError
 from salt.utils.event import tagify
 
+
 def tokenify(cmd, token=None):
     '''
     If token is not None Then assign token to 'token' key of cmd dict

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -103,14 +103,14 @@ class APIClient(object):
         eauth: the authentication type such as 'pam' or 'ldap'. Required if token is missing
 
         '''
-        client = 'minion' #default to local minion client
-        mode = cmd.get('mode', 'async') #default to 'async'
+        client = 'minion'  # default to local minion client
+        mode = cmd.get('mode', 'async')  # default to 'async'
 
         # check for wheel or runner prefix to fun name to use wheel or runner client
         funparts = cmd.get('fun', '').split('.')
-        if len(funparts) > 2 and funparts[0] in ['wheel', 'runner']: #master
+        if len(funparts) > 2 and funparts[0] in ['wheel', 'runner']:  # master
             client = funparts[0]
-            cmd['fun'] = '.'.join(funparts[1:]) #strip prefix
+            cmd['fun'] = '.'.join(funparts[1:])  # strip prefix
 
         if not ('token' in cmd  or
                 ('eauth' in cmd and 'password' in cmd and 'username' in cmd)):
@@ -146,7 +146,7 @@ class APIClient(object):
         '''
         return self.runnerClient.master_call(**kwargs)
 
-    runner_sync = runner_async # always runner async, so works in either mode
+    runner_sync = runner_async  # always runner async, so works in either mode
 
     def wheel_sync(self, **kwargs):
         '''
@@ -156,7 +156,7 @@ class APIClient(object):
         '''
         return self.wheelClient.master_call(**kwargs)
 
-    wheel_async = wheel_sync # always wheel_sync, so it works either mode
+    wheel_async = wheel_sync  # always wheel_sync, so it works either mode
 
     def signature(self, cmd):
         '''
@@ -199,7 +199,7 @@ class APIClient(object):
         elif client == 'master':
             parts = cmd['module'].split('.')
             client = parts[0]
-            module = '.'.join(parts[1:]) #strip prefix
+            module = '.'.join(parts[1:])  # strip prefix
             if client == 'wheel':
                 functions = self.wheelClient.w_funcs
             elif client == 'runner':

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -112,7 +112,7 @@ class APIClient(object):
             client = funparts[0]
             cmd['fun'] = '.'.join(funparts[1:])  # strip prefix
 
-        if not ('token' in cmd  or
+        if not ('token' in cmd or
                 ('eauth' in cmd and 'password' in cmd and 'username' in cmd)):
             raise EauthAuthenticationError('No authentication credentials given')
 

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -189,7 +189,7 @@ class APIClient(object):
         eauth: the authentication type such as 'pam' or 'ldap'. Required if token is missing
 
         '''
-        result =  {}
+        result = {}
 
         client = cmd.get('client', 'minion')
         if client == 'minion':
@@ -204,7 +204,7 @@ class APIClient(object):
                 functions = self.wheelClient.w_funcs
             elif client == 'runner':
                 functions = self.runnerClient.functions
-            result =  salt.utils.argspec_report(functions, module)
+            result = salt.utils.argspec_report(functions, module)
         return result
 
     def create_token(self, creds):

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -202,7 +202,7 @@ class APIClient(object):
             module = '.'.join(parts[1:]) #strip prefix
             if client == 'wheel':
                 functions = self.wheelClient.w_funcs
-            elif  client == 'runner':
+            elif client == 'runner':
                 functions = self.runnerClient.functions
             result =  salt.utils.argspec_report(functions, module)
         return result

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -39,6 +39,7 @@ class FunctionWrapper(object):
         '''
         if cmd in self.wfuncs:
             return self.wfuncs[cmd]
+
         def caller(*args, **kwargs):
             '''
             The remote execution function

--- a/salt/client/ssh/wrapper/pillar.py
+++ b/salt/client/ssh/wrapper/pillar.py
@@ -82,4 +82,3 @@ def raw(key=None):
 # Allow pillar.data to also be used to return pillar data
 items = raw
 data = items
-

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -84,11 +84,13 @@ class SaltReqTimeoutError(SaltException):
     Thrown when a salt master request call fails to return within the timeout
     '''
 
+
 class TimedProcTimeoutError(SaltException):
     '''
     Thrown when a timed subprocess does not terminate within the timeout,
     or if the specified timeout is not an int or a float
     '''
+
 
 class EauthAuthenticationError(SaltException):
     '''

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -12,8 +12,8 @@ import logging
 # Import salt libs
 import salt.loader
 
-
 log = logging.getLogger(__name__)
+
 
 def generate_mtime_map(path_map):
     '''
@@ -27,6 +27,7 @@ def generate_mtime_map(path_map):
                     file_path = os.path.join(directory, item)
                     file_map[file_path] = os.path.getmtime(file_path)
     return file_map
+
 
 def diff_mtime_map(map1, map2):
     '''
@@ -45,6 +46,7 @@ def diff_mtime_map(map1, map2):
     # we made it, that means we have no changes
     log.debug('diff_mtime_map: the maps are the same')
     return False
+
 
 def reap_fileserver_cache_dir(cache_base, find_func):
     '''
@@ -70,6 +72,7 @@ def reap_fileserver_cache_dir(cache_base, find_func):
                 # if we don't actually have the file, lets clean up the cache object
                 if ret['path'] == '':
                     os.unlink(file_path)
+
 
 def is_file_ignored(opts, fname):
     '''

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -59,7 +59,7 @@ def reap_fileserver_cache_dir(cache_base, find_func):
         for root, dirs, files in os.walk(env_base):
             # if we have an empty directory, lets cleanup
             # This will only remove the directory on the second time "_reap_cache" is called (which is intentional)
-            if len(dirs) == 0 and len (files) == 0:
+            if len(dirs) == 0 and len(files) == 0:
                 os.rmdir(root)
                 continue
             # if not, lets check the files in the directory

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -14,6 +14,7 @@ import salt.fileserver
 import salt.utils
 from salt.utils.event import tagify
 
+
 def find_file(path, env='base', **kwargs):
     '''
     Search the environment for the relative path

--- a/salt/grains/opts.py
+++ b/salt/grains/opts.py
@@ -4,6 +4,7 @@ Simple grain to merge the opts into the grains directly if the grain_opts
 configuration value is set
 '''
 
+
 def opts():
     '''
     Return the minion configuration settings

--- a/salt/key.py
+++ b/salt/key.py
@@ -15,6 +15,7 @@ import salt.utils
 import salt.utils.event
 from salt.utils.event import tagify
 
+
 class KeyCLI(object):
     '''
     Manage key CLI operations

--- a/salt/master.py
+++ b/salt/master.py
@@ -2319,7 +2319,7 @@ class ClearFuncs(object):
 
         new_job_load =  {
                 'jid': clear_load['jid'],
-                'tgt_type':clear_load['tgt_type'],
+                'tgt_type': clear_load['tgt_type'],
                 'tgt': clear_load['tgt'],
                 'user': clear_load['user'],
                 'fun': clear_load['fun'],

--- a/salt/master.py
+++ b/salt/master.py
@@ -1682,7 +1682,7 @@ class ClearFuncs(object):
             eload = {'result': False,
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, tagify(prefix = 'auth'))
+            self.event.fire_event(eload, tagify(prefix='auth'))
             return ret
         elif os.path.isfile(pubfn):
             # The key has been accepted check it
@@ -1697,7 +1697,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, tagify(prefix = 'auth'))
+                self.event.fire_event(eload, tagify(prefix='auth'))
                 return ret
         elif not os.path.isfile(pubfn_pend)\
                 and not self._check_autosign(load['id']):
@@ -1711,7 +1711,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, tagify(prefix = 'auth'))
+                self.event.fire_event(eload, tagify(prefix='auth'))
                 return ret
             # This is a new key, stick it in pre
             log.info(
@@ -1725,7 +1725,7 @@ class ClearFuncs(object):
                      'act': 'pend',
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, tagify(prefix = 'auth'))
+            self.event.fire_event(eload, tagify(prefix='auth'))
             return ret
         elif os.path.isfile(pubfn_pend)\
                 and not self._check_autosign(load['id']):
@@ -1740,7 +1740,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, tagify(prefix = 'auth'))
+                self.event.fire_event(eload, tagify(prefix='auth'))
                 return {'enc': 'clear',
                         'load': {'ret': False}}
             else:
@@ -1753,7 +1753,7 @@ class ClearFuncs(object):
                          'act': 'pend',
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, tagify(prefix = 'auth'))
+                self.event.fire_event(eload, tagify(prefix='auth'))
                 return {'enc': 'clear',
                         'load': {'ret': True}}
         elif os.path.isfile(pubfn_pend)\
@@ -1768,7 +1768,7 @@ class ClearFuncs(object):
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
-                self.event.fire_event(eload, tagify(prefix = 'auth'))
+                self.event.fire_event(eload, tagify(prefix='auth'))
                 return {'enc': 'clear',
                         'load': {'ret': False}}
             else:
@@ -1783,7 +1783,7 @@ class ClearFuncs(object):
             eload = {'result': False,
                      'id': load['id'],
                      'pub': load['pub']}
-            self.event.fire_event(eload, tagify(prefix = 'auth'))
+            self.event.fire_event(eload, tagify(prefix='auth'))
             return {'enc': 'clear',
                     'load': {'ret': False}}
 
@@ -1841,7 +1841,7 @@ class ClearFuncs(object):
                  'act': 'accept',
                  'id': load['id'],
                  'pub': load['pub']}
-        self.event.fire_event(eload, tagify(prefix = 'auth'))
+        self.event.fire_event(eload, tagify(prefix='auth'))
         return ret
 
     def runner(self, clear_load):

--- a/salt/master.py
+++ b/salt/master.py
@@ -1082,7 +1082,7 @@ class AESFuncs(object):
             return False
         if 'events' in load:
             for event in load['events']:
-                self.event.fire_event(event, event['tag']) # old dup event
+                self.event.fire_event(event, event['tag'])  # old dup event
                 if load.get('pretag') is not None:
                     self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
         else:
@@ -1106,7 +1106,7 @@ class AESFuncs(object):
                     self.opts['hash_type'],
                     load.get('nocache', False))
         log.info('Got return from {id} for job {jid}'.format(**load))
-        self.event.fire_event(load, load['jid']) # old dup event
+        self.event.fire_event(load, load['jid'])  # old dup event
         self.event.fire_event(load, tagify([load['jid'], 'ret', load['id']], 'job'))
         self.event.fire_ret_load(load)
         if self.opts['master_ext_job_cache']:
@@ -2328,7 +2328,7 @@ class ClearFuncs(object):
             }
 
         # Announce the job on the event bus
-        self.event.fire_event(new_job_load, 'new_job') # old dup event
+        self.event.fire_event(new_job_load, 'new_job')  # old dup event
         self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new'], 'job'))
 
         # Verify the jid dir

--- a/salt/master.py
+++ b/salt/master.py
@@ -1083,7 +1083,7 @@ class AESFuncs(object):
         if 'events' in load:
             for event in load['events']:
                 self.event.fire_event(event, event['tag']) # old dup event
-                if load.get('pretag') != None:
+                if load.get('pretag') is not None:
                     self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
         else:
             tag = load['tag']

--- a/salt/master.py
+++ b/salt/master.py
@@ -2317,7 +2317,7 @@ class ClearFuncs(object):
                 self.opts['hash_type']
                 )
 
-        new_job_load =  {
+        new_job_load = {
                 'jid': clear_load['jid'],
                 'tgt_type': clear_load['tgt_type'],
                 'tgt': clear_load['tgt'],

--- a/salt/master.py
+++ b/salt/master.py
@@ -537,7 +537,7 @@ class ReqServer(object):
         else:
             log.info('Halite: Not starting. '
                      'Package available is {0}. '
-                     'Opts for "halite" exists is {1}.'\
+                     'Opts for "halite" exists is {1}.'
                      .format(HAS_HALITE, 'halite' in self.opts))
 
     def run(self):
@@ -1964,8 +1964,8 @@ class ClearFuncs(object):
                 log.warning('Authentication failure of type "token" occurred.')
                 return ''
             good = self.ckminions.wheel_check(
-                    self.opts['external_auth'][token['eauth']][token['name']] \
-                        if token['name'] in self.opts['external_auth'][token['eauth']] \
+                    self.opts['external_auth'][token['eauth']][token['name']]
+                        if token['name'] in self.opts['external_auth'][token['eauth']]
                         else self.opts['external_auth'][token['eauth']]['*'],
                     clear_load['fun'])
             if not good:
@@ -2025,8 +2025,8 @@ class ClearFuncs(object):
                 log.warning(msg)
                 return ''
             good = self.ckminions.wheel_check(
-                    self.opts['external_auth'][clear_load['eauth']][name] \
-                        if name in self.opts['external_auth'][clear_load['eauth']] \
+                    self.opts['external_auth'][clear_load['eauth']][name]
+                        if name in self.opts['external_auth'][clear_load['eauth']]
                         else self.opts['external_auth'][token['eauth']]['*'],
                     clear_load['fun'])
             if not good:
@@ -2165,8 +2165,8 @@ class ClearFuncs(object):
                 log.warning('Authentication failure of type "token" occurred.')
                 return ''
             good = self.ckminions.auth_check(
-                    self.opts['external_auth'][token['eauth']][token['name']] \
-                        if token['name'] in self.opts['external_auth'][token['eauth']] \
+                    self.opts['external_auth'][token['eauth']][token['name']]
+                        if token['name'] in self.opts['external_auth'][token['eauth']]
                         else self.opts['external_auth'][token['eauth']]['*'],
                     clear_load['fun'],
                     clear_load['tgt'],
@@ -2206,8 +2206,8 @@ class ClearFuncs(object):
                 )
                 return ''
             good = self.ckminions.auth_check(
-                    self.opts['external_auth'][extra['eauth']][name] \
-                        if name in self.opts['external_auth'][extra['eauth']] \
+                    self.opts['external_auth'][extra['eauth']][name]
+                        if name in self.opts['external_auth'][extra['eauth']]
                         else self.opts['external_auth'][extra['eauth']]['*'],
                     clear_load['fun'],
                     clear_load['tgt'],

--- a/salt/master.py
+++ b/salt/master.py
@@ -2120,7 +2120,7 @@ class ClearFuncs(object):
         for module_re in self.opts['client_acl_blacklist'].get('modules', []):
             # if this is a regular command, its a single function
             if type(clear_load['fun']) == str:
-                funs_to_check = [ clear_load['fun'] ]
+                funs_to_check = [clear_load['fun']]
             # if this a compound function
             else:
                 funs_to_check = clear_load['fun']

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -168,4 +168,3 @@ def set_(name, path):
     if out['retcode'] > 0:
         return out['stderr']
     return out['stdout']
-

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2298,8 +2298,8 @@ def mknod_chrdev(name,
             ret['result'] = None
         else:
             if os.mknod(name,
-                        int(str(mode).lstrip('0'),8)|stat.S_IFCHR,
-                        os.makedev(major,minor)) is None:
+                        int(str(mode).lstrip('0'), 8)|stat.S_IFCHR,
+                        os.makedev(major, minor)) is None:
                 ret['changes'] = {'new' : 'Character device {0} created.'.format(name)}
                 ret['result'] = True
     except OSError as exc:
@@ -2369,8 +2369,8 @@ def mknod_blkdev(name,
             ret['result'] = None
         else:
             if os.mknod(name,
-                        int(str(mode).lstrip('0'),8)|stat.S_IFBLK,
-                        os.makedev(major,minor)) is None:
+                        int(str(mode).lstrip('0'), 8)|stat.S_IFBLK,
+                        os.makedev(major, minor)) is None:
                 ret['changes'] = {'new' : 'Block device {0} created.'.format(name)}
                 ret['result'] = True
     except OSError as exc:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2294,13 +2294,13 @@ def mknod_chrdev(name,
                                                                                        mode))
     try:
         if __opts__['test']:
-            ret['changes'] = {'new' : 'Character device {0} created.'.format(name)}
+            ret['changes'] = {'new': 'Character device {0} created.'.format(name)}
             ret['result'] = None
         else:
             if os.mknod(name,
                         int(str(mode).lstrip('0'), 8)|stat.S_IFCHR,
                         os.makedev(major, minor)) is None:
-                ret['changes'] = {'new' : 'Character device {0} created.'.format(name)}
+                ret['changes'] = {'new': 'Character device {0} created.'.format(name)}
                 ret['result'] = True
     except OSError as exc:
         # be happy it is already there....however, if you are trying to change the
@@ -2365,13 +2365,13 @@ def mknod_blkdev(name,
                                                                                    mode))
     try:
         if __opts__['test']:
-            ret['changes'] = {'new' : 'Block device {0} created.'.format(name)}
+            ret['changes'] = {'new': 'Block device {0} created.'.format(name)}
             ret['result'] = None
         else:
             if os.mknod(name,
                         int(str(mode).lstrip('0'), 8)|stat.S_IFBLK,
                         os.makedev(major, minor)) is None:
-                ret['changes'] = {'new' : 'Block device {0} created.'.format(name)}
+                ret['changes'] = {'new': 'Block device {0} created.'.format(name)}
                 ret['result'] = True
     except OSError as exc:
         # be happy it is already there....however, if you are trying to change the
@@ -2431,11 +2431,11 @@ def mknod_fifo(name,
     log.debug("Creating FIFO name:{0}".format(name))
     try:
         if __opts__['test']:
-            ret['changes'] = {'new' : 'Fifo pipe {0} created.'.format(name)}
+            ret['changes'] = {'new': 'Fifo pipe {0} created.'.format(name)}
             ret['result'] = None
         else:
             if os.mkfifo(name, int(str(mode).lstrip('0'), 8)) is None:
-                ret['changes'] = {'new' : 'Fifo pipe {0} created.'.format(name)}
+                ret['changes'] = {'new': 'Fifo pipe {0} created.'.format(name)}
                 ret['result'] = True
     except OSError as exc:
         #be happy it is already there

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -973,7 +973,7 @@ def replace(path,
             result = re.sub(cpattern, repl, line, count)
 
             # Identity check each potential change until one change is made
-            if has_changes == False and not result is line:
+            if has_changes is False and not result is line:
                 has_changes = True
 
             if show_changes:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2227,6 +2227,7 @@ def makedirs_perms(name,
                 group,
                 int('{0}'.format(mode)) if mode else None)
 
+
 def get_devmm(name):
     '''
     Get major/minor info from a device
@@ -2266,6 +2267,7 @@ def is_chrdev(name):
         else:
             raise
     return stat.S_ISCHR(stat_structure.st_mode)
+
 
 def mknod_chrdev(name,
                  major,
@@ -2315,6 +2317,7 @@ def mknod_chrdev(name,
                 int('{0}'.format(mode)) if mode else None)
     return ret
 
+
 def is_blkdev(name):
     '''
     Check if a file exists and is a block device.
@@ -2335,6 +2338,7 @@ def is_blkdev(name):
         else:
             raise
     return stat.S_ISBLK(stat_structure.st_mode)
+
 
 def mknod_blkdev(name,
                  major,
@@ -2384,6 +2388,7 @@ def mknod_blkdev(name,
                 int('{0}'.format(mode)) if mode else None)
     return ret
 
+
 def is_fifo(name):
     '''
     Check if a file exists and is a FIFO.
@@ -2404,6 +2409,7 @@ def is_fifo(name):
         else:
             raise
     return stat.S_ISFIFO(stat_structure.st_mode)
+
 
 def mknod_fifo(name,
                user=None,
@@ -2444,6 +2450,7 @@ def mknod_fifo(name,
                 group,
                 int('{0}'.format(mode)) if mode else None)
     return ret
+
 
 def mknod(name,
           ntype,
@@ -2490,6 +2497,7 @@ def mknod(name,
     else:
         raise Exception("Node type unavailable: '{0}'. Available node types are character ('c'), block ('b'), and pipe ('p').".format(ntype))
     return ret
+
 
 def list_backups(path, limit=None):
     '''

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2298,7 +2298,7 @@ def mknod_chrdev(name,
             ret['result'] = None
         else:
             if os.mknod(name,
-                        int(str(mode).lstrip('0'), 8)|stat.S_IFCHR,
+                        int(str(mode).lstrip('0'), 8) | stat.S_IFCHR,
                         os.makedev(major, minor)) is None:
                 ret['changes'] = {'new': 'Character device {0} created.'.format(name)}
                 ret['result'] = True
@@ -2369,7 +2369,7 @@ def mknod_blkdev(name,
             ret['result'] = None
         else:
             if os.mknod(name,
-                        int(str(mode).lstrip('0'), 8)|stat.S_IFBLK,
+                        int(str(mode).lstrip('0'), 8) | stat.S_IFBLK,
                         os.makedev(major, minor)) is None:
                 ret['changes'] = {'new': 'Block device {0} created.'.format(name)}
                 ret['result'] = True

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -957,8 +957,8 @@ def replace(path,
 
     # Search the file; track if any changes have been made for the return val
     has_changes = False
-    orig_file = [] # used if show_changes
-    new_file = [] # used if show_changes
+    orig_file = []  # used if show_changes
+    new_file = []  # used if show_changes
     for line in fileinput.input(path,
             inplace=not dry_run, backup=False if dry_run else backup,
             bufsize=bufsize, mode='rb'):

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -24,6 +24,7 @@ def __virtual__():
         return False
     return 'git'
 
+
 def _git_ssh_helper(identity):
     '''
     Returns the path to a helper script which can be used in the GIT_SSH env

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -156,6 +156,7 @@ def get(tgt, fun, expr_form='glob'):
     ret = sreq.send('aes', auth.crypticle.dumps(load))
     return auth.crypticle.loads(ret)
 
+
 def delete(fun):
     '''
     Remove specific function contents of minion. Returns True on success.
@@ -175,6 +176,7 @@ def delete(fun):
     sreq = salt.payload.SREQ(__opts__['master_uri'])
     ret = sreq.send('aes', auth.crypticle.dumps(load))
     return auth.crypticle.loads(ret)
+
 
 def flush():
     '''

--- a/salt/modules/modjk.py
+++ b/salt/modules/modjk.py
@@ -227,6 +227,7 @@ def workers(profile='default'):
 
     return ret
 
+
 def recover_all(lbn, profile='default'):
     '''
     Set the all the workers in lbn to recover and activate them if they are not

--- a/salt/modules/moosefs.py
+++ b/salt/modules/moosefs.py
@@ -6,6 +6,7 @@ Module for gathering and managing information about MooseFS
 # Import salt libs
 import salt.utils
 
+
 def __virtual__():
     '''
     Only load if the mfs commands are installed

--- a/salt/modules/nzbget.py
+++ b/salt/modules/nzbget.py
@@ -10,6 +10,7 @@ __func_alias__ = {
     'list_': 'list'
 }
 
+
 def __virtual__():
     '''
     Only load the module if apache is installed

--- a/salt/modules/rdp.py
+++ b/salt/modules/rdp.py
@@ -9,6 +9,7 @@ import re
 # Import salt libs
 import salt.utils
 
+
 def __virtual__():
     '''
     Only works on Windows systems

--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -956,9 +956,9 @@ def set_replication_enabled(status, host=None, core_name=None):
         return ret
     else:
         if status:
-            return  _replication_request(cmd, host=host, core_name=core_name)
+            return _replication_request(cmd, host=host, core_name=core_name)
         else:
-            return  _replication_request(cmd, host=host, core_name=core_name)
+            return _replication_request(cmd, host=host, core_name=core_name)
 
 
 def signal(signal=None):

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -529,9 +529,9 @@ def recv_known_host(hostname, enc=None, port=None, hash_hostname=False):
     '''
     # The following list of OSes have an old version of openssh-clients
     # and thus require the '-t' option for ssh-keyscan
-    need_dash_t = ['CentOS-5',]
+    need_dash_t = ['CentOS-5']
 
-    chunks = ['ssh-keyscan', ]
+    chunks = ['ssh-keyscan']
     if port:
         chunks += ['-p', str(port)]
     if enc:

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -397,6 +397,7 @@ def status(cwd, targets=None, user=None, username=None, password=None, *opts):
         opts += tuple(shlex.split(targets))
     return _run_svn('status', cwd, user, username, password, opts)
 
+
 def export(cwd,
              remote,
              target=None,

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -17,6 +17,7 @@ try:
 except ImportError:
     pass
 
+
 def __virtual__():
     '''
     Only works on Windows systems

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -39,7 +39,7 @@ def _normalize_dir(string):
     '''
     Normalize the directory to make comparison possible
     '''
-    return  re.sub(r'\\$', '', string.lower())
+    return re.sub(r'\\$', '', string.lower())
 
 
 def rehash():

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -72,7 +72,7 @@ def get_disabled():
         for line in lines:
             if 'DEMAND_START' in line:
                 ret.add(service)
-            elif  'DISABLED' in line:
+            elif 'DISABLED' in line:
                 ret.add(service)
     return sorted(ret)
 

--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -8,6 +8,7 @@ from numbers import Number
 # Import salt libs
 import salt.utils
 
+
 class NestDisplay(object):
     '''
     Manage the nested display contents
@@ -70,6 +71,7 @@ class NestDisplay(object):
                         self.colors['ENDC'])
                 out = self.display(val, indent + 4, '', out)
         return out
+
 
 def output(ret):
     '''

--- a/salt/output/no_out.py
+++ b/salt/output/no_out.py
@@ -3,8 +3,10 @@
 Display no output.
 '''
 
+
 def __virtual__():
     return 'quiet'
+
 
 def output(ret):
     '''

--- a/salt/output/no_return.py
+++ b/salt/output/no_return.py
@@ -3,7 +3,9 @@
 Display output for minions that did not return
 '''
 
+# Import salt libs
 import salt.utils
+
 
 class NestDisplay(object):
     '''
@@ -36,6 +38,7 @@ class NestDisplay(object):
                         self.colors['ENDC'])
                 out = self.display(val, indent + 4, '', out)
         return out
+
 
 def output(ret):
     '''

--- a/salt/output/virt_query.py
+++ b/salt/output/virt_query.py
@@ -3,6 +3,7 @@
 virt.query outputter
 '''
 
+
 def output(data):
     '''
     Display output for the salt-run virt.query function

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -385,7 +385,7 @@ class Pillar(object):
         Render the external pillar data
         '''
         if not 'ext_pillar' in self.opts:
-            return  {}
+            return {}
         if not isinstance(self.opts['ext_pillar'], list):
             log.critical('The "ext_pillar" option is malformed')
             return {}

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -57,6 +57,7 @@ def _get_ref(repo, short):
                 return ref
     return False
 
+
 def init(branch, repo_location):
     '''
     Return the git repo object for this session

--- a/salt/pillar/puppet.py
+++ b/salt/pillar/puppet.py
@@ -13,6 +13,7 @@ import yaml
 # Set up logging
 log = logging.getLogger(__name__)
 
+
 def ext_pillar(minion_id, pillar, command):
     '''
     Execute an unmodified puppet_node_classifier and read the output as YAML

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -48,6 +48,7 @@ setting the configuration option, like in the example above.
 # not work. Thanks to the __virtual__ function, however, the plugin still
 # responds to the name 'reclass'.
 
+from salt.exceptions import SaltInvocationError
 from salt.utils.reclass import (
     prepend_reclass_source_path,
     filter_out_source_path_option,
@@ -75,8 +76,6 @@ def __virtual__(retry=False):
 
         return __virtual__(retry=True)
 
-
-from salt.exceptions import SaltInvocationError
 
 def ext_pillar(minion_id, pillar, **kwargs):
     '''

--- a/salt/renderers/pydsl.py
+++ b/salt/renderers/pydsl.py
@@ -316,6 +316,7 @@ from salt.utils import pydsl
 
 __all__ = ['render']
 
+
 def render(template, env='', sls='', tmplpath=None, rendered_sls=None, **kws):
     mod = imp.new_module(sls)
     # Note: mod object is transient. It's existence only lasts as long as

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -9,21 +9,24 @@ Add the following configuration to your minion configuration files::
 
 '''
 
+# Import python libs
 import pickle
 import socket
 import logging
 import time
 import struct
 
-
 log = logging.getLogger(__name__)
+
 
 def __virtual__():
     return 'carbon'
 
+
 def _formatHostname(hostname, separator='_'):
     ''' carbon uses . as separator, so replace this in the hostname '''
     return hostname.replace('.', separator)
+
 
 def _send_picklemetrics(metrics, carbon_sock):
     ''' Uses pickle protocol to send data '''

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -62,8 +62,6 @@ import sys
 import json
 import logging
 
-log  = logging.getLogger( __name__ )
-
 # Import third party libs
 try:
     import MySQLdb
@@ -71,11 +69,14 @@ try:
 except ImportError:
     HAS_MYSQL = False
 
+log = logging.getLogger(__name__)
+
 
 def __virtual__():
     if not HAS_MYSQL:
         return False
     return 'mysql'
+
 
 def _get_options():
     '''
@@ -96,6 +97,7 @@ def _get_options():
         _options[attr] = _attr
 
     return _options
+
 
 @contextmanager
 def _get_serv(commit=False):

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -48,7 +48,6 @@ Use the commands to create the sqlite3 database and tables::
 import logging
 import json
 import datetime
-log = logging.getLogger(__name__)
 
 # Better safe than sorry here. Even though sqlite3 is included in python
 try:
@@ -57,10 +56,14 @@ try:
 except ImportError:
     HAS_SQLITE3 = False
 
+log = logging.getLogger(__name__)
+
+
 def __virtual__():
     if not HAS_SQLITE3:
         return False
     return 'sqlite3'
+
 
 def _get_conn():
     '''
@@ -82,6 +85,7 @@ def _get_conn():
         timeout = float(__salt__['config.option']('returner.sqlite3.timeout')))
     return conn
 
+
 def _close_conn(conn):
     '''
     Close the sqlite3 database connection
@@ -89,6 +93,7 @@ def _close_conn(conn):
     log.debug('Closing the sqlite3 database connection')
     conn.commit()
     conn.close()
+
 
 def returner(ret):
     '''
@@ -109,6 +114,7 @@ def returner(ret):
                  'success':ret['success']})
     _close_conn(conn)
 
+
 def save_load(jid, load):
     '''
     Save the load to the specified jid
@@ -122,6 +128,7 @@ def save_load(jid, load):
                 {'jid':jid,
                  'load':json.dumps(load)})
     _close_conn(conn)
+
 
 def get_load(jid):
     '''
@@ -138,6 +145,7 @@ def get_load(jid):
         return json.loads(data)
     _close_conn(conn)
     return {}
+
 
 def get_jid(jid):
     '''
@@ -157,6 +165,7 @@ def get_jid(jid):
         log.debug("ret: {0}".format(ret))
     _close_conn(conn)
     return ret
+
 
 def get_fun(fun):
     '''
@@ -185,6 +194,7 @@ def get_fun(fun):
     _close_conn(conn)
     return ret
 
+
 def get_jids():
     '''
     Return a list of all job ids
@@ -200,6 +210,7 @@ def get_jids():
         ret.append(jid[0])
     _close_conn(conn)
     return ret
+
 
 def get_minions():
     '''

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -82,7 +82,7 @@ def _get_conn():
               __salt__['config.option']('returner.sqlite3.timeout')))
     conn = sqlite3.connect(
                   __salt__['config.option']('returner.sqlite3.database'),
-        timeout = float(__salt__['config.option']('returner.sqlite3.timeout')))
+        timeout=float(__salt__['config.option']('returner.sqlite3.timeout')))
     return conn
 
 

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -106,12 +106,12 @@ def returner(ret):
              (fun, jid, id, date, full_ret, success)
              VALUES (:fun, :jid, :id, :date, :full_ret, :success)'''
     cur.execute(sql,
-                {'fun':ret['fun'],
-                 'jid':ret['jid'],
-                 'id':ret['id'],
-                 'date':str(datetime.datetime.now()),
-                 'full_ret':json.dumps(ret['return']),
-                 'success':ret['success']})
+                {'fun': ret['fun'],
+                 'jid': ret['jid'],
+                 'id': ret['id'],
+                 'date': str(datetime.datetime.now()),
+                 'full_ret': json.dumps(ret['return']),
+                 'success': ret['success']})
     _close_conn(conn)
 
 
@@ -125,8 +125,8 @@ def save_load(jid, load):
     cur = conn.cursor()
     sql = '''INSERT INTO jids (jid, load) VALUES (:jid, :load)'''
     cur.execute(sql,
-                {'jid':jid,
-                 'load':json.dumps(load)})
+                {'jid': jid,
+                 'load': json.dumps(load)})
     _close_conn(conn)
 
 
@@ -139,7 +139,7 @@ def get_load(jid):
     cur = conn.cursor()
     sql = '''SELECT load FROM jids WHERE jid = :jid'''
     cur.execute(sql,
-                {'jid':jid})
+                {'jid': jid})
     data = cur.fetchone()
     if data:
         return json.loads(data)
@@ -156,12 +156,12 @@ def get_jid(jid):
     cur = conn.cursor()
     sql = '''SELECT id, full_ret FROM salt_returns WHERE jid = :jid'''
     cur.execute(sql,
-                {'jid':jid})
+                {'jid': jid})
     data = cur.fetchone()
     log.debug('query result: {0}'.format(data))
     ret = {}
     if data and len(data) > 1:
-        ret = {str(data[0]):{u'return':json.loads(data[1])}}
+        ret = {str(data[0]): {u'return': json.loads(data[1])}}
         log.debug("ret: {0}".format(ret))
     _close_conn(conn)
     return ret
@@ -181,7 +181,7 @@ def get_fun(fun):
             WHERE s.fun = :fun
             '''
     cur.execute(sql,
-                {'fun':fun})
+                {'fun': fun})
     data = cur.fetchall()
     ret = {}
     if data:

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -12,6 +12,7 @@ import re
 import salt.loader
 from salt.template import compile_template
 
+
 def targets(tgt, tgt_type='glob', **kwargs):
     '''
     Return the targets from the flat yaml file, checks opts for location but

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -98,6 +98,7 @@ def _clear_cache(tgt=None,
                                                 clear_mine=clear_mine,
                                                 clear_mine_func=clear_mine_func)
 
+
 def clear_pillar(tgt, expr_form='glob'):
     '''
     Clear the cached pillar data of the targeted minions
@@ -109,6 +110,7 @@ def clear_pillar(tgt, expr_form='glob'):
         salt-run cache.clear_pillar
     '''
     return _clear_cache(tgt, expr_form, clear_pillar=True)
+
 
 def clear_grains(tgt=None, expr_form='glob'):
     '''
@@ -122,6 +124,7 @@ def clear_grains(tgt=None, expr_form='glob'):
     '''
     return _clear_cache(tgt, expr_form, clear_grains=True)
 
+
 def clear_mine(tgt=None, expr_form='glob'):
     '''
     Clear the cached mine data of the targeted minions
@@ -134,6 +137,7 @@ def clear_mine(tgt=None, expr_form='glob'):
     '''
     return _clear_cache(tgt, expr_form, clear_mine=True)
 
+
 def clear_mine_func(tgt=None, expr_form='glob', clear_mine_func=None):
     '''
     Clear the cached mine function data of the targeted minions
@@ -145,6 +149,7 @@ def clear_mine_func(tgt=None, expr_form='glob', clear_mine_func=None):
         salt-run cache.clear_mine_func tgt='*',clear_mine_func='network.interfaces'
     '''
     return _clear_cache(tgt, expr_form, clear_mine_func=clear_mine_func)
+
 
 def clear_all(tgt=None, expr_form='glob'):
     '''

--- a/salt/states/apt.py
+++ b/salt/states/apt.py
@@ -45,7 +45,7 @@ def held(name):
             ret.update(result=None,
                        comment='Package {0} is set to be held'.format(name))
     else:
-        ret.update(result= True,
+        ret.update(result=True,
                    comment='Package {0} is already held'.format(name))
 
     return ret

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -581,55 +581,56 @@ def _test_owner(kwargs, user=None):
     return user
 
 
-def _unify_sources_and_hashes(source=None, source_hash=None, 
+def _unify_sources_and_hashes(source=None, source_hash=None,
                               sources=None, source_hashes=None):
     '''
-    Silly lil function to give us a standard tuple list for sources and 
+    Silly lil function to give us a standard tuple list for sources and
     source_hashes
     '''
     if sources is None:
         sources = []
-        
+
     if source_hashes is None:
         source_hashes = []
-        
+
     if ( source and sources ):
-        return (False, 
+        return (False,
                 "source and sources are mutally exclusive", [] )
 
     if ( source_hash and source_hashes ):
-        return (False, 
+        return (False,
                 "source_hash and source_hashes are mutally exclusive", [] )
 
-    if ( source ): 
+    if ( source ):
         return (True, '', [ (source, source_hash) ] )
 
     # Make a nice neat list of tuples exactly len(sources) long..
     return (True, '', map(None, sources, source_hashes[:len(sources)]) )
 
-def _get_template_texts(source_list = None, template='jinja', defaults = None, 
+
+def _get_template_texts(source_list = None, template='jinja', defaults = None,
                         context = None, env = 'base', **kwargs):
     '''
     Iterate a list of sources and process them as templates.
     Returns a list of 'chunks' containing the rendered templates.
     '''
 
-    ret = {'name': '_get_template_texts', 'changes': {}, 
+    ret = {'name': '_get_template_texts', 'changes': {},
            'result': True, 'comment': '', 'data': []}
-           
+
     if source_list is None:
-        return _error(ret, 
+        return _error(ret,
                       '_get_template_texts called with empty source_list')
-  
+
     txtl = []
-  
+
     for (source, source_hash) in source_list:
 
         tmpctx = defaults if defaults else {}
         if context:
             tmpctx.update(context)
-        rndrd_templ_fn = __salt__['cp.get_template'](source, '', 
-                                  template=template, env=env, 
+        rndrd_templ_fn = __salt__['cp.get_template'](source, '',
+                                  template=template, env=env,
                                   context = tmpctx, **kwargs )
         msg = 'cp.get_template returned {0} (Called with: {1})'
         log.debug(msg.format(rndrd_templ_fn, source))
@@ -993,7 +994,7 @@ def managed(name,
 
     contents_pillar
         .. versionadded:: 0.17
-        
+
         Operates like ``contents``, but draws from a value stored in pillar,
         using the pillar path syntax used in :mod:`pillar.get
         <salt.modules.pillar.get>`. This is useful when the pillar value
@@ -2025,7 +2026,7 @@ def append(name,
               - "Salt is born of the purest of parents: the sun and the sea."
 
     Gather text from multiple template files::
-        
+
         /etc/motd:
           file:
               - append
@@ -2034,28 +2035,27 @@ def append(name,
                   - salt://motd/devops-messages.tmpl
                   - salt://motd/hr-messages.tmpl
                   - salt://motd/general-messages.tmpl
-                  
+
     .. versionadded:: 0.9.5
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
     if sources is None:
         sources = []
-        
+
     if source_hashes is None:
         source_hashes = []
-        
+
     # Add sources and source_hashes with template support
-    # NOTE: FIX 'text' and any 'source' are mutally exclusive as 'text' 
+    # NOTE: FIX 'text' and any 'source' are mutally exclusive as 'text'
     #       is re-assigned in the original code.
     (ok, err, sl) = _unify_sources_and_hashes(source = source,
-                                              source_hash = source_hash, 
-                                              sources = sources, 
+                                              source_hash = source_hash,
+                                              sources = sources,
                                               source_hashes = source_hashes )
     if not ok:
         return _error(ret, err)
 
-    
     if makedirs is True:
         dirname = os.path.dirname(name)
         if not __salt__['file.directory_exists'](dirname):
@@ -2075,10 +2075,10 @@ def append(name,
 
     #Follow the original logic and re-assign 'text' if using source(s)...
     if sl:
-        tmpret = _get_template_texts(source_list = sl, 
-                                     template = template, 
-                                     defaults = defaults, 
-                                     context = context, 
+        tmpret = _get_template_texts(source_list = sl,
+                                     template = template,
+                                     defaults = defaults,
+                                     context = context,
                                      env = __env__)
         if not tmpret['result']:
             return tmpret
@@ -2091,7 +2091,6 @@ def append(name,
         slines = fp_.readlines()
 
     count = 0
-
 
     for chunk in text:
 
@@ -2618,6 +2617,7 @@ def serialize(name,
                                         template=None,
                                         show_diff=show_diff,
                                         contents=contents)
+
 
 def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
     '''

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1701,6 +1701,7 @@ def replace(name,
     ret['result'] = True
     return ret
 
+
 def sed(name,
         before,
         after,

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -593,19 +593,19 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
     if source_hashes is None:
         source_hashes = []
 
-    if ( source and sources ):
+    if (source and sources):
         return (False,
-                "source and sources are mutally exclusive", [] )
+                "source and sources are mutally exclusive", [])
 
-    if ( source_hash and source_hashes ):
+    if (source_hash and source_hashes):
         return (False,
-                "source_hash and source_hashes are mutally exclusive", [] )
+                "source_hash and source_hashes are mutally exclusive", [])
 
-    if ( source ):
-        return (True, '', [ (source, source_hash) ] )
+    if (source):
+        return (True, '', [(source, source_hash)])
 
     # Make a nice neat list of tuples exactly len(sources) long..
-    return (True, '', map(None, sources, source_hashes[:len(sources)]) )
+    return (True, '', map(None, sources, source_hashes[:len(sources)]))
 
 
 def _get_template_texts(source_list=None,
@@ -635,7 +635,7 @@ def _get_template_texts(source_list=None,
             tmpctx.update(context)
         rndrd_templ_fn = __salt__['cp.get_template'](source, '',
                                   template=template, env=env,
-                                  context=tmpctx, **kwargs )
+                                  context=tmpctx, **kwargs)
         msg = 'cp.get_template returned {0} (Called with: {1})'
         log.debug(msg.format(rndrd_templ_fn, source))
         if rndrd_templ_fn:
@@ -644,15 +644,15 @@ def _get_template_texts(source_list=None,
                 tmplines = fp_.readlines()
             if not tmplines:
                 msg = 'Failed to read rendered template file {0} ({1})'
-                log.debug( msg.format(rndrd_templ_fn, source))
+                log.debug(msg.format(rndrd_templ_fn, source))
                 ret['name'] = source
-                return _error(ret, msg.format( rndrd_templ_fn, source) )
-            txtl.append( ''.join(tmplines))
+                return _error(ret, msg.format(rndrd_templ_fn, source))
+            txtl.append(''.join(tmplines))
         else:
             msg = 'Failed to load template file {0}'.format(source)
             log.debug(msg)
             ret['name'] = source
-            return _error(ret, msg )
+            return _error(ret, msg)
 
     ret['data'] = txtl
     return ret
@@ -2056,7 +2056,7 @@ def append(name,
     (ok, err, sl) = _unify_sources_and_hashes(source=source,
                                               source_hash=source_hash,
                                               sources=sources,
-                                              source_hashes=source_hashes )
+                                              source_hashes=source_hashes)
     if not ok:
         return _error(ret, err)
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -608,8 +608,12 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
     return (True, '', map(None, sources, source_hashes[:len(sources)]) )
 
 
-def _get_template_texts(source_list = None, template='jinja', defaults = None,
-                        context = None, env = 'base', **kwargs):
+def _get_template_texts(source_list=None,
+                        template='jinja',
+                        defaults=None,
+                        context=None,
+                        env='base',
+                        **kwargs):
     '''
     Iterate a list of sources and process them as templates.
     Returns a list of 'chunks' containing the rendered templates.
@@ -631,7 +635,7 @@ def _get_template_texts(source_list = None, template='jinja', defaults = None,
             tmpctx.update(context)
         rndrd_templ_fn = __salt__['cp.get_template'](source, '',
                                   template=template, env=env,
-                                  context = tmpctx, **kwargs )
+                                  context=tmpctx, **kwargs )
         msg = 'cp.get_template returned {0} (Called with: {1})'
         log.debug(msg.format(rndrd_templ_fn, source))
         if rndrd_templ_fn:
@@ -1997,11 +2001,11 @@ def append(name,
            source=None,
            source_hash=None,
            __env__='base',
-           template = 'jinja',
+           template='jinja',
            sources=None,
            source_hashes=None,
-           defaults = None,
-           context = None):
+           defaults=None,
+           context=None):
     '''
     Ensure that some text appears at the end of a file
 
@@ -2049,10 +2053,10 @@ def append(name,
     # Add sources and source_hashes with template support
     # NOTE: FIX 'text' and any 'source' are mutally exclusive as 'text'
     #       is re-assigned in the original code.
-    (ok, err, sl) = _unify_sources_and_hashes(source = source,
-                                              source_hash = source_hash,
-                                              sources = sources,
-                                              source_hashes = source_hashes )
+    (ok, err, sl) = _unify_sources_and_hashes(source=source,
+                                              source_hash=source_hash,
+                                              sources=sources,
+                                              source_hashes=source_hashes )
     if not ok:
         return _error(ret, err)
 
@@ -2075,11 +2079,11 @@ def append(name,
 
     #Follow the original logic and re-assign 'text' if using source(s)...
     if sl:
-        tmpret = _get_template_texts(source_list = sl,
-                                     template = template,
-                                     defaults = defaults,
-                                     context = context,
-                                     env = __env__)
+        tmpret = _get_template_texts(source_list=sl,
+                                     template=template,
+                                     defaults=defaults,
+                                     context=context,
+                                     env=__env__)
         if not tmpret['result']:
             return tmpret
         text = tmpret['data']

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2752,4 +2752,3 @@ def mknod(name, ntype, major=0, minor=0, user=None, group=None, mode='0600'):
         ret['comment'] = "Node type unavailable: '{0}. Available node types are character ('c'), block ('b'), and pipe ('p')".format(ntype)
 
     return ret
-

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -18,6 +18,7 @@ Note: This does NOT override any grains set in the minion file.
         - value: edam
 '''
 
+
 def present(name, value):
     '''
     Ensure that a grain is set

--- a/salt/states/layman.py
+++ b/salt/states/layman.py
@@ -11,11 +11,13 @@ A state module to manage Gentoo package overlays via layman
         layman.present
 '''
 
+
 def __virtual__():
     '''
     Only load if the layman module is available in __salt__
     '''
     return 'layman' if 'layman.add' in __salt__ else False
+
 
 def present(name):
     '''
@@ -50,6 +52,7 @@ def present(name):
             ret['comment'] = 'Overlay {0} added.'.format(name)
 
     return ret
+
 
 def absent(name):
     '''

--- a/salt/states/makeconf.py
+++ b/salt/states/makeconf.py
@@ -12,11 +12,13 @@ A state module to manage Gentoo's make.conf file
             - value: '-j3'
 '''
 
+
 def __virtual__():
     '''
     Only load if the makeconf module is available in __salt__
     '''
     return 'makeconf' if 'makeconf.get_var' in __salt__ else False
+
 
 def _make_set(var):
     '''
@@ -30,6 +32,7 @@ def _make_set(var):
         else:
             var = list(var)
     return set(var)
+
 
 def present(name, value=None, contains=None, excludes=None):
     '''
@@ -153,6 +156,7 @@ def present(name, value=None, contains=None, excludes=None):
 
     # Now finally return
     return ret
+
 
 def absent(name):
     '''

--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -21,6 +21,7 @@ import salt.utils
 # Set up logger
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     '''
     mdadm provides raid functions for Linux
@@ -30,6 +31,7 @@ def __virtual__():
     if not salt.utils.which('mdadm'):
         return False
     return 'raid'
+
 
 def present(name, opts=None):
     '''

--- a/salt/states/mongodb_database.py
+++ b/salt/states/mongodb_database.py
@@ -5,6 +5,8 @@ Management of Mongodb databases
 Only deletion is supported, creation doesn't make sense
 and can be done using mongodb_user.present
 '''
+
+
 def absent(name,
            user=None,
            password=None,

--- a/salt/states/mongodb_user.py
+++ b/salt/states/mongodb_user.py
@@ -4,6 +4,7 @@ Management of Mongodb users
 ===========================
 '''
 
+
 def present(name,
             passwd,
             database="admin",

--- a/salt/states/pkgng.py
+++ b/salt/states/pkgng.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Manage package remote repo using FreeBSD pkgng.
-==========================================================================
+Manage package remote repo using FreeBSD pkgng
+==============================================
 
 Salt can manage the URL pkgng pulls packages from.
 ATM the state and module are small so use cases are
@@ -14,6 +14,7 @@ typically rather simple:
         - update_packaging_site
         - name: "http://192.168.0.2"
 '''
+
 
 def update_packaging_site(name):
     ret = {

--- a/salt/states/portage_config.py
+++ b/salt/states/portage_config.py
@@ -13,11 +13,13 @@ A state module to manage Portage configuration on Gentoo
                 - openssl
 '''
 
+
 def __virtual__():
     '''
     Only load if the portage_config module is available in __salt__
     '''
     return 'portage_config' if 'portage_config.get_missing_flags' in __salt__ else False
+
 
 def mod_init(low):
     '''
@@ -28,6 +30,7 @@ def mod_init(low):
     except Exception:
         return False
     return True
+
 
 def _flags_helper(conf, atom, new_flags, test=False):
     try:
@@ -42,6 +45,7 @@ def _flags_helper(conf, atom, new_flags, test=False):
         return {'result': True, 'changes': {'old': old_flags, 'new': new_flags}}
     return {'result': None}
 
+
 def _mask_helper(conf, atom, test=False):
     try:
         is_present = __salt__['portage_config.is_present'](conf, atom)
@@ -53,6 +57,7 @@ def _mask_helper(conf, atom, test=False):
             __salt__['portage_config.append_to_package_conf'](conf, string=atom)
         return {'result': True}
     return {'result': None}
+
 
 def flags(name,
           use=None,

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -140,4 +140,3 @@ def absent(name,
             ret['comment'] = 'Policy {0} {1} is not present'.format(vhost, name)
 
     return ret
-

--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -44,6 +44,7 @@ This is how a state configuration could look like:
 # Import python libs
 import re
 
+
 def _check_rbenv(ret, runas=None):
     '''
     Check to see if rbenv is installed.
@@ -52,6 +53,7 @@ def _check_rbenv(ret, runas=None):
         ret['result'] = False
         ret['comment'] = 'Rbenv is not installed.'
     return ret
+
 
 def _ruby_installed(ret, ruby, runas=None):
     '''
@@ -66,6 +68,7 @@ def _ruby_installed(ret, ruby, runas=None):
             break
 
     return ret
+
 
 def _check_and_install_ruby(ret, ruby, default=False, runas=None):
     '''
@@ -87,6 +90,7 @@ def _check_and_install_ruby(ret, ruby, default=False, runas=None):
         __salt__['rbenv.default'](ruby, runas=runas)
 
     return ret
+
 
 def installed(name, default=False, runas=None):
     '''
@@ -121,6 +125,7 @@ def installed(name, default=False, runas=None):
     else:
         return _check_and_install_ruby(ret, name, default, runas=runas)
 
+
 def _check_and_uninstall_ruby(ret, ruby, runas=None):
     '''
     Verify that ruby is uninstalled
@@ -144,6 +149,7 @@ def _check_and_uninstall_ruby(ret, ruby, runas=None):
         ret['comment'] = 'Ruby {0} is already absent'.format(ruby)
 
     return ret
+
 
 def absent(name, runas=None):
     '''

--- a/salt/states/rdp.py
+++ b/salt/states/rdp.py
@@ -3,6 +3,7 @@
 Manage RDP Service on Windows servers
 '''
 
+
 def __virtual__():
     '''
     Load only if network_win is loaded

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -21,6 +21,7 @@ booleans can be set.
     execution module is available.
 '''
 
+
 def __virtual__():
     '''
     Only make this state available if the selinux module is available.

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -40,6 +40,7 @@ Notes:
       Apache Tomcat/7.0.37
 '''
 
+
 # Private
 def __virtual__():
     '''
@@ -47,6 +48,7 @@ def __virtual__():
     '''
 
     return 'tomcat' if 'tomcat.status' in __salt__ else False
+
 
 # Functions
 def war_deployed(name, war, url='http://localhost:8080/manager',
@@ -150,6 +152,7 @@ def war_deployed(name, war, url='http://localhost:8080/manager',
         ret['changes'].pop('deploy')
     return ret
 
+
 def wait(name, url='http://localhost:8080/manager', timeout=180):
     '''
     Wait for the tomcat manager to load
@@ -197,6 +200,7 @@ def wait(name, url='http://localhost:8080/manager', timeout=180):
        }
 
     return ret
+
 
 def mod_watch(name, url='http://localhost:8080/manager', timeout=180):
     '''

--- a/salt/states/win_path.py
+++ b/salt/states/win_path.py
@@ -6,11 +6,13 @@ Manage the Windows System PATH
 # Python Libs
 import re
 
+
 def __virtual__():
     '''
     Load this state if the win_path module exists
     '''
     return 'win_path' if 'win_path.rehash' in __salt__ else False
+
 
 def _normalize_dir(string):
     '''
@@ -48,6 +50,7 @@ def absent(name):
     if not ret['result']:
         ret['comment'] = 'could not remove {0} from the PATH'.format(name)
     return ret
+
 
 def exists(name, index=0):
     '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -93,9 +93,9 @@ TAGS = {
     'minion': 'minion',  # prefix for all salt/minion events (minion sourced events)
     'syndic': 'syndic',  # prefix for all salt/syndic events (syndic minion sourced events)
     'run': 'run',  # prefix for all salt/run events (salt runners)
-    'wheel': 'wheel', # prefix for all salt/wheel events
-    'cloud': 'cloud', # prefix for all salt/cloud events
-    'fileserver': 'fileserver', #prefix for all salt/fileserver events
+    'wheel': 'wheel',  # prefix for all salt/wheel events
+    'cloud': 'cloud',  # prefix for all salt/cloud events
+    'fileserver': 'fileserver',  # prefix for all salt/fileserver events
 }
 
 

--- a/salt/utils/ipaddr.py
+++ b/salt/utils/ipaddr.py
@@ -770,7 +770,7 @@ class _BaseNet(_IPAddrBase):
                 s1, s2 = s2.subnet()
             else:
                 # If we got here, there's a bug somewhere.
-                assert True == False, ('Error performing exclusion: '
+                assert True is False, ('Error performing exclusion: '
                                        's1: %s s2: %s other: %s' %
                                        (str(s1), str(s2), str(other)))
         if s1 == other:
@@ -779,7 +779,7 @@ class _BaseNet(_IPAddrBase):
             ret_addrs.append(s1)
         else:
             # If we got here, there's a bug somewhere.
-            assert True == False, ('Error performing exclusion: '
+            assert True is False, ('Error performing exclusion: '
                                    's1: %s s2: %s other: %s' %
                                    (str(s1), str(s2), str(other)))
 

--- a/salt/utils/ipaddr.py
+++ b/salt/utils/ipaddr.py
@@ -147,7 +147,7 @@ def v6_int_to_packed(address):
     Returns:
         The binary representation of this address.
     """
-    return Bytes(struct.pack('!QQ', address >> 64, address & (2**64 - 1)))
+    return Bytes(struct.pack('!QQ', address >> 64, address & (2 ** 64 - 1)))
 
 
 def _find_address_range(addresses):
@@ -255,7 +255,7 @@ def summarize_address_range(first, last):
         nbits = _count_righthand_zero_bits(first_int, ip_bits)
         current = None
         while nbits >= 0:
-            addend = 2**nbits - 1
+            addend = 2 ** nbits - 1
             current = first_int + addend
             nbits -= 1
             if current <= last_int:
@@ -1021,7 +1021,7 @@ class _BaseV4(object):
     """
 
     # Equivalent to 255.255.255.255 or 32 bits of 1's.
-    _ALL_ONES = (2**IPV4LENGTH) - 1
+    _ALL_ONES = (2 ** IPV4LENGTH) - 1
     _DECIMAL_DIGITS = frozenset('0123456789')
 
     def __init__(self, address):
@@ -1393,7 +1393,7 @@ class _BaseV6(object):
 
     """
 
-    _ALL_ONES = (2**IPV6LENGTH) - 1
+    _ALL_ONES = (2 ** IPV6LENGTH) - 1
     _HEXTET_COUNT = 8
     _HEX_DIGITS = frozenset('0123456789ABCDEFabcdef')
 
@@ -1572,7 +1572,7 @@ class _BaseV6(object):
         hex_str = '%032x' % ip_int
         hextets = []
         for x in range(0, 32, 4):
-            hextets.append('%x' % int(hex_str[x:x+4], 16))
+            hextets.append('%x' % int(hex_str[x:x + 4], 16))
 
         hextets = self._compress_hextets(hextets)
         return ':'.join(hextets)

--- a/salt/utils/ipaddr.py
+++ b/salt/utils/ipaddr.py
@@ -168,6 +168,7 @@ def _find_address_range(addresses):
             break
     return (first, last)
 
+
 def _get_prefix_length(number1, number2, bits):
     """Get the number of leading bits that are same for two numbers.
 
@@ -185,6 +186,7 @@ def _get_prefix_length(number1, number2, bits):
             return bits - i
     return 0
 
+
 def _count_righthand_zero_bits(number, bits):
     """Count the number of zero bits on the right hand side.
 
@@ -201,6 +203,7 @@ def _count_righthand_zero_bits(number, bits):
     for i in range(bits):
         if (number >> i) % 2:
             return i
+
 
 def summarize_address_range(first, last):
     """Summarize a network range given the first and last IP addresses.
@@ -265,6 +268,7 @@ def summarize_address_range(first, last):
         first_int = current + 1
         first = IPAddress(first_int, version=first._version)
     return networks
+
 
 def _collapse_address_list_recursive(addresses):
     """Loops through the addresses, collapsing concurrent netblocks.
@@ -391,6 +395,7 @@ except (NameError, TypeError):
         def __repr__(self):
             return 'Bytes(%s)' % str.__repr__(self)
 
+
 def get_mixed_type_key(obj):
     """Return a key suitable for sorting between networks and addresses.
 
@@ -414,6 +419,7 @@ def get_mixed_type_key(obj):
     elif isinstance(obj, _BaseIP):
         return obj._get_address_key()
     return NotImplemented
+
 
 class _IPAddrBase(object):
 
@@ -988,7 +994,6 @@ class _BaseNet(_IPAddrBase):
             if prefixlen_diff != 1:
                 raise ValueError('cannot set prefixlen_diff and new_prefix')
             prefixlen_diff = self._prefixlen - new_prefix
-
 
         if self.prefixlen - prefixlen_diff < 0:
             raise ValueError(
@@ -1806,7 +1811,6 @@ class IPv6Network(_BaseV6, _BaseNet):
         .prefixlen: 64
 
     """
-
 
     def __init__(self, address, strict=False):
         """Instantiate a new IPv6 Network object.

--- a/salt/utils/ipaddr.py
+++ b/salt/utils/ipaddr.py
@@ -517,7 +517,7 @@ class _BaseIP(_IPAddrBase):
         return '%s(%r)' % (self.__class__.__name__, str(self))
 
     def __str__(self):
-        return  '%s' % self._string_from_ip_int(self._ip)
+        return '%s' % self._string_from_ip_int(self._ip)
 
     def __hash__(self):
         return hash(hex(long(self._ip)))
@@ -633,8 +633,8 @@ class _BaseNet(_IPAddrBase):
         return not eq
 
     def __str__(self):
-        return  '%s/%s' % (str(self.ip),
-                           str(self._prefixlen))
+        return '%s/%s' % (str(self.ip),
+                          str(self._prefixlen))
 
     def __hash__(self):
         return hash(int(self.network) ^ int(self.netmask))

--- a/salt/utils/mako.py
+++ b/salt/utils/mako.py
@@ -11,6 +11,7 @@ from mako.lookup import TemplateCollection, TemplateLookup
 # Import salt libs
 import salt.fileclient
 
+
 class SaltMakoTemplateLookup(TemplateCollection):
     """
     Look up Mako template files on Salt master via salt://... URLs.

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -219,12 +219,12 @@ class MasterPillarUtil(object):
         log.debug('Getting minion grain data for: {0}'.format(minion_ids))
         minion_grains = self._get_minion_grains(
                                         *minion_ids,
-                                        cached_grains = cached_minion_grains)
+                                        cached_grains=cached_minion_grains)
         log.debug('Getting minion pillar data for: {0}'.format(minion_ids))
         minion_pillars = self._get_minion_pillar(
                                         *minion_ids,
-                                        grains = minion_grains,
-                                        cached_pillar = cached_minion_pillars)
+                                        grains=minion_grains,
+                                        cached_pillar=cached_minion_pillars)
         return minion_pillars
 
     def get_minion_grains(self):
@@ -250,7 +250,7 @@ class MasterPillarUtil(object):
         log.debug('Getting minion grain data for: {0}'.format(minion_ids))
         minion_grains = self._get_minion_grains(
                                         *minion_ids,
-                                        cached_grains = cached_minion_grains)
+                                        cached_grains=cached_minion_grains)
         return minion_grains
 
     def clear_cached_minion_data(self,

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -112,7 +112,7 @@ class MasterPillarUtil(object):
 
     def _get_live_minion_pillar(self, minion_id=None, minion_grains=None):
         # Returns a dict of pillar data for one minion
-        if minion_id == None:
+        if minion_id is None:
             return {}
         if not minion_grains:
             log.warn('Cannot get pillar data for {0}: no grains supplied.'.format(minion_id))

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -21,6 +21,7 @@ from salt.exceptions import SaltException
 
 log = logging.getLogger(__name__)
 
+
 class MasterPillarUtil(object):
     '''
     Helper utility for easy access to targeted minion grain and

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -138,14 +138,14 @@ class MasterPillarUtil(object):
         lret = {}
         if self.use_cached_grains:
             cret = dict([(minion_id, mcache) for (minion_id, mcache) in cached_grains.iteritems() if mcache])
-            missed_minions = [ minion_id for minion_id in minion_ids if minion_id not in cret ]
+            missed_minions = [minion_id for minion_id in minion_ids if minion_id not in cret]
             log.debug('Missed cached minion grains for: {0}'.format(missed_minions))
             if self.grains_fallback:
                 lret = self._get_live_minion_grains(missed_minions)
             ret = dict(dict([(minion_id, {}) for minion_id in minion_ids]).items() + lret.items() + cret.items())
         else:
             lret = self._get_live_minion_grains(minion_ids)
-            missed_minions = [ minion_id for minion_id in minion_ids if minion_id not in lret ]
+            missed_minions = [minion_id for minion_id in minion_ids if minion_id not in lret]
             log.debug('Missed live minion grains for: {0}'.format(missed_minions))
             if self.grains_fallback:
                 cret = dict([(minion_id, mcache) for (minion_id, mcache) in cached_grains.iteritems() if mcache])
@@ -163,14 +163,14 @@ class MasterPillarUtil(object):
         lret = {}
         if self.use_cached_pillar:
             cret = dict([(minion_id, mcache) for (minion_id, mcache) in cached_pillar.iteritems() if mcache])
-            missed_minions = [ minion_id for minion_id in minion_ids if minion_id not in cret ]
+            missed_minions = [minion_id for minion_id in minion_ids if minion_id not in cret]
             log.debug('Missed cached minion pillars for: {0}'.format(missed_minions))
             if self.pillar_fallback:
                 lret = dict([(minion_id, self._get_live_minion_pillar(minion_id, grains.get(minion_id, {}))) for minion_id in missed_minions])
             ret = dict(dict([(minion_id, {}) for minion_id in minion_ids]).items() + lret.items() + cret.items())
         else:
             lret = dict([(minion_id, self._get_live_minion_pillar(minion_id, grains.get(minion_id, {}))) for minion_id in minion_ids])
-            missed_minions = [ minion_id for minion_id in minion_ids if minion_id not in lret ]
+            missed_minions = [minion_id for minion_id in minion_ids if minion_id not in lret]
             log.debug('Missed live minion pillars for: {0}'.format(missed_minions))
             if self.pillar_fallback:
                 cret = dict([(minion_id, mcache) for (minion_id, mcache) in cached_pillar.iteritems() if mcache])

--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -84,7 +84,6 @@ class NonBlockingPopen(subprocess.Popen):
                 self._stderr_logger_name_.format(pid=self.pid)
             )
 
-
         self._stderr_logger = logging.getLogger(
             self._stderr_logger_name_.format(pid=self.pid)
         )

--- a/salt/utils/reclass.py
+++ b/salt/utils/reclass.py
@@ -3,8 +3,11 @@
 Common utility functions for the reclass adapters
 http://reclass.pantsfullofunix.net
 '''
+
+# Import python libs
 import sys
 import os
+
 
 def prepend_reclass_source_path(opts):
     source_path = opts.get('reclass_source_path')
@@ -12,10 +15,12 @@ def prepend_reclass_source_path(opts):
         source_path = os.path.abspath(os.path.expanduser(source_path))
         sys.path.insert(0, source_path)
 
+
 def filter_out_source_path_option(opts):
     if 'reclass_source_path' in opts:
         del opts['reclass_source_path']
     # no return required, object was passed by reference
+
 
 def set_inventory_base_uri_default(config, opts):
     if 'inventory_base_uri' in opts:

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -245,8 +245,8 @@ def get_template_context(template, line, num_lines=5, marker=None):
     if line > num_template_lines:
         return template
 
-    context_start = max(0, line-num_lines-1)  # subtract 1 for 0-based indexing
-    context_end = min(num_template_lines, line+num_lines)
+    context_start = max(0, line - num_lines - 1)  # subtract 1 for 0-based indexing
+    context_end = min(num_template_lines, line + num_lines)
     error_line_in_context = line - context_start - 1  # subtract 1 for 0-based indexing
 
     buf = []

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -88,6 +88,7 @@ def zmq_version():
             sys.stderr.write('CRITICAL {0}\n'.format(msg))
     return False
 
+
 def lookup_family(hostname):
     '''
     Lookup a hostname and determine its address family. The first address returned
@@ -105,6 +106,7 @@ def lookup_family(hostname):
         return h[0]
     except socket.gaierror:
         return fallback
+
 
 def verify_socket(interface, pub_port, ret_port):
     '''

--- a/salt/utils/winapi.py
+++ b/salt/utils/winapi.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+
+# Import python libs
 import logging
 import pythoncom
 import threading
 
-
 log = logging.getLogger(__name__)
+
 
 class Com(object):
     def __init__(self):
@@ -15,10 +17,10 @@ class Com(object):
 
     def __enter__(self):
         if self.need_com_init:
-            log.debug("Initializing COM library")
+            log.debug('Initializing COM library')
             pythoncom.CoInitialize()
 
     def __exit__(self, exc_type, exc_value, traceback):
         if self.need_com_init:
-            log.debug("Uninitializing COM library")
+            log.debug('Uninitializing COM library')
             pythoncom.CoUninitialize()

--- a/salt/utils/xmlutil.py
+++ b/salt/utils/xmlutil.py
@@ -3,6 +3,7 @@
 Various XML utilities
 '''
 
+
 def to_dict(xmltree):
     '''
     Convert an XML tree into a dict. The tree that is passed in must be an

--- a/salt/wheel/key.py
+++ b/salt/wheel/key.py
@@ -10,6 +10,7 @@ __func_alias__ = {
     'list_': 'list'
 }
 
+
 def list_(match):
     '''
     List all the keys under a named status


### PR DESCRIPTION
Jenkins is ignoring the following rules:
- E201: whitespace after ‘(‘
- E202: whitespace before ‘)’
- E203: whitespace before ‘:’  
- E211: whitespace before ‘(‘  
- E221: multiple spaces before operator
- E222: multiple spaces after operator
- E223: tab before operator
- E224: tab after operator
- E225: missing whitespace around operator
- E226: missing whitespace around arithmetic operator
- E227: missing whitespace around bitwise or shift operator
- E228: missing whitespace around modulo operator
- E501: line too long (82 > 79 characters)

All other issues that pep8 detects in current salt's source are fixed in this pull request.
