### PR TITLE
Allow git.current_branch to work with git<1.7.8

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -121,7 +121,7 @@ def current_branch(cwd, user=None):
 
         salt '*' git.current_branch /path/to/repo
     '''
-    cmd = r'git branch --list | grep "^*\ " | cut -d " " -f 2 | ' + \
+    cmd = r'git branch | grep "^*\ " | cut -d " " -f 2 | ' + \
         'grep -v "(detached"'
 
     return __salt__['cmd.run_stdout'](cmd, cwd=cwd, runas=user)


### PR DESCRIPTION
"git branch" and "git branch --list" are functionally identical, but the
"--list" parameter was not added to git until version 1.7.8, so older
versions of git (such as the one in the RHEL/CentOS 6 repositories) are
unable to successfully run this function.

This commit removes the "--list" from the git command used in this
function.

Fixes #9468.
