### PR TITLE
Support Oracle Linux 5.x

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -704,6 +704,7 @@ _OS_NAME_MAP = {
     'fedoraremi': 'Fedora',
     'amazonami': 'Amazon',
     'alt': 'ALT',
+    'enterprise': 'OEL',
     'oracleserv': 'OEL',
     'cloudserve': 'CloudLinux',
     'pidora': 'Fedora',


### PR DESCRIPTION
Oracle Linux 5, also known as Unbreakable Linux is currently
not supported by salt.

This one line fix solves this issue.

For reference, the os info extracted through platform.linux_distribution()
python call:
('Enterprise Linux Enterprise Linux Server', '5.1', 'Carthage')

The os is now reported as part of the RedHat family and the pkg module is now working.
