### PR TITLE
Fix regression in file.managed

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1525,9 +1525,7 @@ def copy(src, dst):
         pre_mode = __salt__['config.manage_mode'](get_mode(src))
 
     try:
-        current_umask = os.umask(63)
         shutil.copyfile(src, dst)
-        os.umask(current_umask)
     except OSError:
         raise CommandExecutionError(
             'Could not copy {0!r} to {1!r}'.format(src, dst)
@@ -1880,11 +1878,7 @@ def get_managed(
     return sfn, source_sum, ''
 
 
-def check_perms(name,
-                ret,
-                user,
-                group,
-                mode):
+def check_perms(name, ret, user, group, mode):
     '''
     Check the permissions on files and chown if needed
 
@@ -2288,11 +2282,6 @@ def manage_file(name,
                         ret, 'Failed to commit change, permission error')
             __clean_tmp(tmp)
 
-        if mode is None:
-            mask = os.umask(0)
-            os.umask(mask)
-            # Apply umask and remove exec bit
-            mode = (0o0777 ^ mask) & 0o0666
         ret, perms = check_perms(name, ret, user, group, mode)
 
         if ret['changes']:
@@ -2343,7 +2332,7 @@ def manage_file(name,
             # Create the file, user rw-only if mode will be set to prevent
             # a small security race problem before the permissions are set
             if mode:
-                current_umask = os.umask(63)
+                current_umask = os.umask(077)
 
             # Create a new file when test is False and source is None
             if contents is None:
@@ -2386,12 +2375,14 @@ def manage_file(name,
                                 __opts__['cachedir'])
             __clean_tmp(sfn)
 
-        # Check and set the permissions if necessary
+        # This is a new file, if no mode specified, use the umask to figure
+        # out what mode to use for the new file.
         if mode is None:
+            # Get current umask
             mask = os.umask(0)
             os.umask(mask)
-            # Apply umask and remove exec bit
-            mode = (0o0777 ^ mask) & 0o0666
+            # Calculate the mode value that results from the umask
+            mode = oct((0777 ^ mask) & 0666)
         ret, perms = check_perms(name, ret, user, group, mode)
 
         if not ret['comment']:


### PR DESCRIPTION
Pull request #8818 caused a couple of regressions. Firstly, it assumes
that, if "mode" is not specified (and thus defaults to None), that you
want the permissions to be equal to those dictated by the umask. This
means that a file with perms 640, which already exists, will be chmod'ed
to 644 if the system umask is 022 and no "mode" parameter was specified
in the state. This is not the expected behavior.

Secondly, the calculated perms are passed to file.check_perms as an
integer whose octal representation is the correct value for the file
permissions (i.e. 0o644, which is == 420 in decimal). However,
file.check_perms is designed to be run from the CLI, and thus requires
a value of 644 (decimal) to be passed, in order to set 644 permissions.
file.check_perms can also accept the mode as a string, so this is how
this commit passes the value to file.check_perms when a new file is
created.
