### PR TITLE
Fix the following crash in a minion when master executes

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -20,6 +20,7 @@ import salt.payload
 import salt.state
 import salt.client
 import salt.utils
+import salt.utils.process
 import salt.transport
 from salt.exceptions import SaltReqTimeoutError
 from salt._compat import string_types


### PR DESCRIPTION
state.highstate on it.

```
2014-01-07 01:45:43,315 [salt.minion      ][INFO    ] User sudo_ubuntu Executing command state.highstate with jid 20140107014542797484
2014-01-07 01:45:43,332 [salt.minion      ][WARNING ] The minion function caused an exception: Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/minion.py", line 626, in _thread_return
    '''
  File "/usr/local/lib/python2.7/dist-packages/salt/modules/state.py", line 237, in highstate
    conflict = running()
  File "/usr/local/lib/python2.7/dist-packages/salt/modules/state.py", line 91, in running
    active = __salt__['saltutil.is_running']('state.*')
  File "/usr/local/lib/python2.7/dist-packages/salt/modules/saltutil.py", line 365, in is_running
    '''
  File "/usr/local/lib/python2.7/dist-packages/salt/modules/saltutil.py", line 396, in running
    continue
AttributeError: 'module' object has no attribute 'os_is_running'

2014-01-07 01:45:43,333 [salt.minion      ][INFO    ] Returning information for job: 20140107014542797484
```
