### PR TITLE
Allow 'known_hosts_file' as SSH client option

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -77,6 +77,9 @@ class Shell(object):
         options.append('ConnectTimeout={0}'.format(self.timeout))
         if self.opts.get('ignore_host_keys'):
             options.append('StrictHostKeyChecking=no')
+        known_hosts = self.opts.get('known_hosts_file')
+        if known_hosts:
+            options.append('UserKnownHostsFile={0}'.format(known_hosts))
         if self.port:
             options.append('Port={0}'.format(self.port))
         if self.priv:


### PR DESCRIPTION
This allows us to use a known hosts file so we don't have to disable
strict host key checking to SSH into hosts we haven't SSH'd into before.

This is related to issue #8250
