### PR TITLE
Allow access to any environment variable from grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1157,6 +1157,16 @@ def path():
     #   path
 
     return {'path': os.environ['PATH'].strip()}
+    
+
+def environ():
+    '''
+    Returns the environment variables
+    '''
+    # Provides:
+    #   environ
+    
+    return {'environ': os.environ}
 
 
 def pythonversion():


### PR DESCRIPTION
This PR fixes #7873. I haven't tested it but it should work.
Should we deprecate the path grain as a result?
Should we strip() any value in os.environ?
