### PR TITLE
Fix for bug #9128: issue with salt-master ttys with lvdisplay command

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -259,11 +259,10 @@ def daemonize(redirect_out=True):
     # not cleanly redirected and the parent process dies when the
     # multiprocessing process attempts to access stdout or err.
     if redirect_out:
-        dev_null_r = open('/dev/null', 'r')
-        dev_null_w = open('/dev/null', 'w')
-        os.dup2(dev_null_r.fileno(), sys.stdin.fileno())
-        os.dup2(dev_null_w.fileno(), sys.stdout.fileno())
-        os.dup2(dev_null_w.fileno(), sys.stderr.fileno())
+        dev_null = open('/dev/null', 'w')
+        os.dup2(dev_null.fileno(), sys.stdin.fileno())
+        os.dup2(dev_null.fileno(), sys.stdout.fileno())
+        os.dup2(dev_null.fileno(), sys.stderr.fileno())
 
 
 def daemonize_if(opts):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -259,10 +259,11 @@ def daemonize(redirect_out=True):
     # not cleanly redirected and the parent process dies when the
     # multiprocessing process attempts to access stdout or err.
     if redirect_out:
-        dev_null = open('/dev/null', 'w')
-        os.dup2(dev_null.fileno(), sys.stdin.fileno())
-        os.dup2(dev_null.fileno(), sys.stdout.fileno())
-        os.dup2(dev_null.fileno(), sys.stderr.fileno())
+        dev_null_r = open('/dev/null', 'r')
+        dev_null_w = open('/dev/null', 'w')
+        os.dup2(dev_null_r.fileno(), sys.stdin.fileno())
+        os.dup2(dev_null_w.fileno(), sys.stdout.fileno())
+        os.dup2(dev_null_w.fileno(), sys.stderr.fileno())
 
 
 def daemonize_if(opts):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -259,7 +259,7 @@ def daemonize(redirect_out=True):
     # not cleanly redirected and the parent process dies when the
     # multiprocessing process attempts to access stdout or err.
     if redirect_out:
-        dev_null = open('/dev/null', 'w')
+        dev_null = open('/dev/null', 'r+')
         os.dup2(dev_null.fileno(), sys.stdin.fileno())
         os.dup2(dev_null.fileno(), sys.stdout.fileno())
         os.dup2(dev_null.fileno(), sys.stderr.fileno())

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -259,7 +259,7 @@ def daemonize(redirect_out=True):
     # not cleanly redirected and the parent process dies when the
     # multiprocessing process attempts to access stdout or err.
     if redirect_out:
-        dev_null_r = open('/dev/null', 'r')
+        dev_null_r = open('/dev/null', 'r+')
         dev_null_w = open('/dev/null', 'w')
         os.dup2(dev_null_r.fileno(), sys.stdin.fileno())
         os.dup2(dev_null_w.fileno(), sys.stdout.fileno())

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -259,7 +259,7 @@ def daemonize(redirect_out=True):
     # not cleanly redirected and the parent process dies when the
     # multiprocessing process attempts to access stdout or err.
     if redirect_out:
-        dev_null_r = open('/dev/null', 'r+')
+        dev_null_r = open('/dev/null', 'r')
         dev_null_w = open('/dev/null', 'w')
         os.dup2(dev_null_r.fileno(), sys.stdin.fileno())
         os.dup2(dev_null_w.fileno(), sys.stdout.fileno())


### PR DESCRIPTION
lvdisplay checks the file flags of the ttys file descriptors.
Currently all three stds file descriptor are set write only.

This fix :
- set stdin as read only
- set stdout, stderr as write only
