### PR TITLE
gitfs: attach to gitfs remote cachedir if present (0.17 branch)

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -124,7 +124,28 @@ def init():
         rp_ = os.path.join(bp_, repo_hash)
         if not os.path.isdir(rp_):
             os.makedirs(rp_)
-        repo = git.Repo.init(rp_)
+
+        if not os.listdir(rp_):
+            repo = git.Repo.init(rp_)
+        else:
+            try:
+                repo = git.Repo(rp_)
+            except git.exc.InvalidGitRepositoryError:
+                log.error(
+                    'Cache path {0} (corresponding remote: {1}) exists but '
+                    'is not a valid git repository. You will need to manually '
+                    'delete this directory on the master to continue to use '
+                    'this gitfs remote.'.format(rp_, opt)
+                )
+                continue
+            except Exception as exc:
+                log.error(
+                    'GitPython exception caught while initializing repo {0}'
+                    'for gitfs: {1}. Perhaps git is not available.'
+                    .format(opt, exc)
+                )
+                continue
+
         if not repo.remotes:
             try:
                 repo.create_remote('origin', opt)


### PR DESCRIPTION
This commit makes Salt check for the repository before attempting to
initialize it.
