### PR TITLE
Adding missing network functions for debian_ip.py

### DIFF
--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -1,13 +1,16 @@
 {% if data.enabled %}auto {{name}}
 {%endif%}{% if data.hotplug %}allow-hotplug {{name}}
-{%endif%}{% for interface in data.data %}iface {{name}} {{interface.inet_type}} {{interface.proto}}
+{%endif%}{% if data.data['inet'] %}
+{%- set interface = data.data['inet'] -%}
+iface {{name}} {{interface.inet_type}} {{interface.proto}}
 {% if interface.address %}    address {{interface.address}}
 {%endif%}{% if interface.netmask %}    netmask {{interface.netmask}}
 {%endif%}{% if interface.broadcast %}    broadcast {{interface.broadcast}}
 {%endif%}{% if interface.gateway %}    gateway {{interface.gateway}}
 {%endif%}{% if interface.addr %}    hwaddress {{interface.addr}}
 {%endif%}{% if interface.vlan_raw_device %}    vlan-raw-device {{interface.vlan_raw_device}}
-{%endif%}{%if interface.ethtool %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
+{%endif%}{% if interface.dns %}    dns-nameservers {%for item in interface.dns %}{{item}} {%endfor%}
+{%endif%}{% if interface.ethtool %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
 {%endfor%}{%endif%}{%if data.bonding %}{%for item in data.bonding %}    bond_{{item}} {{data.bonding[item]}}
 {%endfor%}{%endif%}{% if interface.bridge_options -%}
 {% if interface.bridge_options.ports %}    bridge_ports {{interface.bridge_options.ports}}
@@ -23,6 +26,24 @@
 {%endif%}{% if interface.pre_down_cmds %}{% for cmd in interface.pre_down_cmds %}    pre-down {{ cmd }}
 {%endfor-%}
 {%endif%}{% if interface.post_down_cmds %}{% for cmd in interface.post_down_cmds %}    post-down {{ cmd }}
+{%endfor-%}{%endif%}
+{%endif%}{% if data.data['inet6'] %}
+{%- set interface = data.data['inet6'] -%}
+iface {{name}} {{interface.inet_type}} {{interface.proto}}
+{% if interface.address %}    address {{interface.address}}
+{%endif%}{% if interface.netmask %}    netmask {{interface.netmask}}
+{%endif%}{% if interface.broadcast %}    broadcast {{interface.broadcast}}
+{%endif%}{% if interface.gateway %}    gateway {{interface.gateway}}
+{%endif%}{% if interface.up_cmds %}{% for cmd in interface.up_cmds %}    up {{ cmd }}
 {%endfor-%}
+{%endif%}{% if interface.down_cmds %}{% for cmd in interface.down_cmds %}    down {{ cmd }}
+{%endfor-%}
+{%endif%}{% if interface.pre_up_cmds %}{% for cmd in interface.pre_up_cmds %}    pre-up {{ cmd }}
+{%endfor-%}
+{%endif%}{% if interface.post_up_cmds %}{% for cmd in interface.post_up_cmds %}    post-up {{ cmd }}
+{%endfor-%}
+{%endif%}{% if interface.pre_down_cmds %}{% for cmd in interface.pre_down_cmds %}    pre-down {{ cmd }}
+{%endfor-%}
+{%endif%}{% if interface.post_down_cmds %}{% for cmd in interface.post_down_cmds %}    post-down {{ cmd }}
+{%endfor-%}{%endif%}
 {%endif%}
-{%endfor%}

--- a/salt/templates/debian_ip/display-network.jinja
+++ b/salt/templates/debian_ip/display-network.jinja
@@ -1,0 +1,6 @@
+{% if CONFIGURE_INTERFACES %}NETWORKING={{CONFIGURE_INTERFACES}}
+{%endif%}{% if hostname %}HOSTNAME={{hostname}}
+{%endif%}{% if gateway %}GATEWAY={{gateway}}
+{%endif%}{% if gatewaydev %}GATEWAYDEV={{gatewaydev}}
+{%endif%}{% if nisdomain %}NISDOMAIN={{nisdomain}}
+{%endif%}{% if nozeroconf %}NOZEROCONF={{nozeroconf}}{%endif%}

--- a/salt/templates/debian_ip/network.jinja
+++ b/salt/templates/debian_ip/network.jinja
@@ -1,0 +1,12 @@
+# Configuration for networking init script being run during
+# the boot sequence
+
+# Set to 'no' to skip interfaces configuration on boot
+CONFIGURE_INTERFACES={{networking}}
+
+# Don't configure these interfaces. Shell wildcards supported/
+#EXCLUDE_INTERFACES=
+
+# Set to 'yes' to enable additional verbosity
+#VERBOSE=no
+

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -61,8 +61,6 @@ class SysModuleTest(integration.ModuleCase):
                 'runtests_decorators.depends_will_fallback',
                 'runtests_decorators.missing_depends',
                 'runtests_decorators.missing_depends_will_fallback',
-                'ip.build_network_settings',
-                'ip.get_network_settings',
         )
 
         for fun in docs:


### PR DESCRIPTION
Added missing definitions for networking setting, add and get.  
Changed interface parsing to use a dictionary for inet and inet6 interfaces instead of an array.  
Certain assumptions were made within the code on the order the ipv4 & ipv6 interfaces would appear, using a dictionary instead resolves some potential issues that could have popped up with an array.  
Removing the tests for ip.get_network_settings and ip.build_network_settings from the exclusion.
