### PR TITLE
A minute optimization in yumpkg._pkg_arch

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -234,15 +234,15 @@ def _pkg_arch(name):
     that packages that are for the system architecture should not have the
     architecture specified in the passed string.
     '''
-    all_arches = rpmUtils.arch.getArchList()
-    if not any(name.endswith('.{0}'.format(x)) for x in all_arches):
-        return name, __grains__['cpuarch']
     try:
         pkgname, pkgarch = name.rsplit('.', 1)
     except ValueError:
         return name, __grains__['cpuarch']
-    else:
-        return pkgname, pkgarch
+
+    if pkgarch not in rpmUtils.arch.getArchList():
+        return name, __grains__['cpuarch']
+
+    return pkgname, pkgarch
 
 
 def latest_version(*names, **kwargs):


### PR DESCRIPTION
If package name cannot be split by dot, there is no need to loop through all architectures to check if package name ends with '.arch-name'.
