### PR TITLE
Add ability to fetch cached mine data in cache.py runner module

### DIFF
--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -75,6 +75,33 @@ def pillar(tgt=None, expr_form='glob', **kwargs):
     salt.output.display_output(cached_pillar, None, __opts__)
     return cached_pillar
 
+def mine(tgt=None, expr_form='glob', **kwargs):
+    '''
+    Return cached mine data of the targeted minions
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run cache.mine
+    '''
+    deprecated_minion = kwargs.get('minion', None)
+    if tgt is None and deprecated_minion is None:
+        log.warn("DEPRECATION WARNING: {0}".format(deprecation_warning))
+        tgt = '*'  # targat all minions for backward compatibility
+    elif tgt is None and isinstance(deprecated_minion, string_types):
+        log.warn("DEPRECATION WARNING: {0}".format(deprecation_warning))
+        tgt = deprecated_minion
+    elif tgt is None:
+        return {}
+    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
+                                                use_cached_grains=False,
+                                                grains_fallback=False,
+                                                use_cached_pillar=False,
+                                                pillar_fallback=False,
+                                                opts=__opts__)
+    cached_mine = pillar_util.get_cached_mine_data()
+    salt.output.display_output(cached_mine, None, __opts__)
 
 def _clear_cache(tgt=None,
                  expr_form='glob',
@@ -146,7 +173,7 @@ def clear_mine_func(tgt=None, expr_form='glob', clear_mine_func=None):
 
     .. code-block:: bash
 
-        salt-run cache.clear_mine_func tgt='*',clear_mine_func='network.interfaces'
+        salt-run cache.clear_mine_func tgt='*' clear_mine_func='network.interfaces'
     '''
     return _clear_cache(tgt, expr_form, clear_mine_func=clear_mine_func)
 

--- a/salt/utils/master.py
+++ b/salt/utils/master.py
@@ -93,6 +93,29 @@ class MasterPillarUtil(object):
             )
         )
 
+    def _get_cached_mine_data(self, *minion_ids):
+        # Return one dict with the cached mine data of the targeted minions
+        mine_data = dict([(minion_id, {}) for minion_id in minion_ids])
+        if (not self.opts.get('minion_data_cache', False)
+                and not self.opts.get('enforce_mine_cache', False)):
+                    log.debug('Skipping cached mine data minion_data_cache'
+                              'and enfore_mine_cache are both disabled.')
+                    return mine_data
+        mdir = os.path.join(self.opts['cachedir'], 'minions')
+        try:
+            for minion_id in minion_ids:
+                if not salt.utils.verify.valid_id(self.opts, minion_id):
+                    continue
+                path = os.path.join(mdir, minion_id, 'mine.p')
+                if os.path.isfile(path):
+                    with salt.utils.fopen(path) as fp_:
+                        mdata = self.serial.loads(fp_.read())
+                        if isinstance(mdata, dict):
+                            mine_data[minion_id] = mdata
+        except (OSError, IOError):
+            return mine_data
+        return mine_data
+
     def _get_cached_minion_data(self, *minion_ids):
         # Return two separate dicts of cached grains and pillar data of the
         # minions
@@ -276,6 +299,16 @@ class MasterPillarUtil(object):
                                         *minion_ids,
                                         cached_grains=cached_minion_grains)
         return minion_grains
+
+    def get_cached_mine_data(self):
+        '''
+        Get cached mine data for the targeted minions.
+        '''
+        mine_data = {}
+        minion_ids = self._tgt_to_list()
+        log.debug('Getting cached mine data for: {0}'.format(minion_ids))
+        mine_data = self._get_cached_mine_data(*minion_ids)
+        return mine_data
 
     def clear_cached_minion_data(self,
                                  clear_pillar=False,


### PR DESCRIPTION
I'll add the ability to fetch per-function cached mine data soon. For now this will fetch the entire cached mine contents for the targeted minions.
