### PR TITLE
The code or schedule had a better example than the doc.

### DIFF
--- a/doc/topics/jobs/schedule.rst
+++ b/doc/topics/jobs/schedule.rst
@@ -6,11 +6,8 @@ In Salt versions greater than 0.12.0, the scheduling system allows incremental
 executions on minions or the master. The schedule system exposes the execution 
 of any execution function on minions or any runner on the master.
 
-To set up the scheduler on the master add the schedule option to the master
-config file. 
-
-To set up the scheduler on the minion add the schedule option to
-the minion config file or to the minion's pillar.
+Scheduling is enabled via the ``schedule`` option on either the master or minion 
+config files, or via a minion's pillar data.
 
 .. note::
 
@@ -18,8 +15,34 @@ the minion config file or to the minion's pillar.
     running on the master the functions reference runner functions, when
     running on the minion the functions specify execution functions.
 
-The schedule option defines jobs which execute at certain intervals. To set up a highstate
-to run on a minion every 60 minutes set this in the minion config or pillar:
+Specify ``maxrunning`` to ensure that there are no more than N copies of
+a particular routine running.  Use this for jobs that may be long-running
+and could step on each other or otherwise double execute.  The default for 
+``maxrunning`` is 1.
+
+States are executed on the minion, as all states are. You can pass positional
+arguments are provide a yaml dict of named arguments.
+
+States
+======
+
+.. code-block:: yaml
+
+    schedule:
+      log-loadavg:
+        function: cmd.run
+        seconds: 3660
+        args:
+          - 'logger -t salt < /proc/loadavg'
+        kwargs:
+          stateful: False
+          shell: True
+
+Highstates
+==========
+
+To set up a highstate to run on a minion every 60 minutes set this in the
+minion config or pillar:
 
 .. code-block:: yaml
 
@@ -28,9 +51,13 @@ to run on a minion every 60 minutes set this in the minion config or pillar:
         function: state.highstate
         minutes: 60
 
-Time intervals can be specified as seconds, minutes, hours, or days. Runner
-executions can also be specified on the master within the master configuration
-file:
+Time intervals can be specified as seconds, minutes, hours, or days. 
+
+Runners
+=======
+
+Runner executions can also be specified on the master within the master 
+configuration file:
 
 .. code-block:: yaml
 
@@ -64,5 +91,5 @@ returner database:
         returner: mysql
       
 Since specifying the returner repeatedly can be tiresome, the
-`schedule_returner` option is available to specify one or a list of global
+``schedule_returner`` option is available to specify one or a list of global
 returners to be used by the minions when scheduling.


### PR DESCRIPTION
The source code documents calling a state periodically on a minion with args and kwargs.

I also documented 'maxrunning'
