### PR TITLE
Corrected typos.

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -70395,7 +70395,7 @@ settings for software packages that support that option.
 .sp
 In order to facilitate managing a Salt Windows software repo with Salt on a
 Standalone Minion on Windows, a new module named winrepo has been added to
-Salt. wirepo matches what is available in the salt runner and allows you to
+Salt. winrepo matches what is available in the salt runner and allows you to
 manage the Windows software repo contents. Example: \fBsalt \(aq*\(aq
 winrepo.genrepo\fP
 .SS Git Hosted Repo

--- a/doc/ref/states/top.rst
+++ b/doc/ref/states/top.rst
@@ -20,8 +20,8 @@ Environments
 .. note::
 
     Environments in Salt are very flexible, this section defines how the top
-    file can be used to define what ststates from what environments are to be
-    used fro specific minions.
+    file can be used to define what states from what environments are to be
+    used for specific minions.
 
     If the intent is to bind minions to specific environments, then the
     `environment` option can be set in the minion configuration file.

--- a/doc/ref/windows-package-manager.rst
+++ b/doc/ref/windows-package-manager.rst
@@ -237,7 +237,7 @@ Standalone Minion Salt Windows Repo Module
 
 In order to facilitate managing a Salt Windows software repo with Salt on a
 Standalone Minion on Windows, a new module named winrepo has been added to
-Salt. wirepo matches what is available in the salt runner and allows you to
+Salt. winrepo matches what is available in the salt runner and allows you to
 manage the Windows software repo contents. Example: ``salt '*'
 winrepo.genrepo``
 


### PR DESCRIPTION
Typos:
- wirepo → winrepo
- fro → for
- ststates → states
