### PR TITLE
Avoid unnecessary getgrall code. Use getgrouplist if available

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1704,13 +1704,12 @@ class ClearFuncs(object):
             return True
 
         # After we've ascertained we're not on windows
-        import grp
         try:
             user = self.opts['user']
             pwnam = pwd.getpwnam(user)
             uid = pwnam[2]
             gid = pwnam[3]
-            groups = [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
+            groups = salt.utils.get_gid_list(user, include_default=False)
         except KeyError:
             log.error(
                 'Failed to determine groups for user {0}. The user is not '

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -28,7 +28,6 @@ from salt.log import LOG_LEVELS
 # Only available on POSIX systems, nonfatal on windows
 try:
     import pwd
-    import grp
 except ImportError:
     pass
 
@@ -69,11 +68,14 @@ def _chugid(runas):
     #        and g.gr_gid not in supgroups_seen and not supgroups_seen.add(g.gr_gid)
     # ]
 
-    supgroups = [g.gr_gid for g in grp.getgrall()
-                      if uinfo.pw_name in g.gr_mem
-                          and g.gr_gid not in supgroups_seen
-                          and not supgroups_seen.add(g.gr_gid)
-                ]
+    group_list = __salt__['user.list_groups'](runas)
+    supgroups = []
+    for group_name in group_list:
+        gid = __salt__['group.info'](group_name)['gid']
+        if (gid not in supgroups_seen
+           and not supgroups_seen.add(gid)):
+                supgroups.append(gid)
+
     # No logging can happen on this function
     #
     # 08:46:32,161 [salt.loaded.int.module.cmdmod:276 ][DEBUG   ] stderr: Traceback (most recent call last):

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -74,7 +74,7 @@ def _chugid(runas):
         gid = __salt__['group.info'](group_name)['gid']
         if (gid not in supgroups_seen
            and not supgroups_seen.add(gid)):
-                supgroups.append(gid)
+            supgroups.append(gid)
 
     # No logging can happen on this function
     #

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -408,24 +408,8 @@ def list_groups(name):
 
         salt '*' user.list_groups foo
     '''
-    ugrp = set()
-
-    # Add the primary user's group
-    try:
-        ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
-    except KeyError:
-        # The user's applied default group is undefined on the system, so
-        # it does not exist
-        pass
-
-    groups = [x for x in grp.getgrall() if not x.gr_name.startswith('_')]
-
-    # Now, all other groups the user belongs to
-    for group in groups:
-        if name in group.gr_mem:
-            ugrp.add(group.gr_name)
-
-    return sorted(list(ugrp))
+    groups = [group for group in salt.utils.get_group_list(name) if not group.startswith('_')]
+    return groups
 
 
 def list_users():

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -5,7 +5,6 @@ Manage users on Mac OS 10.7+
 
 # Import python libs
 try:
-    import grp
     import pwd
 except ImportError:
     pass

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -414,24 +414,4 @@ def list_groups(name):
 
         salt '*' user.list_groups foo
     '''
-    ugrp = set()
-    # Add the primary user's group
-    try:
-        ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
-    except KeyError:
-        # The user's applied default group is undefined on the system, so
-        # it does not exist
-        pass
-
-    # If we already grabbed the group list, it's overkill to grab it again
-    if 'user.getgrall' in __context__:
-        groups = __context__['user.getgrall']
-    else:
-        groups = grp.getgrall()
-        __context__['user.getgrall'] = groups
-
-    # Now, all other groups the user belongs to
-    for group in groups:
-        if name in group.gr_mem:
-            ugrp.add(group.gr_name)
-    return sorted(list(ugrp))
+    return salt.utils.get_group_list(name)

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -5,7 +5,6 @@ Manage users with the useradd command
 
 # Import python libs
 try:
-    import grp
     import pwd
 except ImportError:
     pass

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -434,20 +434,4 @@ def list_groups(name):
 
         salt '*' user.list_groups foo
     '''
-    ugrp = set()
-    # Add the primary user's group
-    ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
-
-    # If we already grabbed the group list, it's overkill to grab it again
-    if 'user.getgrall' in __context__:
-        groups = __context__['user.getgrall']
-    else:
-        groups = grp.getgrall()
-        __context__['user.getgrall'] = groups
-
-    # Now, all other groups the user belongs to
-    for group in groups:
-        if name in group.gr_mem:
-            ugrp.add(group.gr_name)
-
-    return sorted(list(ugrp))
+    return salt.utils.get_group_list(name)

--- a/salt/modules/solaris_user.py
+++ b/salt/modules/solaris_user.py
@@ -5,7 +5,6 @@ Manage users with the useradd command
 
 # Import python libs
 try:
-    import grp
     import pwd
 except ImportError:
     pass

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -484,24 +484,7 @@ def list_groups(name):
 
         salt '*' user.list_groups foo
     '''
-    ugrp = set()
-
-    # Add the primary user's group
-    try:
-        ugrp.add(grp.getgrgid(pwd.getpwnam(name).pw_gid).gr_name)
-    except KeyError:
-        # The user's applied default group is undefined on the system, so
-        # it does not exist
-        pass
-
-    groups = grp.getgrall()
-
-    # Now, all other groups the user belongs to
-    for group in groups:
-        if name in group.gr_mem:
-            ugrp.add(group.gr_name)
-
-    return sorted(list(ugrp))
+    return salt.utils.get_group_list(name)
 
 
 def list_users():

--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -7,7 +7,6 @@ Manage users with the useradd command
 import re
 
 try:
-    import grp
     import pwd
 except ImportError:
     pass

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -26,7 +26,6 @@ as either absent or present
 
 # Import python libs
 import logging
-import sys
 
 # Import salt libs
 import salt.utils

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -383,11 +383,6 @@ def present(name,
             else:
                 __salt__['user.ch{0}'.format(key)](name, val)
 
-        # Clear cached groups
-        sys.modules[
-            __salt__['test.ping'].__module__
-        ].__context__.pop('user.getgrall', None)
-
         post = __salt__['user.info'](name)
         spost = {}
         if 'shadow.info' in __salt__:
@@ -554,11 +549,9 @@ def absent(name, purge=False, force=False):
             ret['result'] = None
             ret['comment'] = 'User {0} set for removal'.format(name)
             return ret
-        beforegroups = set(
-                [g['name'] for g in __salt__['group.getent'](refresh=True)])
+        beforegroups = set(salt.utils.get_group_list(name))
         ret['result'] = __salt__['user.delete'](name, purge, force)
-        aftergroups = set(
-                [g['name'] for g in __salt__['group.getent'](refresh=True)])
+        aftergroups = set([g for g in beforegroups if __salt__['group.info'](g)])
         if ret['result']:
             ret['changes'] = {}
             for g in beforegroups - aftergroups:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2097,6 +2097,7 @@ def repack_dictlist(data):
             ret.update(element)
     return ret
 
+
 def get_group_list(user=None, include_default=True):
     '''
     Returns a list of all of the system group names of which the user
@@ -2111,7 +2112,7 @@ def get_group_list(user=None, include_default=True):
         try:
             group_names = list(os.getgrouplist(user, pwd.getpwnam(user).pw_gid))
             log.trace('os.getgrouplist for user {0!r}: {1!r}'.format(user, group_names))
-        except:
+        except Exception:
             pass
     else:
         # Try pysss.getgrouplist
@@ -2120,7 +2121,7 @@ def get_group_list(user=None, include_default=True):
             import pysss
             group_names = list(pysss.getgrouplist(user))
             log.trace('pysss.getgrouplist for user {0!r}: {1!r}'.format(user, group_names))
-        except:
+        except Exception:
             pass
     if group_names is None:
         # Fall back to generic code

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -188,12 +188,11 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
     if salt.utils.is_windows():
         return True
     import pwd  # after confirming not running Windows
-    import grp
     try:
         pwnam = pwd.getpwnam(user)
         uid = pwnam[2]
         gid = pwnam[3]
-        groups = [g.gr_gid for g in grp.getgrall() if user in g.gr_mem]
+        groups = salt.utils.get_gid_list(user, include_default=False)
 
     except KeyError:
         err = ('Failed to prepare the Salt environment for user '
@@ -288,15 +287,13 @@ def check_user(user):
     if user == getpass.getuser():
         return True
     import pwd  # after confirming not running Windows
-    import grp
     try:
         pwuser = pwd.getpwnam(user)
         try:
             if hasattr(os, 'initgroups'):
                 os.initgroups(user, pwuser.pw_gid)
             else:
-                os.setgroups([e.gr_gid for e in grp.getgrall()
-                              if user in e.gr_mem] + [pwuser.pw_gid])
+                os.setgroups(salt.utils.get_gid_list(user, include_default=False))
             os.setgid(pwuser.pw_gid)
             os.setuid(pwuser.pw_uid)
 


### PR DESCRIPTION
This code should greatly improve speed for systems that must talk to a remote ldap server that has thousands of users/groups over slow links. This should fix https://github.com/saltstack/salt/issues/9743
- The new functions in salt.utils will first try to use os.getgrouplist() which is available in python >= 3.3
- If that fails, try to use pysss.getgrouplist() which is the equivalent of os.getgrouplist() for python < 3.3. In order to use this, you must have a python sssd library that supports getgrouplist().
- Failing those two options, it will fall back to using to looping over grp.getgrall().

The salt.utils.get_group_list() function will return the user's primary group, which is a different behavior than the old getgrall() loop used historically by salt. This should not cause a problem with most things, but can be turned off by passing include_default=False when called.
