### PR TITLE
Add backups_enabled for Digital Ocean salt-cloud provider

### DIFF
--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -43,6 +43,8 @@ Set up an initial profile at ``/etc/salt/cloud.profiles`` or in the
         image: Ubuntu 12.10 x64
         size: 512MB
         location: New York 1
+        private_networking: True
+        backups_enabled: True
 
 Sizes can be obtained using the ``--list-sizes`` option for the ``salt-cloud``
 command:

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -285,13 +285,21 @@ def create(vm_):
             )
         )
 
-    for boolean_kwarg in ('private_networking', 'backups_enabled'):
-        config_value = config.get_cloud_config_value(
-            boolean_kwarg, vm_, __opts__, search_global=False
-        )
-        if not isinstance(config_value, bool):
-            raise SaltCloudConfigError("'%s' should be a boolean value." % boolean_kwarg)
-        kwargs[boolean_kwarg] = config_value
+    private_networking = config.get_cloud_config_value(
+        'private_networking', vm_, __opts__, search_global=False, default=None,
+    )
+    if private_networking is not None:
+        if not isinstance(private_networking, bool):
+            raise SaltCloudConfigError("'private_networking' should be a boolean value.")
+        kwargs['private_networking'] = private_networking
+
+    backups_enabled = config.get_cloud_config_value(
+        'backups_enabled', vm_, __opts__, search_global=False, default=None,
+    )
+    if backups_enabled is not None:
+        if not isinstance(backups_enabled, bool):
+            raise SaltCloudConfigError("'backups_enabled' should be a boolean value.")
+        kwargs['backups_enabled'] = backups_enabled
 
     salt.utils.cloud.fire_event(
         'event',

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -285,10 +285,13 @@ def create(vm_):
             )
         )
 
-    private_networking = config.get_cloud_config_value(
-        'private_networking', vm_, __opts__, search_global=False, default=None
-    )
-    kwargs['private_networking'] = 'true' if private_networking else 'false'
+    for boolean_kwarg in ('private_networking', 'backups_enabled'):
+        config_value = config.get_cloud_config_value(
+            boolean_kwarg, vm_, __opts__, search_global=False
+        )
+        if not isinstance(config_value, bool):
+            raise SaltCloudConfigError("'%s' should be a boolean value." % boolean_kwarg)
+        kwargs[boolean_kwarg] = config_value
 
     salt.utils.cloud.fire_event(
         'event',


### PR DESCRIPTION
Digital Ocean profiles can now take 'backups_enabled: [True|False]'. (As of Jan 2014 this option must be specified on instance creation and can no longer be enabled for already-created droplets, so it's fairly necessary.)

Also added private_networking and backups_enabled to the documentation for the Digital Ocean provider; there was previously no mention of private_networking was an option, but it was in the code.

An incidental change is that private_networking won't default to False if not specified - by salt-cloud - but that is still the provider's default, and where the default should be coming from if a profile isn't explicit (i.e. there's no functional change but people will start getting private networking by default if Digital Ocean enables it by default).
