### PR TITLE
New module busywork

### DIFF
--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -223,4 +223,5 @@ Full list of builtin execution modules
     zcbuildout
     zfs
     zpool
+    znc
     zypper

--- a/doc/ref/modules/all/salt.modules.znc.rst
+++ b/doc/ref/modules/all/salt.modules.znc.rst
@@ -1,0 +1,6 @@
+================
+salt.modules.znc
+================
+
+.. automodule:: salt.modules.znc
+    :members:

--- a/salt/modules/znc.py
+++ b/salt/modules/znc.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
 znc - An advanced IRC bouncer
+
+.. versionadded:: Helium
+
+Provides an interace to basic ZNC functionality
 '''
 
 # Import python libs


### PR DESCRIPTION
Added new ZNC module to docs, and additionally added a `versionadded` RST directive to note that this module is not yet available.
