### PR TITLE
Added a note to the service docs to link over to requisites since we do not explain watch.

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -34,6 +34,12 @@ service, then set the reload value to True:
         - reload: True
         - watch:
           - pkg: redis
+
+.. note::
+
+    More details regarding ``watch`` can be found in the
+    :doc:`Requisites </ref/states/requisites>` documentation.
+
 '''
 
 


### PR DESCRIPTION
This partially resolves https://github.com/saltstack/salt/issues/9810, however please don't close that issue yet, as there is discussion going on there. It may need to be transitioned to a new issue.
