### PR TITLE
Add BSD fallback for syspaths.CONFIG_DIR

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -40,12 +40,16 @@ try:
     )
 except ImportError:
     # The installation time was not generated, let's define the default values
-    if sys.platform.startswith('win'):
+    platform = sys.platform.lower()
+    if platform.startswith('win'):
         ROOT_DIR = r'c:\salt' or '/'
         CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
     else:
         ROOT_DIR = '/'
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
+        if 'bsd' in platform:
+            CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
+        else:
+            CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
     CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')
     SOCK_DIR = os.path.join(ROOT_DIR, 'var', 'run', 'salt')
     SRV_ROOT_DIR = os.path.join(ROOT_DIR, 'srv')


### PR DESCRIPTION
In the absence of _syspaths.py, make sure that the BSDs still look for
configuration files in /usr/local/etc/salt.
