### PR TITLE
Patch `salt.utils.which` to fix Django tests.

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -26,7 +26,7 @@ __outputter__ = {
 }
 
 # http://stackoverflow.com/a/12414913/127816
-infinitedict = lambda: collections.defaultdict(infinitedict)
+_infinitedict = lambda: collections.defaultdict(_infinitedict)
 
 
 def _serial_sanitizer(instr):
@@ -339,7 +339,7 @@ def _dict_from_path(path, val, delim=':'):
     >>> _dict_from_path('foo:bar:baz', 'somevalue')
     {"foo": {"bar": {"baz": "somevalue"}}
     '''
-    nested_dict = infinitedict()
+    nested_dict = _infinitedict()
     keys = path.rsplit(delim)
     lastplace = reduce(operator.getitem, keys[:-1], nested_dict)
     lastplace[keys[-1]] = val

--- a/tests/integration/modules/django.py
+++ b/tests/integration/modules/django.py
@@ -15,6 +15,7 @@ django.__salt__ = {}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@patch('salt.utils.which', lambda exe: exe)
 class DjangoModuleTest(integration.ModuleCase):
     '''
     Test the django module


### PR DESCRIPTION
After the check added in 8deefc16, the django salt module integration test cases started to fail if the django administration script was not found in `$PATH`.
