### PR TITLE
Fix corruption of files pushed to master with cp.push

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1030,10 +1030,10 @@ class AESFuncs(object):
                 os.makedirs(cdir)
             except os.error:
                 pass
-        if os.path.isfile(cpath):
-            mode = 'w'
+        if os.path.isfile(cpath) and load['loc'] != 0:
+            mode = 'ab'
         else:
-            mode = 'w+'
+            mode = 'wb'
         with salt.utils.fopen(cpath, mode) as fp_:
             if load['loc']:
                 fp_.seek(load['loc'])

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -449,7 +449,7 @@ def push(path):
             'id': __opts__['id'],
             'path': path.lstrip(os.sep)}
     sreq = salt.payload.SREQ(__opts__['master_uri'])
-    with salt.utils.fopen(path) as fp_:
+    with salt.utils.fopen(path, 'rb') as fp_:
         while True:
             load['loc'] = fp_.tell()
             load['data'] = fp_.read(__opts__['file_buffer_size'])


### PR DESCRIPTION
salt.master.AESFuncs._file_recv(), which receives the files transmitted
using the cp.push execution function, is executed once for each chunk
received. However, it was opening the filehandle using a 'w' or 'w+'
mode, which always truncates the file. So, when a file that exceeds the
size of the file_buffer_size minion config option (default: 262144
bytes), is pushed to the minion, and is thus sent in more than one
chunk, the file on the master is truncated. The filehandle then seeks to
the offset location of the chunk that was transmitted and writes the
chunk.

With the file being truncated every time a chunk is written, the result
is a file which contains null bytes everywhere but the final chunk,
causing the file to be corrupted.

This commit changes salt.master.AESFuncs._file_recv() so that it opens
the file for appending (instead of writing) if the destination file on
the master exists and the offset is nonzero. Otherwise, the file is
opened for writing.

Resolves #6495.
