### PR TITLE
Add warning about Debian/Ubuntu augeas packaging bug

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -2,7 +2,26 @@
 '''
 Manages configuration files via augeas
 
-:strong:`NOTE:` This state requires the ``augeas`` Python module.
+This module requires the ``augeas`` Python module.
+
+.. _Augeas: http://augeas.net/
+
+.. warning::
+
+    Minimal installations of Debian and Ubuntu have been seen to have packaging
+    bugs with python-augeas, causing the augeas module to fail to import. If
+    the minion has the augeas module installed, but the functions in this
+    execution module fail to run due to being unavailable, first restart the
+    salt-minion service. If the problem persists past that, the following
+    command can be run from the master to determine what is causing the import
+    to fail:
+
+    .. code-block:: bash
+
+        salt minion-id cmd.run 'python -c "from augeas import Augeas"'
+
+    For affected Debian/Ubuntu hosts, installing ``libpython2.7`` has been
+    known to resolve the issue.
 '''
 
 # Import python libs

--- a/salt/states/augeas.py
+++ b/salt/states/augeas.py
@@ -3,7 +3,7 @@
 Configuration management using Augeas
 =====================================
 
-:strong:`NOTE:` This state requires the ``augeas`` Python module.
+This state requires the ``augeas`` Python module.
 
 .. _Augeas: http://augeas.net/
 
@@ -11,31 +11,49 @@ Augeas_ can be used to manage configuration files. Currently only the ``set``
 command is supported via this state. The :mod:`augeas
 <salt.modules.augeas_cfg>` module also has support for get, match, remove, etc.
 
-Examples:
+.. warning::
 
-Set the first entry in ``/etc/hosts`` to ``localhost``:
+    Minimal installations of Debian and Ubuntu have been seen to have packaging
+    bugs with python-augeas, causing the augeas module to fail to import. If
+    the minion has the augeas module installed, and the state fails with a
+    comment saying that the state is unavailable, first restart the salt-minion
+    service. If the problem persists past that, the following command can be
+    run from the master to determine what is causing the import to fail:
 
-.. code-block:: yaml
+    .. code-block:: bash
 
-    hosts:
-      augeas.setvalue:
-        - changes:
-          - /files/etc/hosts/1/canonical: localhost
+        salt minion-id cmd.run 'python -c "from augeas import Augeas"'
 
-Add a new host to ``/etc/hosts`` with the IP address ``192.168.1.1`` and
-hostname ``test``:
+    For affected Debian/Ubuntu hosts, installing ``libpython2.7`` has been
+    known to resolve the issue.
 
-.. code-block:: yaml
 
-    hosts:
-      augeas.setvalue:
-        - changes:
-          - /files/etc/hosts/2/ipaddr: 192.168.1.1
-          - /files/etc/hosts/2/canonical: foo.bar.com
-          - /files/etc/hosts/2/alias[1]: foosite
-          - /files/etc/hosts/2/alias[2]: foo
+Usage examples:
 
-You can also set a prefix if you want to avoid redundancy:
+1. Set the first entry in ``/etc/hosts`` to ``localhost``:
+
+   .. code-block:: yaml
+
+        hosts:
+          augeas.setvalue:
+            - changes:
+              - /files/etc/hosts/1/canonical: localhost
+
+2. Add a new host to ``/etc/hosts`` with the IP address ``192.168.1.1`` and
+   hostname ``test``:
+
+   .. code-block:: yaml
+
+        hosts:
+          augeas.setvalue:
+            - changes:
+              - /files/etc/hosts/2/ipaddr: 192.168.1.1
+              - /files/etc/hosts/2/canonical: foo.bar.com
+              - /files/etc/hosts/2/alias[1]: foosite
+              - /files/etc/hosts/2/alias[2]: foo
+
+
+A prefix can also be set, to avoid redundancy:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
This adds a warning to the docstrings for both the augeas state and
execution module, explaining the issue discovered in #6082. For more
information, see the comments here: https://github.com/saltstack/salt/issues/6082#issuecomment-27234356
