### PR TITLE
fcntl incompatibility when using SunOS/SmartOS as a host

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -12,7 +12,7 @@ import logging
 
 try:
     import fcntl
-    HAS_FCNTL = True
+    HAS_FCNTL = os.uname()[0] != "SunOS"
 except ImportError:
     # fcntl is not available on windows
     HAS_FCNTL = False


### PR DESCRIPTION
![Uploading smartos error.png . . .]()
Attached is a picture of the output when trying to use file.managed in a salt state on SmartOS. According to the SunOS man page on flock:

flock() applies or removes an advisory lock on the file associ-
     ated with the file descriptor fd. The compatibility version of
     flock() has been implemented on top of fcntl(2) locking.  It does
     not provide complete binary compatibility

This lack of binary compatibility results in some odd behavior when
running salt-master on a SunOS/SmartOS host. Specifically an IOError
[Errno 9] is thrown whenever the master calls the file_hash method.

Specifically it has to do with the fact that on SunOS/SmartOS the lock
is released when the file is closed,  whereas in Linux the lock is kept
until it is released. An article discussing the problem in detail can be
found here:

http://infinitesque.net/articles/2010/on%20Python%20flock/index.html

To get this working I changed salt/fileserver/roots.py to check os.uname()
to make sure it's a Linux host when setting HAS_FCNTL. Comments indicate
Windows shouldn't have this set either.
