### PR TITLE
Some fixes and the addition of GnuPG to smtp_return

### DIFF
--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -76,11 +76,11 @@ def returner(ret):
             'function args: {2}\r\n'
             'jid: {3}\r\n'
             'return: {4}\r\n').format(
-                    ret['id'],
-                    ret['fun'],
+                    ret.get('id'),
+                    ret.get('fun'),
                     ret.get('fun_args'),
-                    ret['jid'],
-                    pprint.pformat(ret['return']))
+                    ret.get('jid'),
+                    pprint.pformat(ret.get('return')))
     if gpgowner:
         gpg = gnupg.GPG(gnupghome=os.path.expanduser('~%s/.gnupg' % gpgowner), options=['--trust-model always'])
         encrypted_data = gpg.encrypt(content, to_addrs)

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -55,7 +55,7 @@ except ImportError:
 def __virtual__():
     if not HAS_GNUPG:
         log.info('smtp_return: python-gnupg not available, no encryption will be used.')
-    return 'smtp_return'
+    return 'smtp'
 
 def returner(ret):
     '''

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -84,10 +84,14 @@ def returner(ret):
                              ret['jid'],
                              content)
 
+    log.debug('smtp_return: Connecting to the server...')
     server = smtplib.SMTP(host, int(port))
     if __salt__['config.option']('smtp.tls') is True:
         server.starttls()
+        log.debug('smtp_return: TLS enabled')
     if user and passwd:
         server.login(user, passwd)
+        log.debug('smtp_return: Authenticated')
     server.sendmail(from_addr, to_addrs, message)
+    log.debug('smtp_return: Message sent.')
     server.quit()

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -19,8 +19,8 @@ There are a few things to keep in mind:
 
 * If a username is used, a password is also required.
 * If gpgowner is left unset, no encryption will be used.
-* The field gpgowner specifies the user which has a gpg public key in his
-  respective ~/.gpg directory
+* The field gpgowner specifies the user which has a gpg public key matching the
+  adress the mail is sent to in his respective ~/.gpg directory
 * You should at least declare a subject, but you don't have to.
 * smtp.fields lets you include the value(s) of various fields in the subject
   line of the email. These are comma-delimited. For instance:

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -62,7 +62,7 @@ def returner(ret):
     for field in fields:
         if field in ret.keys():
             subject += ' {0}'.format(ret[field])
-    log.debug('subject')
+    log.debug("smtp_return: Subject is '{0}'".format(subject))
 
     content = pprint.pformat(ret['return'])
     message = ('From: {0}\r\n'

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -78,7 +78,7 @@ def returner(ret):
             'return: {4}\r\n').format(
                     ret['id'],
                     ret['fun'],
-                    ret['fun_args'],
+                    ret.get('fun_args'),
                     ret['jid'],
                     pprint.pformat(ret['return']))
     if gpgowner:


### PR DESCRIPTION
I fixed some minor bugs present in this returner, and I also added some basic GnuPG encryption to it. Its implementation rather straigthforward. A more sophisticated solution may add the option to sign.
I have used it for a while know and it does not cause any problems.

Some details:
- The new setting, gpgowner, refers to the user whose ~/.gnupg directory contains a public key matching the receipient
- It adds python-gnupg as a dependency. I have no idea if this is part of the standard python distribution or if this is a dealbreaker to you.
- I set gnupg's trust setting to always, as the public key is intended for automated distribution and use. You could probably use default trust settings too, but I thought that this will suffice if you just want to grab the public key from a keyserver (using a state for example) and don't want to bother with generating a keyring/ trusting this key with your account.

I would at least recommend the other commits fixing bugs, but I would welcome GnuPG support in this returner.

Some other loosely related, major and possibly stuff-breaking changes I will leave to a developer knowing the consequences: 
- indenting the server.login(user, pass) function near the end of this file by four spaces (i.e. make plaintext authentication impossible)
- making the configuguration for this returner a dict. That means:

```
smtp:
  - host: bla
  - user: bla
```

rather than:

```
smpt.host: bla
smtp.user: bla
```
