### PR TITLE
Fix for #8560

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -230,9 +230,9 @@ def managed(name, **kwargs):
     # out of the state itself and into a module that it makes more sense
     # to use.  Most package providers will simply return the data provided
     # it doesn't require any "specialized" data massaging.
-    sanitizedkwargs = __salt__['pkg.expand_repo_def'](kwargs)
+    sanitizedkwargs = __salt__['pkg.expand_repo_def'](repokwargs)
     if __grains__['os_family'] == 'Debian':
-        kwargs['repo'] = _strip_uri(kwargs['repo'])
+        repokwargs['repo'] = _strip_uri(repokwargs['repo'])
 
     if repo:
         notset = False


### PR DESCRIPTION
EDIT: indentation issue has been resolved by s0undt3ch. I've removed it from this pull req.

This pull request contains a fix for the pkgrepo fix in #8560, as well as an IndentationError that keeps setup.py from running successfully.

The fix for #8560 is being made here in 0.17 because there has been a bit of churn in the pkgrepo.managed state, and develop works fine. It looks like something got cherrypicked that shouldn't have, or the cherrypick resulted in a merge conflict that was not properly resolved due to the divergence in the logic between 0.17.0 and the current develop branch.
