### PR TITLE
fix for broken salt-ssh key_deploy

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -204,7 +204,7 @@ class SSH(object):
                 )
         pub = '{0}.pub'.format(priv)
         with open(pub, 'r') as fp_:
-            return '{0} root@master'.format(fp_.read().split()[1])
+            return '{0} rsa root@master'.format(fp_.read().split()[1])
 
     def key_deploy(self, host, ret):
         '''


### PR DESCRIPTION
running salt-ssh using the --key_deploy option has no effect due to argument missmatch:

```
`--> salt-ssh -c ~/salt/etc/salt --key-deploy --passwd=somepw node1.myenv test.ping -l debug
```

```
...
$PYTHON $SALT --local --out json -l quiet ssh.set_auth_key root AAAAB3NzaC1yc2EAAAADAQABAAABAQC3VhWEqVOX46SVyQvaNtpH+MBu/JIHfc5IWGUJ7QjcFYcYFwT1j1mbaMjfOboVO7hvnePQrmSamQ5Xpz7g1qEMjrf+ZFqLuzRIXZjp+Ib4rCXXBOYnhkLHIoEY6HqmZ/5lpU5hZIjPRaIQJDQ8O8ja3ewKUVtgCq67SQ57SXGS8xTSyfvC0ij7DRByxpcSPZy/fJNrrn1zlE4ytBlEP7v2nmjVQRniS5VFqKSfrkyRz670Y/6Xrwnsxe7ejOv9qu86OLTo682qbMrnw4Ug2067DdaXfCdsZGd2zXOXQLWSAuHKcEPAktscGlQ8gkzvgMQhz5gFtg5orvCP/2AwmkMB root@master
...
Error running 'ssh.set_auth_key': Incorrect encryption key type 'root@master'.
...
```

the set_auth_key method in  modules/ssh.py expects env as third arg but root@master is the third argument and is overwriting the defaults....

Anyway the code in salt/client/ssh/**init**.py is quite static in terms of key encryption so I guess we can simply add the missing env arg...
