### PR TITLE
Finish freebsdports module

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -19,6 +19,7 @@ Full Table of Contents
     topics/master_tops/index
     topics/jobs/*
     topics/nonroot
+    topics/translating
     topics/troubleshooting/index
     topics/troubleshooting/yaml_idiosyncrasies
     topics/community

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -55,6 +55,7 @@ Full list of builtin execution modules
     freebsdjail
     freebsdkmod
     freebsdpkg
+    freebsdports
     freebsdservice
     gem
     gentoo_service


### PR DESCRIPTION
This finishes the freebsdports module, adding `install`, `deinstall`, and `update` functions. It also adds this new module to the docs, and fixes a sphinx build error by adding the new "translating" page to the TOC.
