### PR TITLE
master.py: rm unused import of SaltRunnerError

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -51,7 +51,7 @@ import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
 from salt.utils.debug import enable_sigusr1_handler, inspect_stack
-from salt.exceptions import SaltMasterError, MasterExit, SaltRunnerError
+from salt.exceptions import SaltMasterError, MasterExit
 from salt.utils.event import tagify
 from salt.pillar import git_pillar
 


### PR DESCRIPTION
```
salt/master.py:54: [W0611(unused-import), ] Unused import SaltRunnerError
```
