### PR TITLE
Fix setting rabbitmq users tags and permissions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -23,6 +23,7 @@ Developers
 
 Aaron Bull Schaefer <aaron@elasticdog.com>
 Aaron Toponce <aaron.toponce@gmail.com>
+Andre Sachs <andre@sachs.nom.za>
 Andrew Kuhnhausen <trane@errstr.com>
 Antti Kaihola <akaihol+github@ambitone.com>
 archme <archme.mail@gmail.com>

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -253,7 +253,8 @@ def set_user_tags(name, tags, runas=None):
     res = __salt__['cmd.run'](
         'rabbitmqctl set_user_tags {0} {1}'.format(name, tags),
         runas=runas)
-    return [r.split('\t') for r in res.splitlines()]
+    msg = "Tag(s) set"
+    return _format_response(res,msg)
 
 
 def status(user=None):

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -50,7 +50,7 @@ def present(name,
         If user exists, forcibly change the password
     tags
         Optionally set user tags for user
-    permissions
+    perms
         A list of dicts with vhost keys and 3-tuple values
     runas
         Name of the user to run the command
@@ -81,9 +81,10 @@ def present(name,
             if tags:
                 result = __salt__['rabbitmq.set_user_tags'](
                     name, tags, runas=runas)
-            for vhost, perm in perms:
-                result = __salt__['rabbitmq.set_permissions'](
-                    vhost, name, perm[0], perm[1], perm[2], runas)
+            for element in perms:
+                for vhost, perm in element.items():
+                    result = __salt__['rabbitmq.set_permissions'](
+                        vhost, name, perm[0], perm[1], perm[2], runas)
         elif force:
             log.debug('User exists and force is set - Overriding')
             if password is not None:
@@ -97,10 +98,11 @@ def present(name,
                 result.update(__salt__['rabbitmq.set_user_tags'](
                     name, tags, runas=runas)
                 )
-            for vhost, perm in perms:
-                result.update(__salt__['rabbitmq.set_permissions'](
-                    vhost, name, perm[0], perm[1], perm[2], runas)
-                )
+            for element in perms:
+                for vhost, perm in element.items():
+                    result.update(__salt__['rabbitmq.set_permissions'](
+                        vhost, name, perm[0], perm[1], perm[2], runas)
+                    )
         else:
             log.debug('User exists, and force is not set - Abandoning')
             ret['comment'] = 'User {0} is not going to be modified'.format(name)


### PR DESCRIPTION
Fix a the return from setting a rabbitmq users tag, this was failing religiously due to the lack of tabs in the output.
Fix the documentation for the perms attribute (was permissions).
Fix the perms handling, as it is a list of dicts that is called in.
