### PR TITLE
Reuse channels

### DIFF
--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -5,9 +5,14 @@ Encapsulate the different transports available to Salt.  Currently this is only 
 
 import salt.payload
 import salt.auth
-
+import os
 
 class Channel(object):
+    # store a cache of the channels so a single pid can re-use a connection
+    # this needs to be per pid as when you fork you keep the original memory
+    # space and we can't control currency across pids
+    channel_cache = {}
+
     @staticmethod
     def factory(opts, **kwargs):
         # Default to ZeroMQ for now
@@ -19,7 +24,10 @@ class Channel(object):
             ttype = opts['pillar']['master']['transport_type']
 
         if ttype == 'zeromq':
-            return ZeroMQChannel(opts, **kwargs)
+            pid = os.getpid()
+            if pid not in Channel.channel_cache:
+                Channel.channel_cache[pid] = ZeroMQChannel(opts, **kwargs)
+            return Channel.channel_cache[pid]
         else:
             raise Exception("Channels are only defined for ZeroMQ")
             # return NewKindOfChannel(opts, **kwargs)

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -8,8 +8,8 @@ import salt.auth
 import os
 
 class Channel(object):
-    # store a cache of the channels so a single pid can re-use a connection
-    # this needs to be per pid as when you fork you keep the original memory
+    # store a cache of the channels so a single pid can re-use a connection.
+    # This needs to be per pid as when you fork you keep the original memory
     # space and we can't control currency across pids
     channel_cache = {}
 


### PR DESCRIPTION
One of the things i've noticed with a fairly large salt install is that the majority of the master's time seems to be authenticating requests. After some digging it is apparent that we end up creating and destroying zmq channels all over creation. This is an attempt to allow for session re-use. The objective is to re-use the same channel for all requests in a single execution/thread/process-- as having a single long running connection back to the master is a much larger job.
