### PR TITLE
fileserver.gitfs.update(): rm superfluous parens

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -657,7 +657,7 @@ def update():
                     # Prune stale refs
                     for ref in repo.get_refs():
                         if ref not in refs_post:
-                            del(repo[ref])
+                            del repo[ref]
         except Exception as exc:
             log.warning(
                 'Exception caught while fetching: {0}'.format(exc)


### PR DESCRIPTION
`del` is a Python keyword, not a function.

```
************* Module salt.fileserver.gitfs
salt/fileserver/gitfs.py:660: [C0325(superfluous-parens), ] Unnecessary parens after u'del' keyword
```
