### PR TITLE
Fix file state tracebacks when source is a list

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1186,30 +1186,35 @@ def managed(name,
             context = {}
         context['accumulator'] = _ACCUMULATORS[name]
 
-    if __opts__['test']:
-        ret['result'], ret['comment'] = __salt__['file.check_managed'](
-            name,
+    try:
+        if __opts__['test']:
+            ret['result'], ret['comment'] = __salt__['file.check_managed'](
+                name,
+                source,
+                source_hash,
+                user,
+                group,
+                mode,
+                template,
+                makedirs,
+                context,
+                defaults,
+                __env__,
+                contents,
+                **kwargs
+            )
+            return ret
+
+        # If the source is a list then find which file exists
+        source, source_hash = __salt__['file.source_list'](
             source,
             source_hash,
-            user,
-            group,
-            mode,
-            template,
-            makedirs,
-            context,
-            defaults,
-            __env__,
-            contents,
-            **kwargs
+            __env__
         )
+    except CommandExecutionError as exc:
+        ret['result'] = False
+        ret['comment'] = 'Unable to manage file: {0}'.format(exc)
         return ret
-
-    # If the source is a list then find which file exists
-    source, source_hash = __salt__['file.source_list'](
-        source,
-        source_hash,
-        __env__
-    )
 
     # Gather the source file from the server
     try:


### PR DESCRIPTION
If file.managed state has a source param which is a list, and none of the URIs in that list are found, a traceback occurs. This pull request modifies salt.modules.file.source_list to raise an exception when source is a list and no matches are found, and then catches that exception in the file.managed state so that Salt can return gracefully with a False result and meaningful error message.

Additionally, the same issue existed in file.recurse, and is also fixed by this pull request.

Fixes #9620.
