### PR TITLE
Match against lists in nested dicts in grains

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1099,6 +1099,11 @@ def subdict_match(data, expr, delim=':', regex_match=False):
         if isinstance(match, list):
             # We are matching a single component to a single list member
             for member in match:
+                if isinstance(member, dict):
+                    if matchstr.startswith('*:'):
+                        matchstr = matchstr.lstrip('*:')
+                    if subdict_match(member, matchstr, regex_match=regex_match):
+                        return True
                 if _match(member, matchstr, regex_match=regex_match):
                     return True
             continue

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1101,7 +1101,7 @@ def subdict_match(data, expr, delim=':', regex_match=False):
             for member in match:
                 if isinstance(member, dict):
                     if matchstr.startswith('*:'):
-                        matchstr = matchstr.lstrip('*:')
+                        matchstr = matchstr[2:]
                     if subdict_match(member, matchstr, regex_match=regex_match):
                         return True
                 if _match(member, matchstr, regex_match=regex_match):


### PR DESCRIPTION
This changes the behavior of all matcher which use `subdict_match` (which means, grains, pillars and probably more). 

The goal here is to cover matching things like `{'baz': [{'foo': 'bar}]}`.

@terminalmage was kind enough to review this change and brought up the point that he's not certain that we should support both `baz:*:foo:bar` _and_ `baz:foo:bar`. My thinking here originally was that it would be nice to explicitly use a `*` to indicate matching against a list but supporting both behaviors might be problematic. 

This should definitely _not_ by cherry-picked as it will need extensive testing over time. Refs #9991.
