### PR TITLE
Fix cron state to work on SmartOS

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -64,7 +64,7 @@ def _get_cron_cmdstr(user, path):
     Returns a platform-specific format string, to be used to build a crontab
     command.
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         return 'su - {0} -c "crontab {1}"'.format(user, path)
     else:
         return 'crontab -u {0} {1}'.format(user, path)
@@ -103,7 +103,7 @@ def _write_cron_lines(user, lines):
     path = salt.utils.mkstemp()
     with salt.utils.fopen(path, 'w+') as fp_:
         fp_.writelines(lines)
-    if __grains__['os'] == 'Solaris' and user != "root":
+    if __grains__['os_family'] == 'Solaris' and user != "root":
         __salt__['cmd.run']('chown {0} {1}'.format(user, path))
     ret = __salt__['cmd.run_all'](_get_cron_cmdstr(user, path))
     os.remove(path)
@@ -130,7 +130,7 @@ def raw_cron(user):
 
         salt '*' cron.raw_cron root
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         cmd = 'crontab -l {0}'.format(user)
     else:
         cmd = 'crontab -l -u {0}'.format(user)

--- a/salt/modules/incron.py
+++ b/salt/modules/incron.py
@@ -60,7 +60,7 @@ def _get_incron_cmdstr(user, path):
     Returns a platform-specific format string, to be used to build a incrontab
     command.
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         return 'su - {0} -c "incrontab {1}"'.format(user, path)
     else:
         return 'incrontab -u {0} {1}'.format(user, path)
@@ -104,7 +104,7 @@ def _write_incron_lines(user, lines):
         path = salt.utils.mkstemp()
         with salt.utils.fopen(path, 'w+') as fp_:
             fp_.writelines(lines)
-        if __grains__['os'] == 'Solaris' and user != "root":
+        if __grains__['os_family'] == 'Solaris' and user != "root":
             __salt__['cmd.run']('chown {0} {1}'.format(user, path))
         ret = __salt__['cmd.run_all'](_get_incron_cmdstr(user, path))
         os.remove(path)
@@ -164,7 +164,7 @@ def raw_incron(user):
 
         salt '*' incron.raw_cron root
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         cmd = 'incrontab -l {0}'.format(user)
     else:
         cmd = 'incrontab -l -u {0}'.format(user)

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -156,7 +156,7 @@ def _get_cron_info():
     elif __grains__['os'] == 'OpenBSD':
         group = 'crontab'
         crontab_dir = '/var/cron/tabs'
-    elif __grains__['os'] == 'Solaris':
+    elif __grains__['os_family'] == 'Solaris':
         group = 'root'
         crontab_dir = '/var/spool/cron/crontabs'
     elif __grains__['os'] == 'MacOS':

--- a/salt/states/incron.py
+++ b/salt/states/incron.py
@@ -77,7 +77,7 @@ def _get_cron_info():
     elif __grains__['os'] == 'OpenBSD':
         group = 'crontab'
         crontab_dir = '/var/spool/incron'
-    elif __grains__['os'] == 'Solaris':
+    elif __grains__['os_family'] == 'Solaris':
         group = 'root'
         crontab_dir = '/var/spool/incron'
     else:

--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -44,7 +44,7 @@ class PsTestCase(TestCase):
 
     def test__get_cron_cmdstr_solaris(self):
         cron.__grains__ = __grains__
-        with patch.dict(cron.__grains__, {'os': 'Solaris'}):
+        with patch.dict(cron.__grains__, {'os_family': 'Solaris'}):
             self.assertEqual('su - root -c "crontab /tmp"',
                              cron._get_cron_cmdstr(STUB_USER, STUB_PATH))
 


### PR DESCRIPTION
SmartOS and Solaris are both in the Solaris os_family
If we use that grain, the module should work on SmartOS
