### PR TITLE
digital_ocean._get_node: rm unused 'location' arg

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -540,7 +540,7 @@ def show_instance(name, call=None):
     return _get_node(name)
 
 
-def _get_node(name, location=None):
+def _get_node(name):
     attempts = 10
     while attempts >= 0:
         try:


### PR DESCRIPTION
```
salt/cloud/clouds/digital_ocean.py:543: [W0613(unused-argument), _get_node] Unused argument 'location'
```

None of the function's callers pass a value for it either.
