### PR TITLE
rm unused imports from states/win_system.py

### DIFF
--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -21,10 +21,8 @@ description.
 
 # Import python libs
 import logging
-import sys
 
 # Import salt libs
-from salt._compat import string_types
 import salt.utils
 
 


### PR DESCRIPTION
```
************* Module salt.states.win_system
salt/states/win_system.py:24: [W0611(unused-import), ] Unused import sys
salt/states/win_system.py:27: [W0611(unused-import), ] Unused import string_types
```
