### PR TITLE
Fixed Issue #9932: Only the first git repository is initialized and working using git_pillar

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -195,12 +195,11 @@ class Master(SMaster):
         ckminions = salt.utils.minions.CkMinions(self.opts)
         event = salt.utils.event.MasterEvent(self.opts['sock_dir'])
 
-        pillargitfs = None
+        pillargitfs = []
         for opts_dict in [x for x in self.opts.get('ext_pillar', [])]:
             if 'git' in opts_dict:
                 br, loc = opts_dict['git'].strip().split()
-                pillargitfs = git_pillar.GitPillar(br, loc, self.opts)
-                break
+                pillargitfs.append(git_pillar.GitPillar(br, loc, self.opts))
 
         old_present = set()
         while True:
@@ -248,8 +247,8 @@ class Master(SMaster):
             salt.utils.verify.check_max_open_files(self.opts)
 
             try:
-                if pillargitfs is not None:
-                    pillargitfs.update()
+                for pillargit in pillargitfs:
+                    pillargit.update()
             except Exception as exc:
                 log.error('Exception {0} occurred in file server update '
                           'for git_pillar module.'.format(exc))

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -341,10 +341,18 @@ class Pillar(object):
         errors = []
         fn_ = self.client.get_state(sls, saltenv).get('dest', False)
         if not fn_:
-            msg = ('Specified SLS {0!r} in environment {1!r} is not'
-                   ' available on the salt master').format(sls, saltenv)
-            log.error(msg)
-            errors.append(msg)
+            if self.opts['pillar_roots'].get(saltenv):
+                msg = ('Specified SLS {0!r} in environment {1!r} is not'
+                       ' available on the salt master').format(sls, saltenv)
+                log.error(msg)
+                errors.append(msg)
+            else:
+                log.debug('Specified SLS {0!r} in environment {1!r} is not'
+                          ' found, which might be due to environment {1!r}'
+                          ' not being present in "pillar_roots" yet!'
+                          .format(sls, saltenv))
+                # return state, mods, errors
+                return None, mods, errors
         state = None
         try:
             state = compile_template(

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -217,10 +217,12 @@ def ext_pillar(minion_id, pillar, repo_string):
     if __opts__['pillar_roots'].get(branch, []) == [gitpil.working_dir]:
         return {}
 
+    gitpil.update()
+
     opts = deepcopy(__opts__)
 
     opts['pillar_roots'][branch] = [gitpil.working_dir]
 
-    pil = Pillar(opts, __grains__, minion_id, 'base')
+    pil = Pillar(opts, __grains__, minion_id, branch)
 
     return pil.compile_pillar()


### PR DESCRIPTION
Main issue was as following:
If an ext_pillar item is not loaded and its branch
is not present in pillar_roots, the corresponding
salt environment will not be available. However,
this is not an issue, since it will be available
when all of ext_pillar items are parsed; therefore,
when trying to get the SLS from that non-present
salt environment, we should merely log a debug
message and continue on.
