### PR TITLE
Remember cron comment

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -175,17 +175,15 @@ def list_tab(user):
             elif len(line.split()) > 5:
                 # Appears to be a standard cron line
                 comps = line.split()
-                dat = {}
-                if comment is not None:
-                    dat['comment'] = comment
-                    comment = None
-                dat['minute'] = comps[0]
-                dat['hour'] = comps[1]
-                dat['daymonth'] = comps[2]
-                dat['month'] = comps[3]
-                dat['dayweek'] = comps[4]
-                dat['cmd'] = ' '.join(comps[5:])
+                dat = {'minute': comps[0],
+                       'hour': comps[1],
+                       'daymonth': comps[2],
+                       'month': comps[3],
+                       'dayweek': comps[4],
+                       'cmd': ' '.join(comps[5:]),
+                       'comment': comment}
                 ret['crons'].append(dat)
+                comment = None
             elif line.find('=') > 0:
                 # Appears to be a ENV setup line
                 comps = line.split('=')

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -310,7 +310,8 @@ def set_job(user, minute, hour, daymonth, month, dayweek, cmd, comment):
                 else:
                     return jret
             return 'present'
-    cron = {'cmd': cmd}
+    cron = {'cmd': cmd,
+            'comment': comment}
     cron.update(_get_cron_date_time(minute=minute, hour=hour,
                                     daymonth=daymonth, month=month,
                                     dayweek=dayweek))


### PR DESCRIPTION
Two small fixes to how existing & new cron entries are handled with regards to comments. Code was sometimes forgetting to pass along a comment, or not adding a blank one. Later code would try to read it and throw a KeyError.

Rather than make that code use .get('comment') and potentially hide future problems like this, I opted to explicitly add in a comment key to the cron dict, even if blank. Seems like a sensible contract with the lower level cron code in salt.
