### PR TITLE
Default for filter_by method in module grains 

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -14,6 +14,7 @@ import yaml
 # Import salt libs
 import salt.utils
 import salt.utils.dictupdate
+from salt.exceptions import SaltException
 
 # Seed the grains dict so cython will build
 __grains__ = {}
@@ -287,7 +288,7 @@ def ls():  # pylint: disable=C0103
     return sorted(__grains__)
 
 
-def filter_by(lookup_dict, grain='os_family', merge=None):
+def filter_by(lookup_dict, grain='os_family', merge=None, default='default'):
     '''
     .. versionadded:: 0.17.0
 
@@ -303,6 +304,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None):
         {% set apache = salt['grains.filter_by']({
             'Debian': {'pkg': 'apache2', 'srv': 'apache2'},
             'RedHat': {'pkg': 'httpd', 'srv': 'httpd'},
+            'default': {'pkg': 'apache', 'srv': 'apache'},
         }) %}
 
         myapache:
@@ -347,17 +349,32 @@ def filter_by(lookup_dict, grain='os_family', merge=None):
         values for non-standard package names such as when using a different
         Python version from the default Python version provided by the OS
         (e.g., ``python26-mysql`` instead of ``python-mysql``).
+    :param default: default lookup_dict's key used if the grain does not exists
+         or if the grain value has no match on lookup_dict.
+         this parameter was added in version 0.17.2
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' grains.filter_by '{Debian: Debheads rule, RedHat: I love my hat}'
+        # this one will render {D: {E: I, G: H}, J: K}
+        salt '*' grains.filter_by '{A: B, C: {D: {E: F,G: H}}}' 'xxx' '{D: {E: I},J: K}' 'C'
     '''
-    ret = lookup_dict.get(__grains__[grain], None)
+    ret = lookup_dict.get( __grains__.get(grain, default), lookup_dict.get(default,None) )
 
     if merge:
-        salt.utils.dictupdate.update(ret, merge)
+
+        if not isinstance(merge, dict):
+            raise SaltException('filter_by merge argument must be a dictionnary.')
+
+        else:
+
+            if ret is None:
+                ret = merge
+
+            else:
+                salt.utils.dictupdate.update(ret, merge)
 
     return ret
 

--- a/tests/unit/modules/grains_test.py
+++ b/tests/unit/modules/grains_test.py
@@ -1,0 +1,97 @@
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+from salt.exceptions import SaltException
+from salt.modules import grains as grainsmod
+grainsmod.__grains__ = {
+  'os_family': 'MockedOS'
+}
+class GrainsModuleTestCase(TestCase):
+
+    def test_filter_by(self):
+        dict1={'A': 'B', 'C': {'D': {'E': 'F','G': 'H'}}}
+        mdict={'D': {'E': 'I'},'J': 'K'}
+
+        # test None result with non existent grain and no default
+        res=grainsmod.filter_by(dict1, grain='xxx')
+        self.assertIs(res,None)
+
+        # test None result with os_family grain and no matching result
+        res=grainsmod.filter_by(dict1)
+        self.assertIs(res,None)
+
+        # test with non existent grain, and a given default key
+        res=grainsmod.filter_by(dict1, grain='xxx', default='C')
+        self.assertEqual(res,{'D': {'E': 'F','G': 'H'}})
+
+        # add a merge dictionnary, F disapears
+        res=grainsmod.filter_by(dict1, grain='xxx', merge=mdict, default='C')
+        self.assertEqual(res,{'D': {'E': 'I','G': 'H'},'J': 'K'})
+        # dict1 was altered, restablish
+        dict1={'A': 'B', 'C': {'D': {'E': 'F','G': 'H'}}}
+
+        # default is not present in dict1, check we only have merge in result
+        res=grainsmod.filter_by(dict1, grain='xxx', merge=mdict, default='Z')
+        self.assertEqual(res,mdict)
+
+        # default is not present in dict1, and no merge, should get None
+        res=grainsmod.filter_by(dict1, grain='xxx', default='Z')
+        self.assertIs(res,None)
+
+        #test giving a list as merge argument raise exception
+        self.assertRaises(
+            SaltException,
+            grainsmod.filter_by,
+            dict1,
+            'xxx',
+            ['foo'],
+            'C'
+        )
+
+        #Now, re-test with an existing grain (os_family), but with no match.
+        res=grainsmod.filter_by(dict1)
+        self.assertIs(res,None)
+        res=grainsmod.filter_by(dict1, default='C')
+        self.assertEqual(res,{'D': {'E': 'F','G': 'H'}})
+        res=grainsmod.filter_by(dict1, merge=mdict, default='C')
+        self.assertEqual(res,{'D': {'E': 'I','G': 'H'},'J': 'K'})
+        # dict1 was altered, restablish
+        dict1={'A': 'B', 'C': {'D': {'E': 'F','G': 'H'}}}
+        res=grainsmod.filter_by(dict1, merge=mdict, default='Z')
+        self.assertEqual(res,mdict)
+        res=grainsmod.filter_by(dict1, default='Z')
+        self.assertIs(res,None)
+        # this one is in fact a traceback in updatedict, merging a string with a dictionnary
+        self.assertRaises(
+            TypeError,
+            grainsmod.filter_by,
+            dict1,
+            merge=mdict,
+            default='A'
+        )
+
+        #Now, re-test with a matching grain.
+        dict1={'A': 'B', 'MockedOS': {'D': {'E': 'F','G': 'H'}}}
+        res=grainsmod.filter_by(dict1)
+        self.assertEquals(res,{'D': {'E': 'F','G': 'H'}})
+        res=grainsmod.filter_by(dict1, default='A')
+        self.assertEquals(res,{'D': {'E': 'F','G': 'H'}})
+        res=grainsmod.filter_by(dict1, merge=mdict, default='A')
+        self.assertEqual(res,{'D': {'E': 'I','G': 'H'},'J': 'K'})
+        # dict1 was altered, restablish
+        dict1={'A': 'B', 'MockedOS': {'D': {'E': 'F','G': 'H'}}}
+        res=grainsmod.filter_by(dict1, merge=mdict, default='Z')
+        self.assertEqual(res,{'D': {'E': 'I', 'G': 'H'},'J': 'K'})
+        # dict1 was altered, restablish
+        dict1={'A': 'B', 'MockedOS': {'D': {'E': 'F','G': 'H'}}}
+        res=grainsmod.filter_by(dict1, default='Z')
+        self.assertEqual(res,{'D': {'E': 'F','G': 'H'}})
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(GrainsModuleTestCase, needs_daemon=False)


### PR DESCRIPTION
This is both a new feature (adding a default key handling in filter_by) so that you set some values in the dictionnary for two cases:
- when the grain is not present
- when the grain value as no matching case in the given dictionnary
  <pre>
  {% set apache = salt['grains.filter_by']({
            'Debian': {'pkg': 'apache2', 'srv': 'apache2'},
            'RedHat': {'pkg': 'httpd', 'srv': 'httpd'},
            'default': {'pkg': 'apache', 'srv': 'apache'},
        }) %}
  </pre>
  And it also feature an Exception when the merge dictionnary is not a dictionnary (very easy to make when using the pillar for merge data, easy to add a `-` and transform the dictionnary in list). Makina this error when using filter_by in jinja will not prevent a Stack Trace but the message will be easyier to understand I think.

In the current implementation if grain is not matched in the dictionnary or not present the result is always None (or a crash if you pass a merge dictionnary which try to merge with None)

Unit tests present.
