### PR TITLE
add module to check existence of files/dir with path expansion

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -29,6 +29,7 @@ import stat
 import sys
 import tempfile
 import time
+from glob import glob
 
 try:
     import grp
@@ -1863,6 +1864,22 @@ def file_exists(path):
     '''
     return os.path.isfile(path)
 
+def path_exists_glob(path):
+    '''
+    Tests to see if path after expansion is a valid path (file or directory).
+    Expansion allows usage of ? * and character ranges []. Tilde expansion
+    is not supported. Returns True/False.
+
+    .. versionadded::
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.path_exists_glob /etc/pam*/pass*
+
+    '''
+    return True if len(glob(path)) > 0 else False
 
 def restorecon(path, recursive=False):
     '''

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1870,7 +1870,7 @@ def path_exists_glob(path):
     Expansion allows usage of ? * and character ranges []. Tilde expansion
     is not supported. Returns True/False.
 
-    .. versionadded::
+    .. versionadded:: Hellium
 
     CLI Example:
 
@@ -1879,7 +1879,7 @@ def path_exists_glob(path):
         salt '*' file.path_exists_glob /etc/pam*/pass*
 
     '''
-    return True if len(glob(path)) > 0 else False
+    return True if glob(path) else False
 
 def restorecon(path, recursive=False):
     '''


### PR DESCRIPTION
Didn't know which version to mark it as being added to.
Seems like a good shortcut for what I needed to do in the sls file before for lack of other ways:

{% for role in grains['roles'] %}
{% set path = '/usr/local/salt/service/*/'+role %}
{% set expanded_role = salt['cmd.run']('echo '+path%29 %}
{% if salt['file.exists']%28expanded_role) %}
TOP_STATE
{% endif %}
{% endfor %}

{% for role in grains['roles'] %}
{% if salt['file.path_exists_glob('/usr/local/salt/service/*/'+role) %}
TOP_STATE
{% endif %}
{% endfor %}
