### PR TITLE
[URGENT / SECURITY] Postgresql fixes

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -492,6 +492,7 @@ def user_list(user=None, host=None, port=None, maintenance_db=None,
                       port=port,
                       maintenance_db=maintenance_db,
                       password=password)
+
     def get_bool(rowdict, key):
         '''
         Returns the boolean value of the key, instead of 't' and 'f' strings.

--- a/salt/states/postgres_group.py
+++ b/salt/states/postgres_group.py
@@ -172,8 +172,8 @@ def present(name,
             and group_attr['inherits privileges'] != inherit
         ):
             update['inherit'] = inherit
-        if login is not None and group_attr['can login'] != login:
-            update['createdb'] = createdb
+        if (login is not None and group_attr['can login'] != login):
+            update['login'] = login
         if (
             createroles is not None
             and group_attr['can create roles'] != createroles

--- a/salt/states/postgres_group.py
+++ b/salt/states/postgres_group.py
@@ -53,7 +53,7 @@ def present(name,
             db_user=None):
     '''
     Ensure that the named group is present with the specified privileges
-    Please note that the guser/roup notion in postgresql is just abstract, we
+    Please note that the user/group notion in postgresql is just abstract, we
     have roles, where users can be seens as roles with the LOGIN privilege
     and groups the others.
 

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -12,11 +12,14 @@ The postgres_users module is used to create and manage Postgres users.
 '''
 
 # Import Python libs
-import hashlib
 
 # Import salt libs
 import salt.utils
 import logging
+
+# Salt imports
+from salt.modules import postgres
+
 
 log = logging.getLogger(__name__)
 
@@ -50,6 +53,9 @@ def present(name,
             db_user=None):
     '''
     Ensure that the named user is present with the specified privileges
+    Please note that the guser/roup notion in postgresql is just abstract, we
+    have roles, where users can be seens as roles with the LOGIN privilege
+    and groups the others.
 
     name
         The name of the user to manage
@@ -80,6 +86,13 @@ def present(name,
 
     password
         The user's password
+        It can be either a plain string or a md5 postgresql hashed password::
+
+            'md5{MD5OF({password}{role}}'
+
+        If encrypted is None or True, the password will be automaticly
+        encrypted to the previous
+        format if it is not already done.
 
     groups
         A string of comma separated groups the user should be in
@@ -119,6 +132,14 @@ def present(name,
     )
     if createuser:
         createroles = True
+    # default to encrypted passwords
+    if encrypted is not False:
+        encrypted = postgres._DEFAULT_PASSWORDS_ENCRYPTION
+    # maybe encrypt if if not already and neccesary
+    password = postgres._maybe_encrypt_password(name,
+                                                password,
+                                                encrypted=encrypted)
+
     if runas:
         # Warn users about the deprecation
         ret.setdefault('warnings', []).append(
@@ -148,7 +169,8 @@ def present(name,
 
     # check if user exists
     mode = 'create'
-    user_attr = __salt__['postgres.role_get'](name, **db_args)
+    user_attr = __salt__['postgres.role_get'](
+        name, return_password=True, **db_args)
     if user_attr is not None:
         mode = 'update'
 
@@ -184,15 +206,7 @@ def present(name,
             update['replication'] = replication
         if superuser is not None and user_attr['superuser'] != superuser:
             update['superuser'] = superuser
-        if (
-            password is not None
-            and user_attr['password'] != "md5{0}".format(
-                hashlib.md5('{0}{1}'.format(password, name)).hexdigest())
-        ):
-            log.info('MD5 hash of the password of user {0} '
-                     'is not what was expected. However, '
-                     'Please note that postgres.user_exists '
-                     'only supports MD5 hashed passwords'.format(name))
+        if (password is not None and user_attr['password'] != password):
             update['password'] = True
     if mode == 'create' or (mode == 'update' and update):
         cret = __salt__['postgres.user_{0}'.format(mode)](

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -53,7 +53,7 @@ def present(name,
             db_user=None):
     '''
     Ensure that the named user is present with the specified privileges
-    Please note that the guser/roup notion in postgresql is just abstract, we
+    Please note that the user/group notion in postgresql is just abstract, we
     have roles, where users can be seens as roles with the LOGIN privilege
     and groups the others.
 

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -170,8 +170,8 @@ def present(name,
             and user_attr['inherits privileges'] != inherit
         ):
             update['inherit'] = inherit
-        if login is not None and user_attr['can login'] != login:
-            update['createdb'] = createdb
+        if (login is not None and user_attr['can login'] != login):
+            update['login'] = login
         if (
             createroles is not None
             and user_attr['can create roles'] != createroles

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -63,7 +63,8 @@ class PostgresTestCase(TestCase):
             '/usr/bin/pgsql --no-align --no-readline --username testuser '
             '--host testhost --port testport --dbname maint_db '
             '-c \'ALTER DATABASE "dbname" OWNER TO "otheruser"\'',
-            host='testhost', password='foo', runas='foo', port='testport')
+            host='testhost', user='testuser',
+            password='foo', runas='foo', port='testport')
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
@@ -84,7 +85,8 @@ class PostgresTestCase(TestCase):
             '--host testhost --port testport --dbname maint_db -c '
             '\'CREATE DATABASE "dbname" '
             'WITH TABLESPACE = testspace OWNER = "otheruser"\'',
-            host='testhost', password='foo', runas='foo', port='testport')
+            host='testhost', user='testuser',
+            password='foo', runas='foo', port='testport')
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None,
@@ -149,7 +151,8 @@ class PostgresTestCase(TestCase):
             "/usr/bin/pgsql --no-align --no-readline --username testuser "
             "--host testhost --port testport --dbname maint_db "
             "-c 'DROP DATABASE test_db'",
-            host='testhost', password='foo', runas='foo', port='testport')
+            host='testhost', user='testuser',
+            password='foo', runas='foo', port='testport')
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
@@ -194,7 +197,8 @@ class PostgresTestCase(TestCase):
             "/usr/bin/pgsql --no-align --no-readline --username testuser "
             "--host testhost --port testport "
             "--dbname maint_db -c 'DROP ROLE testgroup'",
-            host='testhost', password='foo', runas='foo', port='testport')
+            host='testhost',  user='testuser',
+            password='foo', runas='foo', port='testport')
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
@@ -345,7 +349,7 @@ class PostgresTestCase(TestCase):
             "/usr/bin/pgsql --no-align --no-readline --username test_user "
             "--host test_host --port test_port "
             "--dbname maint_db -c 'DROP ROLE test_user'",
-            host='test_host', port='test_port',
+            host='test_host', port='test_port', user='test_user',
             password='test_password', runas='foo')
 
     @patch('salt.modules.postgres._run_psql',


### PR DESCRIPTION
- The first commit just fixes some pylint issues, but also handle the connection user and password file generation better.
- The commit related to password encryption is a better user friendly password user management, we store password encrypted and do not rely on users to forge the md5 string on their own, and that was even not documented. Now, the user can also force the password to be unencrypted.
- The second commit fixes a regression on updates that could allow createdb depending on states informations.
  The risk is low as the login was introduced with my previous PR, so i doubt someone did used it anyway.
  This is even more low as createdb is False by default anyway...

/cc @thatch45 @s0undt3ch
