### PR TITLE
Fix bug in pkgrepo when switching to/from mirrorlist-based repo def

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -23,7 +23,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 # Import third party libs
 try:
@@ -1083,6 +1083,11 @@ def mod_repo(repo, basedir=None, **kwargs):
     # Filter out '__pub' arguments
     repo_opts = dict((x, kwargs[x]) for x in kwargs if not x.startswith('__'))
 
+    if all(x in repo_opts for x in ('mirrorlist', 'baseurl')):
+        raise SaltInvocationError(
+            'Only one of \'mirrorlist\' and \'baseurl\' can be specified'
+        )
+
     # Build a list of keys to be deleted
     todelete = []
     for key in repo_opts:
@@ -1090,9 +1095,16 @@ def mod_repo(repo, basedir=None, **kwargs):
             del repo_opts[key]
             todelete.append(key)
 
+    # Add baseurl or mirrorlist to the 'todelete' list if the other was
+    # specified in the repo_opts
+    if 'mirrorlist' in repo_opts:
+        todelete.append('baseurl')
+    elif 'baseurl' in repo_opts:
+        todelete.append('mirrorlist')
+
     # Fail if the user tried to delete the name
     if 'name' in todelete:
-        return 'Error: The repo name cannot be deleted'
+        raise SaltInvocationError('The repo name cannot be deleted')
 
     # Give the user the ability to change the basedir
     repos = {}
@@ -1110,12 +1122,16 @@ def mod_repo(repo, basedir=None, **kwargs):
         repofile = '{0}/{1}.repo'.format(basedir, repo)
 
         if 'name' not in repo_opts:
-            return ('Error: The repo does not exist and needs to be created, '
-                    'but a name was not given')
+            raise SaltInvocationError(
+                'The repo does not exist and needs to be created, but a name '
+                'was not given'
+            )
 
         if 'baseurl' not in repo_opts and 'mirrorlist' not in repo_opts:
-            return ('Error: The repo does not exist and needs to be created, '
-                    'but either a baseurl or a mirrorlist needs to be given')
+            raise SaltInvocationError(
+                'The repo does not exist and needs to be created, but either '
+                'a baseurl or a mirrorlist needs to be given'
+            )
         filerepos[repo] = {}
     else:
         # The repo does exist, open its file
@@ -1126,11 +1142,15 @@ def mod_repo(repo, basedir=None, **kwargs):
     if 'baseurl' in todelete:
         if 'mirrorlist' not in repo_opts and 'mirrorlist' \
                 not in filerepos[repo].keys():
-            return 'Error: Cannot delete baseurl without specifying mirrorlist'
+            raise SaltInvocationError(
+                'Cannot delete baseurl without specifying mirrorlist'
+            )
     if 'mirrorlist' in todelete:
         if 'baseurl' not in repo_opts and 'baseurl' \
                 not in filerepos[repo].keys():
-            return 'Error: Cannot delete mirrorlist without specifying baseurl'
+            raise SaltInvocationError(
+                'Cannot delete mirrorlist without specifying baseurl'
+            )
 
     # Delete anything in the todelete list
     for key in todelete:

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -12,6 +12,7 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
 
@@ -745,6 +746,11 @@ def mod_repo(repo, basedir=None, **kwargs):
     # Filter out '__pub' arguments
     repo_opts = dict((x, kwargs[x]) for x in kwargs if not x.startswith('__'))
 
+    if all(x in repo_opts for x in ('mirrorlist', 'baseurl')):
+        raise SaltInvocationError(
+            'Only one of \'mirrorlist\' and \'baseurl\' can be specified'
+        )
+
     # Build a list of keys to be deleted
     todelete = []
     for key in repo_opts:
@@ -752,9 +758,16 @@ def mod_repo(repo, basedir=None, **kwargs):
             del repo_opts[key]
             todelete.append(key)
 
+    # Add baseurl or mirrorlist to the 'todelete' list if the other was
+    # specified in the repo_opts
+    if 'mirrorlist' in repo_opts:
+        todelete.append('baseurl')
+    elif 'baseurl' in repo_opts:
+        todelete.append('mirrorlist')
+
     # Fail if the user tried to delete the name
     if 'name' in todelete:
-        return 'Error: The repo name cannot be deleted'
+        raise SaltInvocationError('The repo name cannot be deleted')
 
     # Give the user the ability to change the basedir
     repos = {}
@@ -772,12 +785,16 @@ def mod_repo(repo, basedir=None, **kwargs):
         repofile = '{0}/{1}.repo'.format(basedir, repo)
 
         if 'name' not in repo_opts:
-            return ('Error: The repo does not exist and needs to be created, '
-                    'but a name was not given')
+            raise SaltInvocationError(
+                'The repo does not exist and needs to be created, but a name '
+                'was not given'
+            )
 
         if 'baseurl' not in repo_opts and 'mirrorlist' not in repo_opts:
-            return ('Error: The repo does not exist and needs to be created, '
-                    'but either a baseurl or a mirrorlist needs to be given')
+            raise SaltInvocationError(
+                'The repo does not exist and needs to be created, but either '
+                'a baseurl or a mirrorlist needs to be given'
+            )
         filerepos[repo] = {}
     else:
         # The repo does exist, open its file
@@ -788,11 +805,15 @@ def mod_repo(repo, basedir=None, **kwargs):
     if 'baseurl' in todelete:
         if 'mirrorlist' not in repo_opts and 'mirrorlist' \
                 not in filerepos[repo].keys():
-            return 'Error: Cannot delete baseurl without specifying mirrorlist'
+            raise SaltInvocationError(
+                'Cannot delete baseurl without specifying mirrorlist'
+            )
     if 'mirrorlist' in todelete:
         if 'baseurl' not in repo_opts and 'baseurl' \
                 not in filerepos[repo].keys():
-            return 'Error: Cannot delete mirrorlist without specifying baseurl'
+            raise SaltInvocationError(
+                'Cannot delete mirrorlist without specifying baseurl'
+            )
 
     # Delete anything in the todelete list
     for key in todelete:


### PR DESCRIPTION
This adds a check to ensure that both of mirrorlist and baseurl aren't
specified, and also deletes mirrorlist when baseurl is specified (and
vice-versa). Additionally, rather than returning a string containing
errors when they are encountered, raise an exception instead.

Fixes #9121.
