### PR TITLE
The `__virtual__()` function should only return strings on renames.

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -114,10 +114,7 @@ def __virtual__():
     '''
     Only load on Linux systems
     '''
-    if HAS_PAM:
-        return 'pam'
-    else:
-        return False
+    return HAS_PAM
 
 
 def authenticate(username, password, service='login'):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -836,14 +836,10 @@ class Loader(object):
                                     )
                                 continue
 
-                            if virtual is True:
-                                # The module is not renaming itself, continue!
-                                continue
-
                             # At this point, __virtual__ did not return a
                             # boolean value, let's check for deprecated usage
                             # or module renames
-                            if module_name == virtual:
+                            if virtual is not True and module_name == virtual:
                                 # The module was not renamed, it should
                                 # have returned True instead
                                 salt.utils.warn_until(
@@ -856,9 +852,8 @@ class Loader(object):
                                         mod.__name__,
                                     )
                                 )
-                                continue
 
-                            if module_name != virtual:
+                            elif virtual is not True and module_name != virtual:
                                 # The module is renaming itself. Updating the
                                 # module name with the new name
                                 log.debug(

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -836,12 +836,31 @@ class Loader(object):
                                     )
                                 continue
 
-                            if virtual is not True and module_name != virtual:
-                                # If __virtual__ returned True the module will
-                                # be loaded with the same name, if it returned
-                                # other value than `True`, it should be a new
-                                # name for the module.
-                                # Update the module name with the new name
+                            if virtual is True:
+                                # The module is not renaming itself, continue!
+                                continue
+
+                            # At this point, __virtual__ did not return a
+                            # boolean value, let's check for deprecated usage
+                            # or module renames
+                            if module_name == virtual:
+                                # The module was not renamed, it should
+                                # have returned True instead
+                                salt.utils.warn_until(
+                                    'Helium',
+                                    'The {0!r} module is NOT renaming itself '
+                                    'and is returning a string. In this case '
+                                    'the __virtual__() function should simply '
+                                    'return `True`. This usage will become an '
+                                    'error in Salt Helium'.format(
+                                        mod.__name__,
+                                    )
+                                )
+                                continue
+
+                            if module_name != virtual:
+                                # The module is renaming itself. Updating the
+                                # module name with the new name
                                 log.debug(
                                     'Loaded {0} as virtual {1}'.format(
                                         module_name, virtual
@@ -862,10 +881,31 @@ class Loader(object):
                                             virtual
                                         )
                                     )
-                                module_name = virtual
 
-                            elif virtual and hasattr(mod, '__virtualname__'):
-                                module_name = mod.__virtualname__
+                                # Get the module's virtual name
+                                virtualname = getattr(
+                                    mod, '__virtualname__', virtual
+                                )
+
+                                if virtualname != virtual:
+                                    # The __virtualname__ attribute does not
+                                    # match what's being returned by the
+                                    # __virtual__() function. This should be
+                                    # considered an error.
+                                    log.error(
+                                        'The module {0!r} is showing some bad '
+                                        'usage. It\'s __virtualname__ '
+                                        'attribute is set to {1!r} yet the '
+                                        '__virtual__() function is returning '
+                                        '{2!r}. These values should '
+                                        'match!'.format(
+                                            mod.__name__,
+                                            virtualname,
+                                            virtual
+                                        )
+                                    )
+
+                                module_name = virtualname
 
                 except KeyError:
                     # Key errors come out of the virtual function when passing

--- a/salt/modules/alternatives.py
+++ b/salt/modules/alternatives.py
@@ -30,7 +30,7 @@ def __virtual__():
     Only if alternatives dir is available
     '''
     if os.path.isdir('/etc/alternatives'):
-        return 'alternatives'
+        return True
     return False
 
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -24,7 +24,7 @@ def __virtual__():
     # If none of the above commands are in $PATH this module is a no-go
     if not any(_which(cmd) for cmd in commands):
         return False
-    return 'archive'
+    return True
 
 
 @decorators.which('tar')

--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -20,9 +20,9 @@ __func_alias__ = {
 
 def __virtual__():
     '''
-    Ensure correct name
+    Always load
     '''
-    return 'composer'
+    return True
 
 
 def _valid_composer(composer):

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -21,7 +21,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'disk'
+    return True
 
 
 def _clean_flags(args, caller):

--- a/salt/modules/dnsmasq.py
+++ b/salt/modules/dnsmasq.py
@@ -19,7 +19,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'dnsmasq'
+    return True
 
 
 def version():

--- a/salt/modules/dnsutil.py
+++ b/salt/modules/dnsutil.py
@@ -18,7 +18,7 @@ def __virtual__():
     Generic, should work on any platform (including Windows). Functionality
     which requires dependencies outside of Python do not belong in this module.
     '''
-    return 'dnsutil'
+    return True
 
 
 def parse_hosts(hostsfile='/etc/hosts', hosts=None):

--- a/salt/modules/extfs.py
+++ b/salt/modules/extfs.py
@@ -18,7 +18,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'extfs'
+    return True
 
 
 def mkfs(device, fs_type, **kwargs):

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -64,7 +64,7 @@ def __virtual__():
     # win_file takes care of windows
     if salt.utils.is_windows():
         return False
-    return 'file'
+    return True
 
 
 def __clean_tmp(sfn):

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -22,7 +22,7 @@ def __virtual__():
     '''
     if not all((utils.which('git'), HAS_PIPES)):
         return False
-    return 'git'
+    return True
 
 
 def _git_ssh_helper(identity):

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -19,7 +19,7 @@ def __virtual__():
     Only load the module if iptables is installed
     '''
     if salt.utils.which('iptables'):
-        return 'iptables'
+        return True
     return False
 
 

--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -15,9 +15,8 @@ def __virtual__():
     Only work on supported POSIX-like systems
     '''
     if __grains__['os_family'] in ('Arch', 'Redhat', 'Debian', 'Gentoo'):
-        return 'keyboard'
-    else:
-        return False
+        return True
+    return False
 
 
 def get_sys():

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -15,7 +15,7 @@ def __virtual__():
     '''
     Only runs on Linux systems
     '''
-    return 'kmod' if __grains__['kernel'] == 'Linux' else False
+    return __grains__['kernel'] == 'Linux'
 
 
 def _new_mods(pre_mods, post_mods):

--- a/salt/modules/locate.py
+++ b/salt/modules/locate.py
@@ -18,7 +18,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'locate'
+    return True
 
 
 def version():

--- a/salt/modules/logrotate.py
+++ b/salt/modules/logrotate.py
@@ -26,7 +26,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'logrotate'
+    return True
 
 
 def _parse_conf(conf_file=default_conf):

--- a/salt/modules/modjk.py
+++ b/salt/modules/modjk.py
@@ -40,8 +40,7 @@ def __virtual__():
     '''
     Always load
     '''
-
-    return 'modjk'
+    return True
 
 
 def _auth(url, user, passwd, realm):

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -153,7 +153,7 @@ def __virtual__():
     Only load this module if the mysql libraries exist
     '''
     if HAS_MYSQLDB:
-        return 'mysql'
+        return True
     return False
 
 

--- a/salt/modules/openstack_config.py
+++ b/salt/modules/openstack_config.py
@@ -37,7 +37,7 @@ __func_alias__ = {
 def __virtual__():
     if _quote is None and not HAS_DEPS:
         return False
-    return 'openstack_config'
+    return True
 
 
 def _fallback(*args, **kw):

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -57,7 +57,7 @@ def __virtual__():
     Only load this module if the psql bin exists
     '''
     if all((salt.utils.which('psql'), HAS_ALL_IMPORTS)):
-        return 'postgres'
+        return True
     return False
 
 

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -20,9 +20,6 @@ try:
 except ImportError:
     HAS_PSUTIL = False
 
-# Define the module's virtual name
-__virtualname__ = 'ps'
-
 
 def __virtual__():
     if not HAS_PSUTIL:
@@ -36,7 +33,7 @@ def __virtual__():
     # most distributions have already moved to later versions (for example,
     # as of Dec. 2013 EPEL is on 0.6.1, Debian 7 is on 0.5.1, etc.).
     if psutil.version_info >= (0, 3, 0):
-        return __virtualname__
+        return True
     return False
 
 

--- a/salt/modules/riak.py
+++ b/salt/modules/riak.py
@@ -16,7 +16,7 @@ def __virtual__():
     Only available on systems with Riak installed.
     '''
     if salt.utils.which('riak'):
-        return 'riak'
+        return True
     return False
 
 

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -46,7 +46,7 @@ def __virtual__():
     '''
     Should work on any modern Python installation
     '''
-    return 's3'
+    return True
 
 
 def delete(bucket, path=None, action=None, key=None, keyid=None,

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -15,7 +15,7 @@ import salt.utils
 
 
 def __virtual__():
-    return 'shadow' if __grains__.get('kernel', '') == 'Linux' else False
+    return __grains__.get('kernel', '') == 'Linux'
 
 
 def default_hash():

--- a/salt/modules/sqlite3.py
+++ b/salt/modules/sqlite3.py
@@ -16,7 +16,7 @@ except ImportError:
 def __virtual__():
     if not HAS_SQLITE3:
         return False
-    return 'sqlite3'
+    return True
 
 
 def _connect(db=None):

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -21,7 +21,7 @@ __opts__ = {}
 def __virtual__():
     if salt.utils.is_windows():
         return False
-    return 'status'
+    return True
 
 
 def _number(text):

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -19,7 +19,7 @@ def __virtual__():
     Only load if svn is installed
     '''
     if utils.which('svn'):
-        return 'svn'
+        return True
     return False
 
 

--- a/salt/modules/system.py
+++ b/salt/modules/system.py
@@ -12,7 +12,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows() or not salt.utils.which('shutdown'):
         return False
-    return 'system'
+    return True
 
 
 def halt():

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     if salt.utils.is_windows():
         return False
-    return 'timezone'
+    return True
 
 
 def get_zone():

--- a/salt/pillar/django_orm.py
+++ b/salt/pillar/django_orm.py
@@ -108,7 +108,10 @@ log = logging.getLogger(__name__)
 
 
 def __virtual__():
-    return 'django_orm'
+    '''
+    Always load
+    '''
+    return True
 
 
 def ext_pillar(minion_id,

--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -171,7 +171,7 @@ except ImportError:
 def __virtual__():
     if not HAS_MYSQL:
         return False
-    return 'mysql'
+    return True
 
 
 def _get_options():

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -80,7 +80,7 @@ log = logging.getLogger(__name__)
 def __virtual__():
     if not HAS_MYSQL:
         return False
-    return 'mysql'
+    return True
 
 
 def _get_options():

--- a/salt/runners/doc.py
+++ b/salt/runners/doc.py
@@ -14,7 +14,10 @@ import salt.wheel
 
 
 def __virtual__():
-    return 'doc'
+    '''
+    Always load
+    '''
+    return True
 
 
 def runner():

--- a/salt/states/apt.py
+++ b/salt/states/apt.py
@@ -17,7 +17,7 @@ def __virtual__():
     '''
     Only work on apt-based platforms with pkg.get_selections
     '''
-    return 'apt' if 'pkg.get_selections' in __salt__ else False
+    return 'pkg.get_selections' in __salt__
 
 
 def held(name):

--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load if the cloud module is available in __salt__
     '''
-    return 'cloud' if 'cloud.profile' in __salt__ else False
+    return 'cloud.profile' in __salt__
 
 
 def _check_name(name):

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -45,7 +45,7 @@ def __virtual__():
     '''
     Only load if the composer module is available in __salt__
     '''
-    return 'composer' if 'composer.install' in __salt__ else False
+    return 'composer.install' in __salt__
 
 
 def installed(name,

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load if gem module is available in __salt__
     '''
-    return 'gem' if 'gem.list' in __salt__ else False
+    return 'gem.list' in __salt__
 
 
 def installed(name,          # pylint: disable=C0103

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -30,7 +30,7 @@ def __virtual__():
     '''
     Only load if git is available
     '''
-    return 'git' if __salt__['cmd.has_exec']('git') else False
+    return __salt__['cmd.has_exec']('git')
 
 
 def latest(name,

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -110,7 +110,7 @@ def __virtual__():
     '''
     Only load if the locale module is available in __salt__
     '''
-    return 'iptables' if 'iptables.version' in __salt__ else False
+    return 'iptables.version' in __salt__
 
 
 def chain_present(name, table='filter', family='ipv4'):

--- a/salt/states/keyboard.py
+++ b/salt/states/keyboard.py
@@ -23,7 +23,7 @@ def __virtual__():
     '''
     Only load if the keyboard module is available in __salt__
     '''
-    return 'keyboard' if 'keyboard.get_sys' in __salt__ else False
+    return 'keyboard.get_sys' in __salt__
 
 
 def system(name):

--- a/salt/states/kmod.py
+++ b/salt/states/kmod.py
@@ -19,7 +19,7 @@ def __virtual__():
     '''
     Only load if the kmod module is available in __salt__
     '''
-    return 'kmod' if 'kmod.available' in __salt__ else False
+    return 'kmod.available' in __salt__
 
 
 def present(name, persist=False):

--- a/salt/states/locale.py
+++ b/salt/states/locale.py
@@ -16,7 +16,7 @@ def __virtual__():
     '''
     Only load if the locale module is available in __salt__
     '''
-    return 'locale' if 'locale.get_locale' in __salt__ else False
+    return 'locale.get_locale' in __salt__
 
 
 def system(name):

--- a/salt/states/modjk.py
+++ b/salt/states/modjk.py
@@ -14,7 +14,7 @@ def __virtual__():
     Load this state if modjk is loaded
     '''
 
-    return 'modjk' if 'modjk.workers' in __salt__ else False
+    return 'modjk.workers' in __salt__
 
 
 def _bulk_state(saltfunc, lbn, workers, profile):

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -24,7 +24,7 @@ def __virtual__():
     '''
     Check if we have peer access ?
     '''
-    return 'modjk_worker'
+    return True
 
 
 def _send_command(cmd,

--- a/salt/states/mysql_database.py
+++ b/salt/states/mysql_database.py
@@ -22,7 +22,7 @@ def __virtual__():
     '''
     Only load if the mysql module is available in __salt__
     '''
-    return 'mysql_database' if 'mysql.db_exists' in __salt__ else False
+    return 'mysql.db_exists' in __salt__
 
 
 def _get_mysql_error():

--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -49,7 +49,7 @@ def __virtual__():
     '''
     Only load if the mysql module is available
     '''
-    return 'mysql_grants' if 'mysql.grant_exists' in __salt__ else False
+    return 'mysql.grant_exists' in __salt__
 
 
 def _get_mysql_error():

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -26,7 +26,7 @@ def __virtual__():
     '''
     Only load if the mysql module is available in __salt__
     '''
-    return 'mysql_query' if 'mysql.query' in __salt__ else False
+    return 'mysql.query' in __salt__
 
 
 def _get_mysql_error():

--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -47,7 +47,7 @@ def __virtual__():
     '''
     Only load if the mysql module is in __salt__
     '''
-    return 'mysql_user' if 'mysql.user_create' in __salt__ else False
+    return 'mysql.user_create' in __salt__
 
 
 def _get_mysql_error():

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -161,9 +161,6 @@ import salt.utils
 import salt.utils.network
 from salt.loader import _create_loader
 
-# Define the module's virtual name
-__virtualname__ = 'network'
-
 # Set up logging
 import logging
 log = logging.getLogger(__name__)
@@ -175,7 +172,7 @@ def __virtual__():
     module available.
     '''
     if not salt.utils.is_windows() and 'ip.get_interface' in __salt__:
-        return __virtualname__
+        return True
     return False
 
 

--- a/salt/states/openstack_config.py
+++ b/salt/states/openstack_config.py
@@ -23,7 +23,7 @@ def __virtual__():
         return False
     if 'openstack_config.delete' not in __salt__:
         return False
-    return 'openstack_config'
+    return True
 
 
 def present(name, filename, section, value, parameter=None):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -76,7 +76,7 @@ def __virtual__():
     Only make these states available if a pkg provider has been detected or
     assigned for this minion
     '''
-    return 'pkg' if 'pkg.install' in __salt__ else False
+    return 'pkg.install' in __salt__
 
 
 def __gen_rtag():

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -69,7 +69,7 @@ def __virtual__():
     '''
     Only load if modifying repos is available for this package type
     '''
-    return 'pkgrepo' if 'pkg.mod_repo' in __salt__ else False
+    return 'pkg.mod_repo' in __salt__
 
 
 def managed(name, **kwargs):

--- a/salt/states/postgres_database.py
+++ b/salt/states/postgres_database.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     Only load if the postgres module is present
     '''
-    return 'postgres_database' if 'postgres.user_exists' in __salt__ else False
+    return 'postgres.user_exists' in __salt__
 
 
 def present(name,

--- a/salt/states/postgres_extension.py
+++ b/salt/states/postgres_extension.py
@@ -24,9 +24,7 @@ def __virtual__():
     '''
     Only load if the postgres module is present
     '''
-    return 'postgres_extension' if (
-        'postgres.create_extension' in __salt__
-    ) else False
+    return 'postgres.create_extension' in __salt__
 
 
 def present(name,

--- a/salt/states/postgres_group.py
+++ b/salt/states/postgres_group.py
@@ -28,9 +28,7 @@ def __virtual__():
     '''
     Only load if the postgres module is present
     '''
-    return 'postgres_group' if (
-        'postgres.group_create' in __salt__
-    ) else False
+    return 'postgres.group_create' in __salt__
 
 
 def present(name,

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -28,9 +28,7 @@ def __virtual__():
     '''
     Only load if the postgres module is present
     '''
-    return 'postgres_user' if (
-        'postgres.user_exists' in __salt__
-    ) else False
+    return 'postgres.user_exists' in __salt__
 
 
 def present(name,

--- a/salt/states/process.py
+++ b/salt/states/process.py
@@ -14,7 +14,7 @@ Ensure a process matching a given pattern is absent.
 
 
 def __virtual__():
-    return 'process' if 'ps.pkill' in __salt__ else False
+    return 'ps.pkill' in __salt__
 
 
 def absent(name):

--- a/salt/states/rabbitmq_cluster.py
+++ b/salt/states/rabbitmq_cluster.py
@@ -16,6 +16,9 @@ Example:
 # Import python libs
 import logging
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -23,10 +26,7 @@ def __virtual__():
     '''
     Only load if RabbitMQ is installed.
     '''
-    name = 'rabbitmq_cluster'
-    if not __salt__['cmd.has_exec']('rabbitmqctl'):
-        name = False
-    return name
+    return salt.utils.which('rabbitmqctl') is not None
 
 
 def join(name, host, user='rabbit', runas=None):

--- a/salt/states/rabbitmq_plugin.py
+++ b/salt/states/rabbitmq_plugin.py
@@ -24,10 +24,9 @@ def __virtual__():
     '''
     Only load if RabbitMQ is installed.
     '''
-    name = 'rabbitmq_plugin'
-    if not __salt__['cmd.has_exec']('rabbitmqctl'):
-        name = False
-    return name
+    if __salt__['cmd.has_exec']('rabbitmqctl'):
+        return True
+    return False
 
 
 def enabled(name, runas=None):

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -20,7 +20,7 @@ Example:
 
 # Import python libs
 import logging
-from salt import exceptions, utils
+import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -29,12 +29,7 @@ def __virtual__():
     '''
     Only load if RabbitMQ is installed.
     '''
-    name = 'rabbitmq_policy'
-    try:
-        utils.check_or_die('rabbitmqctl')
-    except exceptions.CommandNotFoundError:
-        name = False
-    return name
+    return salt.utils.which('rabbitmqctl') is not None
 
 
 def present(name,

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -23,6 +23,9 @@ Example:
 # Import python libs
 import logging
 
+# Import salt libs
+import salt.utils
+
 log = logging.getLogger(__name__)
 
 
@@ -30,10 +33,7 @@ def __virtual__():
     '''
     Only load if RabbitMQ is installed.
     '''
-    name = 'rabbitmq_user'
-    if not __salt__['cmd.has_exec']('rabbitmqctl'):
-        name = False
-    return name
+    return salt.utils.which('rabbitmqctl') is not None
 
 
 def present(name,

--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -28,10 +28,7 @@ def __virtual__():
     '''
     Only load if RabbitMQ is installed.
     '''
-    name = 'rabbitmq_vhost'
-    if not __salt__['cmd.has_exec']('rabbitmqctl'):
-        name = False
-    return name
+    return salt.utils.which('rabbitmqctl') is not None
 
 
 def present(name,

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -48,7 +48,7 @@ def __virtual__():
     Only make these states available if a service provider has been detected or
     assigned for this minion
     '''
-    return 'service' if 'service.start' in __salt__ else False
+    return 'service.start' in __salt__
 
 
 def _enabled_used_error(ret):

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -27,9 +27,7 @@ def __virtual__():
     '''
     Only load if svn is available
     '''
-    if __salt__['cmd.has_exec']('svn'):
-        return 'svn'
-    return False
+    return __salt__['cmd.has_exec']('svn')
 
 
 def latest(name,

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -20,7 +20,7 @@ def __virtual__():
     '''
     This state is only available on Minions which support sysctl
     '''
-    return 'sysctl' if 'sysctl.show' in __salt__ else False
+    return 'sysctl.show' in __salt__
 
 
 def present(name, value, config=None):

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -33,7 +33,7 @@ def __virtual__():
     '''
     Only load if the timezone module is available in __salt__
     '''
-    return 'timezone' if 'timezone.get_zone' in __salt__ else False
+    return 'timezone.get_zone' in __salt__
 
 
 def system(name, utc=''):

--- a/tests/integration/files/extension_modules/pillar/test_ext_pillar_opts.py
+++ b/tests/integration/files/extension_modules/pillar/test_ext_pillar_opts.py
@@ -19,7 +19,7 @@ MY_NAME = 'test_ext_pillar_opts'
 
 def __virtual__():
     log.debug('Loaded external pillar {0} as {1}'.format(__name__, MY_NAME))
-    return MY_NAME
+    return True
 
 
 def ext_pillar(minion_id, pillar, *args):


### PR DESCRIPTION
If the module is not renaming itself, it should simply return True.
Additionally we now also check for different values on `__virtualname__`
and `__virtual__(), these should always match.`
