### PR TITLE
Use environment for archive.extracted. Fixes #10324.

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -109,7 +109,8 @@ def extracted(name,
                     {'name': filename},
                     {'source': source},
                     {'source_hash': source_hash},
-                    {'makedirs': True}
+                    {'makedirs': True},
+                    {'saltenv': __env__}
                 ]
             }
         }


### PR DESCRIPTION
One line fix to add saltenv to the synthetic file.managed state created internally inside archive.extracted.
