### PR TITLE
Revert "Updated network io counter function."

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -503,7 +503,7 @@ def network_io_counters():
 
         salt '*' ps.network_io_counters
     '''
-    return dict(psutil.net_io_counters()._asdict())
+    return dict(psutil.network_io_counters()._asdict())
 
 
 def disk_io_counters():


### PR DESCRIPTION
This reverts commit e4d3d38ed5195cd0dc89b7d60464adbbbad67e07.
- psutil.network_io_counters() isn't deprecated until psutil v1.0.0
