### PR TITLE
Fix rbenv updating

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -87,7 +87,7 @@ def _update_rbenv(path, runas=None):
         return False
 
     return 0 == __salt__['cmd.retcode'](
-        'git pull --git-dir {0}'.format(path), runas=runas)
+        'cd {0} && git pull'.format(path), runas=runas)
 
 
 def _update_ruby_build(path, runas=None):
@@ -96,7 +96,7 @@ def _update_ruby_build(path, runas=None):
         return False
 
     return 0 == __salt__['cmd.retcode'](
-        'git pull --git-dir {0}'.format(path), runas=runas)
+        'cd {0} && git pull'.format(path), runas=runas)
 
 
 def install(runas=None, path=None):


### PR DESCRIPTION
--git-dir doesn't work right (it needs the .git directory) and you also need to change the working tree, or else it will pull into `pwd`. This method should be much more "fool proof".
