### PR TITLE
Client api run

### DIFF
--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -105,6 +105,7 @@ class APIClient(object):
         eauth: the authentication type such as 'pam' or 'ldap'. Required if token is missing
 
         '''
+        cmd = dict(cmd) # make copy
         client = 'minion'  # default to local minion client
         mode = cmd.get('mode', 'async')  # default to 'async'
 

--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -14,7 +14,6 @@ import salt.client
 import salt.runner
 import salt.wheel
 import salt.utils
-import salt.cloud
 import salt.syspaths as syspaths
 from salt.utils.event import tagify
 from salt.exceptions import EauthAuthenticationError
@@ -48,9 +47,6 @@ class APIClient(object):
         self.localClient = salt.client.LocalClient(self.opts['conf_file'])
         self.runnerClient = salt.runner.RunnerClient(self.opts)
         self.wheelClient = salt.wheel.Wheel(self.opts)
-        self.cloudClient = salt.cloud.CloudClient(
-                os.path.join(os.path.dirname(self.opts['conf_file']), 'cloud')
-                )
         self.resolver = salt.auth.Resolver(self.opts)
         self.event = salt.utils.event.SaltEvent('master', self.opts['sock_dir'])
 
@@ -111,7 +107,7 @@ class APIClient(object):
 
         # check for wheel or runner prefix to fun name to use wheel or runner client
         funparts = cmd.get('fun', '').split('.')
-        if len(funparts) > 2 and funparts[0] in ['wheel', 'runner', 'cloud']:  # master
+        if len(funparts) > 2 and funparts[0] in ['wheel', 'runner']:  # master
             client = funparts[0]
             cmd['fun'] = '.'.join(funparts[1:])  # strip prefix
 
@@ -150,16 +146,6 @@ class APIClient(object):
         return self.runnerClient.master_call(**kwargs)
 
     runner_sync = runner_async  # always runner async, so works in either mode
-
-    def cloud_async(self, **kwargs):
-        '''
-        Wrap CloudClient for executing cloud routines
-        Expects that one of the kwargs is key 'fun' whose value is the namestring
-        of the function to call
-        '''
-        return self.cloudClient.master_call(**kwargs)
-
-    cloud_sync = cloud_async  # always runner async, so works in either mode
 
     def wheel_sync(self, **kwargs):
         '''


### PR DESCRIPTION
Now makes copy of cmd argument passed into .run so that changes inside run do not affect the original cmd object.

Removed all references to cloud api as we are now using the runner.cloud for the cloud api
