### PR TITLE
minion connection timeout is too small

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -496,7 +496,7 @@ class MultiMinion(object):
                         try:
                             if not isinstance(minion, dict):
                                 minions[master] = {'minion': minion}
-                            t_minion = Minion(minion, 1, False)
+                            t_minion = Minion(minion, 5, False)
                             minions[master]['minion'] = t_minion
                             minions[master]['generator'] = t_minion.tune_in_no_block()
                             auth_wait = self.opts['acceptance_wait_time']


### PR DESCRIPTION
When network is slow (e.g. 3g connection), minions in multi-master mode fail
to connect: the timeout of 1sec expires before the connection can be
established.

This pull request fixes the issue that I reported on the mailing list:
https://groups.google.com/d/topic/salt-users/sOxJu0n14qU/discussion

This patch is trivial and sets the timeout to 5s instead of 1s. Do we need to make this timeout configurable?
