### PR TITLE
workaround for bad output format dpkg-query command

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -635,7 +635,7 @@ def list_pkgs(versions_as_list=False, removed=False, **kwargs):
         try:
             linetype, status, name, version_num, arch = \
                 [cols[x] for x in (0, 2, 3, 4, 5)]
-        except ValueError:
+        except (ValueError, IndexError):
             continue
         if __grains__.get('cpuarch', '') == 'x86_64':
             osarch = __grains__.get('osarch', '')


### PR DESCRIPTION
fixes the following error trace:

```
  File "/usr/lib/pymodules/python2.7/salt/state.py", line 1258, in call
    *cdata['args'], **cdata['kwargs'])
  File "/usr/lib/pymodules/python2.7/salt/states/pkg.py", line 421, in installed
    fromrepo=fromrepo, **kwargs)
  File "/usr/lib/pymodules/python2.7/salt/states/pkg.py", line 108, in _find_install_targets
    cur_pkgs = __salt__['pkg.list_pkgs'](versions_as_list=True)
  File "/usr/lib/pymodules/python2.7/salt/modules/apt.py", line 609, in list_pkgs
    [cols[x] for x in (0, 2, 3, 4, 5)]
IndexError: list index out of range
```

This is the line in my dpkg output that causes it:

`install reinstreq half-installed libossp-uuid16 {Version}`

which i believe is the result of a half-installed package in a bad state
