### PR TITLE
Replacing pull request #7178 with this. Adding file:// URL support for mako template and mine_get acl support (Issue#5467)

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -434,6 +434,26 @@
 #  foo.example.com:
 #    - manage.up
 
+#####         Mine settings     #####
+##########################################
+# Restrict mine.get access from minions. By default any minion has a full access
+# to get all mine data from master cache. In acl definion below, only pcre matches
+# are allowed.
+#
+# mine_get:
+#   .*:
+#     - .*
+#
+# Example below enables minion foo.example.com to get  'network.interfaces' mine data only
+# , minions web* to get all network.* and disk.* mine data and all other minions won't get
+# any mine data.
+#
+# mine_get:
+#   foo.example.com:
+#     - network.inetrfaces
+#   web.*:
+#     - network.*
+#     - disk.*
 
 #####         Logging settings       #####
 ##########################################

--- a/salt/master.py
+++ b/salt/master.py
@@ -901,6 +901,21 @@ class AESFuncs(object):
         '''
         if any(key not in load for key in ('id', 'tgt', 'fun')):
             return {}
+        if 'mine_get' in self.opts:
+            # If master side acl defined.
+            if not isinstance(self.opts['mine_get'],dict):
+                return {}
+            perms = set()
+            for match in self.opts['mine_get']:
+                if re.match(match, load['id']):
+                    if isinstance(self.opts['mine_get'][match], list):
+                            perms.update(self.opts['mine_get'][match])
+            good = False
+            for perm in perms:
+                if re.match(perm, load['fun']):
+                    good = True
+            if not good:
+                return {}
         ret = {}
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return ret


### PR DESCRIPTION
(1) Adding file:// URL support to lookup mako templates on local file system...
If mako templates are already present on a local file system on a
minion, it can use file:// URL to lookup a local copy. This in addition
to salt:// url support that is already present, which fetches a copy
from a salt server.

(2) Issue#5467 : Adding master side acl support for mine.get
