### PR TITLE
fileserver/roots.py: rm unused import of `time` module

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -8,7 +8,6 @@ option.
 
 # Import python libs
 import os
-import time
 import logging
 
 try:


### PR DESCRIPTION
```
************* Module salt.fileserver.roots
salt/fileserver/roots.py:11: [W0611(unused-import), ] Unused import time
```
