### PR TITLE
Syndic main loop develop

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -184,6 +184,8 @@ VALID_OPTS = {
     'salt_transport': str,
     'enumerate_proxy_minions': bool,
     'gather_job_timeout': int,
+    'syndic_event_forward_timeout': float,
+    'syndic_max_event_process_time': float,
 }
 
 # default configurations
@@ -391,6 +393,8 @@ DEFAULT_MASTER_OPTS = {
     'salt_transport': 'zeromq',
     'enumerate_proxy_minions': False,
     'gather_job_timeout': 2,
+    'syndic_event_forward_timeout': 0.5,
+    'syndic_max_event_process_time': 0.5,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1569,20 +1569,24 @@ class Syndic(Minion):
         loop_interval = int(self.opts['loop_interval'])
         while True:
             try:
+                log.trace('Polling')
                 socks = dict(self.poller.poll(
                     loop_interval * 1000)
                 )
                 if self.socket in socks and socks[self.socket] == zmq.POLLIN:
                     payload = self.serial.loads(self.socket.recv())
+                    log.trace('Handling payload')
                     self._handle_payload(payload)
                 time.sleep(0.05)
                 jids = {}
                 raw_events = []
+                log.trace('Checking events')
                 while True:
                     event = self.local.event.get_event(0.5, full=True)
                     if event is None:
                         # Timeout reached
                         break
+                    log.trace('Got event %s', event['tag'])
                     if salt.utils.is_jid(event['tag']) and 'return' in event['data']:
                         if not event['tag'] in jids:
                             if not 'jid' in event['data']:
@@ -1601,8 +1605,10 @@ class Syndic(Minion):
                         if not 'retcode' in event['data']:
                             raw_events.append(event)
                 if raw_events:
+                    log.trace('Forwarding events')
                     self._fire_master(events=raw_events, pretag=tagify(self.opts['id'], base='syndic'))
                 for jid in jids:
+                    log.trace('Forwarding job returns')
                     self._return_pub(jids[jid], '_syndic_return')
             except zmq.ZMQError:
                 # This is thrown by the interrupt caused by python handling the

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1571,7 +1571,7 @@ class Syndic(Minion):
         self._reset_event_aggregation()
         while True:
             try:
-                # Do all the maths in seconds 
+                # Do all the maths in seconds
                 timeout = loop_interval
                 if self.event_forward_timeout is not None:
                     timeout = min(timeout,
@@ -1588,7 +1588,7 @@ class Syndic(Minion):
                     self._process_cmd_socket()
                 if socks.get(self.local.event.sub) == zmq.POLLIN:
                     self._process_event_socket()
-                if (self.event_forward_timeout is not None and 
+                if (self.event_forward_timeout is not None and
                     self.event_forward_timeout < time.time()):
                     self._forward_events()
             # We don't handle ZMQErrors like the other minions
@@ -1607,7 +1607,7 @@ class Syndic(Minion):
             payload = self.serial.loads(self.socket.recv(zmq.NOBLOCK))
         except zmq.ZMQError as e:
             # Swallow errors for bad wakeups or signals needing processing
-            if (e.errno != errno.EAGAIN and e.errno != errno.EINTR):
+            if e.errno != errno.EAGAIN and e.errno != errno.EINTR:
                 raise
         log.trace('Handling payload')
         self._handle_payload(payload)
@@ -1624,7 +1624,7 @@ class Syndic(Minion):
                 event = self.local.event.get_event_noblock()
             except zmq.ZMQError as e:
                 # EAGAIN indicates no more events at the moment
-                # EINTR some kind of signal maybe someone trying 
+                # EINTR some kind of signal maybe someone trying
                 # to get us to quit so escape our timeout
                 if e.errno == errno.EAGAIN or e.errno == errno.EINTR:
                     break
@@ -1655,7 +1655,9 @@ class Syndic(Minion):
     def _forward_events(self):
         log.trace('Forwarding events')
         if self.raw_events:
-            self._fire_master(events=self.raw_events, pretag=tagify(self.opts['id'], base='syndic'))
+            self._fire_master(events=self.raw_events,
+                              pretag=tagify(self.opts['id'], base='syndic'),
+                              )
         for jid in self.jids:
             self._return_pub(self.jids[jid], '_syndic_return')
         self._reset_event_aggregation()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1333,7 +1333,7 @@ class Minion(object):
                 # SIGCHLD. Throws this error with errno == EINTR.
                 # Nothing to recieve on the zmq socket throws this error
                 # with EAGAIN.
-                # Both are sage to ignore
+                # Both are safe to ignore
                 if e.errno != errno.EAGAIN and e.errno != errno.EINTR:
                     log.critical('Unexpected ZMQError while polling minion',
                                  exc_info=True)
@@ -1524,7 +1524,8 @@ class Syndic(Minion):
         self.context = zmq.Context()
 
         # Start with the publish socket
-        self.poller = zmq.Poller()
+        # Share the poller with the event object
+        self.poller = self.local.event.poller
         self.socket = self.context.socket(zmq.SUB)
         self.socket.setsockopt(zmq.SUBSCRIBE, '')
         self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
@@ -1567,64 +1568,106 @@ class Syndic(Minion):
         enable_sigusr1_handler()
 
         loop_interval = int(self.opts['loop_interval'])
+        self._reset_event_aggregation()
         while True:
             try:
-                log.trace('Polling')
-                socks = dict(self.poller.poll(
-                    loop_interval * 1000)
-                )
-                if self.socket in socks and socks[self.socket] == zmq.POLLIN:
-                    payload = self.serial.loads(self.socket.recv())
-                    log.trace('Handling payload')
-                    self._handle_payload(payload)
-                time.sleep(0.05)
-                jids = {}
-                raw_events = []
-                log.trace('Checking events')
-                while True:
-                    event = self.local.event.get_event(0.5, full=True)
-                    if event is None:
-                        # Timeout reached
-                        break
-                    log.trace('Got event %s', event['tag'])
-                    if salt.utils.is_jid(event['tag']) and 'return' in event['data']:
-                        if not event['tag'] in jids:
-                            if not 'jid' in event['data']:
-                                # Not a job return
-                                continue
-                            jids[event['tag']] = {}
-                            jids[event['tag']]['__fun__'] = event['data'].get('fun')
-                            jids[event['tag']]['__jid__'] = event['data']['jid']
-                            jids[event['tag']]['__load__'] = salt.utils.jid_load(
-                                event['data']['jid'],
-                                self.local.opts['cachedir'],
-                                self.opts['hash_type'])
-                        jids[event['tag']][event['data']['id']] = event['data']['return']
-                    else:
-                        # Add generic event aggregation here
-                        if not 'retcode' in event['data']:
-                            raw_events.append(event)
-                if raw_events:
-                    log.trace('Forwarding events')
-                    self._fire_master(events=raw_events, pretag=tagify(self.opts['id'], base='syndic'))
-                for jid in jids:
-                    log.trace('Forwarding job returns')
-                    self._return_pub(jids[jid], '_syndic_return')
-            except zmq.ZMQError:
-                # This is thrown by the interrupt caused by python handling the
-                # SIGCHLD. This is a safe error and we just start the poll
-                # again
-                continue
+                # Do all the maths in seconds 
+                timeout = loop_interval
+                if self.event_forward_timeout is not None:
+                    timeout = min(timeout,
+                                  self.event_forward_timeout - time.time())
+                if timeout >= 0:
+                    log.trace('Polling timeout: %f', timeout)
+                    socks = dict(self.poller.poll(timeout * 1000))
+                else:
+                    # This shouldn't really happen.
+                    # But there's no harm being defensive
+                    log.warning('Negative timeout in syndic main loop')
+                    socks = {}
+                if socks.get(self.socket) == zmq.POLLIN:
+                    self._process_cmd_socket()
+                if socks.get(self.local.event.sub) == zmq.POLLIN:
+                    self._process_event_socket()
+                if (self.event_forward_timeout is not None and 
+                    self.event_forward_timeout < time.time()):
+                    self._forward_events()
+            # We don't handle ZMQErrors like the other minions
+            # I've put explicit handling around the recieve calls
+            # in the process_*_socket methods. If we see any other
+            # errors they may need some kind of handling so log them
+            # for now.
             except Exception:
                 log.critical(
                     'An exception occurred while polling the syndic',
                     exc_info=True
                 )
 
+    def _process_cmd_socket(self):
+        try:
+            payload = self.serial.loads(self.socket.recv(zmq.NOBLOCK))
+        except zmq.ZMQError as e:
+            # Swallow errors for bad wakeups or signals needing processing
+            if (e.errno != errno.EAGAIN and e.errno != errno.EINTR):
+                raise
+        log.trace('Handling payload')
+        self._handle_payload(payload)
+
+    def _reset_event_aggregation(self):
+        self.jids = {}
+        self.raw_events = []
+        self.event_forward_timeout = None
+
+    def _process_event_socket(self):
+        tout = time.time() + self.opts['syndic_max_event_process_time']
+        while tout > time.time():
+            try:
+                event = self.local.event.get_event_noblock()
+            except zmq.ZMQError as e:
+                # EAGAIN indicates no more events at the moment
+                # EINTR some kind of signal maybe someone trying 
+                # to get us to quit so escape our timeout
+                if e.errno == errno.EAGAIN or e.errno == errno.EINTR:
+                    break
+                raise
+            log.trace('Got event %s', event['tag'])
+            if self.event_forward_timeout is None:
+                self.event_forward_timeout = (
+                        time.time() + self.opts['syndic_event_forward_timeout']
+                        )
+            if salt.utils.is_jid(event['tag']) and 'return' in event['data']:
+                if not 'jid' in event['data']:
+                    # Not a job return
+                    continue
+                jdict = self.jids.setdefault(event['tag'], {})
+                if not jdict:
+                    jdict['__fun__'] = event['data'].get('fun')
+                    jdict['__jid__'] = event['data']['jid']
+                    jdict['__load__'] = salt.utils.jid_load(
+                        event['data']['jid'],
+                        self.local.opts['cachedir'],
+                        self.opts['hash_type'])
+                jdict[event['data']['id']] = event['data']['return']
+            else:
+                # Add generic event aggregation here
+                if not 'retcode' in event['data']:
+                    self.raw_events.append(event)
+
+    def _forward_events(self):
+        log.trace('Forwarding events')
+        if self.raw_events:
+            self._fire_master(events=self.raw_events, pretag=tagify(self.opts['id'], base='syndic'))
+        for jid in self.jids:
+            self._return_pub(self.jids[jid], '_syndic_return')
+        self._reset_event_aggregation()
+
     def destroy(self):
         '''
         Tear down the syndic minion
         '''
+        # We borrowed the local clients poller so give it back before
+        # it's destroyed.
+        # This does not delete the poller just our reference to it.
+        del self.poller
         super(Syndic, self).destroy()
         if hasattr(self, 'local'):
             del self.local

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -251,14 +251,15 @@ class SaltEvent(object):
 
         start = time.time()
         while not wait or time.time() <= start + wait:
-            socks = dict(self.poller.poll(wait * 1000))  # convert to milliseconds
+            # convert to milliseconds
+            socks = dict(self.poller.poll(wait * 1000))
             if socks.get(self.sub) != zmq.POLLIN:
                 continue
-            
+
             try:
                 ret = self.get_event_noblock()
-            except zmq.ZMQError as e:
-                if e.errno == errno.EAGAIN or e.errno == errno.EINTR:
+            except zmq.ZMQError as ex:
+                if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
                     continue
                 else:
                     raise
@@ -273,6 +274,8 @@ class SaltEvent(object):
         return None
 
     def get_event_noblock(self):
+        '''Get the raw event without blocking or any other niceties
+        '''
         raw = self.sub.recv(zmq.NOBLOCK)
         mtag, data = self.unpack(raw, self.serial)
         return {'data': data, 'tag': mtag}

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -252,23 +252,30 @@ class SaltEvent(object):
         start = time.time()
         while not wait or time.time() <= start + wait:
             socks = dict(self.poller.poll(wait * 1000))  # convert to milliseconds
-            if self.sub in socks and socks[self.sub] == zmq.POLLIN:
-                raw = self.sub.recv()
-            else:
+            if socks.get(self.sub) != zmq.POLLIN:
                 continue
-            mtag, data = self.unpack(raw, self.serial)
+            
+            try:
+                ret = self.get_event_noblock()
+            except zmq.ZMQError as e:
+                if e.errno == errno.EAGAIN or e.errno == errno.EINTR:
+                    continue
+                else:
+                    raise
 
-            ret = {'data': data,
-                    'tag': mtag}
-
-            if not mtag.startswith(tag):  # tag not match
+            if not ret['tag'].startswith(tag):  # tag not match
                 self.pending_events.append(ret)
                 continue
 
             if full:
                 return ret
-            return data
+            return ret['data']
         return None
+
+    def get_event_noblock(self):
+        raw = self.sub.recv(zmq.NOBLOCK)
+        mtag, data = self.unpack(raw, self.serial)
+        return {'data': data, 'tag': mtag}
 
     def iter_events(self, tag='', full=False):
         '''


### PR DESCRIPTION
See Issue #10164. 

The main loop in this PR never spends more than syndic_max_event_process_time processing events and always goes back to the poller if there isn't an event immediately available. Having tested this I never saw it in my set up hit the 0.5s limit provided by syndic_max_event_process_time. Exiting the event process loop when ever it would block would have been sufficient.

Because we're now exiting the event process loop whenever it blocks there is also a timer added to control event aggregation. To get similar behaviour to before events are stored by default 0.5s (syndic_event_forward_timeout) to potentially be aggregated before being forwarded to the master.
