### PR TITLE
add sequence filter for jinja

### DIFF
--- a/doc/ref/renderers/all/salt.renderers.jinja.rst
+++ b/doc/ref/renderers/all/salt.renderers.jinja.rst
@@ -253,6 +253,28 @@ Filters
 
 Saltstack extends `builtin filters`_ with his custom filters:
 
+
+sequence
+  Ensure that a variable is a sequence. For example:
+
+  .. code-block:: yaml
+
+      {% set my_string = "foo" %}
+      {% set my_list = ["bar", ] %}
+      {% set my_dict = {"baz": "qux"} %}
+
+      {{ my_string|sequence|first }}
+      {{ my_list|sequence|first }}
+      {{ my_dict|sequence|first }}
+
+  will be rendered as:
+
+  .. code-block:: yaml
+
+      foo
+      bar
+      baz
+
 strftime
   Converts any time related object into a time based string. It requires a
   valid :ref:`strftime directives <python2:strftime-strptime-behavior>`. An

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -156,6 +156,28 @@ class PrintableDict(OrderedDict):
         return '{' + ', '.join(output) + '}'
 
 
+class SequenceExtension(Extension, object):
+    '''
+    Ensure sequenced data.
+
+    **sequence**
+        ensure that parsed data is a sequence
+
+    '''
+
+    def __init__(self, environment):
+        super(SerializerExtension, self).__init__(environment)
+        self.environment.filters.update({
+            'sequence': self.ensure_sequence,
+        })
+
+    def ensure_sequence(data):
+        """Ensures that data is a sequence"""
+        if not isinstance(data, (list, tuple, set, dict)):
+            return [data]
+        return data
+
+
 class SerializerExtension(Extension, object):
     '''
     Yaml and Json manipulation.

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -23,6 +23,7 @@ import salt.utils
 from salt.exceptions import SaltRenderError
 from salt.utils.jinja import SaltCacheLoader as JinjaSaltCacheLoader
 from salt.utils.jinja import SerializerExtension as JinjaSerializerExtension
+from salt.utils.jinja import SequenceExtension as JinjaSequenceExtension
 from salt import __path__ as saltpath
 
 log = logging.getLogger(__name__)
@@ -226,6 +227,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         env_args['extensions'].append('jinja2.ext.do')
     if hasattr(jinja2.ext, 'loopcontrols'):
         env_args['extensions'].append('jinja2.ext.loopcontrols')
+    env_args['extensions'].append(JinjaSequenceExtension)
     env_args['extensions'].append(JinjaSerializerExtension)
 
     # Pass through trim_blocks and lstrip_blocks Jinja parameters

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -16,7 +16,7 @@ ensure_in_syspath('../../')
 import salt.utils
 from salt.exceptions import SaltRenderError
 from salt.utils import get_context
-from salt.utils.jinja import SaltCacheLoader, SerializerExtension
+from salt.utils.jinja import SaltCacheLoader, SequenceExtension, SerializerExtension
 from salt.utils.templates import (
     JINJA,
     render_jinja_tmpl,
@@ -583,6 +583,29 @@ class TestCustomExtensions(TestCase):
                                                             )
                                                         ])
         self.assertEqual(rendered, u"[{'foo': 'bar'}, {'baz': 42}]")
+
+    def test_sequence(self):
+        env = Environment(extensions=[SequenceExtension])
+
+        rendered = env.from_string('{{ data | sequence | length }}') \
+                      .render(data='foo')
+        self.assertEqual(rendered, '1')
+
+        rendered = env.from_string('{{ data | sequence | length }}') \
+                      .render(data=['foo', 'bar'])
+        self.assertEqual(rendered, '2')
+
+        rendered = env.from_string('{{ data | sequence | length }}') \
+                      .render(data=('foo', 'bar'))
+        self.assertEqual(rendered, '2')
+
+        rendered = env.from_string('{{ data | sequence | length }}') \
+                      .render(data=set('foo', 'bar'))
+        self.assertEqual(rendered, '2')
+
+        rendered = env.from_string('{{ data | sequence | length }}') \
+                      .render(data={'foo': 'bar'})
+        self.assertEqual(rendered, '1')
 
     # def test_print(self):
     #     env = Environment(extensions=[SerializerExtension])


### PR DESCRIPTION
the polymorphic nature of pillar and grains can leads to messy template.

for example, these 2 config files:

``` jinja
# minion1.sls
grains:
  role: web
```

``` jinja
# minion2.sls
grains:
  role:
    - web
    - db
```

must be expressed like that:

``` jinja
# state.sls
{% if grains['role'] is list %}
{% set roles = grains['role'] %}
{% else %}
{% set roles = [grains['role']] %}
{% endif %}

{% for role in roles %}
- {{ role }}
{% endfor %}
```

this pull request adds a `sequence`jinja filter that standardizes any value to a list like value.
with this new filter, the previous template can be lighten to:

``` jinja
# state.sls
{% set roles = grains['role'] | sequence %}

{% for role in roles %}
- {{ role }}
{% endfor %}
```
