### PR TITLE
Added test for salt.modules.file.extract_hash() to verify support for simple Maven checksum file format

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1034,6 +1034,7 @@ def managed(name,
 
             /etc/rc.conf ef6e82e4006dee563d98ada2a2a80a27
             sha254c8525aee419eb649f0233be91c151178b30f0dff8ebbdcc8de71b1d5c8bcc06a  /etc/resolv.conf
+            ead48423703509d37c4a90e6a0d53e143b6fc268
 
         Known issues:
             If the remote server URL has the hash file as an apparent

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -381,6 +381,37 @@ class FileModuleTestCase(TestCase):
             with open(tfile.name) as tfile2:
                 self.assertEqual(tfile2.read(), 'bar\n')
 
+    def test_extract_hash(self):
+        '''
+        Check various hash file formats.
+        '''
+        # With file name
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write('rc.conf ef6e82e4006dee563d98ada2a2a80a27\n')
+            tfile.write(
+                'ead48423703509d37c4a90e6a0d53e143b6fc268 example.tar.gz\n')
+            tfile.flush()
+            result = filemod.extract_hash(tfile.name, '', '/rc.conf')
+            self.assertEqual(result, {
+                'hsum': 'ef6e82e4006dee563d98ada2a2a80a27',
+                'hash_type': 'md5'
+            })
+
+            result = filemod.extract_hash(tfile.name, '', '/example.tar.gz')
+            self.assertEqual(result, {
+                'hsum': 'ead48423703509d37c4a90e6a0d53e143b6fc268',
+                'hash_type': 'sha1'
+            })
+        # Solohash - no file name (Maven repo checksum file format)
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write('ead48423703509d37c4a90e6a0d53e143b6fc268\n')
+            tfile.flush()
+            result = filemod.extract_hash(tfile.name, '', '/testfile')
+            self.assertEqual(result, {
+                'hsum': 'ead48423703509d37c4a90e6a0d53e143b6fc268',
+                'hash_type': 'sha1'
+            })
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
I didn't know this simple file format is supported in the coming version 2014.1 until I created a test for that.
https://groups.google.com/forum/#!topic/salt-users/MCFlLF7poGU

This pull request contributes the unit test which verifies part of extract_hash() functionality.
