### PR TITLE
Don't run event tests on systems that can't support them.

### DIFF
--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -76,7 +76,7 @@ def eventsender_process(data, tag, wait=0):
         proc.terminate()
         proc.join()
 
-#@skipIf(NO_LONG_IPC, "This system does not support long IPC paths. Skipping event tests!")
+@skipIf(NO_LONG_IPC, "This system does not support long IPC paths. Skipping event tests!")
 class TestSaltEvent(TestCase):
     def setUp(self):
         if not os.path.exists(SOCK_DIR):

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -13,11 +13,12 @@
 import os
 import hashlib
 import time
+import zmq
 from contextlib import contextmanager
 from multiprocessing import Process
 
 # Import Salt Testing libs
-from salttesting import expectedFailure
+from salttesting import (expectedFailure, skipIf)
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
@@ -28,6 +29,8 @@ from salt.utils import event
 
 SOCK_DIR = os.path.join(integration.TMP, 'test-socks')
 
+if getattr(zmq, 'IPC_PATH_MAX_LEN', 103) >= 103:
+    NO_LONG_IPC = True
 
 @contextmanager
 def eventpublisher_process():
@@ -43,7 +46,6 @@ def eventpublisher_process():
     finally:
         proc.terminate()
         proc.join()
-
 
 class EventSender(Process):
     def __init__(self, data, tag, wait):
@@ -74,7 +76,7 @@ def eventsender_process(data, tag, wait=0):
         proc.terminate()
         proc.join()
 
-
+#@skipIf(NO_LONG_IPC, "This system does not support long IPC paths. Skipping event tests!")
 class TestSaltEvent(TestCase):
     def setUp(self):
         if not os.path.exists(SOCK_DIR):

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -29,7 +29,8 @@ from salt.utils import event
 
 SOCK_DIR = os.path.join(integration.TMP, 'test-socks')
 
-if getattr(zmq, 'IPC_PATH_MAX_LEN', 103) >= 103:
+NO_LONG_IPC = False
+if getattr(zmq, 'IPC_PATH_MAX_LEN', 103) <= 103:
     NO_LONG_IPC = True
 
 @contextmanager


### PR DESCRIPTION
These tests have always failed under OS X because it doesn't support long IPC paths. 

@s0und3ch, could you put some eyes on this to make sure this approach seems sensible to you?
