### PR TITLE
Change yum module to not nuke the package cache every state run

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -402,15 +402,27 @@ def refresh_db():
     Since yum refreshes the database automatically, this runs a yum clean,
     so that the next yum operation will have a clean database
 
+    Returns:
+
+    - ``True``: Database updated successfully
+    - ``False``: Problem updating database
+    - ``None``: Database already up-to-date
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pkg.refresh_db
     '''
-    cmd = 'yum -q clean dbcache'
-    __salt__['cmd.retcode'](cmd)
-    return True
+    retcodes = {
+        100: True,
+        0: None,
+        1: False,
+    }
+
+    cmd = 'yum -q check-update'
+    ret = __salt__['cmd.retcode'](cmd)
+    return retcodes.get(ret, False)
 
 
 def install(name=None,


### PR DESCRIPTION
This change mirrors the behavior in the apt module. Previous behavior of
nuking the package cache would cause yum to download ~30 MB of data for
each and every highstate run.
