### PR TITLE
Apache configuration files

### DIFF
--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -379,7 +379,7 @@ def server_status(profile='default'):
 
 
 def _parse_config(config, slot=None):
-    ret = cStringIO.StringIO('# This file is managed by saltstack.')
+    ret = cStringIO.StringIO()
     if isinstance(config, str):
         if slot:
             print('{0} {1}'.format(slot, config), file=ret, end='')
@@ -430,5 +430,6 @@ def config(name, config, edit=True):
         configs = _parse_config(entry[key], key)
         if edit:
             with open(name, 'w') as configfile:
+                configfile.write('# This file is managed by saltstack.\n')
                 configfile.write(configs)
     return configs

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -407,7 +407,7 @@ def _parse_config(config, slot=None):
     return ret.read()
 
 
-def config(name, config):
+def config(name, config, edit=True):
     '''
     Create VirtualHost configuration files
 
@@ -427,7 +427,8 @@ def config(name, config):
 
     for entry in config:
         key = entry.keys()[0]
-        with open(name, 'w') as configfile:
-            configs = _parse_config(entry[key], key)
-            configfile.write(configs + '\n')
-    return True
+        configs = _parse_config(entry[key], key)
+        if edit:
+            with open(name, 'w') as configfile:
+                configfile.write(configs)
+    return configs

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -190,11 +190,19 @@ def vhosts():
             if comps[0] == 'default':
                 ret[namevhost]['default'] = {}
                 ret[namevhost]['default']['vhost'] = comps[2]
-                ret[namevhost]['default']['conf'] = re.sub(r'\(|\)', '', comps[3])
+                ret[namevhost]['default']['conf'] = re.sub(
+                    r'\(|\)',
+                    '',
+                    comps[3]
+                )
             if comps[0] == 'port':
                 ret[namevhost][comps[3]] = {}
                 ret[namevhost][comps[3]]['vhost'] = comps[3]
-                ret[namevhost][comps[3]]['conf'] = re.sub(r'\(|\)', '', comps[4])
+                ret[namevhost][comps[3]]['conf'] = re.sub(
+                    r'\(|\)',
+                    '',
+                    comps[4]
+                )
                 ret[namevhost][comps[3]]['port'] = comps[1]
     return ret
 
@@ -315,11 +323,26 @@ def server_status(profile='default'):
     }
 
     # Get configuration from pillar
-    url = __salt__['config.get']('apache.server-status:{0}:url'.format(profile), 'http://localhost/server-status')
-    user = __salt__['config.get']('apache.server-status:{0}:user'.format(profile), '')
-    passwd = __salt__['config.get']('apache.server-status:{0}:pass'.format(profile), '')
-    realm = __salt__['config.get']('apache.server-status:{0}:realm'.format(profile), '')
-    timeout = __salt__['config.get']('apache.server-status:{0}:timeout'.format(profile), 5)
+    url = __salt__['config.get'](
+        'apache.server-status:{0}:url'.format(profile),
+        'http://localhost/server-status'
+    )
+    user = __salt__['config.get'](
+        'apache.server-status:{0}:user'.format(profile),
+        ''
+    )
+    passwd = __salt__['config.get'](
+        'apache.server-status:{0}:pass'.format(profile),
+        ''
+    )
+    realm = __salt__['config.get'](
+        'apache.server-status:{0}:realm'.format(profile),
+        ''
+    )
+    timeout = __salt__['config.get'](
+        'apache.server-status:{0}:timeout'.format(profile),
+        5
+    )
 
     # create authentication handler if configuration exists
     if user and passwd:
@@ -365,7 +388,11 @@ def _parse_config(config, slot=None):
     elif isinstance(config, list):
         print('{0} {1}'.format(str(slot), ' '.join(config)), file=ret, end='')
     elif isinstance(config, dict):
-        print('<{0} {1}>'.format(slot, _parse_config(config['this'])), file=ret)
+        print('<{0} {1}>'.format(
+            slot,
+            _parse_config(config['this'])),
+            file=ret
+        )
         del config['this']
         for key, value in config.items():
             if isinstance(value, str):
@@ -378,6 +405,7 @@ def _parse_config(config, slot=None):
 
     ret.seek(0)
     return ret.read()
+
 
 def config(name, config):
     '''
@@ -392,7 +420,8 @@ def config(name, config):
     Config is meant to be an ordered dict of all of the apache configs.
 
     .. code-block:: bash
-        salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '22'}]"
+        salt '*' apache.config /etc/httpd/conf.d/ports.conf \
+                config="[{'Listen': '22'}]"
 
     '''
 

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -8,10 +8,14 @@ deb_apache.py, but will still load under the ``apache`` namespace when a
 Debian-based system is detected.
 '''
 
+# Python3 generators
+from __future__ import generators, print_function, with_statement
+
 # Import python libs
 import re
 import logging
 import urllib2
+import cStringIO
 
 # Import salt libs
 import salt.utils
@@ -349,3 +353,52 @@ def server_status(profile='default'):
 
     # return the good stuff
     return ret
+
+
+def _parse_config(config, slot=None):
+    ret = cStringIO.StringIO()
+    if isinstance(config, str):
+        if slot:
+            print('{0} {1}'.format(slot, config), file=ret, end='')
+        else:
+            print('{0}'.format(config), file=ret, end='')
+    elif isinstance(config, list):
+        print('{0} {1}'.format(str(slot), ' '.join(config)), file=ret, end='')
+    elif isinstance(config, dict):
+        print('<{0} {1}>'.format(slot, _parse_config(config['this'])), file=ret)
+        del config['this']
+        for key, value in config.items():
+            if isinstance(value, str):
+                print('{0} {1}'.format(key, value), file=ret)
+            elif isinstance(value, list):
+                print('{0} {1}'.format(key, ' '.join(value)), file=ret)
+            elif isinstance(value, dict):
+                print(_parse_config(value, key), file=ret)
+        print('</{0}>'.format(slot), file=ret, end='')
+
+    ret.seek(0)
+    return ret.read()
+
+def config(name, config):
+    '''
+    Create VirtualHost configuration files
+
+    name
+        File for the virtual host
+    config
+        VirtualHost configurations
+
+    Note: This function is not meant to be used from the command line.
+    Config is meant to be an ordered dict of all of the apache configs.
+
+    .. code-block:: bash
+        salt '*' apache.config /etc/httpd/conf.d/ports.conf config="[{'Listen': '22'}]"
+
+    '''
+
+    for entry in config:
+        key = entry.keys()[0]
+        with open(name, 'w') as configfile:
+            configs = _parse_config(entry[key], key)
+            configfile.write(configs + '\n')
+    return True

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -379,7 +379,7 @@ def server_status(profile='default'):
 
 
 def _parse_config(config, slot=None):
-    ret = cStringIO.StringIO()
+    ret = cStringIO.StringIO('# This file is managed by saltstack.')
     if isinstance(config, str):
         if slot:
             print('{0} {1}'.format(slot, config), file=ret, end='')

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -20,6 +20,7 @@ the above word between angle brackets (<>).
             - dev.website.com
           ErrorLog: logs/website.com-error_log
           CustomLog: logs/website.com-access_log combinded
+          DocumentRoot: /var/www/vhosts/website.com
           Directory:
             this: /var/www/vhosts/website.com
             Order: Deny,Allow

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -20,34 +20,64 @@ the above word between angle brackets (<>).
             - dev.website.com
           ErrorLog: logs/website.com-error_log
           CustomLog: logs/website.com-access_log combinded
-          Directory: 
-            this: /var/www/vhosts/website.com 
-            Order: Deny,Allow 
-            Deny from: all 
-            Allow from: 
-              - 127.0.0.1 
-              - 192.168.100.0/24 
-            Options: 
-              - +Indexes 
-              - FollowSymlinks 
-            AllowOverrides: All 
+          Directory:
+            this: /var/www/vhosts/website.com
+            Order: Deny,Allow
+            Deny from: all
+            Allow from:
+              - 127.0.0.1
+              - 192.168.100.0/24
+            Options:
+              - +Indexes
+              - FollowSymlinks
+            AllowOverrides: All
 '''
+
+# Import python libs
+import os.path
+
+# Import salt libs
+import salt.cloud.utils
+
 
 def __virtual__():
     return 'apache.config' in __salt__
 
-def config(name, config):
+
+def _check_name(name):
     ret = {'name': name,
            'changes': {},
-           'result': False,
-           'comment': 'Failed to setup configuration file.'}
+           'result': None,
+           'comment': ''}
+    if suc.check_name(name, 'a-zA-Z0-9._-/<>'):
+        ret['comment'] = 'Invalid characters in name.'
+        ret['result'] = False
+        return ret
+    else:
+        ret['result'] = True
+        return ret
 
-    ret['changes'] = {
-        'old': None,
-        'new': __salt__['apache.config'](name, config)
-    }
 
-    ret['result'] = True
-    ret['comment'] = 'Successfully created configuration.'
+def config(name, config, force=False):
+    ret = _check_name(str(config))
+
+    if os.path.exists(name) and not force:
+        ret['result'] = True
+        ret['comment'] = 'Configuration file exists.'
+    elif __opts__['test']:
+        ret['comment'] = 'Configuration will update.'
+        ret['result'] = None
+        return ret
+
+    try:
+        ret['changes'] = {
+            'old': None,
+            'new': __salt__['apache.config'](name, config)
+        }
+        ret['result'] = True
+        ret['comment'] = 'Successfully created configuration.'
+    except Exception as exc:
+        ret['result'] = False
+        ret['comment'] = 'Failed to create apache configuration.'
 
     return ret

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+'''
+Apache state
+
+Allows for inputting a yaml dictionary into a file for apache configuration
+files.
+
+The variable 'this' is special and signifies what should be included with
+the above word between angle brackets (<>).
+
+/etc/httpd/conf.d/website.com.conf:
+  apache.config:
+    - config:
+      - VirtualHost:
+          this: '*:80'
+          ServerName:
+            -website.com
+          ServerAlias:
+            - www.website.com
+            - dev.website.com
+          ErrorLog: logs/website.com-error_log
+          CustomLog: logs/website.com-access_log combinded
+          Directory: 
+            this: /var/www/vhosts/website.com 
+            Order: Deny,Allow 
+            Deny from: all 
+            Allow from: 
+              - 127.0.0.1 
+              - 192.168.100.0/24 
+            Options: 
+              - +Indexes 
+              - FollowSymlinks 
+            AllowOverrides: All 
+'''
+
+def __virtual__():
+    return 'apache.config' in __salt__
+
+def config(name, config):
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': 'Failed to setup configuration file.'}
+
+    ret['changes'] = {
+        'old': None,
+        'new': __salt__['apache.config'](name, config)
+    }
+
+    ret['result'] = True
+    ret['comment'] = 'Successfully created configuration.'
+
+    return ret

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -52,7 +52,7 @@ def _check_name(name):
            'result': None,
            'comment': ''}
     if salt.utils.cloud.check_name(
-        name, ' a-zA-Z0-9.,_/\[\]\(\)\<\>\'*+:-' # pylint: disable=W1401
+        name, ' a-zA-Z0-9.,_/\[\]\(\)\<\>\'*+:-'  # pylint: disable=W1401
     ):
         ret['comment'] = 'Invalid characters in name.'
         ret['result'] = False

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -31,7 +31,7 @@ the above word between angle brackets (<>).
             Options:
               - +Indexes
               - FollowSymlinks
-            AllowOverrides: All
+            AllowOverride: All
 '''
 
 from __future__ import with_statement, print_function

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -51,7 +51,9 @@ def _check_name(name):
            'changes': {},
            'result': None,
            'comment': ''}
-    if salt.utils.cloud.check_name(name, ' a-zA-Z0-9.,_/\[\]\(\)\<\>\'*+:-'):
+    if salt.utils.cloud.check_name(
+        name, ' a-zA-Z0-9.,_/\[\]\(\)\<\>\'*+:-' # pylint: disable=W1401
+    ):
         ret['comment'] = 'Invalid characters in name.'
         ret['result'] = False
         return ret


### PR DESCRIPTION
This state is to help configure apache settings, in /etc/httpd/conf.d/something.com.conf or whereever you are keeping them.

The module takes a list of dictionaries to be able to cycle through them and use the basic logic of apache configurations to setup virtualhosts or other settings.

Thanks,
Daniel
