### PR TITLE
Adding support for cron comments

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -44,6 +44,8 @@ def _render_tab(lst):
         else:
             ret.append('{0}={1}\n'.format(env['name'], env['value']))
     for cron in lst['crons']:
+        if cron['comment'] is not None:
+            ret.append('# {0}\n'.format(cron['comment']))
         ret.append('{0} {1} {2} {3} {4} {5}\n'.format(cron['minute'],
                                                       cron['hour'],
                                                       cron['daymonth'],
@@ -151,6 +153,7 @@ def list_tab(user):
            'special': [],
            'env': []}
     flag = False
+    comment = None
     for line in data.splitlines():
         if line == '# Lines below here are managed by Salt, do not edit':
             flag = True
@@ -166,10 +169,16 @@ def list_tab(user):
                 dat['spec'] = comps[0]
                 dat['cmd'] = ' '.join(comps[1:])
                 ret['special'].append(dat)
+            elif line.startswith('#'):
+                # It's a comment! Catch it!
+                comment = line.lstrip('# ')
             elif len(line.split()) > 5:
                 # Appears to be a standard cron line
                 comps = line.split()
                 dat = {}
+                if comment is not None:
+                    dat['comment'] = comment
+                    comment = None
                 dat['minute'] = comps[0]
                 dat['hour'] = comps[1]
                 dat['daymonth'] = comps[2]
@@ -254,7 +263,7 @@ def _get_cron_date_time(**kwargs):
     return ret
 
 
-def set_job(user, minute, hour, daymonth, month, dayweek, cmd):
+def set_job(user, minute, hour, daymonth, month, dayweek, cmd, comment):
     '''
     Sets a cron job up for a specified user.
 
@@ -276,7 +285,7 @@ def set_job(user, minute, hour, daymonth, month, dayweek, cmd):
             if any([_needs_change(x, y) for x, y in
                     ((cron['minute'], minute), (cron['hour'], hour),
                      (cron['daymonth'], daymonth), (cron['month'], month),
-                     (cron['dayweek'], dayweek))]):
+                     (cron['dayweek'], dayweek), (cron['comment'], comment))]):
                 rm_job(user, cmd)
 
                 # Use old values when setting the new job if there was no
@@ -291,9 +300,11 @@ def set_job(user, minute, hour, daymonth, month, dayweek, cmd):
                     month = cron['month']
                 if not _needs_change(cron['dayweek'], dayweek):
                     dayweek = cron['dayweek']
+                if not _needs_change(cron['comment'], comment):
+                    comment = cron['comment']
 
                 jret = set_job(user, minute, hour, daymonth,
-                               month, dayweek, cmd)
+                               month, dayweek, cmd, comment)
                 if jret == 'new':
                     return 'updated'
                 else:

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -73,7 +73,8 @@ def _check_cron(user,
                 hour=None,
                 daymonth=None,
                 month=None,
-                dayweek=None):
+                dayweek=None,
+                comment=None):
     '''
     Return the changes
     '''
@@ -93,7 +94,7 @@ def _check_cron(user,
             if any([_needs_change(x, y) for x, y in
                     ((cron['minute'], minute), (cron['hour'], hour),
                      (cron['daymonth'], daymonth), (cron['month'], month),
-                     (cron['dayweek'], dayweek))]):
+                     (cron['dayweek'], dayweek), (cron['comment'], comment))]):
                 return 'update'
             return 'present'
     return 'absent'
@@ -125,7 +126,8 @@ def present(name,
             hour='*',
             daymonth='*',
             month='*',
-            dayweek='*'):
+            dayweek='*',
+            comment=None):
     '''
     Verifies that the specified cron job is present for the specified user.
     For more advanced information about what exactly can be set in the cron
@@ -156,6 +158,9 @@ def present(name,
 
     dayweek
         The information to be set in the day of week section. Default is ``*``
+
+    comment
+        User comment to be added on line previous the cron job
     '''
     name = ' '.join(name.strip().split())
     ret = {'changes': {},
@@ -169,7 +174,8 @@ def present(name,
                              hour,
                              daymonth,
                              month,
-                             dayweek)
+                             dayweek,
+                             comment)
         ret['result'] = None
         if status == 'absent':
             ret['comment'] = 'Cron {0} is set to be added'.format(name)
@@ -186,7 +192,8 @@ def present(name,
                                     daymonth=daymonth,
                                     month=month,
                                     dayweek=dayweek,
-                                    cmd=name)
+                                    cmd=name,
+                                    comment=comment)
     if data == 'present':
         ret['comment'] = 'Cron {0} already present'.format(name)
         return ret


### PR DESCRIPTION
Solves #8409

I would like the ability to add comment lines for my crons in the crontab. These changes make that a possibility. 
