### PR TITLE
Fix references to masterapi in daemons.ioflo.master

### DIFF
--- a/salt/daemons/ioflo/master.py
+++ b/salt/daemons/ioflo/master.py
@@ -60,7 +60,7 @@ class RemoteMaster(ioflo.base.deeding.Deed):
         '''
         Set up required objects
         '''
-        self.remote = salt.masterapi.RemoteFuncs(self.opts.value)
+        self.remote = salt.daemons.masterapi.RemoteFuncs(self.opts.value)
 
     def action(self):
         '''
@@ -93,7 +93,7 @@ class LocalMaster(ioflo.base.deeding.Deed):
         '''
         Set up required objects
         '''
-        self.remote = salt.masterapi.LocalFuncs(self.opts.value)
+        self.remote = salt.daemons.masterapi.LocalFuncs(self.opts.value)
 
     def action(self):
         '''


### PR DESCRIPTION
```
************* Module salt.daemons.ioflo.master
salt/daemons/ioflo/master.py:63: [E1101(no-member), RemoteMaster.postioinit] Module 'salt' has no 'masterapi' member
salt/daemons/ioflo/master.py:96: [E1101(no-member), LocalMaster.postioinit] Module 'salt' has no 'masterapi' member
```
