### PR TITLE
SmartOS Esky Packaging: Fix PATH for services

### DIFF
--- a/pkg/smartos/esky/salt-master.xml
+++ b/pkg/smartos/esky/salt-master.xml
@@ -32,7 +32,7 @@
                    timeout_seconds="60">
         <method_context>
           <method_environment>
-            <envvar name="PATH" value="/bin:/usr/bin:/opt/local/bin:SALT_PREFIX/bin" />
+            <envvar name="PATH" value="/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin:SALT_PREFIX/bin" />
           </method_environment>
         </method_context>
       </exec_method>

--- a/pkg/smartos/esky/salt-minion.xml
+++ b/pkg/smartos/esky/salt-minion.xml
@@ -32,7 +32,7 @@
                    timeout_seconds="60">
         <method_context>
           <method_environment>
-            <envvar name="PATH" value="/bin:/usr/bin:/opt/local/bin:SALT_PREFIX/bin" />
+            <envvar name="PATH" value="/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin:SALT_PREFIX/bin" />
           </method_environment>
         </method_context>
       </exec_method>

--- a/pkg/smartos/esky/salt-syndic.xml
+++ b/pkg/smartos/esky/salt-syndic.xml
@@ -32,7 +32,7 @@
                    timeout_seconds="60">
         <method_context>
           <method_environment>
-            <envvar name="PATH" value="/bin:/usr/bin:/opt/local/bin:SALT_PREFIX/bin" />
+            <envvar name="PATH" value="/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin:SALT_PREFIX/bin" />
           </method_environment>
         </method_context>
       </exec_method>


### PR DESCRIPTION
We ran into some weird issues with these SMF manifests
with certain critical binaries not being found in the PATH.

This PATH is derived from root's default PATH when logging
in to a SmartOS zone.
