### PR TITLE
Feature/test fixes

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1135,7 +1135,7 @@ def apply_vm_profiles_config(providers, overrides, defaults=None):
     vms = {}
 
     for key, val in config.items():
-        if key in ('conf_file', 'include', 'default_include'):
+        if key in ('conf_file', 'include', 'default_include', 'user'):
             continue
         if not isinstance(val, dict):
             raise salt.cloud.exceptions.SaltCloudConfigError(
@@ -1292,7 +1292,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
 
     providers = {}
     for key, val in config.items():
-        if key in ('conf_file', 'include', 'default_include'):
+        if key in ('conf_file', 'include', 'default_include', 'user'):
             continue
 
         if not isinstance(val, (list, tuple)):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -665,10 +665,12 @@ class AdaptedConfigurationTestCaseMixIn(object):
             # Running as root, the running user does not need to be updated
             return integration_config_dir
 
-        for fname in os.listdir(integration_config_dir):
-            if fname.startswith(('.', '_')):
-                continue
-            self.get_config_file_path(fname)
+        for triplet in os.walk(integration_config_dir):
+            partial = triplet[0].replace(integration_config_dir,"")[1:]
+            for fname in triplet[2]:
+                if fname.startswith(('.', '_')):
+                    continue
+                self.get_config_file_path(os.path.join(partial, fname))
         return TMP_CONF_DIR
 
     def get_config_file_path(self, filename):
@@ -679,10 +681,11 @@ class AdaptedConfigurationTestCaseMixIn(object):
             # Running as root, the running user does not need to be updated
             return integration_config_file
 
-        if not os.path.isdir(TMP_CONF_DIR):
-            os.makedirs(TMP_CONF_DIR)
-
         updated_config_path = os.path.join(TMP_CONF_DIR, filename)
+        partial = os.path.dirname(updated_config_path)
+        if not os.path.isdir(partial):
+            os.makedirs(partial)
+
         if not os.path.isfile(updated_config_path):
             self.__update_config(integration_config_file, updated_config_path)
         return updated_config_path

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -666,7 +666,7 @@ class AdaptedConfigurationTestCaseMixIn(object):
             return integration_config_dir
 
         for triplet in os.walk(integration_config_dir):
-            partial = triplet[0].replace(integration_config_dir,"")[1:]
+            partial = triplet[0].replace(integration_config_dir, "")[1:]
             for fname in triplet[2]:
                 if fname.startswith(('.', '_')):
                     continue

--- a/tests/integration/modules/file.py
+++ b/tests/integration/modules/file.py
@@ -8,7 +8,7 @@ import os
 import shutil
 import sys
 
-from mock import patch, MagicMock
+from salttesting.mock import patch, MagicMock
 
 # Import Salt Testing libs
 from salttesting import skipIf

--- a/tests/integration/modules/mysql.py
+++ b/tests/integration/modules/mysql.py
@@ -3,7 +3,7 @@
 # Import python libs
 import logging
 
-from mock import patch
+from salttesting.mock import patch
 
 # Import Salt Testing libs
 from salttesting import skipIf


### PR DESCRIPTION
a5fee18ac8676d4e9dd469118f8f35466c8ce325 and 4b6694bf0ed39ed94b999a18b126d41fc7929c2a are aimed at running tests as a non-root user.  The code that makes a temp copy of the test with the correct user wasn't playing with the new salt.cloud code.  These two commits get a lot of tests that were broken for me to play ball.
See #10022 for more details.

In 0a7546b1b1159f370f9c731f0615028401e0606e I have adjusted the import to pull saltesting.mock rather than mock directly, in the hopes that slightly more tests will pass if the real mock lib isn't installed.  I don't see harm in this since there doesn't seem to be any instances where the tests results will have more failures than they would have without this change.
If mock is missing, only tests that can't use the fake mock will fail rather than the entire file failing on an import error.
If mock is available, the result is the same as if mock was included directly.
We may need to wrap some tests in `NO_MOCK` tests if they can't cope with the fake MagicMock class.
It might be worth expanding the fake class a little, to handle more of the simpler tests, but it's good enough for now.
