### PR TITLE
fix typo: salt.config.{minion_conf=>minion_config}

### DIFF
--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -67,7 +67,7 @@ def _minion_opts(cfg='minion'):
         default_dir = salt.syspaths.CONFIG_DIR,
     cfg = os.environ.get(
         'SALT_MINION_CONFIG', os.path.join(default_dir, cfg))
-    opts = config.minion_conf(cfg)
+    opts = config.minion_config(cfg)
     return opts
 
 


### PR DESCRIPTION
```
************* Module salt.cloud.clouds.lxc
salt/cloud/clouds/lxc.py:70: [E1101(no-member), _minion_opts] Module 'salt.config' has no 'minion_conf' member
```
