### PR TITLE
Add RHEL6-specific upstart config files

### DIFF
--- a/pkg/salt-master.upstart.rhel6
+++ b/pkg/salt-master.upstart.rhel6
@@ -1,0 +1,16 @@
+description "Salt Master"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+limit nofile 100000 100000
+
+script
+  # Read configuration variable file if it is present
+  [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
+
+  # Activate the virtualenv if defined
+  [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
+
+  # invoke salt-master via su so that /etc/environment is read
+  exec su -c salt-master
+end script

--- a/pkg/salt-minion.upstart.rhel6
+++ b/pkg/salt-minion.upstart.rhel6
@@ -1,0 +1,22 @@
+description "Salt Minion"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+# The respawn in the minion is known to cause problems
+# because if the main minion process dies it has done
+# so most likely for a good reason. Uncomment these
+# two lines to enable respawn
+#respawn
+#respawn limit 10 5
+
+script
+  # Read configuration variable file if it is present
+  [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
+
+  # Activate the virtualenv if defined
+  [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
+
+  # invoke salt-minion via su so that /etc/environment is read
+  exec su -c salt-minion
+end script

--- a/pkg/salt-syndic.upstart.rhel6
+++ b/pkg/salt-syndic.upstart.rhel6
@@ -1,0 +1,15 @@
+description "salt-syndic"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+script
+  # Read configuration variable file if it is present
+  [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
+
+  # Activate the virtualenv if defined
+  [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
+
+  # invoke salt-syndic via su so that /etc/environment is read
+  exec su -c salt-syndic
+end script


### PR DESCRIPTION
RHEL6 doesn't use the `net-device-up` and `local-filesystems` targets,
meaning that if someone decides to use this upstart config then the
master/minion/syndic does not start on boot.

We don't deploy upstart configs in our RPMs, but this provides a working
upstart config file for those that wish to use it.
