### PR TITLE
Add enc, comment and options for ssh_auth.absent

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -116,19 +116,19 @@ def present(
         config='.ssh/authorized_keys',
         **kwargs):
     '''
-    Verifies that the specified ssh key is present for the specified user
+    Verifies that the specified SSH key is present for the specified user
 
     name
-        The ssh key to manage
+        The SSH key to manage
 
     user
-        The user who owns the ssh authorized keys file to modify
+        The user who owns the SSH authorized keys file to modify
 
     enc
-        Defines what type of key is being used, can be ecdsa ssh-rsa, ssh-dss
+        Defines what type of key is being used; can be ecdsa, ssh-rsa or ssh-dss
 
     comment
-        The comment to be placed with the ssh public key
+        The comment to be placed with the SSH public key
 
     source
         The source file for the key(s). Can contain any number of public keys,
@@ -244,13 +244,22 @@ def absent(name,
            options=None,
            config='.ssh/authorized_keys'):
     '''
-    Verifies that the specified ssh key is absent
+    Verifies that the specified SSH key is absent
 
     name
-        The ssh key to manage
+        The SSH key to manage
 
     user
-        The user who owns the ssh authorized keys file to modify
+        The user who owns the SSH authorized keys file to modify
+
+    enc
+        Defines what type of key is being used; can be ecdsa, ssh-rsa or ssh-dss
+
+    comment
+        The comment to be placed with the SSH public key
+
+    options
+        The options passed to the key, pass a list object
 
     config
         The location of the authorized keys file relative to the user's home

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -3,7 +3,7 @@
 Control of entries in SSH authorized_key files.
 ===============================================
 
-The information stored in a user's ssh authorized key file can be easily
+The information stored in a user's SSH authorized key file can be easily
 controlled via the ssh_auth state. Defaults can be set by the enc, options,
 and comment keys. These defaults can be overridden by including them in the
 name.

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -237,7 +237,12 @@ def present(
     return ret
 
 
-def absent(name, user, config='.ssh/authorized_keys'):
+def absent(name,
+           user,
+           enc='ssh-rsa',
+           comment='',
+           options=None,
+           config='.ssh/authorized_keys'):
     '''
     Verifies that the specified ssh key is absent
 
@@ -263,9 +268,9 @@ def absent(name, user, config='.ssh/authorized_keys'):
         check = __salt__['ssh.check_key'](
                 user,
                 name,
-                '',
-                '',
-                [],
+                enc,
+                comment,
+                options or [],
                 config)
         if check == 'update' or check == 'exists':
             ret['result'] = None


### PR DESCRIPTION
These are present for ssh_auth.present, but not for ssh_auth.absent.
This poses a problem further into the code in ssh.check_key (or rather
`_refine_enc()` in the ssh module) when it is validating the encryption
type.

Fixes #8043.
