### PR TITLE
Fixes for pkg state docs

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -364,7 +364,7 @@ def installed(
 
     pkgs
         A list of packages to install from a software repository. All packages
-        listed under names will be installed via a single command.
+        listed under ``pkgs`` will be installed via a single command.
 
     Usage::
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -366,7 +366,6 @@ def installed(
         A list of packages to install from a software repository. All packages
         listed under names will be installed via a single command.
 
-
     Usage::
 
         mypkgs:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -363,8 +363,9 @@ def installed(
     Multiple Package Installation Options: (not supported in Windows or pkgng)
 
     pkgs
-        A list of packages to install from a software repository. Each package
-        will be installed individually by the package manager.
+        A list of packages to install from a software repository. All packages
+        listed under names will be installed via a single command.
+
 
     Usage::
 
@@ -417,8 +418,8 @@ def installed(
                     - baz
 
     names
-        A list of packages to install from a software repository. All packages
-        listed under names will be installed via a single command.
+        A list of packages to install from a software repository. Each package
+        will be installed individually by the package manager.
 
     Usage::
 


### PR DESCRIPTION
I put the docs for `pkgs` into `names` a few nights ago when I added `names`, and this just fixes that.
