### PR TITLE
Don't log errors for nonzero returns in salt.modules.aptpkg.version_cmp (2014.1 branch)

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -28,19 +28,19 @@ log = logging.getLogger(__name__)
 try:
     from aptsources import sourceslist
     apt_support = True
-except ImportError as e:
+except ImportError:
     apt_support = False
 
 try:
     import softwareproperties.ppa
     ppa_format_support = True
-except ImportError as e:
+except ImportError:
     ppa_format_support = False
 
 try:
     import apt.debfile
     resolve_dep_support = True
-except ImportError as e:
+except ImportError:
     resolve_dep_support = False
 
 # Source format for urllib fallback on PPA handling
@@ -780,8 +780,8 @@ def version_cmp(pkg1, pkg2):
                   '{2!r}'.format(pkg1, oper, pkg2)
             if __salt__['cmd.retcode'](cmd, output_loglevel='debug') == 0:
                 return ret
-    except Exception as e:
-        log.error(e)
+    except Exception as exc:
+        log.error(exc)
     return None
 
 
@@ -1126,11 +1126,11 @@ def mod_repo(repo, saltenv='base', **kwargs):
                         'Launchpad does not know about {0}/{1}: {2}'.format(
                             owner_name, ppa_name, exc)
                     )
-                except IndexError as e:
+                except IndexError as exc:
                     raise CommandExecutionError(
                         'Launchpad knows about {0}/{1} but did not '
                         'return a fingerprint. Please set keyid '
-                        'manually: {2}'.format(owner_name, ppa_name, e)
+                        'manually: {2}'.format(owner_name, ppa_name, exc)
                     )
 
                 if 'keyserver' not in kwargs:

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -778,7 +778,10 @@ def version_cmp(pkg1, pkg2):
         for oper, ret in (('lt', -1), ('eq', 0), ('gt', 1)):
             cmd = 'dpkg --compare-versions {0!r} {1} ' \
                   '{2!r}'.format(pkg1, oper, pkg2)
-            if __salt__['cmd.retcode'](cmd, output_loglevel='debug') == 0:
+            retcode = __salt__['cmd.retcode'](
+                cmd, output_loglevel='debug', ignore_retcode=True
+            )
+            if retcode == 0:
                 return ret
     except Exception as exc:
         log.error(exc)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -517,6 +517,7 @@ def run(cmd,
         quiet=False,
         timeout=None,
         reset_system_locale=True,
+        ignore_retcode=False,
         saltenv='base',
         **kwargs):
     '''
@@ -573,7 +574,7 @@ def run(cmd,
 
     lvl = _check_loglevel(output_loglevel, quiet)
     if lvl is not None:
-        if ret['retcode'] != 0:
+        if not ignore_retcode and ret['retcode'] != 0:
             if lvl < LOG_LEVELS['error']:
                 lvl = LOG_LEVELS['error']
             log.error(
@@ -599,6 +600,7 @@ def run_stdout(cmd,
                quiet=False,
                timeout=None,
                reset_system_locale=True,
+               ignore_retcode=False,
                saltenv='base',
                **kwargs):
     '''
@@ -648,7 +650,7 @@ def run_stdout(cmd,
 
     lvl = _check_loglevel(output_loglevel, quiet)
     if lvl is not None:
-        if ret['retcode'] != 0:
+        if not ignore_retcode and ret['retcode'] != 0:
             if lvl < LOG_LEVELS['error']:
                 lvl = LOG_LEVELS['error']
             log.error(
@@ -677,6 +679,7 @@ def run_stderr(cmd,
                quiet=False,
                timeout=None,
                reset_system_locale=True,
+               ignore_retcode=False,
                saltenv='base',
                **kwargs):
     '''
@@ -726,7 +729,7 @@ def run_stderr(cmd,
 
     lvl = _check_loglevel(output_loglevel, quiet)
     if lvl is not None:
-        if ret['retcode'] != 0:
+        if not ignore_retcode and ret['retcode'] != 0:
             if lvl < LOG_LEVELS['error']:
                 lvl = LOG_LEVELS['error']
             log.error(
@@ -755,6 +758,7 @@ def run_all(cmd,
             quiet=False,
             timeout=None,
             reset_system_locale=True,
+            ignore_retcode=False,
             saltenv='base',
             **kwargs):
     '''
@@ -804,7 +808,7 @@ def run_all(cmd,
 
     lvl = _check_loglevel(output_loglevel, quiet)
     if lvl is not None:
-        if ret['retcode'] != 0:
+        if not ignore_retcode and ret['retcode'] != 0:
             if lvl < LOG_LEVELS['error']:
                 lvl = LOG_LEVELS['error']
             log.error(
@@ -832,6 +836,7 @@ def retcode(cmd,
             quiet=False,
             timeout=None,
             reset_system_locale=True,
+            ignore_retcode=False,
             saltenv='base',
             **kwargs):
     '''
@@ -881,7 +886,7 @@ def retcode(cmd,
 
     lvl = _check_loglevel(output_loglevel, quiet)
     if lvl is not None:
-        if ret['retcode'] != 0:
+        if not ignore_retcode and ret['retcode'] != 0:
             if lvl < LOG_LEVELS['error']:
                 lvl = LOG_LEVELS['error']
             log.error(

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -192,7 +192,7 @@ def get_hwclock():
     elif 'Debian' in __grains__['os_family']:
         #Original way to look up hwclock on Debian-based systems
         cmd = 'grep "UTC=" /etc/default/rcS | grep -vE "^#"'
-        out = __salt__['cmd.run'](cmd).split('=')
+        out = __salt__['cmd.run'](cmd, ignore_retcode=True).split('=')
         if len(out) > 1:
             if out[1] == 'yes':
                 return 'UTC'


### PR DESCRIPTION
This is a cherry-pick of #11220 against the 2014.1 branch.
