### PR TITLE
External pillars yaml

### DIFF
--- a/salt/pillar/cmd_yaml.py
+++ b/salt/pillar/cmd_yaml.py
@@ -21,7 +21,8 @@ def ext_pillar(minion_id, pillar, command):
     Execute a command and read the output as YAML
     '''
     try:
-        return yaml.safe_load(__salt__['cmd.run']('{0} {1}'.format(command, minion_id)))
+        return yaml.safe_load(
+          __salt__['cmd.run']('{0} {1}'.format(command, minion_id)))
     except Exception:
         log.critical(
                 'YAML data from {0} failed to parse'.format(command)

--- a/salt/pillar/cmd_yaml.py
+++ b/salt/pillar/cmd_yaml.py
@@ -21,7 +21,7 @@ def ext_pillar(minion_id, pillar, command):
     Execute a command and read the output as YAML
     '''
     try:
-        return yaml.safe_load(__salt__['cmd.run']('{0}'.format(command)))
+        return yaml.safe_load(__salt__['cmd.run']('{0} {1}'.format(command, minion_id)))
     except Exception:
         log.critical(
                 'YAML data from {0} failed to parse'.format(command)


### PR DESCRIPTION
The external command is supposed to generate minion-specific results, so it needs to know the minion id.  See puppet.py for how it ought to work.
