### PR TITLE
Don't even try to parse a version string if it's not a **Salt** git checkout

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -368,6 +368,10 @@ def __get_version(version, version_info):
             os.path.dirname(inspect.getsourcefile(__get_version))
         )
 
+    if not os.path.exists(os.path.join(os.path.dirname(cwd), '.git')):
+        # This is not a Salt git checkout!!! Don't even try to parse...
+        return version, version_info
+
     try:
         kwargs = dict(
             stdout=subprocess.PIPE,


### PR DESCRIPTION
Fixes #8090
