### PR TITLE
Improve detection of changes when pull or build an image

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -302,11 +302,12 @@ def _get_image_infos(image):
     '''
     Verify that the image exists
     We will try to resolve either by:
-        - the mapping grain->docker id or directly
-        - dockerid
+        - name
+        - image_id
+        - tag
 
     image
-        Image Id / grain name
+        Image Name / Image Id / Image Tag
 
     Returns the image id
     '''
@@ -1250,7 +1251,7 @@ def import_image(src, repo, tag=None, *args, **kwargs):
     try:
         ret = client.import_image(src, repository=repo, tag=tag)
         if ret:
-            logs, info = _parse_image_multilogs_string(ret)
+            logs, info = _parse_image_multilogs_string(ret, repo)
             _create_image_assemble_error_status(status, ret, logs)
             if status['status'] is not False:
                 infos = _get_image_infos(logs[0]['status'])
@@ -1493,7 +1494,7 @@ def inspect_image(image, *args, **kwargs):
     return status
 
 
-def _parse_image_multilogs_string(ret):
+def _parse_image_multilogs_string(ret, repo):
     '''
     Parse image log strings into grokable data
     '''
@@ -1519,7 +1520,7 @@ def _parse_image_multilogs_string(ret):
         for l in logs:
             if isinstance(l, dict):
                 if l.get('status') == 'Download complete' and l.get('id'):
-                    infos = _get_image_infos(l['id'])
+                    infos = _get_image_infos(repo)
                     break
     return logs, infos
 
@@ -1625,13 +1626,14 @@ def pull(repo, tag=None, *args, **kwargs):
     try:
         ret = client.pull(repo, tag=tag)
         if ret:
-            logs, infos = _parse_image_multilogs_string(ret)
+            logs, infos = _parse_image_multilogs_string(ret, repo)
             if infos and infos.get('id', None):
                 repotag = repo
                 if tag:
                     repotag = '{0}:{1}'.format(repo, tag)
                 valid(status,
-                      out=logs and logs or ret,
+                      out=logs if logs else ret,
+                      id=infos['id'],
                       comment='Image {0} was pulled ({1})'.format(
                           repotag, infos['id']))
 
@@ -1710,7 +1712,7 @@ def push(repo, *args, **kwargs):
     status = base_status.copy()
     registry, repo_name = docker.auth.resolve_repository_name(repo)
     ret = client.push(repo)
-    logs, infos = _parse_image_multilogs_string(ret)
+    logs, infos = _parse_image_multilogs_string(ret, repo)
     if logs:
         laststatus = logs[0].get('status', None)
         if laststatus and (

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1712,7 +1712,7 @@ def push(repo, *args, **kwargs):
     status = base_status.copy()
     registry, repo_name = docker.auth.resolve_repository_name(repo)
     ret = client.push(repo)
-    logs, infos = _parse_image_multilogs_string(ret, repo)
+    logs, infos = _parse_image_multilogs_string(ret, repo_name)
     if logs:
         laststatus = logs[0].get('status', None)
         if laststatus and (

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -246,10 +246,14 @@ def pulled(name, force=False, *args, **kwargs):
         return _valid(
             name=name,
             comment='Image already pulled: {0}'.format(name))
+    previous_id = iinfos['out']['id']
     func = __salt('docker.pull')
-    a, kw = [name], {}
-    status = _ret_status(func(*a, **kw), name)
-    return status
+    returned = func(name)
+    if previous_id != returned['id']:
+        changes = {name: True}
+    else:
+        changes = {}
+    return _ret_status(returned, name, changes=changes)
 
 
 def built(name,
@@ -278,17 +282,21 @@ def built(name,
             name=name,
             comment='Image already built: {0}, id: {1}'.format(
                 name, iinfos['out']['id']))
+    previous_id = iinfos['out']['id']
     func = __salt('docker.build')
-    a, kw = [], dict(
-        tag=name,
-        path=path,
-        quiet=quiet,
-        nocache=nocache,
-        rm=rm,
-        timeout=timeout,
-    )
-    status = _ret_status(func(*a, **kw), name)
-    return status
+    kw = dict(tag=name,
+              path=path,
+              quiet=quiet,
+              nocache=nocache,
+              rm=rm,
+              timeout=timeout,
+              )
+    returned = func(**kw)
+    if previous_id != returned['id']:
+        changes = {name: True}
+    else:
+        changes = {}
+    return _ret_status(returned, name, changes=changes)
 
 
 def installed(name,


### PR DESCRIPTION
There is something that trouble me in this PR
if I return from a state

``` python
changes = {name: False}
```

The state that watch for it, is still triggered by mod_watch...

I didn't found the answer reading the doc
http://docs.saltstack.com/ref/states/ordering.html
I'll be glad to improve that part before merging
