### PR TITLE
Be more liberal about the format of the key we are looking for.

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -269,7 +269,11 @@ def absent(name,
            'comment': ''}
 
     # Get just the key
-    name = name.split(' ')[0]
+    keydata = name.split(' ')
+    if len(keydata) > 1:
+        name = keydata[1]
+    else:
+        name = keydata[0]
 
     if __opts__['test']:
         check = __salt__['ssh.check_key'](


### PR DESCRIPTION
  e.g. accept 'ssh-rsa AAB3NzaC... comment' as well as just 'AAB3NzaC...'
