### PR TITLE
Covering case where kwarg cannot be un-yaml'd

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -63,7 +63,7 @@ def condition_kwarg(arg, kwarg):
     if isinstance(kwarg, dict):
         kw_ = []
         for key, val in kwarg.items():
-            kw_.append('{0}={1}'.format(key, val))
+            kw_.append({'__kwarg__': True, key:val})
         return list(arg) + kw_
     return arg
 

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -61,10 +61,10 @@ def condition_kwarg(arg, kwarg):
     Return a single arg structure for the publisher to safely use
     '''
     if isinstance(kwarg, dict):
-        kw_ = []
+        kw_ = {'__kwarg__': True}
         for key, val in kwarg.items():
-            kw_.append({'__kwarg__': True, key:val})
-        return list(arg) + kw_
+            kw_[key] = val
+        return list(arg) + [kw_]
     return arg
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -146,6 +146,7 @@ def parse_args_and_kwargs(func, args, data=None):
     _args = []
     kwargs = {}
     for arg in args:
+        # support old yamlify syntax
         if isinstance(arg, string_types):
             arg_name, arg_value = salt.utils.parse_kwarg(arg)
             if arg_name:
@@ -155,6 +156,13 @@ def parse_args_and_kwargs(func, args, data=None):
             else:
                 # Not a kwarg
                 pass
+        # if the arg is a dict with __kwarg__ == True, then its a kwarg
+        elif isinstance(arg, dict) and arg.get('__kwarg__') is True:
+            for key, val in arg.iteritems():
+                if key == '__kwarg__':
+                    continue
+                kwargs[key] = val
+            continue
         _args.append(yamlify_arg(arg))
     if has_kwargs and isinstance(data, dict):
         # this function accepts **kwargs, pack in the publish data

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -185,6 +185,23 @@ def arg(*args, **kwargs):
     '''
     return {"args": args, "kwargs": kwargs}
 
+def arg_type(*args, **kwargs):
+    '''
+    Print out the types of the args and kwargs. This is used to test the types
+    of the args and kwargs passed down to the minion
+    '''
+    ret = {'args': [], 'kwargs':{}}
+    # all the args
+    for arg in args:
+        ret['args'].append(str(type(arg)))
+
+    # all the kwargs
+    for key, val in kwargs.iteritems():
+        ret['kwargs'][key] = str(type(val))
+
+    return ret
+
+
 
 def arg_repr(*args, **kwargs):
     '''

--- a/tests/integration/client/kwarg.py
+++ b/tests/integration/client/kwarg.py
@@ -87,6 +87,24 @@ class StdTest(integration.ModuleCase):
         self.assertEqual(data['ret']['baz'], 'quo')
         self.assertEqual(data['ret']['qux'], 'quux')
 
+    def test_kwarg_type(self):
+        '''
+        Test that kwargs end up on the client as the same type
+        '''
+        terrible_yaml_string = 'foo: ""\n# \''
+        ret = self.client.cmd_full_return(
+                'minion',
+                'test.arg_type',
+                ['a', 1],
+                kwarg={'outer': {'a': terrible_yaml_string},
+                       'inner': 'value'}
+                )
+        data = ret['minion']['ret']
+        self.assertIn('str', data['args'][0])
+        self.assertIn('int', data['args'][1])
+        self.assertIn('dict', data['kwargs']['outer'])
+        self.assertIn('str', data['kwargs']['inner'])
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
In the past the master has been taking the kwargs passed in and converting them to a string (kwy=value) and letting the minion de-yaml that arg string. In general this is okay, but it doesn't work well if you are calling from the python LocalClient interface-- since the kwarg you passed already had a type. With this change instead of converting the kwarg to a string it is converted to a dict with a flag to mark it as a kwarg dict, then it is unpacked on the minion side while still maintining type.

IMO we should parse out the YAML args on the master (never on the minion)-- that way all args on the minion side are already parsed and have a type. Bit confusing when you write code to pass data structures down and the transport messes it all up ;)
