### PR TITLE
Add markupsafe to requirements file because it is required for salt-ssh.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ msgpack-python
 pycrypto
 PyYAML
 pyzmq >= 2.1.9
+markupsafe


### PR DESCRIPTION
salt-ssh will not run without the markupsafe dep. 
