### PR TITLE
unit.modules.virtualenv_test.VirtualenvTestCase.test_python_argument

### DIFF
--- a/tests/unit/modules/virtualenv_test.py
+++ b/tests/unit/modules/virtualenv_test.py
@@ -12,6 +12,7 @@
 # Import python libraries
 import warnings
 import os
+import sys
 
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase
@@ -317,16 +318,13 @@ class VirtualenvTestCase(TestCase):
 
     def test_python_argument(self):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        if os.path.isfile('/usr/bin/python2.7'):
-            python = '/usr/bin/python2.7'
-        elif os.path.isfile('/usr/bin/python2.6'):
-            python = '/usr/bin/python2.6'
+
         with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
             virtualenv_mod.create(
-                '/tmp/foo', python=python,
+                '/tmp/foo', python=sys.executable,
             )
             mock.assert_called_once_with(
-                'virtualenv --python={0} /tmp/foo'.format(python),
+                'virtualenv --python={0} /tmp/foo'.format(sys.executable),
                 runas=None
             )
 


### PR DESCRIPTION
work with non-standard interpreter locations

  Fixes #10251
