### PR TITLE
Look for crontabs in /usr/lib/cron/tabs when on MacOS

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -129,6 +129,9 @@ def _get_cron_info():
     elif __grains__['os'] == 'Solaris':
         group = 'root'
         crontab_dir = '/var/spool/cron/crontabs'
+    elif __grains__['os'] == 'MacOS':
+        group = 'wheel'
+        crontab_dir = '/usr/lib/cron/tabs'
     else:
         group = 'root'
         crontab_dir = '/var/spool/cron'


### PR DESCRIPTION
Kept getting "Failed to change group to root" when setting a crontab, this fixes it
