### PR TITLE
Fixed wrong return statement

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -552,7 +552,7 @@ class ReactWrap(object):
                     'Failed to execute {0}: {1}\n'.format(low['state'], l_fun),
                     exc_info=True
                     )
-            return ret
+            return False
         return ret
 
     def cmd(self, *args, **kwargs):


### PR DESCRIPTION
`ret` variable is not present if some error occurs. Which leads to this traceback:

```
Process Reactor-4:
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/event.py", line 416, in run
    self.call_reactions(chunks)
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/event.py", line 403, in call_reactions
    self.wrap.run(chunk)
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/event.py", line 440, in run
    return ret
UnboundLocalError: local variable 'ret' referenced before assignment
```
