### PR TITLE
Allow noarch packages to be found for yum installation.

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -393,14 +393,14 @@ def check_db(*names, **kwargs):
         pkgname, pkgarch = _pkg_arch(name)
         ret.setdefault(name, {})['found'] = bool(
             [x for x in yumbase.searchPackages(('name', 'arch'), (pkgname,))
-             if x.name == pkgname and x.arch == pkgarch]
+             if x.name == pkgname and x.arch in (pkgarch, 'noarch')]
         )
         if ret[name]['found'] is False:
             provides = [
                 x for x in yumbase.whatProvides(
                     pkgname, None, None
                 ).returnPackages()
-                if x.arch == pkgarch
+                if x.arch in (pkgarch, 'noarch')
             ]
             if provides:
                 for pkg in provides:


### PR DESCRIPTION
I'm attempting to install a number of "noarch" packages via a Salt state, such as Python-based packages via EPEL. Because their architecture doesn't exactly match my minon's architecture (eg 'noarch' vs 'x86_64'), the yumpkg `check_db` function determines that nothing can be found.  This pull request modifies the architecture check, as 'noarch' packages are installable on any architecture type. 

My Salt states are like this:

```
supervisor:
    pkg.installed
```

with the underlying package named something like `supervisor-2.1-3.el6.noarch`.  The `yumpkg` module check fails to find this package (at https://github.com/saltstack/salt/blob/develop/salt/modules/yumpkg.py#L396) because the conditional statement only checks for an exact architecture match.

Separately, I discovered from reading the code I could use `supervisor.noarch` as the package name, but the call to `yum.searchPackages` (https://github.com/saltstack/salt/blob/develop/salt/modules/yumpkg.py#L395) returns nothing  using this as the full package name.  Seemingly the format of `packagename.architecture` isn't supported here as nothing is returned by the underlying yum module.  

This change appears to be the most sensible to solve this issue.
