### PR TITLE
Don't try to access the default tenant id in user_list and user_get

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -623,6 +623,8 @@ def user_list(profile=None, **connection_args):
                           'name': user.name,
                           'email': user.email,
                           'enabled': user.enabled}
+        if hasattr(user.__dict__, 'tenantId'):
+            ret[user.name]['tenant_id'] = user.__dict__['tenantId']
     return ret
 
 
@@ -652,6 +654,8 @@ def user_get(user_id=None, name=None, profile=None, **connection_args):
                       'name': user.name,
                       'email': user.email,
                       'enabled': user.enabled}
+    if hasattr(user.__dict__, 'tenantId'):
+        ret[user.name]['tenant_id'] = user.__dict__['tenantId']
     return ret
 
 

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -622,8 +622,7 @@ def user_list(profile=None, **connection_args):
         ret[user.name] = {'id': user.id,
                           'name': user.name,
                           'email': user.email,
-                          'enabled': user.enabled,
-                          'tenant_id': user.tenantId}
+                          'enabled': user.enabled}
     return ret
 
 
@@ -652,8 +651,7 @@ def user_get(user_id=None, name=None, profile=None, **connection_args):
     ret[user.name] = {'id': user.id,
                       'name': user.name,
                       'email': user.email,
-                      'enabled': user.enabled,
-                      'tenant_id': user.tenantId}
+                      'enabled': user.enabled}
     return ret
 
 


### PR DESCRIPTION
I'm just getting started with OpenStack and have run into a problem with Salt's Keystone modules.  I'm using OpenStack Havana on Fedora 20 Beta, so this may be an API change in Havana that I'm seeing, I've not used previous versions so I'm not sure.

As you can see the command-line client successfully retrieves the user list:

```
# export OS_SERVICE_TOKEN=XXXXXXXXXXXXXXXXXXXXXX
# export OS_SERVICE_ENDPOINT=http://os.example.org:35357/v2.0
# keystone user-list
+----------------------------------+-------+---------+----------------+
|                id                |  name | enabled |     email      |
+----------------------------------+-------+---------+----------------+
| 2e8083d63ff5429db70b009f1a8f8196 | admin |   True  | root@example.org |
+----------------------------------+-------+---------+----------------+
```

Trying the same using Salt fails:

```
# salt-call keystone.user_list
[INFO    ] Starting new HTTP connection (1): oshst01.dmacc.net
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
AttributeError: tenantId
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 77, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/__init__.py", line 303, in run
    caller.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 135, in run
    ret = self.call()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 78, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/keystone.py", line 607, in user_list
    'tenant_id': user.tenantId}
  File "/usr/lib/python2.7/site-packages/keystoneclient/base.py", line 426, in __getattr__
    raise AttributeError(k)
AttributeError: tenantId
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/site-packages/salt/scripts.py", line 77, in salt_call
    client.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/__init__.py", line 303, in run
    caller.run()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 135, in run
    ret = self.call()
  File "/usr/lib/python2.7/site-packages/salt/cli/caller.py", line 78, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/salt/modules/keystone.py", line 607, in user_list
    'tenant_id': user.tenantId}
  File "/usr/lib/python2.7/site-packages/keystoneclient/base.py", line 426, in __getattr__
    raise AttributeError(k)
AttributeError: tenantId
```

After patching I get the following:

```
# salt-call keystone.user_list
[INFO    ] Starting new HTTP connection (1): oshst01.dmacc.net
local:
    ----------
    admin:
        ----------
        email:
            root@dmacc.net
        enabled:
            True
        id:
            2e8083d63ff5429db70b009f1a8f8196
        name:
            admin
```
