### PR TITLE
DRY up a bunch of shared minion code.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -300,11 +300,15 @@ class MinionBase(object):
     def __init__(self, opts):
         self.opts = opts
 
+    def _init_context_and_poller(self):
+        self.context = zmq.Context()
+        self.poller = zmq.Poller()
+
     def _prepare_minion_event_system(self):
         # Prepare the minion event system
         #
         # Start with the publish socket
-        self.context = zmq.Context()
+        self._init_context_and_poller()
 
         id_hash = hashlib.md5(self.opts['id']).hexdigest()
 
@@ -386,8 +390,6 @@ class MinionBase(object):
                 epull_sock_path,
                 448
             )
-
-        self.poller = zmq.Poller()
 
 
 class MasterMinion(object):
@@ -1348,8 +1350,8 @@ class Minion(MinionBase):
         management of the event bus assuming that these are handled outside
         the tune_in sequence
         '''
-        self.context = zmq.Context()
-        self.poller = zmq.Poller()
+        self._init_context_and_poller()
+
         self.socket = self.context.socket(zmq.SUB)
 
         self._setsockopts()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1076,6 +1076,11 @@ class Minion(MinionBase):
                 zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
             )
 
+    def _set_ipv4only(self):
+        if self.opts['ipv6'] is True and hasattr(zmq, 'IPV4ONLY'):
+            # IPv6 sockets work for both IPv6 and IPv4 addresses
+            self.socket.setsockopt(zmq.IPV4ONLY, 0)
+
     @property
     def master_pub(self):
         '''
@@ -1212,9 +1217,7 @@ class Minion(MinionBase):
 
         self._set_reconnect_ivl_max()
 
-        if self.opts['ipv6'] is True and hasattr(zmq, 'IPV4ONLY'):
-            # IPv6 sockets work for both IPv6 and IPv4 addresses
-            self.socket.setsockopt(zmq.IPV4ONLY, 0)
+        self._set_ipv4only()
 
         self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
@@ -1343,10 +1346,10 @@ class Minion(MinionBase):
         self.socket = self.context.socket(zmq.SUB)
         self.socket.setsockopt(zmq.SUBSCRIBE, '')
         self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
-        if self.opts['ipv6'] is True and hasattr(zmq, 'IPV4ONLY'):
-            # IPv6 sockets work for both IPv6 and IPv4 addresses
-            self.socket.setsockopt(zmq.IPV4ONLY, 0)
+        self._set_ipv4only()
+
         self._set_reconnect_ivl_max()
+
         self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1051,6 +1051,21 @@ class Minion(MinionBase):
                     }
             })
 
+    def _set_tcp_keepalive(self):
+        if hasattr(zmq, 'TCP_KEEPALIVE'):
+            self.socket.setsockopt(
+                zmq.TCP_KEEPALIVE, self.opts['tcp_keepalive']
+            )
+            self.socket.setsockopt(
+                zmq.TCP_KEEPALIVE_IDLE, self.opts['tcp_keepalive_idle']
+            )
+            self.socket.setsockopt(
+                zmq.TCP_KEEPALIVE_CNT, self.opts['tcp_keepalive_cnt']
+            )
+            self.socket.setsockopt(
+                zmq.TCP_KEEPALIVE_INTVL, self.opts['tcp_keepalive_intvl']
+            )
+
     @property
     def master_pub(self):
         '''
@@ -1198,19 +1213,7 @@ class Minion(MinionBase):
             # IPv6 sockets work for both IPv6 and IPv4 addresses
             self.socket.setsockopt(zmq.IPV4ONLY, 0)
 
-        if hasattr(zmq, 'TCP_KEEPALIVE'):
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE, self.opts['tcp_keepalive']
-            )
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE_IDLE, self.opts['tcp_keepalive_idle']
-            )
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE_CNT, self.opts['tcp_keepalive_cnt']
-            )
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE_INTVL, self.opts['tcp_keepalive_intvl']
-            )
+        self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
         self.poller.register(self.epull_sock, zmq.POLLIN)
@@ -1344,19 +1347,7 @@ class Minion(MinionBase):
             self.socket.setsockopt(
                 zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
             )
-        if hasattr(zmq, 'TCP_KEEPALIVE'):
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE, self.opts['tcp_keepalive']
-            )
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE_IDLE, self.opts['tcp_keepalive_idle']
-            )
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE_CNT, self.opts['tcp_keepalive_cnt']
-            )
-            self.socket.setsockopt(
-                zmq.TCP_KEEPALIVE_INTVL, self.opts['tcp_keepalive_intvl']
-            )
+        self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
         # Send an event to the master that the minion is live

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1066,6 +1066,16 @@ class Minion(MinionBase):
                 zmq.TCP_KEEPALIVE_INTVL, self.opts['tcp_keepalive_intvl']
             )
 
+    def _set_reconnect_ivl_max(self):
+        if hasattr(zmq, 'RECONNECT_IVL_MAX'):
+            log.debug("Setting zmq_reconnect_ivl_max to '{0}ms'".format(
+                self.opts['recon_default'] + self.opts['recon_max'])
+            )
+
+            self.socket.setsockopt(
+                zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
+            )
+
     @property
     def master_pub(self):
         '''
@@ -1200,14 +1210,7 @@ class Minion(MinionBase):
         log.debug("Setting zmq_reconnect_ivl to '{0}ms'".format(recon_delay))
         self.socket.setsockopt(zmq.RECONNECT_IVL, recon_delay)
 
-        if hasattr(zmq, 'RECONNECT_IVL_MAX'):
-            log.debug("Setting zmq_reconnect_ivl_max to '{0}ms'".format(
-                self.opts['recon_default'] + self.opts['recon_max'])
-            )
-
-            self.socket.setsockopt(
-                zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
-            )
+        self._set_reconnect_ivl_max()
 
         if self.opts['ipv6'] is True and hasattr(zmq, 'IPV4ONLY'):
             # IPv6 sockets work for both IPv6 and IPv4 addresses
@@ -1343,10 +1346,7 @@ class Minion(MinionBase):
         if self.opts['ipv6'] is True and hasattr(zmq, 'IPV4ONLY'):
             # IPv6 sockets work for both IPv6 and IPv4 addresses
             self.socket.setsockopt(zmq.IPV4ONLY, 0)
-        if hasattr(zmq, 'RECONNECT_IVL_MAX'):
-            self.socket.setsockopt(
-                zmq.RECONNECT_IVL_MAX, self.opts['recon_max']
-            )
+        self._set_reconnect_ivl_max()
         self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1081,6 +1081,24 @@ class Minion(MinionBase):
             # IPv6 sockets work for both IPv6 and IPv4 addresses
             self.socket.setsockopt(zmq.IPV4ONLY, 0)
 
+    def _fire_master_minion_start(self):
+        # Send an event to the master that the minion is live
+        self._fire_master(
+            'Minion {0} started at {1}'.format(
+            self.opts['id'],
+            time.asctime()
+            ),
+            'minion_start'
+        )
+        # dup name spaced event
+        self._fire_master(
+            'Minion {0} started at {1}'.format(
+            self.opts['id'],
+            time.asctime()
+            ),
+            tagify([self.opts['id'], 'start'], 'minion'),
+        )
+
     @property
     def master_pub(self):
         '''
@@ -1223,21 +1241,8 @@ class Minion(MinionBase):
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
         self.poller.register(self.epull_sock, zmq.POLLIN)
-        # Send an event to the master that the minion is live
-        self._fire_master(
-            'Minion {0} started at {1}'.format(
-            self.opts['id'],
-            time.asctime()
-            ),
-            'minion_start'
-        )
-        self._fire_master(
-            'Minion {0} started at {1}'.format(
-            self.opts['id'],
-            time.asctime()
-            ),
-            tagify([self.opts['id'], 'start'], 'minion'),
-        )
+
+        self._fire_master_minion_start()
 
         # Make sure to gracefully handle SIGUSR1
         enable_sigusr1_handler()
@@ -1353,22 +1358,9 @@ class Minion(MinionBase):
         self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
-        # Send an event to the master that the minion is live
-        self._fire_master(
-            'Minion {0} started at {1}'.format(
-            self.opts['id'],
-            time.asctime()
-            ),
-            'minion_start'
-        )
-        # dup name spaced event
-        self._fire_master(
-            'Minion {0} started at {1}'.format(
-            self.opts['id'],
-            time.asctime()
-            ),
-            tagify([self.opts['id'], 'start'], 'minion'),
-        )
+
+        self._fire_master_minion_start()
+
         loop_interval = int(self.opts['loop_interval'])
         while self._running is True:
             try:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1422,7 +1422,7 @@ class Syndic(Minion):
         self._syndic_interface = opts.get('interface')
         self._syndic = True
         opts['loop_interval'] = 1
-        Minion.__init__(self, opts)
+        super(Syndic, self).__init__(opts)
 
     def _handle_aes(self, load, sig=None):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1099,6 +1099,13 @@ class Minion(MinionBase):
             tagify([self.opts['id'], 'start'], 'minion'),
         )
 
+    def _setsockopts(self):
+        self.socket.setsockopt(zmq.SUBSCRIBE, '')
+        self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
+        self._set_ipv4only()
+        self._set_reconnect_ivl_max()
+        self._set_tcp_keepalive()
+
     @property
     def master_pub(self):
         '''
@@ -1214,8 +1221,6 @@ class Minion(MinionBase):
         self._prepare_minion_event_system()
 
         self.socket = self.context.socket(zmq.SUB)
-        self.socket.setsockopt(zmq.SUBSCRIBE, '')
-        self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
 
         recon_delay = self.opts['recon_default']
 
@@ -1233,11 +1238,8 @@ class Minion(MinionBase):
         log.debug("Setting zmq_reconnect_ivl to '{0}ms'".format(recon_delay))
         self.socket.setsockopt(zmq.RECONNECT_IVL, recon_delay)
 
-        self._set_reconnect_ivl_max()
+        self._setsockopts()
 
-        self._set_ipv4only()
-
-        self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
         self.poller.register(self.epull_sock, zmq.POLLIN)
@@ -1349,13 +1351,9 @@ class Minion(MinionBase):
         self.context = zmq.Context()
         self.poller = zmq.Poller()
         self.socket = self.context.socket(zmq.SUB)
-        self.socket.setsockopt(zmq.SUBSCRIBE, '')
-        self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
-        self._set_ipv4only()
 
-        self._set_reconnect_ivl_max()
+        self._setsockopts()
 
-        self._set_tcp_keepalive()
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)
 


### PR DESCRIPTION
Factor out a bunch of setsockopt and initialization.

This makes it much easier to see the actual differences between Minion.tune_in(), Minion.tune_in_no_block(), and MultiMinion.tune_in().
