### PR TITLE
added default value of 4096 bits to config for master and minion RSA-Key

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -177,6 +177,7 @@ VALID_OPTS = {
     'jinja_trim_blocks': bool,
     'minion_id_caching': bool,
     'sign_pub_messages': bool,
+    'keysize' : int
 }
 
 # default configurations
@@ -268,6 +269,7 @@ DEFAULT_MINION_OPTS = {
     'modules_max_memory': -1,
     'grains_refresh_every': 0,
     'minion_id_caching': True,
+    'keysize' : 4096
 }
 
 DEFAULT_MASTER_OPTS = {
@@ -375,6 +377,7 @@ DEFAULT_MASTER_OPTS = {
     'jinja_lstrip_blocks': False,
     'jinja_trim_blocks': False,
     'sign_pub_messages': False,
+    'keysize' : 4096
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -164,7 +164,7 @@ class MasterKeys(dict):
             log.info('Generating keys: {0}'.format(self.opts['pki_dir']))
             gen_keys(self.opts['pki_dir'],
                      'master',
-                     4096,
+                     self.opts['keysize'],
                      self.opts.get('user'))
             key = RSA.load_key(self.rsa_path)
         return key
@@ -218,7 +218,7 @@ class Auth(object):
             log.info('Generating keys: {0}'.format(self.opts['pki_dir']))
             gen_keys(self.opts['pki_dir'],
                      'minion',
-                     4096,
+                     self.opts['keysize'],
                      self.opts.get('user'))
             key = RSA.load_key(self.rsa_path)
         return key


### PR DESCRIPTION
Hey,

While testing the salt-mine i discovered, that the authentication phase for minions in larger setups (7000 minions, single master) can become quite expensive cpu-wise for the salt-master. About a 1000 minions reporting values via the salt-mine can raise the load of a DELL R610, 16 Cores, 16GB Ram, etc. to about 6-10. Having more minions report, would certainly kill the master sooner or later.

Salt uses 4096 bit keys per default (hardcoded in crypt.py). After researching a bit i think, that 2048 bit are still fine for most use-cases. The NIST and other sources claim, that 2048 bit keys  will be fine for the next few years.
Im not a crypto-guy, im relying on a few articles here. 

After some performance testing with different key-sizes (mainly 2048 and 4096) i discovered, that using 2048 bit keys is about 6 times as fast compared to 4096 bit keys. The skript used is this one:

https://github.com/felskrone/utils/blob/master/key-perf.py

$ key-perf.py <keysize> <decryptions>

msg: "test fusel"
keysize: 2048 bit
decryptions: 5000
duration: 1:28 min

msg: "test fusel"
keysize: 4096 bit
decryptions: 5000
duration: 7:43 min

I have not done any testing with 2048 bit keys within salt besides checking that the master also can handle 2048 bit keys. If the authentication-performance will increase by as much as my test-skript, for some it might be a real option to use 2048 bit keys.

Even though im not sure i'll be using 2048 bit keys in the future, i think being able to configure it would be nice. 
