### PR TITLE
Full rewrite of memcached state and execution module

### DIFF
--- a/doc/ref/modules/all/salt.modules.memcached.rst
+++ b/doc/ref/modules/all/salt.modules.memcached.rst
@@ -4,3 +4,4 @@ salt.modules.memcached
 
 .. automodule:: salt.modules.memcached
     :members:
+    :exclude-members: incr, decr


### PR DESCRIPTION
This pull request makes the newly-added memcached state and execution module more "salty". The old states were not actually stateful, and literally just wrapped each of the functions in the execution module.

Resolves #9363.
Resolves #9093.
