### PR TITLE
Slightly improved pip state usage documentation.

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -117,17 +117,60 @@ def installed(name,
     Make sure the package is installed
 
     name
-        The name of the python package to install
+        The name of the python package to install. You can also specify version
+        numbers here using the standard operators ``==, >=, <=``.
+
+    Example::
+
+        django:
+          pip.installed:
+            - name: django >= 1.6, <= 1.7
+            - require:
+              - pkg: python-pip
+
+    This will install the latest Django version greater than 1.6 but less
+    than 1.7.
+
     user
         The user under which to run pip
-    pip_bin : None
-        Deprecated, use bin_env
+
     use_wheel : False
         Prefer wheel archives (requires pip>=1.4)
-    env : None
-        Deprecated, use bin_env
+
     bin_env : None
-        the pip executable or virtualenv to use
+        Absolute path to a virtual environment directory or absolute path to
+        a pip executable. The example below assumes a virtual environment
+        has been created at ``/foo/.virtualenvs/bar``.
+
+    Example::
+
+        django:
+          pip.installed:
+            - name: django >= 1.6, <= 1.7
+            - bin_env: /foo/.virtualenvs/bar
+            - require:
+              - pkg: python-pip
+
+    Or
+
+    Example::
+
+        django:
+          pip.installed:
+            - name: django >= 1.6, <= 1.7
+            - bin_env: /foo/.virtualenvs/bar/bin/pip
+            - require:
+              - pkg: python-pip
+
+    .. admonition:: Attention
+
+        The following arguments are deprecated, do not use.
+
+    pip_bin : None
+        Deprecated, use ``bin_env``
+
+    env : None
+        Deprecated, use ``bin_env``
 
     .. versionchanged:: 0.17.0
         ``use_wheel`` option added.


### PR DESCRIPTION
My first pull request on salt. :)

Just adds some more detail to the pip state documentation. Specifically around the ability to specifying package version numbers in the `name` argument which was not previously documented and also how to use the `bin_env` argument.
