### PR TITLE
Use the existing pubkey for the sign in payload

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -237,9 +237,6 @@ class Auth(object):
         public key to encrypt the AES key sent back form the master.
         '''
         payload = {}
-        key = self.get_keys()
-        tmp_pub = salt.utils.mkstemp()
-        key.save_pub_key(tmp_pub)
         payload['enc'] = 'clear'
         payload['load'] = {}
         payload['load']['cmd'] = '_auth'
@@ -251,9 +248,8 @@ class Auth(object):
             payload['load']['token'] = pub.public_encrypt(self.token, RSA.pkcs1_oaep_padding)
         except Exception:
             pass
-        with salt.utils.fopen(tmp_pub, 'r') as fp_:
+        with salt.utils.fopen(self.pub_path, 'r') as fp_:
             payload['load']['pub'] = fp_.read()
-        os.remove(tmp_pub)
         return payload
 
     def decrypt_aes(self, payload, master_pub=True):


### PR DESCRIPTION
Rather than making a temp file to save out the public key just to read it back in to give to the master for sign in, we can just read the existing public key file that was just created.  I should mention that I have not tested this change, as I do not yet have a salt environment up and running.  I have looked through the minion sign in flow, and by this point, the keys have already been created if they didn't exist, so removing the call to salt.get_keys() is perfectly safe.  I would highly suggest testing starting up a minion, both a fresh one and one that has been running for a while, to verify that both cases don't run into any issues.
