### PR TITLE
blockreplace - ensure newline before appending

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1150,6 +1150,10 @@ def blockreplace(path,
             new_file.insert(0, marker_start + '\n')
             done = True
         elif append_if_not_found:
+            # Make sure we have a newline at the end of the file
+            if 0 != len(new_file):
+                if not new_file[-1].ends_with('\n'):
+                    new_file[-1] += '\n'
             # add the markers and content at the end of file
             new_file.append(marker_start + '\n')
             new_file.append(content + '\n')

--- a/tests/unit/modules/file_test.py
+++ b/tests/unit/modules/file_test.py
@@ -212,6 +212,40 @@ class FileBlockReplaceTestCase(TestCase):
                           + "\n" + new_content
                           + "\n" + '#-- END BLOCK 2', fp.read())
 
+    def test_replace_append_newline_at_eof(self):
+        '''
+        Check that file.blockreplace works consistently on files with and
+        without newlines at end of file.
+        '''
+        base = 'bar'
+        args = {
+                'marker_start': '#start',
+                'marker_end': '#stop',
+                'content': 'baz',
+                'append_if_not_found': True,
+        }
+        block = '{marker_start}\n{content}\n{marker_end}\n'.format(**args)
+        expected = base + '\n' + block
+        # File ending with a newline
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write(base + '\n')
+            tfile.flush()
+            filemod.blockreplace(tfile.name, **args)
+            with open(tfile.name) as tfile2:
+                self.assertEqual(tfile2.read(), expected)
+        # File not ending with a newline
+        with tempfile.NamedTemporaryFile() as tfile:
+            tfile.write(base)
+            tfile.flush()
+            filemod.blockreplace(tfile.name, **args)
+            with open(tfile.name) as tfile2:
+                self.assertEqual(tfile2.read(), expected)
+        # A newline should not be added in empty files
+        with tempfile.NamedTemporaryFile() as tfile:
+            filemod.blockreplace(tfile.name, **args)
+            with open(tfile.name) as tfile2:
+                self.assertEqual(tfile2.read(), block)
+
     def test_replace_prepend(self):
         new_content = "Well, I didn't vote for you."
 


### PR DESCRIPTION
append makes sure there is a newline before appending the data

blockreplace might be appending data, but if the file does not end with a newline, the marker_start would follow the line, and not be found in next call.
