### PR TITLE
Implement #8333, passthrough some Jinja config variables.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -225,6 +225,19 @@
 # The renderer to use on the minions to render the state data
 #renderer: yaml_jinja
 
+# The Jinja renderer can strip extra carriage returns and whitespace
+# See http://jinja.pocoo.org/docs/api/#high-level-api
+#
+# If this is set to True the first newline after a Jinja block is removed
+# (block, not variable tag!). Defaults to False, corresponds to the Jinja
+# environment init variable "trim_blocks". 
+# jinja_trim_blocks: False
+#
+# If this is set to True leading spaces and tabs are stripped from the start
+# of a line to a block. Defaults to False, corresponds to the Jinja
+# environment init variable "lstrip_blocks".
+# jinja_lstrip_blocks: False
+
 # The failhard option tells the minions to stop immediately after the first
 # failure detected in the state execution, defaults to False
 #failhard: False

--- a/salt/config.py
+++ b/salt/config.py
@@ -169,6 +169,8 @@ VALID_OPTS = {
     'grains_refresh_every': int,
     'enable_lspci': bool,
     'syndic_wait': int,
+    'jinja_lstrip_blocks': bool,
+    'jinja_trim_blocks': bool,
 }
 
 # default configurations
@@ -363,6 +365,8 @@ DEFAULT_MASTER_OPTS = {
                                              'win', 'repo', 'winrepo.p'),
     'win_gitrepos': ['https://github.com/saltstack/salt-winrepo.git'],
     'syndic_wait': 1,
+    'jinja_lstrip_blocks': False,
+    'jinja_trim_blocks': False,
 }
 
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -923,6 +923,8 @@ class AESFuncs(object):
         mopts['nodegroups'] = self.opts['nodegroups']
         mopts['state_auto_order'] = self.opts['state_auto_order']
         mopts['state_events'] = self.opts['state_events']
+        mopts['jinja_lstrip_blocks'] = self.opts['jinja_lstrip_blocks']
+        mopts['jinja_trim_blocks'] = self.opts['jinja_trim_blocks']
         return mopts
 
     def _mine_get(self, load):

--- a/salt/state.py
+++ b/salt/state.py
@@ -1763,6 +1763,8 @@ class BaseHighState(object):
                     opts['state_auto_order'])
             opts['file_roots'] = mopts['file_roots']
             opts['state_events'] = mopts.get('state_events')
+            opts['jinja_lstrip_blocks'] = mopts.get('jinja_lstrip_blocks', False)
+            opts['jinja_trim_blocks'] = mopts.get('jinja_trim_blocks', False)
         return opts
 
     def _get_envs(self):

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -113,7 +113,6 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     loader = None
     newline = False
 
-
     if tmplstr and not isinstance(tmplstr, unicode):
         # http://jinja.pocoo.org/docs/api/#unicode
         tmplstr = tmplstr.decode(SLS_ENCODING)
@@ -146,13 +145,12 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     # Pass through trim_blocks and lstrip_blocks Jinja parameters
     # trim_blocks removes newlines around Jinja blocks
-    # lstrip_blocks strips tabs and spaces from the beginning of 
-    # line to the start of a block. 
-
-    if opts.get('pillar').get('master').get('jinja_trim_blocks'):
+    # lstrip_blocks strips tabs and spaces from the beginning of
+    # line to the start of a block.
+    if opts.get('jinja_trim_blocks', False):
         log.debug('Jinja2 trim_blocks is enabled')
         env_args['trim_blocks'] = True
-    if opts.get('pillar').get('master').get('jinja_lstrip_blocks'):
+    if opts.get('jinja_lstrip_blocks', False):
         log.debug('Jinja2 lstrip_blocks is enabled')
         env_args['lstrip_blocks'] = True
 
@@ -284,9 +282,9 @@ def get_template_context(template, line, num_lines=5, marker=None):
     if line > num_template_lines:
         return template
 
-    context_start = max(0, line - num_lines - 1)  # subtract 1 for 0-based indexing
+    context_start = max(0, line - num_lines - 1)  # subt 1 for 0-based indexing
     context_end = min(num_template_lines, line + num_lines)
-    error_line_in_context = line - context_start - 1  # subtract 1 for 0-based indexing
+    error_line_in_context = line - context_start - 1  # subtr 1 for 0-based idx
 
     buf = []
     if context_start > 0:

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -113,6 +113,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     loader = None
     newline = False
 
+
     if tmplstr and not isinstance(tmplstr, unicode):
         # http://jinja.pocoo.org/docs/api/#unicode
         tmplstr = tmplstr.decode(SLS_ENCODING)
@@ -142,6 +143,18 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
     if hasattr(jinja2.ext, 'loopcontrols'):
         env_args['extensions'].append('jinja2.ext.loopcontrols')
     env_args['extensions'].append(JinjaSerializerExtension)
+
+    # Pass through trim_blocks and lstrip_blocks Jinja parameters
+    # trim_blocks removes newlines around Jinja blocks
+    # lstrip_blocks strips tabs and spaces from the beginning of 
+    # line to the start of a block. 
+
+    if opts.get('pillar').get('master').get('jinja_trim_blocks'):
+        log.debug('Jinja2 trim_blocks is enabled')
+        env_args['trim_blocks'] = True
+    if opts.get('pillar').get('master').get('jinja_lstrip_blocks'):
+        log.debug('Jinja2 lstrip_blocks is enabled')
+        env_args['lstrip_blocks'] = True
 
     if opts.get('allow_undefined', False):
         jinja_env = jinja2.Environment(**env_args)


### PR DESCRIPTION
Add two config options to the salt-master config--"jinja_lstrip_blocks' and 'jinja_trim_blocks' so we can strip unnecessary newlines.  Implements #8333.
