### PR TITLE
Updated docs to include defining service_url and using 's3fs' in fileser...

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -8,7 +8,7 @@ This backend exposes directories in S3 buckets as Salt environments.  This
 feature is managed by the :conf_master:`fileserver_backend` option in the Salt
 Master config.
 
-:configuration: S3 credentials can be either set in the master file using:
+:configuration: 
 
     S3 credentials can be set in the master config file with::
 
@@ -17,6 +17,19 @@ Master config.
 
     Alternatively, if on EC2 these credentials can be automatically loaded from
     instance metadata.
+
+    You will need to specify the service_url with:
+
+        service_url: s3.amazonaws.com
+
+    You can find a listing of the S3 enpoints at:
+
+        http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
+
+    Lastly, include s3fs in your fileserver_backend:
+
+        fileserver_backend:
+          - s3fs
 
     This fileserver supports two modes of operation for the buckets:
 


### PR DESCRIPTION
Updated the docs. Previously had no mention of needing to define 'service_url' and didn't mention if 's3' or 's3fs' should be in fileserver_backends.

Somewhat related to #7448.
