### PR TITLE
exactly match minion in list

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -112,6 +112,8 @@ class CkMinions(object):
         '''
         Return the minions found by looking via a list
         '''
+        if isinstance(expr, str):
+            expr = [m for m in expr.split(',') if m]
         ret = []
         for fn_ in os.listdir(os.path.join(self.opts['pki_dir'], 'minions')):
             if fn_ in expr:


### PR DESCRIPTION
My nodegroup:

<pre>
nodegroups:
  bug: L@192.168.1.172,192.168.1.173
</pre>


run cmd with the "bug" group, and i have a minion with name "192.168.1.17", will like this:

<pre>
[root@salt-master salt]# salt -N bug cmd.run 'uptime' -v
Executing job with jid 20140209210600669692
-------------------------------------------
192.168.1.172:
     21:06:01 up 87 days,  5:55,  0 users,  load average: 0.00, 0.00, 0.00
192.168.1.173:
     21:06:01 up 120 days,  4:59,  0 users,  load average: 0.03, 0.03, 0.00
192.168.1.17:  (should not be here)
    Minion did not return
</pre>
