### PR TITLE
salt.log.setup: rm unused import

### DIFF
--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -33,7 +33,6 @@ GARBAGE = logging.GARBAGE = 1
 QUIET = logging.QUIET = 1000
 
 # Import salt libs
-from salt._compat import string_types
 from salt.log.handlers import TemporaryLoggingHandler
 from salt.log.mixins import LoggingMixInMeta, NewStyleClassMixIn
 


### PR DESCRIPTION
```
salt/log/setup.py:36: [W0611(unused-import), ] Unused import string_types
```
