### PR TITLE
Cloud Troubleshooting doc version compatibility notes.

### DIFF
--- a/doc/topics/cloud/troubleshooting.rst
+++ b/doc/topics/cloud/troubleshooting.rst
@@ -10,6 +10,18 @@ Generic Troubleshooting Steps
 This section describes a set of instructions that are useful to a large number
 of situations, and are likely to solve most issues that arise.
 
+.. admonition:: Version Compatibility
+
+    One of the most common issues that Salt Cloud users run into is import
+    errors. These are often caused by version compatibility issues with salt.
+
+    Salt 0.16.x works with Salt Cloud 0.8.9 or greater.
+
+    Salt 0.17.x requires Salt Cloud 0.8.11.
+
+    Releases after 0.17.x (0.18 or greater) should not encounter issues as Salt
+    Cloud has been merged into Salt itself.
+
 Debug Mode
 ----------
 Frequently, running Salt Cloud in debug mode will reveal information about a


### PR DESCRIPTION
Added an admonition to the cloud troubleshooting doc that addresses issue with version compatibility. Resolves https://github.com/saltstack/salt/issues/9454
