### PR TITLE
Honor (lack of) mode recurse in file.directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1426,6 +1426,10 @@ def directory(name,
                                      'as a target for recursive ownership ' \
                                      'management'
 
+            if 'mode' not in recurse:
+                file_mode = None
+                dir_mode = None
+
             for root, dirs, files in os.walk(name):
                 for fn_ in files:
                     full = os.path.join(root, fn_)


### PR DESCRIPTION
Currently, we set the mode recursively if the file.directory state is
set to recurse whether or not recurse: mode is specified. This change
makes mode follow the same recurse behavior as user and group.
