### PR TITLE
modules.aws_sqs: rm unused import

### DIFF
--- a/salt/modules/aws_sqs.py
+++ b/salt/modules/aws_sqs.py
@@ -6,7 +6,6 @@ import json
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import CommandExecutionError
 
 _OUTPUT = '--output json'
 


### PR DESCRIPTION
```
salt/modules/aws_sqs.py:9: [W0611(unused-import), ] Unused import CommandExecutionError
```
