### PR TITLE
Fixed wrong include statement behavior

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1975,7 +1975,7 @@ class BaseHighState(object):
 
                     if env_key != xenv_key:
                         # Resolve inc_sls in the specified environment
-                        if env_key in matches and fnmatch.filter(self.avail[env_key], inc_sls):
+                        if env_key in matches or fnmatch.filter(self.avail[env_key], inc_sls):
                             resolved_envs = [env_key]
                         else:
                             resolved_envs = []


### PR DESCRIPTION
Right now I can't include a state from other environment in `include` statement:

```
include:
  - base: test
```

It gives the output:

```
[DEBUG   ] Results of YAML rendering:
OrderedDict([('include', [OrderedDict([('base', 'test')])])])
[CRITICAL] Unknown include: Specified SLS base: test is not available on the salt master in environment(s): base
```

As i investigated, rendering fails because of wrong condition.
Switching `and` with `or` resolves the problem (as i see).
