### PR TITLE
incron module: rm unused import of random

### DIFF
--- a/salt/modules/incron.py
+++ b/salt/modules/incron.py
@@ -6,7 +6,6 @@ Work with incron
 # Import python libs
 import logging
 import os
-import random
 
 # Import salt libs
 import salt.utils


### PR DESCRIPTION
```
************* Module salt.modules.incron
salt/modules/incron.py:9: [W0611(unused-import), ] Unused import random
```
