### PR TITLE
Preserve cmd.run variants issued over SSH.

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -604,9 +604,11 @@ class Single(object):
         # 3. deploy salt-thin
         # 4. execute command
         if self.arg_str.startswith('cmd.run'):
-            cmd_args = ' '.join(self.arg_str.split()[1:])
+            arg_split = self.arg_str.split()
+            cmd = arg_split[0]
+            cmd_args = ' '.join(arg_split[1:])
             if not cmd_args.startswith("'") and not cmd_args.endswith("'"):
-                self.arg_str = "cmd.run '{0}'".format(cmd_args)
+                self.arg_str = "{0} '{1}'".format(cmd, cmd_args)
         sudo = 'sudo' if self.target['sudo'] else ''
         thin_sum = salt.utils.thin.thin_sum(
                 self.opts['cachedir'],


### PR DESCRIPTION
Previously SSH quashed cmd.run_stdout, cmd.run_stderr and cmd.run_all
to cmd.run.

Fixes #10415
