### PR TITLE
Add note about pillar.get() vs salt['pillar.get']() in templates

### DIFF
--- a/doc/topics/pillar/index.rst
+++ b/doc/topics/pillar/index.rst
@@ -211,6 +211,16 @@ back if the value is not available:
 
 This makes handling nested structures much easier.
 
+.. note:: ``pillar.get()`` vs ``salt['pillar.get']()``
+
+    It should be noted that within templating, the ``pillar`` variable is just
+    a dictionary.  This means that calling ``pillar.get()`` inside of a
+    template will just use the default dictionary ``.get()`` function which
+    does not include the extra ``:`` delimeter functionality.  It must be
+    called using the above syntax (``salt['pillar.get']('foo:bar:baz',
+    'qux')``) to get the salt function, instead of the default dictionary
+    behavior.
+
 
 Refreshing Pillar Data
 ======================


### PR DESCRIPTION
Fixes #7566
