### PR TITLE
Compound commands partial fix

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -942,7 +942,7 @@ class Minion(object):
                 load[key] = value
         try:
             oput = self.functions[fun].__outputter__
-        except (KeyError, AttributeError):
+        except (KeyError, AttributeError, TypeError):
             pass
         else:
             if isinstance(oput, string_types):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1669,7 +1669,6 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                 self.exit(42, '\nIncomplete options passed.\n\n')
 
 
-
     def setup_config(self):
         return config.client_config(self.get_config_file_path())
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1662,12 +1662,13 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                         if len(self.config['fun']) != len(self.config['arg']):
                             self.exit(42, 'Cannot execute compound command without '
                                           'defining all arguments.')
+                else:
+                    self.config['fun'] = self.args[1]
+                    self.config['arg'] = self.args[2:]
             except IndexError:
                 self.exit(42, '\nIncomplete options passed.\n\n')
 
-            else:
-                self.config['fun'] = self.args[1]
-                self.config['arg'] = self.args[2:]
+
 
     def setup_config(self):
         return config.client_config(self.get_config_file_path())


### PR DESCRIPTION
Addresses issues outlined in #9746. However, this doesn't fix the exact use case outlined there because multiple invocations of the same command will step on each other. I'm told this did work at one point so there needs to be additional work to debug that case. This does correct compound commands where each function is distinct. (i.e. 'test.ping,cmd.run' but _not_ 'cmd.run,cmd.run'.)

Still, this fixes cases where two different commands are passed in. Hat tip to @tedski for some great detective work here.
