### PR TITLE
Ignore rope project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,9 +33,12 @@ tests/integration/tmp/
 .coverage
 coverage.xml
 htmlcov/
+
+# IDE files
 /.project
 /.pydevproject
 /.idea
+/.ropeproject
 
 # ignore ctags file
 tags


### PR DESCRIPTION
Rope is used in Emacs elpy and others.
