### PR TITLE
Fix cron module for AIX, Fix set_special documentation

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -66,6 +66,8 @@ def _get_cron_cmdstr(user, path):
     '''
     if __grains__.get('os_family') == 'Solaris':
         return 'su - {0} -c "crontab {1}"'.format(user, path)
+    elif __grains__.get('os_family') == 'AIX':
+        return 'su {0} -c "crontab {1}"'.format(user, path)
     else:
         return 'crontab -u {0} {1}'.format(user, path)
 
@@ -103,7 +105,7 @@ def _write_cron_lines(user, lines):
     path = salt.utils.mkstemp()
     with salt.utils.fopen(path, 'w+') as fp_:
         fp_.writelines(lines)
-    if __grains__.get('os_family') == 'Solaris' and user != "root":
+    if __grains__.get('os_family') in ('Solaris','AIX') and user != "root":
         __salt__['cmd.run']('chown {0} {1}'.format(user, path))
     ret = __salt__['cmd.run_all'](_get_cron_cmdstr(user, path))
     os.remove(path)
@@ -130,7 +132,7 @@ def raw_cron(user):
 
         salt '*' cron.raw_cron root
     '''
-    if __grains__.get('os_family') == 'Solaris':
+    if __grains__.get('os_family') in ('Solaris','AIX'):
         cmd = 'crontab -l {0}'.format(user)
     else:
         cmd = 'crontab -l -u {0}'.format(user)
@@ -207,7 +209,7 @@ def set_special(user, special, cmd):
 
     .. code-block:: bash
 
-        salt '*' cron.set_special @hourly 'echo foobar'
+        salt '*' cron.set_special root @hourly 'echo foobar'
     '''
     lst = list_tab(user)
     for cron in lst['special']:


### PR DESCRIPTION
Setup cron module to work on AIX (except for set_special). Also, set_special example did not include username as a required parameter.
