### PR TITLE
Windows state ignore index and fix bugs

### DIFF
--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -99,9 +99,9 @@ def add(path, index=0):
 
     # validate index boundaries
     if index < 0:
-        index = len(sysPath) + index
-    if index > len(sysPath) - 1:
-        index = len(sysPath) - 1
+        index = len(sysPath) + index + 1
+    if index > len(sysPath):
+        index = len(sysPath)
 
     # Check if we are in the system path at the right location
     try:

--- a/salt/states/win_path.py
+++ b/salt/states/win_path.py
@@ -52,11 +52,13 @@ def absent(name):
     return ret
 
 
-def exists(name, index=0):
+def exists(name, index=None):
     '''
     Add the directory to the system PATH at index location
 
-    index: where the directory should be placed in the PATH (default: 0)
+    index: where the directory should be placed in the PATH (default: None)
+    [Note:  Providing no index will append directory to PATH and
+    will not enforce its location within the PATH.]
 
     Example::
 
@@ -76,23 +78,30 @@ def exists(name, index=0):
     sysPath = __salt__['win_path.get_path']()
     path = _normalize_dir(name)
 
-    index = int(index)
-    if index < 0:
-        index = len(sysPath) + index
-    if index > len(sysPath) - 1:
-        index = len(sysPath) - 1
 
     try:
         currIndex = sysPath.index(path)
-        if currIndex != index:
-            sysPath.pop(currIndex)
-            ret['changes']['removed'] = '{0} was removed from index {1}'.format(name, currIndex)
-        else:
+        if index:
+            index = int(index)
+            if index < 0:
+                index = len(sysPath) + index + 1
+            if index > len(sysPath):
+                index = len(sysPath)
+            # check placement within PATH
+            if currIndex != index:
+                sysPath.pop(currIndex)
+                ret['changes']['removed'] = '{0} was removed from index {1}'.format(name, currIndex)
+            else:
+                ret['comment'] = '{0} is already present in the PATH at the right location'.format(name)
+                return ret
+        else:  #path is in system PATH; don't care where
             ret['comment'] = '{0} is already present in the PATH at the right location'.format(name)
             return ret
     except ValueError:
         pass
 
+    if not index:
+        index = len(sysPath)    #put it at the end
     ret['changes']['added'] = '{0} will be added at index {1}'.format(name, index)
     if __opts__['test']:
         ret['result'] = None


### PR DESCRIPTION
Add ability for state to ignore index of the new path within system path.  Also needed to change indexing code in execution module to fix bug so new path can be appended rather than being inserted to the next-to-last place.
