### PR TITLE
Re pattern fix and option/value delimiter fix

### DIFF
--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -25,8 +25,8 @@ def __virtual__():
 
 comment_regexp = re.compile(r'^\s*#\s*(.*)')
 section_regexp = re.compile(r'\s*\[(.+)\]\s*')
-option_regexp1 = re.compile(r'\s*(.+)\s*(=)\s*(.+)\s*')
-option_regexp2 = re.compile(r'\s*(.+)\s*(:)\s*(.+)\s*')
+option_regexp1 = re.compile(r'\s*(.+?)\s*(=)\s*(.+)\s*')
+option_regexp2 = re.compile(r'\s*(.+?)\s*(:)\s*(.+)\s*')
 
 
 def set_option(file_name, sections=None, summary=True):

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -282,7 +282,7 @@ class _Ini(object):
                 file_contents += '[%s]\n' % section.section_name
             for item in section:
                 if isinstance(item, _Option):
-                    file_contents += '%s %s %s\n' % (item.name, item.separator,
+                    file_contents += '%s%s%s\n' % (item.name, item.separator,
                                                      item.value)
                 else:
                     file_contents += '# %s\n' % item
@@ -335,7 +335,7 @@ class _Ini(object):
         if not ma:
             ma = re.match(option_regexp2, line)
         return _Option(ma.group(1).strip(), ma.group(3).strip(),
-                      ma.group(2).strip())
+                       ma.group(2).strip())
 
     @staticmethod
     def iscomment(line):

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -283,7 +283,7 @@ class _Ini(object):
             for item in section:
                 if isinstance(item, _Option):
                     file_contents += '%s%s%s\n' % (item.name, item.separator,
-                                                     item.value)
+                                                   item.value)
                 else:
                     file_contents += '# %s\n' % item
             file_contents += '\n'


### PR DESCRIPTION
patterns have been modified to match the first occurrence of '=' or ':' rather than the last. 
spaces around the '=' while writing back have been removed as some packages have issues with spaces.  
