### PR TITLE
On windows, switch so that colors are off by default

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -77,7 +77,7 @@ def get_printout(out, opts=None, **kwargs):
 
         if opts.get('force_color', False):
             opts['color'] = True
-        elif opts.get('no_color', False) or is_pipe():
+        elif opts.get('no_color', False) or is_pipe() or salt.utils.is_windows():
             opts['color'] = False
         else:
             opts['color'] = True


### PR DESCRIPTION
Since it isn’t supported by the default console.  —force-color can still be used if it is needed.
