### PR TITLE
Add env_absent/present cron states, fix typos

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -391,7 +391,6 @@ def set_env(user, name, value=None):
                 else:
                     return jret
             return 'present'
-    print(value)
     env = {'name': name, 'value': value}
     lst['env'].append(env)
     comdat = _write_cron_lines(user, _render_tab(lst))


### PR DESCRIPTION
This pull request makes environment variables inside of crontab's controllable via Salt states and not just salt modules. This will allow setting the MAILTO variable for when crontabs fail via the salt state.

While here, I also removed an extraneous print, and fixed some comment grammar related to crontabs.
