### PR TITLE
Fix argument parsing for arguments containing pound signs

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -195,6 +195,10 @@ def yamlify_arg(arg):
     try:
         original_arg = str(arg)
         if isinstance(arg, string_types):
+            if '#' in arg:
+                # Don't yamlify this argument or the '#' and everything after
+                # it will be interpreted as a comment.
+                return arg
             if '\n' not in arg:
                 arg = yaml.safe_load(arg)
         if isinstance(arg, dict):

--- a/tests/integration/shell/arguments.py
+++ b/tests/integration/shell/arguments.py
@@ -41,6 +41,18 @@ class ArgumentTestCase(integration.ModuleCase):
             'baz'
         )
 
+    def test_argument_containing_pound_sign(self):
+        '''
+        Tests the argument parsing to ensure that a CLI argument with a pound
+        sign doesn't have the pound sign interpreted as a comment and removed.
+        See https://github.com/saltstack/salt/issues/8585 for more info.
+        '''
+        arg = 'foo bar #baz'
+        self.assertEqual(
+            self.run_function('test.echo', [arg]),
+            arg
+        )
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Passing these through yaml.safe_load() will result in the pound sign and
everything after it being interpreted as a comment. This commit stops
the argument from being passed through yaml.safe_load if it is a string
and contains a pound sign.

Fixes #8585.
