### PR TITLE
cmd.run child proc tracking

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -445,6 +445,9 @@ def signal_job(jid, sig):
         if data['jid'] == jid:
             try:
                 os.kill(int(data['pid']), sig)
+                if 'child_pids' in data:
+                    for pid in data['child_pids']:
+                        os.kill(int(pid), sig)
                 return 'Signal {0} sent to job {1} at pid {2}'.format(
                         int(sig),
                         jid,


### PR DESCRIPTION
WARNING: Please have Tom review prior to commit and let the test run finish first. Thanks!

Store the return pid from a call to _run in the msgpack'd file as 'child_pid'. When killing a job with saltutil.signal_job, look for this pid and attempt to kill it as well. Refs #9855.
