### PR TITLE
BUGFIX: pass env the right way, because when use os.env way, LC_ALL will always be overriden in modules/cmdmod.py

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -380,12 +380,6 @@ def install(name=None,
     if not fromrepo and repo:
         fromrepo = repo
 
-    if kwargs.get('env'):
-        try:
-            os.environ.update(kwargs.get('env'))
-        except Exception as e:
-            log.exception(e)
-
     old = list_pkgs()
 
     downgrade = False
@@ -428,7 +422,7 @@ def install(name=None,
         cmd.append('install')
         cmd.extend(targets)
 
-    __salt__['cmd.run_all'](cmd, python_shell=False)
+    __salt__['cmd.run_all'](cmd, env=kwargs.get('env'), python_shell=False)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return salt.utils.compare_dicts(old, new)
@@ -439,11 +433,6 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
     remove and purge do identical things but with different apt-get commands,
     this function performs the common logic.
     '''
-    if kwargs.get('env'):
-        try:
-            os.environ.update(kwargs.get('env'))
-        except Exception as e:
-            log.exception(e)
 
     pkg_params = __salt__['pkg_resource.parse_targets'](name, pkgs)[0]
     old = list_pkgs()
@@ -455,7 +444,7 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
         return {}
     cmd = ['apt-get', '-q', '-y', action]
     cmd.extend(targets)
-    __salt__['cmd.run_all'](cmd, python_shell=False)
+    __salt__['cmd.run_all'](cmd, env=kwargs.get('env'), python_shell=False)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     new_removed = list_pkgs(removed=True)


### PR DESCRIPTION
I got this bug when try to install postgresql with env LC_ALL
