### PR TITLE
Tweak rpm build

### DIFF
--- a/pkg/rpm/build.py
+++ b/pkg/rpm/build.py
@@ -27,7 +27,7 @@ salt_version = '.'.join(map(str, salt.version.__version_info__[0:3]))
 rpmbuild = join(os.environ['HOME'], 'rpmbuild')
 copy(join(src, 'pkg/rpm/salt.spec'), join(rpmbuild, 'SPECS'))
 for f in os.listdir(join(src, 'pkg/rpm')):
-    if f in ['salt.spec', 'build']:
+    if f in ['salt.spec', 'build.py']:
         continue
     copy(join(src, 'pkg/rpm', f), join(rpmbuild, 'SOURCES'))
 

--- a/pkg/rpm/build.py
+++ b/pkg/rpm/build.py
@@ -22,7 +22,7 @@ sys.path.append(src)
 
 import salt.version
 
-salt_version = '.'.join(map(str, salt.version.__version_info__[0:3]))
+salt_version = salt.version.__saltstack_version__.string
 
 rpmbuild = join(os.environ['HOME'], 'rpmbuild')
 copy(join(src, 'pkg/rpm/salt.spec'), join(rpmbuild, 'SPECS'))


### PR DESCRIPTION
Playing with the release candidate I noticed a couple of problems with helper I wrote for building rpms.
- Doesn't use the right name for skipping over itself when copying sources
- Didn't generate the right version string for release candidates
