### PR TITLE
[PROPOSAL] serializers & aggregation

### DIFF
--- a/doc/ref/internals/aggregation.rst
+++ b/doc/ref/internals/aggregation.rst
@@ -1,0 +1,6 @@
+================
+salt.serializers
+================
+
+.. automodule:: salt.utils.aggregation
+    :members:

--- a/doc/ref/internals/serializers.rst
+++ b/doc/ref/internals/serializers.rst
@@ -1,0 +1,17 @@
+================
+salt.serializers
+================
+
+.. automodule:: salt.utils.serializers
+
+.. automodule:: salt.utils.serializers.json
+    :members:
+
+.. automodule:: salt.utils.serializers.yaml
+    :members:
+
+.. automodule:: salt.utils.serializers.sls
+    :members:
+
+.. automodule:: salt.utils.serializers.msgpack
+    :members:

--- a/doc/topics/yaml/index.rst
+++ b/doc/topics/yaml/index.rst
@@ -52,6 +52,7 @@ Alternatively, a value can be associated with a key through indentation.
     the value for a key is not singular but instead is a *list* of values.
 
 In Python, the above maps to:
+
     {'my_key': 'my_value'}
 
 Dictionaries can be nested:

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -6,9 +6,6 @@ This module is a central location for all salt exceptions
 # Import python libs
 import copy
 
-# Import salt libs
-import salt.utils
-
 
 class SaltException(Exception):
     '''
@@ -99,6 +96,8 @@ class SaltRenderError(SaltException):
         if trace:
             exc_str += '\n{0}\n'.format(trace)
         if self.line_num and self.buffer:
+
+            import salt.utils
             self.context = salt.utils.get_context(
                 self.buffer,
                 self.line_num,

--- a/salt/utils/aggregation.py
+++ b/salt/utils/aggregation.py
@@ -1,0 +1,125 @@
+
+from __future__ import absolute_import
+from copy import copy
+import logging
+
+from salt.utils.odict import OrderedDict
+
+__all__ = ['aggregate', 'Aggregate', 'Map', 'Scalar', 'Sequence']
+
+log = logging.getLogger(__name__)
+
+
+class Aggregate(object):
+    pass
+
+
+class Map(OrderedDict, Aggregate):
+    pass
+
+
+class Sequence(list, Aggregate):
+    pass
+
+
+def Scalar(obj):
+    """
+    Shortcut for Sequence creation
+
+    >>> Scalar('foo') == Sequence(['foo'])
+    True
+    """
+    return Sequence([obj])
+
+
+def levelise(level):
+    """
+    Describe which levels are allowed to do deep merging.
+
+    level can be:
+
+    True
+        all levels are True
+
+    False
+        all levels are False
+
+    an int
+        only the first levels are True, the others are False
+
+    a sequence
+        it describes which levels are True, it can be:
+
+        * a list of bool and int values
+        * a string of 0 and 1 characters
+
+    """
+
+    if not level:  # False, 0, [] ...
+        return False, False
+    if level is True:
+        return True, True
+    if isinstance(level, int):
+        return True, level - 1
+    try:  # a sequence
+        deep, subs = int(level[0]), level[1:]
+        return bool(deep), subs
+    except Exception as error:
+        log.warning(error)
+        raise
+
+
+def mark(obj, Map=Map, Sequence=Sequence):
+    if isinstance(obj, Aggregate):
+        return obj
+    if isinstance(obj, dict):
+        return Map(obj)
+    if isinstance(obj, (list, tuple, set)):
+        return Sequence(obj)
+    else:
+        return Sequence([obj])
+
+
+def aggregate(a, b, level=False, Map=Map, Sequence=Sequence):  # NOQA
+    """
+    >>> aggregate('first', 'second', True) == ['first', 'second']
+    True
+    """
+    deep, subdeep = levelise(level)
+
+    if deep:
+        a, b = mark(a), mark(b)
+
+    specs = {
+        'level': subdeep,
+        'Map': Map,
+        'Sequence': Sequence
+    }
+
+    if isinstance(a, dict) and isinstance(b, dict):
+        if isinstance(a, Aggregate) and isinstance(b, Aggregate):
+            # deep merging is more or less a.update(b)
+            response = copy(a)
+        else:
+            # introspection on b keys only
+            response = copy(b)
+
+        for key, value in b.items():
+            if key in a:
+                value = aggregate(a[key], value, **specs)
+            response[key] = value
+        return response
+
+    if isinstance(a, Sequence) and isinstance(a, Sequence):
+        response = a.__class__(a[:])
+        for value in b:
+            if value not in a:
+                response.append(value)
+        return response
+
+    if isinstance(a, Aggregate) or isinstance(a, Aggregate):
+        log.info('only one value marked as aggregate. keep `a` value')
+        return b
+
+    log.debug('no value marked as aggregate. keep `a` value')
+    return b

--- a/salt/utils/serializers/__init__.py
+++ b/salt/utils/serializers/__init__.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.utils.serializers
+    ~~~~~~~~~~~~~~~~~~~~~~
+
+    This module implements all the serializers needed by salt.
+    Each serializer offers the same functions and attributes:
+
+    :deserialize: function for deserializing string or stream
+
+    :serialize: function for serializing a Python object
+
+    :available: flag that tells if the serializer is available
+                (all dependencies are met etc.)
+
+'''
+
+from __future__ import absolute_import
+from salt.exceptions import SaltException, SaltRenderError
+
+
+class DeserializationError(SaltRenderError, RuntimeError):
+    """Raised when stream of string failed to be deserialized"""
+    pass
+
+
+class SerializationError(SaltException, RuntimeError):
+    """Raised when stream of string failed to be serialized"""
+    pass

--- a/salt/utils/serializers/json.py
+++ b/salt/utils/serializers/json.py
@@ -39,8 +39,8 @@ def deserialize(stream_or_string, **options):
             stream_or_string = stream_or_string.decode('utf-8')
 
         return json.loads(stream_or_string)
-    except Exception as e:
-        raise DeserializationError(e)
+    except Exception as error:
+        raise DeserializationError(error)
 
 
 def serialize(obj, **options):

--- a/salt/utils/serializers/json.py
+++ b/salt/utils/serializers/json.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.utils.serializers.json
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Implements JSON serializer.
+
+    It's just a wrapper around json (or simplejson if available).
+'''
+
+from __future__ import absolute_import
+
+try:
+    import simplejson as json
+except ImportError:
+    import json
+
+from salt._compat import string_types
+from salt.utils.serializers import DeserializationError, SerializationError
+
+__all__ = ['deserialize', 'serialize', 'available']
+
+available = True
+
+
+def deserialize(stream_or_string, **options):
+    """
+    Deserialize any string of stream like object into a Python data structure.
+
+    :param stream_or_string: stream or string to deserialize.
+    :param options: options given to lower json/simplejson module.
+    """
+
+    try:
+        if not isinstance(stream_or_string, (bytes, string_types)):
+            return json.load(stream_or_string, **options)
+
+        if isinstance(stream_or_string, bytes):
+            stream_or_string = stream_or_string.decode('utf-8')
+
+        return json.loads(stream_or_string)
+    except Exception as e:
+        raise DeserializationError(e)
+
+
+def serialize(obj, **options):
+    """
+    Serialize Python data to JSON.
+
+    :param obj: the datastructure to serialize
+    :param options: options given to lower json/simplejson module.
+    """
+
+    try:
+        if 'fp' in options:
+            return json.dump(obj, **options)
+        else:
+            return json.dumps(obj, **options)
+    except Exception as error:
+        raise SerializationError(error)

--- a/salt/utils/serializers/msgpack.py
+++ b/salt/utils/serializers/msgpack.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.utils.serializers.msgpack
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Implements MsgPack serializer.
+'''
+
+from __future__ import absolute_import
+from copy import copy
+import logging
+
+from salt.log import setup_console_logger
+from salt.utils.serializers import DeserializationError, SerializationError
+
+log = logging.getLogger(__name__)
+
+
+try:
+    # Attempt to import msgpack
+    import msgpack
+    # There is a serialization issue on ARM and potentially other platforms
+    # for some msgpack bindings, check for it
+    if msgpack.loads(msgpack.dumps([1, 2, 3]), use_list=True) is None:
+        raise ImportError
+    available = True
+except ImportError:
+    # Fall back to msgpack_pure
+    try:
+        import msgpack_pure as msgpack
+    except ImportError:
+        # TODO: Come up with a sane way to get a configured logfile
+        #       and write to the logfile when this error is hit also
+        LOG_FORMAT = '[%(levelname)-8s] %(message)s'
+        setup_console_logger(log_format=LOG_FORMAT)
+        log.fatal('Unable to import msgpack or msgpack_pure python modules')
+        # Don't exit if msgpack is not available, this is to make local mode
+        # work without msgpack
+        #sys.exit(1)
+        available = False
+
+
+if not available:
+
+    def _fail():
+        raise RuntimeError('msgpack is not available')
+
+    def _serialize(obj, **options):
+        _fail()
+
+    def _deserialize(stream_or_string, **options):
+        _fail()
+
+elif msgpack.version >= (0, 2, 0):
+
+    def _serialize(obj, **options):
+        if options:
+            log.warning('options are currently unusued')
+        try:
+            return msgpack.dumps(obj)
+        except Exception as error:
+            raise SerializationError(error)
+
+    def _deserialize(stream_or_string, **options):
+        try:
+            options.setdefault('use_list', True)
+            return msgpack.loads(stream_or_string, **options)
+        except Exception as error:
+            raise DeserializationError(error)
+
+else:  # msgpack.version < 0.2.0
+
+    def _encoder(obj):
+        '''
+        Since OrderedDict is identified as a dictionary, we can't make use of
+        msgpack custom types, we will need to convert by hand.
+
+        This means iterating through all elements of dictionaries, lists and
+        tuples.
+        '''
+        if isinstance(obj, dict):
+            data = [(key, _encoder(value)) for key, value in obj.items()]
+            return dict(data)
+        elif isinstance(obj, (list, tuple)):
+            return [_encoder(value) for value in obj]
+        return copy(obj)
+
+    def _decoder(obj):
+        return obj
+
+    def _serialize(obj, **options):
+        if options:
+            log.warning('options are currently unusued')
+        try:
+            obj = _encoder(obj)
+            return msgpack.dumps(obj)
+        except Exception as error:
+            raise SerializationError(error)
+
+    def _deserialize(stream_or_string, **options):
+        options.setdefault('use_list', True)
+        try:
+            obj = msgpack.loads(stream_or_string)
+            return _decoder(obj)
+        except Exception as error:
+            raise DeserializationError(error)
+
+serialize = _serialize
+deserialize = _deserialize
+
+serialize.__doc__ = '''
+    Serialize Python data to MsgPack.
+
+    :param obj: the datastructure to serialize
+    :param options: options given to lower msgpack module.
+'''
+
+deserialize.__doc__ = '''
+    Deserialize any string of stream like object into a Python data structure.
+
+    :param stream_or_string: stream or string to deserialize.
+    :param options: options given to lower msgpack module.
+'''

--- a/salt/utils/serializers/sls.py
+++ b/salt/utils/serializers/sls.py
@@ -1,0 +1,249 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.utils.serializers.sls
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    SLS is a format that allows to make things like sls file more intuitive.
+
+    It's an extension of YAML that implements all the salt magic.
+    For example it implies omap for any dict like.
+
+    For example, the file `states.sls` has this contents:
+
+    .. code-block:: yaml
+
+        foo:
+          bar: 42
+          baz: [1, 2, 3]
+
+    The file can be parsed into Python like this
+
+    .. code-block:: python
+
+        from salt.utils.serializers import sls
+
+        with open('state.sls', 'r') as stream:
+            obj = sls.deserialize(stream)
+
+    Check that ``obj`` is an OrderedDict
+
+    .. code-block:: python
+
+        from salt.utils.odict import OrderedDict
+
+        assert isinstance(obj, dict)
+        assert isinstance(obj, OrderedDict)
+
+
+    Silas `__repr__` and `__str__` objects' methods render YAML understandable
+    string. It means that they are template friendly.
+
+
+    .. code-block:: python
+
+        print '{0}'.format(obj)
+
+    returns:
+
+    ::
+
+        {foo: {bar: 42, baz: [1, 2, 3]}}
+
+    and they are still valid YAML:
+
+    .. code-block:: python
+
+        from salt.utils.serializers import yaml
+        yml_obj = yaml.deserialize(str(obj))
+        assert yml_obj == obj
+'''
+
+from __future__ import absolute_import
+import logging
+
+import yaml
+from yaml.nodes import MappingNode
+from yaml.constructor import ConstructorError
+from yaml.scanner import ScannerError
+
+from salt._compat import string_types
+from salt.utils.serializers import DeserializationError, SerializationError
+from salt.utils.odict import OrderedDict
+
+__all__ = ['deserialize', 'serialize', 'available']
+
+log = logging.getLogger(__name__)
+
+available = True
+
+# prefer C bindings over python when available
+Loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+Dumper = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
+
+ERROR_MAP = {
+    ("found character '\\t' "
+     "that cannot start any token"): 'Illegal tab character'
+}
+
+
+def deserialize(stream_or_string, **options):
+    """
+    Deserialize any string of stream like object into a Python data structure.
+
+    :param stream_or_string: stream or string to deserialize.
+    :param options: options given to lower yaml module.
+    """
+
+    options.setdefault('Loader', SLSLoader)
+    try:
+        return yaml.load(stream_or_string, **options)
+    except ScannerError as error:
+        err_type = ERROR_MAP.get(error.problem, 'Unknown yaml render error')
+        line_num = error.problem_mark.line + 1
+        raise DeserializationError(err_type,
+                                   line_num,
+                                   error.problem_mark.buffer)
+    except ConstructorError as error:
+        raise DeserializationError(error)
+    except Exception as error:
+        raise DeserializationError(error)
+
+
+def serialize(obj, **options):
+    """
+    Serialize Python data to YAML.
+
+    :param obj: the datastructure to serialize
+    :param options: options given to lower yaml module.
+    """
+
+    options.setdefault('Dumper', SLSDumper)
+    try:
+        response = yaml.dump(obj, **options)
+        if response.endswith('\n...\n'):
+            return response[:-5]
+        if response.endswith('\n'):
+            return response[:-1]
+        return response
+    except Exception as error:
+        raise SerializationError(error)
+
+
+def ignore(key, old, new):
+    return new
+
+
+def warning(key, old, new):
+    log.warn('Conflicting ID "{0}"'.format(key))
+    return new
+
+
+def error(key, old, new):  # pylint: disable=W0611
+    raise ConstructorError('Conflicting ID "{0}"'.format(key))
+
+
+class SLSLoader(Loader):
+    '''
+    Create a custom YAML loader that uses the custom constructor. This allows
+    for the YAML loading defaults to be manipulated based on needs within salt
+    to make things like sls file more intuitive.
+    '''
+
+    # who should we resolve conflicting ids?
+    conflict_resolver = None
+
+    def __init__(self, stream, conflict_resolver=None):
+        Loader.__init__(self, stream)
+        self.conflict_resolver = conflict_resolver or ignore
+
+    def construct_sls_map(self, node):
+        '''
+        Build the SLSMap
+        '''
+        sls_map = SLSMap()
+        yield sls_map
+
+        if not isinstance(node, MappingNode):
+            raise ConstructorError(
+                None,
+                None,
+                'expected a mapping node, but found {0}'.format(node.id),
+                node.start_mark)
+
+        self.flatten_mapping(node)
+
+        for key_node, value_node in node.value:
+            key = self.construct_object(key_node, deep=False)
+            try:
+                hash(key)
+            except TypeError:
+                err = ('While constructing a mapping {0} found unacceptable '
+                       'key {1}').format(node.start_mark, key_node.start_mark)
+                raise ConstructorError(err)
+            value = self.construct_object(value_node, deep=False)
+            if key in sls_map:
+                self.conflict_resolver(key, sls_map[key], value)
+            sls_map[key] = value
+
+    def construct_sls_int(self, node):
+        '''
+        Verify integers and pass them in correctly is they are declared
+        as octal
+        '''
+        if node.value == '0':
+            pass
+        elif node.value.startswith('0') \
+                and not node.value.startswith(('0b', '0x')):
+            node.value = node.value.lstrip('0')
+            # If value was all zeros, node.value would have been reduced to
+            # an empty string. Change it to '0'.
+            if node.value == '':
+                node.value = '0'
+        return int(node.value)
+
+SLSLoader.add_constructor('tag:yaml.org,2002:map', SLSLoader.construct_sls_map)  # NOQA
+SLSLoader.add_constructor('tag:yaml.org,2002:omap', SLSLoader.construct_sls_map)  # NOQA
+SLSLoader.add_constructor('tag:yaml.org,2002:int', SLSLoader.construct_sls_int)
+
+
+class SLSMap(OrderedDict):
+    '''
+    Ensures that dict str() and repr() are YAML friendly.
+
+    .. code-block:: python
+
+        mapping = OrderedDict([('a', 'b'), ('c', None)])
+        print mapping
+        # OrderedDict([('a', 'b'), ('c', None)])
+
+        sls_map = SLSMap(mapping)
+        print sls_map
+        # {'a': 'b', 'c': None}
+
+    '''
+
+    def __str__(self):
+        output = []
+        for key, value in self.items():
+            if isinstance(value, string_types):
+                # keeps quotes around strings
+                output.append('{0!r}: {1!r}'.format(key, value))
+            else:
+                # let default output
+                output.append('{0!r}: {1!s}'.format(key, value))
+        return '{' + ', '.join(output) + '}'
+
+    def __repr__(self):  # pylint: disable=W0221
+        output = []
+        for key, value in self.items():
+            output.append('{0!r}: {1!r}'.format(key, value))
+        return '{' + ', '.join(output) + '}'
+
+
+class SLSDumper(Dumper):  # pylint: disable=W0232
+    def represent_odict(self, data):
+        return self.represent_dict(data.items())
+        return self.represent_mapping('tag:yaml.org,2002:map', data.items())
+
+# make every dict like obj to be represented as a map
+SLSDumper.add_multi_representer(dict, SLSDumper.represent_odict)

--- a/salt/utils/serializers/sls.py
+++ b/salt/utils/serializers/sls.py
@@ -109,12 +109,12 @@ ERROR_MAP = {
 
 
 def deserialize(stream_or_string, **options):
-    """
+    '''
     Deserialize any string of stream like object into a Python data structure.
 
     :param stream_or_string: stream or string to deserialize.
     :param options: options given to lower yaml module.
-    """
+    '''
 
     options.setdefault('Loader', Loader)
     try:
@@ -133,12 +133,12 @@ def deserialize(stream_or_string, **options):
 
 
 def serialize(obj, **options):
-    """
+    '''
     Serialize Python data to YAML.
 
     :param obj: the datastructure to serialize
     :param options: options given to lower yaml module.
-    """
+    '''
 
     options.setdefault('Dumper', Dumper)
     try:
@@ -309,7 +309,7 @@ class SLSMap(OrderedDict):
 
 
 class SLSString(str):
-    """
+    '''
     Ensures that str str() and repr() are YAML friendly.
 
     .. code-block:: python
@@ -322,7 +322,7 @@ class SLSString(str):
         >>> print sls_scalar
         "foo"
 
-    """
+    '''
 
     def __str__(self):
         return serialize(self, default_style='"')

--- a/salt/utils/serializers/yaml.py
+++ b/salt/utils/serializers/yaml.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+    salt.utils.serializers.yaml
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Implements YAML serializer.
+
+    Underneath, it is based on pyyaml and use the safe dumper and loader.
+    It also use C bindings if they are available.
+'''
+
+from __future__ import absolute_import
+
+import yaml
+from yaml.constructor import ConstructorError
+from yaml.scanner import ScannerError
+
+from salt.utils.serializers import DeserializationError, SerializationError
+
+__all__ = ['deserialize', 'serialize', 'available']
+
+available = True
+
+# prefer C bindings over python when available
+Loader = getattr(yaml, 'CSafeLoader', yaml.SafeLoader)
+Dumper = getattr(yaml, 'CSafeDumper', yaml.SafeDumper)
+
+ERROR_MAP = {
+    ("found character '\\t' "
+     "that cannot start any token"): 'Illegal tab character'
+}
+
+
+def deserialize(stream_or_string, **options):
+    """
+    Deserialize any string of stream like object into a Python data structure.
+
+    :param stream_or_string: stream or string to deserialize.
+    :param options: options given to lower yaml module.
+    """
+
+    options.setdefault('Loader', Loader)
+    try:
+        return yaml.load(stream_or_string, **options)
+    except ScannerError as error:
+        err_type = ERROR_MAP.get(error.problem, 'Unknown yaml render error')
+        line_num = error.problem_mark.line + 1
+        raise DeserializationError(err_type,
+                                   line_num,
+                                   error.problem_mark.buffer)
+    except ConstructorError as error:
+        raise DeserializationError(error)
+    except Exception as error:
+        raise DeserializationError(error)
+
+
+def serialize(obj, **options):
+    """
+    Serialize Python data to YAML.
+
+    :param obj: the datastructure to serialize
+    :param options: options given to lower yaml module.
+    """
+
+    options.setdefault('Dumper', Dumper)
+    try:
+        response = yaml.dump(obj, **options)
+        if response.endswith('\n...\n'):
+            return response[:-5]
+        if response.endswith('\n'):
+            return response[:-1]
+        return response
+    except Exception as error:
+        raise SerializationError(error)

--- a/tests/unit/utils/aggregation_test.py
+++ b/tests/unit/utils/aggregation_test.py
@@ -1,0 +1,143 @@
+# -*- coding: utf-8 -*-
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+from salt.utils.aggregation import aggregate, Map, Scalar
+
+
+class TestAggregation(TestCase):
+    def test_merging(self):
+        a = {
+            'foo': 42,
+            'bar': 'first'
+        }
+        b = {
+            'bar': 'second'
+        }
+
+        c, d = 'first', 'second'
+
+        # introspection
+        for level in (None, False, 0, []):
+            assert aggregate(a, b, level=level) == {
+                'bar': 'second'
+            }
+            assert aggregate(c, d, level=level) == 'second'
+
+        # first level aggregation
+        for level in (1, [1, 0], [True], '10000'):
+            assert aggregate(a, b, level=level) == {
+                'foo': 42,
+                'bar': 'second'
+            }
+            assert aggregate(c, d, level=level) == ['first', 'second']
+
+        # 1-2nd level aggregation
+        for level in (2, [1, 1], [True, True], '11'):
+            assert aggregate(a, b, level=level) == {
+                'foo': 42,
+                'bar': ['first', 'second']
+            }, aggregate(a, b, level=2)
+            assert aggregate(c, d, level=level) == ['first', 'second']
+
+        # full aggregation
+        for level in (True,):
+            assert aggregate(a, b, level=level) == {
+                'foo': 42,
+                'bar': ['first', 'second']
+            }
+            assert aggregate(c, d, level=level) == ['first', 'second']
+
+    def test_nested(self):
+        a = {
+            'foo': {
+                'bar': 'first'
+            }
+        }
+        b = {
+            'foo': {
+                'bar': 'second'
+            }
+        }
+        assert aggregate(a, b) == {
+            'foo': {
+                'bar': 'second'
+            }
+        }, aggregate(a, b)
+
+        a = {
+            'foo': {
+                'bar': Scalar('first')
+            }
+        }
+        b = {
+            'foo': {
+                'bar': Scalar('second'),
+            }
+        }
+
+        assert aggregate(a, b) == {
+            'foo': {
+                'bar': ['first', 'second']
+            }
+        }, aggregate(a, b)
+
+    def test_introspection(self):
+
+        a = {
+            'foo': {
+                'lvl1': {
+                    'lvl2-a': 'first',
+                    'lvl2-b': 'first'
+                }
+            }
+        }
+
+        b = {
+            'foo': {
+                'lvl1': {
+                    'lvl2-a': 'second'
+                }
+            }
+        }
+
+        assert aggregate(a, b) == {
+            'foo': {
+                'lvl1': {
+                    'lvl2-a': 'second'
+                }
+            }
+        }, aggregate(a, b)
+
+    def test_instruction(self):
+        a = {
+            'foo': Map({
+                'bar': Scalar('first')
+            })
+        }
+        b = {
+            'foo': Map({
+                'bar': Scalar('second')
+            })
+        }
+        c = {
+            'foo': Map({
+                'another': 'value'
+            })
+        }
+        result = aggregate(c, aggregate(a, b), level=2)
+        assert result == {
+            'foo': {
+                'bar': ['first', 'second'],
+                'another': 'value'
+            }
+        }, result
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(TestAggregation, needs_daemon=False)

--- a/tests/unit/utils/serializers_test.py
+++ b/tests/unit/utils/serializers_test.py
@@ -205,7 +205,30 @@ class TestSerializers(TestCase):
         """).strip()
 
         sls_obj = sls.deserialize(src)
-        assert sls_obj == {'placeholder': {'foo': {'foo': 42, 'bar': None, 'baz': 'inga'}}}, sls_obj
+        assert sls_obj == {
+            'placeholder': {
+                'foo': {
+                    'foo': 42,
+                    'bar': None,
+                    'baz': 'inga'
+                }
+            }
+        }, sls_obj
+
+
+    @skipIf(not sls.available, SKIP_MESSAGE % 'sls')
+    def test_sls_repr(self):
+        def convert(obj):
+            return sls.deserialize(sls.serialize(obj))
+        sls_obj = convert(OrderedDict([('foo', 'bar'), ('baz', 'qux')]))
+
+        # ensure that repr and str are yaml friendly
+        assert sls_obj.__str__() == '{foo: bar, baz: qux}'
+        assert sls_obj.__repr__() == '{foo: bar, baz: qux}'
+
+        # ensure that repr and str are already quoted
+        assert sls_obj['foo'].__str__() == '"bar"'
+        assert sls_obj['foo'].__repr__() == '"bar"'
 
     @skipIf(not msgpack.available, SKIP_MESSAGE % 'msgpack')
     def test_msgpack(self):

--- a/tests/unit/utils/serializers_test.py
+++ b/tests/unit/utils/serializers_test.py
@@ -195,7 +195,13 @@ class TestSerializers(TestCase):
         """).strip()
 
         sls_obj = sls.deserialize(src)
-        assert sls_obj == {'placeholder': {'foo': 42, 'bar': None, 'baz': 'inga'}}, sls_obj
+        assert sls_obj == {
+            'placeholder': {
+                'foo': 42,
+                'bar': None,
+                'baz': 'inga'
+            }
+        }, sls_obj
 
         # test that !aggregate aggregates deep dicts
         src = dedent("""
@@ -215,6 +221,41 @@ class TestSerializers(TestCase):
             }
         }, sls_obj
 
+        # test that {foo: !aggregate bar} and {!aggregate foo: bar}
+        # are roughly equivalent.
+        src = dedent("""
+            placeholder: {!aggregate foo: {foo: 42}}
+            placeholder: {!aggregate foo: {bar: null}}
+            placeholder: {!aggregate foo: {baz: inga}}
+        """).strip()
+
+        sls_obj = sls.deserialize(src)
+        assert sls_obj == {
+            'placeholder': {
+                'foo': {
+                    'foo': 42,
+                    'bar': None,
+                    'baz': 'inga'
+                }
+            }
+        }, sls_obj
+
+    @skipIf(not sls.available, SKIP_MESSAGE % 'sls')
+    def test_sls_reset(self):
+        src = dedent("""
+            placeholder: {!aggregate foo: {foo: 42}}
+            placeholder: {!aggregate foo: {bar: null}}
+            !reset placeholder: {!aggregate foo: {baz: inga}}
+        """).strip()
+
+        sls_obj = sls.deserialize(src)
+        assert sls_obj == {
+            'placeholder': {
+                'foo': {
+                    'baz': 'inga'
+                }
+            }
+        }, sls_obj
 
     @skipIf(not sls.available, SKIP_MESSAGE % 'sls')
     def test_sls_repr(self):


### PR DESCRIPTION
Hello folks, 

I want to propose these two new utils libraries that lay the foundations of saltstack/salt#3991, saltstack/salt#2466 and other .sls files misbehaviors.
### salt.utils.aggregation

salt.utils.aggregation is a smart merging tool for Python objects.

for example:

``` python
from salt.utils.aggregation import aggregate, Scalar

# explicit aggregation
a = Scalar('first')
b = Scalar('second')
assert aggregate(a, b) == ["first", "second"]

# introspection on nested values
a = {
    "foo": {
        "bar": Scalar('first'),
        "baz": "should not be displayed"
    }
}
b = {
    "foo": {
        "bar": Scalar('second')
    }
}
assert aggregate(a, b) == {"foo": {"bar": ["first", "second"]}}

```
### salt.utils.serializers

salt.utils.serializers is a start for cleanup data serialization/deserialization issues. 

Currently is implements **yaml**, **json**, **msgpack** and a fresh **sls** data structures format with their optims & fallback.

The most notable feature between these codecs is that they implement the same interfaces. For example:

``` python
from salt.utils.serializers import json, yaml, msgpack, sls

for codec in (json, yaml, msgpack, sls):
    obj = codec.decode(src)
    codec.encode(obj)
```

I've also added a new codec named **sls** based yaml, which able to handle all the salt magic:
- defacto OrderedDict
- yaml nice printing (for templates)
- data aggregation with `!aggregation` yaml tag, based on the salt.utils.aggregation.

for example:

``` python
from salt.utils.serializers import sls

src = "{foo: bar, baz: qux}"
obj = sls.decode(src)

# defacto OrderedDict
assert isinstance(obj, OrderedDict)

# yaml nice printing 
assert obj.__str__() == "{foo: bar, baz: qux}"
assert obj["foo"].__str__() == "\"bar\""
```

instructed aggregation within the `!aggregation` and the `!reset` tags:

``` yaml
# pillar.sls
foo: !aggregate first
foo: !aggregate second
bar: !aggregate {first: foo}
bar: !aggregate {second: bar}
baz: !aggregate 42
qux: !aggregate default
!reset qux: !aggregate my custom data
```

is roughly equivalent to

``` yaml
foo: [first, second]
bar: {first: foo, second: bar}
baz: [42]
qux: [my custom data]
```

more examples and use cases are present in the unit tests.
