### PR TITLE
Addresses #9032.

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -952,17 +952,7 @@ def script(source,
         # Backwards compatibility
         saltenv = __env__
 
-    if not salt.utils.is_windows():
-        path = salt.utils.mkstemp(dir=cwd)
-    else:
-        path = __salt__['cp.cache_file'](source, saltenv)
-        if not path:
-            _cleanup_tempfile(path)
-            return {'pid': 0,
-                    'retcode': 1,
-                    'stdout': '',
-                    'stderr': '',
-                    'cache_error': True}
+    path = salt.utils.mkstemp(dir=cwd, suffix=os.path.splitext(source)[1])
 
     if template:
         fn_ = __salt__['cp.get_template'](source,
@@ -978,16 +968,15 @@ def script(source,
                     'stderr': '',
                     'cache_error': True}
     else:
-        if not salt.utils.is_windows():
-            fn_ = __salt__['cp.cache_file'](source, saltenv)
-            if not fn_:
-                _cleanup_tempfile(path)
-                return {'pid': 0,
-                        'retcode': 1,
-                        'stdout': '',
-                        'stderr': '',
-                        'cache_error': True}
-            shutil.copyfile(fn_, path)
+        fn_ = __salt__['cp.cache_file'](source, saltenv)
+        if not fn_:
+            _cleanup_tempfile(path)
+            return {'pid': 0,
+                    'retcode': 1,
+                    'stdout': '',
+                    'stderr': '',
+                    'cache_error': True}
+        shutil.copyfile(fn_, path)
     if not salt.utils.is_windows():
         os.chmod(path, 320)
         os.chown(path, __salt__['file.user_to_uid'](runas), -1)


### PR DESCRIPTION
Fix so that cmd.script no longer deletes the original file on windows standalone minions.  

This Removes the special handling of windows script files, which resulted in using the original location in the repository as the temp file path.  It seems the only special handling needed was only there to preserve the original extension (a .bat file needs the .bat extension to run on windows, but it wouldn't on linux).  This is confirmed working on windows standalone minion.  Untested on non-windows.  The only change to non-windows is the addition of the extension to temp files, so it _should_ be ok there.
