### PR TITLE
Support 10GigE speed in rh_ip module

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -157,7 +157,7 @@ def _parse_ethtool_opts(opts, iface):
             _raise_error_iface(iface, 'mtu', ['integer'])
 
     if 'speed' in opts:
-        valid = ['10', '100', '1000']
+        valid = ['10', '100', '1000', '10000']
         if str(opts['speed']) in valid:
             config.update({'speed': opts['speed']})
         else:


### PR DESCRIPTION
Debian module already supports 101GigE speed option: https://github.com/saltstack/salt/blob/develop/salt/modules/debian_ip.py#L433
