### PR TITLE
Fixes for the mongodb_user state module, Fixes #10430

### DIFF
--- a/salt/states/mongodb_user.py
+++ b/salt/states/mongodb_user.py
@@ -50,6 +50,15 @@ def present(name,
            'changes': {},
            'result': True,
            'comment': 'User {0} is already present'.format(name)}
+
+    # Check for valid port
+    try:
+        port = int(port)
+    except TypeError:
+        ret['result'] = False
+        ret['comment'] = 'Port ({0}) is not an integer.'.format(port)
+        return ret
+
     # check if user exists
     if __salt__['mongodb.user_exists'](name, user, password, host, port, database):
         return ret

--- a/salt/states/mongodb_user.py
+++ b/salt/states/mongodb_user.py
@@ -4,6 +4,15 @@ Management of Mongodb users
 ===========================
 '''
 
+# Define the module's virtual name
+__virtualname__ = 'mongodb_user'
+
+
+def __virtual__():
+    if 'mongodb.user_exists' in __salt__:
+        return __virtualname__
+    return False
+
 
 def present(name,
             passwd,


### PR DESCRIPTION
Fixes #10430

Add `__virtual__` to `mongodb_user` state which checks for the existence of the execution module.

Check for valid (integer) port for `mongodb_user.present` state.
