### PR TITLE
Fixing grant_option False being evaluated as a string and therefore True

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -998,16 +998,6 @@ def __grant_generate(grant,
     if grant == 'ALL':
         grant = 'ALL PRIVILEGES'
 
-    # If False gets passed in by the user it is interpreted as a string.
-    # That means that str 'False' will evaluate to bool True.
-    # This prevents that.
-    if grant_option == 'False':
-        grant_option = False
-    elif grant_option == 'True':
-        grant_option = True
-    else:
-        grant_option = False
-
     db_part = database.rpartition('.')
     dbc = db_part[0]
     table = db_part[2]
@@ -1020,7 +1010,7 @@ def __grant_generate(grant,
     qry = 'GRANT {0} ON {1}.{2} TO {3!r}@{4!r}'.format(
         grant, dbc, table, user, host
     )
-    if grant_option:
+    if salt.utils.is_true(grant_option):
         qry += ' WITH GRANT OPTION'
     log.debug('Query generated: {0}'.format(qry))
     return qry

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1161,7 +1161,7 @@ def grant_revoke(grant,
         return False
     cur = dbc.cursor()
 
-    if salt.util.is_true(grant_option):
+    if salt.utils.is_true(grant_option):
         grant += ', GRANT OPTION'
     qry = 'REVOKE {0} ON {1} FROM {2!r}@{3!r};'.format(
         grant, database, user, host

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -998,6 +998,16 @@ def __grant_generate(grant,
     if grant == 'ALL':
         grant = 'ALL PRIVILEGES'
 
+    # If False gets passed in by the user it is interpreted as a string.
+    # That means that str 'False' will evaluate to bool True.
+    # This prevents that.
+    if grant_option == 'False':
+        grant_option = False
+    elif grant_option == 'True':
+        grant_option = True
+    else:
+        grant_option = False
+
     db_part = database.rpartition('.')
     dbc = db_part[0]
     table = db_part[2]

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1161,7 +1161,7 @@ def grant_revoke(grant,
         return False
     cur = dbc.cursor()
 
-    if grant_option:
+    if salt.util.is_true(grant_option):
         grant += ', GRANT OPTION'
     qry = 'REVOKE {0} ON {1} FROM {2!r}@{3!r};'.format(
         grant, database, user, host


### PR DESCRIPTION
If False gets passed in by the user it is interpreted as a string. That means that str 'False' will evaluate to bool True. This prevents that.
