### PR TITLE
 Preserve stdout, stderr and retcode from salt-ssh raw command

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -604,9 +604,11 @@ class Single(object):
         # 3. deploy salt-thin
         # 4. execute command
         if self.arg_str.startswith('cmd.run'):
-            cmd_args = ' '.join(self.arg_str.split()[1:])
+            arg_split = self.arg_str.split()
+            cmd = arg_split[0]
+            cmd_args = ' '.join(arg_split[1:])
             if not cmd_args.startswith("'") and not cmd_args.endswith("'"):
-                self.arg_str = "cmd.run '{0}'".format(cmd_args)
+                self.arg_str = "{0} '{1}'".format(cmd, cmd_args)
         sudo = 'sudo' if self.target['sudo'] else ''
         thin_sum = salt.utils.thin.thin_sum(
                 self.opts['cachedir'],

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -236,7 +236,7 @@ class SSH(object):
                     self.opts['arg_str'],
                     host,
                     **target)
-            stdout, stderr = single.cmd_block()
+            stdout, stderr, retcode = single.cmd_block()
             try:
                 data = salt.utils.find_json(stdout)
                 return {host: data.get('local', data)}
@@ -257,25 +257,27 @@ class SSH(object):
                 host,
                 **target)
         ret = {'id': single.id}
-        stdout, stderr = single.run()
+        stdout, stderr, retcode = single.run()
         if stdout.startswith('deploy'):
             single.deploy()
-            stdout, stderr = single.run()
+            stdout, stderr, retcode = single.run()
         # This job is done, yield
         try:
-            if not stdout and stderr:
-                if 'Permission denied' in stderr:
-                    ret['ret'] = 'Permission denied'
-                else:
-                    ret['ret'] = stderr
+            data = salt.utils.find_json(stdout)
+            if len(data) < 2 and 'local' in data:
+                ret['ret'] = data['local']
             else:
-                data = salt.utils.find_json(stdout)
-                if len(data) < 2 and 'local' in data:
-                    ret['ret'] = data['local']
-                else:
-                    ret['ret'] = data
+                ret['ret'] = {
+                    'stdout': stdout,
+                    'stderr': stderr,
+                    'retcode': retcode,
+                }
         except Exception:
-            ret['ret'] = stdout
+            ret['ret'] =  {
+                'stdout': stdout,
+                'stderr': stderr,
+                'retcode': retcode,
+            }
         que.put(ret)
 
     def handle_ssh(self):
@@ -484,27 +486,27 @@ class Single(object):
         If a (re)deploy is needed, then retry the operation after a deploy
         attempt
 
-        Returns tuple of (stdout, stderr)
+        Returns tuple of (stdout, stderr, retcode)
         '''
-        stdout, stderr = None, None
+        stdout = stderr = retcode = None
         arg_str = self.arg_str
 
         if self.opts.get('raw_shell'):
             if not arg_str.startswith(('"', "'")) and not arg_str.endswith(('"', "'")):
                 arg_str = "'{0}'".format(arg_str)
-            stdout, stderr = self.shell.exec_cmd(arg_str)
+            stdout, stderr, retcode = self.shell.exec_cmd(arg_str)
 
         elif self.fun in self.wfuncs:
-            stdout, stderr = self.run_wfunc()
+            stdout, stderr, retcode = self.run_wfunc()
 
         else:
-            stdout, stderr = self.cmd_block()
+            stdout, stderr, retcode = self.cmd_block()
 
         if stdout.startswith('deploy') and not deploy_attempted:
             self.deploy()
             return self.run(deploy_attempted=True)
 
-        return stdout, stderr
+        return stdout, stderr, retcode
 
     def run_wfunc(self):
         '''
@@ -566,7 +568,7 @@ class Single(object):
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper)
         wrapper.wfuncs = self.wfuncs
         ret = json.dumps(self.wfuncs[self.fun](*self.arg))
-        return ret, ''
+        return ret, '', None
 
     def cmd(self):
         '''
@@ -592,8 +594,8 @@ class Single(object):
                 self.opts['hash_type'],
                 thin_sum,
                 self.minion_config)
-        for stdout, stderr in self.shell.exec_nb_cmd(cmd):
-            yield stdout, stderr
+        for stdout, stderr, retcode in self.shell.exec_nb_cmd(cmd):
+            yield stdout, stderr, retcode
 
     def cmd_block(self, is_retry=False):
         '''
@@ -620,26 +622,27 @@ class Single(object):
                 thin_sum,
                 self.minion_config)
         log.debug('Performing shimmed command as follows:\n{0}'.format(cmd))
-        stdout, stderr = self.shell.exec_cmd(cmd)
+        stdout, stderr, retcode = self.shell.exec_cmd(cmd)
 
         log.debug('STDOUT {1}\n{0}'.format(stdout, self.target['host']))
         log.debug('STDERR {1}\n{0}'.format(stderr, self.target['host']))
+        log.debug('RETCODE {1}\n{0}'.format(retcode, self.target['host']))
 
-        error = self.categorize_shim_errors(stdout, stderr)
+        error = self.categorize_shim_errors(stdout, stderr, retcode)
         if error:
-            return 'ERROR: {0}'.format(error), stderr
+            return 'ERROR: {0}'.format(error), stderr, retcode
 
         if RSTR in stdout:
             stdout = stdout.split(RSTR)[1].strip()
         if stdout.startswith('deploy'):
             self.deploy()
-            stdout, stderr = self.shell.exec_cmd(cmd)
+            stdout, stderr, retcode = self.shell.exec_cmd(cmd)
             if RSTR in stdout:
                 stdout = stdout.split(RSTR)[1].strip()
 
-        return stdout, stderr
+        return stdout, stderr, retcode
 
-    def categorize_shim_errors(self, stdout, stderr):
+    def categorize_shim_errors(self, stdout, stderr, retcode):
         perm_error_fmt = 'Permissions problem, target user may need '\
                          'to be root or use sudo:\n {0}'
         if stderr.startswith('Permission denied'):
@@ -763,8 +766,6 @@ class SSHHighState(salt.state.BaseHighState):
         salt.state.BaseHighState.__init__(self, opts)
         self.state = SSHState(opts, pillar, wrapper)
         self.matcher = salt.minion.Matcher(self.opts)
-
-
 def lowstate_file_refs(chunks):
     '''
     Create a list of file ref objects to reconcile

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -273,7 +273,7 @@ class SSH(object):
                     'retcode': retcode,
                 }
         except Exception:
-            ret['ret'] =  {
+            ret['ret'] = {
                 'stdout': stdout,
                 'stderr': stderr,
                 'retcode': retcode,
@@ -643,6 +643,11 @@ class Single(object):
         return stdout, stderr, retcode
 
     def categorize_shim_errors(self, stdout, stderr, retcode):
+        # Unused stdout and retcode for now but these may be used to
+        # categorize errors
+        _ = stdout
+        _ = retcode
+
         perm_error_fmt = 'Permissions problem, target user may need '\
                          'to be root or use sudo:\n {0}'
         if stderr.startswith('Permission denied'):

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -162,7 +162,7 @@ class Shell(object):
         '''
         Execute ssh-copy-id to plant the id file on the target
         '''
-        stdout, stderr, retcode = self._run_cmd(self._copy_id_str_old())
+        _, stderr, _ = self._run_cmd(self._copy_id_str_old())
         if stderr.startswith('Usage'):
             self._run_cmd(self._copy_id_str_new())
 
@@ -227,12 +227,12 @@ class Shell(object):
                 time.sleep(0.1)
                 out = proc.recv()
                 err = proc.recv_err()
-                rc = proc.returncode
+                rcode = proc.returncode
                 if out is None and err is None:
                     break
                 if err:
                     err = self.get_error(err)
-                yield out, err, rc
+                yield out, err, rcode
         except Exception:
             yield ('', 'Unknown Error', None)
 
@@ -242,7 +242,7 @@ class Shell(object):
         '''
         r_out = []
         r_err = []
-        rc    = None
+        rcode = None
         cmd = self._cmd_str(cmd)
 
         logmsg = 'Executing non-blocking command: {0}'.format(cmd)
@@ -250,13 +250,13 @@ class Shell(object):
             logmsg = logmsg.replace(self.passwd, ('*' * len(self.passwd))[:6])
         log.debug(logmsg)
 
-        for out, err, rc in self._run_nb_cmd(cmd):
+        for out, err, rcode in self._run_nb_cmd(cmd):
             if out is not None:
                 r_out.append(out)
             if err is not None:
                 r_err.append(err)
             yield None, None, None
-        yield ''.join(r_out), ''.join(r_err), rc
+        yield ''.join(r_out), ''.join(r_err), rcode
 
     def exec_cmd(self, cmd):
         '''

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -162,7 +162,7 @@ class Shell(object):
         '''
         Execute ssh-copy-id to plant the id file on the target
         '''
-        stdout, stderr = self._run_cmd(self._copy_id_str_old())
+        stdout, stderr, retcode = self._run_cmd(self._copy_id_str_old())
         if stderr.startswith('Usage'):
             self._run_cmd(self._copy_id_str_new())
 
@@ -208,9 +208,9 @@ class Shell(object):
             )
 
             data = proc.communicate()
-            return data
+            return data[0], data[1], proc.returncode
         except Exception:
-            return ('local', 'Unknown Error')
+            return ('local', 'Unknown Error', None)
 
     def _run_nb_cmd(self, cmd):
         '''
@@ -227,13 +227,14 @@ class Shell(object):
                 time.sleep(0.1)
                 out = proc.recv()
                 err = proc.recv_err()
+                rc = proc.returncode
                 if out is None and err is None:
                     break
                 if err:
                     err = self.get_error(err)
-                yield out, err
+                yield out, err, rc
         except Exception:
-            yield ('', 'Unknown Error')
+            yield ('', 'Unknown Error', None)
 
     def exec_nb_cmd(self, cmd):
         '''
@@ -241,6 +242,7 @@ class Shell(object):
         '''
         r_out = []
         r_err = []
+        rc    = None
         cmd = self._cmd_str(cmd)
 
         logmsg = 'Executing non-blocking command: {0}'.format(cmd)
@@ -248,13 +250,13 @@ class Shell(object):
             logmsg = logmsg.replace(self.passwd, ('*' * len(self.passwd))[:6])
         log.debug(logmsg)
 
-        for out, err in self._run_nb_cmd(cmd):
+        for out, err, rc in self._run_nb_cmd(cmd):
             if out is not None:
                 r_out.append(out)
             if err is not None:
                 r_err.append(err)
-            yield None, None
-        yield ''.join(r_out), ''.join(r_err)
+            yield None, None, None
+        yield ''.join(r_out), ''.join(r_err), rc
 
     def exec_cmd(self, cmd):
         '''

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -54,10 +54,10 @@ class FunctionWrapper(object):
                     ''.join(arg_str),
                     **self.kwargs
             )
-            stdout, stderr, retcode = single.cmd_block()
+            stdout, _, _ = single.cmd_block()
             if stdout.startswith('deploy'):
                 single.deploy()
-                stdout, stderr, retcode = single.cmd_block()
+                stdout, _, _ = single.cmd_block()
             try:
                 ret = json.loads(stdout, object_hook=salt.utils.decode_dict)
             except ValueError:

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -54,10 +54,10 @@ class FunctionWrapper(object):
                     ''.join(arg_str),
                     **self.kwargs
             )
-            stdout, stderr = single.cmd_block()
+            stdout, stderr, retcode = single.cmd_block()
             if stdout.startswith('deploy'):
                 single.deploy()
-                stdout, stderr = single.cmd_block()
+                stdout, stderr, retcode = single.cmd_block()
             try:
                 ret = json.loads(stdout, object_hook=salt.utils.decode_dict)
             except ValueError:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -418,6 +418,7 @@ def _run(cmd,
     except TimedProcTimeoutError as exc:
         ret['stdout'] = str(exc)
         ret['stderr'] = ''
+        ret['retcode'] = None
         ret['pid'] = proc.process.pid
         # ok return code for timeouts?
         ret['retcode'] = 1
@@ -679,6 +680,8 @@ def run_stdout(cmd,
             log.log(lvl, 'stdout: {0}'.format(ret['stdout']))
         if ret['stderr']:
             log.log(lvl, 'stderr: {0}'.format(ret['stderr']))
+        if ret['retcode']:
+            log.log(lvl, 'retcode: {0}'.format(ret['retcode']))
     return ret['stdout']
 
 
@@ -757,6 +760,8 @@ def run_stderr(cmd,
             log.log(lvl, 'stdout: {0}'.format(ret['stdout']))
         if ret['stderr']:
             log.log(lvl, 'stderr: {0}'.format(ret['stderr']))
+        if ret['retcode']:
+            log.log(lvl, 'retcode: {0}'.format(ret['retcode']))
     return ret['stderr']
 
 
@@ -835,6 +840,8 @@ def run_all(cmd,
             log.log(lvl, 'stdout: {0}'.format(ret['stdout']))
         if ret['stderr']:
             log.log(lvl, 'stderr: {0}'.format(ret['stderr']))
+        if ret['retcode']:
+            log.log(lvl, 'retcode: {0}'.format(ret['retcode']))
     return ret
 
 

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -10,6 +10,7 @@ import tarfile
 # Import third party libs
 import jinja2
 import yaml
+import msgpack
 try:
     import markupsafe
     HAS_MARKUPSAFE = True
@@ -60,6 +61,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False):
             os.path.dirname(salt.__file__),
             os.path.dirname(jinja2.__file__),
             os.path.dirname(yaml.__file__),
+            os.path.dirname(msgpack.__file__),
             ]
     for mod in [m for m in extra_mods.split(',') if m]:
         if mod not in locals() and mod not in globals():


### PR DESCRIPTION
This is for review purposes _only_ at this point.  I believe that this
works.  However it should receive additional scrutiny because I am
unfamiliar with the "retcode-passthrough" and "local" concepts - which
this may impact.  This may be significant in locations where stdout is
processed with salt.utils.find_json and the 'local' value is
extracted.
# 

salt-ssh raw mode only emits stdout lines; it emits neither stderr nor
the return code.  salt-ssh raw works more like cmd.run rather than
cmd.run_all.  Preserving stdout, stderr and the return code are
imperative for validating the results of a salt-ssh raw command.

This stores 'stdout', 'stderr' and 'retcode' in the ret dictionary so
that the complete information can be emitted by the outputter.

Fixes #10432
