### PR TITLE
Implement a system for caching grains on the minion.

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -194,6 +194,16 @@
 # If the value is set to zero, this check is disabled.
 #grains_refresh_every: 1
 
+# Cache grains on the minion. Default is False.
+# grains_cache: False
+
+# Grains cache expiration, in seconds. If the cache file is older than this
+# number of seconds then the grains cache will be dumped and fully re-populated
+# with fresh data. Defaults to 5 minutes. Will have no effect if 'grains_cache'
+# is not enabled.
+# grains_cache_expiration: 300
+
+
 # When healing, a dns_check is run. This is to make sure that the originally
 # resolved dns has not changed. If this is something that does not happen in
 # your environment, set this value to False.

--- a/salt/config.py
+++ b/salt/config.py
@@ -195,6 +195,8 @@ DEFAULT_MINION_OPTS = {
     'id': None,
     'cachedir': os.path.join(salt.syspaths.CACHE_DIR, 'minion'),
     'cache_jobs': False,
+    'grains_cache': False,
+    'grains_cache_expiration': 300,
     'conf_file': os.path.join(salt.syspaths.CONFIG_DIR, 'minion'),
     'sock_dir': os.path.join(salt.syspaths.SOCK_DIR, 'minion'),
     'backup_mode': '',

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -10,6 +10,7 @@ import sys
 import salt
 import logging
 import tempfile
+import time
 
 # Import salt libs
 from salt.exceptions import LoaderError
@@ -290,6 +291,8 @@ def grains(opts):
     Return the functions for the dynamic grains and the values for the static
     grains.
     '''
+    if opts.get('skip_grains', False):
+	return {}
     if 'conf_file' in opts:
         pre_opts = {}
         pre_opts.update(salt.config.load_config(
@@ -435,6 +438,8 @@ class Loader(object):
         self.opts = self.__prep_mod_opts(opts)
         self.loaded_base_name = loaded_base_name or LOADED_BASE_NAME
         self.mod_type_check = mod_type_check or _mod_type
+	if self.opts.get('grains_cache', False):
+	    self.serial = salt.payload.Serial(self.opts)
 
     def __prep_mod_opts(self, opts):
         '''
@@ -989,6 +994,26 @@ class Loader(object):
         members. Then verify that the returns are python dict's and return
         a dict containing all of the returned values.
         '''
+	if self.opts.get('grains_cache', False):
+	    cfn = os.path.join(
+		self.opts['cachedir'],
+		'{0}.cache.p'.format('grains')
+	    )
+	    if os.path.isfile(cfn):
+		grains_cache_age = int(time.time() - os.path.getmtime(cfn))
+		if self.opts.get('grains_cache_expiration', 300) >= grains_cache_age and not \
+			self.opts.get('refresh_grains_cache', False):
+		    log.debug('Retrieving grains from cache')
+		    try:
+			with salt.utils.fopen(cfn, 'r') as fp_:
+			    cached_grains = self.serial.load(fp_)
+			return cached_grains
+		    except (IOError, OSError):
+			pass
+		else:
+		    log.debug('Grains cache last modified {0} seconds ago and cache expiration is set to {1}. '
+			     'Grains cache expired. Refreshing.'.format(
+			grains_cache_age, self.opts.get('grains_cache_expiration', 300)))
         grains_data = {}
         funcs = self.gen_functions()
         for key, fun in funcs.items():
@@ -1015,4 +1040,21 @@ class Loader(object):
             if not isinstance(ret, dict):
                 continue
             grains_data.update(ret)
+	# Write cache if enabled
+	if self.opts.get('grains_cache', False):
+	    cumask = os.umask(191)
+	    try:
+		if salt.utils.is_windows():
+		    # Make sure cache file isn't read-only
+		    self.state.functions['cmd.run']('attrib -R "{0}"'.format(cfn), output_loglevel='quiet')
+		with salt.utils.fopen(cfn, 'w+') as fp_:
+		    try:
+			self.serial.dump(grains_data, fp_)
+		    except TypeError:
+			# Can't serialize pydsl
+			pass
+	    except (IOError, OSError):
+		msg = 'Unable to write to grains cache file {0}'
+		log.error(msg.format(cfn))
+	    os.umask(cumask)
         return grains_data

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1937,6 +1937,18 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help=('Specify the minion id to use. If this option is omitted, '
                   'the id option from the minion config will be used.')
         )
+	self.add_option(
+	    '--skip-grains',
+	    default=False,
+	    action='store_true',
+	    help=('Do not load grains.')
+	)
+	self.add_option(
+	    '--refresh-grains-cache',
+	    default=False,
+	    action='store_true',
+	    help=('Force a refresh of the grains cache')
+	)
 
     def _mixin_after_parsed(self):
         if not self.args and not self.options.grains_run \


### PR DESCRIPTION
- Creates a new flag for salt-call called '--skip-grains' that will completely bypass the grains loader. (Mostly for testing. Will break many modules in practice!)
- Creates a new flag for salt-call called '--refresh-grains-cache'. This forces a refresh of the grains cache on a minion.
- Adds a new minion config option called 'grains_cache'. Defaults to False.
- Adds a new minion config options called 'grains_cache_expiration'. Specifies the number of seconds allowable for before a minion grain cache is declared to be stale.
- Correct a potential syntax error in the minion config variable, 'grains_refresh_every'.
- Modify the 'apt' module so that it does not stack-trace in **virtual**() if grains aren't loaded.
- A new caching layer for the grains loader that can write to and read from a msgpack'd serialized data file containing grains that is stored in the minion cache.
