### PR TITLE
Debian copying

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,29 @@
+
+--
+salt/doc/_build/html/_static/css/bootstrap-responsive.css
+Licensed under the Apache License v2.0
+--
+
+--
+salt/doc/_build/html/_static/jquery.js
+Dual licensed under the MIT or GPL Version 2 licenses.
+--
+
+--
+salt/doc/_build/html/_static/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js
+MIT & BSD
+--
+
+--
+salt/salt/utils/ipaddr.py
+Licensed under the Apache License, Version 2.0
+--
+
+--
+salt/salt/auth/pam.py
+Licensed under the MIT license
+--
+
+--
+All other files licensed according to the LICENSE file included in the top-level of this package
+--

--- a/COPYING
+++ b/COPYING
@@ -25,5 +25,10 @@ Licensed under the MIT license
 --
 
 --
+salt/doc/_ext/youtube.py
+BSD
+--
+
+--
 All other files licensed according to the LICENSE file included in the top-level of this package
 --

--- a/COPYING
+++ b/COPYING
@@ -1,34 +1,135 @@
+Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Upstream-Name: salt
+Upstream-Contact: salt-users@googlegroups.com
+Source: https://github.com/saltstack/salt
 
---
-salt/doc/_build/html/_static/css/bootstrap-responsive.css
-Licensed under the Apache License v2.0
---
+Files: *
+Copyright: 2013 SaltStack Team
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License, Version 2.0 can be
+ found in the file
+ `/usr/share/common-licenses/Apache-2.0'.
 
---
-salt/doc/_build/html/_static/jquery.js
-Dual licensed under the MIT or GPL Version 2 licenses.
---
+Files: debian/*
+Copyright: 2013 Joe Healy <joehealy@gmail.com>
+           2012 Michael Prokop <mika@debian.org>
+           2012 Christian Hofstaedtler <christian@hofstaedtler.name>
+           2012 Ulrich Dangel <mru@spamt.net>
+           2012 Corey Quinn <corey@sequestered.net>
+           2011 Aaron Toponce <aaron.toponce@gmail.com>
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License, Version 2.0 can be
+ found in the file
+ `/usr/share/common-licenses/Apache-2.0'.
 
---
-salt/doc/_build/html/_static/js/vendor/modernizr-2.6.2-respond-1.1.0.min.js
-MIT & BSD
---
+Files: salt/auth/pam.py
+Copyright: 2007 Chris AtLee <chris@atlee.ca>
+License: MIT License
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+  .
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+  .
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
 
---
-salt/salt/utils/ipaddr.py
-Licensed under the Apache License, Version 2.0
---
+Files: salt/utils/ipaddr.py
+Copyright: 2007 Google Inc.
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License, Version 2.0 can be
+ found in the file
+ `/usr/share/common-licenses/Apache-2.0'.
 
---
-salt/salt/auth/pam.py
-Licensed under the MIT license
---
+Files: doc/_ext/youtube.py
+Copyright: 2009 Chris Pickel <sfiera@gmail.com>
+License: BSD-2-clause
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions are
+ met:
+ .
+ * Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+ .
+ * Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+ .
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
---
-salt/doc/_ext/youtube.py
-BSD
---
 
---
-All other files licensed according to the LICENSE file included in the top-level of this package
---
+Files: doc/_ext/images
+Copyright: 2013 SaltStack Team
+License: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ .
+     http://www.apache.org/licenses/LICENSE-2.0
+ .
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ .
+ On Debian systems, the full text of the Apache License, Version 2.0 can be
+ found in the file
+ `/usr/share/common-licenses/Apache-2.0'.
+ .
+ Files in this directory were created in-house.


### PR DESCRIPTION
A top-level COPYING file to assist package maintainers in determining licensing information for files included in Salt. Refs #7842.
