### PR TITLE
Fix missing connection_args for user_present's role logic.

### DIFF
--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -156,13 +156,15 @@ def user_present(name,
             ret['changes']['Password'] = 'Updated'
         if roles:
             for tenant_role in roles[0].keys():
-                args = {'user_name': name, 'tenant_name': tenant_role}
+                args = dict({'user_name': name, 'tenant_name':
+                             tenant_role, 'profile': profile}, **connection_args)
                 tenant_roles = __salt__['keystone.user_role_list'](**args)
                 for role in roles[0][tenant_role]:
                     if role not in tenant_roles:
-                        addargs = {'user': name,
-                                   'role': role,
-                                   'tenant': tenant_role}
+                        addargs = dict({'user': name, 'role': role,
+                                        'tenant': tenant_role,
+                                        'profile': profile},
+                                       **connection_args)
                         newrole = __salt__['keystone.user_role_add'](**addargs)
                         if 'roles' in ret['changes']:
                             ret['changes']['roles'].append(newrole)


### PR DESCRIPTION
Fixes my previous PR that failed to include args for a few **salt**['keystone....'] calls. 
