### PR TITLE
Update list of community projects in docs

### DIFF
--- a/doc/topics/development/salt_projects.rst
+++ b/doc/topics/development/salt_projects.rst
@@ -11,3 +11,5 @@ https://github.com/terminalmage/djangocon2013-sls
 https://github.com/jesusaurus/hpcs-salt-state
 
 https://github.com/gravyboat/hungryadmin-sls
+
+https://github.com/wunki/django-salted


### PR DESCRIPTION
Updated salt_projects.rst to include Django-Salted Vagrant project.

This will close issue #11210.
