### PR TITLE
Catch bad args in salt-call

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -75,7 +75,11 @@ class Caller(object):
                 # Don't require msgpack with local
                 pass
             func = self.minion.functions[fun]
-            ret['return'] = func(*args, **kwargs)
+            try:
+                ret['return'] = func(*args, **kwargs)
+            except TypeError as exc:
+                sys.stderr.write(('Passed invalid arguments: {0}\n').format(exc))
+                sys.exit(1)
             ret['retcode'] = sys.modules[func.__module__].__context__.get(
                     'retcode', 0)
         except (CommandExecutionError) as exc:


### PR DESCRIPTION
Instead of throwing an ugly stack trace, catch a type error, format the exception and display it. Then exit with a proper retcode.
