### PR TITLE
states.git.latest(): fix bad format call

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -269,8 +269,8 @@ def latest(name,
                     shutil.rmtree(target)
             # git clone is required, but target exists and is non-empty
             elif os.listdir(target):
-                return _fail(ret, "Directory '{0}' exists, is non-empty, and\
-                             force option not in use").format(target)
+                return _fail(ret, 'Directory \'{0}\' exists, is non-empty, and '
+                             'force option not in use'.format(target))
 
         # git clone is required
         log.debug(


### PR DESCRIPTION
```
salt/states/git.py:272: [E1101(no-member), latest] Instance of 'dict' has no 'format' member
```
