### PR TITLE
Updated the gitfs tutorial.

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -45,6 +45,13 @@ Now the gitfs system needs to be configured with a remote:
     gitfs_remotes:
       - git://github.com/saltstack/salt-states.git
 
+.. note::
+
+    The salt-states repo is not currently updated with the latest versions
+    of the available states. Please review
+    https://github.com/saltstack-formulas for the latest versions.
+
+
 These changes require a restart of the master, then the git repo will be cached
 on the master and new requests for the ``salt://`` protocol will send files
 found in the remote git repository via the master.


### PR DESCRIPTION
Today it was noted in the IRC that the lack of a note stating that the salt-states repo doesn't have the latest versions of all the states is very confusing to new users as they expect that to have 'working' states that they can then use freely. Maybe at some point we can somehow sync the saltstack-formulas into the salt-states repo in a simplified way.
