### PR TITLE
Fix minor documentation bug in states.mount.unmount

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -223,7 +223,7 @@ def unmounted(name,
     .. note::
         This state will be available in verion 0.17.0.
 
-    Verify that a device is mounted
+    Verify that a device is not mounted
 
     name
         The path to the location where the device is to be unmounted from


### PR DESCRIPTION
The documentation currently states that states.mount.UNmount verifies "that a device is mounted". That seems wrong.
