### PR TITLE
Better reporting for rendering errors + jinja render error fix

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -3,6 +3,12 @@
 This module is a central location for all salt exceptions
 '''
 
+# Import python libs
+import copy
+
+# Import salt libs
+import salt.utils
+
 
 class SaltException(Exception):
     '''
@@ -59,19 +65,6 @@ class MinionError(SaltException):
     '''
 
 
-class RenderError(SaltException):
-    '''
-    Problems rendering data
-    '''
-    def __init__(self, error, line_num, buf):
-        self.error = error
-        self.line_num = line_num
-        self.buffer = buf
-        SaltException.__init__(
-            self, 'Problem rendering data: {0}'.format(error)
-        )
-
-
 class SaltInvocationError(SaltException, TypeError):
     '''
     Used when the wrong number of arguments are sent to modules or invalid
@@ -88,8 +81,31 @@ class PkgParseError(SaltException):
 
 class SaltRenderError(SaltException):
     '''
-    Used when a renderer needs to raise an explicit error
+    Used when a renderer needs to raise an explicit error. If a line number and
+    buffer string are passed, get_context will be invoked to get the location
+    of the error.
     '''
+    def __init__(self,
+                 error,
+                 line_num=None,
+                 buf='',
+                 marker='    <======================'):
+        self.error = error
+        exc_str = copy.deepcopy(error)
+        self.line_num = line_num
+        self.buffer = buf
+        self.context = ''
+        if self.line_num and self.buffer:
+            self.context = salt.utils.get_context(
+                self.buffer,
+                self.line_num,
+                marker=marker
+            )
+            exc_str += '; line {0}\n\n{1}'.format(
+                    self.line_num,
+                    self.context
+            )
+        SaltException.__init__(self, exc_str)
 
 
 class SaltReqTimeoutError(SaltException):

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -9,7 +9,7 @@ from yaml.scanner import ScannerError
 # Import salt libs
 from salt.utils.yamlloader import CustomLoader, load
 from salt.utils.odict import OrderedDict
-from salt.exceptions import RenderError
+from salt.exceptions import SaltRenderError
 
 log = logging.getLogger(__name__)
 
@@ -43,8 +43,7 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
         except ScannerError as exc:
             err_type = _ERROR_MAP.get(exc.problem, 'Unknown yaml render error')
             line_num = exc.problem_mark.line + 1
-            err_msg = '{0}, line {1} of template'.format(err_type, line_num)
-            raise RenderError(err_msg, line_num, exc.problem_mark.buffer)
+            raise SaltRenderError(err_type, line_num, exc.problem_mark.buffer)
         if len(warn_list) > 0:
             for item in warn_list:
                 log.warn(

--- a/salt/state.py
+++ b/salt/state.py
@@ -33,8 +33,7 @@ import salt.syspaths as syspaths
 from salt.utils import context
 from salt._compat import string_types
 from salt.template import compile_template, compile_template_str
-from salt.utils.templates import get_template_context
-from salt.exceptions import RenderError, SaltReqTimeoutError, SaltException
+from salt.exceptions import SaltRenderError, SaltReqTimeoutError, SaltException
 
 log = logging.getLogger(__name__)
 
@@ -1997,13 +1996,8 @@ class BaseHighState(object):
                 fn_, self.state.rend, self.state.opts['renderer'], saltenv,
                 sls, rendered_sls=mods
             )
-        except RenderError as exc:
-            context = get_template_context(
-                exc.buffer,
-                exc.line_num,
-                marker='    <======================'
-            )
-            msg = 'Rendering SLS failed: {0}\n{1}'.format(exc.error, context)
+        except SaltRenderError as exc:
+            msg = 'Rendering SLS failed: {0}'.format(exc)
             log.critical(msg)
             errors.append(msg)
         except Exception as exc:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -187,6 +187,41 @@ def get_colors(use=True):
     return colors
 
 
+def get_context(template, line, num_lines=5, marker=None):
+    '''
+    Returns debugging context around a line in a given string
+
+    Returns:: string
+    '''
+    template_lines = template.splitlines()
+    num_template_lines = len(template_lines)
+
+    # in test, a single line template would return a crazy line number like,
+    # 357.  do this sanity check and if the given line is obviously wrong, just
+    # return the entire template
+    if line > num_template_lines:
+        return template
+
+    context_start = max(0, line - num_lines - 1)  # subt 1 for 0-based indexing
+    context_end = min(num_template_lines, line + num_lines)
+    error_line_in_context = line - context_start - 1  # subtr 1 for 0-based idx
+
+    buf = []
+    if context_start > 0:
+        buf.append('[...]')
+        error_line_in_context += 1
+
+    buf.extend(template_lines[context_start:context_end])
+
+    if context_end < num_template_lines:
+        buf.append('[...]')
+
+    if marker:
+        buf[error_line_in_context] += marker
+
+    return '---\n{0}\n---'.format('\n'.join(buf))
+
+
 def daemonize(redirect_out=True):
     '''
     Daemonize a process


### PR DESCRIPTION
In #8364, I made some changes that improve reporting on YAML rendering errors. To do this, I created a new exception class. I found later that there was a similarly-named exception already being used elsewhere in the codebase, so this pull req does the following:
1. Merges the `SaltRenderError` and `RenderError` exceptions.
2. Fixes all refs to the old RenderError exception that I created in #8364.
3. Fixes #8418, thereby reporting the correct line for jinja render errors. See https://github.com/saltstack/salt/issues/8418#issuecomment-28277788 for more information.

Pending discussion, this should be good to merge.
