### PR TITLE
new external_ip grain for salt - requires that requests be installed

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1322,25 +1322,4 @@ def get_master():
     #   master
     return {'master': __opts__.get('master', '')}
 
-try:
-    import requests
-    HAS_REQUESTS = True
-except:
-    HAS_REQUESTS = False
-
-def external_ip():
-    '''
-    Return the external IP address reported by ipecho.net
-    '''
-
-    if not HAS_REQUESTS:
-        return False
-
-    try:
-        r = requests.get('http://ipecho.net/plain')
-        ip = r.content
-    except:
-        ip = False
-    return {'external_ip': ip}
-
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1322,4 +1322,25 @@ def get_master():
     #   master
     return {'master': __opts__.get('master', '')}
 
+try:
+    import requests
+    HAS_REQUESTS = True
+except:
+    HAS_REQUESTS = False
+
+def external_ip():
+    '''
+    Return the external IP address reported by ipecho.net
+    '''
+
+    if not HAS_REQUESTS:
+        return False
+
+    try:
+        r = requests.get('http://ipecho.net/plain')
+        ip = r.content
+    except:
+        ip = False
+    return {'external_ip': ip}
+
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/grains/external_ip.py
+++ b/salt/grains/external_ip.py
@@ -1,0 +1,20 @@
+try:
+    import requests
+    HAS_REQUESTS = True
+except:
+    HAS_REQUESTS = False
+
+def external_ip():
+    '''
+    Return the external IP address reported by ipecho.net
+    '''
+
+    if not HAS_REQUESTS:
+        return []
+
+    try:
+        r = requests.get('http://ipecho.net/plain')
+        ip = r.content
+    except:
+        ip = []
+    return {'external_ip': ip}


### PR DESCRIPTION
Was always using cmd.run to call wget on the private cloud servers to find the associated external IP via ipecho.net, so wrote a grain.
