### PR TITLE
[salt] Pacman shouldn't default to refresh

### DIFF
--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -223,7 +223,7 @@ def refresh_db():
 
 
 def install(name=None,
-            refresh=True,
+            refresh=False,
             pkgs=None,
             sources=None,
             **kwargs):


### PR DESCRIPTION
Because refreshing requires you to update the entire system and
installing should by default limited to only the package you are
installing.
