### PR TITLE
Openstack provider work better for certain scenarios at Rackspace

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -603,9 +603,9 @@ def create(vm_):
         # when ssh_interface is set to private_ips and public_ips exist
         if not result and ssh_interface(vm_) == 'private_ips':
             for private_ip in private:
-              ignore_ip = ignore_cidr(vm_, private_ip)
-              if private_ip not in data.private_ips and not ignore_ip:
-                  result.append(private_ip)
+                ignore_ip = ignore_cidr(vm_, private_ip)
+                if private_ip not in data.private_ips and not ignore_ip:
+                    result.append(private_ip)
 
         if result:
             log.debug('result = {0}'.format(result))


### PR DESCRIPTION
If I want to use private_ips in a RackConnect environment setting ssh_interface to private_ips triggers a never ending loop, resulting in a wait_for_ip timeout.  Public IPs do exist, and the logic was a little off.
Also, ignore_cidr was returning a string when netaddr wasn't available, which evaluated to True in later logic checks.  This still logs the Warning, but returns a False match and assumes it's not on the list.
