### PR TITLE
Update return with libcloud's Node object.

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -269,7 +269,7 @@ def create(vm_):
                 )
             )
 
-    ret.update(data)
+    ret.update(data.__dict__)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
     log.debug(


### PR DESCRIPTION
In 0155b88827a2f570e59dbfc8ac5679ef34e12a63, support for linode was broken in salt-cloud's provisioning by changing

``` python
ret.update(data.__dict__)
```

 to

``` python
ret.update(data)
```

Now causing the following error:

```
[ERROR   ] There was a profile error: 'Node' object is not iterable
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cloud/cli.py", line 332, in run
    self.config.get('names')
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 940, in run_profile
    ret[name] = self.create(vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 854, in create
    output = self.clouds[func](vm_)
  File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/linode.py", line 272, in create
    ret.update(data)
TypeError: 'Node' object is not iterable
```
