### PR TITLE
Fix #9520 State  can't handle multiple swap partitions

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -224,7 +224,7 @@ def set_fstab(
                     # Invalid entry
                     lines.append(line)
                     continue
-                if comps[1] == name or comps[0] == device:
+                if comps[0] == device:
                     # check to see if there are changes
                     # and fix them if there are any
                     present = True

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -99,7 +99,7 @@ def mounted(name,
         if real_device not in device_list:
             # name matches but device doesn't - need to umount
             ret['changes']['umount'] = "Forced unmount because devices " \
-                                     + "don't match. Wanted: " + device
+                                       + "don't match. Wanted: " + device
             if real_device != device:
                 ret['changes']['umount'] += " (" + real_device + ")"
             ret['changes']['umount'] += ", current: " + ', '.join(device_list)
@@ -229,7 +229,7 @@ def swap(name, persist=True, config='/etc/fstab'):
             return ret
 
         if 'none' in fstab_data:
-            if fstab_data['none']['device'] == name:
+            if fstab_data['none']['device'] == name and fstab_data['none']['fstype'] != 'swap':
                 return ret
 
         # present, new, change, bad config


### PR DESCRIPTION
This fixes the #9520 issue and works with #7079. We should only check the device name since it is unique within the /etc/fstab file.
