### PR TITLE
utils.parsers: rm unused import of yaml

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -19,7 +19,6 @@ import getpass
 import logging
 import optparse
 import traceback
-import yaml
 from functools import partial
 
 # Import salt libs


### PR DESCRIPTION
```
************* Module salt.utils.parsers
salt/utils/parsers.py:22: [W0611(unused-import), ] Unused import yaml
```
