### PR TITLE
Fixed a problem of changing mysql passwords

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -981,6 +981,17 @@ def user_exists(user,
         salt '*' mysql.user_exists 'username' passwordless=True
     '''
     dbc = _connect(**connection_args)
+    # Did we fail to connect with the user we are checking
+    # Its password might have previousely change with the same command/state
+    if dbc is None \
+            and __context__['mysql.error'] \
+                .startswith("MySQL Error 1045: Access denied for user '{0}'@".format(user)) \
+            and password:
+        # Clear the previous error
+        __context__['mysql.error'] = None
+        log.info('Retrying with "{0}" as connection password for {1} ...'.format(password, user))
+        connection_args['connection_pass'] = password
+        dbc = _connect(**connection_args)
     if dbc is None:
         return False
 


### PR DESCRIPTION
There was a chicken and egg problem discussed in issue #5918:
"Setting mysql root password the first time"

Now the following SLS file works for me:

``` YAML
set_localhost_root_password:
    mysql_user.present:
        - name: root
        - host: localhost
        - password: {{ pillar['mysql.pass'] }}
        - connection_pass: ""
        - watch:
            - pkg: mysql-server
            - service: mysqld
```

It sets mysql root password the first time and does not fail after that.
