### PR TITLE
Added document for use of salt-cloud with HP Cloud 1.1

### DIFF
--- a/doc/topics/cloud/hpcloud.rst
+++ b/doc/topics/cloud/hpcloud.rst
@@ -1,0 +1,131 @@
+==============================
+Getting Started With HP Cloud 
+==============================
+
+HP Cloud is a major public cloud platform and uses the libcloud 
+`openstack` driver. The current version of OpenStack that HP Cloud
+uses is Grizzly. When an instance is booted, it must have a 
+floating IP added to it in order to connect to it and further below 
+you will see an example that adds context to this statement.
+
+To use the `openstack` driver for HP Cloud, set up the cloud 
+provider configuration file as in the example shown below: 
+  ``/etc/salt/cloud.providers.d/hpcloud.conf``:
+
+.. code-block:: yaml
+
+    hpcloud-config:
+      # Set the location of the salt-master
+      #
+      minion:
+        master: saltmaster.example.com
+
+      # Configure HP Cloud using the OpenStack plugin
+      #
+      identity_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/tokens
+      compute_name: Compute 
+      protocol: ipv4
+
+      # Set the compute region:
+      #
+      compute_region: region-b.geo-1 
+
+      # Configure HP Cloud authentication credentials
+      #
+      user: myname
+      tenant: myname-project1  
+      password: xxxxxxxxx
+
+      # keys to allow connection to the instance launched
+      #
+      ssh_key_name: yourkey
+      ssh_key_file: /path/to/key/yourkey.priv
+
+      provider: openstack
+
+
+The subsequent example that follows is using the openstack driver.
+
+
+Compute Region
+==============
+
+Originally, HP Cloud, in its OpenStack Essex version (1.0), had 3
+availability zones in one region, AW2, which each behaved as a region should. 
+This has since changed, and the current OpenStack Grizzly version of 
+HP Cloud (1.1) now has simplified this and now has two regions to choose from:
+
+.. code-block:: bash
+
+    region-a.geo-1 -> AW2/US West 
+    region-b.geo-1 -> AE1/US East
+
+Authentication
+==============
+
+The ``user`` is the same user as is used to log into the HP Cloud management
+UI. The ``tenant`` can be found in the upper left under "Project/Region/Scope". 
+It is often named the same as ``user`` albeit with a ``-project1`` appended.
+The ``password`` is of course what you created your account with. The management
+UI also has other information such as being able to select US East or US West 
+(AE1 or AW2). 
+
+The profile shown below is a know working profile for an Ubuntu instance. The
+profile configuration file is stored in the following location:
+
+``/etc/salt/cloud.profiles.d/hp_ae1_ubuntu.conf``:
+
+.. code-block:: yaml
+
+    hp_ae1_ubuntu:
+        provider: hp_ae1 
+        image: 9302692b-b787-4b52-a3a6-daebb79cb498 
+        ignore_cidr: 10.0.0.1/24
+        networks:
+          - floating: Ext-Net
+        size: standard.small
+        ssh_key_file: /root/keys/test.key
+        ssh_key_name: test
+        ssh_username: ubuntu
+
+Some important things about the example above:
+
+* The ``image`` parameter can use either the image name or image ID which you can obtain by running in the example below (this case AE1):
+
+.. code-block:: bash 
+
+    # salt-cloud --list-images hp_ae1
+
+* The parameter ``ignore_cidr`` specifies a range of addresses to ignore when trying to connect to the instance. In this case, it's the range of IP addresses used for an internal IP of the instance. 
+
+* The parameter ``networks`` is very important to include. This is what makes it possible for salt-cloud to be able to attach a floating IP to the instance in order to connect to the instance and set up the minion
+
+* The ``ssh_key_file`` and ``ssh_key_name`` are the keys that will make it possible to connect to the instance to set up the minion
+
+* The ``ssh_username`` parameter, in this case, being that the image used will be ubuntu, will make it possible to not only log in but install the minion 
+
+
+
+To instantiate a machine based on this profile (example):
+
+.. code-block:: bash
+
+    # salt-cloud -p hp_ae1_ubuntu ubuntu_instance_1
+
+
+After several minutes, this will create an instance named ubuntu_instance_1
+running in HP Cloud in the AE1 region and will set up the minion and then 
+return information about the instance once completed.
+
+Once the instance has been created with salt-minion installed, connectivity to 
+it can be verified with Salt:
+
+.. code-block:: bash
+
+    # salt ubuntu_instance_1 ping
+
+Additionally, the instance can be acessed via SSH using the floating IP assigned to it
+
+.. code-block:: bash
+
+    # ssh ubuntu@<floating ip>

--- a/doc/topics/cloud/index.rst
+++ b/doc/topics/cloud/index.rst
@@ -22,6 +22,7 @@ Getting Started
     Getting Started With OpenStack <openstack>
     Getting Started With Parallels <parallels>
     Getting Started With Rackspace <rackspace>
+    Getting Started With HP Cloud <hpcloud>
     Getting Started With SoftLayer <softlayer>
 
 Core Configuration


### PR DESCRIPTION
Hi there! I have finally found a way to get salt-cloud to work with HP Cloud 1.1 (OpenStack Grizzly-based). The docs for salt-cloud (salt-cloud.readthedocs.org) is way out of date and even the current docs that are now part of salt itself are lacking some documentation for features that I was only able to find in the source. 
