### PR TITLE
Fix cli example of salt.modules.network.arp

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -159,7 +159,7 @@ def arp():
 
     .. code-block:: bash
 
-        salt '*' '*' network.arp
+        salt '*' network.arp
     '''
     ret = {}
     out = __salt__['cmd.run']('arp -an')


### PR DESCRIPTION
Remove an useless '*' symbol in cli example of salt.modules.network.arp
