### PR TITLE
client/ssh/wrapper/config.py: rm unused import of urllib2

### DIFF
--- a/salt/client/ssh/wrapper/config.py
+++ b/salt/client/ssh/wrapper/config.py
@@ -6,7 +6,6 @@ Return config information
 # Import python libs
 import re
 import os
-import urllib2
 
 # Import salt libs
 import salt.utils


### PR DESCRIPTION
```
************* Module salt.client.ssh.wrapper.config
salt/client/ssh/wrapper/config.py:9: [W0611(unused-import), ] Unused import urllib2
```
