### PR TITLE
Mysql additions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 
 before_install:
   - sudo apt-get update
-  - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig rabbitmq-server ruby
+  - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig rabbitmq-server ruby mysql-server libmysqlclient-dev
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
   - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io mock timelib
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
@@ -15,7 +15,9 @@ before_install:
   - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io unittest2 ordereddict; fi"
   - pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
 
-install: pip install -r requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io
+install:
+  - pip install -r requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io
+  - pip install -r opt_requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io
 
 before_script:
   - "/home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pylint --rcfile=.testing.pylintrc salt/ && echo 'Finished Pylint Check Cleanly' || echo 'Finished Pylint Check With Errors'"

--- a/opt_requirements.txt
+++ b/opt_requirements.txt
@@ -1,0 +1,1 @@
+mysql-python

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1027,6 +1027,12 @@ def tokenize_grant(grant):
     External wrapper function
     :param grant:
     :return: dict
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mysql.grant_to_tokens "GRANT SELECT ON `testdb`.* TO 'testuser'@'localhost'"
     '''
     return _grant_to_tokens(grant)
 

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -217,13 +217,15 @@ def _grant_to_tokens(grant):
                 grant=grant_tokens,
                 database=database)
 
+
 def _quoteIdentifier(identifier):
     '''
     Return an identifier name (column, table, database, etc) escaped accordingly for MySQL
-    
+
     This means surrounded by "`" charecter and escaping this charater inside.
     '''
-    return '`' + identifier.replace('`','``') + '`'
+    return '`' + identifier.replace('`', '``') + '`'
+
 
 def query(database, query, **connection_args):
     '''
@@ -542,7 +544,7 @@ def db_tables(name, **connection_args):
         return []
     cur = dbc.cursor()
     s_name = _quoteIdentifier(name)
-    qry = 'SHOW TABLES IN %(dbname)s' % dict(dbname = s_name)
+    qry = 'SHOW TABLES IN %(dbname)s' % dict(dbname=s_name)
     log.debug('Doing query: {0}'.format(qry))
     try:
         cur.execute(qry)
@@ -577,10 +579,10 @@ def db_exists(name, **connection_args):
     # Warn: here db identifier is bot backtyped but should be
     #  escaped as a string value
     qry = "SHOW DATABASES LIKE %(dbname)s;"
-    args = { "dbname" : name }
-    log.debug('Doing query: {0} args: {1} '.format(qry,repr(args)))
+    args = {"dbname": name}
+    log.debug('Doing query: {0} args: {1} '.format(qry, repr(args)))
     try:
-        cur.execute(qry,args)
+        cur.execute(qry, args)
     except MySQLdb.OperationalError as exc:
         err = 'MySQL Error {0}: {1}'.format(*exc)
         __context__['mysql.error'] = err
@@ -596,10 +598,10 @@ def db_create(name, character_set=None, collate=None, **connection_args):
 
     name
         The name of the database to manage
-    
+
     character_set
         The character set, if left empty the MySQL default will be used
-    
+
     collate
         The collation, if left empty the MySQL default will be used
 
@@ -621,17 +623,17 @@ def db_create(name, character_set=None, collate=None, **connection_args):
         return False
     cur = dbc.cursor()
     s_name = _quoteIdentifier(name)
-    qry = 'CREATE DATABASE %(dbname)s' % dict(dbname = s_name)
+    qry = 'CREATE DATABASE %(dbname)s' % dict(dbname=s_name)
     args = {}
     if character_set is not None:
         qry += ' CHARACTER SET %(character_set)s'
-        args['character_set']= character_set
+        args['character_set'] = character_set
     if collate is not None:
         qry += ' COLLATE %(collate)s'
         args['collate'] = collate
     qry += ';'
 
-    log.debug('Query: {0} args: {1}'.format(qry,repr(args)))
+    log.debug('Query: {0} args: {1}'.format(qry, repr(args)))
     try:
         if cur.execute(qry, args):
             log.info('DB {0!r} created'.format(name))
@@ -662,13 +664,13 @@ def db_remove(name, **connection_args):
         log.info('DB {0!r} may not be removed'.format(name))
         return False
 
-    # db does exists, proceed
+    # db doesxists, proceed
     dbc = _connect(**connection_args)
     if dbc is None:
         return False
     cur = dbc.cursor()
     s_name = _quoteIdentifier(name)
-    qry = 'DROP DATABASE %(dbname)s;' % dict(dbname = s_name)
+    qry = 'DROP DATABASE %(dbname)s;' % dict(dbname=s_name)
     log.debug('Doing query: {0}'.format(qry))
     try:
         cur.execute(qry)

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -217,6 +217,13 @@ def _grant_to_tokens(grant):
                 grant=grant_tokens,
                 database=database)
 
+def _quoteIdentifier(identifier):
+    '''
+    Return an identifier name (column, table, database, etc) escaped accordingly for MySQL
+    
+    This means surrounded by "`" charecter and escaping this charater inside.
+    '''
+    return '`' + identifier.replace('`','``') + '`'
 
 def query(database, query, **connection_args):
     '''
@@ -534,7 +541,8 @@ def db_tables(name, **connection_args):
     if dbc is None:
         return []
     cur = dbc.cursor()
-    qry = 'SHOW TABLES IN {0}'.format(name)
+    s_name = _quoteIdentifier(name)
+    qry = 'SHOW TABLES IN %(dbname)s' % dict(dbname = s_name)
     log.debug('Doing query: {0}'.format(qry))
     try:
         cur.execute(qry)
@@ -566,10 +574,13 @@ def db_exists(name, **connection_args):
     if dbc is None:
         return False
     cur = dbc.cursor()
-    qry = 'SHOW DATABASES LIKE {0!r}'.format(name)
-    log.debug('Doing query: {0}'.format(qry))
+    # Warn: here db identifier is bot backtyped but should be
+    #  escaped as a string value
+    qry = "SHOW DATABASES LIKE %(dbname)s;"
+    args = { "dbname" : name }
+    log.debug('Doing query: {0} args: {1} '.format(qry,repr(args)))
     try:
-        cur.execute(qry)
+        cur.execute(qry,args)
     except MySQLdb.OperationalError as exc:
         err = 'MySQL Error {0}: {1}'.format(*exc)
         __context__['mysql.error'] = err
@@ -579,15 +590,25 @@ def db_exists(name, **connection_args):
     return cur.rowcount == 1
 
 
-def db_create(name, **connection_args):
+def db_create(name, character_set=None, collate=None, **connection_args):
     '''
     Adds a databases to the MySQL server.
+
+    name
+        The name of the database to manage
+    
+    character_set
+        The character set, if left empty the MySQL default will be used
+    
+    collate
+        The collation, if left empty the MySQL default will be used
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' mysql.db_create 'dbname'
+        salt '*' mysql.db_create 'dbname' 'utf8' 'utf8_general_ci'
     '''
     # check if db exists
     if db_exists(name, **connection_args):
@@ -599,10 +620,20 @@ def db_create(name, **connection_args):
     if dbc is None:
         return False
     cur = dbc.cursor()
-    qry = 'CREATE DATABASE `{0}`;'.format(name)
-    log.debug('Query: {0}'.format(qry))
+    s_name = _quoteIdentifier(name)
+    qry = 'CREATE DATABASE %(dbname)s' % dict(dbname = s_name)
+    args = {}
+    if character_set is not None:
+        qry += ' CHARACTER SET %(character_set)s'
+        args['character_set']= character_set
+    if collate is not None:
+        qry += ' COLLATE %(collate)s'
+        args['collate'] = collate
+    qry += ';'
+
+    log.debug('Query: {0} args: {1}'.format(qry,repr(args)))
     try:
-        if cur.execute(qry):
+        if cur.execute(qry, args):
             log.info('DB {0!r} created'.format(name))
             return True
     except MySQLdb.OperationalError as exc:
@@ -631,12 +662,13 @@ def db_remove(name, **connection_args):
         log.info('DB {0!r} may not be removed'.format(name))
         return False
 
-    # db doesn't exist, proceed
+    # db does exists, proceed
     dbc = _connect(**connection_args)
     if dbc is None:
         return False
     cur = dbc.cursor()
-    qry = 'DROP DATABASE `{0}`;'.format(name)
+    s_name = _quoteIdentifier(name)
+    qry = 'DROP DATABASE %(dbname)s;' % dict(dbname = s_name)
     log.debug('Doing query: {0}'.format(qry))
     try:
         cur.execute(qry)

--- a/tests/integration/modules/mysql.py
+++ b/tests/integration/modules/mysql.py
@@ -55,7 +55,18 @@ class MysqlModuleTest(integration.ModuleCase,
             if 'is already installed' in value['comment']:
                 self.present_packages.append(pkg)
 
-            #if ret
+        travis_python_version = os.environ.get('TRAVIS_PYTHON_VERSION', None)
+        if travis_python_version is not None:
+            # we're in Travis, try to add python-mysql via pip
+            # inside the travis python virtualenv
+            # and reload module to get mysql module activated
+            ret = self.run_state('pip.installed',
+                                 name='mysql-python',
+                                 bin_env='/home/travis/virtualenv/python'
+                                         + travis_python_version
+                                         + '/bin/pip',
+                                 reload_modules=True
+            )
         # now ensure we known the mysql root password
         # one of theses two should work
         ret1 = self.run_state(

--- a/tests/integration/modules/mysql.py
+++ b/tests/integration/modules/mysql.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+import os
+
+from mock import patch, MagicMock
+
+# Import Salt Testing libs
+from salttesting import skipIf
+from salttesting.helpers import (
+    destructiveTest,
+    ensure_in_syspath,
+    requires_system_grains
+)
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+from salt.modules import mysql as mysqlmod
+
+_PKG_MYSQL = {
+    'Debian': ['mysql-server', 'libmysqlclient-dev','python-mysqldb'],
+    'RedHat': ['mysql-server', 'mysql','MySQL-python','python26-mysqldb'],
+}
+
+class MysqlModuleTest(integration.ModuleCase,
+                      integration.SaltReturnAssertsMixIn):
+
+    user='root'
+    password='poney'
+    present_packages=[]
+
+
+    @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'not tested on windows yet')
+    @requires_system_grains
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def setUp(self, grains=None):
+        '''
+        Initialize environnement with a MySQL server, a root password, and python bindings
+        ''' 
+        super(MysqlModuleTest, self).setUp()
+        # Use salt to install MySQL server
+        #os_family = self.run_function('grains.item', ['os_family'])
+        os_family = grains.get('os_family', '')
+        install_pkgs = _PKG_MYSQL.get(os_family, [])
+        # Make sure that we have targets that match the os_family. If this
+        # fails then the _PKG_MYSQL dict above needs to have an entry added,
+        # with mysql packages and python bindings needed for theses test cases
+        for pkg in install_pkgs:
+            ret = self.run_state('pkg.installed', name=pkg)
+            self.assertSaltTrueReturn(ret)
+            key, value = ret.popitem()
+            if 'is already installed' in value['comment']:
+                self.present_packages.append(pkg)
+
+            #if ret
+        # now ensure we known the mysql root password
+        # one of theses two should work
+        ret1 = self.run_state(
+            'cmd.run', 
+             name='mysqladmin -u '
+               + self.user
+               + ' flush-privileges password "'
+               + self.password
+               + '"'
+        )
+        ret2 = self.run_state(
+            'cmd.run', 
+             name='mysqladmin -u '
+               + self.user
+               + ' --password="'
+               + self.password
+               + '" flush-privileges password "'
+               + self.password
+               + '"'
+        )
+
+    @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'not tested on windows yet')
+    @requires_system_grains
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def tearDown(self, grains=None):
+        # remove ony added mysql packages
+        os_family = grains.get('os_family', '')
+        install_pkgs = _PKG_MYSQL.get(os_family, [])
+        for pkg in install_pkgs:
+            if pkg not in self.present_packages:
+                self.run_state('pkg.removed', name=pkg)
+        super(MysqlModuleTest, self).tearDown()
+
+    @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'not tested on windows yet')
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_database_creation_level1(self):
+        '''
+        Create database, test it exists and remove it
+        '''
+        # create
+        ret = self.run_function(
+          'mysql.db_create',
+          name='foo 1',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+
+        # test db exists
+        ret = self.run_function(
+          'mysql.db_exists',
+          name='foo 1',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+
+        # redoing the same should fail
+        ret = self.run_function(
+          'mysql.db_create',
+          name='foo 1',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertFalse(ret)
+
+        # Now remove database
+        ret = self.run_function(
+          'mysql.db_remove',
+          name='foo 1',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+
+    @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'not tested on windows yet')
+    @skipIf(os.geteuid() != 0, 'you must be root to run this test')
+    def test_database_creation_level2(self):
+        '''
+        Same as level1 with strange names and with character set and collate keywords
+        '''
+        # ```````
+        # create
+        # also with character_set and collate only
+        ret = self.run_function(
+          'mysql.db_create',
+          name='foo`2',
+          character_set='utf8',
+          collate='utf8_general_ci',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+        # test db exists
+        ret = self.run_function(
+          'mysql.db_exists',
+          name='foo`2',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+        # redoing the same should fail
+        # even with other character sets or collations
+        ret = self.run_function(
+          'mysql.db_create',
+          name='foo`2',
+          character_set='utf8',
+          collate='utf8_general_ci',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertFalse(ret)
+        # redoing the same should fail
+        ret = self.run_function(
+          'mysql.db_create',
+          name='foo`2',
+          character_set='utf8',
+          collate='utf8_general_ci',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertFalse(ret)
+        # Now remove database
+        ret = self.run_function(
+          'mysql.db_remove',
+          name='foo`2',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+
+        # '''''''
+        # create
+        # also with character_set only
+        ret = self.run_function(
+          'mysql.db_create',
+          name="foo'3",
+          character_set='utf8',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+        # test db exists
+        ret = self.run_function(
+          'mysql.db_exists',
+          name="foo'3",
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+        # Now remove database
+        ret = self.run_function(
+          'mysql.db_remove',
+          name="foo'3",
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+
+        # """"""""
+        # also with collate only
+        ret = self.run_function(
+          'mysql.db_create',
+          name='foo"4',
+          collate='utf8_general_ci',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+        # test db exists
+        ret = self.run_function(
+          'mysql.db_exists',
+          name='foo"4',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+        # Now remove database
+        ret = self.run_function(
+          'mysql.db_remove',
+          name='foo"4',
+          connection_user=self.user,
+          connection_pass=self.password
+        )
+        self.assertTrue(ret)
+
+        # Unicode
+        # TODO: failure in salt highstates, so before me
+        #ret = self.run_function(
+        #    'mysql.db_create',
+        #    name='標準語',
+        #    connection_user=self.user,
+        #    connection_pass=self.password
+        #)
+        #self.assertTrue(ret)
+        # test db exists
+        #ret = self.run_function(
+        #    'mysql.db_exists',
+        #    name='標準語',
+        #    connection_user=self.user,
+        #    connection_pass=self.password
+        #)
+        #self.assertTrue(ret)
+        # Now remove database
+        #ret = self.run_function(
+        #    'mysql.db_remove',
+        #    name='標準語',
+        #    connection_user=self.user,
+        #    connection_pass=self.password
+        #)
+        #self.assertTrue(ret)
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MysqlModuleTest)

--- a/tests/integration/modules/mysql.py
+++ b/tests/integration/modules/mysql.py
@@ -222,30 +222,29 @@ class MysqlModuleTest(integration.ModuleCase,
         self.assertTrue(ret)
 
         # Unicode
-        # TODO: failure in salt highstates, so before me
-        #ret = self.run_function(
-        #    'mysql.db_create',
-        #    name='標準語',
-        #    connection_user=self.user,
-        #    connection_pass=self.password
-        #)
-        #self.assertTrue(ret)
+        ret = self.run_function(
+            'mysql.db_create',
+            name=u'標準語',
+            connection_user=self.user,
+            connection_pass=self.password
+        )
+        self.assertTrue(ret)
         # test db exists
-        #ret = self.run_function(
-        #    'mysql.db_exists',
-        #    name='標準語',
-        #    connection_user=self.user,
-        #    connection_pass=self.password
-        #)
-        #self.assertTrue(ret)
+        ret = self.run_function(
+            'mysql.db_exists',
+            name=u'標準語',
+            connection_user=self.user,
+            connection_pass=self.password
+        )
+        self.assertTrue(ret)
         # Now remove database
-        #ret = self.run_function(
-        #    'mysql.db_remove',
-        #    name='標準語',
-        #    connection_user=self.user,
-        #    connection_pass=self.password
-        #)
-        #self.assertTrue(ret)
+        ret = self.run_function(
+            'mysql.db_remove',
+            name=u'標準語',
+            connection_user=self.user,
+            connection_pass=self.password
+        )
+        self.assertTrue(ret)
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/modules/mysql_test.py
+++ b/tests/unit/modules/mysql_test.py
@@ -160,7 +160,7 @@ class MySQLTestCase(TestCase):
         '''
         Test grant revoke in mysql exec module
         '''
-        self._test_call(mysql.grant_revoke, '', 'SELECT,INSERT,UPDATE', 'datebase.*', 'frank', 'localhost')
+        self._test_call(mysql.grant_revoke, '', 'SELECT,INSERT,UPDATE', 'database.*', 'frank', 'localhost')
 
     def test_processlist(self):
         '''

--- a/tests/unit/modules/mysql_test.py
+++ b/tests/unit/modules/mysql_test.py
@@ -33,6 +33,7 @@ DEBUG = True
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 @skipIf(NO_MYSQL, 'Install MySQL bindings before running MySQL unit tests.')
 class MySQLTestCase(TestCase):
+
     def test_user_create_when_user_exists(self):
         '''
         Test to ensure we don't try to create a user when one already exists


### PR DESCRIPTION
this could be a starting point for #4465 and support of collate and character set in database names. Reading the code I saw some very not robust queries (or should I say insecure).

So I started a mysql integration test also, That should certainly be reviewed, I'm not sure it's the right way to do that. But I definitevely want to have tests with database names like f`oo""jhlk (legit).

Seems also on my travis test I should add something to load python-mysql in the virtualenv, or something like that.
