### PR TITLE
Updated docs to reflect salt-ssh requirement on msgpack

### DIFF
--- a/doc/topics/conventions/packaging.rst
+++ b/doc/topics/conventions/packaging.rst
@@ -183,6 +183,7 @@ Depends
 
 - `Salt Common`
 - `sshpass`
+- `Python MessagePack` (Messagepack C lib, or msgpack-pure)
 
 Salt Doc
 --------


### PR DESCRIPTION
Docs indicated that salt-ssh did not depend on msgpack. This seems not to be the case.

This PR updates the docs.
