### PR TITLE
Fix iptables masquerading

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -114,8 +114,8 @@ def build_rule(table=None, chain=None, command=None, position='', full=None,
         else:
             flag = '--'
 
-        return 'iptables {0}{1} {2} {3} {4}'.format(flag, command, chain,
-            position, rule)
+        return 'iptables -t {0} {1}{2} {3} {4} {5}'.format(table,
+            flag, command, chain, position, rule)
 
     return rule
 

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -46,6 +46,11 @@ def append(name, **kwargs):
            'changes': {},
            'result': None,
            'comment': ''}
+
+    for ignore in "__env__",  "__sls__", "order":
+        if ignore in kwargs:
+            del kwargs[ignore]
+
     rule = __salt__['iptables.build_rule'](**kwargs)
     command = __salt__['iptables.build_rule'](full=True, command='A', **kwargs)
     if __salt__['iptables.check'](kwargs['table'], kwargs['chain'], rule) is True:


### PR DESCRIPTION
I was trying to make a state for a masquerading iptables rule. unfortunalty, it seem that the build rule, in iptables module, don't use the table argument. this pull request aims to fix that.
