### PR TITLE
MultiMinion loop fixes

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -497,6 +497,8 @@ class MultiMinion(MinionBase):
         '''
         self._prepare_minion_event_system()
 
+        self.poller.register(self.epull_sock, zmq.POLLIN)
+
         module_refresh = False
         pillar_refresh = False
 
@@ -515,7 +517,8 @@ class MultiMinion(MinionBase):
                     continue
                 loop_interval = self.process_schedule(minion, loop_interval)
                 break
-            if self.poller.poll(1):
+            socks = dict(self.poller.poll(1))
+            if socks.get(self.epull_sock) == zmq.POLLIN:
                 try:
                     while True:
                         package = self.epull_sock.recv(zmq.NOBLOCK)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -516,7 +516,6 @@ class MultiMinion(MinionBase):
                 if not hasattr(minion, 'schedule'):
                     continue
                 loop_interval = self.process_schedule(minion, loop_interval)
-                break
             socks = dict(self.poller.poll(1))
             if socks.get(self.epull_sock) == zmq.POLLIN:
                 try:


### PR DESCRIPTION
process all minion schedules (remove break) and register the epull_sock so that we're actually polling it.
