### PR TITLE
Fix issue 5951 - correct __opts__['file_roots'] in ext_pillars

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -81,7 +81,11 @@ class Pillar(object):
             self.functions = salt.loader.minion_mods(self.opts)
         self.matcher = salt.minion.Matcher(self.opts, self.functions)
         self.rend = salt.loader.render(self.opts, self.functions)
-        self.ext_pillars = salt.loader.pillars(self.opts, self.functions)
+        # Fix self.opts['file_roots'] so that ext_pillars know the real
+        # location of file_roots. Issue 5951
+        ext_pillar_opts = dict(self.opts)
+        ext_pillar_opts['file_roots'] = self.actual_file_roots
+        self.ext_pillars = salt.loader.pillars(ext_pillar_opts, self.functions)
 
     def __valid_ext(self, ext):
         '''

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -167,14 +167,15 @@ class TestDaemon(object):
                 TMP_STATE_TREE
             ]
         }
-        self.master_opts['ext_pillar'] = [
+        self.master_opts['ext_pillar'].append(
             {'cmd_yaml': 'cat {0}'.format(
                 os.path.join(
                     FILES,
                     'ext.yaml'
                 )
             )}
-        ]
+        )
+        self.master_opts['extension_modules'] = os.path.join(INTEGRATION_TEST_DIR, 'files', 'extension_modules')
         # clean up the old files
         self._clean()
 

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -19,7 +19,8 @@ token_file: /tmp/ksfjhdgiuebfgnkefvsikhfjdgvkjahcsidk
 file_buffer_size: 8192
 
 ext_pillar:
-  - cmd_yaml: cat ext.yaml
+  - test_ext_pillar_opts:
+    - test_issue_5951_actual_file_roots_in_opts
 
 config_opt:
   layer2: 'kosher'

--- a/tests/integration/files/extension_modules/pillar/test_ext_pillar_opts.py
+++ b/tests/integration/files/extension_modules/pillar/test_ext_pillar_opts.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+'''
+External pillar module for testing the contents of __opts__ as seen
+by external pillar modules.
+
+Returns a hash of the name of the pillar module as defined in
+_virtual__ with the value __opts__
+'''
+
+# Import python libs
+import logging
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+# DRY up the name we use
+MY_NAME = 'test_ext_pillar_opts'
+
+
+def __virtual__():
+    log.debug('Loaded external pillar {0} as {1}'.format(__name__, MY_NAME))
+    return MY_NAME
+
+
+def ext_pillar(minion_id, pillar, *args):
+    return {MY_NAME: __opts__}

--- a/tests/integration/modules/pillar.py
+++ b/tests/integration/modules/pillar.py
@@ -43,6 +43,11 @@ class PillarModuleTest(integration.ModuleCase):
                 self.run_function('pillar.data')['ext_spam'], 'eggs'
                 )
 
+    def test_issue_5951_actual_file_roots_in_opts(self):
+        self.assertIn(
+            integration.TMP_STATE_TREE,
+            self.run_function('pillar.data')['test_ext_pillar_opts']['file_roots']['base']
+        )
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Although issue https://github.com/saltstack/salt/issues/5951 is marked as a duplicate of https://github.com/saltstack/salt/issues/5449 they are different and separate fixes of the same root cause. This PR fixes #5951.
