### PR TITLE
Fix git.latest to run current branch and ls remote as correct user

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -33,12 +33,12 @@ def __virtual__():
     return 'git' if __salt__['cmd.has_exec']('git') else False
 
 
-def __ls_remote__(name, branch):
+def __ls_remote__(name, branch, user, cwd):
     '''
     Returns the upstream hash for any given URL and branch.
     '''
     cmd = "git ls-remote -h " + name + " " + branch + " | cut -f 1"
-    return __salt__['cmd.run_stdout'](cmd)
+    return __salt__['cmd.run_stdout'](cmd, cwd, runas=user)
 
 
 def latest(name,
@@ -169,11 +169,11 @@ def latest(name,
 
             # handle the case where a branch was provided for rev
             remote_rev = None
-            branch = __salt__['git.current_branch'](target, user=runas)
+            branch = __salt__['git.current_branch'](target, user=user)
             # We're only interested in the remote branch if a branch
             # (instead of a hash, for example) was provided for rev.
             if len(branch) > 0 and branch == rev:
-                remote_rev = __ls_remote__(name, branch)
+                remote_rev = __ls_remote__(name, branch, user, target)
 
             # only do something, if the specified rev differs from the
             # current_rev and remote_rev


### PR DESCRIPTION
During a git.latest call our scripts weren't getting run as the correct user that caused SSH prompt/issues
