### PR TITLE
Documentation changes/updates

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -625,8 +625,11 @@ configuration is the same as :conf_master:`file_roots`:
 
 The ext_pillar option allows for any number of external pillar interfaces to be
 called when populating pillar data. The configuration is based on ext_pillar
-functions. The available ext_pillar functions are: hiera, cmd_yaml. By default
-the ext_pillar interface is not configured to run.
+functions. The available ext_pillar functions can be found herein:
+
+:blob:`salt/pillar`
+
+By default, the ext_pillar interface is not configured to run.
 
 Default:: ``None``
 
@@ -811,7 +814,7 @@ Master Logging Settings
 
 Default: ``/var/log/salt/master``
 
-The master log can be sent to a regular file, local path name, or network 
+The master log can be sent to a regular file, local path name, or network
 location. See also :conf-log:`log_file`.
 
 Examples:
@@ -853,7 +856,7 @@ The level of messages to send to the console. See also :conf-log:`log_level`.
 
 Default: ``warning``
 
-The level of messages to send to the log file. See also 
+The level of messages to send to the log file. See also
 :conf-log:`log_level_logfile`.
 
 .. code-block:: yaml
@@ -869,7 +872,7 @@ The level of messages to send to the log file. See also
 
 Default: ``%H:%M:%S``
 
-The date and time format used in console log messages. See also 
+The date and time format used in console log messages. See also
 :conf-log:`log_datefmt`.
 
 .. code-block:: yaml
@@ -886,7 +889,7 @@ The date and time format used in console log messages. See also
 
 Default: ``%Y-%m-%d %H:%M:%S``
 
-The date and time format used in log file messages. See also 
+The date and time format used in log file messages. See also
 :conf-log:`log_datefmt_logfile`.
 
 .. code-block:: yaml
@@ -902,7 +905,7 @@ The date and time format used in log file messages. See also
 
 Default: ``[%(levelname)-8s] %(message)s``
 
-The format of the console logging messages. See also 
+The format of the console logging messages. See also
 :conf-log:`log_fmt_console`.
 
 .. code-block:: yaml
@@ -918,7 +921,7 @@ The format of the console logging messages. See also
 
 Default: ``%(asctime)s,%(msecs)03.0f [%(name)-17s][%(levelname)-8s] %(message)s``
 
-The format of the log file logging messages. See also 
+The format of the log file logging messages. See also
 :conf-log:`log_fmt_logfile`.
 
 .. code-block:: yaml
@@ -934,7 +937,7 @@ The format of the log file logging messages. See also
 
 Default: ``{}``
 
-This can be used to control logging levels more specifically. See also 
+This can be used to control logging levels more specifically. See also
 :conf-log:`log_granular_levels`.
 
 
@@ -973,7 +976,7 @@ option then the master will log a warning message.
 
     # Include files from a master.d directory in the same
     # directory as the master config file
-    include: master.d/*.conf
+    include: master.d/*
 
     # Include a single extra file into the configuration
     include: /etc/roles/webserver

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -361,6 +361,22 @@ If you are on Python < 2.7 then you will also need unittest2:
 
     pip install unittest2
 
+
+.. note::
+
+    In Salt 0.17, testing libraries were migrated into their own repo. To install them:
+
+     .. code-block:: bash
+
+         pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
+
+
+    Failure to install SaltTesting will result in import errors similar to the following:
+
+     .. code-block:: bash
+
+        ImportError: No module named salttesting
+
 Finally you use setup.py to run the tests with the following command:
 
 .. code-block:: bash


### PR DESCRIPTION
WARNING: Please review for accuracy, as I am fairly certain that my understanding is correct but not 100% proof-positive: An update to the documentation for the external pillars. This reflects the fact that many more external pillars are now in existence than when the documentation was likely initially written.  

Also, an update to the documentation for establishing a development environment to reflect the fact that salt-testing has migrated testing libraries into a separate repository.
