### PR TITLE
updated suse spec to salt 0.17.0

### DIFF
--- a/pkg/suse/salt.changes
+++ b/pkg/suse/salt.changes
@@ -1,4 +1,29 @@
 -------------------------------------------------------------------
+Thu Sep 19 17:18:06 UTC 2013 - aboe76@gmail.com
+
+- Updated 0.17.0 Feauture Release
+  Major features:
+  - halite (web Gui)
+  - salt ssh (remote execution/states over ssh) with its own package
+  - Rosters (list system targets not know to master)
+  - State Auto Order (state evaluation and execute in order of define)
+  - state.sls Runner (system orchestration from within states via master)
+  - Mercurial Fileserver Backend
+  - External Logging Handlers (sentry and logstash support)
+  - Jenkins Testing
+  - Salt Testing Project (testing libraries for salt)
+  - StormPath External Authentication support
+  - LXC Support (lxc support for salt-virt)
+  - Package dependencies reordering:
+     * salt-master requires python-pyzmq, and recommends python-halite
+     * salt-minion requires python-pyzmq
+     * salt-ssh requires sshpass
+     * salt-syndic requires salt-master
+  Minor features:
+  - 0.17.0 release wil be last release for 0.XX.X numbering system
+    Next release will be <Year>.<Month>.<Minor>
+     
+-------------------------------------------------------------------
 Sat Sep  7 22:44:41 UTC 2013 - aboe76@gmail.com
 
 - Update 0.16.4 bugfix release:

--- a/pkg/suse/salt.spec
+++ b/pkg/suse/salt.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           salt
-Version:        0.16.4
+Version:        0.17.0
 Release:        0
 Summary:        A parallel remote execution system
 License:        Apache-2.0
@@ -44,16 +44,14 @@ BuildRequires:  python-msgpack-python
 BuildRequires:  python-pycrypto
 BuildRequires:  python-pyzmq >= 2.1.9
 BuildRequires:  unzip
-# Disabled for now when salt-testing and salt 0.17 is available.
-#BuildRequires:  salt-testing
 Requires:       logrotate
 Requires:       python-Jinja2
 Requires:       python-M2Crypto
 Requires:       python-PyYAML
 Requires:       python-msgpack-python
 Requires:       python-pycrypto
-Requires:       python-pyzmq >= 2.1.9
 Requires:		python-GitPython
+Requires:		git
 Requires(pre): %fillup_prereq
 Requires(pre): %insserv_prereq
 %if 0%{?suse_version} >= 1210
@@ -72,15 +70,14 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 BuildArch:      noarch
 %endif
 
-# Disabled for now when salt-testing and salt 0.17 is available.
-#%if 0%{?suse_version} != 1220 && 0%{?suse_version} != 1230
-BuildRequires: python-unittest2
-# this BR causes windows tests to happen
-# clearly, that's not desired
-# https://github.com/saltstack/salt/issues/3749
-BuildRequires: python-mock
-BuildRequires: git
-#%endif
+## Disabled for now python-mock issues
+#%%if 0%{?suse_version} != 1220 && 0%{?suse_version} != 1230
+##BuildRequires: python-unittest2
+##BuildRequires: python-salt-testing
+##BuildRequires: python-xml
+##BuildRequires: python-mock
+##BuildRequires: git
+#%%endif
 
 %description
 Salt is a distributed remote execution system used to execute commands and
@@ -94,6 +91,8 @@ servers, handle them quickly and through a simple and manageable interface.
 Summary:        Management component for salt, a parallel remote execution system
 Group:          System/Monitoring
 Requires:       %{name} = %{version}
+Requires:       python-pyzmq >= 2.1.9
+Recommends:		python-halite
 Requires(pre):  %fillup_prereq
 Requires(pre):  %insserv_prereq
 
@@ -106,6 +105,7 @@ than serially.
 Summary:        Client component for salt, a parallel remote execution system
 Group:          System/Monitoring
 Requires:       %{name} = %{version}
+Requires:       python-pyzmq >= 2.1.9
 Requires(pre):  %fillup_prereq
 Requires(pre):  %insserv_prereq
 
@@ -117,6 +117,7 @@ Listens to the salt master and execute the commands.
 Summary:        Syndic component for salt, a parallel remote execution system
 Group:          System/Monitoring
 Requires:       %{name} = %{version}
+Requires:       %{name}-master = %{version}
 Requires(pre):  %fillup_prereq
 Requires(pre):  %insserv_prereq
 
@@ -124,6 +125,18 @@ Requires(pre):  %insserv_prereq
 Salt syndic is the master-of-masters for salt
 The master of masters for salt-- it enables
 the management of multiple masters at a time..
+
+%package ssh
+Summary:        Ssh component for salt, a parallel remote execution system
+Group:          System/Monitoring
+Requires:       %{name} = %{version}
+Requires:		sshpass
+Requires(pre):  %fillup_prereq
+Requires(pre):  %insserv_prereq
+
+%description ssh
+Salt ssh is a master running without zmq.
+it enables the management of minions over a ssh connection.
 
 %prep
 %setup -q
@@ -168,12 +181,12 @@ install -Dpm 0644  %{SOURCE7} %{buildroot}%{_sysconfdir}/logrotate.d/salt
 ##SuSEfirewall2 file
 install -Dpm 0644  %{SOURCE8} %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2.d/services/salt
 
-# Disabled for now when salt-testing and salt 0.17 is available.
-#%if 0%{?suse_version} != 1220 && 0%{?suse_version} != 1230
-#%check
-#export only_local_network=False
-#%{__python} setup.py test --runtests-opts=-u
-#%endif
+## Disabled for now python-mock issues
+#%%if 0%{?suse_version} != 1220 && 0%{?suse_version} != 1230
+#%%check
+##export only_local_network=False
+#%%{__python} setup.py test --runtests-opts=-u
+#%%endif
 
 %preun -n salt-syndic
 %stop_on_removal salt-syndic
@@ -232,6 +245,11 @@ install -Dpm 0644  %{SOURCE8} %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2
 %endif
 %insserv_cleanup
 
+%files -n salt-ssh
+%defattr(-,root,root)
+%{_bindir}/salt-ssh
+%{_mandir}/man1/salt-ssh.1.*
+
 %files -n salt-syndic
 %defattr(-,root,root)
 %{_bindir}/salt-syndic
@@ -263,8 +281,6 @@ install -Dpm 0644  %{SOURCE8} %{buildroot}%{_sysconfdir}/sysconfig/SuSEfirewall2
 %{_bindir}/salt-cp
 %{_bindir}/salt-key
 %{_bindir}/salt-run
-# Salt-ssh only available in salt 0.17
-#%{_bindir}/salt-ssh
 %{_mandir}/man1/salt-master.1.*
 %{_mandir}/man1/salt.1.*
 %{_mandir}/man1/salt-cp.1.*


### PR DESCRIPTION
created salt-ssh as a separate package
Package dependencies reordering:
     \* salt-master requires python-pyzmq, and recommends python-halite
     \* salt-minion requires python-pyzmq
     \* salt-ssh requires sshpass (needs to be accepted in opensuse)
     \* salt-syndic requires salt-master
