### PR TITLE
Fix bug in pkgrepo when switching to/from mirrorlist-based repo def

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import SaltInvocationError
 from salt.utils import namespaced_function as _namespaced_function
 from salt.modules.yumpkg import (mod_repo, _parse_repo_file, list_repos,
                                  get_repo, expand_repo_def, del_repo)


### PR DESCRIPTION
**NOTE: This is a cherry-pick of #9133 against 0.17**

This adds a check to ensure that both of mirrorlist and baseurl aren't
specified, and also deletes mirrorlist when baseurl is specified (and
vice-versa). Additionally, rather than returning a string containing
errors when they are encountered, raise an exception.
