### PR TITLE
Fix regression in salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -98,8 +98,6 @@ class Caller(object):
             oput = self.minion.functions[fun].__outputter__
             if isinstance(oput, string_types):
                 ret['out'] = oput
-            if oput == 'highstate':
-                ret['return'] = {'local': ret['return']}
         if self.opts.get('return', ''):
             ret['id'] = self.opts['id']
             ret['fun'] = fun


### PR DESCRIPTION
This fixes a regression that I inadvertently caused in d749e5a by
always wrapping the return data in a dict. An extra step here in the
Caller class was duplicating this action, causing a traceback when
attempting to increment the result counts for the highstate outputter.

Resolves #7456.
