### PR TITLE
Alias cmd.watch to cmd.wait

### DIFF
--- a/doc/ref/states/all/salt.states.cmd.rst
+++ b/doc/ref/states/all/salt.states.cmd.rst
@@ -4,3 +4,4 @@ salt.states.cmd
 
 .. automodule:: salt.states.cmd
     :members:
+    :exclude-members: watch

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -155,10 +155,6 @@ from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
-__func_alias__ = {
-    'wait': 'watch'
-}
-
 
 def _reinterpreted_state(state):
     '''
@@ -332,6 +328,9 @@ def wait(name,
             'result': True,
             'comment': ''}
 
+
+# Alias "cmd.watch" to "cmd.wait", as this is a common misconfiguration
+watch = wait
 
 def wait_script(name,
                 source=None,


### PR DESCRIPTION
The current method of aliasing causes the docs to display cmd.watch instead of cmd.wait, when it should be the other way around (cmd.watch being a "hidden" alias).
