### PR TITLE
Allow '_in' requisites to match both on ID and name

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -986,14 +986,22 @@ class State(object):
         for ext_chunk in ext:
             for name, body in ext_chunk.items():
                 if name not in high:
-                    errors.append(
-                        'Cannot extend ID {0} in "{1}:{2}". It is not part '
-                        'of the high state.'.format(
-                            name,
-                            body.get('__env__', 'base'),
-                            body.get('__sls__', 'base'))
-                        )
-                    continue
+                    state_type = next(
+                        x for x in body if not x.startswith('__')
+                    )
+                    # Check for a matching 'name' override in high data
+                    id_ = find_name(name, state_type, high)
+                    if id_:
+                        name = id_
+                    else:
+                        errors.append(
+                            'Cannot extend ID {0} in "{1}:{2}". It is not '
+                            'part of the high state.'.format(
+                                name,
+                                body.get('__env__', 'base'),
+                                body.get('__sls__', 'base'))
+                            )
+                        continue
                 for state, run in body.items():
                     if state.startswith('__'):
                         continue


### PR DESCRIPTION
Under the hood, all `_in` requisites are changed to extends of
their corresponding type. For example, a `require_in` for a given state
extends the target of the `require_in` with a `require` requisite,
pointing back at the state where the `require_in` was located.

When these extends are reconciled, only the ID declarations are examined
to see if there is a state matching the requisite's target, meaning that
these `_in` requisites cannot point to a `name` override in the same way
as their counterparts are able to. For more info, see https://github.com/saltstack/salt/issues/9061.

This commit modifies the extend reconciliation behavior. If there is no
ID declaration matching the requisite's target, then
`salt.state.find_name()` is used to search the high data for an ID
declaration with a `name` param matching the requisite target. If a
match is found, then the extend is reconciled against that matching ID.
If no match is found, then the requisite is not found the appropriate
error is returned.

Fixes #9061.
