### PR TITLE
Carbon returner's pickle protocol

### DIFF
--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -12,15 +12,31 @@ optionally specify in your minion configuration or the pillar::
 
     carbon.skip_on_error: True
 
+By default, data will be sent to carbon using the plaintext protocol. You may
+choose to send data using the pickle protocol by including ``carbon.mode`` in
+your configuration::
+
+    carbon.mode: pickle
+
+Alternatively, you may configure your carbon settings as::
+
+    carbon:
+        host: <server IP or hostname>
+        port: <carbon port>
+        skip_on_error: True
+        mode: (pickle|text)
+
 '''
 
+
 # Import python libs
-import pickle
-import socket
-import logging
-import time
-import struct
+from contextlib import contextmanager
 import collections
+import logging
+import cPickle as pickle
+import socket
+import struct
+import time
 
 log = logging.getLogger(__name__)
 
@@ -32,40 +48,75 @@ def __virtual__():
     return __virtualname__
 
 
-def _send_picklemetrics(metrics, carbon_sock):
-    ''' Uses pickle protocol to send data '''
+@contextmanager
+def _carbon(host, port):
+    """
+    Context manager to ensure the clean creation and destruction of a socket.
+
+    host
+        The IP or hostname of the carbon server
+    port
+        The port that carbon is listening on
+
+    """
+
+    carbon_sock = None
+
+    try:
+        carbon_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM,
+                                    socket.IPPROTO_TCP)
+
+        carbon_sock.connect((host, port))
+    except socket.error as e:
+        log.error('Error connecting to {0}:{1}, {2}'.format(host, port, e))
+        raise
+    else:
+        log.debug('Connected to carbon')
+        yield carbon_sock
+    finally:
+        if carbon_sock is not None:
+            # Shut down and close socket
+            log.debug('Destroying carbon socket')
+
+            carbon_sock.shutdown(socket.SHUT_RDWR)
+            carbon_sock.close()
+
+
+def _send_picklemetrics(metrics):
+    """Format metrics for the carbon pickle protocol"""
 
     metrics = [(metric_name, (timestamp, value))
-               for (metric_name, timestamp, value) in metrics]
+               for (metric_name, value, timestamp) in metrics]
 
-    data = pickle.dumps(metrics, protocol=-1)
-    struct_format = '!I'
-    data = struct.pack(struct_format, len(data)) + data
-    total_sent_bytes = 0
-    while total_sent_bytes < len(data):
-        sent_bytes = carbon_sock.send(data[total_sent_bytes:])
-        if sent_bytes == 0:
-            log.error('Bytes sent 0, Connection reset?')
-            return
-        total_sent_bytes += sent_bytes
-        logging.debug('Sent {0} bytes to carbon'.format(sent_bytes))
+    data = pickle.dumps(metrics, -1)
+    payload = struct.pack('!L', len(data)) + data
+
+    return payload
+
+
+def _send_textmetrics(metrics):
+    """Format metrics for the carbon plaintext protocol"""
+
+    data = [' '.join(map(str, metric)) for metric in metrics] + ['']
+
+    return '\n'.join(data)
 
 
 def _walk(path, value, metrics, timestamp, skip):
     """
     Recursively include metrics from *value*.
 
-    *path*
+    path
         The dot-separated path of the metric.
-    *value*
+    value
         A dictionary or value from a dictionary. If a dictionary, ``_walk``
         will be called again with the each key/value pair as a new set of
         metrics.
-    *metrics*
+    metrics
         The list of metrics that will be sent to carbon, formatted as::
 
             (path, value, timestamp)
-    *skip*
+    skip
         Whether or not to skip metrics when there's an error casting the value
         to a float. Defaults to `False`.
 
@@ -79,10 +130,12 @@ def _walk(path, value, metrics, timestamp, skip):
             val = float(value)
             metrics.append((path, val, timestamp))
         except (TypeError, ValueError):
-            log.error('Error in carbon returner, when trying to'
-                      'convert metric:{0}, with val:{1}'.format(path, value))
-
-            if not skip:
+            msg = 'Error in carbon returner, when trying to convert metric: ' \
+                  '{0}, with val: {1}'.format(path, value)
+            if skip:
+                log.debug(msg)
+            else:
+                log.info(msg)
                 raise
 
 
@@ -96,20 +149,18 @@ def returner(ret):
 
     '''
 
-    host = __salt__['config.option']('carbon.host')
-    port = __salt__['config.option']('carbon.port')
-    skip = __salt__['config.option']('carbon.skip_on_error', False)
+    c_cfg = __opts__.get('carbon', {})
+
+    host = c_cfg.get('host', __opts__.get('carbon.host', None))
+    port = c_cfg.get('port', __opts__.get('carbon.port', None))
+    skip = c_cfg.get('skip_on_error', __opts__.get('carbon.skip_on_error', False))
+    mode = c_cfg.get('mode', __opts__.get('carbon.mode', 'text')).lower()
 
     log.debug('Carbon minion configured with host: {0}:{1}'.format(host, port))
+    log.debug('Using carbon protocol: {}'.format(mode))
+
     if not (host and port):
         log.error('Host or port not defined')
-        return
-
-    try:
-        carbon_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
-        carbon_sock.connect((host, port))
-    except socket.error as e:
-        log.error('Error connecting to {0}:{1}, {2}'.format(host, port, e))
         return
 
     # TODO: possible to use time return from salt job to be slightly more precise?
@@ -119,36 +170,25 @@ def returner(ret):
 
     saltdata = ret['return']
     metric_base = ret['fun']
+    handler = _send_picklemetrics if mode == 'pickle' else _send_textmetrics
 
     # Strip the hostname from the carbon base if we are returning from virt
     # module since then we will get stable metric bases even if the VM is
     # migrate from host to host
     if not metric_base.startswith('virt.'):
         metric_base += '.' + ret['id'].replace('.', '_')
+
     metrics = []
-
     _walk(metric_base, saltdata, metrics, timestamp, skip)
+    data = handler(metrics)
 
-    def _send_textmetrics(metrics):
-        ''' Use text protorocol to send metric over socket '''
-        data = []
-        for metric in metrics:
-            metric = '{0} {1} {2}'.format(metric[0], metric[1], metric[2])
-            data.append(metric)
-        data = '\n'.join(data) + '\n'
+    with _carbon(host, port) as sock:
         total_sent_bytes = 0
         while total_sent_bytes < len(data):
-            sent_bytes = carbon_sock.send(data[total_sent_bytes:])
+            sent_bytes = sock.send(data[total_sent_bytes:])
             if sent_bytes == 0:
                 log.error('Bytes sent 0, Connection reset?')
                 return
+
             log.debug('Sent {0} bytes to carbon'.format(sent_bytes))
-
             total_sent_bytes += sent_bytes
-
-    # Send metrics
-    _send_textmetrics(metrics)
-
-    # Shut down and close socket
-    carbon_sock.shutdown(socket.SHUT_RDWR)
-    carbon_sock.close()


### PR DESCRIPTION
I've updated the carbon returner to work with the pickle protocol. There's also a new option to ignore errors (disabled by default) when casting values to float. When enabled, it allows numeric values from status.all_status to be sent directly to carbon instead of crashing on the first non-numeric value.  I added lots of documentation as well.
