### PR TITLE
Master troubleshooting guide update regarding ulimit refresh.

### DIFF
--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -79,6 +79,10 @@ if running Salt as the root user:
     wish to increase them if your Salt master is doing more than just running
     Salt.
 
+After making these changes, ``ulimit -n`` will still show a value of 1024. 
+You must re-establish your session as the specified user or the output will
+remain the same.
+
 Salt Master Stops Responding
 ============================
 


### PR DESCRIPTION
Added a line explaining that the user would need to re-establish their sessions as the user they modified the limits for in the master troubleshooting guide.
