### PR TITLE
Don't make pkg/service states available unless provider module is loaded

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -61,6 +61,14 @@ if salt.utils.is_windows():
 log = logging.getLogger(__name__)
 
 
+def __virtual__():
+    '''
+    Only make these states available if a pkg provider has been detected or
+    assigned for this minion
+    '''
+    return 'pkg' if 'pkg.install' in __salt__ else False
+
+
 def __gen_rtag():
     '''
     Return the location of the refresh tag

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -39,9 +39,10 @@ service, then set the reload value to True:
 
 def __virtual__():
     '''
-    Ensure that the service state returns the correct name
+    Only make these states available if a service provider has been detected or
+    assigned for this minion
     '''
-    return 'service'
+    return 'service' if 'service.start' in __salt__ else False
 
 
 def _enabled_used_error(ret):


### PR DESCRIPTION
This prevents ugly tracebacks when an OS does is not properly detected,
and no pkg or service provider was loaded for the minion. pkg and
service states will still fail, but they'll fail more gracefully,
without the traceback.
