### PR TITLE
More SmartOS esky fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -405,6 +405,17 @@ elif sys.platform.startswith('linux'):
         FREEZER_INCLUDES.append('yum')
     except ImportError:
         pass
+elif sys.platform.startswith('sunos'):
+    # 0.17.5 build fails to pull in pipes and csv
+    FREEZER_INCLUDES.append('pipes')
+    FREEZER_INCLUDES.append('csv')
+    try:
+        # SmartOS should eventually have the spwd module
+        # and when it does, we should pull it in.
+        import spwd
+        FREEZER_INCLUDES.append('spwd')
+    except ImportError:
+        pass
 
 if HAS_ESKY:
     # if the user has the esky / bbfreeze libraries installed, add the


### PR DESCRIPTION
bbfreeze doesn't find pipes module for 0.17.5 which breaks
the git module (someone should check this for Linux and Windows)
(Interestingly it does find it in the 2014.1.0rc3 build)

Also, SmartOS should eventually get the spwd module
so we should try to import and include it like we do for Linux
( see https://github.com/joyent/pkgsrc/issues/164 )
