### PR TITLE
Fast-fail for down master when authenticating

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -284,6 +284,14 @@ class Auth(object):
                 return 'retry'
             raise SaltClientError
 
+        if not salt.utils.port_responds(
+                self.opts['master_ip'],
+                self.opts['master_port']
+            ):
+            if safe:
+                return 'master_not_running'
+            raise SaltClientError
+
         sreq = salt.payload.SREQ(
             self.opts['master_uri'],
         )
@@ -449,6 +457,12 @@ class SAuth(Auth):
                 self.opts.get('_auth_timeout', 60),
                 self.opts.get('_safe_auth', True)
             )
+
+            if creds == 'master_not_running':
+                if self.opts.get('caller'):
+                    print ('Master did not respond. Is master running?')
+                sys.exit(2)
+
             if creds == 'retry':
                 if self.opts.get('caller'):
                     print('Minion failed to authenticate with the master, '

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -440,6 +440,18 @@ def ip_bracket(addr):
     return addr
 
 
+def port_responds(hostname, port):
+    '''
+    Determines whether or not we can establish a TCP connection to a port
+    '''
+    s = socket.socket()
+    try:
+        s.connect((hostname, int(port)))
+        return True
+    except socket.error, e:
+        return False
+
+
 def dns_check(addr, safe=False, ipv6=False):
     '''
     Return the ip resolved by dns, but do not exit on failure, only raise an


### PR DESCRIPTION
Modify the sign_in function to first check to see if a TCP connection can be established to the master. If not, fail immediatley instead of waiting for the default timeout of 60 seconds. Refs #7001.
