### PR TITLE
Wait until droplets are fully loaded before bootstrapping.

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -328,7 +328,8 @@ def create(vm_):
         if not data:
             # Trigger an error in the wait_for_ip function
             return False
-        if data.get('ip_address', None) is not None:
+        if (data.get('ip_address') and data.get('status') == 'active' and
+                data.get('locked', 'False') == 'False'):
             return data
 
     try:


### PR DESCRIPTION
The wait_for_ip callback currently gets on with deployment as soon as a droplet has an IP; it should wait until the new VM also marks its own status as 'active' (after a period of 'new') and is not 'Locked'.
