### PR TITLE
Correct grain for test "os" => "os_family": issue-10215

### DIFF
--- a/tests/unit/modules/cron_test.py
+++ b/tests/unit/modules/cron_test.py
@@ -50,7 +50,7 @@ class PsTestCase(TestCase):
 
     def test__get_cron_cmdstr(self):
         cron.__grains__ = __grains__
-        with patch.dict(cron.__grains__, {'os': None}):
+        with patch.dict(cron.__grains__, {'os_family': None}):
             self.assertEqual('crontab -u root /tmp',
                              cron._get_cron_cmdstr(STUB_USER, STUB_PATH))
 


### PR DESCRIPTION
Fixes #10215
