### PR TITLE
Fix infinite recursion when a file is invalid (corrupted, empty, or mid-write)

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -165,6 +165,8 @@ def file_hash(load, fnd):
                     hsum, mtime = fp_.read().split(':')
                 except ValueError:
                     log.debug('Fileserver attempted to read incomplete cache file. Retrying.')
+                    # Delete the file since its incomplete (either corrupted or incomplete)
+                    os.unlink(cache_path)
                     file_hash(load, fnd)
                     return(ret)
                 if os.path.getmtime(path) == mtime:
@@ -173,6 +175,8 @@ def file_hash(load, fnd):
                     return ret
         except os.error:  # Can't use Python select() because we need Windows support
             log.debug("Fileserver encountered lock when reading cache file. Retrying.")
+            # Delete the file since its incomplete (either corrupted or incomplete)
+            os.unlink(cache_path)
             file_hash(load, fnd)
             return(ret)
 


### PR DESCRIPTION
Fixes some infinite recursion if the cache file was corrupted (someone touch-s the file)
