### PR TITLE
Move the check_max_open_files into loop_interval.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -230,6 +230,10 @@ class Master(SMaster):
                 log.error(
                     'Exception {0} occurred in file server update'.format(exc)
                 )
+
+            # check how close to FD limits you are
+            salt.utils.verify.check_max_open_files(self.opts)
+
             try:
                 schedule.eval()
                 # Check if scheduler requires lower loop interval than
@@ -1777,15 +1781,13 @@ class ClearFuncs(object):
         This method fires an event over the master event manager. The event is
         tagged "auth" and returns a dict with information about the auth
         event
-        '''
-        # 0. Check for max open files
-        # 1. Verify that the key we are receiving matches the stored key
-        # 2. Store the key if it is not there
-        # 3. make an RSA key with the pub key
-        # 4. encrypt the AES key as an encrypted salt.payload
-        # 5. package the return and return it
 
-        salt.utils.verify.check_max_open_files(self.opts)
+        # Verify that the key we are receiving matches the stored key
+        # Store the key if it is not there
+        # Make an RSA key with the pub key
+        # Encrypt the AES key as an encrypted salt.payload
+        # Package the return and return it
+        '''
 
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             log.info(


### PR DESCRIPTION
Since check_max_open_files has no bearing on wether we accept the minion or not, there is no reason to list the directory on every auth call. With this mechanism it is a "fixed cost" since it will run at loop_interval instead of on each auth call
