### PR TITLE
Add color output control to salt-run

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2149,7 +2149,6 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             help='Force colored output'
         )
 
-
     def _mixin_after_parsed(self):
         if len(self.args) > 0:
             self.config['fun'] = self.args[0]

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2131,6 +2131,24 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'runner.function to see documentation on only that runner '
                   'or function.')
         )
+        group = self.output_options_group = optparse.OptionGroup(
+            self, 'Output Options', 'Configure your preferred output format'
+        )
+        self.add_option_group(group)
+
+        group.add_option(
+            '--no-color', '--no-colour',
+            default=False,
+            action='store_true',
+            help='Disable all colored output'
+        )
+        group.add_option(
+            '--force-color', '--force-colour',
+            default=False,
+            action='store_true',
+            help='Force colored output'
+        )
+
 
     def _mixin_after_parsed(self):
         if len(self.args) > 0:


### PR DESCRIPTION
Add options '--force-color' and '--no-color' to salt-run
Add salt-run help to include new commands

```
  Output Options:
    Configure your preferred output format

    --no-color, --no-colour
                        Disable all colored output
    --force-color, --force-colour
                        Force colored output
```
