### PR TITLE
[salt.cloud] master_minion_name referenced before assignment

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1480,6 +1480,7 @@ class Map(Cloud):
         if self.opts['parallel']:
             parallel_data = []
         master_name = None
+        master_minion_name = None
         master_host = None
         master_finger = None
         try:


### PR DESCRIPTION
Fixes error caused by 42ca06c9

[ERROR   ] There was a query error: local variable 'master_minion_name' referenced before assignment
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/cli.py", line 389, in run
    ret = mapper.run_map(dmap)
  File "/usr/lib/python2.7/site-packages/salt/cloud/**init**.py", line 1611, in run_map
    if name in (master_name, master_minion_name):
UnboundLocalError: local variable 'master_minion_name' referenced before assignment
