### PR TITLE
Better trace for nested jinja errors

### DIFF
--- a/tests/unit/templates/files/test/hello_import_error
+++ b/tests/unit/templates/files/test/hello_import_error
@@ -1,0 +1,2 @@
+{% from 'macroerror' import mymacro -%}
+{{ mymacro('Hey') ~ mymacro(a|default('a'), b|default('b')) }}

--- a/tests/unit/templates/files/test/hello_import_undefined
+++ b/tests/unit/templates/files/test/hello_import_undefined
@@ -1,0 +1,2 @@
+{% from 'macroundefined' import mymacro -%}
+{{ mymacro() }}

--- a/tests/unit/templates/files/test/macroerror
+++ b/tests/unit/templates/files/test/macroerror
@@ -1,0 +1,4 @@
+# macro
+{% macro mymacro(greeting, greetee='world') -} <-- error is here
+{{ greeting ~ ' ' ~ greetee }} !
+{%- endmacro %}

--- a/tests/unit/templates/files/test/macroundefined
+++ b/tests/unit/templates/files/test/macroundefined
@@ -1,0 +1,3 @@
+{% macro mymacro() -%}
+{{b.greetee}} <-- error is here
+{%- endmacro %}


### PR DESCRIPTION
When we have an error in a jinja macro, it is something hard to go to the real underlying template when  you use extensibly macros.

this conditionnaly show the macro line when we have an error in a macro and not directly in the rendered template
