### PR TITLE
Add versionadded directive to dockerio module

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1,8 +1,9 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 '''
-Management of dockers: overview of this module
-==============================================
+Management of dockers
+=====================
+
+.. versionadded:: Hydrogen
 
 .. note::
 


### PR DESCRIPTION
Also changed the top line of the docstring, as this affects its
appearance in the docs, and this top line should be a simple explanation
of the module. Having "overview of this module" in this line is
redundant.
