### PR TITLE
fix bad indentation in salt/states/group.py

### DIFF
--- a/salt/states/group.py
+++ b/salt/states/group.py
@@ -131,7 +131,7 @@ def present(name,
         ret['comment'] = (
             'The following group attributes are set to be changed:\n')
         for key, val in changes.items():
-                ret['comment'] += '{0}: {1}\n'.format(key, val)
+            ret['comment'] += '{0}: {1}\n'.format(key, val)
 
         if __opts__['test']:
             ret['result'] = None


### PR DESCRIPTION
```
************* Module salt.states.group
salt/states/group.py:134: [W0311(bad-indentation), ] Bad indentation. Found 16 spaces, expected 12
```
