### PR TITLE
Small fixes for commit 825ec2e regarding issue #7755

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -190,6 +190,7 @@ def file_hash(load, fnd):
                     hsum, mtime = fp_.read().split(':')
                 except ValueError:
                     log.debug('Fileserver attempted to read incomplete cache file. Retrying.')
+                    ret['hsum'] = None
                     file_hash(load, fnd)
                     return(ret)
                 if os.path.getmtime(path) == mtime:


### PR DESCRIPTION
Without initiating ret['hsum'], it was possible to sometimes get traceback like this on minions:

```
----------
    State: - file
    Name:      /root/.vim
    Function:  recurse
        Result:    False
        Comment:   An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/salt/state.py", line 1256, in call
    *cdata['args'], **cdata['kwargs'])
  File "/usr/lib/pymodules/python2.7/salt/states/file.py", line 1621, in recurse
    manage_file(dest, src)
  File "/usr/lib/pymodules/python2.7/salt/states/file.py", line 1544, in manage_file
    **pass_kwargs)
  File "/usr/lib/pymodules/python2.7/salt/states/file.py", line 1131, in managed
    contents)
  File "/usr/lib/pymodules/python2.7/salt/modules/file.py", line 1944, in manage_file
    if source and source_sum['hsum'] != name_sum:
KeyError: 'hsum'
```
