### PR TITLE
Rewrite environ modules

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1195,6 +1195,20 @@ class Minion(MinionBase):
         ).compile_pillar()
         self.module_refresh()
 
+    def environ_setenv(self, package):
+        '''
+        Set the salt-minion main process environment according to
+        the data contained in the minion event data
+        '''
+        tag, data = salt.utils.event.MinionEvent.unpack(package)
+        environ = data.get('environ', None)
+        if environ is None:
+            return False
+        false_unsets = data.get('false_unsets', False)
+        clear_all = data.get('clear_all', False)
+        import salt.modules.environ as mod_environ
+        return mod_environ.setenv(environ, false_unsets, clear_all)
+
     def clean_die(self, signum, frame):
         '''
         Python does not handle the SIGTERM cleanly, if it is signaled exit
@@ -1313,6 +1327,8 @@ class Minion(MinionBase):
                             if self.grains_cache != self.opts['grains']:
                                 self.pillar_refresh()
                                 self.grains_cache = self.opts['grains']
+                        elif package.startswith('environ_setenv'):
+                            self.environ_setenv(package)
                         elif package.startswith('fire_master'):
                             tag, data = salt.utils.event.MinionEvent.unpack(package)
                             log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))

--- a/salt/modules/environ.py
+++ b/salt/modules/environ.py
@@ -106,7 +106,8 @@ def setenv(environ, false_unsets=False, clear_all=False, update_minion=False):
         Default: False
 
     clear_all
-        USE WITH CAUTION!
+        USE WITH CAUTION! This option can unset environment variables
+        needed for salt to function properly.
         If clear_all is True, then any environment variables not
         defined in the environ dict will be deleted.
         Default: False

--- a/salt/modules/environ.py
+++ b/salt/modules/environ.py
@@ -60,7 +60,7 @@ def setval(key, val, false_unsets=False):
                 return None
             except Exception as exc:
                 log.error(
-                    '{0}: Exception occurred when unsetting'
+                    '{0}: Exception occurred when unsetting '
                     'environ key "{1!r}": {2!r}'
                     .format(__name__, key, exc)
                 )
@@ -80,7 +80,7 @@ def setval(key, val, false_unsets=False):
             return False
     else:
         log.debug(
-            '{0}: "val" argument for key "{1!r}" is not a string'
+            '{0}: "val" argument for key "{1!r}" is not a string '
             'or False: {2!r}'
             .format(__name__, key, val)
         )
@@ -145,7 +145,7 @@ def setenv(environ, false_unsets=False, clear_all=False, update_minion=False):
             ret[key] = setval(key, val, false_unsets)
         else:
             log.debug(
-                '{0}: "val" argument for key "{1!r}" is not a string'
+                '{0}: "val" argument for key "{1!r}" is not a string '
                 'or False: {2!r}'
                 .format(__name__, key, val)
             )

--- a/salt/modules/environ.py
+++ b/salt/modules/environ.py
@@ -31,7 +31,7 @@ def setval(key, val, false_unsets=False):
 
     val
         The value to set. Must be a string or False. Refer to the
-        'descrtuctive' parameter for behavior when set to False.
+        'false_unsets' parameter for behavior when set to False.
 
     false_unsets
         If val is False and false_unsets is True, then the key will be
@@ -95,7 +95,7 @@ def setenv(environ, false_unsets=False, clear_all=False, update_minion=False):
     environ
         Must be a dict. The top-level keys of the dict are the names
         of the environment variables to set. Each key's value must be
-        a string or False. Refer to the 'descrtuctive' parameter for
+        a string or False. Refer to the 'false_unsets' parameter for
         behavior when a value set to False.
 
     false_unsets

--- a/salt/modules/environ.py
+++ b/salt/modules/environ.py
@@ -6,14 +6,12 @@ of the current salt process.
 
 # Import python libs
 import os
+import logging
 
 # Import salt libs
 from salt._compat import string_types
-from salt.exceptions import SaltException
 
-__func_alias__ = {
-    'set_': 'set'
-}
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -23,51 +21,228 @@ def __virtual__():
     return True
 
 
-def set_(environ):
+def setval(key, val, false_unsets=False):
     '''
-    Set the salt process environment variables.
+    Set a single salt process environment variable. Returns True
+    on success.
 
-    Accepts a dict 'environ'. Each top-level key of the dict
-    are the names of the environment variables to set.
-    The value to set must be a string.
+    key
+        The environment key to set. Must be a string.
+
+    val
+        The value to set. Must be a string or False. Refer to the
+        'descrtuctive' parameter for behavior when set to False.
+
+    false_unsets
+        If val is False and false_unsets is True, then the key will be
+        removed from the salt processes environment dict entirely.
+        If val is False and false_unsets is not True, then the key's
+        value will be set to an empty string.
+        Default: False.
 
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' environ.set '{"foo": "bar", "baz": "quux"}'
+        salt '*' environ.setval foo bar
+        salt '*' environ.setval baz val=False false_unsets=True
     '''
+    if not isinstance(key, string_types):
+        log.debug(
+            '{0}: "key" argument is not a string type: {1!r}'
+            .format(__name__, key)
+        )
+    if val is False:
+        if false_unsets is True:
+            try:
+                os.environ.pop(key, None)
+                return None
+            except Exception as exc:
+                log.error(
+                    '{0}: Exception occurred when unsetting'
+                    'environ key "{1!r}": {2!r}'
+                    .format(__name__, key, exc)
+                )
+                return False
+        else:
+            val = ''
+    if isinstance(val, string_types):
+        try:
+            os.environ[key] = val
+            return os.environ[key]
+        except Exception as exc:
+            log.error(
+                '{0}: Exception occurred when setting'
+                'environ key "{1!r}": {2!r}'
+                .format(__name__, key, exc)
+            )
+            return False
+    else:
+        log.debug(
+            '{0}: "val" argument for key "{1!r}" is not a string'
+            'or False: {2!r}'
+            .format(__name__, key, val)
+        )
+        return False
 
+
+def setenv(environ, false_unsets=False, clear_all=False, update_minion=False):
+    '''
+    Set multiple salt process environment variables from a dict.
+    Returns a dict.
+
+    environ
+        Must be a dict. The top-level keys of the dict are the names
+        of the environment variables to set. Each key's value must be
+        a string or False. Refer to the 'descrtuctive' parameter for
+        behavior when a value set to False.
+
+    false_unsets
+        If a key's value is False and false_unsets is True, then the
+        key will be removed from the salt processes environment dict
+        entirely. If a key's value is Flase and false_unsets is not
+        True, then the key's value will be set to an empty string.
+        Default: False
+
+    clear_all
+        USE WITH CAUTION!
+        If clear_all is True, then any environment variables not
+        defined in the environ dict will be deleted.
+        Default: False
+
+    update_minion
+        If True, apply these environ changes to the main salt-minion
+        process. If False, the environ changes will only affect the
+        current salt subprocess.
+        Default: False
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' environ.setenv '{"foo": "bar", "baz": "quux"}'
+        salt '*' environ.setenv '{"a": "b", "c": False}' false_unsets=True
+    '''
     ret = {}
     if not isinstance(environ, dict):
-        raise SaltException('The "environ" argument variable must be a dict')
-    try:
-        for key, val in environ.items():
-            if not isinstance(val, string_types):
-                raise SaltException(
-                    'The value of "environ" keys must be string type'
-                )
-            os.environ[key] = val
-            ret[key] = os.environ[key]
-    except Exception as exc:
-        raise SaltException(exc)
+        log.debug(
+            '{0}: "environ" argument is not a dict: {1!r}'
+            .format(__name__, environ)
+        )
+        return False
+    if clear_all is True:
+        # Unset any keys not defined in 'environ' dict supplied by user
+        to_unset = [key for key in os.environ.keys() if key not in environ]
+        for key in to_unset:
+            ret[key] = setval(key, False, false_unsets)
+    for key, val in environ.items():
+        if isinstance(val, string_types):
+            ret[key] = setval(key, val)
+        elif val is False:
+            ret[key] = setval(key, val, false_unsets)
+        else:
+            log.debug(
+                '{0}: "val" argument for key "{1!r}" is not a string'
+                'or False: {2!r}'
+                .format(__name__, key, val)
+            )
+            return False
+
+    if update_minion is True:
+        __salt__['event.fire']({'environ': environ,
+                                'false_unsets': false_unsets,
+                                'clear_all': clear_all
+                                },
+                               'environ_setenv')
     return ret
 
 
-def get(keys):
+def get(key, default=''):
     '''
-    Get the salt process environment variables.
+    Get a single salt process environment variable.
 
-    'keys' can be either a string or a list of strings that will
-    be used as the keys for environment lookup.
+    key
+        String used as the key for environment lookup.
+
+    default
+        If the key is not found in the enironment, return this value.
+        Default: ''
+
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' environ.get foo
-        salt '*' environ.get '[foo, baz]'
+        salt '*' environ.get baz default=False
+    '''
+    if not isinstance(key, string_types):
+        log.debug(
+            '{0}: "key" argument is not a string type: {1!r}'
+            .format(__name__, key)
+        )
+        return False
+    return os.environ.get(key, default)
+
+
+def has_value(key, value=None):
+    '''
+    Determine whether the key exists in the current salt process
+    environment dictionary. Optionally compare the current value
+    of the environment against the supplied value string.
+
+    key
+        Must be a string. Used as key for environment lookup.
+
+    value:
+        Optional. If key exists in the environment, compare the
+        current value with this value. Return True if they are equal.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' environ.has_value foo
+    '''
+    if not isinstance(key, string_types):
+        log.debug(
+            '{0}: "key" argument is not a string type: {1!r}'
+            .format(__name__, key)
+        )
+        return False
+    try:
+        cur_val = os.environ[key]
+        if value is not None:
+            if cur_val == value:
+                return True
+            else:
+                return False
+    except KeyError:
+        return False
+    return True
+
+
+def item(keys, default=''):
+    '''
+    Get one or more salt process environment variables.
+    Returns a dict.
+
+    keys
+        Either a string or a list of strings that will be used as the
+        keys for environment lookup.
+
+    default
+        If the key is not found in the enironment, return this value.
+        Default: ''
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' environ.item foo
+        salt '*' environ.item '[foo, baz]' default=None
     '''
     ret = {}
     key_list = []
@@ -76,15 +251,16 @@ def get(keys):
     elif isinstance(keys, list):
         key_list = keys
     else:
-        raise SaltException(
-            'The "keys" argument variable must be string or list.'
+        log.debug(
+            '{0}: "keys" argument is not a string or list type: {1!r}'
+            .format(__name__, keys)
         )
     for key in key_list:
-        ret[key] = os.environ[key]
+        ret[key] = os.environ.get(key, default)
     return ret
 
 
-def get_all():
+def items():
     '''
     Return a dict of the entire environment set for the salt process
 
@@ -92,6 +268,6 @@ def get_all():
 
     .. code-block:: bash
 
-        salt '*' environ.get:all
+        salt '*' environ.items
     '''
     return dict(os.environ)

--- a/salt/states/environ.py
+++ b/salt/states/environ.py
@@ -10,10 +10,6 @@ import os
 # Import salt libs
 from salt._compat import string_types
 
-__func_alias__ = {
-    'set_': 'set'
-}
-
 
 def __virtual__():
     '''
@@ -22,18 +18,41 @@ def __virtual__():
     return True
 
 
-def set_(name, value):
+def setenv(name,
+           value,
+           false_unsets=False,
+           clear_all=False,
+           update_minion=False):
     '''
     Set the salt process environment variables.
 
     name
-        The environment variable key to set if 'value' is a string
+        The environment key to set. Must be a string.
 
     value
         Either a string or dict. When string, it will be the value
-        set for the environment variable of 'name' above.
+        set for the environment key of 'name' above.
         When a dict, each key/value pair represents an environment
         variable to set.
+
+    false_unsets
+        If a key's value is False and false_unsets is True, then the
+        key will be removed from the salt processes environment dict
+        entirely. If a key's value is Flase and false_unsets is not
+        True, then the key's value will be set to an empty string.
+        Default: False
+
+    clear_all
+        USE WITH CAUTION!
+        If clear_all is True, then any environment variables not
+        defined in the environ dict will be deleted.
+        Default: False
+
+    update_minion
+        If True, apply these environ changes to the main salt-minion
+        process. If False, the environ changes will only affect the
+        current salt subprocess.
+        Default: False
 
     CLI Example:
 
@@ -43,6 +62,7 @@ def set_(name, value):
            environ.set:
              - name: foo
              - value: bar
+             - update_minion: True
 
         a_dict_env:
            environ.set:
@@ -65,12 +85,43 @@ def set_(name, value):
         ret['result'] = False
         ret['comment'] = 'Environ value must be string or dict'
         return ret
+
+    if clear_all is True:
+        # Any keys not in 'environ' dict supplied by user will be unset
+        to_unset = [key for key in os.environ.keys() if key not in environ]
+        for key in to_unset:
+            if false_unsets is not True:
+                # This key value will change to ''
+                ret['changes'].update({key: ''})
+            else:
+                # We're going to delete the key
+                ret['changes'].update({key: None})
+
     current_environ = dict(os.environ)
     already_set = []
     for key, val in environ.items():
-        if current_environ.get(key, '') == val:
+        if val is False:
+            # We unset this key from the environment if
+            # false_unsets is True. Otherwise we want to set
+            # the value to ''
+            if current_environ.get(key, None) is None:
+                # The key does not exist in environment
+                if false_unsets is not True:
+                    # This key will be added with value ''
+                    ret['changes'].update({key: ''})
+            else:
+                # The key exists.
+                if false_unsets is not True:
+                    # Check to see if the value will change
+                    if current_environ.get(key, None) != '':
+                        # This key value will change to ''
+                        ret['changes'].update({key: ''})
+                else:
+                    # We're going to delete the key
+                    ret['changes'].update({key: None})
+        elif current_environ.get(key, '') == val:
             already_set.append(key)
-            environ.pop(key)
+            #environ.pop(key)
         else:
             ret['changes'].update({key: val})
 
@@ -82,7 +133,10 @@ def set_(name, value):
             ret['comment'] = 'Environ values are already set with the correct values'
         return ret
 
-    environ_ret = __salt__['environ.set'](environ)
+    environ_ret = __salt__['environ.setenv'](environ,
+                                             false_unsets,
+                                             clear_all,
+                                             update_minion)
     if not environ_ret:
         ret['result'] = False
         ret['comment'] = 'Failed to set environ variables'

--- a/salt/states/environ.py
+++ b/salt/states/environ.py
@@ -43,7 +43,8 @@ def setenv(name,
         Default: False
 
     clear_all
-        USE WITH CAUTION!
+        USE WITH CAUTION! This option can unset environment variables
+        needed for salt to function properly.
         If clear_all is True, then any environment variables not
         defined in the environ dict will be deleted.
         Default: False

--- a/salt/states/environ.py
+++ b/salt/states/environ.py
@@ -122,7 +122,6 @@ def setenv(name,
                     ret['changes'].update({key: None})
         elif current_environ.get(key, '') == val:
             already_set.append(key)
-            #environ.pop(key)
         else:
             ret['changes'].update({key: val})
 


### PR DESCRIPTION
- Make environ modules behave a bit more like 'grains' modules. 
- Add ability to update the salt-minion's environ dict by firing an event on the minion.
- Return False on and log any errors instead of raising SaltException.
