### PR TITLE
Fixing __import__ method behavior to respect importlib method behavior

### DIFF
--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -55,8 +55,8 @@ def _check_xenapi():
     try:
         if HAS_IMPORTLIB:
             return importlib.import_module('xen.xm.XenAPI')
-        return __import__('xen.xm.XenAPI')
-    except ImportError:
+        return __import__('xen.xm.XenAPI').xm.XenAPI
+    except ImportError, AttributeError:
         return False
 
 


### PR DESCRIPTION
I added a light fix to XenAPI import method in order to return the same object pointer.
We are already using this fix in production by our side, if you have a cleaner method, I'll be glad to know.

Keep up the good work, and many thanks for everything you've done.
