### PR TITLE
Pass '--return' settings in batch mode.

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -112,7 +112,8 @@ class Batch(object):
                 # create a new iterator for this batch of minions
                 new_iter = self.local.cmd_iter_no_block(
                                 *args,
-                                raw=self.opts.get('raw', False))
+                                raw=self.opts.get('raw', False),
+                                ret=self.opts.get('return', ''))
                 # add it to our iterators and to the minion_tracker
                 iters.append(new_iter)
                 minion_tracker[new_iter] = {}


### PR DESCRIPTION
When invoking:

```
salt '*' test.ping --return mongo
```

the returner settings works as expected, however, when invoking:

```
salt -b 10 '*' test.ping --return mongo
```

the returnner settings are ignored, the minion get `ret=''`.

An issue #9146  is opened 3 months ago, seems no one did fixed it yet. (Or maybe I just didn't find another pull request that does.)
