### PR TITLE
State git.latest's "ls-remote" step uses the specified SSH key

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -843,3 +843,35 @@ def config_get(cwd, setting_name, user=None):
     _check_git()
 
     return _git_run('git config {0}'.format(setting_name), cwd=cwd, runas=user)
+
+
+def ls_remote(cwd, repository="origin", branch="master", user=None, identity=None):
+    '''
+    Returns the upstream hash for any given URL and branch.
+
+    cwd
+        The path to the Git repository
+
+    repository: origin
+        The name of the repository to get the revision from. Can be the name of
+        a remote, an URL, etc.
+
+    branch: master
+        The name of the branch to get the revision from.
+
+    user : none
+        run git as a user other than what the minion runs as
+
+    identity : none
+        a path to a private key to use over ssh
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' git.ls_remote /pat/to/repo origin master
+
+    '''
+    _check_git()
+    cmd = "git ls-remote -h " + repository + " " + branch + " | cut -f 1"
+    return _git_run(cmd, cwd=cwd, runas=user, identity=identity)

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -33,14 +33,6 @@ def __virtual__():
     return 'git' if __salt__['cmd.has_exec']('git') else False
 
 
-def __ls_remote__(name, branch, user, cwd):
-    '''
-    Returns the upstream hash for any given URL and branch.
-    '''
-    cmd = "git ls-remote -h " + name + " " + branch + " | cut -f 1"
-    return __salt__['cmd.run_stdout'](cmd, cwd, runas=user)
-
-
 def latest(name,
            rev=None,
            target=None,
@@ -173,7 +165,10 @@ def latest(name,
             # We're only interested in the remote branch if a branch
             # (instead of a hash, for example) was provided for rev.
             if len(branch) > 0 and branch == rev:
-                remote_rev = __ls_remote__(name, branch, user, target)
+                remote_rev = __salt__['git.ls_remote'](target,
+                                                       repository=name,
+                                                       branch=branch, user=user,
+                                                       identity=identity)
 
             # only do something, if the specified rev differs from the
             # current_rev and remote_rev


### PR DESCRIPTION
This is a fix for #8094

It moves the `__ls_remote__` out of the `git` Salt's state module to the `git` Salt's module so it can profit from the SSH wrapper there.

Previously, the `__ls_remote__` function wasn't implementing the full `git.latest` parameters and in particular, wasn't using the `identity` setting which caused #8094.

I believe the `ls_remote` function has little interest in itself in the Git module, but it seemed the best to reuse the SSH wrapper from `salt.modules.git`.
