### PR TITLE
[salt.cloud] clear salt mine on delete

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -460,11 +460,12 @@ def create(vm_):
         'salt/cloud/{0}/requesting'.format(vm_['name']),
         {'kwargs': {'name': kwargs['name'],
                     'image': kwargs['image'].name,
-                    'size': kwargs['size'].name}},
+                    'size': kwargs['size'].name,
+                    'profile': vm_['profile']}}
     )
 
     kwargs['ex_metadata'] = config.get_cloud_config_value(
-        'metadata', vm_, __opts__, default={}, search_global=False
+        'metadata', vm_, __opts__, default={'profile': vm_['profile']}, search_global=False
     )
     if not isinstance(kwargs['ex_metadata'], dict):
         raise SaltCloudConfigError(

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -24,6 +24,7 @@ from libcloud.compute.deployment import (
 # Import salt libs
 import salt._compat
 import salt.utils.event
+import salt.client
 
 # Import salt cloud libs
 import salt.utils.cloud
@@ -346,8 +347,22 @@ def destroy(name, conn=None, call=None):
         conn = get_conn()   # pylint: disable=E0602
 
     node = get_node(conn, name)
+    profiles = get_configured_provider()['profiles']
     if node is None:
         log.error('Unable to find the VM {0}'.format(name))
+    profile = None
+    if 'metadata' in node.extra and 'profile' in node.extra['metadata']:
+        profile = node.extra['metadata']['profile']
+    flush_mine_on_destroy = False
+    if profile is not None and profile in profiles:
+        if 'flush_mine_on_destroy' in profiles[profile]:
+            flush_mine_on_destroy = profiles[profile]['flush_mine_on_destroy']
+    if flush_mine_on_destroy:
+        log.info('Clearing Salt Mine: {0}'.format(name))
+        client = salt.client.LocalClient(__opts__['conf_file'])
+        minions = client.cmd(name, 'mine.flush')
+
+    log.info('Clearing Salt Mine: {0}, {1}'.format(name, flush_mine_on_destroy))
     log.info('Destroying VM: {0}'.format(name))
     ret = conn.destroy_node(node)
     if ret:


### PR DESCRIPTION
Set the profile the server was built with in the metadata.  When the
server is deleted, if the flush_mine_on_destroy is set on that profile,
flush the mine of data.

Please take a looke @techhat . I think I was using vm_['profile'] instead of 'profiles' and that is why it wasn't working before.

Thanks,
Daniel Wallace
