### PR TITLE
Fix misuse of !r string formatting when building command line strings/lists

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1442,7 +1442,7 @@ def get_selections(pattern=None, state=None):
     ret = {}
     cmd = 'dpkg --get-selections'
     if pattern:
-        cmd += ' {0!r}'.format(pattern)
+        cmd += ' \'{0}\''.format(pattern)
     else:
         cmd += ' "*"'
     stdout = __salt__['cmd.run_stdout'](cmd, output_loglevel='debug')

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -108,18 +108,18 @@ def add(name,
     if not isinstance(gid, int):
         raise SaltInvocationError('gid must be an integer')
 
-    _dscl('/Users/{0} UniqueID {1!r}'.format(name, uid))
-    _dscl('/Users/{0} PrimaryGroupID {1!r}'.format(name, gid))
-    _dscl('/Users/{0} UserShell {1!r}'.format(name, shell))
-    _dscl('/Users/{0} NFSHomeDirectory {1!r}'.format(name, home))
-    _dscl('/Users/{0} RealName {1!r}'.format(name, fullname))
+    _dscl('/Users/{0} UniqueID \'{1}\''.format(name, uid))
+    _dscl('/Users/{0} PrimaryGroupID \'{1}\''.format(name, gid))
+    _dscl('/Users/{0} UserShell \'{1}\''.format(name, shell))
+    _dscl('/Users/{0} NFSHomeDirectory \'{1}\''.format(name, home))
+    _dscl('/Users/{0} RealName \'{1}\''.format(name, fullname))
 
     # Set random password, since without a password the account will not be
     # available. TODO: add shadow module
     randpass = ''.join(
         random.choice(string.letters + string.digits) for x in xrange(20)
     )
-    _dscl('/Users/{0} {1!r}'.format(name, randpass), ctype='passwd')
+    _dscl('/Users/{0} \'{1}\''.format(name, randpass), ctype='passwd')
 
     # dscl buffers changes, sleep before setting group membership
     time.sleep(1)
@@ -189,7 +189,7 @@ def chuid(name, uid):
     if uid == pre_info['uid']:
         return True
     _dscl(
-        '/Users/{0} UniqueID {1!r} {2!r}'.format(name, pre_info['uid'], uid),
+        '/Users/{0} UniqueID \'{1}\' \'{2}\''.format(name, pre_info['uid'], uid),
         ctype='change'
     )
     # dscl buffers changes, sleep 1 second before checking if new value
@@ -216,7 +216,7 @@ def chgid(name, gid):
     if gid == pre_info['gid']:
         return True
     _dscl(
-        '/Users/{0} PrimaryGroupID {1!r} {2!r}'.format(
+        '/Users/{0} PrimaryGroupID \'{1}\' \'{2}\''.format(
             name, pre_info['gid'], gid
         ),
         ctype='change'
@@ -243,7 +243,7 @@ def chshell(name, shell):
     if shell == pre_info['shell']:
         return True
     _dscl(
-        '/Users/{0} UserShell {1!r} {2!r}'.format(
+        '/Users/{0} UserShell \'{1}\' \'{2}\''.format(
             name, pre_info['shell'], shell
         ),
         ctype='change'
@@ -270,7 +270,7 @@ def chhome(name, home):
     if home == pre_info['home']:
         return True
     _dscl(
-        '/Users/{0} NFSHomeDirectory {1!r} {2!r}'.format(
+        '/Users/{0} NFSHomeDirectory \'{1}\' \'{2}\''.format(
             name, pre_info['home'], home
         ),
         ctype='change'
@@ -298,7 +298,7 @@ def chfullname(name, fullname):
     if fullname == pre_info['fullname']:
         return True
     _dscl(
-        '/Users/{0} RealName {1!r}'.format(name, fullname),
+        '/Users/{0} RealName \'{1}\''.format(name, fullname),
         # use a "create" command, because a "change" command would fail if
         # current fullname is an empty string. The "create" will just overwrite
         # this field.

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -314,7 +314,7 @@ def install(pkgs=None,
                 )
                 __salt__['file.chown'](treq, user, None)
                 cleanup_requirements.append(treq)
-            cmd.append('--requirement={0!r}'.format(treq or requirement))
+            cmd.append('--requirement={0}'.format(treq or requirement))
 
     if use_wheel:
         min_version = '1.4'
@@ -339,7 +339,7 @@ def install(pkgs=None,
         cmd.append('--log={0}'.format(log))
 
     if proxy:
-        cmd.append('--proxy={0!r}'.format(proxy))
+        cmd.append('--proxy={0}'.format(proxy))
 
     if timeout:
         try:
@@ -372,14 +372,14 @@ def install(pkgs=None,
             raise CommandExecutionError(
                 '{0!r} must be a valid URL'.format(index_url)
             )
-        cmd.append('--index-url={0!r}'.format(index_url))
+        cmd.append('--index-url={0}'.format(index_url))
 
     if extra_index_url:
         if not salt.utils.valid_url(extra_index_url, VALID_PROTOS):
             raise CommandExecutionError(
                 '{0!r} must be a valid URL'.format(extra_index_url)
             )
-        cmd.append('--extra-index-url={0!r}'.format(extra_index_url))
+        cmd.append('--extra-index-url={0}'.format(extra_index_url))
 
     if no_index:
         cmd.append('--no-index')
@@ -453,14 +453,14 @@ def install(pkgs=None,
             global_options = [go.strip() for go in global_options.split(',')]
 
         for opt in global_options:
-            cmd.append('--global-option={0!r}'.format(opt))
+            cmd.append('--global-option={0}'.format(opt))
 
     if install_options:
         if isinstance(install_options, string_types):
             install_options = [io.strip() for io in install_options.split(',')]
 
         for opt in install_options:
-            cmd.append('--install-option={0!r}'.format(opt))
+            cmd.append('--install-option={0}'.format(opt))
 
     if pkgs:
         if isinstance(pkgs, string_types):
@@ -471,7 +471,7 @@ def install(pkgs=None,
         # Put the commas back in while making sure the names are contained in
         # quotes, this allows for proper version spec passing salt>=0.17.0
         cmd.extend(
-            ['{0!r}'.format(p.replace(';', ',')) for p in pkgs]
+            ['{0}'.format(p.replace(';', ',')) for p in pkgs]
         )
 
     if editable:
@@ -630,7 +630,7 @@ def uninstall(pkgs=None,
                 )
                 __salt__['file.chown'](treq, user, None)
                 cleanup_requirements.append(treq)
-            cmd.append('--requirement={0!r}'.format(treq or requirement))
+            cmd.append('--requirement={0}'.format(treq or requirement))
 
     if log:
         try:
@@ -642,7 +642,7 @@ def uninstall(pkgs=None,
         cmd.append('--log={0}'.format(log))
 
     if proxy:
-        cmd.append('--proxy={0!r}'.format(proxy))
+        cmd.append('--proxy={0}'.format(proxy))
 
     if timeout:
         try:

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -36,7 +36,7 @@ def _parse_pkg_meta(path):
                          'certainly a bug.')
             return '', ''
         pkginfo = __salt__['cmd.run_stdout'](
-            'rpm -qp --queryformat {0!r} {1!r}'.format(
+            'rpm -qp --queryformat \'{0}\' \'{1}\''.format(
                 # Binary packages have no REPOID, replace this so the rpm
                 # command does not fail with "invalid tag" error
                 __QUERYFORMAT.replace('%{REPOID}', 'binarypkg'),
@@ -51,7 +51,7 @@ def _parse_pkg_meta(path):
 
     def parse_rpm_suse(path):
         pkginfo = __salt__['cmd.run_stdout'](
-            'rpm -qp --queryformat {0!r} {1!r}'.format(
+            'rpm -qp --queryformat \'{0}\' \'{1}\''.format(
                 r'%{NAME}_|-%{VERSION}_|-%{RELEASE}\n',
                 path
             )

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -62,9 +62,9 @@ def _pkg(jail=None, chroot=None):
     '''
     ret = 'pkg'
     if jail:
-        ret += ' -j {0!r}'.format(jail)
+        ret += ' -j \'{0}\''.format(jail)
     elif chroot:
-        ret += ' -c {0!r}'.format(chroot)
+        ret += ' -c \'{0}\''.format(chroot)
     return ret
 
 
@@ -477,7 +477,7 @@ def backup(file_name, jail=None, chroot=None):
             salt '*' pkg.backup /tmp/pkg chroot=/path/to/chroot
     '''
     res = __salt__['cmd.run'](
-        '{0} backup -d {1!r}'.format(_pkg(jail, chroot), file_name),
+        '{0} backup -d \'{1}\''.format(_pkg(jail, chroot), file_name),
         output_loglevel='debug'
     )
     return res.split('...')[1]
@@ -517,7 +517,7 @@ def restore(file_name, jail=None, chroot=None):
             salt '*' pkg.restore /tmp/pkg chroot=/path/to/chroot
     '''
     return __salt__['cmd.run'](
-        '{0} backup -r {0!r}'.format(_pkg(jail, chroot), file_name),
+        '{0} backup -r \'{0}\''.format(_pkg(jail, chroot), file_name),
         output_loglevel='debug'
     )
 

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -357,11 +357,11 @@ def db_create(name,
     with_args = {
         # owner needs to be enclosed in double quotes so postgres
         # doesn't get thrown by dashes in the name
-        'OWNER': owner and '"{0}"'.format(owner),
+        'OWNER': owner and '\'{0}\''.format(owner),
         'TEMPLATE': template,
-        'ENCODING': encoding and '{0!r}'.format(encoding),
-        'LC_COLLATE': lc_collate and '{0!r}'.format(lc_collate),
-        'LC_CTYPE': lc_ctype and '{0!r}'.format(lc_ctype),
+        'ENCODING': encoding and '\'{0}\''.format(encoding),
+        'LC_COLLATE': lc_collate and '\'{0}\''.format(lc_collate),
+        'LC_CTYPE': lc_ctype and '\'{0}\''.format(lc_ctype),
         'TABLESPACE': tablespace,
     }
     with_chunks = []
@@ -648,7 +648,7 @@ def _role_cmd_args(name,
     ):
         skip_passwd = True
     if isinstance(rolepassword, basestring) and bool(rolepassword):
-        escaped_password = '{0!r}'.format(
+        escaped_password = '\'{0}\''.format(
             _maybe_encrypt_password(name,
                                     rolepassword.replace('\'', '\'\''),
                                     encrypted=encrypted))

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -126,7 +126,7 @@ def add_user(name, password=None, runas=None):
             string.ascii_uppercase + string.digits) for x in range(15))
 
     res = __salt__['cmd.run'](
-        'rabbitmqctl add_user {0} {1!r}'.format(name, password),
+        'rabbitmqctl add_user {0} \'{1}\''.format(name, password),
         runas=runas)
 
     if clear_pw:
@@ -172,7 +172,7 @@ def change_password(name, password, runas=None):
         salt '*' rabbitmq.change_password rabbit_user password
     '''
     res = __salt__['cmd.run'](
-        'rabbitmqctl change_password {0} {1!r}'.format(name, password),
+        'rabbitmqctl change_password {0} \'{1}\''.format(name, password),
         runas=runas)
     msg = 'Password Changed'
 

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -206,7 +206,7 @@ def _chroot_exec(root, cmd):
     if os.path.isfile(os.path.join(root, 'bin/bash')):
         sh_ = '/bin/bash'
 
-    cmd = 'chroot {0} {1} -c {2!r}'.format(
+    cmd = 'chroot {0} {1} -c \'{2}\''.format(
         root,
         sh_,
         cmd)

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -222,7 +222,7 @@ def create(path,
             else:
                 cmd.append('--never-download')
         if prompt is not None and prompt.strip() != '':
-            cmd.append('--prompt={0!r}'.format(prompt))
+            cmd.append('--prompt={0}'.format(prompt))
     else:
         # venv module from the Python >= 3.3 standard library
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -130,16 +130,16 @@ def _get_repo_options(**kwargs):
     repo_arg = ''
     if fromrepo:
         log.info('Restricting to repo {0!r}'.format(fromrepo))
-        repo_arg = ('--disablerepo={0!r} --enablerepo={1!r}'
+        repo_arg = ('--disablerepo=\'{0}\' --enablerepo=\'{1}\''
                     .format('*', fromrepo))
     else:
         repo_arg = ''
         if disablerepo:
             log.info('Disabling repo {0!r}'.format(disablerepo))
-            repo_arg += '--disablerepo={0!r} '.format(disablerepo)
+            repo_arg += '--disablerepo=\'{0}\''.format(disablerepo)
         if enablerepo:
             log.info('Enabling repo {0!r}'.format(enablerepo))
-            repo_arg += '--enablerepo={0!r} '.format(enablerepo)
+            repo_arg += '--enablerepo=\'{0}\''.format(enablerepo)
     return repo_arg
 
 
@@ -413,7 +413,7 @@ def check_db(*names, **kwargs):
     for name in names:
         ret.setdefault(name, {})['found'] = name in avail
         if not ret[name]['found']:
-            repoquery_cmd = repoquery_base + ' {0!r}'.format(name)
+            repoquery_cmd = repoquery_base + ' \'{0}\''.format(name)
             provides = set(x.name for x in _repoquery_pkginfo(repoquery_cmd))
             if provides:
                 for pkg in provides:
@@ -899,7 +899,7 @@ def group_info(name):
         'default packages': [],
         'description': ''
     }
-    cmd_template = 'repoquery --group --grouppkgs={0} --list {1!r}'
+    cmd_template = 'repoquery --group --grouppkgs={0} --list \'{1}\''
 
     cmd = cmd_template.format('all', name)
     out = __salt__['cmd.run_stdout'](cmd, output_loglevel='debug')
@@ -923,7 +923,7 @@ def group_info(name):
     # considered to be conditional packages.
     ret['conditional packages'] = sorted(all_pkgs)
 
-    cmd = 'repoquery --group --info {0!r}'.format(name)
+    cmd = 'repoquery --group --info \'{0}\''.format(name)
     out = __salt__['cmd.run_stdout'](cmd, output_loglevel='debug')
     if out:
         ret['description'] = '\n'.join(out.splitlines()[1:]).strip()

--- a/salt/pillar/hiera.py
+++ b/salt/pillar/hiera.py
@@ -32,7 +32,7 @@ def ext_pillar(minion_id, pillar, conf):
     cmd = 'hiera -c {0}'.format(conf)
     for key, val in __grains__.items():
         if isinstance(val, string_types):
-            cmd += ' {0}={1!r}'.format(key, val)
+            cmd += ' {0}=\'{1}\''.format(key, val)
     try:
         data = yaml.safe_load(__salt__['cmd.run'](cmd))
     except Exception:

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -143,10 +143,10 @@ class PrintableDict(OrderedDict):
         for key, value in self.items():
             if isinstance(value, string_types):
                 # keeps quotes around strings
-                output.append('{0!r}: {1!r}'.format(key, value))
+                output.append('\'{0}\': \'{1}\''.format(key, value))
             else:
                 # let default output
-                output.append('{0!r}: {1!s}'.format(key, value))
+                output.append('\'{0}\': {1!s}'.format(key, value))
         return '{' + ', '.join(output) + '}'
 
     def __repr__(self):  # pylint: disable=W0221

--- a/tests/jenkins.py
+++ b/tests/jenkins.py
@@ -318,7 +318,7 @@ def run(opts):
     # Do we need extra setup?
     if opts.salt_url != SALT_GIT_URL:
         cmds = (
-            'salt -t 100 {vm_name} git.remote_set /testing name={0!r} url={1!r}'.format(
+            'salt -t 100 {vm_name} git.remote_set /testing name=\'{0}\' url=\'{1}\''.format(
                 'upstream',
                 SALT_GIT_URL,
                 vm_name=vm_name


### PR DESCRIPTION
Where cli strings are being used then use single quotes. You want to run `mkdir '/foo\ bar'` not `mkdir '/foo\\ bar'`.

Where cli lists are being used then don't quote at all, subprocess handles this already:

```
>>> subprocess.list2cmdline(['mkdir', 'foo\ bar'])
'mkdir "foo\\ bar"'
```

I've left all log/error/exception messages as is.

Fixes issue #9592 and a similar issue in yum.
