### PR TITLE
Added load_text filter and import_text tag to Jinja environment

### DIFF
--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -510,6 +510,16 @@ class TestCustomExtensions(TestCase):
         with self.assertRaises(exceptions.TemplateNotFound):
             env.from_string('{% import_json "does not exists" as doc %}').render()
 
+    def test_load_text_template(self):
+        loader = DictLoader({'foo': 'Foo!'})
+        env = Environment(extensions=[SerializerExtension], loader=loader)
+
+        rendered = env.from_string('{% import_text "foo" as doc %}{{ doc }}').render()
+        self.assertEqual(rendered, u"Foo!")
+
+        with self.assertRaises(exceptions.TemplateNotFound):
+            env.from_string('{% import_text "does not exists" as doc %}').render()
+
     def test_catalog(self):
         loader = DictLoader({
             'doc1': '{bar: "my god is blue"}',


### PR DESCRIPTION
Adds loading text files off the file system (same as the current loading JSON and YAML files). This can, for example, load SSH keys or SSL certs off the file system and make those available to states as variables which allows people to keep those files as flat files and avoid having to reformat as valid YAML. I'll add usage docs for Pillar templates in a separate pull req.
