### PR TITLE
delay chmod of copied files to check_perms()

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -1,5 +1,5 @@
 ======================
-Full Table of Contents
+Salt Table of Contents
 ======================
 
 .. toctree::

--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -12,7 +12,7 @@ Synopsis
 Description
 ===========
 
-Salt ssh allows for salt routines to be executed using only ssh for transport
+Salt SSH allows for salt routines to be executed using only SSH for transport
 
 Options
 =======

--- a/doc/topics/cloud/action.rst
+++ b/doc/topics/cloud/action.rst
@@ -25,7 +25,7 @@ The following is a list of actions currently supported by salt-cloud:
 
     all providers:
         - reboot
-    aws:
+    ec2:
         - start
         - stop
     joyent:

--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -10,113 +10,111 @@ been deprecated in favor of the `ec2` provider. Configuration using the old
 `aws` provider will still function, but that driver is no longer in active
 development.
 
-Set up the cloud config at ``/etc/salt/cloud``:
-
 .. code-block:: yaml
 
-    # Note: This example is for /etc/salt/cloud
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
 
-    providers:
-      my-ec2-southeast-public-ips:
-        # Set up the location of the salt master
-        #
-        minion:
-          master: saltmaster.example.com
+    my-ec2-southeast-public-ips:
+      # Set up the location of the salt master
+      #
+      minion:
+        master: saltmaster.example.com
 
-        # Set up grains information, which will be common for all nodes
-        # using this provider
-        grains:
-          node_type: broker
-          release: 1.0.1
+      # Set up grains information, which will be common for all nodes
+      # using this provider
+      grains:
+        node_type: broker
+        release: 1.0.1
 
-        # Specify whether to use public or private IP for deploy script.
-        #
-        # Valid options are:
-        #     private_ips - The salt-master is also hosted with EC2
-        #     public_ips - The salt-master is hosted outside of EC2
-        #
-        ssh_interface: public_ips
+      # Specify whether to use public or private IP for deploy script.
+      #
+      # Valid options are:
+      #     private_ips - The salt-master is also hosted with EC2
+      #     public_ips - The salt-master is hosted outside of EC2
+      #
+      ssh_interface: public_ips
 
-        # Set the EC2 access credentials (see below)
-        #
-        id: HJGRYCILJLKJYG
-        key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      # Set the EC2 access credentials (see below)
+      #
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
 
-        # Make sure this key is owned by root with permissions 0400.
-        #
-        private_key: /etc/salt/my_test_key.pem
-        keyname: my_test_key
-        securitygroup: default
+      # Make sure this key is owned by root with permissions 0400.
+      #
+      private_key: /etc/salt/my_test_key.pem
+      keyname: my_test_key
+      securitygroup: default
 
-        # Optionally configure default region
-        #
-        location: ap-southeast-1
-        availability_zone: ap-southeast-1b
+      # Optionally configure default region
+      #
+      location: ap-southeast-1
+      availability_zone: ap-southeast-1b
 
-        # Configure which user to use to run the deploy script. This setting is
-        # dependent upon the AMI that is used to deploy. It is usually safer to
-        # configure this individually in a profile, than globally. Typical users
-        # are:
-        #
-        # Amazon Linux -> ec2-user
-        # RHEL         -> ec2-user
-        # CentOS       -> ec2-user
-        # Ubuntu       -> ubuntu
-        #
-        ssh_username: ec2-user
+      # Configure which user to use to run the deploy script. This setting is
+      # dependent upon the AMI that is used to deploy. It is usually safer to
+      # configure this individually in a profile, than globally. Typical users
+      # are:
+      #
+      # Amazon Linux -> ec2-user
+      # RHEL         -> ec2-user
+      # CentOS       -> ec2-user
+      # Ubuntu       -> ubuntu
+      #
+      ssh_username: ec2-user
 
-        # Optionally add an IAM profile
-        iam_profile: 'arn:aws:iam::123456789012:instance-profile/ExampleInstanceProfile'
+      # Optionally add an IAM profile
+      iam_profile: 'arn:aws:iam::123456789012:instance-profile/ExampleInstanceProfile'
 
-        provider: ec2
+      provider: ec2
 
 
-      my-ec2-southeast-private-ips:
-        # Set up the location of the salt master
-        #
-        minion:
-          master: saltmaster.example.com
+    my-ec2-southeast-private-ips:
+      # Set up the location of the salt master
+      #
+      minion:
+        master: saltmaster.example.com
 
-        # Specify whether to use public or private IP for deploy script.
-        #
-        # Valid options are:
-        #     private_ips - The salt-master is also hosted with EC2
-        #     public_ips - The salt-master is hosted outside of EC2
-        #
-        ssh_interface: private_ips
+      # Specify whether to use public or private IP for deploy script.
+      #
+      # Valid options are:
+      #     private_ips - The salt-master is also hosted with EC2
+      #     public_ips - The salt-master is hosted outside of EC2
+      #
+      ssh_interface: private_ips
 
-        # Set the EC2 access credentials (see below)
-        #
-        id: HJGRYCILJLKJYG
-        key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
+      # Set the EC2 access credentials (see below)
+      #
+      id: HJGRYCILJLKJYG
+      key: 'kdjgfsgm;woormgl/aserigjksjdhasdfgn'
 
-        # Make sure this key is owned by root with permissions 0400.
-        #
-        private_key: /etc/salt/my_test_key.pem
-        keyname: my_test_key
-        securitygroup: default
+      # Make sure this key is owned by root with permissions 0400.
+      #
+      private_key: /etc/salt/my_test_key.pem
+      keyname: my_test_key
+      securitygroup: default
 
-        # Optionally configure default region
-        #
-        location: ap-southeast-1
-        availability_zone: ap-southeast-1b
+      # Optionally configure default region
+      #
+      location: ap-southeast-1
+      availability_zone: ap-southeast-1b
 
-        # Configure which user to use to run the deploy script. This setting is
-        # dependent upon the AMI that is used to deploy. It is usually safer to
-        # configure this individually in a profile, than globally. Typical users
-        # are:
-        #
-        # Amazon Linux -> ec2-user
-        # RHEL         -> ec2-user
-        # CentOS       -> ec2-user
-        # Ubuntu       -> ubuntu
-        #
-        ssh_username: ec2-user
+      # Configure which user to use to run the deploy script. This setting is
+      # dependent upon the AMI that is used to deploy. It is usually safer to
+      # configure this individually in a profile, than globally. Typical users
+      # are:
+      #
+      # Amazon Linux -> ec2-user
+      # RHEL         -> ec2-user
+      # CentOS       -> ec2-user
+      # Ubuntu       -> ubuntu
+      #
+      ssh_username: ec2-user
 
-        # Optionally add an IAM profile
-        iam_profile: 'my other profile name'
+      # Optionally add an IAM profile
+      iam_profile: 'my other profile name'
 
-        provider: ec2
+      provider: ec2
 
 
 Access Credentials

--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -497,9 +497,9 @@ the API Access tab.
 .. code-block:: yaml
 
     my-digitalocean-config:
+      provider: digital_ocean
       client_key: wFGEwgregeqw3435gDger
       api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
-      provider: digital_ocean
       location: New York 1
 
 

--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -1,0 +1,99 @@
+=================================
+Getting Started With Digtal Ocean
+=================================
+
+Digital Ocean is a public cloud provider that specializes Linux instances.
+
+
+Dependencies
+============
+The Digital Ocean driver requires no special dependencies outside of Salt.
+
+
+Configuration
+=============
+Using Salt for Digital Ocean requires a client_key and an api_key. These can be
+found in the Digital Ocean web interface, in the "My Settings" section, under
+the API Access tab.
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
+
+    my-digitalocean-config:
+      provider: digital_ocean
+      client_key: wFGEwgregeqw3435gDger
+      api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
+      location: New York 1
+
+
+Profiles
+========
+
+Cloud Profiles
+~~~~~~~~~~~~~~
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
+``/etc/salt/cloud.profiles.d/`` directory:
+
+.. code-block:: yaml
+
+    digitalocean-ubuntu:
+        provider: my-digitalocean-config
+        image: Ubuntu 12.10 x64
+        size: 512MB
+        location: New York 1
+
+Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-sizes my-digitalocean-config
+    my-digitalocean-config:
+        ----------
+        digital_ocean:
+            ----------
+            512MB:
+                ----------
+                cost_per_hour:
+                    0.00744
+                cost_per_month:
+                    5.0
+                cpu:
+                    1
+                disk:
+                    20
+                id:
+                    66
+                memory:
+                    512
+                name:
+                    512MB
+                slug:
+                    None
+    ...SNIP...
+
+Images can be obtained using the ``--list-images`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-images my-digitalocean-config
+    my-digitalocean-config:
+        ----------
+        digital_ocean:
+            ----------
+            Arch Linux 2013.05 x64:
+                ----------
+                distribution:
+                    Arch Linux
+                id:
+                    350424
+                name:
+                    Arch Linux 2013.05 x64
+                public:
+                    True
+                slug:
+                    None
+    ...SNIP...

--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -2,7 +2,7 @@
 Getting Started With Digtal Ocean
 =================================
 
-Digital Ocean is a public cloud provider that specializes Linux instances.
+Digital Ocean is a public cloud provider that specializes in Linux instances.
 
 
 Dependencies

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -2,7 +2,7 @@
 Getting Started With Google Compute Engine
 ==========================================
 
-Google Compute Engine (GCE) is Goolge-infrastructure as a service that lets you
+Google Compute Engine (GCE) is Google-infrastructure as a service that lets you
 run your large-scale computing workloads on virtual machines.  This document
 covers how to use Salt Cloud to provision and manage your virtual machines
 hosted within Google's infrastructure.
@@ -14,7 +14,7 @@ at https://cloud.google.com.
 Dependencies
 ============
 * `Libcloud <http://libcloud.apache.org>`_ version 0.14.0-beta3 or greater
-* A Google Cloud Platform account with Copmute Engine enabled
+* A Google Cloud Platform account with Compute Engine enabled
 * A registered Service Account for authorization
 * Oh, and obviously you'll need `salt <https://github.com/saltstack/salt>`_
 

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -1,0 +1,244 @@
+==========================================
+Getting Started With Google Compute Engine
+==========================================
+
+Google Compute Engine (GCE) is Goolge-infrastructure as a service that lets you
+run your large-scale computing workloads on virtual machines.  This document
+covers how to use Salt Cloud to provision and manage your virtual machines
+hosted within Google's infrastructure.
+
+You can find out more about GCE and other Google Cloud Platform services
+at https://cloud.google.com.
+
+
+Dependencies
+============
+* `Libcloud <http://libcloud.apache.org>`_ version 0.14.0-beta3 or greater
+* A Google Cloud Platform account with Copmute Engine enabled
+* A registered Service Account for authorization
+* Oh, and obviously you'll need `salt <https://github.com/saltstack/salt>`_
+
+
+Google Compute Engine Setup
+===========================
+#. Sign up for Google Cloud Platform
+   Go to https://cloud.google.com and use your Google account to sign up for
+   Google Cloud Platform and complete the guided instructions.
+
+#. Create a Project
+   Next, go to the console at https://cloud.google.com/console and create a
+   new Project.  Make sure to select your new Project if you are not
+   automatically directed to the Project.
+
+   Projects are a way of grouping together related users, services, and
+   billing.  You may opt to create multiple Projects and the remaining
+   instructions will need to be completed for each Project if you wish to
+   use GCE and Salt Cloud to manage your virtual machines.
+
+#. Enable the Google Compute Engine service
+   In your Project, go to the *APIs & auth* section and *APIs* link and
+   enable the Google Compute Engine service.
+
+#. Create a Service Account
+   To set up authorization, navigate to *APIs & auth* section and then the
+   *Registered apps* link and click the *REGISTER APP* button.  Give it a
+   meaningful name like and select *Web Application*.  After clicking the
+   *Register* button, select *Certificate* in the next screen.  Click the
+   *Generate Certificate* button, record the generated email address for
+   use in the ``service_account_email_address`` of your ``/etc/salt/cloud``
+   file.  Also download and save the generated private key.
+
+#. You will need to convert the private key to a format compatible with
+   libcloud.  The original Google-generated private key was encrypted using
+   *notasecret* as a passphrase.  Use the following command and record the
+   location of the converted private key and record the location for use
+   in the ``service_account_private_key`` of your ``/etc/salt/cloud`` file::
+
+     openssl pkcs12 -in ORIG.pkey -passin pass:notasecret \
+     -nodes -nocerts | openssl rsa -out NEW.pem
+
+
+
+Configuration
+=============
+
+Set up the cloud config at ``/etc/salt/cloud``:
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud
+
+    providers:
+      gce-config:
+        # Set up the Project name and Service Account authorization
+        #
+        project: "your_project_name"
+        service_account_email_address: "123-a5gt@developer.gserviceaccount.com"
+        service_account_private_key: "/path/to/your/NEW.pem"
+
+        # Set up the location of the salt master
+        #
+        minion:
+          master: saltmaster.example.com
+
+        # Set up grains information, which will be common for all nodes
+        # using this provider
+        grains:
+          node_type: broker
+          release: 1.0.1
+
+        provider: gce
+
+
+
+Cloud Profiles
+==============
+Set up an initial profile at ``/etc/salt/cloud.profiles``:
+
+.. code-block:: yaml
+
+    all_settings:
+      image: centos-6
+      size: n1-standard-1
+      location: europe-west1-b
+      network: default
+      tags: '["one", "two", "three"]'
+      metadata: '{"one": "1", "2": "two"}'
+      use_persistent_disk: True
+      delete_boot_pd: False
+      deploy: True
+      make_master: False
+      provider: gce-config
+
+The profile can be realized now with a salt command:
+
+.. code-block:: bash
+
+    salt-cloud -p all_settings gce-instance
+
+This will create an salt minion instance named ``gce-instance`` in GCE.  If
+the command was executed on the salt-master, its Salt key will automatically
+be signed on the master.
+
+Once the instance has been created with salt-minion installed, connectivity to
+it can be verified with Salt:
+
+.. code-block:: bash
+
+    salt 'ami.example.com' test.ping
+
+
+GCE Specific Settings
+=====================
+Consult the sample profile below for more information about GCE specific
+settings.  Some of them are mandatory and are properly labeled below but
+typically also include a hard-coded default.
+
+.. code-block:: yaml
+
+    all_settings:
+
+      # Image is used to define what Operating System image should be used
+      # to for the instance.  Examples are Debian 7 (wheezy) and CentOS 6.
+      #
+      # MANDATORY
+      #
+      image: centos-6
+
+      # A 'size', in GCE terms, refers to the instance's 'machine type'.  See
+      # the on-line documentation for a complete list of GCE machine types.
+      # 
+      # MANDATORY
+      #
+      size: n1-standard-1
+
+      # A 'location', in GCE terms, refers to the instance's 'zone'.  GCE
+      # has the notion of both Regions (e.g. us-central1, europe-west1, etc)
+      # and Zones (e.g. us-central1-a, us-central1-b, etc).
+      #
+      # MANDATORY
+      #
+      location: europe-west1-b
+
+      # Use this setting to define the network resource for the instance.
+      # All GCE projects contain a network named 'default' but it's possible
+      # to use this setting to create instances belonging to a different
+      # network resource.
+      #
+      network: default
+
+      # GCE supports instance/network tags and this setting allows you to
+      # set custom tags.  It should be a list of strings and must be
+      # parse-able by the python ast.literal_eval() function to convert it
+      # to a python list.
+      #
+      tags: '["one", "two", "three"]'
+
+      # GCE supports instance metadata and this setting allows you to
+      # set custom metadata.  It should be a hash of key/value strings and
+      # parse-able by the python ast.literal_eval() function to convert it
+      # to a python dictionary.
+      #
+      metadata: '{"one": "1", "2": "two"}'
+
+      # Use this setting to ensure that when new instances are created,
+      # they will use a persistent disk to preserve data between instance
+      # terminations and re-creations.
+      #
+      use_persistent_disk: True
+
+      # In the event that you wish the boot persistent disk to be permanently
+      # deleted when you destroy an instance, set delete_boot_pd to True.
+      #
+      delete_boot_pd: False
+
+
+GCE instances do not allow remote access to the root user by default.
+Instead, another user must be used to run the deploy script using sudo.
+
+.. code-block:: yaml
+
+    my-gce-config:
+      # Configure which user to use to run the deploy script
+      ssh_username: user
+      ssh_keyfile: /home/user/.ssh/google_compute_engine
+
+
+show_instance
+=============
+This action is a thin wrapper around --full-query, which displays details on a
+single instance only. In an environment with several machines, this will save a
+user from having to sort through all instance data, just to examine a single
+instance.
+
+.. code-block:: bash
+
+    salt-cloud -a show_instance myinstance
+
+
+destroy, persistent disks, and metadata
+=======================================
+As noted in the provider configuration, it's possible to force the boot
+persistent disk to be deleted when you destroy the instance.  The way that
+this has been implemented is to use the instance metadata to record the
+cloud profile used when creating the instance.  When ``destroy`` is called,
+if the instance contains a ``salt-cloud-profile`` key, it's value is used
+to reference the matching profile to determine if ``delete_boot_pd`` is
+set to ``True``.
+
+Be aware that any GCE instances created with salt cloud will contain this
+custom ``salt-cloud-profile`` metadata entry.
+
+
+list_things
+===========
+It's also possible to list several GCE resources similar to what can be done
+with other providers.  The following commands can be used to list GCE zones
+(locations), machine types (sizes), and images.
+
+.. code-block:: bash
+
+    salt-cloud --list-locations gce
+    salt-cloud --list-sizes gce
+    salt-cloud --list-images gce
+

--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -25,8 +25,6 @@ in the configuration file to enable interfacing with GoGrid:
     # Note: This example is for /etc/salt/cloud.providers or any file in the
     # /etc/salt/cloud.providers.d/ directory.
 
-.. code-block:: yaml
-
     my-gogrid-config:
       provider: gogrid
       apikey: asdff7896asdh789

--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -1,0 +1,103 @@
+===========================
+Getting Started With GoGrid
+===========================
+
+GoGrid is a public cloud provider supporting Linux and Windows.
+
+
+Dependencies
+============
+The GoGrid driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
+installed.
+
+
+Configuration
+=============
+To use Salt Cloud with GoGrid log into the GoGrid web interface and create an 
+API key. Do this by clicking on "My Account" and then going to the API Keys 
+tab.
+
+The ``apikey`` and the ``sharedsecret`` configuration parameters need to be set
+in the configuration file to enable interfacing with GoGrid:
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
+
+.. code-block:: yaml
+
+    my-gogrid-config:
+      provider: gogrid
+      apikey: asdff7896asdh789
+      sharedsecret: saltybacon
+
+
+Profiles
+========
+
+Cloud Profiles
+~~~~~~~~~~~~~~
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
+``/etc/salt/cloud.profiles.d/`` directory:
+
+.. code-block:: yaml
+
+    gogrid_512:
+      provider: my-gogrid-config
+      size: 512MB
+      image: CentOS 6.2 (64-bit) w/ None
+
+Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-sizes my-gogrid-config
+    my-gogrid-config:
+        ----------
+        gogrid:
+            ----------
+            512MB:
+                ----------
+                bandwidth:
+                    None
+                disk:
+                    30
+                driver:
+                get_uuid:
+                id:
+                    512MB
+                name:
+                    512MB
+                price:
+                    0.095
+                ram:
+                    512
+                uuid:
+                    bde1e4d7c3a643536e42a35142c7caac34b060e9
+    ...SNIP...
+
+Images can be obtained using the ``--list-images`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-images my-gogrid-config
+    my-gogrid-config:
+        ----------
+        gogrid:
+            ----------
+            CentOS 6.4 (64-bit) w/ None:
+                ----------
+                driver:
+                extra:
+                    ----------
+                get_uuid:
+                id:
+                    18094
+                name:
+                    CentOS 6.4 (64-bit) w/ None
+                uuid:
+                    bfd4055389919e01aa6261828a96cf54c8dcc2c4
+    ...SNIP...

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -29,12 +29,13 @@ Getting Started
 
 * :doc:`Installing salt cloud <install/index>`
 
-Some quick guides covering getting started with Amazon AWS, Rackspace, and
-Parallels.
+Some quick guides covering getting started with Amazon AWS, Google Compute
+Engine, Parallels, Rackspace, and Softlayer.
 
 * :doc:`Getting Started With AWS <aws>`
-* :doc:`Getting Started With Rackspace <rackspace>`
+* :doc:`Getting Started With Google Compute Engine <gce>`
 * :doc:`Getting Started With Parallels <parallels>`
+* :doc:`Getting Started With Rackspace <rackspace>`
 * :doc:`Getting Started With SoftLayer <softlayer>`
 
 Core Configuration

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -86,6 +86,11 @@ Miscellaneous Options
 
 * :doc:`Miscellaneous <misc>`
 
+Troubleshooting Steps
+=====================
+
+* :doc:`Troubleshooting <troubleshooting>`
+
 Extending Salt Cloud
 ====================
 

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -40,6 +40,7 @@ SoftLayer.
 * :doc:`Getting Started With Linode <linode>`
 * :doc:`Getting Started With Joyent <joyent>`
 * :doc:`Getting Started With Parallels <parallels>`
+* :doc:`Getting Started With OpenStack <openstack>`
 * :doc:`Getting Started With Rackspace <rackspace>`
 * :doc:`Getting Started With SoftLayer <softlayer>`
 

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -32,8 +32,9 @@ Getting Started
 Some quick guides covering getting started with Amazon AWS, Google Compute
 Engine, Parallels, Rackspace, and Softlayer.
 
-* :doc:`Getting Started With AWS <aws>`
+* :doc:`Getting Started With AWS/EC2 <aws>`
 * :doc:`Getting Started With Google Compute Engine <gce>`
+* :doc:`Getting Started With Linode <linode>`
 * :doc:`Getting Started With Parallels <parallels>`
 * :doc:`Getting Started With Rackspace <rackspace>`
 * :doc:`Getting Started With SoftLayer <softlayer>`

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -29,10 +29,13 @@ Getting Started
 
 * :doc:`Installing salt cloud <install/index>`
 
-Some quick guides covering getting started with Amazon AWS, Google Compute
-Engine, Parallels, Rackspace, and Softlayer.
+Some quick guides covering getting started with Amazon EC2, Digital Ocean,
+GoGrid, Google Compute Engine, Linode, Joyent, Parallels, Rackspace, and
+SoftLayer.
 
 * :doc:`Getting Started With AWS/EC2 <aws>`
+* :doc:`Getting Started With Digital Ocean <digitalocean>`
+* :doc:`Getting Started With GoGrid <gogrid>`
 * :doc:`Getting Started With Google Compute Engine <gce>`
 * :doc:`Getting Started With Linode <linode>`
 * :doc:`Getting Started With Joyent <joyent>`

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -35,6 +35,7 @@ Engine, Parallels, Rackspace, and Softlayer.
 * :doc:`Getting Started With AWS/EC2 <aws>`
 * :doc:`Getting Started With Google Compute Engine <gce>`
 * :doc:`Getting Started With Linode <linode>`
+* :doc:`Getting Started With Joyent <joyent>`
 * :doc:`Getting Started With Parallels <parallels>`
 * :doc:`Getting Started With Rackspace <rackspace>`
 * :doc:`Getting Started With SoftLayer <softlayer>`

--- a/doc/topics/cloud/joyent.rst
+++ b/doc/topics/cloud/joyent.rst
@@ -27,13 +27,11 @@ send the provisioning commands up to the freshly created virtual machine.
 .. code-block:: yaml
 
     my-joyent-config:
+        provider: joyent
         user: fred
         password: saltybacon
         private_key: /root/joyent.pem
-        provider: joyent
 
-The password needs to be 8 characters and contain lowercase, uppercase and 
-numbers.
 
 Profiles
 ========
@@ -84,7 +82,7 @@ command:
 .. code-block:: bash
 
     # salt-cloud --list-images my-joyent-config
-    techhat-joyent:
+    my-joyent-config:
         ----------
         joyent:
             ----------

--- a/doc/topics/cloud/joyent.rst
+++ b/doc/topics/cloud/joyent.rst
@@ -1,0 +1,115 @@
+===========================
+Getting Started With Joyent
+===========================
+
+Joyent is a public cloud provider supporting SmartOS, Linux, FreeBSD and
+Windows.
+
+
+Dependencies
+============
+The Joyent driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
+installed.
+
+
+Configuration
+=============
+The Joyent cloud requires three configuration parameters. The user name and 
+password that are used to log into the Joyent system, and the location of the 
+private ssh key associated with the Joyent account. The ssh key is needed to 
+send the provisioning commands up to the freshly created virtual machine.
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
+
+.. code-block:: yaml
+
+    my-joyent-config:
+        user: fred
+        password: saltybacon
+        private_key: /root/joyent.pem
+        provider: joyent
+
+The password needs to be 8 characters and contain lowercase, uppercase and 
+numbers.
+
+Profiles
+========
+
+Cloud Profiles
+~~~~~~~~~~~~~~
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
+``/etc/salt/cloud.profiles.d/`` directory:
+
+.. code-block:: yaml
+
+    joyent_512
+      provider: my-joyent-config
+      size: Extra Small 512 MB
+      image: Arch Linux 2013.06
+
+Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-sizes my-joyent-config
+    my-joyent-config:
+        ----------
+        joyent:
+            ----------
+            Extra Small 512 MB:
+                ----------
+                default:
+                    false
+                disk:
+                    15360
+                id:
+                    Extra Small 512 MB
+                memory:
+                    512
+                name:
+                    Extra Small 512 MB
+                swap:
+                    1024
+                vcpus:
+                    1
+    ...SNIP...
+
+Images can be obtained using the ``--list-images`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-images my-joyent-config
+    techhat-joyent:
+        ----------
+        joyent:
+            ----------
+            base:
+                ----------
+                description:
+                    A 32-bit SmartOS image with just essential packages
+                    installed. Ideal for users who are comfortable with setting
+                    up their own environment and tools.
+                disabled:
+                    False
+                files:
+                    ----------
+                    - compression:
+                        bzip2
+                    - sha1:
+                        40cdc6457c237cf6306103c74b5f45f5bf2d9bbe
+                    - size:
+                        82492182
+                name:
+                    base
+                os:
+                    smartos
+                owner:
+                    352971aa-31ba-496c-9ade-a379feaecd52
+                public:
+                    True
+    ...SNIP...

--- a/doc/topics/cloud/joyent.rst
+++ b/doc/topics/cloud/joyent.rst
@@ -24,8 +24,6 @@ send the provisioning commands up to the freshly created virtual machine.
     # Note: This example is for /etc/salt/cloud.providers or any file in the
     # /etc/salt/cloud.providers.d/ directory.
 
-.. code-block:: yaml
-
     my-joyent-config:
         provider: joyent
         user: fred

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -1,0 +1,102 @@
+===========================
+Getting Started With Linode
+===========================
+
+Linode is a public cloud provider with a focus on Linux instances.
+
+Dependencies
+============
+The Linode driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
+installed.
+
+
+Configuration
+=============
+Linode requires a single API key, but the default root password for new 
+instances also needs to be set:
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
+
+    my-linode-config:
+      apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
+      password: F00barbaz
+      provider: linode
+
+The password needs to be 8 characters and contain lowercase, uppercase and 
+numbers.
+
+Profiles
+========
+
+Cloud Profiles
+~~~~~~~~~~~~~~
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
+``/etc/salt/cloud.profiles.d/`` directory:
+
+.. code-block:: yaml
+
+    linode_1024:
+      provider: my-linode-config
+      size: Linode 1024
+      image: Arch Linux 2013.06
+
+Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-sizes my-linode-config
+    my-linode-config:
+        ----------
+        linode:
+            ----------
+            Linode 1024:
+                ----------
+                bandwidth:
+                    2000
+                disk:
+                    49152
+                driver:
+                get_uuid:
+                id:
+                    1
+                name:
+                    Linode 1024
+                price:
+                    20.0
+                ram:
+                    1024
+                uuid:
+                    03e18728ce4629e2ac07c9cbb48afffb8cb499c4
+    ...SNIP...
+
+Images can be obtained using the ``--list-images`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-images my-linode-config
+    my-linode-config:
+        ----------
+        linode:
+            ----------
+            Arch Linux 2013.06:
+                ----------
+                driver:
+                extra:
+                    ----------
+                    64bit:
+                        1
+                    pvops:
+                        1
+                get_uuid:
+                id:
+                    112
+                name:
+                    Arch Linux 2013.06
+                uuid:
+                    8457f92eaffc92b7666b6734a96ad7abe1a8a6dd
+    ...SNIP...

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -13,17 +13,17 @@ machines to make from said profile:
 .. code-block:: yaml
 
     fedora_small:
-        - web1
-        - web2
-        - web3
+      - web1
+      - web2
+      - web3
     fedora_high:
-        - redis1
-        - redis2
-        - redis3
+      - redis1
+      - redis2
+      - redis3
     cent_high:
-        - riak1
-        - riak2
-        - riak3
+      - riak1
+      - riak2
+      - riak3
 
 This map file can then be called to roll out all of these virtual machines. Map
 files are called from the salt-cloud command with the -m option:

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -60,18 +60,18 @@ A map file can include grains and minion configuration options:
 .. code-block:: yaml
 
     fedora_small:
-        - web1:
-            minion:
-                log_level: debug
-                grains:
-                    cheese: tasty
-                    omelet: du fromage
-        - web2:
-            minion:
-                log_level: warn
-                grains:
-                    cheese: more tasty
-                    omelet: with peppers
+      - web1:
+          minion:
+            log_level: debug
+          grains:
+            cheese: tasty
+            omelet: du fromage
+      - web2:
+          minion:
+            log_level: warn
+          grains:
+            cheese: more tasty
+            omelet: with peppers
 
 A map file may also be used with the various query options:
 

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -78,7 +78,7 @@ A map file may also be used with the various query options:
 .. code-block:: bash
 
     $ salt-cloud -m /path/to/mapfile -Q
-    {'aws': {'web1': {'id': 'i-e6aqfegb',
+    {'ec2': {'web1': {'id': 'i-e6aqfegb',
                          'image': None,
                          'private_ips': [],
                          'public_ips': [],

--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -13,8 +13,8 @@ to pass arguments to the deploy script:
 
 .. code-block:: yaml
 
-    aws-amazon:
-        provider: aws
+    ec2-amazon:
+        provider: ec2
         image: ami-1624987f
         size: Micro Instance
         ssh_username: ec2-user

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -1,0 +1,87 @@
+==============================
+Getting Started With OpenStack
+==============================
+
+OpenStack is one the most popular cloud projects. It's an open source project
+to build public and/or private clouds. You can use Salt Cloud to launch
+OpenStack instances.
+
+* Using the new format, set up the cloud configuration at 
+  ``/etc/salt/cloud.providers`` or 
+  ``/etc/salt/cloud.providers.d/rackspace.conf``:
+
+.. code-block:: yaml
+
+    my-openstack-config:
+      # Set the location of the salt-master
+      #
+      minion:
+        master: saltmaster.example.com
+
+      # Configure Rackspace using the OpenStack plugin
+      #
+      identity_url: http://identity.youopenstack.com/v2.0/
+      compute_name: nova
+      protocol: ipv4
+
+      compute_region: RegionOne
+
+      # Configure Rackspace authentication credentials
+      #
+      user: myname
+      password: 123456
+      # tenant is the project name
+      tenant: myproject
+
+      provider: openstack
+
+
+
+Using nova client to get information from OpenStack
+===================================================
+
+One of the best ways to get information about OpenStack is using the novaclient
+python package (available in pypi as python-novaclient). The client
+configuration is a set of environment variables that you can get from the
+Dashboard. Log in and then go to Project -> Access & security -> API Access and
+download the "OpenStack RC file". Then:
+
+.. code-block:: yaml
+    source /path/to/your/rcfile
+    nova credentials
+    nova endpoints
+
+In the ``nova endpoints`` output you can see the information about
+``compute_region`` and ``compute_name``.
+
+
+Compute Region
+==============
+
+It depends on the OpenStack cluster that you are using. Please, have a look at
+the previous sections.
+
+
+Authentication
+==============
+
+The ``user`` and ``password`` is the same user as is used to log into the
+OpenStack Dashboard.
+
+
+Profiles
+========
+
+Here is an example of a profile:
+
+.. code-block:: yaml
+    openstack_512:
+        provider: my-openstack-config
+        size: m1.tiny
+        image: cirros-0.3.1-x86_64-uec
+        ssh_key_file: /tmp/test.pem
+
+``size`` can be one of the options listed in the output of ``nova flavor-list``.
+
+``image`` can be one of the options listed in the output of ``nova image-list``.
+

--- a/doc/topics/cloud/profiles.rst
+++ b/doc/topics/cloud/profiles.rst
@@ -63,16 +63,16 @@ Larger Example
 
 .. code-block:: yaml
 
-    rhel_aws:
-        provider: aws
+    rhel_ec2:
+        provider: ec2
         image: ami-e565ba8c
         size: Micro Instance
         script: RHEL6
         minion:
             cheese: edam
 
-    ubuntu_aws:
-        provider: aws
+    ubuntu_ec2:
+        provider: ec2
         image: ami-7e2da54e
         size: Micro Instance
         script: Ubuntu

--- a/doc/topics/cloud/troubleshooting.rst
+++ b/doc/topics/cloud/troubleshooting.rst
@@ -1,0 +1,151 @@
+==========================
+Troubleshooting Salt Cloud
+==========================
+
+This page describes various steps for troubleshooting problems that may arise
+while using Salt Cloud.
+
+Generic Troubleshooting Steps
+=============================
+This section describes a set of instructions that are useful to a large number
+of situations, and are likely to solve most issues that arise.
+
+Debug Mode
+----------
+Frequently, running Salt Cloud in debug mode will reveal information about a
+deployment which would otherwise not be obvious:
+
+.. code-block:: bash
+
+    salt-cloud -p myprofile myinstance -l debug
+
+Keep in mind that a number of messages will appear that look at first like
+errors, but are in fact intended to give developers factual information to
+assist in debugging. A number of messages that appear will be for cloud
+providers that you do not have configured; in these cases, the message usually
+is intended to confirm that they are not configured.
+
+
+Salt Bootstrap
+--------------
+By default, Salt Cloud uses the Salt Bootstrap script to provision instances:
+
+.. _`Salt Bootstrap`: https://github.com/saltstack/salt-bootstrap
+
+This script is packaged with Salt Cloud, but may be updated without updating
+the Salt package:
+
+.. code-block:: bash
+
+    salt-cloud -u
+
+
+The Bootstrap Log
+-----------------
+If the default deploy script was used, there should be a file in the ``/tmp/``
+directory called ``bootstrap-salt.log``. This file contains the full output from
+the deployment, including any errors that may have occurred.
+
+
+Keeping Temp Files
+------------------
+Salt Cloud uploads minion-specific files to instances once they are available
+via SSH, and then executes a deploy script to put them into the correct place
+and install Salt. The ``--keep-tmp`` option will instruct Salt Cloud not to
+remove those files when finished with them, so that the user may inspect them
+for problems:
+
+.. code-block:: bash
+
+    salt-cloud -p myprofile myinstance --keep-tmp
+
+By default, Salt Cloud will create a directory on the target instance called
+``/tmp/.saltcloud/``. This directory should be owned by the user that is to
+execute the deploy script, and should have permissions of ``0700``.
+
+Most cloud providers are configured to use ``root`` as the default initial user
+for deployment, and as such, this directory and all files in it should be owned
+by the ``root`` user.
+
+The ``/tmp/.saltcloud/`` directory should the following files:
+
+- A ``deploy.sh`` script. This script should have permissions of ``0755``.
+- A ``.pem`` and ``.pub`` key named after the minion. The ``.pem`` file should
+  have permissions of ``0600``. Ensure that the ``.pem`` and ``.pub`` files have
+  been properly copied to the ``/etc/salt/pki/minion/`` directory.
+- A file called ``minion``. This file should have been copied to the
+  ``/etc/salt/`` directory. 
+- Optionally, a file called ``grains``. This file, if present, should have been
+  copied to the ``/etc/salt/`` directory.
+
+
+Unprivileged Primary Users
+--------------------------
+Some providers, most notably EC2, are configured with a different primary user.
+Some common examples are ``ec2-user``, ``ubuntu``, ``fedora`` and ``bitnami``.
+In these cases, the ``/tmp/.saltcloud/`` directory and all files in it should
+be owned by this user.
+
+Some providers, such as EC2, are configured to not require these users to
+provide a password when using the ``sudo`` command. Because it is more secure
+to require ``sudo`` users to provide a password, other providers are configured
+that way.
+
+If this instance is required to provide a password, it needs to be configured
+in Salt Cloud. A password for sudo to use may be added to either the provider
+configuration or the profile configuration:
+
+.. code-block:: yaml
+
+    sudo_password: mypassword
+
+
+``/tmp/`` is Mounted as ``noexec``
+----------------------------------
+It is more secure to mount the ``/tmp/`` directory with a ``noexec`` option.
+This is uncommon on most cloud providers, but very common in private
+environments. To see if the ``/tmp/`` directory is mounted this way, run the
+following command:
+
+.. code-block:: bash
+
+    mount | grep tmp
+
+The if the output of this command includes a line that looks like this, then
+the ``/tmp/`` directory is mounted as ``noexec``:
+
+.. code-block:: bash
+
+    tmpfs on /tmp type tmpfs (rw,noexec)
+
+If this is the case, then the ``deploy_command`` will need to be changed
+in order to run the deploy script through the ``sh`` command, rather than trying
+to execute it directly. This may be specified in either the provider or the
+profile config:
+
+.. code-block:: yaml
+
+    deploy_command: sh /tmp/.saltcloud/deploy.sh
+
+Please note that by default, Salt Cloud will place its files in a directory
+called ``/tmp/.saltcloud/``. This may be also be changed in the provider or
+profile configuration:
+
+.. code-block:: yaml
+
+    tmp_dir: /tmp/.saltcloud/
+
+If this directory is changed, then the ``deploy_command`` need to be changed
+in order to reflect the ``tmp_dir`` configuration.
+
+
+Executing the Deploy Script Manually
+------------------------------------
+If all of the files needed for deployment were successfully uploaded to the
+correct locations, and contain the correct permissions and ownerships, the
+deploy script may be executed manually in order to check for other issues:
+
+.. code-block:: bash
+
+    cd /tmp/.saltcloud/
+    ./deploy.sh

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -4,6 +4,10 @@ Salt SSH
 
 .. note::
 
+    SALT-SSH IS ALPHA SOFTWARE AND MAY NOT BE READY FOR PRODUCTION USE
+
+.. note::
+
     On many systems, ``salt-ssh`` will be in its own package, usually named
     ``salt-ssh``.
 

--- a/doc/topics/tutorials/halite.rst
+++ b/doc/topics/tutorials/halite.rst
@@ -210,15 +210,7 @@ module:
 
     salt '*' tls.create_self_signed_cert test 
 
-You can use ``salt-call`` to create a self-signed cert on the box running
-Halite. That way you can create the cert directly on the Halite box without
-having to go through the master.
-
-.. note::
-
-    The following command requires that you have the ``salt-minion`` package
-    installed.
-
+You can also use ``salt-call`` to create a self-signed cert.
 .. code-block:: bash
 
     salt-call tls.create_self_signed_cert tls

--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -9,7 +9,6 @@ This module has been replaced by the EC2 cloud module, and is no longer
 supported. The documentation shown here is for reference only; it is highly
 recommended to change all usages of this driver over to the EC2 driver.
 
-
 To use the AWS cloud module, using the old cloud providers configuration
 syntax, the following configuration parameters need to be set in the main cloud
 configuration file:

--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -5,6 +5,11 @@ The AWS Cloud Module
 
 The AWS cloud module is used to interact with the Amazon Web Services system.
 
+This module has been replaced by the EC2 cloud module, and is no longer
+supported. The documentation shown here is for reference only; it is highly
+recommended to change all usages of this driver over to the EC2 driver.
+
+
 To use the AWS cloud module, using the old cloud providers configuration
 syntax, the following configuration parameters need to be set in the main cloud
 configuration file:

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -808,10 +808,24 @@ def avail_images():
 
         salt-cloud --list-images
     '''
-    rcode, items = query2(command='/my/datasets')
-    if rcode not in VALID_RESPONSE_CODES:
-        return {}
-    return key_list(items=items)
+    img_url = 'https://images.joyent.com/images'
+    request = urllib2.Request(img_url)
+    request.get_method = lambda: 'GET'
+    result = urllib2.urlopen(request)
+    content = result.read()
+    result.close()
+
+    ret = {}
+    for image in yaml.safe_load(content):
+        ret[image['name']] = image
+    return ret
+
+    # It appears the API has changed on us again
+    #rcode, items = query2(command='/my/datasets')
+    #log.debug(rcode)
+    #if rcode not in VALID_RESPONSE_CODES:
+    #    return {}
+    #return key_list(items=items)
 
 
 def avail_sizes():

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -5,6 +5,10 @@ The AWS Cloud Module
 
 The AWS cloud module is used to interact with the Amazon Web Services system.
 
+This module has been replaced by the EC2 cloud module, and is no longer
+supported. The documentation shown here is for reference only; it is highly
+recommended to change all usages of this driver over to the EC2 driver.
+
 To use the AWS cloud module, using the old cloud providers configuration
 syntax, the following configuration parameters need to be set in the main cloud
 configuration file:

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -18,7 +18,7 @@ from libcloud.compute.deployment import (
     ScriptDeployment,
     SSHKeyDeployment
 )
-# pylint: enable-msg=W0611
+# pylint: enable=W0611
 
 
 # Import salt libs

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -894,15 +894,15 @@ def _get_flags(flags):
 
 
 def replace(path,
-        pattern,
-        repl,
-        count=0,
-        flags=0,
-        bufsize=1,
-        backup='.bak',
-        dry_run=False,
-        search_only=False,
-        show_changes=True,
+            pattern,
+            repl,
+            count=0,
+            flags=0,
+            bufsize=1,
+            backup='.bak',
+            dry_run=False,
+            search_only=False,
+            show_changes=True,
         ):
     '''
     Replace occurances of a pattern in a file

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -971,8 +971,10 @@ def replace(path,
         pre_group = get_group(path)
         pre_mode = __salt__['config.manage_mode'](get_mode(path))
     for line in fileinput.input(path,
-            inplace=not dry_run, backup=False if dry_run else backup,
-            bufsize=bufsize, mode='rb'):
+                                inplace=not dry_run,
+                                backup=False if dry_run else backup,
+                                bufsize=bufsize,
+                                mode='rb'):
 
         if search_only:
             # Just search; bail as early as a match is found

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1518,7 +1518,9 @@ def copy(src, dst):
         pre_mode = __salt__['config.manage_mode'](get_mode(src))
 
     try:
+        current_umask = os.umask(63)
         shutil.copyfile(src, dst)
+        os.umask = current_umask
     except OSError:
         raise CommandExecutionError(
             'Could not copy {0!r} to {1!r}'.format(src, dst)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1518,7 +1518,7 @@ def copy(src, dst):
         pre_mode = __salt__['config.manage_mode'](get_mode(src))
 
     try:
-        shutil.copyfile(src, dst)
+        salt.utils.copyfile(src, dst)
     except OSError:
         raise CommandExecutionError(
             'Could not copy {0!r} to {1!r}'.format(src, dst)
@@ -1916,6 +1916,12 @@ def check_perms(name,
                     )
                 else:
                     ret['changes']['mode'] = mode
+    else:
+        # Use umask to determine correct perms
+        current_umask = os.umask(0)
+        os.chmod(name, 0666 - current_umask)
+        os.umask(current_umask)
+
     # user/group changes if needed, then check if it worked
     if user:
         if user != perms['luser']:
@@ -2359,12 +2365,10 @@ def manage_file(name,
             with salt.utils.fopen(tmp, 'w') as tmp_:
                 tmp_.write(str(contents))
             # Copy into place
-            current_umask = os.umask(63)
             salt.utils.copyfile(tmp,
                                 name,
                                 __salt__['config.backup_mode'](backup),
                                 __opts__['cachedir'])
-            os.umask(current_umask)
             __clean_tmp(tmp)
         # Now copy the file contents if there is a source file
         elif sfn:

--- a/salt/modules/lvs.py
+++ b/salt/modules/lvs.py
@@ -11,6 +11,7 @@ import salt.utils
 import salt.utils.decorators as decorators
 from salt.exceptions import SaltException
 
+
 # Cache the output of running which('ipvsadm')
 @decorators.memoize
 def __detect_os():
@@ -25,6 +26,7 @@ def __virtual__():
         return False
 
     return 'lvs'
+
 
 def _build_cmd(**kwargs):
     '''
@@ -59,26 +61,24 @@ def _build_cmd(**kwargs):
         if kwargs['server_address']:
             cmd += ' -r {0}'.format(kwargs['server_address'])
             if 'packet_forward_method' in kwargs and kwargs['packet_forward_method']:
-                 if kwargs['packet_forward_method'] == 'dr':
-                     cmd += ' -g'
-                 elif kwargs['packet_forward_method'] == 'tunnel':
-                     cmd += ' -i'
-                 elif kwargs['packet_forward_method'] == 'nat':
-                     cmd += ' -m'
-                 else:
-                     raise SaltException('Error: only support dr, tunnel and nat')
-                 del kwargs['packet_forward_method']
+                if kwargs['packet_forward_method'] == 'dr':
+                    cmd += ' -g'
+                elif kwargs['packet_forward_method'] == 'tunnel':
+                    cmd += ' -i'
+                elif kwargs['packet_forward_method'] == 'nat':
+                    cmd += ' -m'
+                else:
+                    raise SaltException('Error: only support dr, tunnel and nat')
+                del kwargs['packet_forward_method']
             if 'weight' in kwargs and kwargs['weight']:
-                 cmd += ' -w {0}'.format(kwargs['weight'])
-                 del kwargs['weight']
+                cmd += ' -w {0}'.format(kwargs['weight'])
+                del kwargs['weight']
         else:
             raise SaltException('Error: server_address should specified')
         del kwargs['server_address']
 
     return cmd
 
-    
-            
 
 def add_service(protocol=None, service_address=None, scheduler='wlc'):
     '''
@@ -100,7 +100,7 @@ def add_service(protocol=None, service_address=None, scheduler='wlc'):
 
         salt '*' lvs.add_service tcp 1.1.1.1:80 rr
     '''
-    
+
     cmd = '{0} -A {1}'.format(__detect_os(),
                               _build_cmd(protocol=protocol,
                                          service_address=service_address,
@@ -135,7 +135,7 @@ def edit_service(protocol=None, service_address=None, scheduler=None):
 
         salt '*' lvs.edit_service tcp 1.1.1.1:80 rr
     '''
-    
+
     cmd = '{0} -E {1}'.format(__detect_os(),
                               _build_cmd(protocol=protocol,
                                          service_address=service_address,
@@ -160,12 +160,12 @@ def delete_service(protocol=None, service_address=None):
 
     service_address
         The LVS service address.
-    
+
 
     CLI Example:
-      
+
     .. code-block:: bash
-     
+
         salt '*' lvs.delete_service tcp 1.1.1.1:80
     '''
 
@@ -195,18 +195,18 @@ def add_server(protocol=None, service_address=None, server_address=None, packet_
 
     server_address
         The real server address.
-    
+
     packet_forward_method
         The LVS packet forwarding method(``dr`` for direct routing, ``tunnel`` for tunneling, ``nat`` for network access translation).
 
     weight
         The capacity  of a server relative to the others in the pool.
 
-    
+
     CLI Example:
-    
+
     .. code-block:: bash
-     
+
         salt '*' lvs.add_server tcp 1.1.1.1:80 192.168.0.11:8080 nat 1
     '''
 
@@ -240,18 +240,18 @@ def edit_server(protocol=None, service_address=None, server_address=None, packet
 
     server_address
         The real server address.
-    
+
     packet_forward_method
         The LVS packet forwarding method(``dr`` for direct routing, ``tunnel`` for tunneling, ``nat`` for network access translation).
 
     weight
         The capacity  of a server relative to the others in the pool.
 
-    
+
     CLI Example:
-    
+
     .. code-block:: bash
-     
+
         salt '*' lvs.edit_server tcp 1.1.1.1:80 192.168.0.11:8080 nat 1
     '''
 
@@ -285,12 +285,12 @@ def delete_server(protocol=None, service_address=None, server_address=None):
 
     server_address
         The real server address.
-    
-    
+
+
     CLI Example:
 
     .. code-block:: bash
-   
+
         salt '*' lvs.delete_server tcp 1.1.1.1:80 192.168.0.11:8080
     '''
 
@@ -310,7 +310,7 @@ def delete_server(protocol=None, service_address=None, server_address=None):
 
 def clear():
     '''
-   
+
     Clear the virtual server table
 
     CLI Example:
@@ -334,11 +334,11 @@ def clear():
 
 def get_rules():
     '''
-    
+
     Get the virtual server rules
 
     CLI Example:
-    
+
     .. code-block:: bash
 
         salt '*' lvs.get_rules
@@ -356,12 +356,12 @@ def list(protocol=None, service_address=None):
     List the virtual server table if service_address is not specified. If a service_address is selected, list this service only.
 
     CLI Example:
-     
+
     .. code-block:: bash
 
         salt '*' lvs.list
-    ''' 
-    
+    '''
+
     if service_address:
         cmd = '{0} -L {1} -n'.format(__detect_os(),
                                   _build_cmd(protocol=protocol,
@@ -378,15 +378,16 @@ def list(protocol=None, service_address=None):
 
     return ret
 
+
 def zero(protocol=None, service_address=None):
     '''
 
     Zero the packet, byte and rate counters in a service or all services.
 
     CLI Example:
-   
+
     .. code-block:: bash
-   
+
         salt '*' lvs.zero
     '''
 
@@ -410,7 +411,7 @@ def check_service(protocol=None, service_address=None, **kwargs):
     '''
 
     Check the virtual service exists.
-    
+
     CLI Example:
 
     .. code-block:: bash
@@ -423,7 +424,7 @@ def check_service(protocol=None, service_address=None, **kwargs):
                                    **kwargs))
     # Exact match
     if not kwargs:
-         cmd += ' '
+        cmd += ' '
 
     all_rules = get_rules()
     out = all_rules.find(cmd)
@@ -433,6 +434,7 @@ def check_service(protocol=None, service_address=None, **kwargs):
     else:
         ret = 'Error: service not exists'
     return ret
+
 
 def check_server(protocol=None, service_address=None, server_address=None, **kwargs):
     '''

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -5,12 +5,12 @@ Support for ``pkgng``, the new package manager for FreeBSD
 .. warning::
 
     This module has been completely rewritten. Up to and includng version
-    0.17.0, it was available as the ``pkgng`` module, (``pkgng.install``,
+    0.17.x, it was available as the ``pkgng`` module, (``pkgng.install``,
     ``pkgng.delete``, etc.), but moving forward this module will no longer be
     available as ``pkgng``, as it will behave like a normal Salt ``pkg``
     provider. The documentation below should not be considered to apply to this
-    module in versions <= 0.17.0. If your minion is running one of these
-    versions, then the documentation for this module can be viewed using the
+    module in versions <= 0.17.x. If your minion is running a 0.17.x release or
+    older, then the documentation for this module can be viewed using the
     :mod:`sys.doc <salt.modules.sys.doc>` function:
 
     .. code-block:: bash

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -504,7 +504,7 @@ def pid(sig):
     cmd = "{0[ps]} | grep {1} | grep -v grep | awk '{{print $2}}'".format(
         __grains__, sig)
     return (__salt__['cmd.run_stdout'](cmd) or '')
-    
+
 
 def version():
     '''
@@ -522,6 +522,3 @@ def version():
     ret = salt.utils.fopen(procf, 'r').read().strip()
 
     return ret
-
-
-

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -455,6 +455,12 @@ def create_self_signed_cert(
     .. code-block:: bash
 
         salt '*' tls.create_self_signed_cert
+
+    Passing options from the command line:
+
+    .. code-block:: bash
+
+        salt 'minion' tls.create_self_signed_cert CN='test.mysite.org'
     '''
 
     if not os.path.exists('{0}/{1}/certs/'.format(_cert_base_path(), tls_dir)):

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -108,7 +108,7 @@ class RunnerClient(object):
                 target=self._proc_runner,
                 args=(fun, low, user, tag, jid))
         proc.start()
-        return tag
+        return {'tag': tag}
 
     def master_call(self, **kwargs):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -44,7 +44,7 @@ class RunnerClient(object):
         event.fire_event(data, tagify('new', base=tag))
 
         try:
-            data['ret'] = self.low(fun, low)
+            data['return'] = self.low(fun, low)
             data['success'] = True
         except Exception as exc:
             data['ret'] = 'Exception occured in runner {0}: {1}'.format(

--- a/salt/states/lvs_server.py
+++ b/salt/states/lvs_server.py
@@ -7,6 +7,7 @@ Management of LVS(Linux Virtual Server) Real Server.
 This lvs_server module is used to add and manage LVS Real Server in the specified service. Server can be set as either absent or present.
 '''
 
+
 def __virtual__():
     '''
 
@@ -14,12 +15,13 @@ def __virtual__():
     '''
     return 'lvs_server' if 'lvs.get_rules' in __salt__ else False
 
+
 def present(name,
             protocol=None,
             service_address=None,
             server_address=None,
             packet_forward_method='dr',
-            weight=1 
+            weight=1
            ):
     '''
     Ensure that the named service is present.
@@ -35,7 +37,7 @@ def present(name,
 
     server_address
         The real server address.
-    
+
     packet_forward_method
         The LVS packet forwarding method(``dr`` for direct routing, ``tunnel`` for tunneling, ``nat`` for network access translation).
 
@@ -111,22 +113,22 @@ def present(name,
                 return ret
 
     return ret
-        
+
 
 def absent(name, protocol=None, service_address=None, server_address=None):
     '''
-    
+
     Ensure the LVS Real Server in specified service is absent.
 
     name
         The name of the LVS server.
-    
+
     protocol
         The service protocol(only support ``tcp``, ``udp`` and ``fwmark`` service).
-        
+
     service_address
         The LVS service adress.
-   
+
     server_address
         The LVS real server address.
     '''
@@ -134,7 +136,7 @@ def absent(name, protocol=None, service_address=None, server_address=None):
            'changes': {},
            'result': True,
            'comment': ''}
-    
+
     #check if server exists and remove it
     server_check = __salt__['lvs.check_server'](protocol=protocol,
                                                 service_address=service_address,

--- a/salt/states/lvs_service.py
+++ b/salt/states/lvs_service.py
@@ -7,12 +7,14 @@ Management of LVS(Linux Virtual Server) Service.
 This lvs_service module is used to create and manage LVS Service. Service can be set as either absent or present.
 '''
 
+
 def __virtual__():
     '''
 
     Only load if the lvs module is available in __salt__
     '''
     return 'lvs_service' if 'lvs.get_rules' in __salt__ else False
+
 
 def present(name,
             protocol=None,
@@ -93,11 +95,11 @@ def present(name,
                 return ret
 
     return ret
-        
+
 
 def absent(name, protocol=None, service_address=None):
     '''
-    
+
     Ensure the LVS service is absent.
 
     name
@@ -113,7 +115,7 @@ def absent(name, protocol=None, service_address=None):
            'changes': {},
            'result': True,
            'comment': ''}
-    
+
     #check if service exists and remove it
     service_check = __salt__['lvs.check_service'](protocol=protocol,
                                                   service_address=service_address)

--- a/salt/tops/mongo.py
+++ b/salt/tops/mongo.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Read tops data from a mongodb collection.
+Read tops data from a mongodb collection
 
 This module will load tops data from a mongo collection. It uses the node's id
 for lookups.

--- a/salt/tops/reclass_adapter.py
+++ b/salt/tops/reclass_adapter.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
+Read tops data from a reclass database
+
 .. |reclass| replace:: **reclass**
 
 This :doc:`master_tops </topics/master_tops/index>` plugin provides access to

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -608,9 +608,6 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     dname = os.path.dirname(os.path.abspath(dest))
     tgt = mkstemp(prefix=bname, dir=dname)
     shutil.copyfile(source, tgt)
-    mask = os.umask(0)
-    os.umask(mask)
-    os.chmod(tgt, 0666 - mask)
     bkroot = ''
     if cachedir:
         bkroot = os.path.join(cachedir, 'file_backup')

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -608,6 +608,9 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     dname = os.path.dirname(os.path.abspath(dest))
     tgt = mkstemp(prefix=bname, dir=dname)
     shutil.copyfile(source, tgt)
+    mask = os.umask(0)
+    os.umask(mask)
+    os.chmod(tgt, 0666 - mask)
     bkroot = ''
     if cachedir:
         bkroot = os.path.join(cachedir, 'file_backup')

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -531,8 +531,8 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 root_cmd('service sshd restart', tty, sudo, **kwargs)
 
             root_cmd(
-                '[ ! -d {0} ] && (mkdir -p {0}; chown 700 {0}) || '
-                'echo "Directory {0!r} already exists..."'.format(tmp_dir),
+                '[ ! -d {0} ] && (mkdir -p {0}; chmod 700 {0}) || '
+                'echo "Directory {0} already exists..."'.format(tmp_dir),
                 tty, sudo, **kwargs
             )
             if sudo:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1119,10 +1119,13 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                 self.args[2] = self.args[2]
 
         if self.options.list:
-            if ',' in self.args[0]:
-                self.config['tgt'] = self.args[0].split(',')
-            else:
-                self.config['tgt'] = self.args[0].split()
+            try:
+                if ',' in self.args[0]:
+                    self.config['tgt'] = self.args[0].split(',')
+                else:
+                    self.config['tgt'] = self.args[0].split()
+            except IndexError:
+                self.exit(42, '\nCannot execute command without defining a target.\n\n')
         else:
             try:
                 self.config['tgt'] = self.args[0]
@@ -1130,35 +1133,39 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                 self.exit(42, '\nCannot execute command without defining a target.\n\n')
         # Detect compound command and set up the data for it
         if self.args:
-            if ',' in self.args[1]:
-                self.config['fun'] = self.args[1].split(',')
-                self.config['arg'] = [[]]
-                cmd_index = 0
-                if (self.args[2:].count(self.options.args_separator) ==
-                        len(self.config['fun']) - 1):
-                    # new style parsing: standalone argument separator
-                    for arg in self.args[2:]:
-                        if arg == self.options.args_separator:
-                            cmd_index += 1
-                            self.config['arg'].append([])
-                        else:
-                            self.config['arg'][cmd_index].append(arg)
-                else:
-                    # old style parsing: argument separator can be inside args
-                    for arg in self.args[2:]:
-                        if self.options.args_separator in arg:
-                            sub_args = arg.split(self.options.args_separator)
-                            for sub_arg_index, sub_arg in enumerate(sub_args):
-                                if sub_arg:
-                                    self.config['arg'][cmd_index].append(sub_arg)
-                                if sub_arg_index != len(sub_args) - 1:
-                                    cmd_index += 1
-                                    self.config['arg'].append([])
-                        else:
-                            self.config['arg'][cmd_index].append(arg)
-                    if len(self.config['fun']) != len(self.config['arg']):
-                        self.exit(42, 'Cannot execute compound command without '
-                                      'defining all arguments.')
+            try:
+                if ',' in self.args[1]:
+                    self.config['fun'] = self.args[1].split(',')
+                    self.config['arg'] = [[]]
+                    cmd_index = 0
+                    if (self.args[2:].count(self.options.args_separator) ==
+                            len(self.config['fun']) - 1):
+                        # new style parsing: standalone argument separator
+                        for arg in self.args[2:]:
+                            if arg == self.options.args_separator:
+                                cmd_index += 1
+                                self.config['arg'].append([])
+                            else:
+                                self.config['arg'][cmd_index].append(arg)
+                    else:
+                        # old style parsing: argument separator can be inside args
+                        for arg in self.args[2:]:
+                            if self.options.args_separator in arg:
+                                sub_args = arg.split(self.options.args_separator)
+                                for sub_arg_index, sub_arg in enumerate(sub_args):
+                                    if sub_arg:
+                                        self.config['arg'][cmd_index].append(sub_arg)
+                                    if sub_arg_index != len(sub_args) - 1:
+                                        cmd_index += 1
+                                        self.config['arg'].append([])
+                            else:
+                                self.config['arg'][cmd_index].append(arg)
+                        if len(self.config['fun']) != len(self.config['arg']):
+                            self.exit(42, 'Cannot execute compound command without '
+                                          'defining all arguments.')
+            except IndexError:
+                self.exit(42, '\nIncomplete options passed.\n\n')
+
             else:
                 self.config['fun'] = self.args[1]
                 self.config['arg'] = self.args[2:]

--- a/tests/integration/files/file/base/requisites/fullsls_prereq.sls
+++ b/tests/integration/files/file/base/requisites/fullsls_prereq.sls
@@ -1,0 +1,7 @@
+include:
+  - requisites.fullsls_test
+A:
+  cmd.run:
+    - name: echo A
+    - prereq:
+      - sls: requisites.fullsls_test

--- a/tests/integration/files/file/base/requisites/fullsls_require.sls
+++ b/tests/integration/files/file/base/requisites/fullsls_require.sls
@@ -1,0 +1,7 @@
+include:
+  - requisites.fullsls_test
+A:
+  cmd.run:
+    - name: echo A
+    - require:
+      - sls: requisites.fullsls_test

--- a/tests/integration/files/file/base/requisites/fullsls_require_in.sls
+++ b/tests/integration/files/file/base/requisites/fullsls_require_in.sls
@@ -1,0 +1,7 @@
+include:
+  - requisites.fullsls_test
+A:
+  cmd.run:
+    - name: echo A
+    - require_in:
+      - sls: requisites.fullsls_test

--- a/tests/integration/files/file/base/requisites/fullsls_test.sls
+++ b/tests/integration/files/file/base/requisites/fullsls_test.sls
@@ -1,0 +1,6 @@
+B:
+  cmd.run:
+    - name: echo B
+C:
+  cmd.run:
+    - name: echo C

--- a/tests/integration/files/file/base/requisites/prereq_compile_error1.sls
+++ b/tests/integration/files/file/base/requisites/prereq_compile_error1.sls
@@ -1,0 +1,10 @@
+A:
+  cmd.run:
+    - name: echo A
+
+B:
+  cmd.run:
+    - name: echo B
+    - prereq:
+      - foobar: A
+

--- a/tests/integration/files/file/base/requisites/prereq_compile_error2.sls
+++ b/tests/integration/files/file/base/requisites/prereq_compile_error2.sls
@@ -1,0 +1,9 @@
+A:
+  cmd.run:
+    - name: echo A
+
+B:
+  cmd.run:
+    - name: echo B
+    - prereq:
+      - foobar: C

--- a/tests/integration/files/file/base/requisites/prereq_complex.sls
+++ b/tests/integration/files/file/base/requisites/prereq_complex.sls
@@ -1,0 +1,56 @@
+# issue #8211
+#             expected rank
+# B --+             1
+#     |
+# C <-+ ----+       2/3
+#           |
+# D ---+    |       3/2
+#      |    |
+# A <--+ <--+       4
+#
+#             resulting rank
+# D --+
+#     |
+# A <-+ <==+
+#          |
+# B --+    +--> unrespected A prereq_in C (FAILURE)
+#     |    |
+# C <-+ ===+
+
+# runs after C
+A:
+  cmd.run:
+    - name: echo A fourth
+    # is running in test mode before C
+    # C gets executed first if this states modify something
+    - prereq_in:
+      - cmd: C
+
+# runs before C
+B:
+  cmd.run:
+    - name: echo B first
+    # will test C and be applied only if C changes,
+    # and then will run before C
+    - prereq:
+      - cmd: C
+
+C:
+  cmd.run:
+    - name: echo C second
+    # replacing A prereq_in C by theses lines
+    # changes nothing actually
+    #- prereq:
+    #  - cmd: A
+
+# Removing D, A gets executed after C
+# as described in (A prereq_in C)
+# runs before A
+D:
+  cmd.run:
+    - name: echo D third
+    # will test A and be applied only if A changes,
+    # and then will run before A
+    - prereq:
+      - cmd: A
+

--- a/tests/integration/files/file/base/requisites/prereq_recursion_error.sls
+++ b/tests/integration/files/file/base/requisites/prereq_recursion_error.sls
@@ -1,0 +1,10 @@
+A:
+  cmd.run:
+    - name: echo A
+    - prereq_in:
+      - cmd: B
+B:
+  cmd.run:
+    - name: echo B
+    - prereq_in:
+      - cmd: A

--- a/tests/integration/files/file/base/requisites/prereq_simple.sls
+++ b/tests/integration/files/file/base/requisites/prereq_simple.sls
@@ -8,7 +8,7 @@
 A:
   cmd.run:
     - name: echo A third
-    # is runing in test mode before C
+    # is running in test mode before C
     # C gets executed first if this states modify something
     - prereq_in:
       - cmd: C

--- a/tests/integration/files/file/base/requisites/prereq_simple.sls
+++ b/tests/integration/files/file/base/requisites/prereq_simple.sls
@@ -1,0 +1,38 @@
+# B --+
+#     |
+# C <-+ ----+
+#           |
+# A <-------+
+
+# runs after C
+A:
+  cmd.run:
+    - name: echo A third
+    # is runing in test mode before C
+    # C gets executed first if this states modify something
+    - prereq_in:
+      - cmd: C
+
+# runs before C
+B:
+  cmd.run:
+    - name: echo B first
+    # will test C and be applied only if C changes,
+    # and then will run before C
+    - prereq:
+      - cmd: C
+C:
+  cmd.run:
+    - name: echo C second
+
+# will fail with "The following requisites were not found"
+I:
+  cmd.run:
+    - name: echo I
+    - prereq:
+      - cmd: Z
+J:
+  cmd.run:
+    - name: echo J
+    - prereq:
+      - foobar: A

--- a/tests/integration/files/file/base/requisites/require.sls
+++ b/tests/integration/files/file/base/requisites/require.sls
@@ -1,0 +1,51 @@
+A:
+  cmd.run:
+    - name: echo A fifth
+    - require:
+      - cmd: C
+B:
+  cmd.run:
+    - name: echo B second
+    - require_in:
+      - cmd: A
+      # waiting for issue #8773 fix
+      # this will generate a warning but will still be done
+      # right syntax is cmd: C
+      #- cmd.run: C
+      - cmd: C
+
+C:
+  cmd.run:
+    - name: echo C third
+
+D:
+  cmd.run:
+    - name: echo D first
+    # waiting for issue #8773 fix
+    # this will generate a warning but will still be done
+    # as in B, here testing the non-list form (no '-')
+    - require_in:
+        cmd: B
+        # cmd.foo: B
+
+E:
+  cmd.run:
+    - name: echo E fourth
+    - require:
+      - cmd: B
+    - require_in:
+      - cmd: A
+
+# will fail with "The following requisites were not found"
+F:
+  cmd.run:
+    - name: echo F
+    - require:
+      - foobar: A
+# will fail with "The following requisites were not found"
+G:
+  cmd.run:
+    - name: echo G
+    - require:
+      - cmd: Z
+

--- a/tests/integration/files/file/base/requisites/require_error1.sls
+++ b/tests/integration/files/file/base/requisites/require_error1.sls
@@ -1,0 +1,7 @@
+# will fail with "Data failed to compile:"
+A:
+  cmd.run:
+    - name: echo A
+    - require_in:
+      - foobar: W
+

--- a/tests/integration/files/file/base/requisites/require_error2.sls
+++ b/tests/integration/files/file/base/requisites/require_error2.sls
@@ -1,0 +1,13 @@
+# issue #8772
+# should fail with "Data failed to compile:"
+B:
+  cmd.run:
+    - name: echo B last
+    - require_in:
+      # state foobar does not exists in A
+      - foobar: A
+
+A:
+  cmd.run:
+    - name: echo A first
+

--- a/tests/integration/files/file/base/requisites/require_recursion_error1.sls
+++ b/tests/integration/files/file/base/requisites/require_recursion_error1.sls
@@ -1,0 +1,12 @@
+A:
+  cmd.run:
+    - name: echo A
+    - require:
+      - cmd: B
+
+B:
+  cmd.run:
+    - name: echo B
+    - require:
+      - cmd: A
+

--- a/tests/integration/files/file/base/requisites/use.sls
+++ b/tests/integration/files/file/base/requisites/use.sls
@@ -1,0 +1,55 @@
+# None of theses states should run
+A:
+  cmd.run:
+    - name: echo "A"
+    - onlyif: return 0
+
+# issue #8235
+#B:
+#  cmd.run:
+#    - name: echo "B"
+#  # here used without "-"
+#    - use:
+#        cmd: A
+
+C:
+  cmd.run:
+    - name: echo "C"
+    - use:
+        - cmd: A
+
+D:
+  cmd.run:
+    - name: echo "D"
+    - onlyif: return 0
+    - use_in:
+        - cmd: E
+
+E:
+  cmd.run:
+    - name: echo "E"
+
+# issue 8235
+#F:
+#  cmd.run:
+#    - name: echo "F"
+#    - onlyif: return 0
+#    - use_in:
+#        cmd: G
+#
+#G:
+#  cmd.run:
+#    - name: echo "G"
+
+# issue xxxx
+#H:
+#  cmd.run:
+#    - name: echo "H"
+#    - use:
+#        - cmd: C
+#I:
+#  cmd.run:
+#    - name: echo "I"
+#    - use:
+#        - cmd: E
+

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -512,6 +512,16 @@ fi
         #    }
         #self.assertEqual(expected_result_complex, result)
 
+    def test_requisites_use(self):
+        '''
+        Call sls file containing several use_in and use.
+
+        '''
+        # TODO issue #8235 & #8774 some examples are still commented in the test file
+        ret = self.run_function('state.sls', mods='requisites.use')
+        for item,descr in ret.iteritems():
+            self.assertEqual(descr['comment'], 'onlyif execution failed')
+
     def test_get_file_from_env_in_top_match(self):
         tgt = os.path.join(integration.SYS_TMP_DIR, 'prod-cheese-file')
         try:

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -456,6 +456,24 @@ fi
                            + '                       foobar: A\n',
                 'result': False}
         }
+        expected_result_complex={
+            'cmd_|-A_|-echo A fourth_|-run': {
+                '__run_num__': 3,
+                'comment':  'Command "echo A fourth" run',
+                'result': True},
+            'cmd_|-B_|-echo B first_|-run': {
+                '__run_num__': 0,
+                'comment': 'Command "echo B first" run',
+                'result': True},
+            'cmd_|-C_|-echo C second_|-run': {
+                '__run_num__': 1,
+                'comment': 'Command "echo C second" run',
+                'result': True},
+            'cmd_|-D_|-echo D third_|-run': {
+                '__run_num__': 2,
+                'comment': 'Command "echo D third" run',
+                'result': True},
+        }
         result={}
         ret = self.run_function('state.sls', mods='requisites.prereq_simple')
         for item,descr in ret.iteritems():
@@ -481,6 +499,18 @@ fi
             + '                   prereq:\n'
             + '                       foobar: C\n'
         )
+
+        # issue #8211, chaining complex prereq & prereq_in
+        # TODO: Actually this test fails
+        #result={}
+        #ret = self.run_function('state.sls', mods='requisites.prereq_complex')
+        #for item,descr in ret.iteritems():
+        #    result[item] = {
+        #        '__run_num__': descr['__run_num__'],
+        #        'comment':descr['comment'],
+        #        'result':descr['result']
+        #    }
+        #self.assertEqual(expected_result_complex, result)
 
     def test_get_file_from_env_in_top_match(self):
         tgt = os.path.join(integration.SYS_TMP_DIR, 'prod-cheese-file')

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -432,6 +432,43 @@ fi
             ['A recursive requisite was found, SLS "requisites.require_recursion_error1" ID "B" ID "A"']
         )
 
+    def test_requisites_full_sls(self):
+        '''
+        Teste the sls special command in requisites
+        '''
+        expected_result={
+            'cmd_|-A_|-echo A_|-run': {
+                '__run_num__': 2,
+                'comment': 'Command "echo A" run',
+                'result': True},
+            'cmd_|-B_|-echo B_|-run': {
+                '__run_num__': 0,
+                'comment': 'Command "echo B" run',
+                'result': True},
+            'cmd_|-C_|-echo C_|-run': {
+                '__run_num__': 1,
+                'comment': 'Command "echo C" run',
+                'result': True},
+        }
+        result={}
+        ret = self.run_function('state.sls', mods='requisites.fullsls_require')
+        for item,descr in ret.iteritems():
+            result[item] = {
+                '__run_num__': descr['__run_num__'],
+                'comment':descr['comment'],
+                'result':descr['result']
+            }
+        self.assertEqual(expected_result, result)
+        
+        # TODO: not done
+        #ret = self.run_function('state.sls', mods='requisites.fullsls_require_in')
+        #self.assertEqual(['sls command can only be used with require requisite'], ret)
+
+        # issue #8233: traceback on prereq sls
+        # TODO: not done
+        #ret = self.run_function('state.sls', mods='requisites.fullsls_prereq')
+        #self.assertEqual(['sls command can only be used with require requisite'], ret)
+
     def test_requisites_prereq_simple_ordering_and_errors(self):
         '''
         Call sls file containing several prereq_in and prereq.

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -417,12 +417,20 @@ fi
             'Cannot extend ID W in "base:requisites.require_error1".'
             + ' It is not part of the high state.'
         ])
+
         # commented until a fix is made for issue #8772
+        # TODO: this test actually fails
         #ret = self.run_function('state.sls', mods='requisites.require_error2')
         #self.assertEqual(ret, [
         #    'Cannot extend state foobar for ID A in "base:requisites.require_error2".'
         #    + ' It is not part of the high state.'
         #])
+
+        ret = self.run_function('state.sls', mods='requisites.require_recursion_error1')
+        self.assertEqual(
+            ret,
+            ['A recursive requisite was found, SLS "requisites.require_recursion_error1" ID "B" ID "A"']
+        )
 
     def test_requisites_prereq_simple_ordering_and_errors(self):
         '''
@@ -511,6 +519,14 @@ fi
         #        'result':descr['result']
         #    }
         #self.assertEqual(expected_result_complex, result)
+
+        # issue #8210 : prereq recursion undetected
+        # TODO: this test fails
+        #ret = self.run_function('state.sls', mods='requisites.prereq_recursion_error')
+        #self.assertEqual(
+        #    ret,
+        #    ['A recursive requisite was found, SLS "requisites.prereq_recursion_error" ID "B" ID "A"']
+        #)
 
     def test_requisites_use(self):
         '''


### PR DESCRIPTION
- salt.utils copyfile() now creates 0600 files when copying. Previously it was
  changing file mode before any state mode was known (if any).
- check_perms is called after the file copy and can decide to apply mode or
  umask based permissions.
