### PR TITLE
Allow state concurrency

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -77,7 +77,7 @@ def _wait(jid):
         states = _prior_running_states(jid)
 
 
-def running():
+def running(concurrent=False):
     '''
     Return a dict of state return data if a state function is already running.
     This function is used to prevent multiple state calls from being run at
@@ -90,6 +90,8 @@ def running():
         salt '*' state.running
     '''
     ret = []
+    if concurrent:
+        return ret
     active = __salt__['saltutil.is_running']('state.*')
     for data in active:
         err = (
@@ -308,6 +310,7 @@ def sls(mods,
         exclude=None,
         queue=False,
         env=None,
+        concurrent=False,
         **kwargs):
     '''
     Execute a set list of state modules from an environment. The default
@@ -315,6 +318,11 @@ def sls(mods,
     to specify a different environment
 
     Custom Pillar data can be passed with the ``pillar`` kwarg.
+
+    concurrent: 
+        WARNING: This flag is potentially dangerous. It is designed 
+        for use when multiple state runs can safely be run at the same 
+        Do not use this flag for performance optimization.
 
     CLI Example:
 
@@ -337,7 +345,7 @@ def sls(mods,
     if queue:
         _wait(kwargs.get('__pub_jid'))
     else:
-        conflict = running()
+        conflict = running(concurrent)
         if conflict:
             __context__['retcode'] = 1
             return conflict

--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -57,6 +57,7 @@ def state(
         test=False,
         fail_minions=None,
         allow_fail=0,
+        concurrent=False,
         timeout=None):
     '''
     Invoke a state run on a given target
@@ -93,6 +94,13 @@ def state(
 
     fail_minions
         An optional list of targeted minions where failure is an option
+
+    concurrent
+        Allow multiple state runs to occur at once.  
+
+        WARNING: This flag is potentially dangerous. It is designed 
+        for use when multiple state runs can safely be run at the same 
+        Do not use this flag for performance optimization.
     '''
     cmd_kw = {'arg': [], 'kwarg': {}, 'ret': ret, 'timeout': timeout}
 
@@ -141,6 +149,13 @@ def state(
         cmd_kw['kwarg']['test'] = test
 
     cmd_kw['kwarg']['saltenv'] = __env__
+
+    if isinstance(concurrent, bool):
+        cmd_kw['kwarg']['concurrent'] = concurrent
+    else:
+        ret['comment'] = ('Must pass in boolean for value of \'concurrent\'')
+        ret['result'] = False
+        return ret
 
     if __opts__['test'] is True:
         ret['comment'] = (


### PR DESCRIPTION
Addresses the issues outlined in #10812 by providing a new 'concurrent' flag that bypasses the concurrency safety checks. Includes some hefty warnings about why you may not want to do this sort of thing.
