### PR TITLE
file.append(append/prepend_if_not_found)

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -894,6 +894,9 @@ def replace(path,
             count=0,
             flags=0,
             bufsize=1,
+            append_if_not_found=False,
+            prepend_if_not_found=False,
+            not_found_content=None,
             backup='.bak',
             dry_run=False,
             search_only=False,
@@ -923,6 +926,15 @@ def replace(path,
         before processing. Note: multiline searches must specify ``file``
         buffering.
     :type bufsize: int or str
+
+    :param append_if_not_found If pattern is not found and set to ``True``
+        then, the content will be appended to the file.
+    :param prepend_if_not_found If pattern is not found and set to ``True``
+        then, the content will be appended to the file.
+    :param not_found_content Content to use for append/prepend if not found. If
+        None (default), uses repl. Useful when repl uses references to group in
+        pattern.
+
     :param backup: The file extension to use for a backup of the file before
         editing. Set to ``False`` to skip making a backup.
     :param dry_run: Don't make any edits to the file
@@ -952,6 +964,12 @@ def replace(path,
             .format(path)
         )
 
+    if search_only and (append_if_not_found or prepend_if_not_found):
+        raise SaltInvocationError('Choose between search_only and append/prepend_if_not_found')
+
+    if append_if_not_found and prepend_if_not_found:
+        raise SaltInvocationError('Choose between append or prepend_if_not_found')
+
     flags_num = _get_flags(flags)
     cpattern = re.compile(pattern, flags_num)
     if bufsize == 'file':
@@ -973,6 +991,7 @@ def replace(path,
                     backup=False if dry_run else backup,
                     bufsize=bufsize,
                     mode='rb')
+    found = False
     for line in fi_file:
 
         if search_only:
@@ -982,7 +1001,11 @@ def replace(path,
             if result:
                 return True
         else:
-            result = re.sub(cpattern, repl, line, count)
+            result, nrepl = re.subn(cpattern, repl, line, count)
+
+            # found anything? (even if no change)
+            if nrepl > 0:
+                found = True
 
             # Identity check each potential change until one change is made
             if has_changes is False and not result is line:
@@ -995,6 +1018,27 @@ def replace(path,
             if not dry_run:
                 print(result, end='', file=sys.stdout)
     fi_file.close()
+
+    if not found and (append_if_not_found or prepend_if_not_found):
+        if None == not_found_content:
+            not_found_content = repl
+        if prepend_if_not_found:
+            new_file.insert(not_found_content + '\n')
+        else:
+            # append_if_not_found
+            # Make sure we have a newline at the end of the file
+            if 0 != len(new_file):
+                if not new_file[-1].endswith('\n'):
+                    new_file[-1] += '\n'
+            new_file.append(not_found_content + '\n')
+        has_changes = True
+        if not dry_run:
+            # backup already done in filter part
+            # write new content in the file while avoiding partial reads
+            f = salt.utils.atomicfile.atomic_open(path, 'wb')
+            for line in new_file:
+                f.write(line)
+            f.close()
 
     if not dry_run and not salt.utils.is_windows():
         check_perms(path, None, pre_user, pre_group, pre_mode)


### PR DESCRIPTION
file.blockreplace already has append/prepend if not found.

No reason the simple file.replace should not have the same mechanism to
edit configuration file.

If that PR gets merged, similar functions should be added to state.file
later.

Any suggestion about not_found_content param name ?
