### PR TITLE
Fixed a typo in cloud troubleshooting, new section for master troubleshooting.

### DIFF
--- a/doc/topics/cloud/troubleshooting.rst
+++ b/doc/topics/cloud/troubleshooting.rst
@@ -13,7 +13,7 @@ of situations, and are likely to solve most issues that arise.
 .. admonition:: Version Compatibility
 
     One of the most common issues that Salt Cloud users run into is import
-    errors. These are often caused by version compatibility issues with salt.
+    errors. These are often caused by version compatibility issues with Salt.
 
     Salt 0.16.x works with Salt Cloud 0.8.9 or greater.
 

--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -156,3 +156,15 @@ do not return output. This is most commonly due to the timeout being reached.
 By default the timeout is set to 5 seconds. The timeout value can easily be
 increased by modifying the ``timeout`` line within your ``/etc/salt/master``
 configuration file.
+
+
+Passing the -c Option to Salt Returns a Permissions Error
+=========================================================
+
+Using the ``-c`` option with the Salt command modifies the configuration
+directory. When the configuratio file is read it will still base data off of
+the ``root_dir`` setting. This can result in unintended behavior if you are
+expecting files such as ``/etc/salt/pki`` to be pulled from the location
+specified with ``-c``. Modify the ``root_dir`` setting to address this
+behavior.
+


### PR DESCRIPTION
I've added a new section to the master troubleshooting docs to help address part of https://github.com/saltstack/salt/issues/8649, and fixed a typo I previously let slip in the cloud troubleshooting.
