### PR TITLE
Use "user" instead of "runas" argument when calling pip.install from virtualenv.managed state

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -163,7 +163,7 @@ def managed(name,
             extra_search_dir=extra_search_dir,
             never_download=never_download,
             prompt=prompt,
-            runas=user
+            user=user
         )
 
         ret['result'] = _ret['retcode'] == 0
@@ -196,7 +196,7 @@ def managed(name,
             requirements=requirements,
             bin_env=name,
             use_wheel=use_wheel,
-            runas=user,
+            user=user,
             cwd=cwd,
             index_url=index_url,
             extra_index_url=extra_index_url,


### PR DESCRIPTION
This commit changes the virtualenv.managed state to use "user" instead of "runas" when it runs pip.install to satisfy a requirements file.

Additionally, it deprecates the "runas" argument in the virtualenv.create function. This is part of a greater movement towards replacing "runas" with "user" where possible.

Fixes #8190.
