### PR TITLE
Notify the user if dmidecode could not be located

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1168,6 +1168,10 @@ def _dmidecode_data(regex_dict):
     elif salt.utils.which('smbios'):
         out = __salt__['cmd.run']('smbios')
     else:
+        log.info(
+            'The `dmidecode` binary is not available on the system. GPU grains '
+            'will not be available.'
+        )
         return ret
 
     for section in regex_dict:


### PR DESCRIPTION
Notify the user if dmidecode was not found. This will avoid users wondering why they can't access the dmidecode attributes.
