### PR TITLE
flopen improvements

### DIFF
--- a/salt/fileserver/minionfs.py
+++ b/salt/fileserver/minionfs.py
@@ -167,8 +167,9 @@ def file_hash(load, fnd):
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
     # save the cache object "hash:mtime"
+    cache_object = '{0}:{1}'.format(ret['hsum'], os.path.getmtime(path))
     with salt.utils.flopen(cache_path, 'w') as fp_:
-        fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
+        fp_.write(cache_object)
     return ret
 
 

--- a/salt/fileserver/minionfs.py
+++ b/salt/fileserver/minionfs.py
@@ -167,15 +167,9 @@ def file_hash(load, fnd):
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
     # save the cache object "hash:mtime"
-    if HAS_FCNTL:
-        with salt.utils.flopen(cache_path, 'w') as fp_:
-            fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
-            fcntl.flock(fp_.fileno(), fcntl.LOCK_UN)
-        return ret
-    else:
-        with salt.utils.fopen(cache_path, 'w') as fp_:
-            fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
-        return ret
+    with salt.utils.flopen(cache_path, 'w') as fp_:
+        fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
+    return ret
 
 
 def file_list(load):

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -217,8 +217,9 @@ def file_hash(load, fnd):
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
     # save the cache object "hash:mtime"
+    cache_object = '{0}:{1}'.format(ret['hsum'], os.path.getmtime(path))
     with salt.utils.flopen(cache_path, 'w') as fp_:
-        fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
+        fp_.write(cache_object)
     return ret
 
 

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -217,15 +217,9 @@ def file_hash(load, fnd):
     if not os.path.exists(cache_dir):
         os.makedirs(cache_dir)
     # save the cache object "hash:mtime"
-    if HAS_FCNTL:
-        with salt.utils.flopen(cache_path, 'w') as fp_:
-            fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
-            fcntl.flock(fp_.fileno(), fcntl.LOCK_UN)
-        return ret
-    else:
-        with salt.utils.fopen(cache_path, 'w') as fp_:
-            fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
-        return ret
+    with salt.utils.flopen(cache_path, 'w') as fp_:
+        fp_.write('{0}:{1}'.format(ret['hsum'], os.path.getmtime(path)))
+    return ret
 
 
 def _file_lists(load, form):

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1056,18 +1056,7 @@ def fopen(*args, **kwargs):
 
 
 def flopen(*args, **kwargs):
-    fhandle = open(*args, **kwargs)
-    if HAS_FCNTL:
-        # modify the file descriptor on systems with fcntl
-        # unix and unix-like systems only
-        try:
-            FD_CLOEXEC = fcntl.FD_CLOEXEC   # pylint: disable=C0103
-        except AttributeError:
-            FD_CLOEXEC = 1                  # pylint: disable=C0103
-        old_flags = fcntl.fcntl(fhandle.fileno(), fcntl.F_GETFD)
-        fcntl.flock(fhandle.fileno(), fcntl.LOCK_SH)
-        fcntl.fcntl(fhandle.fileno(), fcntl.F_SETFD, old_flags | FD_CLOEXEC)
-    return fhandle
+    return fopen(*args, lock=True, **kwargs)
 
 
 def subdict_match(data, expr, delim=':', regex_match=False):


### PR DESCRIPTION
- simplify `flopen()` code;
- simplify `flopen()` usage;
- make it unlock on `__exit__()`;
- make `lock` argument of `fopen()` actually work;
- check that `lock` kwarg is True instead of that it exists;
- reduce size of critical section under `flopen()` in fileserver.
