### PR TITLE
Print debug info not only on `SIGUSR1` but also on `SIGINFO` 

### DIFF
--- a/doc/topics/troubleshooting/index.rst
+++ b/doc/topics/troubleshooting/index.rst
@@ -232,6 +232,9 @@ Then pass the signal to the master or minion when it seems to be unresponsive:
     killall -SIGUSR1 salt-master
     killall -SIGUSR1 salt-minion
 
+Also under BSD and Mac OS X in addition to SIGUSR1 signal, debug subroutine set
+up for SIGINFO which has an advantage of being sent by Ctrl+T shortcut.
+
 When filing an issue or sending questions to the mailing list for a problem
 with an unresponsive daemon this information can be invaluable.
 

--- a/salt/utils/debug.py
+++ b/salt/utils/debug.py
@@ -42,15 +42,23 @@ def _handle_sigusr1(sig, stack):
             _makepretty(output, stack)
 
 
+def enable_sig_handler(signal_name, handler):
+    '''
+    Add signal handler for signal name if it exists on given platform
+    '''
+    if hasattr(signal, signal_name):
+        signal.signal(getattr(signal, signal_name), handler)
+
+
 def enable_sigusr1_handler():
     '''
     Pretty print a stack trace to the console or a debug log under /tmp
     when any of the salt daemons such as salt-master are sent a SIGUSR1
     '''
-    #  Skip setting up this signal on Windows
-    #  SIGUSR1 doesn't exist on Windows and causes the minion to crash
-    if not salt.utils.is_windows():
-        signal.signal(signal.SIGUSR1, _handle_sigusr1)
+    enable_sig_handler('SIGUSR1', _handle_sigusr1)
+    # Also canonical BSD-way of printing profress is SIGINFO
+    # which on BSD-deriviatives can be sent via Ctrl+T
+    enable_sig_handler('SIGINFO', _handle_sigusr1)
 
 
 def inspect_stack():


### PR DESCRIPTION
This eases debugging on Mac OS X / *BSD
