### PR TITLE
Gracefully handle certain bad yaml conf files.

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -449,6 +449,14 @@ def _read_conf_file(path):
                 'Error parsing configuration file: {0} - {1}'.format(path, err)
             )
             conf_opts = {}
+        # only interpret documents as a valid conf, not things like strings,
+        # which might have been caused by invalid yaml syntax
+        if not isinstance(conf_opts, dict):
+            log.error(
+                'Error parsing configuration file: {0} - conf should be a '
+                'document, not {1}.'.format(path, type(conf_opts))
+            )
+            conf_opts = {}
         # allow using numeric ids: convert int to string
         if 'id' in conf_opts:
             conf_opts['id'] = str(conf_opts['id'])


### PR DESCRIPTION
Salt already handles incorrect yaml conf files and keeps going with an empty
conf. But if the conf file is valid yaml, but not a document, like a number
or a string, it raises an exception and quits.

```
heewa@salt:/var/pip_from_git$ echo 'not a valid conf' | sudo tee /etc/salt/master
not a valid conf

heewa@salt:/var/pip_from_git$ sudo salt-master -l info
[ERROR   ] string indices must be integers, not str
Traceback (most recent call last):
  File "/var/pip_from_git/src/salt-master/salt/utils/parsers.py", line 146, in parse_args
    process_option_func()
  File "/var/pip_from_git/src/salt-master/salt/utils/parsers.py", line 285, in process_config_dir
    self.config = self.setup_config()
  File "/var/pip_from_git/src/salt-master/salt/utils/parsers.py", line 941, in setup_config
    return config.master_config(self.get_config_file_path())
  File "/var/pip_from_git/src/salt-master/salt/config.py", line 907, in master_config
    overrides = load_config(path, env_var, DEFAULT_MASTER_OPTS['conf_file'])
  File "/var/pip_from_git/src/salt-master/salt/config.py", line 512, in load_config
    opts = _read_conf_file(path)
  File "/var/pip_from_git/src/salt-master/salt/config.py", line 454, in _read_conf_file
    conf_opts['id'] = str(conf_opts['id'])
TypeError: string indices must be integers, not str
Usage: salt-master

salt-master: error: Error while processing <bound method Master.process_config_dir of <salt.Master object at 0x27dc210>>: Traceback (most recent call last):
  File "/var/pip_from_git/src/salt-master/salt/utils/parsers.py", line 146, in parse_args
    process_option_func()
  File "/var/pip_from_git/src/salt-master/salt/utils/parsers.py", line 285, in process_config_dir
    self.config = self.setup_config()
  File "/var/pip_from_git/src/salt-master/salt/utils/parsers.py", line 941, in setup_config
    return config.master_config(self.get_config_file_path())
  File "/var/pip_from_git/src/salt-master/salt/config.py", line 907, in master_config
    overrides = load_config(path, env_var, DEFAULT_MASTER_OPTS['conf_file'])
  File "/var/pip_from_git/src/salt-master/salt/config.py", line 512, in load_config
    opts = _read_conf_file(path)
  File "/var/pip_from_git/src/salt-master/salt/config.py", line 454, in _read_conf_file
    conf_opts['id'] = str(conf_opts['id'])
TypeError: string indices must be integers, not str
```

Parsing a conf file as valid yaml might still yield something other than
a dictionary, which is required. So check for that case, log an error,
and continue the same way that an invalid yaml conf file would be handled.

```
...
[INFO    ] Setting up the master communication server
[INFO    ] Starting Salt worker process 0
[INFO    ] Skipping lspci call because enable_gpu_grains was set to False in the config. GPU grains will not be available.
[ERROR   ] Error parsing configuration file: /etc/salt/master - conf should be a document, not <type 'str'>.
[INFO    ] Starting Salt worker process 1
...
```
