### PR TITLE
fix indentation and simplify flow control slightly

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1159,9 +1159,9 @@ def grant_exists(grant,
             grant_tokens = _grant_to_tokens(grant)
             if grant_tokens['user'] == target_tokens['user'] and \
                 grant_tokens['database'] == target_tokens['database'] and \
-                grant_tokens['host'] == target_tokens['host']:
-                    if set(grant_tokens['grant']) == set(target_tokens['grant']):
-                        return True
+                grant_tokens['host'] == target_tokens['host'] and \
+                set(grant_tokens['grant']) == set(target_tokens['grant']):
+                    return True
 
         except Exception as exc:  # Fallback to strict parsing
             log.debug("OH NO CAUGHT EXCEPTION: {0}".format(exc))


### PR DESCRIPTION
```
************* Module salt.modules.mysql
salt/modules/mysql.py:1163: [W0311(bad-indentation), ] Bad indentation. Found 20 spaces, expected 16
salt/modules/mysql.py:1164: [W0311(bad-indentation), ] Bad indentation. Found 24 spaces, expected 20
```
