### PR TITLE
Add two options in the salt-ssh documentation

### DIFF
--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -21,6 +21,10 @@ Options
 
     Execute a raw shell command.
 
+.. option:: --priv
+
+    Specify the SSH private key file to be used for authentication.
+
 .. option:: --roster
 
     Define which roster system to use, this defines if a database backend,
@@ -46,6 +50,11 @@ Options
     defines how many processes are opened up at a time to manage connections,
     the more running process the faster communication should be, default
     is 25.
+    
+.. option:: -i, --ignore-host-keys
+
+    Ignore the ssh host keys which by default are honored and connections
+    would ask for approval.
 
 .. option:: --passwd
 


### PR DESCRIPTION
The --priv option is missing from documentation and it could be difficult for new users to figure out how to do SSH key authentication.
