### PR TITLE
cmdmod: rm unused import of operator module

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -10,7 +10,6 @@ access to the master root execution access to all salt minions
 import functools
 import json
 import logging
-import operator
 import os
 import shutil
 import subprocess


### PR DESCRIPTION
```
salt/modules/cmdmod.py:13: [W0611(unused-import), ] Unused import operator
```
