### PR TITLE
Keep pid of salt CLI command from showing in status.pid output

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -501,8 +501,8 @@ def pid(sig):
     if (not sig.endswith('"') and not sig.endswith("'") and
             not sig.startswith('-')):
         sig = "'" + sig + "'"
-    cmd = "{0[ps]} | grep {1} | grep -v grep | awk '{{print $2}}'".format(
-        __grains__, sig)
+    cmd = ("{0[ps]} | grep {1} | grep -v grep | fgrep -v status.pid | "
+           "awk '{{print $2}}'".format(__grains__, sig))
     return (__salt__['cmd.run_stdout'](cmd) or '')
 
 


### PR DESCRIPTION
When status.pid is executed by the salt-minion instance running on the
master, it also returns the pid of the salt CLI command, because the
search string matches. This commit adds another grep to the ps/grep/awk
one-liner, which filters out lines matching 'status.pid'.

Fixes #8720.
