### PR TITLE
seed and lxc seeding & cloning improvements

### DIFF
--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -84,9 +84,7 @@ def apply_(path, id_=None, config=None, approve_key=True, install=True,
         Install salt-minion, if absent. Default: true.
 
     prep_install
-        Prepare the bootstrap script, but don't run it. The files needed for
-        installation (bootstrap.py, config, and keys) will be placed in /tmp
-        on the target path/device. Default: false
+        Prepare the bootstrap script, but don't run it. Default: false
     '''
     stats = __salt__['file.stats'](path, follow_symlinks=True)
     if not stats:
@@ -199,9 +197,17 @@ def _check_resolv(mpt):
 
 
 def _check_install(root):
-    cmd = ('chroot {0} /bin/sh -c if ! type salt-minion; '
-           'then exit 1; fi').format(root)
-    return not __salt__['cmd.retcode'](cmd, output_loglevel='quiet')
+    sh_ = '/bin/sh'
+    if os.path.isfile(os.path.join(root, 'bin/bash')):
+        sh_ = '/bin/bash'
+
+    cmd = ('if ! type salt-minion; then exit 1; fi').format(root)
+    cmd = 'chroot {0} {1} -c {2!r}'.format(
+        root,
+        sh_,
+        cmd)
+
+    return not __salt__['cmd.retcode'](cmd) #, output_loglevel='quiet')
 
 
 def _chroot_exec(root, cmd):

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -207,7 +207,7 @@ def _check_install(root):
         sh_,
         cmd)
 
-    return not __salt__['cmd.retcode'](cmd) #, output_loglevel='quiet')
+    return not __salt__['cmd.retcode'](cmd, output_loglevel='quiet')
 
 
 def _chroot_exec(root, cmd):

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -79,7 +79,8 @@ def init(name,
                 [nic=nic_profile] [profile=lxc_profile] \\
                 [nic_opts=nic_opts] [start=(true|false)] \\
                 [seed=(true|false)] [install=(true|false)] \\
-                [config=minion_config]
+                [config=minion_config] [clone=original] \\
+                [snapshot=(true|false)]
 
     name
         Name of the container.
@@ -123,45 +124,55 @@ def init(name,
     data = __salt__['lxc.list'](host, quiet=True)
     for host, containers in data.items():
         if name in sum(containers.values(), []):
-            print('Container "{0}" is already deployed'.format(name))
-            return 'fail'
+            print('Container \'{0}\' already exists on host \'{1}\''.format(
+                host))
+            return False
 
     if host is None:
         #TODO: Support selection of host based on available memory/cpu/etc.
-        print('A host must be provided.')
-        return 'fail'
+        print('A host must be provided')
+        return False
 
     if host not in data:
-        print('Host "{0}" was not found'.format(host))
-        return 'fail'
+        print('Host \'{0}\' was not found'.format(host))
+        return False
 
-    seed = kwargs.get('seed', True)
-    if seed:
+    #kwkeys = ('cpuset', 'cpushare', 'memory', 'nic', 'profile',
+    #          'nic_opts', 'start', 'seed', 'install', 'config',
+    #          'approve_key', 'clone', 'snapshot')
+    kw = dict((k, v) for k, v in kwargs.items() if not k.startswith('__'))
+    approve_key = kw.get('approve_key', True)
+    if approve_key:
         kv = salt.utils.virt.VirtKey(host, name, __opts__)
         if kv.authorize():
-            print('Minion will be preseeded.')
+            print('Container key will be preauthorized')
         else:
-            print('Preauthorization failed.')
-            return 'fail'
+            print('Container key preauthorization failed')
+            return False
 
     client = salt.client.LocalClient(__opts__['conf_file'])
 
-    print('Creating container {0} on host {1}.'.format(name, host))
-    args = [name]
+    print('Creating container \'{0}\' on host \'{1}\''.format(name, host))
 
+    args = [name]
     cmd_ret = client.cmd_iter(host,
                               'lxc.init',
                               args,
                               kwarg=kwargs,
                               timeout=600)
-
     ret = next(cmd_ret)
-    if not ret:
-        print('Container {0} was not initialized.'.format(name))
-        return 'fail'
+    if ret and host in ret:
+        ret = ret[host]['ret']
+    else:
+        ret = {}
 
-    print('Container {0} initialized on host {1}'.format(name, host))
-    return 'good'
+    if ret.get('created', False) or ret.get('cloned', False):
+        print('Container \'{0}\' initialized on host \'{1}\''.format(
+            name, host))
+    else:
+        error = ret.get('error', 'unknown error')
+        print('Container \'{0}\' was not initialized: {1}'.format(name, error))
+    return ret or None
 
 
 def list_(host=None, quiet=False):

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -137,9 +137,6 @@ def init(name,
         print('Host \'{0}\' was not found'.format(host))
         return False
 
-    #kwkeys = ('cpuset', 'cpushare', 'memory', 'nic', 'profile',
-    #          'nic_opts', 'start', 'seed', 'install', 'config',
-    #          'approve_key', 'clone', 'snapshot')
     kw = dict((k, v) for k, v in kwargs.items() if not k.startswith('__'))
     approve_key = kw.get('approve_key', True)
     if approve_key:


### PR DESCRIPTION
**salt.modules.lxc:**
- Add cloning support to `lxc.init`
- In `lxc.bootstrap`, start the container before seeding the keys/config to /tmp (this is necessary since /tmp may be wiped out on boot).

**salt.runners.lxc:**
- More uniform progress reporting and more meaningful return values.

**salt.modules.seed:**
- in `_check_install`, use bash if available
