### PR TITLE
fix zypper install interface (missing an escape)

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -178,7 +178,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             __salt__['pkg_resource.stringify'](ret)
             return ret
 
-    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\n"'
+    cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\\n"'
     ret = {}
     for line in __salt__['cmd.run'](cmd).splitlines():
         name, pkgver, rel = line.split('_|-')


### PR DESCRIPTION
On my setup (OpenSuSE 11.4), this command is issued with its \n unescaped.
It works with double escaping of the \n, that is \n.

This is a one char fix, but it fixes a lot for me.
Did not test on other OpenSuSE versions.
