### PR TITLE
Make the yumpkg5 module MUCH faster

### DIFF
--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -88,6 +88,7 @@ def _parse_pkginfo(line):
 
     return pkginfo(name, pkg_version, arch, repoid)
 
+
 def _repoquery_pkginfo(repoquery_args):
     '''
     Wrapper to call repoquery and parse out all the tuples

--- a/salt/modules/yumpkg5.py
+++ b/salt/modules/yumpkg5.py
@@ -88,21 +88,28 @@ def _parse_pkginfo(line):
 
     return pkginfo(name, pkg_version, arch, repoid)
 
+def _repoquery_pkginfo(repoquery_args):
+    '''
+    Wrapper to call repoquery and parse out all the tuples
+    '''
+    ret = []
+    for line in _repoquery(repoquery_args):
+        pkginfo = _parse_pkginfo(line)
+        if pkginfo is not None:
+            ret.append(pkginfo)
+    return ret
 
-def _repoquery(repoquery_args):
+
+def _repoquery(repoquery_args, query_format=__QUERYFORMAT):
     '''
     Runs a repoquery command and returns a list of namedtuples
     '''
     ret = []
     cmd = 'repoquery --queryformat="{0}" {1}'.format(
-        __QUERYFORMAT, repoquery_args
+        query_format, repoquery_args
     )
     out = __salt__['cmd.run_stdout'](cmd, output_loglevel='debug')
-    for line in out.splitlines():
-        pkginfo = _parse_pkginfo(line)
-        if pkginfo is not None:
-            ret.append(pkginfo)
-    return ret
+    return out.splitlines()
 
 
 def _get_repo_options(**kwargs):
@@ -195,7 +202,7 @@ def latest_version(*names, **kwargs):
 
     # Get updates for specified package(s)
     repo_arg = _get_repo_options(**kwargs)
-    updates = _repoquery(
+    updates = _repoquery_pkginfo(
         '{0} --pkgnarrow=available {1}'.format(repo_arg, ' '.join(names))
     )
 
@@ -270,7 +277,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
             return ret
 
     ret = {}
-    for pkginfo in _repoquery('--all --pkgnarrow=installed'):
+    for pkginfo in _repoquery_pkginfo('--all --pkgnarrow=installed'):
         if pkginfo is None:
             continue
         __salt__['pkg_resource.add_pkg'](ret, pkginfo.name, pkginfo.version)
@@ -329,7 +336,7 @@ def list_repo_pkgs(*args, **kwargs):
         repoquery_cmd = '--all --repoid="{0}"'.format(repo)
         for arg in args:
             repoquery_cmd += ' "{0}"'.format(arg)
-        all_pkgs = _repoquery(repoquery_cmd)
+        all_pkgs = _repoquery_pkginfo(repoquery_cmd)
         for pkg in all_pkgs:
             ret.setdefault(pkg.repoid, []).append({pkg.name: pkg.version})
 
@@ -352,7 +359,7 @@ def list_upgrades(refresh=True, **kwargs):
         refresh_db()
 
     repo_arg = _get_repo_options(**kwargs)
-    updates = _repoquery('{0} --all --pkgnarrow=updates'.format(repo_arg))
+    updates = _repoquery_pkginfo('{0} --all --pkgnarrow=updates'.format(repo_arg))
     return dict([(x.name, x.version) for x in updates])
 
 
@@ -382,14 +389,14 @@ def check_db(*names, **kwargs):
     repoquery_base = '{0} --all --quiet --whatprovides'.format(repo_arg)
 
     # get list of available packages
-    available_packages = __salt__['cmd.run']('repoquery --pkgnarrow=all --qf "%{name}"  -a').splitlines()
+    available_packages = _repoquery('--pkgnarrow=all -a', query_format='%{name}')
 
     ret = {}
     for name in names:
         ret.setdefault(name, {})['found'] = name in available_packages
         if not ret[name]['found']:
             repoquery_cmd = repoquery_base + ' {0!r}'.format(name)
-            provides = set(x.name for x in _repoquery(repoquery_cmd))
+            provides = set(x.name for x in _repoquery_pkginfo(repoquery_cmd))
             if provides:
                 for pkg in provides:
                     ret[name]['suggestions'] = list(provides)
@@ -867,7 +874,7 @@ def group_info(name):
 
         salt '*' pkg.group_info 'Perl Support'
     '''
-    # Not using _repoquery() here because group queries are handled
+    # Not using _repoquery_pkginfo() here because group queries are handled
     # differently, and ignore the '--queryformat' param
     ret = {
         'mandatory packages': [],


### PR DESCRIPTION
**NOTE: This is #9820 with the first three commits only. The additional work of deprecating yumpkg will be done separately.**

benchmarked with a state with 52 packages

```
before
real 0m58.023s
user 0m37.749s
sys 0m10.262s

after
real 0m9.650s
user 0m6.192s
sys 0m1.728s
```

This now actually makes yumpkg5 faster than yumpkg!
