### PR TITLE
not env when minion not in the top.sls

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -40,11 +40,12 @@ def _sync(form, saltenv=None):
     if saltenv is None:
         # No environment passed, detect them based on gathering the top files
         # from the master
-        saltenv = 'base'
         st_ = salt.state.HighState(__opts__)
         top = st_.get_top()
         if top:
             saltenv = st_.top_matches(top).keys()
+        if not saltenv:
+            saltenv = 'base'
     if isinstance(saltenv, string_types):
         saltenv = saltenv.split(',')
     ret = []


### PR DESCRIPTION
if the top.sls in exist, but the minion is not in the top.sls, it can't sync_all
