### PR TITLE
Fix ref to changed parameter name in file.stats

### DIFF
--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -83,7 +83,7 @@ def apply_(path, id_=None, config=None, approve_key=True, install=True):
         Install salt-minion, if absent. Default: true.
     '''
 
-    stats = __salt__['file.stats'](path, follow_symlink=True)
+    stats = __salt__['file.stats'](path, follow_symlinks=True)
     if not stats:
         return '{0} does not exist'.format(path)
     ftype = stats['type']


### PR DESCRIPTION
A few weeks ago in 7d4c470, the argument name "follow_symlink" was
changed for consisency with the rest of the functions in the "file"
execution module. This commit fixes a missed ref to the file.stats
function.

Fixes #9903.
