### PR TITLE
fixed both errors after sphinx build

### DIFF
--- a/doc/topics/conventions/formulas.rst
+++ b/doc/topics/conventions/formulas.rst
@@ -218,11 +218,14 @@ The ``CHANGELOG.rst`` file should detail the individual versions, their
 release date and a set of bullet points for each version highlighting the
 overall changes in a given version of the formula.
 
-A sample skeleton for the ``CHANGELOG.rst` file:
+A sample skeleton for the `CHANGELOG.rst` file:
 
 :file:`CHANGELOG.rst`:
 
+.. code:: rest
+
     foo formula
+    ===========
 
     0.0.2 (2013-01-01)
 

--- a/doc/topics/conventions/packaging.rst
+++ b/doc/topics/conventions/packaging.rst
@@ -15,7 +15,7 @@ pypi. Release packages should *NEVER* use a git checkout as the source for
 distribution.
 
 Single Package
-=============
+==============
 
 Shipping Salt as a single package, where the minion, master and all tools are
 together is perfectly acceptable and practiced by distributions such as


### PR DESCRIPTION
fixed two sphinx build errors:
salt-git/src/salt/doc/topics/conventions/formulas.rst:224: WARNING: Inline literal start-string without end-string.
salt-git/src/salt/doc/topics/conventions/packaging.rst:21: WARNING: Title underline too short.
