### PR TITLE
Fix for minion_id detection regression + unit tests (2014.1 branch)

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1692,9 +1692,10 @@ def get_id(root_dir=None, minion_id=False, cache=True):
         with salt.utils.fopen('/etc/hosts') as hfl:
             for line in hfl:
                 names = line.split()
-                if not names:
+                try:
+                    ip_ = names.pop(0)
+                except IndexError:
                     continue
-                ip_ = names.pop(0)
                 if ip_.startswith('127.'):
                     for name in names:
                         if name != 'localhost':

--- a/salt/config.py
+++ b/salt/config.py
@@ -1693,7 +1693,7 @@ def get_id(root_dir=None, minion_id=False, cache=True):
             for line in hfl:
                 names = line.split()
                 if not names:
-                    continue # empty line in hosts
+                    continue
                 ip_ = names.pop(0)
                 if ip_.startswith('127.'):
                     for name in names:

--- a/salt/config.py
+++ b/salt/config.py
@@ -1692,6 +1692,8 @@ def get_id(root_dir=None, minion_id=False, cache=True):
         with salt.utils.fopen('/etc/hosts') as hfl:
             for line in hfl:
                 names = line.split()
+                if not names:
+                    continue # empty line in hosts
                 ip_ = names.pop(0)
                 if ip_.startswith('127.'):
                     for name in names:

--- a/salt/config.py
+++ b/salt/config.py
@@ -1707,29 +1707,30 @@ def get_id(root_dir=None, minion_id=False, cache=True):
     except (IOError, OSError):
         pass
 
-    # Can Windows 'hosts' file help?
-    try:
-        windir = os.getenv('WINDIR')
-        with salt.utils.fopen(windir + r'\system32\drivers\etc\hosts') as hfl:
-            for line in hfl:
-                # skip commented or blank lines
-                if line[0] == '#' or len(line) <= 1:
-                    continue
-                # process lines looking for '127.' in first column
-                try:
-                    entry = line.split()
-                    if entry[0].startswith('127.'):
-                        for name in entry[1:]:  # try each name in the row
-                            if name != 'localhost':
-                                log.info('Found minion id in hosts file: {0}'
-                                         .format(name))
-                                if minion_id and cache:
-                                    _cache_id(name, id_cache)
-                                return name, False
-                except IndexError:
-                    pass  # could not split line (malformed entry?)
-    except (IOError, OSError):
-        pass
+    if salt.utils.is_windows():
+        # Can Windows 'hosts' file help?
+        try:
+            windir = os.getenv('WINDIR')
+            with salt.utils.fopen(windir + r'\system32\drivers\etc\hosts') as hfl:
+                for line in hfl:
+                    # skip commented or blank lines
+                    if line[0] == '#' or len(line) <= 1:
+                        continue
+                    # process lines looking for '127.' in first column
+                    try:
+                        entry = line.split()
+                        if entry[0].startswith('127.'):
+                            for name in entry[1:]:  # try each name in the row
+                                if name != 'localhost':
+                                    log.info('Found minion id in hosts file: {0}'
+                                            .format(name))
+                                    if minion_id and cache:
+                                        _cache_id(name, id_cache)
+                                    return name, False
+                    except IndexError:
+                        pass  # could not split line (malformed entry?)
+        except (IOError, OSError):
+            pass
 
     # What IP addresses do we have?
     ip_addresses = [salt.utils.network.IPv4Address(addr) for addr

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-
-# -*- coding: utf-8 -*-
 '''
     :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
     :copyright: © 2012-2013 by the SaltStack Team, see AUTHORS for more details

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -44,7 +44,7 @@ MOCK_ETC_HOSTS = (
     '# localhost is used to configure the loopback interface\n'
     '# when the system is booting.  Do not change this entry.\n'
     '##\n'
-    '\n'
+    '\n'  # This empty line MUST STAY HERE, it factors into the tests
     '127.0.0.1      localhost   foo.bar.net\n'
     '10.0.0.100     foo.bar.net\n'
 )

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -35,13 +35,37 @@ mock_etc_hosts = (
     '# when the system is booting.  Do not change this entry.\n'
     '##\n'
     '\n'
-    '127.0.0.1	localhost	foo.bar.net\n'
-    '10.0.0.100   foo.bar.net\n'
+    '127.0.0.1      localhost   foo.bar.net\n'
+    '10.0.0.100     foo.bar.net\n'
 )
 mock_etc_hostname = 'foo.bar.com\n'
 
+def _unhandled_mock_read(filename):
+    '''
+    Raise an error because we should not be calling salt.utils.fopen()
+    '''
+    raise CommandExecutionError('Unhandled mock read for {0}'.format(filename))
+
+
+@contextmanager
+def _fopen_side_effect_etc_hostname(filename):
+    '''
+    Mock reading from /etc/hostname
+    '''
+    log.debug('Mock-reading {0}'.format(filename))
+    if filename == '/etc/hostname':
+        mock_open = MagicMock()
+        mock_open.read.return_value = MOCK_ETC_HOSTNAME
+        yield mock_open
+    else:
+        _unhandled_mock_read(filename)
+
+
 @contextmanager
 def _fopen_side_effect_etc_hosts(filename):
+    '''
+    Mock /etc/hostname not existing, and falling back to reading /etc/hosts
+    '''
     log.debug('Mock-reading {0}'.format(filename))
     if filename == '/etc/hostname':
         raise IOError(2, "No such file or directory: '/etc/hostname'")
@@ -50,7 +74,7 @@ def _fopen_side_effect_etc_hosts(filename):
         mock_open.__iter__.return_value = MOCK_ETC_HOSTS.splitlines()
         yield mock_open
     else:
-        raise CommandExecutionError('Unhandled mock read for {0}'.format(filename))
+        _unhandled_mock_read(filename)
 
 
 class ConfigTestCase(TestCase):
@@ -408,6 +432,29 @@ class ConfigTestCase(TestCase):
         finally:
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
+
+    @patch('socket.getfqdn', MagicMock(return_value='foo.bar.org'))
+    def test_get_id_socket_getfqdn(self):
+        '''
+        Test calling salt.config.get_id() and getting the hostname from
+        socket.getfqdn()
+        '''
+        with patch('salt.utils.fopen',
+                   MagicMock(side_effect=_unhandled_mock_read)):
+            self.assertEqual(
+                sconfig.get_id(cache=False), ('foo.bar.org', False)
+            )
+
+    @patch('socket.getfqdn', MagicMock(return_value='localhost'))
+    def test_get_id_etc_hostname(self):
+        '''
+        Test calling salt.config.get_id() and falling back to looking at
+        /etc/hostname.
+        '''
+        with patch('salt.utils.fopen', _fopen_side_effect_etc_hostname):
+            self.assertEqual(
+                sconfig.get_id(cache=False), ('foo.bar.com', False)
+            )
 
     @patch('socket.getfqdn', MagicMock(return_value='localhost'))
     def test_get_id_etc_hosts(self):

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -25,9 +25,19 @@ from salttesting.mock import MagicMock, patch, mock_open, call
 from salttesting.helpers import ensure_in_syspath, TestsLoggingHandler
 from salt.exceptions import CommandExecutionError
 
+ensure_in_syspath('../')
+
+# Import salt libs
+import salt.minion
+import salt.utils
+import integration
+from salt import config as sconfig, version as salt_version
+from salt.version import SaltStackVersion
+
 log = logging.getLogger(__name__)
 
-mock_etc_hosts = (
+
+MOCK_ETC_HOSTS = (
     '##\n'
     '# Host Database\n'
     '#\n'
@@ -38,7 +48,8 @@ mock_etc_hosts = (
     '127.0.0.1      localhost   foo.bar.net\n'
     '10.0.0.100     foo.bar.net\n'
 )
-mock_etc_hostname = 'foo.bar.com\n'
+MOCK_ETC_HOSTNAME = 'foo.bar.com\n'
+
 
 def _unhandled_mock_read(filename):
     '''


### PR DESCRIPTION
**This is against the 2014.1 branch**

2014.1.0 introduced a regression for edge cases where minion_id detection falls all the way back to parsing /etc/hosts, and there is an empty line in /etc/hosts.

This pull request includes the following:
1. The initial fix for that regression, originally contributed on 22 February.
2. A more pythonic fix, which replaces the original solution.
3. Unit tests I wrote to cover minion_id detection.
