### PR TITLE
Mysql grant downgrade

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -208,13 +208,10 @@ def _grant_to_tokens(grant):
 
         position_tracker += 1
 
-    return {
-        'user':     user,
-        'host':     host,
-        'grant':    grant_tokens,
-        'database': database,
-
-    }
+    return dict(user=user,
+                host=host,
+                grant=grant_tokens,
+                database=database)
 
 
 

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -187,7 +187,7 @@ def _grant_to_tokens(grant):
             continue
 
         if phrase == 'grants':
-            if token[-1:] == ',' or exploded_grant[position_tracker+1] == 'ON':  # Read-ahead
+            if token.endswith(',') or exploded_grant[position_tracker+1] == 'ON':  # Read-ahead
                 cleaned_token = token.rstrip(',')
                 if multiword_statement:
                     multiword_statement.append(cleaned_token)
@@ -965,6 +965,14 @@ def user_remove(user,
     return False
 
 
+def tokenize_grant(grant):
+    '''
+    External wrapper function
+    :param grant:
+    :return: dict
+    '''
+    return  _grant_to_tokens(grant)
+
 # Maintenance
 def db_check(name,
              table=None,
@@ -1139,9 +1147,6 @@ def grant_exists(grant,
 
         salt '*' mysql.grant_exists 'SELECT,INSERT,UPDATE,...' 'database.*' 'frank' 'localhost'
     '''
-    # TODO: This function is a bit tricky, since it requires the ordering to
-    #       be exactly the same. Perhaps should be replaced/reworked with a
-    #       better/cleaner solution.
     target = __grant_generate(
         grant, database, user, host, grant_option, escape
     )
@@ -1158,10 +1163,11 @@ def grant_exists(grant,
                 grant_tokens['database'] == target_tokens['database'] and \
                 grant_tokens['host'] == target_tokens['host']:
                     if set(grant_tokens['grant']) == set(target_tokens['grant']):
+                        log.debug(grant_tokens)
+                        log.debug(target_tokens)
                         return True
 
         except Exception as exc:  # Fallback to strict parsing
-            log.debug("OH NO CAUGHT EXCEPTION: {0}".format(exc))
             if grants is not False and target in grants:
                 log.debug('Grant exists.')
                 return True

--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -69,6 +69,7 @@ def present(name,
             host='localhost',
             grant_option=False,
             escape=True,
+            revoke_if_necessary=False,
             **connection_args):
     '''
     Ensure that the grant is present with the specified properties
@@ -93,6 +94,22 @@ def present(name,
 
     escape
         Defines if the database value gets escaped or not. default: True
+
+    revoke_first
+        By default, MySQL will not do anything if you issue a command to grant
+        privileges that are more restrictive than what's already in place. This
+        effectively means that you cannot downgrade permissions without first
+        revoking permissions applied to a db.table/user pair first.
+
+        To have Salt forcibly revoke perms before applying a new grant, enable
+        the 'revoke_first options.
+
+        WARNING: This will *remove* permissions for a database before attempting to apply
+        new permissions. There is no guarantee that new permissions will be applied correctly
+        which can leave your database security in an unknown and potentially dangerous state.
+        Use with caution!
+
+        default: False
     '''
     comment = 'Grant {0} on {1} to {2}@{3} is already present'
     ret = {'name': name,
@@ -111,6 +128,25 @@ def present(name,
             ret['comment'] = err
             ret['result'] = False
             return ret
+
+    #  for each grant, break into tokens and see if its on the same user/db as ours. (there is probably only one)
+    for user_grant in __salt__['mysql.user_grants'](user, host, **connection_args):
+
+        print "Comparing: "
+        print __salt__['mysql.tokenize_grant'](user_grant)['database'].replace('`', '')
+        print " to "
+        print database.replace('`', '')
+
+        if __salt__['mysql.tokenize_grant'](user_grant)['database'].replace('`', '')\
+        == database.replace('`', ''):
+            grant_to_revoke = ','.join(__salt__['mysql.tokenize_grant'](user_grant)['grant']).rstrip(',')
+            __salt__['mysql.grant_revoke'](grant_to_revoke,
+            database,
+            user,
+            host=host,
+            grant_option=grant_option,
+            escape=escape,
+            connection_args=connection_args)  #  Probably needs some ordering love
 
     # The grant is not present, make it!
     if __opts__['test']:
@@ -131,6 +167,7 @@ def present(name,
             ret['comment'] += ' ({0})'.format(err)
         ret['result'] = False
     return ret
+
 
 
 def absent(name,


### PR DESCRIPTION
Add a new flag for the mysql_grants state that will cause Salt to revoke any applicable perms prior to adding new ones. Defaults to False. This should address the issue outlined in #6606. 
