### PR TITLE
Service state fixes

### DIFF
--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -2,10 +2,16 @@
 '''
 daemontools service module. This module will create daemontools type
 service watcher.
-This module is states.service compatible so it can be used to maintain
-service state via provider interface:
 
-  - provider: daemontools
+This module is compatible with the :mod:`service <salt.states.service>` states,
+so it can be used to maintain services using the ``provider`` argument:
+
+.. code-block:: yaml
+
+    myservice:
+      service:
+        - running
+        - provider: daemontools
 '''
 
 # Import python libs
@@ -144,13 +150,26 @@ def status(name, sig=None):
         salt '*' daemontools.status <service name>
     '''
     cmd = 'svstat {0}'.format(_service_path(name))
-    ret = __salt__['cmd.run_stdout'](cmd)
-    match = re.search(r'\(pid (\d+)\)', ret)
+    out = __salt__['cmd.run_stdout'](cmd)
     try:
-        pid = match.group(1)
-    except Exception:
+        pid = re.search(r'\(pid (\d+)\)', out).group(1)
+    except AttributeError:
         pid = ''
     return pid
+
+
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' daemontools.available foo
+    '''
+    return name in get_all()
 
 
 def get_all():

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -71,6 +71,20 @@ def get_disabled():
     return sorted(set(get_all()) - set(get_enabled()))
 
 
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return all available boot services

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -245,6 +245,19 @@ def disabled(name):
     return not enabled(name)
 
 
+def available(name):
+    '''
+    Check that the given service is available.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return a list of all available services
@@ -336,16 +349,3 @@ def status(name, sig=None):
         return bool(__salt__['status.pid'](sig))
     cmd = '{0} {1} onestatus'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
-
-
-def available(name):
-    '''
-    Check that the given service is available.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' service.available sshd
-    '''
-    return name in get_all()

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -57,6 +57,20 @@ def get_disabled():
     return sorted(ret)
 
 
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return all available boot services

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -168,6 +168,20 @@ def get_disabled():
     return _get_svc_list('NO')
 
 
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return all available boot services

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -138,6 +138,20 @@ def reload_(name):
     return not __salt__['cmd.retcode'](cmd)
 
 
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return a list of all available services
@@ -151,16 +165,3 @@ def get_all():
     if not os.path.isdir(_GRAINMAP.get(__grains__.get('os'), '/etc/init.d')):
         return []
     return sorted(os.listdir(_GRAINMAP.get(__grains__.get('os'), '/etc/init.d')))
-
-
-def available(name):
-    '''
-    Return if the specified service is available
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' service.available
-    '''
-    return name in get_all()

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -68,6 +68,19 @@ def get_disabled():
     return sorted(ret)
 
 
+def available(name):
+    '''
+    Return if the specified service is available
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return all installed services

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -255,6 +255,20 @@ def get_disabled():
     return sorted(ret)
 
 
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return all installed services

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -77,6 +77,20 @@ def get_disabled():
     return sorted(ret)
 
 
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available <service name>
+    '''
+    return name in get_all()
+
+
 def get_all():
     '''
     Return all installed services


### PR DESCRIPTION
This pull req does two things:
1. Adds "available" functions to each provider that has a get_all function. This keeps service state overrides from falling back to the default provider's available function when service states check to see if the specified state is available (resolves #7361).
2. Improves reporting for service.dead states with enable=None.
