### PR TITLE
Added McAfee OS to rh_service

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -50,7 +50,8 @@ def __virtual__():
         'Fedora',
         'ALT',
         'OEL',
-        'SUSE  Enterprise Server'
+        'SUSE  Enterprise Server',
+        'McAfee  OS Server'
     ))
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -38,7 +38,8 @@ def __virtual__():
         'SUSE  Enterprise Server',
         'OEL',
         'Linaro',
-        'elementary OS'
+        'elementary OS',
+        'McAfee  OS Server'
     ))
     if __grains__.get('os', '') in disable:
         return False


### PR DESCRIPTION
McAfee OS is a rebranded from the RHEL family and uses the same init system.
