### PR TITLE
salt-ssh opts

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -527,7 +527,8 @@ class Single(object):
                 self.opts,
                 self.id,
                 **self.target)
-            opts_pkg = pre_wrapper['test.opts_pkg']()
+            default_opts = pre_wrapper['test.opts_pkg']()
+            opts_pkg = dict(default_opts.items() + self.opts.items())
             pillar = salt.pillar.Pillar(
                     opts_pkg,
                     opts_pkg['grains'],


### PR DESCRIPTION
DO NOT BLINDLY MERGE

@thatch45 While this does address the concern raised in the issues below, I don't fully understand the reasoning behind test.opts_pkg. (I think it's possibly to avoid a chicken-and-egg problem but I'm not positive.) At any rate, please review this to ensure that this is the correct approach. There's every chance that you have more expansive plans for handling configuration options in salt-ssh that I just don't know about. This might be waaaay too simple, so I'd like you to look at it, please.

This is a two-line change that merges the user-defined options into SSH wrappers. It addresses concerns raised by users that that salt-ssh does not respect settings like file-roots when they are defined in a configuration file. Refs #8005 and #8271.
