### PR TITLE
s/existant/existent/

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -48,7 +48,7 @@ def __virtual__():
 def _enabled_used_error(ret):
     ret['result'] = False
     ret['comment'] = (
-        'Service {0} uses non-existant option "enabled".  ' +
+        'Service {0} uses non-existent option "enabled".  ' +
         'Perhaps "enable" option was intended?'
     ).format(ret['name'])
     return ret


### PR DESCRIPTION
Just a little typo I noticed while I was setting up services using salt.
