### PR TITLE
denied minions keys are written to $pki_dir/minions_denied

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -70,6 +70,7 @@ class Master(parsers.MasterOptionParser):
                         self.config['pki_dir'],
                         os.path.join(self.config['pki_dir'], 'minions'),
                         os.path.join(self.config['pki_dir'], 'minions_pre'),
+                        os.path.join(self.config['pki_dir'], 'minions_denied'),
                         os.path.join(self.config['pki_dir'],
                                      'minions_rejected'),
                         self.config['cachedir'],

--- a/salt/master.py
+++ b/salt/master.py
@@ -1849,6 +1849,9 @@ class ClearFuncs(object):
         pubfn_rejected = os.path.join(self.opts['pki_dir'],
                 'minions_rejected',
                 load['id'])
+        pubfn_denied = os.path.join(self.opts['pki_dir'],
+                'minions_denied',
+                load['id'])
         if self.opts['open_mode']:
             # open mode is turned on, nuts to checks and overwrite whatever
             # is there
@@ -1871,6 +1874,9 @@ class ClearFuncs(object):
                     'keys did not match. This may be an attempt to compromise '
                     'the Salt cluster.'.format(**load)
                 )
+                # put denied minion key into minions_denied
+                with salt.utils.fopen(pubfn_denied, 'w+') as fp_: 
+                    fp_.write(load['pub'])
                 eload = {'result': False,
                          'id': load['id'],
                          'pub': load['pub']}
@@ -1955,6 +1961,9 @@ class ClearFuncs(object):
                         'attempt to compromise the Salt cluster.'
                         .format(**load)
                     )
+                    # put denied minion key into minions_denied
+                    with salt.utils.fopen(pubfn_denied, 'w+') as fp_: 
+                        fp_.write(load['pub'])
                     eload = {'result': False,
                              'id': load['id'],
                              'pub': load['pub']}
@@ -1986,6 +1995,9 @@ class ClearFuncs(object):
                         'attempt to compromise the Salt cluster.'
                         .format(**load)
                     )
+                    # put denied minion key into minions_denied
+                    with salt.utils.fopen(pubfn_denied, 'w+') as fp_: 
+                        fp_.write(load['pub'])
                     eload = {'result': False,
                              'id': load['id'],
                              'pub': load['pub']}


### PR DESCRIPTION
Enables the possibility of seeing which minions were denied from connecting to the salt-master by looking into

/etc/salt/pki/master/minions_denied/

Denying minions can happen quite easily in dynamic environments.

The code for salt-key to also handle denied keys will follow, I'd rather keep the patches small.
