### PR TITLE
Honor (lack of) mode recurse in file.directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1426,23 +1426,24 @@ def directory(name,
                                      'as a target for recursive ownership ' \
                                      'management'
 
-            for root, dirs, files in os.walk(name):
-                for fn_ in files:
-                    full = os.path.join(root, fn_)
-                    ret, perms = __salt__['file.check_perms'](
-                        full,
-                        ret,
-                        user,
-                        group,
-                        file_mode)
-                for dir_ in dirs:
-                    full = os.path.join(root, dir_)
-                    ret, perms = __salt__['file.check_perms'](
-                        full,
-                        ret,
-                        user,
-                        group,
-                        dir_mode)
+            if 'mode' in recurse:
+                for root, dirs, files in os.walk(name):
+                    for fn_ in files:
+                        full = os.path.join(root, fn_)
+                        ret, perms = __salt__['file.check_perms'](
+                            full,
+                            ret,
+                            user,
+                            group,
+                            file_mode)
+                    for dir_ in dirs:
+                        full = os.path.join(root, dir_)
+                        ret, perms = __salt__['file.check_perms'](
+                            full,
+                            ret,
+                            user,
+                            group,
+                            dir_mode)
 
     if clean:
         keep = _gen_keep_files(name, require)


### PR DESCRIPTION
Currently, we set the mode recursively if the file.directory state is
set to recurse whether or not recurse: mode is specified. This change
makes mode follow the same recurse behavior as user and group.
