### PR TITLE
Make ambiguous or unknown includes failhard always

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2061,8 +2061,7 @@ class BaseHighState(object):
                                             inc_sls,
                                             ', '.join(resolved_envs))
                         log.critical(msg)
-                        if self.opts['failhard']:
-                            errors.append(msg)
+                        errors.append(msg)
                 self._handle_iorder(state)
         else:
             state = {}


### PR DESCRIPTION
NOTE:  @thatch45 should probably be the one to merge this.

This is an opinionated change.  In my opinion, if you try to include an SLS that doesn't exist, or use an ambiguous include, it should abort the state run.  The `failhard` option is designed to fail hard when a state fails and not execute the remainder.  However, in this case, the state doesn't exist, and this could have unintended consequences.  I can definitely see the argument for not wanting to set `failhard` to `True`, but still wanting it to fail if you try to include an unknown state.

If we don't want to always fail on unknown includes, then I would argue for another option, similar to `failhard`, but which only fails when includes fail, not when states return `False`.  `failhard` is too broad for this case.  (again, in my opinion)

Fixes #8093
