### PR TITLE
Modified parsing the output from ls -lZ to use regex instead of split() in order to resolve issue 9845

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1892,7 +1892,13 @@ def get_selinux_context(path):
         salt '*' file.get_selinux_context /etc/hosts
     '''
     out = __salt__['cmd.run']('ls -Z {0}'.format(path))
-    return out.split(' ')[4]
+
+    try:
+        ret = re.search('\w+:\w+:\w+:\w+', out).group(0)
+    except AttributeError:
+        ret = "No selinux context information is available for {0}".format(path)
+
+    return ret
 
 
 def set_selinux_context(path,

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1896,7 +1896,7 @@ def get_selinux_context(path):
     try:
         ret = re.search('\w+:\w+:\w+:\w+', out).group(0)
     except AttributeError:
-        ret = "No selinux context information is available for {0}".format(path)
+        ret = 'No selinux context information is available for {0}'.format(path)
 
     return ret
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1894,7 +1894,7 @@ def get_selinux_context(path):
     out = __salt__['cmd.run']('ls -Z {0}'.format(path))
 
     try:
-        ret = re.search('\w+:\w+:\w+:\w+', out).group(0)
+        ret = re.search(r'\w+:\w+:\w+:\w+', out).group(0)
     except AttributeError:
         ret = 'No selinux context information is available for {0}'.format(path)
 


### PR DESCRIPTION
This change aims to address the problem documented in: #9845.

A pull request was originally raised to fix this issue (https://github.com/saltstack/salt/pull/9846) but after discussion I believe that the modifications made in this PR are more appropriate.

Further work will be done under a different ticket to modify selinux related code to using the python selinux module (rather than calling cmd.run) in order to avoid similar bugs in the future.
## 

Bowen
