### PR TITLE
Updates to multiple salt-ssh/roster docs.

### DIFF
--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -17,6 +17,38 @@ Salt ssh allows for salt routines to be executed using only ssh for transport
 Options
 =======
 
+.. option:: -r, --raw, --raw-shell
+
+    Execute a raw shell command.
+
+.. option:: --roster-file
+
+    Define which roster system to use, this defines if a database backend,
+    scanner, or custom roster system is used. Default is the flat file roster.
+
+.. option:: --refresh, --refresh-cache
+
+    Force a refresh of the master side data cache of the target's data. This
+    is needed if a target's grains have been changed and the auto refresh
+    timeframe has not been reached.
+
+.. option:: --max-procs
+
+    Set the number of concurrent minions to communicate with. This value
+    defines how many processes are opened up at a time to manage connections,
+    the more running process the faster communication should be, default
+    is 25.
+
+.. option:: --passwd
+
+    Set te default password to attempt to use when authenticating.
+
+.. option:: --key-deploy
+
+   Set this flag to attempt to deploy the authorized ssh key with all
+   minions. This combined with --passwd can make initial deployment of keys
+   very fast and easy.
+
 .. program:: salt
 
 .. include:: _includes/common-options.rst

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -60,7 +60,9 @@ command:
 Commands with ``salt-ssh`` follow the same syntax as the ``salt`` command.
 
 The standard salt functions are available! The output is the same as ``salt``
-and many of the same flags are available.
+and many of the same flags are available. Please see 
+http://docs.saltstack.com/ref/cli/salt-ssh.html for all of the available
+options.
 
 Raw Shell Calls
 ---------------

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -14,7 +14,8 @@ identify which systems need to be targeted for execution.
 
 Since the roster system is pluggable, it can be easily augmented to attach to
 any existing systems to gather information about what servers are presently
-available and should be attached to by ``salt-ssh``.
+available and should be attached to by ``salt-ssh``. By default the roster
+file is located at /etc/salt/roster.
 
 How Rosters Work
 ================

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1561,7 +1561,7 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help='Set the number of concurrent minions to communicate with. '
                  'This value defines how many processes are opened up at a '
                  'time to manage connections, the more running processes the '
-                 'faster communication should be, default is 5')
+                 'faster communication should be, default is 25')
         self.add_option(
             '--passwd',
             dest='ssh_passwd',


### PR DESCRIPTION
Updated the salt-ssh.rst to add the new options that are available via the command line. Modified the ssh index.rst to include a link to the salt-ssh cli commands page. Updated parsers.py to fix the default value that is present in the documentation from 5 to 25 (as 25 is the actual default). Updated roster.rst to note that the default file location is /etc/salt/roster since it was absent, and might be confusing if you head to the roster documentation before reading the rest of the salt-ssh documentation.
