### PR TITLE
Added quotes surrounding the filename in the untar portion of the archive.py state.

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -143,7 +143,7 @@ def extracted(name,
         else:
             # this is needed until merging PR 2651
             log.debug("Untar %s in %s", filename, name)
-            results = __salt__['cmd.run_all']('tar -x{0}f {1}'.format(tar_options,
+            results = __salt__['cmd.run_all']('tar -x{0}f "{1}"'.format(tar_options,
                                                                  filename),
                                               cwd=name)
             if results['retcode'] != 0:


### PR DESCRIPTION
Added quotes surrounding the filename in the untar portion of the archive.py state.  Necessary if filename
 has spaces in it.
