### PR TITLE
Feat: Add a prepend_if_not_found arg to file.blockreplace

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1008,6 +1008,7 @@ def blockreplace(path,
         marker_end='#-- end managed zone --',
         content='',
         append_if_not_found=False,
+        prepend_if_not_found=False,
         backup='.bak',
         dry_run=False,
         show_changes=True,
@@ -1049,6 +1050,11 @@ def blockreplace(path,
         If markers are not found and set to ``True`` then, the markers and
         content will be appended to the file.
 
+    prepend_if_not_found : False
+        If markers are not found and set to ``True`` then, the markers and
+        content will be prepended to the file.
+
+
     backup
         The file extension to use for a backup of the file if any edit is made.
         Set to ``False`` to skip making a backup.
@@ -1070,6 +1076,9 @@ def blockreplace(path,
     '''
     if not os.path.exists(path):
         raise SaltInvocationError('File not found: {0}'.format(path))
+
+    if append_if_not_found and prepend_if_not_found:
+        raise SaltInvocationError('Choose between append or prepend_if_not_found')
 
     if not salt.utils.istextfile(path):
         raise SaltInvocationError(
@@ -1129,7 +1138,13 @@ def blockreplace(path,
         )
 
     if not done:
-        if append_if_not_found:
+        if prepend_if_not_found:
+            # add the markers and content at the beginning of file
+            new_file.insert(0, marker_end + '\n')
+            new_file.insert(0, content + '\n')
+            new_file.insert(0, marker_start + '\n')
+            done = True
+        elif append_if_not_found:
             # add the markers and content at the end of file
             new_file.append(marker_start + '\n')
             new_file.append(content + '\n')

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1835,6 +1835,7 @@ def blockreplace(name,
             marker_end='#-- end managed zone --',
             content='',
             append_if_not_found=False,
+            prepend_if_not_found=False,
             backup='.bak',
             show_changes=True):
     '''
@@ -1864,6 +1865,8 @@ def blockreplace(name,
         marker_start and marker_stop.
     :param append_if_not_found: False by default, if markers are not found and
         set to True then the markers and content will be appended to the file
+    :param prepend_if_not_found: False by default, if markers are not found and
+        set to True then the markers and content will be prepended to the file
     :param backup: The file extension to use for a backup of the file if any
         edit is made. Set to ``False`` to skip making a backup.
     :param dry_run: Don't make any edits to the file
@@ -1931,6 +1934,7 @@ def blockreplace(name,
                                        marker_end,
                                        content=content,
                                        append_if_not_found=append_if_not_found,
+                                       prepend_if_not_found=prepend_if_not_found,
                                        backup=backup,
                                        dry_run=__opts__['test'],
                                        show_changes=show_changes)

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -173,6 +173,28 @@ class FileBlockReplaceTestCase(TestCase):
         with open(self.tfile.name, 'rb') as fp:
             self.assertIn('#-- START BLOCK 2'+"\n"+new_content+"\n"+'#-- END BLOCK 2', fp.read())
 
+    def test_replace_prepend(self):
+        new_content = "Well, I didn't vote for you."
+
+        self.assertRaises(
+            CommandExecutionError,
+            filemod.blockreplace,
+            self.tfile.name,
+            '#-- START BLOCK 2',
+            '#-- END BLOCK 2',
+            new_content,
+            prepend_if_not_found=False,
+            backup=False
+        )
+        with open(self.tfile.name, 'rb') as fp:
+            self.assertNotIn('#-- START BLOCK 2'+"\n"+new_content+"\n"+'#-- END BLOCK 2', fp.read())
+
+        filemod.blockreplace(self.tfile.name, '#-- START BLOCK 2', '#-- END BLOCK 2', new_content, backup=False,prepend_if_not_found=True)
+
+        with open(self.tfile.name, 'rb') as fp:
+            self.assertTrue(fp.read().startswith('#-- START BLOCK 2'+"\n"+new_content+"\n"+'#-- END BLOCK 2'))
+
+
 
     def test_replace_partial_marked_lines(self):
         filemod.blockreplace(self.tfile.name, '// START BLOCK', '// END BLOCK', 'new content 1', backup=False)


### PR DESCRIPTION
We may also want to add data to the beginning of a file instead of appending to it.

This fixes #8707
