### PR TITLE
security: avoid race between file creation and chmod(2)

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -388,18 +388,19 @@ class Publisher(multiprocessing.Process):
         pub_uri = 'tcp://{interface}:{publish_port}'.format(**self.opts)
         # Prepare minion pull socket
         pull_sock = context.socket(zmq.PULL)
-        pull_uri = 'ipc://{0}'.format(
-            os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
-        )
+        pull_path = os.path.join(self.opts['sock_dir'], 'publish_pull.ipc')
+        pull_mode = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        pull_uri = 'ipc://{0}'.format(pull_path)
+        salt.utils.check_ipc_path_max_len(pull_uri)
+
+        # Securely create pull socket file
+        log.debug('Creating pull socket {0}'.format(pull_path))
+        os.close(os.open(pull_path, pull_mode, 0600))
+
         # Start the minion command publisher
         log.info('Starting the Salt Publisher on {0}'.format(pub_uri))
         pub_sock.bind(pub_uri)
         pull_sock.bind(pull_uri)
-        # Restrict access to the socket
-        os.chmod(
-            os.path.join(self.opts['sock_dir'], 'publish_pull.ipc'),
-            448
-        )
 
         try:
             while True:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -374,22 +374,18 @@ class MinionBase(object):
                     # Let's stop at this stage
                     raise
 
+        # Securely create socket files
+        if self.opts.get('ipc_mode', '') != 'tcp':
+            mode = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+            for path in (epub_sock_path, epull_sock_path):
+                log.debug('Creating pull socket {0}'.format(path))
+                os.close(os.open(path, mode, 0600))
+
         # Create the pull socket
         self.epull_sock = self.context.socket(zmq.PULL)
         # Bind the event sockets
         self.epub_sock.bind(epub_uri)
         self.epull_sock.bind(epull_uri)
-
-        # Restrict access to the sockets
-        if self.opts.get('ipc_mode', '') != 'tcp':
-            os.chmod(
-                epub_sock_path,
-                448
-            )
-            os.chmod(
-                epull_sock_path,
-                448
-            )
 
     @staticmethod
     def process_schedule(minion, loop_interval):


### PR DESCRIPTION
Also:
- salt.utils.check_ipc_path_max_len() on master pull socket
- change mode from 0700 to 0600
- added debug logging

TODO: move file creation with specified mode to separate utils function.
