### PR TITLE
example should use escape character

### DIFF
--- a/doc/topics/development/external_pillars.rst
+++ b/doc/topics/development/external_pillars.rst
@@ -205,4 +205,4 @@ external pillar, add something like this to your master config:
 .. code-block:: yaml
 
     ext_pillar:
-      - cmd_json: "echo {'arg':'value'}"
+      - cmd_json: 'echo {\"arg\":\"value\"}'


### PR DESCRIPTION
echo command will clear the quotation mark, should use escape character("\")
