### PR TITLE
More fixes for OS X. The shipped /sbin/md5 command outputs differently t...

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -76,6 +76,13 @@ SSH_SHIM = '''/bin/sh << 'EOF'
          SUMCHECK={{2}}
       fi
 
+      if [ $SUMCHECK = '/sbin/md5' ]
+      then
+         CUT_MARK=4
+      else
+         CUT_MARK=1
+      fi
+
       if [ -f $SALT ]
       then
          if [ $(cat /tmp/.salt/version) != {0} ]
@@ -97,7 +104,7 @@ SSH_SHIM = '''/bin/sh << 'EOF'
          fi
          if [ -f /tmp/.salt/salt-thin.tgz ]
          then
-             [ $($SUMCHECK /tmp/.salt/salt-thin.tgz | cut -f1 -d' ') = {{3}} ] && {{0}} tar xzvf /tmp/.salt/salt-thin.tgz -C /tmp/.salt
+             [ $($SUMCHECK /tmp/.salt/salt-thin.tgz | cut -f$CUT_MARK -d' ') = {{3}} ] && {{0}} tar xzvf /tmp/.salt/salt-thin.tgz -C /tmp/.salt
          else
              install -m 0700 -d /tmp/.salt
              echo "{1}"

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -59,8 +59,7 @@ SSH_SHIM = '''/bin/sh << 'EOF'
          fi
       done
       SALT=/tmp/.salt/salt-call
-
-      if [ {{2}} == 'md5' ]
+      if [ {{2}} = 'md5' ]
       then
          for md5_candidate in \\
             md5sum            \\


### PR DESCRIPTION
...hen the md5sum command so the cut needs to split at a different token.
