### PR TITLE
fix 'OrderedDict' object has no attribute 'append' stack trace in _handle_iorder in case of syntax error

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2093,6 +2093,9 @@ class BaseHighState(object):
                                 if arg.keys()[0] == 'order':
                                     found = True
                     if not found:
+                        if not isinstance(state[name][s_dec], list):
+                            # quite certainly a syntax error, managed elsewhere
+                            continue
                         state[name][s_dec].append(
                                 {'order': self.iorder}
                                 )


### PR DESCRIPTION
This should fix #8114 and #7905
