### PR TITLE
Order is lost in a state defined with pydsl

### DIFF
--- a/salt/utils/pydsl.py
+++ b/salt/utils/pydsl.py
@@ -288,7 +288,7 @@ class StateDeclaration(object):
         return iter(self._mods)
 
     def _repr(self, context=None):
-        return dict(m._repr(context) for m in self)
+        return OrderedDict(m._repr(context) for m in self)
 
     def __call__(self, check=True):
         sls = Sls.get_render_stack()[-1]


### PR DESCRIPTION
An OrderedDict is used for the highstate from a pydsl sls, however regular dicts are used for each state. This becomes a problem when state configurations using the same state object are defined that require an ordering.

For example, this will fail because the service will be enabled before the package is installed:

```
ntpdate = state('ntpdate')
ntpdate.file.managed(
    name = '/etc/sysconfig/ntpdate',
    template = 'jinja',
    user = 'root',
    group = 'root',
    mode = 644,
    source = 'salt://ntpdate.jinja',
)
ntpdate.pkg.installed()
ntpdate.service.enabled()
```
