### PR TITLE
improve shadow password handling on SmartOS

### DIFF
--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -89,11 +89,20 @@ def info(name):
     try:
         data = pwd.getpwnam(name)
         ret.update({
-            'name': name,
-            'passwd': data.pw_dir
+            'name': name
         })
     except KeyError:
         return ret
+
+    # To compensate for lack of spwd module, read in password hash from /etc/shadow
+    s_file = '/etc/shadow'
+    if not os.path.isfile(s_file):
+        return ret
+    with salt.utils.fopen(s_file, 'rb') as ifile:
+        for line in ifile:
+            comps = line.strip().split(':')
+            if comps[0] == name:
+                ret.update({'passwd': comps[1]})
 
     # For SmartOS `passwd -s <username>` and the output format is:
     #   name status mm/dd/yy min max warn
@@ -118,12 +127,11 @@ def info(name):
     if len(fields) == 2:
         # For example:
         #   root      NL
-        return
+        return ret
     # We have all fields:
     #   buildbot L 05/09/2013 0 99999 7
     ret.update({
         'name': data.pw_name,
-        'passwd': data.pw_dir,
         'lstchg': fields[2],
         'min': int(fields[3]),
         'max': int(fields[4]),


### PR DESCRIPTION
Fixes #9874
Also fixes an unreported error that when half of this fix is applied
password setting succeeds but appears to fail due to lack of reading
password hashes from the shadow file.
