### PR TITLE
Fix docker.start port_bindings

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -77029,8 +77029,8 @@ my_service:
         \- container: mysuperdocker
         \- port_bindings:
             "5000/tcp":
-                \- HostIp: ""
-                \- HostPort: "5000"
+                \HostIp: ""
+                \HostPort: "5000"
 .ft P
 .fi
 .UNINDENT
@@ -77306,8 +77306,8 @@ a mapping port\(aqs guest, hostname\(aqs host and port\(aqs host.
 .ft C
 \- port_bindings:
     "5000/tcp":
-        \- HostIp: ""
-        \- HostPort: "5000"
+        \HostIp: ""
+        \HostPort: "5000"
 .ft P
 .fi
 .UNINDENT

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -901,9 +901,11 @@ def start(container, binds=None, ports=None, port_bindings=None,
     try:
         dcontainer = _get_container_infos(container)['id']
         if not is_running(container):
-            bindings = {}
-            for k, v in port_bindings.iteritems():
-                bindings[k] = (v.get('HostIp', ''), v['HostPort'])
+            bindings = None
+            if port_bindings is not None:
+                bindings = {}
+                for k, v in port_bindings.iteritems():
+                    bindings[k] = (v.get('HostIp', ''), v['HostPort'])
             client.start(dcontainer, binds=binds, port_bindings=bindings,
                          lxc_conf=lxc_conf,
                          publish_all_ports=publish_all_ports, links=links)

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -901,7 +901,10 @@ def start(container, binds=None, ports=None, port_bindings=None,
     try:
         dcontainer = _get_container_infos(container)['id']
         if not is_running(container):
-            client.start(dcontainer, binds=binds, port_bindings=port_bindings,
+            bindings = {}
+            for k, v in port_bindings.iteritems():
+                bindings[k] = (v.get('HostIp', ''), v['HostPort'])
+            client.start(dcontainer, binds=binds, port_bindings=bindings,
                          lxc_conf=lxc_conf,
                          publish_all_ports=publish_all_ports, links=links)
             if is_running(dcontainer):

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -59,8 +59,8 @@ Available Functions
               - container: mysuperdocker
               - port_bindings:
                   "5000/tcp":
-                      - HostIp: ""
-                      - HostPort: "5000"
+                      HostIp: ""
+                      HostPort: "5000"
 
 
 - absent
@@ -577,8 +577,8 @@ def running(name, container=None, port_bindings=None, binds=None,
 
             - port_bindings:
                 "5000/tcp":
-                    - HostIp: ""
-                    - HostPort: "5000"
+                    HostIp: ""
+                    HostPort: "5000"
     '''
     is_running = __salt('docker.is_running')(container)
     if is_running:


### PR DESCRIPTION
When starting docker container using the following state:

```
my_service:
    docker.running:
        - container: mysuperdocker
        - port_bindings:
            "5000/tcp":
                - HostIp: ""
                - HostPort: "5000"
```

I've realized that bound port on host was wrong (was not port 5000 as requested).
So this pull request intends to fix this. HostIp and HostPort are also now configured as dict keys (not list anymore) since it simplifies implementation.
So with this pull request, the following state works for me:

```
my_service:
    docker.running:
        - container: mysuperdocker
        - port_bindings:
            "5000/tcp":
                HostPort: "5000"
```

@kiorky: it would be great if you could have a look since you're the one who did all the work on docker module and state? 
