### PR TITLE
Updated deprecated flag

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -281,7 +281,7 @@ def install(name=None,
         if _check_pkgng():
             args.extend(('install', '-y'))  # Assume yes when asked
             if not refresh:
-                args.append('-L')  # do not update repo db
+                args.append('-U')  # do not update repo db
         else:
             args.append('-r')  # use remote repo
 


### PR DESCRIPTION
the "-L" flag was a backward compatible flag that is no longer available. Updated to use the "-U" version.
