### PR TITLE
Fix ssh_auth pulling keyfile from correct env

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -64,7 +64,7 @@ def _present_test(user, name, enc, comment, options, source, config):
                 user,
                 source,
                 config,
-                __env__)
+                saltenv=__env__)
         if keys:
             comment = ''
             for key, status in keys.items():
@@ -175,7 +175,8 @@ def present(
         data = __salt__['ssh.set_auth_key_from_file'](
                 user,
                 source,
-                config)
+                config,
+                saltenv=__env__)
     else:
         # check if this is of form {options} {enc} {key} {comment}
         sshre = re.compile(r'^(.*?)\s?((?:ssh\-|ecds)[\w-]+\s.+)$')


### PR DESCRIPTION
When the ssh_auth state is reading the key from a file on the Salt fileserver, the proper environment isn't passed in. If the key file is in a non-'base' environment it fails.

Looks like this got broken in https://github.com/saltstack/salt/commit/fbfd926fdd0c7686b6be4da1dbfe4e9e18bbea60 and affects the 2014.1.0RC3 branch. It was not broken in v0.17.4. Trying to get this in before the release, since it breaks my state files!
