### PR TITLE
Cache minion ID after first time guessing it, Fixes #7558

### DIFF
--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -164,13 +164,14 @@ and accept the new minion's public key.
 
 .. _minion-id-generation:
 
-When the minion is started, it will generate an ``id`` value. This is the name
-by which the minion will attempt to authenticate to the master. The following
-steps are attempted, in order to try to find a value that is not ``localhost``:
+When the minion is started, it will generate an ``id`` value, unless it has
+been generated on a previous run and cached in the configuration directory
+(``/etc/salt`` by default). This is the name by which the minion will attempt
+to authenticate to the master. The following steps are attempted, in order to
+try to find a value that is not ``localhost``:
 
-1. ``/etc/hostname`` is checked (non-Windows only) **Note: Not used currently,
-   will be as of version 0.17.0.**
-2. The Python function ``socket.getfqdn()`` is run
+1. The Python function ``socket.getfqdn()`` is run
+2. ``/etc/hostname`` is checked (non-Windows only)
 3. ``/etc/hosts`` (``%WINDIR%\system32\drivers\etc\hosts`` on Windows hosts) is
    checked for hostnames that map to anything within :strong:`127.0.0.0/8`.
 
@@ -185,7 +186,8 @@ If all else fails, then ``localhost`` is used as a fallback.
 .. note:: Overriding the ``id``
 
     The minion id can be manually specified using the :conf_minion:`id`
-    parameter in the minion config file.
+    parameter in the minion config file.  If this configuration value is
+    specified, it will override all other sources for the ``id``.
 
 
 Using salt-key

--- a/salt/config.py
+++ b/salt/config.py
@@ -668,8 +668,8 @@ def get_id():
     '''
     Guess the id of the minion.
 
-    - Check /etc/hostname for a value other than localhost
     - If socket.getfqdn() returns us something other than localhost, use it
+    - Check /etc/hostname for a value other than localhost
     - Check /etc/hosts for something that isn't localhost that maps to 127.*
     - Look for a routeable / public IP
     - A private IP is better than a loopback IP
@@ -685,6 +685,12 @@ def get_id():
         )
     )
 
+    # Nothing in /etc/hostname or /etc/hostname not found
+    fqdn = socket.getfqdn()
+    if fqdn != 'localhost':
+        log.info('Found minion id from getfqdn(): {0}'.format(fqdn))
+        return fqdn, False
+
     # Check /etc/hostname
     try:
         with salt.utils.fopen('/etc/hostname') as hfl:
@@ -697,12 +703,6 @@ def get_id():
                 return name, False
     except Exception:
         pass
-
-    # Nothing in /etc/hostname or /etc/hostname not found
-    fqdn = socket.getfqdn()
-    if fqdn != 'localhost':
-        log.info('Found minion id from getfqdn(): {0}'.format(fqdn))
-        return fqdn, False
 
     # Can /etc/hosts help us?
     try:

--- a/salt/config.py
+++ b/salt/config.py
@@ -682,8 +682,16 @@ def get_id():
     not an IP address is being used for the ID.
     '''
 
-    # Check for CONFIG_DIR/minion_id (cached minion ID)
-    id_cache = os.path.join(syspaths.CONFIG_DIR, 'minion_id')
+    # Check for cached minion ID
+    libdir = os.path.join('/', 'var', 'lib', 'salt')
+    if salt.utils.is_windows():
+        libdir = os.path.join(r'c:\salt', 'var', 'lib')
+    id_cache = os.path.join(libdir, 'minion_id')
+    try:
+        if not os.path.isdir(libdir):
+            os.makedirs(libdir)
+    except Exception as e:
+        log.error('Could not create directory {0}: {1}'.format(libdir, e))
     try:
         with salt.utils.fopen(id_cache) as idf:
             name = idf.read().strip()

--- a/salt/config.py
+++ b/salt/config.py
@@ -734,7 +734,7 @@ def get_id():
     # Can Windows 'hosts' file help?
     try:
         windir = os.getenv("WINDIR")
-        with salt.utils.fopen(windir + '\\system32\\drivers\\etc\\hosts') as hfl:
+        with salt.utils.fopen(windir + r'\system32\drivers\etc\hosts') as hfl:
             for line in hfl:
                 # skip commented or blank lines
                 if line[0] == '#' or len(line) <= 1:

--- a/salt/config.py
+++ b/salt/config.py
@@ -696,7 +696,7 @@ def get_id():
     log.debug('Guessing ID. The id can be explicitly in set {0}'
               .format(os.path.join(syspaths.CONFIG_DIR, 'minion')))
 
-    # Nothing in /etc/hostname or /etc/hostname not found
+    # Check socket.getfqdn()
     fqdn = socket.getfqdn()
     if fqdn != 'localhost':
         log.info('Found minion id from getfqdn(): {0}'.format(fqdn))

--- a/salt/config.py
+++ b/salt/config.py
@@ -668,6 +668,7 @@ def get_id():
     '''
     Guess the id of the minion.
 
+    - If CONFIG_DIR/minion_id exists, use the cached minion ID from that file
     - If socket.getfqdn() returns us something other than localhost, use it
     - Check /etc/hostname for a value other than localhost
     - Check /etc/hosts for something that isn't localhost that maps to 127.*
@@ -684,6 +685,17 @@ def get_id():
             os.path.join(syspaths.CONFIG_DIR, 'minion')
         )
     )
+
+    # Check for CONFIG_DIR/minion_id (cached minion ID)
+    id_cache = os.path.join(syspaths.CONFIG_DIR, 'minion_id')
+    try:
+        with salt.utils.fopen(id_cache) as idf:
+            name = idf.read().strip()
+        if name:
+            log.info('Using cached minion ID: {0}'.format(name))
+            return name, False
+    except Exception:
+        pass
 
     # Nothing in /etc/hostname or /etc/hostname not found
     fqdn = socket.getfqdn()

--- a/salt/config.py
+++ b/salt/config.py
@@ -676,6 +676,8 @@ def get_id():
     - A private IP is better than a loopback IP
     - localhost may be better than killing the minion
 
+    Any non-ip id will be cached for later use in ``CONFIG_DIR/minion_id``
+
     Returns two values: the detected ID, and a boolean value noting whether or
     not an IP address is being used for the ID.
     '''
@@ -701,6 +703,11 @@ def get_id():
     fqdn = socket.getfqdn()
     if fqdn != 'localhost':
         log.info('Found minion id from getfqdn(): {0}'.format(fqdn))
+        try:
+            with salt.utils.fopen(id_cache, 'w') as idf:
+                idf.write(fqdn)
+        except Exception as e:
+            log.error('Could not cache minion ID: {0}'.format(e))
         return fqdn, False
 
     # Check /etc/hostname
@@ -712,6 +719,11 @@ def get_id():
                         'This file should not contain any whitespace.')
         else:
             if name != 'localhost':
+                try:
+                    with salt.utils.fopen(id_cache, 'w') as idf:
+                        idf.write(name)
+                except Exception as e:
+                    log.error('Could not cache minion ID: {0}'.format(e))
                 return name, False
     except Exception:
         pass
@@ -727,6 +739,12 @@ def get_id():
                         if name != 'localhost':
                             log.info('Found minion id in hosts file: {0}'
                                      .format(name))
+                            try:
+                                with salt.utils.fopen(id_cache, 'w') as idf:
+                                    idf.write(name)
+                            except Exception as e:
+                                log.error('Could not cache minion ID: {0}'
+                                          .format(e))
                             return name, False
     except Exception:
         pass
@@ -745,7 +763,14 @@ def get_id():
                     if entry[0].startswith('127.'):
                         for name in entry[1:]:  # try each name in the row
                             if name != 'localhost':
-                                log.info('Found minion id in hosts file: {0}'.format(name))
+                                log.info('Found minion id in hosts file: {0}'
+                                         .format(name))
+                                try:
+                                    with salt.utils.fopen(id_cache, 'w') as idf:
+                                        idf.write(name)
+                                except Exception as e:
+                                    log.error('Could not cache minion ID: {0}'
+                                              .format(e))
                                 return name, False
                 except IndexError:
                     pass  # could not split line (malformed entry?)

--- a/salt/config.py
+++ b/salt/config.py
@@ -682,12 +682,6 @@ def get_id():
     not an IP address is being used for the ID.
     '''
 
-    log.debug(
-        'Guessing ID. The id can be explicitly in set {0}'.format(
-            os.path.join(syspaths.CONFIG_DIR, 'minion')
-        )
-    )
-
     # Check for CONFIG_DIR/minion_id (cached minion ID)
     id_cache = os.path.join(syspaths.CONFIG_DIR, 'minion_id')
     try:
@@ -698,6 +692,9 @@ def get_id():
             return name, False
     except Exception:
         pass
+
+    log.debug('Guessing ID. The id can be explicitly in set {0}'
+              .format(os.path.join(syspaths.CONFIG_DIR, 'minion')))
 
     # Nothing in /etc/hostname or /etc/hostname not found
     fqdn = socket.getfqdn()

--- a/salt/config.py
+++ b/salt/config.py
@@ -683,15 +683,7 @@ def get_id():
     '''
 
     # Check for cached minion ID
-    libdir = os.path.join('/', 'var', 'lib', 'salt')
-    if salt.utils.is_windows():
-        libdir = os.path.join(r'c:\salt', 'var', 'lib')
-    id_cache = os.path.join(libdir, 'minion_id')
-    try:
-        if not os.path.isdir(libdir):
-            os.makedirs(libdir)
-    except Exception as e:
-        log.error('Could not create directory {0}: {1}'.format(libdir, e))
+    id_cache = os.path.join(syspaths.CONFIG_DIR, 'minion_id')
     try:
         with salt.utils.fopen(id_cache) as idf:
             name = idf.read().strip()


### PR DESCRIPTION
This pull request does a couple of things:
- Switch order of guessing minion ID so that `socket.getfqdn()` is the first thing used (instead of `/etc/hostname`).  This brings back the pre-0.17.0 default behavior
- Cache the minion ID after it is first guessed, and use that cache rather than guessing in the future.  This will prevent unexpected minion ID changes.  The file used is `CONFIG_DIR/minion_id` (so `/etc/salt/minion_id` by default).  Note that if we fall back on IP address for the ID, we don't cache the ID.

Fixes #7558
