### PR TITLE
Add example about jobs.list_jobs, jobs.lookup_jid

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -66,6 +66,34 @@ runner:
 
     salt-run manage.down
 
+Also, if the Master is under heavy load, it is possible that the CLI will exit
+without displaying return data for all targeted Minions. However, this doesn't
+mean that the Minions did not return; this only means that the Salt CLI timed
+out waiting for a response. Minions will still send their return data back to
+the Master once the job completes. If any expected Minions are missing from the
+CLI output, the :mod:`jobs.list_jobs <salt.runners.jobs.list_jobs>` runner can
+be used to show the job IDs of the jobs that have been run, and the
+:mod:`jobs.lookup_jid <salt.runners.jobs.lookup_jid>` runner can be used to get
+the return data for that job.
+
+.. code-block:: bash
+
+    salt-run jobs.list_jobs
+    salt-run jobs.lookup_jid 20130916125524463507
+
+If you find that you are often missing Minion return data on the CLI, only to
+find it with the jobs runners, then this may be a sign that the
+:conf_master:`worker_threads` value may need to be increased in the master
+config file. Additionally, running your Salt CLI commands with the ``-t``
+option will make Salt wait longer for the return data before the CLI command
+exits. For instance, the below command will wait up to 60 seconds for the
+Minions to return:
+
+.. code-block:: bash
+
+    salt -t 60 '*' test.ping
+
+
 How does Salt determine the Minion's id?
 ----------------------------------------
 


### PR DESCRIPTION
Sometimes the salt CLI will exit without displaying the return data from
all minions, but they do actually return data. This commit explains how
to use the jobs runners to obtain job return data and potentially catch
minions that did not return in these edge cases.
