### PR TITLE
Enable highstate failure retcode

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -187,6 +187,7 @@ VALID_OPTS = {
     'gather_job_timeout': int,
     'auth_timeout': int,
     'random_master': bool,
+    'salt_fails_if_highstate_fails': bool,
 }
 
 # default configurations
@@ -397,6 +398,7 @@ DEFAULT_MASTER_OPTS = {
     'salt_transport': 'zeromq',
     'enumerate_proxy_minions': False,
     'gather_job_timeout': 2,
+    'salt_fails_if_highstate_fails': False
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -16,6 +16,8 @@ import traceback
 import salt.loader
 import salt.utils
 
+from salt.exceptions import SaltSystemExit
+
 
 log = logging.getLogger(__name__)
 
@@ -39,6 +41,7 @@ def display_output(data, out, opts=None):
         display_data = get_printout('nested', opts)(data).rstrip()
 
     output_filename = opts.get('output_file', None)
+    salt_fails_if_highstate_fails = opts.get('salt_fails_if_highstate_fails', False)
     try:
         if output_filename is not None:
             with salt.utils.fopen(output_filename, 'a') as ofh:
@@ -47,11 +50,21 @@ def display_output(data, out, opts=None):
             return
         if display_data:
             print(display_data)
+        if salt_fails_if_highstate_fails:
+            if not get_highstate_success(highstate_data=data):
+                raise SaltSystemExit(code=1)
+
     except IOError as exc:
         # Only raise if it's NOT a broken pipe
         if exc.errno != errno.EPIPE:
             raise exc
 
+def get_highstate_success(highstate_data):
+    for i in highstate_data.keys():
+         for j in highstate_data[i].keys():
+            if not highstate_data[i][j]['result']:
+                return False
+    return True
 
 def get_printout(out, opts=None, **kwargs):
     '''


### PR DESCRIPTION
- new config variable to enable/disable the new functionality
- added new function to determine if the highstate return data indicates
  an error or failure has occurred.
- added new logic to the end of the salt cli call that if enabled using
  the config variable, determines if salt should exit with a non zero
  exit code and then will exit if any failures or errors are found in
  the highstate return data.

Should fix issue #7013 
