### PR TITLE
Add state documentation for AWS SQS.

### DIFF
--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -14,6 +14,7 @@ Full list of builtin state modules
     alternatives
     apt
     augeas
+    aws_sqs
     cmd
     cron
     ddns

--- a/doc/ref/states/all/salt.states.aws_sqs.rst
+++ b/doc/ref/states/all/salt.states.aws_sqs.rst
@@ -1,0 +1,6 @@
+===================
+salt.states.aws_sqs
+===================
+
+.. automodule:: salt.states.aws_sqs
+    :members:


### PR DESCRIPTION
It was missing in the states index.
