### PR TITLE
Address the issue "file.managed is TOO secure"

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1876,7 +1876,7 @@ def extract_hash(hash_fn, hash_type='md5', file_name=''):
     '''
     This routine is called from managed() to pull a hash from a remote file.
     The "regular expression" language is used, line by line on the 'source_hash'
-     file, to find a potential candidate of the indicated hash type.
+    file, to find a potential candidate of the indicated hash type.
     This avoids many problems of arbitrary file lay out rules
     It specifically permits pulling hash codes deom debian *.dsc files.
     

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1005,10 +1005,10 @@ def managed(name,
     source_hash:
         This can be one of :
          1) a source hash string
-         2) a file which containing source hash strings
+         2) the URI of a file that contains source hash strings
         
         The function accepts the first encountered long unbroken alphanumeric
-        strings of correct length as a valid hash, in order from most secure to
+        string of correct length as a valid hash, in order from most secure to
         least secure:
              Type     Length
              ====     ======
@@ -1020,8 +1020,9 @@ def managed(name,
               md5        32
         
         The file can contain several checksums for several files. Each line must
-        contain both the file name and the hash.  If no file name is  matched, 
-        the first hash encountered will be used.
+        contain both the file name and the hash.  If no file name is matched, 
+        the first hash encountered will be used, otherwise the most secure hash
+        with the correct source file name will be used.
         
         Debian file type *.dsc is supported.
 
@@ -1032,8 +1033,8 @@ def managed(name,
 
         Known issues::
             If the remote server URL has the hash file as an apparent 
-            sub-directory of the source file, the module will find it has 
-            already cached a directory where a file should be cached.  Eg:
+            sub-directory of the source file, the module will discover that it
+            has already cached a directory where a file should be cached.  Eg:
             
             tomdroid-src-0.7.3.tar.gz:
                 file.managed:

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1003,19 +1003,43 @@ def managed(name,
         argument is also required
 
     source_hash:
-        This can be either a file which contains a source hash string for
-        the source, or a source hash string. The source hash string is the
-        hash algorithm followed by the hash of the file:
-        md5=e138491e9d5b97023cea823fe17bac22
+        This can be one of :
+         1) a source hash string
+         2) a file which containing source hash strings
+        
+        The function accepts the first encountered long unbroken alphanumeric
+        strings of correct length as a valid hash, in order from most secure to
+        least secure:
+             Type     Length
+             ====     ======
+            sha512      128
+            sha384       96
+            sha256       64
+            sha224       56
+             sha1        40
+              md5        32
+        
+        The file can contain several checksums for several files. Each line must
+        contain both the file name and the hash.  If no file name is  matched, 
+        the first hash encountered will be used.
+        
+        Debian file type *.dsc is supported.
 
-        The file can contain checksums for several files, in this case every
-        line must consist of full name of the file and checksum separated by
-        space:
+        Examples::
 
-        Example::
+            /etc/rc.conf ef6e82e4006dee563d98ada2a2a80a27
+            sha254c8525aee419eb649f0233be91c151178b30f0dff8ebbdcc8de71b1d5c8bcc06a  /etc/resolv.conf 
 
-            /etc/rc.conf md5=ef6e82e4006dee563d98ada2a2a80a27
-            /etc/resolv.conf sha256=c8525aee419eb649f0233be91c151178b30f0dff8ebbdcc8de71b1d5c8bcc06a
+        Known issues::
+            If the remote server URL has the hash file as an apparent 
+            sub-directory of the source file, the module will find it has 
+            already cached a directory where a file should be cached.  Eg:
+            
+            tomdroid-src-0.7.3.tar.gz:
+                file.managed:
+                    - name: /tmp/tomdroid-src-0.7.3.tar.gz
+                    - source: https://launchpad.net/tomdroid/beta/0.7.3/+download/tomdroid-src-0.7.3.tar.gz
+                    - source_hash: https://launchpad.net/tomdroid/beta/0.7.3/+download/tomdroid-src-0.7.3.tar.gz/+md5
 
 
     user


### PR DESCRIPTION
As mention here [file.managed is TOO secure](https://github.com/saltstack/salt/issues/9272) _file.managed_ is too aggressive in enforcing a standard file format for secure hash checksums.

This patch use regular expressions, line by line, on any text file format, attempting to discover at least one SHA\* or MD5 candidate.

Only two files are altered:
1. states/file.py
2. modules/file.py

The former has alterations only in documentation.  The latter replaces a few lines out of _file.managed()_ with a call to a new function called _extract_hash()_

This is my first pull request to a multi-branch project.  Please let me know if I should have done it differently.

(You will no doubt see that I overdosed on logging.  Hopefully that will facilitate reviewing prior to approval.)
