### PR TITLE
rm unused imports of re & fnmatch from file state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -221,8 +221,6 @@ import os
 import shutil
 import difflib
 import logging
-import re
-import fnmatch
 import json
 import pprint
 import traceback


### PR DESCRIPTION
```
************* Module salt.states.file
salt/states/file.py:224: [W0611(unused-import), ] Unused import re
salt/states/file.py:225: [W0611(unused-import), ] Unused import fnmatch
```
