### PR TITLE
Fix kwargs containing dashes

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -160,6 +160,8 @@ def parse_args_and_kwargs(func, args, data=None):
         # this function accepts **kwargs, pack in the publish data
         for key, val in data.items():
             kwargs['__pub_{0}'.format(key)] = val
+    log.debug('Parsed args: {0}'.format(_args))
+    log.debug('Parsed kwargs: {0}'.format(kwargs))
     return _args, kwargs
 
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -100,8 +100,8 @@ DEFAULT_COLOR = '\033[00m'
 RED_BOLD = '\033[01;31m'
 ENDC = '\033[0m'
 
-#KWARG_REGEX = re.compile(r'^([^\d\W]\w*)=(.*)$', re.UNICODE) # python 3
-KWARG_REGEX = re.compile(r'^([^\d\W]\w*)=(.*)$')
+#KWARG_REGEX = re.compile(r'^([^\d\W][\w-]*)=(.*)$', re.UNICODE) # python 3
+KWARG_REGEX = re.compile(r'^([^\d\W][\w-]*)=(.*)$')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Kwargs containing dashes were not being correctly parsed. This pull request fixes this, and makes some improvements to the quota.set function, in addition to adding some debug logging to the code in minion.py that handles argument parsing.

Fixes #8102.
