### PR TITLE
Alternative aesthetic for highstate

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -21,7 +21,8 @@ state_output:
     state failed, in which case full output will be used.
 state_tabular:
     If `state_output` uses the terse output, set this to `True` for an aligned
-    output format.
+    output format.  If you wish to use a custom format, this can be set to a
+    string.
 '''
 
 # Import python libs
@@ -217,20 +218,25 @@ def _format_terse(tcolor, comps, ret, colors, tabular):
     '''
     Terse formatting of a message.
     '''
-    result_map = {
-        True: "Clean",
-        False: "Failed",
-        None: "Dirty"
-    }
-    if (tabular):
-        fmt_string = '{0}{2:>10}.{3:<10} {4:6}   Name: {1}{5}'
+    result = "Clean"
+    if (ret['changes']):
+        result = "Changed"
+    if (ret['result'] == False):
+        result = "Failed"
+    elif (ret['result'] == None):
+        result = "Differs"
+    if (tabular == True):
+        fmt_string = '{0}{2:>10}.{3:<10} {4:7}   Name: {1}{5}'
+    elif (isinstance(tabular, str)):
+        fmt_string = tabular
     else:
         fmt_string = ' {0} Name: {1} - Function: {2}.{3} - Result: {4}{5}'
     msg = fmt_string.format(tcolor,
                             comps[2],
                             comps[0],
                             comps[-1],
-                            result_map[ret['result']],
-                            colors['ENDC'])
+                            result,
+                            colors['ENDC'],
+                            ret)
 
     return msg

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -223,7 +223,7 @@ def _format_terse(tcolor, comps, ret, colors, tabular):
         None: "Dirty"
     }
     if (tabular):
-        fmt_string = '{0}{2:>10}.{3:<10} {4}   Name: {1}{5}'
+        fmt_string = '{0}{2:>10}.{3:<10} {4:6}   Name: {1}{5}'
     else:
         fmt_string = ' {0} Name: {1} - Function: {2}.{3} - Result: {4}{5}'
     msg = fmt_string.format(tcolor,

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -19,6 +19,9 @@ state_output:
     is set to `terse` then the output is greatly simplified and shown in only
     one line.  If `mixed` is used, then terse output will be used unless a
     state failed, in which case full output will be used.
+state_tabular:
+    If `state_output` uses the terse output, set this to `True` for an aligned
+    output format.
 '''
 
 # Import python libs
@@ -35,6 +38,7 @@ def output(data):
     highstate return data.
     '''
     colors = salt.utils.get_colors(__opts__.get('color'))
+    tabular = __opts__.get('state_tabular', False)
     for host in data:
         rcounts = {}
         hcolor = colors['GREEN']
@@ -81,20 +85,20 @@ def output(data):
                 if __opts__.get('state_output', 'full').lower() == 'terse':
                     # Print this chunk in a terse way and continue in the
                     # loop
-                    msg = _format_terse(tcolor, comps, ret, colors)
+                    msg = _format_terse(tcolor, comps, ret, colors, tabular)
                     hstrs.append(msg)
                     continue
                 elif __opts__.get('state_output', 'full').lower() == 'mixed':
                     # Print terse unless it failed
                     if ret['result'] is not False:
-                        msg = _format_terse(tcolor, comps, ret, colors)
+                        msg = _format_terse(tcolor, comps, ret, colors, tabular)
                         hstrs.append(msg)
                         continue
                 elif __opts__.get('state_output', 'full').lower() == 'changes':
                     # Print terse if no error and no changes, otherwise, be
                     # verbose
                     if ret['result'] and not ret['changes']:
-                        msg = _format_terse(tcolor, comps, ret, colors)
+                        msg = _format_terse(tcolor, comps, ret, colors, tabular)
                         hstrs.append(msg)
                         continue
                 hstrs.append(('{0}----------\n    State: - {1}{2[ENDC]}'
@@ -209,16 +213,24 @@ def _strip_clean(returns):
     return returns
 
 
-def _format_terse(tcolor, comps, ret, colors):
+def _format_terse(tcolor, comps, ret, colors, tabular):
     '''
     Terse formatting of a message.
     '''
-    msg = (' {0}Name: {1} - Function: {2}.{3} - '
-           'Result: {4}{5}').format(tcolor,
-                                    comps[2],
-                                    comps[0],
-                                    comps[-1],
-                                    str(ret['result']),
-                                    colors['ENDC'])
+    result_map = {
+        True: "Clean",
+        False: "Failed",
+        None: "Dirty"
+    }
+    if (tabular):
+        fmt_string = '{0}{2:>10}.{3:<10} {4}   Name: {1}{5}'
+    else:
+        fmt_string = ' {0} Name: {1} - Function: {2}.{3} - Result: {4}{5}'
+    msg = fmt_string.format(tcolor,
+                            comps[2],
+                            comps[0],
+                            comps[-1],
+                            result_map[ret['result']],
+                            colors['ENDC'])
 
     return msg


### PR DESCRIPTION
This is a speculative pull request ... I wrote this to satisfy my own itch of having the output look more pleasing but I don't know if it's of interest for inclusion.

Setting state_tabular to True makes the terse output lines look like this (you'll have to imagine the colours, sorry):

```
  makeconf.present    Clean   Name: PHP_TARGETS
      file.managed    Dirty   Name: /etc/portage/package.use/php53
       pkg.installed  Clean   Name: dev-php/suhosin
       pkg.installed  Clean   Name: dev-lang/php
      file.managed    Clean   Name: /etc/php/apache2-php5.3/ext-active/00_extras.ini
      file.managed    Clean   Name: /etc/php/apache2-php5.3/ext/suhosin.ini
```

I've split the formatter string off rather than duplicating the formatter call to allow for the possible ideas of adding other terse display modes, or even moving it to a config option.
I set the formatting width to 10 characters on a guess as to what would give a reasonable aesthetic... might need to revise that or push it to a config option.

Rational is that name is the part of the message that has the most size variance and thus should be last item.  The other two, in most cases, align cleanly with a minimum of horizontal waste and thus allow the eye to quickly scan the output.

Thoughts?
