### PR TITLE
Fixing avail_images in joyent driver

### DIFF
--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -808,10 +808,24 @@ def avail_images():
 
         salt-cloud --list-images
     '''
-    rcode, items = query2(command='/my/datasets')
-    if rcode not in VALID_RESPONSE_CODES:
-        return {}
-    return key_list(items=items)
+    img_url = 'https://images.joyent.com/images'
+    request = urllib2.Request(img_url)
+    request.get_method = lambda: 'GET'
+    result = urllib2.urlopen(request)
+    content = result.read()
+    result.close()
+
+    ret = {}
+    for image in yaml.safe_load(content):
+        ret[image['name']] = image
+    return ret
+
+    # It appears the API has changed on us again
+    #rcode, items = query2(command='/my/datasets')
+    #log.debug(rcode)
+    #if rcode not in VALID_RESPONSE_CODES:
+    #    return {}
+    #return key_list(items=items)
 
 
 def avail_sizes():


### PR DESCRIPTION
This is probably a temporary fix; it uses a method that does not require authentication, but seems to work. And since the old one stopped working, we're still better off than we were before.
