### PR TITLE
Make sure execute bit set on dirs created by file.managed with makedirs==True

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2317,7 +2317,17 @@ def manage_file(name,
 
             if not os.path.isdir(os.path.dirname(name)):
                 if makedirs:
-                    makedirs(name, user=user, group=group, mode=dir_mode or mode)
+                    if dir_mode is None:
+                        # Add execute bit to each nonzero digit in the mode, if
+                        # dir_mode was not specified. Otherwise, any
+                        # directories created with makedirs() below can't be
+                        # listed via a shell.
+                        mode_list = [x for x in str(mode)][-3:]
+                        for idx in xrange(len(mode_list)):
+                            if mode_list[idx] != '0':
+                                mode_list[idx] = str(int(mode_list[idx]) | 1)
+                        dir_mode = ''.join(mode_list)
+                    makedirs(name, user=user, group=group, mode=dir_mode)
                 else:
                     __clean_tmp(sfn)
                     return _error(ret, 'Parent directory not present')


### PR DESCRIPTION
When a file.managed state is created with makedirs == True and no
dir_mode specified, the file mode is used as the mode for any parent
directories created by the state. However, this means that if you have a
file mode of 600, the parent dirs are also created with that mode,
making them unable to be traversed via CLI by the owner of the
file/directory that is being managed.

This commit checks each digit of the mode and adds the execute bit if
the digit is nonzero, making the mode 700 if the mode of the file is
600. 640 becomes 750, 644 becomes 755, etc.
