### PR TITLE
Clear available pkgs cache when available packages are likely to have changed

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -389,8 +389,8 @@ def check_db(*names, **kwargs):
     repo_arg = _get_repo_options(**kwargs)
     repoquery_base = '{0} --all --quiet --whatprovides'.format(repo_arg)
 
-    if 'avail' in __context__:
-        avail = __context__['avail']
+    if 'pkg._avail' in __context__:
+        avail = __context__['pkg._avail']
     else:
         # get list of available packages
         avail = []
@@ -407,7 +407,7 @@ def check_db(*names, **kwargs):
                 avail.append('.'.join((name, arch)))
             else:
                 avail.append(name)
-        __context__['avail'] = avail
+        __context__['pkg._avail'] = avail
 
     ret = {}
     for name in names:
@@ -717,7 +717,10 @@ def install(name=None,
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+    if ret:
+        __context__.pop('pkg._avail', None)
+    return ret
 
 
 def upgrade(refresh=True):
@@ -742,7 +745,10 @@ def upgrade(refresh=True):
     __salt__['cmd.run'](cmd, output_loglevel='debug')
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+    if ret:
+        __context__.pop('pkg._avail', None)
+    return ret
 
 
 def remove(name=None, pkgs=None, **kwargs):
@@ -785,7 +791,10 @@ def remove(name=None, pkgs=None, **kwargs):
     __salt__['cmd.run'](cmd, output_loglevel='debug')
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+    if ret:
+        __context__.pop('pkg._avail', None)
+    return ret
 
 
 def purge(name=None, pkgs=None, **kwargs):


### PR DESCRIPTION
yumpkg.py stores the information on available packages in `__context__` to avoid re-performing this data collection. However, if the configured repositories have changed (or if packages are installed/removed, since packages can provide repos), then this cache data may be outdated.

This pull req clears the variable from `__context__` in these cases, forcing `check_db()` to re-gather this information on its next run.

Resolves #11001.
