### PR TITLE
Catch uncaught OSError in hash_cache stuffs

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -192,9 +192,11 @@ def file_hash(load, fnd):
                 except ValueError:
                     log.debug('Fileserver attempted to read incomplete cache file. Retrying.')
                     # Delete the file since its incomplete (either corrupted or incomplete)
-                    os.unlink(cache_path)
-                    file_hash(load, fnd)
-                    return ret
+                    try:
+                        os.unlink(cache_path)
+                    except OSError:
+                        pass
+                    return file_hash(load, fnd)
                 if os.path.getmtime(path) == mtime:
                     # check if mtime changed
                     ret['hsum'] = hsum
@@ -202,9 +204,11 @@ def file_hash(load, fnd):
         except os.error:  # Can't use Python select() because we need Windows support
             log.debug("Fileserver encountered lock when reading cache file. Retrying.")
             # Delete the file since its incomplete (either corrupted or incomplete)
-            os.unlink(cache_path)
-            file_hash(load, fnd)
-            return ret
+            try:
+                os.unlink(cache_path)
+            except OSError:
+                pass
+            return file_hash(load, fnd)
 
     # if we don't have a cache entry-- lets make one
     ret['hsum'] = salt.utils.get_hash(path, __opts__['hash_type'])


### PR DESCRIPTION
This is usually a race condition between multiple master worker processes
