### PR TITLE
Issue 7626 tmplpath

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -55,6 +55,8 @@ def wrap_tmpl_func(render_str):
                 tmplstr = tmplsrc
             else:
                 try:
+                    if tmplpath is not None:
+                        tmplsrc = os.path.join(tmplpath, tmplsrc)
                     with codecs.open(tmplsrc, 'r', SLS_ENCODING) as _tmplsrc:
                         tmplstr = _tmplsrc.read()
                 except (UnicodeDecodeError, ValueError) as exc:

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -40,8 +40,12 @@ SLS_ENCODER = codecs.getencoder(SLS_ENCODING)
 
 
 def wrap_tmpl_func(render_str):
-    def render_tmpl(tmplsrc, from_str=False, to_str=False,
-                    context=None, tmplpath=None, **kws):
+    def render_tmpl(tmplsrc,
+                    from_str=False,
+                    to_str=False,
+                    context=None,
+                    tmplpath=None,
+                    **kws):
         if context is None:
             context = {}
         # We want explicit context to overwrite the **kws

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -63,7 +63,10 @@ def wrap_tmpl_func(render_str):
                         tmplsrc = os.path.join(tmplpath, tmplsrc)
                     with codecs.open(tmplsrc, 'r', SLS_ENCODING) as _tmplsrc:
                         tmplstr = _tmplsrc.read()
-                except (UnicodeDecodeError, ValueError) as exc:
+                except (UnicodeDecodeError,
+                        ValueError,
+                        OSError,
+                        IOError) as exc:
                     if salt.utils.is_bin_file(tmplsrc):
                         # Template is a bin file, return the raw file
                         return dict(result=True, data=tmplsrc)


### PR DESCRIPTION
Before this change you had to directly use `render_*_tmpl()` in order to
use `tmplpath`. Failing that, by using the renderers wrapped with
`wrap_tmpl_func()` the `tmplpath` argument was not used.
