### PR TITLE
Fix reg state thinking DWORD value set to 0 exists even if it doesn't.

### DIFF
--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -75,14 +75,11 @@ def read_key(hkey, path, key):
 
     registry = Registry()
     hkey2 = getattr(registry, hkey)
-    # handle = _winreg.OpenKey(hkey2, path)
-    # value, type = _winreg.QueryValueEx(handle, key)
-    # return value
     try:
         handle = _winreg.OpenKey(hkey2, path)
         return _winreg.QueryValueEx(handle, key)[0]
     except Exception:
-        return False
+        return None
 
 
 def set_key(hkey, path, key, value, vtype='REG_DWORD'):


### PR DESCRIPTION
reg state use

```
if value == __salt__['reg.read_key'](hive, path, key)
```

to verify if a value is registry value is properly set.

If you want to set a DWORD value to 0 and this value doesn't exist, `__salt__['reg.read_key'](hive, path, key)` returns `False` causing the `if` condition being evaluated to True (`0 == False`).

Returning `None` from `__salt__['reg.read_key']` when the value doesn't exist fix the issue.
