### PR TITLE
Remove logging in __virtual__ func.

### DIFF
--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -30,7 +30,6 @@ def __virtual__():
         return False
 
     if salt.utils.which('debconf-get-selections') is None:
-        log.info('Package debconf-utils is not installed.')
         return False
 
     return __virtualname__


### PR DESCRIPTION
With default settings.

Before:

``` bash
(salt)root@master:~# salt-call --local test.version
[INFO    ] Package debconf-utils is not installed.
[INFO    ] Package debconf-utils is not installed.
local:
    0.17.0-4831-g43ec66d
```

After:

``` bash
(salt)root@master:~# salt-call --local test.version
local:
    0.17.0-4831-gd7e5346
```
