### PR TITLE
master: publish_session is in seconds, not minutes

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -226,7 +226,7 @@ class Master(SMaster):
                                 shutil.rmtree(f_path)
 
             if self.opts.get('publish_session'):
-                if now - rotate >= self.opts['publish_session'] * 60:
+                if now - rotate >= self.opts['publish_session']:
                     salt.crypt.dropfile(self.opts['cachedir'])
                     rotate = now
             if self.opts.get('search'):


### PR DESCRIPTION
Judging by default value of `86400`, `publish_session` is measured in seconds, not in minutes.
This will rotate key once a day instead of once in ~two months by default.

PS. Probably `publish_session` itself should be renamed to a) reflect change behaviour b) reflect what config tunable is responsible for.
