### PR TITLE
Refactor minion for single pre-tune-in routine. 

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -562,10 +562,7 @@ class MultiMinion(MinionBase):
                     minion['minion'].module_refresh()
                 if pillar_refresh:
                     minion['minion'].pillar_refresh()
-                try:
-                    minion['generator'].next()
-                except StopIteration:
-                    continue
+                minion['generator'].next()
 
 
 class Minion(MinionBase):
@@ -1222,11 +1219,10 @@ class Minion(MinionBase):
         self._running = False
         exit(0)
 
-    # Main Minion Tune In
-    def tune_in(self):
+    def _pre_tune(self):
         '''
-        Lock onto the publisher. This is the main event loop for the minion
-        :rtype : None
+        Set the minion running flag and issue the appropriate warnings if
+        the minion cannot be started or is already running
         '''
         if self._running is None:
             self._running = True
@@ -1260,6 +1256,16 @@ class Minion(MinionBase):
                 ),
                 exc_info=err
             )
+
+
+    # Main Minion Tune In
+    def tune_in(self):
+        '''
+        Lock onto the publisher. This is the main event loop for the minion
+        :rtype : None
+        '''
+
+        self._pre_tune()
 
         # Properly exit if a SIGTERM is signalled
         signal.signal(signal.SIGTERM, self.clean_die)
@@ -1367,6 +1373,8 @@ class Minion(MinionBase):
         management of the event bus assuming that these are handled outside
         the tune_in sequence
         '''
+
+        self._pre_tune()
         self._init_context_and_poller()
 
         self.socket = self.context.socket(zmq.SUB)


### PR DESCRIPTION
Resolves #10732 by setting _running in tune_in_no_block().

@s0undt3ch, does this look like a good approach?
