### PR TITLE
dockerio: do not override default CMD declared in image

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -546,7 +546,7 @@ def export(container, path, *args, **kwargs):
 
 
 def create_container(image,
-                     command='/sbin/init',
+                     command=None,
                      hostname=None,
                      user=None,
                      detach=True,

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -293,7 +293,7 @@ def built(name,
 
 def installed(name,
               image,
-              command='/sbin/init',
+              command=None,
               hostname=None,
               user=None,
               detach=True,


### PR DESCRIPTION
I'm using the following SLS to bootstrap https://github.com/shipyard/shipyard, as you can see I had to add `command: null` to force creating a container that uses the command declared as default by the docker image.

It doesn't make sense to me, so this pull request proposes changing salt's dockerio state to follow the defaults that comes from docker images as much as possible.

```
include:                                                                                                                                                                                                                            
  - docker                                                                                                                                                                                                                          

image:                                                                                                                                                                                                                              
  docker.pulled:                                                                                                                                                                                                                    
    - name: shipyard/shipyard                                                                                                                                                                                                       
    - require:                                                                                                                                                                                                                      
      - sls: docker                                                                                                                                                                                                                 

container:                                                                                                                                                                                                                          
  docker.installed:                                                                                                                                                                                                                 
    - name: shipyard                                                                                                                                                                                                                
    - image: shipyard/shipyard                                                                                                                                                                                                      
    - command: null                                                                                                                                                                                                                 
    - ports:                                                                                                                                                                                                                        
      - "80/tcp"                                                                                                                                                                                                                    
      - "8000/tcp"                                                                                                                                                                                                                  
    - environment:                                                                                                                                                                                                                  
      - CELERY_WORKERS: 3                                                                                                                                                                                                           
      - HIPACHE_WORKERS: 3                                                                                                                                                                                                          
    - require:                                                                                                                                                                                                                      
      - docker: image                                                                                                                                                                                                               

app:                                                                                                                                                                                                                                
  docker.running:                                                                                                                                                                                                                   
    - container: shipyard                                                                                                                                                                                                           
    - port_bindings:                                                                                                                                                                                                                
        "80/tcp":                                                                                                                                                                                                                   
            HostIp: ""                                                                                                                                                                                                              
            HostPort: "80"                                                                                                                                                                                                          
        "8000/tcp":                                                                                                                                                                                                                 
            HostIp: ""                                                                                                                                                                                                              
            HostPort: "8000"                                                                                                                                                                                                        
    - require:                                                                                                                                                                                                                      
      - docker: container 
```
