### PR TITLE
apache module: rm unused import of `os`

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -9,7 +9,6 @@ Debian-based system is detected.
 '''
 
 # Import python libs
-import os
 import re
 import logging
 import urllib2


### PR DESCRIPTION
```
************* Module salt.modules.apache
salt/modules/apache.py:12: [W0611(unused-import), ] Unused import os
```
