### PR TITLE
modules.mount.active(): fix FreeBSD check

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -87,7 +87,7 @@ def active():
         salt '*' mount.active
     '''
     ret = {}
-    if __grains__['os'] in ('FreeBSD'):
+    if __grains__['os'] == 'FreeBSD':
         _active_mounts_freebsd(ret)
     else:
         try:


### PR DESCRIPTION
Apparently someone forgot the trailing comma in their singleton tuple literal.
It just so happens to work as-is, but it's misleading/confusing.
