### PR TITLE
Function arguments for smtp returner

### DIFF
--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -67,13 +67,15 @@ def returner(ret):
                '\r\n'
                'id: {4}\r\n'
                'function: {5}\r\n'
-               'jid: {6}\r\n'
-               '{7}').format(from_addr,
+               'function args: {6}\r\n'
+               'jid: {7}\r\n'
+               '{8}').format(from_addr,
                              to_addrs,
                              formatdate(localtime=True),
                              subject,
                              ret['id'],
                              ret['fun'],
+                             ret['fun_args'],
                              ret['jid'],
                              content)
 

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -7,6 +7,7 @@ The following fields can be set in the minion conf file:
     smtp.from (required)
     smtp.to (required)
     smtp.host (required)
+    smtp.port (optional, defaults to 25)
     smtp.username (optional)
     smtp.password (optional)
     smtp.tls (optional, defaults to False)
@@ -49,6 +50,7 @@ def returner(ret):
     from_addr = __salt__['config.option']('smtp.from')
     to_addrs = __salt__['config.option']('smtp.to')
     host = __salt__['config.option']('smtp.host')
+    port = __salt__['config.option']('smtp.port')
     user = __salt__['config.option']('smtp.username')
     passwd = __salt__['config.option']('smtp.password')
     subject = __salt__['config.option']('smtp.subject')
@@ -79,7 +81,7 @@ def returner(ret):
                              ret['jid'],
                              content)
 
-    server = smtplib.SMTP(host)
+    server = smtplib.SMTP(host, int(port))
     if __salt__['config.option']('smtp.tls') is True:
         server.starttls()
     if user and passwd:

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -51,6 +51,9 @@ def returner(ret):
     to_addrs = __salt__['config.option']('smtp.to')
     host = __salt__['config.option']('smtp.host')
     port = __salt__['config.option']('smtp.port')
+    if not port:
+        port = 25
+    log.debug('smtp port has been set to {0}'.format(port))
     user = __salt__['config.option']('smtp.username')
     passwd = __salt__['config.option']('smtp.password')
     subject = __salt__['config.option']('smtp.subject')


### PR DESCRIPTION
Added smtp function arguments to the body of the outbound message. 

I realized that I could not set the smtp port for the smtp returner, so I added an optional config to the smtp returner where one can set the smtp host port for outbound communication. Defaults to 25 if port is not specified.

Tested with gmail, works like a charm.

I will add function args to more of the returners as time permits. Returner schema changes can break stuff, so I am shying away from any returner that will require a schema change (i.e postgres).

Unsure how you want to handle that.
