### PR TITLE
Fix bug preventing minions from unloading custom modules.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -871,9 +871,12 @@ class Loader(object):
         # the available modules and inject the special __salt__ namespace that
         # contains these functions.
         for mod in modules:
-            if not hasattr(mod, '__salt__'):
+            if not hasattr(mod, '__salt__') or (
+                not in_pack(pack, '__salt__') and
+                not str(mod.__name__).startswith('salt.loaded.int.grain')
+            ):
                 mod.__salt__ = funcs
-            elif not in_pack(pack, '__salt__'):
+            elif not in_pack(pack, '__salt__') and str(mod.__name__).startswith('salt.loaded.int.grain'):
                 mod.__salt__.update(funcs)
         return funcs
 


### PR DESCRIPTION
DO NOT BLINDLY MERGE.

@thatch45 Please review. I think this should resolve the issue but it does change how the loader operates to a certain extent so I'd like you to take a peek and make sure I'm not causing regressions here.

This change no longer blindly updates the **salt** dict for each module upon module refresh but instead rebuilds the dictionary from scratch. Refs #7691.
