### PR TITLE
Change the check for git rev-parse to fail if the SHA is not found. Refs...

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -212,7 +212,7 @@ def latest(name,
                                           identity=identity)
                 elif rev:
 
-                    cmd = "git rev-parse " + rev
+                    cmd = "git rev-parse " + rev + '^{commit}'
                     retcode = __salt__['cmd.retcode'](cmd,
                                                       cwd=target,
                                                       runas=user)


### PR DESCRIPTION
... #8163.

Hat tip to @basepi. 
