### PR TITLE
Make function args available to returners in salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -101,6 +101,7 @@ class Caller(object):
         if self.opts.get('return', ''):
             ret['id'] = self.opts['id']
             ret['fun'] = fun
+            ret['fun_args'] = self.opts['arg']
             for returner in self.opts['return'].split(','):
                 try:
                     self.minion.returners['{0}.returner'.format(returner)](ret)


### PR DESCRIPTION
This addresses #7352.

The change makes function arguments available to returners as they are invoked from salt-call.
