### PR TITLE
Fix minion ID caching for minions using non-default root_dir

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -664,7 +664,7 @@ def syndic_config(master_config_path,
     return opts
 
 
-def get_id():
+def get_id(root_dir='/'):
     '''
     Guess the id of the minion.
 
@@ -683,14 +683,16 @@ def get_id():
     '''
 
     # Check for cached minion ID
-    id_cache = os.path.join(syspaths.CONFIG_DIR, 'minion_id')
+    id_cache = os.path.join(
+        root_dir, syspaths.CONFIG_DIR.lstrip('/'), 'minion_id'
+    )
     try:
         with salt.utils.fopen(id_cache) as idf:
             name = idf.read().strip()
         if name:
             log.info('Using cached minion ID: {0}'.format(name))
             return name, False
-    except Exception:
+    except (IOError, OSError):
         pass
 
     log.debug('Guessing ID. The id can be explicitly in set {0}'
@@ -703,8 +705,8 @@ def get_id():
         try:
             with salt.utils.fopen(id_cache, 'w') as idf:
                 idf.write(fqdn)
-        except Exception as e:
-            log.error('Could not cache minion ID: {0}'.format(e))
+        except (IOError, OSError) as exc:
+            log.error('Could not cache minion ID: {0}'.format(exc))
         return fqdn, False
 
     # Check /etc/hostname
@@ -719,10 +721,10 @@ def get_id():
                 try:
                     with salt.utils.fopen(id_cache, 'w') as idf:
                         idf.write(name)
-                except Exception as e:
-                    log.error('Could not cache minion ID: {0}'.format(e))
+                except (IOError, OSError) as exc:
+                    log.error('Could not cache minion ID: {0}'.format(exc))
                 return name, False
-    except Exception:
+    except (IOError, OSError):
         pass
 
     # Can /etc/hosts help us?
@@ -739,11 +741,11 @@ def get_id():
                             try:
                                 with salt.utils.fopen(id_cache, 'w') as idf:
                                     idf.write(name)
-                            except Exception as e:
+                            except (IOError, OSError) as exc:
                                 log.error('Could not cache minion ID: {0}'
-                                          .format(e))
+                                          .format(exc))
                             return name, False
-    except Exception:
+    except (IOError, OSError):
         pass
 
     # Can Windows 'hosts' file help?
@@ -765,13 +767,13 @@ def get_id():
                                 try:
                                     with salt.utils.fopen(id_cache, 'w') as idf:
                                         idf.write(name)
-                                except Exception as e:
+                                except (IOError, OSError) as exc:
                                     log.error('Could not cache minion ID: {0}'
-                                              .format(e))
+                                              .format(exc))
                                 return name, False
                 except IndexError:
                     pass  # could not split line (malformed entry?)
-    except Exception:
+    except (IOError, OSError):
         pass
 
     # What IP addresses do we have?
@@ -824,7 +826,7 @@ def apply_minion_config(overrides=None, defaults=None, check_dns=None):
     # No ID provided. Will getfqdn save us?
     using_ip_for_id = False
     if opts['id'] is None:
-        opts['id'], using_ip_for_id = get_id()
+        opts['id'], using_ip_for_id = get_id(opts['root_dir'])
 
     # it does not make sense to append a domain to an IP based id
     if not using_ip_for_id and 'append_domain' in opts:


### PR DESCRIPTION
Caught this in my testing since I run my development testing in
virtuialenvs and need to use the `root_dir` option.

This commit uses the `root_dir` minion option when deriving a location for
the minion ID cache file. It also cleans up some stuff that drives
pylint crazy like single-letter variable names, and generic exception
catching in try/except.
