### PR TITLE
Cache gitfs environments

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -73,6 +73,22 @@ def write_file_list_cache(opts, data, list_cache, w_lock):
         log.trace('Lockfile {0} removed'.format(w_lock))
 
 
+def check_env_cache(opts, env_cache):
+    '''
+    Returns cached env names, if present. Otherwise returns None.
+    '''
+    if not os.path.isfile(env_cache):
+        return None
+    try:
+        with salt.utils.fopen(env_cache, 'r') as fp_:
+            log.trace('Returning env cache data from {0}'.format(env_cache))
+            serial = salt.payload.Serial(opts)
+            return serial.load(fp_)
+    except (IOError, OSError):
+        pass
+    return None
+
+
 def generate_mtime_map(path_map):
     '''
     Generate a dict of filename -> mtime


### PR DESCRIPTION
This commit improves performance by not repeatedly looking up the
list of available environments whenever they are needed, and instead
writing them to a cache file whenever the fileserver is updated (and
changes are found). envs() will prefer the cache if it is available.
