### PR TITLE
Don't run pkg.refresh_db before checking targets

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -419,14 +419,10 @@ def installed(
               - qux: /minion/path/to/qux.rpm
     '''
     rtag = __gen_rtag()
+    refresh = bool(salt.utils.is_true(refresh) or os.path.isfile(rtag))
 
     if not isinstance(version, basestring) and version is not None:
         version = str(version)
-
-    if salt.utils.is_true(refresh) or os.path.isfile(rtag):
-        __salt__['pkg.refresh_db']()
-        if os.path.isfile(rtag):
-            os.remove(rtag)
 
     result = _find_install_targets(name, version, pkgs, sources,
                                    fromrepo=fromrepo, **kwargs)
@@ -468,6 +464,9 @@ def installed(
                                           pkgs=pkgs,
                                           sources=sources,
                                           **kwargs)
+
+        if os.path.isfile(rtag):
+            os.remove(rtag)
     except CommandExecutionError as exc:
         return {'name': name,
                 'changes': {},

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -272,6 +272,12 @@ def managed(name, **kwargs):
         ret['comment'] = ('Failed to configure repo {0!r}: {1}'
                           .format(name, str(e)))
         return ret
+    else:
+        # Repo was modified, refresh the pkg db if on an apt-based OS. Other
+        # package managers do this sort of thing automatically.
+        if __grains__['os_family'] == 'Debian':
+            __salt__['pkg.refresh_db']()
+
     try:
         repodict = __salt__['pkg.get_repo'](kwargs['repo'],
                                             ppa_auth=kwargs.get('ppa_auth',


### PR DESCRIPTION
In 5a95286, a call to pkg.refresh_db was placed before the function that
checks to see which targeted packages need to be installed. This was
done specifically to make newly-added repos available to pkg states in
the same highstate run. This commit moves the refresh_db to the pkgrepo
state instead.

Fixes #9341.
