### PR TITLE
Use __opts__.get

### DIFF
--- a/tests/saltsh.py
+++ b/tests/saltsh.py
@@ -80,7 +80,7 @@ def get_salt_vars():
     __pillar__ = salt.pillar.get_pillar(
         __opts__,
         __grains__,
-        __opts__['id'],
+        __opts__.get('id'),
         __opts__.get('environment'),
     ).compile_pillar()
 


### PR DESCRIPTION
This switches `tests/saltsh.py` to using `__opts__.get('id')` rather than `__opts__['id']`.

Problem:

When trying to use saltsh.py, on a fresh box `__opts__['id']` was not present. This resulted in saltsh.py failing:

```
root@qa01:~/salt/tests# python saltsh.py
Traceback (most recent call last):
  File "saltsh.py", line 132, in <module>
    main()
  File "saltsh.py", line 101, in main
    salt_vars = get_salt_vars()
  File "saltsh.py", line 83, in get_salt_vars
    __opts__['id'],
KeyError: 'id'
```

Version data

```
root@qa01:~/salt/tests# salt --versions-report
           Salt: 2014.1.0-733-g2649cbc
         Python: 2.7.5+ (default, Sep 19 2013, 13:48:49)
         Jinja2: 2.7
       M2Crypto: 0.21.1
 msgpack-python: 0.3.0
   msgpack-pure: Not Installed
       pycrypto: 2.6
         PyYAML: 3.10
          PyZMQ: 13.1.0
            ZMQ: 3.2.3
```
