### PR TITLE
list_pkgs became quiet

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -601,7 +601,7 @@ def list_pkgs(versions_as_list=False, removed=False, **kwargs):
     cmd = 'dpkg-query --showformat=\'${Status} ${Package} ' \
           '${Version} ${Architecture}\n\' -W'
 
-    out = __salt__['cmd.run_all'](cmd).get('stdout', '')
+    out = __salt__['cmd.run_all'](cmd, quiet=True).get('stdout', '')
     # Typical lines of output:
     # install ok installed zsh 4.3.17-1ubuntu1 amd64
     # deinstall ok config-files mc 3:4.8.1-2ubuntu1 amd64

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -79,7 +79,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     ret = {}
     cmd = 'brew list --versions'
-    for line in __salt__['cmd.run'](cmd).splitlines():
+    for line in __salt__['cmd.run'](cmd, quiet=True).splitlines():
         try:
             name, version_num = line.split(' ')[0:2]
         except ValueError:

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -235,7 +235,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             return ret
 
     ret = {}
-    for line in __salt__['cmd.run_stdout']('pkg_info').splitlines():
+    for line in __salt__['cmd.run_stdout']('pkg_info', quiet=True).splitlines():
         if not line:
             continue
         try:

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -58,7 +58,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     ret = {}
     cmd = 'pkg_info -q -a'
-    out = __salt__['cmd.run_all'](cmd).get('stdout', '')
+    out = __salt__['cmd.run_all'](cmd, quiet=True).get('stdout', '')
     for line in out.splitlines():
         try:
             pkgname, pkgver, flavor = __PKG_RE.match(line).groups()

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -163,7 +163,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     cmd = 'pacman -Q'
     ret = {}
-    out = __salt__['cmd.run'](cmd).splitlines()
+    out = __salt__['cmd.run'](cmd, quiet=True).splitlines()
     for line in out:
         if not line:
             continue

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -214,7 +214,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     ret = {}
 
-    for line in __salt__['cmd.run'](pkg_command).splitlines():
+    for line in __salt__['cmd.run'](pkg_command, quiet=True).splitlines():
         if not line:
             continue
         pkg, ver = line.split(' ')[0].rsplit('-', 1)

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -292,7 +292,7 @@ def list_pkgs(versions_as_list=False, jail=None, chroot=None, **kwargs):
 
     ret = {}
     cmd = '{0} info'.format(_pkg(jail, chroot))
-    for line in __salt__['cmd.run_stdout'](cmd).splitlines():
+    for line in __salt__['cmd.run_stdout'](cmd, quiet=True).splitlines():
         if not line:
             continue
         try:

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -142,7 +142,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     # Package information returned two lines per package. On even-offset
     # lines, the package name is in the first column. On odd-offset lines, the
     # package version is in the second column.
-    lines = __salt__['cmd.run'](cmd).splitlines()
+    lines = __salt__['cmd.run'](cmd, quiet=True).splitlines()
     for index, line in enumerate(lines):
         if index % 2 == 0:
             name = line.split()[0].strip()

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -95,7 +95,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
     # Package information returned two lines per package. On even-offset
     # lines, the package name is in the first column. On odd-offset lines, the
     # package version is in the second column.
-    lines = __salt__['cmd.run'](cmd).splitlines()
+    lines = __salt__['cmd.run'](cmd, quiet=True).splitlines()
     for index, line in enumerate(lines):
         if index % 2 == 0:
             name = line.split()[0].strip()

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -264,7 +264,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     ret = {}
     cmd = 'rpm -qa --queryformat "{0}\n"'.format(__QUERYFORMAT)
-    for line in __salt__['cmd.run'](cmd).splitlines():
+    for line in __salt__['cmd.run'](cmd, quiet=True).splitlines():
         pkginfo = _parse_pkginfo(line)
         if pkginfo is None:
             continue

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -183,7 +183,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     cmd = 'rpm -qa --queryformat "%{NAME}_|-%{VERSION}_|-%{RELEASE}\\n"'
     ret = {}
-    for line in __salt__['cmd.run'](cmd).splitlines():
+    for line in __salt__['cmd.run'](cmd, quiet=True).splitlines():
         name, pkgver, rel = line.split('_|-')
         if rel:
             pkgver += '-{0}'.format(rel)


### PR DESCRIPTION
I think, there's no need to see all these lines in debug log when interacting with package managers:

```
------------- Truncated -----------------------
install ok installed libqtcore4 4:4.8.4+dfsg-0ubuntu18 i386
install ok installed libqtgui4 4:4.8.4+dfsg-0ubuntu18 amd64
install ok installed libqtgui4 4:4.8.4+dfsg-0ubuntu18 i386
install ok installed libqtwebkit4 2.3.2-0ubuntu3 amd64
install ok installed libqtwebkit4 2.3.2-0ubuntu3 i386
install ok installed libquadmath0 4.8.1-10ubuntu9 amd64
install ok installed libquvi-scripts 0.4.18-1 all
install ok installed libquvi7 0.4.1-1ubuntu2 amd64
install ok installed libraptor2-0 2.0.9-1 amd64
install ok installed librarian0 0.8.1-5build1 amd64
install ok installed librasqal3 0.9.30-1 amd64
install ok installed libraw1394-11 2.1.0-1 amd64
deinstall ok config-files libraw1394-11 2.1.0-1 i386
deinstall ok config-files libraw5 0.14.7-0ubuntu1.13.04.2 amd64
install ok installed libraw9 0.15.3-1ubuntu1 amd64
install ok installed librdf0 1.0.16-1 amd64
install ok installed libreadline5 5.2+dfsg-2 amd64
install ok installed libreadline6 6.2-9ubuntu1 amd64
deinstall ok config-files libreadline6 6.2-9ubuntu1 i386
install ok installed libreoffice-base-core 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-calc 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-common 1:4.1.3-0ubuntu1 all
install ok installed libreoffice-core 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-draw 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-emailmerge 1:4.1.3-0ubuntu1 all
install ok installed libreoffice-gnome 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-gtk 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-help-en-us 1:4.1.3-0ubuntu1 all
install ok installed libreoffice-impress 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-math 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-ogltrans 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-pdfimport 1:4.1.3-0ubuntu1 amd64
install ok installed libreoffice-presentation-minimizer 1.0.4+LibO4.1.3-0ubuntu1 amd64
install ok installed libreoffice-presenter-console 1:4.1.3-0ubuntu1 all
install ok installed libreoffice-style-human 1:4.1.3-0ubuntu1 all
install ok installed libreoffice-style-tango 1:4.1.3-0ubuntu1 all
install ok installed libreoffice-writer 1:4.1.3-0ubuntu1 amd64
install ok installed libresid-builder0c2a 2.1.1-14 amd64
install ok installed librest-0.7-0 0.7.90-0ubuntu1 amd64
deinstall ok config-files librhythmbox-core6 2.98-0ubuntu5 amd64
install ok installed librhythmbox-core7 2.99.1-0ubuntu1 amd64
install ok installed libroken18-heimdal 1.6~git20120403+dfsg1-3ubuntu0.1 amd64
deinstall ok config-files libroken18-heimdal 1.6~git20120403+dfsg1-3ubuntu0.1 i386
install ok installed librsvg2-2 2.36.4-2 amd64
------------- Truncated -----------------------
```
