### PR TITLE
Adding IPv6 support into the iptables module and state.

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -23,23 +23,45 @@ def __virtual__():
     return False
 
 
-def _conf():
+def _iptables_cmd(family='ipv4'):
+    '''
+    Return correct command based on the family, eg. ipv4 or ipv6
+    '''
+    if family == 'ipv6':
+        return 'ip6tables'
+    else:
+        return 'iptables'
+
+
+def _conf(family='ipv4'):
     '''
     Some distros have a specific location for config files
     '''
     if __grains__['os_family'] == 'RedHat':
-        return '/etc/sysconfig/iptables'
+        if family == 'ipv6':
+            return '/etc/sysconfig/ip6tables'
+        else:
+            return '/etc/sysconfig/iptables'
     elif __grains__['os_family'] == 'Arch':
-        return '/etc/iptables/iptables.rules'
+        if family == 'ipv6':
+            return '/etc/iptables/ip6tables.rules'
+        else:
+            return '/etc/iptables/iptables.rules'
     elif __grains__['os_family'] == 'Debian':
-        return '/etc/iptables/rules.v4'
+        if family == 'ipv6':
+            return '/etc/iptables/rules.v4'
+        else:
+            return '/etc/iptables/rules.v6'
     elif __grains__['os'] == 'Gentoo':
-        return '/var/lib/iptables/rules-save'
+        if family == 'ipv6':
+            return '/var/lib/ip6tables/rules-save'
+        else:
+            return '/var/lib/iptables/rules-save'
     else:
         return False
 
 
-def version():
+def version(family='ipv4'):
     '''
     Return version from iptables --version
 
@@ -48,13 +70,16 @@ def version():
     .. code-block:: bash
 
         salt '*' iptables.version
+
+        IPv6:
+        salt '*' iptables.version family=ipv6
     '''
-    cmd = 'iptables --version'
+    cmd = '{0} --version' . format(_iptables_cmd(family))
     out = __salt__['cmd.run'](cmd).split()
     return out[1]
 
 
-def build_rule(table=None, chain=None, command=None, position='', full=None,
+def build_rule(table=None, chain=None, command=None, position='', full=None, family='ipv4',
                **kwargs):
     '''
     Build a well-formatted iptables rule based on kwargs. Long options must be
@@ -79,6 +104,15 @@ def build_rule(table=None, chain=None, command=None, position='', full=None,
             connstate=RELATED,ESTABLISHED jump=ACCEPT
         salt '*' iptables.build_rule filter INPUT command=I position=3 \\
             full=True match=state state=RELATED,ESTABLISHED jump=ACCEPT
+
+        IPv6:
+        salt '*' iptables.build_rule match=state \\
+            connstate=RELATED,ESTABLISHED jump=ACCEPT \\
+            family=ipv6
+        salt '*' iptables.build_rule filter INPUT command=I position=3 \\
+            full=True match=state state=RELATED,ESTABLISHED jump=ACCEPT \\
+            family=ipv6
+
     '''
     if 'target' in kwargs:
         kwargs['jump'] = kwargs['target']
@@ -162,13 +196,13 @@ def build_rule(table=None, chain=None, command=None, position='', full=None,
         else:
             flag = '--'
 
-        return 'iptables -t {0} {1}{2} {3} {4} {5}'.format(table,
-            flag, command, chain, position, rule)
+        return '{0} -t {1} {2}{3} {4} {5} {6}'.format(_iptables_cmd(family),
+            table, flag, command, chain, position, rule)
 
     return rule
 
 
-def get_saved_rules(conf_file=None):
+def get_saved_rules(conf_file=None, family='ipv4'):
     '''
     Return a data structure of the rules in the conf file
 
@@ -177,11 +211,14 @@ def get_saved_rules(conf_file=None):
     .. code-block:: bash
 
         salt '*' iptables.get_saved_rules
+
+        IPv6:
+        salt '*' iptables.get_saved_rules family=ipv6
     '''
-    return _parse_conf(conf_file)
+    return _parse_conf(conf_file, family)
 
 
-def get_rules():
+def get_rules(family='ipv4'):
     '''
     Return a data structure of the current, in-memory rules
 
@@ -190,11 +227,15 @@ def get_rules():
     .. code-block:: bash
 
         salt '*' iptables.get_rules
+
+        IPv6:
+        salt '*' iptables.get_rules family=ipv6
+
     '''
-    return _parse_conf(in_mem=True)
+    return _parse_conf(in_mem=True, family=family)
 
 
-def get_saved_policy(table='filter', chain=None, conf_file=None):
+def get_saved_policy(table='filter', chain=None, conf_file=None, family='ipv4'):
     '''
     Return the current policy for the specified table/chain
 
@@ -205,15 +246,21 @@ def get_saved_policy(table='filter', chain=None, conf_file=None):
         salt '*' iptables.get_saved_policy filter INPUT
         salt '*' iptables.get_saved_policy filter INPUT \\
             conf_file=/etc/iptables.saved
+
+        IPv6:
+        salt '*' iptables.get_saved_policy filter INPUT family=ipv6
+        salt '*' iptables.get_saved_policy filter INPUT \\
+            conf_file=/etc/iptables.saved family=ipv6
+
     '''
     if not chain:
         return 'Error: Chain needs to be specified'
 
-    rules = _parse_conf(conf_file)
+    rules = _parse_conf(conf_file, family=family)
     return rules[table][chain]['policy']
 
 
-def get_policy(table='filter', chain=None):
+def get_policy(table='filter', chain=None, family='ipv4'):
     '''
     Return the current policy for the specified table/chain
 
@@ -222,15 +269,18 @@ def get_policy(table='filter', chain=None):
     .. code-block:: bash
 
         salt '*' iptables.get_policy filter INPUT
+
+        IPv6:
+        salt '*' iptables.get_policy filter INPUT family=ipv6
     '''
     if not chain:
         return 'Error: Chain needs to be specified'
 
-    rules = _parse_conf(in_mem=True)
+    rules = _parse_conf(in_mem=True, family=family)
     return rules[table][chain]['policy']
 
 
-def set_policy(table='filter', chain=None, policy=None):
+def set_policy(table='filter', chain=None, policy=None, family='ipv4'):
     '''
     Set the current policy for the specified table/chain
 
@@ -239,18 +289,21 @@ def set_policy(table='filter', chain=None, policy=None):
     .. code-block:: bash
 
         salt '*' iptables.set_policy filter INPUT ACCEPT
+
+        IPv6:
+        salt '*' iptables.set_policy filter INPUT ACCEPT family=ipv6
     '''
     if not chain:
         return 'Error: Chain needs to be specified'
     if not policy:
         return 'Error: Policy needs to be specified'
 
-    cmd = 'iptables -t {0} -P {1} {2}'.format(table, chain, policy)
+    cmd = '{0} -t {1} -P {2} {3}'.format(_iptables_cmd(family), table, chain, policy)
     out = __salt__['cmd.run'](cmd)
     return out
 
 
-def save(filename=None):
+def save(filename=None, family='ipv4'):
     '''
     Save the current in-memory rules to disk
 
@@ -259,6 +312,9 @@ def save(filename=None):
     .. code-block:: bash
 
         salt '*' iptables.save /etc/sysconfig/iptables
+
+        IPv6:
+        salt '*' iptables.save /etc/sysconfig/iptables family=ipv6
     '''
     if _conf() and not filename:
         filename = _conf()
@@ -266,12 +322,12 @@ def save(filename=None):
     parent_dir = os.path.dirname(filename)
     if not os.path.isdir(parent_dir):
         os.makedirs(parent_dir)
-    cmd = 'iptables-save > {0}'.format(filename)
+    cmd = '{0}-save > {1}'.format(_iptables_cmd(family), filename)
     out = __salt__['cmd.run'](cmd)
     return out
 
 
-def check(table='filter', chain=None, rule=None):
+def check(table='filter', chain=None, rule=None, family='ipv4'):
     '''
     Check for the existance of a rule in the table and chain
 
@@ -286,6 +342,11 @@ def check(table='filter', chain=None, rule=None):
 
         salt '*' iptables.check filter INPUT \\
             rule='-m state --state RELATED,ESTABLISHED -j ACCEPT'
+
+        IPv6:
+        salt '*' iptables.check filter INPUT \\
+            rule='-m state --state RELATED,ESTABLISHED -j ACCEPT' \\
+            family=ipv6
     '''
     if not chain:
         return 'Error: Chain needs to be specified'
@@ -293,7 +354,7 @@ def check(table='filter', chain=None, rule=None):
         return 'Error: Rule needs to be specified'
 
     if __grains__['os_family'] == 'RedHat':
-        cmd = 'iptables-save'
+        cmd = '{0}-save' . format(_iptables_cmd(family))
         out = __salt__['cmd.run'](cmd).find('-A {1} {2}'.format(
             table,
             chain,
@@ -304,7 +365,7 @@ def check(table='filter', chain=None, rule=None):
         else:
             return False
     else:
-        cmd = 'iptables -t {0} -C {1} {2}'.format(table, chain, rule)
+        cmd = '{0} -t {1} -C {2} {3}'.format(_iptables_cmd(family), table, chain, rule)
         out = __salt__['cmd.run'](cmd)
 
     if not out:
@@ -312,7 +373,7 @@ def check(table='filter', chain=None, rule=None):
     return out
 
 
-def check_chain(table='filter', chain=None):
+def check_chain(table='filter', chain=None, family='ipv4'):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
@@ -323,12 +384,15 @@ def check_chain(table='filter', chain=None):
     .. code-block:: bash
 
         salt '*' iptables.check_chain filter INPUT
+
+        IPv6:
+        salt '*' iptables.check_chain filter INPUT family=ipv6
     '''
 
     if not chain:
         return 'Error: Chain needs to be specified'
 
-    cmd = 'iptables-save -t {0}'.format(table)
+    cmd = '{0}-save -t {0}'.format(_iptables_cmd(family), table)
     out = __salt__['cmd.run'](cmd).find(':{1} '.format(table, chain))
 
     if out != -1:
@@ -339,7 +403,7 @@ def check_chain(table='filter', chain=None):
     return out
 
 
-def new_chain(table='filter', chain=None):
+def new_chain(table='filter', chain=None, family='ipv4'):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
@@ -350,12 +414,15 @@ def new_chain(table='filter', chain=None):
     .. code-block:: bash
 
         salt '*' iptables.new_chain filter CUSTOM_CHAIN
+
+        IPv6:
+        salt '*' iptables.new_chain filter CUSTOM_CHAIN family=ipv6
     '''
 
     if not chain:
         return 'Error: Chain needs to be specified'
 
-    cmd = 'iptables -t {0} -N {1}'.format(table, chain)
+    cmd = '{0} -t {1} -N {2}'.format(_iptables_cmd(family), table, chain)
     out = __salt__['cmd.run'](cmd)
 
     if not out:
@@ -363,7 +430,7 @@ def new_chain(table='filter', chain=None):
     return out
 
 
-def delete_chain(table='filter', chain=None):
+def delete_chain(table='filter', chain=None, family='ipv4'):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
@@ -374,12 +441,15 @@ def delete_chain(table='filter', chain=None):
     .. code-block:: bash
 
         salt '*' iptables.delete_chain filter CUSTOM_CHAIN
+
+        IPv6:
+        salt '*' iptables.delete_chain filter CUSTOM_CHAIN family=ipv6
     '''
 
     if not chain:
         return 'Error: Chain needs to be specified'
 
-    cmd = 'iptables -t {0} -X {1}'.format(table, chain)
+    cmd = '{0} -t {1} -X {2}'.format(_iptables_cmd(family), table, chain)
     out = __salt__['cmd.run'](cmd)
 
     if not out:
@@ -387,7 +457,7 @@ def delete_chain(table='filter', chain=None):
     return out
 
 
-def append(table='filter', chain=None, rule=None):
+def append(table='filter', chain=None, rule=None, family='ipv4'):
     '''
     Append a rule to the specified table/chain.
 
@@ -402,13 +472,18 @@ def append(table='filter', chain=None, rule=None):
 
         salt '*' iptables.append filter INPUT \\
             rule='-m state --state RELATED,ESTABLISHED -j ACCEPT'
+
+        IPv6:
+        salt '*' iptables.append filter INPUT \\
+            rule='-m state --state RELATED,ESTABLISHED -j ACCEPT' \\
+            family=ipv6
     '''
     if not chain:
         return 'Error: Chain needs to be specified'
     if not rule:
         return 'Error: Rule needs to be specified'
 
-    cmd = 'iptables -t {0} -A {1} {2}'.format(table, chain, rule)
+    cmd = '{0} -t {1} -A {2} {3}'.format(_iptables_cmd(family), table, chain, rule)
     out = __salt__['cmd.run'](cmd)
     if len(out) == 0:
         return True
@@ -416,7 +491,7 @@ def append(table='filter', chain=None, rule=None):
         return False
 
 
-def insert(table='filter', chain=None, position=None, rule=None):
+def insert(table='filter', chain=None, position=None, rule=None, family='ipv4'):
     '''
     Insert a rule into the specified table/chain, at the specified position.
 
@@ -431,6 +506,11 @@ def insert(table='filter', chain=None, position=None, rule=None):
 
         salt '*' iptables.insert filter INPUT position=3 \\
             rule='-m state --state RELATED,ESTABLISHED -j ACCEPT'
+
+        IPv6:
+        salt '*' iptables.insert filter INPUT position=3 \\
+            rule='-m state --state RELATED,ESTABLISHED -j ACCEPT' \\
+            family=ipv6
     '''
     if not chain:
         return 'Error: Chain needs to be specified'
@@ -439,12 +519,12 @@ def insert(table='filter', chain=None, position=None, rule=None):
     if not rule:
         return 'Error: Rule needs to be specified'
 
-    cmd = 'iptables -t {0} -I {1} {2} {3}'.format(table, chain, position, rule)
+    cmd = '{0} -t {1} -I {2} {3} {4}'.format(_iptables_cmd(family), table, chain, position, rule)
     out = __salt__['cmd.run'](cmd)
     return out
 
 
-def delete(table, chain=None, position=None, rule=None):
+def delete(table, chain=None, position=None, rule=None, family='ipv4'):
     '''
     Delete a rule from the specified table/chain, specifying either the rule
         in its entirety, or the rule's position in the chain.
@@ -461,6 +541,12 @@ def delete(table, chain=None, position=None, rule=None):
         salt '*' iptables.delete filter INPUT position=3
         salt '*' iptables.delete filter INPUT \\
             rule='-m state --state RELATED,ESTABLISHED -j ACCEPT'
+
+        IPv6:
+        salt '*' iptables.delete filter INPUT position=3 family=ipv6
+        salt '*' iptables.delete filter INPUT \\
+            rule='-m state --state RELATED,ESTABLISHED -j ACCEPT' \\
+            family=ipv6
     '''
 
     if position and rule:
@@ -469,12 +555,12 @@ def delete(table, chain=None, position=None, rule=None):
     if position:
         rule = position
 
-    cmd = 'iptables -t {0} -D {1} {2}'.format(table, chain, rule)
+    cmd = '{0} -t {1} -D {2} {3}'.format(_iptables_cmd(family), table, chain, rule)
     out = __salt__['cmd.run'](cmd)
     return out
 
 
-def flush(table='filter', chain=''):
+def flush(table='filter', chain='', family='ipv4'):
     '''
     Flush the chain in the specified table, flush all chains in the specified
     table if not specified chain.
@@ -484,30 +570,33 @@ def flush(table='filter', chain=''):
     .. code-block:: bash
 
         salt '*' iptables.flush filter INPUT
+
+        IPv6:
+        salt '*' iptables.flush filter INPUT family=ipv6
     '''
 
     if chain:
-        cmd = 'iptables -t {0} -F {1}'.format(table, chain)
+        cmd = '{0} -t {1} -F {2}'.format(_iptables_cmd(family), table, chain)
     else:
-        cmd = 'iptables -t {0} -F'.format(table)
+        cmd = '{0} -t {1} -F'.format(_iptables_cmd(family), table)
     out = __salt__['cmd.run'](cmd)
     return out
 
 
-def _parse_conf(conf_file=None, in_mem=False):
+def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
     '''
     If a file is not passed in, and the correct one for this OS is not
     detected, return False
     '''
     if _conf() and not conf_file and not in_mem:
-        conf_file = _conf()
+        conf_file = _conf(family)
 
     rules = ''
     if conf_file:
         with salt.utils.fopen(conf_file, 'r') as ifile:
             rules = ifile.read()
     elif in_mem:
-        cmd = 'iptables-save'
+        cmd = '{0}-save' . format(_iptables_cmd(family))
         rules = __salt__['cmd.run'](cmd)
     else:
         raise SaltException('A file was not found to parse')

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -22,6 +22,19 @@ at some point be deprecated in favor of a more generic `firewall` state.
         - save: True
 
     httpd:
+      iptables.append:
+        - table: filter
+        - family: ipv6
+        - chain: INPUT
+        - jump: ACCEPT
+        - match: state
+        - connstate: NEW
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    httpd:
       iptables.insert:
         - position: 1
         - table: filter
@@ -35,6 +48,20 @@ at some point be deprecated in favor of a more generic `firewall` state.
         - save: True
 
     httpd:
+      iptables.insert:
+        - position: 1
+        - table: filter
+        - family: ipv6
+        - chain: INPUT
+        - jump: ACCEPT
+        - match: state
+        - connstate: NEW
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    httpd:
       iptables.delete:
         - table: filter
         - chain: INPUT
@@ -50,6 +77,19 @@ at some point be deprecated in favor of a more generic `firewall` state.
       iptables.delete:
         - position: 1
         - table: filter
+        - chain: INPUT
+        - jump: ACCEPT
+        - match: state
+        - connstate: NEW
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    httpd:
+      iptables.delete:
+        - table: filter
+        - family: ipv6
         - chain: INPUT
         - jump: ACCEPT
         - match: state
@@ -73,7 +113,7 @@ def __virtual__():
     return 'iptables' if 'iptables.version' in __salt__ else False
 
 
-def chain_present(name, table='filter'):
+def chain_present(name, table='filter', family='ipv4'):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
@@ -84,6 +124,9 @@ def chain_present(name, table='filter'):
 
     table
         The table to own the chain.
+
+    family
+        Networking family, either ipv4 or ipv6
     '''
 
     ret = {'name': name,
@@ -91,35 +134,39 @@ def chain_present(name, table='filter'):
            'result': None,
            'comment': ''}
 
-    chain_check = __salt__['iptables.check_chain'](table, name)
+    chain_check = __salt__['iptables.check_chain'](table, name, family)
     if chain_check is True:
         ret['result'] = True
-        ret['comment'] = ('iptables {0} chain is already exist in {1} table'
-                          .format(name, table))
+        ret['comment'] = ('iptables {0} chain is already exist in {1} table for {2}'
+                          .format(name, table, family))
         return ret
 
-    command = __salt__['iptables.new_chain'](table, name)
+    command = __salt__['iptables.new_chain'](table, name, family)
     if command is True:
         ret['changes'] = {'locale': name}
         ret['result'] = True
-        ret['comment'] = ('iptables {0} chain in {1} table create success'
-                          .format(name, table))
+        ret['comment'] = ('iptables {0} chain in {1} table create success for {2}'
+                          .format(name, table, family))
         return ret
     else:
         ret['result'] = False
-        ret['comment'] = 'Failed to create {0} chain in {1} table: {2}'.format(
+        ret['comment'] = 'Failed to create {0} chain in {1} table: {2} for {3}'.format(
             name,
             table,
             command.strip(),
+            family
         )
         return ret
 
 
-def chain_absent(name, table='filter'):
+def chain_absent(name, table='filter', family='ipv4'):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
     Verify the chain is absent.
+
+    family
+        Networking family, either ipv4 or ipv6
     '''
 
     ret = {'name': name,
@@ -127,36 +174,37 @@ def chain_absent(name, table='filter'):
            'result': None,
            'comment': ''}
 
-    chain_check = __salt__['iptables.check_chain'](table, name)
+    chain_check = __salt__['iptables.check_chain'](table, name, family)
     if not chain_check:
         ret['result'] = True
-        ret['comment'] = ('iptables {0} chain is already absent in {1} table'
-                          .format(name, table))
+        ret['comment'] = ('iptables {0} chain is already absent in {1} table for {2}'
+                          .format(name, table, family))
         return ret
 
-    flush_chain = __salt__['iptables.flush'](table, name)
+    flush_chain = __salt__['iptables.flush'](table, name, family)
     if not flush_chain:
-        command = __salt__['iptables.delete_chain'](table, name)
+        command = __salt__['iptables.delete_chain'](table, name, family)
         if command is True:
             ret['changes'] = {'locale': name}
             ret['result'] = True
-            ret['comment'] = ('iptables {0} chain in {1} table delete success'
-                              .format(name, table))
+            ret['comment'] = ('iptables {0} chain in {1} table delete success for {2}'
+                              .format(name, table, family))
         else:
             ret['result'] = False
-            ret['comment'] = ('Failed to delete {0} chain in {1} table: {2}'
-                              .format(name, table, command.strip()))
+            ret['comment'] = ('Failed to delete {0} chain in {1} table: {2} for {2}'
+                              .format(name, table, command.strip(), family))
     else:
         ret['result'] = False
-        ret['comment'] = 'Failed to flush {0} chain in {1} table: {2}'.format(
+        ret['comment'] = 'Failed to flush {0} chain in {1} table: {2} for {3}'.format(
             name,
             table,
             flush_chain.strip(),
+            family
         )
     return ret
 
 
-def append(name, **kwargs):
+def append(name, family='ipv4', **kwargs):
     '''
     .. versionadded:: 0.17.0
 
@@ -166,6 +214,9 @@ def append(name, **kwargs):
         A user-defined name to call this rule by in another part of a state or
         formula. This should not be an actual rule.
 
+    family
+        Network family, ipv4 or ipv6.
+
     All other arguments are passed in with the same name as the long option
     that would normally be used for iptables, with one exception: `--state` is
     specified as `connstate` instead of `state` (not to be confused with
@@ -179,43 +230,47 @@ def append(name, **kwargs):
     for ignore in _STATE_INTERNAL_KEYWORDS:
         if ignore in kwargs:
             del kwargs[ignore]
-    rule = __salt__['iptables.build_rule'](**kwargs)
-    command = __salt__['iptables.build_rule'](full=True, command='A', **kwargs)
+    rule = __salt__['iptables.build_rule'](family=family, **kwargs)
+    command = __salt__['iptables.build_rule'](full=True, family=family, command='A', **kwargs)
     if __salt__['iptables.check'](kwargs['table'],
                                   kwargs['chain'],
-                                  rule) is True:
+                                  rule,
+                                  family) is True:
         ret['result'] = True
-        ret['comment'] = 'iptables rule for {0} already set ({1})'.format(
+        ret['comment'] = 'iptables rule for {0} already set ({1}) for {1}'.format(
             name,
-            command.strip())
+            command.strip(),
+            family)
         return ret
     if __opts__['test']:
-        ret['comment'] = 'iptables rule for {0} needs to be set ({1})'.format(
+        ret['comment'] = 'iptables rule for {0} needs to be set ({1}) for {2}'.format(
             name,
-            command.strip())
+            command.strip(),
+            family)
         return ret
-    if __salt__['iptables.append'](kwargs['table'], kwargs['chain'], rule):
+    if __salt__['iptables.append'](kwargs['table'], kwargs['chain'], rule, family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
-        ret['comment'] = 'Set iptables rule for {0} to: {1}'.format(
+        ret['comment'] = 'Set iptables rule for {0} to: {1} for {2}'.format(
             name,
-            command.strip())
+            command.strip(),
+            family)
         if 'save' in kwargs:
             if kwargs['save']:
-                __salt__['iptables.save'](filename=None)
+                __salt__['iptables.save'](filename=None, family=family)
                 ret['comment'] = ('Set and Saved iptables rule for {0} to: '
-                                  '{1}'.format(name, command.strip()))
+                                  '{1} for {2}'.format(name, command.strip(), family))
         return ret
     else:
         ret['result'] = False
         ret['comment'] = ('Failed to set iptables rule for {0}.\n'
-                          'Attempted rule was {1}').format(
+                          'Attempted rule was {1} for {2}').format(
                               name,
-                              command.strip())
+                              command.strip(), family)
         return ret
 
 
-def insert(name, **kwargs):
+def insert(name, family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
@@ -225,6 +280,9 @@ def insert(name, **kwargs):
         A user-defined name to call this rule by in another part of a state or
         formula. This should not be an actual rule.
 
+    family
+        Networking family, either ipv4 or ipv6
+
     All other arguments are passed in with the same name as the long option
     that would normally be used for iptables, with one exception: `--state` is
     specified as `connstate` instead of `state` (not to be confused with
@@ -238,32 +296,36 @@ def insert(name, **kwargs):
     for ignore in _STATE_INTERNAL_KEYWORDS:
         if ignore in kwargs:
             del kwargs[ignore]
-    rule = __salt__['iptables.build_rule'](**kwargs)
-    command = __salt__['iptables.build_rule'](full=True, command='I', **kwargs)
+    rule = __salt__['iptables.build_rule'](family, **kwargs)
+    command = __salt__['iptables.build_rule'](full=True, family=family, command='I', **kwargs)
     if __salt__['iptables.check'](kwargs['table'],
                                   kwargs['chain'],
-                                  rule) is True:
+                                  rule,
+                                  family) is True:
         ret['result'] = True
-        ret['comment'] = 'iptables rule for {0} already set ({1})'.format(
+        ret['comment'] = 'iptables rule for {0} already set for {1} ({2})'.format(
             name,
+            family,
             command.strip())
         return ret
     if __opts__['test']:
-        ret['comment'] = 'iptables rule for {0} needs to be set ({1})'.format(
+        ret['comment'] = 'iptables rule for {0} needs to be set for {1} ({2})'.format(
             name,
+            family,
             command.strip())
         return ret
-    if not __salt__['iptables.insert'](kwargs['table'], kwargs['chain'], kwargs['position'], rule):
+    if not __salt__['iptables.insert'](kwargs['table'], kwargs['chain'], kwargs['position'], rule, family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
-        ret['comment'] = 'Set iptables rule for {0} to: {1}'.format(
+        ret['comment'] = 'Set iptables rule for {0} to: {1} for {2}'.format(
             name,
-            command.strip())
+            command.strip(),
+            family)
         if 'save' in kwargs:
             if kwargs['save']:
-                __salt__['iptables.save'](filename=None)
+                __salt__['iptables.save'](filename=None, family=family)
                 ret['comment'] = ('Set and Saved iptables rule for {0} to: '
-                                  '{1}'.format(name, command.strip()))
+                                  '{1} for {2}'.format(name, command.strip()), family)
         return ret
     else:
         ret['result'] = False
@@ -274,7 +336,7 @@ def insert(name, **kwargs):
         return ret
 
 
-def delete(name, **kwargs):
+def delete(name, family='ipv4', **kwargs):
     '''
     .. versionadded:: 0.17.0
 
@@ -283,6 +345,9 @@ def delete(name, **kwargs):
     name
         A user-defined name to call this rule by in another part of a state or
         formula. This should not be an actual rule.
+
+    family
+        Networking family, either ipv4 or ipv6
 
     All other arguments are passed in with the same name as the long option
     that would normally be used for iptables, with one exception: `--state` is
@@ -297,19 +362,22 @@ def delete(name, **kwargs):
     for ignore in _STATE_INTERNAL_KEYWORDS:
         if ignore in kwargs:
             del kwargs[ignore]
-    rule = __salt__['iptables.build_rule'](**kwargs)
-    command = __salt__['iptables.build_rule'](full=True, command='D', **kwargs)
+    rule = __salt__['iptables.build_rule'](family=family, **kwargs)
+    command = __salt__['iptables.build_rule'](full=True, family=family, command='D', **kwargs)
     if not __salt__['iptables.check'](kwargs['table'],
                                   kwargs['chain'],
-                                  rule) is True:
+                                  rule,
+                                  family) is True:
         ret['result'] = True
-        ret['comment'] = 'iptables rule for {0} already absent ({1})'.format(
+        ret['comment'] = 'iptables rule for {0} already absent for {1} ({2})'.format(
             name,
+            family,
             command.strip())
         return ret
     if __opts__['test']:
-        ret['comment'] = 'iptables rule for {0} needs to be deleted ({1})'.format(
+        ret['comment'] = 'iptables rule for {0} needs to be deleted for {1} ({2})'.format(
             name,
+            family,
             command.strip())
         return ret
 
@@ -317,11 +385,13 @@ def delete(name, **kwargs):
         result = __salt__['iptables.delete'](
                 kwargs['table'],
                 kwargs['chain'],
+                family=family,
                 position=kwargs['position'])
     else:
         result = __salt__['iptables.delete'](
                 kwargs['table'],
                 kwargs['chain'],
+                family=family,
                 rule=rule)
 
     if not result:
@@ -332,9 +402,9 @@ def delete(name, **kwargs):
             command.strip())
         if 'save' in kwargs:
             if kwargs['save']:
-                __salt__['iptables.save'](filename=None)
-                ret['comment'] = ('Deleted and Saved iptables rule for {0} '
-                                  '{1}'.format(name, command.strip()))
+                __salt__['iptables.save'](filename=None, family=family)
+                ret['comment'] = ('Deleted and Saved iptables rule for {0} for {1}'
+                                  '{2}'.format(name, command.strip()), family)
         return ret
     else:
         ret['result'] = False
@@ -345,11 +415,15 @@ def delete(name, **kwargs):
         return ret
 
 
-def set_policy(name, **kwargs):
+def set_policy(name, family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
     Sets the default policy for iptables firewall tables
+
+    family
+        Networking family, either ipv4 or ipv6
+
     '''
     ret = {'name': name,
         'changes': {},
@@ -362,21 +436,24 @@ def set_policy(name, **kwargs):
 
     if __salt__['iptables.get_policy'](
             kwargs['table'],
-            kwargs['chain']) == kwargs['policy']:
+            kwargs['chain'], 
+            family) == kwargs['policy']:
         ret['result'] = True
-        ret['comment'] = ('iptables default policy for {0} already set to {1}'
-                          .format(kwargs['table'], kwargs['policy']))
+        ret['comment'] = ('iptables default policy for {0} for {1} already set to {2}'
+                          .format(kwargs['table'], family, kwargs['policy']))
         return ret
 
     if not __salt__['iptables.set_policy'](
             kwargs['table'],
             kwargs['chain'],
-            kwargs['policy']):
+            kwargs['policy'],
+            family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
-        ret['comment'] = 'Set default policy for {0} to {1}'.format(
+        ret['comment'] = 'Set default policy for {0} to {1} family {2]'.format(
             kwargs['chain'],
             kwargs['policy'],
+            family
         )
         return ret
     else:
@@ -385,11 +462,15 @@ def set_policy(name, **kwargs):
         return ret
 
 
-def flush(name, **kwargs):
+def flush(name, family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
     Flush current iptables state
+
+    family
+        Networking family, either ipv4 or ipv6
+
     '''
     ret = {'name': name,
            'changes': {},
@@ -403,12 +484,13 @@ def flush(name, **kwargs):
     if not 'chain' in kwargs:
         kwargs['chain'] = ''
 
-    if not __salt__['iptables.flush'](kwargs['table'], kwargs['chain']):
+    if not __salt__['iptables.flush'](kwargs['table'], kwargs['chain'], family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
-        ret['comment'] = 'Flush iptables rules in {0} table {1} chain'.format(
+        ret['comment'] = 'Flush iptables rules in {0} table {1} chain {2] family'.format(
             kwargs['table'],
             kwargs['chain'],
+            family
         )
         return ret
     else:


### PR DESCRIPTION
Adding IPv6 support into the iptables module and state.  Firewalls for IPv6 use ip6tables to manage it, the module has been updated to accept a new argument for each function named family.  Family will default to ipv4 which will cause the module to use iptables specific commands and files, passes ipv6 for the family will cause the module to use ip6tables and friends.  The state was also updated to accept the family option  with a default of ipv6.
