### PR TITLE
Test for the presence of a yaml parsing log message. Fixes #6714.

### DIFF
--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -17,7 +17,7 @@ import warnings
 
 # Import Salt Testing libs
 from salttesting import TestCase
-from salttesting.helpers import ensure_in_syspath
+from salttesting.helpers import ensure_in_syspath, TestsLoggingHandler
 
 ensure_in_syspath('../')
 
@@ -356,6 +356,34 @@ class ConfigTestCase(TestCase):
                 '{0}.'.format(helium_version.formatted_version),
                 str(w[-1].message)
             )
+
+    def test_issue_6714_parsing_errors_logged(self):
+        try:
+            tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+            test_config = os.path.join(tempdir, 'config')
+
+            # Let's populate a master configuration file with some basic
+            # settings
+            salt.utils.fopen(test_config, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {0}/foo.log\n'.format(tempdir) +
+                '\n\n\n'
+                'blah:false\n'
+            )
+
+            with TestsLoggingHandler() as handler:
+                # Let's load the configuration
+                config = sconfig.master_config(test_config)
+                for message in handler.messages:
+                    if message.startswith('ERROR:Error parsing configuration'):
+                        break
+                else:
+                    raise AssertionError(
+                        'No parsing error message was logged'
+                    )
+        finally:
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Additionally, moved the yaml syntax error checking to the proper place.
