### PR TITLE
BUGFIX: Argument order `pw usermod` command.

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -234,16 +234,14 @@ def chhome(name, home, persist=False):
     pre_info = info(name)
     if home == pre_info['home']:
         return True
-    cmd = 'pw usermod -d {0} '.format(home)
+    cmd = 'pw usermod {0} -d {1}'.format(name, home)
     if persist:
         cmd += ' -m '
-    cmd += name
     __salt__['cmd.run'](cmd)
     post_info = info(name)
     if post_info['home'] != pre_info['home']:
         return post_info['home'] == home
     return False
-
 
 def chgroups(name, groups, append=False):
     '''


### PR DESCRIPTION
The argument order of `pw usermod` is (see [man](http://www.freebsd.org/cgi/man.cgi?query=pw&sektion=8)):

```
pw [-V etcdir] usermod [name|uid]
```

This was incorrect for the `chhome` function. The updated version is
tested on FreeBSD.
