### PR TITLE
yumpkg: add link to pkg.purge docstring

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -773,7 +773,7 @@ def remove(name=None, pkgs=None, **kwargs):
 def purge(name=None, pkgs=None, **kwargs):
     '''
     Package purges are not supported by yum, this function is identical to
-    ``remove()``.
+    :mod:`pkg.remove <salt.modules.yumpkg.remove>`.
 
     name
         The name of the package to be deleted.


### PR DESCRIPTION
This resolves #9760 by making pkg.purge include a direct link to the
docs for pkg.remove.
