### PR TITLE
Optimize event timeouts

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1153,7 +1153,7 @@ class LocalClient(object):
         jid_dir = salt.utils.jid_dir(jid,
                                      self.opts['cachedir'],
                                      self.opts['hash_type'])
-        start = int(time.time())
+        start = time.time()
         timeout_at = start + timeout
         found = set()
         wtag = os.path.join(jid_dir, 'wtag*')
@@ -1165,7 +1165,7 @@ class LocalClient(object):
         last_time = False
         while True:
             # Process events until timeout is reached or all minions have returned
-            time_left = timeout_at - int(time.time())
+            time_left = timeout_at - time.time()  # Splay of up to 1s
             # Wait 0 == forever, use a minimum of 1s
             wait = max(1, time_left)
             raw = self.event.get_event(wait, jid)
@@ -1188,7 +1188,7 @@ class LocalClient(object):
                     if self.opts['order_masters']:
                         if syndic_wait < self.opts.get('syndic_wait', 1):
                             syndic_wait += 1
-                            timeout_at = int(time.time()) + 1
+                            timeout_at = time.time() + 1
                             continue
                     break
                 continue
@@ -1198,10 +1198,10 @@ class LocalClient(object):
                 if self.opts['order_masters']:
                     if syndic_wait < self.opts.get('syndic_wait', 1):
                         syndic_wait += 1
-                        timeout_at = int(time.time()) + 1
+                        timeout_at = time.time() + 1
                         continue
                 break
-            if glob.glob(wtag) and int(time.time()) <= timeout_at + 1:
+            if glob.glob(wtag) and time.time() <= timeout_at + 1:
                 # The timeout +1 has not been reached and there is still a
                 # write tag for the syndic
                 continue
@@ -1219,7 +1219,7 @@ class LocalClient(object):
                                     }
                                 })
                 break
-            if int(time.time()) > timeout_at:
+            if time.time() > timeout_at:
                 # The timeout has been reached, check the jid to see if the
                 # timeout needs to be increased
                 jinfo = self.gather_job_info(jid, tgt, tgt_type, **kwargs)
@@ -1232,7 +1232,7 @@ class LocalClient(object):
                             )
                         more_time = True
                 if more_time:
-                    timeout_at = int(time.time()) + timeout
+                    timeout_at = time.time() + timeout
                     continue
                 else:
                     last_time = True

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1165,7 +1165,7 @@ class LocalClient(object):
         last_time = False
         while True:
             # Process events until timeout is reached or all minions have returned
-            time_left = timeout_at - time.time()  # Splay of up to 1s
+            time_left = timeout_at - time.time()
             # Wait 0 == forever, use a minimum of 1s
             wait = max(1, time_left)
             raw = self.event.get_event(wait, jid)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -250,7 +250,8 @@ class SaltEvent(object):
                 return evt['data']
 
         start = time.time()
-        while not wait or time.time() <= start + wait:
+        timeout_at = start + wait
+        while not wait or time.time() <= timeout_at:
             socks = dict(self.poller.poll(wait * 1000))  # convert to milliseconds
             if self.sub in socks and socks[self.sub] == zmq.POLLIN:
                 raw = self.sub.recv()
@@ -263,6 +264,7 @@ class SaltEvent(object):
 
             if not mtag.startswith(tag):  # tag not match
                 self.pending_events.append(ret)
+                wait = timeout_at - time.time()
                 continue
 
             if full:


### PR DESCRIPTION
- Don't round down timestamps in get_cli_event_returns().
- Don't re-poll for the full timeout if we get an unresponsive minion. Refs #8087.
