### PR TITLE
Allow formatting of partitions

### DIFF
--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -22,6 +22,10 @@ A state module to manage blockdevices
 
 '''
 
+# Import python libs
+import os
+import os.path
+
 # Import salt libs
 import salt.utils
 
@@ -62,7 +66,8 @@ def tuned(name, **kwargs):
            'result': True}
 
     if not __salt__['file.is_blkdev']:
-        ret['comment'] = 'Changes to {0} cannot be applied. Not a block device '.format(name)
+        ret['comment'] = ('Changes to {0} cannot be applied. '
+                          'Not a block device. ').format(name)
     elif __opts__['test']:
         ret['comment'] = 'Changes to {0} will be applied '.format(name)
         ret['result'] = None
@@ -70,9 +75,74 @@ def tuned(name, **kwargs):
     else:
         changes = __salt__['blockdev.tune'](name, **kwargs)
         if changes:
-            ret['comment'] = 'Block device {0} successfully modified '.format(name)
+            ret['comment'] = ('Block device {0} '
+                              'successfully modified ').format(name)
             ret['changes'] = changes
         else:
             ret['comment'] = 'Failed to modify block device {0}'.format(name)
             ret['result'] = False
+    return ret
+
+
+def formatted(name, fs_type='ext4', **kwargs):
+    '''
+    Manage filesystems of partitions.
+
+    name
+        The name of the block device
+
+    fs_type
+        The filesystem it should be formatted as
+    '''
+    ret = {'changes': {},
+           'comment': '{0} already formatted with {1}'.format(name, fs_type),
+           'name': name,
+           'result': False}
+
+    if not os.path.exists(name):
+        ret['comment'] = '{0} does not exist'.format(name)
+        return ret
+
+    blk = __salt__['cmd.run']('lsblk -o fstype {0}'.format(name)).splitlines()
+
+    if len(blk) == 1:
+        current_fs = ''
+    else:
+        current_fs = blk[1]
+
+    if current_fs == fs_type:
+        ret['result'] = True
+        return ret
+    elif not salt.utils.which('mkfs.{0}'.format(fs_type)):
+        ret['comment'] = 'Invalid fs_type: {0}'.format(fs_type)
+        ret['result'] = False
+        return ret
+    elif __opts__['test']:
+        ret['comment'] = 'Changes to {0} will be applied '.format(name)
+        ret['result'] = None
+        return ret
+
+    cmd = 'mkfs -t {0} '.format(fs_type)
+    if 'inode_size' in kwargs:
+        if fs_type[:3] == 'ext':
+            cmd += '-i {0}'.format(kwargs['inode_size'])
+        elif fs_type == 'xfs':
+            cmd += '-i size={0} '.format(kwargs['inode_size'])
+    cmd += name
+    __salt__['cmd.run'](cmd).splitlines()
+    blk = __salt__['cmd.run']('lsblk -o fstype {0}'.format(name)).splitlines()
+
+    if len(blk) == 1:
+        current_fs = ''
+    else:
+        current_fs = blk[1]
+
+    if current_fs == fs_type:
+        ret['comment'] = ('{0} has been formatted '
+                          'with {1}').format(name, fs_type)
+        ret['changes'] = {'new': fs_type, 'old': current_fs}
+        ret['result'] = True
+    else:
+        ret['comment'] = 'Failed to format {0}'.format(name)
+        ret['result'] = False
     return ret


### PR DESCRIPTION
I want a state so that I can check and make sure that a partition is formatted correctly.

Specifically on Rackspace servers when I have added a new cloud block storage, or for the data partition on the performance servers.

This achieves that, and allows me to set any extra argument I want, such as -i size=512 for xttr attributes for use with things like glusterfs.

Thanks,
Daniel Wallace
