### PR TITLE
fixed typo in rpm module documentation

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -141,9 +141,9 @@ def file_dict(*packages):
 
     CLI Examples::
 
-        salt '*' lowpkg.file_list httpd
-        salt '*' lowpkg.file_list httpd postfix
-        salt '*' lowpkg.file_list
+        salt '*' lowpkg.file_dict httpd
+        salt '*' lowpkg.file_dict httpd postfix
+        salt '*' lowpkg.file_dict
     '''
     errors = []
     ret = {}


### PR DESCRIPTION
Noticed a typo in the rpm module docs. This should correct it.
