### PR TITLE
Pass cmd as list, not string, to subprocess.Popen.

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -384,11 +384,10 @@ def install(name=None,
     if pkg_params is None or len(pkg_params) == 0:
         return {}
     elif pkg_type == 'file':
-        cmd = 'dpkg -i {confold} {verify} {pkg}'.format(
-            confold='--force-confold',
-            verify='--force-bad-verify' if skip_verify else '',
-            pkg=' '.join(pkg_params),
-        ).split()
+        cmd = ['dpkg', '-i', '--force-confold']
+        if skip_verify:
+            cmd.append['--force-bad-verify']
+        cmd.extend(pkg_params)
     elif pkg_type == 'repository':
         if pkgs is None and kwargs.get('version') and len(pkg_params) == 1:
             # Only use the 'version' param if 'name' was not specified as a

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -386,7 +386,7 @@ def install(name=None,
     elif pkg_type == 'file':
         cmd = ['dpkg', '-i', '--force-confold']
         if skip_verify:
-            cmd.append['--force-bad-verify']
+            cmd.append('--force-bad-verify')
         cmd.extend(pkg_params)
     elif pkg_type == 'repository':
         if pkgs is None and kwargs.get('version') and len(pkg_params) == 1:

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -388,7 +388,7 @@ def install(name=None,
             confold='--force-confold',
             verify='--force-bad-verify' if skip_verify else '',
             pkg=' '.join(pkg_params),
-        )
+        ).split()
     elif pkg_type == 'repository':
         if pkgs is None and kwargs.get('version') and len(pkg_params) == 1:
             # Only use the 'version' param if 'name' was not specified as a


### PR DESCRIPTION
When installing debian packages from file i.e.

<pre>
pkg1
  pkg.install:
    - sources:
      - pkg1: salt://module/pkg1.deb
</pre>


cmd is passed as string instead of list to subprocess.Popen, install failing with: 
OSError: [Errno 2] No such file or directory

This was brought up by setting python_shell = False in the cmd.run_all call.
