### PR TITLE
Improve error reporting from verify_files

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -161,11 +161,17 @@ def verify_files(files, user):
         sys.exit(2)
     for fn_ in files:
         dirname = os.path.dirname(fn_)
-        if not os.path.isdir(dirname):
-            os.makedirs(dirname)
-        if not os.path.isfile(fn_):
-            with salt.utils.fopen(fn_, 'w+') as fp_:
-                fp_.write('')
+        try:
+            if not os.path.isdir(dirname):
+                os.makedirs(dirname)
+            if not os.path.isfile(fn_):
+                with salt.utils.fopen(fn_, 'w+') as fp_:
+                    fp_.write('')
+        except OSError as err:
+            msg = 'Failed to create path "{0}" - {1}\n'
+            sys.stderr.write(msg.format(fn_, err))
+            sys.exit(err.errno)
+
         stats = os.stat(fn_)
         if uid != stats.st_uid:
             try:


### PR DESCRIPTION
Make it similar to what verify_env already does, so that
we tell people exactly which path was a problem.  I hit this
while running salt-master in a non-standard configuration, and
the change makes it easier to hunt down which path is wrong
in a config.
