### PR TITLE
Check if tok exists before use

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -50,7 +50,7 @@ import salt.utils.event
 import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
-from salt.utils.debug import enable_sigusr1_handler
+from salt.utils.debug import enable_sigusr1_handler, inspect_function
 from salt.exceptions import SaltMasterError, MasterExit
 from salt.utils.event import tagify
 
@@ -830,6 +830,15 @@ class AESFuncs(object):
             return {}
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return {}
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
+            return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
@@ -918,6 +927,15 @@ class AESFuncs(object):
         '''
         if any(key not in load for key in ('id', 'tgt', 'fun')):
             return {}
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
+            return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
@@ -969,6 +987,15 @@ class AESFuncs(object):
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return False
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
+            return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
@@ -1001,6 +1028,15 @@ class AESFuncs(object):
         if 'id' not in load or 'fun' not in load:
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
+            return False
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
             return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!
@@ -1036,6 +1072,15 @@ class AESFuncs(object):
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return False
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
+            return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!
             # We don't want to listen to it!
@@ -1070,6 +1115,15 @@ class AESFuncs(object):
             # Can overwrite master files!!
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
+            return False
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
             return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!
@@ -1138,6 +1192,15 @@ class AESFuncs(object):
         if 'id' not in load:
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
+            return False
+        if 'tok' not in load:
+            log.error(
+                'Received incomplete call from {0} for {1!r}, missing {2!r}'
+                .format(
+                    load['id'],
+                    inspect_stack()['co_name'],
+                    'tok'
+                ))
             return False
         if not self.__verify_minion(load['id'], load['tok']):
             # The minion is not who it says it is!

--- a/salt/master.py
+++ b/salt/master.py
@@ -50,7 +50,7 @@ import salt.utils.event
 import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
-from salt.utils.debug import enable_sigusr1_handler, inspect_function
+from salt.utils.debug import enable_sigusr1_handler, inspect_stack
 from salt.exceptions import SaltMasterError, MasterExit
 from salt.utils.event import tagify
 

--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -10,6 +10,7 @@ import time
 import signal
 import tempfile
 import traceback
+import inspect
 
 # Import salt libs
 import salt.utils
@@ -50,3 +51,10 @@ def enable_sigusr1_handler():
     #  SIGUSR1 doesn't exist on Windows and causes the minion to crash
     if not salt.utils.is_windows():
         signal.signal(signal.SIGUSR1, _handle_sigusr1)
+
+
+def inspect_stack():
+    '''
+    Return a string of which function we are currently in.
+    '''
+    return {'co_name': inspect.stack()[1][3]}


### PR DESCRIPTION
The problem is described in #8078 and was introduced in 151759b.

I am not super happy with the solution here. It seems that checks for
required `load` keys are done differently all over master.py. The reason
why I choose to check for `tok` separately was to be able to pinpoint
which minions have not been upgraded to 0.17.1.

Moving forward the checks for `id`, `data`, `tgt`, `fun`, etc could be
logged the same way, if appropriate.
