### PR TITLE
Fix iptables comment where format params were apparently mismapped

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -191,7 +191,7 @@ def chain_absent(name, table='filter', family='ipv4'):
                               .format(name, table, family))
         else:
             ret['result'] = False
-            ret['comment'] = ('Failed to delete {0} chain in {1} table: {2} for {2}'
+            ret['comment'] = ('Failed to delete {0} chain in {1} table: {2} for {3}'
                               .format(name, table, command.strip(), family))
     else:
         ret['result'] = False
@@ -237,7 +237,7 @@ def append(name, family='ipv4', **kwargs):
                                   rule,
                                   family) is True:
         ret['result'] = True
-        ret['comment'] = 'iptables rule for {0} already set ({1}) for {1}'.format(
+        ret['comment'] = 'iptables rule for {0} already set ({1}) for {2}'.format(
             name,
             command.strip(),
             family)
@@ -397,7 +397,7 @@ def delete(name, family='ipv4', **kwargs):
     if not result:
         ret['changes'] = {'locale': name}
         ret['result'] = True
-        ret['comment'] = 'Delete iptables rule for {1} {1}'.format(
+        ret['comment'] = 'Delete iptables rule for {0} {1}'.format(
             name,
             command.strip())
         if 'save' in kwargs:


### PR DESCRIPTION
In reviewing iptables due to a format bug in 2014.1.0 that has already been fixed, I encountered several comments that appeared to have been cut/paste mismappings.  Beyond these changes, the comment text could stand to be reviewed and standardized.
