### PR TITLE
Grains detection for LXC and fix error in disk.usage under Docker

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -510,6 +510,9 @@ def _virtual(osdata):
     isdir = os.path.isdir
     sysctl = salt.utils.which('sysctl')
     if osdata['kernel'] in choices:
+        if os.path.isfile('/proc/1/cgroup'):
+            if ':/lxc/' in salt.utils.fopen('/proc/1/cgroup', 'r').read():
+                grains['virtual_subtype'] = 'LXC'
         if isdir('/proc/vz'):
             if os.path.isfile('/proc/vz/version'):
                 grains['virtual'] = 'openvzhn'

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -5,6 +5,7 @@ Module for gathering disk information
 
 # Import python libs
 import logging
+import os
 
 # Import salt libs
 import salt.utils
@@ -52,6 +53,11 @@ def usage(args=None):
         salt '*' disk.usage
     '''
     flags = _clean_flags(args, 'disk.usage')
+    if not os.path.isfile('/etc/mtab'):
+        log.warn("df cannot run without /etc/mtab ")
+        if __grains__.get('virtual_subtype') == 'LXC':
+            log.warn('df command failed and LXC detected. If you are running a Docker container, consider linking /proc/mounts to /etc/mtab or running with consider running Docker with -privileged')
+        return {}
     if __grains__['kernel'] == 'Linux':
         cmd = 'df -P'
     elif __grains__['kernel'] == 'OpenBSD':

--- a/tests/integration/modules/disk.py
+++ b/tests/integration/modules/disk.py
@@ -19,17 +19,20 @@ class DiskModuleVirtualizationTest(integration.ModuleCase):
     This is factored into its own class so that we can have some certainty that setUp() and tearDown() are run.
     '''
     @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'No mtab on Windows')
     def setUp(self):
         # Make /etc/mtab unreadable
         if os.path.isfile('/etc/mtab'):
             shutil.move('/etc/mtab', '/tmp/mtab')
 
     @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'No mtab on Windows')
     def test_no_mtab(self):
         ret = self.run_function('disk.usage')
         self.assertDictEqual(ret, {})
 
     @destructiveTest
+    @skipIf(salt.utils.is_windows(), 'No mtab on Windows')
     def tearDown(self):
         if os.path.isfile('/tmp/mtab'):
             shutil.move('/tmp/mtab', '/etc/mtab')

--- a/tests/integration/modules/disk.py
+++ b/tests/integration/modules/disk.py
@@ -1,11 +1,38 @@
 # -*- coding: utf-8 -*-
 
 # Import Salt Testing libs
-from salttesting.helpers import ensure_in_syspath
+from salttesting.helpers import (ensure_in_syspath, destructiveTest)
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+from salt.modules import disk
+
+# Import Python libs
+import os
+import shutil
+
+class DiskModuleVirtualizationTest(integration.ModuleCase):
+    '''
+    Test to make sure we return a clean result under Docker. Refs #8976
+
+    This is factored into its own class so that we can have some certainty that setUp() and tearDown() are run.
+    '''
+    @destructiveTest
+    def setUp(self):
+        # Make /etc/mtab unreadable
+        if os.path.isfile('/etc/mtab'):
+            shutil.move('/etc/mtab', '/tmp/mtab')
+
+    @destructiveTest
+    def test_no_mtab(self):
+        ret = self.run_function('disk.usage')
+        self.assertDictEqual(ret, {})
+
+    @destructiveTest
+    def tearDown(self):
+        if os.path.isfile('/tmp/mtab'):
+            shutil.move('/tmp/mtab', '/etc/mtab')
 
 
 class DiskModuleTest(integration.ModuleCase):


### PR DESCRIPTION
I have modified the core grains detection routines where dragons often lay, so this should be reviewed carefully.

I have elected to set the LXC detection inside virtual_subtype for account for cases wherein a user might be running inside VirtualBox (as the tutorial for Docker leads one to do). Moreover, I also allow the virtualization detection to continue after LXC is detected, as I believe it may even be possibly for Xen and LXC to co-exist. (Though, let's be honest -- probably not recommended!)

Finally, disk.usage now correctly fails with a warning message and includes a work-around for gathering disk usage under Docker containers. This refs #8976.
