### PR TITLE
Make newly-added repo available to pkg states

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -418,6 +418,11 @@ def installed(
     if not isinstance(version, basestring) and version is not None:
         version = str(version)
 
+    if salt.utils.is_true(refresh) or os.path.isfile(rtag):
+        __salt__['pkg.refresh_db']()
+        if os.path.isfile(rtag):
+            os.remove(rtag)
+
     result = _find_install_targets(name, version, pkgs, sources,
                                    fromrepo=fromrepo, **kwargs)
     try:
@@ -449,26 +454,14 @@ def installed(
                 'comment': comment}
 
     comment = []
-    if salt.utils.is_true(refresh) or os.path.isfile(rtag):
-        pkg_ret = __salt__['pkg.install'](name,
-                                          refresh=True,
-                                          version=version,
-                                          fromrepo=fromrepo,
-                                          skip_verify=skip_verify,
-                                          pkgs=pkgs,
-                                          sources=sources,
-                                          **kwargs)
-        if os.path.isfile(rtag):
-            os.remove(rtag)
-    else:
-        pkg_ret = __salt__['pkg.install'](name,
-                                          refresh=False,
-                                          version=version,
-                                          fromrepo=fromrepo,
-                                          skip_verify=skip_verify,
-                                          pkgs=pkgs,
-                                          sources=sources,
-                                          **kwargs)
+    pkg_ret = __salt__['pkg.install'](name,
+                                      refresh=False,
+                                      version=version,
+                                      fromrepo=fromrepo,
+                                      skip_verify=skip_verify,
+                                      pkgs=pkgs,
+                                      sources=sources,
+                                      **kwargs)
     if isinstance(pkg_ret, dict):
         changes = pkg_ret
     elif isinstance(pkg_ret, basestring):


### PR DESCRIPTION
If a package is added using a pkgrepo.managed state, and a pkg.installed
state needs access to this newly-added repo, it will not be able to find
the package since the pkg.refresh_db happens in the call to pkg.install
(just prior to the package installation), and not when the package
targets are initially looked for. This commit adds a pkg.refresh_db
before the targets are checked, and then supresses the refresh_db when
the package is actually installed (because at that point, it would be
redundant).

Fixes #8156.
