### PR TITLE
Update salt.modules.files.replace

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -970,7 +970,7 @@ def replace(path,
             if result:
                 return True
         else:
-            result = re.sub(cpattern, repl, line, count)
+            result = re.sub(cpattern, repl, line, count, flags_num)
 
             # Identity check each potential change until one change is made
             if has_changes is False and not result is line:


### PR DESCRIPTION
When using salt.modules.files.replace, flags are not passed to re.sub if search_only is false.
