### PR TITLE
Use non-zero timeout in mine.update method and don't ignore exceptions.

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -73,11 +73,8 @@ def update(clear=False):
             'tok': auth.gen_token('salt'),
     }
     sreq = salt.payload.SREQ(__opts__['master_uri'])
-    try:
-        sreq.send('aes', auth.crypticle.dumps(load), 1, 0)
-    except Exception:
-        pass
-    return True
+    ret = sreq.send('aes', auth.crypticle.dumps(load))
+    return auth.crypticle.loads(ret)
 
 
 def send(func, *args, **kwargs):
@@ -119,11 +116,8 @@ def send(func, *args, **kwargs):
             'tok': auth.gen_token('salt'),
     }
     sreq = salt.payload.SREQ(__opts__['master_uri'])
-    try:
-        sreq.send('aes', auth.crypticle.dumps(load), 1, 10)
-    except Exception:
-        return True
-    return True
+    ret = sreq.send('aes', auth.crypticle.dumps(load))
+    return auth.crypticle.loads(ret)
 
 
 def get(tgt, fun, expr_form='glob'):

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -64,6 +64,13 @@ def update(clear=False):
             log.error('Function {0} in mine_functions failed to execute'
                       .format(func))
             continue
+    if __opts__['file_client'] == 'local':
+        if not clear:
+            old = __salt__['data.getval']('mine_cache')
+            if isinstance(old, dict):
+                old.update(data)
+                data = old
+        return __salt__['data.update']('mine_cache', data)
     auth = _auth()
     load = {
             'cmd': '_mine',
@@ -108,6 +115,12 @@ def send(func, *args, **kwargs):
         log.error('Function {0} in mine.send failed to execute: {1}'
                   .format(func, exc))
         return False
+    if __opts__['file_client'] == 'local':
+        old = __salt__['data.getval']('mine_cache')
+        if isinstance(old, dict):
+            old.update(data)
+            data = old
+        return __salt__['data.update']('mine_cache', data)
     auth = _auth()
     load = {
             'cmd': '_mine',
@@ -142,6 +155,21 @@ def get(tgt, fun, expr_form='glob'):
     if expr_form.lower == 'pillar':
         log.error('Pillar matching not supported on mine.get')
         return ''
+    if __opts__['file_client'] == 'local':
+        ret = {}
+        is_target = {'glob': __salt__['match.glob'],
+                     'pcre': __salt__['match.pcre'],
+                     'list': __salt__['match.list'],
+                     'grain': __salt__['match.grain'],
+                     'grain_pcre': __salt__['match.grain_pcre'],
+                     'compound': __salt__['match.compound'],
+                     'ipcidr': __salt__['match.ipcidr'],
+                     }[expr_form](tgt)
+        if is_target:
+            data = __salt__['data.getval']('mine_cache')
+            if isinstance(data, dict) and fun in data:
+                ret[__opts__['id']] = data[fun]
+        return ret
     auth = _auth()
     load = {
             'cmd': '_mine_get',
@@ -166,6 +194,11 @@ def delete(fun):
 
         salt '*' mine.delete 'network.interfaces'
     '''
+    if __opts__['file_client'] == 'local':
+        data = __salt__['data.getval']('mine_cache')
+        if isinstance(data, dict) and fun in data:
+            del data[fun]
+        return __salt__['data.update']('mine_cache', data)
     auth = _auth()
     load = {
             'cmd': '_mine_delete',
@@ -188,6 +221,8 @@ def flush():
 
         salt '*' mine.flush
     '''
+    if __opts__['file_client'] == 'local':
+        return __salt__['data.update']('mine_cache', {})
     auth = _auth()
     load = {
             'cmd': '_mine_flush',


### PR DESCRIPTION
Timeout in mine.update method was set to 0 which doesn't mean no timeout.
As a result update might not work on loaded systems or slow network.
Also timeout exception was silently ignored.
Now sreq.send() is used in the same way as in other methods.
