### PR TITLE
Improve behaviour of the salt.state state function

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -8,11 +8,15 @@ for managing outputters.
 import os
 import sys
 import errno
+import logging
+import traceback
 
 # Import salt libs
 import salt.loader
 import salt.utils
 
+
+log = logging.getLogger(__name__)
 
 STATIC = (
     'yaml_out',
@@ -29,6 +33,7 @@ def display_output(data, out, opts=None):
     try:
         display_data = get_printout(out, opts)(data).rstrip()
     except (KeyError, AttributeError):
+        log.debug(traceback.format_exc())
         opts.pop('output', None)
         display_data = get_printout('nested', opts)(data).rstrip()
 

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -40,166 +40,194 @@ def output(data):
     be used with the state.highstate function, or a function that returns
     highstate return data.
     '''
+    for host, hostdata in data.iteritems():
+        return _format_host(host, hostdata)[0]
+
+
+def _format_host(host, data):
     colors = salt.utils.get_colors(__opts__.get('color'))
     tabular = __opts__.get('state_tabular', False)
-    for host in data:
-        rcounts = {}
-        hcolor = colors['GREEN']
-        hstrs = []
-        if isinstance(data[host], list):
-            # Errors have been detected, list them in RED!
-            hcolor = colors['RED_BOLD']
-            hstrs.append(('    {0}Data failed to compile:{1[ENDC]}'
-                          .format(hcolor, colors)))
-            for err in data[host]:
-                hstrs.append(('{0}----------\n    {1}{2[ENDC]}'
-                              .format(hcolor, err, colors)))
-        if isinstance(data[host], dict):
-            # Strip out the result: True, without changes returns if
-            # state_verbose is False
-            if not __opts__.get('state_verbose', False):
-                data[host] = _strip_clean(data[host])
-            # Verify that the needed data is present
-            for tname, info in data[host].items():
-                if not '__run_num__' in info:
-                    err = ('The State execution failed to record the order '
-                           'in which all states were executed. The state '
-                           'return missing data is:')
-                    hstrs.insert(0, pprint.pformat(info))
-                    hstrs.insert(0, err)
-            # Everything rendered as it should display the output
-            for tname in sorted(
-                    data[host],
-                    key=lambda k: data[host][k].get('__run_num__', 0)):
-                ret = data[host][tname]
-                # Increment result counts
-                rcounts.setdefault(ret['result'], 0)
-                rcounts[ret['result']] += 1
-                tcolor = colors['GREEN']
-                if ret['changes']:
-                    tcolor = colors['CYAN']
-                if ret['result'] is False:
-                    hcolor = colors['RED']
-                    tcolor = colors['RED']
-                if ret['result'] is None:
-                    hcolor = colors['YELLOW']
-                    tcolor = colors['YELLOW']
-                comps = tname.split('_|-')
-                if __opts__.get('state_output', 'full').lower() == 'terse':
-                    # Print this chunk in a terse way and continue in the
-                    # loop
+    rcounts = {}
+    hcolor = colors['GREEN']
+    hstrs = []
+    changed = False
+    if isinstance(data, list):
+        # Errors have been detected, list them in RED!
+        hcolor = colors['RED_BOLD']
+        hstrs.append(('    {0}Data failed to compile:{1[ENDC]}'
+                      .format(hcolor, colors)))
+        for err in data:
+            hstrs.append(('{0}----------\n    {1}{2[ENDC]}'
+                          .format(hcolor, err, colors)))
+    if isinstance(data, dict):
+        # Strip out the result: True, without changes returns if
+        # state_verbose is False
+        if not __opts__.get('state_verbose', False):
+            data = _strip_clean(data)
+        # Verify that the needed data is present
+        for tname, info in data.items():
+            if not '__run_num__' in info:
+                err = ('The State execution failed to record the order '
+                       'in which all states were executed. The state '
+                       'return missing data is:')
+                hstrs.insert(0, pprint.pformat(info))
+                hstrs.insert(0, err)
+        # Everything rendered as it should display the output
+        for tname in sorted(
+                data,
+                key=lambda k: data[k].get('__run_num__', 0)):
+            ret = data[tname]
+            # Increment result counts
+            rcounts.setdefault(ret['result'], 0)
+            rcounts[ret['result']] += 1
+            tcolor = colors['GREEN']
+            schanged, ctext = _format_changes(ret['changes'])
+            changed = changed or schanged
+            if schanged:
+                tcolor = colors['CYAN']
+            if ret['result'] is False:
+                hcolor = colors['RED']
+                tcolor = colors['RED']
+            if ret['result'] is None:
+                hcolor = colors['YELLOW']
+                tcolor = colors['YELLOW']
+            comps = tname.split('_|-')
+            if __opts__.get('state_output', 'full').lower() == 'terse':
+                # Print this chunk in a terse way and continue in the
+                # loop
+                msg = _format_terse(tcolor, comps, ret, colors, tabular)
+                hstrs.append(msg)
+                continue
+            elif __opts__.get('state_output', 'full').lower() == 'mixed':
+                # Print terse unless it failed
+                if ret['result'] is not False:
                     msg = _format_terse(tcolor, comps, ret, colors, tabular)
                     hstrs.append(msg)
                     continue
-                elif __opts__.get('state_output', 'full').lower() == 'mixed':
-                    # Print terse unless it failed
-                    if ret['result'] is not False:
-                        msg = _format_terse(tcolor, comps, ret, colors, tabular)
-                        hstrs.append(msg)
-                        continue
-                elif __opts__.get('state_output', 'full').lower() == 'changes':
-                    # Print terse if no error and no changes, otherwise, be
-                    # verbose
-                    if ret['result'] and not ret['changes']:
-                        msg = _format_terse(tcolor, comps, ret, colors, tabular)
-                        hstrs.append(msg)
-                        continue
-                state_lines = [
-                    '{tcolor}----------{colors[ENDC]}',
-                    '    {tcolor}      ID: {comps[1]}{colors[ENDC]}',
-                    '    {tcolor}Function: {comps[0]}.{comps[3]}{colors[ENDC]}',
-                    '    {tcolor}  Result: {ret[result]!s}{colors[ENDC]}',
-                    '    {tcolor} Comment: {comment}{colors[ENDC]}'
-                ]
-                # This isn't the prettiest way of doing this, but it's readable.
-                if comps[1] != comps[2]:
-                    state_lines.insert(
-                        3, '    {tcolor}    Name: {comps[2]}{colors[ENDC]}')
-                svars = {
-                    'tcolor': tcolor,
-                    'comps': comps,
-                    'ret': ret,
-                    # This nukes any trailing \n and indents the others.
-                    'comment': ret['comment'].strip().replace(
-                        '\n',
-                        '\n' + ' ' * 14),
-                    'colors': colors
-                }
-                hstrs.extend([sline.format(**svars) for sline in state_lines])
-                changes = '     Changes:   '
-                if not isinstance(ret['changes'], dict):
-                    changes += 'Invalid Changes data: {0}'.format(
-                            ret['changes'])
-                else:
-                    pass_opts = __opts__
-                    if __opts__['color']:
-                        pass_opts['color'] = 'CYAN'
-                    pass_opts['nested_indent'] = 14
-                    changes += '\n'
-                    changes += salt.output.out_format(
-                            ret['changes'],
-                            'nested',
-                            pass_opts)
-                hstrs.append(('{0}{1}{2[ENDC]}'
-                              .format(tcolor, changes, colors)))
+            elif __opts__.get('state_output', 'full').lower() == 'changes':
+                # Print terse if no error and no changes, otherwise, be
+                # verbose
+                if ret['result'] and not schanged:
+                    msg = _format_terse(tcolor, comps, ret, colors, tabular)
+                    hstrs.append(msg)
+                    continue
+            state_lines = [
+                '{tcolor}----------{colors[ENDC]}',
+                '    {tcolor}      ID: {comps[1]}{colors[ENDC]}',
+                '    {tcolor}Function: {comps[0]}.{comps[3]}{colors[ENDC]}',
+                '    {tcolor}  Result: {ret[result]!s}{colors[ENDC]}',
+                '    {tcolor} Comment: {comment}{colors[ENDC]}'
+            ]
+            # This isn't the prettiest way of doing this, but it's readable.
+            if comps[1] != comps[2]:
+                state_lines.insert(
+                    3, '    {tcolor}    Name: {comps[2]}{colors[ENDC]}')
+            svars = {
+                'tcolor': tcolor,
+                'comps': comps,
+                'ret': ret,
+                # This nukes any trailing \n and indents the others.
+                'comment': ret['comment'].strip().replace(
+                    '\n',
+                    '\n' + ' ' * 14),
+                'colors': colors
+            }
+            hstrs.extend([sline.format(**svars) for sline in state_lines])
+            changes = '     Changes:   ' + ctext
+            hstrs.append(('{0}{1}{2[ENDC]}'
+                          .format(tcolor, changes, colors)))
 
-            # Append result counts to end of output
-            colorfmt = '{0}{1}{2[ENDC]}'
-            rlabel = {True: 'Succeeded', False: 'Failed', None: 'Not Run'}
-            count_max_len = max([len(str(x)) for x in rcounts.values()] or [0])
-            label_max_len = max([len(x) for x in rlabel.values()] or [0])
-            line_max_len = label_max_len + count_max_len + 2  # +2 for ': '
+        # Append result counts to end of output
+        colorfmt = '{0}{1}{2[ENDC]}'
+        rlabel = {True: 'Succeeded', False: 'Failed', None: 'Not Run'}
+        count_max_len = max([len(str(x)) for x in rcounts.values()] or [0])
+        label_max_len = max([len(x) for x in rlabel.values()] or [0])
+        line_max_len = label_max_len + count_max_len + 2  # +2 for ': '
+        hstrs.append(
+            colorfmt.format(
+                colors['CYAN'],
+                '\nSummary\n{0}'.format('-' * line_max_len),
+                colors
+            )
+        )
+
+        def _counts(label, count):
+            return '{0}: {1:>{2}}'.format(
+                label,
+                count,
+                line_max_len - (len(label) + 2)
+            )
+
+        # Successful states
+        hstrs.append(
+            colorfmt.format(
+                colors['GREEN'],
+                _counts(rlabel[True], rcounts.get(True, 0)),
+                colors
+            )
+        )
+
+        # Failed states
+        num_failed = rcounts.get(False, 0)
+        hstrs.append(
+            colorfmt.format(
+                colors['RED'] if num_failed else colors['CYAN'],
+                _counts(rlabel[False], num_failed),
+                colors
+            )
+        )
+
+        # test=True states
+        if None in rcounts:
             hstrs.append(
                 colorfmt.format(
-                    colors['CYAN'],
-                    '\nSummary\n{0}'.format('-' * line_max_len),
+                    colors['YELLOW'],
+                    _counts(rlabel[None], rcounts.get(None, 0)),
                     colors
                 )
             )
 
-            def _counts(label, count):
-                return '{0}: {1:>{2}}'.format(
-                    label,
-                    count,
-                    line_max_len - (len(label) + 2)
-                )
+        totals = '{0}\nTotal: {1:>{2}}'.format('-' * line_max_len,
+                                               sum(rcounts.values()),
+                                               line_max_len - 7)
+        hstrs.append(colorfmt.format(colors['CYAN'], totals, colors))
 
-            # Successful states
-            hstrs.append(
-                colorfmt.format(
-                    colors['GREEN'],
-                    _counts(rlabel[True], rcounts.get(True, 0)),
-                    colors
-                )
-            )
+    hstrs.insert(0, ('{0}{1}:{2[ENDC]}'.format(hcolor, host, colors)))
+    return '\n'.join(hstrs), changed
 
-            # Failed states
-            num_failed = rcounts.get(False, 0)
-            hstrs.append(
-                colorfmt.format(
-                    colors['RED'] if num_failed else colors['CYAN'],
-                    _counts(rlabel[False], num_failed),
-                    colors
-                )
-            )
 
-            # test=True states
-            if None in rcounts:
-                hstrs.append(
-                    colorfmt.format(
-                        colors['YELLOW'],
-                        _counts(rlabel[None], rcounts.get(None, 0)),
-                        colors
-                    )
-                )
+def _format_changes(changes):
+    global __opts__
 
-            totals = '{0}\nTotal: {1:>{2}}'.format('-' * line_max_len,
-                                                   sum(rcounts.values()),
-                                                   line_max_len - 7)
-            hstrs.append(colorfmt.format(colors['CYAN'], totals, colors))
+    if not changes:
+        return False, ''
 
-        hstrs.insert(0, ('{0}{1}:{2[ENDC]}'.format(hcolor, host, colors)))
-        return '\n'.join(hstrs)
+    if not isinstance(changes, dict):
+        return True, 'Invalid Changes data: {0}'.format(ret['changes'])
+
+    ret = changes.get('ret')
+    if ret is not None and changes.get('out') == 'highstate':
+        ctext = ''
+        changed = False
+        for host, hostdata in ret.iteritems():
+            s, c = _format_host(host, hostdata)
+            ctext += '\n' + '\n'.join((' '* 14 + l) for l in s.splitlines())
+            changed = changed or c
+    else:
+        changed = True
+        opts = __opts__.copy()
+        # Pass the __opts__ dict. The loader will splat this modules __opts__ dict
+        # anyway so have to restore it after the other outputter is done
+        if __opts__['color']:
+            __opts__['color'] = 'CYAN'
+        __opts__['nested_indent'] = 14
+        ctext = '\n'
+        ctext += salt.output.out_format(
+                changes,
+                'nested',
+                __opts__)
+        __opts__ = opts
+    return changed, ctext
 
 
 def _strip_clean(returns):

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -138,27 +138,54 @@ def state(
         ret['result'] = None
         return ret
     cmd_ret = __salt__['saltutil.cmd'](tgt, fun, **cmd_kw)
+
     changes = {}
-    for mid, mdata in cmd_ret.iteritems():
-        if mdata['out'] != 'highstate':
-            log.warning("Output from salt state not highstate")
-        changes[mid] = mdata['ret']
-    ret['changes'] = {'out': 'highstate', 'ret': changes}
     fail = set()
+    failures = {}
+    no_change = set()
     if isinstance(fail_minions, str):
         fail_minions = [fail_minions]
-    for minion, m_ret in changes.iteritems():
-        if minion in fail_minions:
-            continue
+
+    for minion, mdata in cmd_ret.iteritems():
+        if mdata['out'] != 'highstate':
+            log.warning("Output from salt state not highstate")
+        m_ret = mdata['ret']
         m_state = salt.utils.check_state_result({minion: m_ret})
         if not m_state:
-            fail.add(minion)
+            if minion not in fail_minions:
+                fail.add(minion)
+            failures[minion] = m_ret
+            continue
+        for state_item in m_ret.itervalues():
+            if state_item['changes']:
+                changes[minion] = m_ret
+                break
+        else:
+            no_change.add(minion)
+
+    if changes:
+        ret['changes'] = {'out': 'highstate', 'ret': changes}
     if fail:
         ret['result'] = False
         ret['comment'] = 'Run failed on minions: {0}'.format(', '.join(fail))
-        return ret
-    ret['comment'] = 'States ran successfully on {0}'.format(
-            ', '.join(cmd_ret))
+    else:
+        ret['comment'] = 'States ran successfully.'
+        if changes:
+            ret['comment'] += ' Updating {0}.'.format(', '.join(changes))
+        if no_change:
+            ret['comment'] += ' Without changing {0}.'.format(', '.join(no_change))
+    if failures:
+        ret['comment'] += '\nFailures:\n'
+        for minion, failure in failures.iteritems():
+            ret['comment'] += '\n'.join(
+                    (' '*4 + l)
+                    for l in salt.output.out_format(
+                        {minion: failure},
+                        'highstate',
+                        __opts__,
+                        ).splitlines()
+                    )
+            ret['comment'] += '\n'
     return ret
 
 


### PR DESCRIPTION
This improves the behaviour of the salt.state state function in three ways:
- Doesn't always report failure
- Formats the output of subordinate highstate/state.sls runs using the highstate format.
- Trims the contents of the changes dict to only include the output from minions where actual changes took place. This allows it to be used sensibly to trigger other states through watch. 
