### PR TITLE
cobbler ext_pillar params should be a dict

### DIFF
--- a/salt/pillar/cobbler.py
+++ b/salt/pillar/cobbler.py
@@ -15,8 +15,8 @@ modules.
 
   ext_pillar:
   - cobbler:
-    - key: cobbler # Nest results within this key. By default, values are not nested.
-    - only: [parameters] # Add only these keys to pillar.
+      key: cobbler # Nest results within this key. By default, values are not nested.
+      only: [parameters] # Add only these keys to pillar.
 
   cobbler.url: https://example.com/cobbler_api #default is http://localhost/cobbler_api
   cobbler.user: username # default is no username


### PR DESCRIPTION
Otherwise:

Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/pillar/**init**.py", line 423, in ext_pillar
    ext = self.ext_pillars[key](self.opts['id'], pillar, *val)
  File "/usr/lib/python2.6/site-packages/salt/pillar/cobbler.py", line 71, in ext_pillar
    result = {key: result}
TypeError: unhashable type: 'dict'
