### PR TITLE
Fix cron state to work on SmartOS

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -62,7 +62,7 @@ def _get_cron_cmdstr(user, path):
     Returns a platform-specific format string, to be used to build a crontab
     command.
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         return 'su - {0} -c "crontab {1}"'.format(user, path)
     else:
         return 'crontab -u {0} {1}'.format(user, path)
@@ -101,7 +101,7 @@ def _write_cron_lines(user, lines):
     path = salt.utils.mkstemp()
     with salt.utils.fopen(path, 'w+') as fp_:
         fp_.writelines(lines)
-    if __grains__['os'] == 'Solaris' and user != "root":
+    if __grains__['os_family'] == 'Solaris' and user != "root":
         __salt__['cmd.run']('chown {0} {1}'.format(user, path))
     ret = __salt__['cmd.run_all'](_get_cron_cmdstr(user, path))
     os.remove(path)
@@ -128,7 +128,7 @@ def raw_cron(user):
 
         salt '*' cron.raw_cron root
     '''
-    if __grains__['os'] == 'Solaris':
+    if __grains__['os_family'] == 'Solaris':
         cmd = 'crontab -l {0}'.format(user)
     else:
         cmd = 'crontab -l -u {0}'.format(user)

--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -110,7 +110,7 @@ def _get_cron_info():
     elif __grains__['os'] == 'OpenBSD':
         group = 'crontab'
         crontab_dir = '/var/cron/tabs'
-    elif __grains__['os'] == 'Solaris':
+    elif __grains__['os_family'] == 'Solaris':
         group = 'root'
         crontab_dir = '/var/spool/cron/crontabs'
     elif __grains__['os'] == 'MacOS':


### PR DESCRIPTION
SmartOS and Solaris are both in the Solaris os_family
If we use that grain, the module should work on SmartOS
