### PR TITLE
Fix a fall back

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1380,11 +1380,9 @@ class State(object):
             if len(cdata['args']) > 0:
                 name = cdata['args'][0]
             elif 'name' in cdata['kwargs']:
-                name = cdata['kwargs'].get(
-                    'name',
-                    low.get('name',
-                            low.get('__id__'))
-                )
+                name = cdata['kwargs']['name']
+            else:
+                name = low.get('name', low.get('__id__'))
             ret = {
                 'result': False,
                 'name': name,


### PR DESCRIPTION
Since this code only runs if `name` is in `cdata['kwargs']`, it's never going to use the default param given to `dict.get()`.
I think it was intended to be an else / fall through so I've rewritten it thus.  IMO, writing it as an else makes it slightly more readable than changing it to use the default param correctly.
