### PR TITLE
cleanup of gnomedesktop support.  fixed pylint issues.  moved to using t...

### DIFF
--- a/salt/modules/gnomedesktop.py
+++ b/salt/modules/gnomedesktop.py
@@ -4,6 +4,7 @@ GNOME implementations
 '''
 
 try:
+    import pwd
     from gi.repository import Gio, GLib
     HAS_GLIB = True
 except ImportError:
@@ -11,7 +12,6 @@ except ImportError:
 
 import logging
 import psutil
-import pwd
 import os
 import re
 import subprocess


### PR DESCRIPTION
Cleanup of gnomedesktop support.  
Fixed pylint issues.
Moved to using the salt cmd module instead of attempting to use python functions.
Removed all eval calls in favor of using locals().
