### PR TITLE
rm unused imports in deb_apache module

### DIFF
--- a/salt/modules/deb_apache.py
+++ b/salt/modules/deb_apache.py
@@ -9,9 +9,7 @@ loading under the ``apache`` namespace.
 
 # Import python libs
 import os
-import re
 import logging
-import urllib2
 
 # Import salt libs
 import salt.utils


### PR DESCRIPTION
```
************* Module salt.modules.deb_apache
salt/modules/deb_apache.py:14: [W0611(unused-import), ] Unused import urllib2
salt/modules/deb_apache.py:12: [W0611(unused-import), ] Unused import re
```
