### PR TITLE
Pass data to minion when using salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -61,13 +61,13 @@ class Caller(object):
             sys.stderr.write('Function {0} is not available\n'.format(fun))
             sys.exit(-1)
         try:
-            args, kwargs = salt.minion.parse_args_and_kwargs(
-                self.minion.functions[fun], self.opts['arg'])
             sdata = {
                     'fun': fun,
                     'pid': os.getpid(),
                     'jid': ret['jid'],
                     'tgt': 'salt-call'}
+            args, kwargs = salt.minion.parse_args_and_kwargs(
+                self.minion.functions[fun], self.opts['arg'], data=sdata)
             try:
                 with salt.utils.fopen(proc_fn, 'w+') as fp_:
                     fp_.write(self.serial.dumps(sdata))


### PR DESCRIPTION
This fixes running "salt-call state.highstate queue=true", Otherwise it ends up without a jid and throws a KeyError.
