### PR TITLE
Give publish.runner module call a timeout

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -202,7 +202,7 @@ def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
                     form='full')
 
 
-def runner(fun, arg=None):
+def runner(fun, arg=None, timeout=5):
     '''
     Execute a runner on the master and return the data from the runner
     function
@@ -223,6 +223,7 @@ def runner(fun, arg=None):
             'fun': fun,
             'arg': arg,
             'tok': tok,
+            'tmo': timeout,
             'id': __opts__['id']}
 
     sreq = salt.transport.Channel.factory(__opts__)


### PR DESCRIPTION
It's important to be able to set a timeout for publish.runner calls
as it's generally unlikely that most runners will return in the
default timeout. When publish.runner times out, the runner stops
running at that point, likely breaking whatever was occuring.
