### PR TITLE
Added detection for upstart on Debian/Raspbian distros

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -60,8 +60,14 @@ def __virtual__():
     # Disable on these platforms, specific service modules exist:
     if __grains__['os'] in ('Ubuntu', 'Linaro', 'elementary OS'):
         return __virtualname__
+    elif __grains__['os'] in ('Debian', 'Raspbian'):
+        debian_initctl = '/sbin/initctl'
+        if os.path.isfile(debian_initctl):
+            initctl_version = salt.modules.cmdmod._run_quiet(debian_initctl + ' version')
+            if 'upstart' in initctl_version:
+                return 'service'
     return False
-
+    
 
 def _find_utmp():
     '''


### PR DESCRIPTION
Upstart is detected on Debian (and Raspbian) by calling '/sbin/initctl version' and checking for 'upstart' in the return string, as is done in /lib/lsb/init-functions

This commit fixes issue #8039
