### PR TITLE
Add sync & async options for master_call in RunnerClient and WheelClient

### DIFF
--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -153,9 +153,25 @@ class APIClient(object):
         Expects that one of the kwargs is key 'fun' whose value is the namestring
         of the function to call
         '''
+        kwargs['mode'] = 'async'
         return self.runnerClient.master_call(**kwargs)
 
-    runner_sync = runner_async  # always runner async, so works in either mode
+    def runner_sync(self, **kwargs):
+        '''
+        Wrap RunnerClient for executing :ref:`runner modules <all-salt.runners>`
+        Expects that one of the kwargs is key 'fun' whose value is the namestring
+        of the function to call
+        '''
+        return self.runnerClient.master_call(**kwargs)
+
+    def wheel_async(self, **kwargs):
+        '''
+        Wrap Wheel to enable executing :ref:`wheel modules <all-salt.wheel>`
+        Expects that one of the kwargs is key 'fun' whose value is the namestring
+        of the function to call
+        '''
+        kwargs['mode'] = 'async'
+        return self.wheelClient.master_call(**kwargs)
 
     def wheel_sync(self, **kwargs):
         '''
@@ -164,8 +180,6 @@ class APIClient(object):
         of the function to call
         '''
         return self.wheelClient.master_call(**kwargs)
-
-    wheel_async = wheel_sync  # always wheel_sync, so it works either mode
 
     def signature(self, cmd):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -2045,10 +2045,10 @@ class ClearFuncs(object):
         if not token:
             raise salt.exceptions.TokenAuthenticationError()
 
-        if token['eauth'] not in self.opts['external_auth']:
+        if not token['eauth'] in self.opts['external_auth']:
             raise salt.exceptions.TokenAuthenticationError()
 
-        if token['name'] not in self.opts['external_auth'][token['eauth']]:
+        if not token['name'] in self.opts['external_auth'][token['eauth']]:
             raise salt.exceptions.TokenAuthenticationError()
 
         good = check_func(
@@ -2066,10 +2066,10 @@ class ClearFuncs(object):
         '''
         Check a clear_load dictionary for valid eauth credentials
         '''
-        if 'eauth' not in clear_load:
+        if not 'eauth' in clear_load:
             raise salt.exceptions.EauthAuthenticationError()
 
-        if clear_load['eauth'] not in self.opts['external_auth']:
+        if not clear_load['eauth'] in self.opts['external_auth']:
             raise salt.exceptions.EauthAuthenticationError()
 
         name = self.loadauth.load_name(clear_load)

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -169,6 +169,11 @@ class RunnerClient(object):
                 'password': 'saltdev',
                 'eauth': 'pam',
             })
+
+        Synchronous or asyncronous operation can be configured with the
+        ``mode`` key. If ``mode`` is ``sync`` then :py:meth:`low` will be
+        called. If ``mode`` is ``async`` then :py:meth:`async` will be
+        called.
         '''
         load = kwargs
         load['cmd'] = 'runner'

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -94,6 +94,11 @@ class WheelClient(object):
                 'user': 'saltdev'
             },
             'tag': 'salt/wheel/20131219224744416681'}
+
+        Synchronous or asyncronous operation can be configured with the
+        ``mode`` key. If ``mode`` is ``sync`` then :py:meth:`call_func`
+        will be called. If ``mode`` is ``async`` then :py:meth:`call_func`
+        will be called.
         '''
         load = kwargs
         load['cmd'] = 'wheel'

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -5,6 +5,8 @@ Set up the Salt integration test suite
 '''
 
 # Import Python libs
+import errno
+import re
 import os
 import sys
 import time

--- a/tests/integration/runner/__init__.py
+++ b/tests/integration/runner/__init__.py
@@ -32,6 +32,15 @@ class RunnerModuleTest(integration.ClientCase):
             'password': 'saltdev',
         })
 
+    def _get_token(self, low):
+        import salt.auth
+
+        opts = self.get_opts()
+        self.mkdir_p(os.path.join(opts['root_dir'], 'cache', 'tokens'))
+
+        auth = salt.auth.LoadAuth(opts)
+        return auth.mk_token(low)
+
     def test_token(self):
         '''
         Test executing master_call with lowdata
@@ -39,13 +48,7 @@ class RunnerModuleTest(integration.ClientCase):
         The choice of using error.error for this is arbitrary and should be
         changed to some mocked function that is more testing friendly.
         '''
-        import salt.auth
-
-        opts = self.get_opts()
-        self.mkdir_p(os.path.join(opts['root_dir'], 'cache', 'tokens'))
-
-        auth = salt.auth.LoadAuth(opts)
-        token = auth.mk_token({
+        token = self._get_token({
             'username': 'saltdev',
             'password': 'saltdev',
             'eauth': 'auto',

--- a/tests/integration/runner/__init__.py
+++ b/tests/integration/runner/__init__.py
@@ -32,6 +32,22 @@ class RunnerModuleTest(integration.ClientCase):
             'password': 'saltdev',
         })
 
+    def test_eauth_async(self):
+        '''
+        Test executing async master_call with lowdata
+
+        The choice of using error.error for this is arbitrary and should be
+        changed to some mocked function that is more testing friendly.
+        '''
+        self.runner.master_call(**{
+            'client': 'runner',
+            'fun': 'error.error',
+            'eauth': 'auto',
+            'username': 'saltdev',
+            'password': 'saltdev',
+            'mode': 'async',
+        })
+
     def _get_token(self, low):
         import salt.auth
 
@@ -58,6 +74,26 @@ class RunnerModuleTest(integration.ClientCase):
             'client': 'runner',
             'fun': 'error.error',
             'token': token['token'],
+        })
+
+    def test_token_async(self):
+        '''
+        Test executing master_call with lowdata
+
+        The choice of using error.error for this is arbitrary and should be
+        changed to some mocked function that is more testing friendly.
+        '''
+        token = self._get_token({
+            'username': 'saltdev',
+            'password': 'saltdev',
+            'eauth': 'auto',
+        })
+
+        self.runner.master_call(**{
+            'client': 'runner',
+            'fun': 'error.error',
+            'token': token['token'],
+            'mode': 'async',
         })
 
 

--- a/tests/integration/wheel/__init__.py
+++ b/tests/integration/wheel/__init__.py
@@ -32,6 +32,22 @@ class WheelModuleTest(integration.ClientCase):
             'password': 'saltdev',
         })
 
+    def test_eauth_async(self):
+        '''
+        Test executing async master_call with lowdata
+
+        The choice of using key.list_all for this is arbitrary and should be
+        changed to some mocked function that is more testing friendly.
+        '''
+        self.wheel.master_call(**{
+            'client': 'wheel',
+            'fun': 'key.list_all',
+            'eauth': 'auto',
+            'username': 'saltdev',
+            'password': 'saltdev',
+            'mode': 'async',
+        })
+
     def _get_token(self, low):
         import salt.auth
 
@@ -60,6 +76,14 @@ class WheelModuleTest(integration.ClientCase):
             'token': token['token'],
         })
 
+    def test_token_async(self):
+        '''
+        Test executing async master_call with lowdata
+
+        The choice of using key.list_all for this is arbitrary and should be
+        changed to some mocked function that is more testing friendly.
+        '''
+        token = self._get_token({
             'username': 'saltdev',
             'password': 'saltdev',
             'eauth': 'auto',
@@ -69,7 +93,9 @@ class WheelModuleTest(integration.ClientCase):
             'client': 'wheel',
             'fun': 'key.list_all',
             'token': token['token'],
+            'mode': 'async',
         })
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/wheel/__init__.py
+++ b/tests/integration/wheel/__init__.py
@@ -32,6 +32,15 @@ class WheelModuleTest(integration.ClientCase):
             'password': 'saltdev',
         })
 
+    def _get_token(self, low):
+        import salt.auth
+
+        opts = self.get_opts()
+        self.mkdir_p(os.path.join(opts['root_dir'], 'cache', 'tokens'))
+
+        auth = salt.auth.LoadAuth(opts)
+        return auth.mk_token(low)
+
     def test_token(self):
         '''
         Test executing master_call with lowdata
@@ -39,13 +48,18 @@ class WheelModuleTest(integration.ClientCase):
         The choice of using key.list_all for this is arbitrary and should be
         changed to some mocked function that is more testing friendly.
         '''
-        import salt.auth
+        token = self._get_token({
+            'username': 'saltdev',
+            'password': 'saltdev',
+            'eauth': 'auto',
+        })
 
-        opts = self.get_opts()
-        self.mkdir_p(os.path.join(opts['root_dir'], 'cache', 'tokens'))
+        self.wheel.master_call(**{
+            'client': 'wheel',
+            'fun': 'key.list_all',
+            'token': token['token'],
+        })
 
-        auth = salt.auth.LoadAuth(opts)
-        token = auth.mk_token({
             'username': 'saltdev',
             'password': 'saltdev',
             'eauth': 'auto',

--- a/tests/integration/wheel/__init__.py
+++ b/tests/integration/wheel/__init__.py
@@ -17,7 +17,7 @@ class WheelModuleTest(integration.ClientCase):
         '''
         self.wheel = salt.wheel.Wheel(self.get_opts())
 
-    def test_master_call(self):
+    def test_eauth(self):
         '''
         Test executing master_call with lowdata
 


### PR DESCRIPTION
This pull req fixes #9324.

tl;dr: This adds a `mode` key to `clear_load` in `master_call` for both RunnerClient and WheelClient which can be set to `sync` or `async`.

@thatch45 & @SmithSamuelM this change is not backward compatible for Halite because it changes the default to 'sync' for RunnerClient(). I figure this is the easier route because we have community and customers that are using WheelClient() in production (which defaults to 'sync').

FWIW, these changes pass the master_call integration tests from yesterday. (Not that those tests are exactly battle-hardened...)
