### PR TITLE
Throw an error rather than just logging for missing SLS, Fix #5998

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2214,7 +2214,7 @@ class BaseHighState(object):
                 statefiles = fnmatch.filter(self.avail[env], sls_match)
                 if not statefiles:
                     # No matching sls file was found!  Output an error
-                    log.error(
+                    all_errors.append(
                             'No matching sls found for \'{0}\' in env \'{1}\''
                             .format(sls_match, env)
                     )


### PR DESCRIPTION
Looking back at the arguments for and against (ref #5430), @cachedout and I decided that continuing without error in case of a missing SLS was much more dangerous and problematic than having to use the workaround defined in #5430.  If an SLS is not found, an error will not be output and the staterun will abort.
