### PR TITLE
Don't assume the fileserver cache dir has been created

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -144,7 +144,10 @@ def init():
 
 def purge_cache():
     bp_ = os.path.join(__opts__['cachedir'], 'gitfs')
-    remove_dirs = os.listdir(bp_)
+    try:
+        remove_dirs = os.listdir(bp_)
+    except OSError:
+        remove_dirs = []
     for _, opt in enumerate(__opts__['gitfs_remotes']):
         repo_hash = hashlib.md5(opt).hexdigest()
         try:

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -142,7 +142,10 @@ def init():
 
 def purge_cache():
     bp_ = os.path.join(__opts__['cachedir'], 'hgfs')
-    remove_dirs = os.listdir(bp_)
+    try:
+        remove_dirs = os.listdir(bp_)
+    except OSError:
+        remove_dirs = []
     for _, opt in enumerate(__opts__['hgfs_remotes']):
         repo_hash = hashlib.md5(opt).hexdigest()
         try:

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -74,7 +74,10 @@ def init():
 
 def purge_cache():
     bp_ = os.path.join(__opts__['cachedir'], 'svnfs')
-    remove_dirs = os.listdir(bp_)
+    try:
+        remove_dirs = os.listdir(bp_)
+    except OSError:
+        remove_dirs = []
     for _, opt in enumerate(__opts__['svnfs_remotes']):
         repo_hash = hashlib.md5(opt).hexdigest()
         try:


### PR DESCRIPTION
This was preventing gitfs (or <any>fs) from working on new masters.  It should now continue on to the init() step where those directories are created.
