### PR TITLE
Fix RunnerClient.master_call docstring

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -163,12 +163,12 @@ class RunnerClient(object):
 
         .. code-block:: python
 
-            runner.master_call({
-                'fun': 'jobs.list_jobs',
-                'username': 'saltdev',
-                'password': 'saltdev',
-                'eauth': 'pam',
-            })
+            runner.master_call(
+                fun='jobs.list_jobs',
+                username='saltdev',
+                password='saltdev',
+                eauth='pam'
+            )
         '''
         load = kwargs
         load['cmd'] = 'runner'


### PR DESCRIPTION
The docstring example introduced by https://github.com/saltstack/salt/commit/6f22ac72a18bebe5b8214413f1f8e90c6f83d277#diff-f039891ad8c749233c14fce7bdf4fc65R157 was wrong, maybe a *\* is missing but the traditional keyword argument syntax is maybe more adapted as docstring.
