### PR TITLE
Fix requisite type in supervisor state

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -11,7 +11,7 @@ Interaction with the Supervisor daemon
         - require:
           - pkg: supervisor
         - watch:
-          - file.managed: /etc/nginx/sites-enabled/wsgi_server.conf
+          - file: /etc/nginx/sites-enabled/wsgi_server.conf
 '''
 
 # Import python libs


### PR DESCRIPTION
Requisite types can't contain dots (have to use `file` instead of `file.managed`).

Running this example results in:

```
Invalid requisite type 'file.managed' in state 'wsgi_server', in SLS 'wsgi_server'. Requisite types must not contain dots, did you mean 'file'?
```
