### PR TITLE
Stop calling sudo for RVM installs when running as non-root user.

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -111,7 +111,11 @@ def install_ruby(ruby, runas=None):
     #   git-core zlib1g zlib1g-dev libssl-dev libyaml-dev libsqlite3-0
     #   libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev
     #   libncurses5-dev automake libtool bison subversion ruby
-    return _rvm('install', ruby, runas=runas)
+    if runas and runas != 'root':
+            _rvm('autolibs disable', ruby, runas=runas)
+	    return _rvm('install --disable-binary', ruby, runas=runas)
+    else:
+	    return _rvm('install', ruby, runas=runas)
 
 
 def reinstall_ruby(ruby, runas=None):


### PR DESCRIPTION
I was having problems with deploying non-root installation of RVM and Ruby using salt's rvm module.
It turns out that by default, autolibs will try to elevate privileges if there are some missing packages for requested Ruby version. It does make sense for interactive installations, but fails miserably in scripted environments. 
If all dependencies are properly installed it is possible to compile and install new Ruby on a user level without need to elevate privileges. Only thing required to stop RVM from trying to sudo is to disable autolibs and add '--disable-binary'. 

I was able to successfully install non-root, user level RVM with compiled ruby on a blank Debian/Ubuntu box.
