### PR TITLE
Docs housekeeping

### DIFF
--- a/doc/_incl/requisite_incl.rst
+++ b/doc/_incl/requisite_incl.rst
@@ -1,10 +1,10 @@
 **Before continuing** make sure you have a working Salt installation by
-following the :doc:`installation </topics/installation/index>` and the :doc:`configuration
-</topics/configuration>` instructions.
+following the :doc:`installation </topics/installation/index>` and the
+:doc:`configuration </ref/configuration/index>` instructions.
 
 .. admonition:: Stuck?
 
-    There are many ways to :doc:`get help from the Salt community
-    </topics/community>` including our
+    There are many ways to :ref:`get help from the Salt community
+    <salt-community>` including our
     `mailing list <https://groups.google.com/forum/#!forum/salt-users>`_
     and our `IRC channel <http://webchat.freenode.net/?channels=salt>`_ #salt.

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -25,6 +25,7 @@ Salt Table of Contents
     topics/master_tops/index
     topics/ssh/*
     ref/index
+    topics/best_practices
     topics/troubleshooting/index
     topics/development/index
     topics/releases/index

--- a/doc/ref/clouds/all/index.rst
+++ b/doc/ref/clouds/all/index.rst
@@ -16,7 +16,6 @@ Full list of Salt Cloud modules
     ec2
     gce
     gogrid
-    ibmsce
     joyent
     lxc
     libcloud_aws

--- a/doc/ref/clouds/all/salt.cloud.clouds.ibmsce.rst
+++ b/doc/ref/clouds/all/salt.cloud.clouds.ibmsce.rst
@@ -1,6 +1,0 @@
-========================
-salt.cloud.clouds.ibmsce
-========================
-
-.. automodule:: salt.cloud.clouds.ibmsce
-    :members:

--- a/doc/ref/states/index.rst
+++ b/doc/ref/states/index.rst
@@ -12,7 +12,7 @@ state of systems from a central manager.
 
     *
 
-State management
+State Management
 ================
 
 State management, also frequently called Software Configuration Management

--- a/doc/topics/cloud/hpcloud.rst
+++ b/doc/topics/cloud/hpcloud.rst
@@ -9,8 +9,9 @@ floating IP added to it in order to connect to it and further below
 you will see an example that adds context to this statement.
 
 To use the `openstack` driver for HP Cloud, set up the cloud 
-provider configuration file as in the example shown below: 
-  ``/etc/salt/cloud.providers.d/hpcloud.conf``:
+provider configuration file as in the example shown below.
+
+``/etc/salt/cloud.providers.d/hpcloud.conf``:
 
 .. code-block:: yaml
 

--- a/doc/topics/cloud/lxc.rst
+++ b/doc/topics/cloud/lxc.rst
@@ -5,8 +5,9 @@ The LXC module is designed to install a LXC container  Salt via a salt master on
 controlled and possible remote minion.
 
 In other words, we connect to a minion, then from that minion:
-    - we provision and configure a container for networking access
-    - We use saltify to deploy salt and rattach to master
+
+- we provision and configure a container for networking access
+- We use saltify to deploy salt and rattach to master
 
 Limitation
 ------------
@@ -18,18 +19,18 @@ Operation
 This do not use lxc.init to provide a more generic fashion to tie minions
 to their master (if any and defined) to allow custom association code.
 
-Order of operation
+Order of operation:
 
-    - Spin up the lxc template container using salt.modules.lxc
-      on desired minion (clone or template)
-    - Change lxc config option if any to be changed
-    - Start container
-    - Change base passwords if any
-    - Change base DNS base configuration if neccessary
-    - Wait for lxc container to be up and ready for ssh
-    - Test ssh connection and bailout in error
-    - Via ssh (with the help of saltify, upload deploy script and seeds
-      and reattach minion.
+- Spin up the lxc template container using salt.modules.lxc on desired minion
+  (clone or template)
+- Change lxc config option if any to be changed
+- Start container
+- Change base passwords if any
+- Change base DNS base configuration if neccessary
+- Wait for lxc container to be up and ready for ssh
+- Test ssh connection and bailout in error
+- Via ssh (with the help of saltify, upload deploy script and seeds and
+  reattach minion.
 
 
 Provider configuration
@@ -38,6 +39,7 @@ Here are the options to configure your containers
 
 
 Exemple:
+
 .. code-block:: yaml
 
     # Note: This example is for /etc/salt/cloud.providers or any file in the
@@ -121,4 +123,4 @@ The driver support
 ------------------
 - Container creation
 - Image listing (lxc templates)
-- Running container informations (ips , etc)
+- Running container informations (ips, etc)

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -96,6 +96,8 @@ the Salt project so that we can all benefit together as Salt grows.
 Please feel free to sprinkle Salt around your systems and let the
 deliciousness come forth.
 
+.. _salt-community:
+
 Salt Community
 ==============
 

--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -5,8 +5,8 @@ Installation
 ============
 .. seealso::
 
-    :doc:`Installing Salt for development </topics/hacking>` and contributing
-    to the project.
+    :doc:`Installing Salt for development </topics/development/hacking>` and
+    contributing to the project.
 
 Quick Install
 -------------

--- a/doc/topics/releases/0.16.0.rst
+++ b/doc/topics/releases/0.16.0.rst
@@ -61,9 +61,9 @@ Improved Windows Support
 Support for Salt on Windows continues to improve. Software management on
 Windows has become more seamless with Linux/UNIX/BSD software management.
 Installed software is now recognized by the short names defined in the
-:doc:`repository SLS </ref/windows-package-manager>`. This makes it possible to
-run ``salt '*' pkg.version firefox`` and get back results from Windows and
-non-Windows minions alike.
+:doc:`repository SLS </topics/windows/windows-package-manager>`. This makes it
+possible to run ``salt '*' pkg.version firefox`` and get back results from
+Windows and non-Windows minions alike.
 
 When templating files on Windows, Salt will now correctly use Windows
 appropriate line endings. This makes it much easier to edit and consume files

--- a/doc/topics/releases/0.8.0.rst
+++ b/doc/topics/releases/0.8.0.rst
@@ -1,6 +1,7 @@
 ========================
 Salt 0.8.0 release notes
 ========================
+
 Salt 0.8.0 is ready for general consumption!
 The source tarball is available on GitHub for download:
 
@@ -27,8 +28,9 @@ Advanced minion threading
 Configurable minion modules
 
 
-Salt-cp -
-=======================
+Salt-cp
+=======
+
 The salt-cp command introduces the ability to copy simple files via salt to
 targeted servers. Using salt-cp is very simple, just call salt-cp with a target
 specification, the source file(s) and where to copy the files on the minions.
@@ -41,8 +43,9 @@ Will copy the local /etc/hosts file to all of the minions.
 Salt-cp is very young, in the future more advanced features will be added, and
 the functionality will much more closely resemble the cp command.
 
-Cython minion modules -
-========================
+Cython minion modules
+=====================
+
 Cython is an amazing tool used to compile Python modules down to c. This is
 arguably the fastest way to run Python code, and since pyzmq requires cython,
 adding support to salt for cython adds no new dependencies.
@@ -55,8 +58,9 @@ distribution called cytest.pyx:
 
 :blob:`salt/modules/cytest.pyx`
 
-Dynamic Returners -
-========================
+Dynamic Returners
+=================
+
 By default salt returns command data back to the salt master, but now salt can
 return command data to any system. This is enabled via the new returners
 modules feature for salt. The returners modules take the return data and sends
@@ -73,22 +77,23 @@ There are 2 simple stock returners in the returners directory:
 The documentation on writing returners will be added to the wiki shortly, and
 returners can be written in pure Python, or in cython.
 
-Configurable Minion Modules -
-==============================
+Configurable Minion Modules
+===========================
 Minion modules may need to be configured, now the options passed to the minion
 configuration file can be accessed inside of the minion modules via the __opt__
 dict.
 
 Information on how to use this simple addition has been added to the wiki:
-:doc:`Writing modules </ref/states/>`
+:doc:`Writing modules </ref/states/writing>`
 
 The test module has an example of using the __opts__ dict, and how to set
 default options:
 
 :blob:`salt/modules/test.py`
 
-Advanced Minion Threading:
-==============================
+Advanced Minion Threading
+=========================
+
 In 0.7.0 the minion would block after receiving a command from the master, now
 the minion will spawn a thread or multiprocess. By default Python threads are
 used because for general use they have proved to be faster, but the minion can
@@ -100,7 +105,8 @@ The configuration option can be found in the minion configuration file:
 
 :blob:`conf/minion`
 
-Lowered Supported Python to 2.6 -
+Lowered Supported Python to 2.6
+===============================
 
 The requirement for Python 2.7 has been removed to support Python 2.6. I have
 received requests to take the minimum Python version back to 2.4, but
@@ -110,6 +116,7 @@ not support Python 2.4.
 Salt 0.8.0 is a very major update, it also changes the network protocol slightly
 which makes communication with older salt daemons impossible, your master and
 minions need to be upgraded together!
+
 I could use some help bringing salt to the people! Right now I only have
 packages for Arch Linux, Fedora 14 and Gentoo. We need packages for Debian and
 people willing to help test on more platforms. We also need help writing more

--- a/doc/topics/releases/0.8.9.rst
+++ b/doc/topics/releases/0.8.9.rst
@@ -42,9 +42,7 @@ A big feature is the addition of Salt run, the ``salt-run`` command allows for
 master side execution modules to be made that gather specific information or
 execute custom routines from the master.
 
-Documentation for salt-run can be found here:
-
-:doc:`Runners </ref/runners>`
+Documentation for salt-run can be found :doc:`here </ref/runners/index>`
 
 Refined Outputters
 ``````````````````
@@ -61,9 +59,7 @@ Cross Calling Salt Modules
 
 Salt modules can now call each other, the ``__salt__`` dict has been added to
 the predefined references in minion modules. This new feature is documented in
-the modules documentation:
-
-:doc:`Modules </ref/modules>`
+the :doc:`modules documentation </ref/modules/index>`.
 
 Watch Option Added to Salt State System
 ````````````````````````````````````````

--- a/doc/topics/releases/0.9.0.rst
+++ b/doc/topics/releases/0.9.0.rst
@@ -35,9 +35,10 @@ New Features
 Salt Syndic
 ```````````
 
-The new :doc:`Syndic interface </ref/syndic>` allows a master to be commanded via another higher
-level salt master. This is a powerful solution allowing a master control
-structure to exist, allowing salt to scale to much larger levels then before.
+The new :ref:`Syndic interface <syndic>` allows a master to be
+commanded via another higher level salt master. This is a powerful solution
+allowing a master control structure to exist, allowing salt to scale to much
+larger levels then before.
 
 Peer Communication
 ``````````````````

--- a/doc/topics/tutorials/states_pt4.rst
+++ b/doc/topics/tutorials/states_pt4.rst
@@ -188,7 +188,7 @@ can be found on Github in the `saltstack-formulas`_ collection of repositories.
 .. _`saltstack-formulas`: https://github.com/saltstack-formulas
 
 If you have any questions, suggestions, or just want to chat with other people
-who are using Salt, we have a very :doc:`active community </topics/community>`
+who are using Salt, we have a very :ref:`active community <salt-community>`
 and we'd love to hear from you.
 
 In addition, by continuing to :doc:`part 5 <states_pt5>`, you can learn about

--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -257,15 +257,19 @@ start with looks like this:
 
 The ``*`` is the target, which specifies all minions.
 
-``test.ping`` tells the minion to run the :py:func:`test.ping <salt.modules.test.ping>` function.
+``test.ping`` tells the minion to run the :py:func:`test.ping
+<salt.modules.test.ping>` function.
 
-In the case of ``test.ping``, ``test`` refers to a :doc:`execution module </ref/modules/>`.
-``ping`` refers to the :py:func:`ping <salt.modules.test.ping>` function contained in the
-aforementioned ``test`` module.
+In the case of ``test.ping``, ``test`` refers to a :doc:`execution module
+</ref/modules/index>`.  ``ping`` refers to the :py:func:`ping
+<salt.modules.test.ping>` function contained in the aforementioned ``test``
+module.
 
 .. note::
-    Execution modules are the workhorses of Salt. They do the work on the system to perform
-    various tasks, such as manipulating files and restarting services.
+
+    Execution modules are the workhorses of Salt. They do the work on the
+    system to perform various tasks, such as manipulating files and restarting
+    services.
 
 The result of running this command will be the master instructing all of the
 minions to execute :py:func:`test.ping <salt.modules.test.ping>` in parallel
@@ -281,8 +285,9 @@ connected.
     the minion's hostname, but can be explicitly defined in the minion config as
     well by using the :conf_minion:`id` parameter.
 
-Of course, there are hundreds of other modules that can be called just as ``test.ping`` can.
-For example, the following would return disk usage on all targeted minions:
+Of course, there are hundreds of other modules that can be called just as
+``test.ping`` can.  For example, the following would return disk usage on all
+targeted minions:
 
 .. code-block:: bash
 

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -315,9 +315,11 @@ class CloudClient(object):
 
         Example:
 
-        client.volume_action(names=['myblock'], action='create',
-            provider='my-nova', kwargs={'voltype': 'SSD', 'size': 1000}
-        )
+        .. code-block:: python
+
+            client.volume_action(names=['myblock'], action='create',
+                provider='my-nova', kwargs={'voltype': 'SSD', 'size': 1000}
+            )
         '''
         mapper = salt.cloud.Map(self._opts_defaults())
         providers = mapper.map_providers_parallel()
@@ -353,6 +355,8 @@ class CloudClient(object):
         Execute a single action via the cloud plugin backend
 
         Examples:
+
+        .. code-block:: python
 
             client.action(fun='show_instance', names=['myinstance'])
             client.action(fun='show_image', provider='my-ec2-config',

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2746,14 +2746,19 @@ def copy_snapshot(kwargs=None, call=None):
 
 def describe_snapshots(kwargs=None, call=None):
     '''
-    Describe a snapshots
-    Options:   snapshot_id - One or more snapshot IDs.
-                             Multiple IDs must be separated by ",".
-                     owner - Returns the snapshots owned by the specified owner. Multiple owners can be specified.
-                             Valid values: self | amazon | AWS Account ID
-                             Multiple values must be separated by ",".
-             restorable_by - One or more AWS accounts IDs that can create volumes from the snapshot.
-                             Multiple aws account IDs must be separated by ",".
+    Describe a snapshot (or snapshots)
+
+    snapshot_id
+        One or more snapshot IDs. Multiple IDs must be separated by ",".
+
+    owner
+        Return the snapshots owned by the specified owner. Valid values
+        include: self, amazon, <AWS Account ID>. Multiple values must be
+        separated by ",".
+
+    restorable_by
+        One or more AWS accounts IDs that can create volumes from the snapshot.
+        Multiple aws account IDs must be separated by ",".
 
     TODO: Add all of the filters.
     '''

--- a/salt/modules/apache.py
+++ b/salt/modules/apache.py
@@ -420,9 +420,9 @@ def config(name, config, edit=True):
     Config is meant to be an ordered dict of all of the apache configs.
 
     .. code-block:: bash
+
         salt '*' apache.config /etc/httpd/conf.d/ports.conf \
                 config="[{'Listen': '22'}]"
-
     '''
 
     for entry in config:

--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -34,9 +34,8 @@ def tune(device, **kwargs):
 
         salt '*' blockdev.tune /dev/sda1 read-ahead=1024 read-write=True
 
-    Valid options are::
-
-  read-ahead:
+    Valid options are: ``read-ahead``, ``filesystem-read-ahead``,
+    ``read-only``, ``read-write``.
 
     See the ``blockdev(8)`` manpage for a more complete description of these
     options.

--- a/salt/utils/aggregation.py
+++ b/salt/utils/aggregation.py
@@ -99,7 +99,7 @@
     Introspection
     -------------
 
-    .. todo:: write this part
+    TODO: write this part
 
 '''
 


### PR DESCRIPTION
- Remove old pages that refer to nonexistant modules
- Add new docs pages to toctree
- Fix a buttload of sphinx warnings and errors, most of them broken links from the recent docs restructuring.
