### PR TITLE
modules.win_dns_client: fix error in add_dns()

### DIFF
--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -80,6 +80,10 @@ def add_dns(ip, interface='Local Area Connection', index=1):
     '''
     servers = get_dns_servers(interface)
 
+    # Return False if could not find the interface
+    if servers is False:
+        return False
+
     # Return true if configured
     try:
         if servers[index - 1] == ip:


### PR DESCRIPTION
modules.win_dns_client: fix error in add_dns() when the interface could not be found
