### PR TITLE
Remove unused import

### DIFF
--- a/tests/unit/modules/virt_test.py
+++ b/tests/unit/modules/virt_test.py
@@ -2,7 +2,6 @@
 
 # Import python libs
 import sys
-from xml.etree import ElementTree as ElementTree
 
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase


### PR DESCRIPTION
We use ElementTree from salt._compat.
