### PR TITLE
Remove "Total" count in highstate output

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -207,10 +207,8 @@ def _format_host(host, data):
             )
         )
 
-        totals = '{0}\nTotal: {1:>{2}}'.format('-' * line_max_len,
-                                               sum(rcounts.values()),
-                                               line_max_len - 7)
-        hstrs.append(colorfmt.format(colors['CYAN'], totals, colors))
+        line = '-' * line_max_len
+        hstrs.append(colorfmt.format(colors['CYAN'], line, colors))
 
     hstrs.insert(0, ('{0}{1}:{2[ENDC]}'.format(hcolor, host, colors)))
     return '\n'.join(hstrs), nchanges > 0


### PR DESCRIPTION
I find it more bloating than necessary. See #11198 for background.

This commit fixes #11198.
