### PR TITLE
fix return null iptables.append

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -407,7 +407,10 @@ def append(table='filter', chain=None, rule=None):
 
     cmd = 'iptables -t {0} -A {1} {2}'.format(table, chain, rule)
     out = __salt__['cmd.run'](cmd)
-    return out
+    if len(out) == 0 :
+        return True
+    else:
+        return False
 
 
 def insert(table='filter', chain=None, position=None, rule=None):


### PR DESCRIPTION
return null in iptables.append,fix it

```
salt 'node1' iptables.append filter INPUT rule='-s 0.0.0.0 -p tcp --dport 80 -j ACCEPT' 
node1:
    True
salt 'node1' iptables.append filter INPUT rule='-s 0.0.0.0 -p tcp --dport 80 -j ACCEPT4'
node1:
    False
```
