### PR TITLE
git_pillar: Don't merge updates

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -97,11 +97,10 @@ def update(branch, repo_location):
     pid = os.getpid()
     repo = init(branch, repo_location)
     try:
-        repo.git.checkout(branch)
+        repo.git.checkout("origin/" + branch)
     except git.exc.GitCommandError as e:
         logging.error('Unable to checkout branch {0}: {1}'.format(branch, e))
         return False
-    repo.git.pull()
     return True
 
 


### PR DESCRIPTION
When updating the local cached repository don't try to pull/merge the
changes as the operation will fail if merge conflicts exist.  We only
want to mirror what's in the remote repository.

This resolves  Issue #6992
