### PR TITLE
Correctly parse grub.conf stanzas that aren't separated by new lines

### DIFF
--- a/salt/modules/grub_legacy.py
+++ b/salt/modules/grub_legacy.py
@@ -78,8 +78,14 @@ def conf():
                         stanzas.append(stanza)
                     stanza = ''
                     continue
-                if line.startswith('title'):
-                    in_stanza = True
+                if line.strip().startswith('title'):
+                    if in_stanza:
+                        stanza += 'order {0}'.format(pos)
+                        pos += 1
+                        stanzas.append(stanza)
+                        stanza = ''
+                    else:
+                        in_stanza = True
                 if in_stanza:
                     stanza += line
                 if not in_stanza:


### PR DESCRIPTION
Not all distros separate stanzas with new lines, now if in a stanza and the start of a stanza is detected start a new stanza
