### PR TITLE
salt.utils.parsers: fix typo in module docstring

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -8,7 +8,7 @@
     salt.utils.parsers
     ~~~~~~~~~~~~~~~~~~
 
-    This is were all the black magic happens on all of salt's CLI tools.
+    This is where all the black magic happens on all of salt's CLI tools.
 '''
 
 # Import python libs


### PR DESCRIPTION
I don't think werewolves or were-anythings are involved in this black magic.
