### PR TITLE
Add BSD fallback for syspaths.CONFIG_DIR (2014.1 branch)

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -40,13 +40,13 @@ try:
     )
 except ImportError:
     # The installation time was not generated, let's define the default values
-    platform = sys.platform.lower()
-    if platform.startswith('win'):
+    __platform = sys.platform.lower()
+    if __platform.startswith('win'):
         ROOT_DIR = r'c:\salt' or '/'
         CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
     else:
         ROOT_DIR = '/'
-        if 'bsd' in platform:
+        if 'bsd' in __platform:
             CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
         else:
             CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -40,12 +40,16 @@ try:
     )
 except ImportError:
     # The installation time was not generated, let's define the default values
-    if sys.platform.startswith('win'):
+    platform = sys.platform.lower()
+    if platform.startswith('win'):
         ROOT_DIR = r'c:\salt' or '/'
         CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
     else:
         ROOT_DIR = '/'
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
+        if 'bsd' in platform:
+            CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
+        else:
+            CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
     CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')
     SOCK_DIR = os.path.join(ROOT_DIR, 'var', 'run', 'salt')
     SRV_ROOT_DIR = os.path.join(ROOT_DIR, 'srv')


### PR DESCRIPTION
**Note: as this bugfix spans two separate pull reqs against develop, I am submitting them together as a pull req against 2014.1 to ensure they are merged to 2014.1 together.**

In the absence of _syspaths.py, make sure that the BSDs still look for
configuration files in /usr/local/etc/salt.
