### PR TITLE
Add zmqversion grain

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1196,6 +1196,16 @@ def saltversion():
     return {'saltversion': __version__}
 
 
+def zmqversion():
+    '''
+    Return the zeromq version
+    '''
+    # Provides:
+    #   zmqversion
+    import zmq
+    return {'zmqversion': zmq.zmq_version()}
+
+
 def saltversioninfo():
     '''
     Return the version_info of salt


### PR DESCRIPTION
Like saltversion, this grain can help show the effective version of a
particular component (in this case ZMQ) that is in use on the running
minion, and help aid in troubleshooting.
