### PR TITLE
Minor fix in ports state __virtual__ function

### DIFF
--- a/salt/states/ports.py
+++ b/salt/states/ports.py
@@ -29,7 +29,7 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    if __grains__.get('os', '') == 'FreeBSD' and 'ports.install':
+    if __grains__.get('os', '') == 'FreeBSD' and 'ports.install' in __salt__:
         return 'ports'
     return False
 


### PR DESCRIPTION
The if statement should have been checking to see if `ports.install` is
in the `__salt__` dict. As it was before this commit, the second half of
the if statement would always resolve to True.
