### PR TITLE
Doc changes (mostly regarding the test suite)

### DIFF
--- a/doc/topics/community.rst
+++ b/doc/topics/community.rst
@@ -50,11 +50,16 @@ is happening in Salt development:
 
 .. _community-blog:
 
-The Red45 Blog
-==============
+Blogs
+=====
 
-News and thoughts on Salt and related projects is often posted on Thomas' blog
-`The Red45`_:
+SaltStack Inc. keeps a `blog`_ with recent news and advancements:
+
+http://www.saltstack.com/blog/
+
+.. _`blog`: http://www.saltstack.com/blog/
+
+Thomas Hatch also shares news and thoughts on Salt and related projects in his personal blog `The Red45`_:
 
 http://red45.wordpress.com/
 

--- a/doc/topics/community.rst
+++ b/doc/topics/community.rst
@@ -98,4 +98,9 @@ Other community links
 - `Twitter <https://twitter.com/SaltStackInc>`_
 - `Wikipedia page <http://en.wikipedia.org/wiki/Salt_(software)>`_
 
-.. include:: hacking.rst
+Hack the Source
+===============
+
+If you want to get involved with the development of source code or the
+documentation efforts, please review the :doc:`hacking section
+<hacking>`!

--- a/doc/topics/community.rst
+++ b/doc/topics/community.rst
@@ -35,9 +35,6 @@ can use the `Freenode webchat client`__ right from your browser.
 .. __: http://webchat.freenode.net/?channels=salt&uio=Mj10cnVlJjk9dHJ1ZSYxMD10cnVl83
 .. __: http://irclog.perlgeek.de/salt/
 
-Salt development
-----------------
-
 If you wish to discuss the development of Salt itself join us in
 ``#salt-devel``.
 

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -1,7 +1,7 @@
 Developing Salt
 ===============
 
-There is a great need for contributions to salt and patches are welcome! The goal
+There is a great need for contributions to Salt and patches are welcome! The goal
 here is to make contributions clear, make sure there is a trail for where the code
 has come from, and most importantly, to give credit where credit is due!
 
@@ -346,56 +346,6 @@ be installed:
 
     USE_SETUPTOOLS=1 easy_install salt
 
-Running the tests
-~~~~~~~~~~~~~~~~~
-
-You will need ``mock`` to run the tests:
-
-.. code-block:: bash
-
-    pip install mock
-
-If you are on Python < 2.7 then you will also need unittest2:
-
-.. code-block:: bash
-
-    pip install unittest2
-
-
-.. note::
-
-    In Salt 0.17, testing libraries were migrated into their own repo. To install them:
-
-     .. code-block:: bash
-
-         pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
-
-
-    Failure to install SaltTesting will result in import errors similar to the following:
-
-     .. code-block:: bash
-
-        ImportError: No module named salttesting
-
-Finally you use setup.py to run the tests with the following command:
-
-.. code-block:: bash
-
-    ./setup.py test
-
-For greater control while running the tests, please try something like:
-
-.. code-block:: bash
-
-    ./tests/runtests.py -n integration.modules.virt -vv
-    ./tests/runtests.py -n unit.modules.virt_test -vv
-
-Also see the help for all options:
-
-.. code-block:: bash
-
-    ./tests/runtests.py -h
-
 
 Editing and previewing the documentation
 ----------------------------------------
@@ -445,3 +395,14 @@ launch a simple Python HTTP server to see your changes:
 .. code-block:: bash
 
     cd _build/html; python -m SimpleHTTPServer
+
+Running unit and integration tests
+----------------------------------
+
+Run the test suite with following command:
+
+.. code-block:: bash
+
+    ./setup.py test
+
+See :doc:`here <tests/index>` for more information regarding the test suite.

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -335,8 +335,8 @@ and 103 characters on BSD-based systems.
     </topics/installation/osx>` instructions.
 
 
-Using easy_install to Install Salt
-----------------------------------
+Installing Salt from the Python Package Index
+---------------------------------------------
 
 If you are installing using ``easy_install``, you will need to define a
 :strong:`USE_SETUPTOOLS` environment variable, otherwise dependencies will not

--- a/doc/topics/tests/index.rst
+++ b/doc/topics/tests/index.rst
@@ -2,23 +2,53 @@
 Running The Tests
 =================
 
-To run the tests, use ``tests/runtests.py``, see ``--help`` for more info.
+There are requirements, in addition to Salt's requirements, which
+needs to be installed in order to run the test suite. Install one of
+the lines below, depending on the relevant Python version:
+
+.. code-block:: bash
+
+    pip install -r dev_requirements_python26.txt
+    pip install -r dev_requirements_python27.txt
+
+.. note::
+
+    In Salt 0.17, testing libraries were migrated into their own repo. To install them:
+
+     .. code-block:: bash
+
+         pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
+
+
+    Failure to install SaltTesting will result in import errors similar to the following:
+
+     .. code-block:: bash
+
+        ImportError: No module named salttesting
+
+Once all require requirements are set, use ``tests/runtests.py`` to
+run the tests, see ``--help`` for more info.
+
+And alternative way of invoking the tests is available in setup.py,
+run the tests with the following command:
+
+.. code-block:: bash
+
+    ./setup.py test
 
 Examples:
 
-* To run all tests: ``sudo ./tests/runtests.py``
 * Run unit tests only: ``sudo ./tests/runtests.py --unit-tests``
-
-You will need 'mock' (https://pypi.python.org/pypi/mock) in addition to salt 
-requirements in order to run the tests.
+* Run a specific set of integration tests only: ``sudo ./tests/runtests.py -n integration.modules.virt -vv``
+* Run a specific set of unit tests only: ``./tests/runtests.py -n unit.modules.virt_test -vv``
 
 
 Running The Tests In A Docker Container
 =======================================
 
-If the ``runtests.py`` binary supports the ``--docked`` option flag, you can 
-choose to execute the tests suite under the provided `docker`_ container. You 
-need to have your `docker`_  properly configured on your system and the 
+If the ``runtests.py`` binary supports the ``--docked`` option flag, you can
+choose to execute the tests suite under the provided `docker`_ container. You
+need to have your `docker`_  properly configured on your system and the
 containers need to have access to the internet.
 
 Here's a simple usage example:
@@ -34,14 +64,14 @@ You can also provide the full `docker` container repository:
     tests/runtests.py --docked=salttest/ubuntu-12.04 -v
 
 
-The SaltStack team is creating some containers which will have the necessary 
-dependencies pre-installed allowing you, for example, to run the destructive 
-tests without making a single destructive change to your system, or, to run the 
+The SaltStack team is creating some containers which will have the necessary
+dependencies pre-installed allowing you, for example, to run the destructive
+tests without making a single destructive change to your system, or, to run the
 tests suite under a different distribution than the one you're currently using.
 
 You can see the current list of test suite images on our `docker repository`__.
 
-If you wish to provide your own `docker`_ container, you can submit pull 
+If you wish to provide your own `docker`_ container, you can submit pull
 requests against our `docker salt test containers`__ repository.
 
 .. _docker: http://www.docker.io/

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -9,7 +9,7 @@ deploying/restarting service
 Mandatory Settings:
 
 - The minion needs to have permission to publish the :strong:`modjk.*`
-  functions (see :doc:`here </ref/peer>` here for information on configuring
+  functions (see :doc:`here </ref/peer>` for information on configuring
   peer publishing permissions)
 
 - The modjk load balancer must be configured as stated in the :strong:`modjk`


### PR DESCRIPTION
There were a whole lot of information regarding running the test suite
in the hacking file, while there are a separate tests section of the
documentation. I attempt to slim this down a bit and give a helpful
pointer to the full section in order to avoid duplicated texts.

A few other small changes crept into this PR as well. Review the 
commit message of each commit for the reasoning.
