### PR TITLE
FreeBSD's pkg v1.2 no longer has the legacy -L option

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -276,7 +276,7 @@ def install(name=None,
         if _check_pkgng():
             args.extend(('install', '-y'))  # Assume yes when asked
             if not refresh:
-                args.append('-L')  # do not update repo db
+                args.append('-U')  # do not update repo db
         else:
             args.append('-r')  # use remote repo
 


### PR DESCRIPTION
pkg >1.2 on FreeBSD now uses the -U flag, which has been available in pkg for a while
