### PR TITLE
Again, more robustness for zcbuildout tests

### DIFF
--- a/tests/unit/modules/zcbuildout_test.py
+++ b/tests/unit/modules/zcbuildout_test.py
@@ -65,6 +65,15 @@ class Base(TestCase):
                 download_to(url, dest)
             except urllib2.URLError:
                 log.debug('Failed to download {0}'.format(url))
+        # creating a new setuptools install
+        cls.ppy_st = os.path.join(cls.rdir, 'psetuptools')
+        cls.py_st = os.path.join(cls.ppy_st, 'bin', 'python')
+        ret1 = buildout._Popen((
+            'virtualenv --no-site-packages {0};'
+            '{0}/bin/pip install -U setuptools; '
+            '{0}/bin/easy_install -U distribute;'
+        ).format(cls.ppy_st))
+        assert ret1['retcode'] == 0
 
     @classmethod
     def tearDownClass(cls):
@@ -281,19 +290,9 @@ class BuildoutOnlineTestCase(Base):
     def setUpClass(cls):
         super(BuildoutOnlineTestCase, cls).setUpClass()
         cls.ppy_dis = os.path.join(cls.rdir, 'pdistibute')
-        cls.ppy_st = os.path.join(cls.rdir, 'psetuptools')
         cls.ppy_blank = os.path.join(cls.rdir, 'pblank')
         cls.py_dis = os.path.join(cls.ppy_dis, 'bin', 'python')
-        cls.py_st = os.path.join(cls.ppy_st, 'bin', 'python')
         cls.py_blank = os.path.join(cls.ppy_blank, 'bin', 'python')
-        # creating a new setuptools install
-        ret1 = buildout._Popen((
-            'virtualenv --no-site-packages {0};'
-            '{0}/bin/pip install -U setuptools; '
-            '{0}/bin/easy_install -U distribute;'
-        ).format(cls.ppy_st))
-        assert ret1['retcode'] == 0
-
         # creating a distribute based install
         try:
             ret20 = buildout._Popen((

--- a/tests/unit/states/zcbuildout_test.py
+++ b/tests/unit/states/zcbuildout_test.py
@@ -52,7 +52,7 @@ class BuildoutTestCase(Base):
     @requires_network()
     def test_quiet(self):
         c_dir = os.path.join(self.tdir, 'c')
-        cret = buildout.installed(c_dir, quiet=True)
+        cret = buildout.installed(c_dir, python=self.py_st, quiet=True)
         self.assertTrue(cret['result'])
         self.assertFalse('OUTPUT:' in cret['comment'])
         self.assertFalse('Log summary:' in cret['comment'])
@@ -60,7 +60,7 @@ class BuildoutTestCase(Base):
     @requires_network()
     def test_error(self):
         b_dir = os.path.join(self.tdir, 'e')
-        ret = buildout.installed(b_dir)
+        ret = buildout.installed(b_dir, python=self.py_st)
         self.assertTrue(
             'We did not get any expectable '
             'answer from buildout'
@@ -74,16 +74,20 @@ class BuildoutTestCase(Base):
     @requires_network()
     def test_installed(self):
         b_dir = os.path.join(self.tdir, 'b')
-        ret = buildout.installed(b_dir, onlyif='/bin/false')
+        ret = buildout.installed(b_dir,
+                                 python=self.py_st,
+                                 onlyif='/bin/false')
         self.assertEqual(ret['comment'], '\nonlyif execution failed')
         self.assertEqual(ret['result'], True)
         self.assertTrue('/b' in ret['name'])
         b_dir = os.path.join(self.tdir, 'b')
-        ret = buildout.installed(b_dir, unless='/bin/true')
+        ret = buildout.installed(b_dir,
+                                 python=self.py_st,
+                                 unless='/bin/true')
         self.assertEqual(ret['comment'], '\nunless execution succeeded')
         self.assertEqual(ret['result'], True)
         self.assertTrue('/b' in ret['name'])
-        ret = buildout.installed(b_dir)
+        ret = buildout.installed(b_dir, python=self.py_st)
         self.assertEqual(ret['result'], True)
         self.assertTrue('OUTPUT:' in ret['comment'])
         self.assertTrue('Log summary:' in ret['comment'])


### PR DESCRIPTION
All is said in the title, fix the virtualenv to use even for basic api tests to ensure what's in the test environement
