### PR TITLE
Don't rely on the dictupdate for defaults.py

### DIFF
--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -118,7 +118,7 @@ def get(key, default=''):
 
     defaults = _load(pillar_name, defaults_path)
 
-    value = __salt__['pillar.get']("%s:%s" % (pillar_name, key), None)
+    value = __salt__['pillar.get']('{0}:{1}'.format(pillar_name, key), None)
 
     if value is None:
         value = salt.utils.traverse_dict(defaults, key, None)

--- a/salt/modules/defaults.py
+++ b/salt/modules/defaults.py
@@ -117,8 +117,14 @@ def get(key, default=''):
     _get_files(pillar_name)
 
     defaults = _load(pillar_name, defaults_path)
-    data = salt.utils.dictupdate.update(defaults, __salt__['pillar.get'](pillar_name, {}))
-    value = salt.utils.traverse_dict(data, key, default)
+
+    value = __salt__['pillar.get']("%s:%s" % (pillar_name, key), None)
+
+    if value is None:
+        value = salt.utils.traverse_dict(defaults, key, None)
+
+    if value is None:
+        value = default
 
     if isinstance(value, unicode):
         value = str(value)


### PR DESCRIPTION
defaults.py can sometimes throw an exception if its trying to dictupdate an empty dict. This removes the dictupdate call and makes it a little more clear on what is going on as it traverses the possible places to find the value.
