### PR TITLE
Add pygit2 support to git fileserver backend

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -382,8 +382,20 @@
 #fileserver_events: False
 #
 # Git fileserver backend configuration
+#
+# Gitfs can be provided by one of two python modules: GitPython or pygit2. If
+# using pygit2, both libgit2 and git must also be installed.
+#gitfs_provider: gitpython
+#
 # When using the git fileserver backend at least one git remote needs to be
 # defined. The user running the salt master will need read access to the repo.
+#
+# The repos will be searched in order to find the file requested by a client
+# and the first repo to have the file will return it.
+# When using the git backend branches and tags are translated into salt
+# environments.
+# Note:  file:// repos will be treated as a remote, so refs you want used must
+# exist in that repo as *local* refs.
 #
 #gitfs_remotes:
 #  - git://github.com/saltstack/salt-states.git
@@ -396,12 +408,6 @@
 # is a security concern, you may want to try using the ssh transport.
 #gitfs_ssl_verify: True
 #
-# The repos will be searched in order to find the file requested by a client
-# and the first repo to have the file will return it.
-# When using the git backend branches and tags are translated into salt
-# environments.
-# Note:  file:// repos will be treated as a remote, so refs you want used must
-# exist in that repo as *local* refs.
 #
 # The gitfs_root option gives the ability to serve files from a subdirectory
 # within the repository. The path is defined relative to the root of the

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -201,7 +201,7 @@ jobs dir
 ``ext_job_cache``
 -----------------
 
-Default: ''
+Default: ``''``
 
 Used to specify a default returner for all minions, when this option is set
 the specified returner needs to be properly configured and the minions will
@@ -576,7 +576,7 @@ Example:
 
     fileserver_backend:
       - roots
-      - gitfs
+      - git
 
 .. conf_master:: file_roots
 
@@ -639,6 +639,83 @@ The buffer size in the file server in bytes
 .. code-block:: yaml
 
     file_buffer_size: 1048576
+
+.. conf_master:: gitfs_provider
+
+``gitfs_provider``
+------------------
+
+.. versionadded:: Helium
+
+Gitfs can be provided by one of two python modules: `GitPython`_ or `pygit2`_.
+If using pygit2, both libgit2 and git itself must also be installed. More
+information can be found in the :mod:`gitfs backend documentation
+<salt.fileserver.gitfs>`.
+
+.. _GitPython: https://github.com/gitpython-developers/GitPython
+.. _pygit2: https://github.com/libgit2/pygit2
+
+.. code-block:: yaml
+
+    gitfs_provider: pygit2
+
+.. conf_master:: gitfs_remotes
+
+``gitfs_remotes``
+-----------------
+
+Default: ``[]``
+
+When using the git fileserver backend at least one git remote needs to be
+defined. The user running the salt master will need read access to the repo.
+
+The repos will be searched in order to find the file requested by a client
+and the first repo to have the file will return it.
+When using the git backend branches and tags are translated into salt
+environments.
+
+.. code-block:: yaml
+
+    gitfs_remotes:
+      - git://github.com/saltstack/salt-states.git
+      - file:///var/git/saltmaster
+
+.. note::
+    ``file://`` repos will be treated as a remote, so refs you want used must
+    exist in that repo as *local* refs.
+
+.. conf_master:: gitfs_ssl_verify
+
+``gitfs_ssl_verify``
+--------------------
+
+Default: ``[]``
+
+The ``gitfs_ssl_verify`` option specifies whether to ignore ssl certificate
+errors when contacting the gitfs backend. You might want to set this to
+false if you're using a git backend that uses a self-signed certificate but
+keep in mind that setting this flag to anything other than the default of True
+is a security concern, you may want to try using the ssh transport.
+
+.. code-block:: yaml
+
+    gitfs_ssl_verify: True
+
+.. conf_master:: gitfs_root
+
+``gitfs_root``
+--------------
+
+Default: ``''``
+
+The ``gitfs_root`` option gives the ability to serve files from a subdirectory
+within the repository. The path is defined relative to the root of the
+repository and defaults to the repository root.
+
+.. code-block:: yaml
+
+    gitfs_root: somefolder/otherfolder
+
 
 .. _pillar-configuration:
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -10,26 +10,39 @@ the fileserver_backend option in the salt master config.
 '''
 
 # Import python libs
+import distutils.version  # pylint: disable=E0611
 import glob
-import os
-import shutil
-import time
 import hashlib
 import logging
-import distutils.version  # pylint: disable=E0611
+import os
+import re
+import shutil
+import subprocess
+import time
 
-# Import third party libs
-HAS_GIT = False
-try:
-    import git
-    HAS_GIT = True
-except ImportError:
-    pass
+PROVIDER_PARAM = 'gitfs_provider'
+VALID_PROVIDERS = ('gitpython', 'pygit2')
 
 # Import salt libs
 import salt.utils
 import salt.fileserver
+from salt.exceptions import SaltException
 from salt.utils.event import tagify
+
+# Import third party libs
+HAS_GITPYTHON = False
+HAS_PYGIT2 = False
+try:
+    import git
+    HAS_GITPYTHON = True
+except ImportError:
+    pass
+
+try:
+    import pygit2
+    HAS_PYGIT2 = True
+except ImportError:
+    pass
 
 log = logging.getLogger(__name__)
 
@@ -37,40 +50,146 @@ log = logging.getLogger(__name__)
 __virtualname__ = 'git'
 
 
+def _verify_gitpython():
+    '''
+    Check if GitPython is available and at a compatible version (>= 0.3.0)
+    '''
+    pygit2_msg = (
+        'pygit2 is installed, you may wish to set gitfs_provider to '
+        '\'pygit2\' in the master config file to use pygit2 for '
+        'gitfs support.'
+    )
+    if not HAS_GITPYTHON:
+        log.error(
+            'Git fileserver backend is enabled in master config file, but '
+            'could not be loaded, is GitPython installed?'
+        )
+        if HAS_PYGIT2:
+            log.error(pygit2_msg)
+        return False
+    gitver = distutils.version.LooseVersion(git.__version__)
+    minver_str = '0.3.0'
+    minver = distutils.version.LooseVersion(minver_str)
+    errors = []
+    if gitver < minver:
+        errors.append(
+            'Git fileserver backend is enabled in master config file, but '
+            'the GitPython version is earlier than {0}. Version {1} '
+            'detected.'.format(minver_str, git.__version__)
+        )
+    if errors:
+        # Check if pygit2 is available
+        if HAS_PYGIT2:
+            errors.append(pygit2_msg)
+        for error in errors:
+            log.error(error)
+        return False
+    return True
+
+
+def _verify_pygit2():
+    '''
+    Check if pygit2/libgit2 are available and at a compatible version. Both
+    must be at least 0.19.0.
+    '''
+    gitpython_msg = (
+        'GitPython is installed, you may wish to set gitfs_provider to '
+        '\'gitpython\' in the master config file to use GitPython for '
+        'gitfs support.'
+    )
+    if not HAS_PYGIT2:
+        log.error(
+            'Git fileserver backend is enabled in master config file, but '
+            'could not be loaded, are pygit2 and libgit2 installed?'
+        )
+        if HAS_GITPYTHON:
+            log.error(gitpython_msg)
+        return False
+    pygit2ver = distutils.version.LooseVersion(pygit2.__version__)
+    libgit2ver = distutils.version.LooseVersion(pygit2.LIBGIT2_VERSION)
+    minver_str = '0.19.0'
+    minver = distutils.version.LooseVersion(minver_str)
+    errors = []
+    if pygit2ver < minver:
+        errors.append(
+            'Git fileserver backend is enabled in master config file, but '
+            'pygit2 version is earlier than {0}. Version {1} detected.'
+            .format(minver_str, pygit2.__version__)
+        )
+    if libgit2ver < minver:
+        errors.append(
+            'Git fileserver backend is enabled in master config file, but '
+            'libgit2 version is earlier than {0}. Version {1} detected.'
+            .format(minver_str, pygit2.__version__)
+        )
+    if not salt.utils.which('git'):
+        errors.append(
+            'The git command line utility is required by the Git fileserver '
+            'backend when using the \'pygit2\' provider.'
+        )
+    if errors:
+        # Check if GitPython is available
+        if HAS_GITPYTHON:
+            errors.append(gitpython_msg)
+        for error in errors:
+            log.error(error)
+        return False
+    return True
+
+
+def _invalid_provider(provider):
+    raise SaltException(
+        'Invalid gitfs provider {0!r}'.format(provider)
+    )
+
+
 def __virtual__():
     '''
-    Only load if gitpython is available
+    Only load if the desired provider module is present and gitfs is enabled
+    properly in the master config file.
     '''
     if not isinstance(__opts__['gitfs_remotes'], list):
         return False
     if not isinstance(__opts__['gitfs_root'], str):
         return False
-    if not 'git' in __opts__['fileserver_backend']:
+    if not __virtualname__ in __opts__['fileserver_backend']:
         return False
-    if not HAS_GIT:
-        log.error('Git fileserver backend is enabled in configuration but '
-                  'could not be loaded, is GitPython installed?')
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        log.error('Invalid gitfs_provider {0!r}. Valid choices are: {1}'
+                  .format(provider, VALID_PROVIDERS))
         return False
-    gitver = distutils.version.LooseVersion(git.__version__)
-    minver = distutils.version.LooseVersion('0.3.0')
-    if gitver < minver:
-        log.error('Git fileserver backend is enabled in configuration but '
-                  'GitPython version is not greater than 0.3.0, '
-                  'version {0} detected'.format(git.__version__))
-        return False
-    return __virtualname__
+    if provider == 'gitpython':
+        verified = _verify_gitpython()
+    elif provider == 'pygit2':
+        verified = _verify_pygit2()
+    return __virtualname__ if verified else False
 
 
-def _get_ref(repo, short):
+def _get_ref_gitpython(repo, short):
     '''
-    Return bool if the short ref is in the repo
+    Return the ref if found, otherwise return False
     '''
     for ref in repo.refs:
-        if isinstance(ref, git.RemoteReference):
+        if isinstance(ref, (git.RemoteReference, git.TagReference)):
             parted = ref.name.partition('/')
             refname = parted[2] if parted[2] else parted[0]
             if short == refname:
                 return ref
+    return False
+
+
+def _get_ref_pygit2(repo, short):
+    '''
+    Return the ref if found, otherwise return False
+    '''
+    for ref in repo.listall_references():
+        _, rtype, rspec = ref.split('/', 2)
+        if rtype in ('remotes', 'tags'):
+            parted = rspec.partition('/')
+            refname = parted[2] if parted[2] else parted[0]
+            if short == refname:
+                return repo.lookup_reference(ref)
     return False
 
 
@@ -116,11 +235,35 @@ def _wait_lock(lk_fn, dest):
     return False
 
 
+def _stale_refs_pygit2(repo):
+    '''
+    Return a list of stale refs by running git remote prune --dry-run <remote>,
+    since libgit2 can't do this.
+    '''
+    remote = repo.remotes[0].name
+    key = ' * [would prune] '
+    ret = []
+    for line in subprocess.Popen(
+            'git remote prune --dry-run {0!r}'.format(remote),
+            shell=True,
+            close_fds=True,
+            cwd=repo.workdir,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT).communicate()[0].splitlines():
+        if line.startswith(key):
+            line = line.replace(key, '')
+            ret.append(line)
+    return ret
+
+
 def init():
     '''
     Return the git repo object for this session
     '''
     bp_ = os.path.join(__opts__['cachedir'], 'gitfs')
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     repos = []
     for _, opt in enumerate(__opts__['gitfs_remotes']):
         repo_hash = hashlib.md5(opt).hexdigest()
@@ -129,20 +272,29 @@ def init():
             os.makedirs(rp_)
 
         try:
-            repo = git.Repo.init(rp_)
-        except Exception as e:
-            log.error('GitPython exception caught while initializing the repo '
-                      'for gitfs: {0}. Maybe git is not available.'.format(e))
+            if provider == 'gitpython':
+                repo = git.Repo.init(rp_)
+            elif provider == 'pygit2':
+                repo = pygit2.init_repository(rp_)
+            else:
+                _invalid_provider(provider)
+        except Exception as exc:
+            log.error(
+                'Exception caught while initializing the repo for gitfs: '
+                '{0}. Perhaps git is not available.'.format(exc)
+            )
             return repos
 
         if not repo.remotes:
             try:
                 repo.create_remote('origin', opt)
                 # ignore git ssl verification if requested
-                if __opts__.get('gitfs_ssl_verify', True):
-                    repo.git.config('http.sslVerify', 'true')
-                else:
-                    repo.git.config('http.sslVerify', 'false')
+                ssl_verify = 'true' if __opts__.get('gitfs_ssl_verify', True) \
+                    else 'false'
+                if provider == 'gitpython':
+                    repo.git.config('http.sslVerify', ssl_verify)
+                elif provider == 'pygit2':
+                    repo.config.set_multivar('http.sslVerify', '', ssl_verify)
             except os.error:
                 # This exception occurs when two processes are trying to write
                 # to the git config at once, go ahead and pass over it since
@@ -166,7 +318,8 @@ def purge_cache():
             remove_dirs.remove(repo_hash)
         except ValueError:
             pass
-    remove_dirs = [os.path.join(bp_, r) for r in remove_dirs if r not in ('hash', 'refs')]
+    remove_dirs = [os.path.join(bp_, r) for r in remove_dirs
+                   if r not in ('hash', 'refs')]
     if remove_dirs:
         for r in remove_dirs:
             shutil.rmtree(r)
@@ -181,21 +334,34 @@ def update():
     # data for the fileserver event
     data = {'changed': False,
             'backend': 'gitfs'}
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     pid = os.getpid()
     data['changed'] = purge_cache()
     repos = init()
     for repo in repos:
         origin = repo.remotes[0]
-        lk_fn = os.path.join(repo.working_dir, 'update.lk')
+        if provider == 'gitpython':
+            working_dir = repo.working_dir
+        elif provider == 'pygit2':
+            working_dir = repo.workdir
+        lk_fn = os.path.join(working_dir, 'update.lk')
         with salt.utils.fopen(lk_fn, 'w+') as fp_:
             fp_.write(str(pid))
         try:
-            for fetch in origin.fetch():
-                if fetch.old_commit is not None:
+            if provider == 'gitpython':
+                for fetch in origin.fetch():
+                    if fetch.old_commit is not None:
+                        data['changed'] = True
+            elif provider == 'pygit2':
+                fetch = origin.fetch()
+                if fetch.get('received_objects', 0):
                     data['changed'] = True
         except Exception as exc:
-            log.warning('GitPython exception caught while fetching: '
-                        '{0}'.format(exc))
+            log.warning(
+                'Exception caught while fetching: {0}'.format(exc)
+            )
         try:
             os.remove(lk_fn)
         except (IOError, OSError):
@@ -220,21 +386,62 @@ def envs():
     Return a list of refs that can be used as environments
     '''
     base_branch = __opts__['gitfs_base']
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     ret = set()
     repos = init()
     for repo in repos:
-        remote = repo.remote()
-        for ref in repo.refs:
-            parted = ref.name.partition('/')
-            short = parted[2] if parted[2] else parted[0]
-            if isinstance(ref, git.Head):
+        if provider == 'gitpython':
+            ret.update(_checkenv_gitpython(repo), base_branch)
+        elif provider == 'pygit2':
+            ret.update(_checkenv_pygit2(repo), base_branch)
+        else:
+            _invalid_provider(provider)
+    return sorted(ret)
+
+
+def _checkenv_gitpython(repo, base_branch):
+    '''
+    Check the refs and return a list of the ones which can be used as salt
+    environments.
+    '''
+    ret = set()
+    remote = repo.remotes[0]
+    for ref in repo.refs:
+        parted = ref.name.partition('/')
+        short = parted[2] if parted[2] else parted[0]
+        if isinstance(ref, git.Head):
+            if short == base_branch:
+                short = 'base'
+            if ref not in remote.stale_refs:
+                ret.add(short)
+        elif isinstance(ref, git.Tag):
+            ret.add(short)
+    return ret
+
+
+def _checkenv_pygit2(repo, base_branch):
+    '''
+    Check the refs and return a list of the ones which can be used as salt
+    environments.
+    '''
+    ret = set()
+    remote = repo.remotes[0]
+    stale_refs = _stale_refs_pygit2(repo)
+    for ref in repo.listall_references():
+        ref = re.sub('^refs/', '', ref)
+        rtype, rspec = ref.split('/', 1)
+        if rtype == 'tags':
+            ret.add(rspec)
+        elif rtype == 'remotes':
+            if rspec not in stale_refs:
+                parted = rspec.partition('/')
+                short = parted[2] if parted[2] else parted[0]
                 if short == base_branch:
                     short = 'base'
-                if ref not in remote.stale_refs:
-                    ret.add(short)
-            elif isinstance(ref, git.Tag):
                 ret.add(short)
-    return list(ret)
+    return ret
 
 
 def find_file(path, short='base', **kwargs):
@@ -245,6 +452,9 @@ def find_file(path, short='base', **kwargs):
     fnd = {'path': '',
            'rel': ''}
     base_branch = __opts__['gitfs_base']
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     if os.path.isabs(path):
         return fnd
 
@@ -284,20 +494,33 @@ def find_file(path, short='base', **kwargs):
             # Invalid index option
             return fnd
     for repo in repos:
-        ref = _get_ref(repo, short)
-        if not ref:
-            # Branch or tag not found in repo, try the next
-            continue
-        tree = ref.commit.tree
-        try:
-            blob = tree / path
-        except KeyError:
-            continue
+        if provider == 'gitpython':
+            ref = _get_ref_gitpython(repo, short)
+            if not ref:
+                # Branch or tag not found in repo, try the next
+                continue
+            tree = ref.commit.tree
+            try:
+                blob = tree / path
+            except KeyError:
+                continue
+            blob_hexsha = blob.hexsha
+        elif provider == 'pygit2':
+            ref = _get_ref_pygit2(repo, short)
+            if not ref:
+                # Branch or tag not found in repo, try the next
+                continue
+            tree = ref.get_object().tree
+            try:
+                blob = repo[tree[path].oid]
+            except KeyError:
+                continue
+            blob_hexsha = blob.hex
         _wait_lock(lk_fn, dest)
         if os.path.isfile(blobshadest) and os.path.isfile(dest):
             with salt.utils.fopen(blobshadest, 'r') as fp_:
                 sha = fp_.read()
-                if sha == blob.hexsha:
+                if sha == blob_hexsha:
                     fnd['rel'] = local_path
                     fnd['path'] = dest
                     return fnd
@@ -309,9 +532,12 @@ def find_file(path, short='base', **kwargs):
             except Exception:
                 pass
         with salt.utils.fopen(dest, 'w+') as fp_:
-            blob.stream_data(fp_)
+            if provider == 'gitpython':
+                blob.stream_data(fp_)
+            elif provider == 'pygit2':
+                fp_.write(blob.data)
         with salt.utils.fopen(blobshadest, 'w+') as fp_:
-            fp_.write(blob.hexsha)
+            fp_.write(blob_hexsha)
         try:
             os.remove(lk_fn)
         except (OSError, IOError):
@@ -408,30 +634,88 @@ def file_list(load):
         )
         load['saltenv'] = load.pop('env')
 
-    ret = []
     base_branch = __opts__['gitfs_base']
+    gitfs_root = __opts__['gitfs_root']
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     if 'saltenv' not in load:
-        return ret
+        return []
     if load['saltenv'] == 'base':
         load['saltenv'] = base_branch
     repos = init()
+    ret = set()
     for repo in repos:
-        ref = _get_ref(repo, load['saltenv'])
-        if not ref:
+        if provider == 'gitpython':
+            ret.update(
+                _file_list_gitpython(repo, load['saltenv'], gitfs_root)
+            )
+        elif provider == 'pygit2':
+            ret.update(
+                _file_list_pygit2(repo, load['saltenv'], gitfs_root)
+            )
+    return sorted(ret)
+
+
+def _file_list_gitpython(repo, ref_tgt, gitfs_root):
+    '''
+    Get file list using GitPython
+    '''
+    ret = set()
+    ref = _get_ref_gitpython(repo, ref_tgt)
+    if not ref:
+        return ret
+    tree = ref.commit.tree
+    if gitfs_root:
+        try:
+            tree = tree / gitfs_root
+        except KeyError:
+            return ret
+    for blob in tree.traverse():
+        if not isinstance(blob, git.Blob):
             continue
-        tree = ref.commit.tree
-        if __opts__['gitfs_root']:
-            try:
-                tree = tree / __opts__['gitfs_root']
-            except KeyError:
-                continue
-        for blob in tree.traverse():
-            if not isinstance(blob, git.Blob):
-                continue
-            if __opts__['gitfs_root']:
-                ret.append(os.path.relpath(blob.path, __opts__['gitfs_root']))
-                continue
-            ret.append(blob.path)
+        if gitfs_root:
+            ret.add(os.path.relpath(blob.path, gitfs_root))
+            continue
+        ret.add(blob.path)
+    return ret
+
+
+def _file_list_pygit2(repo, ref_tgt, gitfs_root):
+    '''
+    Get file list using pygit2
+    '''
+    def _traverse(tree, repo, blobs, prefix):
+        '''
+        Traverse through a pygit2 Tree object recursively, accumulating all the
+        blob paths within it in the "blobs" list
+        '''
+        for entry in iter(tree):
+            blob = repo[entry.oid]
+            if isinstance(blob, pygit2.Blob):
+                blobs.append(os.path.join(prefix, entry.name))
+            elif isinstance(blob, pygit2.Tree):
+                _traverse(blob, repo, blobs, os.path.join(prefix, entry.name))
+    ret = set()
+    ref = _get_ref_pygit2(repo, ref_tgt)
+    if not ref:
+        return ret
+    tree = ref.get_object().tree
+    if gitfs_root:
+        try:
+            tree = repo[tree[gitfs_root].oid]
+        except KeyError:
+            return ret
+        if not isinstance(tree, pygit2.Tree):
+            return ret
+    blobs = []
+    if len(tree):
+        _traverse(tree, repo, blobs, gitfs_root)
+    for blob in blobs:
+        if gitfs_root:
+            ret.add(os.path.relpath(blob, gitfs_root))
+            continue
+        ret.add(blob)
     return ret
 
 
@@ -447,40 +731,101 @@ def file_list_emptydirs(load):
         )
         load['saltenv'] = load.pop('env')
 
-    ret = []
     base_branch = __opts__['gitfs_base']
+    gitfs_root = __opts__['gitfs_root']
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     if 'saltenv' not in load:
-        return ret
+        return []
     if load['saltenv'] == 'base':
         load['saltenv'] = base_branch
     repos = init()
+    ret = set()
     for repo in repos:
-        ref = _get_ref(repo, load['saltenv'])
-        if not ref:
-            continue
+        if provider == 'gitpython':
+            ret.update(
+                _file_list_emptytdirs_gitpython(
+                    repo, load['saltenv'], gitfs_root
+                )
+            )
+        elif provider == 'pygit2':
+            ret.update(
+                _file_list_emptydirs_pygit2(
+                    repo, load['saltenv'], gitfs_root
+                )
+            )
+    return sorted(ret)
 
-        tree = ref.commit.tree
-        if __opts__['gitfs_root']:
-            try:
-                tree = tree / __opts__['gitfs_root']
-            except KeyError:
+
+def _file_list_emptydirs_gitpython(repo, ref_tgt, gitfs_root):
+    '''
+    Get empty directories using GitPython
+    '''
+    ret = set()
+    ref = _get_ref_gitpython(repo, ref_tgt)
+    if not ref:
+        return ret
+    tree = ref.commit.tree
+    if gitfs_root:
+        try:
+            tree = tree / gitfs_root
+        except KeyError:
+            return ret
+    for blob in tree.traverse():
+        if not isinstance(blob, git.Tree):
+            continue
+        if not blob.blobs:
+            if __opts__['gitfs_root']:
+                ret.add(os.path.relpath(blob.path, gitfs_root))
                 continue
-        for blob in tree.traverse():
-            if not isinstance(blob, git.Tree):
-                continue
-            if not blob.blobs:
-                if __opts__['gitfs_root']:
-                    ret.append(
-                        os.path.relpath(blob.path, __opts__['gitfs_root'])
-                    )
-                    continue
-                ret.append(blob.path)
+            ret.add(blob.path)
     return ret
+
+
+def _file_list_emptydirs_pygit2(repo, ref_tgt, gitfs_root):
+    '''
+    Get empty directories using pygit2
+    '''
+    def _traverse(tree, repo, blobs, prefix):
+        '''
+        Traverse through a pygit2 Tree object recursively, accumulating all the
+        empty directories within it in the "blobs" list
+        '''
+        for entry in iter(tree):
+            blob = repo[entry.oid]
+            if not isinstance(blob, pygit2.Tree):
+                continue
+            if not len(blob):
+                blobs.append(os.path.join(prefix, entry.name))
+            else:
+                _traverse(blob, repo, blobs, os.path.join(prefix, entry.name))
+    ret = set()
+    ref = _get_ref_pygit2(repo, ref_tgt)
+    if not ref:
+        return ret
+    tree = ref.get_object().tree
+    if gitfs_root:
+        try:
+            tree = repo[tree[gitfs_root].oid]
+        except KeyError:
+            return ret
+        if not isinstance(tree, pygit2.Tree):
+            return ret
+    blobs = []
+    if len(tree):
+        _traverse(tree, repo, blobs, gitfs_root)
+    for blob in blobs:
+        if gitfs_root:
+            ret.add(os.path.relpath(blob, gitfs_root))
+            continue
+        ret.add(blob)
+    return sorted(ret)
 
 
 def dir_list(load):
     '''
-    Return a list of all directories on the master
+    Get a list of all directories on the master
     '''
     if 'env' in load:
         salt.utils.warn_until(
@@ -490,29 +835,83 @@ def dir_list(load):
         )
         load['saltenv'] = load.pop('env')
 
-    ret = []
     base_branch = __opts__['gitfs_base']
+    gitfs_root = __opts__['gitfs_root']
+    provider = __opts__.get(PROVIDER_PARAM, 'gitpython').lower()
+    if provider not in VALID_PROVIDERS:
+        _invalid_provider(provider)
     if 'saltenv' not in load:
-        return ret
+        return []
     if load['saltenv'] == 'base':
         load['saltenv'] = base_branch
     repos = init()
+    ret = set()
     for repo in repos:
-        ref = _get_ref(repo, load['saltenv'])
-        if not ref:
-            continue
+        if provider == 'gitpython':
+            ret.update(_dir_list_gitpython(repo, load['saltenv'], gitfs_root))
+        elif provider == 'pygit2':
+            ret.update(_dir_list_pygit2(repo, load['saltenv'], gitfs_root))
+    return sorted(ret)
 
-        tree = ref.commit.tree
-        if __opts__['gitfs_root']:
-            try:
-                tree = tree / __opts__['gitfs_root']
-            except KeyError:
+
+def _dir_list_gitpython(repo, ref_tgt, gitfs_root):
+    '''
+    Get list of directories using GitPython
+    '''
+    ret = set()
+    ref = _get_ref_gitpython(repo, ref_tgt)
+    if not ref:
+        return ret
+    tree = ref.commit.tree
+    if gitfs_root:
+        try:
+            tree = tree / gitfs_root
+        except KeyError:
+            return ret
+    for blob in tree.traverse():
+        if not isinstance(blob, git.Tree):
+            continue
+        if gitfs_root:
+            ret.add(os.path.relpath(blob.path, gitfs_root))
+            continue
+        ret.add(blob.path)
+    return ret
+
+
+def _dir_list_pygit2(repo, ref_tgt, gitfs_root):
+    '''
+    Get a list of directories using pygit2
+    '''
+    def _traverse(tree, repo, blobs, prefix):
+        '''
+        Traverse through a pygit2 Tree object recursively, accumulating all the
+        empty directories within it in the "blobs" list
+        '''
+        for entry in iter(tree):
+            blob = repo[entry.oid]
+            if not isinstance(blob, pygit2.Tree):
                 continue
-        for blob in tree.traverse():
-            if not isinstance(blob, git.Tree):
-                continue
-            if __opts__['gitfs_root']:
-                ret.append(os.path.relpath(blob.path, __opts__['gitfs_root']))
-                continue
-            ret.append(blob.path)
+            blobs.append(os.path.join(prefix, entry.name))
+            if len(blob):
+                _traverse(blob, repo, blobs, os.path.join(prefix, entry.name))
+    ret = set()
+    ref = _get_ref_pygit2(repo, ref_tgt)
+    if not ref:
+        return ret
+    tree = ref.get_object().tree
+    if gitfs_root:
+        try:
+            tree = repo[tree[gitfs_root].oid]
+        except KeyError:
+            return ret
+        if not isinstance(tree, pygit2.Tree):
+            return ret
+    blobs = []
+    if len(tree):
+        _traverse(tree, repo, blobs, gitfs_root)
+    for blob in blobs:
+        if gitfs_root:
+            ret.add(os.path.relpath(blob, gitfs_root))
+            continue
+        ret.add(blob)
     return ret


### PR DESCRIPTION
This pull request adds pygit2 support to the git fileserver backend, alongside the existing GitPython support. It establishes minimum requirements of 0.19.0 for both pygit2 and libgit2.

Additionally, a new master configuration file parameter `gitfs_provider` is added to manually specify which provider should be used. If this parameter is not present, pygit2 will be preferred over GitPython.

I've included language in these commits that targets this feature for the Helium release. @thatch45, let me know if this sounds good.

Reasons for adding pygit2 support:
1. GitPython wraps the git CLI, and expects the shell output to be very specific. Slight variances in the CLI output, such as an /etc/issue on the git server, or the ssh_config loglevel being verbose enough to add lines to the output, cause assertions to fail, sometimes making gitfs entirely unusable.
2. pygit2 uses libgit2, which (as @SEJeff notes [here](https://github.com/saltstack/salt/issues/4210#issuecomment-15503487)) enjoys a greater level of adoption.
3. pygit2 and libgit2 are more actively developed than GitPython. Case in point, as of today (3 January 2014) the most recent activity in the development branch was [283 days ago](https://github.com/gitpython-developers/GitPython/commit/660bdca125aa9dcca7a7730535bec433edb8ba02), while pygit2 has had a release as recently as 10 days ago, with a few major releases in the same span of time in which GitPython has seen _literally_ zero activity.
4. pygit2 is compatible with Python 3, while GitPython is not. This will make the inevitable quest for Salt to support Python 3 that much easier.
