### PR TITLE
Work around windows multiprocessing bug

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -238,7 +238,8 @@ def highstate(test=None, queue=False, **kwargs):
         if conflict:
             __context__['retcode'] = 1
             return conflict
-    opts = copy.copy(__opts__)
+    orig_test = __opts__.get('test', None)
+    opts = copy.deepcopy(__opts__)
 
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
@@ -282,6 +283,9 @@ def highstate(test=None, queue=False, **kwargs):
         log.error(msg.format(cache_file))
     os.umask(cumask)
     _set_retcode(ret)
+    # Work around Windows multiprocessing bug, set __opts__['test'] back to
+    # value from before this function was run.
+    __opts__['test'] = orig_test
     return ret
 
 
@@ -310,7 +314,8 @@ def sls(mods, env='base', test=None, exclude=None, queue=False, **kwargs):
         err = ['Pillar failed to render with the following messages:']
         err += __pillar__['_errors']
         return err
-    opts = copy.copy(__opts__)
+    orig_test = __opts__.get('test', None)
+    opts = copy.deepcopy(__opts__)
 
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
@@ -371,6 +376,9 @@ def sls(mods, env='base', test=None, exclude=None, queue=False, **kwargs):
         log.error(msg.format(cache_file))
     os.umask(cumask)
     _set_retcode(ret)
+    # Work around Windows multiprocessing bug, set __opts__['test'] back to
+    # value from before this function was run.
+    __opts__['test'] = orig_test
     with salt.utils.fopen(cfn, 'w+') as fp_:
         try:
             serial.dump(high_, fp_)
@@ -404,11 +412,13 @@ def top(topfn, test=None, queue=False, **kwargs):
         err = ['Pillar failed to render with the following messages:']
         err += __pillar__['_errors']
         return err
+    orig_test = __opts__.get('test', None)
+    opts = copy.deepcopy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):
-        __opts__['test'] = True
+        opts['test'] = True
     else:
-        __opts__['test'] = __opts__.get('test', None)
-    st_ = salt.state.HighState(__opts__)
+        opts['test'] = __opts__.get('test', None)
+    st_ = salt.state.HighState(opts)
     st_.push_active()
     st_.opts['state_top'] = os.path.join('salt://', topfn)
     try:
@@ -420,6 +430,9 @@ def top(topfn, test=None, queue=False, **kwargs):
     finally:
         st_.pop_active()
     _set_retcode(ret)
+    # Work around Windows multiprocessing bug, set __opts__['test'] back to
+    # value from before this function was run.
+    __opts__['test'] = orig_test
     return ret
 
 
@@ -494,7 +507,8 @@ def show_low_sls(mods, env='base', test=None, queue=False, **kwargs):
         if conflict:
             __context__['retcode'] = 1
             return conflict
-    opts = copy.copy(__opts__)
+    orig_test = __opts__.get('test', None)
+    opts = copy.deepcopy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
     else:
@@ -511,7 +525,11 @@ def show_low_sls(mods, env='base', test=None, queue=False, **kwargs):
     if errors:
         __context__['retcode'] = 1
         return errors
-    return st_.state.compile_high_data(high_)
+    ret = st_.state.compile_high_data(high_)
+    # Work around Windows multiprocessing bug, set __opts__['test'] back to
+    # value from before this function was run.
+    __opts__['test'] = orig_test
+    return ret
 
 
 def show_sls(mods, env='base', test=None, queue=False, **kwargs):
@@ -532,7 +550,8 @@ def show_sls(mods, env='base', test=None, queue=False, **kwargs):
         if conflict:
             __context__['retcode'] = 1
             return conflict
-    opts = copy.copy(__opts__)
+    orig_test = __opts__.get('test', None)
+    opts = copy.deepcopy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
     else:
@@ -546,6 +565,9 @@ def show_sls(mods, env='base', test=None, queue=False, **kwargs):
     finally:
         st_.pop_active()
     errors += st_.state.verify_high(high_)
+    # Work around Windows multiprocessing bug, set __opts__['test'] back to
+    # value from before this function was run.
+    __opts__['test'] = orig_test
     if errors:
         __context__['retcode'] = 1
         return errors
@@ -612,7 +634,8 @@ def single(fun, name, test=None, queue=False, **kwargs):
                    'fun': comps[1],
                    '__id__': name,
                    'name': name})
-    opts = copy.copy(__opts__)
+    orig_test = __opts__.get('test', None)
+    opts = copy.deepcopy(__opts__)
     if salt.utils.test_mode(test=test, **kwargs):
         opts['test'] = True
     else:
@@ -626,6 +649,9 @@ def single(fun, name, test=None, queue=False, **kwargs):
     ret = {'{0[state]}_|-{0[__id__]}_|-{0[name]}_|-{0[fun]}'.format(kwargs):
             st_.call(kwargs)}
     _set_retcode(ret)
+    # Work around Windows multiprocessing bug, set __opts__['test'] back to
+    # value from before this function was run.
+    __opts__['test'] = orig_test
     return ret
 
 


### PR DESCRIPTION
Set **opts**['test'] back to it's prior value at the end of the various
functions in salt.modules.state which use it.

Fixes #7714.
