### PR TITLE
Allow salt-key -a/-r to work on rejected/accepted keys

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -57,32 +57,37 @@ class KeyCLI(object):
                 'key',
                 self.opts)
 
-    def accept(self, match):
+    def accept(self, match, ignore_rejected=False):
         '''
         Accept the keys matched
         '''
         def _print_accepted(matches, after_match):
-            if 'minions_pre' in after_match:
-                accepted = set(matches['minions_pre']).difference(
-                        set(after_match['minions_pre'])
-                        )
-            else:
-                accepted = matches['minions_pre']
-            for key in accepted:
-                print('Key for minion {0} accepted.'.format(key))
-
-        matches = self.key.name_match(match)
-        if not matches.get('minions_pre', False):
-            print(
-                'The key glob {0} does not match any unaccepted keys.'.format(
-                    match
+            if 'minions' in after_match:
+                accepted = sorted(
+                    set(after_match['minions']).difference(
+                        set(matches.get('minions', []))
                     )
                 )
+                for key in accepted:
+                    print('Key for minion {0} accepted.'.format(key))
+
+        matches = self.key.name_match(match)
+        keys = {}
+        if 'minions_pre' in matches:
+            keys['minions_pre'] = matches['minions_pre']
+        if not ignore_rejected and 'minions_rejected' in matches:
+            keys['minions_rejected'] = matches['minions_rejected']
+        if not keys:
+            msg = (
+                'The key glob {0!r} does not match any unaccepted {1}keys.'
+                .format(match, 'or rejected ' if not ignore_rejected else '')
+            )
+            print(msg)
             return
         if not self.opts.get('yes', False):
             print('The following keys are going to be accepted:')
             salt.output.display_output(
-                    {'minions_pre': matches['minions_pre']},
+                    keys,
                     'key',
                     self.opts)
             try:
@@ -90,28 +95,48 @@ class KeyCLI(object):
             except KeyboardInterrupt:
                 raise SystemExit("\nExiting on CTRL-c")
             if not veri or veri.lower().startswith('y'):
-                _print_accepted(matches, self.key.accept(match))
+                _print_accepted(
+                    matches,
+                    self.key.accept(match, ignore_rejected=ignore_rejected)
+                )
         else:
             print('The following keys are going to be accepted:')
             salt.output.display_output(
-                    {'minions_pre': matches['minions_pre']},
+                    keys,
                     'key',
                     self.opts)
-            _print_accepted(matches, self.key.accept(match))
+            _print_accepted(
+                matches,
+                self.key.accept(match, ignore_rejected=ignore_rejected)
+            )
 
     def accept_all(self):
         '''
         Accept all keys
         '''
-        self.accept('*')
+        self.accept('*', ignore_rejected=True)
 
     def delete(self, match):
         '''
         Delete the matched keys
         '''
+        def _print_deleted(matches, after_match):
+            deleted = []
+            for keydir in ('minions', 'minions_pre', 'minions_rejected'):
+                deleted.extend(list(
+                    set(matches.get(keydir, [])).difference(
+                        set(after_match.get(keydir, []))
+                    )
+                ))
+            for key in sorted(deleted):
+                print('Key for minion {0} deleted.'.format(key))
+
         matches = self.key.name_match(match)
         if not matches:
-            print('No keys to delete.')
+            print(
+                'The key glob {0!r} does not match any accepted, unaccepted '
+                'or rejected keys.'.format(match)
+            )
             return
         if not self.opts.get('yes', False):
             print('The following keys are going to be deleted:')
@@ -124,14 +149,14 @@ class KeyCLI(object):
             except KeyboardInterrupt:
                 raise SystemExit("\nExiting on CTRL-c")
             if veri.lower().startswith('y'):
-                self.key.delete_key(match)
+                _print_deleted(matches, self.key.delete_key(match))
         else:
             print('Deleting the following keys:')
             salt.output.display_output(
                     matches,
                     'key',
                     self.opts)
-            self.key.delete_key(match)
+            _print_deleted(matches, self.key.delete_key(match))
 
     def delete_all(self):
         '''
@@ -139,32 +164,53 @@ class KeyCLI(object):
         '''
         self.delete('*')
 
-    def reject(self, match):
+    def reject(self, match, ignore_accepted=False):
         '''
         Reject the matched keys
         '''
+        def _print_rejected(matches, after_match):
+            if 'minions_rejected' in after_match:
+                rejected = sorted(
+                    set(after_match['minions_rejected']).difference(
+                        set(matches.get('minions_rejected', []))
+                    )
+                )
+                for key in rejected:
+                    print('Key for minion {0} rejected.'.format(key))
+
         matches = self.key.name_match(match)
+        keys = {}
         if 'minions_pre' in matches:
-            matches = {'minions_pre': matches['minions_pre']}
-        else:
-            print('No keys found to reject')
+            keys['minions_pre'] = matches['minions_pre']
+        if not ignore_accepted and 'minions' in matches:
+            keys['minions'] = matches['minions']
+        if not keys:
+            msg = 'The key glob {0!r} does not match any {1} keys.'.format(
+                match,
+                'accepted or unaccepted' if not ignore_accepted
+                else 'unaccepted'
+            )
+            print(msg)
             return
         if not self.opts.get('yes', False):
             print('The following keys are going to be rejected:')
             salt.output.display_output(
-                    matches,
+                    keys,
                     'key',
                     self.opts)
             veri = raw_input('Proceed? [n/Y] ')
             if veri.lower().startswith('n'):
                 return
-        self.key.reject(match)
+        _print_rejected(
+            matches,
+            self.key.reject(match, ignore_accepted=ignore_accepted)
+        )
 
     def reject_all(self):
         '''
         Reject all keys
         '''
-        self.reject('*')
+        self.reject('*', ignore_accepted=True)
 
     def print_key(self, match):
         '''
@@ -384,19 +430,22 @@ class Key(object):
                     ret[status][key] = fp_.read()
         return ret
 
-    def accept(self, match):
+    def accept(self, match, ignore_rejected=False):
         '''
         Accept a specified host's public key based on name or keys based on
         glob
         '''
         matches = self.name_match(match)
-        if 'minions_pre' in matches:
-            for key in matches['minions_pre']:
+        keydirs = ['minions_pre']
+        if not ignore_rejected:
+            keydirs.append('minions_rejected')
+        for keydir in keydirs:
+            for key in matches.get(keydir, []):
                 try:
                     shutil.move(
                             os.path.join(
                                 self.opts['pki_dir'],
-                                'minions_pre',
+                                keydir,
                                 key),
                             os.path.join(
                                 self.opts['pki_dir'],
@@ -472,18 +521,21 @@ class Key(object):
         salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
 
-    def reject(self, match):
+    def reject(self, match, ignore_accepted=False):
         '''
         Reject a specified host's public key or keys based on a glob
         '''
         matches = self.name_match(match)
-        if 'minions_pre' in matches:
-            for key in matches['minions_pre']:
+        keydirs = ['minions_pre']
+        if not ignore_accepted:
+            keydirs.append('minions')
+        for keydir in keydirs:
+            for key in matches.get(keydir, []):
                 try:
                     shutil.move(
                             os.path.join(
                                 self.opts['pki_dir'],
-                                'minions_pre',
+                                keydir,
                                 key),
                             os.path.join(
                                 self.opts['pki_dir'],
@@ -491,8 +543,8 @@ class Key(object):
                                 key)
                             )
                     eload = {'result': True,
-                             'act': 'reject',
-                             'id': key}
+                            'act': 'reject',
+                            'id': key}
                     self.event.fire_event(eload, tagify(prefix='key'))
                 except (IOError, OSError):
                     pass

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -987,11 +987,11 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'queries')
         )
         self.add_option(
-           '--show-timeout',
-           default=False,
-           action='store_true',
-           help=('Display minions that timeout')
-       )
+            '--show-timeout',
+            default=False,
+            action='store_true',
+            help=('Display minions that timeout')
+        )
         self.add_option(
             '-b', '--batch',
             '--batch-size',
@@ -1199,7 +1199,8 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         actions_group.add_option(
             '-a', '--accept',
             default='',
-            help='Accept the following key'
+            help='Accept the specified public key (use --include-all to '
+                 'match rejected keys in addition to pending keys)'
         )
 
         actions_group.add_option(
@@ -1212,7 +1213,8 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         actions_group.add_option(
             '-r', '--reject',
             default='',
-            help='Reject the specified public key'
+            help='Reject the specified public key (use --include-all to '
+                 'match accepted keys in addition to pending keys)'
         )
 
         actions_group.add_option(
@@ -1220,6 +1222,13 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             default=False,
             action='store_true',
             help='Reject all pending keys'
+        )
+
+        actions_group.add_option(
+            '--include-all',
+            default=False,
+            action='store_true',
+            help='Include non-pending keys when accepting/rejecting'
         )
 
         actions_group.add_option(


### PR DESCRIPTION
PLEASE HOLD OFF ON MERGING UNTIL THIS PULL REQUEST HAS BEEN DISCUSSED. SEE COMMENTS BELOW FOR DETAILS.

This commit modifies salt-key so that -a looks at rejected keys in
addition to pending keys, and -r looks at accepted keys in addition to
pending keys.

The -A and -R arguments still operate on pending keys only.

In addition, this commit improves reporting on the CLI when keys are
rejected and deleted.
