### PR TITLE
Make django_orm load virtualenv packages before system packages

### DIFF
--- a/salt/pillar/django_orm.py
+++ b/salt/pillar/django_orm.py
@@ -130,7 +130,7 @@ def ext_pillar(pillar,
                 log.error('Virtualenv {} not a directory!'.format(path))
                 return {}
         # load the virtualenv
-        sys.path.append(virtualenv.path_locations(env)[1] + '/site-packages/')
+        sys.path[0:0] = (virtualenv.path_locations(env)[1] + '/site-packages/',)
 
     # load the django project
     sys.path.append(project_path)


### PR DESCRIPTION
A django app may require a specific version of a package that it
depends on, and will have ensured the correct version is in the
virtualenv.

This commit ensures that this version will be used, even if a
different version is installed in the system python.

See issue #8024
