### PR TITLE
Add partial support docker v1.6 api

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -639,20 +639,12 @@ def create_container(image,
             name=name,
         )
         container = info['Id']
-        kill(container)
-        ret_start = start(container, binds=binds)
         callback = valid
         comment = 'Container created'
         out = {
             'info': _get_container_infos(container),
-            'started': ret_start,
             'out': info
         }
-        if not ret_start['status']:
-            callback = invalid
-            comment = 'Container created but cannot be started\n{0}'.format(
-                ret_start['out']
-            )
         return callback(status, id=container, comment=comment, out=out)
     except Exception:
         invalid(status, id=image, out=traceback.format_exc())

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -109,6 +109,7 @@ You have those methods:
 
 - start
 - stop
+- restart
 - kill
 - wait
 - get_containers
@@ -556,7 +557,7 @@ def create_container(image,
                      volumes_from=None,
                      *args, **kwargs):
     '''
-    Get container diffs
+    Create a new container
 
     image
         image to create the container from
@@ -739,7 +740,7 @@ def stop(container, timeout=10, *args, **kwargs):
           ex::
 
             {'id': 'abcdef123456789',
-           'status': True}
+             'status': True}
 
     CLI Example:
 

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -870,7 +870,9 @@ def restart(container, timeout=10, *args, **kwargs):
     return status
 
 
-def start(container, binds=None, ports=None, *args, **kwargs):
+def start(container, binds=None, ports=None, port_bindings=None,
+          lxc_conf=None, publish_all_ports=None, links=None,
+          *args, **kwargs):
     '''
     restart the specified container
 
@@ -895,7 +897,9 @@ def start(container, binds=None, ports=None, *args, **kwargs):
     try:
         dcontainer = _get_container_infos(container)['id']
         if not is_running(container):
-            client.start(dcontainer, binds=binds)
+            client.start(dcontainer, binds=binds, port_bindings=port_bindings,
+                         lxc_conf=lxc_conf,
+                         publish_all_ports=publish_all_ports, links=links)
             if is_running(dcontainer):
                 valid(status,
                       comment='Container {0} was started'.format(container),

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -555,6 +555,8 @@ def create_container(image,
                      dns=None,
                      volumes=None,
                      volumes_from=None,
+                     privileged=False,
+                     name=None,
                      *args, **kwargs):
     '''
     Create a new container
@@ -587,6 +589,10 @@ def create_container(image,
         let stdin open
     volumes_from
         container to get volumes definition from
+    privileged
+        run container in privileged mode
+    name
+        name given to container
 
     EG:
 
@@ -629,6 +635,8 @@ def create_container(image,
             dns=dns,
             volumes=mountpoints,
             volumes_from=volumes_from,
+            privileged=privileged,
+            name=name,
         )
         container = info['Id']
         kill(container)

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -22,7 +22,8 @@ Installation prerequisites
 --------------------------
 
 - You will need the 'docker-py' python package in your python installation
-  running salt.
+  running salt. The version of docker-py should support `version 1.6 of docker
+  remote API. <https://docs.docker.io/en/latest/api/docker_remote_api_v1.6/>`_.
 - For now, you need docker-py from sources:
 
     https://github.com/dotcloud/docker-py

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -517,7 +517,7 @@ def run(name,
 
 def running(name, container=None, port_bindings=None, binds=None,
             publish_all_ports=False, links=None, lxc_conf=None):
-    """
+    '''
     name
         name of the service
     container
@@ -551,7 +551,7 @@ def running(name, container=None, port_bindings=None, binds=None,
                 "5000/tcp":
                     - HostIp: ""
                     - HostPort: "5000"
-    """
+    '''
     running = __salt('docker.is_running')(container)
     if running:
         return _valid(

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -209,13 +209,27 @@ def built(name,
     return status
 
 
-def _toggle_container_running_status(cid, started):
+def _toggle_container_running_status(cid, started, binds=None,
+                                     port_bindings=None,
+                                     lxc_conf=None,
+                                     publish_all_ports=None,
+                                     links=None, **kwargs):
     '''
     Start or stop a container
     cid
         Container id
     started
         True if container is meant to be started
+    binds
+        check docker-py Client.start API
+    port_bindings
+        check docker-py Client.start API
+    lxc_conf
+        check docker-py Client.start API
+    publish_all_ports
+        check docker-py Client.start API
+    links
+        check docker-py Client.start API
     '''
     running = __salt('docker.is_running')(cid)
     # if container exists but is not started, try to start it
@@ -223,7 +237,10 @@ def _toggle_container_running_status(cid, started):
         if running:
             return _valid(comment='Container {0} is started'.format(cid))
         else:
-            started = __salt('docker.start')(cid)
+            started = __salt('docker.start')(
+                cid, binds=binds, port_bindings=port_bindings,
+                lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
+                links=links)
             running = __salt('docker.is_running')(cid)
             if running:
                 return _valid(
@@ -313,7 +330,8 @@ def installed(name,
     cinfos = ins_container(existing_cid)
     # if container exists but is not started, try to start it
     if existing_cid and cinfos['status']:
-        return _toggle_container_running_status(existing_cid, started)
+        return _toggle_container_running_status(existing_cid, started,
+                                                **kwargs)
     if not ports:
         ports = []
     if not volumes:

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -617,7 +617,6 @@ def script(name,
     if not hostname:
         hostname = cid
     retcode = __salt__['docker.retcode']
-    dretcode = __salt__['cmd.retcode']
     drun = __salt__['docker.run']
     cmd_kwargs = ''
     if onlyif is not None:

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -10,6 +10,9 @@ A Docker is a light-weight, portable, self-sufficient container.
 
     This state module is beta; the API is subject to change and no promise
     as to performance or functionality is yet present
+    This module requires a docker-py that support `version 1.6 of docker
+    remote API.
+    <https://docs.docker.io/en/latest/api/docker_remote_api_v1.6/>`_.
 
 Available Functions
 -------------------

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -105,10 +105,10 @@ def __salt(fn):
 
 
 def _ret_status(exec_status=None,
-               name='',
-               comment='',
-               result=None,
-               changes=None):
+                name='',
+                comment='',
+                result=None,
+                changes=None):
     if not changes:
         changes = {}
     if exec_status is None:
@@ -133,18 +133,18 @@ def _ret_status(exec_status=None,
 
 def _valid(exec_status=None, name='', comment='', changes=None):
     return _ret_status(exec_status=exec_status,
-                      comment=comment,
-                      name=name,
-                      changes=changes,
-                      result=True)
+                       comment=comment,
+                       name=name,
+                       changes=changes,
+                       result=True)
 
 
 def _invalid(exec_status=None, name='', comment='', changes=None):
     return _ret_status(exec_status=exec_status,
-                      comment=comment,
-                      name=name,
-                      changes=changes,
-                      result=False)
+                       comment=comment,
+                       name=name,
+                       changes=changes,
+                       result=False)
 
 
 def pulled(name, force=False, *args, **kwargs):

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -33,10 +33,23 @@ Available Functions
 
   .. code-block:: yaml
 
-      mysuperdocker:
+      mysuperdocker-container:
           docker.installed:
+              - name: mysuperdocker
               - hostname: superdocker
               - image: corp/mysuperdocker_img
+- running
+
+  .. code-block:: yaml
+
+      my_service:
+          docker.running:
+              - container: mysuperdocker
+              - port_bindings:
+                  "5000/tcp":
+                      - HostIp: ""
+                      - HostPort: "5000"
+
 
 - absent
 
@@ -247,60 +260,6 @@ def built(name,
     return status
 
 
-def _toggle_container_running_status(cid, started, binds=None,
-                                     port_bindings=None,
-                                     lxc_conf=None,
-                                     publish_all_ports=None,
-                                     links=None, **kwargs):
-    '''
-    Start or stop a container
-    cid
-        Container id
-    started
-        True if container is meant to be started
-    binds
-        check docker-py Client.start API
-    port_bindings
-        check docker-py Client.start API
-    lxc_conf
-        check docker-py Client.start API
-    publish_all_ports
-        check docker-py Client.start API
-    links
-        check docker-py Client.start API
-    '''
-    running = __salt('docker.is_running')(cid)
-    # if container exists but is not started, try to start it
-    if started:
-        if running:
-            return _valid(comment='Container {0} is started'.format(cid))
-        else:
-            started = __salt('docker.start')(
-                cid, binds=binds, port_bindings=port_bindings,
-                lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
-                links=links)
-            running = __salt('docker.is_running')(cid)
-            if running:
-                return _valid(
-                    comment=('Container {0} was already stopped,\n'
-                             'Container {0} was started.\n').format(cid))
-            else:
-                return _invalid(comment=(
-                    'Container {0} cannot be started\n{1}'
-                ).format(cid, started['out']))
-    else:
-        if running:
-            __salt('docker.stop')(cid, 1)
-            running = __salt('docker.is_running')(cid)
-            if running:
-                return _invalid(
-                    comment='Container {0} could not be stopped'.format(cid))
-            else:
-                return _valid(comment='Container {0} was stopped,'.format(cid))
-        else:
-            return _valid(comment='Container {0} is stopped,'.format(cid))
-
-
 def installed(name,
               image,
               command='/sbin/init',
@@ -315,15 +274,13 @@ def installed(name,
               dns=None,
               volumes=None,
               volumes_from=None,
-              force=False,
-              started=True,
+              privileged=False,
               *args, **kwargs):
     '''
     Build a new container from an image
 
     name
-        this name will be stored in grain for not
-        reinstalling again and again the same container
+        name of the container
     image
         the image from which to build this container
     path
@@ -337,23 +294,7 @@ def installed(name,
             - a port to map
             - a mapping of mapping portInHost : PortInContainer
     volumes
-        List of volumes mappings definitions, either:
-            - a volume inside the host which is mounted as the same location
-              in the container
-            - a mapping mountpointInContainer:MountpointinHost
-    started
-        Is the container running (default: true)
-    port_bindings
-        List of ports to expose on host system
-            - a mapping port's guest, hostname's host and port's host.
-
-        .. code-block:: yaml
-
-            - port_bindings:
-                "5000/tcp":
-                    - HostIp: ""
-                    - HostPort: "5000"
-
+        List of volumes
 
     For other parameters, please look at the module
     documentation
@@ -371,16 +312,14 @@ def installed(name,
     ins_container = __salt('docker.inspect_container')
     create = __salt('docker.create_container')
     iinfos = ins_image(image)
-    dports, dvolumes, denvironment = {}, [], {}
-    iinfos = ins_image(image)
     if not iinfos['status']:
         return _invalid(comment='image "{0}" does not exist'.format(image))
-    existing_cid = _get_container_id(name)
-    cinfos = ins_container(existing_cid)
+    cinfos = ins_container(name)
+    already_exists = cinfos['status']
     # if container exists but is not started, try to start it
-    if existing_cid and cinfos['status']:
-        return _toggle_container_running_status(existing_cid, started,
-                                                **kwargs)
+    if already_exists:
+        return _valid(comment='image {!r} already exists'.format(name))
+    dports, dvolumes, denvironment = {}, [], {}
     if not ports:
         ports = []
     if not volumes:
@@ -419,73 +358,20 @@ def installed(name,
         environment=denvironment,
         dns=dns,
         volumes=dvolumes,
-        volumes_from=volumes_from)
-    already_exists = False
-    if already_exists and not force:
-        return _valid(
-            name=name,
-            comment='Container already exist {0}, id: {1}'.format(1, 1))
-    if not already_exists or force:
-        out = create(*a, **kw)
-        # if container has been created, even if not started, we mark
-        # it as installed
-        try:
-            cid = out['out']['info']['id']
-        except Exception:
-            # not created at all
-            cid = None
-        if cid:
-            _set_container_id(name, cid)
-            out['comment'] = 'Container {0} created'.format(cid)
-            # force start or stop status of this container
-            # only if creation process is successful
-            if out['status']:
-                toggle_s = _toggle_container_running_status(cid, started)
-                out['result'] = toggle_s['result']
-                out['status'] = toggle_s['result']
-                out['comment'] += '\n' + toggle_s['comment']
-        ret = _ret_status(out, name)
-    return ret
-
-
-def _get_container_id(name):
-    k = CONTAINER_GRAIN_ID.format(id=name)
-    val = None
-    if not k in MAPPING_CACHE:
-        getval = __salt('grains.get')
-        val = getval(k, None)
+        volumes_from=volumes_from,
+        name=name,
+        privileged=privileged)
+    out = create(*a, **kw)
+    # if container has been created, even if not started, we mark
+    # it as installed
+    try:
+        cid = out['out']['info']['id']
+    except Exception:
+        pass
     else:
-        val = MAPPING_CACHE[k]
-    if val:
-        MAPPING_CACHE[k] = val
-    return val
-
-
-def _set_container_id(name, val):
-    setval = __salt('grains.setval')
-    k = CONTAINER_GRAIN_ID.format(id=name)
-    MAPPING_CACHE[k] = val
-    ret = setval(k, val)
+        out['comment'] = 'Container {0} created'.format(cid)
+    ret = _ret_status(out, name)
     return ret
-
-
-def _del_container_id(name=None, cid=None):
-    delval = __salt('grains.delval')
-    getval = __salt('grains.get')
-    grains = __salt('grains.items')()
-    values = []
-    if name:
-        values.append(name)
-    for g, val in grains.items():
-        if val == cid and CONTAINER_GRAIN_ID_RE.match(g):
-            values.append(g)
-    for n in values:
-        k = CONTAINER_GRAIN_ID.format(id=n)
-        if k in MAPPING_CACHE:
-            del MAPPING_CACHE[k]
-        val = getval(k, None)
-        if val:
-            delval(k)
 
 
 def absent(name):
@@ -493,28 +379,34 @@ def absent(name):
     Container should be absent or
     will be killed, destroyed, and eventually we will remove the grain matching
 
-    You can match by either a state id or a container id
+    You can match by either a container's name or id
 
     name:
-        Either the state_id or container id
+        Either the container name or id
 
     '''
-    cid = _get_container_id(name)
-    ins_container = __salt('docker.inspect_container')
-    if cid:
-        cinfos = ins_container(cid)
-    else:
-        # fallback directly on container id
-        cinfos = ins_container(name)
+    ins_container = __salt__['docker.inspect_container']
+    cinfos = ins_container(name)
     if cinfos['status']:
         cid = cinfos['id']
+        running = __salt__['docker.is_running'](cid)
         # destroy if we found meat to do
-        _toggle_container_running_status(cid, False)
-        ret = _ret_status(__salt('docker.remove_container')(cid))
-        _del_container_id(cid=cid)
-        return ret
+        if running:
+            __salt__['docker.stop'](cid)
+            running = __salt('docker.is_running')(cid)
+            if running:
+                return _invalid(
+                    comment=('Container {!r}'
+                             ' could not be stopped'.format(cid)))
+            else:
+                return _valid(comment=('Container {!r}'
+                                       ' was stopped,'.format(cid)),
+                              changes={name: True})
+        else:
+            return _valid(comment=('Container {!r}'
+                                   ' is stopped,'.format(cid)))
     else:
-        return _valid(comment='Container {0} not found'.format(name))
+        return _valid(comment='Container {!r} not found'.format(name))
 
 
 def present(name):
@@ -527,13 +419,8 @@ def present(name):
         Either the state_id or container id
 
     '''
-    cid = _get_container_id(name)
     ins_container = __salt('docker.inspect_container')
-    if cid:
-        cinfos = ins_container(cid)
-    else:
-        # fallback directly on container id
-        cinfos = ins_container(name)
+    cinfos = ins_container(name)
     if cinfos['status']:
         cid = cinfos['id']
         return _valid(comment='Container {0} exists'.format(cid))
@@ -584,7 +471,6 @@ def run(name,
     if not hostname:
         hostname = cid
     retcode = __salt__['docker.retcode']
-    dretcode = __salt__['cmd.retcode']
     drun = __salt__['docker.run']
     cmd_kwargs = ''
     if onlyif is not None:
@@ -627,6 +513,64 @@ def run(name,
                 return {'comment': 'docked_unless execution succeeded',
                         'result': True}
     return drun(**cmd_kwargs)
+
+
+def running(name, container=None, port_bindings=None, binds=None,
+            publish_all_ports=False, links=None, lxc_conf=None):
+    """
+    name
+        name of the service
+    container
+        name of the container to start
+
+    binds
+        like -v of docker run command
+
+        ..code-block:: yaml
+
+            - binds:
+                - /var/log/service: /var/log/service
+
+    publish_all_ports
+
+    links
+        Link several container together
+
+        ..code-block:: yaml
+
+            - links:
+                name_other_container: alias_for_other_container
+
+    port_bindings
+        List of ports to expose on host system
+            - a mapping port's guest, hostname's host and port's host.
+
+        .. code-block:: yaml
+
+            - port_bindings:
+                "5000/tcp":
+                    - HostIp: ""
+                    - HostPort: "5000"
+    """
+    running = __salt('docker.is_running')(container)
+    if running:
+        return _valid(
+            comment='Container {!r} is started'.format(container))
+    else:
+        started = __salt__['docker.start'](
+            container, binds=binds, port_bindings=port_bindings,
+            lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
+            links=links)
+        running = __salt__['docker.is_running'](container)
+        if running:
+            return _valid(
+                comment=('Container {!r} started.\n').format(container),
+                changes={name: True})
+        else:
+            return _invalid(
+                comment=('Container {!r}'
+                         ' cannot be started\n{!s}').format(container,
+                                                            started['out']))
 
 
 def script(name,

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -305,6 +305,17 @@ def installed(name,
             - a mapping mountpointInContainer:MountpointinHost
     started
         Is the container running (default: true)
+    port_bindings
+        List of ports to expose on host system
+            - a mapping port's guest, hostname's host and port's host.
+
+        .. code-block:: yaml
+
+            - port_bindings:
+                "5000/tcp":
+                    - HostIp: ""
+                    - HostPort: "5000"
+
 
     For other parameters, please look at the module
     documentation


### PR DESCRIPTION
This PR Introduce a new state `docker.running`.

Before `docker.installed` was also starting the container.
It was too hard to make it work properly, and break salt philosophy: KISS.

This PR introduce non backward compatible changes, and requires docker-py that is not yet released on pypi :angry: . (I'm using the master of the project the time I wrote this changeset.)

Thus, I'm not sure it is ready to be merged in this state.

Please, can you review the PR  ? also pay more attention to the mod_watch implementation, I'm not sure I did it correctly.

Thx.
