### PR TITLE
halite tutorial change tls.create_ca_signed_cert to create_self_signed_...

### DIFF
--- a/doc/topics/tutorials/halite.rst
+++ b/doc/topics/tutorials/halite.rst
@@ -203,7 +203,7 @@ module:
 
 .. code-block:: bash
 
-    salt '*' tls.create_ca_signed_cert test localhost
+    salt '*' tls.create_self_signed_cert test 
 
 
 When using self-signed certs, browsers will need approval before accepting the


### PR DESCRIPTION
fix typo in halite tutorial.
