### PR TITLE
output/highstate.py: rm unused import

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -26,7 +26,6 @@ import pprint
 
 # Import salt libs
 import salt.utils
-from salt._compat import string_types
 
 
 def output(data):


### PR DESCRIPTION
```
salt/output/highstate.py:29: [W0611(unused-import), ] Unused import string_types
```
