### PR TITLE
Clear remote fs backend env cache on master start (2014.1 branch)

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -208,6 +208,25 @@ class Master(SMaster):
                 br, loc = opts_dict['git'].strip().split()
                 pillargitfs.append(git_pillar.GitPillar(br, loc, self.opts))
 
+        # Clear remote fileserver backend env cache so it gets recreated during
+        # the first loop_interval
+        for backend in ('git', 'hg', 'svn'):
+            if backend in self.opts['fileserver_backend']:
+                env_cache = os.path.join(
+                    self.opts['cachedir'],
+                    '{0}fs'.format(backend),
+                    'envs.p'
+                )
+                if os.path.isfile(env_cache):
+                    log.debug('Clearing {0}fs env cache'.format(backend))
+                    try:
+                        os.remove(env_cache)
+                    except (IOError, OSError) as exc:
+                        log.critical(
+                            'Unable to clear env cache file {0}: {1}'
+                            .format(env_cache, exc)
+                        )
+
         old_present = set()
         while True:
             now = int(time.time())


### PR DESCRIPTION
Clear remote fileserver backend env cache so it gets recreated during
the initial loop_interval. Allows envs to be rebuilt if changes are made
to an env whitelist/blacklist.

**Note: the whitelist/blacklist feature is not going to be in any of the Hydrogen releases, however this issue could still impact users in cases where a remote is deleted and there are no other immediate changes to any of the remotes that would result in the fileserver cache being updated (and thus the re-creation of the env cache). An edge case, but one worth fixing for 2014.1.1.**
