### PR TITLE
Fixing 'zero length field name in format' error in the MySQL module.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1050,7 +1050,7 @@ def user_grants(user,
     for grant in results:
         tmp = grant[0].split(' IDENTIFIED BY')[0]
         if 'WITH GRANT OPTION' in grant[0]:
-            tmp = '{} WITH GRANT OPTION'.format(tmp)
+            tmp = '{0} WITH GRANT OPTION'.format(tmp)
         ret.append(tmp)
     log.debug(ret)
     return ret


### PR DESCRIPTION
{} should be {0}. This was preventing the MySQL module from working with MySQL grants containing WITH GRANT OPTION.
