### PR TITLE
[Clean] Strip leading path separator characters in a portable way.

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1643,7 +1643,7 @@ def get_id(root_dir=None, minion_id=False, cache=True):
 
     # Check for cached minion ID
     id_cache = os.path.join(root_dir,
-                            config_dir.lstrip('\\'),
+                            config_dir.lstrip(os.path.sep),
                             'minion_id')
 
     if cache:


### PR DESCRIPTION
Picking #10036 on to develop.  Original author and all credit to @plastikos
Origin: https://github.com/plastikos/salt/commit/c92af969f789a2f0c6fa74bb1ee69a122549a53f

Original PR message:

> Addresses bug where ROOT_DIR was discarded and salt.config.get_id() only looks in /etc/salt/minion_id.
