### PR TITLE
Fix remove possible trailing slash in name of mounted state

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -77,6 +77,9 @@ def mounted(name,
     elif opts is None:
         opts = ['defaults']
 
+    # remove possible trailing slash
+    name = name.rstrip("/")
+
     # Get the active data
     active = __salt__['mount.active']()
     if name in active:


### PR DESCRIPTION
Mounted state will fail if a state describe a valid mount point ending with one or several "/" because it will not find in a the mount.active data. (fail with "Result: False, Comment: mount: /dev/mapper/xx already mounted or /xx/ busy.
mount: according to mtab, /dev/mapper/xx is already mounted on /xx")
