### PR TITLE
file.replace: replicate ownership/permissions on new file

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -967,7 +967,7 @@ def replace(path,
     orig_file = []  # used if show_changes
     new_file = []  # used if show_changes
     fstat_pre = os.stat(path)
-    fperm_pre = fstat_pre.st_mode & 4095
+    fperm_pre = salt.utils.file_perms(fstat_pre)
     for line in fileinput.input(path,
             inplace=not dry_run, backup=False if dry_run else backup,
             bufsize=bufsize, mode='rb'):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -31,7 +31,7 @@ import types
 import warnings
 import yaml
 from calendar import month_abbr as months
-
+from posix import stat_result
 
 try:
     import timelib
@@ -956,6 +956,30 @@ def str_to_num(text):
             return float(text)
         except ValueError:
             return text
+
+
+def file_perms(path):
+    '''
+    the posix.stat_result struct returned from os.stat() has a parameter
+    st_mode, which does not play nicely with os.chmod(). This function will
+    accept either a file path or a posix.stat_result struct, and will return an
+    integer representing the mode. This integer can be passed directly to
+    os.chmod(), but if you want a human-readable permission string you'll need
+    to use oct() to convert the return value to octal.
+
+    If any problems are encountered, they will be logged and None will be
+    returned.
+    '''
+    if isinstance(path, string_types):
+        try:
+            path = os.stat(path)
+        except (IOError, OSError) as exc:
+            log.error('Unable to stat {0}: {1}'.format(path, exc))
+            return None
+    if not isinstance(path, stat_result):
+        log.error('Invalid data passed to salt.utils.file_perms()')
+        return None
+    return path.st_mode & 4095
 
 
 def fopen(*args, **kwargs):


### PR DESCRIPTION
Since file.replace was changed to use fileinput.input (and perhaps
before this), this function would create a new file with the desired
replacements, and this file would be owned by the user running salt,
with permissions governed by the umask. This is not the expected
behavior. One would expect that the new file would have the same
ownership and permissions as the original file. This commit performs an
os.stat before making changes, and then sets the ownership/permissions
after the changes are made.

Rather than stat-ing the file again after making the changes, since stat
can be an expensive operation, the ownership and permissions are set
irrespective of whether or not they differ from the original state.

Fixes #8399.
