### PR TITLE
Add Glossary and Table of Contents to links header in docs

### DIFF
--- a/doc/_themes/saltstack/layout.html
+++ b/doc/_themes/saltstack/layout.html
@@ -2,6 +2,11 @@
 <!DOCTYPE html>
 {%- endblock %}
 
+{% set xxx = rellinks.extend([
+    ('glossary', 'Glossary', 'g', 'Glossary'),
+    ('contents', 'Table of Contents', 't', 'Table of Contents'),
+]) %}
+
 {%- set reldelim1 = reldelim1 is not defined and ' &raquo;' or reldelim1 %}
 {%- set reldelim2 = reldelim2 is not defined and ' |' or reldelim2 %}
 {%- set render_sidebar = (not embedded) and (not theme_nosidebar|tobool) and (sidebars != []) %}


### PR DESCRIPTION
This might be too much in the header, but let's get it online and try it out.
