### PR TITLE
Update doc build to use latest GH release system.

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -144,7 +144,7 @@ autosummary_generate = True
 # Define a substitution for linking to the latest release tarball
 rst_prolog = """\
 .. |saltrepo| replace:: https://github.com/saltstack/salt
-.. |latest| replace:: https://github.com/downloads/saltstack/salt/salt-%s.tar.gz
+.. |latest| replace:: https://github.com/saltstack/salt/archive/v%s.tar.gz
 """ % salt.version.__version__
 
 # A shortcut for linking to tickets on the GitHub issue tracker


### PR DESCRIPTION
It looks like GH has deprecated the download system that we were using. This fix just updates our doc build to point to the new system. Here's the blog post for reference:

https://github.com/blog/1302-goodbye-uploads

This resolves many errors that appear when running 'make linkcheck' against our docs.
