### PR TITLE
Allows salt minion to run directly from source on Windows

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -29,6 +29,7 @@ import salt.pillar
 import salt.syspaths
 
 import sys
+#can't use salt.utils.is_windows, because config.py is included from salt.utils
 if not sys.platform.lower().startswith('win'):
     import salt.cloud.exceptions
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -28,8 +28,9 @@ import salt.utils.network
 import salt.pillar
 import salt.syspaths
 
-# Import salt cloud libs
-import salt.cloud.exceptions
+import sys
+if not sys.platform.lower().startswith('win'):
+    import salt.cloud.exceptions
 
 log = logging.getLogger(__name__)
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -27,10 +27,10 @@ import salt.utils as utils
 import salt.version as version
 import salt.syspaths as syspaths
 import salt.log.setup as log
+import salt.utils
 from salt.utils.validate.path import is_writeable
 
-if not sys.platform.lower().startswith('win'):
-    # Import salt cloud libs
+if not salt.utils.is_windows():
     import salt.cloud.exceptions
 
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -29,8 +29,9 @@ import salt.syspaths as syspaths
 import salt.log.setup as log
 from salt.utils.validate.path import is_writeable
 
-# Import salt cloud libs
-import salt.cloud.exceptions
+if not sys.platform.lower().startswith('win'):
+    # Import salt cloud libs
+    import salt.cloud.exceptions
 
 
 def _sorted(mixins_or_funcs):


### PR DESCRIPTION
salt.cloud depends on importing pipes, which isn't present on windows.  It's excluded from the binary distribution, so there's no issue there, but it's annoying having to modify the source to get the scripts to run under windows.

In order to run on Windows directly from the Python scripts (Instead of the binary distribution), I've made the imports to salt.cloud\* conditional on the platform.  This prevents me from having to go through the setup process each time I want to test a build, or from having to delete the cloud directory in my working copy to avoid it from being imported.  

I'm not a Python expert, so I may be doing this wrong so am very open to any other ideas.

Thanks in advance for any advice / considerations.
