### PR TITLE
If a specific repo is requested, force the installation. 

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -343,7 +343,7 @@ def install(name=None,
     old = list_pkgs()
     downgrades = []
     if fromrepo:
-        fromrepoopt = "--from {0} ".format(fromrepo)
+        fromrepoopt = "--force --force-resolution --from {0} ".format(fromrepo)
         log.info('Targeting repo {0!r}'.format(fromrepo))
     else:
         fromrepoopt = ""

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -988,8 +988,9 @@ def managed(name,
         hosted on either the salt master server, or on an HTTP or FTP server.
         For files hosted on the salt file server, if the file is located on
         the master in the directory named spam, and is called eggs, the source
-        string is salt://spam/eggs. If source is left blank or None, the file
-        will be created as an empty file and the content will not be managed
+        string is salt://spam/eggs. If source is left blank or None
+        (use ~ in YAML), the file will be created as an empty file and
+        the content will not be managed
 
         If the file is hosted on a HTTP or FTP server then the source_hash
         argument is also required


### PR DESCRIPTION
Otherwise, zypper asks interactively whether the vendor is to be changed, which blocks salt.
