### PR TITLE
Removed extra indent to allow the function to return false if an IP is not able to be converted

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -261,7 +261,7 @@ def preferred_ip(vm_, ips):
         except Exception:
             continue
 
-        return False
+    return False
 
 
 def ignore_cidr(vm_, ip):


### PR DESCRIPTION
This fix is the same type of fix as my previous pull request https://github.com/saltstack/salt/pull/10225, but is now dealing with a different file. It seems that the code was copied and pasted allowing the bug to exist in both files. 
