### PR TITLE
Partially revert b3c2015a to add `exsel` back mapped to `self._all_minions`

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -402,6 +402,7 @@ class CkMinions(object):
                        'compound': self._check_compound_minions,
                        'ipcidr': self._check_ipcidr_minions,
                        'range': self._check_range_minions,
+                       'exsel': self._all_minions,
                        }[expr_form](expr)
         except Exception:
             log.exception(


### PR DESCRIPTION
On the refactoring done in `b3c2015a` I think the `exsel` key was removed as an error, or, it's dedicated function was not added. This makes the `integration.shell.matcher.MatchTest.test_exsel` test pass.
