### PR TITLE
Fix eventlisten.py for minion event bus

### DIFF
--- a/tests/eventlisten.py
+++ b/tests/eventlisten.py
@@ -44,14 +44,14 @@ def parse():
         if v is not None:
             opts[k] = v
 
+    opts['sock_dir'] = os.path.join(opts['sock_dir'], opts['node'])
+
     if 'minion' in options.node:
         if args:
             opts['id'] = args[0]
             return opts
 
         opts['id'] = options.node
-
-    opts['sock_dir'] = os.path.join(opts['sock_dir'], opts['node'])
 
     return opts
 


### PR DESCRIPTION
The sock_dir modification was happening after the minion opts had
already returned.  Just make sure it happens before any return
statement.
