### PR TITLE
Log tracebacks caught in fileserver updates

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -38,6 +38,7 @@ import salt.utils.event
 import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
+import traceback
 from salt.utils.event import tagify
 from salt.exceptions import SaltMasterError
 
@@ -154,9 +155,10 @@ def fileserver_update(fileserver):
                       'able to serve files to minions')
             raise SaltMasterError('No fileserver backends available')
         fileserver.update()
-    except Exception as exc:
+    except Exception:
         log.error(
-            'Exception {0} occurred in file server update'.format(exc)
+            'Exception occurred in file server update:\n{0}'
+            .format(traceback.format_exc())
         )
 
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -38,7 +38,6 @@ import salt.utils.event
 import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
-import traceback
 from salt.utils.event import tagify
 from salt.exceptions import SaltMasterError
 
@@ -155,10 +154,10 @@ def fileserver_update(fileserver):
                       'able to serve files to minions')
             raise SaltMasterError('No fileserver backends available')
         fileserver.update()
-    except Exception:
+    except Exception as exc:
         log.error(
-            'Exception occurred in file server update:\n{0}'
-            .format(traceback.format_exc())
+            'Exception {0} occurred in file server update'.format(exc),
+            exc_info=log.isEnabledFor(logging.DEBUG)
         )
 
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -57,6 +57,7 @@ import os
 import re
 import shutil
 import subprocess
+import traceback
 from datetime import datetime
 
 VALID_PROVIDERS = ('gitpython', 'pygit2', 'dulwich')
@@ -785,9 +786,10 @@ def update():
                     for ref in repo.get_refs():
                         if ref not in refs_post:
                             del repo[ref]
-        except Exception as exc:
-            log.warning(
-                'Exception caught while fetching: {0}'.format(exc)
+        except Exception:
+            log.error(
+                'Exception caught while fetching:\n{0}'
+                .format(traceback.format_exc())
             )
         try:
             os.remove(lk_fn)

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -57,7 +57,6 @@ import os
 import re
 import shutil
 import subprocess
-import traceback
 from datetime import datetime
 
 VALID_PROVIDERS = ('gitpython', 'pygit2', 'dulwich')
@@ -786,10 +785,11 @@ def update():
                     for ref in repo.get_refs():
                         if ref not in refs_post:
                             del repo[ref]
-        except Exception:
+        except Exception as exc:
             log.error(
-                'Exception caught while fetching:\n{0}'
-                .format(traceback.format_exc())
+                'Exception {0} caught while fetching gitfs remote {1}'
+                .format(exc, repo_conf['uri']),
+                exc_info=log.isEnabledFor(logging.DEBUG)
             )
         try:
             os.remove(lk_fn)

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -30,7 +30,6 @@ import hashlib
 import logging
 import os
 import shutil
-import traceback
 from datetime import datetime
 
 VALID_BRANCH_METHODS = ('branches', 'bookmarks', 'mixed')
@@ -285,10 +284,11 @@ def update():
         curtip = repo.tip()
         try:
             success = repo.pull()
-        except Exception:
+        except Exception as exc:
             log.error(
-                'Exception caught while updating hgfs:\n{0}'
-                .format(traceback.format_exc())
+                'Exception {0} caught while updating hgfs remote {1}'
+                .format(exc, repo_conf['uri']),
+                exc_info=log.isEnabledFor(logging.DEBUG)
             )
         else:
             newtip = repo.tip()

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -30,6 +30,7 @@ import hashlib
 import logging
 import os
 import shutil
+import traceback
 from datetime import datetime
 
 VALID_BRANCH_METHODS = ('branches', 'bookmarks', 'mixed')
@@ -284,9 +285,10 @@ def update():
         curtip = repo.tip()
         try:
             success = repo.pull()
-        except Exception as exc:
+        except Exception:
             log.error(
-                'Exception caught while updating hgfs: {0}'.format(exc)
+                'Exception caught while updating hgfs:\n{0}'
+                .format(traceback.format_exc())
             )
         else:
             newtip = repo.tip()


### PR DESCRIPTION
When a traceback is triggered in a fileserver update, it is caught and
printed. However, all that is printed is the result of `exc.__str__()`,
which is not helpful when debugging, and makes it harder to track down
fileserver update issues.

This pull request changes the behavior and writes the full text of the
exception to the master log.
