### PR TITLE
Fix for matching minions under syndics

### DIFF
--- a/doc/ref/syndic.rst
+++ b/doc/ref/syndic.rst
@@ -48,3 +48,12 @@ starting the other Salt daemons.
 .. code-block:: bash
 
     # salt-syndic
+
+
+.. note::
+
+    If you have an exceptionally large infrastructure or many layers of
+    syndics, you may find that the CLI doesn't wait long enough for the syndics
+    to return their events.  If you think this is the case, you can set the
+    ``syndic_wait`` value in the upper master config.  The default value is
+    ``1``, and should work for the majority of deployments.

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1030,7 +1030,7 @@ class LocalClient(object):
         syndic_wait = 0
         while True:
             raw = self.event.get_event(timeout, jid)
-            if raw is not None and 'id' in raw:
+            if raw is not None:
                 if 'minions' in raw.get('data', {}):
                     minions.update(raw['data']['minions'])
                     continue

--- a/salt/config.py
+++ b/salt/config.py
@@ -168,6 +168,7 @@ VALID_OPTS = {
     'modules_max_memory': int,
     'grains_refresh_every': int,
     'enable_lspci': bool,
+    'syndic_wait': int,
 }
 
 # default configurations
@@ -361,6 +362,7 @@ DEFAULT_MASTER_OPTS = {
     'win_repo_mastercachefile': os.path.join(syspaths.BASE_FILE_ROOTS_DIR,
                                              'win', 'repo', 'winrepo.p'),
     'win_gitrepos': ['https://github.com/saltstack/salt-winrepo.git'],
+    'syndic_wait': 1,
 }
 
 


### PR DESCRIPTION
Fixes #7671

Equal credit to @cachedout, we found this one together.

Basically, because of the recent changes in the event system, we ended up filtering out certain events from the syndic -- specifically, the event that defined which minions matched the target below the syndic.  So it resulted in delays waiting for the syndic at best, and missed returns at worst.
