### PR TITLE
Windows packages are being wrongly detected as as an msi installer

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -345,10 +345,15 @@ def _get_reg_software():
                 pass
                 #Unsinstall key may not exist for all users
             for name, num, blank, time in win32api.RegEnumKeyEx(reg_handle):
-                if name[0] == '{':
-                    break
                 prd_uninst_key = "\\".join([reg_key, name])
                 #These reg values aren't guaranteed to exist
+                windows_installer = _get_reg_value(
+                    reg_hive,
+                    prd_uninst_key,
+                    'WindowsInstaller')
+                if windows_installer == 'Not Found' or not windows_installer:
+                    break
+
                 prd_name = _get_reg_value(
                     reg_hive,
                     prd_uninst_key,


### PR DESCRIPTION
I have been configuring windows installers but some installers write their registry key as a guid and salt assumes all installed entries starting with a '{' are msi installers and it will then filter ones that want to write a guid and are not msi installers. I changed it to look at the key that checks holds whether or not it is an msi installer.

An installer that had this issue was the ruby 1.8.7 windows installer
