### PR TITLE
Allow SmartOS to use the smf module

### DIFF
--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -16,6 +16,7 @@ def __virtual__():
     # Don't let this work on Solaris 9 since SMF doesn't exist on it.
     enable = set((
         'Solaris',
+        'SmartOS',
     ))
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Solaris' and __grains__['kernelrelease'] == "5.9":


### PR DESCRIPTION
Cherry-picked from develop to get SMF support working on SmartOS for 0.17.2
