### PR TITLE
Add https in recognized protos for distant hash_source  in salt.modules.get_managed()

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1812,7 +1812,7 @@ def get_managed(
                 if not source_sum:
                     return '', {}, 'Source file {0} not found'.format(source)
             elif source_hash:
-                protos = ['salt', 'http', 'ftp']
+                protos = ['salt', 'http', 'https', 'ftp']
                 if salt._compat.urlparse(source_hash).scheme in protos:
                     # The source_hash is a file on a server
                     hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)


### PR DESCRIPTION
Without this patch, hash_source urls starting with https are recognized as hash_source strings.
