### PR TITLE
Updates to several documents regarding backup_mode to make it more visible, as well as a backup_mode documentation type fix.

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -140,3 +140,12 @@ As of release 0.17.1 backwards compatibility was broken (specifically for
 security purposes. The Salt team continues to emphasize backwards compatiblity
 as an important feature and plans to support it to the best of our ability to
 do so.
+
+Does Salt support backing up managed files?
+-------------------------------------------
+
+Yes. Salt provides an easy to use addition to your file.managed states that
+allow you to back up files via :doc:`backup_mode </ref/states/backup_mode>`,
+backup_mode can be configured on a per state basis, or in the minion config
+(note that if set in the minion config this would simply be the default
+method to use, you still need to specify that the file should be backed up!).

--- a/doc/ref/states/backup_mode.rst
+++ b/doc/ref/states/backup_mode.rst
@@ -4,7 +4,7 @@ File State Backups
 
 In 0.10.2 a new feature was added for backing up files that are replaced by
 the file.managed and file.recurse states. The new feature is called the backup
-mode. Setting the backup mode is easy, but is can be set in a number of
+mode. Setting the backup mode is easy, but it can be set in a number of
 places.
 
 The backup_mode can be set in the minion config file:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -56,6 +56,13 @@ salt fileserver. Here's an example:
         - user: foo
         - group: users
         - mode: 644
+        - backup: minion
+
+.. note::
+
+    Salt supports backing up managed files via the backup option. For more
+    details on this functionality please review the
+    :doc:`backup_mode documentation </ref/states/backup_mode>`.
 
 The ``source`` parameter can also specify a file in another Salt environment.
 In this example ``foo.conf`` in the ``dev`` environment will be used instead.


### PR DESCRIPTION
updated the faq to add a note about backup_mode, fixed a typo in the backup mode docs, and updated one of the file.managed examples with a backup line, as well as an additional note directing the user to the backup mode documentation in a highly visible area. This resolves https://github.com/saltstack/salt/issues/9058
