### PR TITLE
File manage fails if it needs to create directories and no mode argument was supplied

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2609,7 +2609,7 @@ def manage_file(name,
 
             if not os.path.isdir(os.path.dirname(name)):
                 if makedirs:
-                    if dir_mode is None:
+                    if dir_mode is None and mode is not None:
                         # Add execute bit to each nonzero digit in the mode, if
                         # dir_mode was not specified. Otherwise, any
                         # directories created with makedirs() below can't be

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -225,6 +225,7 @@ import re
 import fnmatch
 import json
 import pprint
+import traceback
 
 # Import third party libs
 import yaml
@@ -1226,6 +1227,7 @@ def managed(name,
         )
     except Exception as exc:
         ret['changes'] = {}
+        log.debug(traceback.format_exc())
         return _error(ret, 'Unable to manage file: {0}'.format(exc))
 
     if comment_ and contents is None:
@@ -1250,6 +1252,7 @@ def managed(name,
             )
         except Exception as exc:
             ret['changes'] = {}
+            log.debug(traceback.format_exc())
             return _error(ret, 'Unable to manage file: {0}'.format(exc))
 
 


### PR DESCRIPTION
I was just having a problem that file.manage was failing with:
Unable to manage file: invalid literal for int() with base 10: 'o'
It seems it was trying to interpret the string None as a mode. My patch uses the default directory mode if it neither mode or dir_mode is specified.

I also include the debugging I added as a separate commit. 
