### PR TITLE
Initial commit to add the salt_projects page.

### DIFF
--- a/doc/topics/salt_projects.rst
+++ b/doc/topics/salt_projects.rst
@@ -1,0 +1,13 @@
+Community Projects That Use Salt
+================================
+
+Below is a list of repositories that show real world Salt applications that
+you can use to get started. Please note that these projects do not adhere to
+any standards and express a wide variety of ideas and opinions on how an
+action can be completed with Salt.
+
+https://github.com/terminalmage/djangocon2013-sls
+
+https://github.com/jesusaurus/hpcs-salt-state
+
+https://github.com/gravyboat/hungryadmin-sls


### PR DESCRIPTION
This is just the first commit of the repos I'm aware of that use Salt so new users can get up to speed seeing real world projects and examples that they can work off of. These projects are not vetted or screened in any way. This sort of resolves https://github.com/saltstack/salt/issues/9120 though I'd like to see more in here before it's considered closed.
