### PR TITLE
Allow salt cloud to start maintaining its own cachedir

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -712,8 +712,11 @@ def path_join(*parts):
 
 def pem_finger(path=None, key=None, sum_type='md5'):
     '''
-    Pass in the location of a pem file and the type of cryptographic hash to
-    use. The default is md5.
+    Pass in either a raw pem string, or the path on disk to the location of a
+    pem file, and the type of cryptographic hash to use. The default is md5.
+    The fingerprint of the pem will be returned.
+
+    If neither a key nor a path are passed in, a blank string will be returned.
     '''
     if not key:
         if not os.path.isfile(path):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -710,15 +710,18 @@ def path_join(*parts):
     ))
 
 
-def pem_finger(path, sum_type='md5'):
+def pem_finger(path=None, key=None, sum_type='md5'):
     '''
     Pass in the location of a pem file and the type of cryptographic hash to
     use. The default is md5.
     '''
-    if not os.path.isfile(path):
-        return ''
-    with fopen(path, 'rb') as fp_:
-        key = ''.join(fp_.readlines()[1:-1])
+    if not key:
+        if not os.path.isfile(path):
+            return ''
+
+        with fopen(path, 'rb') as fp_:
+            key = ''.join(fp_.readlines()[1:-1])
+
     pre = getattr(hashlib, sum_type)(key).hexdigest()
     finger = ''
     for ind in range(len(pre)):


### PR DESCRIPTION
These functions will allow salt cloud to start keeping track of minion state. It is not currently being used in any cloud providers, but that will change soon enough. I am submitting it now because it includes a change that @thatch45 thought he could make use of elsewhere.
