### PR TITLE
make sure top.sls is evaluated in order

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -36,6 +36,7 @@ from salt._compat import string_types
 from salt.utils.immutabletypes import ImmutableLazyProxy
 from salt.template import compile_template, compile_template_str
 from salt.exceptions import SaltRenderError, SaltReqTimeoutError, SaltException
+from salt.utils.odict import  OrderedDict, DefaultOrderedDict
 
 log = logging.getLogger(__name__)
 
@@ -1881,9 +1882,9 @@ class BaseHighState(object):
         '''
         Gather the top files
         '''
-        tops = collections.defaultdict(list)
-        include = collections.defaultdict(list)
-        done = collections.defaultdict(list)
+        tops = DefaultOrderedDict(list)
+        include = DefaultOrderedDict(list)
+        done = DefaultOrderedDict(list)
         # Gather initial top files
         if self.opts['environment']:
             tops[self.opts['environment']] = [
@@ -1951,7 +1952,7 @@ class BaseHighState(object):
         '''
         Cleanly merge the top files
         '''
-        top = collections.defaultdict(dict)
+        top = DefaultOrderedDict(OrderedDict) 
         for ctops in tops.values():
             for ctop in ctops:
                 for saltenv, targets in ctop.items():

--- a/salt/utils/odict.py
+++ b/salt/utils/odict.py
@@ -14,7 +14,14 @@
     provides an ``OrderedDict`` implementation based on::
 
         http://code.activestate.com/recipes/576669/
+
+    It also implements a DefaultOrderedDict Class that serves  as a
+    combination of ``OrderedDict`` and ``defaultdict``
+    It's source was submitted here::
+
+        http://stackoverflow.com/questions/6190331/
 '''
+from collections import Callable
 
 try:
     from collections import OrderedDict  # pylint: disable=E0611
@@ -282,3 +289,45 @@ except ImportError:
 #                "od.viewitems() -> a set-like object providing a view on od's items"
 #                return ItemsView(self)
 #        ## end of http://code.activestate.com/recipes/576693/ }}}
+finally:
+    class DefaultOrderedDict(OrderedDict):
+        'Dictionary that remembers insertion order and '
+        def __init__(self, default_factory=None, *a, **kw):
+            if (default_factory is not None and
+                not isinstance(default_factory, Callable)):
+                raise TypeError('first argument must be callable')
+            OrderedDict.__init__(self, *a, **kw)
+            self.default_factory = default_factory
+
+        def __getitem__(self, key):
+            try:
+                return OrderedDict.__getitem__(self, key)
+            except KeyError:
+                return self.__missing__(key)
+
+        def __missing__(self, key):
+            if self.default_factory is None:
+                raise KeyError(key)
+            self[key] = value = self.default_factory()
+            return value
+
+        def __reduce__(self):
+            if self.default_factory is None:
+                args = tuple()
+            else:
+                args = self.default_factory,
+            return type(self), args, None, None, self.items()
+
+        def copy(self):
+            return self.__copy__()
+
+        def __copy__(self):
+            return type(self)(self.default_factory, self)
+
+        def __deepcopy__(self, memo):
+            import copy
+            return type(self)(self.default_factory,
+                              copy.deepcopy(self.items()))
+        def __repr__(self):
+            return 'DefaultOrderedDict(%s, %s)' % (self.default_factory,
+                                            OrderedDict.__repr__(self))


### PR DESCRIPTION
This is more of a request for comments.
IMHO ordering top.sls seems like a natural thing, would like to open discussion around this.
Haven't yet made tests around it but if we can agree on the direction of this patch I would.
