### PR TITLE
Optimize salt-cloud providers when map_providers_parallel is called.

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -386,8 +386,7 @@ class Cloud(object):
         self.__cached_provider_queries[query] = output
         return output
 
-    def get_running_by_names(self, names, query='list_nodes', cached=False,
-                             profile=None):
+    def get_running_by_names(self, names, query='list_nodes', cached=False):
         if isinstance(names, basestring):
             names = [names]
 
@@ -398,16 +397,6 @@ class Cloud(object):
             for driver, vms in drivers.iteritems():
                 if driver not in handled_drivers:
                     handled_drivers[driver] = alias
-                # When a profile is specified, only return an instance
-                # that matches the provider specified in the profile.
-                # This solves the issues when many providers return the
-                # same instance. For example there may be one provider for
-                # each avaliablity zone in amazon in the same region, but
-                # the search returns the same instance for each provider because
-                # amazon returns all instances in a region, not avaliabilty zone.
-                if profile:
-                    if alias not in self.opts['profiles'][profile]['provider'].split(':')[0]:
-                        continue
 
                 for vm_name, details in vms.iteritems():
                     # XXX: The logic bellow can be removed once the aws driver

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1852,6 +1852,3 @@ def run_parallel_map_providers_query(data):
         )
         # Failed to communicate with the provider, don't list any nodes
         return (data['alias'], data['driver'], ())
-
-
-

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -237,8 +237,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 matching = mapper.delete_map(query='list_nodes')
             else:
                 matching = mapper.get_running_by_names(
-                    self.config.get('names', ()),
-                    profile = self.options.profile
+                    self.config.get('names', ())
                 )
 
             if not matching:

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2647,5 +2647,3 @@ def delete_keypair(kwargs=None, call=None):
 
     data = query(params, return_root=True)
     return data
-
-


### PR DESCRIPTION
@techhat I think this is a cleaner way to solve the needing to specify a profile when destroying an instance. Instead of working around the problem of querying the same region multiple times with the same queries, I'v created an optimizer for the ec2 provider. Any provider can add in an optimization function specific to that provider, if needed. If a provider does not have an optimization function, no worries, that provider will be added as is and proccessed as normal.

I've done extensive testing with this code adding multiple providers and testing to make sure I didn't break current fuctionality. However, it'd be great to have a second pair of eyes on this and maybe even suggest where I can clean up some code as I whiped this up today pretty fast.

What this does is:
1. Check to see if your provider can optimize before querying. This is important because each provider may need to optimize differently.
2. Build an optimized providers list. This will add both optimized and non-optimized providers to the list.
3. Returns list of providers.
### ec2 provider

Optimization is based on region and credentails (id and key). If all three values match, then we remove the duplicate provider. Both providers have the same access since they use the same credentials and access the same region. There is no need to query both providers as this will lead to duplicates.

---

As a side note, this sped up my queries significantly. I have 25 providers configured across 9 regions. I went from querying 25 times to 9, once per region. That is optimization baby! Better yet, the destroy function now works great without a profile specified. Same with tagging and any other action.
