### PR TITLE
Sam raet 25 Refactored the service methods of the Udp Uxd stacks.

### DIFF
--- a/salt/transport/road/raet/behaving.py
+++ b/salt/transport/road/raet/behaving.py
@@ -239,7 +239,7 @@ class MessengerStackUdpRaet(deeding.Deed):  # pylint: disable=W0232
             stack = self.stack.value
             if stack and isinstance(stack, stacking.StackUdp):
                 deid = self.destination.value
-                stack.txMsg(msg=msg, deid=deid)
+                stack.transmit(msg=msg, deid=deid)
 
 
 class PrinterStackUdpRaet(deeding.Deed):  # pylint: disable=W0232

--- a/salt/transport/road/raet/stacking.py
+++ b/salt/transport/road/raet/stacking.py
@@ -832,12 +832,12 @@ class StackUxd(object):
                             console.terse("Reaped yard {0}\n".format(yard.name))
                     elif ex.errno == errno.EAGAIN or ex.errno == errno.EWOULDBLOCK:
                         #busy with last message save it for later
-                        self.laters.append((tx, ta))
+                        laters.append((tx, ta))
                     else:
                         console.terse("socket.error = {0}\n".format(ex))
                         raise
             while laters:
-                self.txes.append(self.laters.popleft())
+                self.txes.append(laters.popleft())
 
 
     def serviceTxMsgs(self):

--- a/salt/transport/road/raet/stacking.py
+++ b/salt/transport/road/raet/stacking.py
@@ -357,9 +357,9 @@ class StackUdp(object):
         '''
         self.stats[key] = value
 
-    def serviceUdp(self):
+    def serviceUdpRx(self):
         '''
-        Service the UDP receive and transmit queues
+        Service the UDP receive and fill the rxes deque
         '''
         if self.server:
             while True:
@@ -369,10 +369,50 @@ class StackUdp(object):
                 # triple = ( packet, source address, destination address)
                 self.rxes.append((rx, ra, self.server.ha))
 
+        return None
+
+    def serviceRxes(self):
+        '''
+        Process all messages in .rxes deque
+        '''
+        while self.rxes:
+            self.processUdpRx()
+
+    def serviceTxes(self):
+        '''
+        Service the .txes deque to send Udp messages
+        '''
+        if self.server:
+            laters = deque()
             while self.txes:
                 tx, ta = self.txes.popleft()  # duple = (packet, destination address)
-                self.server.send(tx, ta)
+                try:
+                    self.server.send(tx, ta)
+                except socket.error as ex:
+                    if ex.errno == errno.EAGAIN or ex.errno == errno.EWOULDBLOCK:
+                        #busy with last message save it for later
+                        laters.append((tx, ta))
+                    else:
+                        console.terse("socket.error = {0}\n".format(ex))
+                        raise
+            while laters:
+                self.txes.append(laters.popleft())
 
+    def serviceTxMsgs(self):
+        '''
+        Service .txMsgs queue of outgoing  messages and start message transactions
+        '''
+        while self.txMsgs:
+            body, deid = self.txMsgs.popleft() # duple (body dict, destination eid)
+            self.message(body, deid)
+            console.verbose("{0} sending\n{1}\n".format(self.name, body))
+
+    def serviceUdp(self):
+        '''
+        Service the UDP receive and transmit queues
+        '''
+        self.serviceUdpRx()
+        self.serviceTxes()
         return None
 
     def serviceAll(self):
@@ -386,38 +426,15 @@ class StackUdp(object):
            UDP Socket send
 
         '''
-        if self.server:
-            while True:
-                rx, ra = self.server.receive()  # if no data the duple is ('',None)
-                if not rx:  # no received data so break
-                    break
-                # triple = ( packet, source address, destination address)
-                self.rxes.append((rx, ra, self.server.ha))
+        self.serviceUdpRx()
+        self.serviceRxes()
+        self.process()
 
-            self.serviceUdpRx()
-
-            self.process()
-
-            self.serviceTxMsg()
-
-            while self.txes:
-                tx, ta = self.txes.popleft()  # duple = (packet, destination address)
-                self.server.send(tx, ta)
-
+        self.serviceTxMsgs()
+        self.serviceTxes()
         return None
 
-    def txUdp(self, packed, deid):
-        '''
-        Queue duple of (packed, da) on stack transmit queue
-        Where da is the ip destination (host,port) address associated with
-        the estate with deid
-        '''
-        if deid not in self.estates:
-            msg = "Invalid destination estate id '{0}'".format(deid)
-            raise raeting.StackError(msg)
-        self.txes.append((packed, self.estates[deid].ha))
-
-    def txMsg(self, msg, deid=None):
+    def transmit(self, msg, deid=None):
         '''
         Append duple (msg,deid) to .txMsgs deque
         If msg is not mapping then raises exception
@@ -431,16 +448,44 @@ class StackUdp(object):
             #raise raeting.StackError(emsg)
         self.txMsgs.append((msg, deid))
 
-    transmit = txMsg
+    txMsg = transmit
 
-    def serviceTxMsg(self):
+    def txUdp(self, packed, deid):
         '''
-        Service .udpTxMsgs queue of outgoint udp messages for message transactions
+        Queue duple of (packed, da) on stack transmit queue
+        Where da is the ip destination (host,port) address associated with
+        the estate with deid
         '''
-        while self.txMsgs:
-            body, deid = self.txMsgs.popleft() # duple (body dict, destination eid)
-            self.message(body, deid)
-            console.verbose("{0} sending\n{1}\n".format(self.name, body))
+        if deid not in self.estates:
+            msg = "Invalid destination estate id '{0}'".format(deid)
+            raise raeting.StackError(msg)
+        self.txes.append((packed, self.estates[deid].ha))
+
+    def processUdpRx(self):
+        '''
+        Retrieve next packet from stack receive queue if any and parse
+        Process associated transaction or reply with new correspondent transaction
+        '''
+        packet = self.fetchParseUdpRx()
+        if not packet:
+            return
+
+        console.verbose("{0} received packet data\n{1}\n".format(self.name, packet.data))
+        console.verbose("{0} received packet index = '{1}'\n".format(self.name, packet.index))
+
+        trans = self.transactions.get(packet.index, None)
+        if trans:
+            trans.receive(packet)
+            return
+
+        if packet.data['cf']: #correspondent to stale transaction so drop
+            emsg = "{0} Stale Transaction, dropping ...".format(self.name)
+            console.terse(emsg + '\n')
+            self.incStat('stale_correspondent_attempt')
+            # Should send abort nack to drop transaction on other side
+            return
+
+        self.reply(packet)
 
     def fetchParseUdpRx(self):
         '''
@@ -475,39 +520,6 @@ class StackUdp(object):
         packet.data.update(sh=sh, sp=sp, dh=dh, dp=dp)
 
         return packet # outer only has been parsed
-
-    def processUdpRx(self):
-        '''
-        Retrieve next packet from stack receive queue if any and parse
-        Process associated transaction or reply with new correspondent transaction
-        '''
-        packet = self.fetchParseUdpRx()
-        if not packet:
-            return
-
-        console.verbose("{0} received packet data\n{1}\n".format(self.name, packet.data))
-        console.verbose("{0} received packet index = '{1}'\n".format(self.name, packet.index))
-
-        trans = self.transactions.get(packet.index, None)
-        if trans:
-            trans.receive(packet)
-            return
-
-        if packet.data['cf']: #correspondent to stale transaction so drop
-            emsg = "{0} Stale Transaction, dropping ...".format(self.name)
-            console.terse(emsg + '\n')
-            self.incStat('stale_correspondent_attempt')
-            # Should send abort nack to drop transaction on other side
-            return
-
-        self.reply(packet)
-
-    def serviceUdpRx(self):
-        '''
-        Process all packets in .udpRxes deque
-        '''
-        while self.rxes:
-            self.processUdpRx()
 
     def reply(self, packet):
         '''
@@ -795,7 +807,7 @@ class StackUxd(object):
 
     def serviceUxdRx(self):
         '''
-        Service the Uxd recieves and fill the .rxes deque
+        Service the Uxd receive and fill the .rxes deque
         '''
         if self.server:
             while True:
@@ -807,10 +819,10 @@ class StackUxd(object):
 
     def serviceRxes(self):
         '''
-        Process all messages in .uxdRxes deque
+        Process all messages in .rxes deque
         '''
         while self.rxes:
-            self.processUdpRx()
+            self.processUxdRx()
 
     def serviceTxes(self):
         '''
@@ -838,7 +850,6 @@ class StackUxd(object):
                         raise
             while laters:
                 self.txes.append(laters.popleft())
-
 
     def serviceTxMsgs(self):
         '''
@@ -879,7 +890,7 @@ class StackUxd(object):
 
     def txUxd(self, packed, name):
         '''
-        Queue duple of (packed, da) on stack transmit queue
+        Queue duple of (packed, da) on stack .txes queue
         Where da is the ip destination address associated with
         the estate with name
         If name is None then it will default to the first entry in .yards
@@ -900,7 +911,7 @@ class StackUxd(object):
             #raise raeting.StackError(msg)
         self.txes.append((packed, self.yards[name].ha))
 
-    def txMsg(self, msg, name=None):
+    def transmit(self, msg, name=None):
         '''
         Append duple (msg, name) to .txMsgs deque
         If msg is not mapping then raises exception
@@ -914,7 +925,7 @@ class StackUxd(object):
             #raise raeting.StackError(emsg)
         self.txMsgs.append((msg, name))
 
-    transmit = txMsg # alias
+    txMsg = transmit # alias
 
     def packUxdTx(self, body=None, name=None, kind=None):
         '''
@@ -954,6 +965,17 @@ class StackUxd(object):
 
         return packed
 
+    def processUxdRx(self):
+        '''
+        Retrieve next message from stack receive queue if any and parse
+        '''
+        body = self.fetchParseUxdRx()
+        if not body:
+            return
+
+        console.verbose("{0} received message data\n{1}\n".format(self.name, body))
+
+        self.rxMsgs.append(body)
 
     def fetchParseUxdRx(self):
         '''
@@ -1046,17 +1068,6 @@ class StackUxd(object):
 
         return body
 
-    def processUdpRx(self):
-        '''
-        Retrieve next message from stack receive queue if any and parse
-        '''
-        body = self.fetchParseUxdRx()
-        if not body:
-            return
-
-        console.verbose("{0} received message data\n{1}\n".format(self.name, body))
-
-        self.rxMsgs.append(body)
 
 
 

--- a/salt/transport/road/raet/test/test_stackUdp.py
+++ b/salt/transport/road/raet/test/test_stackUdp.py
@@ -72,7 +72,7 @@ def testStackUdp(bk=raeting.bodyKinds.json):
         stack1.serviceUdp()
         stack0.serviceUdp()
 
-    stack0.serviceUdpRx()
+    stack0.serviceRxes()
     stack0.process()
 
     timer.restart()
@@ -80,7 +80,7 @@ def testStackUdp(bk=raeting.bodyKinds.json):
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack1.serviceUdpRx()
+    stack1.serviceRxes()
 
 
     print "{0} eid={1}".format(stack0.name, stack0.estate.eid)
@@ -106,28 +106,28 @@ def testStackUdp(bk=raeting.bodyKinds.json):
         stack1.serviceUdp()
         stack0.serviceUdp()
 
-    stack0.serviceUdpRx()
+    stack0.serviceRxes()
 
     timer.restart()
     while not timer.expired:
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack1.serviceUdpRx()
+    stack1.serviceRxes()
 
     timer.restart()
     while not timer.expired:
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack0.serviceUdpRx()
+    stack0.serviceRxes()
 
     timer.restart()
     while not timer.expired:
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack1.serviceUdpRx()
+    stack1.serviceRxes()
 
     print "{0} eid={1}".format(stack0.name, stack0.estate.eid)
     print "{0} estates=\n{1}".format(stack0.name, stack0.estates)
@@ -153,14 +153,14 @@ def testStackUdp(bk=raeting.bodyKinds.json):
         stack1.serviceUdp()
         stack0.serviceUdp()
 
-    stack0.serviceUdpRx()
+    stack0.serviceRxes()
 
     timer.restart()
     while not timer.expired:
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack1.serviceUdpRx()
+    stack1.serviceRxes()
 
     print "{0} eid={1}".format(stack0.name, stack0.estate.eid)
     print "{0} estates=\n{1}".format(stack0.name, stack0.estates)
@@ -183,14 +183,14 @@ def testStackUdp(bk=raeting.bodyKinds.json):
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack1.serviceUdpRx()
+    stack1.serviceRxes()
 
     timer.restart()
     while not timer.expired:
         stack1.serviceUdp()
         stack0.serviceUdp()
 
-    stack0.serviceUdpRx()
+    stack0.serviceRxes()
 
     print "{0} eid={1}".format(stack0.name, stack0.estate.eid)
     print "{0} estates=\n{1}".format(stack0.name, stack0.estates)
@@ -225,24 +225,24 @@ def testStackUdp(bk=raeting.bodyKinds.json):
     stack1.txMsgs.append((odict(house="Mama mia1", queue="big stuff", stuff=stuff), None))
     stack0.txMsgs.append((odict(house="Papa pia4", queue="gig stuff", stuff=stuff), None))
 
-    stack1.serviceTxMsg()
-    stack0.serviceTxMsg()
+    stack1.serviceTxMsgs()
+    stack0.serviceTxMsgs()
 
     timer.restart()
     while not timer.expired:
         stack1.serviceUdp()
         stack0.serviceUdp()
 
-    stack0.serviceUdpRx()
-    stack1.serviceUdpRx()
+    stack0.serviceRxes()
+    stack1.serviceRxes()
 
     timer.restart()
     while not timer.expired:
         stack0.serviceUdp()
         stack1.serviceUdp()
 
-    stack1.serviceUdpRx()
-    stack0.serviceUdpRx()
+    stack1.serviceRxes()
+    stack0.serviceRxes()
 
 
     print "{0} eid={1}".format(stack0.name, stack0.estate.eid)
@@ -262,15 +262,15 @@ def testStackUdp(bk=raeting.bodyKinds.json):
 
     print "\n********* Message Transactions Both Ways Again **********"
 
-    stack1.txMsg(odict(house="Oh Boy1", queue="Nice"))
-    stack1.txMsg(odict(house="Oh Boy2", queue="Mean"))
-    stack1.txMsg(odict(house="Oh Boy3", queue="Ugly"))
-    stack1.txMsg(odict(house="Oh Boy4", queue="Pretty"))
+    stack1.transmit(odict(house="Oh Boy1", queue="Nice"))
+    stack1.transmit(odict(house="Oh Boy2", queue="Mean"))
+    stack1.transmit(odict(house="Oh Boy3", queue="Ugly"))
+    stack1.transmit(odict(house="Oh Boy4", queue="Pretty"))
 
-    stack0.txMsg(odict(house="Yeah Baby1", queue="Good"))
-    stack0.txMsg(odict(house="Yeah Baby2", queue="Bad"))
-    stack0.txMsg(odict(house="Yeah Baby3", queue="Fast"))
-    stack0.txMsg(odict(house="Yeah Baby4", queue="Slow"))
+    stack0.transmit(odict(house="Yeah Baby1", queue="Good"))
+    stack0.transmit(odict(house="Yeah Baby2", queue="Bad"))
+    stack0.transmit(odict(house="Yeah Baby3", queue="Fast"))
+    stack0.transmit(odict(house="Yeah Baby4", queue="Slow"))
 
     #segmented packets
     stuff = []
@@ -278,8 +278,8 @@ def testStackUdp(bk=raeting.bodyKinds.json):
         stuff.append(str(i).rjust(4, " "))
     stuff = "".join(stuff)
 
-    stack1.txMsg(odict(house="Snake eyes", queue="near stuff", stuff=stuff))
-    stack0.txMsg(odict(house="Craps", queue="far stuff", stuff=stuff))
+    stack1.transmit(odict(house="Snake eyes", queue="near stuff", stuff=stuff))
+    stack0.transmit(odict(house="Craps", queue="far stuff", stuff=stuff))
 
     timer.restart(duration=2)
     while not timer.expired:


### PR DESCRIPTION
Added
.serviceRx 
.serviceTx 
to both StackUdp and StackUxd so can split .serviceAll into two behaviors to reduce unneccessary servicing
of the Rx or Tx set of queues.

The pattern is

.serviceRx
route and process
.serviceTx

instead of
.serviceAll
router and process
.serviceAll
