### PR TITLE
Remove "upgrade instructions" wording for releases index.rst, Fix #10482

### DIFF
--- a/doc/topics/releases/index.rst
+++ b/doc/topics/releases/index.rst
@@ -1,6 +1,6 @@
-======================================
-Release notes and upgrade instructions
-======================================
+=============
+Release notes
+=============
 
 .. releasestree::
     :maxdepth: 1


### PR DESCRIPTION
Fixes #10482
