### PR TITLE
Various Debian network fixes

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -432,15 +432,8 @@ def _parse_ethtool_opts(opts, iface):
         else:
             _raise_error_iface(iface, 'duplex', valid)
 
-    if 'mtu' in opts:
-        try:
-            int(opts['mtu'])
-            config.update({'mtu': opts['mtu']})
-        except ValueError:
-            _raise_error_iface(iface, 'mtu', ['integer'])
-
     if 'speed' in opts:
-        valid = ['10', '100', '1000']
+        valid = ['10', '100', '1000', '10000']
         if str(opts['speed']) in valid:
             config.update({'speed': opts['speed']})
         else:
@@ -956,7 +949,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     if 'ipaddr' in opts:
         adapters[iface]['data']['inet']['address'] = opts['ipaddr']
 
-    for opt in ['netmask', 'network', 'gateway', 'addr']:
+    for opt in ['gateway', 'mtu', 'netmask', 'network']:
         if opt in opts:
             adapters[iface]['data']['inet'][opt] = opts[opt]
 


### PR DESCRIPTION
- MTU is not ethtool option, parse it even if interface is type bridge
- add 10gigabit ethtool speed parameter
- don't parse garbage addr parameter
