### PR TITLE
Fix quoting problem in multiple modules 

### DIFF
--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -96,7 +96,7 @@ def set_password(name, password):
         cmd = 'pw user mod {0} -H 0'.format(name)
         stdin = password
     else:
-        cmd = 'usermod -p \'{0}\' {1}'.format(password, name)
+        cmd = 'usermod -p {0!r} {1}'.format(password, name)
         stdin = None
     __salt__['cmd.run'](cmd, stdin=stdin)
     return info(name)['passwd'] == password

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -170,7 +170,7 @@ def change_password(name, password, runas=None):
         salt '*' rabbitmq.change_password rabbit_user password
     '''
     res = __salt__['cmd.run'](
-        'rabbitmqctl change_password {0} \'{1}\''.format(name, password),
+        'rabbitmqctl change_password {0} {1!r}'.format(name, password),
         runas=runas)
     msg = 'Password Changed'
 

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -207,7 +207,7 @@ def _chroot_exec(root, cmd):
     if os.path.isfile(os.path.join(root, 'bin/bash')):
         sh_ = '/bin/bash'
 
-    cmd = 'chroot {0} {1} -c \'{2}\''.format(
+    cmd = 'chroot {0} {1} -c {2!r}'.format(
         root,
         sh_,
         cmd)

--- a/salt/pillar/hiera.py
+++ b/salt/pillar/hiera.py
@@ -32,7 +32,7 @@ def ext_pillar(minion_id, pillar, conf):
     cmd = 'hiera -c {0}'.format(conf)
     for key, val in __grains__.items():
         if isinstance(val, string_types):
-            cmd += ' {0}=\'{1}\''.format(key, val)
+            cmd += ' {0}={1!r}'.format(key, val)
     try:
         data = yaml.safe_load(__salt__['cmd.run'](cmd))
     except Exception:


### PR DESCRIPTION
For rabbitmq module, I missed change this in my last PR, so I fix it here.
For salt/modules/bsd_shadow.py, I think password can contain single quote, so I fix it same way as rabbitmq.
For  salt/modules/seed.py, the command it run may contain single quote so I guess it need to fix

For salt/pillar/hiera.py, as the loop over **grains**.items, as user can add their custom grains with value contains single quote, so I fix that (for grain key, I think no need to fix it because the key with single quote seems not right).

I also found this quoting problem in many places but they seem not cause any harm

```
./state.py:1707:                    'The \'{0}\' declaration found on \'{1}\' is invalid when '
./state.py:1750:                            'Name \'{0}\' in template \'{1}\' contains '
./minion.py:1057:                '{0} is starting as user \'{1}\''.format(
./master.py:359:            'salt-master is starting as user \'{0}\''.format(getpass.getuser())
./cloud/clouds/openstack.py:403:                    'No such security group: \'{0}\''.format(vmg)
./cloud/clouds/ec2.py:1233:                log.error('Spot instance request resulted in state \'{0}\'. '
./cloud/clouds/nova.py:354:                    'No such security group: \'{0}\''.format(vmg)
./cli/caller.py:82:            msg = 'Error running \'{0}\': {1}\n'
./cli/caller.py:90:            msg = 'Command required for \'{0}\' not found: {1}\n'
./grains/core.py:179:                log.debug('Unexpected lspci output: \'{0}\''.format(line))
./grains/core.py:439:                    'Although \'{0}\' was found in path, the current user '
./grains/core.py:616:        grains['ps'] = 'ps -fH -p $(grep -l \"^envID:[[:space:]]*0\\$\" /proc/[0-9]*/status | sed -e \"s=/proc/\\([0-9]*\\)/.*=\\1=\")  | awk \'{ $7=\"\"; print }\''
./config.py:1373:                            'trying to extend data from \'{2}:{3}\' though '
./states/npm.py:104:        ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
./states/npm.py:129:        ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)
./states/npm.py:197:        ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)
./states/npm.py:271:        ret['comment'] = 'Error Bootstrapping \'{0}\': {1}'.format(name, err)
./states/mount.py:157:                                      'output \'{1}\' from call to '
./states/composer.py:124:        ret['comment'] = 'Error executing composer in \'{0!r}\': {1!r}'.format(name, err)
./states/pip_state.py:411:                    'There was no error installing package \'{0}\' although '
./states/pip_state.py:496:        ret['comment'] = 'Error uninstalling \'{0}\': {1}'.format(name, err)
./states/git.py:272:                return _fail(ret, 'Directory \'{0}\' exists, is non-empty, and '
./utils/network.py:488:        log.error('Invalid CIDR \'{0}\''.format(cidr))
./utils/network.py:494:        log.error('Invalid network starting IP \'{0}\' in CIDR '
./utils/network.py:495:                  '\'{1}\''.format(netstart, cidr))
./utils/parsers.py:342:                     'Default: \'{1}\'.'.format(
./utils/parsers.py:361:                 'Default: \'{1}\'.'.format(
./utils/cloud.py:841:                            'setenv {0} \'{1}\' >/dev/null 2>&1 || '
./utils/cloud.py:842:                            'export {0}=\'{1}\''.format(key, value)
./utils/__init__.py:492:        err = ('This master address: \'{0}\' was previously resolvable '
./utils/__init__.py:532:    msg = '\'{0}\' requires these python modules: {1}'
./utils/jinja.py:99:                'Discarded template path \'{0}\', relative paths are '
./pillar/mongo.py:119:    log.debug('using database \'{0}\''.format(__opts__['mongo.db']))
./pillar/mongo.py:126:        log.debug('authenticating as \'{0}\''.format(user))
./pillar/mongo.py:134:        'ext_pillar.mongo: looking up pillar def for {{\'{0}\': \'{1}\'}} '
./pillar/mongo.py:145:                '\'{0}\''.format(
./tops/mongo.py:107:    log.debug('using database \'{0}\''.format(__opts__['mongo.db']))
./tops/mongo.py:114:        log.debug('authenticating as \'{0}\''.format(user))
./tops/mongo.py:123:        'ext_tops.mongo: looking up tops def for {{\'{0}\': \'{1}\'}} '
./modules/smartos_vmadm.py:120:        cmd = 'echo \'{0}\' | {1} validate create'.format(ret, vmadm)
./modules/smartos_vmadm.py:126:        cmd = 'echo \'{0}\' | {1} create'.format(ret, vmadm)
./modules/reg.py:47:            msg = 'No hkey named \'{0}. Try one of {1}\''
./modules/file.py:3148:           'comment': 'Invalid backup_id \'{0}\''.format(backup_id)}
./modules/file.py:3157:        ret['comment'] = 'backup_id \'{0}\' does not exist for ' \
./modules/file.py:3205:           'comment': 'Invalid backup_id \'{0}\''.format(backup_id)}
./modules/file.py:3214:        ret['comment'] = 'backup_id \'{0}\' does not exist for ' \
./modules/cmdmod.py:319:                env_cmd = ('su - {1} -c "{0} -c \'{2}\'"'
./modules/cmdmod.py:383:            msg = 'Invalid umask: \'{0}\''.format(umask)
./modules/dig.py:71:            'dig returned exit code \'{0}\'. Returning empty list as '
./modules/dig.py:103:            'dig returned exit code \'{0}\'. Returning empty list as '
./modules/dig.py:135:            'dig returned exit code \'{0}\'. Returning empty list as '
./modules/dig.py:185:            'dig returned exit code \'{0}\'. Returning empty list as '
./modules/dig.py:231:            'dig returned exit code \'{0}\'. Returning empty list as '
./modules/win_status.py:95:        log.warning('Error getting owner of process; PID=\'{0}\'; Error: {1}'
./modules/netbsdservice.py:224:    ret = __salt__['cmd.retcode']('grep \'{0}\' {1}'.format(rxname, rcconf))
```
