### PR TITLE
Rewrite jid comparison for job cache cleanup

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -92,11 +92,15 @@ def clean_old_jobs(opts):
                         # Parse the jid into a proper datetime object.  We only
                         # parse down to the minute, since keep_jobs is measured
                         # in hours, so a minute difference is not important
-                        jidtime = datetime.datetime(jid[0:4],
-                                                    jid[4:6],
-                                                    jid[6:8],
-                                                    jid[8:10],
-                                                    jid[10:12])
+                        try:
+                            jidtime = datetime.datetime(int(jid[0:4]),
+                                                        int(jid[4:6]),
+                                                        int(jid[6:8]),
+                                                        int(jid[8:10]),
+                                                        int(jid[10:12]))
+                        except ValueError as e:
+                            # Invalid jid, scrub the dir
+                            shutil.rmtree(f_path)
                         difference = cur - jidtime
                         hours_difference = difference.seconds / 3600.0
                         if hours_difference > opts['keep_jobs']:

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -82,7 +82,8 @@ def clean_old_jobs(opts):
                     f_path = os.path.join(t_path, final)
                     jid_file = os.path.join(f_path, 'jid')
                     if not os.path.isfile(jid_file):
-                        continue
+                        # No jid file means corrupted cache entry, scrub it
+                        shutil.rmtree(f_path)
                     with salt.utils.fopen(jid_file, 'r') as fn_:
                         jid = fn_.read()
                     if len(jid) < 18:

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -73,7 +73,7 @@ def clean_old_jobs(opts):
     '''
     if opts['keep_jobs'] != 0:
         jid_root = os.path.join(opts['cachedir'], 'jobs')
-        cur = '{0:%Y%m%d%H}'.format(datetime.datetime.now())
+        cur = datetime.datetime.now()
 
         if os.path.exists(jid_root):
             for top in os.listdir(jid_root):
@@ -88,9 +88,19 @@ def clean_old_jobs(opts):
                     if len(jid) < 18:
                         # Invalid jid, scrub the dir
                         shutil.rmtree(f_path)
-                    elif int(cur) - int(jid[:10]) > \
-                            opts['keep_jobs']:
-                        shutil.rmtree(f_path)
+                    else:
+                        # Parse the jid into a proper datetime object.  We only
+                        # parse down to the minute, since keep_jobs is measured
+                        # in hours, so a minute difference is not important
+                        jidtime = datetime.datetime(jid[0:4],
+                                                    jid[4:6],
+                                                    jid[6:8],
+                                                    jid[8:10],
+                                                    jid[10:12])
+                        difference = cur - jidtime
+                        hours_difference = difference.seconds / 3600.0
+                        if hours_difference > opts['keep_jobs']:
+                            shutil.rmtree(f_path)
 
 
 def access_keys(opts):


### PR DESCRIPTION
Previous iteration was naive, just converted the first 10 characters of
the jid to integers and subtracted.  However, that means that any time
we go tick over midnight, it adds 76 to the difference (since hours are
not tracked in base 10).  Now, we parse out the jid, convert to a
datetime object, and compare using a timedelta object.

Will not cherry-pick cleanly, so I will submit that as a secondary pull request.
