### PR TITLE
Don't fail badly on setting VT screen size. Refs #9742.

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -382,7 +382,16 @@ class Terminal(object):
 
                 # Set the terminal size
                 self.child_fd = self.stdin
-                self.setwinsize(self.rows, self.cols)
+
+                try:
+                    self.setwinsize(self.rows, self.cols)
+                except IOError, err:
+                    log.warning(
+                        'Failed to set the VT terminal size: {0}'.format(
+                            err,
+                            exc_info=log.isEnabledFor(logging.DEBUG)
+                        )
+                    )
 
                 # Do not allow child to inherit open file descriptors from
                 # parent


### PR DESCRIPTION
We still need to be able to set the screen size within a multiprocessing
process.
