### PR TITLE
Fire the event's data, not the entire _minion_event command

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1238,7 +1238,7 @@ class AESFuncs(object):
                     self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
         else:
             tag = load['tag']
-            self.event.fire_event(load, tag)
+            self.event.fire_event(load['data'], tag)
         return True
 
     def _return(self, load):


### PR DESCRIPTION
I noticed the entire load coming from a minion was pushed to the master's event bus when using the data and tag parameters separately. This patch is a fix so it exhibits the same behaviour as when using an array of events.
