### PR TITLE
Workaround bug in yum python API

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -23,6 +23,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 # Import third party libs
 try:
@@ -785,6 +786,13 @@ def remove(name=None, pkgs=None, **kwargs):
         else:
             arch = None
         yumbase.remove(name=target, arch=arch)
+
+    log.info('Performing transaction test')
+    try:
+        callback = yum.callbacks.ProcessTransNoOutputCallback()
+        result = yumbase._doTestTransaction(callback)
+    except yum.Errors.YumRPMCheckError as exc:
+        raise CommandExecutionError('\n'.join(exc.__dict__['value']))
 
     log.info('Resolving dependencies')
     yumbase.resolveDeps()

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -40,6 +40,7 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 from salt.modules.pkg_resource import _repack_pkgs
 
 if salt.utils.is_windows():
@@ -818,7 +819,13 @@ def removed(name, pkgs=None, **kwargs):
 
     .. versionadded:: 0.16.0
     '''
-    return _uninstall(action='remove', name=name, pkgs=pkgs, **kwargs)
+    try:
+        return _uninstall(action='remove', name=name, pkgs=pkgs, **kwargs)
+    except CommandExecutionError as exc:
+        return {'name': name,
+                'changes': {},
+                'result': False,
+                'comment': str(exc)}
 
 
 def purged(name, pkgs=None, **kwargs):
@@ -838,7 +845,13 @@ def purged(name, pkgs=None, **kwargs):
 
     .. versionadded:: 0.16.0
     '''
-    return _uninstall(action='purge', name=name, pkgs=pkgs, **kwargs)
+    try:
+        return _uninstall(action='purge', name=name, pkgs=pkgs, **kwargs)
+    except CommandExecutionError as exc:
+        return {'name': name,
+                'changes': {},
+                'result': False,
+                'comment': str(exc)}
 
 
 def mod_init(low):


### PR DESCRIPTION
This works around a bug in the yum python API where removal of packages
that are required by other packages results in the removal of those
packages as well, and does not raise an exception when errors are
encountered during the transaction test, causing all packages to be
removed.

This commit manually performs the transaction test, and raises an
exception if any errors are found. It also adds a try/except to the
pkg.removed and pkg.purged states which catches the exception and
gracefully returns False without a traceback.

See https://github.com/saltstack/salt/issues/8201 for more information.

Fixes #8201.
