### PR TITLE
Pipes are illegal in Windows paths and filenames

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -238,6 +238,9 @@ def cache_file(path, env='base'):
         salt '*' cp.cache_file salt://path/to/file
     '''
     _mk_client()
+    if path.startswith('salt://|'):
+        # Strip pipe. Windows doesn't allow pipes in filenames
+        path = 'salt://{0}'.format(path.lstrip('salt://|')
     result = __context__['cp.fileclient'].cache_file(path, env)
     if not result:
         log.error(


### PR DESCRIPTION
Fixes #7967
