### PR TITLE
run after cloud-init if it's installed

### DIFF
--- a/debian/salt-minion.init
+++ b/debian/salt-minion.init
@@ -1,7 +1,7 @@
 #!/bin/sh
 ### BEGIN INIT INFO
 # Provides:          salt-minion
-# Required-Start:    $remote_fs $network
+# Required-Start:    $remote_fs $network +cloud-init
 # Required-Stop:     $remote_fs $network
 # Default-Start:     2 3 4 5
 # Default-Stop:      0 1 6


### PR DESCRIPTION
this change allows to run after cloud-init if it's installed (if is not no changes will be made) so minion_id is created with the correct hostname

man 8 insserv for more details on the syntax
