### PR TITLE
ExposedPort should be a mapping, not a list

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -573,7 +573,7 @@ def create_container(image,
     dns
         list of DNS servers
     ports
-        ports redirections (['222:22'])
+        ports redirections ({'222': {}})
     volumes
         list of volumes mapping::
 

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -305,7 +305,7 @@ def installed(name,
     ins_container = __salt('docker.inspect_container')
     create = __salt('docker.create_container')
     iinfos = ins_image(image)
-    dports, dvolumes, denvironment = [], [], {}
+    dports, dvolumes, denvironment = {}, [], {}
     iinfos = ins_image(image)
     if not iinfos['status']:
         return _invalid(comment='image "{0}" does not exist'.format(image))
@@ -327,13 +327,11 @@ def installed(name,
                 for k in p:
                     denvironment[u'%s' % k] = u'%s' % p[k]
     for p in ports:
-        vals = []
         if not isinstance(p, dict):
-            vals.append('%s' % p)
+            dports[str(p)] = {}
         else:
             for k in p:
-                vals.append('{0}:{1}'.format(k, p[k]))
-        dports.extend(vals)
+                dports[str(p)] = {}
     for p in volumes:
         vals = []
         if not isinstance(p, dict):


### PR DESCRIPTION
According to http://docs.docker.io/en/latest/api/docker_remote_api_v1.6/#create-a-container ,
the API version that introduce ExposedPort parameter, the value of ports should be a dict and not a list.

Note that the value has no effect, only the keys. This is why an empty dict is given as value.
Also when using api 1.4, ports is ignored, this is why docker didn't complain so far.
