### PR TITLE
OS X doesn't call md5sum by its full name. Instead, it is installed as s...

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -59,6 +59,15 @@ SSH_SHIM = '''/bin/sh << 'EOF'
          fi
       done
       SALT=/tmp/.salt/salt-call
+
+      if ( ( [ ! -f {{2}} ] ) && ([ {{2}} == 'md5' ]) )
+      then
+        SUMCHECK='md5'
+      else
+        SUMCHECK={{2}}sum
+      fi
+
+
       if [ -f $SALT ]
       then
          if [ $(cat /tmp/.salt/version) != {0} ]
@@ -80,7 +89,7 @@ SSH_SHIM = '''/bin/sh << 'EOF'
          fi
          if [ -f /tmp/.salt/salt-thin.tgz ]
          then
-             [ $({{2}}sum /tmp/.salt/salt-thin.tgz | cut -f1 -d' ') = {{3}} ] && {{0}} tar xzvf /tmp/.salt/salt-thin.tgz -C /tmp/.salt
+             [ $($SUMCHECK /tmp/.salt/salt-thin.tgz | cut -f1 -d' ') = {{3}} ] && {{0}} tar xzvf /tmp/.salt/salt-thin.tgz -C /tmp/.salt
          else
              install -m 0700 -d /tmp/.salt
              echo "{1}"

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -60,13 +60,21 @@ SSH_SHIM = '''/bin/sh << 'EOF'
       done
       SALT=/tmp/.salt/salt-call
 
-      if ( ( [ ! -f {{2}} ] ) && ([ {{2}} == 'md5' ]) )
+      if [ {{2}} == 'md5' ]
       then
-        SUMCHECK='md5'
+         for md5_candidate in \\
+            md5sum            \\
+            md5               ;
+         do
+            if [ $(which $md5_candidate 2>/dev/null) ]
+            then
+                SUMCHECK=$(which $md5_candidate)
+                break
+            fi
+         done
       else
-        SUMCHECK={{2}}sum
+         SUMCHECK={{2}}
       fi
-
 
       if [ -f $SALT ]
       then


### PR DESCRIPTION
...imple 'md5'. Because we don't know what OS we're deploying to ahead of time, we need to check that condition for that in the shim script and account for it. Does not ref any open issues because I discovered it while debugging another salt-ssh issue.
