### PR TITLE
Change assertEquals to assertEqual

### DIFF
--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -69,7 +69,7 @@ class CMDModuleTest(integration.ModuleCase):
 
             environment2 = os.environ.copy()
 
-            self.assertEqualn(environment, environment2)
+            self.assertEqual(environment, environment2)
 
             getpwnam_mock.assert_called_with('foobar')
             loads_mock.assert_called_with('{}')

--- a/tests/integration/modules/cmdmod.py
+++ b/tests/integration/modules/cmdmod.py
@@ -69,7 +69,7 @@ class CMDModuleTest(integration.ModuleCase):
 
             environment2 = os.environ.copy()
 
-            self.assertEquals(environment, environment2)
+            self.assertEqualn(environment, environment2)
 
             getpwnam_mock.assert_called_with('foobar')
             loads_mock.assert_called_with('{}')

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -134,7 +134,7 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         )
 
         changes = ret.values()[0]['changes']
-        self.assertEquals('<show_diff=False>', changes['diff'])
+        self.assertEqual('<show_diff=False>', changes['diff'])
 
     def test_directory(self):
         '''

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -282,21 +282,21 @@ class ConfigTestCase(TestCase):
         )
         syndic_opts.update(salt.minion.resolve_dns(syndic_opts))
         # id & pki dir are shared & so configured on the minion side
-        self.assertEquals(syndic_opts['id'], 'minion')
-        self.assertEquals(syndic_opts['pki_dir'], '/tmp/salttest/pki')
+        self.assertEqual(syndic_opts['id'], 'minion')
+        self.assertEqual(syndic_opts['pki_dir'], '/tmp/salttest/pki')
         # the rest is configured master side
-        self.assertEquals(syndic_opts['master_uri'], 'tcp://127.0.0.1:54506')
-        self.assertEquals(syndic_opts['master_port'], 54506)
-        self.assertEquals(syndic_opts['master_ip'], '127.0.0.1')
-        self.assertEquals(syndic_opts['master'], 'localhost')
-        self.assertEquals(syndic_opts['sock_dir'], '/tmp/salttest/minion_sock')
-        self.assertEquals(syndic_opts['cachedir'], '/tmp/salttest/cachedir')
-        self.assertEquals(syndic_opts['log_file'], '/tmp/salttest/osyndic.log')
-        self.assertEquals(syndic_opts['pidfile'], '/tmp/salttest/osyndic.pid')
+        self.assertEqual(syndic_opts['master_uri'], 'tcp://127.0.0.1:54506')
+        self.assertEqual(syndic_opts['master_port'], 54506)
+        self.assertEqual(syndic_opts['master_ip'], '127.0.0.1')
+        self.assertEqual(syndic_opts['master'], 'localhost')
+        self.assertEqual(syndic_opts['sock_dir'], '/tmp/salttest/minion_sock')
+        self.assertEqual(syndic_opts['cachedir'], '/tmp/salttest/cachedir')
+        self.assertEqual(syndic_opts['log_file'], '/tmp/salttest/osyndic.log')
+        self.assertEqual(syndic_opts['pidfile'], '/tmp/salttest/osyndic.pid')
         # Show that the options of localclient that repub to local master
         # are not merged with syndic ones
-        self.assertEquals(syndic_opts['_master_conf_file'], minion_config_path)
-        self.assertEquals(syndic_opts['_minion_conf_file'], syndic_conf_path)
+        self.assertEqual(syndic_opts['_master_conf_file'], minion_config_path)
+        self.assertEqual(syndic_opts['_minion_conf_file'], syndic_conf_path)
 
     def test_check_dns_deprecation_warning(self):
         helium_version = SaltStackVersion.from_name('Helium')

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -253,7 +253,7 @@ class FileModuleTestCase(TestCase):
             filemod.sed(path, before, after, limit=limit)
 
             with open(path, 'rb') as newfile:
-                self.assertEquals(
+                self.assertEqual(
                     SED_CONTENT.replace(before, ''),
                     newfile.read()
                 )

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -29,7 +29,7 @@ class PostgresTestCase(TestCase):
         postgres._run_psql('echo "hi"')
         cmd = SALT_STUB['cmd.run_all']
 
-        self.assertEquals('postgres', cmd.call_args[1]['runas'])
+        self.assertEqual('postgres', cmd.call_args[1]['runas'])
 
 
 if __name__ == '__main__':

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -39,16 +39,16 @@ class TestFileState(TestCase):
         }
 
         filestate.serialize('/tmp', dataset)
-        self.assertEquals(yaml.load(returner.returned), dataset)
+        self.assertEqual(yaml.load(returner.returned), dataset)
 
         filestate.serialize('/tmp', dataset, formatter="yaml")
-        self.assertEquals(yaml.load(returner.returned), dataset)
+        self.assertEqual(yaml.load(returner.returned), dataset)
 
         filestate.serialize('/tmp', dataset, formatter="json")
-        self.assertEquals(json.loads(returner.returned), dataset)
+        self.assertEqual(json.loads(returner.returned), dataset)
 
         filestate.serialize('/tmp', dataset, formatter="python")
-        self.assertEquals(returner.returned, pprint.pformat(dataset))
+        self.assertEqual(returner.returned, pprint.pformat(dataset))
 
     def test_contents_and_contents_pillar(self):
         def returner(contents, *args, **kwargs):
@@ -63,7 +63,7 @@ class TestFileState(TestCase):
         filestate.__salt__['config.manage_mode'] = manage_mode_mock
 
         ret = filestate.managed('/tmp/foo', contents='hi', contents_pillar='foo:bar')
-        self.assertEquals(False, ret['result'])
+        self.assertEqual(False, ret['result'])
 
     def test_contents_pillar_adds_newline(self):
         # make sure the newline
@@ -105,10 +105,10 @@ class TestFileState(TestCase):
         pillar_mock.assert_called_once_with(pillar_path)
 
         # make sure no errors are returned
-        self.assertEquals(None, ret)
+        self.assertEqual(None, ret)
 
         # make sure the value is correct
-        self.assertEquals(expected, returner.returned[1][-1])
+        self.assertEqual(expected, returner.returned[1][-1])
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -292,7 +292,7 @@ class TestCustomExtensions(TestCase):
         }
         env = Environment(extensions=[SerializerExtension])
         rendered = env.from_string('{{ dataset|json }}').render(dataset=dataset)
-        self.assertEquals(dataset, json.loads(rendered))
+        self.assertEqual(dataset, json.loads(rendered))
 
     def test_serialize_yaml(self):
         dataset = {
@@ -303,7 +303,7 @@ class TestCustomExtensions(TestCase):
         }
         env = Environment(extensions=[SerializerExtension])
         rendered = env.from_string('{{ dataset|yaml }}').render(dataset=dataset)
-        self.assertEquals(dataset, yaml.load(rendered))
+        self.assertEqual(dataset, yaml.load(rendered))
 
     def test_serialize_python(self):
         dataset = {
@@ -314,16 +314,16 @@ class TestCustomExtensions(TestCase):
         }
         env = Environment(extensions=[SerializerExtension])
         rendered = env.from_string('{{ dataset|python }}').render(dataset=dataset)
-        self.assertEquals(rendered, pprint.pformat(dataset))
+        self.assertEqual(rendered, pprint.pformat(dataset))
 
     def test_load_yaml(self):
         env = Environment(extensions=[SerializerExtension])
         rendered = env.from_string('{% set document = "{foo: it works}"|load_yaml %}{{ document.foo }}').render()
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
         rendered = env.from_string('{% set document = document|load_yaml %}'
                                    '{{ document.foo }}').render(document="{foo: it works}")
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
         with self.assertRaises(exceptions.TemplateRuntimeError):
             env.from_string('{% set document = document|load_yaml %}'
@@ -337,13 +337,13 @@ class TestCustomExtensions(TestCase):
                                         '{{ docu.foo }}'
 
         rendered = env.from_string(source).render(bar="barred")
-        self.assertEquals(rendered, u"barred, it works")
+        self.assertEqual(rendered, u"barred, it works")
 
         source = '{{ bar }}, {% load_json as docu %}{"foo": "it works", "{{ bar }}": "baz"}{% endload %}' + \
                                         '{{ docu.foo }}'
 
         rendered = env.from_string(source).render(bar="barred")
-        self.assertEquals(rendered, u"barred, it works")
+        self.assertEqual(rendered, u"barred, it works")
 
         with self.assertRaises(exceptions.TemplateSyntaxError):
             env.from_string('{% load_yamle as document %}{foo, bar: it works}{% endload %}').render()
@@ -356,11 +356,11 @@ class TestCustomExtensions(TestCase):
         env = Environment(extensions=[SerializerExtension])
         rendered = env.from_string('{% set document = \'{"foo": "it works"}\'|load_json %}'
                                    '{{ document.foo }}').render()
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
         rendered = env.from_string('{% set document = document|load_json %}'
                                    '{{ document.foo }}').render(document='{"foo": "it works"}')
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
         # bad quotes
         with self.assertRaises(exceptions.TemplateRuntimeError):
@@ -374,7 +374,7 @@ class TestCustomExtensions(TestCase):
         loader = DictLoader({'foo': '{bar: "my god is blue", foo: [1, 2, 3]}'})
         env = Environment(extensions=[SerializerExtension], loader=loader)
         rendered = env.from_string('{% import_yaml "foo" as doc %}{{ doc.bar }}').render()
-        self.assertEquals(rendered, u"my god is blue")
+        self.assertEqual(rendered, u"my god is blue")
 
         with self.assertRaises(exceptions.TemplateNotFound):
             env.from_string('{% import_yaml "does not exists" as doc %}').render()
@@ -383,7 +383,7 @@ class TestCustomExtensions(TestCase):
         loader = DictLoader({'foo': '{"bar": "my god is blue", "foo": [1, 2, 3]}'})
         env = Environment(extensions=[SerializerExtension], loader=loader)
         rendered = env.from_string('{% import_json "foo" as doc %}{{ doc.bar }}').render()
-        self.assertEquals(rendered, u"my god is blue")
+        self.assertEqual(rendered, u"my god is blue")
 
         with self.assertRaises(exceptions.TemplateNotFound):
             env.from_string('{% import_json "does not exists" as doc %}').render()
@@ -420,22 +420,22 @@ class TestCustomExtensions(TestCase):
 
         env = Environment(extensions=[SerializerExtension], loader=loader)
         rendered = env.get_template('main1').render()
-        self.assertEquals(rendered, u"my god is blue")
+        self.assertEqual(rendered, u"my god is blue")
 
         rendered = env.get_template('main2').render()
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
         rendered = env.get_template('main3').render().strip()
-        self.assertEquals(rendered, u"my god is blue")
+        self.assertEqual(rendered, u"my god is blue")
 
         rendered = env.get_template('main4').render().strip()
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
         rendered = env.get_template('main5').render().strip()
-        self.assertEquals(rendered, u"my god is blue")
+        self.assertEqual(rendered, u"my god is blue")
 
         rendered = env.get_template('main6').render().strip()
-        self.assertEquals(rendered, u"it works")
+        self.assertEqual(rendered, u"it works")
 
     # def test_print(self):
     #     env = Environment(extensions=[SerializerExtension])


### PR DESCRIPTION
According to
http://docs.python.org/2/library/unittest.html#deprecated-aliases
assertEquals is a deprecated alias of assertEqual.
