### PR TITLE
Update recursively pillar 

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -407,7 +407,7 @@ class Pillar(object):
                             )
                         )
                         continue
-                    pillar.update(pstate)
+                    update(pillar, pstate)
 
         return pillar, errors
 


### PR DESCRIPTION
Pillars are currently read from tops and ordered.
Because the current code update the pillar dictionary key at top level, it complety overwrite the value, while ext_pillar uses update from salt.utils.dictupdate which recursively update the dictionnary.
In order to unified the behavior, my patch uses the dictupdate method instead of the python dictionary update.
