### PR TITLE
Split Key class initialization

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -312,8 +312,16 @@ class Key(object):
     '''
     The object that encapsulates saltkey actions
     '''
+
     def __init__(self, opts):
         self.opts = opts
+        self._prepare()
+
+    def _prepare(self):
+        '''
+        Simple method called when this class is initialized used for additional
+        setup
+        '''
         self.event = salt.utils.event.MasterEvent(opts['sock_dir'])
 
     def _check_minions_directories(self):
@@ -678,8 +686,12 @@ class RaetKey(Key):
     '''
     Manage keys from the raet backend
     '''
-    def __init__(self, opts):
-        self.opts = opts
+
+    def _prepare(self):
+        '''
+        Simple method called when this class is initialized used for additional
+        setup
+        '''
         self.serial = salt.payload.Serial(self.opts)
 
     def _check_minions_directories(self):

--- a/salt/key.py
+++ b/salt/key.py
@@ -322,7 +322,7 @@ class Key(object):
         Simple method called when this class is initialized used for additional
         setup
         '''
-        self.event = salt.utils.event.MasterEvent(opts['sock_dir'])
+        self.event = salt.utils.event.MasterEvent(self.opts['sock_dir'])
 
     def _check_minions_directories(self):
         '''

--- a/salt/key.py
+++ b/salt/key.py
@@ -312,7 +312,6 @@ class Key(object):
     '''
     The object that encapsulates saltkey actions
     '''
-
     def __init__(self, opts):
         self.opts = opts
         self._prepare()
@@ -686,7 +685,6 @@ class RaetKey(Key):
     '''
     Manage keys from the raet backend
     '''
-
     def _prepare(self):
         '''
         Simple method called when this class is initialized used for additional


### PR DESCRIPTION
@thatch45, [this](https://github.com/s0undt3ch/salt/commit/f0db1759c09e0678d70f9a04bc03007c4b1e4b44) was the breakage.

If it really makes no sense to you to separate these, close this PR and I'll tell PyLint to ignore the fact that we're not calling our parent class.
