### PR TITLE
Adding help function to all modules

### DIFF
--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -13,6 +13,14 @@ import tempfile
 import salt.utils
 from salt.utils import which as _which
 
+import logging
+
+log = logging.getLogger(__name__)
+
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
 
 __outputter__ = {
     'rm_alias': 'txt',
@@ -195,3 +203,26 @@ def rm_alias(alias):
 
     __write_aliases_file(out)
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' aliases.help
+
+        salt '*' aliases.help rm_alias
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -21,7 +21,8 @@ log = logging.getLogger(__name__)
 
 # Don't shadow built-in's.
 __func_alias__ = {
-    'set_': 'set'
+    'set_': 'set',
+    'help_': 'help'
 }
 
 
@@ -162,3 +163,26 @@ def set_(name, path):
     if out['retcode'] > 0:
         return out['stderr']
     return out['stdout']
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' alternatives.help
+
+        salt '*' alternatives.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -18,6 +18,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -349,3 +354,26 @@ def server_status(profile='default'):
 
     # return the good stuff
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' apache.help
+
+        salt '*' apache.help useradd
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -24,6 +24,10 @@ from salt.exceptions import (
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
 
 try:
     from aptsources import sourceslist
@@ -1579,3 +1583,26 @@ def _resolve_deps(name, pkgs, **kwargs):
             except MinionError as exc:
                 raise CommandExecutionError(exc)
     return
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-A module to wrap archive calls
+a module to wrap archive calls
 
 .. versionadded:: 2014.1.0 (Hydrogen)
 '''
@@ -15,7 +15,8 @@ import salt.utils.decorators as decorators
 
 # Don't shadow built-in's.
 __func_alias__ = {
-    'zip_': 'zip'
+    'zip_': 'zip',
+    'help_': 'help'
 }
 
 
@@ -271,3 +272,26 @@ def unrar(rarfile, dest, excludes=None, template=None):
             cmd.extend(['-x', exclude])
     cmd.append(dest)
     return __salt__['cmd.run'](' '.join(cmd), template=template).splitlines()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' archive.help
+
+        salt '*' archive.help tar
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/at.py
+++ b/salt/modules/at.py
@@ -20,6 +20,11 @@ import salt.utils
 # Tested on OpenBSD 5.0
 BSD = ('OpenBSD', 'FreeBSD')
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -360,3 +365,26 @@ def jobcheck(**kwargs):
         return {'error': 'You have given a condition'}
 
     return _atq(**kwargs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' at.help
+
+        salt '*' at.help atrm
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -41,6 +41,11 @@ from salt.exceptions import SaltInvocationError
 # Define the module's virtual name
 __virtualname__ = 'augeas'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -289,3 +294,26 @@ def tree(path):
     path = path.rstrip('/') + '/'
     match_path = path
     return dict([i for i in _recurmatch(match_path, aug)])
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' augeas.help
+
+        salt '*' augeas.help tree
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/aws_sqs.py
+++ b/salt/modules/aws_sqs.py
@@ -9,6 +9,11 @@ import salt.utils
 
 _OUTPUT = '--output json'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     if salt.utils.which('aws'):
@@ -178,3 +183,26 @@ def _parse_queue_list(list_output):
     '''
     queues = dict((q.split('/')[-1], q) for q in list_output['stdout'])
     return queues
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' aws_sqs.help
+
+        salt '*' aws_sqs.help list_queues
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -14,6 +14,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -110,3 +115,28 @@ def dump(device, args=None):
             return ret
     else:
         return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' blockdev.help
+
+        salt '*' blockdev.help wipe
+
+        salt '*' extfs.help dump
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/bluez.py
+++ b/salt/modules/bluez.py
@@ -25,8 +25,10 @@ try:
 except Exception as exc:
     pass
 
+# Don't shadow built-in's.
 __func_alias__ = {
-    'address_': 'address'
+    'address_': 'address',
+    'help_': 'help'
 }
 
 # Define the module's virtual name
@@ -311,3 +313,26 @@ def stop():
     '''
     out = __salt__['service.stop']('bluetooth')
     return out
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' bluetooth.help
+
+        salt '*' bluetooth.help stop
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -345,3 +345,26 @@ def upgrade_available(pkg):
         salt '*' pkg.upgrade_available <package name>
     '''
     return pkg in list_upgrades()
+
+
+def help(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help list_ugprades
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/bridge.py
+++ b/salt/modules/bridge.py
@@ -9,7 +9,8 @@ import salt.utils
 
 
 __func_alias__ = {
-    'list_': 'list'
+    'list_': 'list',
+    'help_': 'help'
 }
 
 
@@ -390,5 +391,27 @@ def stp(br=None, state='disable', iface=None):
         states = {'enable': 'stp', 'disable': '-stp'}
         return _os_dispatch('stp', br, states[state], iface)
 
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' bridge.help
+
+        salt '*' bridge.help addif
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/bsd_shadow.py
+++ b/salt/modules/bsd_shadow.py
@@ -12,6 +12,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'shadow'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     return __virtualname__ if 'BSD' in __grains__.get('os', '') else False
@@ -100,3 +105,26 @@ def set_password(name, password):
         stdin = None
     __salt__['cmd.run'](cmd, stdin=stdin, output_loglevel='quiet')
     return info(name)['passwd'] == password
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.help
+
+        salt '*' shadow.help set_password
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/cassandra.py
+++ b/salt/modules/cassandra.py
@@ -19,6 +19,11 @@ log = logging.getLogger(__name__)
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 HAS_PYCASSA = False
 try:
     from pycassa.system_manager import SystemManager
@@ -197,3 +202,26 @@ def column_family_definition(keyspace=None, column_family=None):
     except Exception:
         log.debug('Invalid Keyspace/CF combination')
         return None
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cassandra.help
+
+        salt '*' cassandra.help info
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -18,7 +18,8 @@ from salt.exceptions import CommandExecutionError, CommandNotFoundError
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
-    'list_': 'list'
+    'list_': 'list',
+    'help_': 'help'
 }
 
 
@@ -657,3 +658,26 @@ def version(name, check_remote=False, source=None, pre_versions=False):
                 ret[key] = value
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' chocolatey.help
+
+        salt '*' chocolatey.help rm_alias
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -19,7 +19,8 @@ import salt.utils
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
-    'profile_': 'profile'
+    'profile_': 'profile',
+    'help_': 'help'
 }
 
 
@@ -199,3 +200,26 @@ def create(provider, names, **kwargs):
     client = _get_client()
     info = client.create(provider, names, **kwargs)
     return info
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cloud.help
+
+        salt '*' cloud.help create
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -40,6 +40,11 @@ log = logging.getLogger(__name__)
 
 DEFAULT_SHELL = salt.grains.extra.shell()['shell']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -1147,3 +1152,26 @@ def exec_code(lang, code, cwd=None):
     ret = run(cmd, cwd=cwd)
     os.remove(codefile)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cmd.help
+
+        salt '*' cmd.help which
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -14,7 +14,8 @@ log = logging.getLogger(__name__)
 
 # Function alias to make sure not to shadow built-in's
 __func_alias__ = {
-    'list_': 'list'
+    'list_': 'list',
+    'help_': 'help'
 }
 
 
@@ -155,3 +156,26 @@ def install(dir,
         return True
 
     return result['stdout']
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' composer.help
+
+        salt '*' composer.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -14,6 +14,11 @@ import salt.syspaths as syspaths
 
 __proxyenabled__ = ['*']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 # Set up the default values for all systems
 DEFAULTS = {'mongo.db': 'salt',
             'mongo.host': 'salt',
@@ -269,3 +274,26 @@ def gather_bootstrap_script(replace=False):
     with salt.utils.fopen(fn_, 'w+') as fp_:
         fp_.write(urllib2.urlopen('http://bootstrap.saltstack.org').read())
     return fn_
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' config.help
+
+        salt '*' config.help get
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -18,6 +18,11 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _auth():
     '''
@@ -683,3 +688,26 @@ def push_dir(path, glob=None):
             if not ret:
                 return ret
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cp.help
+
+        salt '*' cp.help list_minion
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -15,6 +15,11 @@ TAG = '# Lines below here are managed by Salt, do not edit\n'
 SALT_CRON_IDENTIFIER = 'SALT_CRON_IDENTIFIER'
 SALT_CRON_NO_IDENTIFIER = 'NO ID SET'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _encode(string):
     if isinstance(string, unicode):
@@ -525,3 +530,26 @@ def rm_env(user, name):
         # Failed to commit, return the error
         return comdat['stderr']
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cron.help
+
+        salt '*' cron.help rm_alias
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/cytest.pyx
+++ b/salt/modules/cytest.pyx
@@ -4,6 +4,11 @@ Module for running arbitrary tests
 
 import time
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def echo(text):
     '''
@@ -74,3 +79,26 @@ def collatz(long start):
                 start = start * 3 + 1
     cdef float end = time.time() - begin
     return steps, end
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' test.help
+
+        salt '*' test.help ping
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/daemontools.py
+++ b/salt/modules/daemontools.py
@@ -23,7 +23,8 @@ from salt.exceptions import CommandExecutionError
 
 # Function alias to not shadow built-ins.
 __func_alias__ = {
-    'reload_': 'reload'
+    'reload_': 'reload',
+    'help_': 'help'
 }
 
 VALID_SERVICE_DIRS = [
@@ -201,3 +202,26 @@ def get_all():
         raise CommandExecutionError("Could not find service directory.")
     #- List all daemontools services in
     return sorted(os.listdir(SERVICE_DIR))
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' daemontools.help
+
+        salt '*' daemontools.help get_all
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/darwin_sysctl.py
+++ b/salt/modules/darwin_sysctl.py
@@ -13,6 +13,11 @@ from salt.exceptions import CommandExecutionError
 # Define the module's virtual name
 __virtualname__ = 'sysctl'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -157,3 +162,26 @@ def persist(name, value, config='/etc/sysctl.conf'):
     with salt.utils.fopen(config, 'w+') as ofile:
         ofile.writelines(nlines)
     return 'Updated'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sysctl.help
+
+        salt '*' sysctl.help rm_alias
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/data.py
+++ b/salt/modules/data.py
@@ -12,6 +12,11 @@ import ast
 import salt.utils
 import salt.payload
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def clear():
     '''
@@ -147,3 +152,26 @@ def cas(key, value, old_value):
 
     store[key] = value
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' data.help
+
+        salt '*' data.help update
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/ddns.py
+++ b/salt/modules/ddns.py
@@ -34,6 +34,11 @@ except ImportError as e:
 
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -222,3 +227,26 @@ def delete(zone, name, rdtype=None, data=None, nameserver='127.0.0.1', **kwargs)
     if answer.rcode() > 0:
         return False
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ddns.help
+
+        salt '*' ddns.help delete
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -14,7 +14,8 @@ import salt.utils
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
-    'set_': 'set'
+    'set_': 'set',
+    'help_': 'help'
 }
 
 # Define the module's virtual name
@@ -157,3 +158,26 @@ def set_file(path, saltenv='base', **kwargs):
         return True
 
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' debconf.help
+
+        salt '*' debconf.help show
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -32,6 +32,11 @@ JINJA = jinja2.Environment(
 # Define the module's virtual name
 __virtualname__ = 'ip'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -1511,3 +1516,27 @@ def build_network_settings(**settings):
 
     network = template.render(opts)
     return _read_temp(network)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ip.help
+
+        salt '*' ip.help get_interface
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+    log.debug("module_name: {0}" . format(module_name))
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -11,7 +11,8 @@ import re
 from .systemd import _sd_booted
 
 __func_alias__ = {
-    'reload_': 'reload'
+    'reload_': 'reload',
+    'help_': 'help'
 }
 
 # Define the module's virtual name
@@ -265,3 +266,26 @@ def disabled(name):
         salt '*' service.disabled <service name>
     '''
     return name in get_disabled()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -9,6 +9,11 @@ import salt.utils
 
 __virtualname__ = 'defaults'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _mk_client():
     '''
@@ -124,3 +129,26 @@ def get(key, default=''):
         value = str(value)
 
     return value
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' defaults.help
+
+        salt '*' defaults.help get
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/dig.py
+++ b/salt/modules/dig.py
@@ -15,6 +15,11 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = 'dig'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -275,6 +280,29 @@ def MX(domain, resolve=False, nameserver=None):
         ]
 
     return stdout
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dig.help
+
+        salt '*' dig.help a
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 # Let lowercase work, since that is the convention for Salt functions
 a = A

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -14,6 +14,11 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -189,3 +194,26 @@ def percent(args=None):
         return ret[args]
     else:
         return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' disk.help
+
+        salt '*' disk.help percent
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/djangomod.py
+++ b/salt/modules/djangomod.py
@@ -13,6 +13,11 @@ import salt.exceptions
 # Define the module's virtual name
 __virtualname__ = 'django'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     return __virtualname__
@@ -211,3 +216,26 @@ def collectstatic(settings_module,
                    pythonpath,
                    env,
                    *args, **kwargs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' django.help
+
+        salt '*' django.help command
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/dnsmasq.py
+++ b/salt/modules/dnsmasq.py
@@ -12,6 +12,11 @@ import logging
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -157,3 +162,26 @@ def _parse_dnamasq(filename):
                     fileopts['unparsed'] = []
                 fileopts['unparsed'].append(line)
     return fileopts
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnsmasq.help
+
+        salt '*' aliases.help get_config
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -12,6 +12,11 @@ import logging
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -320,3 +325,26 @@ def MX(domain, resolve=False, nameserver=None):
         return __salt__['dig.MX'](domain, resolve, nameserver)
 
     return 'This function requires dig, which is not currently available'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' dnsutil.help
+
+        salt '*' dnsutil.help parse_hosts
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -183,6 +183,11 @@ base_status = {
 # Define the module's virtual name
 __virtualname__ = 'docker'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -2157,3 +2162,26 @@ def script_retcode(container,
                    no_clean=no_clean,
                    saltenv=saltenv,
                    **kwargs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' docker.help
+
+        salt '*' docker.help run_all
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/dpkg.py
+++ b/salt/modules/dpkg.py
@@ -11,6 +11,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'lowpkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -134,3 +139,26 @@ def file_dict(*packages):
             files.append(line)
         ret[pkg] = files
     return {'errors': errors, 'packages': ret}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lowpkg.help
+
+        salt '*' lowpkg.help list_pkgs
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -39,6 +39,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -899,3 +904,26 @@ def check_extra_requirements(pkgname, pkgver):
             return False
 
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help list_pkgs
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/eix.py
+++ b/salt/modules/eix.py
@@ -6,6 +6,11 @@ Support for Eix
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -57,3 +62,26 @@ def update():
     '''
     cmd = 'eix-update --quiet'
     return __salt__['cmd.retcode'](cmd) == 0
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' eix.help
+
+        salt '*' eix.help update
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/environ.py
+++ b/salt/modules/environ.py
@@ -13,6 +13,11 @@ from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -272,3 +277,26 @@ def items():
         salt '*' environ.items
     '''
     return dict(os.environ)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' environ.help
+
+        salt '*' environ.help items
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -6,6 +6,11 @@ Support for eselect, Gentoo's configuration and management tool.
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -93,3 +98,26 @@ def set_target(module, target):
         salt '*' eselect.set_target <module name> <target>
     '''
     return exec_action(module, 'set', target, state_only=True)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' eselect.help
+
+        salt '*' eselect.help set_target
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/event.py
+++ b/salt/modules/event.py
@@ -12,6 +12,11 @@ import salt.transport
 
 __proxyenabled__ = ['*']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def fire_master(data, tag, preload=None):
     '''
@@ -65,3 +70,26 @@ def fire(data, tag):
         return salt.utils.event.MinionEvent(**__opts__).fire_event(data, tag)
     except Exception:
         return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' event.help
+
+        salt '*' event.help fire
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/extfs.py
+++ b/salt/modules/extfs.py
@@ -11,6 +11,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -276,3 +281,26 @@ def dump(device, args=None):
                 line = line.strip()
                 ret['blocks'][group]['extra'].append(line)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' extfs.help
+
+        salt '*' extfs.help mkfs
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -55,6 +55,11 @@ HASHES = [
             ['md5', 32],
          ]
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -3287,3 +3292,26 @@ def grep(path,
         raise CommandExecutionError(exc.strerror)
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.help
+
+        salt '*' file.help grep
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/freebsd_sysctl.py
+++ b/salt/modules/freebsd_sysctl.py
@@ -10,6 +10,11 @@ from salt.exceptions import CommandExecutionError
 # Define the module's virtual name
 __virtualname__ = 'sysctl'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -143,3 +148,26 @@ def persist(name, value, config='/etc/sysctl.conf'):
     if config != '/boot/loader.conf':
         assign(name, value)
     return 'Updated'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sysctl.help
+
+        salt '*' sysctl.help show
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -12,6 +12,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'jail'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -196,3 +201,26 @@ def sysctl():
         key, value = line.split(':', 1)
         ret[key.strip()] = value.strip()
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' jail.help
+
+        salt '*' jail.help rm_alias
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/freebsdkmod.py
+++ b/salt/modules/freebsdkmod.py
@@ -9,6 +9,11 @@ import os
 # Define the module's virtual name
 __virtualname__ = 'kmod'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -137,3 +142,26 @@ def remove(mod):
     __salt__['cmd.run_all']('kldunload {0}'.format(mod))
     post_mods = lsmod()
     return _rm_mods(pre_mods, post_mods)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kmod.help
+
+        salt '*' kmod.help remove
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -81,6 +81,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -529,3 +534,26 @@ def file_dict(*packages):
             continue  # unexpected string
 
     return {'errors': errors, 'files': files}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -31,6 +31,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'ports'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     return __virtualname__ if __grains__.get('os', '') == 'FreeBSD' else False
@@ -457,3 +462,26 @@ def search(name):
             if fnmatch.fnmatch(port.rsplit('/')[-1], name):
                 ret.append(port)
         return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ports.help
+
+        salt '*' ports.help search
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -13,6 +13,7 @@ import salt.utils.decorators as decorators
 from salt.exceptions import CommandNotFoundError
 
 __func_alias__ = {
+    'help_': 'help',
     'reload_': 'reload'
 }
 
@@ -367,3 +368,26 @@ def status(name, sig=None):
         return bool(__salt__['status.pid'](sig))
     cmd = '{0} {1} onestatus'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help status
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -7,6 +7,7 @@ Manage ruby gems.
 import re
 
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -224,3 +225,26 @@ def sources_list(ruby=None, runas=None):
     '''
     ret = _gem('sources', ruby, runas=runas)
     return [] if ret is False else ret.splitlines()[2:]
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' gem.help
+
+        salt '*' gem.help sources_list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -7,6 +7,11 @@ to the correct service manager
 # Define the module's virtual name
 __virtualname__ = 'service'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -212,3 +217,26 @@ def disabled(name):
         salt '*' service.disabled <service name>
     '''
     return name in get_disabled()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/gentoolkitmod.py
+++ b/salt/modules/gentoolkitmod.py
@@ -18,6 +18,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'gentoolkit'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -289,3 +294,26 @@ def glsa_check_list(glsa_list):
     out = __salt__['cmd.run'](cmd).split('\n')
     ret = _glsa_list_process_output(out)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' gentoolkit.help
+
+        salt '*' gentoolkit.help glsa_check_list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -15,6 +15,11 @@ except ImportError:
 # Import salt libs
 from salt import utils, exceptions
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -875,3 +880,26 @@ def ls_remote(cwd, repository="origin", branch="master", user=None, identity=Non
     _check_git()
     cmd = "git ls-remote -h " + repository + " " + branch + " | cut -f 1"
     return _git_run(cmd, cwd=cwd, runas=user, identity=identity)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' git.help
+
+        salt '*' git.help ls_remote
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/glance.py
+++ b/salt/modules/glance.py
@@ -47,6 +47,11 @@ try:
 except ImportError:
     pass
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -222,6 +227,29 @@ def _item_list(profile=None):
         #        'name': item.name,
         #    }
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glance.help
+
+        salt '*' glance.help item_list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 #The following is a list of functions that need to be incorporated in the
 #glance module. This list should be updated as functions are added.

--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -15,6 +15,11 @@ import salt.utils.cloud as suc
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -190,3 +195,26 @@ def start(name):
         cmd = 'gluster volume start {0}'.format(name)
         return __salt__['cmd.run'](cmd)
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' glusterfs.help
+
+        salt '*' glusterfs.help start
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/gnomedesktop.py
+++ b/salt/modules/gnomedesktop.py
@@ -20,7 +20,8 @@ __virtualname__ = 'gnome'
 
 # Don't shadow built-in's.
 __func_alias__ = {
-    'set_': 'set'
+    'set_': 'set',
+    'help_': 'help'
 }
 
 
@@ -272,3 +273,26 @@ def set_(schema=None, key=None, user=None, value=None, **kwargs):
     '''
     _gsession = _GSettings(user=user, schema=schema, key=key)
     return _gsession._set(value)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' gnome.help
+
+        salt '*' gnome.help set
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -23,6 +23,11 @@ __proxyenabled__ = ['*']
 # Seed the grains dict so cython will build
 __grains__ = {}
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 # Change the default outputter to make it more readable
 __outputter__ = {
     'items': 'grains',
@@ -452,3 +457,26 @@ def get_or_set_hash(name,
         setval(name, val)
 
     return get(name)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grains.help
+
+        salt '*' grains.help get_or_set_hash
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -12,6 +12,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'group'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -126,3 +131,26 @@ def chgid(name, gid):
     if post_gid != pre_gid:
         return post_gid == gid
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.help
+
+        salt '*' group.help chgid
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/grub_legacy.py
+++ b/salt/modules/grub_legacy.py
@@ -14,6 +14,11 @@ from salt.exceptions import CommandExecutionError
 # Define the module's virtual name
 __virtualname__ = 'grub'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -121,3 +126,26 @@ def _parse_line(line=''):
     key = parts.pop(0)
     value = ' '.join(parts)
     return key, value
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' grub.help
+
+        salt '*' grub.help conf
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/guestfs.py
+++ b/salt/modules/guestfs.py
@@ -14,6 +14,11 @@ import random
 # Import Salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -59,3 +64,26 @@ def mount(location, access='rw'):
     cmd = 'guestmount -i -a {0} --{1} {2}'.format(location, access, root)
     __salt__['cmd.run'](cmd)
     return root
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' guest.help
+
+        salt '*' guest.help mount
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/hadoop.py
+++ b/salt/modules/hadoop.py
@@ -15,6 +15,11 @@ import salt.utils
 
 __authorized_modules__ = ['namenode', 'dfsadmin', 'dfs', 'fs']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -132,3 +137,26 @@ def namenode_format(force=None):
         force_param = '-force'
 
     return _hadoop_cmd('namenode', 'format', '-nonInteractive', force_param)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hadoop.help
+
+        salt '*' hadoop.help dfs_absent
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -11,6 +11,11 @@ if utils.is_windows():
 else:
     hg_binary = "hg"
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _check_hg():
     utils.check_or_die(hg_binary)
@@ -205,3 +210,26 @@ def clone(cwd, repository, opts=None, user=None):
         opts = ''
     cmd = 'hg clone {0} {1} {2}'.format(repository, cwd, opts)
     return __salt__['cmd.run'](cmd, runas=user)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hg.help
+
+        salt '*' hg.help clone
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -10,6 +10,11 @@ import os
 import salt.utils
 import salt.utils.odict as odict
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 # pylint: disable=C0103
 def __get_hosts_filename():
@@ -229,3 +234,26 @@ def _write_hosts(hosts):
                 [l.strip() for l in lines if l.strip()]
             )
         )
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' hosts.help
+
+        salt '*' hosts.help add_host
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -17,6 +17,11 @@ log = logging.getLogger(__name__)
 
 __virtualname__ = 'webutil'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -89,3 +94,26 @@ def userdel(pwfile, user):
     cmd = ['htpasswd', '-D', pwfile, user]
     out = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     return out
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' webutil.help
+
+        salt '*' webutil.help useradd
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/img.py
+++ b/salt/modules/img.py
@@ -10,6 +10,11 @@ import logging
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def mount_image(location):
     '''
@@ -96,3 +101,26 @@ def bootstrap(location, size, fmt):
     __salt__['partition.mkfs']('{0}p1'.format(nbd), 'ext4')
     mnt = __salt__['qemu_nbd.mount'](nbd)
     #return __salt__['pkg.bootstrap'](nbd, mnt.keys()[0])
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' img.help
+
+        salt '*' img.help bootstrap
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/incron.py
+++ b/salt/modules/incron.py
@@ -13,6 +13,11 @@ import salt.utils
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 TAG = '# Line managed by Salt, do not edit'
 _INCRON_SYSTEM_TAB = '/etc/incron.d/'
 
@@ -315,5 +320,28 @@ def rm_job(user,
         return comdat['stderr']
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' incron.help
+
+        salt '*' incron.help rm_job
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 rm = rm_job  # pylint: disable=C0103

--- a/salt/modules/ini_manage.py
+++ b/salt/modules/ini_manage.py
@@ -16,6 +16,11 @@ import re
 
 __virtualname__ = 'ini'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -206,6 +211,29 @@ def remove_section(file_name, section):
         if sect:
             inifile.flush()
             return sect.contents()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ini.help
+
+        salt '*' ini.help remove_section
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 
 class _Section(list):

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -13,6 +13,11 @@ import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -1014,3 +1019,26 @@ def _parser():
     add_arg('--ulog-qthreshold', dest='ulog-qthreshold', action='append')
 
     return parser
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' iptables.help
+
+        salt '*' iptables.help get_rules
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/junos.py
+++ b/salt/modules/junos.py
@@ -32,6 +32,11 @@ __virtualname__ = 'junos'
 
 __proxyenabled__ = ['junos']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -127,3 +132,25 @@ def ping():
     conn = __opts__['proxyobject']
     ret['message'] = conn.cli('show system uptime')
     ret['out'] = True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' junos.help
+
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/key.py
+++ b/salt/modules/key.py
@@ -9,6 +9,11 @@ import os
 # Import Salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def finger():
     '''
@@ -23,3 +28,26 @@ def finger():
     return salt.utils.pem_finger(
             os.path.join(__opts__['pki_dir'], 'minion.pub')
             )
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' key.help
+
+        salt '*' key.help finger
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -11,6 +11,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -94,3 +99,26 @@ def set_x(layout):
     cmd = 'setxkbmap {0}'.format(layout)
     __salt__['cmd.run'](cmd)
     return layout
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' keyboard.help
+
+        salt '*' keyboard.help set_x
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -51,6 +51,11 @@ try:
 except ImportError:
     pass
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -962,3 +967,26 @@ def _item_list(profile=None, **connection_args):
     #                    protocols and
     #bootstrap           Grants a new role to a new user on a new tenant, after
     #                    creating each.
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' keystone.help
+
+        salt '*' keystone.help item_list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -10,6 +10,11 @@ import re
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -272,3 +277,26 @@ def remove(mod, persist=False, comment=True):
     if persist:
         persist_mods = _remove_persistent_module(mod, comment)
     return sorted(list(mods | persist_mods))
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' kmod.help
+
+        salt '*' kmod.help remove
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/launchctl.py
+++ b/salt/modules/launchctl.py
@@ -15,6 +15,11 @@ import salt.utils.decorators as decorators
 # Define the module's virtual name
 __virtualname__ = 'service'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -234,3 +239,26 @@ def restart(job_label, runas=None):
     '''
     stop(job_label, runas=runas)
     return start(job_label, runas=runas)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help restart
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -5,6 +5,11 @@ Support for Layman
 
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -126,3 +131,26 @@ def list_local():
     out = __salt__['cmd.run'](cmd).split('\n')
     ret = [line.split()[1] for line in out if len(line.split()) > 2]
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' layman.help
+
+        salt '*' layman.help list_local
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -51,6 +51,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'ldap'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -152,6 +157,29 @@ def search(filter,      # pylint: disable=C0103
         'time': {'human': elapsed_h, 'raw': str(round(elapsed, 5))},
     }
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ldap.help
+
+        salt '*' ldap.help search
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 
 class _LDAPConnection(object):

--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -9,6 +9,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'acl'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -222,3 +227,26 @@ def delfacl(acl_type, acl_name, *args):
         cmd += ' {0}'.format(dentry)
     __salt__['cmd.run'](cmd)
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' acl.help
+
+        salt '*' acl.help modfacl
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -9,6 +9,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'lvm'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -301,3 +306,26 @@ def lvremove(lvname, vgname):
     cmd = 'lvremove -f {0}/{1}'.format(vgname, lvname)
     out = __salt__['cmd.run'](cmd)
     return out.strip()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lvm.help
+
+        salt '*' lvm.help lvremove
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -22,6 +22,11 @@ __virtualname__ = 'sysctl'
 # TODO: Add unpersist() to remove either a sysctl or sysctl/value combo from
 # the config
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -224,3 +229,26 @@ def persist(name, value, config=None):
 
     assign(name, value)
     return 'Updated'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sysctl.help
+
+        salt '*' sysctl.help get
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -15,6 +15,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'locale'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -142,3 +147,26 @@ def set_locale(locale):
         return __salt__['cmd.retcode'](cmd) == 0
 
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' locale.help
+
+        salt '*' locale.help set_locale
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/locate.py
+++ b/salt/modules/locate.py
@@ -11,6 +11,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -120,3 +125,26 @@ def locate(pattern, database='', limit=0, **kwargs):
     cmd = 'locate {0} {1}'.format(options, pattern)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' locate.help
+
+        salt '*' locate.help locate
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -16,6 +16,7 @@ default_conf = '/etc/logrotate.conf'
 
 # Define a function alias in order not to shadow built-in's
 __func_alias__ = {
+    'help_': 'help',
     'set_': 'set'
 }
 
@@ -183,3 +184,26 @@ def _dict_to_stanza(key, stanza):
             stanza[skey] = ''
         ret += '    {0} {1}\n'.format(skey, stanza[skey])
     return '{0} {{\n{1}}}'.format(key, ret)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' logrotate.help
+
+        salt '*' logrotate.help set
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/lvs.py
+++ b/salt/modules/lvs.py
@@ -13,6 +13,7 @@ from salt.exceptions import SaltException
 
 
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -469,3 +470,26 @@ def check_server(protocol=None, service_address=None, server_address=None, **kwa
     else:
         ret = 'Error: server not exists'
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lvs.help
+
+        salt '*' lvs.help check_server
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -19,6 +19,7 @@ log = logging.getLogger(__name__)
 
 # Don't shadow built-in's.
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -510,3 +511,26 @@ def info(name):
         ret['memory_free'] = free
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lxc.help
+
+        salt '*' lxc.help info
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/mac_group.py
+++ b/salt/modules/mac_group.py
@@ -16,6 +16,11 @@ from salt.modules.mac_user import _osmajor, _dscl, _flush_dscl_cache
 # Define the module's virtual name
 __virtualname__ = 'group'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     global _osmajor, _dscl, _flush_dscl_cache
@@ -153,3 +158,26 @@ def chgid(name, gid):
         return True
     cmd = 'dseditgroup -o edit -i {0} {1}'.format(gid, name)
     return __salt__['cmd.retcode'](cmd) == 0
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.help
+
+        salt '*' group.help getent
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -24,6 +24,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'user'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     if __grains__.get('kernel') != 'Darwin':
@@ -439,3 +444,26 @@ def list_users():
         salt '*' user.list_users
     '''
     return sorted([user.pw_name for user in pwd.getpwall()])
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.help
+
+        salt '*' user.help list_users
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -15,6 +15,11 @@ log = logging.getLogger(__name__)
 
 LIST_ACTIVE_ONLY = True
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -351,3 +356,26 @@ def upgrade(refresh=True):
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
     return __salt__['pkg_resource.find_changes'](old, new)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help upgrade
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -4,6 +4,11 @@ Support for modifying make.conf under Gentoo
 
 '''
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -796,3 +801,26 @@ def features_contains(value):
         salt '*' makeconf.features_contains 'webrsync-gpg'
     '''
     return var_contains('FEATURES', value)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' makeconf.help
+
+        salt '*' makeconf.help trim_features
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -10,6 +10,7 @@ import logging
 import salt.minion
 
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -192,3 +193,26 @@ def glob(tgt):
     except Exception as exc:
         log.exception(exc)
         return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' match.help
+
+        salt '*' match.help list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 
 # Define a function alias in order not to shadow built-in's
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -261,3 +262,26 @@ def save_config():
         __salt__['file.append'](cfg_file, scan)
 
     return __salt__['cmd.run']('update-initramfs -u')
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' raid.help
+
+        salt '*' raid.help save_config
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/memcached.py
+++ b/salt/modules/memcached.py
@@ -29,6 +29,7 @@ log = logging.getLogger(__name__)
 
 # Don't shadow built-ins
 __func_alias__ = {
+    'help_': 'help',
     'set_': 'set'
 }
 
@@ -262,5 +263,28 @@ def decrement(key, delta=1, host=DEFAULT_HOST, port=DEFAULT_PORT):
         return conn.decr(key, delta)
     except ValueError:
         raise SaltInvocationError('Delta value must be an integer')
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' memcached.help
+
+        salt '*' memcached.help decrement
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 decr = decrement

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -15,6 +15,11 @@ __proxyenabled__ = ['*']
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _auth():
     '''
@@ -253,3 +258,26 @@ def flush():
     sreq = salt.transport.Channel.factory(__opts__)
     ret = sreq.send(load)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mine.help
+
+        salt '*' mine.help flush
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/modjk.py
+++ b/salt/modules/modjk.py
@@ -35,6 +35,11 @@ this module.
 import urllib
 import urllib2
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -531,3 +536,26 @@ def worker_edit(worker, lbn, settings, profile='default'):
     settings['sw'] = worker
 
     return _do_http(settings, profile)['worker.result.type'] == 'OK'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' modjk.help
+
+        salt '*' modjk.help worker_activate
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -29,6 +29,11 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -246,3 +251,26 @@ def user_remove(name, user=None, password=None, host=None, port=None,
         return err.message
 
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mongodb.help
+
+        salt '*' mongodb.help user_remove
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/monit.py
+++ b/salt/modules/monit.py
@@ -7,6 +7,11 @@ service watcher.
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     if salt.utils.which('monit') is not None:
@@ -118,3 +123,26 @@ def summary(svc_name=''):
                     ret[resource] = {}
                 ret[resource][name] = status
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' monit.help
+
+        salt '*' monit.help summary
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/moosefs.py
+++ b/salt/modules/moosefs.py
@@ -6,6 +6,11 @@ Module for gathering and managing information about MooseFS
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -161,3 +166,26 @@ def getgoal(path, opts=None):
                 ret[keytext] = {}
             ret[keytext][comps[3]] = comps[5]
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' moosefs.help
+
+        salt '*' moosefs.help getgoal
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -17,6 +17,11 @@ from salt.exceptions import CommandNotFoundError, CommandExecutionError
 # Set up logger
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _list_mounts():
     ret = {}
@@ -470,3 +475,26 @@ def swapoff(name):
             return False
         return True
     return None
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' moosefs.help
+
+        salt '*' moosefs.help getgoal
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/munin.py
+++ b/salt/modules/munin.py
@@ -13,6 +13,11 @@ from salt._compat import string_types
 
 PLUGINDIR = '/etc/munin/plugins/'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -102,3 +107,26 @@ def list_plugins():
         if executebit:
             ret.append(plugin)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' munin.help
+
+        salt '*' munin.help list_plugins
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -56,6 +56,11 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 # TODO: this is not used anywhere in the code?
 __opts__ = {}
 
@@ -1915,3 +1920,26 @@ def showglobal(**connection_args):
 
     log.debug('{0}-->{1}'.format(mod, len(rtnv[0])))
     return rtnv
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mysql.help
+
+        salt '*' mysql.help showglobal
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/nagios.py
+++ b/salt/modules/nagios.py
@@ -13,6 +13,11 @@ import logging
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 PLUGINDIR = '/usr/lib/nagios/plugins/'
 
 
@@ -253,3 +258,26 @@ def list_plugins():
         if execute_bit:
             ret.append(plugin)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nagios.help
+
+        salt '*' nagios.help list_plugins
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/netbsd_sysctl.py
+++ b/salt/modules/netbsd_sysctl.py
@@ -11,6 +11,11 @@ from salt.exceptions import CommandExecutionError
 # Define the module's virtual name
 __virtualname__ = 'sysctl'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -141,5 +146,29 @@ def persist(name, value):
     assign(name, value)
 
     return 'Updated'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sysctl.help
+
+        salt '*' sysctl.help get
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -8,6 +8,7 @@ import os
 import glob
 
 __func_alias__ = {
+    'help_': 'help',
     'reload_': 'reload'
 }
 
@@ -283,5 +284,28 @@ def disabled(name):
     '''
     return _get_svc('/etc/rc.d/{0}'.format(name), 'NO')
 
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -13,6 +13,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -401,3 +406,27 @@ def mod_hostname(hostname):
     f.write(networkfile)
     f.close()
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.help
+
+        salt '*' network.help interfaces
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/nfs3.py
+++ b/salt/modules/nfs3.py
@@ -11,6 +11,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -92,3 +97,27 @@ def _write_exports(exports, edict):
                 options = ','.join(perms['options'])
                 line += ' {0}({1})'.format(hosts, options)
             efh.write('{0}\n'.format(line))
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nfs.help
+
+        salt '*' nfs.help list_exports
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -7,6 +7,11 @@ import urllib2
 import salt.utils
 import salt.utils.decorators as decorators
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 # Cache the output of running which('nginx') so this module
 # doesn't needlessly walk $PATH looking for the same binary
@@ -132,3 +137,27 @@ def status(url="http://127.0.0.1/status"):
         'writing': int(writing),
         'waiting': int(waiting),
     }
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nginx.help
+
+        salt '*' nginx.help status
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -57,6 +57,7 @@ log = logging.getLogger(__name__)
 
 # Function alias to not shadow built-ins
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -946,6 +947,30 @@ def _item_list(profile=None):
         #        'name': item.name,
         #    }
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nova.help
+
+        salt '*' nova.help item_list
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 #The following is a list of functions that need to be incorporated in the
 #nova module. This list should be updated as functions are added.

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -17,6 +17,7 @@ log = logging.getLogger(__name__)
 
 # Function alias to make sure not to shadow built-in's
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -196,3 +197,27 @@ def list_(pkg=None, dir=None):
         raise CommandExecutionError(result['stderr'])
 
     return json.loads(result['stdout']).get('dependencies', {})
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' npm.help
+
+        salt '*' npm.help install
+    '''
+
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -18,6 +18,10 @@ import struct
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
 
 try:
     import pypureomapi as omapi
@@ -118,3 +122,26 @@ def delete_host(mac=None, name=None):
     if response.opcode != omapi.OMAPI_OP_STATUS:
         return False
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' omapi.help
+
+        salt '*' omapi.help add_host
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/openbsdpkg.py
+++ b/salt/modules/openbsdpkg.py
@@ -20,6 +20,11 @@ __PKG_RE = re.compile('^((?:[^-]+|-(?![0-9]))+)-([0-9][^-]*)(?:-(.*))?$')
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 # XXX need a way of setting PKG_PATH instead of inheriting from the environment
 
 
@@ -253,3 +258,26 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return remove(name=name, pkgs=pkgs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -11,6 +11,11 @@ import os
 # Define the module's virtual name
 __virtualname__ = 'service'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -82,3 +87,26 @@ def status(name, sig=None):
         return bool(__salt__['status.pid'](sig))
     cmd = '/etc/rc.d/{0} -f check'.format(name)
     return not __salt__['cmd.retcode'](cmd)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help start
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/openstack_config.py
+++ b/salt/modules/openstack_config.py
@@ -30,6 +30,7 @@ else:
 
 # Don't shadow built-in's.
 __func_alias__ = {
+    'help_': 'help',
     'set_': 'set'
 }
 
@@ -158,3 +159,26 @@ def delete(filename, section, parameter):
         return result['stdout']
     else:
         raise salt.exceptions.CommandExecutionError(result['stderr'])
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' openstack_config.help
+
+        salt '*' openstack_config.help delete
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/osxdesktop.py
+++ b/salt/modules/osxdesktop.py
@@ -6,6 +6,11 @@ Mac OS X implementations of various commands in the "desktop" interface
 # Define the module's virtual name
 __virtualname__ = 'desktop'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -90,3 +95,26 @@ def say(*words):
     '''
     cmd = 'say {0}'.format(' '.join(words))
     return __salt__['cmd.run'](cmd)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' desktop.help
+
+        salt '*' desktop.help lock
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -18,6 +18,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -529,3 +534,26 @@ def file_dict(*packages):
                 ret[comps[0]] = []
             ret[comps[0]].append((' '.join(comps[1:])))
     return {'errors': errors, 'packages': ret}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pagerduty.py
+++ b/salt/modules/pagerduty.py
@@ -27,6 +27,11 @@ except ImportError:
 
 __virtualname__ = 'pagerduty'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -180,3 +185,26 @@ def create_event(service_key, description, details, incident_key=None,
         incident_key=incident_key,
     )
     return {'incident_key': str(event)}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pagerduty.help
+
+        salt '*' pagerduty.help create_event
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pam.py
+++ b/salt/modules/pam.py
@@ -9,6 +9,11 @@ import os
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -78,3 +83,26 @@ def read_file(file_name):
         salt '*' pam.read_file /etc/pam.d/login
     '''
     return _parse(file_name=file_name)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pam.help
+
+        salt '*' pam.help read_file
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -32,6 +32,7 @@ __virtualname__ = 'partition'
 __func_alias__ = {
     'set_': 'set',
     'list_': 'list',
+    'help_': 'help'
 }
 
 
@@ -696,3 +697,26 @@ def toggle(device, partition, flag):
     cmd = 'parted -m -s {0} toggle {1} {2} {3}'.format(device, partition, flag)
     out = __salt__['cmd.run'](cmd).splitlines()
     return out
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' partition.help
+
+        salt '*' partition.help name
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pecl.py
+++ b/salt/modules/pecl.py
@@ -11,6 +11,7 @@ import logging
 import salt.utils
 
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -137,3 +138,26 @@ def list_():
             pecls[match.group(1)] = [match.group(2), match.group(3)]
 
     return pecls
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pecl.help
+
+        salt '*' pecl.help list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -12,6 +12,11 @@ import salt.utils
 
 __proxyenabled__ = ['*']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def get(key, default=''):
     '''
@@ -140,3 +145,26 @@ def ext(external):
     ret = pillar.compile_pillar()
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pillar.help
+
+        salt '*' pillar.help items
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 # Don't shadow built-in's.
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -831,3 +832,26 @@ def version(bin_env=None):
         return re.match(r'^pip (\S+)', output).group(1)
     except AttributeError:
         return None
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pip.help
+
+        salt '*' pip.help list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -20,6 +20,11 @@ import salt.utils
 log = logging.getLogger(__name__)
 __SUFFIX_NOT_NEEDED = ('x86_64', 'noarch')
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _parse_pkg_meta(path):
     '''
@@ -415,3 +420,26 @@ def check_extra_requirements(pkgname, pkgver):
         return __salt__['pkg.check_extra_requirements'](pkgname, pkgver)
 
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg_resource.help
+
+        salt '*' pkg_resource.help check_extra_requirements
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -19,6 +19,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 @decorators.memoize
 def _check_pkgin():
@@ -527,5 +532,29 @@ def file_dict(package):
 
     print files
     return {'errors': errors, 'files': files}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
+
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -45,6 +45,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -1565,3 +1570,26 @@ def updating(name,
         '{0} updating {1} {2}'.format(_pkg(jail, chroot), opts, name),
         output_loglevel='debug'
     )
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pkgutil.py
+++ b/salt/modules/pkgutil.py
@@ -10,6 +10,11 @@ import copy
 import salt.utils
 from salt.exceptions import CommandExecutionError, MinionError
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -362,3 +367,26 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return remove(name=name, pkgs=pkgs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/portage_config.py
+++ b/salt/modules/portage_config.py
@@ -32,6 +32,11 @@ BASE_PATH = '/etc/portage/package.{0}'
 SUPPORTED_CONFS = ('accept_keywords', 'env', 'license', 'mask', 'properties',
                    'unmask', 'use')
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -477,3 +482,26 @@ def is_present(conf, atom):
                 if match_list.issubset(line_list):
                     return True
             return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' portage.help
+
+        salt '*' portage.help is_present
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -38,6 +38,10 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
 
 _DEFAULT_PASSWORDS_ENCRYPTION = True
 _EXTENSION_NOT_INSTALLED = 'EXTENSION NOT INSTALLED'
@@ -1500,3 +1504,26 @@ def owner_to(dbname,
                                    password=password,
                                    maintenance_db=dbname)
     return cmdret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' postgres.help
+
+        salt '*' postgres.help user_create
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/poudriere.py
+++ b/salt/modules/poudriere.py
@@ -12,6 +12,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -283,3 +288,26 @@ def bulk_build(jail, pkg_file, keep=False):
             return line
     return ('There may have been an issue building packages dumping output: '
             '{0}').format(res)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' poudriere.help
+
+        salt '*' poudriere.help list_jails
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/powerpath.py
+++ b/salt/modules/powerpath.py
@@ -23,6 +23,11 @@ POLICY_MAP_DICT = {
 
 POLICY_RE = re.compile('.*policy=([^;]+)')
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def has_powerpath():
     if os.path.exists('/sbin/emcpreg'):
@@ -123,3 +128,25 @@ def remove_license(key):
         result['result'] = True
 
     return result
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' powerpath.help
+
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -23,6 +23,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'ps'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     if not HAS_PSUTIL:
@@ -567,3 +572,26 @@ def get_users():
 #                rec['host'] = u[4][1:-1]
 #            result.append(rec)
 #        return result
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ps.help
+
+        salt '*' ps.help top
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -17,6 +17,11 @@ from salt._compat import string_types, integer_types
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _publish(
         tgt,
@@ -233,3 +238,26 @@ def runner(fun, arg=None, timeout=5):
         #    sreq.send('aes', auth.crypticle.dumps(load), 1))
     except SaltReqTimeoutError:
         return '{0!r} runner publish timed out'.format(fun)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' publish.help
+
+        salt '*' publish.help runner
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -6,6 +6,11 @@ Execute puppet routines
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -212,3 +217,26 @@ def fact(name, puppet=False):
     if not ret:
         return ''
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' puppet.help
+
+        salt '*' puppet.help run
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pw_group.py
+++ b/salt/modules/pw_group.py
@@ -21,6 +21,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'group'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -129,3 +134,26 @@ def chgid(name, gid):
     if post_gid != pre_gid:
         return post_gid == gid
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.help
+
+        salt '*' group.help chgid
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -22,6 +22,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'user'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -435,3 +440,26 @@ def list_groups(name):
         if name in group.gr_mem:
             ugrp.add(group.gr_name)
     return sorted(list(ugrp))
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.help
+
+        salt '*' user.help list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/qemu_img.py
+++ b/salt/modules/qemu_img.py
@@ -14,6 +14,11 @@ import os
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -47,3 +52,26 @@ def make_image(location, size, fmt):
                 size)):
         return location
     return ''
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' qemu.help
+
+        salt '*' qemu.help make_image
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/qemu_nbd.py
+++ b/salt/modules/qemu_nbd.py
@@ -22,6 +22,11 @@ import salt.crypt
 # Set up logging
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -137,3 +142,26 @@ def clear(mnt):
     for nbd in nbds:
         __salt__['cmd.run']('qemu-nbd -d {0}'.format(nbd))
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' qemu_nbd.help
+
+        salt '*' qemu_nbd.help clear
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/quota.py
+++ b/salt/modules/quota.py
@@ -236,3 +236,26 @@ def get_mode(device):
             }
         ret[comps[3]][comps[0]] = comps[6]
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' quota.help
+
+        salt '*' quota.help off
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -16,6 +16,11 @@ import string
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -594,3 +599,26 @@ def disable_plugin(name, runas=None):
             'rabbitmq-plugins disable {0}'.format(name),
             runas=runas)
     return _format_response(ret, 'Disabled')
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rabbitmq.help
+
+        salt '*' rabbitmq.help disable_plugin
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -14,6 +14,7 @@ import logging
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -317,3 +318,26 @@ def do_with_ruby(ruby, cmdline, runas=None):
         cmd = cmdline
 
     return do(cmd, runas=runas)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rbenv.help
+
+        salt '*' rbenv.help do
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rdp.py
+++ b/salt/modules/rdp.py
@@ -9,6 +9,11 @@ import re
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -86,3 +91,26 @@ def status():
 
     out = int(_psrdp('echo $RDP.AllowTSConnections').strip())
     return out != 0
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rdp.help
+
+        salt '*' rdp.help status
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/reg.py
+++ b/salt/modules/reg.py
@@ -28,6 +28,11 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 class Registry(object):
     '''
@@ -170,3 +175,26 @@ def delete_key(hkey, path, key, reflection=True):
     except Exception:
         _winreg.CloseKey(handle)
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' reg.help
+
+        salt '*' reg.help delete_key
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rest_package.py
+++ b/salt/modules/rest_package.py
@@ -13,6 +13,11 @@ __proxyenabled__ = ['rest_sample']
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -76,3 +81,26 @@ def installed(
     else:
         if p is not None:
             return version == str(p)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rest_sample.py
+++ b/salt/modules/rest_sample.py
@@ -17,6 +17,11 @@ __virtualname__ = 'rest_example'
 
 __proxyenabled__ = ['rest_example']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -44,3 +49,25 @@ def ping():
         ret['out'] = True
     else:
         ret['out'] = False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rest_example.help
+
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rest_service.py
+++ b/salt/modules/rest_service.py
@@ -14,6 +14,7 @@ __virtualname__ = 'service'
 
 # Don't shadow built-ins.
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -96,3 +97,26 @@ def list_():
         salt '*' rest_service.list <service name>
     '''
     return __opts__['proxyobject'].service_list()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rest_service.help
+
+        salt '*' rest_service.help list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/ret.py
+++ b/salt/modules/ret.py
@@ -6,6 +6,11 @@ Module to integrate with the returner system and retrieve data sent to a salt re
 # Import salt libs
 import salt.loader
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def get_jid(returner, jid):
     '''
@@ -61,3 +66,26 @@ def get_minions(returner):
     '''
     returners = salt.loader.returners(__opts__, __salt__)
     return returners['{0}.get_minions'.format(returner)]()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ret.help
+
+        salt '*' ret.help get_minions
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -31,6 +31,11 @@ JINJA = jinja2.Environment(
 # Define the module's virtual name
 __virtualname__ = 'ip'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -1066,3 +1071,26 @@ def build_network_settings(**settings):
     _write_file_network(network, _RH_NETWORK_FILE)
 
     return _read_file(_RH_NETWORK_FILE)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ip.help
+
+        salt '*' ip.help get_interface
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -15,6 +15,7 @@ import salt.utils
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
+    'help_': 'help',
     'reload_': 'reload'
 }
 
@@ -481,3 +482,26 @@ def disabled(name):
         return not _upstart_is_enabled(name)
     else:
         return not _sysv_is_enabled(name)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/riak.py
+++ b/salt/modules/riak.py
@@ -10,6 +10,11 @@ Author: David Boucha <boucha@gmail.com>
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -126,3 +131,26 @@ def member_status():
                                           'Pending': vals[2],
                                           }
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' riak.help
+
+        salt '*' riak.help status
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -14,6 +14,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'lowpkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -185,3 +190,26 @@ def file_dict(*packages):
             files.append(line)
         ret[pkg] = files
     return {'errors': errors, 'packages': ret}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' lowpkg.help
+
+        salt '*' lowpkg.help file_list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rsync.py
+++ b/salt/modules/rsync.py
@@ -17,6 +17,11 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _check(delete, force, update, passwordfile, exclude, excludefrom):
     '''
@@ -147,3 +152,26 @@ def config(confile='/etc/rsyncd.conf'):
         raise CommandExecutionError(exc.strerror)
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rsync.help
+
+        salt '*' rsync.help config
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -12,6 +12,7 @@ log = logging.getLogger(__name__)
 
 # Don't shadow built-in's.
 __func_alias__ = {
+    'list_': 'list',
     'list_': 'list'
 }
 
@@ -412,3 +413,26 @@ def do(ruby, command, runas=None):  # pylint: disable=C0103
         salt '*' rvm.do 2.0.0 <command>
     '''
     return _rvm_do(ruby, command, runas=runas)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' rvm.help
+
+        salt '*' rvm.help do
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -41,6 +41,11 @@ import salt.utils.s3
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -206,3 +211,26 @@ def _get_key(key, keyid, service_url):
         service_url = 's3.amazonaws.com'
 
     return key, keyid, service_url
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' s3.help
+
+        salt '*' s3.help put
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/saltcloudmod.py
+++ b/salt/modules/saltcloudmod.py
@@ -18,6 +18,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'saltcloud'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -45,3 +50,26 @@ def create(name, profile):
     except ValueError:
         ret = {}
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltcloud.help
+
+        salt '*' saltcloud.help create
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -39,6 +39,11 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _sync(form, saltenv=None):
     '''
@@ -678,3 +683,26 @@ def mmodule(saltenv, fun, *args, **kwargs):
     '''
     mminion = _MMinion(saltenv)
     return mminion.functions[fun](*args, **kwargs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.help
+
+        salt '*' saltutil.help kill_job
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -22,7 +22,8 @@ log = logging.getLogger(__name__)
 
 # Don't shadow built-in's.
 __func_alias__ = {
-    'apply_': 'apply'
+    'apply_': 'apply',
+    'help_': 'help'
 }
 
 
@@ -241,3 +242,25 @@ def _chroot_pids(chroot):
                 os.path.dirname(root)
             )))
     return pids
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' seed.help
+
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -20,6 +20,11 @@ import salt.utils.decorators as decorators
 from salt._compat import string_types
 from salt.exceptions import CommandExecutionError
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -188,3 +193,26 @@ def list_sebool():
                          'Default': comps[3][:-1],
                          'Description': ' '.join(comps[4:])}
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' selinux.help
+
+        salt '*' selinux.help list_sebool
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -16,6 +16,11 @@ _GRAINMAP = {
     'Arch ARM': '/etc/rc.d'
 }
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -181,3 +186,26 @@ def get_all():
     if not os.path.isdir(_GRAINMAP.get(__grains__.get('os'), '/etc/init.d')):
         return []
     return sorted(os.listdir(_GRAINMAP.get(__grains__.get('os'), '/etc/init.d')))
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -13,6 +13,11 @@ except ImportError:
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     return 'shadow' if __grains__.get('kernel', '') == 'Linux' else False
@@ -216,3 +221,26 @@ def set_date(name, date):
     '''
     cmd = 'chage -d {0} {1}'.format(date, name)
     __salt__['cmd.run'](cmd)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.help
+
+        salt '*' shadow.help set_date
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/smartos_imgadm.py
+++ b/salt/modules/smartos_imgadm.py
@@ -15,6 +15,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'imgadm'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 @decorators.memoize
 def _check_imgadm():
@@ -227,5 +232,27 @@ def delete(uuid=None):
     ret[uuid] = res['stdout'].splitlines()
     return ret
 
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' imgadm.help
+
+        salt '*' imgadm.help delete
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/smartos_vmadm.py
+++ b/salt/modules/smartos_vmadm.py
@@ -14,6 +14,11 @@ import salt.utils.decorators as decorators
 # Define the module's virtual name
 __virtualname__ = 'virt'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 @decorators.memoize
 def _check_vmadm():
@@ -403,5 +408,27 @@ def get_macs(uuid=None):
         return ret
     raise CommandExecutionError('We can\'t find the MAC address of this VM')
 
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.help
+
+        salt '*' virt.help get_macs
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
 
 # vim: tabstop=4 expandtab shiftwidth=4 softtabstop=4

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -11,6 +11,11 @@ __func_alias__ = {
 # Define the module's virtual name
 __virtualname__ = 'service'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -317,3 +322,26 @@ def get_disabled():
     '''
     # Note that this returns the full FMRI
     return _get_enabled_disabled("false")
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/solaris_group.py
+++ b/salt/modules/solaris_group.py
@@ -12,6 +12,10 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
 
 try:
     import grp
@@ -131,3 +135,26 @@ def chgid(name, gid):
     if post_gid != pre_gid:
         return post_gid == gid
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.help
+
+        salt '*' group.help chgid
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/solaris_shadow.py
+++ b/salt/modules/solaris_shadow.py
@@ -22,6 +22,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'shadow'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -241,3 +246,26 @@ def set_warndays(name, warndays):
     if post_info['warn'] != pre_info['warn']:
         return post_info['warn'] == warndays
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.help
+
+        salt '*' shadow.help set_password
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -21,6 +21,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'user'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -451,3 +456,26 @@ def list_groups(name):
             ugrp.add(group.gr_name)
 
     return sorted(list(ugrp))
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.help
+
+        salt '*' user.help list_users
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/solarispkg.py
+++ b/salt/modules/solarispkg.py
@@ -17,6 +17,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -461,3 +466,26 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return remove(name=name, pkgs=pkgs, **kwargs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help purge
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -69,6 +69,11 @@ import urllib2
 import salt.utils
 from salt._compat import string_types, url_open
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 ########################## PRIVATE METHODS ##############################
 
@@ -1332,3 +1337,26 @@ def import_status(handler, host=None, core_name=None, verbose=False):
         extra.append("verbose=true")
     url = _format_url(handler, host=host, core_name=core_name, extra=extra)
     return _http_request(url)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' solr.help
+
+        salt '*' solr.help import_status
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/sqlite3.py
+++ b/salt/modules/sqlite3.py
@@ -11,6 +11,11 @@ try:
 except ImportError:
     HAS_SQLITE3 = False
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 # pylint: disable=C0103
 def __virtual__():
@@ -149,3 +154,26 @@ def indexes(db=None):
         salt '*' sqlite3.indexes /root/test.db
     '''
     return indices(db)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sqlite3.help
+
+        salt '*' sqlite3.help indexes
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -20,6 +20,11 @@ from salt.exceptions import (
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     # TODO: This could work on windows with some love
@@ -749,3 +754,26 @@ def set_known_host(user, hostname,
     if os.geteuid() == 0:
         os.chown(full, uinfo['uid'], uinfo['gid'])
     return {'status': 'updated', 'old': stored_host, 'new': remote_host}
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ssh.help
+
+        salt '*' ssh.help set_known_host
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -32,6 +32,11 @@ __outputter__ = {
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _filter_running(runnings):
     '''
@@ -807,3 +812,26 @@ def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
     except (IOError, OSError):
         pass
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.help
+
+        salt '*' state.help pkg
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -15,6 +15,11 @@ import salt.utils
 
 __opts__ = {}
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 # TODO: Make this module support windows hosts
 # TODO: Make this module support BSD hosts properly, this is very Linux specific
@@ -522,3 +527,26 @@ def version():
     ret = salt.utils.fopen(procf, 'r').read().strip()
 
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' status.help
+
+        salt '*' status.help version
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/supervisord.py
+++ b/salt/modules/supervisord.py
@@ -12,6 +12,11 @@ import salt.utils
 from salt.exceptions import CommandExecutionError, CommandNotFoundError
 from salt._compat import configparser, string_types
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def _get_supervisorctl_bin(bin_env):
     '''
@@ -363,3 +368,26 @@ def options(name, conf_file=None):
                 val = False
         ret[key] = val
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' supervisord.help
+
+        salt '*' supervisord.help options
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -13,6 +13,11 @@ from salt import utils, exceptions
 
 _INI_RE = re.compile(r"^([^:]+):\s+(\S.*)$", re.M)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -476,3 +481,26 @@ def export(cwd,
     if target:
         opts += (target,)
     return _run_svn('export', cwd, user, username, password, opts)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' svn.help
+
+        salt '*' svn.help export
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/sysbench.py
+++ b/salt/modules/sysbench.py
@@ -9,6 +9,11 @@ CPU, Memory, FileI/O, Threads and Mutex.
 import re
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -245,3 +250,26 @@ def fileio():
 def ping():
 
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sysbench.help
+
+        salt '*' sysbench.help fileio
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -15,6 +15,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'sys'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -141,3 +146,26 @@ def argspec(module=''):
         salt '*' sys.argspec
     '''
     return salt.utils.argspec_report(__salt__, module)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' sys.help
+
+        salt '*' sys.help argspec
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -5,6 +5,11 @@ Support for reboot, shutdown, etc
 
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -92,3 +97,26 @@ def shutdown(at_time=None):
         cmd = 'shutdown -h now'
     ret = __salt__['cmd.run'](cmd)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.help
+
+        salt '*' system.help reboot
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -10,6 +10,7 @@ import re
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
+    'help_': 'help',
     'reload_': 'reload'
 }
 
@@ -374,3 +375,26 @@ def disabled(name):
         salt '*' service.disabled <service name>
     '''
     return not _enabled(name)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -16,6 +16,11 @@ import salt.loader
 
 __proxyenabled__ = ['*']
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def echo(text):
     '''
@@ -420,3 +425,26 @@ def tty(device, echo=None):
                 teletype,
                 ret['retcode'])
         }
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' test.help
+
+        salt '*' test.help ping
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -13,6 +13,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -274,3 +279,26 @@ def set_hwclock(clock):
             '/etc/conf.d/hwclock', '^clock=.*', 'clock="{0}"'.format(clock))
 
     return True
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' timezone.help
+
+        salt '*' timezone.help set_hwclock
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -32,6 +32,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -741,3 +746,26 @@ if __name__ == '__main__':
             )
     create_ca_signed_cert('koji', 'test_system')
     create_pkcs12('koji', 'test_system', passphrase='test')
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tls.help
+
+        salt '*' tls.help create_pkcs12
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -53,6 +53,7 @@ import os
 import salt.utils
 
 __func_alias__ = {
+    'help_': 'help',
     'reload_': 'reload'
 }
 
@@ -622,3 +623,26 @@ def signal(signal=None):
         __catalina_home(), valid_signals[signal]
     )
     __salt__['cmd.run'](cmd)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' tomcat.help
+
+        salt '*' tomcat.help signal
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -47,6 +47,7 @@ import os
 import salt.utils
 
 __func_alias__ = {
+    'help_': 'reload',
     'reload_': 'reload'
 }
 
@@ -508,3 +509,26 @@ def disabled(name):
         if _service_is_sysv(name):
             return _sysv_is_disabled(name)
     return None
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -27,6 +27,11 @@ RETCODE_12_ERROR_REGEX = re.compile(
 # Define the module's virtual name
 __virtualname__ = 'user'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -515,3 +520,26 @@ def list_users():
         salt '*' user.list_users
     '''
     return sorted([user.pw_name for user in pwd.getpwall()])
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.help
+
+        salt '*' user.help list_users
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/uwsgi.py
+++ b/salt/modules/uwsgi.py
@@ -13,6 +13,11 @@ import json
 # Import Salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -43,3 +48,26 @@ def stats(socket):
     cmd = 'uwsgi --connect-and-read {0}'.format(socket)
     out = __salt__['cmd.run'](cmd)
     return json.loads(out)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' wsgi.help
+
+        salt '*' wsgi.help stats
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -36,6 +36,11 @@ from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 # Set up template environment
 JINJA = jinja2.Environment(
     loader=jinja2.FileSystemLoader(
@@ -1766,3 +1771,26 @@ def vm_diskstats(vm_=None):
         for vm_ in list_active_vms():
             info[vm_] = _info(vm_)
     return info
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.help
+
+        salt '*' virt.help vm_blockstats
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -358,3 +358,26 @@ def _install_script(source, cwd, python, user, saltenv='base'):
         )
     finally:
         os.remove(tmppath)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virtualenv.help
+
+        salt '*' virtualenv.help get_site_packages
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_autoruns.py
+++ b/salt/modules/win_autoruns.py
@@ -13,6 +13,7 @@ import salt.utils
 
 # Define a function alias in order not to shadow built-in's
 __func_alias__ = {
+    'help_': 'help',
     'list_': 'list'
 }
 
@@ -75,3 +76,26 @@ def list_():
             pass
 
     return autoruns
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' autoruns.help
+
+        salt '*' autoruns.help list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_disk.py
+++ b/salt/modules/win_disk.py
@@ -20,6 +20,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'disk'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -77,3 +82,26 @@ def usage():
                 'capacity': None,
             }
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' disk.help
+
+        salt '*' disk.help usage
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -15,6 +15,11 @@ except ImportError:
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -132,3 +137,26 @@ def get_dns_config(interface='Local Area Connection'):
         for iface in c.Win32_NetworkAdapterConfiguration(IPEnabled=1):
             if interface == iface.Description:
                 return iface.DHCPEnabled
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_dns_client.help
+
+        salt '*' win_dns_client.help get_dns_config
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -51,6 +51,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'file'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -511,3 +516,26 @@ def set_mode(path, mode):
         salt '*' file.set_mode /etc/passwd 0644
     '''
     return get_mode(path)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.help
+
+        salt '*' file.help set_mode
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_firewall.py
+++ b/salt/modules/win_firewall.py
@@ -12,6 +12,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'firewall'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -61,3 +66,26 @@ def disable():
     return __salt__['cmd.run'](
             'netsh advfirewall set allprofiles state off'
             ) == 'Ok.'
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' firewall.help
+
+        salt '*' firewall.help disable
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_groupadd.py
+++ b/salt/modules/win_groupadd.py
@@ -9,6 +9,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'group'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -126,3 +131,26 @@ def getent(refresh=False):
 
     __context__['group.getent'] = ret2
     return ret2
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' group.help
+
+        salt '*' group.help getent
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_ip.py
+++ b/salt/modules/win_ip.py
@@ -23,6 +23,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'ip'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -397,3 +402,26 @@ def get_default_gateway():
         ))
     except StopIteration:
         raise CommandExecutionError('Unable to find default gateway')
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ip.help
+
+        salt '*' ip.help get_default_gateway
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_network.py
+++ b/salt/modules/win_network.py
@@ -21,6 +21,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'network'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -267,3 +272,26 @@ def ip_addrs6(interface=None, include_loopback=False):
                                         include_loopback=include_loopback)
 
 ipaddrs6 = ip_addrs6
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.help
+
+        salt '*' network.help ip_addrs6
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -16,6 +16,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'ntp'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -66,3 +71,26 @@ def get_servers():
             _, ntpsvrs = line.rstrip(' (Local)').split(':', 1)
             return sorted(ntpsvrs.split())
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ntp.help
+
+        salt '*' ntp.help get_servers
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_path.py
+++ b/salt/modules/win_path.py
@@ -25,6 +25,11 @@ import salt.utils
 # Settings
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -152,3 +157,26 @@ def remove(path):
         return rehash()
     else:
         return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_path.help
+
+        salt '*' win_path.help add
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -37,6 +37,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -747,3 +752,26 @@ def _get_latest_pkg_version(pkginfo):
         return pkginfo.keys().pop()
     pkgkeys = pkginfo.keys()
     return sorted(pkgkeys, cmp=_reverse_cmp_pkg_versions).pop()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_repo.py
+++ b/salt/modules/win_repo.py
@@ -31,6 +31,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'winrepo'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -118,3 +123,26 @@ def update_git_repos():
         ret[result['name']] = result['result']
     salt.output.display_output(ret, 'pprint', __opts__)
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' winrepo.help
+
+        salt '*' winrepo.help genrepo
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -7,6 +7,11 @@ Manage Windows features via the ServerManager powershell module
 # Import salt libs
 import salt.utils
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -116,3 +121,26 @@ def remove(feature):
     '''
     out = _srvmgr('"Remove-WindowsFeature -Name {0} -erroraction silentlycontinue | format-list"'.format(feature))
     return _parse_powershell_list(out)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' win_servermanager.help
+
+        salt '*' win_servermanager.help remove
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -11,6 +11,11 @@ __virtualname__ = 'service'
 
 BUFFSIZE = 5000
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -332,3 +337,26 @@ def disabled(name):
         salt '*' service.disabled <service name>
     '''
     return name in get_disabled()
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.help
+
+        salt '*' service.help disabled
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_shadow.py
+++ b/salt/modules/win_shadow.py
@@ -8,6 +8,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'shadow'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -55,3 +60,26 @@ def set_password(name, password):
     ret = __salt__['cmd.run_all'](cmd)
 
     return not ret['retcode']
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' shadow.help
+
+        salt '*' shadow.help set_password
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_status.py
+++ b/salt/modules/win_status.py
@@ -29,6 +29,11 @@ __opts__ = {}
 # Define the module's virtual name
 __virtualname__ = 'status'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -94,3 +99,26 @@ def _get_process_owner(process):
         log.warning('Error getting owner of process; PID=\'{0}\'; Error: {1}'
                     .format(process.ProcessId, error_code))
     return owner
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' status.help
+
+        salt '*' status.help procs
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -16,6 +16,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'system'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -347,3 +352,26 @@ def stop_time_service():
         salt '*' system.stop_time_service
     '''
     return __salt__['service.stop']('w32time')
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' system.help
+
+        salt '*' system.help stop_time_service
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_timezone.py
+++ b/salt/modules/win_timezone.py
@@ -451,6 +451,11 @@ LINTOWIN = {
 # Define the module's virtual name
 __virtualname__ = 'timezone'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -583,3 +588,26 @@ def set_hwclock(clock):
     '''
     # Need to search for a way to figure it out ...
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' timezone.help
+
+        salt '*' timezone.help set_hwclock
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -19,6 +19,11 @@ except ImportError:
 # Define the module's virtual name
 __virtualname__ = 'user'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -396,3 +401,26 @@ def list_users():
         return user_list
     except win32net.error:
         pass
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.help
+
+        salt '*' user.help getent
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/xapi.py
+++ b/salt/modules/xapi.py
@@ -36,6 +36,11 @@ import salt.utils
 # Define the module's virtual name
 __virtualname__ = 'virt'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 # This module has only been tested on Debian GNU/Linux and NetBSD, it
 # probably needs more path appending for other distributions.
 # The path to append is the path to python Xen libraries, where resides
@@ -934,3 +939,26 @@ def vm_diskstats(vm_=None):
             for vm_ in list_vms():
                 info[vm_] = _info(vm_)
         return info
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' virt.help
+
+        salt '*' virt.help vm_diskstats
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/xmpp.py
+++ b/salt/modules/xmpp.py
@@ -45,6 +45,11 @@ except ImportError:
 
 __virtualname__ = 'xmpp'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -101,3 +106,26 @@ def send_msg(recipient, message, jid=None, password=None, profile=None):
         xmpp.process(block=True)
         return True
     return False
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' xmpp.help
+
+        salt '*' xmpp.help send_msg
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -38,6 +38,11 @@ __ARCHES = (
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -1274,3 +1279,26 @@ def expand_repo_def(repokwargs):
     '''
     # YUM doesn't need the data massaged.
     return repokwargs
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help file_list
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -27,6 +27,11 @@ You have those following methods:
 # Define the module's virtual name
 __virtualname__ = 'buildout'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -997,5 +1002,29 @@ def _check_onlyif_unless(onlyif, unless, directory, runas=None, env=()):
     if status['status']:
         ret = status
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' buildout.help
+
+        salt '*' buildout.help buildout
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))
+
 
 # vim:set et sts=4 ts=4 tw=80:

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -19,7 +19,9 @@ log = logging.getLogger(__name__)
 
 # Function alias to set mapping. Filled
 # in later on.
-__func_alias__ = {}
+__func_alias__ = {
+    'help_': 'help'
+}
 
 
 @decorators.memoize
@@ -133,3 +135,25 @@ if _check_zfs():
 
         # Update the function alias so that salt finds the functions properly.
         __func_alias__['{0}_'.format(available_cmd)] = available_cmd
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zfs.help
+
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/znc.py
+++ b/salt/modules/znc.py
@@ -19,6 +19,11 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -116,3 +121,26 @@ def version():
     out = __salt__['cmd.run'](cmd).splitlines()
     ret = out[0].split(' - ')
     return ret[0]
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' znc.help
+
+        salt '*' znc.help version
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/zpool.py
+++ b/salt/modules/zpool.py
@@ -13,6 +13,11 @@ import salt.utils.decorators as decorators
 
 log = logging.getLogger(__name__)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 @decorators.memoize
 def _check_zpool():
@@ -304,3 +309,26 @@ def create_file_vdev(size, *vdevs):
     ret['status'] = True
     ret[cmd] = cmd
     return ret
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' zpool.help
+
+        salt '*' zpool.help status
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -17,6 +17,11 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'pkg'
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'help_': 'help'
+}
+
 
 def __virtual__():
     '''
@@ -498,3 +503,26 @@ def purge(name=None, pkgs=None, **kwargs):
         salt '*' pkg.purge pkgs='["foo", "bar"]'
     '''
     return _uninstall(action='purge', name=name, pkgs=pkgs)
+
+
+def help_(cmd=None):
+    '''
+    Display help for module
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.help
+
+        salt '*' pkg.help install
+    '''
+    if '__virtualname__' in globals():
+        module_name = __virtualname__
+    else:
+        module_name = __name__.split('.')[-1]
+
+    if cmd is None:
+        return __salt__['sys.doc']('{0}' . format(module_name))
+    else:
+        return __salt__['sys.doc']('{0}.{1}' . format(module_name, cmd))


### PR DESCRIPTION
Adding help function to all modules, to allow the ability to see available commands and usage using salt and salt-run.  Example, salt '_' ip.help or salt '_' ip.help up.  The help function does a call to the sys.doc salt function using the **name** variable to get the module or the **virtualname** if its available.
