### PR TITLE
Change osfinger to use os grain instead of osfullname

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -940,11 +940,11 @@ def os_data():
         grains['osmajorrelease'] = grains['osrelease'].split('.', 1)
 
         grains['osfinger'] = '{os}-{ver}'.format(
-                os=grains['osfullname'],
+                os=grains['os'],
                 ver=grains['osrelease'].partition('.')[0])
     elif grains.get('osfullname') == 'Ubuntu':
         grains['osfinger'] = '{os}-{ver}'.format(
-                os=grains['osfullname'],
+                os=grains['os'],
                 ver=grains['osrelease'])
 
     return grains


### PR DESCRIPTION
The osfinger is a concise mnemonic name representing OS and major
version. As such it should be derived from the concise, single-token,
OS name used by Salt. This also avoids trivial parsing issues
introduced when the osfullname contains spaces.

This patch replaces grains['osfullname'] with grains['os'] in the
creation of the osfinger grain.

NOTE: Exactly one os grain name contains spaces: 'Arch ARM'. (It
ought to be 'ArchARM', but that is not dealt with here.)
