### PR TITLE
Track mine processes, fixes #5729

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -870,7 +870,9 @@ def apply_minion_config(overrides=None,
             '__mine_interval':
             {
                 'function': 'mine.update',
-                'minutes': opts['mine_interval']
+                'minutes': opts['mine_interval'],
+                'jid_include' : True,
+                'maxrunning' : 2
             }
         })
     return opts

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -213,6 +213,8 @@ class SMinion(object):
         # module
         opts['grains'] = salt.loader.grains(opts)
         self.opts = opts
+
+        # Clean out the proc directory (default /var/cache/salt/minion/proc)
         if self.opts.get('file_client', 'remote') == 'remote':
             if isinstance(self.opts['master'], list):
                 masters = self.opts['master']
@@ -233,6 +235,7 @@ class SMinion(object):
                 self.gen_modules()
         else:
             self.gen_modules()
+
 
     def gen_modules(self):
         '''

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -19,6 +19,7 @@ import sys
 import salt.payload
 import salt.state
 import salt.client
+import salt.utils
 from salt.exceptions import SaltReqTimeoutError
 from salt._compat import string_types
 
@@ -28,6 +29,13 @@ try:
     HAS_ESKY = True
 except ImportError:
     HAS_ESKY = False
+
+if salt.utils.is_windows():
+    try:
+        import wmi
+        HAS_WMI = True
+    except ImportError:
+        HAS_WMI = False
 
 log = logging.getLogger(__name__)
 
@@ -379,7 +387,8 @@ def running():
 
         salt '*' saltutil.running
     '''
-    procs = __salt__['status.procs']()
+
+
     ret = []
     serial = salt.payload.Serial(__opts__)
     pid = os.getpid()
@@ -400,7 +409,7 @@ def running():
         if not isinstance(data, dict):
             # Invalid serial object
             continue
-        if not procs.get(str(data['pid'])):
+        if not _os_is_running(data['pid']):
             # The process is no longer running, clear out the file and
             # continue
             os.remove(path)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -30,13 +30,6 @@ try:
 except ImportError:
     HAS_ESKY = False
 
-if salt.utils.is_windows():
-    try:
-        import wmi
-        HAS_WMI = True
-    except ImportError:
-        HAS_WMI = False
-
 log = logging.getLogger(__name__)
 
 
@@ -409,7 +402,7 @@ def running():
         if not isinstance(data, dict):
             # Invalid serial object
             continue
-        if not _os_is_running(data['pid']):
+        if not salt.util.process.os_is_running(data['pid']):
             # The process is no longer running, clear out the file and
             # continue
             os.remove(path)

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -201,3 +201,5 @@ def _walk_through(job_dir):
             job = serial.load(salt.utils.fopen(load_path, 'rb'))
             jid = job['jid']
             yield jid, job, t_path, final
+
+

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -6,10 +6,17 @@ import signal
 import time
 import sys
 
-# Import salt libs
+# import salt libs
 import salt.utils
 
 log = logging.getLogger(__name__)
+
+HAS_PSUTIL = False
+try:
+    import psutil
+    HAS_PSUTIL = True
+except ImportError:
+    pass
 
 
 def set_pidfile(pidfile, user):
@@ -88,3 +95,17 @@ def clean_proc(proc, wait_for_kill=10):
         # Catch AttributeError when the process dies between proc.is_alive()
         # and proc.terminate() and turns into a NoneType
         pass
+
+def os_is_running(pid):
+    '''
+    Use OS facilities to determine if a process is running
+    '''
+    if HAS_PSUTIL:
+        return psutil.pid_exists(pid)
+    else:
+        try:
+            os.kill(pid, 0) # SIG 0 is the "are you alive?" signal
+            return True
+        except OSError:
+            return False
+

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -71,7 +71,7 @@ class Schedule(object):
                'fun': func,
                'jid': '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())}
         salt.utils.daemonize_if(self.opts)
-        if 'jid_include' in self.opts and self.opts['jid_include'] is True:
+        if 'jid_include' in data and data['jid_include']:
             log.info("XXX adding this job to the jobcache")
             # write this to /var/cache/salt/minion/proc
 
@@ -169,7 +169,8 @@ class Schedule(object):
             else:
                 log.debug('Running scheduled job: {0}'.format(job))
 
-            if 'jid_include' in self.opts:
+
+            if 'jid_include' in data:
                 log.info("XXX This job was scheduled with jid_include, adding to cache")
                 if 'maxrunning' in self.opts:
                     log.info("XXX This job was scheduled with a max number of {}".format(self.opts['maxrunning']))

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -249,7 +249,7 @@ def clean_proc_dir(opts):
             job = salt.payload.Serial(opts).load(fp_)
             log.debug('schedule.clean_proc_dir: checking job {} for process existence'.format(job))
             if 'pid' in job:
-                if salt.utils.process.os_is_running(pid):
+                if salt.utils.process.os_is_running(job['pid']):
                     log.debug('schedule.clean_proc_dir: Cleaning proc dir, pid {0} still exists.'.format(job['pid']))
                 else:
                     # Windows cannot delete an open file

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -71,6 +71,9 @@ class Schedule(object):
                'fun': func,
                'jid': '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())}
         salt.utils.daemonize_if(self.opts)
+        if 'jid_include' in self.opts and self.opts['jid_include'] is True:
+            log.info("adding this job to the jobcache")
+            # write this to /var/cache/salt/minion/proc
 
         args = None
         if 'args' in data:
@@ -165,6 +168,15 @@ class Schedule(object):
                 continue
             else:
                 log.debug('Running scheduled job: {0}'.format(job))
+
+            if 'jid_include' in self.opts:
+                log.info("This job was scheduled with jid_include, adding to cache")
+                if 'maxrunning' in self.opts:
+                    log.info("This job was scheduled with a max number of {}".format(self.opts['maxrunning']))
+                    # search jobcache for this process
+                    # if there are more than maxrunning, log info and return
+                    # else
+                    # continue
 
             if self.opts.get('multiprocessing', True):
                 thread_cls = multiprocessing.Process

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -72,7 +72,7 @@ class Schedule(object):
                'jid': '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())}
         salt.utils.daemonize_if(self.opts)
         if 'jid_include' in self.opts and self.opts['jid_include'] is True:
-            log.info("adding this job to the jobcache")
+            log.info("XXX adding this job to the jobcache")
             # write this to /var/cache/salt/minion/proc
 
         args = None
@@ -170,9 +170,9 @@ class Schedule(object):
                 log.debug('Running scheduled job: {0}'.format(job))
 
             if 'jid_include' in self.opts:
-                log.info("This job was scheduled with jid_include, adding to cache")
+                log.info("XXX This job was scheduled with jid_include, adding to cache")
                 if 'maxrunning' in self.opts:
-                    log.info("This job was scheduled with a max number of {}".format(self.opts['maxrunning']))
+                    log.info("XXX This job was scheduled with a max number of {}".format(self.opts['maxrunning']))
                     # search jobcache for this process
                     # if there are more than maxrunning, log info and return
                     # else

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -451,3 +451,5 @@ def valid_id(opts, id_):
     Returns if the passed id is valid
     '''
     return bool(clean_path(opts['pki_dir'], id_))
+
+


### PR DESCRIPTION
This pull request adds support for scheduled jobs being added to the /var/cache/salt/minion/procs directory so we can keep track of them and prevent too many of the same process from being started at the same time.  It also includes a small performance optimization for listing processes--in one case in the code we don't need to grab a list of all the processes and check against each one--we only need to know if the process we care about is still running.
@thatch : you probably want to look at this somewhat closely.

This fixes #5729.
