### PR TITLE
file.blockreplace: fix typo endswith

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1152,7 +1152,7 @@ def blockreplace(path,
         elif append_if_not_found:
             # Make sure we have a newline at the end of the file
             if 0 != len(new_file):
-                if not new_file[-1].ends_with('\n'):
+                if not new_file[-1].endswith('\n'):
                     new_file[-1] += '\n'
             # add the markers and content at the end of file
             new_file.append(marker_start + '\n')


### PR DESCRIPTION
PR#11137 introduced that bug.
Not sure why it did not show on tests.
Noticed it by running (at last) tests on my side!
