### PR TITLE
Adds ssh gateway option to ec2 provider closes #9782

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ htmlcov/
 /.pydevproject
 /.idea
 /.ropeproject
+/*.iml
 
 # ignore ctags file
 tags

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -662,35 +662,35 @@ def get_ssh_gateway_config(vm_):
     # Create dictionary of configuration items
 
     # ssh_gateway
-    ssh_gateway_config = {'gateway': ssh_gateway}
+    ssh_gateway_config = {'ssh_gateway': ssh_gateway}
 
     # ssh_gateway_username
-    ssh_gateway_config['username'] = config.get_cloud_config_value(
+    ssh_gateway_config['ssh_gateway_user'] = config.get_cloud_config_value(
         'ssh_gateway_username', vm_, __opts__, default=None,
         search_global=False
     )
 
     # ssh_gateway_private_key
-    ssh_gateway_config['key_filename'] = config.get_cloud_config_value(
+    ssh_gateway_config['ssh_gateway_key'] = config.get_cloud_config_value(
         'ssh_gateway_private_key', vm_, __opts__, default=None,
         search_global=False
     )
 
     # ssh_gateway_password
-    ssh_gateway_config['password'] = config.get_cloud_config_value(
+    ssh_gateway_config['ssh_gateway_password'] = config.get_cloud_config_value(
         'ssh_gateway_password', vm_, __opts__, default=None,
         search_global=False
     )
 
     # Check if private key exists
-    key_filename = ssh_gateway_config['key_filename']
+    key_filename = ssh_gateway_config['ssh_gateway_key']
     if key_filename is not None and not os.path.isfile(key_filename):
         raise SaltCloudConfigError(
             'The defined ssh_gateway_private_key {0!r} does not exist'.format(
                 key_filename
             )
         )
-    elif key_filename is None and not ssh_gateway_config['password']:
+    elif key_filename is None and not ssh_gateway_config['ssh_gateway_password']:
         raise SaltCloudConfigError(
             'No authentication method. Please define: '
             ' ssh_gateway_password or ssh_gateway_private_key'

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -690,7 +690,7 @@ def get_ssh_gateway_config(vm_):
                 key_filename
             )
         )
-    elif not ssh_gateway_config['password']:
+    elif key_filename is None and not ssh_gateway_config['password']:
         raise SaltCloudConfigError(
             'No authentication method. Please define: '
             ' ssh_gateway_password or ssh_gateway_private_key'
@@ -1391,7 +1391,8 @@ def create(vm_=None, call=None):
                 ssh_timeout=config.get_cloud_config_value(
                     'wait_for_passwd_timeout', vm_, __opts__, default=1 * 60),
                 key_filename=key_filename,
-                display_ssh_output=display_ssh_output
+                display_ssh_output=display_ssh_output,
+                gateway=ssh_gateway_config
             ):
                 username = user
                 break

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -645,6 +645,15 @@ def ssh_interface(vm_):
         search_global=False
     )
 
+def ssh_gateway(vm_):
+    '''
+    Return the ssh_gateway IP address to connect to.
+    '''
+    return config.get_cloud_config_value(
+        'ssh_gateway', vm_, __opts__, default=None,
+        search_global=False
+    )
+
 
 def get_location(vm_=None):
     '''

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1355,8 +1355,7 @@ def create(vm_=None, call=None):
         'event',
         'waiting for ssh',
         'salt/cloud/{0}/waiting_for_ssh'.format(vm_['name']),
-        {'ip_address': ip_address,
-         'ssh_gateway': ssh_gateway_config},
+        {'ip_address': ip_address},
     )
 
     ssh_connect_timeout = config.get_cloud_config_value(
@@ -1478,6 +1477,10 @@ def create(vm_=None, call=None):
                 'win_password', vm_, __opts__, default=''
             )
 
+        # Copy ssh_gateway_config into deploy scripts
+        if ssh_gateway_config:
+            deploy_kwargs['gateway'] = ssh_gateway_config
+
         # Store what was used to the deploy the VM
         event_kwargs = copy.deepcopy(deploy_kwargs)
         del event_kwargs['minion_pem']
@@ -1485,6 +1488,9 @@ def create(vm_=None, call=None):
         del event_kwargs['sudo_password']
         if 'password' in event_kwargs:
             del event_kwargs['password']
+        if 'gateway' in event_kwargs:
+            if 'ssh_gateway_password' in event_kwargs['gateway']:
+                del event_kwargs['gateway']['ssh_gateway_password']
         ret['deploy_kwargs'] = event_kwargs
 
         salt.utils.cloud.fire_event(

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1377,8 +1377,8 @@ def create(vm_=None, call=None):
             raise SaltCloudSystemExit(
                 'Failed to authenticate against remote windows host'
             )
-    elif salt.utils.cloud.wait_for_port(ip_address, ssh_gateway_config,
-                                        timeout=ssh_connect_timeout):
+    elif salt.utils.cloud.wait_for_port(ip_address, timeout=ssh_connect_timeout,
+                                        gateway=ssh_gateway_config):
         for user in usernames:
             if salt.utils.cloud.wait_for_passwd(
                 host=ip_address,

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1377,7 +1377,7 @@ def create(vm_=None, call=None):
             raise SaltCloudSystemExit(
                 'Failed to authenticate against remote windows host'
             )
-    elif salt.utils.cloud.wait_for_port(ip_address,
+    elif salt.utils.cloud.wait_for_port(ip_address, ssh_gateway_config,
                                         timeout=ssh_connect_timeout):
         for user in usernames:
             if salt.utils.cloud.wait_for_passwd(

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -645,14 +645,53 @@ def ssh_interface(vm_):
         search_global=False
     )
 
-def ssh_gateway(vm_):
+
+def get_ssh_gateway_config(vm_):
     '''
-    Return the ssh_gateway IP address to connect to.
+    Return the ssh_gateway configuration.
     '''
-    return config.get_cloud_config_value(
+    ssh_gateway = config.get_cloud_config_value(
         'ssh_gateway', vm_, __opts__, default=None,
         search_global=False
     )
+
+    # Check to see if a SSH Gateway will be used.
+    if not isinstance(ssh_gateway, str):
+        return None
+
+    # Create dictionary of configuration items
+
+    # ssh_gateway
+    ssh_gateway_config = {'gateway': ssh_gateway}
+
+    # ssh_gateway_username
+    ssh_gateway_config['username'] = config.get_cloud_config_value(
+        'ssh_gateway_username', vm_, __opts__, default=None,
+        search_global=False
+    )
+
+    # ssh_gateway_private_key
+    ssh_gateway_config['key_filename'] = config.get_cloud_config_value(
+        'ssh_gateway_private_key', vm_, __opts__, default=None,
+        search_global=False
+    )
+
+    # ssh_gateway_password
+    ssh_gateway_config['password'] = config.get_cloud_config_value(
+        'ssh_gateway_password', vm_, __opts__, default=None,
+        search_global=False
+    )
+
+    # Check if private key exists
+    key_filename = ssh_gateway_config['key_filename']
+    if key_filename is not None and not os.path.isfile(key_filename):
+        raise SaltCloudConfigError(
+            'The defined ssh_gateway_private_key {0!r} does not exist'.format(
+                key_filename
+            )
+        )
+
+    return ssh_gateway_config
 
 
 def get_location(vm_=None):

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -32,13 +32,17 @@ To use the EC2 cloud module, set up the cloud configuration at
       # can explicitly define the endpoint:
       endpoint: myendpoint.example.com:1138/services/Cloud
 
-      # SSH Gateway's can be used with this provider. Gateways can be used
+      # SSH Gateways can be used with this provider. Gateways can be used
       # when a salt-master is not on the same private network as the instance
       # that is being deployed.
 
-      # Defaults to port 22
+      # Defaults to None
       # Required
-      ssh_gateway: gateway.example.com:22
+      ssh_gateway: gateway.example.com
+
+      # Defaults to port 22
+      # Optional
+      ssh_gateway_port: 22
 
       # Defaults to root
       # Optional
@@ -684,6 +688,12 @@ def get_ssh_gateway_config(vm_):
 
     # ssh_gateway
     ssh_gateway_config = {'ssh_gateway': ssh_gateway}
+
+    # ssh_gateway_port
+    ssh_gateway_config['ssh_gateway_port'] = config.get_cloud_config_value(
+        'ssh_gateway_port', vm_, __opts__, default=None,
+        search_global=False
+    )
 
     # ssh_gateway_username
     ssh_gateway_config['ssh_gateway_user'] = config.get_cloud_config_value(

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -690,6 +690,11 @@ def get_ssh_gateway_config(vm_):
                 key_filename
             )
         )
+    elif not ssh_gateway_config['password']:
+        raise SaltCloudConfigError(
+            'No authentication method. Please define: '
+            ' ssh_gateway_password or ssh_gateway_private_key'
+        )
 
     return ssh_gateway_config
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -919,6 +919,11 @@ def create(vm_=None, call=None):
             )
         )
 
+    # Get SSH Gateway config early to verify the private_key,
+    # if used, exists or not. We don't want to deploy an instance
+    # and not be able to access it via the gateway.
+    ssh_gateway_config = get_ssh_gateway_config(vm_)
+
     location = get_location(vm_)
     log.info('Creating Cloud VM {0} in {1}'.format(vm_['name'], location))
     usernames = ssh_username(vm_)
@@ -1345,7 +1350,8 @@ def create(vm_=None, call=None):
         'event',
         'waiting for ssh',
         'salt/cloud/{0}/waiting_for_ssh'.format(vm_['name']),
-        {'ip_address': ip_address},
+        {'ip_address': ip_address,
+         'ssh_gateway': ssh_gateway_config},
     )
 
     ssh_connect_timeout = config.get_cloud_config_value(

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -32,6 +32,27 @@ To use the EC2 cloud module, set up the cloud configuration at
       # can explicitly define the endpoint:
       endpoint: myendpoint.example.com:1138/services/Cloud
 
+      # SSH Gateway's can be used with this provider. Gateways can be used
+      # when a salt-master is not on the same private network as the instance
+      # that is being deployed.
+
+      # Defaults to port 22
+      # Required
+      ssh_gateway: gateway.example.com:22
+
+      # Defaults to root
+      # Optional
+      ssh_gateway_username: root
+
+      # One authentication method is required. If both
+      # are specified, Private key wins.
+
+      # Private key defaults to None
+      ssh_gateway_private_key: /path/to/key.pem
+
+      # Password defaults to None
+      ssh_gateway_password: ExamplePasswordHere
+
       provider: ec2
 
 '''

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -294,7 +294,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     test_ssh_port = port
     if gateway:
         ssh_gateway = gateway['gateway']
-        ssh_gateway_port = '22'
+        ssh_gateway_port = 22
         if ':' in ssh_gateway:
             ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
         test_ssh_host = ssh_gateway
@@ -369,7 +369,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     command = 'nc -z -w5 -q0 {0} {1}'.format(host, port)
     # SSH command
     cmd = 'ssh {0} {1}@{2} -p {3} {4}'.format(
-        ' '.join(ssh_args), ssh_gateway['username'], ssh_gateway,
+        ' '.join(ssh_args), gateway['username'], ssh_gateway,
         ssh_gateway_port, pipes.quote(command)
     )
     log.debug('SSH command: {0!r}'.format(cmd))
@@ -395,8 +395,9 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
                     )
                     proc.terminate()
                     return 1
-            proc.sendline(ssh_gateway['password'])
+            proc.sendline(gateway['password'])
             sent_password = True
+            time.sleep(0.25)
         # Get the exit code of the SSH command.
         # If 0 then the port is open.
         if proc.status == 0:

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1013,6 +1013,28 @@ def scp_file(dest_path, contents, kwargs):
             '-i {0}'.format(kwargs['key_filename'])
         ])
 
+    if 'ssh_gateway' in kwargs:
+        ssh_gateway = kwargs['ssh_gateway']
+        ssh_gateway_port = 22
+        ssh_gateway_key = ''
+        ssh_gateway_user = 'root'
+        if ':' in ssh_gateway:
+            ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+        if 'ssh_gateway_key' in kwargs:
+            ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
+        if 'ssh_gateway_user' in kwargs:
+            ssh_gateway_user = kwargs['ssh_gateway_user']
+
+        ssh_args.extend([
+            # Setup ProxyCommand
+            '-oProxyCommand="ssh {0} {1}@{2} -p {3} nc -q0 %h %p"'.format(
+                ssh_gateway_key,
+                ssh_gateway_user,
+                ssh_gateway,
+                ssh_gateway_port
+            )
+        ])
+
     cmd = 'scp {0} {1} {2[username]}@{2[hostname]}:{3}'.format(
         ' '.join(ssh_args), tmppath, kwargs, dest_path
     )

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -376,7 +376,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     command = 'nc -z -w5 -q0 {0} {1}'.format(host, port)
     # SSH command
     cmd = 'ssh {0} {1}@{2} -p {3} {4}'.format(
-        ' '.join(ssh_args), gateway['username'], ssh_gateway,
+        ' '.join(ssh_args), gateway['ssh_gateway_user'], ssh_gateway,
         ssh_gateway_port, pipes.quote(command)
     )
     log.debug('SSH command: {0!r}'.format(cmd))

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -288,7 +288,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
     test_ssh_host = host
     test_ssh_port = port
     if gateway:
-        ssh_gateway = gateway['gateway']
+        ssh_gateway = gateway['ssh_gateway']
         ssh_gateway_port = 22
         if ':' in ssh_gateway:
             ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
@@ -360,7 +360,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
         '-oControlPath=none'
     ])
     # There should never be both a password and an ssh key passed in, so
-    if 'key_filename' in gateway:
+    if 'ssh_gateway_key' in gateway:
         ssh_args.extend([
             # tell SSH to skip password authentication
             '-oPasswordAuthentication=no',
@@ -370,7 +370,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
             # No Keyboard interaction!
             '-oKbdInteractiveAuthentication=no',
             # Also, specify the location of the key file
-            '-i {0}'.format(gateway['key_filename'])
+            '-i {0}'.format(gateway['ssh_gateway_key'])
         ])
     # Netcat command testing remote port
     command = 'nc -z -w5 -q0 {0} {1}'.format(host, port)
@@ -402,7 +402,7 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
                     )
                     proc.terminate()
                     return 1
-            proc.sendline(gateway['password'])
+            proc.sendline(gateway['ssh_gateway_password'])
             sent_password = True
             time.sleep(0.25)
         # Get the exit code of the SSH command.
@@ -448,9 +448,9 @@ def wait_for_passwd(host, port=22, ssh_timeout=15, username='root',
                       'timeout': ssh_timeout,
                       'display_ssh_output': display_ssh_output}
             if gateway:
-                kwargs['ssh_gateway'] = gateway['gateway']
-                kwargs['ssh_gateway_key'] = gateway['key_filename']
-                kwargs['ssh_gateway_user'] = gateway['username']
+                kwargs['ssh_gateway'] = gateway['ssh_gateway']
+                kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
+                kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
 
             if key_filename:
                 if not os.path.isfile(key_filename):

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -292,6 +292,8 @@ def wait_for_port(host, port=22, timeout=900, gateway=None):
         ssh_gateway_port = 22
         if ':' in ssh_gateway:
             ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+        if 'ssh_gateway_port' in gateway:
+            ssh_gateway_port = gateway['ssh_gateway_port']
         test_ssh_host = ssh_gateway
         test_ssh_port = ssh_gateway_port
         log.debug(
@@ -1020,6 +1022,8 @@ def scp_file(dest_path, contents, kwargs):
         ssh_gateway_user = 'root'
         if ':' in ssh_gateway:
             ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+        if 'ssh_gateway_port' in kwargs:
+            ssh_gateway_port = kwargs['ssh_gateway_port']
         if 'ssh_gateway_key' in kwargs:
             ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
         if 'ssh_gateway_user' in kwargs:
@@ -1189,6 +1193,8 @@ def root_cmd(command, tty, sudo, **kwargs):
         ssh_gateway_user = 'root'
         if ':' in ssh_gateway:
             ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+        if 'ssh_gateway_port' in kwargs:
+            ssh_gateway_port = kwargs['ssh_gateway_port']
         if 'ssh_gateway_key' in kwargs:
             ssh_gateway_key = '-i {0}'.format(kwargs['ssh_gateway_key'])
         if 'ssh_gateway_user' in kwargs:

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1048,6 +1048,26 @@ def root_cmd(command, tty, sudo, **kwargs):
             '-i {0}'.format(kwargs['key_filename'])
         ])
 
+    if 'ssh_gateway' in kwargs:
+        ssh_gateway = kwargs['ssh_gateway']
+        ssh_gateway_port = '22'
+        if ':' in ssh_gateway:
+            ssh_gateway, ssh_gateway_port = ssh_gateway.split(':')
+
+        ssh_args.extend([
+            # Setup ProxyCommand
+            '-oProxyCommand="ssh {0}:{1} nc -q0 %h %p"'.format(
+                ssh_gateway,
+                ssh_gateway_port
+            ),
+            # Forward the SSH agent
+            '-oForwardAgent=yes'
+        ])
+        log.info(
+            'Using SSH gateway {0}:{1}'.format(
+                ssh_gateway, ssh_gateway_port
+            )
+        )
     cmd = 'ssh {0} {1[username]}@{1[hostname]} {2}'.format(
         ' '.join(ssh_args), kwargs, pipes.quote(command)
     )

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -629,15 +629,19 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 key_filename
             )
         )
+    gateway=None
+    if kwargs['gateway']:
+        gateway = kwargs['gateway']
     starttime = time.mktime(time.localtime())
     log.debug('Deploying {0} at {1}'.format(host, starttime))
-    if wait_for_port(host=host, port=port):
+
+    if wait_for_port(host=host, port=port, gateway=gateway):
         log.debug('SSH port {0} on {1} is available'.format(port, host))
         newtimeout = timeout - (time.mktime(time.localtime()) - starttime)
         if wait_for_passwd(host, port=port, username=username,
                            password=password, key_filename=key_filename,
                            ssh_timeout=ssh_timeout,
-                           display_ssh_output=display_ssh_output):
+                           display_ssh_output=display_ssh_output, gateway=gateway):
             log.debug(
                 'Logging into {0}:{1} as {2}'.format(
                     host, port, username
@@ -652,20 +656,16 @@ def deploy_script(host, port=22, timeout=900, username='root',
                 'display_ssh_output': display_ssh_output,
                 'sudo_password': sudo_password,
             }
+            if gateway:
+                kwargs['ssh_gateway'] = gateway['ssh_gateway']
+                kwargs['ssh_gateway_key'] = gateway['ssh_gateway_key']
+                kwargs['ssh_gateway_user'] = gateway['ssh_gateway_user']
             if key_filename:
                 log.debug('Using {0} as the key_filename'.format(key_filename))
                 kwargs['key_filename'] = key_filename
             elif password:
                 log.debug('Using {0} as the password'.format(password))
                 kwargs['password'] = password
-
-            #FIXME: this try-except doesn't make sense! Something is missing...
-            try:
-                log.debug('SSH connection to {0} successful'.format(host))
-            except Exception as exc:
-                log.error(
-                    'There was an error in deploy_script: {0}'.format(exc)
-                )
 
             if provider == 'ibmsce':
                 subsys_command = (

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -275,7 +275,7 @@ def wait_for_fun(fun, timeout=900, **kwargs):
             )
 
 
-def wait_for_port(host, gateway=None, port=22, timeout=900):
+def wait_for_port(host, port=22, timeout=900, gateway=None):
     '''
     Wait until a connection to the specified port can be made on a specified
     host. This is usually port 22 (for SSH), but in the case of Windows


### PR DESCRIPTION
This adds the ability to specify a ssh gateway host so that your salt-master does not have to be on the same private network as your minion.

I've only added the functionality for the ec2 provider as I don't have access to the other clouds to develop with, however, each provider can take advantage of the ssh gateway by adding the options to the provider. No work should be need elsewhere.
#9782
