### PR TITLE
avoid shadowing of info() in dockerio module

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -345,11 +345,11 @@ def _get_container_infos(container):
     status = base_status.copy()
     client = _get_client()
     try:
-        info = client.inspect_container(container)
-        if info:
+        container_info = client.inspect_container(container)
+        if container_info:
             valid(status,
-                  id=info['ID'],
-                  out=info)
+                  id=container_info['ID'],
+                  out=container_info)
     except Exception:
         pass
     if not status['id']:


### PR DESCRIPTION
```
salt/modules/dockerio.py:348: [W0621(redefined-outer-name), _get_container_infos] Redefining name 'info' from outer scope (line 674)
```
