### PR TITLE
Fix reporting of file.blockreplace state when test=True

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1990,11 +1990,16 @@ def blockreplace(name,
 
     if changes:
         ret['changes'] = {'diff': changes}
-        ret['comment'] = 'Changes were made'
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Changes would be made'
+        else:
+            ret['result'] = True
+            ret['comment'] = 'Changes were made'
     else:
-        ret['comment'] = 'No changes were made'
+        ret['result'] = True
+        ret['comment'] = 'No changes needed to be made'
 
-    ret['result'] = True
     return ret
 
 


### PR DESCRIPTION
When test=True is used, this state does a dry run and doesn't change the
file (as expected), but reports that changes were made. This commit
fixes the reporting so that it states that changes would have been made.
