### PR TITLE
Minion log file 0600

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -183,7 +183,9 @@ class Minion(parsers.MinionOptionParser):
                                                                    'udp://',
                                                                    'file://')):
                     # Logfile is not using Syslog, verify
+                    current_umask = os.umask(0077)
                     verify_files([logfile], self.config['user'])
+                    os.umask(current_umask)
         except OSError as err:
             sys.exit(err.errno)
 


### PR DESCRIPTION
Set restrictive umask on minion log file during the verify step to ensure it's created with 0600. (It is currently created as 0644). I cannot think of any cases offhand where salt would need to read this log file but not be able to write to it. This change has been approved by @basepi in his comments on the issue but I think @thatch45 should probably be the one to merge this so that he can check for cases that I might not have thought of. Refs #10030.
