### PR TITLE
Added exception handler for git repo init

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -127,7 +127,14 @@ def init():
         rp_ = os.path.join(bp_, repo_hash)
         if not os.path.isdir(rp_):
             os.makedirs(rp_)
-        repo = git.Repo.init(rp_)
+
+        try:
+            repo = git.Repo.init(rp_)
+        except Exception as e:
+            log.error('GitPython exception caught while initializing the repo: '
+                      '{0}. Maybe git is not available.'.format(e))
+            return repos
+
         if not repo.remotes:
             try:
                 repo.create_remote('origin', opt)


### PR DESCRIPTION
If GitPython failed to init a git repo, currently the error message is

```
Exception No such file or directory occurred in file server update
```

from https://github.com/saltstack/salt/blob/00faa5f/salt/master.py#L232, and the message is actually coming out of `subprocess` module, as an OSError exception.

We should give user a clear hint that this error actually occurred in GitPython, which should emit an meaningful exception here. And probably, GitPython cannot find the command line tool of git.
