### PR TITLE
Add minimum version for apache-libcloud

### DIFF
--- a/doc/topics/conventions/packaging.rst
+++ b/doc/topics/conventions/packaging.rst
@@ -209,7 +209,7 @@ Depends
 
 - `Salt Common`
 - `sshpass`
-- `apache libcloud`
+- `apache libcloud` >= 0.14.0
 
 Salt Doc
 --------

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ pycrypto
 PyYAML
 pyzmq >= 2.2.0
 MarkupSafe
-apache-libcloud
+apache-libcloud >= 0.14.0


### PR DESCRIPTION
@thatch45, please review; version 0.14.0 has been made the baseline by @s0undt3ch elsewhere in the salt-cloud code, and is necessary for certain GCE and OpenStack features.
