### PR TITLE
digital_ocean.script(): rename local var to avoid shadowing

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -517,7 +517,7 @@ def script(vm_):
     '''
     Return the script deployment object
     '''
-    script = salt.utils.cloud.os_script(
+    deploy_script = salt.utils.cloud.os_script(
         config.get_cloud_config_value('script', vm_, __opts__),
         vm_,
         __opts__,
@@ -525,7 +525,7 @@ def script(vm_):
             salt.utils.cloud.minion_config(__opts__, vm_)
         )
     )
-    return script
+    return deploy_script
 
 
 def show_instance(name, call=None):


### PR DESCRIPTION
```
************* Module salt.cloud.clouds.digital_ocean
salt/cloud/clouds/digital_ocean.py:520: [W0621(redefined-outer-name), script] Redefining name 'script' from outer scope (line 516)
```
