### PR TITLE
Make sure multiple names retain original order

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -390,12 +390,19 @@ class Compiler(object):
             if 'order' in chunk:
                 if not isinstance(chunk['order'], int):
                     continue
-                if chunk['order'] > cap - 1 and chunk['order'] > 0:
-                    cap = chunk['order'] + 100
+
+                chunk_order = chunk['order']
+                if 'name_order' in chunk:
+                    chunk_order = chunk_order + chunk['name_order']
+
+                if chunk_order > cap - 1 and chunk_order > 0:
+                    cap = chunk_order + 100
         for chunk in chunks:
             if 'order' not in chunk:
                 chunk['order'] = cap
             else:
+                if isinstance(chunk['order'], int) and 'name_order' in chunk:
+                    chunk['order'] = chunk['order'] + chunk.pop('name_order')
                 if not isinstance(chunk['order'], int):
                     if chunk['order'] == 'last':
                         chunk['order'] = cap + 1000000
@@ -439,9 +446,12 @@ class Compiler(object):
                             else:
                                 chunk.update(arg)
                 if names:
+                    name_order = 1
                     for low_name in names:
                         live = copy.deepcopy(chunk)
                         live['name'] = low_name
+                        live['name_order'] = name_order
+                        name_order = name_order + 1
                         for fun in funcs:
                             live['fun'] = fun
                             chunks.append(live)
@@ -851,12 +861,19 @@ class State(object):
             if 'order' in chunk:
                 if not isinstance(chunk['order'], int):
                     continue
-                if chunk['order'] > cap - 1 and chunk['order'] > 0:
-                    cap = chunk['order'] + 100
+
+                chunk_order = chunk['order']
+                if 'name_order' in chunk:
+                    chunk_order = chunk_order + chunk['name_order']
+
+                if chunk_order > cap - 1 and chunk_order > 0:
+                    cap = chunk_order + 100
         for chunk in chunks:
             if 'order' not in chunk:
                 chunk['order'] = cap
             else:
+                if isinstance(chunk['order'], int) and 'name_order' in chunk:
+                    chunk['order'] = chunk['order'] + chunk.pop('name_order')
                 if not isinstance(chunk['order'], int):
                     if chunk['order'] == 'last':
                         chunk['order'] = cap + 1000000
@@ -906,9 +923,12 @@ class State(object):
                             else:
                                 chunk[key] = val
                 if names:
+                    name_order = 1
                     for low_name in names:
                         live = copy.deepcopy(chunk)
                         live['name'] = low_name
+                        live['name_order'] = name_order
+                        name_order = name_order + 1
                         for fun in funcs:
                             live['fun'] = fun
                             chunks.append(live)

--- a/tests/integration/files/file/base/issue-7649-handle-iorder.sls
+++ b/tests/integration/files/file/base/issue-7649-handle-iorder.sls
@@ -1,0 +1,9 @@
+handle-iorder:
+  cmd:
+      - cwd: /tmp/ruby-1.9.2-p320
+      - names:
+        - ./configure
+        - make
+        - make install
+      - run
+

--- a/tests/integration/states/handle_iorder.py
+++ b/tests/integration/states/handle_iorder.py
@@ -1,0 +1,32 @@
+'''
+tests for host state
+'''
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+
+
+class HandleOrderTest(integration.ModuleCase):
+    '''
+    Validate that ordering works correctly
+    '''
+    def test_handle_iorder(self):
+        '''
+        Test the error with multiple states of the same type
+        '''
+        ret = self.run_function('state.show_low_sls', mods='issue-7649-handle-iorder')
+
+        sorted_chunks = sorted(ret, key=lambda c: c.get('order'))
+
+        self.assertEqual(sorted_chunks[0]['name'], './configure')
+        self.assertEqual(sorted_chunks[1]['name'], 'make')
+        self.assertEqual(sorted_chunks[2]['name'], 'make install')
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(HandleOrderTest)


### PR DESCRIPTION
Add an ephemeral 'name_order' key in chunks to provide a place to put an ordering count.  The ordering count is added to the 'order' value when the state is compiled to low_chunks.
