### PR TITLE
Add EC2 error message to logging; Add interval multiplier to spot instan...

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1189,6 +1189,7 @@ def wait_for_ip(update_callback,
                 update_kwargs=None,
                 timeout=5 * 60,
                 interval=5,
+                interval_multiplier=1,
                 max_failures=10):
     '''
     Helper function that waits for an IP address for a specific maximum amount
@@ -1203,6 +1204,8 @@ def wait_for_ip(update_callback,
                     address.
     :param interval: The looping interval, ie, the amount of time to sleep
                      before the next iteration.
+    :param interval_multiplier: Increase the interval by this multiplier after
+                                each request; helps with throttling
     :param max_failures: If update_callback returns ``False`` it's considered
                          query failure. This value is the amount of failures
                          accepted before giving up.
@@ -1247,6 +1250,13 @@ def wait_for_ip(update_callback,
             )
         time.sleep(interval)
         timeout -= interval
+
+        if interval_multiplier > 1:
+            interval *= interval_multiplier
+            if interval > timeout:
+                interval = timeout + 1
+            log.info('Interval multiplier in effect; interval is '
+                     'now {0}s'.format(interval))
 
 
 def simple_types_filter(datadict):


### PR DESCRIPTION
...ce and wait_for_ip polling

This modifies the `clouds/ec2.py::wait_for_spot_instance` and `utils/cloud.py::wait_for_ip` methods to add an optional argument `interval_multiplier`. If set to a value greater than one, the interval will be multiplied on each subsequent request. This is useful for getting around throttling issues from cloud providers (especially EC2.)

NOTE: The default functionality of the modified methods has not changed, but may be overridden with new configuration parameters.

Additional optional configuration added:
- `wait_for_spot_timeout` - the timeout for waiting for spot instances
- `wait_for_spot_interval` - the initial interval in seconds to wait before checking again
- `wait_for_spot_interval_multiplier` - if set and greater than one, will multiply the current interval by the multiplier after each request
- `wait_for_spot_max_failures` - total number of spot instance check failures before quitting
- `wait_for_ip_interval_multiplier` - just like `wait_for_spot_interval_multiplier`, but for the `wait_for_ip` method in utils/cloud.py
