### PR TITLE
Fix issue #10581

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -799,7 +799,8 @@ class Minion(MinionBase):
             )
         else:
             process = threading.Thread(
-                target=target, args=(instance, self.opts, data)
+                target=target, args=(instance, self.opts, data),
+                name=data['jid']
             )
         process.start()
 
@@ -813,13 +814,18 @@ class Minion(MinionBase):
         # multiprocessing communication.
         if not minion_instance:
             minion_instance = cls(opts)
+        fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
         if opts['multiprocessing']:
-            fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
             salt.utils.daemonize_if(opts)
             sdata = {'pid': os.getpid()}
-            sdata.update(data)
-            with salt.utils.fopen(fn_, 'w+b') as fp_:
-                fp_.write(minion_instance.serial.dumps(sdata))
+        else:
+            sdata = {
+                'pid': os.getpid(),
+                'tid': threading.currentThread().name
+            }
+        sdata.update(data)
+        with salt.utils.fopen(fn_, 'w+b') as fp_:
+            fp_.write(minion_instance.serial.dumps(sdata))
         ret = {'success': False}
         function_name = data['fun']
         if function_name in minion_instance.functions:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -817,12 +817,7 @@ class Minion(MinionBase):
         fn_ = os.path.join(minion_instance.proc_dir, data['jid'])
         if opts['multiprocessing']:
             salt.utils.daemonize_if(opts)
-            sdata = {'pid': os.getpid()}
-        else:
-            sdata = {
-                'pid': os.getpid(),
-                'tid': threading.currentThread().name
-            }
+        sdata = {'pid': os.getpid()}
         sdata.update(data)
         with salt.utils.fopen(fn_, 'w+b') as fp_:
             fp_.write(minion_instance.serial.dumps(sdata))

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -422,7 +422,10 @@ def running():
         else:
             if data.get('pid') != pid:
                 continue
-            if data.get('tid') == current_thread:
+            if data.get('jid') == current_thread:
+                continue
+            if not data.get('jid') in [x.name for x in threading.enumerate()]:
+                os.remove(path)
                 continue
         ret.append(data)
     return ret

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -407,6 +407,14 @@ def running():
     for fn_ in os.listdir(proc_dir):
         path = os.path.join(proc_dir, fn_)
         with salt.utils.fopen(path, 'rb') as fp_:
+            buf = fp_.read()
+            fp_.close()
+            if buf:
+                data = serial.loads(buf)
+            else:
+                # Proc file is empty, remove
+                os.remove(path)
+                continue
             data = serial.loads(fp_.read())
         if not isinstance(data, dict):
             # Invalid serial object

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -429,6 +429,7 @@ def running():
                 continue
         else:
             if data.get('pid') != pid:
+                os.remove(path)
                 continue
             if data.get('jid') == current_thread:
                 continue

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -415,7 +415,6 @@ def running():
                 # Proc file is empty, remove
                 os.remove(path)
                 continue
-            data = serial.loads(fp_.read())
         if not isinstance(data, dict):
             # Invalid serial object
             continue


### PR DESCRIPTION
Fix issue #10581.

I'm not getting any more timeouts with the 0.17.5-2 minion with this change running:
2x `while :; do salt winminion test.sleep 10`. Previously this would always timeout as find_job will be called.
1x `while :; do salt winminion test.ping`. Just to throw lots of very short lived jobs at the minion at the same time to try to trigger any really obvious threading issues.

Running the tests on linux with multiprocessing=False also looks good.
