### PR TITLE
Fix gitfs regression

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -325,7 +325,7 @@ def _get_tree_gitpython(repo, short):
     '''
     Return a git.Tree object if the branch/tag/SHA is found, otherwise None
     '''
-    if short in envs():
+    if short == __opts__['gitfs_base'] or short in envs():
         for ref in repo.refs:
             if isinstance(ref, (git.RemoteReference, git.TagReference)):
                 parted = ref.name.partition('/')
@@ -350,7 +350,7 @@ def _get_tree_pygit2(repo, short):
     '''
     Return a pygit2.Tree object if the branch/tag/SHA is found, otherwise None
     '''
-    if short in envs():
+    if short == __opts__['gitfs_base'] or short in envs():
         for ref in repo.listall_references():
             _, rtype, rspec = ref.split('/', 2)
             if rtype in ('remotes', 'tags'):
@@ -378,7 +378,7 @@ def _get_tree_dulwich(repo, short):
     Return a dulwich.objects.Tree object if the branch/tag/SHA is found,
     otherwise None
     '''
-    if short in envs():
+    if short == __opts__['gitfs_base'] or short in envs():
         refs = repo.get_refs()
         # Sorting ensures we check heads (branches) before tags
         for ref in sorted(_dulwich_env_refs(refs)):


### PR DESCRIPTION
This was introduced when I added the gitfs whitelists feature recently.
If the base environment is requested, it will not be matched since the
branch name is passed to the `_get_tree_*` functions.

This should not need to be cherrypicked as the code is newer than 2014.1.0 and thus this regression does not exist in that version. Additionally, it was introduced in feature work which will not be made available until Helium.
