### PR TITLE
salt-cloud: ec2 cloud provider fix issue of windows minion deployment

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1258,6 +1258,17 @@ def create(vm_=None, call=None):
         username = config.get_cloud_config_value(
                 'win_username', vm_, __opts__, default='Administrator'
             )
+        win_passwd = config.get_cloud_config_value(
+                'win_password', vm_, __opts__, default=''
+            )
+        if not salt.utils.cloud.wait_for_port(ip_address, port=445, timeout=ssh_connect_timeout):
+            raise SaltCloudSystemExit(
+                'Failed to connect to remote windows host'
+            )
+        if not salt.utils.cloud.validate_windows_cred(ip_address, 445, username, win_passwd):
+            raise SaltCloudSystemExit(
+                'Failed to authenticate against remote windows host'
+            )
     elif salt.utils.cloud.wait_for_port(ip_address, timeout=ssh_connect_timeout):
         for user in usernames:
             if salt.utils.cloud.wait_for_passwd(

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1254,7 +1254,11 @@ def create(vm_=None, call=None):
         'ssh_connect_timeout', vm_, __opts__, 900   # 15 minutes
     )
 
-    if salt.utils.cloud.wait_for_port(ip_address, timeout=ssh_connect_timeout):
+    if config.get_cloud_config_value('win_installer', vm_, __opts__):
+        username = config.get_cloud_config_value(
+                'win_username', vm_, __opts__, default='Administrator'
+            )
+    elif salt.utils.cloud.wait_for_port(ip_address, timeout=ssh_connect_timeout):
         for user in usernames:
             if salt.utils.cloud.wait_for_passwd(
                 host=ip_address,

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -312,6 +312,15 @@ def wait_for_port(host, port=22, timeout=900):
                 )
             )
 
+def validate_windows_cred(host, port=445, username='Administrator',
+                          password=None):
+    '''
+    Check if the windows credentials are valid
+    '''
+    retcode = win_cmd('winexe -U {0}%{1} //{2} "hostname"'.format(
+        username, password, host
+    ))
+    return retcode == 0
 
 def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
                     password=None, key_filename=None, maxtries=15,


### PR DESCRIPTION
In a continue to the thread below
https://groups.google.com/forum/#!searchin/salt-users/salt-cloud$20windows/salt-users/Qm9jqCjcwh8/qHmf2FL7W9cJ

when a windows minion is deployed there is no need to check for ssh_user authentication
checking for port 445 is done later in the deploy_windows function

I checked this on salt-cloud 0.8.11 & salt 0.17.2 with the following changes
note that here `get_config_value()` is used instead of `get_cloud_config_value()`

```
1255,1259c1255
<     if config.get_config_value('win_installer', vm_, __opts__):
<         username = config.get_config_value(
<                 'win_username', vm_, __opts__, default='Administrator'
<             )
<     elif saltcloud.utils.wait_for_port(ip_address, timeout=ssh_connect_timeout):

---
>     if saltcloud.utils.wait_for_port(ip_address, timeout=ssh_connect_timeout):
```
