### PR TITLE
Quiet the logstash handler loading message

### DIFF
--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -139,7 +139,7 @@ __virtualname__ = 'logstash'
 def __virtual__():
     if not any(['logstash_udp_handler' in __opts__,
                 'logstash_zmq_handler' in __opts__]):
-        log.debug(
+        log.trace(
             'None of the required configuration sections, '
             '\'logstash_udp_handler\' and \'logstash_zmq_handler\', '
             'were found the in the configuration. Not loading the Logstash '


### PR DESCRIPTION
@s0undt3ch ping.  If you think this is a bad change, I'd be happy to
discuss it with you, but 99% of salt users don't use that handler (as
far as I know) and it's just garbage in the debug log.
