### PR TITLE
More granular master job targeting

### DIFF
--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -27,6 +27,11 @@ class SaltMasterError(SaltException):
     Problem reading the master root key
     '''
 
+class SaltSyndicMasterError(SaltException):
+    '''
+    Problem while proxying a request in the syndication master
+    '''
+
 
 class MasterExit(SystemExit):
     '''

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -27,6 +27,7 @@ class SaltMasterError(SaltException):
     Problem reading the master root key
     '''
 
+
 class SaltSyndicMasterError(SaltException):
     '''
     Problem while proxying a request in the syndication master

--- a/salt/master.py
+++ b/salt/master.py
@@ -411,7 +411,21 @@ class Publisher(multiprocessing.Process):
                 # SIGUSR1 gracefully so we don't choke and die horribly
                 try:
                     package = pull_sock.recv()
-                    pub_sock.send(package)
+                    unpacked_package = salt.payload.unpackage(package)
+                    payload = unpacked_package['payload']
+
+                    # if you have a specific topic list, use that
+                    if 'topic_lst' in unpacked_package:
+                        for topic in unpacked_package['topic_lst']:
+                            # zmq filters are substring match, hash the topic
+                            # to avoid collisions
+                            htopic = hashlib.sha1(topic).hexdigest()
+                            pub_sock.send(htopic, flags=zmq.SNDMORE)
+                            pub_sock.send(payload)
+                    # otherwise its a broadcast
+                    else:
+                        pub_sock.send('broadcast', flags=zmq.SNDMORE)
+                        pub_sock.send(payload)
                 except zmq.ZMQError as exc:
                     if exc.errno == errno.EINTR:
                         continue
@@ -2638,7 +2652,14 @@ class ClearFuncs(object):
             os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
             )
         pub_sock.connect(pull_uri)
-        pub_sock.send(self.serial.dumps(payload))
+
+        int_payload = {'payload': self.serial.dumps(payload)}
+
+        # add some targeting stuff for lists only (for now)
+        if load['tgt_type'] == 'list':
+            int_payload['topic_lst'] = load['tgt']
+
+        pub_sock.send(self.serial.dumps(int_payload))
         return {
             'enc': 'clear',
             'load': {

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -56,7 +56,8 @@ except ImportError:
 # Import salt libs
 from salt.exceptions import (
     AuthenticationError, CommandExecutionError, CommandNotFoundError,
-    SaltInvocationError, SaltReqTimeoutError, SaltClientError, SaltSystemExit
+    SaltInvocationError, SaltReqTimeoutError, SaltClientError,
+    SaltSystemExit, SaltSyndicMasterError
 )
 import salt.client
 import salt.crypt
@@ -1600,8 +1601,6 @@ class Syndic(Minion):
                 raise SaltSyndicMasterError('Syndication master recieved message of invalid len ({0}/2)'.format(messages_len))
 
             payload = self.serial.loads(messages[idx])
-
-
 
         except zmq.ZMQError as e:
             # Swallow errors for bad wakeups or signals needing processing


### PR DESCRIPTION
Please DO NOT MERGE IMMEDIATELY.

Salt targeting is done using the zmq pub/sub mechanism. No filtering is done so all requests go to all minions. This is an attempt to make the requests more target-able. ZeroMQ supports filters on these sockets which are processed publisher side. So the thought is to set it to the minion id and a shared "broadcast" one. Only requests of tgt_type == list will use this. The thought is if we like this we can use other data (mine etc) to determine a more specific target on the master (such as a list) from a glob match etc.

This is more or less backwards compatible, during my testing it still works but the old minion will throw an exception like:

```
[CRITICAL] An exception occurred while polling the minion
Traceback (most recent call last):
  File "/home/thjackso/src/salt/salt/minion.py", line 1324, in tune_in
    payload = self.serial.loads(self.socket.recv(zmq.NOBLOCK))
  File "/home/thjackso/src/salt/salt/payload.py", line 95, in loads
    return msgpack.loads(msg, use_list=True)
  File "_unpacker.pyx", line 114, in msgpack._unpacker.unpackb (msgpack/_unpacker.cpp:114)
ExtraData: unpack(b) recieved extra data.
```

So if we decide this is a good idea we'll probably want to wrap the new master side logic in a config option, and just merge in the minion side changes for the first release.
