### PR TITLE
s3fs names must match in their letter case.

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -38,6 +38,9 @@ Master config.
             - bucket3
             - bucket4
 
+    Note that bucket names must be all lowercase both in the AWS console
+    and in Salt, otherwise you may encounter "SignatureDoesNotMatch" errors.
+
     A multiple environment bucket must adhere to the following root directory
     structure::
 


### PR DESCRIPTION
It appears that if the case of the bucket names in AWS is not all lowercase that errors can sometimes present themselves. I've added a note to try and ensure users don't encounter that issue, or at least have a direction to go in.
