### PR TITLE
fix indentation in salt.output.highstate

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -123,13 +123,13 @@ def _format_host(host, data):
                 state_lines.insert(
                     3, '    {tcolor}    Name: {comps[2]}{colors[ENDC]}')
             try:
-               comment = ret['comment'].strip().replace(
-                   '\n',
-                   '\n' + ' ' * 14)
+                comment = ret['comment'].strip().replace(
+                    '\n',
+                    '\n' + ' ' * 14)
             except AttributeError:
-               comment = ret['comment'].join(' ').replace(
-                   '\n',
-                   '\n' + ' ' * 13)
+                comment = ret['comment'].join(' ').replace(
+                    '\n',
+                    '\n' + ' ' * 13)
             svars = {
                 'tcolor': tcolor,
                 'comps': comps,


### PR DESCRIPTION
```
************* Module salt.output.highstate
salt/output/highstate.py:126: [W0311(bad-indentation), ] Bad indentation. Found 15 spaces, expected 16
salt/output/highstate.py:130: [W0311(bad-indentation), ] Bad indentation. Found 15 spaces, expected 16
```
