### PR TITLE
Fix npm.list_ breaking with newer versions of npm

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -184,6 +184,10 @@ def list_(pkg=None, dir=None):
 
     result = __salt__['cmd.run_all'](cmd, cwd=dir)
 
+    # newer NPM versions have a return code of 1 when not installed
+    if result['stdout'] == '{}':
+        return {}
+
     if result['retcode'] != 0:
         raise CommandExecutionError(result['stderr'])
 


### PR DESCRIPTION
Newer versions of NPM have changed the return code when calling npm ls <pkg> and <pkg> doesn't exist.
