### PR TITLE
ddns: ensure name is str

### DIFF
--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -153,6 +153,7 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1'):
 
         salt ns1 ddns.delete example.com host1 A
     '''
+    name = str(name)
     fqdn = '{}.{}'.format(name, zone)
     request = dns.message.make_query(fqdn, (rdtype or 'ANY'))
 


### PR DESCRIPTION
For some reverse zones, name gets passed in as an int. This ensures that the name param is a str.
