### PR TITLE
Ensure ~/.salt_token is created with 0600 permissions, Fix #10422

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -340,10 +340,12 @@ class Resolver(object):
         if 'token' not in tdata:
             return tdata
         try:
+            oldmask = os.umask(0177)
             with salt.utils.fopen(self.opts['token_file'], 'w+') as fp_:
                 fp_.write(tdata['token'])
+            os.umask(oldmask)
         except (IOError, OSError):
-            pass
+            os.umask(oldmask)
         return tdata
 
     def mk_token(self, load):


### PR DESCRIPTION
Previously was being created with 0644, which is not secure.

Fixes #10422
