### PR TITLE
Add mysql auth via unix_socket plugin.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -615,6 +615,7 @@ def user_exists(user,
                 password=None,
                 password_hash=None,
                 passwordless=False,
+                unix_socket=False,
                 **connection_args):
     '''
     Checks if a user exists on the MySQL server. A login can be checked to see
@@ -641,7 +642,10 @@ def user_exists(user,
            'Host = {1!r}'.format(user, host))
 
     if salt.utils.is_true(passwordless):
-        qry += ' AND Password = \'\''
+        if salt.utils.is_true(unix_socket):
+            qry += ' AND plugin={0!r}'.format('unix_socket')
+        else:
+            qry += ' AND Password = \'\''
     elif password:
         qry += ' AND Password = PASSWORD({0!r})'.format(password)
     elif password_hash:
@@ -694,6 +698,7 @@ def user_create(user,
                 password=None,
                 password_hash=None,
                 allow_passwordless=False,
+                unix_socket=False,
                 **connection_args):
     '''
     Creates a MySQL user
@@ -722,6 +727,9 @@ def user_create(user,
         If ``True``, then ``password`` and ``password_hash`` can be omitted (or
         set to ``None``) to permit a passwordless login.
 
+    unix_socket
+        If ``True`` and allow_passwordless is ``True`` then will be used unix_socket auth plugin.
+
     .. versionadded:: 0.16.2
         The ``allow_passwordless`` option was added.
 
@@ -747,7 +755,13 @@ def user_create(user,
         qry += ' IDENTIFIED BY {0!r}'.format(password)
     elif password_hash is not None:
         qry += ' IDENTIFIED BY PASSWORD {0!r}'.format(password_hash)
-    elif not salt.utils.is_true(allow_passwordless):
+    elif salt.utils.is_true(allow_passwordless):
+        if salt.utils.is_true(unix_socket):
+            if host == 'localhost':
+                qry += ' IDENTIFIED VIA unix_socket'
+            else:
+                log.error('Auth via unix_socket can be set only for host=localhost')
+    else:
         log.error('password or password_hash must be specified, unless '
                   'allow_passwordless=True')
         return False

--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -62,6 +62,7 @@ def present(name,
             password=None,
             password_hash=None,
             allow_passwordless=False,
+            unix_socket=False,
             **connection_args):
     '''
     Ensure that the named user is present with the specified properties. A
@@ -94,6 +95,9 @@ def present(name,
     allow_passwordless
         If ``True``, then ``password`` and ``password_hash`` can be omitted to
         permit a passwordless login.
+
+    unix_socket
+        If ``True`` and allow_passwordless is ``True`` then will be used unix_socket auth plugin.
 
     .. note::
         The ``allow_passwordless`` option will be available in version 0.16.2.


### PR DESCRIPTION
Mysql have plugin called 'unix_socket'. It allows authenticate to mysql without password if system user name equal to database user name.
To enable it you need to add to my.cnf:

plugin-load=unix_socket=auth_socket.so

And grant privileges like this:
GRANT ALL PRIVILEGES ON _._ TO 'root'@'localhost' identified via unix_socket with GRANT OPTION;

This patch add parameter 'unix_socket'. If it's True and `allow_passwordles` is also True - unix_socket auth is set for mysql user. Works only if Host='localhost'.
