### PR TITLE
Fix for Linux gpus grain, issue #6945

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -159,7 +159,9 @@ def _linux_gpu_data():
 
         cur_dev = {}
         error = False
-        for line in lspci_out.splitlines():
+        lspci_list = lspci_out.splitlines()
+        lspci_list.append('')
+        for line in lspci_list:
             # check for record-separating empty lines
             if line == '':
                 if cur_dev.get('Class', '') == 'VGA compatible controller':

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -159,6 +159,8 @@ def _linux_gpu_data():
 
         cur_dev = {}
         error = False
+        # Add a blank element to the lspci_out.splitlines() list,
+        # otherwise the last device is not evaluated as a cur_dev and ignored.
         lspci_list = lspci_out.splitlines()
         lspci_list.append('')
         for line in lspci_list:


### PR DESCRIPTION
Fixes issue #6945.
There is probably a much better way to do this but this is a quick and easy fix which doesn't require rewriting all the logic in this function. Append a blank string onto the list created by lspci_out.splitlines() so that the code for identifying devices doesn't ignore the last device from the lspci output.
