### PR TITLE
Update build_rule to ignore kwargs __env__, __sls__, order

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -81,7 +81,7 @@ def build_rule(table=None, chain=None, command=None, position='', full=None,
         kwargs['jump'] = kwargs['target']
         del kwargs['target']
 
-    for ignore in '__id__', 'fun', 'table', 'chain':
+    for ignore in '__id__', 'fun', 'table', 'chain','__env__','__sls__','order':
         if ignore in kwargs:
             del kwargs[ignore]
 


### PR DESCRIPTION
The rules now created without these switches in the iptables command.
