### PR TITLE
Use single quotes in cmd string to prevent shell expansion of passwords

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -125,7 +125,7 @@ class Shell(object):
         Return the string to execute ssh-copy-id
         '''
         if self.passwd and salt.utils.which('sshpass'):
-            return 'sshpass -p "{0}" {1} {2} "{3} -p {4} {5}@{6}"'.format(
+            return "sshpass -p '{0}' {1} {2} '{3} -p {4} {5}@{6}'".format(
                     self.passwd,
                     'ssh-copy-id',
                     '-i {0}.pub'.format(self.priv),
@@ -141,7 +141,7 @@ class Shell(object):
         have two commands
         '''
         if self.passwd and salt.utils.which('sshpass'):
-            return 'sshpass -p "{0}" {1} {2} {3} -p {4} {5}@{6}'.format(
+            return "sshpass -p '{0}' {1} {2} {3} -p {4} {5}@{6}".format(
                     self.passwd,
                     'ssh-copy-id',
                     '-i {0}.pub'.format(self.priv),


### PR DESCRIPTION
When salt-ssh asks for a password to deploy its key it fails if the password contains '$' because the generated shell command expands the '$' sign and the following characters as shell variable.

Using single quotes prevents shell expansion and passwords containig '$' signs work again.
