### PR TITLE
Add pre-check function for range matcher

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1713,10 +1713,10 @@ class Matcher(object):
             range_ = seco.range.Range(self.opts['range_server'])
             try:
                 return self.opts['grains']['fqdn'] in range_.expand(tgt)
-            except seco.range.RangeException as e:
-                log.debug('Range exception in compound match: {0}'.format(e))
+            except seco.range.RangeException as exc:
+                log.debug('Range exception in compound match: {0}'.format(exc))
                 return False
-        return
+        return False
 
     def compound_match(self, tgt):
         '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -13,6 +13,14 @@ import logging
 # Import salt libs
 import salt.payload
 import salt.utils
+from salt.exceptions import CommandExecutionError
+
+HAS_RANGE = False
+try:
+    import seco.range
+    HAS_RANGE = True
+except ImportError:
+    pass
 
 log = logging.getLogger(__name__)
 
@@ -203,6 +211,43 @@ class CkMinions(object):
                             minions.remove(id_)
         return list(minions)
 
+    def _check_range_minions(self, expr):
+        '''
+        Return the minions found by looking via range expression
+        '''
+        if not HAS_RANGE:
+            raise CommandExecutionError(
+                'Range matcher unavailble (unable to import seco.range, '
+                'module most likely not installed)'
+            )
+        minions = set(
+            os.listdir(os.path.join(self.opts['pki_dir'], 'minions'))
+        )
+        if self.opts.get('minion_data_cache', False):
+            cdir = os.path.join(self.opts['cachedir'], 'minions')
+            if not os.path.isdir(cdir):
+                return list(minions)
+            for id_ in os.listdir(cdir):
+                if id_ not in minions:
+                    continue
+                datap = os.path.join(cdir, id_, 'data.p')
+                if not os.path.isfile(datap):
+                    continue
+                grains = self.serial.load(
+                    salt.utils.fopen(datap)
+                ).get('grains')
+
+                range_ = seco.range.Range(self.opts['range_server'])
+                try:
+                    if grains.get('fqdn', '') not in range_.expand(expr):
+                        minions.remove(id_)
+                except seco.range.RangeException as exc:
+                    log.debug(
+                        'Range exception in compound match: {0}'.format(exc)
+                    )
+                    minions.remove(id_)
+        return list(minions)
+
     def _check_compound_minions(self, expr):
         '''
         Return the minions found by looking via compound matcher
@@ -356,12 +401,13 @@ class CkMinions(object):
                        'pillar': self._check_pillar_minions,
                        'compound': self._check_compound_minions,
                        'ipcidr': self._check_ipcidr_minions,
+                       'range': self._check_range_minions,
                        }[expr_form](expr)
         except Exception:
             log.exception(
                     'Failed matching available minions with {0} pattern: {1}'
                     .format(expr_form, expr))
-            minions = expr
+            minions = []
         return minions
 
     def validate_tgt(self, valid, expr, expr_form):


### PR DESCRIPTION
This adds a pre-check function for the range matcher, fixing a KeyError
when one attempts to use the range matcher without the required module
being installed.

Resolves #9236.
