### PR TITLE
Because of integer conversion get_event has a minimum wait time of  1.0 .second even if 0.0 < wait < 1.0

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -249,8 +249,8 @@ class SaltEvent(object):
             else:
                 return evt['data']
 
-        start = int(time.time())
-        while not wait or int(time.time()) <= start + wait:
+        start = time.time() #int(time.time())
+        while not wait or time.time() <= start + wait:
             socks = dict(self.poller.poll(wait * 1000))  # convert to milliseconds
             if self.sub in socks and socks[self.sub] == zmq.POLLIN:
                 raw = self.sub.recv()


### PR DESCRIPTION
This is a problem for ioflo and halite in terms of tuning how fast events are pulled down when there are not
very many events happening otherwise on the master. They would break the non blocking io of ioflo (as well as halite)  If there were not any events on the event bus.
