### PR TITLE
doc: fix references in salt.modules.pkg

### DIFF
--- a/doc/ref/modules/all/salt.modules.pkg.rst
+++ b/doc/ref/modules/all/salt.modules.pkg.rst
@@ -7,7 +7,7 @@ salt.modules.pkg
 
 ``pkg`` is a virtual module that is fulfilled by one of the following modules:
 
-* :mod:`salt.modules.apt`
+* :mod:`salt.modules.aptpkg`
 * :mod:`salt.modules.brew`
 * :mod:`salt.modules.ebuild`
 * :mod:`salt.modules.freebsdpkg`
@@ -19,5 +19,4 @@ salt.modules.pkg
 * :mod:`salt.modules.solarispkg`
 * :mod:`salt.modules.win_pkg`
 * :mod:`salt.modules.yumpkg`
-* :mod:`salt.modules.yumpkg5`
 * :mod:`salt.modules.zypper`


### PR DESCRIPTION
fix old references on apt and yumpkg5 modules
