### PR TITLE
Fix versionadded:: for filter_by() "default=" parameter

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -352,7 +352,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default'):
     :param default: default lookup_dict's key used if the grain does not exists
          or if the grain value has no match on lookup_dict.
 
-         .. versionadded:: 0.17.2
+         .. versionadded:: 2014.1
 
     CLI Example:
 


### PR DESCRIPTION
This parameter has been introduced by commit dbfe790a, which has not
been merged in 0.17 branch. Only in 2014.1.
