### PR TITLE
Fix remaining refs to pkg.compare

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -86,20 +86,23 @@ def latest_version(*names, **kwargs):
             ret[name] = ''
             if full_name in pkgs:
                 version_num = pkgs[full_name]
-            if __salt__['pkg.compare'](pkg1=str(candidate), oper='>',
-                                       pkg2=str(version_num)):
+            if salt.utils.compare_versions(ver1=str(candidate),
+                                           oper='>',
+                                           ver2=str(version_num)):
                 ret[name] = candidate
             continue
         for ver in pkginfo.keys():
-            if __salt__['pkg.compare'](pkg1=str(ver), oper='>',
-                                       pkg2=str(candidate)):
+            if salt.utils.compare_versions(ver1=str(ver),
+                                           oper='>',
+                                           ver2=str(candidate)):
                 candidate = ver
         full_name = pkginfo[candidate]['full_name']
         ret[name] = ''
         if full_name in pkgs:
             version_num = pkgs[full_name]
-        if __salt__['pkg.compare'](pkg1=str(candidate), oper='>',
-                                   pkg2=str(version_num)):
+        if salt.utils.compare_versions(ver1=str(candidate),
+                                       oper='>',
+                                       ver2=str(version_num)):
             ret[name] = candidate
     if len(names) == 1:
         return ret[names[0]]

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -467,9 +467,9 @@ def install(name=None,
                 else:
                     arch = ''
                 pkgstr = '"{0}-{1}{2}"'.format(pkgname, version_num, arch)
-                if not cver or __salt__['pkg.compare'](pkg1=version_num,
-                                                       oper='>=',
-                                                       pkg2=cver):
+                if not cver or salt.utils.compare_versions(ver1=version_num,
+                                                           oper='>=',
+                                                           ver2=cver):
                     targets.append(pkgstr)
                 else:
                     downgrade.append(pkgstr)


### PR DESCRIPTION
Pull request #7636 fixed a regression caused by refs to a removed
execution function 'pkg.compare'. This function was moved to salt.utils
and made a common interface so that version comparison could be done
elsewhere in the salt codebase, and these refs were missed when doing
the cleanup.
