### PR TITLE
iptables mod: add missing space after comma & add parens around tuple

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -81,7 +81,7 @@ def build_rule(table=None, chain=None, command=None, position='', full=None,
         kwargs['jump'] = kwargs['target']
         del kwargs['target']
 
-    for ignore in '__id__', 'fun', 'table', 'chain','__env__','__sls__','order':
+    for ignore in ('__id__', 'fun', 'table', 'chain', '__env__', '__sls__', 'order'):
         if ignore in kwargs:
             del kwargs[ignore]
 


### PR DESCRIPTION
```
************* Module salt.modules.iptables
salt/modules/iptables.py:84: [C0324(no-space-after-comma), build_rule] Comma not followed by a space
for ignore in '__id__', 'fun', 'table', 'chain','__env__','__sls__','order':
^^
```
