### PR TITLE
Error message in copyfile now uses dest and not source

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -622,7 +622,7 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
         )
     if not os.path.isdir(os.path.dirname(dest)):
         raise IOError(
-            '[Errno 2] No such file or directory: {0}'.format(source)
+            '[Errno 2] No such file or directory: {0}'.format(dest)
         )
     bname = os.path.basename(dest)
     dname = os.path.dirname(os.path.abspath(dest))


### PR DESCRIPTION
The error refers to a missing directory at the destination, but mistakenly refers to the source.  Makes debugging quite confusing.
