### PR TITLE
Add salt.states.file.blockreplace to maintain a comment delimited block of text in an unmanaged file

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -40,6 +40,7 @@ except ImportError:
 import salt.utils
 import salt.utils.find
 import salt.utils.filebuffer
+import salt.utils.atomicfile
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 import salt._compat
 
@@ -985,6 +986,156 @@ def replace(path,
 
     if show_changes:
         return ''.join(difflib.unified_diff(orig_file, new_file))
+
+    return has_changes
+
+def blockreplace(path,
+        marker_start='#-- start managed zone --',
+        marker_end='#-- end managed zone --',
+        content='',
+        append_if_not_found=False,
+        backup='.bak',
+        dry_run=False,
+        show_changes=True,
+        ):
+    '''
+    Replace content of a text block in a file, delimited by line markers
+
+    .. versionadded:: 0.18.0
+
+    A block of content delimited by comments can help you manage several lines entries without
+    worrying about old entries removal.
+    Note: this function will store two copies of the file in-memory
+    (the original version and the edited version) in order to detect changes
+    and only edit the targeted file if necessary.
+
+    :param path: Filesystem path to the file to be edited
+    :param marker_start: The line content identifying a line as the start of
+        the content block. Note that the whole line containing this marker will
+        be considered, so whitespaces or extra content before or after the
+        marker is included in final output
+    :param marker_end: The line content identifying a line as the end of
+        the content block. Note that the whole line containing this marker will
+        be considered, so whitespaces or extra content before or after the
+        marker is included in final output
+    :param content: The content to be used between the two lines identified by
+        marker_start and marker_stop.
+    :param append_if_not_found: False by default, if markers are not found and
+        set to True then the markers and content will be appended to the file
+    :param backup: The file extension to use for a backup of the file if any
+        edit is made. Set to ``False`` to skip making a backup.
+    :param dry_run: Don't make any edits to the file
+    :param show_changes: Output a unified diff of the old file and the new
+        file. If ``False`` return a boolean if any changes were made.
+
+    :rtype: bool or str
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.blockreplace /etc/hosts '#-- start managed zone foobar : DO NOT EDIT --' \
+         '#-- end managed zone foobar --' $'10.0.1.1 foo.foobar\n10.0.1.2 bar.foobar' True
+    '''
+    if not os.path.exists(path):
+        raise SaltInvocationError("File not found: %s", path)
+
+    if not salt.utils.istextfile(path):
+        raise SaltInvocationError(
+            "Cannot perform string replacements on a binary file: %s", path)
+
+    # Search the file; track if any changes have been made for the return val
+    has_changes = False
+    orig_file = []
+    new_file = []
+    in_block = False
+    old_content = ''
+    done=False
+    # we do not use in_place editing to avoid file attrs modifications when
+    # no changes are required and to avoid any file access on a partially
+    # written file.
+    # we could also use salt.utils.filebuffer.BufferedReader
+    for line in fileinput.input(path,
+            inplace=False, backup=False,
+            bufsize=1, mode='rb'):
+
+        result = line
+
+        if marker_start in line:
+            # managed block start found, start recording
+            in_block = True
+
+        else :
+
+            if in_block:
+                if marker_end in line:
+                    # end of block detected
+                    in_block = False
+
+                    # push new block content in file
+                    for cline in content.split("\n"):
+                        new_file.append(cline+"\n")
+
+                    done=True
+
+                else:
+                    # remove old content, but keep a trace
+                    old_content += line
+                    result = None
+        # else: we are not in the marked block, keep saving things
+
+        orig_file.append(line)
+        if result is not None:
+            new_file.append(result)
+
+
+    # end for. If we are here without block managment we maybe have some problems,
+    # or we need to initialise the marked block
+
+    if in_block:
+        # unterminated block => bad, always fail
+        raise CommandExecutionError("Unterminated marked block. End of file reached before marker_end.")
+
+    if not done:
+        if append_if_not_found:
+           # add the markers and content at the end of file
+           new_file.append(marker_start+"\n")
+           new_file.append(content+"\n")
+           new_file.append(marker_end+"\n")
+           done=True
+        else:
+            raise CommandExecutionError("Cannot edit marked block. Markers were not found in file.")
+
+    if done:
+        diff = ''.join(difflib.unified_diff(orig_file, new_file))
+        has_changes = diff is not ''
+        if has_changes and not dry_run:
+            # changes detected
+            # backup old content
+            if backup != False:
+                shutil.copy2(path, '{0}{1}'.format(path, backup))
+
+            # backup file attrs
+            perms = {}
+            perms['user'] = get_user(path)
+            perms['group'] = get_group(path)
+            perms['mode'] = __salt__['config.manage_mode'](get_mode(path))
+
+            # write new content in the file while avoiding partial reads
+            f=salt.utils.atomicfile.atomic_open(path,'wb')
+            for line in new_file:
+              f.write(line)
+            f.close()
+
+            # this may have overwritten file attrs
+            check_perms(path,
+                    None,
+                    perms['user'],
+                    perms['group'],
+                    perms['mode'])
+
+        if show_changes:
+            return diff
 
     return has_changes
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1776,6 +1776,123 @@ def replace(name,
     return ret
 
 
+
+def blockreplace(name,
+            marker_start='#-- start managed zone --',
+            marker_end='#-- end managed zone --',
+            content='',
+            append_if_not_found=False,
+            backup='.bak',
+            show_changes=True):
+    '''
+    Maintain an edit in a file in a zone delimited by two line markers
+
+    .. versionadded:: 0.18.0
+
+    A block of content delimited by comments can help you manage several lines 
+    entries without worrying about old entries removal. This can help you maintaining
+    an unmanaged file containing manual edits.
+    Note: this function will store two copies of the file in-memory
+    (the original version and the edited version) in order to detect changes
+    and only edit the targeted file if necessary.
+
+    :param name: Filesystem path to the file to be edited
+    :param marker_start: The line content identifying a line as the start of
+        the content block. Note that the whole line containing this marker will
+        be considered, so whitespaces or extra content before or after the
+        marker is included in final output
+    :param marker_end: The line content identifying a line as the end of
+        the content block. Note that the whole line containing this marker will
+        be considered, so whitespaces or extra content before or after the
+        marker is included in final output.
+        Note: you can use file.accumulated and target this state. All accumulated
+        datas dictionnaries content will be added as new lines in the content.
+    :param content: The content to be used between the two lines identified by
+        marker_start and marker_stop.
+    :param append_if_not_found: False by default, if markers are not found and
+        set to True then the markers and content will be appended to the file
+    :param backup: The file extension to use for a backup of the file if any
+        edit is made. Set to ``False`` to skip making a backup.
+    :param dry_run: Don't make any edits to the file
+    :param show_changes: Output a unified diff of the old file and the new
+        file. If ``False`` return a boolean if any changes were made.
+
+    :rtype: bool or str
+
+     Exemple of usage with an accumulator and with a variable::
+
+        {% set myvar = 42 %}
+        hosts-config-block-{{ myvar }}:
+          file.blockreplace:
+            - name: /etc/hosts
+            - marker_start: "# START managed zone {{ myvar }} -DO-NOT-EDIT-"
+            - marker_end: "# END managed zone {{ myvar }} --"
+            - content: 'First line of content'
+            - append_if_not_found: True
+            - backup: '.bak'
+            - show_changes: True
+        
+        hosts-config-block-{{ myvar }}-accumulated1:
+          file.accumulated:
+            - filename: /etc/hosts
+            - name: my-accumulator-{{ myvar }}
+            - text: "text 2"
+            - require_in:
+              - file: foobar-config-block-{{ myvar }}
+        
+        hosts-config-block-{{ myvar }}-accumulated2:
+          file.accumulated:
+            - filename: /etc/hosts
+            - name: my-accumulator-{{ myvar }}
+            - text: |
+                 text 3
+                 text 4
+            - require_in:
+              - file: foobar-config-block-{{ myvar }}
+
+    will generate and maintain a block of content in ``/etc/hosts``::
+
+        # START managed zone 42 -DO-NOT-EDIT-
+        First line of content
+        text 2
+        text 3
+        text 4
+        # END managed zone 42 --
+    '''
+    ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
+
+    check_res, check_msg = _check_file(name)
+    if not check_res:
+        return _error(ret, check_msg)
+
+    if name in _ACCUMULATORS:
+        accumulator = _ACCUMULATORS[name]
+        for acc, acc_content in accumulator.iteritems():
+            for line in acc_content:
+                if content=='':
+                    content = line
+                else:
+                    content += "\n" + line
+    changes = __salt__['file.blockreplace'](name,
+                                       marker_start,
+                                       marker_end,
+                                       content=content,
+                                       append_if_not_found=append_if_not_found,
+                                       backup=backup,
+                                       dry_run=__opts__['test'],
+                                       show_changes=show_changes)
+
+    if changes:
+        ret['changes'] = changes
+        ret['comment'] = 'Changes were made'
+    else:
+        ret['comment'] = 'No changes were made'
+
+    ret['result'] = True
+    return ret
+
+
+
 def sed(name,
         before,
         after,
@@ -2548,7 +2665,8 @@ def rename(name, source, force=False, makedirs=False):
 def accumulated(name, filename, text, **kwargs):
     '''
     Prepare accumulator which can be used in template in file.managed state.
-    Accumulator dictionary becomes available in template.
+    Accumulator dictionary becomes available in template. It can also be used
+    in file.blockreplace.
 
     name
         Accumulator name

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -6,17 +6,20 @@ import textwrap
 # Import Salt Testing libs
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import MagicMock
 
 ensure_in_syspath('../../')
 
 # Import Salt libs
 from salt.modules import file as filemod
 from salt.modules import cmdmod
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 filemod.__salt__ = {
     'cmd.run': cmdmod.run,
     'cmd.run_all': cmdmod.run_all
 }
+filemod.__opts__ = {'test': False}
 
 SED_CONTENT = """test
 some
@@ -101,6 +104,140 @@ class FileReplaceTestCase(TestCase):
     def test_re_int_flags(self):
         filemod.replace(self.tfile.name, r'Etiam', 'Salticus', flags=10)
 
+class FileBlockReplaceTestCase(TestCase):
+    MULTILINE_STRING = textwrap.dedent('''\
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam rhoncus
+        enim ac bibendum vulputate. Etiam nibh velit, placerat ac auctor in,
+        lacinia a turpis. Nulla elit elit, ornare in sodales eu, aliquam sit
+        amet nisl.
+
+        Fusce ac vehicula lectus. Vivamus justo nunc, pulvinar in ornare nec,
+        sollicitudin id sem. Pellentesque sed ipsum dapibus, dapibus elit id,
+        malesuada nisi.
+
+        first part of start line // START BLOCK : part of start line not removed
+        to be removed
+        first part of end line // END BLOCK : part of end line not removed
+
+        #-- START BLOCK UNFINISHED
+
+        #-- START BLOCK 1
+        old content part 1
+        old content part 2
+        #-- END BLOCK 1
+
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec
+        venenatis tellus eget massa facilisis, in auctor ante aliquet. Sed nec
+        cursus metus. Curabitur massa urna, vehicula id porttitor sed, lobortis
+        quis leo.
+        ''')
+
+    def setUp(self):
+        self.tfile = tempfile.NamedTemporaryFile(delete=False,prefix='blockrepltmp')
+        self.tfile.write(self.MULTILINE_STRING)
+        self.tfile.close()
+        manage_mode_mock = MagicMock()
+        filemod.__salt__['config.manage_mode'] = manage_mode_mock
+
+    def tearDown(self):
+        os.remove(self.tfile.name)
+
+    def test_replace_multiline(self):
+        new_multiline_content = "Who's that then?\nWell, how'd you become king, then?\nWe found them. I'm not a witch.\nWe shall say 'Ni' again to you, if you do not appease us."
+        filemod.blockreplace(self.tfile.name, '#-- START BLOCK 1', '#-- END BLOCK 1', new_multiline_content, backup=False)
+
+        with open(self.tfile.name, 'rb') as fp:
+            filecontent=fp.read()
+        self.assertIn('#-- START BLOCK 1'+"\n"+new_multiline_content+"\n"+'#-- END BLOCK 1', filecontent)
+        self.assertNotIn('old content part 1', filecontent)
+        self.assertNotIn('old content part 2', filecontent)
+
+    def test_replace_append(self):
+        new_content = "Well, I didn't vote for you."
+
+        self.assertRaises(
+            CommandExecutionError,
+            filemod.blockreplace,
+            self.tfile.name,
+            '#-- START BLOCK 2',
+            '#-- END BLOCK 2',
+            new_content,
+            append_if_not_found=False,
+            backup=False
+        )
+        with open(self.tfile.name, 'rb') as fp:
+            self.assertNotIn('#-- START BLOCK 2'+"\n"+new_content+"\n"+'#-- END BLOCK 2', fp.read())
+
+        filemod.blockreplace(self.tfile.name, '#-- START BLOCK 2', '#-- END BLOCK 2', new_content, backup=False,append_if_not_found=True)
+
+        with open(self.tfile.name, 'rb') as fp:
+            self.assertIn('#-- START BLOCK 2'+"\n"+new_content+"\n"+'#-- END BLOCK 2', fp.read())
+
+
+    def test_replace_partial_marked_lines(self):
+        filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 1', backup=False)
+
+        with open(self.tfile.name, 'rb') as fp:
+            filecontent=fp.read()
+        self.assertIn('new content 1', filecontent)
+        self.assertNotIn('to be removed', filecontent)
+        self.assertIn('first part of start line', filecontent)
+        self.assertIn('first part of end line', filecontent)
+        self.assertIn('part of start line not removed', filecontent)
+        self.assertIn('part of end line not removed', filecontent)
+
+    def test_backup(self):
+        fext = '.bak'
+        bak_file = '{0}{1}'.format(self.tfile.name, fext)
+
+        filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 2', backup=fext)
+
+        self.assertTrue(os.path.exists(bak_file))
+        os.unlink(bak_file)
+        self.assertFalse(os.path.exists(bak_file))
+
+        fext = '.bak'
+        bak_file = '{0}{1}'.format(self.tfile.name, fext)
+
+        filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 3', backup=False)
+
+        self.assertFalse(os.path.exists(bak_file))
+
+    def test_no_modifications(self):
+        filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 4', backup=False)
+        before_ctime = os.stat(self.tfile.name).st_mtime
+        filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 4', backup=False)
+        after_ctime = os.stat(self.tfile.name).st_mtime
+
+        self.assertEqual(before_ctime, after_ctime)
+
+    def test_dry_run(self):
+        before_ctime = os.stat(self.tfile.name).st_mtime
+        filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 5', dry_run=True)
+        after_ctime = os.stat(self.tfile.name).st_mtime
+
+        self.assertEqual(before_ctime, after_ctime)
+
+    def test_show_changes(self):
+        ret = filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 6', backup=False, show_changes=True)
+
+        self.assertTrue(ret.startswith('---')) # looks like a diff
+
+        ret = filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 7', backup=False, show_changes=False)
+
+        self.assertIsInstance(ret, bool)
+
+    def test_unfinished_block_exception(self):
+        self.assertRaises(
+            CommandExecutionError,
+            filemod.blockreplace,
+            self.tfile.name,
+            '#-- START BLOCK UNFINISHED',
+            '#-- END BLOCK UNFINISHED',
+            'foobar',
+             backup=False
+        )
+
 
 class FileModuleTestCase(TestCase):
     def test_sed_limit_escaped(self):
@@ -149,4 +286,4 @@ class FileModuleTestCase(TestCase):
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(FileModuleTestCase, FileReplaceTestCase, needs_daemon=False)
+    run_tests(FileModuleTestCase, FileReplaceTestCase, FileBlockReplaceTestCase, needs_daemon=False)


### PR DESCRIPTION
When facing files which are not handled by `states.file.managed` it's always quite hard to maintain a block of edited content, while removing old  managed content and keeping manual content intact.

I encouter this need on files like /etc/hosts but it could be also for a bind configuration file, or crontabs with several identical entries like in #7979. One way to do it would be `states.file.replace` with a MULTILINE regex. But, I do not like regex, and they do not work on multiline (see #7999). `states.file.replace` has also some problems like in-place editing via `fileinput.input` which allows parallel reads of an empty or partially filled file by other process while editing is in place. I've tried to reduce this problem using the salt atomic_file open method.

So I made this basic task, and I made it directly in states.file and modules/files as I also like the `states.file.accumulated`` state and I used it to collect data for the edited block (without the templating fine usage).
