### PR TITLE
Allow region_name to be passed through to nova module

### DIFF
--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -11,6 +11,8 @@ Module for handling openstack nova calls.
         keystone.password: verybadpass
         keystone.tenant: admin
         keystone.auth_url: 'http://127.0.0.1:5000/v2.0/'
+        # Optional
+        keystone.region_name: 'regionOne'
 
     If configuration for multiple openstack accounts is required, they can be
     set up as different configuration profiles:

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -75,14 +75,23 @@ def _auth(profile=None):
         password = credentials['keystone.password']
         tenant = credentials['keystone.tenant']
         auth_url = credentials['keystone.auth_url']
+        region_name = credentials.get('keystone.region_name', None)
     else:
         user = __salt__['config.option']('keystone.user')
         password = __salt__['config.option']('keystone.password')
         tenant = __salt__['config.option']('keystone.tenant')
         auth_url = __salt__['config.option']('keystone.auth_url')
-    return client.Client(
-        user, password, tenant, auth_url, service_type="compute"
-    )
+        region_name = __salt__['config.option']('keystone.region_name')
+    kwargs = {
+        'username': user,
+        'api_key': password,
+        'project_id': tenant,
+        'auth_url': auth_url,
+        'service_type': 'compute',
+    }
+    if region_name:
+        kwargs['region_name'] = region_name
+    return client.Client(**kwargs)
 
 
 def boot(name, flavor_id=0, image_id=0, profile=None):


### PR DESCRIPTION
This is necessary for Rackspace to be accessed using this driver.
