### PR TITLE
Don't hardcode the cloud cache directory

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1485,10 +1485,12 @@ def list_nodes_select(nodes, selection, call=None):
     return ret
 
 
-def init_cachedir(base='/var/cache/salt/cloud'):
+def init_cachedir(base=None):
     '''
     Initialize the cachedir needed for Salt Cloud to keep track of minions
     '''
+    if base is None:
+        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
     needed_dirs = (base,
                    os.path.join(base, 'requested'),
                    os.path.join(base, 'active'))
@@ -1503,7 +1505,7 @@ def request_minion_cachedir(
         fingerprint='',
         pubkey=None,
         provider=None,
-        base='/var/cache/salt/cloud',
+        base=None,
     ):
     '''
     Creates an entry in the requested/ cachedir. This means that Salt Cloud has
@@ -1514,6 +1516,9 @@ def request_minion_cachedir(
     fingerprint will be calculated. If both are empty, then the fingerprint
     will be set to None.
     '''
+    if base is None:
+        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+
     if not fingerprint:
         if pubkey is not None:
             fingerprint = salt.utils.pem_finger(key=pubkey)
@@ -1536,7 +1541,7 @@ def change_minion_cachedir(
         minion_id,
         cachedir,
         data=None,
-        base='/var/cache/salt/cloud',
+        base=None,
     ):
     '''
     Changes the info inside a minion's cachedir entry. The type of cachedir
@@ -1554,6 +1559,9 @@ def change_minion_cachedir(
     if not isinstance(data, dict):
         return False
 
+    if base is None:
+        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+
     fname = minion_id + '.json'
     path = os.path.join(base, cachedir, fname)
 
@@ -1566,23 +1574,29 @@ def change_minion_cachedir(
         json.dump(cache_data, fh_)
 
 
-def activate_minion_cachedir(minion_id, base='/var/cache/salt/cloud'):
+def activate_minion_cachedir(minion_id, base=None):
     '''
     Moves a minion from the requested/ cachedir into the active/ cachedir. This
     means that Salt Cloud has verified that a requested instance properly
     exists, and should be expected to exist from here on out.
     '''
+    if base is None:
+        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+
     fname = minion_id + '.json'
     src = os.path.join(base, 'requested', fname)
     dst = os.path.join(base, 'active')
     shutil.move(src, dst)
 
 
-def delete_minion_cachedir(minion_id, base='/var/cache/salt/cloud'):
+def delete_minion_cachedir(minion_id, base=None):
     '''
     Deletes a minion's entry from the cloud cachedir. It will search through
     all cachedirs to find the minion's cache file.
     '''
+    if base is None:
+        base = os.path.join(syspaths.CACHE_DIR, 'cloud')
+
     fname = minion_id + '.json'
     for cachedir in ('requested', 'active'):
         path = os.path.join(base, cachedir, fname)

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1531,7 +1531,7 @@ def request_minion_cachedir(
         'provider': provider,
     }
 
-    fname = minion_id + '.json'
+    fname = '{0}.json'.format(minion_id)
     path = os.path.join(base, 'requested', fname)
     with salt.utils.fopen(path, 'w') as fh_:
         json.dump(data, fh_)
@@ -1562,7 +1562,7 @@ def change_minion_cachedir(
     if base is None:
         base = os.path.join(syspaths.CACHE_DIR, 'cloud')
 
-    fname = minion_id + '.json'
+    fname = '{0}.json'.format(minion_id)
     path = os.path.join(base, cachedir, fname)
 
     with salt.utils.fopen(path, 'r') as fh_:
@@ -1583,7 +1583,7 @@ def activate_minion_cachedir(minion_id, base=None):
     if base is None:
         base = os.path.join(syspaths.CACHE_DIR, 'cloud')
 
-    fname = minion_id + '.json'
+    fname = '{0}.json'.format(minion_id)
     src = os.path.join(base, 'requested', fname)
     dst = os.path.join(base, 'active')
     shutil.move(src, dst)
@@ -1597,7 +1597,7 @@ def delete_minion_cachedir(minion_id, base=None):
     if base is None:
         base = os.path.join(syspaths.CACHE_DIR, 'cloud')
 
-    fname = minion_id + '.json'
+    fname = '{0}.json'.format(minion_id)
     for cachedir in ('requested', 'active'):
         path = os.path.join(base, cachedir, fname)
         if os.path.exists(path):


### PR DESCRIPTION
Use the setup configurable `salt.syspaths` module variables.
