### PR TITLE
Tweak docs for consistency and correctness

### DIFF
--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -106,7 +106,9 @@ same way as in the above example, only without a top-level ``grains:`` key:
 Matching Grains in the Top File
 ===============================
 
-With correctly setup grains on the Minion, the Top file used in Pillar or during Highstate can be made really efficient.  Like for example, you could do:
+With correctly configured grains on the Minion, the :term:`top file` used in
+Pillar or during Highstate can be made very efficient. For example, consider
+the following configuration:
 
 .. code-block:: yaml
 
@@ -126,17 +128,28 @@ With correctly setup grains on the Minion, the Top file used in Pillar or during
         - match: grain
         - lb
         
-For this example to work, you would need the grain ``node_type`` and the correct value to match on.  This simple example is nice, but too much of the code is similar.  To go one step further, we can place some Jinja template code into the Top file.
+For this example to work, you would need to have defined the grain
+``node_type`` for the minions you wish to match. This simple example is nice,
+but too much of the code is similar. To go one step further, Jinja templating
+can be used to simplify the the :term:`top file`.
 
 .. code-block:: yaml
 
-    {% set self = grains['node_type'] %}
+    {% set node_type = salt['grains.get']('node_type', '') %}
 
+    {% if node_type %}
         'node_type:{{ self }}':
             - match: grain
             - {{ self }}
+    {% endif %}
 
-The Jinja code simplified the Top file, and allowed SaltStack to work its magic.
+Using Jinja templating, only one match entry needs to be defined.
+
+.. note::
+
+    The example above uses the :mod:`grains.get <salt.modules.grains.get>`
+    function to account for minions which do not have the ``node_type`` grain
+    set.
 
 .. _writing-grains:
 

--- a/doc/topics/targeting/nodegroups.rst
+++ b/doc/topics/targeting/nodegroups.rst
@@ -23,9 +23,9 @@ nodegroups. Here's an example nodegroup configuration within
 
 .. note::
 
-    The 'L' within group1 is matching a list of minions, while the 'G' in
-    group2 is matching specific grains. See the
-    :doc:`compound matchers <compound>` documentation for more details.
+    The ``L`` within group1 is matching a list of minions, while the ``G`` in
+    group2 is matching specific grains. See the :doc:`compound matchers
+    <compound>` documentation for more details.
 
 To match a nodegroup on the CLI, use the ``-N`` command-line option:
 
@@ -33,8 +33,8 @@ To match a nodegroup on the CLI, use the ``-N`` command-line option:
 
     salt -N group1 test.ping
 
-To match in your :term:`top file`, make sure to put ``- match: nodegroup`` on
-the line directly following the nodegroup name.
+To match a nodegroup in your :term:`top file`, make sure to put ``- match:
+nodegroup`` on the line directly following the nodegroup name.
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The grains example would traceback if the grain was not defined, so I
have replaced this example with a better one. Also made a few changes
for consistency in formatting, and made a couple terms into links to the
relevant documentation.
