### PR TITLE
Bunch of safeguards for utf8 errors in buildout module

### DIFF
--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -51,7 +51,7 @@ from salt._compat import string_types
 INVALID_RESPONSE = 'We did not get any expectable answer from buildout'
 VALID_RESPONSE = ''
 NOTSET = object()
-HR = u'{0}\n'.format('-' * 80)
+HR = '{0}\n'.format('-' * 80)
 RE_F = re.S | re.M | re.U
 BASE_STATUS = {
     'status': None,
@@ -171,6 +171,26 @@ class _Logger(object):
 LOG = _Logger()
 
 
+def _encode_string(string):
+    if isinstance(string, unicode):
+        string = string.encode('utf-8')
+    return string
+
+
+def _encode_status(status):
+    status['out'] = _encode_string(status['out'])
+    status['outlog_by_level'] = _encode_string(status['outlog_by_level'])
+    if status['logs']:
+        for i, data in enumerate(status['logs'][:]):
+            status['logs'][i] = (data[0], _encode_string(data[1]))
+        for logger in 'error', 'warn', 'info', 'debug':
+            logs = status['logs_by_level'].get(logger, [])[:]
+            if logs:
+                for i, log in enumerate(logs):
+                    status['logs_by_level'][logger][i] = _encode_string(log)
+    return status
+
+
 def _set_status(m,
                 comment=INVALID_RESPONSE,
                 status=False,
@@ -182,34 +202,35 @@ def _set_status(m,
     m['status'] = status
     m['logs'] = LOG.messages[:]
     m['logs_by_level'] = LOG.by_level.copy()
-    outlog, outlog_by_level = u'', u''
+    outlog, outlog_by_level = '', ''
     m['comment'] = comment
     if out and isinstance(out, string_types):
         outlog += HR
-        outlog += u'OUTPUT:\n'
-        if not isinstance(out, unicode):
-            out = out.decode('utf-8')
-        outlog += u'{0}\n'.format(out)
+        outlog += 'OUTPUT:\n'
+        outlog += '{0}\n'.format(_encode_string(out))
         outlog += HR
     if m['logs']:
         outlog += HR
-        outlog += u'Log summary:\n'
+        outlog += 'Log summary:\n'
         outlog += HR
         outlog_by_level += HR
-        outlog_by_level += u'Log summary by level:\n'
+        outlog_by_level += 'Log summary by level:\n'
         outlog_by_level += HR
         for level, msg in m['logs']:
-            outlog += u'\n{0}: {1}\n'.format(level.upper(), msg)
+            outlog += '\n{0}: {1}\n'.format(level.upper(),
+                                            _encode_string(msg))
         for logger in 'error', 'warn', 'info', 'debug':
             logs = m['logs_by_level'].get(logger, [])
             if logs:
-                outlog_by_level += u'\n{0}:\n'.format(logger.upper())
-                outlog_by_level += u'\n'.join(logs)
-                outlog_by_level += u'\n'
+                outlog_by_level += '\n{0}:\n'.format(logger.upper())
+                for idx, log in enumerate(logs[:]):
+                    logs[idx] = _encode_string(log)
+                outlog_by_level += '\n'.join(logs)
+                outlog_by_level += '\n'
         outlog += HR
     m['outlog'] = outlog
     m['outlog_by_level'] = outlog_by_level
-    return m
+    return _encode_status(m)
 
 
 def _invalid(m, comment=INVALID_RESPONSE, out=None):
@@ -813,7 +834,7 @@ def _merge_statuses(statuses):
         if status['status'] is not False:
             status['status'] = st['status']
         out = st['out']
-        comment = st['comment']
+        comment = _encode_string(st['comment'])
         logs = st['logs']
         logs_by_level = st['logs_by_level']
         outlog_by_level = st['outlog_by_level']
@@ -823,28 +844,33 @@ def _merge_statuses(statuses):
                 status['out'] = ''
             status['out'] += '\n'
             status['out'] += HR
+            out = _encode_string(out)
             status['out'] += '{0}\n'.format(out)
             status['out'] += HR
         if comment:
             if not status['comment']:
                 status['comment'] = ''
-            status['comment'] += '\n{0}\n'.format(comment)
+            status['comment'] += '\n{0}\n'.format(
+                _encode_string(comment))
         if outlog:
             if not status['outlog']:
                 status['outlog'] = ''
+            outlog = _encode_string(outlog)
             status['outlog'] += '\n{0}'.format(HR)
             status['outlog'] += outlog
         if outlog_by_level:
             if not status['outlog_by_level']:
                 status['outlog_by_level'] = ''
             status['outlog_by_level'] += '\n{0}'.format(HR)
-            status['outlog_by_level'] += outlog_by_level
-        status['logs'].extend(logs)
+            status['outlog_by_level'] += _encode_string(outlog_by_level)
+        status['logs'].extend([
+            (a[0], _encode_string(a[1])) for a in logs])
         for log in logs_by_level:
             if not log in status['logs_by_level']:
                 status['logs_by_level'][log] = []
-            status['logs_by_level'][log].extend(logs_by_level[log])
-    return status
+            status['logs_by_level'][log].extend(
+                [_encode_string(a) for a in logs_by_level[log]])
+    return _encode_status(status)
 
 
 @_salt_callback

--- a/tests/unit/modules/zcbuildout_test.py
+++ b/tests/unit/modules/zcbuildout_test.py
@@ -454,16 +454,41 @@ class BuildoutOnlineTestCase(Base):
 
 class BuildoutAPITestCase(TestCase):
 
+    def test_merge(self):
+        buildout.LOG.clear()
+        buildout.LOG.info('àé')
+        buildout.LOG.info(u'àé')
+        buildout.LOG.error('àé')
+        buildout.LOG.error(u'àé')
+        ret1 = buildout._set_status({}, out='éà')
+        uret1 = buildout._set_status({}, out=u'éà')
+        buildout.LOG.clear()
+        buildout.LOG.info('ççàé')
+        buildout.LOG.info(u'ççàé')
+        buildout.LOG.error('ççàé')
+        buildout.LOG.error(u'ççàé')
+        ret2 = buildout._set_status({}, out='çéà')
+        uret2 = buildout._set_status({}, out=u'çéà')
+        uretm = buildout._merge_statuses([ret1, uret1, ret2, uret2])
+        for ret in ret1, uret1, ret2, uret2:
+            out = ret['out']
+            if not isinstance(ret['out'], unicode):
+                out = ret['out'].decode('utf-8')
+
+        for out in ['àé', 'ççàé']:
+            self.assertTrue(out in uretm['logs_by_level']['info'])
+            self.assertTrue(out in uretm['outlog_by_level'])
+
     def test_setup(self):
         buildout.LOG.clear()
         buildout.LOG.info('àé')
-        buildout.LOG.info('uàé')
+        buildout.LOG.info(u'àé')
         buildout.LOG.error('àé')
-        buildout.LOG.error('uàé')
+        buildout.LOG.error(u'àé')
         ret = buildout._set_status({}, out='éà')
         uret = buildout._set_status({}, out=u'éà')
         self.assertTrue(ret['outlog'] == uret['outlog'])
-        self.assertTrue(u'àé' in uret['outlog_by_level'])
+        self.assertTrue('àé' in uret['outlog_by_level'])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
instead of decoding strings, encode everything back from unicode if neccesary as the underlying API won't accept unicode that much.
