### PR TITLE
Unhandled exception in salt-run #9750

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -174,9 +174,9 @@ def print_job(job_id):
 
 def _format_job_instance(job):
     return {'Function': job['fun'],
-            'Arguments': list(job['arg']),
+            'Arguments': list(job.get('arg', [])),
             'Target': job['tgt'],
-            'Target-type': job['tgt_type'],
+            'Target-type': job.get('tgt_type', []),
             'User': job.get('user', 'root')}
 
 


### PR DESCRIPTION
Fixes Unhandled exception in salt-run #9750 job sample:-

`{'fun': 'pkg.install', 'jid': '20140210221740251018', 'pid': 4456, 'tgt': 'salt-call'}`
