### PR TITLE
Set the default HWM to 1000

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -272,7 +272,7 @@ DEFAULT_MINION_OPTS = {
 DEFAULT_MASTER_OPTS = {
     'interface': '0.0.0.0',
     'publish_port': '4505',
-    'pub_hwm': 100,
+    'pub_hwm': 1000,
     'auth_mode': 1,
     'user': 'root',
     'worker_threads': 5,


### PR DESCRIPTION
This is as suggested in the ZMQ documentation:
http://zguide.zeromq.org/page:all#High-Water-Marks
