### PR TITLE
fix check_state_result

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1174,7 +1174,7 @@ def check_state_result(running):
         if not isinstance(running[host], dict):
             return False
 
-        if host.find('_|-') == 4:
+        if host.find('_|-') >= 3:
             # This is a single ret, no host associated
             rets = running[host]
         else:


### PR DESCRIPTION
Running salt-call on the minion with the state.highstate command will return retcode 2 if you are using the pkg.installed function.

```
----------
    State: - pkg
    Name:      apache2
    Function:  installed
        Result:    True
        Comment:   Package apache2 is already installed
        Changes:   
----------
    State: - file
    Name:      /etc/apache2
    Function:  directory
        Result:    True
        Comment:   Directory /etc/apache2 is in the correct state
        Changes:   

Summary
------------
Succeeded: 2
Failed:    0
------------
Total:     2
root@chef-client:/usr/share/pyshared/salt/utils# echo $?
2
```

This is cause by the comparison in function check_state_result(): host.find('_|-') == 4. After debugging I was able to get the following output:

```
{'pkg_|-apache2_|-apache2_|-installed': {'comment': 'Package apache2 is already installed', '__run_num__': 0, 'changes': {}, 'name': 'apache2', 'result': True}
```

As you can see it is missing a host name but the value is still a dict and should store it in rets. So my suggestion is to match 3 or higher.
