### PR TITLE
Add a Windows network state

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -86,6 +86,7 @@ Full list of builtin state modules
     virtualenv_mod
     win_dns_client
     win_firewall
+    win_network
     win_path
     win_servermanager
     win_system

--- a/doc/ref/states/all/salt.states.win_network.rst
+++ b/doc/ref/states/all/salt.states.win_network.rst
@@ -1,0 +1,6 @@
+=======================
+salt.states.win_network
+=======================
+
+.. automodule:: salt.states.win_network
+    :members:

--- a/doc/topics/development/package_providers.rst
+++ b/doc/topics/development/package_providers.rst
@@ -137,12 +137,11 @@ The second return value will be a string with two possible values:
 
 Both before and after the installing the target(s), you should run
 :strong:`list_pkgs` to obtain a list of the installed packages. You should then
-return the output of
-:mod:`pkg_resource.find_changes <salt.modules.pkg_resource.find_changes>`:
+return the output of ``salt.utils.compare_dicts()``
 
 .. code-block:: python
 
-        return __salt__['pkg_resource.find_changes'](old, new)
+        return salt.utils.compare_dicts(old, new)
 
 
 remove

--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -423,7 +423,7 @@ def install(name=None,
     __salt__['cmd.run_all'](cmd, python_shell=False)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
@@ -452,10 +452,9 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     new = list_pkgs()
     new_removed = list_pkgs(removed=True)
 
-    ret = {'installed': __salt__['pkg_resource.find_changes'](old, new)}
+    ret = {'installed': salt.utils.compare_dicts(old, new)}
     if action == 'purge':
-        ret['removed'] = __salt__['pkg_resource.find_changes'](old_removed,
-                                                               new_removed)
+        ret['removed'] = salt.utils.compare_dicts(old_removed, new_removed)
         return ret
     else:
         return ret['installed']
@@ -546,7 +545,7 @@ def upgrade(refresh=True, **kwargs):
     __salt__['cmd.run_all'](cmd, python_shell=False)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def _clean_pkglist(pkgs):

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -176,7 +176,7 @@ def remove(name=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
@@ -277,7 +277,7 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
         __salt__['cmd.run'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def list_upgrades():

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -553,7 +553,7 @@ def install(name=None,
     if call['retcode'] != 0:
         return _process_emerge_err(call['stderr'])
     new = list_pkgs()
-    changes.update(__salt__['pkg_resource.find_changes'](old, new))
+    changes.update(salt.utils.compare_dicts(old, new))
     return changes
 
 
@@ -598,7 +598,7 @@ def update(pkg, slot=None, fromrepo=None, refresh=False):
     if call['retcode'] != 0:
         return _process_emerge_err(call['stderr'])
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade(refresh=True):
@@ -626,7 +626,7 @@ def upgrade(refresh=True):
     if call['retcode'] != 0:
         return _process_emerge_err(call['stderr'])
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
@@ -681,7 +681,7 @@ def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
@@ -767,7 +767,7 @@ def depclean(name=None, slot=None, fromrepo=None, pkgs=None):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def version_cmp(pkg1, pkg2):

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -334,7 +334,7 @@ def install(name=None,
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     rehash()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade():
@@ -390,7 +390,7 @@ def remove(name=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 # Support pkg.delete to remove packages to more closely match pkg_delete
 delete = remove

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -160,7 +160,7 @@ def install(name, clean=True):
         __context__['ports.install_error'] = result['stderr']
     __context__.pop('pkg.list_pkgs', None)
     new = __salt__['pkg.list_pkgs']()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def deinstall(name):
@@ -178,7 +178,7 @@ def deinstall(name):
     __salt__['cmd.run']('make deinstall BATCH=yes', cwd=portpath)
     __context__.pop('pkg.list_pkgs', None)
     new = __salt__['pkg.list_pkgs']()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def rmconfig(name):

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -175,7 +175,7 @@ def install(name=None, pkgs=None, sources=None, **kwargs):
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -212,7 +212,7 @@ def remove(name=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -325,7 +325,7 @@ def install(name=None,
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade():
@@ -348,7 +348,7 @@ def upgrade():
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
@@ -367,7 +367,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -352,34 +352,6 @@ def stringify(pkgs):
         log.exception(e)
 
 
-def find_changes(old=None, new=None):
-    '''
-    Compare before and after results from pkg.list_pkgs() to determine what
-    changes were made to the packages installed on the minion.
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' pkg_resource.find_changes
-    '''
-    pkgs = {}
-    for npkg in set((new or {}).keys()).union((old or {}).keys()):
-        if npkg not in old:
-            # the package is freshly installed
-            pkgs[npkg] = {'old': '',
-                          'new': new[npkg]}
-        elif npkg not in new:
-            # the package is removed
-            pkgs[npkg] = {'new': '',
-                          'old': old[npkg]}
-        elif new[npkg] != old[npkg]:
-            # the package was here before and the version has changed
-            pkgs[npkg] = {'old': old[npkg],
-                          'new': new[npkg]}
-    return pkgs
-
-
 def version_clean(version):
     '''
     Clean the version string removing extra data.

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -317,7 +317,7 @@ def install(name=None, refresh=False, fromrepo=None,
     new = list_pkgs()
 
     rehash()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade():
@@ -344,7 +344,7 @@ def upgrade():
     old = list_pkgs()
     __salt__['cmd.retcode']('{0} -y fug'.format(pkgin))
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -403,7 +403,7 @@ def remove(name=None, pkgs=None, **kwargs):
 
     new = list_pkgs()
 
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -699,7 +699,7 @@ def install(name=None,
     __salt__['cmd.run_all'](cmd)
     __context__.pop(_contextkey(jail, chroot), None)
     new = list_pkgs(jail=jail, chroot=chroot)
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None,
@@ -836,7 +836,7 @@ def remove(name=None,
     __salt__['cmd.run_all'](cmd)
     __context__.pop(_contextkey(jail, chroot), None)
     new = list_pkgs(jail=jail, chroot=chroot)
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 # Support pkg.delete to remove packages, since this is the CLI usage
 delete = remove

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -107,7 +107,7 @@ def upgrade(refresh=True, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def list_pkgs(versions_as_list=False, **kwargs):
@@ -282,7 +282,7 @@ def install(name=None, refresh=False, version=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -322,7 +322,7 @@ def remove(name=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -317,7 +317,7 @@ def install(name=None, sources=None, **kwargs):
     if not 'admin_source' in kwargs:
         os.unlink(adminfile)
 
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -423,7 +423,7 @@ def remove(name=None, pkgs=None, **kwargs):
         os.unlink(adminfile)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -231,7 +231,9 @@ def set_static_ip(iface, addr, gateway=None, append=False):
         The name of the interface to manage
 
     addr
-        IP address with subnet length (ex. ``10.1.2.3/24``)
+        IP address with subnet length (ex. ``10.1.2.3/24``). The
+        :mod:`ip.get_subnet_length <salt.modules.win_ip.get_subnet_length>`
+        function can be used to calculate the subnet length from a netmask.
 
     gateway : None
         If specified, the default gateway will be set to this value.

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -12,7 +12,10 @@ import time
 import salt.utils
 import salt.utils.network
 import salt.utils.validate.net
-from salt.exceptions import CommandExecutionError, CommandNotFoundError
+from salt.exceptions import (
+    CommandExecutionError,
+    SaltInvocationError
+)
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -203,6 +206,21 @@ def disable(iface):
         'netsh interface set interface "{0}" admin=DISABLED'.format(iface)
     )
     return is_disabled(iface)
+
+
+def get_subnet_length(mask):
+    '''
+    Convenience function to convert the netmask to the CIDR subnet length
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt -G 'os_family:Windows' ip.get_subnet_length 255.255.255.0
+    '''
+    if not salt.utils.validate.net.netmask(mask):
+        raise SaltInvocationError('{0!r} is not a valid netmask'.format(mask))
+    return salt.utils.network.get_net_size(mask)
 
 
 def set_static_ip(iface, addr, gateway=None, append=False):

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -11,6 +11,7 @@ import time
 # Import salt libs
 import salt.utils
 import salt.utils.network
+import salt.utils.validate.net
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 
 # Set up logging
@@ -240,10 +241,10 @@ def set_static_ip(iface, addr, gateway=None, append=False):
             time.sleep(1)
         return {}
 
-    if not salt.utils.network.valid_ipv4(addr):
+    if not salt.utils.validate.net.ipv4_addr(addr):
         raise SaltInvocationError('Invalid address {0!r}'.format(addr))
 
-    if gateway and not salt.utils.network.valid_ipv4(addr):
+    if gateway and not salt.utils.validate.net.ipv4_addr(addr):
         raise SaltInvocationError(
             'Invalid default gateway {0!r}'.format(gateway)
         )

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -545,7 +545,7 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade(refresh=True):
@@ -641,7 +641,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, version=None, **kwargs):

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -688,7 +688,7 @@ def install(name=None,
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade(refresh=True):
@@ -731,7 +731,7 @@ def upgrade(refresh=True):
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -796,7 +796,7 @@ def remove(name=None, pkgs=None, **kwargs):
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -532,7 +532,7 @@ def install(name=None,
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade(refresh=True):
@@ -557,7 +557,7 @@ def upgrade(refresh=True):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -596,7 +596,7 @@ def remove(name=None, pkgs=None, **kwargs):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def purge(name=None, pkgs=None, **kwargs):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -368,7 +368,7 @@ def install(name=None,
         downgrades = downgrades[500:]
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def upgrade(refresh=True):
@@ -393,7 +393,7 @@ def upgrade(refresh=True):
     __salt__['cmd.run_all'](cmd)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def _uninstall(action='remove', name=None, pkgs=None):
@@ -416,7 +416,7 @@ def _uninstall(action='remove', name=None, pkgs=None):
         targets = targets[500:]
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['pkg_resource.find_changes'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def remove(name=None, pkgs=None, **kwargs):

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -152,7 +152,21 @@ supported. This module will therefore only work on RH/CentOS/Fedora.
 
 # Import python libs
 import difflib
+import salt.utils
 from salt.loader import _create_loader
+
+# Define the module's virtual name
+__virtualname__ = 'ip'
+
+
+def __virtual__():
+    '''
+    Confine this module to non-Windows systems with the required execution
+    module available.
+    '''
+    if not salt.utils.is_windows() and 'ip.get_interface' in __salt__:
+        return __virtualname__
+    return False
 
 
 def managed(name, type, enabled=True, **kwargs):

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Configuration of network interfaces.
-====================================
+Configuration of network interfaces
+===================================
 
 The network module is used to create and manage network settings,
 interfaces can be set as either managed or ignored. By default

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -156,7 +156,7 @@ import salt.utils
 from salt.loader import _create_loader
 
 # Define the module's virtual name
-__virtualname__ = 'ip'
+__virtualname__ = 'network'
 
 
 def __virtual__():

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -21,10 +21,11 @@ will be set to UTC, and the system clock will be an offset of that.
       timezone.system:
         - utc: True
 
-The Ubuntu community documentation contains an explanation of this setting, as
-it applies to systems that dual-boot with Windows.
+.. _here: https://help.ubuntu.com/community/UbuntuTime#Multiple_Boot_Systems_Time_Conflicts
 
-http://tinyurl.com/5fjzmn
+The Ubuntu community documentation contains an explanation of this setting, as
+it applies to systems that dual-boot with Windows. This is explained in greater
+detail here_.
 '''
 
 

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -41,7 +41,7 @@ def __virtual__():
     Confine this module to Windows systems with the required execution module
     available.
     '''
-    if salt.utils.is_windows() and 'ip.get_all_interfaces' in __salt__:
+    if salt.utils.is_windows() and 'ip.get_interface' in __salt__:
         return __virtualname__
     return False
 

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -33,7 +33,7 @@ log = logging.getLogger(__name__)
 __VALID_PROTO = ('static', 'dhcp')
 
 # Define the module's virtual name
-__virtualname__ = 'ip'
+__virtualname__ = 'network'
 
 
 def __virtual__():

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -3,21 +3,59 @@
 Configuration of network interfaces on Windows hosts
 ====================================================
 
-The network module is used to create and manage network settings,
-interfaces can be set as either managed or ignored. By default
-all interfaces are ignored unless specified.
+.. versionadded:: Hydrogen
 
-Please note that only Redhat-style networking is currently
-supported. This module will therefore only work on RH/CentOS/Fedora.
+This module provides the ``network`` state(s) on Windows hosts. DNS servers, IP
+addresses and default gateways can currently be managed.
+
+Below is an example of the configuration for an interface that uses DHCP for
+both DNS servers and IP addresses:
 
 .. code-block:: yaml
 
     Local Area Connection #2:
       network.managed:
         - dns_proto: dhcp
+        - ip_proto: dhcp
+
+.. note::
+
+    Both the ``dns_proto`` and ``ip_proto`` arguments are required.
+
+Static DNS and IP addresses can be configured like so:
+
+.. code-block:: yaml
+
+    Local Area Connection #2:
+      network.managed:
+        - dns_proto: static
+        - dns_servers:
+          - 8.8.8.8
+          - 8.8.4.4
         - ip_proto: static
         - ip_addrs:
           - 10.2.3.4/24
+
+.. note::
+
+    IP addresses are specified using the format
+    ``<ip-address>/<subnet-length>``.
+
+Optionally, if you are setting a static IP address, you can also specify the
+default gateway using the ``gateway`` parameter:
+
+.. code-block:: yaml
+
+    Local Area Connection #2:
+      network.managed:
+        - dns_proto: static
+        - dns_servers:
+          - 8.8.8.8
+          - 8.8.4.4
+        - ip_proto: static
+        - ip_addrs:
+          - 10.2.3.4/24
+        - gateway: 10.2.3.1
 '''
 
 # Import python libs

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -1,0 +1,314 @@
+# -*- coding: utf-8 -*-
+'''
+Configuration of network interfaces on Windows hosts
+====================================================
+
+The network module is used to create and manage network settings,
+interfaces can be set as either managed or ignored. By default
+all interfaces are ignored unless specified.
+
+Please note that only Redhat-style networking is currently
+supported. This module will therefore only work on RH/CentOS/Fedora.
+
+.. code-block:: yaml
+
+    Local Area Connection #2:
+      network.managed:
+        - dns_proto: dhcp
+        - ip_proto: static
+        - ip_addrs:
+          - 10.2.3.4/24
+'''
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.utils
+import salt.utils.network
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+__VALID_PROTO = ('static', 'dhcp')
+
+# Define the module's virtual name
+__virtualname__ = 'ip'
+
+
+def __virtual__():
+    '''
+    Confine this module to Windows systems with the required execution module
+    available.
+    '''
+    if salt.utils.is_windows() and 'ip.get_all_interfaces' in __salt__:
+        return __virtualname__
+    return False
+
+
+def _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
+    '''
+    Ensure that the configuration passed is formatted correctly and contains
+    valid IP addresses, etc.
+    '''
+    errors = []
+    # Validate DNS configuration
+    if dns_proto == 'dhcp':
+        if dns_servers is not None:
+            errors.append(
+                'The dns_servers param cannot be set if unless dns_proto is '
+                'set to \'static\'.'
+            )
+    else:
+        if not isinstance(dns_servers, list):
+            errors.append(
+                'The dns_servers param must be formatted as a list.'
+            )
+        else:
+            bad_ips = [x for x in dns_servers
+                       if not salt.utils.network.valid_ipv4(x)]
+            if bad_ips:
+                errors.append('The following DNS server IPs are invalid: '
+                              '{0}'.format(', '.format(bad_ips)))
+
+    # Validate IP configuration
+    if ip_proto == 'dhcp':
+        if ip_addrs is not None:
+            errors.append(
+                'The ip_addrs param cannot be set if unless ip_proto is set '
+                'to \'static\'.'
+            )
+        if gateway is not None:
+            errors.append(
+                'A gateway IP cannot be set if unless ip_proto is set to '
+                '\'static\'.'
+            )
+    else:
+        if not isinstance(dns_servers, list):
+            errors.append(
+                'The ip_addrs param must be formatted as a list.'
+            )
+        else:
+            bad_ips = [x for x in dns_servers
+                       if not salt.utils.network.valid_ipv4(x)]
+            if bad_ips:
+                errors.append('The following static IPs are invalid: '
+                              '{0}'.format(', '.format(bad_ips)))
+
+            # Validate default gateway
+            if gateway is not None:
+                if not salt.utils.network.valid_ipv4(gateway):
+                    errors.append('Gateway IP {0} is invalid'.format(gateway))
+
+    return errors
+
+
+def _changes(cur, dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
+    '''
+    Compares the current interface against the desired configuration and
+    returns a dictionary describing the changes that need to be made.
+    '''
+    changes = {}
+    cur_dns_proto = ('static' if 'Statically Configured DNS Servers' in cur
+                     else 'dhcp')
+    cur_dns_servers = cur.get('Statically Configured DNS Servers', [])
+    cur_ip_proto = 'static' if 'ip_addrs' in cur else 'dhcp'
+    cur_ip_addrs = cur.get('ip_addrs', [])
+    cur_gateway = cur.get('Default Gateway')
+
+    if dns_proto != cur_dns_proto:
+        changes['dns_proto'] = dns_proto
+    if set(dns_servers) != set(cur_dns_servers):
+        changes['dns_servers'] = dns_servers
+    if ip_proto != cur_ip_proto:
+        changes['ip_proto'] = ip_proto
+    if set(ip_addrs) != set(cur_ip_addrs):
+        changes['ip_addrs'] = ip_addrs
+    if gateway != cur_gateway:
+        changes['gateway'] = gateway
+    return changes
+
+
+def managed(name,
+            dns_proto=None,
+            dns_servers=None,
+            ip_proto=None,
+            ip_addrs=None,
+            gateway=None,
+            enabled=True,
+            **kwargs):
+    '''
+    Ensure that the named interface is configured properly.
+
+    name
+        The name of the interface to manage
+
+    dns_proto : dhcp
+        Set to ``static`` and use the ``dns_servers`` parameter to provide a
+        list of DNS nameservers. The default is to get the nameservers via
+        DHCP.
+
+    dns_servers : None
+        A list of static DNS servers.
+
+    ip_proto : dhcp
+        Set to ``static`` and use the ``ip_addrs`` and ``gateway`` parameters
+        to provide a list of static IP addresses and the default gateway. The
+        default is to get the IP and default gateway via DHCP.
+
+    ip_addrs : None
+        A list of static IP addresses.
+
+    gateway : None
+        A list of static IP addresses.
+
+    enabled : True
+        Set to ``False`` to ensure that this interface is disabled.
+
+    '''
+    ret = {
+        'name': name,
+        'changes': {},
+        'result': True,
+        'comment': 'Interface {0!r} is up to date.'.format(name)
+    }
+
+    dns_proto = str(dns_proto).lower()
+    ip_proto = str(ip_proto).lower()
+
+    if dns_proto not in __VALID_PROTO:
+        ret['result'] = False
+        ret['comment'] = ('dns_proto must be one of the following: {0}'
+                          .format(', '.join(__VALID_PROTO)))
+        return ret
+
+    if ip_proto not in __VALID_PROTO:
+        ret['result'] = False
+        ret['comment'] = ('ip_proto must be one of the following: {0}'
+                          .format(', '.join(__VALID_PROTO)))
+        return ret
+
+    if not enabled:
+        if __salt__['ip.is_enabled'](name):
+            if __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = ('Interface {0!r} will be disabled'
+                                  .format(name))
+            else:
+                ret['result'] = __salt__['ip.disable'](name)
+                if not ret['result']:
+                    ret['comment'] = ('Failed to disable interface {0!r}'
+                                      .format(name))
+        else:
+            ret['comment'] += ' (already disabled)'
+        return ret
+    else:
+        currently_enabled = __salt__['ip.is_disabled'](name)
+        if not currently_enabled:
+            if __opts__['test']:
+                ret['result'] = None
+                ret['comment'] = ('Interface {0!r} will be enabled'
+                                  .format(name))
+            else:
+                result = __salt__['ip.enable'](name)
+                if not result:
+                    ret['result'] = False
+                    ret['comment'] = ('Failed to enable interface {0!r} to '
+                                      'make changes'.format(name))
+                    return ret
+
+        errors = _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway)
+        if errors:
+            ret['result'] = False
+            ret['comment'] = ('The following SLS configuration errors were '
+                              'detected: {0}.'.format('. '.join(errors)))
+            return ret
+
+        cur = __salt__['ip.get_interface'](name)
+        if not cur:
+            ret['result'] = False
+            ret['comment'] = ('Unable to get current configuration for '
+                              'interface {0!r}'.format(name))
+            return ret
+
+        changes = _changes(cur,
+                           dns_proto,
+                           dns_servers,
+                           ip_proto,
+                           ip_addrs,
+                           gateway)
+        if not changes:
+            return ret
+
+        if __opts__['test']:
+            comments = []
+            if 'dns_proto' in changes:
+                comments.append('DNS protocol will be changed to: {0}.'
+                                .format(changes['dns_proto']))
+            if dns_proto == 'static' and 'dns_servers' in changes:
+                comments.append(
+                    'DNS servers will be set to the following: {0}.'
+                    .format(', '.join(changes['dns_servers']))
+                )
+            if 'ip_proto' in changes:
+                comments.append('IP protocol will be changed to: {0}.'
+                                .format(changes['ip_proto']))
+            if ip_proto == 'static':
+                if 'ip_addrs' in changes:
+                    comments.append(
+                        'IP addresses will be set to the following: {0}.'
+                        .format(', '.join(changes['ip_addrs']))
+                    )
+                if 'gateway' in changes:
+                    if changes['gateway'] is None:
+                        comments.append('Default gateway will be removed.')
+                    else:
+                        comments.append(
+                            'Default gateway will be set to {0}.'
+                            .format(changes['gateway'])
+                        )
+
+            ret['result'] = None
+            ret['comment'] = ('The following changes will be made to '
+                              'interface {0!r}: {1}.'
+                              .format(name, ' '.join(comments)))
+            return ret
+
+        if changes.get('dns_proto') is not None:
+            if changes.get('dns_proto') == 'dhcp':
+                __salt__['ip.set_dhcp_dns'](name)
+            else:
+                if changes.get('dns_servers'):
+                    __salt__['ip.set_static_dns'](name,
+                                                  *changes['dns_servers'])
+
+        if changes.get('ip_proto') is not None:
+            if changes.get('ip_proto') == 'dhcp':
+                __salt__['ip.set_dhcp_ip'](name)
+            else:
+                if changes.get('ip_addrs'):
+                    for idx in xrange(len(changes['ip_addrs'])):
+                        if idx == 0:
+                            __salt__['ip.set_static_ip'](
+                                name,
+                                changes['ip_addrs'][idx],
+                                gateway=gateway
+                            )
+                        else:
+                            __salt__['ip.set_static_ip'](
+                                name,
+                                changes['ip_addrs'][idx],
+                                gateway=None,
+                                append=True
+                            )
+
+        new = __salt__['ip.get_interface'](name)
+        ret['changes'] = salt.utils.compare_dicts(old, new)
+        if _changes(new, dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
+            ret['result'] = False
+            ret['comment'] = ('Failed to set desired configuration settings '
+                              'for interface {0!r}'.format(name))
+        else:
+            ret['comment'] = ('Successfully updated configuration for '
+                              'interface {0!r}'.format(name))
+        return ret

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -63,7 +63,7 @@ import logging
 
 # Import salt libs
 import salt.utils
-import salt.utils.network
+import salt.utils.validate.net
 
 # Set up logging
 log = logging.getLogger(__name__)
@@ -108,7 +108,7 @@ def _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
             )
         else:
             bad_ips = [x for x in dns_servers
-                       if not salt.utils.network.valid_ipv4(x)]
+                       if not salt.utils.validate.net.ipv4_addr(x)]
             if bad_ips:
                 errors.append('Invalid DNS server IPs: {0}.'
                               .format(', '.join(bad_ips)))
@@ -136,14 +136,14 @@ def _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
             )
         else:
             bad_ips = [x for x in ip_addrs
-                       if not salt.utils.network.valid_ipv4(x)]
+                       if not salt.utils.validate.net.ipv4_addr(x)]
             if bad_ips:
                 errors.append('The following static IPs are invalid: '
                               '{0}.'.format(', '.join(bad_ips)))
 
             # Validate default gateway
             if gateway is not None:
-                if not salt.utils.network.valid_ipv4(gateway):
+                if not salt.utils.validate.net.ipv4_addr(gateway):
                     errors.append('Gateway IP {0} is invalid.'.format(gateway))
 
     return errors

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -39,7 +39,9 @@ Static DNS and IP addresses can be configured like so:
 .. note::
 
     IP addresses are specified using the format
-    ``<ip-address>/<subnet-length>``.
+    ``<ip-address>/<subnet-length>``. Salt provides a convenience function
+    called :mod:`ip.get_subnet_length <salt.modules.win_ip.get_subnet_length>`
+    to calculate the subnet length from a netmask.
 
 Optionally, if you are setting a static IP address, you can also specify the
 default gateway using the ``gateway`` parameter:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1620,6 +1620,28 @@ def compare_versions(ver1='', oper='==', ver2='', cmp_func=None):
         return cmp_result in cmp_map[oper]
 
 
+def compare_dicts(old=None, new=None):
+    '''
+    Compare before and after results from various salt functions, returning a
+    dict describing the changes that were made.
+    '''
+    ret = {}
+    for key in set((new or {}).keys()).union((old or {}).keys()):
+        if key not in old:
+            # New key
+            ret[key] = {'old': '',
+                        'new': new[key]}
+        elif key not in new:
+            # Key removed
+            ret[key] = {'new': '',
+                        'old': old[key]}
+        elif new[key] != old[key]:
+            # Key modified
+            ret[key] = {'old': old[key],
+                        'new': new[key]}
+    return ret
+
+
 def argspec_report(functions, module=''):
     '''
     Pass in a functions dict as it is returned from the loader and return the

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -568,40 +568,6 @@ def ip_addrs6(interface=None, include_loopback=False):
     return sorted(list(ret))
 
 
-def valid_ipv4(addr):
-    '''
-    Returns True if the IP address (and optional subnet) are valid, otherwise
-    returns False.
-    '''
-    try:
-        if '/' not in addr:
-            addr += '/32'
-    except TypeError:
-        return False
-
-    ip, subnet_len = addr.rsplit('/', 1)
-
-    # Verify that IP address is valid
-    try:
-        socket.inet_aton(ip)
-    except socket.error:
-        return False
-    else:
-        if len(ip.split('.')) != 4:
-            return False
-
-    # Verify that subnet length is valid
-    try:
-        subnet_len = int(subnet_len)
-    except ValueError:
-        return False
-    else:
-        if not 1 <= subnet_len <= 32:
-            return False
-
-    return True
-
-
 def hex2ip(hex_ip):
     '''
     Convert a hex string to an ip, if a failure occurs the original hex is

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -86,10 +86,17 @@ def ip_to_host(ip):
 # pylint: enable=C0103
 
 
-def _cidr_to_ipv4_netmask(cidr_bits):
+def cidr_to_ipv4_netmask(cidr_bits):
     '''
     Returns an IPv4 netmask
     '''
+    try:
+        cidr_bits = int(cidr_bits)
+        if not 1 <= cidr_bits <= 32:
+            return ''
+    except ValueError:
+        return ''
+
     netmask = ''
     for idx in range(4):
         if idx:
@@ -109,7 +116,7 @@ def _number_of_set_bits_to_ipv4_netmask(set_bits):  # pylint: disable=C0103
 
     Ex. 0xffffff00 -> '255.255.255.0'
     '''
-    return _cidr_to_ipv4_netmask(_number_of_set_bits(set_bits))
+    return cidr_to_ipv4_netmask(_number_of_set_bits(set_bits))
 
 
 # pylint: disable=C0103
@@ -148,7 +155,7 @@ def _interfaces_ip(out):
             cidr = 32
 
         if type_ == 'inet':
-            mask = _cidr_to_ipv4_netmask(int(cidr))
+            mask = cidr_to_ipv4_netmask(int(cidr))
             if 'brd' in cols:
                 brd = cols[cols.index('brd') + 1]
         elif type_ == 'inet6':

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -561,6 +561,40 @@ def ip_addrs6(interface=None, include_loopback=False):
     return sorted(list(ret))
 
 
+def valid_ipv4(addr):
+    '''
+    Returns True if the IP address (and optional subnet) are valid, otherwise
+    returns False.
+    '''
+    try:
+        if '/' not in addr:
+            addr += '/32'
+    except TypeError:
+        return False
+
+    ip, subnet_len = addr.rsplit('/', 1)
+
+    # Verify that IP address is valid
+    try:
+        socket.inet_aton(ip)
+    except socket.error:
+        return False
+    else:
+        if len(ip.split('.')) != 4:
+            return False
+
+    # Verify that subnet length is valid
+    try:
+        subnet_len = int(subnet_len)
+    except ValueError:
+        return False
+    else:
+        if not 1 <= subnet_len <= 32:
+            return False
+
+    return True
+
+
 def hex2ip(hex_ip):
     '''
     Convert a hex string to an ip, if a failure occurs the original hex is

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -423,7 +423,7 @@ def interfaces():
         return linux_interfaces()
 
 
-def _get_net_start(ipaddr, netmask):
+def get_net_start(ipaddr, netmask):
     ipaddr_octets = ipaddr.split('.')
     netmask_octets = netmask.split('.')
     net_start_octets = [str(int(ipaddr_octets[x]) & int(netmask_octets[x]))
@@ -431,16 +431,16 @@ def _get_net_start(ipaddr, netmask):
     return '.'.join(net_start_octets)
 
 
-def _get_net_size(mask):
+def get_net_size(mask):
     binary_str = ''
     for octet in mask.split('.'):
         binary_str += bin(int(octet))[2:].zfill(8)
     return len(binary_str.rstrip('0'))
 
 
-def _calculate_subnet(ipaddr, netmask):
-    return '{0}/{1}'.format(_get_net_start(ipaddr, netmask),
-                            _get_net_size(netmask))
+def calculate_subnet(ipaddr, netmask):
+    return '{0}/{1}'.format(get_net_start(ipaddr, netmask),
+                            get_net_size(netmask))
 
 
 def _ipv4_to_bits(ipaddr):
@@ -469,7 +469,7 @@ def subnets():
         for ipv4 in ipv4_info.get('inet', []):
             if ipv4['address'] == '127.0.0.1':
                 continue
-            network = _calculate_subnet(ipv4['address'], ipv4['netmask'])
+            network = calculate_subnet(ipv4['address'], ipv4['netmask'])
             subnetworks.append(network)
     return subnetworks
 

--- a/salt/utils/validate/net.py
+++ b/salt/utils/validate/net.py
@@ -18,3 +18,37 @@ def mac(addr):
                       ''',
                       re.VERBOSE | re.IGNORECASE)
     return valid.match(addr) is not None
+
+
+def ipv4_addr(addr):
+    '''
+    Returns True if the IP address (and optional subnet) are valid, otherwise
+    returns False.
+    '''
+    try:
+        if '/' not in addr:
+            addr += '/32'
+    except TypeError:
+        return False
+
+    ip, subnet_len = addr.rsplit('/', 1)
+
+    # Verify that IP address is valid
+    try:
+        socket.inet_aton(ip)
+    except socket.error:
+        return False
+    else:
+        if len(ip.split('.')) != 4:
+            return False
+
+    # Verify that subnet length is valid
+    try:
+        subnet_len = int(subnet_len)
+    except ValueError:
+        return False
+    else:
+        if not 1 <= subnet_len <= 32:
+            return False
+
+    return True

--- a/salt/utils/validate/net.py
+++ b/salt/utils/validate/net.py
@@ -5,6 +5,10 @@ Various network validation utilities
 
 # Import python libs
 import re
+import socket
+
+# Import salt libs
+from salt._compat import string_types
 
 
 def mac(addr):
@@ -52,3 +56,17 @@ def ipv4_addr(addr):
             return False
 
     return True
+
+
+def netmask(mask):
+    '''
+    Returns True if the value passed is a valid netmask, otherwise return False
+    '''
+    if not isinstance(mask, string_types):
+        return False
+
+    octets = mask.split('.')
+    if not len(octets) == 4:
+        return False
+
+    return ipv4_addr(mask) and octets == sorted(octets, reverse=True)


### PR DESCRIPTION
This pull request does the following:
1. Adds a state module for management of network interfaces.
2. Enhances the `win_network` execution module to support multiple IP addresses on a single interface, and adds several new functions.
3. Moves the `find_changes` function from the `pkg_resource` execution module to within `salt.utils`, allowing it to be used to compare changes to the network interface configuration. (refs from the pkg providers have also been updated to reflect this).
