### PR TITLE
Fix localclient

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -700,6 +700,7 @@ class LocalClient(object):
                                                 pub_data['minions'],
                                                 timeout,
                                                 tgt,
+                                                expr_form,
                                                 **kwargs):
                 yield fn_ret
 


### PR DESCRIPTION
We weren't passing in tgt_type to get_iter_returns. This was breaking
batch mode for highstates and probably a bunch of other things.

Resolves #11094, #10470 and probably some other issues surrounding the breakage of batch mode.
