### PR TITLE
Fix missing "-" in salt-key help text, "-L" line.

### DIFF
--- a/doc/man/salt-key.1
+++ b/doc/man/salt-key.1
@@ -149,7 +149,7 @@ Finally, \fBall\fP will list all keys.
 .INDENT 0.0
 .TP
 .B \-L, \-\-list\-all
-List all public keys. (Deprecated: use \fB\-\-list all\fP)
+List all public keys. (Deprecated: use \fB\-\-list\-all\fP)
 .UNINDENT
 .INDENT 0.0
 .TP


### PR DESCRIPTION
I'm pretty sure it's supposed to read `(Deprecated: use "--list-all")` since there's no `salt-key --list all` command.

```
root@salt:~# salt-key -h
Usage: salt-key [options]

Salt key is used to manage Salt authentication keys
...
    -L, --list-all      List all public keys. (Deprecated: use "--list all")
...
```
