### PR TITLE
Wait for explicit minions in gather job info develop

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -179,7 +179,7 @@ class LocalClient(object):
         # Looks like the timeout is invalid, use config
         return self.opts['timeout']
 
-    def gather_job_info(self, jid, tgt, tgt_type, **kwargs):
+    def gather_job_info(self, jid, tgt, tgt_type, minions, **kwargs):
         '''
         Return the information about a given job
         '''
@@ -189,6 +189,7 @@ class LocalClient(object):
                          [jid],
                          self.opts['gather_job_timeout'],
                          tgt_type,
+                         known_minions = minions,
                          **kwargs)
         return jinfo
 
@@ -394,6 +395,7 @@ class LocalClient(object):
             expr_form='glob',
             ret='',
             kwarg=None,
+            known_minions=None,
             **kwargs):
         '''
         Synchronously execute a command on targeted minions
@@ -506,6 +508,9 @@ class LocalClient(object):
 
         if not pub_data:
             return pub_data
+
+        if known_minions:
+            pub_data['minions'] += known_minions
 
         return self.get_returns(pub_data['jid'],
                                 pub_data['minions'],
@@ -789,7 +794,7 @@ class LocalClient(object):
             if int(time.time()) > start + timeout:
                 # The timeout has been reached, check the jid to see if the
                 # timeout needs to be increased
-                jinfo = self.gather_job_info(jid, tgt, tgt_type, **kwargs)
+                jinfo = self.gather_job_info(jid, tgt, tgt_type, minions - found, **kwargs)
                 more_time = False
                 for id_ in jinfo:
                     if jinfo[id_]:
@@ -903,7 +908,7 @@ class LocalClient(object):
             if int(time.time()) > timeout_at:
                 # The timeout has been reached, check the jid to see if the
                 # timeout needs to be increased
-                jinfo = self.gather_job_info(jid, tgt, tgt_type, **kwargs)
+                jinfo = self.gather_job_info(jid, tgt, tgt_type, minions - found, **kwargs)
                 still_running = [id_ for id_, jdat in jinfo.iteritems()
                                  if jdat
                                  ]
@@ -1223,7 +1228,7 @@ class LocalClient(object):
             if int(time.time()) > timeout_at:
                 # The timeout has been reached, check the jid to see if the
                 # timeout needs to be increased
-                jinfo = self.gather_job_info(jid, tgt, tgt_type, **kwargs)
+                jinfo = self.gather_job_info(jid, tgt, tgt_type, minions - found, **kwargs)
                 more_time = False
                 for id_ in jinfo:
                     if jinfo[id_]:

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -865,9 +865,11 @@ class LocalClient(object):
                     ret = {raw['id']: {'ret': raw['return']}}
                     if 'out' in raw:
                         ret[raw['id']]['out'] = raw['out']
+                    log.debug('jid %s return from %s', jid, raw['id'])
                     yield ret
                 if len(found.intersection(minions)) >= len(minions):
                     # All minions have returned, break out of the loop
+                    log.debug('jid %s found all minions %s', jid, found)
                     if self.opts['order_masters']:
                         if syndic_wait < self.opts.get('syndic_wait', 1):
                             syndic_wait += 1
@@ -875,12 +877,12 @@ class LocalClient(object):
                             log.debug('jid %s syndic_wait %s will now timeout at %s',
                                       jid, syndic_wait, datetime.fromtimestamp(timeout_at).time())
                             continue
-                    log.debug('jid %s found all minions', jid)
                     break
                 continue
             # Then event system timeout was reached and nothing was returned
             if len(found.intersection(minions)) >= len(minions):
                 # All minions have returned, break out of the loop
+                log.debug('jid %s found all minions %s', jid, found)
                 if self.opts['order_masters']:
                     if syndic_wait < self.opts.get('syndic_wait', 1):
                         syndic_wait += 1
@@ -888,7 +890,6 @@ class LocalClient(object):
                         log.debug('jid %s syndic_wait %s will now timeout at %s',
                                   jid, syndic_wait, datetime.fromtimestamp(timeout_at).time())
                         continue
-                log.debug('jid %s found all minions', jid)
                 break
             if glob.glob(wtag) and int(time.time()) <= timeout_at + 1:
                 # The timeout +1 has not been reached and there is still a
@@ -897,7 +898,7 @@ class LocalClient(object):
             if last_time:
                 if len(found) < len(minions):
                     log.info('jid %s minions %s did not return in time',
-                             jid, minions)
+                             jid, (minions -found))
                 break
             if int(time.time()) > timeout_at:
                 # The timeout has been reached, check the jid to see if the
@@ -967,7 +968,7 @@ class LocalClient(object):
                 continue
             if int(time.time()) > timeout_at:
                 log.info('jid %s minions %s did not return in time',
-                         jid, minions)
+                         jid, (minions - found))
                 break
             time.sleep(0.01)
         return ret


### PR DESCRIPTION
See Issue #10164

More logging I know but it's in a separate commit this time if you want to revert it.

I experimented with two different ways of getting the list of minions in to the get_returns function. I don't think either are particularly clean. 
