### PR TITLE
Correctly pass kwargs through to wheel.call_func

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -2193,7 +2193,7 @@ class ClearFuncs(object):
                     'user': token['name']}
             try:
                 self.event.fire_event(data, tagify([jid, 'new'], 'wheel'))
-                ret = self.wheel_.call_func(fun, **clear_load.get('kwarg', {}))
+                ret = self.wheel_.call_func(fun, **clear_load)
                 data['return'] = ret
                 data['success'] = True
                 self.event.fire_event(data, tagify([jid, 'ret'], 'wheel'))
@@ -2263,7 +2263,7 @@ class ClearFuncs(object):
                     'user': clear_load.get('username', 'UNKNOWN')}
             try:
                 self.event.fire_event(data, tagify([jid, 'new'], 'wheel'))
-                ret = self.wheel_.call_func(fun, **clear_load.get('kwarg', {}))
+                ret = self.wheel_.call_func(fun, **clear_load)
                 data['return'] = ret
                 data['success'] = True
                 self.event.fire_event(data, tagify([jid, 'ret'], 'wheel'))

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -598,9 +598,8 @@ class ReactWrap(object):
         '''
         Wrap Wheel to enable executing :ref:`wheel modules <all-salt.wheel>`
         '''
-        kwargs['fun'] = fun
         wheel = salt.wheel.Wheel(self.opts)
-        return wheel.call_func(**kwargs)
+        return wheel.call_func(fun, **kwargs)
 
 
 class StateFire(object):


### PR DESCRIPTION
The change in 1de6204 broke what `format_call()` expects in [wheel.Wheel().call_func()](https://github.com/whiteinge/salt/blob/36f70bdcecb7ad89dc6e939d8743f8db3eb4b48b/salt/wheel/__init__.py#L56). That said I'm not sure what nested kwargs are or where they're used so this commit may very well break something elsewhere. In my simple tests `clear_load` never contained a `kwarg` value so I'm submitting this change for review.

@thatch45 ping
