### PR TITLE
Make mysql returner use json to serializer return

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -134,7 +134,7 @@ def returner(ret):
                 VALUES (%s, %s, %s, %s, %s, %s)'''
 
         cur.execute(sql, (ret['fun'], ret['jid'],
-                            str(ret['return']), ret['id'],
+                            json.dumps(ret['return']), ret['id'],
                             ret['success'], json.dumps(ret)))
 
 


### PR DESCRIPTION
See issue #9590

Using str to serializer data is a bad idea as there is no good way
to safely and reliable deserialize it. JSON allows this, and is what
the postgresql returner uses.
