### PR TITLE
Adding a object interface to __salt__ & __pillar__ (pyobjects)

### DIFF
--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -106,6 +106,21 @@ a state.
     Service.running(Extend('apache'),
                     watch=[{'file': '/etc/httpd/extra/httpd-vhosts.conf'}])
 
+Pillar data
+^^^^^^^^^^^
+Pyobjects provides a shortcut function for calling ``salt['pillar.get']`` that
+helps maintain the readability of your state files. It can be accessed using
+the ``Pillar`` object.
+
+The following lines are functionally equivalent:
+
+.. code-block:: python
+   :linenos:
+    #!pyobjects
+
+    value = Pillar('foo:bar:baz', 'qux')
+    value = salt['pillar.get']('foo:bar:baz', 'qux')
+
 SaltObject
 ^^^^^^^^^^
 In the spirit of the object interface for creating state data pyobjects also
@@ -178,6 +193,9 @@ def render(template, saltenv='base', sls='',
 
         # create our SaltObject
         Salt = SaltObject(__salt__)
+
+        # add a Pillar shortcut
+        Pillar = __salt__['pillar.get']
     except NameError:
         pass
 

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -105,12 +105,34 @@ a state.
 
     Service.running(Extend('apache'),
                     watch=[{'file': '/etc/httpd/extra/httpd-vhosts.conf'}])
+
+SaltObject
+^^^^^^^^^^
+In the spirit of the object interface for creating state data pyobjects also
+provides a simple object interface to the ``__salt__`` object.
+
+An object named ``Salt`` exists in scope for your sls files and will dispatch
+its attributes to the ``__salt__`` dictionary.
+
+The following lines are functionally equivalent:
+
+.. code-block:: python
+   :linenos:
+    #!pyobjects
+
+    ret = Salt.cmd.run(bar)
+    ret = salt['cmd.run'](bar)
+
+
+TODO
+^^^^
+* Interface for working with reactor files
 '''
 
 import logging
 
 from salt.loader import states
-from salt.utils.pyobjects import StateRegistry
+from salt.utils.pyobjects import StateRegistry, SaltObject
 from salt.utils.pyobjects import StateFactory  # pylint: disable=W0611
 # DO NOT REMOVE THE DISABLE ABOVE, it's used in an exec call below
 
@@ -153,6 +175,9 @@ def render(template, saltenv='base', sls='',
         pillar = __pillar__
         grains = __grains__
         salt = __salt__
+
+        # create our SaltObject
+        Salt = SaltObject(__salt__)
     except NameError:
         pass
 

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -31,22 +31,22 @@ pydmesg_salt_expected = OrderedDict([('/usr/local/bin/pydmesg', pydmesg_expected
 pydmesg_kwargs = dict(user='root', group='root', mode='0755',
                       source='salt://debian/files/pydmesg.py')
 
-basic_template = """#!pyobjects
+basic_template = '''#!pyobjects
 File.directory('/tmp', mode='1777', owner='root', group='root')
-"""
+'''
 
-invalid_template = """#!pyobjects
+invalid_template = '''#!pyobjects
 File.fail('/tmp')
-"""
+'''
 
-include_template = """#!pyobjects
+include_template = '''#!pyobjects
 Include('http')
-"""
+'''
 
-extend_template = """#!pyobjects
+extend_template = '''#!pyobjects
 Include('http')
 Service.running(Extend('apache'), watch=[{'file': '/etc/file'}])
-"""
+'''
 
 
 class StateTests(TestCase):
@@ -167,6 +167,9 @@ class RendererTests(TestCase):
 
 class SaltObjectTests(TestCase):
     def test_salt_object(self):
+        def attr_fail():
+            Salt.fail.blah()
+
         def times2(x):
             return x*2
 
@@ -176,6 +179,6 @@ class SaltObjectTests(TestCase):
 
         Salt = SaltObject(__salt__)
 
-        self.assertRaises(AttributeError, lambda: Salt.fail.blah())
+        self.assertRaises(AttributeError, attr_fail)
         self.assertEqual(Salt.math.times2, times2)
         self.assertEqual(Salt.math.times2(2), 4)

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -13,7 +13,7 @@ from salt.minion import SMinion
 from salt.renderers.pyobjects import render as pyobjects_render
 from salt.utils.odict import OrderedDict
 from salt.utils.pyobjects import (StateFactory, State, StateRegistry,
-                                  InvalidFunction)
+                                  InvalidFunction, SaltObject)
 
 test_registry = StateRegistry()
 File = StateFactory('file', registry=test_registry)
@@ -163,3 +163,19 @@ class RendererTests(TestCase):
                 }),
             ])),
         ]))
+
+
+class SaltObjectTests(TestCase):
+    def test_salt_object(self):
+        def times2(x):
+            return x*2
+
+        __salt__ = {
+            'math.times2': times2
+        }
+
+        Salt = SaltObject(__salt__)
+
+        self.assertRaises(AttributeError, lambda: Salt.fail.blah())
+        self.assertEqual(Salt.math.times2, times2)
+        self.assertEqual(Salt.math.times2(2), 4)


### PR DESCRIPTION
This is another suggestion from @mgwilliams. It adds an object to the
sls file scope named Salt, which dispatches its attributes to the
`__salt__` dictionary.

For example, the following two lines are functionally the same:

```
ret = Salt.cmd.run(bar)
ret = salt['cmd.run'](bar)
```
