### PR TITLE
Add check for '.' in require/watch requisites

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -341,6 +341,19 @@ class Compiler(object):
                                             continue
                                         req_key = next(iter(req))
                                         req_val = req[req_key]
+                                        if '.' in req_key:
+                                            errors.append((
+                                                'Invalid requisite type {0!r} '
+                                                'in state {1!r}, in SLS '
+                                                '{2!r}. Requisite types must '
+                                                'not contain periods, did you '
+                                                'mean {3!r}?'.format(
+                                                    req_key,
+                                                    name,
+                                                    body['__sls__'],
+                                                    req_key[:req_key.find('.')]
+                                                )
+                                            ))
                                         if not ishashable(req_val):
                                             errors.append((
                                                 'Illegal requisite "{0}", '
@@ -805,6 +818,19 @@ class State(object):
                                             continue
                                         req_key = next(iter(req))
                                         req_val = req[req_key]
+                                        if '.' in req_key:
+                                            errors.append((
+                                                'Invalid requisite type {0!r} '
+                                                'in state {1!r}, in SLS '
+                                                '{2!r}. Requisite types must '
+                                                'not contain periods, did you '
+                                                'mean {3!r}?'.format(
+                                                    req_key,
+                                                    name,
+                                                    body['__sls__'],
+                                                    req_key[:req_key.find('.')]
+                                                )
+                                            ))
                                         if not ishashable(req_val):
                                             errors.append((
                                                 'Illegal requisite "{0}", '

--- a/salt/state.py
+++ b/salt/state.py
@@ -346,7 +346,7 @@ class Compiler(object):
                                                 'Invalid requisite type {0!r} '
                                                 'in state {1!r}, in SLS '
                                                 '{2!r}. Requisite types must '
-                                                'not contain periods, did you '
+                                                'not contain dots, did you '
                                                 'mean {3!r}?'.format(
                                                     req_key,
                                                     name,
@@ -823,7 +823,7 @@ class State(object):
                                                 'Invalid requisite type {0!r} '
                                                 'in state {1!r}, in SLS '
                                                 '{2!r}. Requisite types must '
-                                                'not contain periods, did you '
+                                                'not contain dots, did you '
                                                 'mean {3!r}?'.format(
                                                     req_key,
                                                     name,
@@ -1090,6 +1090,7 @@ class State(object):
             ])
         req_in_all = req_in.union(set(['require', 'watch']))
         extend = {}
+        errors = []
         for id_, body in high.items():
             if not isinstance(body, dict):
                 continue
@@ -1119,11 +1120,18 @@ class State(object):
                                 if name not in extend:
                                     extend[name] = {}
                                 if '.' in _state:
-                                    log.warning(
-                                        'Bad requisite syntax in {0} : {1} for {2},'
-                                        ' requisites should not contain any dot'
-                                        .format(rkey, _state, name)
-                                    )
+                                    errors.append((
+                                        'Invalid requisite in {0}: {1} for '
+                                        '{2}, in SLS {3!r}. Requisites must '
+                                        'not contain dots, did you mean {4!r}?'
+                                        .format(
+                                            rkey,
+                                            _state,
+                                            name,
+                                            body['__sls__'],
+                                            _state[:_state.find('.')]
+                                        )
+                                    ))
                                     _state = _state.split(".")[0]
                                 if _state not in extend[name]:
                                     extend[name][_state] = []
@@ -1155,11 +1163,18 @@ class State(object):
                                 _state = next(iter(ind))
                                 name = ind[_state]
                                 if '.' in _state:
-                                    log.warning(
-                                        'Bad requisite syntax in {0} : {1} for {2},'
-                                        ' requisites should not contain any dot'
-                                        .format(rkey, _state, name)
-                                    )
+                                    errors.append((
+                                        'Invalid requisite in {0}: {1} for '
+                                        '{2}, in SLS {3!r}. Requisites must '
+                                        'not contain dots, did you mean {4!r}?'
+                                        .format(
+                                            rkey,
+                                            _state,
+                                            name,
+                                            body['__sls__'],
+                                            _state[:_state.find('.')]
+                                        )
+                                    ))
                                     _state = _state.split(".")[0]
                                 if key == 'prereq_in':
                                     # Add prerequired to origin
@@ -1259,7 +1274,9 @@ class State(object):
         high['__extend__'] = []
         for key, val in extend.items():
             high['__extend__'].append({key: val})
-        return self.reconcile_extend(high)
+        req_in_high, req_in_errors = self.reconcile_extend(high)
+        errors.extend(req_in_errors)
+        return req_in_high, errors
 
     def call(self, low, chunks=None, running=None):
         '''

--- a/tests/integration/files/file/base/requisites/require.sls
+++ b/tests/integration/files/file/base/requisites/require.sls
@@ -7,7 +7,7 @@
 # B (2) ---+ <-+ <-+ <-+
 #              |   |   |
 # C (3) <--+ --|---|---+
-#          |   |   |
+#          |   |   |
 # E (4) ---|---|---+ <-+
 #          |   |       |
 # A (5) ---+ --+ ------+
@@ -23,10 +23,7 @@ B:
     - name: echo B second
     - require_in:
       - cmd: A
-      # issue #8773
-      # this will generate a warning but will still be done
-      # right syntax is cmd: C
-      - cmd.run: C
+      - cmd: C
 
 C:
   cmd.run:
@@ -35,11 +32,8 @@ C:
 D:
   cmd.run:
     - name: echo D first
-    # issue #8773 fix
-    # this will generate a warning but will still be done
-    # as in B, here testing the non-list form (no '-')
     - require_in:
-        cmd.foo: B
+      - cmd: B
 
 E:
   cmd.run:
@@ -66,5 +60,5 @@ H:
   cmd.run:
     - name: echo H
     - require:
-      - cmd.run: Z
+      - cmd: Z
 

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -487,41 +487,49 @@ fi
             'cmd_|-A_|-echo A fifth_|-run': {
                 '__run_num__': 4,
                 'comment': 'Command "echo A fifth" run',
-                'result': True},
+                'result': True
+            },
             'cmd_|-B_|-echo B second_|-run': {
                 '__run_num__': 1,
                 'comment': 'Command "echo B second" run',
-                'result': True},
+                'result': True
+            },
             'cmd_|-C_|-echo C third_|-run': {
                 '__run_num__': 2,
                 'comment': 'Command "echo C third" run',
-                'result': True},
+                'result': True
+            },
             'cmd_|-D_|-echo D first_|-run': {
                 '__run_num__': 0,
                 'comment': 'Command "echo D first" run',
-                'result': True},
+                'result': True
+            },
             'cmd_|-E_|-echo E fourth_|-run': {
                 '__run_num__': 3,
                 'comment': 'Command "echo E fourth" run',
-                'result': True},
+                'result': True
+            },
             'cmd_|-F_|-echo F_|-run': {
                 '__run_num__': 5,
                 'comment': 'The following requisites were not found:\n'
                            + '                   require:\n'
                            + '                       foobar: A\n',
-                'result': False},
+                'result': False
+            },
             'cmd_|-G_|-echo G_|-run': {
                 '__run_num__': 6,
                 'comment': 'The following requisites were not found:\n'
                            + '                   require:\n'
                            + '                       cmd: Z\n',
-                'result': False},
+                'result': False
+            },
             'cmd_|-H_|-echo H_|-run': {
                 '__run_num__': 7,
                 'comment': 'The following requisites were not found:\n'
                            + '                   require:\n'
                            + '                       cmd: Z\n',
-                'result': False}
+                'result': False
+            }
         }
         result = {}
         ret = self.run_function('state.sls', mods='requisites.require')


### PR DESCRIPTION
**This is in the process of being refactored, do not merge yet.**

This commit will cause require/watch requisites to fail if they contain
dots. The prior behavior just ignored the dot, but since the function
name is ignored, and dots are already illegal in prereq requisites, this
commit makes the behavior more consistent.

Resolves #5919.
