### PR TITLE
Have to rely on source install of libcloud for now.

### DIFF
--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -13,7 +13,7 @@ at https://cloud.google.com.
 
 Dependencies
 ============
-* `Libcloud <http://libcloud.apache.org>`_ version 0.14.0-beta3 or greater
+* Source install of `Libcloud <https://github.com/apache/libcloud>`_ (or greater than 0.14.0-beta3 when available)
 * A Google Cloud Platform account with Compute Engine enabled
 * A registered Service Account for authorization
 * Oh, and obviously you'll need `salt <https://github.com/saltstack/salt>`_


### PR DESCRIPTION
A small change was introduced recently and causes libcloud to throw an error when referencing Image attributes for GCE.  The fix has been merged to libcloud trunk but unfortunately, there is no public release of libcloud yet that includes the new fix.

Adding a temporary update the Salt docs to indicate that libcloud must be installed from source for now.

For reference, the libcloud fix was https://github.com/apache/libcloud/commit/cb5901aace9e3d7546ab581af1b444a14c79975b
