### PR TITLE
pkgrepo state: add missing import of `sys` module

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -57,6 +57,9 @@ Package repositories can be managed with the pkgrepo state:
     once ``python-software-properties`` is installed.
 '''
 
+# Import python libs
+import sys
+
 # Import salt libs
 from salt.modules.aptpkg import _strip_uri
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS


### PR DESCRIPTION
```
************* Module salt.states.pkgrepo
salt/states/pkgrepo.py:303: [E0602(undefined-variable), managed] Undefined variable 'sys'
salt/states/pkgrepo.py:379: [E0602(undefined-variable), absent] Undefined variable 'sys'
```
