### PR TITLE
print_jobs was duplicating results

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -208,5 +208,6 @@ def print_job(job_id):
                                     'Target-type': load['tgt_type'],
                                     'User': load.get('user', 'root'),
                                     'Result': hosts_return}
-                        salt.output.display_output(ret, 'yaml', __opts__)
+                                    
+    salt.output.display_output(ret, 'yaml', __opts__)
     return ret


### PR DESCRIPTION
The display output was indented at the wrong place, therefore adding results each time there's a return_data.

For example, what should be:

``` yaml
'20131011111453088335':
  Arguments: []
  Function: test.ping
  Result:
    fileserver-01: true
    mainbox: true
    streamserver-01: true
    streamserver-02: true
  Start Time: 2013, Oct 11 11:14:53.088335
  Target: '*'
  Target-type: glob
  User: root
```

Becomes

``` yaml
'20131011111453088335':
  Arguments: []
  Function: test.ping
  Result:
    mainbox: true
  Start Time: 2013, Oct 11 11:14:53.088335
  Target: '*'
  Target-type: glob
  User: root
'20131011111453088335':
  Arguments: []
  Function: test.ping
  Result:
    mainbox: true
    streamserver-02: true
  Start Time: 2013, Oct 11 11:14:53.088335
  Target: '*'
  Target-type: glob
  User: root
'20131011111453088335':
  Arguments: []
  Function: test.ping
  Result:
    mainbox: true
    streamserver-01: true
    streamserver-02: true
  Start Time: 2013, Oct 11 11:14:53.088335
  Target: '*'
  Target-type: glob
  User: root
'20131011111453088335':
  Arguments: []
  Function: test.ping
  Result:
    fileserver-01: true
    mainbox: true
    streamserver-01: true
    streamserver-02: true
  Start Time: 2013, Oct 11 11:14:53.088335
  Target: '*'
  Target-type: glob
  User: root
```
