### PR TITLE
fix missing blanks in sphinx syntax

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -74,7 +74,7 @@ def tar(options, tarfile, sources=None, dest=None, cwd=None, template=None):
 
     To unpack a tarfile, for example:
 
-    ..code-block:: bash
+    .. code-block:: bash
 
         salt '*' archive.tar foo.tar xf dest=/target/directory
 

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -369,7 +369,7 @@ def set_dhcp_all(iface):
 
     CLI Example:
 
-    ..code-block:: bash
+    .. code-block:: bash
 
         salt -G 'os_family:Windows' ip.set_dhcp_all 'Local Area Connection'
     '''

--- a/salt/states/rvm.py
+++ b/salt/states/rvm.py
@@ -188,7 +188,7 @@ def installed(name, default=False, runas=None, user=None):
     user: None
         The user to run rvm as.
 
-        ..versionadded:: 0.17.0
+        .. versionadded:: 0.17.0
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 


### PR DESCRIPTION
obsoletes #8853 by finding all instances of this typo:

feel free to add a test for that:

<pre>
fgrep -R '..' *  |fgrep -v '.. ' |fgrep -v '../' |fgrep '::'                                                                                                                                                                                       
salt/modules/win_ip.py:    ..code-block:: bash
salt/modules/archive.py:    ..code-block:: bash
salt/states/rvm.py:        ..versionadded:: 0.17.0
</pre>
