### PR TITLE
Call mod_init when invoking state.single

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -719,6 +719,7 @@ def single(fun, name, test=None, queue=False, **kwargs):
         __context__['retcode'] = 1
         return err
 
+    st_._mod_init(kwargs)
     ret = {'{0[state]}_|-{0[__id__]}_|-{0[name]}_|-{0[fun]}'.format(kwargs):
             st_.call(kwargs)}
     _set_retcode(ret)


### PR DESCRIPTION
This ensures that the state's `mod_init()` function is run when state.single is invoked.
`salt.state.State.call_chunk()` is what runs `mod_init()`, but `call_chunk()` is
not invoked by `state.single` since requisites do not need to be resolved.

This commit adds a call to `salt.state.State._mod_init()` just before
`salt.state.State.call()` is invoked, making sure that the state's
`mod_init()` function is called like it is in `state.sls` and
`state.highstate`.
