### PR TITLE
fix numerous pylint C0325 (superfluous-parens) warnings

### DIFF
--- a/salt/client/api.py
+++ b/salt/client/api.py
@@ -307,7 +307,7 @@ class APIClient(object):
 
         If wait is 0 then block forever or until next event becomes available.
         '''
-        return (self.event.get_event(wait=wait, tag=tag, full=full))
+        return self.event.get_event(wait=wait, tag=tag, full=full)
 
     def fire_event(self, data, tag):
         '''
@@ -316,4 +316,4 @@ class APIClient(object):
         Need to convert this to a master call with appropriate authentication
 
         '''
-        return (self.event.fire_event(data, tagify(tag, 'wui')))
+        return self.event.fire_event(data, tagify(tag, 'wui'))

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -522,7 +522,7 @@ class Single(object):
             refresh = True
         else:
             passed_time = (time.time() - os.stat(datap).st_mtime) / 60
-            if (passed_time > self.opts.get('cache_life', 60)):
+            if passed_time > self.opts.get('cache_life', 60):
                 refresh = True
         if self.opts.get('refresh_cache'):
             refresh = True

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1903,7 +1903,7 @@ def _extract_name_tag(item):
                 if tag['key'] == 'Name':
                     return tag['value']
             return item['instanceId']
-        return (item['tagSet']['item']['value'])
+        return item['tagSet']['item']['value']
     return item['instanceId']
 
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -540,7 +540,7 @@ def create(vm_):
 
     if ssh_interface(vm_) == 'private_ips':
         ip_address = preferred_ip(vm_, data.private_ips)
-    elif (rackconnect(vm_) is True and ssh_interface(vm_) != 'private_ips'):
+    elif rackconnect(vm_) is True and ssh_interface(vm_) != 'private_ips':
         ip_address = data.public_ips
     else:
         ip_address = preferred_ip(vm_, data.public_ips)

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -614,7 +614,7 @@ def create(vm_):
 
     if ssh_interface(vm_) == 'private_ips':
         ip_address = preferred_ip(vm_, data.private_ips)
-    elif (rackconnect(vm_) is True and ssh_interface(vm_) != 'private_ips'):
+    elif rackconnect(vm_) is True and ssh_interface(vm_) != 'private_ips':
         ip_address = data.public_ips
     else:
         ip_address = preferred_ip(vm_, data.public_ips)

--- a/salt/fileserver/minionfs.py
+++ b/salt/fileserver/minionfs.py
@@ -147,7 +147,7 @@ def file_hash(load, fnd):
                 except ValueError:
                     log.debug('Fileserver attempted to read incomplete cache file. Retrying.')
                     file_hash(load, fnd)
-                    return(ret)
+                    return ret
                 if os.path.getmtime(path) == mtime:
                     # check if mtime changed
                     ret['hsum'] = hsum
@@ -155,7 +155,7 @@ def file_hash(load, fnd):
         except os.error:  # Can't use Python select() because we need Windows support
             log.debug("Fileserver encountered lock when reading cache file. Retrying.")
             file_hash(load, fnd)
-            return(ret)
+            return ret
 
     # if we don't have a cache entry-- lets make one
     ret['hsum'] = salt.utils.get_hash(path, __opts__['hash_type'])

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -194,7 +194,7 @@ def file_hash(load, fnd):
                     # Delete the file since its incomplete (either corrupted or incomplete)
                     os.unlink(cache_path)
                     file_hash(load, fnd)
-                    return(ret)
+                    return ret
                 if os.path.getmtime(path) == mtime:
                     # check if mtime changed
                     ret['hsum'] = hsum
@@ -204,7 +204,7 @@ def file_hash(load, fnd):
             # Delete the file since its incomplete (either corrupted or incomplete)
             os.unlink(cache_path)
             file_hash(load, fnd)
-            return(ret)
+            return ret
 
     # if we don't have a cache entry-- lets make one
     ret['hsum'] = salt.utils.get_hash(path, __opts__['hash_type'])

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -385,7 +385,7 @@ def _memdata(osdata):
                 mem = __salt__['cmd.run']('{0} -n hw.memsize'.format(sysctl))
             else:
                 mem = __salt__['cmd.run']('{0} -n hw.physmem'.format(sysctl))
-            if (osdata['kernel'] == 'NetBSD' and mem.startswith('-')):
+            if osdata['kernel'] == 'NetBSD' and mem.startswith('-'):
                 mem = __salt__['cmd.run']('{0} -n hw.physmem64'.format(sysctl))
             grains['mem_total'] = int(mem) / 1024 / 1024
     elif osdata['kernel'] == 'SunOS':

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -70,12 +70,12 @@ def _create_loader(
     for _dir in opts.get('module_dirs', []):
         # Prepend to the list to match cli argument ordering
         maybe_dir = os.path.join(_dir, ext_type)
-        if (os.path.isdir(maybe_dir)):
+        if os.path.isdir(maybe_dir):
             cli_module_dirs.insert(0, maybe_dir)
             continue
 
         maybe_dir = os.path.join(_dir, '_{0}'.format(ext_type))
-        if (os.path.isdir(maybe_dir)):
+        if os.path.isdir(maybe_dir):
             cli_module_dirs.insert(0, maybe_dir)
 
     if loaded_base_name is None:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1700,7 +1700,7 @@ class Matcher(object):
         '''
         if tgt not in self.functions:
             return False
-        return(self.functions[tgt]())
+        return self.functions[tgt]()
 
     def pillar_match(self, tgt, delim=':'):
         '''

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -277,7 +277,7 @@ def check_site_enabled(site):
     '''
     if os.path.islink('/etc/apache2/sites-enabled/{0}'.format(site)):
         return True
-    elif (site == 'default' and os.path.islink('/etc/apache2/sites-enabled/000-{0}'.format(site))):
+    elif site == 'default' and os.path.islink('/etc/apache2/sites-enabled/000-{0}'.format(site)):
         return True
     else:
         return False

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -98,7 +98,7 @@ def bootstrap(force=False):
     # Windows release following Server 2008.
     ps_path = 'C:\\Windows\\SYSTEM32\\WindowsPowerShell\\v1.0\\powershell.exe'
 
-    if not (__salt__['cmd.has_exec'](ps_path)):
+    if not __salt__['cmd.has_exec'](ps_path):
         if (__grains__['osrelease'], __grains__['cpuarch']) in ps_downloads:
             # Install the appropriate release of PowerShell v2.0
             url = ps_downloads[(__grains__['osrelease'], __grains__['cpuarch'])]

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -248,7 +248,7 @@ def showconfig(name, default=False, dict_return=False):
     if not dict_return:
         return '\n'.join(output)
 
-    if ((not output) or ('configuration options' not in output[0])):
+    if (not output) or ('configuration options' not in output[0]):
         return {}
 
     try:

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1780,7 +1780,7 @@ def get_master_status(**connection_args):
     conn.close()
 
     # check for if this minion is not a master
-    if (len(rtnv) == 0):
+    if len(rtnv) == 0:
         rtnv.append([])
 
     log.debug('{0}-->{1}'.format(mod, len(rtnv[0])))
@@ -1848,7 +1848,7 @@ def get_slave_status(**connection_args):
     conn.close()
 
     # check for if this minion is not a slave
-    if (len(rtnv) == 0):
+    if len(rtnv) == 0:
         rtnv.append([])
 
     log.debug('{0}-->{1}'.format(mod, len(rtnv[0])))

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -143,7 +143,7 @@ def traceroute(host):
         if line.startswith('traceroute'):
             continue
 
-        if ('Darwin' in str(traceroute_version[1]) or 'FreeBSD' in str(traceroute_version[1])):
+        if 'Darwin' in str(traceroute_version[1]) or 'FreeBSD' in str(traceroute_version[1]):
             try:
                 traceline = re.findall(r'\s*(\d*)\s+(.*)\s+\((.*)\)\s+(.*)$', line)[0]
             except IndexError:

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -112,7 +112,7 @@ def install(runas=None, path=None):
 
     path = path or _rbenv_path(runas)
     path = os.path.expanduser(path)
-    return (_install_rbenv(path, runas) and _install_ruby_build(path, runas))
+    return _install_rbenv(path, runas) and _install_ruby_build(path, runas)
 
 
 def update(runas=None, path=None):
@@ -129,7 +129,7 @@ def update(runas=None, path=None):
     path = path or _rbenv_path(runas)
     path = os.path.expanduser(path)
 
-    return (_update_rbenv(path, runas) and _update_ruby_build(path, runas))
+    return _update_rbenv(path, runas) and _update_ruby_build(path, runas)
 
 
 def is_installed(runas=None):

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -116,7 +116,7 @@ def _service_is_chkconfig(name):
     Return True if the service is managed by chkconfig.
     '''
     cmdline = '/sbin/chkconfig --list {0}'.format(name)
-    return (__salt__['cmd.retcode'](cmdline) == 0)
+    return __salt__['cmd.retcode'](cmdline) == 0
 
 
 def _sysv_is_enabled(name, runlevel=None):

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -160,7 +160,7 @@ def _install(mpt):
     # Exec the chroot command
     cmd = 'if type salt-minion; then exit 0; '
     cmd += 'else sh /tmp/bootstrap.sh -c /tmp; fi'
-    return (not _chroot_exec(mpt, cmd))
+    return not _chroot_exec(mpt, cmd)
 
 
 def _check_resolv(mpt):
@@ -186,7 +186,7 @@ def _check_resolv(mpt):
 
 def _check_install(root):
     cmd = 'if ! type salt-minion; then exit 1; fi'
-    return (not _chroot_exec(root, cmd))
+    return not _chroot_exec(root, cmd)
 
 
 def _chroot_exec(root, cmd):

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -503,7 +503,7 @@ def pid(sig):
         sig = "'" + sig + "'"
     cmd = ("{0[ps]} | grep {1} | grep -v grep | fgrep -v status.pid | "
            "awk '{{print $2}}'".format(__grains__, sig))
-    return (__salt__['cmd.run_stdout'](cmd) or '')
+    return __salt__['cmd.run_stdout'](cmd) or ''
 
 
 def version():

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -101,7 +101,7 @@ def _untracked_custom_unit_found(name):
     '''
     unit_path = os.path.join('/etc/systemd/system',
                              _canonical_unit_name(name))
-    return (name not in get_all() and os.access(unit_path, os.R_OK))
+    return name not in get_all() and os.access(unit_path, os.R_OK)
 
 
 def _unit_file_changed(name):

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -112,7 +112,7 @@ def output(data):
                     '    {tcolor} Comment: {comment}{colors[ENDC]}'
                 ]
                 # This isn't the prettiest way of doing this, but it's readable.
-                if (comps[1] != comps[2]):
+                if comps[1] != comps[2]:
                     state_lines.insert(
                         3, '    {tcolor}    Name: {comps[2]}{colors[ENDC]}')
                 svars = {

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1856,7 +1856,7 @@ def is_bin_file(path):
         return None
     try:
         with open(path, 'r') as fp_:
-            return(is_bin_str(fp_.read(2048)))
+            return is_bin_str(fp_.read(2048))
     except os.error:
         return None
 

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -117,7 +117,7 @@ def tagify(suffix='', prefix='', base=SALT):
         parts.extend(suffix)
     else:  # string so append
         parts.append(suffix)
-    return (TAGPARTER.join([part for part in parts if part]))
+    return TAGPARTER.join([part for part in parts if part])
 
 
 class SaltEvent(object):


### PR DESCRIPTION
```
"Unnecessary parens after 'return' keyword"
"Unnecessary parens after 'if' keyword"
"Unnecessary parens after 'elif' keyword"
```

It's like some folks forgot that Python isn't C.
