### PR TITLE
SmartOS Esky build: Just try to grab everything

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -531,6 +531,20 @@ elif sys.platform.startswith('linux'):
         FREEZER_INCLUDES.append('yum')
     except ImportError:
         pass
+elif sys.platform.startswith('sunos'):
+    # (The sledgehammer approach)
+    # Just try to include everything
+    # (This may be a better way to generate FREEZER_INCLUDES generally)
+    try:
+        from bbfreeze.modulegraph.modulegraph import ModuleGraph
+        mf = ModuleGraph(sys.path[:])
+        for arg in glob.glob("salt/modules/*.py"):
+                mf.run_script(arg)
+        for mod in mf.flatten():
+            if type(mod).__name__ != "Script" and mod.filename:
+                FREEZER_INCLUDES.append(str(os.path.basename(mod.identifier)))
+    except ImportError:
+        pass
 
 if HAS_ESKY:
     # if the user has the esky / bbfreeze libraries installed, add the


### PR DESCRIPTION
After discovering missing modules one at a time I went in search
of a bigger hammer.

We use the bbfreeze ModuleGraph code to find all deps for
salt.modules.\* and add them to the FREEZER_INCLUDES variable.

It may be worth trying this approach for other platforms...
