### PR TITLE
Updates to globbing and compound matching docs with an extra example, and visibility of documentation.

### DIFF
--- a/doc/topics/targeting/compound.rst
+++ b/doc/topics/targeting/compound.rst
@@ -51,3 +51,9 @@ something like the following must be done:
 .. code-block:: bash
 
     salt -C '* and not G@kernel:Darwin' test.ping
+
+Excluding a minion based on its ID is also possible:
+
+.. code-block:: bash
+
+    salt -C '* and not web-dc1-srv' test.ping

--- a/doc/topics/targeting/globbing.rst
+++ b/doc/topics/targeting/globbing.rst
@@ -69,6 +69,11 @@ Match the ``web-x``, ``web-y``, and ``web-z`` minions:
 
     salt 'web-[x-z]' test.ping
 
+.. note::
+
+    For additional targeting methods please review the
+    :doc:`compound matchers </topics/targeting/compound>` documentation.
+ 
 
 Regular Expressions
 ===================

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -19,6 +19,8 @@ def extracted(name,
               source_hash=None,
               if_missing=None):
     '''
+    .. versionadded:: 2014.1.0 (Hydrogen)
+
     State that make sure an archive is extracted in a directory.
     The downloaded archive is erased if succesfully extracted.
     The archive is downloaded only if necessary.

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -61,6 +61,8 @@ def present(name, value):
 
 def list_present(name, value):
     '''
+    .. versionadded:: 2014.1.0 (Hydrogen)
+
     Ensure the value is present in the list type grain
 
     name


### PR DESCRIPTION
Updated the globbing doc with a link to compound matching, updated the compound matching doc with another example, this resolves https://github.com/saltstack/salt/issues/9768. Also added a version add for the archive state, and the list_present grain which resolves: https://github.com/saltstack/salt/issues/9721
