### PR TITLE
Include msgpack in thin.tgz

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -604,9 +604,11 @@ class Single(object):
         # 3. deploy salt-thin
         # 4. execute command
         if self.arg_str.startswith('cmd.run'):
-            cmd_args = ' '.join(self.arg_str.split()[1:])
+            arg_split = self.arg_str.split()
+            cmd = arg_split[0]
+            cmd_args = ' '.join(arg_split[1:])
             if not cmd_args.startswith("'") and not cmd_args.endswith("'"):
-                self.arg_str = "cmd.run '{0}'".format(cmd_args)
+                self.arg_str = "{0} '{1}'".format(cmd, cmd_args)
         sudo = 'sudo' if self.target['sudo'] else ''
         thin_sum = salt.utils.thin.thin_sum(
                 self.opts['cachedir'],

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -10,6 +10,7 @@ import tarfile
 # Import third party libs
 import jinja2
 import yaml
+import msgpack
 try:
     import markupsafe
     HAS_MARKUPSAFE = True
@@ -60,6 +61,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False):
             os.path.dirname(salt.__file__),
             os.path.dirname(jinja2.__file__),
             os.path.dirname(yaml.__file__),
+            os.path.dirname(msgpack.__file__),
             ]
     for mod in [m for m in extra_mods.split(',') if m]:
         if mod not in locals() and mod not in globals():


### PR DESCRIPTION
While msgpack is an extmod (it uses an platform-dependent .so) it
includes a pure python fall-back.  Including it in thin will not create
a portability problem.

Fixes #10425
