### PR TITLE
Updated the cmd state docs to resolve 8795, and 7902.

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -460,6 +460,25 @@ def run(name,
     timeout
         If the command has not terminated after timeout seconds, send the
         subprocess sigterm, and if sigterm is ignored, follow up with sigkill
+
+    .. note:: 
+
+        cmd.run supports the usage of reload_modules. This functionality
+        allows you to force Salt to reload all modules. You should only use
+        reload_modules if your cmd.run does some sort of installation (such as
+        pip), if you do not reload the modules future items in your state
+        which rely on the software being installed will fail. 
+
+        .. code-block:: yaml
+
+            cmd.run:
+              - name: /usr/bin/python /usr/local/sbin/get-pip.py
+              - unless: which pip
+              - require:
+                - pkg: python
+                - file: /usr/local/sbin/get-pip.py
+              - reload_modules: True
+
     '''
     ### NOTE: The keyword arguments in **kwargs are ignored in this state, but
     ###       cannot be removed from the function definition, otherwise the use


### PR DESCRIPTION
This is simply a documentation update to note how reload_modules works so that users can avoid issues where they install something via cmd.run, and then require it but it isn't found. https://github.com/saltstack/salt/issues/8795 and https://github.com/saltstack/salt/issues/7902 are resolved with this pull request.
