### PR TITLE
Fix pkg.latest regression in apt

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -163,7 +163,7 @@ def latest_version(*names, **kwargs):
     for name in names:
         ret[name] = ''
     pkgs = list_pkgs(versions_as_list=True)
-    repo = ['-o', 'APT::Default-Release={0!r}'.format(fromrepo)] \
+    repo = ['-o', 'APT::Default-Release={0}'.format(fromrepo)] \
         if fromrepo else ''
 
     # Refresh before looking for the latest version available
@@ -1139,8 +1139,8 @@ def mod_repo(repo, **kwargs):
             if not imported:
                 cmd = ('apt-key adv --keyserver {0} --logger-fd 1 '
                        '--recv-keys {1}')
-                ret= __salt__['cmd.run_all'](cmd.format(ks, keyid),
-                                             **kwargs)
+                ret = __salt__['cmd.run_all'](cmd.format(ks, keyid),
+                                              **kwargs)
                 if ret['retcode'] != 0:
                     error_str = 'Error: key retrieval failed: {0}'
                     raise Exception(error_str.format(ret['stdout']))


### PR DESCRIPTION
The recent changes to disable the use of shell=True in cmd.run\* calls
mean that the repo argument no longer needs to be quoted.

Fixes #8067.
