### PR TITLE
Adding optional cloud configuration for controlling multiprocessing pool...

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1583,7 +1583,12 @@ class Map(Cloud):
             output[name] = self.destroy(name)
 
         if self.opts['parallel'] and len(parallel_data) > 0:
-            output_multip = multiprocessing.Pool(len(parallel_data)).map(
+            if 'pool_size' in self.opts:
+                pool_size = self.opts['pool_size']
+            else:
+                pool_size = len(parallel_data)
+            log.info('Cloud pool size: {0}'.format(pool_size))
+            output_multip = multiprocessing.Pool(pool_size).map(
                 func=create_multiprocessing,
                 iterable=parallel_data
             )


### PR DESCRIPTION
... size

We were executing a fairly large launch of machines (200+) and the pool size was way too large and was causing some resource issues. The default remains the same (ie, use the number of machines as the pool size), but we had the need to be able to configure this based on the number of cores that were available to us. Setting `pool_size` in the cloud config will control this.
