### PR TITLE
Fix for #10656: __env__ should be passed around instead of env

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -464,7 +464,7 @@ def file(name,
     # If the source is a list then find which file exists
     source, source_hash = __salt__['file.source_list'](source,
                                                        source_hash,
-                                                       env)
+                                                       __env__)
 
     # Gather the source file from the server
     try:
@@ -476,7 +476,7 @@ def file(name,
             owner,
             group,
             mode,
-            env,
+            __env__,
             context,
             defaults,
             **kwargs
@@ -503,7 +503,7 @@ def file(name,
             owner,
             group,
             mode,
-            env,
+            __env__,
             backup
         )
     except Exception as exc:


### PR DESCRIPTION
This is a fix for cron state where env variable is passed around instead of **env**.  Leading to this problem:

```
[INFO ] Running state [salt://cron/configs/ops_root.txt] at time 16:47:40.498803
[INFO ] Executing state cron.file for salt://cron/configs/ops_root.txt
[INFO ] Executing command 'crontab -l -u root' in directory '/root'
[INFO ] stdout: #

[ERROR ] Unable to manage file: 'NoneType' object has no attribute 'startswith'
[INFO ] Completed state [salt://cron/configs/ops_root.txt] at time 16:47:40.521779
```
