### PR TITLE
Prettify subcommand to kill minions

### DIFF
--- a/tests/minionswarm.py
+++ b/tests/minionswarm.py
@@ -217,8 +217,7 @@ class Swarm(object):
     def shutdown(self):
         print('Killing any remaining running minions')
         subprocess.call(
-            'kill -KILL $(ps aux | grep python | grep "salt-minion" '
-            '| awk \'{print $2}\')',
+            'pkill -KILL -f "python.*salt-minion"',
             shell=True
         )
         if not self.opts['no_clean']:


### PR DESCRIPTION
I realize that this is just cosmetic change. And possibly that there is
a compatibility issue, if minionswarm is to be used on platforms that
don't have pkill.
