### PR TITLE
Add connection kwargs to keystone module and state.

### DIFF
--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -80,7 +80,9 @@ def user_present(name,
                  email,
                  tenant=None,
                  enabled=True,
-                 roles=None):
+                 roles=None,
+                 profile=None,
+                 **connection_args):
     '''
     Ensure that the keystone user is present with the specified properties.
 
@@ -109,7 +111,9 @@ def user_present(name,
 
     # Validate tenant if set
     if tenant is not None:
-        tenantdata = __salt__['keystone.tenant_get'](name=tenant)
+        tenantdata = __salt__['keystone.tenant_get'](name=tenant,
+                                                     profile=profile,
+                                                     **connection_args)
         if 'Error' in tenantdata:
             ret['result'] = False
             ret['comment'] = 'Tenant "{0}" does not exist'.format(tenant)
@@ -119,24 +123,35 @@ def user_present(name,
         tenant_id = None
 
     # Check if user is already present
-    user = __salt__['keystone.user_get'](name=name)
+    user = __salt__['keystone.user_get'](name=name, profile=profile,
+                                         **connection_args)
     if 'Error' not in user:
         if user[name]['email'] != email:
-            __salt__['keystone.user_update'](name=name, email=email)
+            __salt__['keystone.user_update'](name=name, email=email,
+                                             profile=profile, **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Email'] = 'Updated'
         if user[name]['enabled'] != enabled:
-            __salt__['keystone.user_update'](name=name, enabled=enabled)
+            __salt__['keystone.user_update'](name=name,
+                                             enabled=enabled,
+                                             profile=profile,
+                                             **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Enabled'] = 'Now {0}'.format(enabled)
         if tenant and user[name]['tenant_id'] != tenant_id:
-            __salt__['keystone.user_update'](name=name, tenant=tenant)
+            __salt__['keystone.user_update'](name=name, tenant=tenant,
+                                             profile=profile,
+                                             **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Tenant'] = 'Added to "{0}" tenant'.format(tenant)
         if not __salt__['keystone.user_verify_password'](name=name,
-                                                         password=password):
+                                                         password=password,
+                                                         profile=profile,
+                                                         **connection_args):
             __salt__['keystone.user_password_update'](name=name,
-                                                      password=password)
+                                                      password=password,
+                                                      profile=profile,
+                                                      **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Password'] = 'Updated'
         if roles:
@@ -159,21 +174,24 @@ def user_present(name,
                                          password=password,
                                          email=email,
                                          tenant_id=tenant_id,
-                                         enabled=enabled)
+                                         enabled=enabled,
+                                         profile=profile,
+                                         **connection_args)
         if roles:
             for tenant_role in roles[0].keys():
                 for role in roles[0][tenant_role]:
-                    args = {'user': name,
-                            'role': role,
-                            'tenant': tenant_role}
-                    __salt__['keystone.user_role_add'](**args)
+                    __salt__['keystone.user_role_add'](user=name,
+                                                       role=role,
+                                                       tenant_role=tenant_role,
+                                                       profile=profile,
+                                                       **connection_args)
         ret['comment'] = 'Keystone user {0} has been added'.format(name)
         ret['changes']['User'] = 'Created'
 
     return ret
 
 
-def user_absent(name):
+def user_absent(name,profile=None,**connection_args):
     '''
     Ensure that the keystone user is absent.
 
@@ -186,17 +204,20 @@ def user_absent(name):
            'comment': 'User "{0}" is already absent'.format(name)}
 
     # Check if user is present
-    user = __salt__['keystone.user_get'](name=name)
+    user = __salt__['keystone.user_get'](name=name, profile=profile,
+                                         **connection_args)
     if 'Error' not in user:
         # Delete that user!
-        __salt__['keystone.user_delete'](name=name)
+        __salt__['keystone.user_delete'](name=name, profile=profile,
+                                         **connection_args)
         ret['comment'] = 'User "{0}" has been deleted'.format(name)
         ret['changes']['User'] = 'Deleted'
 
     return ret
 
 
-def tenant_present(name, description=None, enabled=True):
+def tenant_present(name, description=None, enabled=True, profile=None,
+                   **connection_args):
     ''''
     Ensures that the keystone tenant exists
 
@@ -215,28 +236,38 @@ def tenant_present(name, description=None, enabled=True):
            'comment': 'Tenant "{0}" already exists'.format(name)}
 
     # Check if user is already present
-    tenant = __salt__['keystone.tenant_get'](name=name)
+    tenant = __salt__['keystone.tenant_get'](name=name,
+                                             profile=profile,
+                                             **connection_args)
 
     if 'Error' not in tenant:
         if tenant[name]['description'] != description:
-            __salt__['keystone.tenant_update'](name, description, enabled)
+            __salt__['keystone.tenant_update'](name, description,
+                                               enabled,
+                                               profile=profile,
+                                               **connection_args)
             comment = 'Tenant "{0}" has been updated'.format(name)
             ret['comment'] = comment
             ret['changes']['Description'] = 'Updated'
         if tenant[name]['enabled'] != enabled:
-            __salt__['keystone.tenant_update'](name, description, enabled)
+            __salt__['keystone.tenant_update'](name, description,
+                                               enabled,
+                                               profile=profile,
+                                               **connection_args)
             comment = 'Tenant "{0}" has been updated'.format(name)
             ret['comment'] = comment
             ret['changes']['Enabled'] = 'Now {0}'.format(enabled)
     else:
         # Create tenant
-        __salt__['keystone.tenant_create'](name, description, enabled)
+        __salt__['keystone.tenant_create'](name, description, enabled,
+                                           profile=profile,
+                                           **connection_args)
         ret['comment'] = 'Tenant "{0}" has been added'.format(name)
         ret['changes']['Tenant'] = 'Created'
     return ret
 
 
-def tenant_absent(name):
+def tenant_absent(name, profile=None, **connection_args):
     '''
     Ensure that the keystone tenant is absent.
 
@@ -249,22 +280,25 @@ def tenant_absent(name):
            'comment': 'Tenant "{0}" is already absent'.format(name)}
 
     # Check if tenant is present
-    tenant = __salt__['keystone.tenant_get'](name=name)
+    tenant = __salt__['keystone.tenant_get'](name=name,
+                                             profile=profile,
+                                             **connection_args)
     if 'Error' not in tenant:
         # Delete tenant
-        __salt__['keystone.tenant_delete'](name=name)
+        __salt__['keystone.tenant_delete'](name=name, profile=profile,
+                                           **connection_args)
         ret['comment'] = 'Tenant "{0}" has been deleted'.format(name)
         ret['changes']['Tenant'] = 'Deleted'
 
     return ret
 
 
-def role_present(name):
+def role_present(name, profile=None, **connection_args):
     ''''
     Ensures that the keystone role exists
 
     name
-        The name of the tenant to manage
+        The name of the role that should be present
     '''
     ret = {'name': name,
            'changes': {},
@@ -272,19 +306,21 @@ def role_present(name):
            'comment': 'Role "{0}" already exists'.format(name)}
 
     # Check if role is already present
-    role = __salt__['keystone.role_get'](name=name)
+    role = __salt__['keystone.role_get'](name=name, profile=profile,
+                                         **connection_args)
 
     if 'Error' not in role:
         return ret
     else:
         # Create role
-        __salt__['keystone.role_create'](name)
+        __salt__['keystone.role_create'](name, profile=profile,
+                                         **connection_args)
         ret['comment'] = 'Role "{0}" has been added'.format(name)
         ret['changes']['Role'] = 'Created'
     return ret
 
-
-def role_absent(name):
+ 
+def role_absent(name, profile=None, **connection_args):
     '''
     Ensure that the keystone role is absent.
 
@@ -297,17 +333,20 @@ def role_absent(name):
            'comment': 'Role "{0}" is already absent'.format(name)}
 
     # Check if role is present
-    role = __salt__['keystone.role_get'](name=name)
+    role = __salt__['keystone.role_get'](name=name, profile=profile,
+                                         **connection_args)
     if 'Error' not in role:
         # Delete role
-        __salt__['keystone.role_delete'](name=name)
+        __salt__['keystone.role_delete'](name=name, profile=profile,
+                                         **connection_args)
         ret['comment'] = 'Role "{0}" has been deleted'.format(name)
         ret['changes']['Role'] = 'Deleted'
 
     return ret
 
 
-def service_present(name, service_type, description=None):
+def service_present(name, service_type, description=None,
+                    profile=None, **connection_args):
     '''
     Ensure service present in Keystone catalog
 
@@ -326,19 +365,24 @@ def service_present(name, service_type, description=None):
            'comment': 'Service "{0}" already exists'.format(name)}
 
     # Check if service is already present
-    role = __salt__['keystone.service_get'](name=name)
+    role = __salt__['keystone.service_get'](name=name,
+                                            profile=profile,
+                                            **connection_args)
 
     if 'Error' not in role:
         return ret
     else:
         # Create service
-        __salt__['keystone.service_create'](name, service_type, description)
+        __salt__['keystone.service_create'](name, service_type,
+                                            description,
+                                            profile=profile,
+                                            **connection_args)
         ret['comment'] = 'Service "{0}" has been added'.format(name)
         ret['changes']['Service'] = 'Created'
     return ret
 
 
-def service_absent(name):
+def service_absent(name, profile=None, **connection_args):
     '''
     Ensure that the service doesn't exist in Keystone catalog
 
@@ -351,10 +395,14 @@ def service_absent(name):
            'comment': 'Service "{0}" is already absent'.format(name)}
 
     # Check if service is present
-    role = __salt__['keystone.service_get'](name=name)
+    role = __salt__['keystone.service_get'](name=name,
+                                            profile=profile,
+                                            **connection_args)
     if 'Error' not in role:
         # Delete service
-        __salt__['keystone.service_delete'](name=name)
+        __salt__['keystone.service_delete'](name=name,
+                                            profile=profile,
+                                            **connection_args)
         ret['comment'] = 'Service "{0}" has been deleted'.format(name)
         ret['changes']['Service'] = 'Deleted'
 


### PR DESCRIPTION
I added connection_args that can be specified via either the cli or with the state when using keystone. The connection_args follow the same scheme as the mysql module and with the existing grains/config variable naming:

``` yaml
keystone-user:
  keystone.user_present:
    - name: user
    - password: a_password
    - connection_user: admin
    - connection_token: TOKEN123 # or connection_pass: admin_password
    - connection_endpoint: http://127.0.0.1:35357/v2.0/ # or connection_auth_url: http://...
```

Building upon the previous additions to the module & state I also included the ability to specify a 'profile' along with a state declaration as well.
