### PR TITLE
Speeds up query of processes by using powershell to query all services

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -274,7 +274,7 @@ def _run(cmd,
         if stack[-2][2] == 'script':
             cmd = 'Powershell -executionpolicy bypass -File ' + cmd
         else:
-            cmd = 'Powershell ' + cmd
+            cmd = 'Powershell "{0}"'.format(cmd.replace('"', '\\"'))
 
     # munge the cmd and cwd through the template
     (cmd, cwd) = _render_cmd(cmd, cwd, template, saltenv)

--- a/salt/state.py
+++ b/salt/state.py
@@ -2468,7 +2468,7 @@ class BaseHighState(object):
         try:
             if salt.utils.is_windows():
                 # Make sure cache file isn't read-only
-                self.state.functions['cmd.run']('attrib -R "{0}"'.format(cfn), quiet=True)
+                self.state.functions['cmd.run']('attrib -R "{0}"'.format(cfn), output_loglevel='quiet')
             with salt.utils.fopen(cfn, 'w+') as fp_:
                 try:
                     self.serial.dump(high, fp_)


### PR DESCRIPTION
If powershell is available, this significantly speeds up the windows minion, as it doesn't have to query each service individually to see if it's enabled/disabled.
