### PR TITLE
Removed :codeauthor: field lists from logging handler docs

### DIFF
--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
-    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
-    :license: Apache 2.0, see LICENSE for more details.
-
-
     salt.log.handlers
     ~~~~~~~~~~~~~~~~~
 

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Pedro Algarvio (pedro@algarvio.me)
-    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
-    :license: Apache 2.0, see LICENSE for more details.
-
-
     Logstash Logging Handler
     ========================
 

--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -1,10 +1,5 @@
 # -*- coding: utf-8 -*-
 '''
-    :codeauthor: Pedro Algarvio (pedro@algarvio.me)
-    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details.
-    :license: Apache 2.0, see LICENSE for more details.
-
-
     Sentry Logging Handler
     ======================
 


### PR DESCRIPTION
Fixes #7692

There is a conflict between author field list fields in rST and the
regular PDF metadata. If there is a workaround for this, I'd love to
know it but I'm pulling this out for now so the PDF will build. Besides,
who is Pedro Alonso and why is he claiming ownership of our modules?
