### PR TITLE
Refactor and modularize of the loader interface, adding Map to pyobjects

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -626,10 +626,114 @@ class Loader(object):
         '''
         Return a dict of functions found in the defined module_dirs
         '''
+        funcs = {}
+        self.load_modules()
+        for mod in self.modules:
+            # If this is a proxy minion then MOST modules cannot work.  Therefore, require that
+            # any module that does work with salt-proxy-minion define __proxyenabled__ as a list
+            # containing the names of the proxy types that the module supports.
+            if not hasattr(mod, 'render') and 'proxy' in self.opts:
+                if not hasattr(mod, '__proxyenabled__'):
+                    # This is a proxy minion but this module doesn't support proxy
+                    # minions at all
+                    continue
+                if not self.opts['proxy']['proxytype'] in mod.__proxyenabled__ or \
+                        '*' in mod.__proxyenabled__:
+                    # This is a proxy minion, this module supports proxy
+                    # minions, but not this particular minion
+                    log.debug(mod)
+                    continue
+
+            if hasattr(mod, '__opts__'):
+                mod.__opts__.update(self.opts)
+            else:
+                mod.__opts__ = self.opts
+
+            mod.__grains__ = self.grains
+            mod.__pillar__ = self.pillar
+
+            if pack:
+                if isinstance(pack, list):
+                    for chunk in pack:
+                        if not isinstance(chunk, dict):
+                            continue
+                        try:
+                            setattr(mod, chunk['name'], chunk['value'])
+                        except KeyError:
+                            pass
+                else:
+                    setattr(mod, pack['name'], pack['value'])
+
+            # Call a module's initialization method if it exists
+            if hasattr(mod, '__init__'):
+                if callable(mod.__init__):
+                    try:
+                        mod.__init__(self.opts)
+                    except TypeError:
+                        pass
+
+            # Trim the full pathname to just the module
+            # this will be the short name that other salt modules and state
+            # will refer to it as.
+            module_name = mod.__name__.rsplit('.', 1)[-1]
+
+            if virtual_enable:
+                # if virtual modules are enabled, we need to look for the
+                # __virtual__() function inside that module and run it.
+                (virtual_ret, virtual_name) = self.process_virtual(mod,
+                                                                   module_name)
+
+                # if process_virtual returned a non-True value then we are
+                # supposed to not process this module
+                if virtual_ret is not True:
+                    continue
+
+                # update our module name to reflect the virtual name
+                module_name = virtual_name
+
+            if whitelist:
+                # If a whitelist is defined then only load the module if it is
+                # in the whitelist
+                if module_name not in whitelist:
+                    continue
+
+            # load the functions from the module and update our dict
+            funcs.update(self.load_functions(mod, module_name))
+
+        # Handle provider overrides
+        if provider_overrides and self.opts.get('providers', False):
+            if isinstance(self.opts['providers'], dict):
+                for mod, provider in self.opts['providers'].items():
+                    newfuncs = raw_mod(self.opts, provider, funcs)
+                    if newfuncs:
+                        for newfunc in newfuncs:
+                            f_key = '{0}{1}'.format(
+                                mod, newfunc[newfunc.rindex('.'):]
+                            )
+                            funcs[f_key] = newfuncs[newfunc]
+
+        # now that all the functions have been collected, iterate back over
+        # the available modules and inject the special __salt__ namespace that
+        # contains these functions.
+        for mod in self.modules:
+            if not hasattr(mod, '__salt__') or (
+                not in_pack(pack, '__salt__') and
+                not str(mod.__name__).startswith('salt.loaded.int.grain')
+            ):
+                mod.__salt__ = funcs
+            elif not in_pack(pack, '__salt__') and \
+                    str(mod.__name__).startswith('salt.loaded.int.grain'):
+                mod.__salt__.update(funcs)
+        return funcs
+
+    def load_modules(self):
+        '''
+        Loads all of the modules from module_dirs and returns a list of them
+        '''
+        self.modules = []
+
         log.trace('loading {0} in {1}'.format(self.tag, self.module_dirs))
         names = {}
-        modules = []
-        funcs = {}
         disable = set(self.opts.get('disable_{0}s'.format(self.tag), []))
 
         cython_enabled = False
@@ -749,256 +853,196 @@ class Loader(object):
                     exc_info=True
                 )
                 continue
-            modules.append(mod)
-        for mod in modules:
-            virtual = ''
+            self.modules.append(mod)
 
-            # If this is a proxy minion then MOST modules cannot work.  Therefore, require that
-            # any module that does work with salt-proxy-minion define __proxyenabled__ as a list
-            # containing the names of the proxy types that the module supports.
-            if not hasattr(mod, 'render') and 'proxy' in self.opts:
-                if not hasattr(mod, '__proxyenabled__'):
-                    # This is a proxy minion but this module doesn't support proxy
-                    # minions at all
-                    continue
-                if not (self.opts['proxy']['proxytype'] in mod.__proxyenabled__ or '*' in mod.__proxyenabled__):
-                    # This is a proxy minion, this module supports proxy
-                    # minions, but not this particular minion
-                    log.debug(mod)
-                    continue
+    def load_functions(self, mod, module_name):
+        '''
+        Load functions returns a dict of all the functions from a module
+        '''
+        funcs = {}
 
-            if hasattr(mod, '__opts__'):
-                mod.__opts__.update(self.opts)
-            else:
-                mod.__opts__ = self.opts
-
-            mod.__grains__ = self.grains
-            mod.__pillar__ = self.pillar
-
-            if pack:
-                if isinstance(pack, list):
-                    for chunk in pack:
-                        if not isinstance(chunk, dict):
-                            continue
-                        try:
-                            setattr(mod, chunk['name'], chunk['value'])
-                        except KeyError:
-                            pass
-                else:
-                    setattr(mod, pack['name'], pack['value'])
-
-            # Call a module's initialization method if it exists
-            if hasattr(mod, '__init__'):
-                if callable(mod.__init__):
-                    try:
-                        mod.__init__(self.opts)
-                    except TypeError:
-                        pass
-
-            # Trim the full pathname to just the module
-            # this will be the short name that other salt modules and state
-            # will refer to it as.
-            module_name = mod.__name__.rsplit('.', 1)[-1]
-
-            if virtual_enable:
-                # if virtual modules are enabled, we need to look for the
-                # __virtual__() function inside that module and run it.
-                # This function will return either a new name for the module,
-                # an empty string(won't be loaded but you just need to check
-                # against the same python type, a string) or False.
-                # This allows us to have things like the pkg module working on
-                # all platforms under the name 'pkg'. It also allows for
-                # modules like augeas_cfg to be referred to as 'augeas', which
-                # would otherwise have namespace collisions. And finally it
-                # allows modules to return False if they are not intended to
-                # run on the given platform or are missing dependencies.
-                try:
-                    if hasattr(mod, '__virtual__'):
-                        if callable(mod.__virtual__):
-                            virtual = mod.__virtual__()
-                            if not virtual:
-                                # if __virtual__() evaluates to false then the
-                                # module wasn't meant for this platform or it's
-                                # not supposed to load for some other reason.
-                                # Some modules might accidentally return None
-                                # and are improperly loaded
-                                if virtual is None:
-                                    log.warning(
-                                        '{0}.__virtual__() is wrongly '
-                                        'returning `None`. It should either '
-                                        'return `True`, `False` or a new '
-                                        'name. If you\'re the developer '
-                                        'of the module {1!r}, please fix '
-                                        'this.'.format(
-                                            mod.__name__,
-                                            module_name
-                                        )
-                                    )
-                                continue
-
-                            # At this point, __virtual__ did not return a
-                            # boolean value, let's check for deprecated usage
-                            # or module renames
-                            if virtual is not True and module_name == virtual:
-                                # The module was not renamed, it should
-                                # have returned True instead
-                                #salt.utils.warn_until(
-                                #    'Helium',
-                                #    'The {0!r} module is NOT renaming itself '
-                                #    'and is returning a string. In this case '
-                                #    'the __virtual__() function should simply '
-                                #    'return `True`. This usage will become an '
-                                #    'error in Salt Helium'.format(
-                                #        mod.__name__,
-                                #    )
-                                #)
-                                pass
-
-                            elif virtual is not True and module_name != virtual:
-                                # The module is renaming itself. Updating the
-                                # module name with the new name
-                                log.debug(
-                                    'Loaded {0} as virtual {1}'.format(
-                                        module_name, virtual
-                                    )
-                                )
-
-                                if not hasattr(mod, '__virtualname__'):
-                                    salt.utils.warn_until(
-                                        'Hydrogen',
-                                        'The {0!r} module is renaming itself '
-                                        'in it\'s __virtual__() function ({1} '
-                                        '=> {2}). Please set it\'s virtual '
-                                        'name as the \'__virtualname__\' '
-                                        'module attribute. Example: '
-                                        '"__virtualname__ = {2!r}"'.format(
-                                            mod.__name__,
-                                            module_name,
-                                            virtual
-                                        )
-                                    )
-
-                                # Get the module's virtual name
-                                virtualname = getattr(
-                                    mod, '__virtualname__', virtual
-                                )
-
-                                if virtualname != virtual:
-                                    # The __virtualname__ attribute does not
-                                    # match what's being returned by the
-                                    # __virtual__() function. This should be
-                                    # considered an error.
-                                    log.error(
-                                        'The module {0!r} is showing some bad '
-                                        'usage. It\'s __virtualname__ '
-                                        'attribute is set to {1!r} yet the '
-                                        '__virtual__() function is returning '
-                                        '{2!r}. These values should '
-                                        'match!'.format(
-                                            mod.__name__,
-                                            virtualname,
-                                            virtual
-                                        )
-                                    )
-
-                                module_name = virtualname
-
-                except KeyError:
-                    # Key errors come out of the virtual function when passing
-                    # in incomplete grains sets, these can be safely ignored
-                    # and logged to debug, still, it includes the traceback to
-                    # help debugging.
-                    log.debug(
-                        'KeyError when loading {0}'.format(module_name),
-                        exc_info=True
-                    )
-
-                except Exception:
-                    # If the module throws an exception during __virtual__()
-                    # then log the information and continue to the next.
-                    log.error(
-                        'Failed to read the virtual function for '
-                        '{0}: {1}'.format(
-                            self.tag, module_name
-                        ),
-                        exc_info=True
-                    )
-                    continue
-
-            if whitelist:
-                # If a whitelist is defined then only load the module if it is
-                # in the whitelist
-                if module_name not in whitelist:
-                    continue
-
-            if getattr(mod, '__load__', False) is not False:
-                log.info(
-                    'The functions from module {0!r} are being loaded from '
-                    'the provided __load__ attribute'.format(
-                        module_name
-                    )
+        if getattr(mod, '__load__', False) is not False:
+            log.info(
+                'The functions from module {0!r} are being loaded from '
+                'the provided __load__ attribute'.format(
+                    module_name
                 )
-            for attr in getattr(mod, '__load__', dir(mod)):
+            )
 
-                if attr.startswith('_'):
-                    # skip private attributes
-                    # log messages omitted for obviousness
-                    continue
+        for attr in getattr(mod, '__load__', dir(mod)):
+            if attr.startswith('_'):
+                # skip private attributes
+                # log messages omitted for obviousness
+                continue
 
-                if callable(getattr(mod, attr)):
-                    # check to make sure this is callable
-                    func = getattr(mod, attr)
-                    if isinstance(func, type):
-                        # skip callables that might be exceptions
-                        if any(['Error' in func.__name__,
-                                'Exception' in func.__name__]):
-                            continue
-                    # now that callable passes all the checks, add it to the
-                    # library of available functions of this type
+            if callable(getattr(mod, attr)):
+                # check to make sure this is callable
+                func = getattr(mod, attr)
+                if isinstance(func, type):
+                    # skip callables that might be exceptions
+                    if any(['Error' in func.__name__,
+                            'Exception' in func.__name__]):
+                        continue
 
-                    # Let's get the function name.
-                    # If the module has the __func_alias__ attribute, it must
-                    # be a dictionary mapping in the form of(key -> value):
-                    #   <real-func-name> -> <desired-func-name>
-                    #
-                    # It default's of course to the found callable attribute
-                    # name if no alias is defined.
-                    funcname = getattr(mod, '__func_alias__', {}).get(
-                        attr, attr
-                    )
+                # now that callable passes all the checks, add it to the
+                # library of available functions of this type
 
-                    # functions are namespaced with their module name
+                # Let's get the function name.
+                # If the module has the __func_alias__ attribute, it must
+                # be a dictionary mapping in the form of(key -> value):
+                #   <real-func-name> -> <desired-func-name>
+                #
+                # It default's of course to the found callable attribute
+                # name if no alias is defined.
+                funcname = getattr(mod, '__func_alias__', {}).get(
+                    attr, attr
+                )
+
+                # functions are namespaced with their module name, unless
+                # the module_name is None (this is a special case added for
+                # pyobjects), in which case just the function name is used
+                if module_name is None:
+                    module_func_name = funcname
+                else:
                     module_func_name = '{0}.{1}'.format(module_name, funcname)
-                    funcs[module_func_name] = func
-                    log.trace(
-                        'Added {0} to {1}'.format(module_func_name, self.tag)
-                    )
-                    self._apply_outputter(func, mod)
 
-        # Handle provider overrides
-        if provider_overrides and self.opts.get('providers', False):
-            if isinstance(self.opts['providers'], dict):
-                for mod, provider in self.opts['providers'].items():
-                    newfuncs = raw_mod(self.opts, provider, funcs)
-                    if newfuncs:
-                        for newfunc in newfuncs:
-                            f_key = '{0}{1}'.format(
-                                mod, newfunc[newfunc.rindex('.'):]
-                            )
-                            funcs[f_key] = newfuncs[newfunc]
-
-        # now that all the functions have been collected, iterate back over
-        # the available modules and inject the special __salt__ namespace that
-        # contains these functions.
-        for mod in modules:
-            if not hasattr(mod, '__salt__') or (
-                not in_pack(pack, '__salt__') and
-                not str(mod.__name__).startswith('salt.loaded.int.grain')
-            ):
-                mod.__salt__ = funcs
-            elif not in_pack(pack, '__salt__') and str(mod.__name__).startswith('salt.loaded.int.grain'):
-                mod.__salt__.update(funcs)
+                funcs[module_func_name] = func
+                log.trace(
+                    'Added {0} to {1}'.format(module_func_name, self.tag)
+                )
+                self._apply_outputter(func, mod)
         return funcs
+
+    def process_virtual(self, mod, module_name):
+        '''
+        Given a loaded module and it's default name determine its virtual name
+
+        This function returns a tuple. The first value will be either True or
+        False and will indicate if the module should be loaded or not (ie. if
+        it threw and exception while processing its __virtual__ function). The
+        second value is the determined virtual name, which may be the same as
+        the value provided.
+
+        The default name can be calculated as follows::
+
+            module_name = mod.__name__.rsplit('.', 1)[-1]
+        '''
+
+        # The __virtual__ function will return either a True or False value.
+        # If it returns a True value it can also set a module level attribute
+        # named __virtualname__ with the name that the module should be
+        # referred to as.
+        #
+        # This allows us to have things like the pkg module working on all
+        # platforms under the name 'pkg'. It also allows for modules like
+        # augeas_cfg to be referred to as 'augeas', which would otherwise have
+        # namespace collisions. And finally it allows modules to return False
+        # if they are not intended to run on the given platform or are missing
+        # dependencies.
+        try:
+            if hasattr(mod, '__virtual__') and callable(mod.__virtual__):
+                virtual = mod.__virtual__()
+                if not virtual:
+                    # if __virtual__() evaluates to False then the module
+                    # wasn't meant for this platform or it's not supposed to
+                    # load for some other reason.
+
+                    # Some modules might accidentally return None and are
+                    # improperly loaded
+                    if virtual is None:
+                        log.warning(
+                            '{0}.__virtual__() is wrongly returning `None`. '
+                            'It should either return `True`, `False` or a new '
+                            'name. If you\'re the developer of the module '
+                            '{1!r}, please fix this.'.format(
+                                mod.__name__,
+                                module_name
+                            )
+                        )
+
+                    return (False, module_name)
+
+                # At this point, __virtual__ did not return a
+                # boolean value, let's check for deprecated usage
+                # or module renames
+                if virtual is not True and module_name == virtual:
+                    # The module was not renamed, it should
+                    # have returned True instead
+                    #salt.utils.warn_until(
+                    #    'Helium',
+                    #    'The {0!r} module is NOT renaming itself and is '
+                    #    'returning a string. In this case the __virtual__() '
+                    #    'function should simply return `True`. This usage will '
+                    #    'become an error in Salt Helium'.format(
+                    #        mod.__name__,
+                    #    )
+                    #)
+                    pass
+
+                elif virtual is not True and module_name != virtual:
+                    # The module is renaming itself. Updating the module name
+                    # with the new name
+                    log.debug('Loaded {0} as virtual {1}'.format(
+                        module_name, virtual
+                    ))
+
+                    if not hasattr(mod, '__virtualname__'):
+                        salt.utils.warn_until(
+                            'Hydrogen',
+                            'The {0!r} module is renaming itself in it\'s '
+                            '__virtual__() function ({1} => {2}). Please '
+                            'set it\'s virtual name as the '
+                            '\'__virtualname__\' module attribute. '
+                            'Example: "__virtualname__ = {2!r}"'.format(
+                                mod.__name__,
+                                module_name,
+                                virtual
+                            )
+                        )
+
+                    # Get the module's virtual name
+                    virtualname = getattr(mod, '__virtualname__', virtual)
+
+                    if virtualname != virtual:
+                        # The __virtualname__ attribute does not match what's
+                        # being returned by the __virtual__() function. This
+                        # should be considered an error.
+                        log.error(
+                            'The module {0!r} is showing some bad usage. It\'s '
+                            '__virtualname__ attribute is set to {1!r} yet the '
+                            '__virtual__() function is returning {2!r}. These '
+                            'values should match!'.format(
+                                mod.__name__,
+                                virtualname,
+                                virtual
+                            )
+                        )
+
+                    module_name = virtualname
+
+        except KeyError:
+            # Key errors come out of the virtual function when passing
+            # in incomplete grains sets, these can be safely ignored
+            # and logged to debug, still, it includes the traceback to
+            # help debugging.
+            log.debug(
+                'KeyError when loading {0}'.format(module_name),
+                exc_info=True
+            )
+
+        except Exception:
+            # If the module throws an exception during __virtual__()
+            # then log the information and continue to the next.
+            log.error(
+                'Failed to read the virtual function for '
+                '{0}: {1}'.format(
+                    self.tag, module_name
+                ),
+                exc_info=True
+            )
+            return (False, module_name)
+
+        return (True, module_name)
 
     def _apply_outputter(self, func, mod):
         '''
@@ -1042,13 +1086,13 @@ class Loader(object):
         '''
         if self.opts.get('grains_cache', False):
             cfn = os.path.join(
-            self.opts['cachedir'],
-            '{0}.cache.p'.format('grains')
+                self.opts['cachedir'],
+                '{0}.cache.p'.format('grains')
             )
             if os.path.isfile(cfn):
                 grains_cache_age = int(time.time() - os.path.getmtime(cfn))
                 if self.opts.get('grains_cache_expiration', 300) >= grains_cache_age and not \
-                    self.opts.get('refresh_grains_cache', False):
+                        self.opts.get('refresh_grains_cache', False):
                     log.debug('Retrieving grains from cache')
                     try:
                         with salt.utils.fopen(cfn, 'rb') as fp_:
@@ -1057,9 +1101,12 @@ class Loader(object):
                     except (IOError, OSError):
                         pass
                 else:
-                    log.debug('Grains cache last modified {0} seconds ago and cache expiration is set to {1}. '
-                         'Grains cache expired. Refreshing.'.format(
-                    grains_cache_age, self.opts.get('grains_cache_expiration', 300)))
+                    log.debug('Grains cache last modified {0} seconds ago and '
+                              'cache expiration is set to {1}. '
+                              'Grains cache expired. Refreshing.'.format(
+                                  grains_cache_age,
+                                  self.opts.get('grains_cache_expiration', 300)
+                              ))
             else:
                 log.debug('Grains cache file does not exist.')
         grains_data = {}

--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -5,11 +5,16 @@
 Pythonic object interface to creating state data, see the pyobjects renderer
 for more documentation.
 '''
+import inspect
+import logging
+
 from collections import namedtuple
 
 from salt.utils.odict import OrderedDict
 
 REQUISITES = ('require', 'watch', 'use', 'require_in', 'watch_in', 'use_in')
+
+log = logging.getLogger(__name__)
 
 
 class StateException(Exception):
@@ -24,46 +29,52 @@ class InvalidFunction(StateException):
     pass
 
 
-class StateRegistry(object):
+class Registry(object):
     '''
     The StateRegistry holds all of the states that have been created.
     '''
-    def __init__(self):
-        self.empty()
+    states = OrderedDict()
+    requisites = []
+    includes = []
+    extends = OrderedDict()
 
-    def empty(self):
-        self.states = OrderedDict()
-        self.requisites = []
-        self.includes = []
-        self.extends = OrderedDict()
+    @classmethod
+    def empty(cls):
+        cls.states = OrderedDict()
+        cls.requisites = []
+        cls.includes = []
+        cls.extends = OrderedDict()
 
-    def include(self, *args):
-        self.includes += args
+    @classmethod
+    def include(cls, *args):
+        cls.includes += args
 
-    def salt_data(self):
+    @classmethod
+    def salt_data(cls):
         states = OrderedDict([
             (id_, states_)
-            for id_, states_ in self.states.iteritems()
+            for id_, states_ in cls.states.iteritems()
         ])
 
-        if self.includes:
-            states['include'] = self.includes
+        if cls.includes:
+            states['include'] = cls.includes
 
-        if self.extends:
+        if cls.extends:
             states['extend'] = OrderedDict([
                 (id_, states_)
-                for id_, states_ in self.extends.iteritems()
+                for id_, states_ in cls.extends.iteritems()
             ])
 
-        self.empty()
+        cls.empty()
 
         return states
 
-    def add(self, id_, state, extend=False):
+    @classmethod
+    def add(cls, id_, state, extend=False):
         if extend:
-            attr = self.extends
+            attr = cls.extends
         else:
-            attr = self.states
+            attr = cls.states
 
         if id_ in attr:
             if state.full_func in attr[id_]:
@@ -75,25 +86,29 @@ class StateRegistry(object):
             attr[id_] = OrderedDict()
 
         # if we have requisites in our stack then add them to the state
-        if len(self.requisites) > 0:
-            for req in self.requisites:
+        if len(cls.requisites) > 0:
+            for req in cls.requisites:
                 if req.requisite not in state.kwargs:
                     state.kwargs[req.requisite] = []
                 state.kwargs[req.requisite].append(req())
 
         attr[id_].update(state())
 
-    def extend(self, id_, state):
-        self.add(id_, state, extend=True)
+    @classmethod
+    def extend(cls, id_, state):
+        cls.add(id_, state, extend=True)
 
-    def make_extend(self, name):
+    @classmethod
+    def make_extend(cls, name):
         return StateExtend(name)
 
-    def push_requisite(self, requisite):
-        self.requisites.append(requisite)
+    @classmethod
+    def push_requisite(cls, requisite):
+        cls.requisites.append(requisite)
 
-    def pop_requisite(self):
-        del self.requisites[-1]
+    @classmethod
+    def pop_requisite(cls):
+        del cls.requisites[-1]
 
 
 class StateExtend(object):
@@ -102,20 +117,19 @@ class StateExtend(object):
 
 
 class StateRequisite(object):
-    def __init__(self, requisite, module, id_, registry):
+    def __init__(self, requisite, module, id_):
         self.requisite = requisite
         self.module = module
         self.id_ = id_
-        self.registry = registry
 
     def __call__(self):
         return {self.module: self.id_}
 
     def __enter__(self):
-        self.registry.push_requisite(self)
+        Registry.push_requisite(self)
 
     def __exit__(self, type, value, traceback):
-        self.registry.pop_requisite()
+        Registry.pop_requisite()
 
 
 class StateFactory(object):
@@ -133,9 +147,8 @@ class StateFactory(object):
 
     The kwargs are passed through to the State object
     '''
-    def __init__(self, module, registry, valid_funcs=None):
+    def __init__(self, module, valid_funcs=None):
         self.module = module
-        self.registry = registry
         if valid_funcs is None:
             valid_funcs = []
         self.valid_funcs = valid_funcs
@@ -150,7 +163,6 @@ class StateFactory(object):
                 id_,
                 self.module,
                 func,
-                registry=self.registry,
                 **kwargs
             )
         return make_state
@@ -160,8 +172,7 @@ class StateFactory(object):
         When an object is called it is being used as a requisite
         '''
         # return the correct data structure for the requisite
-        return StateRequisite(requisite, self.module, id_,
-                              registry=self.registry)
+        return StateRequisite(requisite, self.module, id_)
 
 
 class State(object):
@@ -171,26 +182,21 @@ class State(object):
     The id_ is the id of the state, the func is the full name of the salt
     state (ie. file.managed). All the keyword args you pass in become the
     properties of your state.
-
-    The registry is where the state should be stored. It is optional and will
-    use the default registry if not specified.
     '''
 
-    def __init__(self, id_, module, func, registry, **kwargs):
+    def __init__(self, id_, module, func, **kwargs):
         self.id_ = id_
         self.module = module
         self.func = func
         self.kwargs = kwargs
-        self.registry = registry
 
         if isinstance(self.id_, StateExtend):
-            self.registry.extend(self.id_.name, self)
+            Registry.extend(self.id_.name, self)
             self.id_ = self.id_.name
         else:
-            self.registry.add(self.id_, self)
+            Registry.add(self.id_, self)
 
-        self.requisite = StateRequisite('require', self.module, self.id_,
-                                        registry=self.registry)
+        self.requisite = StateRequisite('require', self.module, self.id_)
 
     @property
     def attrs(self):
@@ -232,10 +238,10 @@ class State(object):
         }
 
     def __enter__(self):
-        self.registry.push_requisite(self.requisite)
+        Registry.push_requisite(self.requisite)
 
     def __exit__(self, type, value, traceback):
-        self.registry.pop_requisite()
+        Registry.pop_requisite()
 
 
 class SaltObject(object):
@@ -269,3 +275,76 @@ class SaltObject(object):
             raise AttributeError
 
         return self.mods[mod]
+
+
+class MapMeta(type):
+    '''
+    This is the metaclass for our Map class, used for building data maps based
+    off of grain data.
+    '''
+    def __init__(cls, name, bases, nmspc):
+        cls.__set_attributes__()
+        super(MapMeta, cls).__init__(name, bases, nmspc)
+
+    def __set_attributes__(cls):
+        match_groups = OrderedDict([])
+
+        # find all of our filters
+        for item in cls.__dict__:
+            if item[0] == '_':
+                continue
+
+            filt = cls.__dict__[item]
+
+            # only process classes
+            if not inspect.isclass(filt):
+                continue
+
+            # which grain are we filtering on
+            grain = getattr(filt, '__grain__', 'os_family')
+            if grain not in match_groups:
+                match_groups[grain] = OrderedDict([])
+
+            # does the object pointed to have a __match__ attribute?
+            # if so use it, otherwise use the name of the object
+            # this is so that you can match complex values, which the python
+            # class name syntax does not allow
+            if hasattr(filt, '__match__'):
+                match = filt.__match__
+            else:
+                match = item
+
+            match_groups[grain][match] = OrderedDict([])
+            for name in filt.__dict__:
+                if name[0] == '_':
+                    continue
+
+                match_groups[grain][match][name] = filt.__dict__[name]
+
+        attrs = {}
+        for grain in match_groups:
+            filtered = Map.__salt__['grains.filter_by'](match_groups[grain],
+                                                        grain=grain)
+            if filtered:
+                attrs.update(filtered)
+
+        if hasattr(cls, 'merge'):
+            pillar = Map.__salt__['pillar.get'](cls.merge)
+            if pillar:
+                attrs.update(pillar)
+
+        for name in attrs:
+            setattr(cls, name, attrs[name])
+
+
+def need_salt(*a, **k):
+    log.error("Map needs __salt__ set before it can be used!")
+    return {}
+
+
+class Map(object):
+    __metaclass__ = MapMeta
+    __salt__ = {
+        'grains.filter_by': need_salt,
+        'pillar.get': need_salt
+    }

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -1,23 +1,19 @@
 # -*- coding: utf-8 -*-
 
-from cStringIO import StringIO
-
 from salttesting import TestCase
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../')
 
+import salt.state
 from salt.config import minion_config
-from salt.loader import states
-from salt.minion import SMinion
-from salt.renderers.pyobjects import render as pyobjects_render
+from salt.template import compile_template_str
 from salt.utils.odict import OrderedDict
-from salt.utils.pyobjects import (StateFactory, State, StateRegistry,
+from salt.utils.pyobjects import (StateFactory, State, Registry,
                                   SaltObject, InvalidFunction, DuplicateState)
 
-test_registry = StateRegistry()
-File = StateFactory('file', registry=test_registry)
-Service = StateFactory('service', registry=test_registry)
+File = StateFactory('file')
+Service = StateFactory('service')
 
 pydmesg_expected = {
     'file.managed': [
@@ -49,15 +45,37 @@ include('http')
 Service.running(extend('apache'), watch=[{'file': '/etc/file'}])
 '''
 
+map_template = '''#!pyobjects
+class Samba(Map):
+    __merge__ = 'samba:lookup'
+
+    class Debian:
+        server = 'samba'
+        client = 'samba-client'
+        service = 'samba'
+
+    class RougeChapeau:
+        __match__ = 'RedHat'
+        server = 'samba'
+        client = 'samba'
+        service = 'smb'
+
+    class Ubuntu:
+        __grain__ = 'os'
+        service = 'smbd'
+
+with Pkg.installed("samba", names=[Samba.server, Samba.client]):
+    Service.running("samba", name=Samba.service)
+'''
+
 
 class StateTests(TestCase):
     def setUp(self):
-        test_registry.empty()
+        Registry.empty()
 
     def test_serialization(self):
         f = State('/usr/local/bin/pydmesg', 'file', 'managed',
                   require=File('/usr/local/bin'),
-                  registry=test_registry,
                   **pydmesg_kwargs)
 
         self.assertEqual(f(), pydmesg_expected)
@@ -68,7 +86,7 @@ class StateTests(TestCase):
                      **pydmesg_kwargs)
 
         self.assertEqual(
-            test_registry.states['/usr/local/bin/pydmesg'],
+            Registry.states['/usr/local/bin/pydmesg'],
             pydmesg_expected
         )
 
@@ -77,7 +95,7 @@ class StateTests(TestCase):
             pydmesg = File.managed('/usr/local/bin/pydmesg', **pydmesg_kwargs)
 
             self.assertEqual(
-                test_registry.states['/usr/local/bin/pydmesg'],
+                Registry.states['/usr/local/bin/pydmesg'],
                 pydmesg_expected
             )
 
@@ -85,7 +103,7 @@ class StateTests(TestCase):
                 File.managed('/tmp/something', owner='root')
 
                 self.assertEqual(
-                    test_registry.states['/tmp/something'],
+                    Registry.states['/tmp/something'],
                     {
                         'file.managed': [
                             {'owner': 'root'},
@@ -103,17 +121,17 @@ class StateTests(TestCase):
                      **pydmesg_kwargs)
 
         self.assertEqual(
-            test_registry.states['/usr/local/bin/pydmesg'],
+            Registry.states['/usr/local/bin/pydmesg'],
             pydmesg_expected
         )
 
         self.assertEqual(
-            test_registry.salt_data(),
+            Registry.salt_data(),
             pydmesg_salt_expected
         )
 
         self.assertEqual(
-            test_registry.states,
+            Registry.states,
             OrderedDict()
         )
 
@@ -127,7 +145,7 @@ class StateTests(TestCase):
         Service.running('dup', name='dup-service')
 
         self.assertEqual(
-            test_registry.states,
+            Registry.states,
             OrderedDict([
                 ('dup', OrderedDict([
                     ('file.managed', [
@@ -141,15 +159,19 @@ class StateTests(TestCase):
         )
 
 
-class RendererTests(TestCase):
-    def render(self, template):
+class RendererMixin(object):
+    def render(self, template, opts=None):
         _config = minion_config(None)
         _config['file_client'] = 'local'
-        _minion = SMinion(_config)
-        _states = states(_config, _minion.functions)
+        if opts:
+            _config.update(opts)
+        _state = salt.state.State(_config)
+        return compile_template_str(template,
+                                    _state.rend,
+                                    _state.opts['renderer'])
 
-        return pyobjects_render(StringIO(template), _states=_states)
 
+class RendererTests(TestCase, RendererMixin):
     def test_basic(self):
         ret = self.render(basic_template)
         self.assertEqual(ret, OrderedDict([
@@ -162,7 +184,7 @@ class RendererTests(TestCase):
             }),
         ]))
 
-        self.assertEqual(test_registry.states, OrderedDict())
+        self.assertEqual(Registry.states, OrderedDict())
 
     def test_invalid_function(self):
         def _test():
@@ -187,6 +209,34 @@ class RendererTests(TestCase):
                 }),
             ])),
         ]))
+
+
+class MapTests(TestCase, RendererMixin):
+    def test_map(self):
+        def samba_with_grains(grains):
+            return self.render(map_template, {'grains': grains})
+
+        def assert_ret(ret, server, client, service):
+            self.assertEqual(ret, OrderedDict([
+                ('samba', {
+                    'pkg.installed': [
+                        {'names': [server, client]}
+                    ],
+                    'service.running': [
+                        {'name': service},
+                        {'require': [{'pkg': 'samba'}]}
+                    ]
+                })
+            ]))
+
+        ret = samba_with_grains({'os_family': 'Debian', 'os': 'Debian'})
+        assert_ret(ret, 'samba', 'samba-client', 'samba')
+
+        ret = samba_with_grains({'os_family': 'Debian', 'os': 'Ubuntu'})
+        assert_ret(ret, 'samba', 'samba-client', 'smbd')
+
+        ret = samba_with_grains({'os_family': 'RedHat', 'os': 'CentOS'})
+        assert_ret(ret, 'samba', 'samba', 'smb')
 
 
 class SaltObjectTests(TestCase):


### PR DESCRIPTION
The problem with using the loaded states (see commit cc8539f) is that
you can end up in situations where a particular state doesn't exist for
whatever reason. This prevents you from building states freely (see
ticket #10918).

The refactor focuses on breaking out the `gen_functions` function into a
number of smaller reusable functions so that pyobjects can load all of
the states and still process `__virtual__()` and `__virtualname__` in a
way that makes sense for building states. After all pyobjects is just
compiling a high state data structure, if a state is available or not
during application time is up to the minion.

As part of this refactor I have also updated all of the inline comments
in the loader to be more consistent with the way things are actually
working now (such as `__virtual__()` returning a string being
deprecated).

There are also some pep8 fixes to the loader file.

Fix #10918

---

This also adds a new feature to pyobjects named `Map`, which allows for
definition of grain dependent data in a pythonic way -- using inner
classes.

---

Lastly this ditches the instance based registry and instead uses a class
based approach like a singleton.
