### PR TITLE
ignore sublime text project files like other IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,8 @@ htmlcov/
 /.idea
 /.ropeproject
 /*.iml
+*.sublime-project
+*.sublime-workspace
 
 # ignore ctags file
 tags


### PR DESCRIPTION
added sublime text project & workspace files to the .gitignore

was surprised they weren't already ignored.
