### PR TITLE
#9356 Add cite to IAM for EC2 credential sharing.

### DIFF
--- a/doc/topics/tutorials/preseed_key.rst
+++ b/doc/topics/tutorials/preseed_key.rst
@@ -31,7 +31,9 @@ master config file.
 3. Distribute the minion keys.
 
 There is no single method to get the keypair to your minion.  The difficulty is
-finding a distribution method which is secure.
+finding a distribution method which is secure. For Amazon EC2 only, an AWS best
+practice is to use IAM Roles to pass credentials. (See blog post, 
+http://blogs.aws.amazon.com/php/post/Tx1F82CR0ANO3ZI/Providing-credentials-to-the-AWS-SDK-for-PHP )
 
 .. admonition:: Security Warning
 


### PR DESCRIPTION
1.Per research on #9356, I found a blog so added reference to it to the tutorial.
2.The master already had removed the specific reference to insecure method; "If you are spooling up minions on EC2, you could pass them in using user_data or a cloud-init script. If you are handing them off to a team of developers for provisioning dev machines, you will need a secure file transfer.".
