### PR TITLE
avoid shadowing in dig module

### DIFF
--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -171,9 +171,9 @@ def NS(domain, resolve=True, nameserver=None):
 
     if resolve:
         ret = []
-        for ns in cmd['stdout'].split('\n'):
-            for a in A(ns, nameserver):
-                ret.append(a)
+        for ns_host in cmd['stdout'].split('\n'):
+            for ip_addr in A(ns_host, nameserver):
+                ret.append(ip_addr)
         return ret
 
     return cmd['stdout'].split('\n')


### PR DESCRIPTION
```
************* Module salt.modules.dig
salt/modules/dig.py:175: [W0621(redefined-outer-name), NS] Redefining name 'a' from outer scope (line 280)
salt/modules/dig.py:174: [W0621(redefined-outer-name), NS] Redefining name 'ns' from outer scope (line 282)
```
