### PR TITLE
Change Powershell command to trust all scripts run by salt

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -272,7 +272,7 @@ def _run(cmd,
         # The last item in the list [-1] is the current method.
         # The third item[2] in each tuple is the name of that method.
         if stack[-2][2] == 'script':
-            cmd = 'Powershell -File ' + cmd
+            cmd = 'Powershell -executionpolicy bypass -File ' + cmd
         else:
             cmd = 'Powershell ' + cmd
 


### PR DESCRIPTION
Adding these arguments allows all scripts to be executed on the destination machine.  This prevents us from having to do Set-ExecutionPolicy on every minion. 
