### PR TITLE
Return list without newlines character

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -764,7 +764,8 @@ def _read_file(path):
     '''
     try:
         with salt.utils.fopen(path, 'rb') as contents:
-            return contents.readlines()
+            # without newlines character. http://stackoverflow.com/questions/12330522/reading-a-file-without-newlines
+            return contents.read().splitlines()
     except Exception:
         return ''
 


### PR DESCRIPTION
For better display like `salt '*' ip.get_interface eth0`
