### PR TITLE
docker-py expect a list a not a dict anymore for port_bindings

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -59,8 +59,8 @@ Available Functions
               - container: mysuperdocker
               - port_bindings:
                   "5000/tcp":
-                      HostIp: ""
-                      HostPort: "5000"
+                      - ""
+                      - "5000"
 
 
 - absent
@@ -576,8 +576,8 @@ def running(name, container=None, port_bindings=None, binds=None,
 
             - port_bindings:
                 "5000/tcp":
-                    HostIp: ""
-                    HostPort: "5000"
+                    - ""
+                    - "5000"
     '''
     is_running = __salt('docker.is_running')(container)
     if is_running:


### PR DESCRIPTION
Reflect it in documentation.
