### PR TITLE
Fix --output-file CLI argument

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -35,7 +35,7 @@ def display_output(data, out, opts=None):
     output_filename = opts.get('output_file', None)
     try:
         if output_filename is not None:
-            with salt.utils.fopen(output_filename, 'w') as ofh:
+            with salt.utils.fopen(output_filename, 'a') as ofh:
                 ofh.write(display_data)
                 ofh.write('\n')
             return

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -879,7 +879,7 @@ class OutputOptionsMixIn(object):
         if self.options.output_file is not None:
             if os.path.isfile(self.options.output_file):
                 try:
-                    utils.fopen(self.options.output_file, 'w').close()
+                    os.remove(self.options.output_file)
                 except (IOError, OSError) as exc:
                     self.error(
                         '{0}: Access denied: {1}'.format(

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -875,6 +875,19 @@ class OutputOptionsMixIn(object):
     def process_output(self):
         self.selected_output_option = self.options.output
 
+    def process_output_file(self):
+        if self.options.output_file is not None:
+            if os.path.isfile(self.options.output_file):
+                try:
+                    utils.fopen(self.options.output_file, 'w').close()
+                except (IOError, OSError) as exc:
+                    self.error(
+                        '{0}: Access denied: {1}'.format(
+                            self.options.output_file,
+                            exc
+                        )
+                    )
+
     def _mixin_after_parsed(self):
         group_options_selected = filter(
             lambda option: (


### PR DESCRIPTION
This commit fixes it so that the file in not overwritten each time a
minion returns information. Fixes #8205.
