### PR TITLE
Fix mtime option in file.find

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -491,7 +491,7 @@ def find(path, **kwargs):
 
     interval::
 
-        [<num>w] [<num>[d]] [<num>h] [<num>m] [<num>s]
+        [<num>w] [<num>d] [<num>h] [<num>m] [<num>s]
 
         where:
             w: week


### PR DESCRIPTION
While the docstring indicates that a +/- modifier is accepted for the
mtime argument to file.find, the regex that parses the mtime expression
does not match a leading plus or minus. This commit modifies that regex,
and then uses the +/- modifier to determine whether to match files older
or newer than the difference indicated by the mtime expression.

Fixes #2828.
