### PR TITLE
use log.debug like all the other cloud drivers.

### DIFF
--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -79,7 +79,7 @@ def __virtual__():
     libcloudfuncs.__opts__ = __opts__
 
     if get_configured_provider() is False:
-        log.info(
+        log.debug(
             'There is no AWS cloud provider configuration available. Not '
             'loading module'
         )


### PR DESCRIPTION
This will cause the cli to not display the message that AWS is
not configured. This was confusing to users who are using the EC2
driver and get a message that AWS was not configured.
