### PR TITLE
Only allow certain linux systems to run keyboard module

### DIFF
--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 '''
-Module for managing keyboards on Arch, Redhat, Debian, and Gentoo systems.
+Module for managing keyboards on supported POSIX-like systems such as
+Arch, Redhat, Debian, and Gentoo systems.
 '''
 
 # Import python libs
@@ -11,7 +12,7 @@ log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
-    Only work on Arch, Redhat, Debian, and Gentoo
+    Only work on supported POSIX-like systems
     '''
     if __grains__['os_family'] in ('Arch', 'Redhat', 'Debian', 'Gentoo'):
         return 'keyboard'

--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -1,24 +1,22 @@
 # -*- coding: utf-8 -*-
 '''
-Module for managing keyboards on POSIX-like systems.
+Module for managing keyboards on Arch, Redhat, Debian, and Gentoo systems.
 '''
 
 # Import python libs
 import logging
-
-# Import salt libs
-import salt.utils
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
     '''
-    Only work on POSIX-like systems
+    Only work on Arch, Redhat, Debian, and Gentoo
     '''
-    if salt.utils.is_windows():
+    if __grains__['os_family'] in ('Arch', 'Redhat', 'Debian', 'Gentoo'):
+        return 'keyboard'
+    else:
         return False
-    return 'keyboard'
 
 
 def get_sys():
@@ -58,11 +56,17 @@ def set_sys(layout):
     if 'Arch' in __grains__['os_family']:
         __salt__['cmd.run']('localectl set-keymap {0}'.format(layout))
     elif 'RedHat' in __grains__['os_family']:
-        __salt__['file.sed']('/etc/sysconfig/keyboard', '^LAYOUT=.*', 'LAYOUT={0}'.format(layout))
+        __salt__['file.sed']('/etc/sysconfig/keyboard',
+                             '^LAYOUT=.*',
+                             'LAYOUT={0}'.format(layout))
     elif 'Debian' in __grains__['os_family']:
-        __salt__['file.sed']('/etc/default/keyboard', '^XKBLAYOUT=.*', 'XKBLAYOUT={0}'.format(layout))
+        __salt__['file.sed']('/etc/default/keyboard',
+                             '^XKBLAYOUT=.*',
+                             'XKBLAYOUT={0}'.format(layout))
     elif 'Gentoo' in __grains__['os_family']:
-        __salt__['file.sed']('/etc/conf.d/keymaps', '^keymap=.*', 'keymap={0}'.format(layout))
+        __salt__['file.sed']('/etc/conf.d/keymaps',
+                             '^keymap=.*',
+                             'keymap={0}'.format(layout))
     return layout
 
 


### PR DESCRIPTION
Previously, all non-windows systems were allowed to run this module, but it doesn't work with OS X.

I confirmed with @techhat that he wrote this module to only work for Arch, Redhat, Debian, and Gentoo families.
