### PR TITLE
Fix installation of packages with dots in pkg name

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -236,13 +236,15 @@ def _pkg_arch(name):
     that packages that are for the system architecture should not have the
     architecture specified in the passed string.
     '''
+    all_arches = rpmUtils.arch.getArchList()
+    if not any(name.endswith('.{0}'.format(x)) for x in all_arches):
+        return name, __grains__['cpuarch']
     try:
         pkgname, pkgarch = name.rsplit('.', 1)
     except ValueError:
         return name, __grains__['cpuarch']
-    if pkgarch in rpmUtils.arch.legitMultiArchesInSameLib() + ['noarch']:
-        pkgname = name
-    return pkgname, pkgarch
+    else:
+        return pkgname, pkgarch
 
 
 def latest_version(*names, **kwargs):

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -25,6 +25,9 @@ log = logging.getLogger(__name__)
 # it without considering its impact there.
 __QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}'
 
+# From rpmUtils.arch.getArchList() (not necessarily available on RHEL/CentOS 5)
+__ALL_ARCHES = ('ia32e', 'x86_64', 'athlon', 'i686', 'i586', 'i486', 'i386',
+                'noarch')
 __SUFFIX_NOT_NEEDED = ('x86_64', 'noarch')
 
 # Define the module's virtual name
@@ -155,13 +158,14 @@ def _pkg_arch(name):
     architecture specified in the passed string.
     '''
     # TODO: Fix __grains__ availability in provider overrides
+    if not any(name.endswith('.{0}'.format(x)) for x in __ALL_ARCHES):
+        return name, __grains__['cpuarch']
     try:
         pkgname, pkgarch = name.rsplit('.', 1)
     except ValueError:
         return name, __grains__['cpuarch']
-    if pkgarch in __SUFFIX_NOT_NEEDED:
-        pkgname = name
-    return pkgname, pkgarch
+    else:
+        return pkgname, pkgarch
 
 
 def latest_version(*names, **kwargs):


### PR DESCRIPTION
This commit fixes a regression which caused packages with dots in the
package name to fail to install. Resolves #8614.
