### PR TITLE
Lint fixes

### DIFF
--- a/salt/daemons/test/test_master.py
+++ b/salt/daemons/test/test_master.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-"""
+'''
 Runs minion floscript
 
-
-"""
+'''
 import os
 import salt.daemons.flo
-import ioflo.app.run
 
 FLO_DIR_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    , 'flo')
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'flo'
+)
 
 
 def test():

--- a/salt/daemons/test/test_minion.py
+++ b/salt/daemons/test/test_minion.py
@@ -1,18 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-
-"""
+'''
 Runs minion floscript
 
-
-"""
+'''
 import os
 import salt.daemons.flo
-import ioflo.app.run
 
 FLO_DIR_PATH = os.path.join(
-    os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    , 'flo')
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'flo'
+)
 
 
 def test():


### PR DESCRIPTION
@thatch45 please review. If ioflo.app.run is really needed here, then we'll need to use `# pylint: disable=E0611` to quiet these lint failures.
