### PR TITLE
Preventing deadlock on subprocess.Popen.poll()

### DIFF
--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -208,13 +208,25 @@ class NonBlockingPopen(subprocess.Popen):
                     fcntl.fcntl(conn, fcntl.F_SETFL, flags)
 
     def poll_and_read_until_finish(self):
+        silent_iterations = 0
         while self.poll() is None:
             if self.stdout is not None:
+                silent_iterations = 0
                 self.recv()
 
             if self.stderr is not None:
+                silent_iterations = 0
                 self.recv_err()
 
+            silent_iterations += 1
+
+            if silent_iterations > 100:
+                silent_iterations = 0
+                (stdoutdata, stderrdata) = self.communicate()
+                if stdoutdata:
+                    log.debug(stdoutdata)
+                if stderrdata:
+                    log.error(stderrdata)
             time.sleep(0.01)
 
     def communicate(self, input=None):


### PR DESCRIPTION
According to
http://docs.python.org/2/library/subprocess.html#subprocess.Popen.poll

Warning: This will deadlock when using stdout=PIPE and/or stderr=PIPE
and the child process generates enough output to a pipe such that it
blocks waiting for the OS pipe buffer to accept more data.
Use communicate() to avoid that.
We count consecutive iterations that do not have any output, and
only if it reaches a certain threshold, self.communicate() is run.
