### PR TITLE
Doc style fixes

### DIFF
--- a/salt/states/alias.py
+++ b/salt/states/alias.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Configuration of email aliases.
-===============================
+Configuration of email aliases
+==============================
 
 The mail aliases file can be managed to contain definitions for specific email
 aliases:

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of cron, the Unix command scheduler.
-===============================================
+Management of cron, the Unix command scheduler
+==============================================
 
 The cron state module allows for user crontabs to be cleanly managed.
 

--- a/salt/states/ddns.py
+++ b/salt/states/ddns.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Dynamic DNS updates.
-====================
+Dynamic DNS updates
+===================
 
 Ensure a DNS record is present or absent utilizing RFC 2136
 type dynamic updates. Requires dnspython module.

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 '''
-Management of dockers
-=====================
+Manage Docker containers
+========================
+
+A Docker is a light-weight, portable, self-sufficient container.
 
 .. note::
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Operations on regular files, special files, directories, and symlinks.
-=======================================================================
+Operations on regular files, special files, directories, and symlinks
+=====================================================================
 
 Salt States can aggressively manipulate files on a system. There are a number
 of ways in which files can be managed.

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Installation of Ruby modules packaged as gems.
-==============================================
+Installation of Ruby modules packaged as gems
+=============================================
 
 A state module to manage rubygems. Gems can be set up to be installed
 or removed. This module will use RVM if it is installed. In that case,

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Interaction with Git repositories.
-==================================
+Interaction with Git repositories
+=================================
 
 Important: Before using git over ssh, make sure your remote host fingerprint
 exists in "~/.ssh/known_hosts" file. To avoid requiring password

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Manage grains on the minion.
-============================
+Manage grains on the minion
+===========================
 
 This state allows for grains to be set. If a grain with the
 given name exists, its value is updated to the new value. If

--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of user groups.
-==========================
+Management of user groups
+=========================
 
 The group module is used to create and manage unix group settings, groups
 can be either present or absent:

--- a/salt/states/hg.py
+++ b/salt/states/hg.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Interaction with Mercurial repositories.
-========================================
+Interaction with Mercurial repositories
+=======================================
 
 Before using hg over ssh, make sure the remote host fingerprint already exists
 in ~/.ssh/known_hosts, and the remote host has this host's public key.

--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of addresses and names in hosts file.
-================================================
+Management of addresses and names in hosts file
+===============================================
 
 The /etc/hosts file can be managed to contain definitions for specific hosts:
 

--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of Keystone users.
-=============================
+Management of Keystone users
+============================
 
 :depends:   - keystoneclient Python module
 :configuration: See :py:mod:`salt.modules.keystone` for setup instructions.

--- a/salt/states/kmod.py
+++ b/salt/states/kmod.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Loading and unloading of kernel modules.
-========================================
+Loading and unloading of kernel modules
+=======================================
 
 The Kernel modules on a system can be managed cleanly with the kmod state
 module:

--- a/salt/states/libvirt.py
+++ b/salt/states/libvirt.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Manage libvirt certs. This state uses the external pillar in the master to call
+Manage libvirt certificates
+===========================
+
+This state uses the external pillar in the master to call
 for the generation and signing of certificates for systems running libvirt:
 
 .. code-block:: yaml

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 '''
-Send commands to a :strong:`modjk` load balancer via the peer system
+Manage modjk workers
+====================
+
+Send commands to a :strong:`modjk` load balancer via the peer system.
 
 This module can be used with the :doc:`prereq </ref/states/requisites>`
 requisite to remove/add the worker from the load balancer before
-deploying/restarting service
+deploying/restarting service.
 
 Mandatory Settings:
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Mounting of filesystems.
-========================
+Mounting of filesystems
+=======================
 
 Mount any type of mountable filesystem with the mounted function:
 

--- a/salt/states/mysql_database.py
+++ b/salt/states/mysql_database.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of MySQL databases (schemas).
-========================================
+Management of MySQL databases (schemas)
+=======================================
 
 :depends:   - MySQLdb Python module
 :configuration: See :py:mod:`salt.modules.mysql` for setup instructions.

--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of MySQL grants (user permissions).
-==============================================
+Management of MySQL grants (user permissions)
+=============================================
 
 :depends:   - MySQLdb Python module
 :configuration: See :py:mod:`salt.modules.mysql` for setup instructions.

--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of MySQL users.
-==========================
+Management of MySQL users
+=========================
 
 :depends:   - MySQLdb Python module
 :configuration: See :py:mod:`salt.modules.mysql` for setup instructions.

--- a/salt/states/postgres_database.py
+++ b/salt/states/postgres_database.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of PostgreSQL databases.
-=============================================
+Management of PostgreSQL databases
+==================================
 
 The postgres_database module is used to create and manage Postgres databases.
 Databases can be set as either absent or present

--- a/salt/states/postgres_group.py
+++ b/salt/states/postgres_group.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of PostgreSQL groups (roles).
-========================================
+Management of PostgreSQL groups (roles)
+=======================================
 
 The postgres_group module is used to create and manage Postgres groups.
 

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of PostgreSQL users (roles).
-=======================================
+Management of PostgreSQL users (roles)
+======================================
 
 The postgres_users module is used to create and manage Postgres users.
 

--- a/salt/states/rabbitmq_cluster.py
+++ b/salt/states/rabbitmq_cluster.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 Manage RabbitMQ Clusters
+========================
+
+Example:
 
 .. code-block:: yaml
 

--- a/salt/states/rabbitmq_plugin.py
+++ b/salt/states/rabbitmq_plugin.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Manage RabbitMQ Plugins.
+Manage RabbitMQ Plugins
+=======================
+
+Example:
 
 .. code-block:: yaml
 

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -1,10 +1,13 @@
 # -*- coding: utf-8 -*-
 '''
-Manage RabbitMQ Policies.
+Manage RabbitMQ Policies
+========================
 
 :maintainer:    Benn Eichhorn <benn@getlocalmeasure.com>
 :maturity:      new
 :platform:      all
+
+Example:
 
 .. code-block:: yaml
 

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Manage RabbitMQ Users.
+Manage RabbitMQ Users
+=====================
+
+Example:
 
 .. code-block:: yaml
 

--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Manage RabbitMQ Virtual Hosts.
+Manage RabbitMQ Virtual Hosts
+=============================
+
+Example:
 
 .. code-block:: yaml
 

--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Managing Ruby installations with rbenv.
-========================================
+Managing Ruby installations with rbenv
+======================================
 
 This module is used to install and manage ruby installations with rbenv.
 Different versions of ruby can be installed, and uninstalled. Rbenv will

--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Managing Ruby installations and gemsets with Ruby Version Manager (RVM).
-========================================================================
+Managing Ruby installations and gemsets with Ruby Version Manager (RVM)
+=======================================================================
 
 This module is used to install and manage ruby installations and
 gemsets with RVM, the Ruby Version Manager. Different versions of ruby

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
+Control the Salt command interface
+==================================
+
 The Salt state is used to control the salt command interface. This state is
 intended for use primarily from the state runner from the master.
 

--- a/salt/states/selinux.py
+++ b/salt/states/selinux.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of SELinux rules.
-============================
+Management of SELinux rules
+===========================
 
 If SELinux is available for the running system, the mode can be managed and
 booleans can be set.

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Starting or restarting of services and daemons.
-===============================================
+Starting or restarting of services and daemons
+==============================================
 
 Services are defined as system daemons typically started with system init or
 rc scripts, services can be defined as running or dead.

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Control of entries in SSH authorized_key files.
-===============================================
+Control of entries in SSH authorized_key files
+==============================================
 
 The information stored in a user's SSH authorized key file can be easily
 controlled via the ssh_auth state. Defaults can be set by the enc, options,

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Control of SSH known_hosts entries.
-===================================
+Control of SSH known_hosts entries
+==================================
 
-Manage the information stored in the known_hosts files
+Manage the information stored in the known_hosts files.
 
 .. code-block:: yaml
 

--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Interaction with the Supervisor daemon.
-=======================================
+Interaction with the Supervisor daemon
+======================================
 
 .. code-block:: yaml
 

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
-Configuration of the Linux kernel using sysctrl.
-================================================
+Configuration of the Linux kernel using sysctrl
+===============================================
 
-Control the kernel sysctl system
+Control the kernel sysctl system.
 
 .. code-block:: yaml
 

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Management of user accounts.
-============================
+Management of user accounts
+===========================
 
 The user module is used to create and manage user settings, users can be set
 as either absent or present

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -8,10 +8,10 @@ Setup of Python virtualenv sandboxes.
 # Import python libs
 import logging
 import os
-import salt.utils
 
 # Import salt libs
 import salt.version
+import salt.utils
 
 log = logging.getLogger(__name__)
 

--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Setup of Python virtualenv sandboxes.
-=====================================
+Setup of Python virtualenv sandboxes
+====================================
 
 '''
 


### PR DESCRIPTION
The display in the [states index](https://salt.readthedocs.org/en/latest/ref/states/all/index.html) was not consistent, and sometimes it rendered incorrectly. Many state modules did end in a dot, but most didn't.
