### PR TITLE
The documentation for state ordering contained duplicate information abo...

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -53894,9 +53894,6 @@ Salt has been created to get the best of both worlds. States are evaluated in
 a finite order, which guarantees that states are always executed in the same
 order, and the states runtime is declarative, making Salt fully aware of
 dependencies via the requisite system.
-.sp
-Also, in Salt 0.17.0, the \fBstate_auto_order\fP option was added to Salt.
-It makes states get evaluated in the order in which they are defined.
 .SS State Auto Ordering
 .sp
 Salt always executes states in a finite manner, meaning that they will always

--- a/doc/ref/states/ordering.rst
+++ b/doc/ref/states/ordering.rst
@@ -17,9 +17,6 @@ a finite order, which guarantees that states are always executed in the same
 order, and the states runtime is declarative, making Salt fully aware of
 dependencies via the requisite system.
 
-Also, in Salt 0.17.0, the ``state_auto_order`` option was added to Salt.
-It makes states get evaluated in the order in which they are defined.
-
 State Auto Ordering
 ===================
 


### PR DESCRIPTION
...ut 0.17 in two contiguous paragraphs. Removed the first of those occurrences to improve readability.
