### PR TITLE
Fix for issue #8053: raise error on duplicate ID's in one state file

### DIFF
--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import
 import logging
 import warnings
 from yaml.scanner import ScannerError
+from yaml.constructor import ConstructorError
 
 # Import salt libs
 from salt.utils.yamlloader import CustomLoader, load
@@ -44,6 +45,8 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
             err_type = _ERROR_MAP.get(exc.problem, 'Unknown yaml render error')
             line_num = exc.problem_mark.line + 1
             raise SaltRenderError(err_type, line_num, exc.problem_mark.buffer)
+        except ConstructorError as exc:
+            raise SaltRenderError(exc)
         if len(warn_list) > 0:
             for item in warn_list:
                 log.warn(

--- a/salt/state.py
+++ b/salt/state.py
@@ -1997,7 +1997,9 @@ class BaseHighState(object):
                 sls, rendered_sls=mods
             )
         except SaltRenderError as exc:
-            msg = 'Rendering SLS failed: {0}'.format(exc)
+            msg = 'Rendering SLS "{0}:{1}" failed: {2}'.format(
+                saltenv, sls, exc
+            )
             log.critical(msg)
             errors.append(msg)
         except Exception as exc:

--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -77,8 +77,7 @@ class CustomLoader(yaml.SafeLoader):
                 raise ConstructorError(err)
             value = self.construct_object(value_node, deep=deep)
             if key in mapping:
-                warnings.warn(
-                    'Duplicate Key: "{0}"'.format(key), DuplicateKeyWarning)
+                raise ConstructorError('Conflicting ID "{0}"'.format(key))
             mapping[key] = value
         return mapping
 


### PR DESCRIPTION
Running the following state:

```
/tmp/file-1:
  file.managed:
    - content: |
        Beep boop.

/tmp/file-1:
  file.touch

```

will now result in this error:

```
local:
    Data failed to compile:
----------
    Rendering SLS "base:duplicates-ids" failed: Conflicting ID "/tmp/file-1"
```

As a bonus, YAML compilation errors are now displayed with the environment and state included — making troubleshooting easier.
