### PR TITLE
Salt Cloud doc update.

### DIFF
--- a/doc/topics/cloud/action.rst
+++ b/doc/topics/cloud/action.rst
@@ -25,7 +25,7 @@ The following is a list of actions currently supported by salt-cloud:
 
     all providers:
         - reboot
-    aws:
+    ec2:
         - start
         - stop
     joyent:

--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -2,7 +2,7 @@
 Getting Started With Google Compute Engine
 ==========================================
 
-Google Compute Engine (GCE) is Goolge-infrastructure as a service that lets you
+Google Compute Engine (GCE) is Google-infrastructure as a service that lets you
 run your large-scale computing workloads on virtual machines.  This document
 covers how to use Salt Cloud to provision and manage your virtual machines
 hosted within Google's infrastructure.
@@ -14,7 +14,7 @@ at https://cloud.google.com.
 Dependencies
 ============
 * `Libcloud <http://libcloud.apache.org>`_ version 0.14.0-beta3 or greater
-* A Google Cloud Platform account with Copmute Engine enabled
+* A Google Cloud Platform account with Compute Engine enabled
 * A registered Service Account for authorization
 * Oh, and obviously you'll need `salt <https://github.com/saltstack/salt>`_
 

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -32,8 +32,9 @@ Getting Started
 Some quick guides covering getting started with Amazon AWS, Google Compute
 Engine, Parallels, Rackspace, and Softlayer.
 
-* :doc:`Getting Started With AWS <aws>`
+* :doc:`Getting Started With AWS/EC2 <aws>`
 * :doc:`Getting Started With Google Compute Engine <gce>`
+* :doc:`Getting Started With Linode <linode>`
 * :doc:`Getting Started With Parallels <parallels>`
 * :doc:`Getting Started With Rackspace <rackspace>`
 * :doc:`Getting Started With SoftLayer <softlayer>`

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -1,0 +1,102 @@
+===========================
+Getting Started With Linode
+===========================
+
+Linode is a public cloud provider with a focus on Linux instances.
+
+Dependencies
+============
+The Linode driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
+installed.
+
+
+Configuration
+=============
+Linode requires a single API key, but the default root password for new 
+instances also needs to be set:
+
+.. code-block:: yaml
+
+    # Note: This example is for /etc/salt/cloud.providers or any file in the
+    # /etc/salt/cloud.providers.d/ directory.
+
+    my-linode-config:
+      apikey: asldkgfakl;sdfjsjaslfjaklsdjf;askldjfaaklsjdfhasldsadfghdkf
+      password: F00barbaz
+      provider: linode
+
+The password needs to be 8 characters and contain lowercase, uppercase and 
+numbers.
+
+Profiles
+========
+
+Cloud Profiles
+~~~~~~~~~~~~~~
+Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
+``/etc/salt/cloud.profiles.d/`` directory:
+
+.. code-block:: yaml
+
+    linode_1024:
+      provider: my-linode-config
+      size: Linode 1024
+      image: Arch Linux 2013.06
+
+Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-sizes my-linode-config
+    my-linode-config:
+        ----------
+        linode:
+            ----------
+            Linode 1024:
+                ----------
+                bandwidth:
+                    2000
+                disk:
+                    49152
+                driver:
+                get_uuid:
+                id:
+                    1
+                name:
+                    Linode 1024
+                price:
+                    20.0
+                ram:
+                    1024
+                uuid:
+                    03e18728ce4629e2ac07c9cbb48afffb8cb499c4
+    ...SNIP...
+
+Images can be obtained using the ``--list-images`` option for the ``salt-cloud``
+command:
+
+.. code-block:: bash
+
+    # salt-cloud --list-images my-linode-config
+    my-linode-config:
+        ----------
+        linode:
+            ----------
+            Arch Linux 2013.06:
+                ----------
+                driver:
+                extra:
+                    ----------
+                    64bit:
+                        1
+                    pvops:
+                        1
+                get_uuid:
+                id:
+                    112
+                name:
+                    Arch Linux 2013.06
+                uuid:
+                    8457f92eaffc92b7666b6734a96ad7abe1a8a6dd
+    ...SNIP...

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -78,7 +78,7 @@ A map file may also be used with the various query options:
 .. code-block:: bash
 
     $ salt-cloud -m /path/to/mapfile -Q
-    {'aws': {'web1': {'id': 'i-e6aqfegb',
+    {'ec2': {'web1': {'id': 'i-e6aqfegb',
                          'image': None,
                          'private_ips': [],
                          'public_ips': [],

--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -13,8 +13,8 @@ to pass arguments to the deploy script:
 
 .. code-block:: yaml
 
-    aws-amazon:
-        provider: aws
+    ec2-amazon:
+        provider: ec2
         image: ami-1624987f
         size: Micro Instance
         ssh_username: ec2-user

--- a/doc/topics/cloud/profiles.rst
+++ b/doc/topics/cloud/profiles.rst
@@ -63,16 +63,16 @@ Larger Example
 
 .. code-block:: yaml
 
-    rhel_aws:
-        provider: aws
+    rhel_ec2:
+        provider: ec2
         image: ami-e565ba8c
         size: Micro Instance
         script: RHEL6
         minion:
             cheese: edam
 
-    ubuntu_aws:
-        provider: aws
+    ubuntu_ec2:
+        provider: ec2
         image: ami-7e2da54e
         size: Micro Instance
         script: Ubuntu


### PR DESCRIPTION
Changed aws to ec2 where appropriate, and fixed spelling errors in GCE doc. Also added a Linode Getting Started doc.
