### PR TITLE
Fix utils.option to recurse dict keys

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -87,13 +87,13 @@ def _auth(uri):
     If user & pass are missing return False
     '''
     try:
-        user = __grains__['tomcat-manager.user']
-        password = __grains__['tomcat-manager.passwd']
+        user = __grains__['tomcat-manager']['user']
+        password = __grains__['tomcat-manager']['passwd']
     except KeyError:
         try:
-            user = salt.utils.option('tomcat-manager.user', '', __opts__,
+            user = salt.utils.option('tomcat-manager:user', '', __opts__,
                     __pillar__)
-            password = salt.utils.option('tomcat-manager.passwd', '', __opts__,
+            password = salt.utils.option('tomcat-manager:passwd', '', __opts__,
                     __pillar__)
         except Exception:
             return False

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1463,12 +1463,15 @@ def option(value, default='', opts=None, pillar=None):
         opts = {}
     if pillar is None:
         pillar = {}
-    if value in opts:
-        return opts[value]
-    if value in pillar.get('master', {}):
-        return pillar['master'][value]
-    if value in pillar:
-        return pillar[value]
+    sources = (
+        (opts, value),
+        (pillar, 'master:{0}'.format(value)),
+        (pillar, value),
+    )
+    for source, val in sources:
+        out = traverse_dict(source, val, default)
+        if out is not default:
+            return out
     return default
 
 

--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -252,6 +252,14 @@ class UtilsTestCase(TestCase):
         self.assertTrue(utils.test_mode(Test=True))
         self.assertTrue(utils.test_mode(tEsT=True))
 
+    def test_option(self):
+        test_two_level_dict = {'foo': {'bar': 'baz'}}
+
+        self.assertDictEqual({'not_found': 'nope'}, utils.option('foo:bar', {'not_found': 'nope'}))
+        self.assertEqual('baz', utils.option('foo:bar', {'not_found': 'nope'}, opts=test_two_level_dict))
+        self.assertEqual('baz', utils.option('foo:bar', {'not_found': 'nope'}, pillar={'master': test_two_level_dict}))
+        self.assertEqual('baz', utils.option('foo:bar', {'not_found': 'nope'}, pillar=test_two_level_dict))
+
     def test_parse_docstring(self):
         test_keystone_str = '''Management of Keystone users
                                 ============================


### PR DESCRIPTION
This fixes an issue encountered while working with [tomcat-formula](https://github.com/saltstack-formulas/tomcat-formula) and modules.tomcat._auth
