### PR TITLE
Be sure not to loose any var in case of multi macro inheritance

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -258,7 +258,9 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         unicode_context[key] = unicode(value, 'utf-8')
 
     try:
-        output = jinja_env.from_string(tmplstr).render(**unicode_context)
+        template = jinja_env.from_string(tmplstr)
+        template.globals.update(unicode_context)
+        output = template.render(**unicode_context)
     except jinja2.exceptions.TemplateSyntaxError as exc:
         trace = traceback.extract_tb(sys.exc_info()[2])
         line, out = _get_jinja_error(trace, context=unicode_context)


### PR DESCRIPTION
In case of multiple chained inheritance,with a bunch of big modules loading in combination with a local pillar, we had some weird jinja errors appearing complaining about salt not to be defined. Wheras it seems, it breaks. I think it may be caused by jinja loosing global vars in chain loaded templates.
If i am not wrong, this pull request fixes it, but i dont know how to make a simple reproducible test case

```
[TRACE   ] Added virt_query.output to output
local:
    Data failed to compile:
----------
    Rendering SLS "base:makina-states.controllers.mastersalt_master" failed: Jinja variable 'salt' is undefined
/var/cache/mastersalt/mastersalt-minion/files/base/makina-states/_macros/localsettings.jinja(11):

---
[...]
{%- import "makina-states/_macros/funcs.jinja" as funcs with context %}
{#- expose imported macros #}
{%- set funcs = funcs %}

{#- see _modules/mc_localsettings.py for exposed settings #}
{%- set settings = salt['mc_localsettings.settings']() %}    <======================
{%- set metadata = salt['mc_localsettings.metadata']() %}
{%- set registry = salt['mc_localsettings.registry']() %}


{# pythonSettings #}
[...]

---
```
