### PR TITLE
Add 'ALL PRIVILEGES' to __grants__

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -60,6 +60,7 @@ log = logging.getLogger(__name__)
 __opts__ = {}
 
 __grants__ = [
+    'ALL PRIVILEGES',
     'ALTER',
     'ALTER ROUTINE',
     'CREATE',


### PR DESCRIPTION
After upgrading from 0.17.x my mysql states are broken because 'ALL PRIVILEGES' is not a recognised grant option.

`Exception: Invalid grant requested: 'ALL PRIVILEGES'`
