### PR TITLE
add kwargs to saltutil.find_jobs

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -439,7 +439,7 @@ def running():
     return ret
 
 
-def find_job(jid):
+def find_job(jid, **kwargs):
     '''
     Return the data for a specific job id
 


### PR DESCRIPTION
It is needed for salt-run and if you use
startup_states: highstate.  This is some of the extra information that
is being passed to the module during an overstate.

```
[DEBUG   ] Find_jobs kwargs: {'__pub_user': 'root', '__pub_arg':
['20140310075236807376', {'raw': True, '__kwarg__': True}], '__pub_fun':
'saltutil.find_job', 'raw': True, '__pub_jid': '20140310075337811291',
'__pub_tgt': ['two.gluster.gtmanfred.com', 'four.gluster.gtmanfred.com',
'five.gluster.gtmanfred.com', 'one.gluster.gtmanfred.com',
'seven.gluster.gtmanfred.com', 'three.gluster.gtmanfred.com',
'six.gluster.gtmanfred.com', 'eight.gluster.gtmanfred.com'],
'__pub_tgt_type': 'list', '__pub_ret': ''}
```
