### PR TITLE
Rename softlayer-hw to softlayer_hw

### DIFF
--- a/doc/topics/cloud/softlayer.rst
+++ b/doc/topics/cloud/softlayer.rst
@@ -48,7 +48,7 @@ Set up the cloud config at ``/etc/salt/cloud.providers``:
       user: MYUSER1138
       apikey: 'e3b68aa711e6deadc62d5b76355674beef7cc3116062ddbacafe5f7e465bfdc9'
 
-      provider: softlayer-hw
+      provider: softlayer_hw
 
 
 Access Credentials
@@ -384,7 +384,7 @@ The `globalIdentifier` returned in this list is necessary for the
 
 Optional Products for SoftLayer HW
 ==================================
-The softlayer-hw provider supports the ability to add optional products, which
+The softlayer_hw provider supports the ability to add optional products, which
 are supported by SoftLayer's API. These products each have an ID associated with
 them, that can be passed into Salt Cloud with the `optional_products` option:
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -17,7 +17,7 @@ configuration at:
       # SoftLayer account api key
       user: MYLOGIN
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
-      provider: softlayer-hw
+      provider: softlayer_hw
 
 '''
 # pylint: disable=E0102
@@ -79,7 +79,7 @@ def get_configured_provider():
     '''
     return config.is_provider_configured(
         __opts__,
-        __active_provider_name__ or 'softlayer-hw',
+        __active_provider_name__ or 'softlayer_hw',
         ('apikey',)
     )
 


### PR DESCRIPTION
Dashes are not allowed in Python modules. Underscores are more Pythonic.
