### PR TITLE
Fix docs for the "Understanding State Ordering" tutorial

### DIFF
--- a/doc/topics/tutorials/states_ordering.rst
+++ b/doc/topics/tutorials/states_ordering.rst
@@ -196,6 +196,7 @@ loaded in the order in which they are included.
 In the following case:
 
 ``foo.sls``
+
 .. code-block:: yaml
 
     include:
@@ -203,12 +204,14 @@ In the following case:
       - baz
 
 ``bar.sls``
+
 .. code-block:: yaml
 
     include:
       - quo
 
 ``baz.sls``
+
 .. code-block:: yaml
 
     include:


### PR DESCRIPTION
"code-block" directives require a blank line before them.
