### PR TITLE
Added an option to limit maximum size of a file that can be pushed to master by files_recv

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -189,8 +189,9 @@
 #file_recv: False
 
 # Set a hard-limit on the size of the files that can be pushed to the master.
-# Default: 100MB
-#file_recv_max_size: 1024*1024*100
+# It will be interpreted as megabytes.
+# Default: 100
+#file_recv_max_size: 100
 
 #####    Master Module Management    #####
 ##########################################

--- a/conf/master
+++ b/conf/master
@@ -188,6 +188,10 @@
 # security purposes.
 #file_recv: False
 
+# Set a hard-limit on the size of the files that can be pushed to the master.
+# Default: 100MB
+#file_recv_max_size: 1024*1024*100
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded

--- a/salt/master.py
+++ b/salt/master.py
@@ -1154,7 +1154,7 @@ class AESFuncs(object):
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return False
-        file_recv_max_size = self.opts.get('file_recv_max_size', 1024*1024*100)
+        file_recv_max_size = 1024*1024 * self.opts.get('file_recv_max_size', 100)
         if len(load['data']) + load.get('loc', 0) > file_recv_max_size:
             log.error(
                 'Exceeding file_recv_max_size limit: {0}'.format(

--- a/salt/master.py
+++ b/salt/master.py
@@ -1154,6 +1154,14 @@ class AESFuncs(object):
             return False
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return False
+        file_recv_max_size = self.opts.get('file_recv_max_size', 1024*1024*100)
+        if len(load['data']) + load.get('loc', 0) > file_recv_max_size:
+            log.error(
+                'Exceeding file_recv_max_size limit: {0}'.format(
+                    file_recv_max_size
+                )
+            )
+            return False
         if 'tok' not in load:
             log.error(
                 'Received incomplete call from {0} for {1!r}, missing {2!r}'


### PR DESCRIPTION
The default is set to 100MB, which means if a larger file is pushed, files_recv will stop when reaches this limit.
This limit can be adjusted by file_recv_max_size option in the master's config file.
