### PR TITLE
Updated salt.states.alternatives to fix incorrect docstring.

### DIFF
--- a/salt/states/alternatives.py
+++ b/salt/states/alternatives.py
@@ -162,8 +162,8 @@ def set_(name, path):
     '''
     .. versionadded:: 0.17.0
 
-    Removes installed alternative for defined <name> and <path>
-    or fallback to default alternative, if some defined before.
+    Sets alternative for <name> to <path>, if <path> is defined
+    as an alternative for <name>.
 
     name
         is the master name for this link group


### PR DESCRIPTION
Doc string for salt.states.alternatives.set_ appears to be compied and pasted from salt.states.alternatives.remove and does not correspond to what the set_ actually method does.  Fixed this.
