### PR TITLE
Enforce `__virtualname__` usage.

### DIFF
--- a/salt/auth/stormpath_mod.py
+++ b/salt/auth/stormpath_mod.py
@@ -23,15 +23,17 @@ try:
 except ImportError:
     HAS_STORMPATH = False
 
+# Define the module's virtual name
+__virtualname__ = 'stormpath'
+
 
 def __virtual__():
     '''
     Only load if stormpath is installed
     '''
     if HAS_STORMPATH:
-        return 'stormpath'
-    else:
-        return False
+        return __virtualname__
+    return False
 
 
 def auth(username, password):

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -33,6 +33,9 @@ from salt.utils.event import tagify
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'git'
+
 
 def __virtual__():
     '''
@@ -55,7 +58,7 @@ def __virtual__():
                   'GitPython version is not greater than 0.3.0, '
                   'version {0} detected'.format(git.__version__))
         return False
-    return 'git'
+    return __virtualname__
 
 
 def _get_ref(repo, short):

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -37,6 +37,9 @@ from salt.utils.event import tagify
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'hg'
+
 
 def __virtual__():
     '''
@@ -54,7 +57,7 @@ def __virtual__():
         log.error('Mercurial fileserver backend is enabled in configuration '
                   'but could not be loaded, is hglib installed?')
         return False
-    return 'hg'
+    return __virtualname__
 
 
 def _get_ref(repo, name):

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -32,6 +32,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'svn'
+
 
 def __virtual__():
     '''
@@ -47,7 +50,7 @@ def __virtual__():
         log.error('subversion fileserver backend is enabled in configuration '
                   'but could not be loaded, is pysvn installed?')
         return False
-    return 'svn'
+    return __virtualname__
 
 
 def init():

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -769,11 +769,12 @@ class Loader(object):
                                     salt.utils.warn_until(
                                         'Hydrogen',
                                         'The {0!r} module is renaming itself '
-                                        'in it\'s __virtual__() function. '
-                                        'Please set it\'s virtual name as the '
-                                        '\'__virtualname__\' module attribute.'
-                                        ' Example: "__virtualname__ = {1!r}"'
-                                        .format(
+                                        'in it\'s __virtual__() function ({1} '
+                                        '=> {2}). Please set it\'s virtual '
+                                        'name as the \'__virtualname__\' '
+                                        'module attribute. Example: '
+                                        '"__virtualname__ = {2!r}"'.format(
+                                            mod.__name__,
                                             module_name,
                                             virtual
                                         )

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -764,7 +764,24 @@ class Loader(object):
                                         module_name, virtual
                                     )
                                 )
+
+                                if not hasattr(mod, '__virtualname__'):
+                                    salt.utils.warn_until(
+                                        'Hydrogen',
+                                        'The {0!r} module is renaming itself '
+                                        'in it\'s __virtual__() function. '
+                                        'Please set it\'s virtual name as the '
+                                        '\'__virtualname__\' module attribute.'
+                                        ' Example: "__virtualname__ = {1!r}"'
+                                        .format(
+                                            module_name,
+                                            virtual
+                                        )
+                                    )
                                 module_name = virtual
+
+                            elif virtual and hasattr(mod, '__virtualname__'):
+                                module_name = mod.__virtualname__
 
                 except KeyError:
                     # Key errors come out of the virtual function when passing

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -125,6 +125,9 @@ from salt.log.mixins import NewStyleClassMixIn
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'logstash'
+
 
 def __virtual__():
     if not any(['logstash_udp_handler' in __opts__,
@@ -136,7 +139,7 @@ def __virtual__():
             'logging handlers module.'
         )
         return False
-    return 'logstash'
+    return __virtualname__
 
 
 def setup_handlers():

--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -79,10 +79,13 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'sentry'
+
 
 def __virtual__():
     if HAS_RAVEN is True:
-        return 'sentry'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -43,6 +43,9 @@ LP_PVT_SRC_FORMAT = 'deb https://{0}private-ppa.launchpad.net/{1}/{2}/ubuntu' \
 _MODIFY_OK = frozenset(['uri', 'comps', 'architectures', 'disabled',
                         'file', 'dist'])
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
@@ -50,7 +53,7 @@ def __virtual__():
     '''
     if __grains__['os_family'] != 'Debian':
         return False
-    return 'pkg'
+    return __virtualname__
 
 
 def __init__(opts):

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -19,13 +19,16 @@ except ImportError:
 # Import salt libs
 from salt.exceptions import SaltInvocationError
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
     Only run this module if the augeas python module is installed
     '''
     if HAS_AUGEAS:
-        return 'augeas'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -29,13 +29,16 @@ __func_alias__ = {
     'address_': 'address'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'bluetooth'
+
 
 def __virtual__():
     '''
     Only load the module if bluetooth is installed
     '''
     if HAS_PYBLUEZ:
-        return 'bluetooth'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -12,6 +12,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
@@ -19,7 +22,7 @@ def __virtual__():
     '''
 
     if salt.utils.which('brew') and __grains__['os'] == 'MacOS':
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -9,9 +9,12 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'shadow'
+
 
 def __virtual__():
-    return 'shadow' if 'BSD' in __grains__.get('os', '') else False
+    return __virtualname__ if 'BSD' in __grains__.get('os', '') else False
 
 
 def default_hash():

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -31,10 +31,11 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'cmd'
 
 # Set up logging
 log = logging.getLogger(__name__)
-
 
 DEFAULT_SHELL = salt.grains.extra.shell()['shell']
 
@@ -44,15 +45,17 @@ def __virtual__():
     Overwriting the cmd python module makes debugging modules
     with pdb a bit harder so lets do it this way instead.
     '''
-    return 'cmd'
+    return __virtualname__
 
 
 def _chugid(runas):
     uinfo = pwd.getpwnam(runas)
     supgroups_seen = set()
-    supgroups = [g.gr_gid for g in grp.getgrall()
-                 if uinfo.pw_name in g.gr_mem and g.gr_gid != uinfo.pw_gid
-                 and g.gr_gid not in supgroups_seen and not supgroups_seen.add(g.gr_gid)]
+    supgroups = [
+        g.gr_gid for g in grp.getgrall()
+        if uinfo.pw_name in g.gr_mem and g.gr_gid != uinfo.pw_gid
+        and g.gr_gid not in supgroups_seen and not supgroups_seen.add(g.gr_gid)
+    ]
 
     # No logging can happen on this function
     #

--- a/salt/modules/darwin_sysctl.py
+++ b/salt/modules/darwin_sysctl.py
@@ -10,12 +10,15 @@ import os
 import salt.utils
 from salt.exceptions import CommandExecutionError
 
+# Define the module's virtual name
+__virtualname__ = 'sysctl'
+
 
 def __virtual__():
     '''
     Only run on Darwin (OS X) systems
     '''
-    return 'sysctl' if __grains__['os'] == 'MacOS' else False
+    return __virtualname__ if __grains__['os'] == 'MacOS' else False
 
 
 def show():

--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -17,6 +17,9 @@ __func_alias__ = {
     'set_': 'set'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'debconf'
+
 
 def __virtual__():
     '''
@@ -30,7 +33,7 @@ def __virtual__():
         log.info('Package debconf-utils is not installed.')
         return False
 
-    return 'debconf'
+    return __virtualname__
 
 
 def _unpack_lines(out):

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -14,13 +14,16 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
     Only work on Debian and when systemd isn't running
     '''
     if __grains__['os'] in ('Debian', 'Raspbian') and not _sd_booted():
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -10,9 +10,12 @@ import os
 import salt.utils
 import salt.exceptions
 
+# Define the module's virtual name
+__virtualname__ = 'django'
+
 
 def __virtual__():
-    return 'django'
+    return __virtualname__
 
 
 def _get_django_admin(bin_env):

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -177,13 +177,16 @@ base_status = {
     'out': None
 }
 
+# Define the module's virtual name
+__virtualname__ = 'docker'
+
 
 def __virtual__():
     '''
     Only load if docker libs are present
     '''
     if HAS_DOCKER:
-        return 'docker'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -6,15 +6,17 @@ Support for DEB packages
 # Import python libs
 import logging
 
-
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'lowpkg'
 
 
 def __virtual__():
     '''
     Confirm this module is on a Debian based system
     '''
-    return 'lowpkg' if __grains__['os_family'] == 'Debian' else False
+    return __virtualname__ if __grains__['os_family'] == 'Debian' else False
 
 
 def list_pkgs(*packages):

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -16,10 +16,6 @@ import re
 # Import salt libs
 import salt.utils
 
-log = logging.getLogger(__name__)
-
-HAS_PORTAGE = False
-
 # Import third party libs
 try:
     import portage
@@ -34,14 +30,22 @@ except ImportError:
             import portage
             HAS_PORTAGE = True
         except ImportError:
-            pass
+            HAS_PORTAGE = False
+
+
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'pkg'
 
 
 def __virtual__():
     '''
     Confirm this module is on a Gentoo based system
     '''
-    return 'pkg' if (HAS_PORTAGE and __grains__['os'] == 'Gentoo') else False
+    if HAS_PORTAGE and __grains__['os'] == 'Gentoo':
+        return __virtualname__
+    return False
 
 
 def _vartree():

--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -7,12 +7,15 @@ Module for viewing and modifying sysctl parameters
 import salt.utils
 from salt.exceptions import CommandExecutionError
 
+# Define the module's virtual name
+__virtualname__ = 'sysctl'
+
 
 def __virtual__():
     '''
     Only run on FreeBSD systems
     '''
-    return 'sysctl' if __grains__['os'] == 'FreeBSD' else False
+    return __virtualname__ if __grains__['os'] == 'FreeBSD' else False
 
 
 def _formatfor(name, value, config, tail=''):

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -9,12 +9,15 @@ import os
 # Import salt libs
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'jail'
+
 
 def __virtual__():
     '''
     Only runs on FreeBSD systems
     '''
-    return 'jail' if __grains__['os'] == 'FreeBSD' else False
+    return __virtualname__ if __grains__['os'] == 'FreeBSD' else False
 
 
 def start(jail=''):

--- a/salt/modules/freebsdkmod.py
+++ b/salt/modules/freebsdkmod.py
@@ -6,12 +6,15 @@ Module to manage FreeBSD kernel modules
 # Import python libs
 import os
 
+# Define the module's virtual name
+__virtualname__ = 'kmod'
+
 
 def __virtual__():
     '''
     Only runs on FreeBSD systems
     '''
-    return 'kmod' if __grains__['kernel'] == 'FreeBSD' else False
+    return __virtualname__ if __grains__['kernel'] == 'FreeBSD' else False
 
 
 def _new_mods(pre_mods, post_mods):

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -76,13 +76,16 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
     Load as 'pkg' on FreeBSD versions less than 10
     '''
     if __grains__['os'] == 'FreeBSD' and float(__grains__['osrelease']) < 10:
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -27,9 +27,12 @@ from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'ports'
+
 
 def __virtual__():
-    return 'ports' if __grains__.get('os', '') == 'FreeBSD' else False
+    return __virtualname__ if __grains__.get('os', '') == 'FreeBSD' else False
 
 
 def _check_portname(name):

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -18,6 +18,9 @@ __func_alias__ = {
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
@@ -25,7 +28,7 @@ def __virtual__():
     '''
     # Disable on these platforms, specific service modules exist:
     if __grains__['os'] == 'FreeBSD':
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -1,7 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-Top level package command wrapper, used to translate the os detected by grains to the correct service manager
+Top level package command wrapper, used to translate the os detected by grains
+to the correct service manager
 '''
+
+# Define the module's virtual name
+__virtualname__ = 'service'
 
 
 def __virtual__():
@@ -9,7 +13,7 @@ def __virtual__():
     Only work on systems which default to systemd
     '''
     if __grains__['os'] == 'Gentoo':
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -15,13 +15,16 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'gentoolkit'
+
 
 def __virtual__():
     '''
     Only work on Gentoo systems with gentoolkit installed
     '''
     if __grains__['os'] == 'Gentoo' and HAS_GENTOOLKIT:
-        return 'gentoolkit'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -9,15 +9,17 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'group'
+
 
 def __virtual__():
     '''
     Set the user module if the kernel is Linux or OpenBSD
     '''
-    return (
-        'group' if __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD')
-        else False
-    )
+    if __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD'):
+        return __virtualname__
+    return False
 
 
 def add(name, gid=None, system=False):

--- a/salt/modules/grub_legacy.py
+++ b/salt/modules/grub_legacy.py
@@ -11,13 +11,16 @@ import salt.utils
 import salt.utils.decorators as decorators
 from salt.exceptions import CommandExecutionError
 
+# Define the module's virtual name
+__virtualname__ = 'grub'
+
 
 def __virtual__():
     '''
     Only load the module if grub is installed
     '''
     if os.path.exists(_detect_conf()):
-        return 'grub'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -12,13 +12,16 @@ import plistlib
 # Import salt libs
 import salt.utils.decorators as decorators
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
     Only work on MacOS
     '''
     if __grains__['os'] == 'MacOS':
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -48,6 +48,9 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'ldap'
+
 
 def __virtual__():
     '''
@@ -55,7 +58,7 @@ def __virtual__():
     '''
     # These config items must be set in the minion config
     if HAS_LDAP:
-        return 'ldap'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -6,13 +6,16 @@ Support for Linux File Access Control Lists
 # Import salt libs
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'acl'
+
 
 def __virtual__():
     '''
     Only load the module if getfacl is installed
     '''
     if salt.utils.which('getfacl'):
-        return 'acl'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -6,13 +6,16 @@ Support for Linux LVM2
 # Import salt libs
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'lvm'
+
 
 def __virtual__():
     '''
     Only load the module if lvm is installed
     '''
     if salt.utils.which('lvm'):
-        return 'lvm'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -16,6 +16,9 @@ from salt.modules.systemd import _sd_booted
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'sysctl'
+
 # TODO: Add unpersist() to remove either a sysctl or sysctl/value combo from
 # the config
 
@@ -28,7 +31,7 @@ def __virtual__():
         return False
     global _sd_booted
     _sd_booted = salt.utils.namespaced_function(_sd_booted, globals())
-    return 'sysctl'
+    return __virtualname__
 
 
 def default_config():

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -12,6 +12,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'locale'
+
 
 def __virtual__():
     '''
@@ -19,7 +22,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'locale'
+    return __virtualname__
 
 
 def _parse_localectl():

--- a/salt/modules/mac_group.py
+++ b/salt/modules/mac_group.py
@@ -13,6 +13,9 @@ import salt.utils
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.modules.mac_user import _osmajor, _dscl, _flush_dscl_cache
 
+# Define the module's virtual name
+__virtualname__ = 'group'
+
 
 def __virtual__():
     global _osmajor, _dscl, _flush_dscl_cache
@@ -23,7 +26,7 @@ def __virtual__():
     _flush_dscl_cache = salt.utils.namespaced_function(
         _flush_dscl_cache, globals()
     )
-    return 'group'
+    return __virtualname__
 
 
 def add(name, gid=None, **kwargs):

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -21,11 +21,14 @@ from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'user'
+
 
 def __virtual__():
     if __grains__.get('kernel') != 'Darwin':
         return False
-    return 'user' if _osmajor() >= 10.7 else False
+    return __virtualname__ if _osmajor() >= 10.7 else False
 
 
 def _osmajor():

--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -20,6 +20,9 @@ __func_alias__ = {
     'list_': 'list'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'raid'
+
 
 def __virtual__():
     '''
@@ -29,7 +32,7 @@ def __virtual__():
         return False
     if not salt.utils.which('mdadm'):
         return False
-    return 'raid'
+    return __virtualname__
 
 
 def list_():

--- a/salt/modules/netbsd_sysctl.py
+++ b/salt/modules/netbsd_sysctl.py
@@ -8,12 +8,15 @@ import re
 import salt.utils
 from salt.exceptions import CommandExecutionError
 
+# Define the module's virtual name
+__virtualname__ = 'sysctl'
+
 
 def __virtual__():
     '''
     Only run on NetBSD systems
     '''
-    return 'sysctl' if __grains__['os'] == 'NetBSD' else False
+    return __virtualname__ if __grains__['os'] == 'NetBSD' else False
 
 
 def show():

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -11,13 +11,16 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
     Only work on NetBSD
     '''
     if __grains__['os'] == 'NetBSD' and os.path.exists('/etc/rc.subr'):
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -16,6 +16,8 @@ log = logging.getLogger(__name__)
 
 __PKG_RE = re.compile('^((?:[^-]+|-(?![0-9]))+)-([0-9][^-]*)(?:-(.*))?$')
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
 
 # XXX need a way of setting PKG_PATH instead of inheriting from the environment
 
@@ -24,7 +26,7 @@ def __virtual__():
     Set the virtual pkg module if the os is OpenBSD
     '''
     if __grains__['os'] == 'OpenBSD':
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -8,6 +8,9 @@ import os
 
 # XXX enable/disable support would be nice
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
@@ -18,7 +21,7 @@ def __virtual__():
         # The -f flag, used to force a script to run even if disabled,
         # was added after the 5.0 release.
         if krel[0] > 5 or (krel[0] == 5 and krel[1] > 0):
-            return 'service'
+            return __virtualname__
     return False
 
 

--- a/salt/modules/osxdesktop.py
+++ b/salt/modules/osxdesktop.py
@@ -3,13 +3,16 @@
 Mac OS X implementations of various commands in the "desktop" interface
 '''
 
+# Define the module's virtual name
+__virtualname__ = 'desktop'
+
 
 def __virtual__():
     '''
     Only load on Mac systems
     '''
     if __grains__['os'] == 'MacOS':
-        return 'desktop'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -14,12 +14,17 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
     Set the virtual pkg module if the os is Arch
     '''
-    return 'pkg' if __grains__['os'] in ('Arch', 'Arch ARM') else False
+    if __grains__['os'] in ('Arch', 'Arch ARM'):
+        return __virtualname__
+    return False
 
 
 def _list_removed(old, new):

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -25,6 +25,8 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'partition'
 
 # Define a function alias in order not to shadow built-in's
 __func_alias__ = {
@@ -39,7 +41,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'partition'
+    return __virtualname__
 
 
 def probe(device=''):

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -15,6 +15,9 @@ import salt.utils.decorators as decorators
 VERSION_MATCH = re.compile(r'pkgin(?:[\s]+)([\d.]+)(?:[\s]+)(?:.*)')
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 @decorators.memoize
 def _check_pkgin():
@@ -58,7 +61,7 @@ def __virtual__():
     supported = ['NetBSD', 'SunOS', 'DragonFly', 'Minix', 'Darwin', 'SmartOS']
 
     if __grains__['os'] in supported and _check_pkgin():
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -41,13 +41,16 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
     Load as 'pkg' on FreeBSD 10 and greater
     '''
     if __grains__['os'] == 'FreeBSD' and float(__grains__['osrelease']) >= 10:
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -18,12 +18,15 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'group'
+
 
 def __virtual__():
     '''
     Set the user module if the kernel is Linux
     '''
-    return 'group' if __grains__['kernel'] == 'FreeBSD' else False
+    return __virtualname__ if __grains__['kernel'] == 'FreeBSD' else False
 
 
 def add(name, gid=None, **kwargs):

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -19,12 +19,15 @@ from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'user'
+
 
 def __virtual__():
     '''
     Set the user module if the kernel is FreeBSD
     '''
-    return 'user' if __grains__['kernel'] == 'FreeBSD' else False
+    return __virtualname__ if __grains__['kernel'] == 'FreeBSD' else False
 
 
 def _get_gecos(name):

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -28,13 +28,16 @@ JINJA = jinja2.Environment(
     )
 )
 
+# Define the module's virtual name
+__virtualname__ = 'ip'
+
 
 def __virtual__():
     '''
     Confine this module to RHEL/Fedora based distros
     '''
     if __grains__['os_family'] == 'RedHat':
-        return 'ip'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -18,6 +18,9 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 # Import upstart module if needed
 HAS_UPSTART = False
 if salt.utils.which('initctl'):
@@ -53,7 +56,7 @@ def __virtual__():
         if __grains__['os'] == 'Fedora':
             if __grains__.get('osrelease', 0) > 15:
                 return False
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -11,6 +11,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'lowpkg'
+
 
 def __virtual__():
     '''
@@ -29,13 +32,13 @@ def __virtual__():
         os_major = 0
 
     if os_grain == 'Amazon':
-        return 'lowpkg'
+        return __virtualname__
     elif os_grain == 'Fedora':
         # Fedora <= 10 used Python 2.5 and below
         if os_major >= 11:
-            return 'lowpkg'
+            return __virtualname__
     elif os_family == 'RedHat' and os_major >= 6:
-        return 'lowpkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/saltcloudmod.py
+++ b/salt/modules/saltcloudmod.py
@@ -15,13 +15,16 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'saltcloud'
+
 
 def __virtual__():
     '''
     Only load if salt cloud is installed
     '''
     if HAS_CLOUD:
-        return 'saltcloud'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -12,6 +12,9 @@ import salt.utils.decorators as decorators
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'imgadm'
+
 
 @decorators.memoize
 def _check_imgadm():
@@ -37,7 +40,7 @@ def __virtual__():
     Provides imgadm only on SmartOS
     '''
     if __grains__['os'] == "SmartOS" and _check_imgadm():
-        return 'imgadm'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -11,6 +11,9 @@ from salt.exceptions import CommandExecutionError
 import salt.utils
 import salt.utils.decorators as decorators
 
+# Define the module's virtual name
+__virtualname__ = 'virt'
+
 
 @decorators.memoize
 def _check_vmadm():
@@ -32,7 +35,7 @@ def __virtual__():
     Provides virt on SmartOS
     '''
     if __grains__['os'] == "SmartOS" and _check_vmadm():
-        return 'virt'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -8,6 +8,9 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
@@ -21,7 +24,7 @@ def __virtual__():
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Solaris' and __grains__['kernelrelease'] == "5.9":
             return False
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -18,12 +18,15 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'group'
+
 
 def __virtual__():
     '''
     Set the group module if the kernel is SunOS
     '''
-    return 'group' if __grains__['kernel'] == 'SunOS' else False
+    return __virtualname__ if __grains__['kernel'] == 'SunOS' else False
 
 
 def add(name, gid=None, **kwargs):

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -19,12 +19,17 @@ except ImportError:
 # Import salt libs
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'shadow'
+
 
 def __virtual__():
     '''
     Only work on POSIX-like systems
     '''
-    return 'shadow' if __grains__.get('kernel', '') == 'SunOS' else False
+    if __grains__.get('kernel', '') == 'SunOS':
+        return __virtualname__
+    return False
 
 
 def default_hash():

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -18,13 +18,16 @@ from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'user'
+
 
 def __virtual__():
     '''
     Set the user module if the kernel is SunOS
     '''
 
-    return 'user' if __grains__['kernel'] == 'SunOS' else False
+    return __virtualname__ if __grains__['kernel'] == 'SunOS' else False
 
 
 def _get_gecos(name):

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -11,8 +11,10 @@ import logging
 # Import salt libs
 import salt.utils
 
-
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'pkg'
 
 
 def __virtual__():
@@ -20,7 +22,7 @@ def __virtual__():
     Set the virtual pkg module if the os is Solaris
     '''
     if __grains__['os'] == 'Solaris':
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -12,12 +12,15 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'sys'
+
 
 def __virtual__():
     '''
     Return as sys
     '''
-    return 'sys'
+    return __virtualname__
 
 
 def _strip_rst(docs):

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -17,13 +17,16 @@ LOCAL_CONFIG_PATH = '/etc/systemd/system'
 VALID_UNIT_TYPES = ['service', 'socket', 'device', 'mount', 'automount',
                     'swap', 'target', 'path', 'timer']
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
     Only work on systems that have been booted with systemd
     '''
     if __grains__['kernel'] == 'Linux' and _sd_booted():
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -49,6 +49,9 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
@@ -56,7 +59,7 @@ def __virtual__():
     '''
     # Disable on these platforms, specific service modules exist:
     if __grains__['os'] in ('Ubuntu', 'Linaro', 'elementary OS'):
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -19,9 +19,13 @@ import salt.utils
 from salt._compat import string_types
 
 log = logging.getLogger(__name__)
+
 RETCODE_12_ERROR_REGEX = re.compile(
     r'userdel(.*)warning(.*)/var/mail(.*)No such file or directory'
 )
+
+# Define the module's virtual name
+__virtualname__ = 'user'
 
 
 def __virtual__():
@@ -29,10 +33,10 @@ def __virtual__():
     Set the user module if the kernel is Linux or OpenBSD
     and remove some of the functionality on OS X
     '''
-    return (
-        'user' if __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD')
-        else False
-    )
+
+    if __grains__['kernel'] in ('Linux', 'OpenBSD', 'NetBSD'):
+        return __virtualname__
+    return False
 
 
 def _get_gecos(name):

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -22,9 +22,12 @@ __opts__ = {
 
 __pillar__ = {}
 
+# Define the module's virtual name
+__virtualname__ = 'virtualenv'
+
 
 def __virtual__():
-    return 'virtualenv'
+    return __virtualname__
 
 
 def create(path,

--- a/salt/modules/win_autoruns.py
+++ b/salt/modules/win_autoruns.py
@@ -16,6 +16,9 @@ __func_alias__ = {
     'list_': 'list'
 }
 
+# Define the module's virtual name
+__virtualname__ = 'autoruns'
+
 
 def __virtual__():
     '''
@@ -23,7 +26,7 @@ def __virtual__():
     '''
 
     if salt.utils.is_windows():
-        return 'autoruns'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -17,13 +17,16 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'disk'
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
     if salt.utils.is_windows():
-        return 'disk'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -41,6 +41,9 @@ from salt.utils import namespaced_function as _namespaced_function
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'file'
+
 
 def __virtual__():
     '''
@@ -60,7 +63,7 @@ def __virtual__():
             mkdir = _namespaced_function(mkdir, globals())
             __clean_tmp = _namespaced_function(__clean_tmp, globals())
 
-            return 'file'
+            return __virtualname__
         log.warn(salt.utils.required_modules_error(__file__, __doc__))
     return False
 

--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -9,13 +9,16 @@ import re
 # Import salt libs
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'firewall'
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
     if salt.utils.is_windows():
-        return 'firewall'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -6,12 +6,15 @@ Manage groups on Windows
 # Import salt libs
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'group'
+
 
 def __virtual__():
     '''
     Set the group module if the kernel is Windows
     '''
-    return 'group' if salt.utils.is_windows() else False
+    return __virtualname__ if salt.utils.is_windows() else False
 
 
 def add(name, gid=None, system=False):

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -13,13 +13,16 @@ import salt.utils
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'ip'
+
 
 def __virtual__():
     '''
     Confine this module to Windows systems
     '''
     if salt.utils.is_windows():
-        return 'ip'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -21,13 +21,16 @@ try:
 except ImportError:
     HAS_DEPENDENCIES = False
 
+# Define the module's virtual name
+__virtualname__ = 'network'
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
     if salt.utils.is_windows() and HAS_DEPENDENCIES is True:
-        return 'network'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -13,6 +13,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'ntp'
+
 
 def __virtual__():
     '''
@@ -20,7 +23,7 @@ def __virtual__():
     '''
     if not salt.utils.is_windows():
         return False
-    return 'ntp'
+    return __virtualname__
 
 
 def set_servers(*servers):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -33,13 +33,16 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
     Set the virtual pkg module if the os is Windows
     '''
     if salt.utils.is_windows() and HAS_DEPENDENCIES:
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -25,13 +25,16 @@ from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'winrepo'
+
 
 def __virtual__():
     '''
     Set the winrepo module if the OS is Windows
     '''
     if salt.utils.is_windows():
-        return 'winrepo'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -7,13 +7,16 @@ Windows Service module.
 import time
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'service'
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
     if salt.utils.is_windows():
-        return 'service'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -5,13 +5,16 @@ Manage the shadow file
 
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'shadow'
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
     if salt.utils.is_windows():
-        return 'shadow'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -27,13 +27,16 @@ except ImportError:
 
 __opts__ = {}
 
+# Define the module's virtual name
+__virtualname__ = 'status'
+
 
 def __virtual__():
     '''
     Only works on Windows systems
     '''
     if salt.utils.is_windows() and has_required_packages:
-        return 'status'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -13,6 +13,9 @@ import salt.utils
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'system'
+
 
 def __virtual__():
     '''
@@ -20,7 +23,7 @@ def __virtual__():
     '''
     if not salt.utils.is_windows():
         return False
-    return 'system'
+    return __virtualname__
 
 
 def halt(timeout=5):

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -448,13 +448,16 @@ LINTOWIN = {
     'Pacific/Wallis': 'UTC+12'
     }
 
+# Define the module's virtual name
+__virtualname__ = 'timezone'
+
 
 def __virtual__():
     '''
     Only load on windows
     '''
     if salt.utils.is_windows():
-        return 'timezone'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -16,13 +16,16 @@ try:
 except ImportError:
     HAS_WIN32NET_MODS = False
 
+# Define the module's virtual name
+__virtualname__ = 'user'
+
 
 def __virtual__():
     '''
     Set the user module if the kernel is Windows
     '''
     if HAS_WIN32NET_MODS is True and salt.utils.is_windows():
-        return 'user'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -33,6 +33,8 @@ except ImportError:
 from salt.exceptions import CommandExecutionError
 import salt.utils
 
+# Define the module's virtual name
+__virtualname__ = 'virt'
 
 # This module has only been tested on Debian GNU/Linux and NetBSD, it
 # probably needs more path appending for other distributions.
@@ -58,7 +60,7 @@ def _check_xenapi():
 
 def __virtual__():
     if _check_xenapi() is not False:
-        return 'virt'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -102,6 +102,9 @@ except (ImportError, AttributeError):
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
@@ -120,19 +123,19 @@ def __virtual__():
         os_major = 0
 
     if os_grain == 'Amazon':
-        return 'pkg'
+        return __virtualname__
     elif os_grain == 'Fedora':
         # Fedora <= 10 used Python 2.5 and below
         if os_major >= 11:
-            return 'pkg'
+            return __virtualname__
     elif os_grain == 'XCP':
         if os_major >= 2:
-            return 'pkg'
+            return __virtualname__
     elif os_grain == 'XenServer':
         if os_major > 6:
-            return 'pkg'
+            return __virtualname__
     elif os_family == 'RedHat' and os_major >= 6:
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -25,6 +25,9 @@ log = logging.getLogger(__name__)
 # it without considering its impact there.
 __QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}'
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
@@ -63,7 +66,7 @@ def __virtual__():
         get_repo = _namespaced_function(get_repo, globals())
         expand_repo_def = _namespaced_function(expand_repo_def, globals())
         del_repo = _namespaced_function(del_repo, globals())
-        return 'pkg'
+        return __virtualname__
     return False
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -13,6 +13,9 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pkg'
+
 
 def __virtual__():
     '''
@@ -23,7 +26,7 @@ def __virtual__():
     # Not all versions of Suse use zypper, check that it is available
     if not salt.utils.which('zypper'):
         return False
-    return 'pkg'
+    return __virtualname__
 
 
 def list_upgrades(refresh=True):

--- a/salt/output/json_out.py
+++ b/salt/output/json_out.py
@@ -9,12 +9,15 @@ import logging
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'json'
+
 
 def __virtual__():
     '''
     Rename to json
     '''
-    return 'json'
+    return __virtualname__
 
 
 def output(data):

--- a/salt/output/no_out.py
+++ b/salt/output/no_out.py
@@ -3,9 +3,12 @@
 Display no output.
 '''
 
+# Define the module's virtual name
+__virtualname__ = 'quiet'
+
 
 def __virtual__():
-    return 'quiet'
+    return __virtualname__
 
 
 def output(ret):

--- a/salt/output/pprint_out.py
+++ b/salt/output/pprint_out.py
@@ -7,12 +7,15 @@ simply passed the data passed into it through the pprint module.
 # Import python libs
 import pprint
 
+# Define the module's virtual name
+__virtualname__ = 'pprint'
+
 
 def __virtual__():
     '''
     Change the name to pprint
     '''
-    return 'pprint'
+    return __virtualname__
 
 
 def output(data):

--- a/salt/output/yaml_out.py
+++ b/salt/output/yaml_out.py
@@ -7,9 +7,12 @@ for better readability.
 # Import third party libs
 import yaml
 
+# Define the module's virtual name
+__virtualname__ = 'yaml'
+
 
 def __virtual__():
-    return 'yaml'
+    return __virtualname__
 
 
 def output(data):

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -30,6 +30,9 @@ from salt.pillar import Pillar
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'git'
+
 
 def __virtual__():
     '''
@@ -44,7 +47,7 @@ def __virtual__():
         return False
     if not git.__version__ > '0.3.0':
         return False
-    return 'git'
+    return __virtualname__
 
 
 def _get_ref(repo, short):

--- a/salt/pillar/reclass_adapter.py
+++ b/salt/pillar/reclass_adapter.py
@@ -55,11 +55,14 @@ from salt.utils.reclass import (
     set_inventory_base_uri_default
 )
 
+# Define the module's virtual name
+__virtualname__ = 'reclass'
+
 
 def __virtual__(retry=False):
     try:
         import reclass
-        return 'reclass'
+        return __virtualname__
 
     except ImportError as e:
         if retry:

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -19,9 +19,12 @@ import collections
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'carbon'
+
 
 def __virtual__():
-    return 'carbon'
+    return __virtualname__
 
 
 def _formatHostname(hostname, separator='_'):

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -32,11 +32,14 @@ __opts__ = {'cassandra.servers': ['localhost:9160'],
             'cassandra.column_family': 'returns',
             'cassandra.consistency_level': 'ONE'}
 
+# Define the module's virtual name
+__virtualname__ = 'cassandra'
+
 
 def __virtual__():
     if not HAS_PYCASSA:
         return False
-    return 'cassandra'
+    return __virtualname__
 
 
 def returner(ret):

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -14,9 +14,12 @@ import json
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'couchdb'
+
 
 def __virtual__():
-    return 'couchdb'
+    return __virtualname__
 
 
 def _get_options():

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -25,11 +25,14 @@ try:
 except ImportError:
     HAS_MEMCACHE = False
 
+# Define the module's virtual name
+__virtualname__ = 'memcache'
+
 
 def __virtual__():
     if not HAS_MEMCACHE:
         return False
-    return 'memcache'
+    return __virtualname__
 
 
 def _get_serv():

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -30,14 +30,16 @@ try:
 except ImportError:
     HAS_PYMONGO = False
 
-
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'mongo'
 
 
 def __virtual__():
     if not HAS_PYMONGO:
         return False
-    return 'mongo'
+    return __virtualname__
 
 
 def _remove_dots(src):

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -21,11 +21,14 @@ try:
 except ImportError:
     HAS_REDIS = False
 
+# Define the module's virtual name
+__virtualname__ = 'redis'
+
 
 def __virtual__():
     if not HAS_REDIS:
         return False
-    return 'redis'
+    return __virtualname__
 
 
 def _get_serv():

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -34,11 +34,14 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'sentry'
+
 
 def __virtual__():
     if not has_raven:
         return False
-    return 'sentry'
+    return __virtualname__
 
 
 def returner(ret):

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -59,11 +59,14 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'sqlite3'
+
 
 def __virtual__():
     if not HAS_SQLITE3:
         return False
-    return 'sqlite3'
+    return __virtualname__
 
 
 def _get_conn():

--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -16,11 +16,14 @@ try:
 except ImportError:
     HAS_SYSLOG = False
 
+# Define the module's virtual name
+__virtualname__ = 'syslog'
+
 
 def __virtual__():
     if not HAS_SYSLOG:
         return False
-    return 'syslog'
+    return __virtualname__
 
 
 def returner(ret):

--- a/salt/search/whoosh_search.py
+++ b/salt/search/whoosh_search.py
@@ -20,12 +20,15 @@ try:
 except ImportError:
     pass
 
+# Define the module's virtual name
+__virtualname__ = 'whoosh'
+
 
 def __virtual__():
     '''
     Only load if the whoosh libs are available
     '''
-    return 'whoosh' if HAS_WHOOSH else False
+    return __virtualname__ if HAS_WHOOSH else False
 
 
 def index():

--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -38,6 +38,10 @@ set_file
 '''
 
 
+# Define the module's virtual name
+__virtualname__ = 'debconf'
+
+
 def __virtual__():
     '''
     Confirm this module is on a Debian based system
@@ -48,7 +52,7 @@ def __virtual__():
     if 'debconf.show' not in __salt__:
         return False
 
-    return 'debconf'
+    return __virtualname__
 
 
 def set_file(name, source, **kwargs):

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -58,15 +58,18 @@ The docker Modules can't be called docker as
 it would conflict with the underlying binding modules: docker-py
 '''
 
+# Import python libs
+import re
+
+# Import salt libs
+from salt._compat import string_types
+
+# Import 3rd-party libs
 try:
     import docker
     HAS_DOCKER = True
 except ImportError:
     HAS_DOCKER = False
-
-import re
-
-from salt._compat import string_types
 
 
 def __virtual__():

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -72,12 +72,16 @@ except ImportError:
     HAS_DOCKER = False
 
 
+# Define the module's virtual name
+__virtualname__ = 'docker'
+
+
 def __virtual__():
     '''
     Only load if docker libs available
     '''
     if HAS_DOCKER:
-        return 'docker'
+        return __virtualname__
     return False
 
 

--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -21,6 +21,9 @@ import salt.utils
 # Set up logger
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'raid'
+
 
 def __virtual__():
     '''
@@ -30,7 +33,7 @@ def __virtual__():
         return False
     if not salt.utils.which('mdadm'):
         return False
-    return 'raid'
+    return __virtualname__
 
 
 def present(name, opts=None):

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -37,13 +37,16 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'pip'
+
 
 def __virtual__():
     '''
     Only load if the pip module is available in __salt__
     '''
     if HAS_PIP and 'pip.list' in __salt__:
-        return 'pip'
+        return __virtualname__
     return False
 
 

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -29,12 +29,15 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'salt'
+
 
 def __virtual__():
     '''
     Named salt
     '''
-    return 'salt'
+    return __virtualname__
 
 
 def state(

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -15,9 +15,12 @@ import salt.version
 
 log = logging.getLogger(__name__)
 
+# Define the module's virtual name
+__virtualname__ = 'virtualenv'
+
 
 def __virtual__():
-    return 'virtualenv'
+    return __virtualname__
 
 
 def managed(name,

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -25,8 +25,10 @@ import logging
 # Import salt libs
 import salt.utils
 
-
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'system'
 
 
 def __virtual__():
@@ -34,7 +36,7 @@ def __virtual__():
     This only supports Windows
     '''
     if salt.utils.is_windows() and 'system.get_computer_desc' in __salt__:
-        return 'system'
+        return __virtualname__
     return False
 
 

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -58,11 +58,14 @@ from salt.utils.reclass import (
 
 from salt.exceptions import SaltInvocationError
 
+# Define the module's virtual name
+__virtualname__ = 'reclass'
+
 
 def __virtual__(retry=False):
     try:
         import reclass
-        return 'reclass'
+        return __virtualname__
     except ImportError:
         if retry:
             return False


### PR DESCRIPTION
This will allow for the documentation to "aggregate" common virtual packages and to display the module name used by salt.
