### PR TITLE
Make git state compatible with numeric revisions. Fix #9718

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -213,7 +213,7 @@ def latest(name,
                                           identity=identity)
                 elif rev:
 
-                    cmd = "git rev-parse " + rev + '^{commit}'
+                    cmd = 'git rev-parse {0} ^{{commit}}'.format(rev)
                     retcode = __salt__['cmd.retcode'](cmd,
                                                       cwd=target,
                                                       runas=user)

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -112,6 +112,24 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    def test_numeric_rev(self):
+        '''
+        git.latest with numeric revision
+        '''
+        name = os.path.join(integration.TMP, 'salt_repo')
+        try:
+            ret = self.run_state(
+                'git.latest',
+                name='https://{0}/saltstack/salt.git'.format(self.__domain),
+                rev=0.11,
+                target=name,
+                submodules=True
+            )
+            self.assertSaltTrueReturn(ret)
+            self.assertTrue(os.path.isdir(os.path.join(name, '.git')))
+        finally:
+            shutil.rmtree(name, ignore_errors=True)
+
     def test_present(self):
         '''
         git.present


### PR DESCRIPTION
I tried to add a test but could not execute the test suite.
