### PR TITLE
Adds master module for populating pillars via external module

### DIFF
--- a/salt/modules/master.py
+++ b/salt/modules/master.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+'''
+Module for functions that run on the salt master with no target
+
+Useful for populating pillars
+'''
+
+# Import Python libs
+import copy
+
+# Import Salt libs
+import salt
+
+# this is the only way I could figure out how to get the REAL file_roots
+# __opt__['file_roots'] is set to  __opt__['pillar_root']
+class MMinion(object):
+    _mminion = None
+    def __new__(cls, *args, **kwargs):
+        if not cls._mminion:
+            cls._mminion = super(MMinion, cls).__new__( cls, *args, **kwargs)
+            opts = copy.deepcopy(__opts__)
+            del opts['file_roots']
+            # grains at this point are in the context of the minion
+            grains = copy.deepcopy(__grains__)
+            cls._mminion = salt.minion.MasterMinion(opts)
+            # this assignment is so that the rest of fxns called by salt still
+            # have minion context
+            __grains__ = grains
+            # this assignment is so that fxns called by mminion have minion
+            # context
+           cls._mminion.opts['grains'] = grains
+        return cls._mminion
+
+def mmodule(env, fun, *args, **kwargs):
+    '''
+    Loads minion modules from an environment so that they can be used in pillars
+    for that environment
+    '''
+    mminion = MMinion()
+    env_roots = mminion.opts['file_roots'][env]
+    mminion.opts['module_dirs'] = [fp + '/_modules' for fp in env_roots]
+    mminion.gen_modules()
+    return mminion.functions[fun](*args, **kwargs)

--- a/salt/modules/master.py
+++ b/salt/modules/master.py
@@ -14,30 +14,39 @@ import salt
 # this is the only way I could figure out how to get the REAL file_roots
 # __opt__['file_roots'] is set to  __opt__['pillar_root']
 class MMinion(object):
-    _mminion = None
-    def __new__(cls, *args, **kwargs):
-        if not cls._mminion:
-            cls._mminion = super(MMinion, cls).__new__( cls, *args, **kwargs)
+    def __new__(cls, env, reload_env=False):
+        # this is to break out of salt.loaded.int and make this a true singleton
+        # hack until https://github.com/saltstack/salt/pull/10273 is resolved
+        # this is starting to look like PHP
+        global _mminions
+        if '_mminions' not in globals():
+            _mminions = {}
+        if env not in _mminions or reload_env:
             opts = copy.deepcopy(__opts__)
             del opts['file_roots']
             # grains at this point are in the context of the minion
+            global __grains__
             grains = copy.deepcopy(__grains__)
-            cls._mminion = salt.minion.MasterMinion(opts)
+            m = salt.minion.MasterMinion(opts)
+
             # this assignment is so that the rest of fxns called by salt still
             # have minion context
             __grains__ = grains
+
             # this assignment is so that fxns called by mminion have minion
             # context
-           cls._mminion.opts['grains'] = grains
-        return cls._mminion
+            m.opts['grains'] = grains
+
+            env_roots = m.opts['file_roots'][env]
+            m.opts['module_dirs'] = [fp + '/_modules' for fp in env_roots]
+            m.gen_modules()
+            _mminions[env] = m
+        return _mminions[env]
 
 def mmodule(env, fun, *args, **kwargs):
     '''
     Loads minion modules from an environment so that they can be used in pillars
     for that environment
     '''
-    mminion = MMinion()
-    env_roots = mminion.opts['file_roots'][env]
-    mminion.opts['module_dirs'] = [fp + '/_modules' for fp in env_roots]
-    mminion.gen_modules()
+    mminion = MMinion(env)
     return mminion.functions[fun](*args, **kwargs)


### PR DESCRIPTION
### Problem: No good way to distribute static cluster information to a set of nodes at deploy time, ie ip addresses for iptables.
#### Current solution 1: Salt Mine

This doesn't scale; you have thousands of nodes all pinging the salt master at a set interval.  Also, for static information (like ip addresses or hostname), updating the information doesn't matter.  You can't access the mine inside a pillar, so the minions must call back to the master to get the mined data.  You can't store arbitrary values, and the key is a function name, instead of a function name with args (I'd like to be able to look up mine data for network.ipaddrs eth0 only, instead of parsing all of network.interfaces minion side every time).
#### Current solution 2: Peer publish

First, peer publish is slow.  2 nodes asking for each other's ip takes on average 3 seconds.  It is also inefficient and doesn't scale: a node must respond once for every other node in the cluster.  Putting the publish in the pillars still doesn't scale, and putting the publish in the state files means extra calls for every appearance in a state file (no caching).
#### Current solution 3: Cmd.run + Jinja magic

This involves embedding a saltutil.cmd to grains in a top level pillar file, then avoiding calling it again by including other pillar files and passing them via defaults.  For example:

```
{% set all_grains = salt['saltutil.cmd']('cluster:' ~ grains['cluster'], 'grains.items', expr_form='grain').values()|map(attribute='ret')|list %}
{% set nodes_by_role = all_grains | groupby('role') %}
{% set app_node_ips = nodes_by_role[0][1:][0]|map(attribute='ip_interfaces')|map(attribute='eth1')|map('first')|list|sort %}
include:
  - app:
      defaults:
        app_node_ips: {{ app_node_ips }}
```

This is quite hacky.  This is what we have been using, and it scales better than the others but is still quite inefficient.  Also, this requires many worker processes to avoid timeouts on larger clusters, which requires a lot of memory (we run with 128 workers, which is around 8GB).  This could probably be done better with cmd.run  + salt-run cache.grains, but dropping into a subshell seems wrong.
#### Proposed solution: Master module

The biggest problem is that the salt variable in jinja doesn't include _modules, so any module you want to include in jinja has to be in the base salt code.  This module will correctly allow you to call _modules from jinja, allowing for flexible development of modules specifically for populating pillars.

For example, this is how to distribute ip addresses to a cluster at deploy time:

file_roots/_modules/cache.py:

```
'''
Module version of salt-run cache

Meant to be called by master.mmodule

Most of these functions will output strings instead of python lists/dicts
because salt's jinja config autoescapes and adds all sorts of \
'''

# Import Salt libs
import salt
import salt.utils.master

def grain(tgt, key, expr_form='glob', default=''):
    '''
    Attempt to retrieve the named value from cached grains, if the named value is not
    available return the passed default. The default return is an empty string.

    The value can also represent a value in a nested dict using a ":" delimiter
    for the dict. This means that if a dict in grains looks like this::

        {'pkg': {'apache': 'httpd'}}

    To retrieve the value associated with the apache key in the pkg dict this
    key can be passed::

        pkg:apache
    '''
    pillar_util = salt.utils.master.MasterPillarUtil(tgt, expr_form,
                                                use_cached_grains=True,
                                                grains_fallback=False,
                                                opts=__opts__)
    cached_grains = pillar_util.get_minion_grains()
    ret = {}
    for node in cached_grains:
        ret[node] = salt.utils.traverse_dict(cached_grains[node], key, default)

    return str(ret)
```

pillar_roots/included_pillar.sls:

```
cluster_ips: {{ salt['master.mmodule'](grains['cluster'], 'cache.grain', 'G@cluster:mycluster', 'ip_interfaces:eth1', expr_form='compound' ) }}
```

This code needs better error reporting/handling, but since jinja mangles it all anyways...
