### PR TITLE
Small doc fix: don't teach people to silence ImportError

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -292,8 +292,8 @@ If a "fallback_function" is defined, it will replace the function instead of rem
     from salt.utils.decorators import depends
     try:
         import dependency_that_sometimes_exists
-    except ImportError:
-        pass
+    except ImportError as e:
+        print("Failed to import dependency_that_sometimes_exists: {}".format(e))
 
     @depends('dependency_that_sometimes_exists')
     def foo():


### PR DESCRIPTION
Fix a pet peeve of mine so that beginners don't repeat the mistake: silencing `ImportError` is evil since you don't know if it came because `dependency_that_sometimes_exists` is unavailable or the `dependency_that_sometimes_exists` tried to import something which was broken.

This can seriously hinder debugging and I think it's a bad thing to teach it to people through documentation.
