### PR TITLE
fix comment example of blockreplace, fix #8342

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1891,7 +1891,7 @@ def blockreplace(name,
             - name: my-accumulator-{{ myvar }}
             - text: "text 2"
             - require_in:
-              - file: foobar-config-block-{{ myvar }}
+              - file: hosts-config-block-{{ myvar }}
 
         hosts-config-block-{{ myvar }}-accumulated2:
           file.accumulated:
@@ -1901,7 +1901,7 @@ def blockreplace(name,
                  text 3
                  text 4
             - require_in:
-              - file: foobar-config-block-{{ myvar }}
+              - file: hosts-config-block-{{ myvar }}
 
     will generate and maintain a block of content in ``/etc/hosts``::
 


### PR DESCRIPTION
Documentation example of `file.blockreplace` accumulators were wrong.
