### PR TITLE
Handle invalid master address in minion config

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -53,7 +53,7 @@ except ImportError:
 # Import salt libs
 from salt.exceptions import (
     AuthenticationError, CommandExecutionError, CommandNotFoundError,
-    SaltInvocationError, SaltReqTimeoutError, SaltClientError
+    SaltInvocationError, SaltReqTimeoutError, SaltClientError, SaltSystemExit
 )
 import salt.client
 import salt.crypt
@@ -112,6 +112,11 @@ def resolve_dns(opts):
                         pass
             else:
                 ret['master_ip'] = '127.0.0.1'
+        except SaltSystemExit:
+            err = 'Master address: {0} could not be resolved. Invalid or unresolveable address.'.format(
+                opts.get('master', 'Unknown'))
+            log.error(err)
+            raise SaltSystemExit(code=42, msg=err)
     else:
         ret['master_ip'] = '127.0.0.1'
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -481,6 +481,9 @@ def dns_check(addr, safe=False, ipv6=False):
                     break
             if not addr:
                 error = True
+    except TypeError:
+        err = ('Attempt to resolve address failed. Invalid or unresolveable address')
+        raise SaltSystemExit(code=42, msg=err)
     except socket.error:
         error = True
 

--- a/tests/unit/minion_test.py
+++ b/tests/unit/minion_test.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+'''
+    :codauthor: :email:`Mike Place <mp@saltstack.com>`
+'''
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import patch
+
+from salt import minion
+from salt.exceptions import SaltSystemExit
+
+
+ensure_in_syspath('../')
+
+__opts__ = {}
+
+
+class MinionTestCase(TestCase):
+    def test_invalid_master_address(self):
+        with patch.dict(__opts__, {'ipv6': False, 'master': float('127.0'), 'master_port': '4555', 'retry_dns': False}):
+            self.assertRaises(SaltSystemExit, minion.resolve_dns, __opts__)


### PR DESCRIPTION
Gracefully exit the minion while informing the user of the cause of the error if the IP address of the master is malformed such that it can not even be dealt with by Python's socket module.

Unit testing for the above condition.

Closes #9440.
