### PR TITLE
utils/validate/net.py: simplify mac()

### DIFF
--- a/salt/utils/validate/net.py
+++ b/salt/utils/validate/net.py
@@ -14,6 +14,4 @@ def mac(mac):
                       |^([0-9A-F]{1,2}[:]){5}([0-9A-F]{1,2})$)
                       ''',
                       re.VERBOSE|re.IGNORECASE)
-    if valid.match(mac) is None:
-            return False
-    return True
+    return valid.match(mac) is not None


### PR DESCRIPTION
Also obviates a pylint warning:
`salt/utils/validate/net.py:18: [W0311(bad-indentation), ] Bad indentation. Found 12 spaces, expected 8`
