### PR TITLE
git state to update repo where rev = branch name

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -36,6 +36,14 @@ def __virtual__():
     return 'git' if __salt__['cmd.has_exec']('git') else False
 
 
+def __ls_remote__(name, branch):
+    '''
+    Returns the upstream hash for any given URL and branch.
+    '''
+    cmd = "git ls-remote -h " + name + " " + branch + " | cut -f 1"
+    return __salt__['cmd.run_stdout'](cmd)
+
+
 def latest(name,
            rev=None,
            target=None,
@@ -162,13 +170,17 @@ def latest(name,
         try:
             current_rev = __salt__['git.revision'](target, user=user)
 
+            # handle the case where a branch was provided for rev
+            remote_rev = None
             branch = __salt__['git.current_branch'](target, user=runas)
-            if len(branch) > 0:
-                current_rev = branch
+            # We're only interested in the remote branch if a branch
+            # (instead of a hash, for example) was provided for rev.
+            if len(branch) > 0 and branch == rev:
+                remote_rev = __ls_remote__(name, branch)
 
-            #only do something, if the specified rev differs from the
-            #current_rev
-            if rev == current_rev:
+            # only do something, if the specified rev differs from the
+            # current_rev and remote_rev
+            if current_rev in [ rev, remote_rev ]:
                 new_rev = current_rev
             else:
 


### PR DESCRIPTION
I have discovered that the fix for #7370 introduced another problem. When rev = a branch name, it's great that it doesn't touch anything that it's not supposed to now, but it also doesn't update when it is supposed to! Sorry - my bad.

I've looked into this more closely, and tried to think of the various use-case scenarios that we need to support in this section of code so as to make sure we have everything covered. Here's what I came up with:
1. A hash was specified, we're not on a branch and there was no updates.
2. A hash was specified, we're not on a branch and there was updates.
3. A hash was specified, we're on a branch and there was no updates.
4. A hash was specified, we're on a branch and there was updates.
5. A branch was specified, we're not on a branch and there was no updates.
6. A branch was specified, we're not on a branch and there was updates.
7. A branch was specified, we're on a branch and there was no updates.
8. A branch was specified, we're on a branch and there was updates.

I think the attached pull request will now work in 7 of those 8 scenarios, but scenario 5 will still fail.

If we specify a branch but are not on a branch, but we have the correct hash, we don't want to touch the code and then say we touched nothing (issue #7370). Unfortunately, since we're not on a branch, we end up with:

```
current_rev = <some hash>
remote_rev = None
branch = ""
rev = 'master'
```

So current_rev won't match rev or remote_rev, and it will go through all the git magic that nukes any local post-pull changes that there might be. Perhaps someone smarter than me can find an elegant way to solve this, although I imagine that this scenario is quite unlikely - it's likely always been broken and nobody has complained.

In the meantime however, the pull request does solve more common scenarios such as number 8 (which I broke). Thanks.
