### PR TITLE
`exsel` matching is no longer supported

### DIFF
--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -178,12 +178,6 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         self.assertIn('minion', data)
         self.assertIn('sub_minion', data)
 
-    def test_exsel(self):
-        data = self.run_salt('-X test.ping test.ping')
-        data = '\n'.join(data)
-        self.assertIn('minion', data)
-        self.assertIn('sub_minion', data)
-
     def test_ipcidr(self):
         subnets_data = self.run_salt('--out yaml \'*\' network.subnets')
         yaml_data = yaml.load('\n'.join(subnets_data))


### PR DESCRIPTION
In case we, in fact, no longer support `exsel` matching(see #9283), this will remove the test case.

Closes #9283.
