### PR TITLE
Fix edge case when rel path changes from file to dir (2014.1 branch)

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -302,9 +302,19 @@ def find_file(path, short='base', **kwargs):
     destdir = os.path.dirname(dest)
     hashdir = os.path.dirname(blobshadest)
     if not os.path.isdir(destdir):
-        os.makedirs(destdir)
+        try:
+            os.makedirs(destdir)
+        except OSError:
+            # Path exists and is a file, remove it and retry
+            os.remove(destdir)
+            os.makedirs(destdir)
     if not os.path.isdir(hashdir):
-        os.makedirs(hashdir)
+        try:
+            os.makedirs(hashdir)
+        except OSError:
+            # Path exists and is a file, remove it and retry
+            os.remove(hashdir)
+            os.makedirs(hashdir)
     repos = init()
     if 'index' in kwargs:
         try:


### PR DESCRIPTION
**This is #11280, cherrypicked for the 2014.1 branch**

This fixes an edge case in gitfs where a path that once was a file is
now a directory.
