### PR TITLE
Change owner for all `jid_dir`

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -229,7 +229,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
                     # chown the file for the new user
                     os.chown(dir_, uid, gid)
             for root, dirs, files in os.walk(dir_):
-                if 'jobs' in root:
+                if 'jobs' in root and not root.endswith('jobs'):
                     continue
                 for name in files:
                     if name.startswith('.'):


### PR DESCRIPTION
Hello.

I encountered with a strange problem described in a #8295 and may be #8842.
The problem was the permission for 'jid_dir' directories.
You can reproduce it. Run a several jobs with 'root' user and then change 'user' option to another user without privileges. Some jobs, which 'jid_dir' is alredy created, is failing.
