### PR TITLE
Fix master._clear_old_jobs for ext_pillars with root parameter

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -161,8 +161,23 @@ class Master(SMaster):
         pillargitfs = []
         for opts_dict in [x for x in self.opts.get('ext_pillar', [])]:
             if 'git' in opts_dict:
-                br, loc = opts_dict['git'].strip().split()
-                pillargitfs.append(git_pillar.GitPillar(br, loc, self.opts))
+                parts = opts_dict['git'].strip().split()
+                try:
+                    br = parts[0]
+                    loc = parts[1]
+                except IndexError:
+                    log.critical(
+                        'Unable to extract exttermal pillar data: {0}'
+                        .format(opts_dict['git'])
+                    )
+                else:
+                    pillargitfs.append(
+                        git_pillar.GitPillar(
+                            br,
+                            loc,
+                            self.opts
+                        )
+                    )
 
         # Clear remote fileserver backend env cache so it gets recreated during
         # the first loop_interval

--- a/salt/master.py
+++ b/salt/master.py
@@ -167,7 +167,7 @@ class Master(SMaster):
                     loc = parts[1]
                 except IndexError:
                     log.critical(
-                        'Unable to extract exttermal pillar data: {0}'
+                        'Unable to extract external pillar data: {0}'
                         .format(opts_dict['git'])
                     )
                 else:


### PR DESCRIPTION
Pillars can now have a root=subdirectory parameter added to it which allows pillars to be loaded from a sub directory within a git repository, see:

http://docs.saltstack.com/topics/tutorials/gitfs.html#using-git-as-an-external-pillar-source

For example:

```
ext_pillar:
  - git: master https://domain.com/pillar.git root=subdirectory
```

However when the Salt Master attempts to clear old jobs it only unpacks out the ext_pillar option in to 2 values by splitting the string at spaces. This results in a `ValueError: too many values to unpack` error when the Salt Master starts and prevents Salt from downloading externally hosted States.

Seeing as we only need the branch and location this solution breaks string and gets the first 2 elements we need of the split list and raises an exception if this fails.
