### PR TITLE
Fix permissions of the ssh-id-wrapper script

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ from distutils.cmd import Command
 from distutils.command.build import build
 from distutils.command.clean import clean
 from distutils.command.sdist import sdist
+from distutils.command.install_lib import install_lib
 # pylint: enable=E0611
 
 try:
@@ -380,6 +381,20 @@ class Install(install):
         install.run(self)
 
 
+class InstallLib(install_lib):
+    def run(self):
+        install_lib.run(self)
+
+        # input and outputs match 1-1
+        inp = self.get_inputs()
+        out = self.get_outputs()
+
+        idx = inp.index('build/lib/salt/templates/git/ssh-id-wrapper')
+        filename = out[idx]
+
+        os.chmod(filename, 0755)
+
+
 NAME = 'salt'
 VER = __version__  # pylint: disable=E0602
 DESC = ('Portable, distributed, remote execution and '
@@ -490,6 +505,7 @@ SETUP_KWARGS = {'name': NAME,
 
 if IS_WINDOWS_PLATFORM is False:
     SETUP_KWARGS['cmdclass']['sdist'] = CloudSdist
+    SETUP_KWARGS['cmdclass']['install_lib'] = InstallLib
     #SETUP_KWARGS['packages'].extend(['salt.cloud',
     #                                 'salt.cloud.clouds'])
     SETUP_KWARGS['package_data']['salt.cloud'] = ['deploy/*.sh']


### PR DESCRIPTION
Following #11196, here's the fix for the ssh-id-wrapper script permissions upon installation implemented in setup.py.
