### PR TITLE
pacman: Don't upgrade by installing a package

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -348,9 +348,12 @@ def install(name=None,
     return salt.utils.compare_dicts(old, new)
 
 
-def upgrade():
+def upgrade(refresh=True):
     '''
     Run a full system upgrade, a pacman -Syu
+
+    refresh
+        Whether or not to refresh the package database before installing.
 
     Return a dict containing the new package names and versions::
 
@@ -364,7 +367,9 @@ def upgrade():
         salt '*' pkg.upgrade
     '''
     old = list_pkgs()
-    cmd = 'pacman -Syu --noprogressbar --noconfirm'
+    cmd = 'pacman -Su --noprogressbar --noconfirm'
+    if salt.utils.is_true(refresh):
+        cmd += ' -y'
     __salt__['cmd.run'](cmd, output_loglevel='debug')
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()


### PR DESCRIPTION
The current setting behavior of pkg.install is dangerous. When you want to
install or upgrade a package, the whole syste is upgraded if Refresh is True.

The Refresh option, reload the database, and allow upgrades of newly pushed
packages.
