### PR TITLE
Minor bug fixes in iptables

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -296,7 +296,7 @@ def insert(name, family='ipv4', **kwargs):
     for ignore in _STATE_INTERNAL_KEYWORDS:
         if ignore in kwargs:
             del kwargs[ignore]
-    rule = __salt__['iptables.build_rule'](family, **kwargs)
+    rule = __salt__['iptables.build_rule'](family=family, **kwargs)
     command = __salt__['iptables.build_rule'](full=True, family=family, command='I', **kwargs)
     if __salt__['iptables.check'](kwargs['table'],
                                   kwargs['chain'],
@@ -325,7 +325,7 @@ def insert(name, family='ipv4', **kwargs):
             if kwargs['save']:
                 __salt__['iptables.save'](filename=None, family=family)
                 ret['comment'] = ('Set and Saved iptables rule for {0} to: '
-                                  '{1} for {2}'.format(name, command.strip()), family)
+                                  '{1} for {2}'.format(name, command.strip(), family))
         return ret
     else:
         ret['result'] = False


### PR DESCRIPTION
Found these 2 minor bugs that prevent iptables insert from working.
First one causes duplicate key 'table' error to be raised. 'build_rule' is also called in the append function with 'family' as a keyword argument.
Second one is just a misplaced parenthesis.
