### PR TITLE
Added --file-root option for local salt run

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -282,6 +282,11 @@ class SaltCall(parsers.SaltCallOptionParser):
                     self.config['user']
                 )
 
+        if self.options.file_root:
+            # check if the argument is pointing to a file on disk
+            file_root = os.path.abspath(self.options.file_root)
+            self.config['file_roots'] = {'base':  [file_root]}
+
         if self.options.local:
             self.config['file_client'] = 'local'
         if self.options.master:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1441,6 +1441,11 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help='Run salt-call locally, as if there was no master running.'
         )
         self.add_option(
+            '--file-root',
+            default=None,
+            help='Set this directory as the base file root.'
+        )
+        self.add_option(
             '--retcode-passthrough',
             default=False,
             action='store_true',


### PR DESCRIPTION
The --file-root option allows salt to run an arbitrary SLS file anywhere
on the filesystem without having to have a Salt master, or states
installed in /srv/salt.  For example, to run a .sls file located at
`/home/user/foo.sls` the following command can be used:

```
salt-call --local --file-root=/home/user state.sls foo
```

Additionally, an entire state tree can be used with this option.  For
example, the sls file `/home/user/states/bootstrap/init.sls` can include
`service.foo` at `/home/user/states/service/foo.sls` with the command:

```
salt-call --local --file-root=/home/user/states state.sls bootstrap
```
