### PR TITLE
config.manage_mode(): Changing zfill(3) to zfill(4) so that we get '0700' instead of '700'

### DIFF
--- a/salt/client/ssh/wrapper/config.py
+++ b/salt/client/ssh/wrapper/config.py
@@ -76,7 +76,7 @@ def manage_mode(mode):
     '''
     if mode is None:
         return None
-    return str(mode).lstrip('0').zfill(3)
+    return str(mode).lstrip('0').zfill(4)
 
 
 def valid_fileproto(uri):

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -77,7 +77,7 @@ def manage_mode(mode):
     '''
     if mode is None:
         return None
-    return str(mode).lstrip('0').zfill(3)
+    return str(mode).lstrip('0').zfill(4)
 
 
 def valid_fileproto(uri):

--- a/tests/integration/modules/config.py
+++ b/tests/integration/modules/config.py
@@ -45,11 +45,11 @@ class ConfigTest(integration.ModuleCase):
         # interpreter is breaking it for remote calls
         # The correct standard is the four digit form.
         self.assertEqual(
-            self.run_function('config.manage_mode', ['775']), '0775')
+            self.run_function('config.manage_mode', ['"775"']), '0775')
         self.assertEqual(
-            self.run_function('config.manage_mode', ['1775']), '1775')
+            self.run_function('config.manage_mode', ['"1775"']), '1775')
         self.assertEqual(
-            self.run_function('config.manage_mode', ['0775']), '0775')
+            self.run_function('config.manage_mode', ['"0775"']), '0775')
 
     def test_option(self):
         '''

--- a/tests/integration/modules/config.py
+++ b/tests/integration/modules/config.py
@@ -43,12 +43,13 @@ class ConfigTest(integration.ModuleCase):
         '''
         # This function is generally only used with cross calls, the yaml
         # interpreter is breaking it for remote calls
+        # The correct standard is the four digit form.
         self.assertEqual(
-            self.run_function('config.manage_mode', ['775']), '775')
+            self.run_function('config.manage_mode', ['775']), '0775')
         self.assertEqual(
             self.run_function('config.manage_mode', ['1775']), '1775')
-        #self.assertEqual(
-        #    self.run_function('config.manage_mode', ['0775']), '775')
+        self.assertEqual(
+            self.run_function('config.manage_mode', ['0775']), '0775')
 
     def test_option(self):
         '''


### PR DESCRIPTION
There is a possibility of this causing regressions, it will work correctly where both params are passed through it or where it's being compared with stat() output.  If there is code expecting a '700' style permission it will fail.  Realistically, '0700' is correct so the other code needs to be fixed.

I've updated the tests, including uncommenting the one that actually tests for this case.

This is to correct the following impossible to resolve state:

```
#  `---> salt 'test1' file.check_perms /root '{}' root root \'0700\' 
test1:
    ----------
    - changes:
        ----------
        mode:
            700
    - comment:

    - name:
        /root
    - result:
        True
    ----------
    - lgroup:
        root
    - lmode:
        0700
    - luser:
        root
```

Calls to managed permissions will never succeed without this.
