### PR TITLE
fix for windows masterless read-only highstate.cache.p file

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2468,7 +2468,7 @@ class BaseHighState(object):
         try:
             if salt.utils.is_windows():
                 # Make sure cache file isn't read-only
-                salt.modules.cmdmod._run_quiet('attrib -R "{0}"'.format(cfn), quiet=True)
+                self.state.functions('attrib -R "{0}"'.format(cfn), quiet=True)
             with salt.utils.fopen(cfn, 'w+') as fp_:
                 try:
                     self.serial.dump(high, fp_)

--- a/salt/state.py
+++ b/salt/state.py
@@ -2468,7 +2468,7 @@ class BaseHighState(object):
         try:
             if salt.utils.is_windows():
                 # Make sure cache file isn't read-only
-                salt.modules.cmdmod._run_quiet('attrib -R "{0}"'.format(cfn))
+                salt.modules.cmdmod._run_quiet('attrib -R "{0}"'.format(cfn), quiet=True)
             with salt.utils.fopen(cfn, 'w+') as fp_:
                 try:
                     self.serial.dump(high, fp_)

--- a/salt/state.py
+++ b/salt/state.py
@@ -2465,12 +2465,20 @@ class BaseHighState(object):
         if not high:
             return ret
         cumask = os.umask(191)
-        with salt.utils.fopen(cfn, 'w+') as fp_:
-            try:
-                self.serial.dump(high, fp_)
-            except TypeError:
-                # Can't serialize pydsl
-                pass
+        try:
+            if salt.utils.is_windows():
+                # Make sure cache file isn't read-only
+                salt.modules.cmdmod._run_quiet('attrib -R "{0}"'.format(cfn))
+            with salt.utils.fopen(cfn, 'w+') as fp_:
+                try:
+                    self.serial.dump(high, fp_)
+                except TypeError:
+                    # Can't serialize pydsl
+                    pass
+        except (IOError, OSError):
+            msg = 'Unable to write to "state.highstate" cache file {0}'
+            log.error(msg.format(cfn))
+
         os.umask(cumask)
         return self.state.call_high(high)
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -2468,7 +2468,7 @@ class BaseHighState(object):
         try:
             if salt.utils.is_windows():
                 # Make sure cache file isn't read-only
-                self.state.functions('attrib -R "{0}"'.format(cfn), quiet=True)
+                self.state.functions['cmd.run']('attrib -R "{0}"'.format(cfn), quiet=True)
             with salt.utils.fopen(cfn, 'w+') as fp_:
                 try:
                     self.serial.dump(high, fp_)


### PR DESCRIPTION
After the first highstate run on windows masterless, all subsequent runs fail, because the highstate cache file is read-only with the error below:

IOError: [Errno 13] Permission denied: 'c:\salt\var\cache\salt\minion\highstate.cache.p'
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "**main**.py", line 726, in <module>
  File "**main**.py", line 332, in bootstrap
  File "**main**.py", line 359, in chainload
  File "**main**.py", line 715, in _chainload
  File "__main__.py", line 128, in <module>
  File "**main__salt-call**.py", line 14, in <module>
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\scripts.py", line 82, in salt_call
    client.run()
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\cli__init__.py", line 313, in run
    caller.run()
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\cli\caller.py", line 137, in run
    ret = self.call()
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\cli\caller.py", line 78, in call
    ret['return'] = func(_args, *_kwargs)
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\modules\state.py", line 268, in highstate
    force=kwargs.get('force', False)
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\state.py", line 2468, in call_highstate
    with salt.utils.fopen(cfn, 'w+') as fp_:
  File "c:\salt\salt-0.17.4.win-amd64\salt-0.17.4-py2.7.egg\salt\utils__init__.py", line 1030, in fopen
    fhandle = open(_args, *_kwargs)
IOError: [Errno 13] Permission denied: 'c:\salt\var\cache\salt\minion\highstate.cache.p'
