### PR TITLE
Added undocumented ssh roster configuration options

### DIFF
--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -36,3 +36,9 @@ The information which can be stored in a roster `target` is the following:
         host:    # The IP address or DNS name of the remote host
         user:    # The user to log in as
         passwd:  # The password to log in with
+
+        # Optional parameters
+        port:    # The target system's ssh port number
+        sudo:    # Boolean to run command via sudo
+        priv:    # File path to ssh private key, defaults to salt-ssh.rsa
+        timeout: # Number of seconds to wait for response


### PR DESCRIPTION
I'm not at all sure about the validity of the comments are after each option, but at least they are all listed.
