### PR TITLE
lint modules/groupadd.py

### DIFF
--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -164,7 +164,7 @@ def deluser(name, username):
             return not retcode
         else:
             return True
-    except:
+    except Exception:
         return True
 
 


### PR DESCRIPTION
```
************* Module salt.modules.groupadd
salt/modules/groupadd.py:184: [C0304(missing-final-newline), ] Final newline missing
salt/modules/groupadd.py:167: [W0702(bare-except), deluser] No exception type(s) specified
```
