### PR TITLE
Ssh work

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -113,6 +113,14 @@ Due to the fact that the targeting approach differs in salt-ssh, only glob
 and regex targets are supported as of this writing, the remaining target
 systems still need to be implemented.
 
+Configuring Salt SSH
+====================
+
+Salt SSH takes its configuration from a master configuration file. Normally, this
+file is in ``/etc/salt/master``. If one wishes to use a customized configuration file,
+the ``-c`` option to Salt SSH facilitates passing in a directory to look inside for a 
+configuration file named ``master``.
+
 Running Salt SSH as non-root user
 =================================
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -59,12 +59,12 @@ SSH_SHIM = r'''/bin/sh << 'EOF'
          MISS_PKG="$MISS_PKG tar"
       fi
 
-      for py_candidate in \\
-            python27      \\
-            python2.7     \\
-            python26      \\
-            python2.6     \\
-            python2       \\
+      for py_candidate in \
+            python27      \
+            python2.7     \
+            python26      \
+            python2.6     \
+            python2       \
             python        ;
       do
          command -v $py_candidate >/dev/null
@@ -83,9 +83,9 @@ SSH_SHIM = r'''/bin/sh << 'EOF'
       SALT="/tmp/.salt/salt-call"
       if [ "{{2}}" = "md5" ]
       then
-         for md5_candidate in \\
-            md5sum            \\
-            md5               \\
+         for md5_candidate in \
+            md5sum            \
+            md5               \
             csum              ;
          do
             command -v $md5_candidate >/dev/null


### PR DESCRIPTION
It looks like salt-ssh has been broken for quite some time, at least on certain shells. Fixed the initial boostrapping shell script and cleaned up docs a little to clarify how configurations are read into salt-ssh. Closes #8062.
