### PR TITLE
Provide the loaded states to renderers

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -268,15 +268,17 @@ def ssh_wrapper(opts, functions=None):
     return load.gen_functions(pack)
 
 
-def render(opts, functions):
+def render(opts, functions, states=None):
     '''
     Returns the render modules
     '''
     load = _create_loader(
         opts, 'renderers', 'render', ext_type_dirs='render_dirs'
     )
-    pack = {'name': '__salt__',
-            'value': functions}
+    pack = [{'name': '__salt__',
+            'value': functions}]
+    if states:
+        pack.append({'name': '__states__', 'value': states})
     rend = load.filter_func('render', pack)
     if not check_render_pipe_str(opts['renderer'], rend):
         err = ('The renderer {0} is unavailable, this error is often because '

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -156,7 +156,6 @@ TODO
 import logging
 import sys
 
-from salt.loader import states
 from salt.utils.pyobjects import StateRegistry, StateFactory, SaltObject
 
 log = logging.getLogger(__name__)
@@ -171,7 +170,13 @@ def render(template, saltenv='base', sls='',
 
     _registry = StateRegistry()
     if _states is None:
-        _states = states(__opts__, __salt__)
+        try:
+            _states = __states__
+        except NameError:
+            from salt.loader import states
+            __opts__['grains'] = __grains__
+            __opts__['pillar'] = __pillar__
+            _states = states(__opts__, __salt__)
 
     # build our list of states and functions
     _st_funcs = {}

--- a/salt/state.py
+++ b/salt/state.py
@@ -596,7 +596,7 @@ class State(object):
                                         )
                                 self.functions[f_key] = funcs[func]
         self.states = salt.loader.states(self.opts, self.functions)
-        self.rend = salt.loader.render(self.opts, self.functions)
+        self.rend = salt.loader.render(self.opts, self.functions, states=self.states)
 
     def module_refresh(self):
         '''
@@ -2615,7 +2615,7 @@ class MasterState(State):
         # Load the states, but they should not be used in this class apart
         # from inspection
         self.states = salt.loader.states(self.opts, self.functions)
-        self.rend = salt.loader.render(self.opts, self.functions)
+        self.rend = salt.loader.render(self.opts, self.functions, states=self.states)
 
 
 class MasterHighState(HighState):


### PR DESCRIPTION
As @mgwilliams has been using pyobjects more he's discovered that when
we load the list of states inside the renderer we need to provide the
pillar & grain data so that it's available to the modules or we get
exceptions like the following.

```
          ID: ls
    Function: cmd.run
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1371, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/states/cmd.py", line 598, in run
                  'shell': shell or __grains__['shell'],
              KeyError: 'shell'
     Changes:
```

We also reasoned that invoking the state loader on every single render
of an sls file is a bit excessive and it would be better to simply have
the already loaded list of states provided to the renderer modules.

The original patch: https://gist.github.com/mgwilliams/f5f7cf1da30e5931e6dc
