### PR TITLE
Allow the new master's minion to answer to local master

### DIFF
--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -115,7 +115,7 @@ Notice that **ALL** bootstrapped minions from the map will answer to the newly
 created salt-master.
 
 To make any of the bootstrapped minions answer to the bootstrapping salt-master 
-as opposed to the newly created salt-master you can do something like:
+as opposed to the newly created salt-master, as an example:
 
 .. code-block:: yaml
 

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -97,3 +97,34 @@ A map file may also be used with the various query options:
 
     Proceed? [N/y]
 
+
+Setting up New Salt Masters
+===========================
+
+Bootstrapping a new master in the map is as simple as:
+
+.. code-block:: yaml
+
+    fedora_small:
+      - web1
+        make_master: True
+      - web2
+      - web3
+
+Notice that **ALL** bootstrapped minions from the map will answer to the newly 
+created salt-master.
+
+If you wish to make the bootstrapped salt-master's minion answer to the 
+bootstrapping salt-master as opposed to the newly bootstrapped salt-master you 
+can do something like:
+
+.. code-block:: yaml
+
+    fedora_small:
+      - web1
+        make_master: True
+        minion:
+          master: <the local master ip address>
+          local_master: True
+      - web2
+      - web3

--- a/doc/topics/cloud/map.rst
+++ b/doc/topics/cloud/map.rst
@@ -114,9 +114,8 @@ Bootstrapping a new master in the map is as simple as:
 Notice that **ALL** bootstrapped minions from the map will answer to the newly 
 created salt-master.
 
-If you wish to make the bootstrapped salt-master's minion answer to the 
-bootstrapping salt-master as opposed to the newly bootstrapped salt-master you 
-can do something like:
+To make any of the bootstrapped minions answer to the bootstrapping salt-master 
+as opposed to the newly created salt-master you can do something like:
 
 .. code-block:: yaml
 
@@ -128,3 +127,23 @@ can do something like:
           local_master: True
       - web2
       - web3
+
+
+The above says the minion running on the newly created salt-master responds to 
+the local master, ie, the master used to bootstrap these VMs.
+
+Another example:
+
+.. code-block:: yaml
+
+    fedora_small:
+      - web1
+        make_master: True
+      - web2
+      - web3
+        minion:
+          master: <the local master ip address>
+          local_master: True
+
+The above example makes the ``web3`` minion answer to the local master, not the 
+newly created master.

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1618,7 +1618,7 @@ class Map(Cloud):
                 # explicitely saying it's the local one
                 local_master = True
 
-            if master_finger is not None and local_master  is False:
+            if master_finger is not None and local_master is False:
                 profile['master_finger'] = master_finger
 
             if master_host is not None:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -835,9 +835,9 @@ class Cloud(object):
                 )
                 vm_['master_pub'] = master_pub
                 vm_['master_pem'] = master_priv
-        elif local_master is True and deploy is True:
-            # Since we're not creating a master, and we're deploying, accept
-            # the key on the local master
+
+        if local_master is True and deploy is True:
+            # Accept the key on the local master
             salt.utils.cloud.accept_key(
                 self.opts['pki_dir'], vm_['pub_key'], key_id
             )
@@ -1487,6 +1487,7 @@ class Map(Cloud):
                 (name, profile) for name, profile in create_list
                 if profile.get('make_master', False) is True
             ).next()
+            master_minion_name = master_name
             log.debug('Creating new master {0!r}'.format(master_name))
             if salt.config.get_cloud_config_value('deploy',
                                        master_profile,
@@ -1516,10 +1517,13 @@ class Map(Cloud):
 
             if master_profile.get('make_minion', True) is True:
                 master_profile.setdefault('minion', {})
+                if 'id' in master_profile['minion']:
+                    master_minion_name = master_profile['minion']['id']
                 # Set this minion's master as local if the user has not set it
-                master_profile['minion'].setdefault('master', '127.0.0.1')
-                if master_finger is not None:
-                    master_profile['master_finger'] = master_finger
+                if 'master' not in master_profile['minion']:
+                    master_profile['minion']['master'] = '127.0.0.1'
+                    if master_finger is not None:
+                        master_profile['master_finger'] = master_finger
 
             # Generate the minion keys to pre-seed the master:
             for name, profile in create_list:
@@ -1542,7 +1546,15 @@ class Map(Cloud):
                 master_profile.setdefault('preseed_minion_keys', {})
                 master_profile['preseed_minion_keys'].update({name: pub})
 
-            out = self.create(master_profile, local_master=False)
+            local_master = False
+            if master_profile['minion'].get('local_master', False) and \
+                    master_profile['minion'].get('master', None) is not None:
+                # The minion is explicitly defining a master and it's
+                # explicitely saying it's the local one
+                local_master = True
+
+            out = self.create(master_profile, local_master=local_master)
+
             if not isinstance(out, dict):
                 log.debug(
                     'Master creation details is not a dictionary: {0}'.format(
@@ -1594,7 +1606,7 @@ class Map(Cloud):
             opts['display_ssh_output'] = False
 
         for name, profile in create_list:
-            if name == master_name:
+            if name in (master_name, master_minion_name):
                 # Already deployed, it's the master's minion
                 continue
 


### PR DESCRIPTION
When deploying a cloud map which will create a master, allow the master's minion to answer to the bootstrapping master as opposed to the bootstrapped master.
