### PR TITLE
[pacman] don't reinstall if it is not needed

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -329,10 +329,10 @@ def install(name=None,
             return {}
 
         if salt.utils.is_true(refresh):
-            cmd = 'pacman -Syu --noprogressbar --noconfirm ' \
+            cmd = 'pacman -Syu --noprogressbar --noconfirm --needed' \
                   '"{0}"'.format('" "'.join(targets))
         else:
-            cmd = 'pacman -S --noprogressbar --noconfirm ' \
+            cmd = 'pacman -S --noprogressbar --noconfirm --needed' \
                   '"{0}"'.format('" "'.join(targets))
 
     old = list_pkgs()


### PR DESCRIPTION
Use the option --needed when installing packages to avoid re-installing a package if it is already at last version.
