### PR TITLE
Add import for cache

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -73,6 +73,7 @@ import salt.payload
 import salt.loader
 import salt.state
 import salt.utils
+import salt.utils.cache
 from salt._compat import string_types
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Seems that (at least on my setup) you must have the next layer of import otherwise its an import error, which takes down the reqserver. Not sure how anything works without this ;)
