### PR TITLE
fix(state/file): populate `change` on touch

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2705,6 +2705,7 @@ def touch(name, atime=None, mtime=None, makedirs=False):
         ret['comment'] = 'Updated times on {0} {1}'.format(
             'directory' if os.path.isdir(name) else 'file', name
         )
+        ret['changes']['touched'] = name
 
     return ret
 


### PR DESCRIPTION
Previously when a file was touched, the `changes` field was never
populated. This commit fixes this.

I decided to have this as a separate pull request from #11269 since someone might object to populating `changes` field for touch changes. Maybe that would disturb someone who has a state that constantly updates that mtime/atime. My counter argument is that a change is a change, and it should be documented.
