### PR TITLE
libevent-dev required to pip install gevent

### DIFF
--- a/doc/topics/tutorials/halite.rst
+++ b/doc/topics/tutorials/halite.rst
@@ -80,6 +80,7 @@ On Debian based distributions:
 
     $ apt-get install gcc
     $ apt-get install python-dev
+    $ apt-get install libevent-dev
     $ pip install gevent
 
 


### PR DESCRIPTION
When following the tutorial this package was missed and caused setup.py install for gevent to fail.
