### PR TITLE
Updated minion.rst with a note on verify env for issue 8281.

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -162,6 +162,13 @@ Verify and set permissions on configuration directories at startup.
 
     verify_env: True
 
+.. note::
+
+    When marked as True the verify_env option requires WRITE access to the 
+    configuration directory (/etc/salt/). In certain situations such as
+    mounting /etc/salt/ as read-only for templating this will create a
+    stack trace when state.highstate is called.
+
 .. conf_minion:: cache_jobs
 
 ``cache_jobs``


### PR DESCRIPTION
Just a quick note to provide some detail on verify_env and why you might see a stack trace with it enabled when the configuration dir is read only. https://github.com/saltstack/salt/issues/8281
