### PR TITLE
Refs #7422 and #4686

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1658,8 +1658,10 @@ class State(object):
 
 class BaseHighState(object):
     '''
-    The BaseHighState is the foundation of running a highstate, extend it and
-    add a self.state object of type State
+    The BaseHighState is an abstract base class that is the foundation of running a highstate, extend it and
+    add a self.state object of type State.
+
+    When extending this class, please note that self.client self.matcher should be instantiated and handled.
     '''
     def __init__(self, opts):
         self.opts = self.__gen_opts(opts)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -71,16 +71,27 @@ class Schedule(object):
                'fun': func,
                'jid': '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())}
         salt.utils.daemonize_if(self.opts)
+
+        args = None
         if 'args' in data:
-            if 'kwargs' in data:
-                ret['return'] = self.functions[func](
-                        *data['args'],
-                        **data['kwargs'])
-            else:
-                ret['return'] = self.functions[func](
-                        *data['args'])
-        else:
+            args = data['args']
+
+        kwargs = None
+        if 'kwargs' in data:
+            kwargs = data['kwargs']
+
+        if args and kwargs:
+            ret['return'] = self.functions[func](*args, **kwargs)
+
+        if args and not kwargs:
+            ret['return'] = self.functions[func](*args)
+
+        if kwargs and not args:
+            ret['return'] = self.functions[func](**kwargs)
+
+        if not kwargs and not args:
             ret['return'] = self.functions[func]()
+
         if 'returner' in data or self.schedule_returner:
             rets = []
             if isinstance(data['returner'], str):


### PR DESCRIPTION
A marginally hackish (but effective?) way to avoid having to unwrap None vars as args/kwags. This fixes an incorrect assumption that to have kwargs, one would first need to provide kwargs. Refs #7422.

Also, documentation update. Refs #4686.
