### PR TITLE
Cache gitfs environments (2014.1 branch)

### DIFF
--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -80,6 +80,22 @@ def write_file_list_cache(opts, data, list_cache, w_lock):
         log.trace('Lockfile {0} removed'.format(w_lock))
 
 
+def check_env_cache(opts, env_cache):
+    '''
+    Returns cached env names, if present. Otherwise returns None.
+    '''
+    if not os.path.isfile(env_cache):
+        return None
+    try:
+        with salt.utils.fopen(env_cache, 'r') as fp_:
+            log.trace('Returning env cache data from {0}'.format(env_cache))
+            serial = salt.payload.Serial(opts)
+            return serial.load(fp_)
+    except (IOError, OSError):
+        pass
+    return None
+
+
 def generate_mtime_map(path_map):
     '''
     Generate a dict of filename -> mtime

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -166,7 +166,8 @@ def purge_cache():
             remove_dirs.remove(repo_hash)
         except ValueError:
             pass
-    remove_dirs = [os.path.join(bp_, r) for r in remove_dirs if r not in ('hash', 'refs')]
+    remove_dirs = [os.path.join(bp_, r) for r in remove_dirs
+                   if r not in ('hash', 'refs', 'envs.p')]
     if remove_dirs:
         for r in remove_dirs:
             shutil.rmtree(r)
@@ -201,6 +202,14 @@ def update():
         except (IOError, OSError):
             pass
 
+    env_cache = os.path.join(__opts__['cachedir'], 'gitfs/envs.p')
+    if data.get('changed', False) is True or not os.path.isfile(env_cache):
+        new_envs = envs(ignore_cache=True)
+        serial = salt.payload.Serial(__opts__)
+        with salt.utils.fopen(env_cache, 'w+') as fp_:
+            fp_.write(serial.dumps(new_envs))
+            log.trace('Wrote env cache data to {0}'.format(env_cache))
+
     # if there is a change, fire an event
     if __opts__.get('fileserver_events', False):
         event = salt.utils.event.MasterEvent(__opts__['sock_dir'])
@@ -215,10 +224,15 @@ def update():
         pass
 
 
-def envs():
+def envs(ignore_cache=False):
     '''
     Return a list of refs that can be used as environments
     '''
+    if not ignore_cache:
+        env_cache = os.path.join(__opts__['cachedir'], 'gitfs/envs.p')
+        cache_match = salt.fileserver.check_env_cache(__opts__, env_cache)
+        if cache_match is not None:
+            return cache_match
     base_branch = __opts__['gitfs_base']
     ret = set()
     repos = init()


### PR DESCRIPTION
This commit improves performance by not repeatedly looking up the
list of available environments whenever they are needed, and instead
writing them to a cache file whenever the fileserver is updated (and
changes are found). envs() will prefer the cache if it is available.
