### PR TITLE
Pass a relative path for proper test execution.

### DIFF
--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -42,7 +42,8 @@ class FileModuleTest(integration.ModuleCase):
         super(FileModuleTest, self).setUp()
 
     def tearDown(self):
-        os.remove(self.myfile)
+        if os.path.isfile(self.myfile):
+            os.remove(self.myfile)
         if os.path.islink(self.mysymlink):
             os.remove(self.mysymlink)
         if os.path.islink(self.mybadsymlink):

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -138,19 +138,19 @@ class FileModuleTest(integration.ModuleCase):
             self.assertEqual(fp.read(), 'Hello world\n')
 
     def test_remove_file(self):
-        ret = self.run_function('file.remove', args=[self.myfile])
+        ret = self.run_function('file.remove', arg=[self.myfile])
         self.assertTrue(ret)
 
     def test_remove_dir(self):
-        ret = self.run_function('file.remove', args=[self.mydir])
+        ret = self.run_function('file.remove', arg=[self.mydir])
         self.assertTrue(ret)
 
     def test_remove_symlink(self):
-        ret = self.run_function('file.remove', args=[self.mysymlink])
+        ret = self.run_function('file.remove', arg=[self.mysymlink])
         self.assertTrue(ret)
 
     def test_remove_broken_symlink(self):
-        ret = self.run_function('file.remove', args=[self.mybadsymlink])
+        ret = self.run_function('file.remove', arg=[self.mybadsymlink])
         self.assertTrue(ret)
 
     def test_cannot_remove(self):

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -154,7 +154,7 @@ class FileModuleTest(integration.ModuleCase):
         self.assertTrue(ret)
 
     def test_cannot_remove(self):
-        ret = self.run_function('file.remove', args=['/dev/tty'])
+        ret = self.run_function('file.remove', arg=['tty'])
         self.assertEqual(
             'ERROR executing \'file.remove\': File path must be absolute.', ret
         )


### PR DESCRIPTION
If we're trying to test a failure which happens when the path is not absolute, let's not pass it an absolute path in the first place.
