### PR TITLE
Rename yumpkg5 to yumpkg

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -205,7 +205,7 @@ Full list of builtin execution modules
     win_useradd
     xapi
     xmpp
-    yumpkg5
+    yumpkg
     zcbuildout
     zfs
     zpool

--- a/doc/ref/modules/all/salt.modules.yumpkg.rst
+++ b/doc/ref/modules/all/salt.modules.yumpkg.rst
@@ -1,0 +1,7 @@
+===================
+salt.modules.yumpkg
+===================
+
+.. automodule:: salt.modules.yumpkg
+    :members:
+    :exclude-members: available_version

--- a/doc/ref/modules/all/salt.modules.yumpkg5.rst
+++ b/doc/ref/modules/all/salt.modules.yumpkg5.rst
@@ -1,7 +1,0 @@
-====================
-salt.modules.yumpkg5
-====================
-
-.. automodule:: salt.modules.yumpkg5
-    :members:
-    :exclude-members: available_version

--- a/doc/ref/states/providers.rst
+++ b/doc/ref/states/providers.rst
@@ -74,7 +74,7 @@ pkgng                   FreeBSD-based OSes using ``pkg(8)``
 pkgutil                 Solaris-based OSes using `OpenCSW`_'s ``pkgutil(1)``
 solarispkg              Solaris-based OSes using ``pkgadd(1M)``
 win_pkg                 Windows
-yumpkg5                 RedHat-based distros and derivatives (wraps ``yum(8)``)
+yumpkg                  RedHat-based distros and derivatives (wraps ``yum(8)``)
 zypper                  SUSE-based distros using ``zypper(8)``
 ======================= =======================================================
 
@@ -148,11 +148,10 @@ module can be used to provide certain functionality.
     emacs:
       pkg.installed:
         - provider:
-          - pkg: yumpkg5
           - cmd: customcmd
 
-In this example the default :py:mod:`~salt.modules.pkg` module is being
-redirected to use the :py:mod:`~salt.modules.yumpkg5` module (:program:`yum`
-via shelling out instead of via the :program:`yum` Python API), but is also
-using a custom module to invoke commands. This could be used to dramatically
-change the behavior of a given state.
+In this example, the state is being instructed to use a custom module to invoke
+commands.
+
+Arbitrary module redirects can be used to dramatically change the behavior of a
+given state.

--- a/doc/topics/releases/0.9.8.rst
+++ b/doc/topics/releases/0.9.8.rst
@@ -268,7 +268,6 @@ Default providers can also be defined in the minion config file:
 .. code-block:: yaml
 
     providers:
-      pkg: yumpkg5
       service: systemd
 
 When default providers are passed in the minion config, then those providers
@@ -333,7 +332,7 @@ with the :doc:`associated </ref/states/all/salt.states.rvm>`
 
 The :doc:`virt </ref/modules/all/salt.modules.virt>` module gained basic Xen support.
 
-The :doc:`yum </ref/modules/all/salt.modules.yumpkg5>` modules gained
+The :doc:`yum </ref/modules/all/salt.modules.yumpkg>` module gained
 Scientific Linux support.
 
 The :doc:`pkg </ref/modules/all/salt.modules.apt>` module on Debian, Ubuntu,

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -28,7 +28,7 @@ def _parse_pkg_meta(path):
     '''
     def parse_rpm(path):
         try:
-            from salt.modules.yumpkg5 import __QUERYFORMAT, _parse_pkginfo
+            from salt.modules.yumpkg import __QUERYFORMAT, _parse_pkginfo
             from salt.utils import namespaced_function as _namespaced_function
             _parse_pkginfo = _namespaced_function(_parse_pkginfo, globals())
         except ImportError:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -43,8 +43,7 @@ def __virtual__():
     '''
     Confine this module to yum based systems
     '''
-    # Work only on RHEL/Fedora based distros with python 2.5 and below
-    if __opts__.get('yum_provider') == 'yumpkg':
+    if __opts__.get('yum_provider') == 'yumpkg_api':
         return False
     try:
         os_grain = __grains__['os'].lower()
@@ -438,7 +437,7 @@ def clean_metadata():
     .. versionadded:: 2014.1.0 (Hydrogen)
 
     Cleans local yum metadata. Functionally identical to :mod:`refresh_db()
-    <salt.modules.yumpkg5.refresh_db>`.
+    <salt.modules.yumpkg.refresh_db>`.
 
     CLI Example:
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -331,8 +331,7 @@ def installed(
         for the following pkg providers: :mod:`apt <salt.modules.apt>`,
         :mod:`ebuild <salt.modules.ebuild>`,
         :mod:`pacman <salt.modules.pacman>`,
-        :mod:`yumpkg <salt.modules.yumpkg>`,
-        :mod:`yumpkg5 <salt.modules.yumpkg5>`, and
+        :mod:`yumpkg <salt.modules.yumpkg>`, and
         :mod:`zypper <salt.modules.zypper>`.
 
     refresh
@@ -365,7 +364,6 @@ def installed(
     ``NOTE:`` For :mod:`apt <salt.modules.apt>`,
     :mod:`ebuild <salt.modules.ebuild>`,
     :mod:`pacman <salt.modules.pacman>`, :mod:`yumpkg <salt.modules.yumpkg>`,
-    :mod:`yumpkg5 <salt.modules.yumpkg5>`,
     and :mod:`zypper <salt.modules.zypper>`, version numbers can be specified
     in the ``pkgs`` argument. Example::
 


### PR DESCRIPTION
This also makes a change that allows the old api-based yumpkg to be used
as the yum provider if the proper config option is set.
