### PR TITLE
salt-ssh: keep raw command to be executed remotely unexpanded

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -146,7 +146,7 @@ class Shell(object):
 
         if self.passwd and salt.utils.which('sshpass'):
             opts = self._passwd_opts()
-            return 'sshpass -p "{0}" {1} {2} {3} {4} {5}'.format(
+            return "sshpass -p '{0}' {1} {2} {3} {4} '{5}'".format(
                     self.passwd,
                     ssh,
                     '' if ssh == 'scp' else self.host,
@@ -155,7 +155,7 @@ class Shell(object):
                     cmd)
         if self.priv:
             opts = self._key_opts()
-            return '{0} {1} {2} {3} {4}'.format(
+            return "{0} {1} {2} {3} '{4}'".format(
                     ssh,
                     '' if ssh == 'scp' else self.host,
                     '-t -t' if self.tty else '',


### PR DESCRIPTION
Hi, first of all. Please let me thank you for making such a great tool :D

If you use salt-ssh to execute some raw command, e.g.:

```
salt-ssh '*' -r 'ls ~'
```

This command intends to list remote users' home directory. Unfortunately, salt-ssh now will expand this command to:

```
sshpass -p PASSWORD ssh HOST SSH_opt1 SSH_opt2 ... ls ~
```

Look at the end part of line, tilde char will be expanded to $HOME, e.g. /home/vvoody. It's a normal bash behavior. But it's not we want obviously. There is may not 'vvoody' user existing on remote.

So the fix is simple, make the command to be executed on remote as a raw string. The example command will be like:

```
sshpass -p PASSWORD ssh HOST SSH_opt1 SSH_opt2 ... 'ls ~'
```
