### PR TITLE
tweak code-block docstring in salt.client.Caller

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1604,7 +1604,7 @@ class Caller(object):
 
         opts = salt.config.minion_config('/etc/salt/minion')
         opts['file_client'] = 'local'
-        caller = salt.client.Caller(opts)
+        caller = salt.client.Caller(mopts=opts)
         caller.sminion.functions['grains.items']()
 
     '''


### PR DESCRIPTION
this correction is attributed to mgw in #salt

the original errors out:

   caller = salt.client.Caller(opts)
 File "/usr/local/lib/python2.7/dist-packages/salt/client/**init**.py", line 1616, in **init**
   self.opts = salt.config.minion_config(c_path)
 File "/usr/local/lib/python2.7/dist-packages/salt/config.py", line 684, in minion_config
   overrides = load_config(path, env_var, DEFAULT_MINION_OPTS['conf_file'])
 File "/usr/local/lib/python2.7/dist-packages/salt/config.py", line 565, in load_config
   if not env_path or not os.path.isfile(env_path):
 File "/usr/lib/python2.7/genericpath.py", line 29, in isfile
   st = os.stat(path)
TypeError: coercing to Unicode: need string or buffer, dict found
