### PR TITLE
fix launchctl module crashing badly with missing files

### DIFF
--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -47,11 +47,11 @@ def _available_services():
         for root, dirs, files in os.walk(launch_dir):
             for filename in files:
                 file_path = os.path.join(root, filename)
+                # Follow symbolic links of files in _launchd_paths
+                true_path = os.path.realpath(file_path)
                 try:
                     # This assumes most of the plist files will be already in XML format
                     with open(file_path):
-                        # Follow symbolic links of files in _launchd_paths
-                        true_path = os.path.realpath(file_path)
                         plist = plistlib.readPlist(true_path)
 
                 except Exception:

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -49,6 +49,10 @@ def _available_services():
                 file_path = os.path.join(root, filename)
                 # Follow symbolic links of files in _launchd_paths
                 true_path = os.path.realpath(file_path)
+                # ignore broken symlinks
+                if not os.path.exists(true_path):
+                    continue
+
                 try:
                     # This assumes most of the plist files will be already in XML format
                     with open(file_path):


### PR DESCRIPTION
```
try:
    with open(file_path):
        true_path = os.path.realpath(file_path)
except:
    do_backup_thing(true_path)

return true_path
```

fails to do the backup thing if file_path can't be opened, because true_path isn't defined
