### PR TITLE
allow ext_dirs for grains

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -316,7 +316,7 @@ def grains(opts):
     else:
         opts['grains'] = {}
 
-    load = _create_loader(opts, 'grains', 'grain', ext_dirs=False)
+    load = _create_loader(opts, 'grains', 'grain')
     grains_info = load.gen_grains()
     grains_info.update(opts['grains'])
     return grains_info


### PR DESCRIPTION
This is the last piece of what i already did in the previous commit allowing to specify custom grains directories, it is good to allow to parameterize them, but even better afterwards to use them in the loader :) !

/cc @s0undt3ch @thatch45 @regilero
