### PR TITLE
Allow pillars to be cleared for all minions

### DIFF
--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -128,7 +128,7 @@ def _clear_cache(tgt=None,
                                                 clear_mine_func=clear_mine_func)
 
 
-def clear_pillar(tgt, expr_form='glob'):
+def clear_pillar(tgt=None, expr_form='glob'):
     '''
     Clear the cached pillar data of the targeted minions
 


### PR DESCRIPTION
This function was requiring an argument while `clear_mine` and `clear_grains` are both clearing the selected data for all minions (or the targeted ones) if no arguments are provided. 
