### PR TITLE
Removing nsProcess plugin. 

### DIFF
--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -193,8 +193,6 @@ and run NSIS.
 
 The NSIS installer can be found here: http://nsis.sourceforge.net/Main_Page
 
-You also need the nsProcess plugin for NSIS. It can be found here: http://nsis.sourceforge.net/NsProcess_plugin
-
 
 Testing the Salt minion
 =======================

--- a/pkg/windows/installer/Salt-Minion-Setup.nsi
+++ b/pkg/windows/installer/Salt-Minion-Setup.nsi
@@ -12,7 +12,6 @@
 !include "nsDialogs.nsh"
 !include "LogicLib.nsh"
 !include "FileFunc.nsh"
-!include "nsProcess.nsh"; using plugin nsProcess
 
 Var Dialog
 Var Label
@@ -127,9 +126,8 @@ ShowUnInstDetails show
 
 Section "MainSection" SEC01
 
-  Exec "sc stop salt-minion" ;stopping service before upgrading
-  ${nsProcess::CloseProcess} "salt-minion.exe" $R0
-  ${nsProcess::Unload}
+  ExecWait "net stop salt-minion" ;stopping service before upgrading
+  Sleep 3000
   SetOutPath "$INSTDIR\"
   SetOverwrite try
   CreateDirectory $INSTDIR\conf\pki\minion
@@ -155,7 +153,7 @@ SectionEnd
 Function .onInstSuccess
   Exec "nssm.exe install salt-minion $INSTDIR\salt-minion.exe -c $INSTDIR\conf -l quiet"
   RMDir /R "$INSTDIR\var\cache\salt" ; removing cache from old version
-  Exec "sc start salt-minion"
+  ExecWait "net start salt-minion"
 FunctionEnd
 
 Function un.onUninstSuccess
@@ -191,8 +189,8 @@ Function .onInit
 FunctionEnd
 
 Section Uninstall
-  Exec "sc stop salt-minion"
-  Exec "sc delete salt-minion"
+  ExecWait "net stop salt-minion"
+  ExecWait "sc delete salt-minion"
   Delete "$INSTDIR\uninst.exe"
   Delete "$INSTDIR\nssm.exe"
   Delete "$INSTDIR\python*"


### PR DESCRIPTION
Using ExecWait instead of Exec and a sleep 3s to stop salt-minion.

On windows 2003 32b it doesn't work without sleep. I know it's a bit dirty but it seems that windows is a bit slow to release c:\salt\python27.dll before NSIS can update it.

Regards
Pierre
