### PR TITLE
Use uppercase for `OS` environment variable

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -146,8 +146,8 @@ def verify_files(files, user):
     '''
     Verify that the named files exist and are owned by the named user
     '''
-    if 'os' in os.environ:
-        if os.environ['os'].startswith('Windows'):
+    if 'OS' in os.environ:
+        if os.environ['OS'].startswith('Windows'):
             return True
     import pwd  # after confirming not running Windows
     try:
@@ -186,8 +186,8 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
     Verify that the named directories are in place and that the environment
     can shake the salt
     '''
-    if 'os' in os.environ:
-        if os.environ['os'].startswith('Windows'):
+    if 'OS' in os.environ:
+        if os.environ['OS'].startswith('Windows'):
             return True
     import pwd  # after confirming not running Windows
     import grp
@@ -285,8 +285,8 @@ def check_user(user):
     '''
     Check user and assign process uid/gid.
     '''
-    if 'os' in os.environ:
-        if os.environ['os'].startswith('Windows'):
+    if 'OS' in os.environ:
+        if os.environ['OS'].startswith('Windows'):
             return True
     if user == getpass.getuser():
         return True


### PR DESCRIPTION
This patch fixes issue #9213.

I learnt that `os.environ` object in Windows uppercases all keys:
http://stackoverflow.com/a/7797329/441652
In fact, all environment variables in Windows are case-insitive. For example, the following commands refer to the same environment variable:

```
echo %os%
echo %OS%
```

However, when `salt-ssh` is used with Windows/Cygwin where Python is "natively" compiled under Cygwin, `os.environ` object apparently does not perform uppercasing anymore. And command `salt-ssh` fails for Cygwin.

The change will fix #9213 issue without affecting Windows-only nodes.
