### PR TITLE
Fix ports.installed state for pkg names that don't match origin

### DIFF
--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -85,18 +85,17 @@ def _get_version(name, results):
     return None
 
 
-def _contextkey(jail=None, chroot=None):
+def _contextkey(jail=None, chroot=None, prefix='pkg.list_pkgs'):
     '''
     As this module is designed to manipulate packages in jails and chroots, use
     the passed jail/chroot to ensure that a key in the __context__ dict that is
     unique to that jail/chroot is used.
     '''
-    ret = 'pkg.list_pkgs'
     if jail:
-        ret += '.jail_{0}'.format(jail)
+        return str(prefix) + '.jail_{0}'.format(jail)
     elif chroot:
-        ret += '.chroot_{0}'.format(chroot)
-    return ret
+        return str(prefix) + '.chroot_{0}'.format(chroot)
+    return prefix
 
 
 def parse_config(file_name='/usr/local/etc/pkg.conf'):
@@ -258,7 +257,11 @@ def latest_version(*names, **kwargs):
 available_version = latest_version
 
 
-def list_pkgs(versions_as_list=False, jail=None, chroot=None, **kwargs):
+def list_pkgs(versions_as_list=False,
+              jail=None,
+              chroot=None,
+              with_origin=False,
+              **kwargs):
     '''
     List the packages currently installed as a dict::
 
@@ -270,6 +273,12 @@ def list_pkgs(versions_as_list=False, jail=None, chroot=None, **kwargs):
     chroot
         List the pacakges in the specified chroot (ignored if ``jail`` is
         specified)
+
+    with_origin : False
+        Return a nested dictionary containing both the origin name and version
+        for each installed package.
+
+        .. versionadded:: 2014.1.0 (Hydrogen)
 
     CLI Example:
 
@@ -284,32 +293,46 @@ def list_pkgs(versions_as_list=False, jail=None, chroot=None, **kwargs):
         return {}
 
     versions_as_list = salt.utils.is_true(versions_as_list)
-    contextkey = _contextkey(jail, chroot)
+    contextkey_pkg = _contextkey(jail, chroot)
+    contextkey_origins = _contextkey(jail, chroot, prefix='pkg.origin')
 
-    if contextkey in __context__:
-        if versions_as_list:
-            return __context__[contextkey]
-        else:
-            ret = copy.deepcopy(__context__[contextkey])
+    if contextkey_pkg in __context__:
+        ret = copy.deepcopy(__context__[contextkey_pkg])
+        if not versions_as_list:
             __salt__['pkg_resource.stringify'](ret)
-            return ret
+        if salt.utils.is_true(with_origin):
+            origins = __context__.get(contextkey_origins, {})
+            return dict([
+                (x, {'origin': origins.get(x, ''), 'version': y})
+                for x, y in ret.iteritems()
+            ])
+        return ret
 
     ret = {}
-    cmd = '{0} info'.format(_pkg(jail, chroot))
+    origins = {}
+    cmd = '{0} info -ao'.format(_pkg(jail, chroot))
     out = __salt__['cmd.run_stdout'](cmd, output_loglevel='debug')
     for line in out.splitlines():
         if not line:
             continue
         try:
-            pkg, ver = line.split()[0].rsplit('-', 1)
-        except (IndexError, ValueError):
+            pkg, origin = line.split()
+            pkgname, pkgver = pkg.rsplit('-', 1)
+        except ValueError:
             continue
-        __salt__['pkg_resource.add_pkg'](ret, pkg, ver)
+        __salt__['pkg_resource.add_pkg'](ret, pkgname, pkgver)
+        origins[pkgname] = origin
 
     __salt__['pkg_resource.sort_pkglist'](ret)
-    __context__[contextkey] = copy.deepcopy(ret)
+    __context__[contextkey_pkg] = copy.deepcopy(ret)
+    __context__[contextkey_origins] = origins
     if not versions_as_list:
         __salt__['pkg_resource.stringify'](ret)
+    if salt.utils.is_true(with_origin):
+        return dict([
+            (x, {'origin': origins.get(x, ''), 'version': y})
+            for x, y in ret.iteritems()
+        ])
     return ret
 
 
@@ -711,6 +734,7 @@ def install(name=None,
     )
     __salt__['cmd.run'](cmd, output_loglevel='debug')
     __context__.pop(_contextkey(jail, chroot), None)
+    __context__.pop(_contextkey(jail, chroot, prefix='pkg.origin'), None)
     new = list_pkgs(jail=jail, chroot=chroot)
     return salt.utils.compare_dicts(old, new)
 
@@ -852,6 +876,7 @@ def remove(name=None,
     )
     __salt__['cmd.run'](cmd, output_loglevel='debug')
     __context__.pop(_contextkey(jail, chroot), None)
+    __context__.pop(_contextkey(jail, chroot, prefix='pkg.origin'), None)
     new = list_pkgs(jail=jail, chroot=chroot)
     return salt.utils.compare_dicts(old, new)
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -143,6 +143,12 @@ def version(*names, **kwargs):
         Get package version information for the specified chroot (ignored if
         ``jail`` is specified)
 
+    with_origin : False
+        Return a nested dictionary containing both the origin name and version
+        for each specified package.
+
+        .. versionadded:: 2014.1.0 (Hydrogen)
+
 
     CLI Example:
 
@@ -152,7 +158,18 @@ def version(*names, **kwargs):
         salt '*' pkg.version <package name> jail=<jail name or id>
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
-    return __salt__['pkg_resource.version'](*names, **kwargs)
+    with_origin = kwargs.pop('with_origin', False)
+    ret = __salt__['pkg_resource.version'](*names, **kwargs)
+    if not salt.utils.is_true(with_origin):
+        return ret
+    # Put the return value back into a dict since we're adding a subdict
+    if len(names) == 1:
+        ret = {names[0]: ret}
+    origins = __context__.get('pkg.origin', {})
+    return dict([
+        (x, {'origin': origins.get(x, ''), 'version': y})
+        for x, y in ret.iteritems()
+    ])
 
 # Support pkg.info get version info, since this is the CLI usage
 info = version

--- a/salt/states/ports.py
+++ b/salt/states/ports.py
@@ -115,10 +115,12 @@ def installed(name, options=None):
     options = _repack_options(options) if options is not None else {}
     desired_options = copy.deepcopy(default_options)
     desired_options.update(options)
-    shortname = name.rsplit('/')[-1]
+    ports_pre = [
+        x['origin'] for x in
+        __salt__['pkg.list_pkgs'](with_origin=True).values()
+    ]
 
-    if current_options == desired_options \
-            and __salt__['pkg.version'](shortname):
+    if current_options == desired_options and name in ports_pre:
         # Port is installed as desired
         if options:
             ret['comment'] += ' ' + _build_option_string(options)
@@ -162,11 +164,14 @@ def installed(name, options=None):
                 return ret
 
     ret['changes'] = __salt__['ports.install'](name)
-    installed_version = __salt__['pkg.version'](shortname)
+    ports_post = [
+        x['origin'] for x in
+        __salt__['pkg.list_pkgs'](with_origin=True).values()
+    ]
     err = sys.modules[
         __salt__['test.ping'].__module__
     ].__context__.pop('ports.install_error', None)
-    if err or not installed_version:
+    if err or name not in ports_post:
         ret['result'] = False
     if ret['result']:
         ret['comment'] = 'Successfully installed {0}'.format(name)


### PR DESCRIPTION
This fixes a bug where `ports.installed` states report failure to install,
due to the package name not matching the name of the port. For example,
if installing `www/mod_perl2` for use with `www/apache22`, this results in a
package name of `ap22-mod_perl2`. The `ports.installed` state thinks the
install failed because of this package name mismatch.

This fix checks the origin names of installed packages, instead of the
name of the package itself.
