### PR TITLE
Verify pillar from master on minion.

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -70,7 +70,14 @@ class RemotePillar(object):
         key = self.auth.get_keys()
         aes = key.private_decrypt(ret['key'], 4)
         pcrypt = salt.crypt.Crypticle(self.opts, aes)
-        return pcrypt.loads(ret['pillar'])
+        ret_pillar = pcrypt.loads(ret['pillar'])
+        if not isinstance(ret_pillar, dict):
+            log.error(
+                'Got a bad pillar from master, type {0}, expecting dict: '
+                '{1}'.format(type(ret_pillar).__name__, ret_pillar)
+            )
+            return {}
+        return ret_pillar
 
 
 class Pillar(object):


### PR DESCRIPTION
In some cases, it's possible for minion to get an invalid pillar from master,
through a mostly valid reply. Check that at least it's a dict, otherwise later
code tries to do lookups in it and fails confusingly:

```
[CRITICAL] Failed to load grains defined in grain file opts.opts in function <function opts at 0x3a7e410>, error:
Traceback (most recent call last):
  File "/var/pip_from_repo/src/salt-minion/salt/loader.py", line 929, in gen_grains
    ret = fun()
  File "/var/pip_from_repo/src/salt-minion/salt/grains/opts.py", line 12, in opts
    if __opts__.get('grain_opts', False) or __pillar__.get('grain_opts', False):
AttributeError: 'bool' object has no attribute 'get'
```

turns to:

```
[ERROR   ] Got a bad pillar from master, type bool, expecting dict: False
```
