### PR TITLE
Less awkward file.check_hash(...)

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -415,7 +415,7 @@ def check_hash(path, hash):
         # Support "=" for backward compatibility.
         hash_parts = hash.split('=', 1)
         if len(hash_parts) != 2:
-          raise ValueError('Bad hash format: {0!r}'.format(hash))
+            raise ValueError('Bad hash format: {0!r}'.format(hash))
     hash_form, hash_value = hash_parts
     return get_hash(path, hash_form) == hash_value
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -401,16 +401,16 @@ def check_hash(path, hash):
     path
         A file path
     hash
-        A string in the form <hash_type>=<hash_value>. For example:
-        ``md5=e138491e9d5b97023cea823fe17bac22``
+        A string in the form <hash_type>:<hash_value>. For example:
+        ``md5:e138491e9d5b97023cea823fe17bac22``
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' file.check_hash /etc/fstab md5=<md5sum>
+        salt '*' file.check_hash /etc/fstab md5:<md5sum>
     '''
-    hash_parts = hash.split('=', 1)
+    hash_parts = hash.split(':', 1)
     if len(hash_parts) != 2:
         raise ValueError('Bad hash format: {0!r}'.format(hash))
     hash_form, hash_value = hash_parts

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -412,7 +412,10 @@ def check_hash(path, hash):
     '''
     hash_parts = hash.split(':', 1)
     if len(hash_parts) != 2:
-        raise ValueError('Bad hash format: {0!r}'.format(hash))
+        # Support "=" for backward compatibility.
+        hash_parts = hash.split('=', 1)
+        if len(hash_parts) != 2:
+          raise ValueError('Bad hash format: {0!r}'.format(hash))
     hash_form, hash_value = hash_parts
     return get_hash(path, hash_form) == hash_value
 


### PR DESCRIPTION
Named parameters on the command line are given on the form "key=val".
This makes things awkward when Salt command line needs to be written on
the form:

```
salt file.check_hash /etc/myfile hash=md5=abcabcabc
```

I'd much prefer

```
salt file.check_hash /etc/myfile md5:absabcabc
```

192d9c4439903b9ae940e76cbf3fd2e4accf02a3 makes sure this change is backward compatible to support the old syntax.
