### PR TITLE
avoid bare `except:`s in grains/external_ip.py

### DIFF
--- a/salt/grains/external_ip.py
+++ b/salt/grains/external_ip.py
@@ -1,7 +1,7 @@
 try:
     import requests
     HAS_REQUESTS = True
-except:
+except ImportError:
     HAS_REQUESTS = False
 
 def external_ip():
@@ -15,6 +15,6 @@ def external_ip():
     try:
         r = requests.get('http://ipecho.net/plain')
         ip = r.content
-    except:
+    except Exception:
         ip = []
     return {'external_ip': ip}


### PR DESCRIPTION
```
************* Module salt.grains.external_ip
salt/grains/external_ip.py:4: [W0702(bare-except), ] No exception type(s) specified
salt/grains/external_ip.py:18: [W0702(bare-except), external_ip] No exception type(s) specified
```
