### PR TITLE
slice the string. Don't use lstrip incorrectly

### DIFF
--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -240,7 +240,7 @@ def cache_file(path, env='base'):
     _mk_client()
     if path.startswith('salt://|'):
         # Strip pipe. Windows doesn't allow pipes in filenames
-        path = 'salt://{0}'.format(path.lstrip('salt://|'))
+        path = 'salt://{0}'.format(path[8:])
     result = __context__['cp.fileclient'].cache_file(path, env)
     if not result:
         log.error(


### PR DESCRIPTION
Fix incorrect usage of lstrip per comment by @cvrebert

https://github.com/saltstack/salt/pull/7973/files#r7103601
