### PR TITLE
utils.network._interfaces_ipconfig(): fix botched singleton tuples

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -346,7 +346,7 @@ def _interfaces_ipconfig(out):
             key, val = line.split(',', 1)
             key = key.strip(' .')
             val = val.strip()
-            if addr and key in ('Subnet Mask'):
+            if addr and key == 'Subnet Mask':
                 addr['netmask'] = val
             elif key in ('IP Address', 'IPv4 Address'):
                 if 'inet' not in iface:
@@ -362,9 +362,9 @@ def _interfaces_ipconfig(out):
                 addr = {'address': val.rstrip('(Preferred)'),
                         'prefixlen': None}
                 iface['inet6'].append(addr)
-            elif key in ('Physical Address'):
+            elif key == 'Physical Address':
                 iface['hwaddr'] = val
-            elif key in ('Media State'):
+            elif key == 'Media State':
                 # XXX seen used for tunnel adaptors
                 # might be useful
                 iface['up'] = (val != 'Media disconnected')


### PR DESCRIPTION
``` py
Python 2.7.6 (default, Nov 11 2013, 11:11:46)
>>> # Parentheses don't make tuples. Commas do that.
>>> ('Subnet Mask') == 'Subnet Mask' != ('Subnet Mask',)
True
>>> x = ('Subnet Mask')
>>> type(x)
<type 'str'>
>>> y = ('Subnet Mask',)
>>> type(y)
<type 'tuple'>
>>> # Why this went unnoticed:
>>> key = 'Subnet Mask'
>>> key in ('Subnet Mask')
True
>>> # Why this is problematic:
>>> key = 'Mask'
>>> key in ('Subnet Mask')
True
```
