### PR TITLE
Reduce scaling issues with `deepcopy`'ing.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -32,8 +32,8 @@ import salt.fileclient
 import salt.utils.event
 import salt.syspaths as syspaths
 from salt.utils import context
-from salt.utils.datafreeze import ImmutableLazyProxy
 from salt._compat import string_types
+from salt.utils.immutabletypes import ImmutableLazyProxy
 from salt.template import compile_template, compile_template_str
 from salt.exceptions import SaltRenderError, SaltReqTimeoutError, SaltException
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -32,6 +32,7 @@ import salt.fileclient
 import salt.utils.event
 import salt.syspaths as syspaths
 from salt.utils import context
+from salt.utils.datafreeze import ImmutableLazyProxy
 from salt._compat import string_types
 from salt.template import compile_template, compile_template_str
 from salt.exceptions import SaltRenderError, SaltReqTimeoutError, SaltException
@@ -1334,9 +1335,9 @@ class State(object):
             # the current state dictionaries.
             # We pass deep copies here because we don't want any misbehaving
             # state module to change these at runtime.
-            '__low__': copy.deepcopy(low),
-            '__running__': copy.deepcopy(running) if running else {},
-            '__lowstate__': copy.deepcopy(chunks) if chunks else {}
+            '__low__': ImmutableLazyProxy(low),
+            '__running__': ImmutableLazyProxy(running) if running else {},
+            '__lowstate__': ImmutableLazyProxy(chunks) if chunks else {}
         }
 
         if low.get('__prereq__'):

--- a/salt/utils/datafreeze.py
+++ b/salt/utils/datafreeze.py
@@ -32,11 +32,11 @@ class ImmutableDict(collections.Mapping):
     def __iter__(self):
         return iter(self.__obj)
 
-    def __repr__(self):
-        return repr(self.__obj)
-
     def __getitem__(self, key):
-        return self.__obj[key]
+        return ImmutableLazyProxy(self.__obj[key])
+
+    def __repr__(self):
+        return '<{0} {1}>'.format(self.__class__.__name__, repr(self.__obj))
 
 
 class ImmutableList(collections.Sequence):
@@ -53,11 +53,11 @@ class ImmutableList(collections.Sequence):
     def __iter__(self):
         return iter(self.__obj)
 
-    def __repr__(self):
-        return repr(self.__obj)
-
     def __getitem__(self, key):
-        return self.__obj[key]
+        return ImmutableLazyProxy(self.__obj[key])
+
+    def __repr__(self):
+        return '<{0} {1}>'.format(self.__class__.__name__, repr(self.__obj))
 
 
 class ImmutableSet(collections.Set):
@@ -74,11 +74,11 @@ class ImmutableSet(collections.Set):
     def __iter__(self):
         return iter(self.__obj)
 
-    def __repr__(self):
-        return repr(self.__obj)
-
     def __contains__(self, key):
         return key in self.__obj
+
+    def __repr__(self):
+        return '<{0} {1}>'.format(self.__class__.__name__, repr(self.__obj))
 
 
 class ImmutableLazyProxy(LazyLoadProxy):

--- a/salt/utils/datafreeze.py
+++ b/salt/utils/datafreeze.py
@@ -53,6 +53,9 @@ class ImmutableList(collections.Sequence):
     def __iter__(self):
         return iter(self.__obj)
 
+    def __add__(self, other):
+        return self.__obj + other
+
     def __getitem__(self, key):
         return ImmutableLazyProxy(self.__obj[key])
 

--- a/salt/utils/datafreeze.py
+++ b/salt/utils/datafreeze.py
@@ -1,0 +1,101 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Pedro Algarvio (pedro@algarvio.me)`
+    :copyright: © 2014 by the SaltStack Team, see AUTHORS for more details.
+    :license: Apache 2.0, see LICENSE for more details.
+
+
+    salt.utils.datafreeze
+    ~~~~~~~~~~~~~~~~~~~~~
+
+    Built-in data types freeze
+'''
+
+# Import python libs
+import collections
+
+# Import salt libs
+from salt.utils.lazyproxy import LazyLoadProxy
+
+
+class ImmutableDict(collections.Mapping):
+    '''
+    An immutable dictionary implementation
+    '''
+
+    def __init__(self, obj):
+        self.__obj = obj
+
+    def __len__(self):
+        return len(self.__obj)
+
+    def __iter__(self):
+        return iter(self.__obj)
+
+    def __repr__(self):
+        return repr(self.__obj)
+
+    def __getitem__(self, key):
+        return self.__obj[key]
+
+
+class ImmutableList(collections.Sequence):
+    '''
+    An immutable list implementation
+    '''
+
+    def __init__(self, obj):
+        self.__obj = obj
+
+    def __len__(self):
+        return len(self.__obj)
+
+    def __iter__(self):
+        return iter(self.__obj)
+
+    def __repr__(self):
+        return repr(self.__obj)
+
+    def __getitem__(self, key):
+        return self.__obj[key]
+
+
+class ImmutableSet(collections.Set):
+    '''
+    An immutable set implementation
+    '''
+
+    def __init__(self, obj):
+        self.__obj = obj
+
+    def __len__(self):
+        return len(self.__obj)
+
+    def __iter__(self):
+        return iter(self.__obj)
+
+    def __repr__(self):
+        return repr(self.__obj)
+
+    def __contains__(self, key):
+        return key in self.__obj
+
+
+class ImmutableLazyProxy(LazyLoadProxy):
+    '''
+    LazyProxy which will return an immutable type when requested
+    '''
+
+    def __init__(self, obj):
+        def __immutable_selection(obj):
+            if isinstance(obj, dict):
+                return ImmutableDict(obj)
+            if isinstance(obj, list):
+                return ImmutableList(obj)
+            if isinstance(obj, set):
+                return ImmutableSet(obj)
+            return obj
+
+        super(ImmutableLazyProxy, self).__init__(
+            lambda: __immutable_selection(obj)
+        )

--- a/salt/utils/immutabletypes.py
+++ b/salt/utils/immutabletypes.py
@@ -5,10 +5,10 @@
     :license: Apache 2.0, see LICENSE for more details.
 
 
-    salt.utils.datafreeze
-    ~~~~~~~~~~~~~~~~~~~~~
+    salt.utils.immutabletypes
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    Built-in data types freeze
+    Immutable types
 '''
 
 # Import python libs

--- a/salt/utils/lazyproxy.py
+++ b/salt/utils/lazyproxy.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+'''
+    :copyright: © 2006 Tomer Filiba
+    :copyright: © 2012 Cory Virok
+    :copyright: © 2014 by the SaltStack Team, see AUTHORS for more details.
+    :license: PSF
+
+
+    salt.utils.lazyproxy
+    ~~~~~~~~~~~~~~~~~~~~
+
+    Lazy object proxying, from the recipe found at:
+        http://code.activestate.com/recipes/578014-lazy-load-object-proxying/
+'''
+
+
+class LazyLoadProxy(object):
+
+    __slots__ = ['_obj_fn', '__weakref__', '__proxy_storage']
+
+    def __init__(self, fn, storage=None):
+        object.__setattr__(self, '_obj_fn', fn)
+        object.__setattr__(self, '__proxy_storage', storage)
+
+    #
+    # proxying (special cases)
+    #
+    def __getattribute__(self, name):
+        return getattr(object.__getattribute__(self, '_obj_fn')(), name)
+
+    def __delattr__(self, name):
+        delattr(object.__getattribute__(self, '_obj_fn')(), name)
+
+    def __setattr__(self, name, value):
+        setattr(object.__getattribute__(self, '_obj_fn')(), name, value)
+
+    def __getitem__(self, index):
+        return object.__getattribute__(self, '_obj_fn')().__getitem__(index)
+
+    def __nonzero__(self):
+        return bool(object.__getattribute__(self, '_obj_fn')())
+
+    def __str__(self):
+        return str(object.__getattribute__(self, '_obj_fn')())
+
+    def __repr__(self):
+        return repr(object.__getattribute__(self, '_obj_fn')())
+
+    def __len__(self):
+        return len(object.__getattribute__(self, '_obj_fn')())
+
+    #
+    # factories
+    #
+    _special_names = [
+        '__abs__', '__add__', '__and__', '__call__', '__cmp__', '__coerce__',
+        '__contains__', '__delitem__', '__delslice__', '__div__', '__divmod__',
+        '__eq__', '__float__', '__floordiv__', '__ge__',  # '__getitem__',
+        '__getslice__', '__gt__', '__hash__', '__hex__', '__iadd__', '__iand__',
+        '__idiv__', '__idivmod__', '__ifloordiv__', '__ilshift__', '__imod__',
+        '__imul__', '__int__', '__invert__', '__ior__', '__ipow__', '__irshift__',
+        '__isub__', '__iter__', '__itruediv__', '__ixor__', '__le__',  # '__len__',
+        '__long__', '__lshift__', '__lt__', '__mod__', '__mul__', '__ne__',
+        '__neg__', '__oct__', '__or__', '__pos__', '__pow__', '__radd__',
+        '__rand__', '__rdiv__', '__rdivmod__', '__reduce__', '__reduce_ex__',
+        '__repr__', '__reversed__', '__rfloorfiv__', '__rlshift__', '__rmod__',
+        '__rmul__', '__ror__', '__rpow__', '__rrshift__', '__rshift__', '__rsub__',
+        '__rtruediv__', '__rxor__', '__setitem__', '__setslice__', '__sub__',
+        '__truediv__', '__xor__', 'next',
+    ]
+
+    @classmethod
+    def _create_class_proxy(cls, theclass):
+        '''creates a proxy for the given class'''
+
+        def make_method(name):
+            def method(self, *args, **kw):
+                return getattr(object.__getattribute__(self, '_obj_fn')(), name)(*args, **kw)
+            return method
+
+        namespace = {}
+        for name in cls._special_names:
+            if hasattr(theclass, name):
+                namespace[name] = make_method(name)
+        return type('%s(%s)' % (cls.__name__, theclass.__name__), (cls,), namespace)
+
+    def __new__(cls, obj, *args, **kwargs):
+        '''
+        creates an proxy instance referencing `obj`. (obj, *args, **kwargs) are
+        passed to this class' __init__, so deriving classes can define an
+        __init__ method of their own.
+        note: _class_proxy_cache is unique per deriving class (each deriving
+        class must hold its own cache)
+        '''
+        try:
+            cache = cls.__dict__['_class_proxy_cache']
+        except KeyError:
+            cls._class_proxy_cache = cache = {}
+        try:
+            theclass = cache[obj.__class__]
+        except KeyError:
+            cache[obj.__class__] = theclass = cls._create_class_proxy(obj.__class__)
+        ins = object.__new__(theclass)
+        theclass.__init__(ins, obj, *args, **kwargs)
+        return ins
+
+
+class Proxy(LazyLoadProxy):
+
+    def __init__(self, obj):
+        super(Proxy, self).__init__(lambda: obj)


### PR DESCRIPTION
Transform `dict`, `list`, `set` into it's immutable partner which is
lazy loaded. So, if no attribute access is being performed, the
built-ins are not converted and cached into it's immutable version.

Fixes #10733.
