### PR TITLE
CRITICAL: State's don't send the environment...

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -547,7 +547,8 @@ class State(object):
         pillar = salt.pillar.get_pillar(
                 self.opts,
                 self.opts['grains'],
-                self.opts['id']
+                self.opts['id'],
+                self.opts['environment'],
                 )
         ret = pillar.compile_pillar()
         if self._pillar_override and isinstance(self._pillar_override, dict):


### PR DESCRIPTION
CRITICAL: State's don't send the environment to render the pillar!

This is why `salt-call pillar.items` works and `salt-call state.highstate` does not.

There defiantly needs to be a test around this bug. I've tested this fix with both the `environment: dev` and `#environment: dev` in `/etc/salt/minion`. It works just fine.
## pillar.items

Here is the corresponding code that does work: https://github.com/saltstack/salt/blob/develop/salt/minion.py#L283
