### PR TITLE
Remove vm_info return value

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -626,7 +626,7 @@ def init(name,
     if start:
         create(name)
 
-    return vm_info(name)
+    return True
 
 
 def list_vms():


### PR DESCRIPTION
Meant to make some minor edits, but the only substantive one was this
return value.  Henrik suggested it may be overly burdensome to vm_info
