### PR TITLE
Bandaid fix to race condition with runner proc_runner and event push pul...

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -6,6 +6,8 @@ Execute salt convenience routines
 # Import python libs
 import multiprocessing
 import datetime
+import time
+import logging
 
 # Import salt libs
 import salt.loader
@@ -14,6 +16,8 @@ import salt.utils
 import salt.minion
 import salt.utils.event
 from salt.utils.event import tagify
+
+logger = logging.getLogger(__name__)
 
 
 class RunnerClient(object):
@@ -53,6 +57,8 @@ class RunnerClient(object):
                             )
         data['user'] = user
         event.fire_event(data, tagify('ret', base=tag))
+        # this is a workaround because process reaping is defeating 0MQ linger
+        time.sleep(2.0) # delat so 0MQ event gets out before runner process reaped
 
     def _verify_fun(self, fun):
         '''


### PR DESCRIPTION
...l ZeroMQ socket

Fix is to add sleep after last fire event so that the runner process is not reaped until after
the event has made it out of the push socket. This is a bandaid because it does not guarantee
to work if the event process is slow and does not process the event before the sleep expires.

Added a timeout to the fire event and push socket so the send call blocks until the message is sent
Also upped the Linger timeout  but neither of these work because of how the process is getting reaped

A better solution is to change how the process is reaped so that linger and timeout will work.

The best solution is to use a req rep socket so there is positive confirmation that the event
made it.
