### PR TITLE
Improve salt-ssh docs

### DIFF
--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -21,7 +21,7 @@ Options
 
     Execute a raw shell command.
 
-.. option:: --roster-file
+.. option:: --roster
 
     Define which roster system to use, this defines if a database backend,
     scanner, or custom roster system is used. Default is the flat file roster.

--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -26,6 +26,14 @@ Options
     Define which roster system to use, this defines if a database backend,
     scanner, or custom roster system is used. Default is the flat file roster.
 
+.. option:: --roster-file
+
+    Define an alternative location for the default roster file location. The
+    default roster file is called ``roster`` and is found in the same directory
+    as the master config file.
+
+    .. versionadded:: 2014.1.0 (Hydrogen)
+
 .. option:: --refresh, --refresh-cache
 
     Force a refresh of the master side data cache of the target's data. This


### PR DESCRIPTION
This fixes an inaccuracy, and adds a new command-line option that was added for 2014.1.0.

Resolves #9796.
