### PR TITLE
switches paths to state files to use forwardslashes on masterless window...

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -365,6 +365,8 @@ class Client(object):
                     else:
                         for found_file in files:
                             stripped_root = os.path.relpath(root, path).replace('/', '.')
+                            if salt.utils.is_windows():
+                                stripped_root = stripped_root.replace('\\', '/')
                             if found_file.endswith(('.sls')):
                                 if found_file.endswith('init.sls'):
                                     if stripped_root.endswith('.'):
@@ -378,6 +380,8 @@ class Client(object):
                                     states.append(stripped_root + found_file[:-4])
         else:
             for path in self.file_list(saltenv):
+                if salt.utils.is_windows():
+                    path = path.replace('\\', '/')
                 if path.endswith('.sls'):
                     # is an sls module!
                     if path.endswith('{0}init.sls'.format('/')):

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -497,18 +497,21 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
 
     old = list_pkgs()
 
-    if pkgs is None and kwargs.get('version') and len(pkg_params) == 1:
+    if pkgs is None and len(pkg_params) == 1:
         # Only use the 'version' param if 'name' was not specified as a
         # comma-separated list
-        pkg_params = {name: kwargs.get('version')}
+        pkg_params = {name: 
+                         {
+                             'version': kwargs.get('version'),
+                             'extra_install_flags': kwargs.get('extra_install_flags')}}
 
-    for param, version_num in pkg_params.iteritems():
-        pkginfo = _get_package_info(param)
+    for pkg_name, options in pkg_params.iteritems():
+        pkginfo = _get_package_info(pkg_name)
         if not pkginfo:
-            log.error('Unable to locate package {0}'.format(name))
+            log.error('Unable to locate package {0}'.format(pkg_name))
             continue
 
-        version_num = version_num or _get_latest_pkg_version(pkginfo)
+        version_num = options and options.get('version') or _get_latest_pkg_version(pkginfo)
 
         if version_num in [old.get(pkginfo[x]['full_name']) for x in pkginfo]:
             # Desired version number already installed
@@ -536,10 +539,11 @@ def install(name=None, refresh=False, pkgs=None, saltenv='base', **kwargs):
 
         cached_pkg = cached_pkg.replace('/', '\\')
         msiexec = pkginfo[version_num].get('msiexec')
+        install_flags = '{0} {1}'.format(pkginfo[version_num]['install_flags'], options and options.get('extra_install_flags'))
         cmd = '{msiexec}"{cached_pkg}" {install_flags}'.format(
             msiexec='msiexec /i ' if msiexec else '',
             cached_pkg=cached_pkg,
-            install_flags=pkginfo[version_num]['install_flags']
+            install_flags=install_flags
         )
         __salt__['cmd.run_all'](cmd)
 


### PR DESCRIPTION
Addresses issue #9021 - Masterless Windows File Paths to States Require Backslashes
