### PR TITLE
memcached.replace(): avoid shadowing status() func

### DIFF
--- a/salt/modules/memcached.py
+++ b/salt/modules/memcached.py
@@ -195,7 +195,7 @@ def replace(key,
     if not isinstance(min_compress_len, integer_types):
         raise SaltInvocationError('\'min_compress_len\' must be an integer')
     conn = _connect(host, port)
-    status = conn.get_stats()
+    stats = conn.get_stats()
     return conn.replace(
         key,
         value,


### PR DESCRIPTION
```
************* Module salt.modules.memcached
salt/modules/memcached.py:198: [W0621(redefined-outer-name), replace] Redefining name 'status' from outer scope (line 68)
```
