### PR TITLE
pip state module requires name even if requirements file is specified

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -118,7 +118,8 @@ def installed(name,
 
     name
         The name of the python package to install. You can also specify version
-        numbers here using the standard operators ``==, >=, <=``.
+        numbers here using the standard operators ``==, >=, <=``. If
+        ``requiremenets`` is given, this parameter will be ignored.
 
     Example::
 
@@ -223,7 +224,7 @@ def installed(name,
 
     from_vcs = False
 
-    if name:
+    if name and not requirements:
         try:
             try:
                 # With pip < 1.2, the __version__ attribute does not exist and

--- a/tests/unit/states/pip_test.py
+++ b/tests/unit/states/pip_test.py
@@ -279,6 +279,20 @@ class PipStateTest(TestCase, integration.SaltReturnAssertsMixIn):
                     {'test': ret}
                 )
 
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        pip_list = MagicMock(return_value={'pep8': '1.3.1'})
+        pip_install = MagicMock(return_value={ 'retcode': 0 })
+        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                             'pip.list': pip_list,
+                                             'pip.install': pip_install}):
+            with patch.dict(pip_state.__opts__, {'test': False}):
+                ret = pip_state.installed(
+                    'arbitrary ID that should be ignored due to requirements specified',
+                    requirements='/tmp/non-existing-requirements.txt'
+                )
+                self.assertSaltTrueReturn({'test': ret})
+
+
         # Test VCS installations using git+git://
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         pip_list = MagicMock(return_value={'pep8': '1.3.1'})


### PR DESCRIPTION
Executing the following state:

``` yaml
a set of nameless requirements:
  pip.installed:
    - requirements: salt://requirements.txt
```

produces the following error:

```
----------
    State: - pip
    Name:      a set of nameless requirements
    Function:  installed
        Result:    False
        Comment:   pip raised an exception while parsing 'a set of nameless requirements': ('Expected version spec in', 'a set of nameless requirements', 'at', ' set of nameless requirements')
        Changes:
```

This worked prior to version 0.17.0.

The problem is that the state module tries to install a package called `a set of nameless requirements`. I think a more reasonable behavior would be to ignore the name attribute if `requirements` file is specified. Right now I get around this error by supplying a bogus package to install, like this:

``` yaml
a set of nameless requirements:
  pip.installed:
    - name: pip
    - requirements: salt://requirements.txt
```
