### PR TITLE
Add missing functions from old yumpkg module

### DIFF
--- a/salt/modules/apt.py
+++ b/salt/modules/apt.py
@@ -678,7 +678,7 @@ def _get_upgradable():
     '''
 
     cmd = 'apt-get --just-print dist-upgrade'
-    out = __salt__['cmd.run_all'](cmd).get('stdout', '')
+    out = __salt__['cmd.run_stdout'](cmd, output_loglevel='debug')
 
     # rexp parses lines that look like the following:
     # Conf libxfont1 (1:1.4.5-1 Debian:testing [i386])
@@ -743,7 +743,7 @@ def version_cmp(pkg1, pkg2):
         for oper, ret in (('lt', -1), ('eq', 0), ('gt', 1)):
             cmd = 'dpkg --compare-versions {0!r} {1} ' \
                   '{2!r}'.format(pkg1, oper, pkg2)
-            if __salt__['cmd.retcode'](cmd) == 0:
+            if __salt__['cmd.retcode'](cmd, output_loglevel='debug') == 0:
                 return ret
     except Exception as e:
         log.error(e)

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -62,7 +62,8 @@ def list_pkgs(*packages):
         cmd = 'rpm -q --qf \'%{{NAME}} %{{VERSION}}\\n\' {0}'.format(
             ' '.join(packages)
         )
-    for line in __salt__['cmd.run'](cmd).splitlines():
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug'):
+    for line in out.splitlines():
         if 'is not installed' in line:
             errors.append(line)
             continue
@@ -92,7 +93,8 @@ def verify(*package):
         cmd = 'rpm -V {0}'.format(packages)
     else:
         cmd = 'rpm -Va'
-    for line in __salt__['cmd.run'](cmd).split('\n'):
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug')
+    for line in out.splitlines():
         fdict = {'mismatch': []}
         if 'missing' in line:
             line = ' ' + line
@@ -141,7 +143,7 @@ def file_list(*packages):
         cmd = 'rpm -qla'
     else:
         cmd = 'rpm -ql {0}'.format(' '.join(packages))
-    ret = __salt__['cmd.run'](cmd).splitlines()
+    ret = __salt__['cmd.run'](cmd, output_loglevel='debug').splitlines()
     return {'errors': [], 'files': ret}
 
 
@@ -168,7 +170,8 @@ def file_dict(*packages):
         cmd = 'rpm -q --qf \'%{{NAME}} %{{VERSION}}\\n\' {0}'.format(
             ' '.join(packages)
         )
-    for line in __salt__['cmd.run'](cmd).splitlines():
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug')
+    for line in out.splitlines():
         if 'is not installed' in line:
             errors.append(line)
             continue
@@ -177,7 +180,8 @@ def file_dict(*packages):
     for pkg in pkgs.keys():
         files = []
         cmd = 'rpm -ql {0}'.format(pkg)
-        for line in __salt__['cmd.run'](cmd).splitlines():
+        out = __salt__['cmd.run'](cmd, output_loglevel='debug')
+        for line in out.splitlines():
             files.append(line)
         ret[pkg] = files
     return {'errors': errors, 'packages': ret}

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -62,7 +62,7 @@ def list_pkgs(*packages):
         cmd = 'rpm -q --qf \'%{{NAME}} %{{VERSION}}\\n\' {0}'.format(
             ' '.join(packages)
         )
-    out = __salt__['cmd.run'](cmd, output_loglevel='debug'):
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug')
     for line in out.splitlines():
         if 'is not installed' in line:
             errors.append(line)

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -836,7 +836,7 @@ def group_list():
         else:
             line = out[idx].strip()
             try:
-                name, lang = re.match('(.+) \[(.+)\]', line).groups()
+                name, lang = re.match(r'(.+) \[(.+)\]', line).groups()
             except AttributeError:
                 pass
             else:


### PR DESCRIPTION
These functions were present before and needed to be added so that the
yum provider didn't lose any functionality from yumpkg being deprecated.
