### PR TITLE
Check return code in rabbitmq module

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -29,9 +29,14 @@ def __virtual__():
 
 
 def _format_response(response, msg):
-    if 'Error' in response:
-        msg = 'Error'
-
+    if isinstance(response, dict):
+        if response['retcode'] != 0:
+            msg = 'Error'
+        else:
+            msg = response['stdout']
+    else:
+        if 'Error' in response:
+            msg = 'Error'
     return {
         msg: response
     }

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -574,7 +574,7 @@ def enable_plugin(name, runas=None):
 
         salt '*' rabbitmq.enable_plugin foo
     '''
-    ret = __salt__['cmd.run'](
+    ret = __salt__['cmd.run_all'](
             'rabbitmq-plugins enable {0}'.format(name),
             runas=runas)
     return _format_response(ret, 'Enabled')
@@ -591,7 +591,7 @@ def disable_plugin(name, runas=None):
         salt '*' rabbitmq.disable_plugin foo
     '''
 
-    ret = __salt__['cmd.run'](
+    ret = __salt__['cmd.run_all'](
             'rabbitmq-plugins disable {0}'.format(name),
             runas=runas)
     return _format_response(ret, 'Disabled')


### PR DESCRIPTION
For commands that may return non-zero status without the word "Error" in their stdout, retcode is now checked by using cmd.run_all.

This intends to address #9944
