### PR TITLE
Mysql utf8 support with tests on db names

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -147,6 +147,8 @@ def _connect(**kwargs):
     _connarg('connection_unix_socket', 'unix_socket')
     _connarg('connection_default_file', 'read_default_file')
     _connarg('connection_default_group', 'read_default_group')
+    _connarg('connection_use_unicode', 'use_unicode')
+    _connarg('connection_charset', 'charset')
 
     try:
         dbc = MySQLdb.connect(**connargs)


### PR DESCRIPTION
Finally I found the two problems of utf8 support in MySQl database names
- need to establish an utf8 enabled connection with mysql, so need to allow it in connection arguments
- need to set the locale  environment to an utf-8 locale when calling salt module function
  So here is the the addition on MySQL connection handling and on integration tests. I made a function to avoid to much copy/paste things. This function :
  - creates the database
  - check db_exists on it
  - retrieve names of database and ensure the name is the right one (without utf8 on the conn utf8 characters would be double encoded)
- drops the db 
