### PR TITLE
Fix for issue #8945

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -27,7 +27,8 @@ def _parse_pkg_meta(path):
     '''
     def parse_rpm(path):
         try:
-            import collections  # needed by _parse_pkginfo, DO NOT REMOVE
+            global __SUFFIX_NOT_NEEDED  # needed by _parse_pkginfo, DO NOT REMOVE
+            from salt.modules.yumpkg5 import __SUFFIX_NOT_NEEDED 
             from salt.modules.yumpkg5 import __QUERYFORMAT, _parse_pkginfo
             from salt.utils import namespaced_function as _namespaced_function
             _parse_pkginfo = _namespaced_function(_parse_pkginfo, globals())


### PR DESCRIPTION
This could also be fixed by importing __SUFFIX_NOT_NEEDED at the top level. I chose a more "local" fix.

I went ahead and removed the 
`import collections  # needed by _parse_pkginfo, DO NOT REMOVE` 
line. It has no effect without a `global collections` declaration and collections is re-imported inside `_parse_pkginfo` anyway.

Christophe
