### PR TITLE
Catch an exception and log rather than dump stacktrace if lock file disappears

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -69,7 +69,10 @@ def write_file_list_cache(opts, data, list_cache, w_lock):
     serial = salt.payload.Serial(opts)
     with salt.utils.fopen(list_cache, 'w+') as fp_:
         fp_.write(serial.dumps(data))
-        os.remove(w_lock)
+        try:
+            os.remove(w_lock)
+        except OSError, e:
+            log.trace("Error removing lockfile {0}:  {1}".format(w_lock, e))
         log.trace('Lockfile {0} removed'.format(w_lock))
 
 


### PR DESCRIPTION
Prevent OSError: [Errno 2] No such file or directory: '/var/cache/salt/master/file_lists/gitfs/.<branch>.w' when lock file is removed outside of salt's run.
