### PR TITLE
Support gem execution with rbenv ruby.

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -16,6 +16,9 @@ def _gem(command, ruby=None, runas=None):
     if __salt__['rvm.is_installed']():
         return __salt__['rvm.do'](ruby, cmdline, runas=runas)
 
+    if __salt__['rbenv.is_installed'](runas=runas):
+        return __salt__['rbenv.do'](cmdline, runas=runas)
+
     ret = __salt__['cmd.run_all'](
         cmdline,
         runas=runas

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -257,3 +257,27 @@ def list_(runas=None):
                 continue
             ret.append(line.strip())
     return ret
+
+
+def do(cmdline=None, runas=None):
+    '''
+    Execute a ruby command with rbenv's shims from the user or the system.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rbenv.do "gem list bundler"
+        salt '*' rbenv.do "gem list bundler" deploy
+    '''
+
+    path = _rbenv_path(runas)
+    result = __salt__['cmd.run_all'](
+        "env PATH={0}/shims:$PATH {1}".format(path, cmdline),
+        runas=runas
+    )
+
+    if result['retcode'] == 0:
+        return result['stdout']
+    else:
+        return False

--- a/tests/unit/modules/gem_test.py
+++ b/tests/unit/modules/gem_test.py
@@ -17,6 +17,7 @@ class TestGemModule(TestCase):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(gem.__salt__,
                         {'rvm.is_installed': MagicMock(return_value=False),
+                         'rbenv.is_installed': MagicMock(return_value=False),
                          'cmd.run_all': mock}):
             gem._gem('install rails')
             mock.assert_called_once_with('gem install rails', runas=None)
@@ -24,10 +25,21 @@ class TestGemModule(TestCase):
         mock = MagicMock(return_value=None)
         with patch.dict(gem.__salt__,
                         {'rvm.is_installed': MagicMock(return_value=True),
+                         'rbenv.is_installed': MagicMock(return_value=False),
                          'rvm.do': mock}):
             gem._gem('install rails', ruby='1.9.3')
             mock.assert_called_once_with(
                 '1.9.3', 'gem install rails', runas=None
+            )
+
+        mock = MagicMock(return_value=None)
+        with patch.dict(gem.__salt__,
+                        {'rvm.is_installed': MagicMock(return_value=False),
+                         'rbenv.is_installed': MagicMock(return_value=True),
+                         'rbenv.do': mock}):
+            gem._gem('install rails')
+            mock.assert_called_once_with(
+                'gem install rails', runas=None
             )
 
     def test_list(self):


### PR DESCRIPTION
This change will enable the gem module to use rbenv's installed ruby versions, just like rvm is supported already today. This feature was approved in issue 7681.

Please note: I have only tested this by overriding modules locally in a _modules folder. It works as expected. But I have not set up the full development environment, or run the tests, for this change. Perhaps, since the change is very contained that could still be acceptable?
