### PR TITLE
Prevent traceback when job is None.

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -269,7 +269,7 @@ def clean_proc_dir(opts):
             job = salt.payload.Serial(opts).load(fp_)
             log.debug('schedule.clean_proc_dir: checking job {0} for process '
                       'existence'.format(job))
-            if 'pid' in job:
+            if job is not None and 'pid' in job:
                 if salt.utils.process.os_is_running(job['pid']):
                     log.debug('schedule.clean_proc_dir: Cleaning proc dir, '
                               'pid {0} still exists.'.format(job['pid']))


### PR DESCRIPTION
Minions will stack trace on start sometimes if there are unusual things in the job cache directory because the iterator variable was None.  Fixes #9138
