### PR TITLE
avoid shadowing set built-in type in memcached state

### DIFF
--- a/salt/states/memcached.py
+++ b/salt/states/memcached.py
@@ -14,6 +14,11 @@ try:
 except ImportError:
     HAS_MEMCACHE = False
 
+# Define a function alias in order not to shadow built-in's
+__func_alias__ = {
+    'set_': 'set'
+}
+
 
 def __virtual__():
     '''
@@ -24,7 +29,7 @@ def __virtual__():
     return 'memcache'
 
 
-def set(name,
+def set_(name,
         host=None,
         port=None,
         val=None):


### PR DESCRIPTION
```
************* Module salt.states.memcached
salt/states/memcached.py:27: [W0622(redefined-builtin), set] Redefining built-in 'set'
```
