### PR TITLE
Fix exception handling on runner and wheel api clients

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -126,6 +126,25 @@ class EauthAuthenticationError(SaltException):
     Thrown when eauth authentication fails
     '''
 
+class TokenAuthenticationError(SaltException):
+    '''
+    Thrown when token authentication fails
+    '''
+
+class AuthorizationError(SaltException):
+    '''
+    Thrown when runner or wheel execution fails due to permissions
+    '''
+
+class SaltRunnerError(SaltException):
+    '''
+    Problem in runner
+    '''
+
+class SaltWheelError(SaltException):
+    '''
+    Problem in wheel
+    '''
 
 class SaltSystemExit(SystemExit):
     '''
@@ -136,3 +155,5 @@ class SaltSystemExit(SystemExit):
         SystemExit.__init__(self, code)
         if msg:
             self.message = msg
+
+

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -8,6 +8,7 @@ import multiprocessing
 import datetime
 import time
 import logging
+import collections
 
 # Import salt libs
 import salt.loader
@@ -16,6 +17,7 @@ import salt.utils
 import salt.minion
 import salt.utils.event
 from salt.utils.event import tagify
+from salt.utils.error import raise_error
 
 logger = logging.getLogger(__name__)
 
@@ -51,8 +53,9 @@ class RunnerClient(object):
             data['return'] = self.low(fun, low)
             data['success'] = True
         except Exception as exc:
-            data['return'] = 'Exception occured in runner {0}: {1}'.format(
+            data['return'] = 'Exception occured in runner {0}: {1}: {2}'.format(
                             fun,
+                            exc.__class__.__name__, 
                             exc,
                             )
             data['success'] = False
@@ -131,8 +134,10 @@ class RunnerClient(object):
                 'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
                 )
         ret = sreq.send('clear', load)
-        if ret == '':
-            raise salt.exceptions.EauthAuthenticationError
+        if isinstance(ret, collections.Mapping):
+           if 'error' in ret:
+               raise_error(**ret['error'])
+            
         return ret
 
 

--- a/salt/runners/error.py
+++ b/salt/runners/error.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+'''
+Error generator to enable integration testing of salt runner error handling
+
+'''
+
+# Import python libs
+
+
+# Import salt libs
+import salt.utils.error
+
+
+def error(name=None, message=''):
+    '''
+    If name is None Then return empty dict
+    Otherwise
+       Raise an exception with __name__ from name, message from message
+
+    CLI Example:
+
+    .. code-block:: bash
+        salt-run error
+        salt-run error.error name="Exception" message="This is an error."
+    '''
+    ret = {}
+    if name is not None:
+        salt.utils.error.raise_error(name=name, message=message)
+    
+    return ret
+
+

--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+'''
+Utilities to enable exception reraising across the master commands
+
+'''
+
+# Import python libs
+import exceptions
+
+
+# Import salt libs
+import salt.exceptions
+
+
+def raise_error(name=None, args=None, message=''):
+    '''
+    Raise an exception with __name__ from name, args from args
+    If args is None Otherwise message from message\
+    If name is empty then use "Exception"
+
+    
+    '''
+    name = name or 'Exception'
+    if hasattr(salt.exceptions, name):
+        ex = getattr(salt.exceptions, name)
+    elif hasattr(exceptions, name):
+        ex = getattr(exceptions, name)
+    else:
+        name = 'SaltException'
+        ex = getattr(salt.exceptions, name)
+    if args is not None:
+        raise ex(*args)
+    else:
+        raise ex(message)
+    
+

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -661,7 +661,7 @@ def remotes_on_local_tcp_port(port):
         data = subprocess.check_output(['lsof', '-i4TCP:{0:d}'.format(port), '-n'])
     except subprocess.CalledProcessError as ex:
         log.error('Failed "lsof" with returncode = {0}'.format(ex.returncode))
-        return remotes
+        raise 
     
     lines = data.split('\n')
     for line in lines:

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -2,12 +2,15 @@
 '''
 Modules used to control the master itself
 '''
+#import python libs
+import collections
 
 # Import salt libs
 import salt.loader
 import salt.payload
 import salt.utils
 import salt.exceptions
+from salt.utils.error import raise_error
 
 
 class Wheel(object):
@@ -54,6 +57,8 @@ class Wheel(object):
                 'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
                 )
         ret = sreq.send('clear', load)
-        if ret == '':
-            raise salt.exceptions.EauthAuthenticationError
+        if isinstance(ret, collections.Mapping):
+           if 'error' in ret:
+               raise_error(**ret['error'])
+            
         return ret

--- a/salt/wheel/error.py
+++ b/salt/wheel/error.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+'''
+Error generator to enable integration testing of salt wheel error handling
+
+'''
+
+# Import python libs
+
+
+# Import salt libs
+import salt.utils.error
+
+
+def error(name=None, message=''):
+    '''
+    If name is None Then return empty dict
+    Otherwise
+       Raise an exception with __name__ from name, message from message
+
+    CLI Example:
+
+    .. code-block:: bash
+        salt-wheel error
+        salt-wheel error.error name="Exception" message="This is an error."
+    '''
+    ret = {}
+    if name is not None:
+        salt.utils.error.raise_error(name=name, message=message)
+    
+    return ret
+
+


### PR DESCRIPTION
Improve the exception handling for the runner and wheel client api.
With the new return semantics when an exception occurs the dict returned now includes an error field
the value of this field is a dict with the keys

name= exception class name
args= exception args
message= exception message

This enables the api to reraise the exception on the api side of the master_call for runner and wheel functions

Improved the error classifiction so eauth and token errors are distinct.
Also exceptions will now be reported more accurately, all exceptions are not eauth exceptions.

A utility function was added in  salt/utils/error called raise_error that raises the exception specified by
the new error field in the return.
This function that s for exception classes with the name first in  salt.exceptions and then exceptions
Other runners that wish to have their exception correctley reraised should add an if clause to this function
Or refactor to have a list that is imported and checked
