### PR TITLE
Group mem/cpu output of ps.top

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -82,11 +82,13 @@ def top(num_processes=5, interval=3):
                 'user': process.username,
                 'status': process.status,
                 'pid': process.pid,
-                'create_time': process.create_time}
+                'create_time': process.create_time,
+                'cpu': {},
+                'mem': {},}
         for key, value in process.get_cpu_times()._asdict().items():
-            info['cpu.{0}'.format(key)] = value
+            info['cpu'][key] = value
         for key, value in process.get_memory_info()._asdict().items():
-            info['mem.{0}'.format(key)] = value
+            info['mem'][key] = value
         result.append(info)
 
     return result

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -84,7 +84,8 @@ def top(num_processes=5, interval=3):
                 'pid': process.pid,
                 'create_time': process.create_time,
                 'cpu': {},
-                'mem': {},}
+                'mem': {}, 
+                }
         for key, value in process.get_cpu_times()._asdict().items():
             info['cpu'][key] = value
         for key, value in process.get_memory_info()._asdict().items():


### PR DESCRIPTION
This groups memory and cpu output of `ps.top`, which makes more sense especially when being used via the API and it turning into a response object. 

Results in output like:

```
    - cmd:
        - /usr/bin/python
        - /usr/bin/salt-minion
        - -l
        - debug
    - cpu:
        ----------
        system:
            0.1
        user:
            0.58
    - create_time:
        1391110543.81
    - mem:
        ----------
        rss:
            35491840
        vms:
            464912384
    - pid:
        23660
```
