### PR TITLE
Exception handling in multi-master setup.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -562,7 +562,10 @@ class MultiMinion(MinionBase):
                     minion['minion'].module_refresh()
                 if pillar_refresh:
                     minion['minion'].pillar_refresh()
-                minion['generator'].next()
+                try:
+                    minion['generator'].next()
+                except StopIteration:
+                    continue
 
 
 class Minion(MinionBase):


### PR DESCRIPTION
Refs #10732

I'm not entirely positive how this regression was introduced but simply catching the end of the iteration and continuing handles both multi-master and single-master in my testing. This should probably go through an entire Jenkins run before being committed but does seem to restore multi-master functionality.

@basepi If this gets merged, it should be cherry-picked.
