### PR TITLE
In case of errors, iinfos['out'] is a string that contains the traceback

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -246,7 +246,7 @@ def pulled(name, force=False, *args, **kwargs):
         return _valid(
             name=name,
             comment='Image already pulled: {0}'.format(name))
-    previous_id = iinfos['out']['id']
+    previous_id = iinfos['out']['id'] if iinfos['status'] else None
     func = __salt('docker.pull')
     returned = func(name)
     if previous_id != returned['id']:
@@ -282,7 +282,7 @@ def built(name,
             name=name,
             comment='Image already built: {0}, id: {1}'.format(
                 name, iinfos['out']['id']))
-    previous_id = iinfos['out']['id']
+    previous_id = iinfos['out']['id'] if iinfos['status'] else None
     func = __salt('docker.build')
     kw = dict(tag=name,
               path=path,


### PR DESCRIPTION
This bug fix remind me we need tests for docker support.
I'll try to come up with something, next week if I have time.
