### PR TITLE
Do not use expired tokens in external_auth

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -2047,7 +2047,7 @@ def client_config(path, env_var='SALT_CLIENT_CONFIG', defaults=None):
     if os.path.isfile(opts['token_file']):
         # Make sure token is still valid
         expire = opts.get('token_expire', 43200)
-        if os.stat(opts['token_file']).st_mtime + expire > int(time.strftime("%s")):
+        if os.stat(opts['token_file']).st_mtime + expire > time.mktime(time.localtime()):
             with salt.utils.fopen(opts['token_file']) as fp_:
                 opts['token'] = fp_.read().strip()
     # On some platforms, like OpenBSD, 0.0.0.0 won't catch a master running on localhost

--- a/salt/config.py
+++ b/salt/config.py
@@ -11,6 +11,7 @@ import socket
 import logging
 import urlparse
 from copy import deepcopy
+import time
 
 # import third party libs
 import yaml
@@ -2044,8 +2045,11 @@ def client_config(path, env_var='SALT_CLIENT_CONFIG', defaults=None):
         )
     # If the token file exists, read and store the contained token
     if os.path.isfile(opts['token_file']):
-        with salt.utils.fopen(opts['token_file']) as fp_:
-            opts['token'] = fp_.read().strip()
+        # Make sure token is still valid
+        expire = opts.get('token_expire', 43200)
+        if os.stat(opts['token_file']).st_mtime + expire > int(time.strftime("%s")):
+            with salt.utils.fopen(opts['token_file']) as fp_:
+                opts['token'] = fp_.read().strip()
     # On some platforms, like OpenBSD, 0.0.0.0 won't catch a master running on localhost
     if opts['interface'] == '0.0.0.0':
         opts['interface'] = '127.0.0.1'


### PR DESCRIPTION
Currently salt_token files that are older than token_expire are still used, resulting in a failed authentication.  This checks the modified time of the file and ignores files beyond the configured token_expire for that user.
