### PR TITLE
gnomedesktop: doesn't seem to make sense for get() to take a `value` arg

### DIFF
--- a/salt/modules/gnomedesktop.py
+++ b/salt/modules/gnomedesktop.py
@@ -239,7 +239,7 @@ def setIdleActivation(kvalue, **kwargs):
     return _gsession._set(kvalue)
 
 
-def get(schema=None, key=None, user=None, value=None, **kwargs):
+def get(schema=None, key=None, user=None, **kwargs):
     '''
     Get key in a particular GNOME schema
 


### PR DESCRIPTION
```
salt/modules/gnomedesktop.py:242: [W0613(unused-argument), get] Unused argument 'value'
```
