### PR TITLE
Allow for pkgname.x86_64 to be used in pkg states

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -144,9 +144,10 @@ def _repack_pkgs(pkgs):
     Repack packages specified using "pkgs" argument to pkg states into a single
     dictionary
     '''
+    _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
     return dict(
         [
-            (str(x), str(y) if y is not None else y)
+            (_normalize_name(str(x)), str(y) if y is not None else y)
             for x, y in salt.utils.repack_dictlist(pkgs).iteritems()
         ]
     )
@@ -166,6 +167,7 @@ def pack_sources(sources):
 
         salt '*' pkg_resource.pack_sources '[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
     '''
+    _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
     if isinstance(sources, basestring):
         try:
             sources = yaml.safe_load(sources)
@@ -179,7 +181,8 @@ def pack_sources(sources):
             log.error('Input must be a list of 1-element dicts')
             return {}
         else:
-            ret.update(source)
+            key = next(iter(source))
+            ret[_normalize_name(key)] = source[key]
     return ret
 
 

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -287,7 +287,10 @@ def parse_targets(name=None,
         return [x[2] for x in srcinfo], 'file'
 
     elif name:
-        return dict([(x, None) for x in name.split(',')]), 'repository'
+        _normalize_name = \
+            __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+        packed = dict([(_normalize_name(x), None) for x in name.split(',')])
+        return packed, 'repository'
 
     else:
         log.error('No package sources passed to pkg.install.')

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -143,6 +143,28 @@ def _get_repo_options(**kwargs):
     return repo_arg
 
 
+def normalize_name(name):
+    '''
+    Strips the architecture from the specified package name, if necessary (in
+    other words, if the arch matches the OS arch, or is ``noarch``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.normalize_name zsh.x86_64
+    '''
+    try:
+        arch = name.rsplit('.', 1)[-1]
+        if arch not in __ARCHES + ('noarch',):
+            return name
+    except ValueError:
+        return name
+    if arch in (__grains__['osarch'], 'noarch'):
+        return name[:-(len(arch) + 1)]
+    return name
+
+
 def latest_version(*names, **kwargs):
     '''
     Return the latest version of the named package available for upgrade or

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -40,12 +40,14 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt.utils import namespaced_function as _namespaced_function
 from salt._compat import string_types
 from salt.exceptions import CommandExecutionError, MinionError
 from salt.modules.pkg_resource import _repack_pkgs
 
+_repack_pkgs = _namespaced_function(_repack_pkgs, globals())
+
 if salt.utils.is_windows():
-    from salt.utils import namespaced_function as _namespaced_function
     from salt.modules.win_pkg import _get_package_info
     from salt.modules.win_pkg import get_repo_data
     from salt.modules.win_pkg import _get_latest_pkg_version
@@ -154,7 +156,8 @@ def _find_install_targets(name=None,
                                    'repository.'.format(name)}
             if version is None:
                 version = _get_latest_pkg_version(pkginfo)
-        desired = {name: version}
+        _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+        desired = {_normalize_name(name): version}
         to_unpurge = _find_unpurge_targets(desired)
 
         cver = cur_pkgs.get(name, [])


### PR DESCRIPTION
This pull request allows for one to specify a package name `zsh.x86_64` on a RHEL-based system, and have it be properly recognized as just `zsh` by the state.

This allows the package name to match the output of `pkg.list_pkgs`, keeping a package state with a target of `zsh.x86_64` from failing despite success in installing the package.

Fixes #7306.
