### PR TITLE
Addresses the issue:  Unable to manage file: stats() got an unexpected keyword argument 'follow_symlinks’

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -296,7 +296,7 @@ def chgrp(path, group):
     return None
 
 
-def stats(path, hash_type='md5', follow_symlink=False):
+def stats(path, hash_type='md5', follow_symlinks=False):
     '''
     Return a dict containing the stats for a given file
 
@@ -309,7 +309,7 @@ def stats(path, hash_type='md5', follow_symlink=False):
     ret = {}
     if not os.path.exists(path):
         return ret
-    if follow_symlink:
+    if follow_symlinks:
         pstat = os.stat(path)
     else:
         pstat = os.lstat(path)


### PR DESCRIPTION
Looks like this argument was renamed in non-windows files, but windows was omitted.
