### PR TITLE
Avoid conflicting options.

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -529,7 +529,7 @@ def _role_create(name,
         sub_cmd = '{0} PASSWORD {1!r}'.format(sub_cmd, escaped_password)
     if createdb:
         sub_cmd = '{0} CREATEDB'.format(sub_cmd)
-    if createuser:
+    if createuser and not superuser:
         sub_cmd = '{0} CREATEUSER'.format(sub_cmd)
     if superuser:
         sub_cmd = '{0} SUPERUSER'.format(sub_cmd)


### PR DESCRIPTION
If you're a superuser, you already have permissions to create a user. Postgres will complain about conflicting options if you attempt to pass both. Refs #8717.
