### PR TITLE
Yaml render error fix

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -59,6 +59,19 @@ class MinionError(SaltException):
     '''
 
 
+class RenderError(SaltException):
+    '''
+    Problems rendering data
+    '''
+    def __init__(self, error, line_num, buf):
+        self.error = error
+        self.line_num = line_num
+        self.buffer = buf
+        SaltException.__init__(
+            self, 'Problem rendering data: {0}'.format(error)
+        )
+
+
 class SaltInvocationError(SaltException, TypeError):
     '''
     Used when the wrong number of arguments are sent to modules or invalid

--- a/salt/state.py
+++ b/salt/state.py
@@ -33,7 +33,8 @@ import salt.syspaths as syspaths
 from salt.utils import context
 from salt._compat import string_types
 from salt.template import compile_template, compile_template_str
-from salt.exceptions import SaltReqTimeoutError, SaltException
+from salt.utils.templates import get_template_context
+from salt.exceptions import RenderError, SaltReqTimeoutError, SaltException
 
 log = logging.getLogger(__name__)
 
@@ -1986,6 +1987,15 @@ class BaseHighState(object):
                 fn_, self.state.rend, self.state.opts['renderer'], env, sls,
                 rendered_sls=mods
             )
+        except RenderError as exc:
+            context = get_template_context(
+                exc.buffer,
+                exc.line_num,
+                marker='    <======================'
+            )
+            msg = 'Rendering SLS failed: {0}\n{1}'.format(exc.error, context)
+            log.critical(msg)
+            errors.append(msg)
         except Exception as exc:
             msg = 'Rendering SLS {0} failed, render error: {1}'.format(
                 sls, exc


### PR DESCRIPTION
This pull request does more graceful handling of yaml rendering errors, providing the context where the error occurred instead of simply displaying a traceback.

It adds a new exception class, `RenderError`.

Before adding this, indenting a yaml template using a tab instead of spaces would generate a long and cryptic traceback. With this new code, the same misconfigured yaml triggers the following error:

```
root@virtubuntu:~# salt virtubuntu state.sls test
virtubuntu:
    Data failed to compile:
----------
    Rendering SLS failed: Illegal tab character, line 5 of template

---
#include:
#       - test2

/tmp/test.txt:
        file.touch    <======================

---
```
