### PR TITLE
Not all versions of PyZMQ have the `destroy()` method!?

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -335,7 +335,8 @@ class SaltEvent(object):
             self.context.term()
 
         # Hardcore destruction
-        self.context.destroy(linger=1)
+        if hasattr(self.context, 'destroy'):
+            self.context.destroy(linger=1)
 
         # https://github.com/zeromq/pyzmq/issues/173#issuecomment-4037083
         # Assertion failed: get_load () == 0 (poller_base.cpp:32)


### PR DESCRIPTION
Sorry @thatch45
