### PR TITLE
Fix bond and bridge option rendering order, add complete option parsing for Debian bridge interfaces

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -112,6 +112,12 @@ _DEB_CONFIG_BONDING_OPTS = [
     'ad_select', 'xmit_hash_policy', 'arp_validate',
     'fail_over_mac', 'all_slaves_active', 'resend_igmp'
 ]
+_DEB_CONFIG_BRIDGE_OPTS = [
+    'ageing', 'bridgeprio', 'fd', 'gcint',
+    'hello', 'hw', 'maxage', 'maxwait',
+    'pathcost', 'portprio', 'ports',
+    'stp', 'waitport'
+]
 _DEB_ROUTES_FILE = '/etc/network/routes'
 _DEB_NETWORK_FILE = '/etc/network/interfaces'
 _DEB_NETWORK_DIR = '/etc/network/interfaces.d'
@@ -345,18 +351,18 @@ def _parse_interfaces():
                             sline.pop(0)
                             value = ' '.join(sline)
 
-                            if not 'bonding' in adapters[iface_name]:
-                                adapters[iface_name]['bonding'] = {}
-                            adapters[iface_name]['bonding'][opt] = value
+                            if not 'bonding' in adapters[iface_name]['data'][context]:
+                                adapters[iface_name]['data'][context]['bonding'] = {}
+                            adapters[iface_name]['data'][context]['bonding'][opt] = value
 
                         if sline[0].startswith('bridge'):
                             opt = sline[0].split('_', 1)[1]
                             sline.pop(0)
                             value = ' '.join(sline)
 
-                            if not 'bridge_options' in adapters[iface_name]['data'][context]:
-                                adapters[iface_name]['data'][context]['bridge_options'] = {}
-                            adapters[iface_name]['data'][context]['bridge_options'][opt] = value
+                            if not 'bridgeing' in adapters[iface_name]['data'][context]:
+                                adapters[iface_name]['data'][context]['bridgeing'] = {}
+                            adapters[iface_name]['data'][context]['bridgeing'][opt] = value
 
                         if sline[0].startswith('dns-nameservers'):
                             if not 'dns' in adapters[iface_name]['data'][context]:
@@ -391,11 +397,13 @@ def _parse_interfaces():
                                 adapters[word] = {}
                             adapters[word]['hotplug'] = True
 
-    # Return a sorted list of the keys for ethtool options to ensure a consistent order
+    # Return a sorted list of the keys for bond, bridge and ethtool options to
+    # ensure a consistent order
     for iface_name in adapters:
-        if 'ethtool' in adapters[iface_name]['data']['inet']:
-            ethtool_keys = sorted(adapters[iface_name]['data']['inet']['ethtool'].keys())
-            adapters[iface_name]['data']['inet']['ethtool_keys'] = ethtool_keys
+        for opt in ['ethtool', 'bonding', 'bridgeing']:
+            if opt in adapters[iface_name]['data']['inet']:
+                opt_keys = sorted(adapters[iface_name]['data']['inet'][opt].keys())
+                adapters[iface_name]['data']['inet'][opt + '_keys'] = opt_keys
 
     return adapters
 
@@ -854,14 +862,26 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     if iface_type == 'bond':
         bonding = _parse_settings_bond(opts, iface)
         if bonding:
-            adapters[iface]['bonding'] = bonding
-            adapters[iface]['bonding']['slaves'] = opts['slaves']
+            adapters[iface]['data']['inet']['bonding'] = bonding
+            adapters[iface]['data']['inet']['bonding']['slaves'] = opts['slaves']
+            adapters[iface]['data']['inet']['bonding_keys'] = sorted(bonding.keys())
 
     if iface_type == 'slave':
         adapters[iface]['master'] = opts['master']
 
     if iface_type == 'vlan':
         adapters[iface]['data']['inet']['vlan_raw_device'] = re.sub(r'\.\d*', '', iface)
+
+    if iface_type == 'bridge':
+        for opt in _DEB_CONFIG_BRIDGE_OPTS:
+            if opt in opts:
+                if not 'bridgeing' in adapters[iface]['data']['inet']:
+                    adapters[iface]['data']['inet']['bridgeing'] = {}
+                adapters[iface]['data']['inet']['bridgeing'][opt] = opts[opt]
+
+        if 'bridgeing' in adapters[iface]['data']['inet']:
+            bridgeing = adapters[iface]['data']['inet']['bridgeing']
+            adapters[iface]['data']['inet']['bridgeing_keys'] = sorted(bridgeing.keys())
 
     if 'proto' in opts:
         valid = ['bootp', 'dhcp', 'none', 'static', 'manual', 'loopback']
@@ -880,13 +900,6 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     for opt in ['netmask', 'network', 'gateway', 'addr']:
         if opt in opts:
             adapters[iface]['data']['inet'][opt] = opts[opt]
-
-    for opt in ['bridge_ports', 'bridge_stp', 'bridge_waitport', 'bridge_fd']:
-        if opt in opts:
-            key = opt.split('_')[1]
-            if not 'bridge_options' in adapters[iface]['data']['inet']:
-                adapters[iface]['data']['inet']['bridge_options'] = {}
-            adapters[iface]['data']['inet']['bridge_options'][key] = opts[opt]
 
     if 'dns' in opts:
         adapters[iface]['data']['inet']['dns'] = opts['dns']
@@ -1189,8 +1202,8 @@ def build_interface(iface, iface_type, enabled, **settings):
             raise AttributeError(msg)
 
     if iface_type == 'bridge':
-        if 'bridge_ports' not in settings:
-            msg = 'bridge_ports is a required setting for bridge interfaces'
+        if 'ports' not in settings:
+            msg = 'ports is a required setting for bridge interfaces'
             log.error(msg)
             raise AttributeError(msg)
         __salt__['pkg.install']('bridge-utils')

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -11,30 +11,8 @@ iface {{name}} {{interface.inet_type}} {{interface.proto}}
 {%endif%}{% if interface.vlan_raw_device %}    vlan-raw-device {{interface.vlan_raw_device}}
 {%endif%}{% if interface.dns %}    dns-nameservers {%for item in interface.dns %}{{item}} {%endfor%}
 {%endif%}{% if interface.ethtool %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
-{%endfor%}{%endif%}{%if data.bonding %}
-{%- set bonding = data.bonding -%}
-{% if bonding.mode %}    bond_mode {{bonding.mode}}
-{%endif%}{% if bonding.miimon %}    bond_miimon {{bonding.miimon}}
-{%endif%}{% if bonding.arp_interval %}    bond_arp_interval {{bonding.arp_interval}}
-{%endif%}{% if bonding.slaves %}    bond_slaves {{bonding.slaves}}
-{%endif%}{% if bonding.arp_ip_target %}    bond_arp_ip_target {{bonding.arp_ip_target}}
-{%endif%}{% if bonding.downdelay %}    bond_downdelay {{bonding.downdelay}}
-{%endif%}{% if bonding.updelay %}    bond_updelay {{bonding.updelay}}
-{%endif%}{% if bonding.use_carrier %}    bond_use_carrier {{bonding.use_carrier}}
-{%endif%}{% if bonding.lacp_rate %}    bond_lacp_rate {{bonding.lacp_rate}}
-{%endif%}{% if bonding.max_bonds %}    bond_max_bonds {{bonding.max_bonds}}
-{%endif%}{% if bonding.tx_queues %}    bond_tx_queues {{bonding.tx_queues}}
-{%endif%}{% if bonding.num_grat_arp %}    bond_num_grat_arp {{bonding.num_grat_arp}}
-{%endif%}{% if bonding.num_unsol_na %}    bond_num_unsol_na {{bonding.num_unsol_na}}
-{%endif%}{% if bonding.primary %}    bond_primary {{bonding.primary}}
-{%endif%}{% if bonding.primary_reselect %}    bond_primary_reselect {{bonding.primary_reselect}}
-{%endif%}{% if bonding.ad_select %}    bond_ad_select {{bonding.ad_select}}
-{%endif%}{% if bonding.xmit_hash_policy %}    bond_xmit_hash_policy {{bonding.xmit_hash_policy}}
-{%endif%}{% if bonding.arp_validate %}    bond_arp_validate {{bonding.arp_validate}}
-{%endif%}{% if bonding.fail_over_mac %}    bond_fail_over_mac {{bonding.fail_over_mac}}
-{%endif%}{% if bonding.all_slaves_active %}    bond_all_slaves_active {{bonding.all_slaves_active}}
-{%endif%}{% if bonding.resend_igmp %}    bond_resend_igmp {{bonding.resend_igmp}}
-{%endif%}{%endif%}{% if interface.bridge_options -%}
+{%endfor%}{%endif%}{%if data.bonding %}{%for item in data.bonding %}    bond_{{item}} {{data.bonding[item]}}
+{%endfor%}{%endif%}{% if interface.bridge_options -%}
 {% if interface.bridge_options.ports %}    bridge_ports {{interface.bridge_options.ports}}
 {%endif-%}
 {%endif%}{% if interface.up_cmds %}{% for cmd in interface.up_cmds %}    up {{ cmd }}

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -11,11 +11,9 @@ iface {{name}} {{interface.inet_type}} {{interface.proto}}
 {%endif%}{% if interface.vlan_raw_device %}    vlan-raw-device {{interface.vlan_raw_device}}
 {%endif%}{% if interface.dns %}    dns-nameservers {%for item in interface.dns %}{{item}} {%endfor%}
 {%endif%}{% if interface.ethtool %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
-{%endfor%}{%endif%}{%if data.bonding %}{%for item in data.bonding %}    bond_{{item}} {{data.bonding[item]}}
-{%endfor%}{%endif%}{% if interface.bridge_options -%}
-{% if interface.bridge_options.ports %}    bridge_ports {{interface.bridge_options.ports}}
-{%endif-%}
-{%endif%}{% if interface.up_cmds %}{% for cmd in interface.up_cmds %}    up {{ cmd }}
+{%endfor%}{%endif%}{% if interface.bonding %}{%for item in interface.bonding_keys %}    {{item}} {{interface.bonding[item]}}
+{%endfor%}{%endif%}{% if interface.bridgeing %}{%for item in interface.bridgeing_keys %}    {{item}} {{interface.bridgeing[item]}}
+{%endfor%}{%endif%}{% if interface.up_cmds %}{% for cmd in interface.up_cmds %}    up {{ cmd }}
 {%endfor-%}
 {%endif%}{% if interface.down_cmds %}{% for cmd in interface.down_cmds %}    down {{ cmd }}
 {%endfor-%}


### PR DESCRIPTION
Fix bond and bridge option rendering order, add more bridge options

Better way of handling option ordering in bond and bridge interfaces and add missing bridge options.

This patch reverts commit from yesterday's pull request:
https://github.com/saltstack/salt/pull/9214

I think this is better way of option order handling.

Also add complete option parsing for Debian bridge interfaces.
