### PR TITLE
Avoid hiding error context in VCS pip install.

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -179,6 +179,8 @@ def installed(name,
         ret.setdefault('warnings', []).append(msg)
         name = repo
 
+    from_vcs = False
+
     if name:
         try:
             try:
@@ -196,6 +198,7 @@ def installed(name,
                 if name.startswith(supported_vcs):
                     for vcs in supported_vcs:
                         if name.startswith(vcs):
+                            from_vcs = True
                             install_req = pip.req.InstallRequirement.from_line(
                                 name.split('{0}+'.format(vcs))[-1]
                             )
@@ -204,7 +207,7 @@ def installed(name,
                     install_req = pip.req.InstallRequirement.from_line(name)
         except ValueError as exc:
             ret['result'] = False
-            if '=' in name and '==' not in name:
+            if not from_vcs and '=' in name and '==' not in name:
                 ret['comment'] = (
                     'Invalid version specification in package {0}. \'=\' is '
                     'not supported, use \'==\' instead.'.format(name)


### PR DESCRIPTION
When an error happens while trying to install a pip package from a VCS, like
git, if there's an '=' in the name, the error handling logic tried to be
clever and give a better error message, but that logic doesn't apply to VCS
names, which can legitimately have a single equal sign. So, in that case
report the original error message.
