### PR TITLE
Fix regression caused by pull #9629

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1979,7 +1979,7 @@ def source_list(source, source_hash, saltenv):
                 proto = salt._compat.urlparse(single_src).scheme
                 if proto == 'salt':
                     if single_src[7:] in mfiles or single_src[7:] in mdirs:
-                        source = single_src
+                        ret = (single_src, single_hash)
                         break
                 elif proto.startswith('http') or proto == 'ftp':
                     dest = salt.utils.mkstemp()


### PR DESCRIPTION
Regression tests caught the following:

http://jenkins.saltstack.com/job/salt-rs-debian7/1368/testReport/integration.modules.file/FileModuleTest/test_source_list_for_list_returns_file_from_dict/

This commit fixes the regression.
