### PR TITLE
Partial fix for cron.present broken on SmartOS

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -46,13 +46,27 @@ def _cron_matched(cron, cmd, identifier=None):
     cid = _cron_id(cron)
     if cid:
         eidentifier = _encode(identifier)
+
+        # If commands match and identifier not set,
+        # set current identifier as identifier
+
         if (
             cron.get('cmd', None) == cmd
             and cid == SALT_CRON_NO_IDENTIFIER
             and identifier
         ):
             cid = eidentifier
-        id_matched = eidentifier == cid
+
+        # If the identifiers are the same, the set
+        # id_matched true, but make sure we aren't
+        # comparing the default identifiers
+        
+        if ( 
+            eidentifier != SALT_CRON_NO_IDENTIFIER
+            and cid != SALT_CRON_NO_IDENTIFIER
+        ):
+            id_matched = eidentifier == cid
+
     if (
         ((id_matched is None) and cmd == cron.get('cmd', None))
         or id_matched


### PR DESCRIPTION
This fixes part of my issue in #10959 where cron.present couldn't add more than a single job. So far, I've only tested this on develop, but my problem came down to the fact that the cron jobs were being created with the same default identifier, and then the cron code thought they were the same job.

I haven't tested it on other platforms, but it is possible this bug is affecting them as well since this is not a SmartOS specific codepath.
