### PR TITLE
added a note about master/minion version incompatibility to the 2014.1.0 release notes

### DIFF
--- a/doc/topics/releases/2014.1.0.rst
+++ b/doc/topics/releases/2014.1.0.rst
@@ -268,3 +268,8 @@ candidate phase.
 - Fix compound commands (:issue:`9746`)
 - Add systemd notification when master is started
 - Many doc improvements
+
+.. note::
+
+    Minions running ``2014.1.0`` are currently incompatible with Masters running
+    ``0.17``.


### PR DESCRIPTION
For issue #10932.
