### PR TITLE
rm unused import from zcbuildout state

### DIFF
--- a/salt/states/zcbuildout.py
+++ b/salt/states/zcbuildout.py
@@ -38,7 +38,6 @@ Available Functions
 '''
 
 # Import python libs
-import re
 import sys
 
 # Import salt libs


### PR DESCRIPTION
```
salt/states/zcbuildout.py:41: [W0611(unused-import), ] Unused import re
```
