### PR TITLE
modules.test.arg_type: avoid shadowing outer arg() func

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -199,8 +199,8 @@ def arg_type(*args, **kwargs):
     '''
     ret = {'args': [], 'kwargs': {}}
     # all the args
-    for arg in args:
-        ret['args'].append(str(type(arg)))
+    for argument in args:
+        ret['args'].append(str(type(argument)))
 
     # all the kwargs
     for key, val in kwargs.iteritems():


### PR DESCRIPTION
```
************* Module salt.modules.test
salt/modules/test.py:202: [W0621(redefined-outer-name), arg_type] Redefining name 'arg' from outer scope (line 173)
```
