### PR TITLE
related to #9274, another place needs exception handling

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -63,7 +63,10 @@ def top(num_processes=5, interval=3):
     time.sleep(interval)
     usage = set()
     for process, start in start_usage.items():
-        user, system = process.get_cpu_times()
+        try:
+            user, system = process.get_cpu_times()
+        except psutil.NoSuchProcess:
+            continue
         now = user + system
         diff = now - start
         usage.add((diff, process))


### PR DESCRIPTION
Example traceback:

```
    Traceback (most recent call last):
      File "/usr/lib/pymodules/python2.7/salt/minion.py", line 695, in _thread_return
        return_data = func(*args, **kwargs)
      File "/usr/lib/pymodules/python2.7/salt/modules/ps.py", line 65, in top
        user, system = process.get_cpu_times()
      File "/usr/lib/python2.7/dist-packages/psutil/__init__.py", line 364, in get_cpu_times
        return self._platform_impl.get_cpu_times()
      File "/usr/lib/python2.7/dist-packages/psutil/_pslinux.py", line 327, in wrapper
        raise NoSuchProcess(self.pid, self._process_name)
    NoSuchProcess: process no longer exists (pid=1068)
```
