### PR TITLE
Strip trailing slash in file.directory state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1196,6 +1196,10 @@ def directory(name,
         When 'clean' is set to True, exclude this pattern from removal list
         and preserve in the destination.
     '''
+    # Remove trailing slash, if present
+    if name[-1] == '/':
+        name = name[:-1]
+
     user = _test_owner(kwargs, user=user)
 
     if 'mode' in kwargs and not dir_mode:


### PR DESCRIPTION
Adding a trailing slash to the directory name (like /etc/chef/) would
fail the state if the directory didn't exist and `makedirs` was False.
This is because it would use os.path.dirname (which would return
/etc/chef) and see that the "parent" directory didn't exist, and fail.
