### PR TITLE
more detailed output when a command fails

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -367,7 +367,7 @@ def _run(cmd,
     try:
         proc = salt.utils.timed_subprocess.TimedProc(cmd, **kwargs)
     except (OSError, IOError) as exc:
-        raise CommandExecutionError('Unable to run command: {0}'.format(exc))
+        raise CommandExecutionError('Unable to run command "{0}" with the context "{1}", reason: {2}'.format(cmd, kwargs, exc))
 
     try:
         proc.wait(timeout)


### PR DESCRIPTION
Hey,

When a command fail, he doesn't even show itself, this can make debugging on state that calls this module quite paintfull. Here is a simple more detailed output to fix this.

Best regards,
