### PR TITLE
Add three tests for minion_id generation

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1722,9 +1722,10 @@ def get_id(root_dir=None, minion_id=False, cache=True):
         with salt.utils.fopen('/etc/hosts') as hfl:
             for line in hfl:
                 names = line.split()
-                if not names:
+                try:
+                    ip_ = names.pop(0)
+                except IndexError:
                     continue
-                ip_ = names.pop(0)
                 if ip_.startswith('127.'):
                     for name in names:
                         if name != 'localhost':


### PR DESCRIPTION
These tests are in response to a regression fixed a couple days ago, where when /etc/hosts needs to be parsed to determine the minion_id and the file contains a blank line, an exception is raised. The following three methods of determining the minion_id are tested:
1. Calling `socket.getfqdn()`
2. Checking `/etc/hostname`
3. Parsing `/etc/hosts`
