### PR TITLE
Add 'email' and 'email.mime.*' to all esky builds

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -358,7 +358,9 @@ FREEZER_INCLUDES = [
     'M2Crypto',
     'Cookie',
     'asyncore',
-    'fileinput'
+    'fileinput',
+    'email',
+    'email.mime.*',
 ]
 
 if IS_WINDOWS_PLATFORM:
@@ -370,17 +372,7 @@ if IS_WINDOWS_PLATFORM:
         'ntsecuritycon',
         '_winreg',
         'wmi',
-        'fileinput',
         'site',
-        'email',
-        'email.mime.audio',
-        'email.mime.base',
-        'email.mime.image',
-        'email.mime.message',
-        'email.mime.multipart',
-        'email.mime.nonmultipart',
-        'email.mime.text',
-        'email.mime.application',
     ])
     SETUP_KWARGS['install_requires'].append('WMI')
 elif sys.platform.startswith('linux'):


### PR DESCRIPTION
Fixes "ImportError: No module named audio" on SmartOS

Uses 'email.mime.*' rather than a full list of entries.

Also removes a duplicate entry for 'fileinput' from the
windows section that was added to the main FREEZER_INCLUDES

Email thread that suggested this fix:
https://groups.google.com/forum/#!msg/salt-users/_9ynHspSgjk/so0hRdbaPM0J

Tested as a fix to a 0.17.1 checkout on SmartOS.
