### PR TITLE
Delete crate.io out of PyPI mirrors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig rabbitmq-server ruby python-apt mysql-server libmysqlclient-dev
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
-  - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org mock
+  - pip install mock
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
-  - pip install --upgrade --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org pep8 'pylint<1.0.0'
-  - pip install --upgrade --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org coveralls
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org unittest2 ordereddict; fi"
+  - pip install --upgrade pep8 'pylint<1.0.0'
+  - pip install --upgrade coveralls
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2 ordereddict; fi"
   - pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
 
 install:
-  - pip install -r requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org
-  - pip install -r opt_requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org
+  - pip install -r requirements.txt
+  - pip install -r opt_requirements.txt
 
 before_script:
   - "/home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pylint --rcfile=.testing.pylintrc salt/ && echo 'Finished Pylint Check Cleanly' || echo 'Finished Pylint Check With Errors'"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,16 @@ before_install:
   - sudo apt-get update
   - sudo apt-get install --fix-broken --ignore-missing -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" swig rabbitmq-server ruby python-apt mysql-server libmysqlclient-dev
   - (git describe && git fetch --tags) || (git remote add upstream git://github.com/saltstack/salt.git && git fetch --tags upstream)
-  - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io mock
+  - pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org mock
   - pip install http://dl.dropbox.com/u/174789/m2crypto-0.20.1.tar.gz
-  - pip install --upgrade --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io pep8 'pylint<1.0.0'
-  - pip install --upgrade --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io coveralls
-  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io unittest2 ordereddict; fi"
+  - pip install --upgrade --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org pep8 'pylint<1.0.0'
+  - pip install --upgrade --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org coveralls
+  - "if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org unittest2 ordereddict; fi"
   - pip install git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
 
 install:
-  - pip install -r requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io
-  - pip install -r opt_requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org --mirrors=http://pypi.crate.io
+  - pip install -r requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org
+  - pip install -r opt_requirements.txt --use-mirrors --mirrors=http://g.pypi.python.org --mirrors=http://c.pypi.python.org
 
 before_script:
   - "/home/travis/virtualenv/python${TRAVIS_PYTHON_VERSION}/bin/pylint --rcfile=.testing.pylintrc salt/ && echo 'Finished Pylint Check Cleanly' || echo 'Finished Pylint Check With Errors'"


### PR DESCRIPTION
crate.io now points to a big data company out of Austria (the actual crate.io has moved to https://preview-pypi.python.org/).
