### PR TITLE
Pyobjects ids

### DIFF
--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -42,8 +42,8 @@ class StateRegistry(object):
 
     def salt_data(self):
         states = OrderedDict([
-            (id_, state())
-            for id_, state in self.states.iteritems()
+            (id_, states_)
+            for id_, states_ in self.states.iteritems()
         ])
 
         if self.includes:
@@ -51,8 +51,8 @@ class StateRegistry(object):
 
         if self.extends:
             states['extend'] = OrderedDict([
-                (id_, state())
-                for id_, state in self.extends.iteritems()
+                (id_, states_)
+                for id_, states_ in self.extends.iteritems()
             ])
 
         self.empty()
@@ -66,7 +66,13 @@ class StateRegistry(object):
             attr = self.states
 
         if id_ in attr:
-            raise DuplicateState("A state with id '%s' already exists" % id_)
+            if state.full_func in attr[id_]:
+                raise DuplicateState("A state with id '%s', type '%s' exists" % (
+                    id_,
+                    state.full_func
+                ))
+        else:
+            attr[id_] = OrderedDict()
 
         # if we have requisites in our stack then add them to the state
         if len(self.requisites) > 0:
@@ -75,7 +81,7 @@ class StateRegistry(object):
                     state.kwargs[req.requisite] = []
                 state.kwargs[req.requisite].append(req())
 
-        attr[id_] = state
+        attr[id_].update(state())
 
     def extend(self, id_, state):
         self.add(id_, state, extend=True)

--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -71,8 +71,8 @@ class StateRegistry(object):
                     id_,
                     state.full_func
                 ))
-            else:
-                attr[id_] = OrderedDict()
+        else:
+            attr[id_] = OrderedDict()
 
         # if we have requisites in our stack then add them to the state
         if len(self.requisites) > 0:

--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -71,8 +71,8 @@ class StateRegistry(object):
                     id_,
                     state.full_func
                 ))
-        else:
-            attr[id_] = OrderedDict()
+            else:
+                attr[id_] = OrderedDict()
 
         # if we have requisites in our stack then add them to the state
         if len(self.requisites) > 0:

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -13,10 +13,11 @@ from salt.minion import SMinion
 from salt.renderers.pyobjects import render as pyobjects_render
 from salt.utils.odict import OrderedDict
 from salt.utils.pyobjects import (StateFactory, State, StateRegistry,
-                                  InvalidFunction, SaltObject)
+                                  SaltObject, InvalidFunction, DuplicateState)
 
 test_registry = StateRegistry()
 File = StateFactory('file', registry=test_registry)
+Service = StateFactory('service', registry=test_registry)
 
 pydmesg_expected = {
     'file.managed': [
@@ -115,6 +116,15 @@ class StateTests(TestCase):
             test_registry.states,
             OrderedDict()
         )
+
+    def test_duplicates(self):
+        def add_dup():
+            File.managed('dup', name='/dup', owner='root')
+
+        add_dup()
+        self.assertRaises(DuplicateState, add_dup)
+
+        Service.running('dup', name='dup-service')
 
 
 class RendererTests(TestCase):

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -68,7 +68,7 @@ class StateTests(TestCase):
                      **pydmesg_kwargs)
 
         self.assertEqual(
-            test_registry.states['/usr/local/bin/pydmesg'](),
+            test_registry.states['/usr/local/bin/pydmesg'],
             pydmesg_expected
         )
 
@@ -77,7 +77,7 @@ class StateTests(TestCase):
             pydmesg = File.managed('/usr/local/bin/pydmesg', **pydmesg_kwargs)
 
             self.assertEqual(
-                test_registry.states['/usr/local/bin/pydmesg'](),
+                test_registry.states['/usr/local/bin/pydmesg'],
                 pydmesg_expected
             )
 
@@ -85,7 +85,7 @@ class StateTests(TestCase):
                 File.managed('/tmp/something', owner='root')
 
                 self.assertEqual(
-                    test_registry.states['/tmp/something'](),
+                    test_registry.states['/tmp/something'],
                     {
                         'file.managed': [
                             {'owner': 'root'},
@@ -103,7 +103,7 @@ class StateTests(TestCase):
                      **pydmesg_kwargs)
 
         self.assertEqual(
-            test_registry.states['/usr/local/bin/pydmesg'](),
+            test_registry.states['/usr/local/bin/pydmesg'],
             pydmesg_expected
         )
 
@@ -119,12 +119,26 @@ class StateTests(TestCase):
 
     def test_duplicates(self):
         def add_dup():
-            File.managed('dup', name='/dup', owner='root')
+            File.managed('dup', name='/dup')
 
         add_dup()
         self.assertRaises(DuplicateState, add_dup)
 
         Service.running('dup', name='dup-service')
+
+        self.assertEqual(
+            test_registry.states,
+            OrderedDict([
+                ('dup', OrderedDict([
+                    ('file.managed', [
+                        {'name': '/dup'}
+                    ]),
+                    ('service.running', [
+                        {'name': 'dup-service'}
+                    ])
+                ]))
+            ])
+        )
 
 
 class RendererTests(TestCase):


### PR DESCRIPTION
As it stands the following will fail as we didn't allow duplicate IDs under any circumstances:

```
with Pkg.installed("nginx"):
    Service.running("nginx")
```

This commit changes the way the StateRegistry stores states to allow the above example to work properly.

Now it behaves much more closely to the YAML + Jinja renderer.
