### PR TITLE
Added note about methods with trailing underscores to module docs.

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -259,6 +259,12 @@ Objects NOT Loaded into the Salt Minion
 
     cheese = {} # Not a callable Python object
 
+.. note::
+
+    Some callable names also end with an underscore ``_``, to avoid keyword clashes
+    with Python keywords.  When using Salt modules, or state modules, with these
+    in them the trailing underscore should be omitted.
+
 Useful Decorators for Modules
 =============================
 Sometimes when writing modules for large scale deployments you run into some small


### PR DESCRIPTION
Not fantastically impressed with what I've written and welcome for someone else to have a stab at it - trying to rectify that it's not clear from the docs ANYWHERE that, e.g., salt.states.alternatives.set_ must be specified as 'alternatives.set' or 'alternatives: - set' in the sls.  'alternatives.set_' or 'alternatives: - set_' will not work.

As a python coder it's obvious what's going on to avoid the name clash in the source but I wouldn't expect all salt users to be python programmers so it needs mentioning somewhere, imho.
