### PR TITLE
dig.SPF fixes

### DIFF
--- a/doc/ref/modules/all/salt.modules.dig.rst
+++ b/doc/ref/modules/all/salt.modules.dig.rst
@@ -4,3 +4,4 @@ salt.modules.dig
 
 .. automodule:: salt.modules.dig
     :members:
+    :exclude-members: a, aaaa, ns, spf, mx

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -193,33 +193,31 @@ def SPF(domain, record='SPF', nameserver=None):
 
         salt ns1 dig.SPF google.com
     '''
-    def _process(x):
+    def _process(element):
         '''
         Parse out valid IP bits of an spf record.
         '''
-        m = re.match(r'(\+|~)?ip4:([0-9./]+)', x)
+        m = re.match(r'(\+|~)?ip4:([0-9./]+)', element)
         if m:
             if check_ip(m.group(2)):
                 return m.group(2)
         return None
 
-    dig = ['dig', '+short', str(domain), record]
+    cmd = ['dig', '+short', str(domain), record]
 
     if nameserver is not None:
-        dig.append('@{0}'.format(nameserver))
+        cmd.append('@{0}'.format(nameserver))
 
-    cmd = __salt__['cmd.run_all'](' '.join(dig))
+    result = __salt__['cmd.run_all'](' '.join(cmd), output_loglevel='debug')
     # In this case, 0 is not the same as False
-    if cmd['retcode'] != 0:
+    if result['retcode'] != 0:
         log.warn(
-            'dig returned exit code \'{0}\'. Returning empty list as '
-            'fallback.'.format(
-                cmd['retcode']
-            )
+            'dig returned exit code {0!r}. Returning empty list as fallback.'
+            .format(result['retcode'])
         )
         return []
 
-    stdout = cmd['stdout']
+    stdout = result['stdout']
     if stdout == '' and record == 'SPF':
         # empty string is successful query, but nothing to return. So, try TXT
         # record.

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -12,14 +12,14 @@ import re
 
 log = logging.getLogger(__name__)
 
+__virtualname__ = 'dig'
+
 
 def __virtual__():
     '''
-    DNS functions which are based on dig
+    Only load module if dig binary is present
     '''
-    if not salt.utils.which('dig'):
-        return False
-    return True
+    return __virtualname__ if salt.utils.which('dig') else False
 
 
 def check_ip(x):

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -218,7 +218,8 @@ def SPF(domain, record='SPF', nameserver=None):
         return []
 
     if sections[1].startswith('redirect='):
-        return SPF(domain, 'SPF', nameserver)
+        # Run a lookup on the part after 'redirect=' (9 chars)
+        return SPF(sections[1][9:], 'SPF', nameserver)
     ret = []
     for section in sections[1:]:
         try:

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -273,3 +273,10 @@ def MX(domain, resolve=False, nameserver=None):
         ]
 
     return stdout
+
+# Let lowercase work, since that is the convention for Salt functions
+a = A
+aaaa = AAAA
+ns = NS
+spf = SPF
+mx = MX

--- a/tests/unit/modules/dig_test.py
+++ b/tests/unit/modules/dig_test.py
@@ -21,94 +21,162 @@ class DigTestCase(TestCase):
         self.assertTrue(dig.check_ip('127.0.0.1'), msg='Not a valid ip address')
 
     def test_check_ip_ipv6(self):
-        self.assertTrue(dig.check_ip('1111:2222:3333:4444:5555:6666:7777:8888'), msg='Not a valid ip address')
+        self.assertTrue(
+            dig.check_ip('1111:2222:3333:4444:5555:6666:7777:8888'),
+            msg='Not a valid ip address'
+        )
 
     @skipIf(True, 'Waiting for 2014.1 release')
     def test_check_ip_ipv6_valid(self):
         self.assertTrue(dig.check_ip('2607:fa18:0:3::4'))
 
     def test_check_ip_neg(self):
-        self.assertFalse(dig.check_ip('-127.0.0.1'), msg="Did not detect negative value as invalid")
+        self.assertFalse(
+            dig.check_ip('-127.0.0.1'),
+            msg="Did not detect negative value as invalid"
+        )
 
     def test_check_ip_empty(self):
-        self.assertFalse(dig.check_ip(''), msg="Did not detect empty value as invalid")
+        self.assertFalse(
+            dig.check_ip(''),
+            msg="Did not detect empty value as invalid"
+        )
 
     def test_a(self):
         dig.__salt__ = {}
-        dig_mock = MagicMock(return_value={
-                'pid': 3656, 'retcode': 0, 'stderr': '', 'stdout': '74.125.193.104\n'
-                                                                   '74.125.193.105\n'
-                                                                   '74.125.193.99\n'
-                                                                   '74.125.193.106\n'
-                                                                   '74.125.193.103\n'
-                                                                   '74.125.193.147'
-        })
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 3656,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': '74.125.193.104\n'
+                          '74.125.193.105\n'
+                          '74.125.193.99\n'
+                          '74.125.193.106\n'
+                          '74.125.193.103\n'
+                          '74.125.193.147'
+            }
+        )
         with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
-            self.assertEqual(dig.A('www.google.com'), ['74.125.193.104',
-                                                       '74.125.193.105',
-                                                       '74.125.193.99',
-                                                       '74.125.193.106',
-                                                       '74.125.193.103',
-                                                       '74.125.193.147'])
+            self.assertEqual(
+                dig.A('www.google.com'),
+                ['74.125.193.104',
+                 '74.125.193.105',
+                 '74.125.193.99',
+                 '74.125.193.106',
+                 '74.125.193.103',
+                 '74.125.193.147']
+            )
 
     @skipIf(True, 'Waiting for 2014.1 release')
     def test_aaaa(self):
         dig.__salt__ = {}
-        dig_mock = MagicMock(return_value={
-            'pid': 25451, 'retcode': 0, 'stderr': '', 'stdout': '2607:f8b0:400f:801::1014'
-        })
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 25451,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': '2607:f8b0:400f:801::1014'
+            }
+        )
         with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
-            self.assertEqual(dig.AAAA('www.google.com'), ['2607:f8b0:400f:801::1014'])
+            self.assertEqual(
+                dig.AAAA('www.google.com'),
+                ['2607:f8b0:400f:801::1014']
+            )
 
     @patch('salt.modules.dig.A', MagicMock(return_value=['ns4.google.com.']))
     def test_ns(self):
         dig.__salt__ = {}
-        dig_mock = MagicMock(return_value={
-            'pid': 26136, 'retcode': 0, 'stderr': '', 'stdout': 'ns4.google.com.'
-        })
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 26136,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': 'ns4.google.com.'
+            }
+        )
         with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
             self.assertEqual(dig.NS('google.com'), ['ns4.google.com.'])
 
     def test_spf(self):
         dig.__salt__ = {}
-        dig_mock = MagicMock(return_value={'pid': 26795,
-                                           'retcode': 0,
-                                           'stderr': '',
-                                           'stdout': 'v=spf1'
-                                                     ' include:_spf.google.com '
-                                                     'ip4:216.73.93.70/31 '
-                                                     'ip4:216.73.93.72/31 ~all'})
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 26795,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': 'v=spf1 ip4:216.73.93.70/31 ip4:216.73.93.72/31 ~all'
+            }
+        )
         with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
-            self.assertEqual(dig.SPF('google.com'),
-                             ['216.73.93.70/31', '216.73.93.72/31'])
+            self.assertEqual(
+                dig.SPF('foo.com'),
+                ['216.73.93.70/31', '216.73.93.72/31']
+            )
 
-    @skipIf(True, 'Waiting for 2014.1 release')
+    @skipIf(True, 'Skip until we figure out how to handle recursion')
     def test_spf_redir(self):
         '''
-        Test was written after a bug was found when a domain is redirecting the SPF ipv4 range
+        Test for SPF records which use the 'redirect' SPF mechanism
+        https://en.wikipedia.org/wiki/Sender_Policy_Framework#Mechanisms
         '''
         dig.__salt__ = {}
-        dig_mock = MagicMock(return_value={'pid': 27282,
-                                           'retcode': 0,
-                                           'stderr': '',
-                                           'stdout': 'v=spf1 a mx '
-                                                     'include:_spf.xmission.com ?all'})
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 26795,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': 'v=spf1 redirect=_spf.xmission.com'
+            }
+        )
         with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
-            self.assertEqual(dig.SPF('xmission.com'), ['198.60.22.0/24', '166.70.13.0/24'])
+            self.assertEqual(
+                dig.SPF('xmission.com'),
+                ['198.60.22.0/24', '166.70.13.0/24']
+            )
+
+    @skipIf(True, 'Skip until we figure out how to handle recursion')
+    def test_spf_include(self):
+        '''
+        Test for SPF records which use the 'include' SPF mechanism
+        https://en.wikipedia.org/wiki/Sender_Policy_Framework#Mechanisms
+        '''
+        dig.__salt__ = {}
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 27282,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': 'v=spf1 a mx include:_spf.xmission.com ?all'
+            }
+        )
+        with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
+            self.assertEqual(
+                dig.SPF('xmission.com'),
+                ['198.60.22.0/24', '166.70.13.0/24']
+            )
 
     def test_mx(self):
         dig.__salt__ = {}
-        dig_mock = MagicMock(return_value={'pid': 27780,
-                                           'retcode': 0,
-                                           'stderr': '',
-                                           'stdout': '10 aspmx.l.google.com.\n'
-                                                     '20 alt1.aspmx.l.google.com.\n'
-                                                     '40 alt3.aspmx.l.google.com.\n'
-                                                     '50 alt4.aspmx.l.google.com.\n'
-                                                     '30 alt2.aspmx.l.google.com.'})
+        dig_mock = MagicMock(
+            return_value={
+                'pid': 27780,
+                'retcode': 0,
+                'stderr': '',
+                'stdout': '10 aspmx.l.google.com.\n'
+                          '20 alt1.aspmx.l.google.com.\n'
+                          '40 alt3.aspmx.l.google.com.\n'
+                          '50 alt4.aspmx.l.google.com.\n'
+                          '30 alt2.aspmx.l.google.com.'
+            }
+        )
         with patch.dict(dig.__salt__, {'cmd.run_all': dig_mock}):
-            self.assertEqual(dig.MX('google.com'), [['10', 'aspmx.l.google.com.'],
-                                                     ['20', 'alt1.aspmx.l.google.com.'],
-                                                     ['40', 'alt3.aspmx.l.google.com.'],
-                                                     ['50', 'alt4.aspmx.l.google.com.'],
-                                                     ['30', 'alt2.aspmx.l.google.com.']])
+            self.assertEqual(
+                dig.MX('google.com'),
+                [['10', 'aspmx.l.google.com.'],
+                 ['20', 'alt1.aspmx.l.google.com.'],
+                 ['40', 'alt3.aspmx.l.google.com.'],
+                 ['50', 'alt4.aspmx.l.google.com.'],
+                 ['30', 'alt2.aspmx.l.google.com.']]
+            )

--- a/tests/unit/modules/dig_test.py
+++ b/tests/unit/modules/dig_test.py
@@ -41,6 +41,7 @@ _SPF_VALUES = {
     },
 }
 
+
 def _spf_side_effect(key, output_loglevel='info'):
     return _SPF_VALUES.get(key, {'pid': 27310,
                                  'retcode': 0,


### PR DESCRIPTION
This pull request does a few things:
- Simplifies `__virtual__` function
- Use `socket.inet_pton()` to validate IP addresses, instead of error-prone regular expressions
- Add aliases for functions in `dig` execution module, so that `dig.spf`, `dig.a`, etc. also work.
- Fix #10367 by recursing `redirect` and `include` entries.
- Adds a new test for `redirect=somedomain` SPF records
