### PR TITLE
Example of how can we properly return a command's retcode

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -114,16 +114,23 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                         kwargs['cli'] = True
                     else:
                         cmd_func = local.cmd_cli
+                    retcode = 0
                     if self.options.static:
                         if self.options.verbose:
                             kwargs['verbose'] = True
                         full_ret = local.cmd_full_return(**kwargs)
+                        for minion, ret in full_ret.items():
+                            if ret['ret']['retcode'] != 0:
+                                retcode = ret['ret']['retcode']
                         ret, out = self._format_ret(full_ret)
                         self._output_ret(ret, out)
                     elif self.config['fun'] == 'sys.doc':
                         ret = {}
                         out = ''
                         for full_ret in local.cmd_cli(**kwargs):
+                            for minion, ret in full_ret.items():
+                                if ret['ret']['retcode'] != 0:
+                                    retcode = ret['ret']['retcode']
                             ret_, out = self._format_ret(full_ret)
                             ret.update(ret_)
                         self._output_ret(ret, out)
@@ -131,12 +138,17 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                         if self.options.verbose:
                             kwargs['verbose'] = True
                         for full_ret in cmd_func(**kwargs):
+                            for minion, ret in full_ret.items():
+                                if ret['ret']['retcode'] != 0:
+                                    retcode = ret['ret']['retcode']
                             ret, out = self._format_ret(full_ret)
                             self._output_ret(ret, out)
+                    return retcode
             except (SaltInvocationError, EauthAuthenticationError) as exc:
                 ret = str(exc)
                 out = ''
                 self._output_ret(ret, out)
+                return 1
 
     def _output_ret(self, ret, out):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -724,8 +724,9 @@ class Minion(object):
             try:
                 func = minion_instance.functions[data['fun']]
                 args, kwargs = parse_args_and_kwargs(func, data['arg'], data)
-                sys.modules[func.__module__].__context__['retcode'] = 0
                 return_data = func(*args, **kwargs)
+                retcode = return_data['retcode']
+                sys.modules[func.__module__].__context__['retcode'] = retcode
                 if isinstance(return_data, types.GeneratorType):
                     ind = 0
                     iret = {}
@@ -745,7 +746,7 @@ class Minion(object):
                     ret['return'] = return_data
                 ret['retcode'] = sys.modules[func.__module__].__context__.get(
                     'retcode',
-                    0
+                    retcode
                 )
                 ret['success'] = True
             except CommandNotFoundError as exc:

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -39,7 +39,10 @@ def ping():
 
         salt '*' test.ping
     '''
-    return True
+    ret = {'result': True,
+           'comment': '',
+           'retcode': 1}
+    return ret
 
 
 def sleep(length):

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -132,6 +132,6 @@ def salt_main():
         sys.path.remove('')
     try:
         client = salt.cli.SaltCMD()
-        client.run()
+        return client.run()
     except KeyboardInterrupt:
         raise SystemExit('\nExiting gracefully on Ctrl-c')


### PR DESCRIPTION
[There](https://github.com/saltstack/salt/issues/7247) [are](https://github.com/saltstack/salt/issues/8180) [many](https://github.com/saltstack/salt/issues/8589) [issues](https://github.com/saltstack/salt/issues/6973) [about](https://github.com/saltstack/salt/issues/7876) the same thing.

I wrote an example how Salt can properly handle a command's retcode.

```
(salt_venv)user@user-salt:~/salt_venv$ salt -c ./etc/salt '*' test.ping
minion-dev:
    ----------
    comment:

    result:
        True
    retcode:
        1
(salt_venv)user@user-salt:~/salt_venv$ echo $?
1
```

Please review and criticize.
