### PR TITLE
Fix ownership/perms on salt.utils.copyfile()

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -640,7 +640,12 @@ def copyfile(source, dest, backup_mode='', cachedir=''):
     if backup_mode == 'master' or backup_mode == 'both' and bkroot:
         # TODO, backup to master
         pass
+    # Get current file stats to they can be replicated after the new file is
+    # moved to the destination path.
+    fstat = os.stat(dest)
     shutil.move(tgt, dest)
+    os.chown(dest, fstat.st_uid, fstat.st_gid)
+    os.chmod(dest, fstat.st_mode)
     # If SELINUX is available run a restorecon on the file
     rcon = which('restorecon')
     if rcon:


### PR DESCRIPTION
When salt.utils.copyfile() uses shutil.move() to move the target file to
the destination, the ownership/permissions from the original file that
existed at the destination path are not preserved. For security reasons,
files cached locally and compared to existing files in file.managed
states are created with ownership of root:root (or user:primarygroup, if
the master is running as non-root), with a mode of 600.

Normally, this would not be an issue since
salt.modules.file.check_perms() is invoked to correct the ownership and
permissions. However, recent modifications to that function have
resulted in the ownership/permissions not being modified if these
parameters are passed to check_perms() as None.

Since the user, group, and mode default to None in file.managed states,
if they are not explicitly defined in a state, this results in is the
newly-created file overwriting the old file, and the
ownership/permissions being left untouched.

This commit modifies salt.utils.copyfile() to restore the old file's
ownership and permissions after shutil.move is invoked to replace the
old file with the new one.

Fixes #9527.
