### PR TITLE
wrap file copy in umasks to secure permissions

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1522,7 +1522,9 @@ def copy(src, dst):
         pre_mode = __salt__['config.manage_mode'](get_mode(src))
 
     try:
+        current_umask = os.umask(63)
         shutil.copyfile(src, dst)
+        os.umask(current_umask)
     except OSError:
         raise CommandExecutionError(
             'Could not copy {0!r} to {1!r}'.format(src, dst)
@@ -2235,10 +2237,12 @@ def manage_file(name,
 
             # Pre requisites are met, and the file needs to be replaced, do it
             try:
+                current_umask = os.umask(54)
                 salt.utils.copyfile(sfn,
                                     name,
                                     __salt__['config.backup_mode'](backup),
                                     __opts__['cachedir'])
+                os.umask(current_umask)
             except IOError:
                 __clean_tmp(sfn)
                 return _error(
@@ -2273,10 +2277,12 @@ def manage_file(name,
 
                 # Pre requisites are met, the file needs to be replaced, do it
                 try:
+                    current_umask = os.umask(54)
                     salt.utils.copyfile(tmp,
                                         name,
                                         __salt__['config.backup_mode'](backup),
                                         __opts__['cachedir'])
+                    os.umask(current_umask)
                 except IOError:
                     __clean_tmp(tmp)
                     return _error(
@@ -2372,11 +2378,13 @@ def manage_file(name,
             __clean_tmp(tmp)
         # Now copy the file contents if there is a source file
         elif sfn:
+            current_umask = os.umask(54)
             salt.utils.copyfile(sfn,
                                 name,
                                 __salt__['config.backup_mode'](backup),
                                 __opts__['cachedir'])
             __clean_tmp(sfn)
+            os.umask(current_umask)
 
         # Check and set the permissions if necessary
         ret, perms = check_perms(name, ret, user, group, mode)

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -569,6 +569,12 @@ def init(name,
                 os.makedirs(img_dir)
             try:
                 salt.utils.copyfile(sfn, img_dest)
+                mask = os.umask(0)
+                os.umask(mask)
+                # Apply umask and remove exec bit
+                mode = (0o0777 ^ mask) & 0o0666
+                os.chmod(img_dest, mode)
+
             except os.error:
                 return False
             seedable = True

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -608,9 +608,6 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     dname = os.path.dirname(os.path.abspath(dest))
     tgt = mkstemp(prefix=bname, dir=dname)
     shutil.copyfile(source, tgt)
-    mask = os.umask(0)
-    os.umask(mask)
-    os.chmod(tgt, 0666 - mask)
     bkroot = ''
     if cachedir:
         bkroot = os.path.join(cachedir, 'file_backup')


### PR DESCRIPTION
- salt.util.copyfile needs preceding with 54 (aka 0066) umask in order
  for new files to correctly get 0600 mode permissions.
- shutil.copyfile is preceded by a 63 (aka 0077) umask.

Fixes issue #8590
