### PR TITLE
Display templating error in cmd.script states

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -150,7 +150,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, SaltRenderError
 from salt._compat import string_types
 
 log = logging.getLogger(__name__)
@@ -723,14 +723,14 @@ def script(name,
 
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Command "{0}" would have been executed'
+            ret['comment'] = 'Command {0!r} would have been executed'
             ret['comment'] = ret['comment'].format(name)
             return _reinterpreted_state(ret) if stateful else ret
 
         # Wow, we passed the test, run this sucker!
         try:
             cmd_all = __salt__['cmd.script'](source, **cmd_kwargs)
-        except (CommandExecutionError, IOError) as err:
+        except (CommandExecutionError, SaltRenderError, IOError) as err:
             ret['comment'] = str(err)
             return ret
 
@@ -741,9 +741,9 @@ def script(name,
             ret['result'] = not bool(cmd_all['retcode'])
         if ret.get('changes', {}).get('cache_error'):
             ret['comment'] = 'Unable to cache script {0} from env ' \
-                             '\'{1}\''.format(source, env)
+                             '{1!r}'.format(source, env)
         else:
-            ret['comment'] = 'Command "{0}" run'.format(name)
+            ret['comment'] = 'Command {0!r} run'.format(name)
         return _reinterpreted_state(ret) if stateful else ret
 
     finally:

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -86,7 +86,8 @@ def wrap_tmpl_func(render_str):
                 output = os.linesep.join(output.splitlines())
 
         except SaltRenderError as exc:
-            return dict(result=False, data=str(exc))
+            #return dict(result=False, data=str(exc))
+            raise
         except Exception:
             return dict(result=False, data=traceback.format_exc())
         else:


### PR DESCRIPTION
In order to fix this, I made a slight change to the templating system which needs to be discussed and signed off on before this is merged. Before, the templating system was catching templating errors and returning a False result. This result is then logged on the minion by state.py.

The change I made was to raise the exception from the templating system, rather than having it return an error to whatever invoked the templating system.

So, is this the right approach, or could it potentially cause other problems in the state system? If this is a good change, I can make another commit that gets rid of the commented-out line that I left in salt/utils/template.py.
