### PR TITLE
Add some links to the fileserver backends docs

### DIFF
--- a/doc/ref/file_server/backends.rst
+++ b/doc/ref/file_server/backends.rst
@@ -9,12 +9,13 @@ example of this is the git backend which allows for all of the Salt formulas
 and files to be maintained in a remote git repository.
 
 The fileserver backend system can accept multiple backends as well. This makes
-it possible to have the environments listed in the file_roots configuration
-available in addition to other backends, or the ability to mix multiple
-backends.
+it possible to have the environments listed in the :conf_master:`file_roots`
+configuration available in addition to other backends, or the ability to mix
+multiple backends.
 
-This feature is managed by the `fileserver_backend` option in the master
-config. The desired backend systems are listed in order of search priority:
+This feature is managed by the :conf_master:`fileserver_backend` option in the
+master config. The desired backend systems are listed in order of search
+priority:
 
 .. code-block:: yaml
 
@@ -22,16 +23,17 @@ config. The desired backend systems are listed in order of search priority:
       - roots
       - git
 
-If this configuration the environments and files defined in the `file_roots`
-configuration will be searched first, if the referenced environment and file
-is not found then the git backend will be searched.
+With this configuration, the environments and files defined in the
+:conf_master:`file_roots` parameter will be searched first, if the referenced
+environment and file is not found then the :mod:`git <salt.fileserver.gitfs>`
+backend will be searched.
 
 Environments
 ------------
 
 The concept of environments is followed in all backend systems. The
-environments in the classic `roots` backend are defined in the `file_roots`
-option. Environments map differently based on the backend, for instance the
-git backend translated branches and tags in git to environments. This makes
-it easy to define environments in git by just setting a tag or forking a
-branch.
+environments in the classic :mod:`roots <salt.fileserver.roots>` backend are
+defined in the :conf_master:`file_roots` option. Environments map differently
+based on the backend, for instance the git backend translated branches and tags
+in git to environments. This makes it easy to define environments in git by
+just setting a tag or forking a branch.


### PR DESCRIPTION
This commit turns some of the config file parameters into links to the
master config file docs, and also links to the pages for the fileserver
backends being described.
