### PR TITLE
pip freeze output has comments sometimes: ignore them

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -767,8 +767,9 @@ def list_(prefix=None,
         raise CommandExecutionError(result['stderr'])
 
     for line in result['stdout'].splitlines():
-        if line.startswith('-f'):
+        if line.startswith('-f') or line.startswith('#'):
             # ignore -f line as it contains --find-links directory
+            # ignore comment lines
             continue
         elif line.startswith('-e'):
             line = line.split('-e ')[1]


### PR DESCRIPTION
Basically ignore comments as comments

The output of pip freeze can contain lines like

```
## FIXME: could not find svn URL in dependency_links for this
package:
```

These shouldn't log an error about being unable to parse a comment.
Especially since the message pip is trying to deliver to the user will
generally be about the following line, which isn't displayed in salt
output.

The current output looks like:

```
[DEBUG   ] stderr: Warning: cannot find svn location for TracDateField==3.0.0dev-r12118
Warning: cannot find svn location for TracSpamFilter==0.8.0dev-r11796
Warning: cannot find svn location for nevernotifyupdaterplugin==0.1.0-r12968
[ERROR   ] Can't parse line '## FIXME: could not find svn URL in dependency_links for this package:'
[ERROR   ] Can't parse line '## FIXME: could not find svn URL in dependency_links for this package:'
[ERROR   ] Can't parse line '## FIXME: could not find svn URL in dependency_links for this package:'
```

The DEBUG stderr output is both more informative and less alarming for no good reason.
