### PR TITLE
fix: master doesn't start when user acl enabled

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -115,7 +115,7 @@ def access_keys(opts):
 
         if user not in users:
             try:
-                user = pwd.getpwnam(user)
+                user = pwd.getpwnam(user).pw_name
             except KeyError:
                 log.error('ACL user {0} is not available'.format(user))
                 continue


### PR DESCRIPTION
salt-master crashes on start with 

```
2014-03-05 13:06:10,745 [salt             ][INFO    ] Setting up the Salt Master
2014-03-05 13:06:10,772 [salt.crypt       ][DEBUG   ] Loaded master key: /etc/salt/pki/master/master.pem
2014-03-05 13:06:10,808 [salt.daemons.masterapi][INFO    ] Preparing the nbryskin key for local communication
2014-03-05 13:06:10,810 [salt.log.setup   ][ERROR   ] An un-handled exception was caught by salt's global exception handler:
IOError: [Errno 2] No such file or directory: "/var/cache/salt/master/.pwd.struct_passwd(pw_name='nbryskin', pw_passwd='*', pw_uid
=22892, pw_gid=21138, pw_gecos='nbryskin', pw_dir='/home/nbryskin', pw_shell='/bin/bash')_key"
Traceback (most recent call last):
  File "/usr/bin/salt-master", line 10, in <module>
    salt_master()
  File "/usr/lib/pymodules/python2.7/salt/scripts.py", line 27, in salt_master
    master.start()
  File "/usr/lib/pymodules/python2.7/salt/__init__.py", line 129, in start
    self.prepare()
  File "/usr/lib/pymodules/python2.7/salt/__init__.py", line 111, in prepare
    self.master = salt.master.Master(self.config)
  File "/usr/lib/pymodules/python2.7/salt/master.py", line 144, in __init__
    SMaster.__init__(self, opts)
  File "/usr/lib/pymodules/python2.7/salt/master.py", line 111, in __init__
    self.key = self.__prep_key()
  File "/usr/lib/pymodules/python2.7/salt/master.py", line 125, in __prep_key
    return salt.daemons.masterapi.access_keys(self.opts)
  File "/usr/lib/pymodules/python2.7/salt/daemons/masterapi.py", line 132, in access_keys
    with salt.utils.fopen(keyfile, 'w+') as fp_:
  File "/usr/lib/pymodules/python2.7/salt/utils/__init__.py", line 1049, in fopen
    fhandle = open(*args, **kwargs)
IOError: [Errno 2] No such file or directory: "/var/cache/salt/master/.pwd.struct_passwd(pw_name='nbryskin', pw_passwd='*', pw_uid
=22892, pw_gid=21138, pw_gecos='nbryskin', pw_dir='/home/nbryskin', pw_shell='/bin/bash')_key"
```
