### PR TITLE
Add --ssh-priv option to SaltSSHOptionParser

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1530,6 +1530,10 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'raw shell command')
         )
         self.add_option(
+            '--ssh-priv',
+            dest='ssh_priv',
+            help=('Ssh private key file'))
+        self.add_option(
             '--roster',
             dest='roster',
             default='',


### PR DESCRIPTION
I'm not sure if this is desired option but I wasn't able to find any way to setup `ssh_priv` value in `SSH` execution object (https://github.com/saltstack/salt/blob/develop/salt/client/ssh/__init__.py#L73). Have I missed something?
