### PR TITLE
Fix sphinx build warning

### DIFF
--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -107,11 +107,20 @@ def boot(name, flavor_id=0, image_id=0, profile=None, timeout=300):
     '''
     Boot (create) a new instance
 
-    <name>        Name of the new instance (must be first)
-    <flavor_id>   Unique integer ID for the flavor
-    <image_id>    Unique integer ID for the image
-    <timeout>     How long to wait, after creating the instance, for the
-                  provider to return information about it (default 300 seconds).
+    name
+        Name of the new instance (must be first)
+
+    flavor_id
+        Unique integer ID for the flavor
+
+    image_id
+        Unique integer ID for the image
+
+    timeout
+        How long to wait, after creating the instance, for the provider to
+        return information about it (default 300 seconds).
+
+        .. versionadded:: Hydrogen
 
     CLI Example:
 
@@ -155,7 +164,8 @@ def suspend(instance_id, profile=None):
     '''
     Suspend an instance
 
-    <instance_id>        ID of the instance to be suspended
+    instance_id
+        ID of the instance to be suspended
 
     CLI Example:
 
@@ -173,7 +183,8 @@ def resume(instance_id, profile=None):
     '''
     Resume an instance
 
-    <instance_id>        ID of the instance to be resumed
+    instance_id
+        ID of the instance to be resumed
 
     CLI Example:
 
@@ -191,7 +202,8 @@ def lock(instance_id, profile=None):
     '''
     Lock an instance
 
-    <instance_id>        ID of the instance to be locked
+    instance_id
+        ID of the instance to be locked
 
     CLI Example:
 
@@ -209,7 +221,8 @@ def delete(instance_id, profile=None):
     '''
     Delete an instance
 
-    <instance_id>        ID of the instance to be deleted
+    instance_id
+        ID of the instance to be deleted
 
     CLI Example:
 
@@ -263,11 +276,16 @@ def flavor_create(name,      # pylint: disable=C0103
     Add a flavor to nova (nova flavor-create). The following parameters are
     required:
 
-    <name>   Name of the new flavor (must be first)
-    <id>     Unique integer ID for the new flavor
-    <ram>    Memory size in MB
-    <disk>   Disk size in GB
-    <vcpus>  Number of vcpus
+    name
+        Name of the new flavor (must be first)
+    id
+        Unique integer ID for the new flavor
+    ram
+        Memory size in MB
+    disk
+        Disk size in GB
+    vcpus
+        Number of vcpus
 
     CLI Example:
 
@@ -294,7 +312,7 @@ def flavor_delete(id, profile=None):  # pylint: disable=C0103
 
     .. code-block:: bash
 
-        salt '*' nova.flavor_delete 7'
+        salt '*' nova.flavor_delete 7
     '''
     nt_ks = _auth(profile)
     nt_ks.flavors.delete(id)
@@ -483,6 +501,12 @@ def show(server_id, profile=None):
     '''
     To maintain the feel of the nova command line, this function simply calls
     the server_show function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nova.show
     '''
     return server_show(server_id, profile)
 
@@ -529,19 +553,26 @@ def server_list_detailed(profile=None):
                 'diskConfig': item.__dict__['OS-DCF:diskConfig']
             }
         if hasattr(item.__dict__, 'OS-EXT-SRV-ATTR:host'):
-            ret[item.name]['OS-EXT-SRV-ATTR']['host'] = item.__dict__['OS-EXT-SRV-ATTR:host']
+            ret[item.name]['OS-EXT-SRV-ATTR']['host'] = \
+                item.__dict__['OS-EXT-SRV-ATTR:host']
         if hasattr(item.__dict__, 'OS-EXT-SRV-ATTR:hypervisor_hostname'):
-            ret[item.name]['OS-EXT-SRV-ATTR']['hypervisor_hostname'] = item.__dict__['OS-EXT-SRV-ATTR:hypervisor_hostname']
+            ret[item.name]['OS-EXT-SRV-ATTR']['hypervisor_hostname'] = \
+                item.__dict__['OS-EXT-SRV-ATTR:hypervisor_hostname']
         if hasattr(item.__dict__, 'OS-EXT-SRV-ATTR:instance_name'):
-            ret[item.name]['OS-EXT-SRV-ATTR']['instance_name'] = item.__dict__['OS-EXT-SRV-ATTR:instance_name']
+            ret[item.name]['OS-EXT-SRV-ATTR']['instance_name'] = \
+                item.__dict__['OS-EXT-SRV-ATTR:instance_name']
         if hasattr(item.__dict__, 'OS-EXT-STS:power_state'):
-            ret[item.name]['OS-EXT-STS']['power_state'] = item.__dict__['OS-EXT-STS:power_state']
+            ret[item.name]['OS-EXT-STS']['power_state'] = \
+                item.__dict__['OS-EXT-STS:power_state']
         if hasattr(item.__dict__, 'OS-EXT-STS:task_state'):
-            ret[item.name]['OS-EXT-STS']['task_state'] = item.__dict__['OS-EXT-STS:task_state']
+            ret[item.name]['OS-EXT-STS']['task_state'] = \
+                item.__dict__['OS-EXT-STS:task_state']
         if hasattr(item.__dict__, 'OS-EXT-STS:vm_state'):
-            ret[item.name]['OS-EXT-STS']['vm_state'] = item.__dict__['OS-EXT-STS:vm_state']
+            ret[item.name]['OS-EXT-STS']['vm_state'] = \
+                item.__dict__['OS-EXT-STS:vm_state']
         if hasattr(item.__dict__, 'security_groups'):
-            ret[item.name]['security_groups'] = item.__dict__['security_groups']
+            ret[item.name]['security_groups'] = \
+                item.__dict__['security_groups']
     return ret
 
 


### PR DESCRIPTION
This fixes a sphinx build warning resulting from improperly formatted
argument names. Also fixed some lines that were >79 chars.
