### PR TITLE
Add win_system state, refine win_ntp module

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -172,6 +172,7 @@ Full list of builtin execution modules
     win_file
     win_groupadd
     win_network
+    win_ntp
     win_pkg
     win_service
     win_shadow

--- a/doc/ref/modules/all/salt.modules.win_ntp.rst
+++ b/doc/ref/modules/all/salt.modules.win_ntp.rst
@@ -4,4 +4,3 @@ salt.modules.win_ntp
 
 .. automodule:: salt.modules.win_ntp
     :members:
-    :exclude-members: get_computer_description

--- a/doc/ref/modules/all/salt.modules.win_ntp.rst
+++ b/doc/ref/modules/all/salt.modules.win_ntp.rst
@@ -1,0 +1,7 @@
+====================
+salt.modules.win_ntp
+====================
+
+.. automodule:: salt.modules.win_ntp
+    :members:
+    :exclude-members: get_computer_description

--- a/doc/ref/modules/all/salt.modules.win_system.rst
+++ b/doc/ref/modules/all/salt.modules.win_system.rst
@@ -4,3 +4,4 @@ salt.modules.win_system
 
 .. automodule:: salt.modules.win_system
     :members:
+    :exclude-members: get_computer_description, set_computer_description

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -45,6 +45,7 @@ Full list of builtin state modules
     mysql_user
     network
     npm
+    ntp
     pecl
     pip_state
     pkg
@@ -71,3 +72,8 @@ Full list of builtin state modules
     tomcat
     user
     virtualenv_mod
+    win_dns_client
+    win_firewall
+    win_path
+    win_servermanager
+    win_system

--- a/doc/ref/states/all/salt.states.win_dns_client.rst
+++ b/doc/ref/states/all/salt.states.win_dns_client.rst
@@ -1,0 +1,7 @@
+======================
+salt.states.win_system
+======================
+
+.. automodule:: salt.states.win_system
+    :members:
+    :exclude-members: computer_description

--- a/doc/ref/states/all/salt.states.win_firewall.rst
+++ b/doc/ref/states/all/salt.states.win_firewall.rst
@@ -1,0 +1,6 @@
+========================
+salt.states.win_firewall
+========================
+
+.. automodule:: salt.states.win_firewall
+    :members:

--- a/doc/ref/states/all/salt.states.win_path.rst
+++ b/doc/ref/states/all/salt.states.win_path.rst
@@ -1,0 +1,6 @@
+====================
+salt.states.win_path
+====================
+
+.. automodule:: salt.states.win_path
+    :members:

--- a/doc/ref/states/all/salt.states.win_servermanager.rst
+++ b/doc/ref/states/all/salt.states.win_servermanager.rst
@@ -1,0 +1,6 @@
+=============================
+salt.states.win_servermanager
+=============================
+
+.. automodule:: salt.states.win_servermanager
+    :members:

--- a/doc/ref/states/all/salt.states.win_system.rst
+++ b/doc/ref/states/all/salt.states.win_system.rst
@@ -1,0 +1,7 @@
+======================
+salt.states.win_system
+======================
+
+.. automodule:: salt.states.win_system
+    :members:
+    :exclude-members: computer_description

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -267,6 +267,9 @@ def highstate(test=None, queue=False, **kwargs):
     # but I'm guessing it likely should not be.
     cumask = os.umask(191)
     try:
+        if salt.utils.is_windows():
+            # Make sure cache file isn't read-only
+            __salt__['cmd.run']('attrib -R "{0}"'.format(cache_file))
         with salt.utils.fopen(cache_file, 'w+') as fp_:
             serial.dump(ret, fp_)
     except (IOError, OSError):
@@ -351,6 +354,9 @@ def sls(mods, env='base', test=None, exclude=None, queue=False, **kwargs):
     cache_file = os.path.join(__opts__['cachedir'], 'sls.p')
     cumask = os.umask(191)
     try:
+        if salt.utils.is_windows():
+            # Make sure cache file isn't read-only
+            __salt__['cmd.run']('attrib -R "{0}"'.format(cache_file))
         with salt.utils.fopen(cache_file, 'w+') as fp_:
             serial.dump(ret, fp_)
     except (IOError, OSError):

--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -31,12 +31,16 @@ def set_servers(*servers):
 
         salt '*' ntp.set_servers 'pool.ntp.org' 'us.pool.ntp.org'
     '''
-    cmd = ('W32tm /config /syncfromflags:manual /manualpeerlist:"{0}" &&'
-          'W32tm /config /reliable:yes &&'
-          'W32tm /config /update &&'
-          'Net stop w32time && Net start w32time'
-          ).format(' '.join(servers))
-    ret = __salt__['cmd.run'](cmd)
+    service_name = 'w32time'
+    if not __salt__['service.status'](service_name):
+        if not __salt__['service.start'](service_name):
+            return False
+    ret = __salt__['cmd.run'](
+        'W32tm /config /syncfromflags:manual /manualpeerlist:"{0}" &&'
+        'W32tm /config /reliable:yes && W32tm /config /update'
+        .format(' '.join(servers))
+    )
+    __salt__['service.restart'](service_name)
     return 'command completed successfully' in ret
 
 

--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
 Management of NTP servers on Windows
+
+.. versionadded:: Hydrogen
 '''
 
 # Import python libs

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -190,17 +190,8 @@ def restart(name):
 
         salt '*' service.restart <service name>
     '''
-    stopcmd = 'sc stop "{0}"'.format(name)
-    __salt__['cmd.run'](stopcmd)
-    servicestate = status(name)
-    while True:
-        servicestate = status(name)
-        if servicestate == '':
-            break
-        else:
-            time.sleep(2)
-    startcmd = 'sc start "{0}"'.format(name)
-    return not __salt__['cmd.retcode'](startcmd)
+    stop(name)
+    return start(name)
 
 
 def status(name, sig=None):

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -191,7 +191,12 @@ def restart(name):
         salt '*' service.restart <service name>
     '''
     stop(name)
-    return start(name)
+    for idx in xrange(5):
+        if status(name):
+            time.sleep(2)
+            continue
+        return start(name)
+    return False
 
 
 def status(name, sig=None):
@@ -211,7 +216,7 @@ def status(name, sig=None):
     for line in statuses:
         if 'RUNNING' in line:
             return True
-        elif 'PENDING' in line:
+        elif 'STOP_PENDING' in line:
             return True
     return False
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -205,7 +205,7 @@ def set_computer_desc(desc):
     '''
     cmd = 'net config server /srvcomment:"{0}"'.format(desc)
     __salt__['cmd.run'](cmd)
-    return {'Computer Description': str(desc)}
+    return {'Computer Description': get_computer_desc()}
 
 
 def get_computer_desc():

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -207,6 +207,8 @@ def set_computer_desc(desc):
     __salt__['cmd.run'](cmd)
     return {'Computer Description': get_computer_desc()}
 
+set_computer_description = set_computer_desc
+
 
 def get_computer_desc():
     '''

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -5,6 +5,7 @@ Support for reboot, shutdown, etc
 
 # Import python libs
 import logging
+import re
 
 # Import salt libs
 import salt.utils
@@ -124,12 +125,52 @@ def set_computer_name(name):
         salt 'minion-id' system.set_computer_name 'DavesComputer'
     '''
     cmd = ('wmic computersystem where name="%COMPUTERNAME%"'
-           ' call rename name="{0}"'
-           )
+           ' call rename name="{0}"')
     log.debug('Attempting to change computer name. Cmd is: '.format(cmd))
     ret = __salt__['cmd.run'](cmd.format(name))
     if 'ReturnValue = 0;' in ret:
-        return {'Computer name': name}
+        ret = {'Computer Name': {'Current': get_computer_name()}}
+        pending = get_pending_computer_name()
+        if pending not in (None, False):
+            ret['Computer Name']['Pending'] = pending
+        return ret
+    return False
+
+
+def get_pending_computer_name():
+    '''
+    Get a pending computer name. If the computer name has been changed, and the
+    change is pending a system reboot, this function will return the pending
+    computer name. Otherwise, ``None`` will be returned. If there was an error
+    retrieving the pending computer name, ``False`` will be returned, and an
+    error message will be logged to the minion log.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt 'minion-id' system.get_pending_computer_name
+    '''
+    current = get_computer_name()
+    cmd = ('reg query HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control'
+           '\\ComputerName\\ComputerName /v ComputerName')
+    output = __salt__['cmd.run'](cmd)
+    pending = None
+    for line in output.splitlines():
+        try:
+            pending = re.search(
+                r'ComputerName\s+REG_SZ\s+(\S+)',
+                line
+            ).group(1)
+            break
+        except AttributeError:
+            continue
+
+    if pending is not None:
+        return pending if pending != current else None
+
+    log.error('Unable to retrieve pending computer name using the '
+              'following command: {0}'.format(cmd))
     return False
 
 
@@ -164,7 +205,7 @@ def set_computer_desc(desc):
     '''
     cmd = 'net config server /srvcomment:"{0}"'.format(desc)
     __salt__['cmd.run'](cmd)
-    return {'Computer Description': desc}
+    return {'Computer Description': str(desc)}
 
 
 def get_computer_desc():

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -226,6 +226,8 @@ def get_computer_desc():
             return desc.strip()
     return False
 
+get_computer_description = get_computer_desc
+
 
 def join_domain(domain, username, passwd, ou, acct_exists=False,):
     '''

--- a/salt/states/ntp.py
+++ b/salt/states/ntp.py
@@ -3,6 +3,8 @@
 Management of NTP servers
 =========================
 
+.. versionadded:: Hydrogen
+
 This state is used to manage NTP servers. Currently only Windows is supported.
 
 .. code-block:: yaml

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -64,15 +64,15 @@ def computer_desc(name):
                           .format(name))
         return ret
 
-    if not __salt__['system.set_computer_desc'](name):
-        ret['result'] = False
-        ret['comment'] = ('Unable to set computer description to '
-                          '{0!r}'.format(name))
-    else:
+    result = __salt__['system.set_computer_desc'](name)
+    if result['Computer Description'] == name:
         ret['comment'] = ('Computer description successfully changed to {0!r}'
                           .format(name))
         ret['changes'] = {'old': before_desc, 'new': name}
-
+    else:
+        ret['result'] = False
+        ret['comment'] = ('Unable to set computer description to '
+                          '{0!r}'.format(name))
     return ret
 
 computer_description = computer_desc

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+'''
+Management of Windows system information
+========================================
+
+This state is used to manage system information such as the computer name and
+description.
+
+.. code-block:: yaml
+
+    ERIK-WORKSTATION:
+      system:
+        - computer_name
+
+    This is Erik's computer, don't touch!:
+      system:
+        - computer_desc
+'''
+
+# Import python libs
+import logging
+import sys
+
+# Import salt libs
+from salt._compat import string_types
+import salt.utils
+
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    This only supports Windows
+    '''
+    if salt.utils.is_windows() and 'system.get_computer_desc' in __salt__:
+        return 'system'
+    return False
+
+
+def computer_desc(name):
+    '''
+    Manage the computer's description field
+
+    name
+        The desired computer description
+    '''
+    # Just in case someone decides to enter a numeric description
+    name = str(name)
+
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Computer description already set to {0!r}'.format(name)}
+
+    before_desc = __salt__['system.get_computer_desc']()
+
+    if before_desc == name:
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = ('Computer description will be changed to {0!r}'
+                          .format(name))
+        return ret
+
+    if not __salt__['system.set_computer_desc'](name):
+        ret['result'] = False
+        ret['comment'] = ('Unable to set computer description to '
+                          '{0!r}'.format(name))
+    else:
+        ret['comment'] = ('Computer description successfully changed to {0!r}'
+                          .format(name))
+        ret['changes'] = {'old': before_desc, 'new': name}
+
+    return ret
+
+computer_description = computer_desc
+
+
+def computer_name(name):
+    '''
+    Manage the computer's name
+
+    name
+        The desired computer name
+    '''
+    # Just in case someone decides to enter a numeric description
+    name = str(name).upper()
+
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': 'Computer name already set to {0!r}'.format(name)}
+
+    before_name = __salt__['system.get_computer_name']()
+    pending_name = __salt__['system.get_pending_computer_name']()
+
+    if before_name == name and pending_name is None:
+        return ret
+    elif pending_name == name:
+        ret['comment'] = ('The current computer name is {0!r}, but will be '
+                          'changed to {1!r} on the next reboot'
+                          .format(before_name, name))
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Computer name will be changed to {0!r}'.format(name)
+        return ret
+
+    result = __salt__['system.set_computer_name'](name)
+    if result is not False:
+        after_name = result['Computer Name']['Current']
+        after_pending = result['Computer Name'].get('Pending')
+        if ((after_pending is not None and after_pending == name) or
+                (after_pending is None and after_name == name)):
+            ret['comment'] = 'Computer name successfully set to {0!r}'.format(name)
+            if after_pending is not None:
+                ret['comment'] += ' (reboot required for change to take effect)'
+        ret['changes'] = {'old': before_name, 'new': name}
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Unable to set computer name to {0!r}'.format(name)
+    return ret

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -3,6 +3,8 @@
 Management of Windows system information
 ========================================
 
+.. versionadded:: Hydrogen
+
 This state is used to manage system information such as the computer name and
 description.
 


### PR DESCRIPTION
This pull request includes several changes/refinements:
1. The win_ntp module has been refined slightly, using built-in service support to restart the ntp service rather than chaining together `net stop w32time && net start w32time`.
2. A bug in how `service.status` module identifies services in the process of stopping/starting was fixed, and `service.restart` was cleaned up and simplified.
3. A new function was added to the win_system module, that identifies computer hostname changes that are pending reboot.
4. A new state module was added to manage the system's hostname/description.
5. New states/modules, as well as some missing windows states, were added to the docs.
