### PR TITLE
Fix Jenkins test failure

### DIFF
--- a/tests/unit/perm_test.py
+++ b/tests/unit/perm_test.py
@@ -50,7 +50,8 @@ EXEMPT_FILES = ['setup.py',
                 'post-update.sample',
                 'prepare-commit-msg.sample',
                 'applypatch-msg.sample',
-                'master.py']
+                'master.py',
+                'build_shar.sh']
 
 EXEMPT_DIRS = ['tests', '.git', 'doc']
 


### PR DESCRIPTION
Add build_shar.sh to list of files permitted to be u+x in the git
repo.
