### PR TITLE
re-adding fix for import error for windows postgres

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -26,8 +26,12 @@ import StringIO
 import hashlib
 import os
 import tempfile
-import csv
-import pipes
+try:
+    import pipes
+    import csv
+    HAS_ALL_IMPORTS = True
+except ImportError:
+    HAS_ALL_IMPORTS = False
 
 # Import salt libs
 import salt.utils
@@ -52,7 +56,7 @@ def __virtual__():
     '''
     Only load this module if the psql bin exists
     '''
-    if salt.utils.which('psql'):
+    if all((salt.utils.which('psql'), HAS_ALL_IMPORTS)):
         return 'postgres'
     return False
 


### PR DESCRIPTION
Gracefully handles missing imports on Windows.  This was present in the past, but got yanked somewhere along the way
