### PR TITLE
Fixes issues w/ starting broken services on Windows

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -206,7 +206,7 @@ def start(name):
 
         salt '*' service.start <service name>
     '''
-    cmd = 'sc start "{0}"'.format(name)
+    cmd = 'net start "{0}"'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -220,7 +220,7 @@ def stop(name):
 
         salt '*' service.stop <service name>
     '''
-    cmd = 'sc stop "{0}"'.format(name)
+    cmd = 'net stop "{0}"'.format(name)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -235,12 +235,7 @@ def restart(name):
         salt '*' service.restart <service name>
     '''
     stop(name)
-    for idx in xrange(5):
-        if status(name):
-            time.sleep(2)
-            continue
-        return start(name)
-    return False
+    return start(name)
 
 
 def status(name, sig=None):


### PR DESCRIPTION
In cases where a salt attempted to start a windows service, but the windows service failed to start, salt was reporting that the service was running successfully.

The problem is that it was using

```
sc start <service name>
```

which is an asynchronous call that always has a return code of 0.  This is now switched to 

```
net start <service name>
```

which blocks until the service starts, or on failure, returns a proper error code salt can detect.  
