### PR TITLE
Support for Logstash v1 event schema (and improved timestamp handling)

### DIFF
--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -123,13 +123,6 @@ from salt._compat import string_types
 from salt.log.setup import LOG_LEVELS
 from salt.log.mixins import NewStyleClassMixIn
 
-# Import 3rd-party libs
-try:
-    from pytz import utc as _UTC
-    HAS_PYTZ = True
-except ImportError:
-    HAS_PYTZ = False
-
 log = logging.getLogger(__name__)
 
 # Define the module's virtual name
@@ -221,10 +214,7 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
         super(LogstashFormatter, self).__init__(fmt=None, datefmt=None)
 
     def formatTime(self, record, datefmt=None):
-        timestamp = datetime.datetime.utcfromtimestamp(record.created)
-        if HAS_PYTZ:
-            return _UTC.localize(timestamp).isoformat()
-        return '{0}+00:00'.format(timestamp.isoformat())
+        return datetime.datetime.utcfromtimestamp(record.created).isoformat()[:-3] + 'Z'
 
     def format(self, record):
         host = socket.getfqdn()

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -237,7 +237,7 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
             ),
             '@source_host': host,
             '@source_path': self.msg_path,
-            '@tags': [],
+            '@tags': ['salt'],
             '@timestamp': self.formatTime(record),
             '@type': self.msg_type,
         }

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -275,10 +275,10 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
         return json.dumps(message_dict)
 
     def format_v1(self, record):
-        host = socket.getfqdn()
         message_dict = {
             '@version': 1,
             '@timestamp': self.formatTime(record),
+            'host': socket.getfqdn(),
             'levelname': record.levelname,
             'logger': record.name,
             'lineno': record.lineno,
@@ -288,15 +288,8 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
             'funcName': record.funcName,
             'processName': record.processName,
             'message': record.getMessage(),
-            'source': '{0}://{1}/{2}'.format(
-                self.msg_type,
-                host,
-                self.msg_path
-            ),
-            'source_host': host,
-            'source_path': self.msg_path,
             'tags': ['salt'],
-            'type': self.msg_type,
+            'type': self.msg_type
         }
 
         if record.exc_info:

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -11,17 +11,18 @@
     UDP Logging Handler
     -------------------
 
-    In order to setup the datagram handler for `Logstash`_, please define on
-    the salt configuration file:
+    For versions of `Logstash`_ before 1.2.0:
+
+    In the salt configuration file:
 
     .. code-block:: yaml
 
         logstash_udp_handler:
           host: 127.0.0.1
           port: 9999
+          version: 0
 
-
-    On the `Logstash`_ configuration file you need something like:
+    In the `Logstash`_ configuration file:
 
     .. code-block:: text
 
@@ -32,6 +33,27 @@
           }
         }
 
+    For version 1.2.0 of `Logstash`_ and newer:
+
+    In the salt configuration file:
+
+    .. code-block:: yaml
+
+        logstash_udp_handler:
+          host: 127.0.0.1
+          port: 9999
+          version: 1
+
+    In the `Logstash`_ configuration file:
+
+    .. code-block:: text
+
+        input {
+          udp {
+            port => 9999
+            codec => json
+          }
+        }
 
     Please read the `UDP input`_ configuration page for additional information.
 
@@ -39,16 +61,17 @@
     ZeroMQ Logging Handler
     ----------------------
 
-    In order to setup the ZMQ handler for `Logstash`_, please define on the
-    salt configuration file:
+    For versions of `Logstash`_ before 1.2.0:
+
+    In the salt configuration file:
 
     .. code-block:: yaml
 
         logstash_zmq_handler:
           address: tcp://127.0.0.1:2021
+          version: 0
 
-
-    On the `Logstash`_ configuration file you need something like:
+    In the `Logstash`_ configuration file:
 
     .. code-block:: text
 
@@ -63,6 +86,27 @@
           }
         }
 
+    For version 1.2.0 of `Logstash`_ and newer:
+
+    In the salt configuration file:
+
+    .. code-block:: yaml
+
+        logstash_zmq_handler:
+          address: tcp://127.0.0.1:2021
+          version: 1
+
+    In the `Logstash`_ configuration file:
+
+    .. code-block:: text
+
+        input {
+          zeromq {
+            topology => "pubsub"
+            address => "tcp://0.0.0.0:2021"
+            codec => json
+          }
+        }
 
     Please read the `ZeroMQ input`_ configuration page for additional
     information.


### PR DESCRIPTION
With version 1.2.0 Logstash introduced a new event schema.  Salt is sending the old-style events with the logstash log handler module.  While it is possible to deal with old-style events on newer Logstash versions, its better long-term to start sending new-style events.  These patches add that support (defaulting to the old-style events).  Also, improvements are made to timestamp handling - there's no need for doing anything fancy with pytz and timezones, logstash is perfectly happy with UTC timestamps.  Also, these patches reduce the precision of timestamps to milliseconds - the library that logstash uses to deal with time (JodaTime) can't handle anything more, and certain versions will choke if given anything more.
