### PR TITLE
Adds support for updating cached git repo url.

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -133,6 +133,9 @@ class GitPillar(object):
                             # write.
                             # This should place a lock down.
                             pass
+                    else:
+                        if self.repo.remotes.origin.url != self.rp_location:
+                            self.repo.remotes.origin.config_writer.set('url', self.rp_location)
 
                 break
 

--- a/tests/integration/modules/pillar.py
+++ b/tests/integration/modules/pillar.py
@@ -51,6 +51,25 @@ class PillarModuleTest(integration.ModuleCase):
             self.run_function('pillar.data')['test_ext_pillar_opts']['file_roots']['base']
         )
 
+    def test_issue_10408_ext_pillar_gitfs_url_update(self):
+        import os
+        from salt.pillar import git_pillar
+        import git
+        original_url = 'git+ssh://original@example.com/home/git/test'
+        changed_url = 'git+ssh://changed@example.com/home/git/test'
+        rp_location = os.path.join(self.master_opts['cachedir'], 'pillar_gitfs/0/.git')
+        opts = {
+            'ext_pillar': [{'git': 'master {0}'.format(original_url)}],
+            'cachedir': self.master_opts['cachedir'],
+        }
+
+        git_pillar.GitPillar('master', original_url, opts)
+        opts['ext_pillar'] = [{'git': 'master {0}'.format(changed_url)}]
+        grepo = git_pillar.GitPillar('master', changed_url, opts)
+        repo = git.Repo(rp_location)
+
+        self.assertEqual(grepo.rp_location, repo.remotes.origin.url)
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(PillarModuleTest)


### PR DESCRIPTION
This fixes issue #10408.

I don't expect the test portion of the commit to be accepted as it is. I'm not sure the test is located in the correct place or if there is overlap between pillar gitfs and the fileserver backend code. Is there a way I can call git_pillar with self.run_function like other tests are doing for modules?

This is my first PR. I would appreciate some direction. I don't mind making any required changes.

Thanks.
