### PR TITLE
Fix language for "failed to update" packages, Fix #9348

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -731,11 +731,12 @@ def latest(
                     'comment': ' '.join(comments)}
         else:
             if len(targets) > 10:
-                comment = 'All targeted {0} packages failed to update.'\
-                    .format(len(targets))
+                comment = ('{0} targeted packages failed to update. '
+                           'See debug log for details.'.format(len(targets)))
             elif len(targets) > 1:
-                comment = 'All targeted packages failed to update: ' \
-                          '({0}).'.format(', '.join(sorted(targets.keys())))
+                comment = ('The following targeted packages failed to update. '
+                           'See debug log for details: ({0}).'
+                           .format(', '.join(sorted(targets.keys()))))
             else:
                 comment = 'Package {0} failed to ' \
                           'update.'.format(targets.keys()[0])

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -688,11 +688,11 @@ def latest(
             # No need to refresh, if a refresh was necessary it would have been
             # performed above when pkg.latest_version was run.
             changes = __salt__['pkg.install'](name,
-                                            refresh=False,
-                                            fromrepo=fromrepo,
-                                            skip_verify=skip_verify,
-                                            pkgs=targeted_pkgs,
-                                            **kwargs)
+                                              refresh=False,
+                                              fromrepo=fromrepo,
+                                              skip_verify=skip_verify,
+                                              pkgs=targeted_pkgs,
+                                              **kwargs)
         except CommandExecutionError as exc:
             return {'name': name,
                     'changes': {},


### PR DESCRIPTION
The "All" was quite misleading.
