### PR TITLE
Fix debian network interfaces order

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1093,7 +1093,7 @@ def _write_file_ifaces(iface, data, folder):
             adapters[adapter]['data']['inet']['proto'] = 'manual'
 
         tmp = template.render({'name': adapter, 'data': adapters[adapter]})
-        ifcfg += tmp
+        ifcfg = tmp + ifcfg
         if adapter == iface:
             saved_ifcfg = tmp
 


### PR DESCRIPTION
Generate interfaces on Debian in correct order, strictly needed for some
interface types (e.g., bond).
