### PR TITLE
Add glossary to toctree

### DIFF
--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -7,6 +7,7 @@ Salt Table of Contents
     :glob:
 
     faq
+    glossary
 
     topics/cloud/index
     topics/community


### PR DESCRIPTION
The glossary page was merged very recently, but it is not in the root toctree so it will not appear in the docs. This commit adds this page to the toctree.

Note that we may just not be ready to publish the glossary, in which case this should wait to be merged until we are absolutely ready.
