### PR TITLE
Make ebuild.ex_mod_init's call to enforce_nice_config opt-in

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -163,7 +163,25 @@ def check_db(*names, **kwargs):
 
 def ex_mod_init(low):
     '''
-    Enforce a nice tree structure for /etc/portage/package.* configuration files.
+    If the config option ``ebuild.enforce_nice_config`` is set to True, this
+    module will enforce a nice tree structure for /etc/portage/package.*
+    configuration files.
+
+    .. versionadded:: 0.17.0
+       Initial automatic enforcement added when pkg is used on a Gentoo system.
+
+    .. versionchanged:: 2014.1.0-Hydrogen
+       Configure option added to make this behaviour optional, defaulting to
+       off.
+
+    .. seealso::
+       ``ebuild.ex_mod_init`` is called automatically when a state invokes a
+       pkg state on a Gentoo system.
+       :py:func:`salt.states.pkg.mod_init`
+
+       ``ebuild.ex_mod_init`` uses ``portage_config.enforce_nice_config`` to do
+       the lifting.
+       :py:func:`salt.modules.portage_config.enforce_nice_config`
 
     CLI Example:
 
@@ -171,7 +189,8 @@ def ex_mod_init(low):
 
         salt '*' pkg.ex_mod_init
     '''
-    __salt__['portage_config.enforce_nice_config']()
+    if __salt__['config.get']('ebuild.enforce_nice_config', False):
+        __salt__['portage_config.enforce_nice_config']()
     return True
 
 

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -62,6 +62,11 @@ def enforce_nice_config():
     Enforce a nice tree structure for /etc/portage/package.* configuration
     files.
 
+    .. seealso::
+       :py:func:`salt.modules.ebuild.ex_mod_init`
+         for information on automatically running this when pkg is used.
+
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -918,6 +918,10 @@ def mod_init(low):
     It also runs the "ex_mod_init" from the package manager module that is
     currently loaded. The "ex_mod_init" is expected to work as a normal
     "mod_init" function.
+
+    .. seealso::
+       :py:func:`salt.modules.ebuild.ex_mod_init`
+
     '''
     ret = True
     if 'pkg.ex_mod_init' in __salt__:


### PR DESCRIPTION
This relates to issue #9767 and provides a work around for /etc/portage/package.\* config files with comments in them.
