### PR TITLE
Ability to destroy instances matching a profile

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -383,7 +383,8 @@ class Cloud(object):
         self.__cached_provider_queries[query] = output
         return output
 
-    def get_running_by_names(self, names, query='list_nodes', cached=False):
+    def get_running_by_names(self, names, query='list_nodes', cached=False,
+                             profile=None):
         if isinstance(names, basestring):
             names = [names]
 
@@ -394,6 +395,16 @@ class Cloud(object):
             for driver, vms in drivers.iteritems():
                 if driver not in handled_drivers:
                     handled_drivers[driver] = alias
+                # When a profile is specified, only return an instance
+                # that matches the provider specified in the profile.
+                # This solves the issues when many providers return the
+                # same instance. For example there may be one provider for
+                # each avaliablity zone in amazon in the same region, but
+                # the search returns the same instance for each provider because
+                # amazon returns all instances in a region, not avaliabilty zone.
+                if profile:
+                    if alias not in self.opts['profiles'][profile]['provider'].split(':')[0]:
+                        continue
 
                 for vm_name, details in vms.iteritems():
                     # XXX: The logic bellow can be removed once the aws driver

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -237,7 +237,8 @@ class SaltCloud(parsers.SaltCloudParser):
                 matching = mapper.delete_map(query='list_nodes')
             else:
                 matching = mapper.get_running_by_names(
-                    self.config.get('names', ())
+                    self.config.get('names', ()),
+                    profile = self.options.profile
                 )
 
             if not matching:

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -238,7 +238,7 @@ class SaltCloud(parsers.SaltCloudParser):
             else:
                 matching = mapper.get_running_by_names(
                     self.config.get('names', ()),
-                    profile = self.options.profile
+                    profile=self.options.profile
                 )
 
             if not matching:


### PR DESCRIPTION
There exists times when there may be multiple providers for a single
region. For example in ec2 you might have a provider for each region.
When salt-cloud runs get_running_by_names it will return runnung
instances for each provider. The ec2 provider returns all running
instances for the entire region, thus the same instance will return
for each avaliability zone. Once salt-cloud destroys this instance
it will thrown an exception when it tries again.

The logic is, if you can specify a profile when creating, why not
when destroying?

Example:

``` bash
root@localhost:~# salt-cloud example1234 -d
[INFO    ] salt-cloud starting
The following virtual machines are set to be destroyed:
  us-west-2b-devops:
    ec2:
      example1234
  us-west-2b-dev:
    ec2:
      example1234
  us-west-2a-dev:
    ec2:
      example1234
  us-west-2a-devops:
    ec2:
      example1234
```

After this fix:

``` bash
root@localhost:~# salt-cloud -p usw2a-dev-web example1234 -d
[INFO    ] salt-cloud starting
The following virtual machines are set to be destroyed:
  us-west-2a-dev:
    ec2:
      example1234
```
