### PR TITLE
Add comment discussing the dangers of pacman -Sy

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -328,6 +328,8 @@ def install(name=None,
                 log.error(problem)
             return {}
 
+        # It is critical that -Syu is run instead of -Sy:
+        # http://gist.io/5660494
         if salt.utils.is_true(refresh):
             cmd = 'pacman -Syu --noprogressbar --noconfirm --needed ' \
                   '"{0}"'.format('" "'.join(targets))


### PR DESCRIPTION
This is in response to #10519, the latest attempt to change how Salt calls pacman. This comes up from time to time, and it would be helpful to let people know beforehand why we use `-Syu` instead of just `-Sy`. Thanks for @gtmanfred for the link.
