### PR TITLE
module/timezone: add newline in `/etc/timezone`

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -128,7 +128,8 @@ def set_zone(timezone):
             '/etc/sysconfig/clock', '^ZONE=.*', 'ZONE="{0}"'.format(timezone))
     elif 'Debian' in __grains__['os_family']:
         with salt.utils.fopen('/etc/timezone', 'w') as ofh:
-            ofh.write(timezone)
+            ofh.write(timezone.strip())
+            ofh.write('\n')
     elif 'Gentoo' in __grains__['os_family']:
         with salt.utils.fopen('/etc/timezone', 'w') as ofh:
             ofh.write(timezone)


### PR DESCRIPTION
This follows the convention used by Debian. I've also stripped/trimmed the
timezone string in case someone's already manually added a newline.

Not sure if this breaks the state in any way, so I would appreciate if someone could review this.
