### PR TITLE
fix of lint error causing #10916 to be reverted

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -125,7 +125,7 @@ def _changes(name,
             change['inactdays'] = inactdays
         if warndays is not 7 and lshad['warn'] != warndays:
             change['warndays'] = warndays
-        if exire is not -1 and lshad['expire'] != expire:
+        if expire is not -1 and lshad['expire'] != expire:
             change['expire'] = expire
     # GECOS fields
     if fullname is not None and lusr['fullname'] != fullname:

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -58,10 +58,19 @@ def _changes(name,
              fullname='',
              roomnumber='',
              workphone='',
-             homephone=''):
+             homephone='',
+             date=0,
+             mindays=0,
+             maxdays=999999,
+             inactdays=0,
+             warndays=7,
+             expire=-1):
     '''
     Return a dict of the changes required for a user if the user is present,
     otherwise return False.
+
+    Updated in Helium to include support for shadow attributes, all
+    attributes supported as integers only.
     '''
 
     if 'shadow.info' in __salt__:
@@ -106,6 +115,18 @@ def _changes(name,
                     or lshad['passwd'] != default_hash and enforce_password:
                 if lshad['passwd'] != password:
                     change['passwd'] = password
+        if date is not 0 and lshad['lstchg'] != date:
+            change['date'] = date
+        if mindays is not 0 and lshad['min'] != mindays:
+            change['mindays'] = mindays
+        if maxdays is not 999999 and lshad['max'] != maxdays:
+            change['maxdays'] = maxdays
+        if inactdays is not 0 and lshad['inact'] != inactdays:
+            change['inactdays'] = inactdays
+        if warndays is not 7 and lshad['warn'] != warndays:
+            change['warndays'] = warndays
+        if exire is not -1 and lshad['expire'] != exiredate:
+            change['expire'] = expire
     # GECOS fields
     if fullname is not None and lusr['fullname'] != fullname:
         change['fullname'] = fullname
@@ -141,7 +162,13 @@ def present(name,
             fullname=None,
             roomnumber=None,
             workphone=None,
-            homephone=None):
+            homephone=None,
+            date=None,
+            mindays=None,
+            maxdays=None,
+            inactdays=None,
+            warndays=None,
+            expire=None):
     '''
     Ensure that the named user is present with the specified properties
 
@@ -226,6 +253,35 @@ def present(name,
 
     homephone
         The user's home phone number (not supported in MacOS)
+
+
+    .. versionchanged:: Helium
+       Shadow attribute support added.
+
+    Shadow attributes support (currently Linux only):
+
+    The below values should be specified as integers.
+
+    date
+        Date of last change of password, represented in days since epoch
+        (January 1, 1970).
+
+    mindays
+        The minimum number of days between password changes.
+
+    maxdays
+        The maximum number of days between password changes.
+
+    inactdays
+        The number of days after a password expires before an account is
+        locked.
+
+    warndays
+        Number of days prior to maxdays to warn users.
+
+    expire
+        Date that account expires, represented in days since epoch (January 1,
+        1970).
     '''
     fullname = str(fullname) if fullname is not None else fullname
     roomnumber = str(roomnumber) if roomnumber is not None else roomnumber
@@ -278,7 +334,13 @@ def present(name,
                        fullname,
                        roomnumber,
                        workphone,
-                       homephone)
+                       homephone,
+                       date,
+                       mindays,
+                       maxdays,
+                       inactdays,
+                       warndays,
+                       expire)
 
     if changes:
         if __opts__['test']:
@@ -295,6 +357,24 @@ def present(name,
         for key, val in changes.items():
             if key == 'passwd':
                 __salt__['shadow.set_password'](name, password)
+                continue
+            if key == 'date':
+                __salt__['shadow.set_date'](name, date)
+                continue
+            if key == 'mindays':
+                __salt__['shadow.set_mindays'](name, mindays)
+                continue
+            if key == 'maxdays':
+                __salt__['shadow.set_maxdays'](name, maxdays)
+                continue
+            if key == 'inactdays':
+                __salt__['shadow.set_inactdays'](name, inactdays)
+                continue
+            if key == 'warndays':
+                __salt__['shadow.set_warndays'](name, warndays)
+                continue
+            if key == 'expire':
+                __salt__['shadow.set_expire'](name, expire)
                 continue
             if key == 'groups':
                 __salt__['user.ch{0}'.format(key)](
@@ -336,7 +416,13 @@ def present(name,
                            fullname,
                            roomnumber,
                            workphone,
-                           homephone)
+                           homephone,
+                           date,
+                           mindays,
+                           maxdays,
+                           inactdays,
+                           warndays,
+                           expire)
 
         if changes:
             ret['comment'] = 'These values could not be changed: {0}'.format(
@@ -370,14 +456,70 @@ def present(name,
                                 createhome=createhome):
             ret['comment'] = 'New user {0} created'.format(name)
             ret['changes'] = __salt__['user.info'](name)
-            if all((password, 'shadow.info' in __salt__)):
-                __salt__['shadow.set_password'](name, password)
-                spost = __salt__['shadow.info'](name)
-                if spost['passwd'] != password and not salt.utils.is_windows():
-                    ret['comment'] = 'User {0} created but failed to set' \
-                                     ' password to {1}'.format(name, password)
-                    ret['result'] = False
-                ret['changes']['password'] = password
+            if 'shadow.info' in __salt__ and not salt.utils.is_windows():
+                if password:
+                    __salt__['shadow.set_password'](name, password)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['passwd'] != password:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' password to' \
+                                         ' {1}'.format(name, password)
+                        ret['result'] = False
+                    ret['changes']['password'] = password
+                if date:
+                    __salt__['shadow.set_date'](name, date)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['lstchg'] != date:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' last change date to' \
+                                         ' {1}'.format(name, date)
+                        ret['result'] = False
+                    ret['changes']['date'] = date
+                if mindays:
+                    __salt__['shadow.set_mindays'](name, mindays)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['min'] != mindays:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' minimum days to' \
+                                         ' {1}'.format(name, mindays)
+                        ret['result'] = False
+                    ret['changes']['mindays'] = mindays
+                if maxdays:
+                    __salt__['shadow.set_maxdays'](name, mindays)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['max'] != maxdays:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' maximum days to' \
+                                         ' {1}'.format(name, maxdays)
+                        ret['result'] = False
+                    ret['changes']['maxdays'] = maxdays
+                if inactdays:
+                    __salt__['shadow.set_inactdays'](name, inactdays)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['inact'] != inactdays:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' inactive days to' \
+                                         ' {1}'.format(name, inactdays)
+                        ret['result'] = False
+                    ret['changes']['inactdays'] = inactdays
+                if warndays:
+                    __salt__['shadow.set_warndays'](name, warndays)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['warn'] != warndays:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' warn days to' \
+                                         ' {1}'.format(name, mindays)
+                        ret['result'] = False
+                    ret['changes']['warndays'] = warndays
+                if expire:
+                    __salt__['shadow.set_expire'](name, expire)
+                    spost = __salt__['shadow.info'](name)
+                    if spost['expire'] != expire:
+                        ret['comment'] = 'User {0} created but failed to set' \
+                                         ' expire days to' \
+                                         ' {1}'.format(name, expire)
+                        ret['result'] = False
+                    ret['changes']['expire'] = expire
         else:
             ret['comment'] = 'Failed to create new user {0}'.format(name)
             ret['result'] = False

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -125,7 +125,7 @@ def _changes(name,
             change['inactdays'] = inactdays
         if warndays is not 7 and lshad['warn'] != warndays:
             change['warndays'] = warndays
-        if exire is not -1 and lshad['expire'] != exiredate:
+        if exire is not -1 and lshad['expire'] != expire:
             change['expire'] = expire
     # GECOS fields
     if fullname is not None and lusr['fullname'] != fullname:


### PR DESCRIPTION
The variable expiredays is what I had initially started using until deciding to match the name in the shadow module, the lint error was because I missed one reference to that variable name.
