### PR TITLE
On systemd hosts, notify systemd when master is started

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -62,6 +62,13 @@ try:
 except ImportError:
     HAS_HALITE = False
 
+try:
+    import systemd.daemon
+    HAS_PYTHON_SYSTEMD = True
+except ImportError:
+    HAS_PYTHON_SYSTEMD = False
+
+
 log = logging.getLogger(__name__)
 
 
@@ -465,6 +472,13 @@ class ReqServer(object):
             proc.start()
 
         self.workers.bind(self.w_uri)
+
+        try:
+            if HAS_PYTHON_SYSTEMD and systemd.daemon.booted():
+                systemd.daemon.notify('READY=1')
+        except SystemError:
+            # Daemon wasn't started by systemd
+            pass
 
         while True:
             try:


### PR DESCRIPTION
**This looks to be working now for @gtmanfred, but I'm still not 100% sure if this is the best solution. Needs further scrutiny.**

Per a discussion with @gtmanfred in #salt, it would be useful to have the master notify the systemd daemon once it finishes starting up, thus allowing the systemd unit to be changed from using `type=simple` to `type=notify`.

@thatch45, this is what I came up with, please let me know if I am wrong here.
