### PR TITLE
Add more RabbitMQ functionality

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Jeff Hutchins <jhutchins@getjive.com>
 Jeffrey C. Ollie <jeff@ocjtech.us>
 Jeff Schroeder <jeffschroeder@computer.org>
 Jonas Buckner <buckner.jonas@gmail.com>
+Jonathan Harker <k.jonathan.harker@hp.com>
 Joseph Hall <joseph@saltstack.com>
 Josmar Dias <josmarnet@gmail.com>
 Kent Tenney <ktenney@gmail.com>

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -30,7 +30,7 @@ def _format_response(response, msg):
         msg = 'Error'
 
     return {
-        msg: response.replace('\n', '')
+        msg: response
     }
 
 
@@ -241,6 +241,21 @@ def list_user_permissions(name, user=None):
     return [r.split('\t') for r in res.splitlines()]
 
 
+def set_user_tags(name, tags, runas=None):
+    '''Add user tags via rabbitctl set_user_tags
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rabbitmq.set_user_tags 'myadmin' 'administrator'
+    '''
+    res = __salt__['cmd.run'](
+        'rabbitmqctl set_user_tags {0} {1}'.format(name, tags),
+        runas=runas)
+    return [r.split('\t') for r in res.splitlines()]
+
+
 def status(user=None):
     '''
     return rabbitmq status
@@ -274,6 +289,26 @@ def cluster_status(user=None):
         runas=user)
 
     return res
+
+
+def join_cluster(host, user='rabbit', runas=None):
+    '''
+    Join a rabbit cluster
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rabbitmq.join_cluster 'rabbit' 'rabbit.example.com'
+    '''
+
+    stop_app(runas)
+    res = __salt__['cmd.run'](
+        'rabbitmqctl join_cluster {0}@{1}'.format(user, host),
+        runas=runas)
+    start_app(runas)
+
+    return _format_response(res, 'Join')
 
 
 def stop_app(runas=None):
@@ -464,3 +499,23 @@ def policy_exists(vhost, name, runas=None):
     '''
     policies = list_policies(runas=runas)
     return bool(vhost in policies and name in policies[vhost])
+
+def enable_plugin(name, runas=None):
+    '''
+    Enable a RabbitMQ plugin via the rabbitmq-plugin command.
+    '''
+
+    ret = __salt__['cmd.run'](
+            'rabbitmq-plugin enable {0}'.format(name),
+            runas=runas)
+    return _format_response(ret, 'Enabled')
+
+def disable_plugin(name, runas=None):
+    '''
+    Disable a RabbitMQ plugin via the rabbitmq-plugin command.
+    '''
+
+    ret = __salt__['cmd.run'](
+            'rabbitmq-plugin disable {0}'.format(name),
+            runas=runas)
+    return _format_response(ret, 'Disabled')

--- a/salt/states/rabbitmq_cluster.py
+++ b/salt/states/rabbitmq_cluster.py
@@ -1,0 +1,58 @@
+'''
+Manage RabbitMQ Clusters
+
+.. code-block:: yaml
+
+    rabbit@rabbit.example.com:
+        rabbitmq_cluster.join:
+          - user: rabbit
+          - host: rabbit.example.com
+'''
+
+# Import python libs
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if RabbitMQ is installed.
+    '''
+    name = 'rabbitmq_cluster'
+    if not __salt__['cmd.has_exec']('rabbitmqctl'):
+        name = False
+    return name
+
+def join(name, host, user='rabbit', runas=None):
+    '''
+    Ensure the RabbitMQ plugin is enabled.
+
+    name
+        The name of the plugin
+    runas
+        The user to run the rabbitmq-plugin command as
+    '''
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    result = {}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Host is set to join cluster {0}@{1}'.format(
+            user, host)
+    else:
+        joined = __salt__['rabbitmq.cluster_status']()
+        if '{0}@{1}'.format(user, host) in joined:
+            ret['comment'] = 'Already joined cluster'
+            return ret
+
+        result = __salt__['rabbitmq.join_cluster'](host, user, runas=runas)
+
+        if 'Error' in result:
+            ret['result'] = False
+            ret['comment'] = result['Error']
+        elif 'Join' in result:
+            ret['comment'] = result['Join']
+
+    return ret

--- a/salt/states/rabbitmq_plugin.py
+++ b/salt/states/rabbitmq_plugin.py
@@ -1,0 +1,78 @@
+'''
+Manage RabbitMQ Plugins.
+
+.. code-block:: yaml
+
+    some_plugin:
+        rabbitmq_plugin:
+          - enabled
+'''
+
+# Import python libs
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Only load if RabbitMQ is installed.
+    '''
+    name = 'rabbitmq_plugin'
+    if not __salt__['cmd.has_exec']('rabbitmqctl'):
+        name = False
+    return name
+
+def enabled(name, runas=None):
+    '''
+    Ensure the RabbitMQ plugin is enabled.
+
+    name
+        The name of the plugin
+    runas
+        The user to run the rabbitmq-plugin command as
+    '''
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    result = {}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Plugin {0} is set to be enabled'.format(name)
+    else:
+        result = __salt__['rabbitmq.enable_plugin'](name, runas=runas)
+
+    if 'Error' in result:
+        ret['result'] = False
+        ret['comment'] = result['Error']
+    elif 'Enabled' in result:
+        ret['comment'] = result['Enabled']
+
+    return ret
+
+def disabled(name, runas=None):
+    '''
+    Ensure the RabbitMQ plugin is enabled.
+
+    name
+        The name of the plugin
+    runas
+        The user to run the rabbitmq-plugin command as
+    '''
+
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    result = {}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Plugin {0} is set to be disabled'.format(name)
+    else:
+        result = __salt__['rabbitmq.disable_plugin'](name, runas=runas)
+
+    if 'Error' in result:
+        ret['result'] = False
+        ret['comment'] = result['Error']
+    elif 'Disabled' in result:
+        ret['comment'] = result['Disabled']
+
+    return ret

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -8,6 +8,13 @@ Manage RabbitMQ Users.
         rabbitmq_user.present:
             - password: password
             - force: True
+            - tags: administrator
+            - permissions:
+              - '/':
+                - '.*'
+                - '.*'
+                - '.*'
+            - runas: rabbitmq
 '''
 
 # Import python libs
@@ -29,6 +36,8 @@ def __virtual__():
 def present(name,
            password=None,
            force=False,
+           tags=None,
+           perms={},
            runas=None):
     '''
     Ensure the RabbitMQ user exists.
@@ -39,9 +48,14 @@ def present(name,
         User's password, if one needs to be set
     force
         If user exists, forcibly change the password
+    tags
+        Optionally set user tags for user
+    permissions
+        A list of dicts with vhost keys and 3-tuple values
     runas
         Name of the user to run the command
     '''
+
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     result = {}
 
@@ -63,8 +77,15 @@ def present(name,
                 "User doesn't exist - Creating")
             result = __salt__['rabbitmq.add_user'](
                 name, password, runas=runas)
+
+            if tags:
+                result = __salt__['rabbitmq.set_user_tags'](
+                    name, tags, runas=runas)
+            for vhost, p in perms:
+                result = __salt__['rabbitmq.set_permissions'](
+                    vhost, name, p[0], p[1], p[2], runas)
         elif force:
-            log.debug('User exists and force is set - Overriding password')
+            log.debug('User exists and force is set - Overriding')
             if password is not None:
                 result = __salt__['rabbitmq.change_password'](
                     name, password, runas=runas)
@@ -72,6 +93,14 @@ def present(name,
                 log.debug('Password is not set - Clearing password')
                 result = __salt__['rabbitmq.clear_password'](
                     name, runas=runas)
+            if tags:
+                result.update(__salt__['rabbitmq.set_user_tags'](
+                    name, tags, runas=runas)
+                )
+            for vhost, p in perms:
+                result.update(__salt__['rabbitmq.set_permissions'](
+                    vhost, name, p[0], p[1], p[2], runas)
+                )
         else:
             log.debug('User exists, and force is not set - Abandoning')
             ret['comment'] = 'User {0} is not going to be modified'.format(name)


### PR DESCRIPTION
Add support for user tags and permissions to the rabbitmq_user state,
which requires adding support for set_user_tags to the rabbitmq module.

Also add a rabbitmq_plugin state, which requires adding rabbitmq-plugin
support to the rabbitmq module.

And add a join_cluster function to the rabbitmq module (and as state to wrap it).
