### PR TITLE
Fixed Test

### DIFF
--- a/tests/unit/modules/dig_test.py
+++ b/tests/unit/modules/dig_test.py
@@ -6,7 +6,7 @@
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
-from salttesting.helpers import ensure_in_syspath, requires_salt_modules
+from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
@@ -14,7 +14,6 @@ from salt.modules import dig
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
-@requires_salt_modules('dig')
 class DigTestCase(TestCase):
 
     def test_check_ip(self):

--- a/tests/unit/modules/dig_test.py
+++ b/tests/unit/modules/dig_test.py
@@ -14,6 +14,7 @@ from salt.modules import dig
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(dig.__virtual__() is False, 'Dig must be installed')
 class DigTestCase(TestCase):
 
     def test_check_ip(self):


### PR DESCRIPTION
We cannot use the requires_salt_modules decorator because we do not inherit from an integration test class. @s0undt3ch should basic unit tests inherit from the integration test class?
