### PR TITLE
Cleaner output for highstate full

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -104,29 +104,27 @@ def output(data):
                         msg = _format_terse(tcolor, comps, ret, colors, tabular)
                         hstrs.append(msg)
                         continue
-                hstrs.append(('{0}----------\n    State: - {1}{2[ENDC]}'
-                              .format(tcolor, comps[0], colors)))
-                hstrs.append('    {0}Name:      {1}{2[ENDC]}'.format(
-                    tcolor,
-                    comps[2],
-                    colors
-                ))
-                hstrs.append('    {0}Function:  {1}{2[ENDC]}'.format(
-                    tcolor,
-                    comps[-1],
-                    colors
-                ))
-                hstrs.append('        {0}Result:    {1}{2[ENDC]}'.format(
-                    tcolor,
-                    str(ret['result']),
-                    colors
-                ))
-                hstrs.append('        {0}Comment:   {1}{2[ENDC]}'.format(
-                    tcolor,
-                    ret['comment'],
-                    colors
-                ))
-                changes = '        Changes:   '
+                state_lines = [
+                    '{tcolor}----------{colors[ENDC]}',
+                    '    {tcolor}      ID: {comps[1]}{colors[ENDC]}',
+                    '    {tcolor}Function: {comps[0]}.{comps[3]}{colors[ENDC]}',
+                    '    {tcolor}  Result: {ret[result]!s}{colors[ENDC]}',
+                    '    {tcolor} Comment: {comment}{colors[ENDC]}'
+                ]
+                # This isn't the prettiest way of doing this, but it's readable.
+                if (comps[1] != comps[2]):
+                    state_lines.insert(
+                        3, '    {tcolor}    Name: {comps[2]}{colors[ENDC]}')
+                svars = {
+                    'tcolor': tcolor,
+                    'comps': comps,
+                    'ret': ret,
+                    # This nukes any trailing \n and indents the others.
+                    'comment': ret['comment'].strip().replace('\n','\n'+' '*14),
+                    'colors': colors
+                }
+                hstrs.extend([sline.format(**svars) for sline in state_lines])
+                changes = '     Changes:   '
                 if not isinstance(ret['changes'], dict):
                     changes += 'Invalid Changes data: {0}'.format(
                             ret['changes'])
@@ -134,7 +132,7 @@ def output(data):
                     pass_opts = __opts__
                     if __opts__['color']:
                         pass_opts['color'] = 'CYAN'
-                    pass_opts['nested_indent'] = 19
+                    pass_opts['nested_indent'] = 14
                     changes += '\n'
                     changes += salt.output.out_format(
                             ret['changes'],


### PR DESCRIPTION
Adjusts hightstate full output in a couple of ways.

```
----------
          ID: php55_makeconf
    Function: makeconf.present
        Name: PHP_TARGETS
      Result: None
     Comment: Variable PHP_TARGETS is to be set to "php5-5" in make.conf
     Changes:   
```

Changes:
- The state's ID is now the first line.
- The state module, is instead displayed in the function line.
- If ID and Name differ, both are shown with ID having the stronger position.
- Name is displayed after function to match its relationship in the state definition code.
- Result value wasn't checked for new lines, causing painful layouts with unindented lines and blank lines. Fixed.
- Indent logic is now consistent, aligned on the colon.

In the process of doing this, I've juggled the code in to an list of keyword formatted output lines, a dict to pass to format() and then used a list comprehension to put the two together.  Seems easier to read and maintain in the long run.

Provides the main feature of issue #8909
