### PR TITLE
Modify file.get_selinux_context to use the python selinux module rather than calling cmd.run

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -33,6 +33,7 @@ import time
 try:
     import grp
     import pwd
+    import selinux
 except ImportError:
     pass
 
@@ -1891,8 +1892,8 @@ def get_selinux_context(path):
 
         salt '*' file.get_selinux_context /etc/hosts
     '''
-    out = __salt__['cmd.run']('ls -Z {0}'.format(path))
-    return out.split(' ')[4]
+    out = selinux.getfilecon(path)
+    return out[1]
 
 
 def set_selinux_context(path,

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1892,8 +1892,12 @@ def get_selinux_context(path):
 
         salt '*' file.get_selinux_context /etc/hosts
     '''
-    out = selinux.getfilecon(path)
-    return out[1]
+    try:
+        return selinux.getfilecon(path)[1]
+    except NameError:
+        return 'Unable to find the selinux module for python. It may not be installed.'
+    except OSError, error:
+        return '{0}'.format(error)
 
 
 def set_selinux_context(path,


### PR DESCRIPTION
Hi,

This change aims to address the immediate problem documented in: https://github.com/saltstack/salt/issues/9845
More work should probably be done to see if the other selinux related functions in the file module can also use the selinux python module rather than calling commands with cmd.run.

Please have a good look over these changes before accepting (I'm sure you will anyway) as I'm a sysadmin by trade, not a dev. This is also my first pull request (to a rather important module). I think it's fairly safe but would prefer for someone more knowledgeable to go over it thoroughly.
## 

Bowen
