### PR TITLE
Typo fix in troubleshooting index, and more additions to master/minion troubleshooting.

### DIFF
--- a/doc/topics/troubleshooting/index.rst
+++ b/doc/topics/troubleshooting/index.rst
@@ -225,7 +225,7 @@ sure the master of minion are running in the foreground:
     salt-master -l debug
     salt-minion -l debug
 
-The pass the signal to the master or minion when it seems to be unresponsive:
+Then pass the signal to the master or minion when it seems to be unresponsive:
 
 .. code-block:: bash
 

--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -2,6 +2,24 @@
 Troubleshooting the Salt Master
 ===============================
 
+Running in the Foreground
+=========================
+
+A great deal of information is available via the debug logging system, if you
+are having issues with minions connecting or not starting run the master in
+the foreground:
+
+.. code-block:: bash
+
+  salt-master -l debug
+
+Anyone wanting to run Salt daemons via a process supervisor such as `monit`_,
+`runit`_, or `supervisord`_, should omit the ``-d`` argument to the daemons and
+run them in the foreground.
+
+.. _`monit`: http://mmonit.com/monit/
+.. _`runit`: http://smarden.org/runit/
+.. _`supervisord`: http://supervisord.org/         
 
 What Ports does the Master Need Open?
 =====================================
@@ -20,3 +38,94 @@ Salt.
 
 .. _`SELinux`: https://en.wikipedia.org/wiki/Security-Enhanced_Linux
 .. _`AppArmor`: http://wiki.apparmor.net/index.php/Main_Page
+
+Too many open files
+===================
+
+The salt-master needs at least 2 sockets per host that connects to it, one for
+the Publisher and one for response port. Thus, large installations may, upon
+scaling up the number of minions accessing a given master, encounter:
+
+.. code-block:: bash
+
+    12:45:29,289 [salt.master    ][INFO    ] Starting Salt worker process 38
+    Too many open files
+    sock != -1 (tcp_listener.cpp:335)
+
+The solution to this would be to check the number of files allowed to be
+opened by the user running salt-master (root by default):
+
+.. code-block:: bash
+
+    [root@salt-master ~]# ulimit -n
+    1024
+
+And modify that value to be at least equal to the number of minions x 2.
+This setting can be changed in limits.conf as the nofile value(s),
+and activated upon new a login of the specified user.
+
+So, an environment with 1800 minions, would need 1800 x 2 = 3600 as a minimum.
+
+Salt Master Stops Responding
+============================
+
+There are known bugs with ZeroMQ versions less than 2.1.11 which can cause the
+Salt master to not respond properly. If you're running a ZeroMQ version greater
+than or equal to 2.1.9, you can work around the bug by setting the sysctls
+``net.core.rmem_max`` and ``net.core.wmem_max`` to 16777216. Next, set the third
+field in ``net.ipv4.tcp_rmem`` and ``net.ipv4.tcp_wmem`` to at least 16777216.
+
+You can do it manually with something like:
+
+.. code-block:: bash
+
+    # echo 16777216 > /proc/sys/net/core/rmem_max
+    # echo 16777216 > /proc/sys/net/core/wmem_max
+    # echo "4096 87380 16777216" > /proc/sys/net/ipv4/tcp_rmem
+    # echo "4096 87380 16777216" > /proc/sys/net/ipv4/tcp_wmem
+
+Or with the following Salt state:
+
+.. code-block:: yaml
+       :linenos:
+
+    net.core.rmem_max:
+      sysctl:
+        - present
+        - value: 16777216
+
+    net.core.wmem_max:
+      sysctl:
+        - present
+        - value: 16777216
+
+    net.ipv4.tcp_rmem:
+      sysctl:
+        - present
+        - value: 4096 87380 16777216
+
+    net.ipv4.tcp_wmem:
+      sysctl:
+        - present
+        - value: 4096 87380 16777216
+
+Live Python Debug Output
+========================
+
+If the master seems to be unresponsive, a SIGUSR1 can be passed to
+the processes to display where in the code they are running. If encountering a
+situation like this, this debug information can be invaluable. First make
+sure the master is running in the foreground:
+
+.. code-block:: bash
+
+    salt-master -l debug
+
+Then pass the signal to the master when it seems to be unresponsive:
+
+.. code-block:: bash
+
+    killall -SIGUSR1 salt-master
+
+When filing an issue or sending questions to the mailing list for a problem
+with an unresponsive daemon this information can be invaluable.

--- a/doc/topics/troubleshooting/minion.rst
+++ b/doc/topics/troubleshooting/minion.rst
@@ -2,6 +2,26 @@
 Troubleshooting the Salt Minion
 ===============================
 
+Running in the Foreground
+=========================
+
+A great deal of information is available via the debug logging system, if you
+are having issues with minions connecting or not starting run the minion in
+the foreground:
+
+.. code-block:: bash
+
+  salt-minion -l debug
+
+Anyone wanting to run Salt daemons via a process supervisor such as `monit`_,
+`runit`_, or `supervisord`_, should omit the ``-d`` argument to the daemons and
+run them in the foreground.
+
+.. _`monit`: http://mmonit.com/monit/
+.. _`runit`: http://smarden.org/runit/
+.. _`supervisord`: http://supervisord.org/
+
+
 What Ports does the Minion Need Open?
 =====================================
 
@@ -26,3 +46,50 @@ Salt.
 
 .. _`SELinux`: https://en.wikipedia.org/wiki/Security-Enhanced_Linux
 .. _`AppArmor`: http://wiki.apparmor.net/index.php/Main_Page
+
+Using salt-call
+===============
+
+The ``salt-call`` command was originally developed for aiding in the development
+of new Salt modules. Since then, many applications have been developed for
+running any Salt module locally on a minion. These range from the original
+intent of salt-call, development assistance, to gathering more verbose output
+from calls like :mod:`state.highstate <salt.modules.state.highstate>`.
+
+When creating your state tree, it is generally recommended to invoke
+:mod:`state.highstate <salt.modules.state.highstate>` with ``salt-call``. This
+displays far more information about the highstate execution than calling it
+remotely. For even more verbosity, increase the loglevel with the same argument
+as ``salt-minion``:
+
+.. code-block:: bash
+
+    salt-call -l debug state.highstate
+
+The main difference between using ``salt`` and using ``salt-call`` is that
+``salt-call`` is run from the minion, and it only runs the selected function on
+that minion. By contrast, ``salt`` is run from the master, and requires you to
+specify the minions on which to run the command using salt's :doc:`targeting
+system </topics/targeting/index>`.
+
+Live Python Debug Output
+========================
+
+If the master seems to be unresponsive, a SIGUSR1 can be passed to
+the processes to display where in the code they are running. If encountering a
+situation like this, this debug information can be invaluable. First make
+sure the minion is running in the foreground:
+
+.. code-block:: bash
+
+    salt-minion -l debug
+
+Then pass the signal to the minion when it seems to be unresponsive:
+
+.. code-block:: bash
+
+    killall -SIGUSR1 salt-minion
+
+When filing an issue or sending questions to the mailing list for a problem
+with an unresponsive daemon this information can be invaluable.
+


### PR DESCRIPTION
Fixed a typo in the troubleshooting index, copied over some content from the index to both the master and the minion, and cleaned them up to be more relevant to each.
