### PR TITLE
Allow the ZMQ to deliver or drop the message before GC. Fixes #9103.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -864,6 +864,10 @@ def fire_event(key, msg, tag, args=None, sock_dir=None):
             args = {key: msg}
         event.fire_event(args, tag)
 
+    # https://github.com/zeromq/pyzmq/issues/173#issuecomment-4037083
+    # Assertion failed: get_load () == 0 (poller_base.cpp:32)
+    time.sleep(0.025)
+
 
 def scp_file(dest_path, contents, kwargs):
     '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -334,6 +334,13 @@ class SaltEvent(object):
         if self.context.closed is False:
             self.context.term()
 
+        # Hardcore destruction
+        self.context.destroy(linger=1)
+
+        # https://github.com/zeromq/pyzmq/issues/173#issuecomment-4037083
+        # Assertion failed: get_load () == 0 (poller_base.cpp:32)
+        time.sleep(0.025)
+
     def fire_ret_load(self, load):
         '''
         Fire events based on information in the return load


### PR DESCRIPTION
This has been a stash that get's applied every time I update salts code on our Jenkins server. It did reduce(if not stopped, haven't been checking lately) the occurrences of the fixed issue.
