### PR TITLE
Add ruby version to gem install for rbenv

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -17,7 +17,7 @@ def _gem(command, ruby=None, runas=None):
         return __salt__['rvm.do'](ruby, cmdline, runas=runas)
 
     if __salt__['rbenv.is_installed'](runas=runas):
-        return __salt__['rbenv.do'](cmdline, runas=runas)
+        return __salt__['rbenv.do_with_ruby'](ruby, cmdline, runas=runas)
 
     ret = __salt__['cmd.run_all'](
         cmdline,

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -290,3 +290,24 @@ def do(cmdline=None, runas=None):
         return result['stdout']
     else:
         return False
+
+
+def do_with_ruby(ruby, cmdline, runas=None):
+    '''
+    Execute a ruby command with rbenv's shims using a specific ruby version.
+
+    CLI Example
+
+    .. code-block:: bash
+
+        salt '*' rbenv.do_with_ruby 2.0.0-p0 'gem list bundler'
+        salt '*' rbenv.do_with_ruby 2.0.0-p0 'gem list bundler' deploy
+    '''
+
+    if ruby:
+        cmd = 'RBENV_VERSION={0} {1}'.format(ruby, cmdline)
+    else:
+        cmd = cmdline
+
+    return do(cmd, runas=runas)
+


### PR DESCRIPTION
- Adds ability to specify which version of ruby to install gems into
- Similar feature to the rvm version
- Allows installing and managing multiple ruby versions
