### PR TITLE
fix(state/file): set 'changes' when creating file

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2695,9 +2695,9 @@ def touch(name, atime=None, mtime=None, makedirs=False):
             ret, 'Directory not present to touch file {0}'.format(name)
         )
 
-    ret['result'] = __salt__['file.touch'](name, atime, mtime)
-
     extant = os.path.exists(name)
+
+    ret['result'] = __salt__['file.touch'](name, atime, mtime)
     if not extant and ret['result']:
         ret['comment'] = 'Created empty file {0}'.format(name)
         ret['changes']['new'] = name


### PR DESCRIPTION
The 'changes' field was never set due to file existence check was done
after the actual creation of the file.
