### PR TITLE
Ensure `master_port` in minion config matches `ret_port` in master config

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -213,6 +213,9 @@ Edit the minion config file:
 4.  Uncomment and change the ``id:`` value to something descriptive like
     "saltdev". This isn't strictly necessary but it will serve as a reminder of
     which Salt installation you are working with.
+5.  If you changed the ``ret_port`` value in the master config because you are
+    also running a non-development version of Salt, then you will have to
+    change the ``master_port`` value in the minion config to match.
 
 .. note:: Using `salt-call` with a :doc:`Standalone Minion </topics/tutorials/standalone_minion>`
 

--- a/doc/topics/hacking.rst
+++ b/doc/topics/hacking.rst
@@ -267,6 +267,9 @@ Edit the minion config file:
 4.  Uncomment and change the ``id:`` value to something descriptive like
     "saltdev". This isn't strictly necessary but it will serve as a reminder of
     which Salt installation you are working with.
+5.  If you changed the ``ret_port`` value in the master config because you are
+    also running a non-development version of Salt, then you will have to
+    change the ``master_port`` value in the minion config to match.
 
 .. note:: Using `salt-call` with a :doc:`Standalone Minion </topics/tutorials/standalone_minion>`
 


### PR DESCRIPTION
Update hacking docs with a note about matching `master_port` in the minion config with `ret_port` in the master config when running a dev version of salt on non-default ports.
