### PR TITLE
Initial addition of minion module memory limit

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -119,10 +119,10 @@
 # to reconnect immediately, if the socket is disconnected (for example if
 # the master processes are restarted). In large setups this will have all
 # minions reconnect immediately which might flood the master (the ZeroMQ-default
-# is usually a 100ms delay). To prevent this, these three recon_* settings 
+# is usually a 100ms delay). To prevent this, these three recon_* settings
 # can be used.
 #
-# recon_default: the interval in milliseconds that the socket should wait before 
+# recon_default: the interval in milliseconds that the socket should wait before
 #                trying to reconnect to the master (100ms = 1 second)
 #
 # recon_max: the maximum time a socket should wait. each interval the time to wait
@@ -136,14 +136,14 @@
 #            reconnect 5: value from previous interval * 2
 #            reconnect x: if value >= recon_max, it starts again with recon_default
 #
-# recon_randomize: generate a random wait time on minion start. The wait time will 
-#                  be a random value between recon_default and recon_default + 
-#                  recon_max. Having all minions reconnect with the same recon_default 
-#                  and recon_max value kind of defeats the purpose of being able to 
-#                  change these settings. If all minions have the same values and your 
-#                  setup is quite large (several thousand minions), they will still 
+# recon_randomize: generate a random wait time on minion start. The wait time will
+#                  be a random value between recon_default and recon_default +
+#                  recon_max. Having all minions reconnect with the same recon_default
+#                  and recon_max value kind of defeats the purpose of being able to
+#                  change these settings. If all minions have the same values and your
+#                  setup is quite large (several thousand minions), they will still
 #                  flood the master. The desired behaviour is to have timeframe within
-#                  all minions try to reconnect. 
+#                  all minions try to reconnect.
 
 # Example on how to use these settings:
 # The goal: have all minions reconnect within a 60 second timeframe on a disconnect
@@ -155,9 +155,9 @@
 #
 # Each minion will have a randomized reconnect value between 'recon_default'
 # and 'recon_default + recon_max', which in this example means between 1000ms
-# 60000ms (or between 1 and 60 seconds). The generated random-value will be 
-# doubled after each attempt to reconnect. Lets say the generated random 
-# value is 11 seconds (or 11000ms). 
+# 60000ms (or between 1 and 60 seconds). The generated random-value will be
+# doubled after each attempt to reconnect. Lets say the generated random
+# value is 11 seconds (or 11000ms).
 #
 # reconnect 1: wait 11 seconds
 # reconnect 2: wait 22 seconds
@@ -238,6 +238,13 @@
 # Enable Cython modules searching and loading. (Default: False)
 #cython_enable: False
 #
+#
+#
+# Specify a max size (in bytes) for modules on import
+# this feature is currently only supported on *nix OSs and requires psutil
+# modules_max_memory: -1
+
+
 
 #####    State Management Settings    #####
 ###########################################

--- a/salt/config.py
+++ b/salt/config.py
@@ -156,6 +156,7 @@ VALID_OPTS = {
     'win_repo': str,
     'win_repo_mastercachefile': str,
     'win_gitrepos': list,
+    'modules_max_memory': int,
 }
 
 # default configurations
@@ -241,6 +242,7 @@ DEFAULT_MINION_OPTS = {
     'tcp_keepalive_idle': 300,
     'tcp_keepalive_cnt': -1,
     'tcp_keepalive_intvl': -1,
+    'modules_max_memory': -1,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -34,6 +34,20 @@ try:
 except ImportError:
     pass
 
+HAS_PSUTIL = False
+try:
+    import psutil
+    HAS_PSUTIL = True
+except ImportError:
+    pass
+
+HAS_RESOURCE = False
+try:
+    import resource
+    HAS_RESOURCE = True
+except ImportError:
+    pass
+
 # Import salt libs
 from salt.exceptions import (
     AuthenticationError, CommandExecutionError, CommandNotFoundError,
@@ -490,9 +504,26 @@ class Minion(object):
         Return the functions and the returners loaded up from the loader
         module
         '''
+        # if this is a *nix system AND modules_max_memory is set, lets enforce
+        # a memory limit on module imports
+        # this feature ONLY works on *nix like OSs (resource module doesn't work on windows)
+        modules_max_memory = False
+        if self.opts.get('modules_max_memory', -1) > 0 and HAS_PSUTIL and HAS_RESOURCE:
+            log.debug('modules_max_memory set, enforcing a maximum of {0}'.format(self.opts['modules_max_memory']))
+            modules_max_memory = True
+            old_mem_limit = resource.getrlimit(resource.RLIMIT_AS)
+            rss, vms = psutil.Process(os.getpid()).get_memory_info()
+            mem_limit = rss + vms + self.opts['modules_max_memory']
+            resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
+
         self.opts['grains'] = salt.loader.grains(self.opts)
         functions = salt.loader.minion_mods(self.opts)
         returners = salt.loader.returners(self.opts, functions)
+
+        # we're done, reset the limits!
+        if modules_max_memory is True:
+            resource.setrlimit(resource.RLIMIT_AS, old_mem_limit)
+
         return functions, returners
 
     def _fire_master(self, data=None, tag=None, events=None, pretag=None):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -515,6 +515,11 @@ class Minion(object):
             rss, vms = psutil.Process(os.getpid()).get_memory_info()
             mem_limit = rss + vms + self.opts['modules_max_memory']
             resource.setrlimit(resource.RLIMIT_AS, (mem_limit, mem_limit))
+        elif self.opts.get('modules_max_memory', -1) > 0:
+            if not HAS_PSUTIL:
+                log.error('Unable to enforce modules_max_memory because psutil is missing')
+            if not HAS_RESOURCE:
+                log.error('Unable to enforce modules_max_memory because resource is missing')
 
         self.opts['grains'] = salt.loader.grains(self.opts)
         functions = salt.loader.minion_mods(self.opts)


### PR DESCRIPTION
This allows you to set a memory cap for modules to consume on load within the minion. This protects you from deploying a module which uses a large amount of memory on load.
