### PR TITLE
fix typo in pillar/__init__.py

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -211,7 +211,7 @@ class Pillar(object):
                     if sls in done[saltenv]:
                         continue
                     try:
-                        tops[satenv].append(
+                        tops[saltenv].append(
                                 compile_template(
                                     self.client.get_state(
                                         sls,


### PR DESCRIPTION
```
salt/pillar/__init__.py:214: [E0602(undefined-variable), Pillar.get_tops] Undefined variable 'satenv'
```
