### PR TITLE
Add explicit `force_yes` arg for non-explicit downgrades

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -358,6 +358,10 @@ def install(name=None,
 
             salt '*' pkg.install sources='[{"foo": "salt://foo.deb"},{"bar": "salt://bar.deb"}]'
 
+    force_yes
+        Passes ``--force-yes`` to the apt-get command.  Don't use this unless
+        you know what you're doing.
+
 
     Returns a dict containing the new package names and versions::
 
@@ -411,7 +415,7 @@ def install(name=None,
         if fromrepo:
             log.info('Targeting repo {0!r}'.format(fromrepo))
         cmd = ['apt-get', '-q', '-y']
-        if downgrade:
+        if downgrade or kwargs.get('force_yes', False):
             cmd.append('--force-yes')
         cmd = cmd + ['-o', 'DPkg::Options::=--force-confold']
         cmd = cmd + ['-o', 'DPkg::Options::=--force-confdef']


### PR DESCRIPTION
User was using a pin file to define a non-standard repo which may have a
lower version.  Version was not explicitly defined, so the state was not
detecting a downgrade.  Add ability to pass in --force-yes (with
warnings that it could be dangerous).
