### PR TITLE
Fix #11173 1st chnage :passed saltenv as kwargs in kg state. 2nd chnage:...

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1577,7 +1577,7 @@ def _resolve_deps(name, pkgs, **kwargs):
     '''
     missing_deps = []
     for pkg_file in pkgs:
-        deb = apt.debfile.DebPackage(filename=pkg_file)
+        deb = apt.debfile.DebPackage(filename=pkg_file, cache=apt.Cache())
         if deb.check():
             missing_deps.extend(deb.missing_deps)
 

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -512,6 +512,7 @@ def installed(
               - baz: ftp://someothersite.org/baz.rpm
               - qux: /minion/path/to/qux.rpm
     '''
+    kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
     refresh = bool(
         salt.utils.is_true(refresh)


### PR DESCRIPTION
Fixed #11173 
1st chnage : passed saltenv as kwargs. So salt module(aptpkg) will pick up correct env to download file from file server. 
2nd chnage:  On ubuntu lucid(10.04) python-apt(0.7.94.2ubuntu6.4 ) not create cache at the time apt.debfile object creation. In upstearm later they fixed it. 

**Tested on:**
Ubuntu 12.04:
           Salt: 2014.1.0
         Python: 2.7.3 (default, Apr 10 2013, 06:20:15)
         Jinja2: 2.6
       M2Crypto: 0.21.1
 msgpack-python: 0.1.10
   msgpack-pure: Not Installed
       pycrypto: 2.4.1
         PyYAML: 3.10
          PyZMQ: 13.0.0
            ZMQ: 3.2.2

Ubuntu 10.04:
           Salt: 2014.1.0
         Python: 2.6.5 (r265:79063, Oct  1 2012, 22:04:36)
         Jinja2: 2.3.1
       M2Crypto: 0.20.1
 msgpack-python: 0.1.9.final
   msgpack-pure: Not Installed
       pycrypto: 2.0.1
         PyYAML: 3.09
          PyZMQ: 13.0.0
            ZMQ: 3.2.2
