### PR TITLE
Pyobjects security & convention

### DIFF
--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -40,12 +40,12 @@ File.fail('/tmp')
 '''
 
 include_template = '''#!pyobjects
-Include('http')
+include('http')
 '''
 
 extend_template = '''#!pyobjects
-Include('http')
-Service.running(Extend('apache'), watch=[{'file': '/etc/file'}])
+include('http')
+Service.running(extend('apache'), watch=[{'file': '/etc/file'}])
 '''
 
 


### PR DESCRIPTION
The main focus of this pull is to limit the scope of the `exec` calls in pyobjects.

During the implementation @mgwilliams and I discussed naming convention and settled that classes should be capitalized but functions should be lower case. `Include` & `Extend` have been renamed lowercase. Also this means that `salt` is now the `SaltObject` while `__salt__` is still available for direct access, as is the case with `pillar`, `grains` & `mine` as well.
