### PR TITLE
Fixed launchctl module

### DIFF
--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -50,6 +50,7 @@ def _available_services():
                 try:
                     # This assumes most of the plist files will be already in XML format
                     with open(file_path):
+                        # Follow symbolic links of files in _launchd_paths
                         true_path = os.path.realpath(file_path)
                         plist = plistlib.readPlist(true_path)
                 except Exception:

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -47,20 +47,21 @@ def _available_services():
         for root, dirs, files in os.walk(launch_dir):
             for filename in files:
                 file_path = os.path.join(root, filename)
-
                 try:
                     # This assumes most of the plist files will be already in XML format
-                    plist = plistlib.readPlist(file_path)
+                    with open(file_path):
+                        true_path = os.path.realpath(file_path)
+                        plist = plistlib.readPlist(true_path)
                 except Exception:
                     # If plistlib is unable to read the file we'll need to use
                     # the system provided plutil program to do the conversion
-                    cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(file_path)
+                    cmd = '/usr/bin/plutil -convert xml1 -o - -- "{0}"'.format(true_path)
                     plist_xml = __salt__['cmd.run_all'](cmd)['stdout']
                     plist = plistlib.readPlistFromString(plist_xml)
 
                 available_services[plist.Label.lower()] = {
                     'filename': filename,
-                    'file_path': file_path,
+                    'file_path': true_path,
                     'plist': plist,
                 }
 

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -53,6 +53,7 @@ def _available_services():
                         # Follow symbolic links of files in _launchd_paths
                         true_path = os.path.realpath(file_path)
                         plist = plistlib.readPlist(true_path)
+
                 except Exception:
                     # If plistlib is unable to read the file we'll need to use
                     # the system provided plutil program to do the conversion


### PR DESCRIPTION
_available_services in the launchctl module raised uncaught exceptions when working on symbolic links within the _launchd_paths directories. Modifying the function to follow symbolic links has resolved the issue. Now any function that calls _available_services should work just fine. 
