### PR TITLE
Fix regression in minion ID caching

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -688,13 +688,14 @@ def get_id(root_dir=None, minion_id=False):
         root_dir = syspaths.ROOT_DIR
 
     config_dir = syspaths.CONFIG_DIR
-    if config_dir.startswith(root_dir):
-        config_dir = config_dir.split(root_dir, 1)[-1]
+    if config_dir.startswith(syspaths.ROOT_DIR):
+        config_dir = config_dir.split(syspaths.ROOT_DIR, 1)[-1]
 
     # Check for cached minion ID
     id_cache = os.path.join(root_dir,
                             config_dir.lstrip('\\'),
                             'minion_id')
+
     try:
         with salt.utils.fopen(id_cache) as idf:
             name = idf.read().strip()


### PR DESCRIPTION
Some changes meant to fix minion ID caching in Windows caused a
regression in caching on *NIX OSes. This commit fixes that regression,
making minion ID caching work for all platforms.
