### PR TITLE
Fix #9568 - users may accidentally quote the port number which will cause mysql connections to fail

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -95,7 +95,10 @@ def _get_options():
             log.debug('Using default for MySQL {0}'.format(attr))
             _options[attr] = defaults[attr]
             continue
-        _options[attr] = _attr
+        if attr == 'port':
+            _options[attr] = int(_attr)
+        else:
+            _options[attr] = _attr
 
     return _options
 


### PR DESCRIPTION
Some users accidentally put quotes around the mysql.port which causes mysql connections to fail.
