### PR TITLE
Reload modules when a ports state installs packages

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -636,7 +636,7 @@ class State(object):
             elif data['fun'] == 'symlink':
                 if 'bin' in data['name']:
                     self.module_refresh()
-        elif data['state'] == 'pkg':
+        elif data['state'] in ('pkg', 'ports'):
             self.module_refresh()
 
     def verify_ret(self, ret):


### PR DESCRIPTION
Since ports states modify the package database, the pkg database should
be reloaded when a port is installed.
