### PR TITLE
Upstart scripts can source a virtualenv

### DIFF
--- a/pkg/salt-master.upstart
+++ b/pkg/salt-master.upstart
@@ -10,5 +10,8 @@ script
   # Read configuration variable file if it is present
   [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
 
+  # Activate the virtualenv if defined
+  [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
+
   exec salt-master
 end script

--- a/pkg/salt-minion.upstart
+++ b/pkg/salt-minion.upstart
@@ -16,5 +16,8 @@ script
   # Read configuration variable file if it is present
   [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
 
+  # Activate the virtualenv if defined
+  [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
+
   exec salt-minion
 end script

--- a/pkg/salt-syndic.upstart
+++ b/pkg/salt-syndic.upstart
@@ -9,5 +9,8 @@ script
   # Read configuration variable file if it is present
   [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
 
+  # Activate the virtualenv if defined
+  [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
+
   exec salt-syndic
 end script


### PR DESCRIPTION
If SALT_USE_VIRTUALENV is defined, the upstart scripts will activate the virtualenv before starting the service. Handy for easily switching between multiple versions installed via virtualenvs.
