### PR TITLE
Suppress tracebacks in states which manage files

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -390,34 +390,51 @@ def file(name,
                                                        env)
 
     # Gather the source file from the server
-    sfn, source_sum, comment = __salt__['file.get_managed'](cron_path,
-                                                            template,
-                                                            source,
-                                                            source_hash,
-                                                            owner,
-                                                            group,
-                                                            mode,
-                                                            env,
-                                                            context,
-                                                            defaults,
-                                                            **kwargs
-                                                            )
+    try:
+        sfn, source_sum, comment = __salt__['file.get_managed'](
+            cron_path,
+            template,
+            source,
+            source_hash,
+            owner,
+            group,
+            mode,
+            env,
+            context,
+            defaults,
+            **kwargs
+        )
+    except Exception as exc:
+        ret['result'] = False
+        ret['changes'] = {}
+        ret['comment'] = 'Unable to manage file: {0}'.format(exc)
+        return ret
+
     if comment:
         ret['comment'] = comment
         ret['result'] = False
         os.unlink(cron_path)
         return ret
 
-    ret = __salt__['file.manage_file'](cron_path,
-                                       sfn,
-                                       ret,
-                                       source,
-                                       source_sum,
-                                       owner,
-                                       group,
-                                       mode,
-                                       env,
-                                       backup)
+    try:
+        ret = __salt__['file.manage_file'](
+            cron_path,
+            sfn,
+            ret,
+            source,
+            source_sum,
+            owner,
+            group,
+            mode,
+            env,
+            backup
+        )
+    except Exception as exc:
+        ret['result'] = False
+        ret['changes'] = {}
+        ret['comment'] = 'Unable to manage file: {0}'.format(exc)
+        return ret
+
     if ret['changes']:
         ret['changes'] = {'diff': ret['changes']['diff']}
         ret['comment'] = 'Crontab for user {0} was updated'.format(user)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1181,36 +1181,47 @@ def managed(name,
     )
 
     # Gather the source file from the server
-    sfn, source_sum, comment_ = __salt__['file.get_managed'](
-        name,
-        template,
-        source,
-        source_hash,
-        user,
-        group,
-        mode,
-        __env__,
-        context,
-        defaults,
-        **kwargs
-    )
+    try:
+        sfn, source_sum, comment_ = __salt__['file.get_managed'](
+            name,
+            template,
+            source,
+            source_hash,
+            user,
+            group,
+            mode,
+            __env__,
+            context,
+            defaults,
+            **kwargs
+        )
+    except Exception as exc:
+        ret['changes'] = {}
+        return _error(ret, 'Unable to manage file: {0}'.format(exc))
+
     if comment_ and contents is None:
         return _error(ret, comment_)
     else:
-        return __salt__['file.manage_file'](name,
-                                            sfn,
-                                            ret,
-                                            source,
-                                            source_sum,
-                                            user,
-                                            group,
-                                            mode,
-                                            __env__,
-                                            backup,
-                                            template,
-                                            show_diff,
-                                            contents,
-                                            dir_mode)
+        try:
+            return __salt__['file.manage_file'](
+                name,
+                sfn,
+                ret,
+                source,
+                source_sum,
+                user,
+                group,
+                mode,
+                __env__,
+                backup,
+                template,
+                show_diff,
+                contents,
+                dir_mode
+            )
+        except Exception as exc:
+            ret['changes'] = {}
+            return _error(ret, 'Unable to manage file: {0}'.format(exc))
 
 
 def directory(name,


### PR DESCRIPTION
This captures exceptions encountered in states that run file.get_managed
or file.manage_file, suppressing the traceback and instead returning a
False result for the state, with a meaningful error message.

Fixes #9232.
