### PR TITLE
Fix incorrect detection of a cloudlinux kernel as an openvzve

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -517,7 +517,7 @@ def _virtual(osdata):
         if isdir('/proc/vz'):
             if os.path.isfile('/proc/vz/version'):
                 grains['virtual'] = 'openvzhn'
-            else:
+            elif os.path.isfile('/proc/vz/veinfo'):
                 grains['virtual'] = 'openvzve'
         elif isdir('/proc/sys/xen') or isdir('/sys/bus/xen') or isdir('/proc/xen'):
             if os.path.isfile('/proc/xen/xsd_kva'):


### PR DESCRIPTION
CloudLinux is a patched linux kernel with advanced isolation capabilities that AFAIK borrows pieces of OpenVZ but it's not a virtualized environment in any way and the `virtual` grain should therefor be detected as physical.

Without this patch CloudLinux is detected as `openvzve` because the `/proc/vz` dir is present like in a real openvzve but there is no `veinfo` file inside, which could be used as a discriminant factor.
