### PR TITLE
Make Amazon Linux use yumpkg5 provider

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -150,9 +150,7 @@ def __virtual__():
     except ValueError:
         os_major = 0
 
-    if os_grain == 'Amazon':
-        return __virtualname__
-    elif os_grain == 'Fedora':
+    if os_grain == 'Fedora':
         # Fedora <= 10 used Python 2.5 and below
         if os_major >= 11:
             return __virtualname__

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -58,6 +58,8 @@ def __virtual__():
     elif os_grain == 'XenServer':
         if os_major_version <= 6:
             valid = True
+    elif os_grain == 'Amazon':
+        valid = True
     else:
         # RHEL <= 5 and all variants need to use this module
         if os_family == 'RedHat' and os_major_version <= 5:


### PR DESCRIPTION
Due to a bug in the rpm python API, Amazon Linux is unable to retrieve
repo metadata over SSL connections. This commit forces Amazon Linux to
use yumpkg5 while we decide what to do about this.

See the following comment from the issue tracker for more info:
https://github.com/saltstack/salt/issues/8226#issuecomment-29664936
