### PR TITLE
Prevent zombies

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -805,6 +805,8 @@ class Minion(MinionBase):
                 name=data['jid']
             )
         process.start()
+        if not sys.platform.startswith('win'):
+            process.join()
 
     @classmethod
     def _thread_return(cls, minion_instance, opts, data):


### PR DESCRIPTION
Join multiprocess because otherwise it never gets cleaned up. Resolves #10867.
