### PR TITLE
Some DRY cleanup/error reporting improvement for gitfs

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -268,9 +268,7 @@ class Master(SMaster):
         if not fileserver.servers:
             errors.append(
                 'Failed to load fileserver backends, the configured backends '
-                'are:\n{0}'.format(
-                    ' '.join(self.opts['fileserver_backend'])
-                )
+                'are: {0}'.format(', '.join(self.opts['fileserver_backend']))
             )
         if not self.opts['fileserver_backend']:
             errors.append('No fileserver backends are configured')


### PR DESCRIPTION
This commit does some DRY cleanup in the `__virtual__` function, as well
as some of the provider verification code. In addition, it fixes a
couple minor aesthetic error reporting issues.
