### PR TITLE
win_network mod: rm unused import of re

### DIFF
--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -3,9 +3,6 @@
 Module for gathering and managing network information
 '''
 
-# Import python libs
-import re
-
 # Import salt libs
 import salt.utils
 


### PR DESCRIPTION
```
salt/modules/win_network.py:7: [W0611(unused-import), ] Unused import re
```
