### PR TITLE
Pass repo_arg to repoquery for available packages

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -394,7 +394,8 @@ def check_db(*names, **kwargs):
         # get list of available packages
         avail = []
         lines = _repoquery(
-            '--pkgnarrow=all --all', query_format='%{NAME}_|-%{ARCH}'
+            '{0} --pkgnarrow=all --all'.format(repo_arg),
+            query_format='%{NAME}_|-%{ARCH}'
         )
         for line in lines:
             try:


### PR DESCRIPTION
On yum based distributions, repo options were not being passed to the call that lists available packages. This was only affecting pkg.installed states, not pkg.install function calls because pkg.installed makes a call to `_preflight_check` which invokes `check_db` in yumpkg.py. 

This is a pretty simple fix to saltstack/salt#10944 but I'd like to add some tests. Unfortunately I'm not sure where the best place would be for this.
