### PR TITLE
use the value of __virtualname__ instead of a string

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -66,7 +66,7 @@ def __virtual__():
         if os.path.isfile(debian_initctl):
             initctl_version = salt.modules.cmdmod._run_quiet(debian_initctl + ' version')
             if 'upstart' in initctl_version:
-                return 'service'
+                return __virtualname__
     return False
 
 


### PR DESCRIPTION
var was introduced but not used consistently.
