### PR TITLE
Add code-block formatting to git_pillar docstring

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -216,4 +216,4 @@ synced, and thus interrupt the sync itself. Try disabling the git fileserver
 backend in the master config, restarting the master, and attempting the sync
 again.
 
-This issue will be worked around in Salt 0.16.4 and newer.
+This issue is worked around in Salt 0.16.4 and newer.

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -2,11 +2,13 @@
 '''
 Clone a remote git repository and use the filesystem as a pillar directory.
 
-This looks like:
+This external pillar source can be configured in the master config file like
+so:
 
-ext_pillar:
-    - git: master git://gitserver/git-pillar.git
+.. code-block:: yaml
 
+    ext_pillar:
+      - git: master git://gitserver/git-pillar.git
 '''
 
 # Import python libs


### PR DESCRIPTION
Without it, the dash in the YAML data gets interpreted by sphinx as a
bullet point, which could be confusing to thos wishing to use this
external pillar.
