### PR TITLE
deleted duplicate parser option for -v, --verbose

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2177,13 +2177,6 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'reached.')
         )
         self.add_option(
-            '-v', '--verbose',
-            default=False,
-            action='store_true',
-            help=('Turn on command verbosity, display jid')
-        )
-
-        self.add_option(
             '--max-procs',
             dest='ssh_max_procs',
             default=25,


### PR DESCRIPTION
The salt-ssh script is broken, and cannot execute due to an error in the argument parser caused by a duplicate option definition for -v, --verbose. This removes the duplicate option.
