### PR TITLE
utils/validate/ssh.py: rm unused import of CommandExecutionError

### DIFF
--- a/salt/utils/validate/ssh.py
+++ b/salt/utils/validate/ssh.py
@@ -11,7 +11,6 @@ import logging
 # Import salt libs
 import salt.utils.validate.net as suvn
 import salt.utils.validate.user as suvu
-from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
```
************* Module salt.utils.validate.ssh
salt/utils/validate/ssh.py:14: [W0611(unused-import), ] Unused import CommandExecutionError
```
