### PR TITLE
Alias module.watch to module.wait

### DIFF
--- a/doc/ref/states/all/salt.states.module.rst
+++ b/doc/ref/states/all/salt.states.module.rst
@@ -4,3 +4,4 @@ salt.states.module
 
 .. automodule:: salt.states.module
     :members:
+    :exclude-members: watch

--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -76,6 +76,9 @@ def wait(name, **kwargs):
             'result': True,
             'comment': ''}
 
+# Alias module.watch to module.wait
+watch = wait
+
 
 def run(name, **kwargs):
     '''


### PR DESCRIPTION
This was done recently for cmd.watch, so this commit aliases the
module.watch state as well for consistency.
