### PR TITLE
Fixes for #8417

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -957,34 +957,6 @@ def str_to_num(text):
             return text
 
 
-def file_perms(path):
-    '''
-    the stat_result struct returned from os.stat() has a parameter st_mode,
-    which does not play nicely with os.chmod(). This function will accept
-    either a file path or a stat_result struct, and will return an integer
-    representing the mode. This integer can be passed directly to os.chmod(),
-    but if you want a human-readable permission string you'll need to use oct()
-    to convert the return value to octal.
-
-    If any problems are encountered, they will be logged and None will be
-    returned.
-    '''
-    # Not implemented yet on Windows
-    if salt.utils.is_windows():
-        return None
-
-    if isinstance(path, string_types):
-        try:
-            path = os.stat(path)
-        except (IOError, OSError) as exc:
-            log.error('Unable to stat {0}: {1}'.format(path, exc))
-            return None
-    if not isinstance(path, os.stat_result):
-        log.error('Invalid data passed to salt.utils.file_perms()')
-        return None
-    return path.st_mode & 4095
-
-
 def fopen(*args, **kwargs):
     '''
     Wrapper around open() built-in to set CLOEXEC on the fd.

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -31,7 +31,6 @@ import types
 import warnings
 import yaml
 from calendar import month_abbr as months
-from posix import stat_result
 
 try:
     import timelib
@@ -960,23 +959,27 @@ def str_to_num(text):
 
 def file_perms(path):
     '''
-    the posix.stat_result struct returned from os.stat() has a parameter
-    st_mode, which does not play nicely with os.chmod(). This function will
-    accept either a file path or a posix.stat_result struct, and will return an
-    integer representing the mode. This integer can be passed directly to
-    os.chmod(), but if you want a human-readable permission string you'll need
-    to use oct() to convert the return value to octal.
+    the stat_result struct returned from os.stat() has a parameter st_mode,
+    which does not play nicely with os.chmod(). This function will accept
+    either a file path or a stat_result struct, and will return an integer
+    representing the mode. This integer can be passed directly to os.chmod(),
+    but if you want a human-readable permission string you'll need to use oct()
+    to convert the return value to octal.
 
     If any problems are encountered, they will be logged and None will be
     returned.
     '''
+    # Not implemented yet on Windows
+    if salt.utils.is_windows():
+        return None
+
     if isinstance(path, string_types):
         try:
             path = os.stat(path)
         except (IOError, OSError) as exc:
             log.error('Unable to stat {0}: {1}'.format(path, exc))
             return None
-    if not isinstance(path, stat_result):
+    if not isinstance(path, os.stat_result):
         log.error('Invalid data passed to salt.utils.file_perms()')
         return None
     return path.st_mode & 4095


### PR DESCRIPTION
This fixes some issues caused by #8417 which cause problems with windows minions. It restricts the ownership/permissions enforcement added in that pull request to non-windows minions only, applies the same fix to file.copy, and fixes a traceback in `utils/__init__.py` on windows minions, which was caused by importing posix.
