### PR TITLE
Dereferenced symbolic links when creating thin.tgz

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -42,7 +42,7 @@ def gen_thin(cachedir):
             ]
     if HAS_MARKUPSAFE:
         tops.append(os.path.dirname(markupsafe.__file__))
-    tfp = tarfile.open(thintar, 'w:gz')
+    tfp = tarfile.open(thintar, 'w:gz', dereference=True)
     start_dir = os.getcwd()
     for top in tops:
         base = os.path.basename(top)


### PR DESCRIPTION
This fixes issue https://github.com/saltstack/salt/issues/7482 (atleast on debian).

I can make this fix in the packaging, but good to get in for the next release.

Joe
