### PR TITLE
Fixing defaults.py for 2014.1rc3

### DIFF
--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -92,7 +92,8 @@ def get(key, default=''):
         frame_args = inspect.getargvalues(frame[0]).locals
 
         for _sls in (
-            frame_args.get('context', {}).get('__sls__'),
+            None if not type(frame_args.get('context')) is dict else frame_args.get('context').get('__sls__'),
+            frame_args.get('mods', [None])[0],
             frame_args.get('sls')
         ):
             if sls is not None:


### PR DESCRIPTION
The arguments changed a bit in 2014.1rc3 and defaults.py was unable to find the sls name.

If there is a better way to find the sls and template name for the current sls or template then please let me know. Crawling the stack works, but its not ideal.
