### PR TITLE
add support to activate virtualenv in pip.installed

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -107,6 +107,7 @@ def installed(name,
               runas=None,
               no_chown=False,
               cwd=None,
+              activate=False,
               pre_releases=False,
               __env__='base'):
     '''
@@ -308,6 +309,7 @@ def installed(name,
         user=user,
         no_chown=no_chown,
         cwd=cwd,
+        activate=activate,
         pre_releases=pre_releases,
         __env__=__env__
     )


### PR DESCRIPTION
trying to solve a problem I had when installing a python package (from bzr+http) into a virtualenv that had bzr installed in the virtualenv and not the main site-packages. therefor I had to activate before installing packages with bzr+http
