### PR TITLE
Allow `pkg.latest_version` to work for `i386`

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -22,7 +22,7 @@ __QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
 # Needs to be improved to somehow include ARM architectures
 __ALL_ARCHES = ('ia32e', 'x86_64', 'athlon', 'i686', 'i586', 'i486', 'i386',
                 'noarch')
-__SUFFIX_NOT_NEEDED = ('x86_64', 'noarch')
+__SUFFIX_NOT_NEEDED = ('i386', 'x86_64', 'noarch')
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'


### PR DESCRIPTION
```
[root@cent5-test /]# yum list *xz-devel*
Loaded plugins: fastestmirror
Loading mirror speeds from cached hostfile
 * epel: fedora-epel.mirror.lstn.net
Available Packages
xz-devel.i386                      4.999.9-0.3.beta.20091007git.el5                    base
xz-devel.x86_64                    4.999.9-0.3.beta.20091007git.el5                    base
```

```
[root@cent5-test testing]# salt-call pkg.latest_version xz-devel.x86_64
local:
    4.999.9-0.3.beta.20091007git.el5

[root@cent5-test testing]# salt-call pkg.latest_version xz-devel
local:
    4.999.9-0.3.beta.20091007git.el5

[root@cent5-test testing]# salt-call pkg.latest_version xz-devel.i386
local:
```

And with this fix:

```
[root@cent5-test /]# salt-call pkg.latest_version xz-devel.i386
local:
    4.999.9-0.3.beta.20091007git.el5
```
