### PR TITLE
Fixed wrong condition

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -336,7 +336,7 @@ def _run(cmd,
             kwargs['executable'] = shell
         kwargs['close_fds'] = True
 
-    if not os.path.isabs(cwd) or not os.path.isdir(cwd):
+    if not (os.path.isabs(cwd) or os.path.isdir(cwd)):
         raise CommandExecutionError(
             'Specified cwd {0!r} either not absolute or does not exist'
             .format(cwd)


### PR DESCRIPTION
<b>$ cat test.sls</b>

```
testing cmd.run with cwd .:
  cmd.run:
    - name: echo $PWD
    - cwd: .
```

<b>$ salt-call state.sls test -l debug</b>

```
[DEBUG   ] Rendered data from file: /var/cache/salt/minion/files/base/test.sls:
testing cmd.run with cwd .:
  cmd.run:
    - name: echo $PWD
    - cwd: .

[DEBUG   ] Results of YAML rendering: 
OrderedDict([('testing cmd.run with cwd .', OrderedDict([('cmd.run', [OrderedDict([('name', 'echo $PWD')]), OrderedDict([('cwd', '.')])])]))])
[INFO    ] Executing state cmd.run for echo $PWD
[INFO    ] Executing command 'echo $PWD' in directory '.'
[ERROR   ] Specified cwd '.' either not absolute or does not exist
[DEBUG   ] loading output in ['/var/cache/salt/minion/extmods/output', '/usr/lib/python2.6/dist-packages/salt/output']
[DEBUG   ] Skipping /var/cache/salt/minion/extmods/output, it is not a directory
[DEBUG   ] Loaded no_out as virtual quiet
[DEBUG   ] Loaded json_out as virtual json
[DEBUG   ] Loaded yaml_out as virtual yaml
[DEBUG   ] Loaded pprint_out as virtual pprint
local:
----------
    State: - cmd
    Name:      echo $PWD
    Function:  run
        Result:    False
        Comment:   Specified cwd '.' either not absolute or does not exist
        Changes:   

Summary
------------
Succeeded: 0
Failed:    1
------------
Total:     1
```

It appears because of wrong conditional statement:
<b>$ python</b>

```
Python 2.6.6 (r266:84292, Dec 26 2010, 22:31:48) 
[GCC 4.4.5] on linux2
Type "help", "copyright", "credits" or "license" for more information.
>>> import os
>>> not os.path.isabs('.') or not os.path.isdir('.')
True
>>> not (os.path.isabs('.') or os.path.isdir('.'))
False
```
