### PR TITLE
Add runner for pillar.show_top, Fix #8191

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -134,3 +134,27 @@ def ext(external):
     ret = pillar.compile_pillar()
 
     return ret
+
+
+def show_top():
+    '''
+    Returns the compiled top data for pillar
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pillar.show_top
+    '''
+    pillar = salt.pillar.get_pillar(
+        __opts__,
+        __grains__,
+        __opts__['id'],
+        __opts__['environment'])
+
+    top, errors = pillar.get_top()
+
+    if errors:
+        return errors
+
+    return top

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -134,27 +134,3 @@ def ext(external):
     ret = pillar.compile_pillar()
 
     return ret
-
-
-def show_top():
-    '''
-    Returns the compiled top data for pillar
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' pillar.show_top
-    '''
-    pillar = salt.pillar.get_pillar(
-        __opts__,
-        __grains__,
-        __opts__['id'],
-        __opts__['environment'])
-
-    top, errors = pillar.get_top()
-
-    if errors:
-        return errors
-
-    return top

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+'''
+Functions to interact with the pillar compiler on the master
+'''
+
+# Import salt libs
+import salt.pillar
+
+
+def show_top():
+    '''
+    Returns the compiled top data for pillar
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run pillar.show_top
+    '''
+    pillar = salt.pillar.Pillar(
+        __opts__,
+        {},
+        __opts__['id'],
+        __opts__['environment'])
+
+    top, errors = pillar.get_top()
+
+    if errors:
+        return errors
+
+    return top

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -19,7 +19,7 @@ def show_top(minion=None, saltenv='base'):
 
         salt-run pillar.show_top
     '''
-    id_, grains = salt.utils.minions.get_grains(minion)
+    id_, grains, _ = salt.utils.minions.get_minion_data(minion, __opts__)
     pillar = salt.pillar.Pillar(
         __opts__,
         grains,

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -6,6 +6,7 @@ Functions to interact with the pillar compiler on the master
 # Import salt libs
 import salt.pillar
 import salt.utils.minions
+import salt.output
 
 
 def show_top(minion=None, saltenv='base'):
@@ -29,6 +30,8 @@ def show_top(minion=None, saltenv='base'):
     top, errors = pillar.get_top()
 
     if errors:
+        salt.output.display_output(errors, 'nested', __opts__)
         return errors
 
+    salt.output.display_output(top, 'nested', __opts__)
     return top

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -5,11 +5,13 @@ Functions to interact with the pillar compiler on the master
 
 # Import salt libs
 import salt.pillar
+import salt.utils.minions
 
 
-def show_top():
+def show_top(minion=None, saltenv='base'):
     '''
-    Returns the compiled top data for pillar
+    Returns the compiled top data for pillar for a specific minion.  If no
+    minion is specified, we use the first minion we find.
 
     CLI Example:
 
@@ -17,11 +19,12 @@ def show_top():
 
         salt-run pillar.show_top
     '''
+    id_, grains = salt.utils.minions.get_grains(minion)
     pillar = salt.pillar.Pillar(
         __opts__,
-        {},
-        __opts__['id'],
-        __opts__['environment'])
+        grains,
+        id_,
+        saltenv)
 
     top, errors = pillar.get_top()
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -17,6 +17,40 @@ import salt.utils
 log = logging.getLogger(__name__)
 
 
+def get_grains(minion=None):
+    '''
+    Get the grains for a specific minion.  If no minion is specified, it will
+    return the grains for the first minion it finds.
+
+    Return value is a tuple of the minion ID and the grains
+    '''
+    if self.opts.get('minion_data_cache', False):
+        cdir = os.path.join(self.opts['cachedir'], 'minions')
+        if not os.path.isdir(cdir):
+            return minion if minion else '', {}
+        minions = os.listdir(cdir)
+        if minion is None:
+            # If no minion specified, take first one with valid grains
+            for id_ in minions:
+                datap = os.path.join(cdir, id_, 'data.p')
+                if not os.path.isfile(datap):
+                    continue
+                grains = self.serial.load(
+                        salt.utils.fopen(datap)).get('grains')
+                if grains:
+                    return id_, grains
+        else:
+            # Search for specific minion
+            datap = os.path.join(cdir, minion, 'data.p')
+            if not os.path.isfile(datap):
+                return minion, {}
+            grains = self.serial.load(
+                    salt.utils.fopen(datap)).get('grains')
+            return minion, grains
+    # No cache dir, return empty dict
+    return minion if minion else '', {}
+
+
 def nodegroup_comp(group, nodegroups, skip=None):
     '''
     Take the nodegroup and the nodegroups and fill in nodegroup refs


### PR DESCRIPTION
Fixes #8191

Add a new runner to show top data for a specific minion.  Can also take no minion as argument and will return for the first minion it finds.

Also added `salt.utils.minions.get_minion_data` to fetch minion grains and pillar.
