### PR TITLE
Document passing arguments with equal signs. Refs a1ba178d.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -142,38 +142,43 @@ def parse_args_and_kwargs(func, args, data=None):
     This is to prevent things like 'echo "Hello: world"' to be parsed as
     dictionaries.
     '''
-    spec_args, _, has_kwargs, _ = salt.utils.get_function_argspec(func)
+    argspec = salt.utils.get_function_argspec(func)
     _args = []
     kwargs = {}
     invalid_kwargs = []
+
     for arg in args:
         # support old yamlify syntax
         if isinstance(arg, string_types):
             arg_name, arg_value = salt.utils.parse_kwarg(arg)
             if arg_name:
-                if has_kwargs or arg_name in spec_args:
+                if argspec.keywords or arg_name in argspec.args:
+                    # Function supports **kwargs or is a positional argument to
+                    # the function.
                     kwargs[arg_name] = yamlify_arg(arg_value)
                     continue
-                else:
-                    # **kwargs not in argspec and parsed argument name not in
-                    # list of positional arguments. This keyword argument is
-                    # invalid.
-                    invalid_kwargs.append(arg)
-            else:
-                # Not a kwarg
-                pass
+
+                # **kwargs not in argspec and parsed argument name not in
+                # list of positional arguments. This keyword argument is
+                # invalid.
+                invalid_kwargs.append(arg)
+
         # if the arg is a dict with __kwarg__ == True, then its a kwarg
         elif isinstance(arg, dict) and arg.get('__kwarg__') is True:
             for key, val in arg.iteritems():
                 if key == '__kwarg__':
                     continue
+                if key in __args:
+                    _args.append(val)
+                    continue
                 kwargs[key] = val
             continue
         _args.append(yamlify_arg(arg))
-    if has_kwargs and isinstance(data, dict):
+    if argspec.keywords and isinstance(data, dict):
         # this function accepts **kwargs, pack in the publish data
         for key, val in data.items():
             kwargs['__pub_{0}'.format(key)] = val
+
     log.debug('Parsed args: {0}'.format(_args))
     log.debug('Parsed kwargs: {0}'.format(kwargs))
     if invalid_kwargs:

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -48,6 +48,7 @@ def _publish(
         log.info('Function name is \'publish.publish\'. Returning {}')
         # Need to log something here
         return {}
+
     arg = _normalize_arg(arg)
 
     log.info('Publishing {0!r} to {master_uri}'.format(fun, **__opts__))
@@ -144,8 +145,26 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
 
         salt system.example.com publish.publish '*' cmd.run 'ls -la /tmp'
 
+
+    .. admonition:: Attention
+
+        If you need to pass a value to a function argument and that value
+        contains an equal sign, you **must** include the argument name.
+        For example:
+
+        .. code-block:: bash
+
+            salt '*' publish.publish test.kwarg arg='cheese=spam'
+
+
     '''
-    return _publish(tgt, fun, arg, expr_form, returner, timeout, 'clean')
+    return _publish(tgt,
+                    fun,
+                    arg=arg,
+                    expr_form=expr_form,
+                    returner=returner,
+                    timeout=timeout,
+                    form='clean')
 
 
 def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
@@ -158,8 +177,25 @@ def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
     .. code-block:: bash
 
         salt system.example.com publish.full_data '*' cmd.run 'ls -la /tmp'
+
+    .. admonition:: Attention
+
+        If you need to pass a value to a function argument and that value
+        contains an equal sign, you **must** include the argument name.
+        For example:
+
+        .. code-block:: bash
+
+            salt '*' publish.full_data test.kwarg arg='cheese=spam'
+
     '''
-    return _publish(tgt, fun, arg, expr_form, returner, timeout, 'full')
+    return _publish(tgt,
+                    fun,
+                    arg=arg,
+                    expr_form=expr_form,
+                    returner=returner,
+                    timeout=timeout,
+                    form='full')
 
 
 def runner(fun, arg=None):

--- a/tests/integration/modules/publish.py
+++ b/tests/integration/modules/publish.py
@@ -16,7 +16,33 @@ class PublishModuleTest(integration.ModuleCase,
         publish.publish
         '''
         ret = self.run_function('publish.publish', ['minion', 'test.ping'])
-        self.assertTrue(ret)
+        self.assertEqual(ret, {'minion': True})
+
+        ret = self.run_function(
+            'publish.publish',
+            ['minion', 'test.kwarg', 'arg="cheese=spam"']
+        )
+        ret = ret['minion']
+
+        check_true = (
+            'cheese',
+            '__pub_arg',
+            '__pub_fun',
+            '__pub_id',
+            '__pub_jid',
+            '__pub_ret',
+            '__pub_tgt',
+            '__pub_tgt_type',
+        )
+        for name in check_true:
+            if not name in ret:
+                print name
+            self.assertTrue(name in ret)
+
+        self.assertEqual(ret['cheese'], 'spam')
+        self.assertEqual(ret['__pub_arg'], ['cheese=spam'])
+        self.assertEqual(ret['__pub_id'], 'minion')
+        self.assertEqual(ret['__pub_fun'], 'test.kwarg')
 
     def test_full_data(self):
         '''
@@ -35,7 +61,7 @@ class PublishModuleTest(integration.ModuleCase,
         '''
         ret = self.run_function(
             'publish.full_data',
-            ['minion', 'test.kwarg', 'cheese=spam']
+            ['minion', 'test.kwarg', 'arg="cheese=spam"']
         )
 
         ret = ret['minion']['ret']
@@ -59,6 +85,14 @@ class PublishModuleTest(integration.ModuleCase,
         self.assertEqual(ret['__pub_arg'], ['cheese=spam'])
         self.assertEqual(ret['__pub_id'], 'minion')
         self.assertEqual(ret['__pub_fun'], 'test.kwarg')
+
+        ret = self.run_function(
+            'publish.full_data',
+            ['minion', 'test.kwarg', 'cheese=spam']
+        )
+        self.assertIn(
+            'The following keyword arguments are not valid: cheese=spam', ret
+        )
 
     def test_reject_minion(self):
         '''


### PR DESCRIPTION
Add additional documentation regarding arguments passing with equal signs for which salt tries hard to turn into keyword arguments. The problem now arises because non supported arguments immediately thrown an exception.
