### PR TITLE
Fix kwarg parsing regression

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -180,7 +180,10 @@ def parse_args_and_kwargs(func, args, data=None):
             for key, val in arg.iteritems():
                 if key == '__kwarg__':
                     continue
-                kwargs[key] = val
+                if isinstance(val, string_types):
+                    kwargs[key] = yamlify_arg(val)
+                else:
+                    kwargs[key] = val
             continue
         _args.append(yamlify_arg(arg))
     if argspec.keywords and isinstance(data, dict):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -160,7 +160,6 @@ def parse_args_and_kwargs(func, args, data=None):
     invalid_kwargs = []
 
     for arg in args:
-        # support old yamlify syntax
         if isinstance(arg, string_types):
             arg_name, arg_value = salt.utils.parse_kwarg(arg)
             if arg_name:


### PR DESCRIPTION
This fixes a regression (only present in develop) where CLI kwargs are not passed through yamlify_arg(), which result in salt not being able to load data structures from the command line.

Fixes #11301.
