### PR TITLE
Fix service restart over salt

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -64,7 +64,7 @@ start() {
             RETVAL=0
         fi
     else
-        if [[ ! -z "$(pidofproc $PROCESS)" ]]; then
+        if [[ ! -z "$(pidofproc -p /var/run/$SERVICE.pid $PROCESS)" ]]; then
             RETVAL=$?
             echo -n "already running"
         else


### PR DESCRIPTION
When you attempt to restart a salt minion using salt it fails to restart properly.

```
[root@host ~]# salt 'foo' cmd.run 'service salt-minion restart'
foo:
    Stopping salt-minion daemon: [  OK  ]
    Starting salt-minion daemon: already running
```

It thinks it's already running because pidofproc mistakes the process that is running the restart command for the main salt-minion process.

The fix is to help pidofproc identify the main salt-minion process by telling it the pidfile to use so it doesn't have to guess.

Tested on CentOS 6.5
