### PR TITLE
[salt.cloud] key_filename is not always set for expanduser

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -326,13 +326,14 @@ def create(vm_):
     key_filename = config.get_cloud_config_value(
         'ssh_key_file', vm_, __opts__, search_global=False, default=None
     )
-    key_filename = os.path.expanduser(key_filename)
-    if key_filename is not None and not os.path.isfile(key_filename):
-        raise SaltCloudConfigError(
-            'The defined ssh_key_file {0!r} does not exist'.format(
-                key_filename
+    if key_filename is not None:
+        key_filename = os.path.expanduser(key_filename)
+        if not os.path.isfile(key_filename):
+            raise SaltCloudConfigError(
+                'The defined ssh_key_file {0!r} does not exist'.format(
+                    key_filename
+                )
             )
-        )
 
     if deploy is True and key_filename is None and \
             salt.utils.which('sshpass') is None:


### PR DESCRIPTION
[ERROR   ] There was a query error: 'NoneType' object has no attribute 'startswith'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/cli.py", line 381, in run
    ret = mapper.run_map(dmap)
  File "/usr/lib/python2.7/site-packages/salt/cloud/**init**.py", line 1692, in run_map
    profile, local_master=local_master
  File "/usr/lib/python2.7/site-packages/salt/cloud/**init**.py", line 905, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/openstack.py", line 329, in create
    key_filename = os.path.expanduser(key_filename)
  File "/usr/lib64/python2.7/posixpath.py", line 261, in expanduser
    if not path.startswith('~'):
AttributeError: 'NoneType' object has no attribute 'startswith'
