### PR TITLE
Adds extra_uninstall_flags option for windows packages

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -576,7 +576,7 @@ def upgrade(refresh=True):
     return {}
 
 
-def remove(name=None, pkgs=None, version=None, **kwargs):
+def remove(name=None, pkgs=None, version=None, extra_uninstall_flags=None, **kwargs):
     '''
     Remove packages.
 
@@ -638,7 +638,7 @@ def remove(name=None, pkgs=None, version=None, **kwargs):
                 and '(x86)' in cached_pkg:
             cached_pkg = cached_pkg.replace('(x86)', '')
         cmd = '"' + str(os.path.expandvars(
-            cached_pkg)) + '"' + str(pkginfo[version].get('uninstall_flags', ''))
+            cached_pkg)) + '"' + str(pkginfo[version].get('uninstall_flags', '') + " " + (extra_uninstall_flags or ''))
         if pkginfo[version].get('msiexec'):
             cmd = 'msiexec /x ' + cmd
         __salt__['cmd.run'](cmd, output_loglevel='debug')


### PR DESCRIPTION
To handle automated uninstalls where settings files are required like for uninstallation, like with InstallShield.

InstallShield requires you to generate an automated uninstall settings by running through the uninstaller.  This can be  installation specific rather than package specific, so they need to be supplied in the state file, rather than the package repository.  This mirrors the extra_install_flags option.
