### PR TITLE
Ensure that the variable candidate is referenced

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -180,6 +180,7 @@ def latest_version(*names, **kwargs):
         if isinstance(repo, list):
             cmd = cmd + repo
         out = __salt__['cmd.run_all'](cmd, python_shell=False)
+        candidate = ''
         for line in out['stdout'].splitlines():
             if 'Candidate' in line:
                 candidate = line.split()


### PR DESCRIPTION
If package doesn't exist it would return exception. 

```
Traceback (most recent call last):
  File "/usr/local/bin/salt-call", line 9, in <module>
    load_entry_point('salt==0.17.1', 'console_scripts', 'salt-call')()
  File "/usr/local/salt/virtualenv/lib/python2.7/site-packages/salt/scripts.py", line 77, in salt_call
    client.run()
  File "/usr/local/salt/virtualenv/lib/python2.7/site-packages/salt/cli/__init__.py", line 303, in run
    caller.run()
  File "/usr/local/salt/virtualenv/lib/python2.7/site-packages/salt/cli/caller.py", line 135, in run
    ret = self.call()
  File "/usr/local/salt/virtualenv/lib/python2.7/site-packages/salt/cli/caller.py", line 78, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/local/salt/virtualenv/lib/python2.7/site-packages/salt/modules/apt.py", line 182, in latest_version
    if len(candidate) >= 2:
UnboundLocalError: local variable 'candidate' referenced before assignment
```
