### PR TITLE
Fix #8773: allow syntax error state.foo in requisites with a warning.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1092,6 +1092,13 @@ class State(object):
                                 found = False
                                 if name not in extend:
                                     extend[name] = {}
+                                if '.' in _state:
+                                    log.warning(
+                                        'Bad requisite syntax in {0} : {1} for {2},'
+                                        + ' requisites should not contain any dot'
+                                        .format(rkey,_state,name)
+                                    )
+                                    _state = _state.split(".")[0]
                                 if _state not in extend[name]:
                                     extend[name][_state] = []
                                 extend[name]['__env__'] = body['__env__']
@@ -1121,6 +1128,13 @@ class State(object):
                                     continue
                                 _state = next(iter(ind))
                                 name = ind[_state]
+                                if '.' in _state:
+                                    log.warning(
+                                        'Bad requisite syntax in {0} : {1} for {2},'
+                                        + ' requisites should not contain any dot'
+                                        .format(rkey,_state,name)
+                                    )
+                                    _state = _state.split(".")[0]
                                 if key == 'prereq_in':
                                     # Add prerequired to origin
                                     if id_ not in extend:

--- a/tests/integration/files/file/base/requisites/mixed_complex1.sls
+++ b/tests/integration/files/file/base/requisites/mixed_complex1.sls
@@ -37,12 +37,10 @@ C:
 D:
   cmd.run:
     - name: echo D first
-    # waiting for issue #8773 fix
+    # issue #8773
     # this will generate a warning but will still be done
-    # as in B, here testing the non-list form (no '-')
     - require_in:
-        cmd: B
-        # cmd.foo: B
+        cmd.foo: B
 
 E:
   cmd.run:

--- a/tests/integration/files/file/base/requisites/require.sls
+++ b/tests/integration/files/file/base/requisites/require.sls
@@ -23,11 +23,10 @@ B:
     - name: echo B second
     - require_in:
       - cmd: A
-      # waiting for issue #8773 fix
+      # issue #8773
       # this will generate a warning but will still be done
       # right syntax is cmd: C
-      #- cmd.run: C
-      - cmd: C
+      - cmd.run: C
 
 C:
   cmd.run:
@@ -36,12 +35,11 @@ C:
 D:
   cmd.run:
     - name: echo D first
-    # waiting for issue #8773 fix
+    # issue #8773 fix
     # this will generate a warning but will still be done
     # as in B, here testing the non-list form (no '-')
     - require_in:
-        cmd: B
-        # cmd.foo: B
+        cmd.foo: B
 
 E:
   cmd.run:
@@ -63,4 +61,10 @@ G:
     - name: echo G
     - require:
       - cmd: Z
+# will fail with "The following requisites were not found"
+H:
+  cmd.run:
+    - name: echo H
+    - require:
+      - cmd.run: Z
 

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -526,6 +526,12 @@ fi
                 'comment': 'The following requisites were not found:\n'
                            + '                   require:\n'
                            + '                       cmd: Z\n',
+                'result': False},
+            'cmd_|-H_|-echo H_|-run': {
+                '__run_num__': 7,
+                'comment': 'The following requisites were not found:\n'
+                           + '                   require:\n'
+                           + '                       cmd: Z\n',
                 'result': False}
         }
         result={}


### PR DESCRIPTION
Should fix #8773.

This prevents silent ignore of an easy syntax error (refering a state by its full name instead of only using the state type).

Intergration are altered to test this fact, and I added an error case in theses states also.
