### PR TITLE
Increase timeout for pkg tests.

### DIFF
--- a/tests/integration/states/pkgrepo.py
+++ b/tests/integration/states/pkgrepo.py
@@ -37,7 +37,7 @@ class PkgrepoTest(integration.ModuleCase,
                 self.skipTest(
                     'aptsources.sourceslist python module not found'
                 )
-        ret = self.run_function('state.sls', mods='pkgrepo.managed')
+        ret = self.run_function('state.sls', mods='pkgrepo.managed', timeout=120)
         # If the below assert fails then no states were run, and the SLS in
         # tests/integration/files/file/base/pkgrepo/managed.sls needs to be
         # corrected.
@@ -52,7 +52,7 @@ class PkgrepoTest(integration.ModuleCase,
         This is a destructive test as it removes the repository added in the
         above test.
         '''
-        ret = self.run_function('state.sls', mods='pkgrepo.absent')
+        ret = self.run_function('state.sls', mods='pkgrepo.absent', timeout=120)
         # If the below assert fails then no states were run, and the SLS in
         # tests/integration/files/file/base/pkgrepo/absent.sls needs to be
         # corrected.


### PR DESCRIPTION
- Since we started running a refresh_db in pkgrepo (7c3d0cc80db5d455fde8cd5044a3dc91bfa272f0), we may be checking an exit code prematurely. This increases the timeouts to 120 seconds to see if Jenkins will calm itself.
