### PR TITLE
Fix insecure recommendations in preseed tutorial, Fix #9997

### DIFF
--- a/doc/topics/tutorials/preseed_key.rst
+++ b/doc/topics/tutorials/preseed_key.rst
@@ -2,9 +2,9 @@
 Preseed Minion with Accepted Key
 =================================
 
-In some situations, it is not convenient to wait for a minion to start before 
-accepting its key on the master. For instance, you may want the minion to 
-bootstrap itself as soon as it comes online. You may also want to to let your 
+In some situations, it is not convenient to wait for a minion to start before
+accepting its key on the master. For instance, you may want the minion to
+bootstrap itself as soon as it comes online. You may also want to to let your
 developers provision new development machines on the fly.
 
 There is a general four step process to do this:
@@ -23,9 +23,9 @@ Pick a name for the key, such as the minion's id.
 
     root@saltmaster# cp key_name.pub /etc/salt/pki/master/minions/[minion_id]
 
-It is necessary that the public key file has the same name as your minion id. 
-This is how Salt matches minions with their keys. Also note that the pki folder 
-could be in a different location, depending on your OS or if specified in the 
+It is necessary that the public key file has the same name as your minion id.
+This is how Salt matches minions with their keys. Also note that the pki folder
+could be in a different location, depending on your OS or if specified in the
 master config file.
 
 3. Distribute the minion keys.
@@ -35,8 +35,8 @@ finding a distribution method which is secure.
 
 .. admonition:: Security Warning
 
-    Since the minion key is already accepted on the master, distributing 
-    the private key poses a potential security risk. A malicious party 
+    Since the minion key is already accepted on the master, distributing
+    the private key poses a potential security risk. A malicious party
     will have access to your entire state tree and other sensitive data if they
     gain access to a preseeded minion key.
 
@@ -49,6 +49,6 @@ You will want to place the minion keys before starting the salt-minion daemon:
     /etc/salt/pki/minion/minion.pem
     /etc/salt/pki/minion/minion.pub
 
-Once in place, you should be able to start salt-minion and run 
-``salt-call state.highstate`` or any other salt commands that require master 
+Once in place, you should be able to start salt-minion and run
+``salt-call state.highstate`` or any other salt commands that require master
 authentication.

--- a/doc/topics/tutorials/preseed_key.rst
+++ b/doc/topics/tutorials/preseed_key.rst
@@ -30,16 +30,15 @@ master config file.
 
 3. Distribute the minion keys.
 
-There is no single method to get the keypair to your minion. If you are
-spooling up minions on EC2, you could pass them in using user_data or a
-cloud-init script. If you are handing them off to a team of developers for
-provisioning dev machines, you will need a secure file transfer.
+There is no single method to get the keypair to your minion.  The difficulty is
+finding a distribution method which is secure.
 
 .. admonition:: Security Warning
 
-	Since the minion key is already accepted on the master, distributing 
-	the private key poses a potential security risk. A malicious party 
-	will have access to your entire state tree and other sensitive data.
+    Since the minion key is already accepted on the master, distributing 
+    the private key poses a potential security risk. A malicious party 
+    will have access to your entire state tree and other sensitive data if they
+    gain access to a preseeded minion key.
 
 4. Preseed the Minion with the keys
 


### PR DESCRIPTION
user_data/cloud-init info lives for the life of an instance and is accessible to any user on the system (including non-root owned services, which would then be able to own the server and possibly other parts of the infrastructure)

This fixes that recommendation and puts additional emphasis on the need to make the key distribution secure.
