### PR TITLE
Removing references to the old cloud configuration syntax

### DIFF
--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -9,25 +9,7 @@ This module has been replaced by the EC2 cloud module, and is no longer
 supported. The documentation shown here is for reference only; it is highly
 recommended to change all usages of this driver over to the EC2 driver.
 
-To use the AWS cloud module, using the old cloud providers configuration
-syntax, the following configuration parameters need to be set in the main cloud
-configuration file:
-
-.. code-block:: yaml
-
-    # The AWS API authentication id
-    AWS.id: GKTADJGHEIQSXMKKRBJ08H
-    # The AWS API authentication key
-    AWS.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
-    # The ssh keyname to use
-    AWS.keyname: default
-    # The amazon security group
-    AWS.securitygroup: ssh_open
-    # The location of the private key which corresponds to the keyname
-    AWS.private_key: /root/default.pem
-
-
-Using the new format, set up the cloud configuration at
+If this driver is still needed, set up the cloud configuration at
  ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/aws.conf``:
 
 .. code-block:: yaml

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -6,20 +6,9 @@ Digital Ocean Cloud Module
 The Digital Ocean cloud module is used to control access to the Digital Ocean
 VPS system.
 
-Use of this module only requires the ``api_key`` parameter to be set. Using the
-old cloud providers configuration syntax, in the main cloud configuration
-file:
-
-.. code-block:: yaml
-
-    # Digital Ocean account keys
-    DIGITAL_OCEAN.client_key: wFGEwgregeqw3435gDger
-    DIGITAL_OCEAN.api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
-
-
-Using the new format, set up the cloud configuration at
- ``/etc/salt/cloud.providers`` or
- ``/etc/salt/cloud.providers.d/digital_ocean.conf``:
+Use of this module only requires the ``api_key`` parameter to be set. Set up the
+cloud configuration at ``/etc/salt/cloud.providers`` or
+``/etc/salt/cloud.providers.d/digital_ocean.conf``:
 
 .. code-block:: yaml
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -6,33 +6,7 @@ The EC2 Cloud Module
 The EC2 cloud module is used to interact with the Amazon Elastic Cloud
 Computing. This driver is highly experimental! Use at your own risk!
 
-To use the EC2 cloud module, when using the old format the following
-configuration parameters need to be set in the main cloud configuration:
-
-.. code-block:: yaml
-
-    # The EC2 API authentication id
-    EC2.id: GKTADJGHEIQSXMKKRBJ08H
-    # The EC2 API authentication key
-    EC2.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
-    # The ssh keyname to use
-    EC2.keyname: default
-    # The amazon security group
-    EC2.securitygroup: ssh_open
-    # The location of the private key which corresponds to the keyname
-    EC2.private_key: /root/default.pem
-
-    # Be default, service_url is set to amazonaws.com. If you are using this
-    # driver for something other than Amazon EC2, change it here:
-    EC2.service_url: amazonaws.com
-
-    # The endpoint that is ultimately used is usually formed using the region
-    # and the service_url. If you would like to override that entirely, you can
-    # explicitly define the endpoint:
-    EC2.endpoint: myendpoint.example.com:1138/services/Cloud
-
-
-Using the new format, set up the cloud configuration at
+To use the EC2 cloud module, set up the cloud configuration at
  ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/ec2.conf``:
 
 .. code-block:: yaml

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -8,20 +8,8 @@ service. To use Salt Cloud with GoGrid log into the GoGrid web interface and
 create an api key. Do this by clicking on "My Account" and then going to the
 API Keys tab.
 
-Using the old providers configuration syntax format, the ``GOGRID.apikey`` and
-the ``GOGRID.sharedsecret`` configuration parameters need to be set in the
-configuration file to enable interfacing with GoGrid:
-
-.. code-block:: yaml
-
-    # The generated api key to use
-    GOGRID.apikey: asdff7896asdh789
-    # The apikey's shared secret
-    GOGRID.sharedsecret: saltybacon
-
-
-Using the new format, set up the cloud configuration at
-``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/gogrid.conf``:
+Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
+``/etc/salt/cloud.providers.d/gogrid.conf``:
 
 .. code-block:: yaml
 

--- a/salt/cloud/clouds/ibmsce.py
+++ b/salt/cloud/clouds/ibmsce.py
@@ -7,23 +7,8 @@ The IBM SCE cloud module. This module interfaces with the IBM SCE public cloud
 service. To use Salt Cloud with IBM SCE log into the IBM SCE web interface and
 create an SSH key.
 
-Using the old configuration syntax, the following parameters are required in
-order to create a node:
-
-.. code-block:: yaml
-
-    # The generated api key to use
-    IBMSCE.user: myuser@mycompany.com
-    # The user's password
-    IBMSCE.password: saltybacon
-    # The name of the ssh key to use
-    IBMSCE.ssh_key_name: mykey
-    # The ID of the datacenter to use
-    IBMSCE.location: Raleigh
-
-
-Using the new format, set up the cloud configuration at
-``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/ibmsce.conf``:
+Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
+``/etc/salt/cloud.providers.d/ibmsce.conf``:
 
 .. code-block:: yaml
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -5,20 +5,8 @@ Joyent Cloud Module
 
 The Joyent Cloud module is used to interact with the Joyent cloud system.
 
-Using the old cloud configuration syntax, it requires that the ``username`` and
-``password`` to the joyent account be configured:
-
-.. code-block:: yaml
-
-    # The Joyent login user
-    JOYENT.user: fred
-    # The Joyent user's password
-    JOYENT.password: saltybacon
-    # The location of the ssh private key that can log into the new VM
-    JOYENT.private_key: /root/joyent.pem
-
-Using the new format, set up the cloud configuration at
- ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/joyent.conf``:
+Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
+``/etc/salt/cloud.providers.d/joyent.conf``:
 
 .. code-block:: yaml
 

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -9,25 +9,7 @@ This module has been replaced by the EC2 cloud module, and is no longer
 supported. The documentation shown here is for reference only; it is highly
 recommended to change all usages of this driver over to the EC2 driver.
 
-To use the AWS cloud module, using the old cloud providers configuration
-syntax, the following configuration parameters need to be set in the main cloud
-configuration file:
-
-.. code-block:: yaml
-
-    # The AWS API authentication id
-    AWS.id: GKTADJGHEIQSXMKKRBJ08H
-    # The AWS API authentication key
-    AWS.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
-    # The ssh keyname to use
-    AWS.keyname: default
-    # The amazon security group
-    AWS.securitygroup: ssh_open
-    # The location of the private key which corresponds to the keyname
-    AWS.private_key: /root/default.pem
-
-
-Using the new format, set up the cloud configuration at
+If this driver is still needed, set up the cloud configuration at
  ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/aws.conf``:
 
 .. code-block:: yaml

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -6,17 +6,9 @@ Linode Cloud Module
 The Linode cloud module is used to control access to the Linode VPS system
 
 Use of this module only requires the ``apikey`` parameter.
-If using the old cloud configuration syntax, add to salt cloud configuration
-file:
 
-.. code-block:: yaml
-
-    # Linode account api key
-    LINODE.apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
-
-
-Using the new format, set up the cloud configuration at
- ``/etc/salt/cloud.providers`` or ``/etc/salt/cloud.providers.d/linode.conf``:
+Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
+``/etc/salt/cloud.providers.d/linode.conf``:
 
 .. code-block:: yaml
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -17,33 +17,7 @@ This module has been tested to work with HP Cloud and Rackspace. See the
 documentation for specific options for either of these providers. Some
 examples, using the old cloud configuration syntax, are provided below:
 
-.. code-block:: yaml
-
-    # The OpenStack identity service url
-    OPENSTACK.identity_url: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/
-    # The OpenStack compute region
-    OPENSTACK.compute_region: az-1.region-a.geo-1
-    # The OpenStack compute service name
-    OPENSTACK.compute_name: Compute
-    # The OpenStack tenant name (not tenant ID)
-    OPENSTACK.tenant: myuser-tenant1
-    # The OpenStack user name
-    OPENSTACK.user: myuser
-    # The OpenStack keypair name
-    OPENSTACK.ssh_key_name
-
-Either a password or an API key must also be specified:
-
-.. code-block:: yaml
-
-    # The OpenStack password
-    OPENSTACK.password: letmein
-    # The OpenStack API key
-    OPENSTACK.apikey: 901d3f579h23c8v73q9
-
-
-And using the new format, these examples could be set up in the cloud
-configuration at ``/etc/salt/cloud.providers`` or
+Set up in the cloud configuration at ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/openstack.conf``:
 
 

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -6,21 +6,8 @@ Parallels Cloud Module
 The Parallels cloud module is used to control access to cloud providers using
 the Parallels VPS system.
 
-Use of this module requires, if using the old salt cloud configuration syntax,
-the following PARALLELS parameters to be set in the cloud configuration file.
-
-.. code-block:: yaml
-
-    # Parallels account information
-    PARALLELS.user: myuser
-    PARALLELS.password: mypassword
-    PARALLELS.url: https://api.cloud.xmission.com:4465/paci/v1.0/
-
-
-Using the new format, set up the cloud configuration at
- ``/etc/salt/cloud.providers`` or
+Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
  ``/etc/salt/cloud.providers.d/parallels.conf``:
-
 
 .. code-block:: yaml
 


### PR DESCRIPTION
As in Logan's Run, we need to clear out the old guys, to make way for the new ones.
