### PR TITLE
Update the parser options with values from config file. Fixes #8447.

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -238,6 +238,11 @@ class MergeConfigMixIn(object):
                 # value, this allows to tweak settings on the configuration
                 # files bypassing the shell option flags
                 self.config[option.dest] = value
+            elif option.dest in self.config:
+                # Let's update the option value with the one from the
+                # configuration file. This allows the parsers to make use of
+                # the updated value by using self.options.<option>
+                setattr(self.options, option.dest, self.config[option.dest])
 
         # Merge parser group options if any
         for group in self.option_groups:
@@ -252,12 +257,18 @@ class MergeConfigMixIn(object):
                     if value is not None:
                         # There's an actual value, add it to the config
                         self.config[option.dest] = value
-                else:
-                    if value is not None and value != default:
-                        # Only set the value in the config file IF it's not the
-                        # default value, this allows to tweak settings on the
-                        # configuration files bypassing the shell option flags
-                        self.config[option.dest] = value
+                elif value is not None and value != default:
+                    # Only set the value in the config file IF it's not the
+                    # default value, this allows to tweak settings on the
+                    # configuration files bypassing the shell option flags
+                    self.config[option.dest] = value
+                elif option.dest in self.config:
+                    # Let's update the option value with the one from the
+                    # configuration file. This allows the parsers to make use
+                    # of the updated value by using self.options.<option>
+                    setattr(self.options,
+                            option.dest,
+                            self.config[option.dest])
 
 
 class ConfigDirMixIn(object):


### PR DESCRIPTION
The way the parser merges the CLI configuration with the file configuration is.

For each option:
1. If a value was passed to the CLI, that value rules.
2. If not value was passed to the CLI and no value is defined in the config file. The default, it any, is used.
3. If a value is not passed to the CLI and the value is defined in the config file, the config file one will be used.

Some code was using the parser options for logic and values after the configuration loaded, but the parser options were never updated to the configuration files values.
So:
1. Do what we said in the above 3, **and**, update the parser option to have that value.
