### PR TITLE
File perms exception handling

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -75,6 +75,8 @@ class Caller(object):
             except NameError:
                 # Don't require msgpack with local
                 pass
+            except IOError:
+                sys.stderr.write('Cannot write to process directory. Do you have permissions to write to {0} ?\n'.format(proc_fn))
             func = self.minion.functions[fun]
             try:
                 ret['return'] = func(*args, **kwargs)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -58,7 +58,11 @@ def _sync(form, saltenv=None):
     mod_dir = os.path.join(__opts__['extension_modules'], '{0}'.format(form))
     if not os.path.isdir(mod_dir):
         log.info('Creating module dir {0!r}'.format(mod_dir))
-        os.makedirs(mod_dir)
+        try:
+            os.makedirs(mod_dir)
+        except (IOError, OSError):
+            msg = 'Cannot create cache module directory {0}. Check permissions.'
+            log.error(msg.format(mod_dir))
     for sub_env in saltenv:
         log.info('Syncing {0} for environment {1!r}'.format(form, sub_env))
         cache = []

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -13,7 +13,6 @@ import logging
 import tarfile
 import datetime
 import tempfile
-import sys
 
 # Import salt libs
 import salt.utils
@@ -397,10 +396,8 @@ def sls(mods,
         with salt.utils.fopen(cache_file, 'w+') as fp_:
             serial.dump(ret, fp_)
     except (IOError, OSError):
-        msg = 'Unable to write to SLS cache file {0}. Check permission. This is a fatal error. Exiting.'
+        msg = 'Unable to write to SLS cache file {0}. Check permission.'
         log.error(msg.format(cache_file))
-        # This is actually a fatal error because the state system is badly broken if continue.
-        sys.exit(1)
 
     os.umask(cumask)
     _set_retcode(ret)


### PR DESCRIPTION
There are a number of cases wherein we throw exceptions to the console when we can't write to various cache files, etc. I hate exceptions. :]

Handle these by logging to the error level and bailing out when they're truly fatal for a given operation.
