### PR TITLE
Fix "Invalid Changes data" in file.replace/blockreplace states

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1861,7 +1861,7 @@ def replace(name,
                                        show_changes=show_changes)
 
     if changes:
-        ret['changes'] = changes
+        ret['changes'] = {'diff': changes}
         ret['comment'] = 'Changes were made'
     else:
         ret['comment'] = 'No changes were made'
@@ -1989,7 +1989,7 @@ def blockreplace(name,
                                        show_changes=show_changes)
 
     if changes:
-        ret['changes'] = changes
+        ret['changes'] = {'diff': changes}
         ret['comment'] = 'Changes were made'
     else:
         ret['comment'] = 'No changes were made'


### PR DESCRIPTION
This commit returns the diffs from these two states within a dictionary,
instead of a string, getting rid of a warning that the changes data is
invalid.

Fixes #9123.
