### PR TITLE
Checking for newline at EOF in modules.file.append()

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1186,7 +1186,14 @@ def append(path, *args):
     '''
     # Largely inspired by Fabric's contrib.files.append()
 
-    with salt.utils.fopen(path, "a") as ofile:
+    with salt.utils.fopen(path, "r+") as ofile:
+        # Make sure we have a newline at the end of the file
+        ofile.seek(-1, os.SEEK_END)
+        if ofile.read(1) != '\n':
+            ofile.seek(0, os.SEEK_END)
+            ofile.write('\n')
+        else:
+            ofile.seek(0, os.SEEK_END)
         for line in args:
             ofile.write('{0}\n'.format(line))
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1188,12 +1188,21 @@ def append(path, *args):
 
     with salt.utils.fopen(path, "r+") as ofile:
         # Make sure we have a newline at the end of the file
-        ofile.seek(-1, os.SEEK_END)
-        if ofile.read(1) != '\n':
-            ofile.seek(0, os.SEEK_END)
-            ofile.write('\n')
+        try:
+            ofile.seek(-1, os.SEEK_END)
+        except IOError as exc:
+            if exc.errno == errno.EINVAL:
+                # Empty file, simply append lines at the beginning of the file
+                pass
+            else:
+                raise
         else:
-            ofile.seek(0, os.SEEK_END)
+            if ofile.read(1) != '\n':
+                ofile.seek(0, os.SEEK_END)
+                ofile.write('\n')
+            else:
+                ofile.seek(0, os.SEEK_END)
+        # Append lines
         for line in args:
             ofile.write('{0}\n'.format(line))
 

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -126,18 +126,25 @@ class FileModuleTestCase(TestCase):
         Check that file.append works consistently on files with and without
         newlines at end of file.
         '''
+        # File ending with a newline
         with tempfile.NamedTemporaryFile() as tfile:
             tfile.write('foo\n')
             tfile.flush()
             filemod.append(tfile.name, 'bar')
             with open(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), 'foo\nbar\n')
+        # File not ending with a newline
         with tempfile.NamedTemporaryFile() as tfile:
             tfile.write('foo')
             tfile.flush()
             filemod.append(tfile.name, 'bar')
             with open(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), 'foo\nbar\n')
+        # A newline should not be added in empty files
+        with tempfile.NamedTemporaryFile() as tfile:
+            filemod.append(tfile.name, 'bar')
+            with open(tfile.name) as tfile2:
+                self.assertEqual(tfile2.read(), 'bar\n')
 
 
 if __name__ == '__main__':

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -121,6 +121,24 @@ class FileModuleTestCase(TestCase):
                     newfile.read()
                 )
 
+    def test_append_newline_at_eof(self):
+        '''
+        Check that file.append works consistently on files with and without
+        newlines at end of file.
+        '''
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write('foo\n')
+            tfile.flush()
+            filemod.append(tfile.name, 'bar')
+            with open(tfile.name) as tfile2:
+                self.assertEqual(tfile2.read(), 'foo\nbar\n')
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write('foo')
+            tfile.flush()
+            filemod.append(tfile.name, 'bar')
+            with open(tfile.name) as tfile2:
+                self.assertEqual(tfile2.read(), 'foo\nbar\n')
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
This patch makes sure that a newline is present at end of file before appending.

In files not ending with a newline, it avoids ending with the last original line mixed up with the first appended line.
