### PR TITLE
Update requirements concerning ZMQ version

### DIFF
--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -71,8 +71,8 @@ Dependencies
 Salt should run on any Unix-like platform so long as the dependencies are met.
 
 * `Python 2.6`_ >= 2.6 <3.0
-* `ZeroMQ`_ >= 2.1.9
-* `pyzmq`_ >= 2.1.9 - ZeroMQ Python bindings
+* `ZeroMQ`_ >= 3.2.0
+* `pyzmq`_ >= 2.2.0 - ZeroMQ Python bindings
 * `PyCrypto`_ - The Python cryptography toolkit
 * `msgpack-python`_ - High-performance message interchange format
 * `YAML`_ - Python YAML bindings

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ M2Crypto
 msgpack-python
 pycrypto
 PyYAML
-pyzmq >= 2.1.9
+pyzmq >= 2.2.0
 MarkupSafe
 apache-libcloud


### PR DESCRIPTION
Commit 60fbb6ffa616512f947c57f76eee44e33436b36e requires ZMQ >= 3.2.0.
PyZMQ should be >= 2.2.0 to fully support ZMQ 3.x.
