### PR TITLE
Complying with ISO 8601, don't omit the [T]

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -323,7 +323,7 @@ class SaltEvent(object):
         if not self.cpush:
             self.connect_pull(timeout=timeout)
 
-        data['_stamp'] = datetime.datetime.now().isoformat('_')
+        data['_stamp'] = datetime.datetime.now().isoformat()
 
         tagend = ''
         if len(tag) <= 20:  # old style compatible tag


### PR DESCRIPTION
These events are useful and the timestamp is critical. Please don't change the standards. The rest of salt code does this correctly. If you need it for readability I suggest taking the event and emitting a log message with the format you wish to view it or tell your application reading the event to change the standard into non-standard.

---

ISO 8601:2004(E): ISO. 2004-12-01. "4.3.2 NOTE: By mutual agreement of the partners in information interchange,  **the character[T] may be omitted in applications where there is no risk of confusing a date and time of day representation with others defined in this International Standard.**
