### PR TITLE
Fix bug #9740 to allow for multiple PIDs to be returned

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -64,7 +64,7 @@ start() {
             RETVAL=0
         fi
     else
-        if [[ $(pidofproc $PROCESS) ]]; then
+        if [[ ! -z "$(pidofproc $PROCESS)" ]]; then
             RETVAL=$?
             echo -n "already running"
         else


### PR DESCRIPTION
Bug:

```
[root@pronghorn04 ~]# service salt-minion restart
Stopping salt-minion daemon:                               [  OK  ]
Starting salt-minion daemon: /etc/init.d/salt-minion: line 67: [: 22610:
unary operator expected
                                                           [  OK  ]
```

Traced bug:

```
++ pidof -c -o 21702 -o 21341 -o %PPID -x salt-minion
+ '[' 22610 7606 ']'
/etc/init.d/salt-minion: line 67: [: 22610: unary operator expected
```
