### PR TITLE
Take into account python types not just Yaml strings

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -652,7 +652,7 @@ class State(object):
             errors.append('Missing "fun" data')
         if 'name' not in data:
             errors.append('Missing "name" data')
-        if not isinstance(data['name'], string_types):
+        if data['name'] and not isinstance(data['name'], string_types):
             err = ('The name {0} in sls {1} is not formed as a '
                    'string but is a {2}').format(
                            data['name'], data['__sls__'], type(data['name']))

--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -22,7 +22,7 @@ import salt.utils
 
 _PKG_TARGETS = {
     'Arch': ['python2-django', 'finch'],
-    'Debian': ['python-plist', 'finch'],
+    'Debian': ['python-plist', 'apg'],
     'RedHat': ['xz-devel', 'zsh-html'],
     'FreeBSD': ['aalib', 'pth'],
     'Suse': ['aalib', 'finch']


### PR DESCRIPTION
- Install a smaller and with less dependencies package when testing the `pkg` state.
- Since salt is now able to pass real types and not just yaml, take that into account.

Refs the changes from #8289.
