### PR TITLE
Clean up img module docs

### DIFF
--- a/doc/ref/modules/all/salt.modules.img.rst
+++ b/doc/ref/modules/all/salt.modules.img.rst
@@ -4,3 +4,4 @@ salt.modules.img
 
 .. automodule:: salt.modules.img
     :members:
+    :exclude-members: mnt_image

--- a/salt/modules/img.py
+++ b/salt/modules/img.py
@@ -84,7 +84,7 @@ def bootstrap(location, size, fmt):
 
     .. code-block:: bash
 
-        salt '*' qemu_nbd.bootstrap /srv/salt-images/host.qcow 4096 qcow2
+        salt '*' img.bootstrap /srv/salt-images/host.qcow 4096 qcow2
     '''
     location = __salt__['img.make_image'](location, size, fmt)
     if not location:


### PR DESCRIPTION
This fixes a CLI example and also hides an aliased function so that it doesn't show up twice in the docs.
