### PR TITLE
Enable cryptographic signing of messages published from the master.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -193,6 +193,23 @@
 # Default: 100
 #file_recv_max_size: 100
 
+# Signature verification on messages published from the master.
+# This causes the master to cryptographically sign all messages published to its event
+# bus, and minions then verify that signature before acting on the message.
+#
+# This is False by default.
+#
+# Note that to facilitate interoperability with masters and minions that are different
+# versions, if sign_pub_messages is True but a message is received by a minion with
+# no signature, it will still be accepted, and a warning message will be logged.
+# Conversely, if sign_pub_messages is False, but a minion receives a signed
+# message it will be accepted, the signature will not be checked, and a warning message
+# will be logged.  This behavior will go away in Salt 0.17.6 (or Hydrogen RC1, whichever
+# comes first) and these two situations will cause minion to throw an exception and
+# drop the message.
+#
+# sign_pub_messages: False
+
 #####    Master Module Management    #####
 ##########################################
 # Manage how master side modules are loaded

--- a/salt/config.py
+++ b/salt/config.py
@@ -176,6 +176,7 @@ VALID_OPTS = {
     'jinja_lstrip_blocks': bool,
     'jinja_trim_blocks': bool,
     'minion_id_caching': bool,
+    'sign_pub_messages': bool,
 }
 
 # default configurations
@@ -373,6 +374,7 @@ DEFAULT_MASTER_OPTS = {
     'syndic_wait': 1,
     'jinja_lstrip_blocks': False,
     'jinja_trim_blocks': False,
+    'sign_pub_messages': False,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/master.py
+++ b/salt/master.py
@@ -2589,6 +2589,10 @@ class ClearFuncs(object):
         log.debug('Published command details {0}'.format(load))
 
         payload['load'] = self.crypticle.dumps(load)
+        if self.opts['sign_pub_messages']:
+            master_pem_path = os.path.join(self.opts['pki_dir'], 'master.pem')
+            log.debug("Signing data packet")
+            payload['sig'] = salt.crypt.sign_message(master_pem_path, payload['load'])
         # Send 0MQ to the publisher
         context = zmq.Context(1)
         pub_sock = context.socket(zmq.PUSH)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -603,13 +603,40 @@ class Minion(object):
         '''
         {'aes': self._handle_aes,
          'pub': self._handle_pub,
-         'clear': self._handle_clear}[payload['enc']](payload['load'])
+         'clear': self._handle_clear}[payload['enc']](payload['load'],
+                                                      payload['sig'] if 'sig' in payload else None)
 
-    def _handle_aes(self, load):
+    def _handle_aes(self, load, sig=None):
         '''
-        Takes the AES encrypted load, decrypts it, and runs the encapsulated
-        instructions
+        Takes the AES encrypted load, checks the signature if pub signatures
+        are turned on, decrypts it, and runs the encapsulated instructions
         '''
+        # Verify that the signature is valid
+        master_pubkey_path = os.path.join(self.opts['pki_dir'], 'minion_master.pub')
+
+        # In other words, here's a table
+        # sign_pub_messages     signature present    signature verified    action
+        # true                  true                 true                  process msg
+        # true                  true                 false                 exception, post 0.17.6
+        # true                  false                N/A                   exception, post 0.17.6
+        # false                 true                 N/A                   exception, post 0.17.6
+        # false                 false                N/A                   process msg
+
+
+        if self.opts['pillar']['master']['sign_pub_messages'] and not sig:
+            salt.utils.warn_until((0, 17, 6), 'Master pub message signing is enabled but we '
+                'did not receive a signature for this message.  '
+                'Most likely this means that your masters and minions are not the same version.  '
+                'After Salt 0.17.6 this situation will throw an exception.')
+        if not self.opts['pillar']['master']['sign_pub_messages'] and sig:
+            salt.utils.warn_until((0, 17, 6), 'Master pub message signing is disabled but we '
+                'received a signature for this message.  Most likely this means that your masters '
+                'and minions are not the same version.  '
+                'After Salt 0.17.6 this situation will throw an exception.')
+        if sig and self.opts['pillar']['master']['sign_pub_messages']:
+            if not salt.crypt.verify_signature(master_pubkey_path, load, sig):
+                raise AuthenticationError('Message signature failed to validate.')
+
         try:
             data = self.crypticle.loads(load)
         except AuthenticationError:
@@ -622,6 +649,7 @@ class Minion(object):
 
             self.authenticate()
             data = self.crypticle.loads(load)
+
         # Verify that the publication is valid
         if 'tgt' not in data or 'jid' not in data or 'fun' not in data \
            or 'arg' not in data:
@@ -658,6 +686,7 @@ class Minion(object):
             )
         log.debug('Command details {0}'.format(data))
         self._handle_decoded_payload(data)
+
 
     def _handle_pub(self, load):
         '''


### PR DESCRIPTION
Create a new master configuration option called 'sign_pub_messages' which causes the master to cryptographically sign all messages published to its event bus, and minions then verify that signature before acting on the message.

Note that to facilitate interoperability with masters and minions that are different versions, if sign_pub_messages is True but a message is received by a minion with no signature, it will still be accepted, and a warning message will be logged. Conversely, if sign_pub_messages is False, but a minion receives a signed message it will be accepted, the signature will not be checked, and a warning message will be logged.  This behavior will go away in Salt 0.17.6 (or Hydrogen RC1, whichever comes first) and these two situations will cause minion to throw an exception and
drop the message.
