### PR TITLE
make zcbuildout._Logger a new-style class

### DIFF
--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -103,7 +103,7 @@ def _salt_callback(func):
     return _call_callback
 
 
-class _Logger():
+class _Logger(object):
     levels = ('info', 'warn', 'debug', 'error')
 
     def __init__(self):


### PR DESCRIPTION
```
salt/modules/zcbuildout.py:106: [C1001(old-style-class), _Logger] Old-style class defined.
```
