### PR TITLE
SmartOS esky build tooling

### DIFF
--- a/pkg/smartos/esky/BUILD_ENVIRONMENT.md
+++ b/pkg/smartos/esky/BUILD_ENVIRONMENT.md
@@ -1,0 +1,56 @@
+# Esky builds for SmartOS
+
+This is intentionally currently not marked executable.
+There are some hard coded bits, it depends on a binary copy of patchelf, etc.
+However it does document pretty thoroughly how I initially created a build environment
+for packaging up esky builds for SmartOS
+
+```bash
+#!/bin/bash
+
+export PATH=$PATH:/opt/local/gcc47/bin/
+HERE=$(pwd)
+
+mv /opt/local /opt/local.backup ; hash -r
+cd /
+curl http://pkgsrc.joyent.com/packages/SmartOS/bootstrap/bootstrap-2013Q3-x86_64.tar.gz | gtar xz
+hash -r
+
+pkgin -y up
+pkgin -y in build-essential salt swig py27-pip unzip 
+pkgin -y rm salt
+
+cd /opt/local/bin
+curl -kO 'https://us-east.manta.joyent.com/nahamu/public/smartos/bins/patchelf'
+chmod +x patchelf
+cat >swig <<"EOF"
+#!/bin/bash
+exec /opt/local/bin/swig2.0 -I/opt/local/include "$@"
+EOF
+
+pip install esky
+yes | pip uninstall bbfreeze
+
+cd $HERE
+curl -kO 'https://pypi.python.org/packages/source/b/bbfreeze-loader/bbfreeze-loader-1.1.0.zip'
+unzip bbfreeze-loader-1.1.0.zip
+
+COMPILE="gcc -fno-strict-aliasing -O2 -pipe -O2 -DHAVE_DB_185_H -I/usr/include -I/opt/local/include -I/opt/local/include/db4 -I/opt/local/include/gettext -I/opt/local/include/ncurses -DNDEBUG -O2 -pipe -O2 -DHAVE_DB_185_H -I/usr/include -I/opt/local/include -I/opt/local/include/db4 -I/opt/local/include/gettext -I/opt/local/include/ncurses -fPIC -I/opt/local/include/python2.7 -static-libgcc"
+$COMPILE -c bbfreeze-loader-1.1.0/_bbfreeze_loader/console.c -o $HERE/console.o
+$COMPILE -c bbfreeze-loader-1.1.0/_bbfreeze_loader/getpath.c -o $HERE/getpath.o
+gcc $HERE/console.o $HERE/getpath.o /opt/local/lib/python2.7/config/libpython2.7.a -L/opt/local/lib -L/opt/local/lib/python2.7/config -L/opt/local/lib -lsocket -lnsl -ldl -lrt -lm -static-libgcc -o $HERE/console.exe
+patchelf --set-rpath '$ORIGIN:$ORIGIN/../lib' $HERE/console.exe
+
+git clone git://github.com/schmir/bbfreeze -b master
+( cd $HERE/bbfreeze && easy_install-2.7 . )
+find /opt/local -name console.exe -exec mv $HERE/console.exe {} \;
+
+git clone git://github.com/saltstack/salt -b 0.17
+( cd $HERE/salt && python2.7 setup.py bdist && python2.7 setup.py bdist_esky )
+
+mv /opt/local /opt/local.build ; hash -r
+mv /opt/local.backup /opt/local ; hash -r
+
+mmkdir -p /$MANTA_USER/public/salt
+mput /$MANTA_USER/public/salt -f $(ls salt/dist/*.zip)
+```

--- a/pkg/smartos/esky/_syspaths.py
+++ b/pkg/smartos/esky/_syspaths.py
@@ -1,0 +1,22 @@
+import os
+import sys
+
+# http://stackoverflow.com/a/404750
+# determine if application is a script file or frozen exe
+if getattr(sys, 'frozen', False):
+    application_path = os.path.dirname(sys.executable)
+elif __file__:
+    application_path = os.path.dirname(__file__)
+
+ROOT_DIR=application_path.split("salt/bin/appdata")[0] + "salt"
+
+# Copied from syspaths.py
+CONFIG_DIR = os.path.join(ROOT_DIR, 'etc')
+CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')
+SOCK_DIR = os.path.join(ROOT_DIR, 'var', 'run', 'salt')
+SRV_ROOT_DIR = os.path.join(ROOT_DIR, 'srv')
+BASE_FILE_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'salt')
+BASE_PILLAR_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'pillar')
+BASE_MASTER_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'salt-master')
+LOGS_DIR = os.path.join(ROOT_DIR, 'var', 'log', 'salt')
+PIDFILE_DIR = os.path.join(ROOT_DIR, 'var', 'run')

--- a/pkg/smartos/esky/build-tarball.sh
+++ b/pkg/smartos/esky/build-tarball.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+PKG_DIR=$(cd $(dirname $0); pwd)
+BUILD_DIR=build/output/salt
+
+rm -rf dist/ $BUILD_DIR &&\
+cp $PKG_DIR/_syspaths.py salt/ &&\
+python2.7 setup.py bdist &&\
+python2.7 setup.py bdist_esky &&\
+rm salt/_syspaths.py &&\
+rm -f dist/*.tar.gz &&\
+mkdir -p $BUILD_DIR/{etc,install,bin/appdata} &&\
+cp conf/* $BUILD_DIR/etc/
+cp $PKG_DIR/*.xml $PKG_DIR/install.sh $BUILD_DIR/install &&\
+chmod +x $BUILD_DIR/install/install.sh &&\
+unzip -d $BUILD_DIR/bin dist/*.zip &&\
+cp $BUILD_DIR/bin/*/libgcc_s.so.1 $BUILD_DIR/bin/ &&\
+find build/output/salt/bin/ -mindepth 1 -maxdepth 1 -type d -not -name appdata -exec mv {} $BUILD_DIR/bin/appdata/ \; &&\
+gtar -C $BUILD_DIR/.. -czvf dist/salt-$(git describe | sed 's|^v||')-esky-smartos.tar.gz salt &&\
+echo "tarball built"

--- a/pkg/smartos/esky/install.sh
+++ b/pkg/smartos/esky/install.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+HERE=$(dirname $0)
+TOP=$(cd $HERE/.. ; pwd)
+
+mkdir $HERE/output
+for file in $HERE/*.xml
+do
+  sed "s#SALT_PREFIX#$TOP#" <$file >$HERE/output/$(basename $file)
+  svccfg import $HERE/output/$(basename $file)
+done
+rm -rf $HERE/output
+
+echo "To enable services, invoke any of"
+echo "    svcadm enable salt-minion"
+echo "    svcadm enable salt-master"
+echo "    svcadm enable salt-syndic"
+echo "as appropriate"

--- a/pkg/smartos/esky/salt-master.xml
+++ b/pkg/smartos/esky/salt-master.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-master">
+    <service name="network/salt-master" type="service" version="1">
+
+      <create_default_instance enabled="false"/>
+
+      <single_instance/>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="SALT_PREFIX/bin/salt-master"
+                   timeout_seconds="60">
+        <method_context>
+          <method_environment>
+            <envvar name="PATH" value="/bin:/usr/bin:/opt/local/bin:SALT_PREFIX/bin" />
+          </method_environment>
+        </method_context>
+      </exec_method>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt Master</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.org"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>

--- a/pkg/smartos/esky/salt-minion.xml
+++ b/pkg/smartos/esky/salt-minion.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-minion">
+    <service name="network/salt-minion" type="service" version="1">
+
+      <create_default_instance enabled="false"/>
+
+      <single_instance/>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="SALT_PREFIX/bin/salt-minion"
+                   timeout_seconds="60">
+        <method_context>
+          <method_environment>
+            <envvar name="PATH" value="/bin:/usr/bin:/opt/local/bin:SALT_PREFIX/bin" />
+          </method_environment>
+        </method_context>
+      </exec_method>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt Minion</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.org"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>

--- a/pkg/smartos/esky/salt-syndic.xml
+++ b/pkg/smartos/esky/salt-syndic.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<!DOCTYPE service_bundle SYSTEM "/usr/share/lib/xml/dtd/service_bundle.dtd.1">
+<!--
+        Created by Manifold
+-->
+  <service_bundle type="manifest" name="salt-syndic">
+    <service name="network/salt-syndic" type="service" version="1">
+
+      <create_default_instance enabled="false"/>
+
+      <single_instance/>
+
+      <dependency name="network"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/milestone/network:default"/>
+      </dependency>
+
+      <dependency name="filesystem"
+                  grouping="require_all"
+                  restart_on="error"
+                  type="service">
+        <service_fmri value="svc:/system/filesystem/local"/>
+      </dependency>
+
+      <method_context/>
+
+      <exec_method type="method"
+                   name="start"
+                   exec="SALT_PREFIX/bin/salt-syndic -c %{config_dir}"
+                   timeout_seconds="60">
+        <method_context>
+          <method_environment>
+            <envvar name="PATH" value="/bin:/usr/bin:/opt/local/bin:SALT_PREFIX/bin" />
+          </method_environment>
+        </method_context>
+      </exec_method>
+
+      <exec_method type="method"
+                   name="stop"
+                   exec=":kill"
+                   timeout_seconds="60"/>
+
+      <property_group name="startd" type="framework">
+        <propval name="duration" type="astring" value="child"/>
+        <propval name="ignore_error" type="astring" value="core,signal"/>
+      </property_group>
+
+      <stability value="Unstable"/>
+
+      <template>
+        <common_name>
+          <loctext xml:lang="C">Salt Syndic</loctext>
+        </common_name>
+
+        <documentation>
+          <doc_link name="SaltStack Documentation"
+                    uri="http://docs.saltstack.org"/>
+        </documentation>
+      </template>
+    </service>
+</service_bundle>


### PR DESCRIPTION
This includes:
Notes on how I created a build environment
The _syspaths.py that allows the esky build to be installed anywhere
"Template" SMF manifests and an install script to import them
A script for building both the esky zip and a deployable tarball
