### PR TITLE
added explicit git revision support to winrepo

### DIFF
--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -105,9 +105,14 @@ def update_git_repos():
         #else:
             #targetname = gitrepo
         targetname = gitrepo
+        rev = None
+        # If a revision is specified, use it.
+        if len(gitrepo.strip().split(' ')) > 1:
+            rev, gitrepo = gitrepo.strip().split(' ')
         gittarget = os.path.join(repo, targetname)
         #result = mminion.states['git.latest'](gitrepo,
         result = __salt__['git.latest'](gitrepo,
+                                        rev=rev,
                                         target=gittarget,
                                         force=True)
         ret[result['name']] = result['result']

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -91,8 +91,13 @@ def update_git_repos():
             targetname = gitrepo.split('/')[-1]
         else:
             targetname = gitrepo
+        rev = None
+        # If a revision is specified, use it.
+        if len(gitrepo.strip().split(' ')) > 1:
+            rev, gitrepo = gitrepo.strip().split(' ')
         gittarget = os.path.join(repo, targetname)
         result = mminion.states['git.latest'](gitrepo,
+                                              rev=rev,
                                               target=gittarget,
                                               force=True)
         ret[result['name']] = result['result']

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -213,7 +213,7 @@ def latest(name,
                                           identity=identity)
                 elif rev:
 
-                    cmd = 'git rev-parse {0} ^{{commit}}'.format(rev)
+                    cmd = 'git rev-parse {0}'.format(rev)
                     retcode = __salt__['cmd.retcode'](cmd,
                                                       cwd=target,
                                                       runas=user)


### PR DESCRIPTION
I need winrepo to be able to support an explicit version from a git repo whether that is a branch or a hash. This change implements that in a similar way that ext_pillar does.

Could someone comment on my change to `salt/states/git.py`? Is it kosher? I don't understand what `^{{commit}}` is being used for, but it errors out in my environment.

```
[INFO    ] Executing command 'git rev-parse e38cac5090 ^{commit}' in directory '/tmp/winrepo'
[ERROR   ] Command 'git rev-parse e38cac5090 ^{commit}' failed with return code: 128
[ERROR   ] output: fatal: ambiguous argument '^{commit}': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions
e38cac5090bc5d680b5289c04d4b44d69a89cddf
^{commit}
```
