### PR TITLE
Adding ability to manage a system incrontab.  Change state identifier from path to a name variable.

### DIFF
--- a/salt/states/incron.py
+++ b/salt/states/incron.py
@@ -14,9 +14,10 @@ factor, so if an existing cron that looks like this:
 
 .. code-block:: yaml
 
-    /home/user:
+    Watch for modifications in /home/user:
         incron.present:
             - user: root
+            - path: /home/user
             - mask:
                 - IN_MODIFY
             - cmd: 'echo "$$ $@"'
@@ -25,9 +26,10 @@ Is changed to this:
 
 .. code-block:: yaml
 
-    /home/user:
+    Watch for modifications and access in /home/user:
         incron.present:
             - user: root
+            - path: /home/user
             - mask:
                 - IN_MODIFY
                 - IN_ACCESS
@@ -85,6 +87,7 @@ def _get_cron_info():
 
 
 def present(name,
+            path,
             mask,
             cmd,
             user='root'):
@@ -96,6 +99,9 @@ def present(name,
     ``man 5 incrontab``.
 
     name
+        Unique comment describing the entry
+
+    path
         The path that should be watched
 
     user
@@ -109,7 +115,6 @@ def present(name,
         The cmd that should be executed
 
     '''
-    path = name
     mask = ',' . join(mask)
 
     ret = {'changes': {},
@@ -155,6 +160,7 @@ def present(name,
 
 
 def absent(name,
+           path,
            mask,
            cmd,
            user='root'):
@@ -163,6 +169,9 @@ def absent(name,
     the name is matched when removing a incron job.
 
     name
+        Unique comment describing the entry
+
+    path
         The path that should be watched
 
     user
@@ -177,7 +186,6 @@ def absent(name,
 
     '''
 
-    path = name
     mask = ',' . join(mask)
 
     ret = {'name': name,


### PR DESCRIPTION
Adding ability to manage a system incrontab via /etc/incron.d/salt.  
Changing the states to use a name instead of using path as the identifier, to allow multiple entries for the same path with different cmds and masks.
