### PR TITLE
fix for keystone.user_present

### DIFF
--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -184,7 +184,7 @@ def user_present(name,
                 for role in roles[0][tenant_role]:
                     __salt__['keystone.user_role_add'](user=name,
                                                        role=role,
-                                                       tenant_role=tenant_role,
+                                                       tenant=tenant_role,
                                                        profile=profile,
                                                        **connection_args)
         ret['comment'] = 'Keystone user {0} has been added'.format(name)


### PR DESCRIPTION
---

```
      ID: glance_user
Function: keystone.user_present
    Name: glance
  Result: False
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/lib/pymodules/python2.7/salt/state.py", line 1371, in call
              **cdata['kwargs'])
            File "/var/cache/salt/minion/extmods/states/keystone.py", line 189, in user_present
              **connection_args)
            File "/var/cache/salt/minion/extmods/modules/keystone.py", line 884, in user_role_add
              **connection_args).keys()[0]['name']
          TypeError: string indices must be integers, not str
```

This error will occur when a new user is being added and then subsequently user role is added.
It does not occur when an existing user is being updated and new roles added.
