### PR TITLE
Added docs for the extension_modules setting

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -67,6 +67,11 @@
 # Directory to store job and cache data
 #cachedir: /var/cache/salt/master
 
+# Directory for custom modules. This directory can contain subdirectories for
+# each of Salt's module types such as "runners", "output", "wheel", "modules",
+# "states", "returners", etc.
+#extension_modules: <no default>
+
 # Verify and set permissions on configuration directories at startup
 #verify_env: True
 

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -180,6 +180,19 @@ The directory to store the pki authentication keys.
 
     pki_dir: /etc/salt/pki
 
+.. conf_master:: extension_modules
+
+``extension_modules``
+---------------------
+
+Directory for custom modules. This directory can contain subdirectories for
+each of Salt's module types such as "runners", "output", "wheel", "modules",
+"states", "returners", etc. This path is appended to :conf_master:`root_dir`.
+
+.. code-block:: yaml
+
+    extension_modules: srv/modules
+
 .. conf_master:: cachedir
 
 ``cachedir``


### PR DESCRIPTION
Refs #11030

@thatch45 I know this directory is also used for caching custom modules. Is there a better way to word this description?
