### PR TITLE
Fixed discrepancies in documentation for the absent function.

### DIFF
--- a/salt/states/postgres_database.py
+++ b/salt/states/postgres_database.py
@@ -204,13 +204,13 @@ def absent(name,
     db_user
         database username if different from config or defaul
 
-    password
+    db_password
         user password if any password for a specified user
 
-    host
+    db_host
         Database host if different from config or default
 
-    port
+    db_port
         Database port if different from config or default
 
     runas


### PR DESCRIPTION
Fixed discrepancies in documentation for db_password, db_host, and db_port arguments to the absent function.  This was reported in issue #10291.
