### PR TITLE
Eauth group support

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -106,20 +106,18 @@ class LoadAuth(object):
         Read in a load and return the groups a user is a member of
         by asking the appropriate provider
         '''
-        print('GETTING GROUPS')
         if 'eauth' not in load:
             return False
         fstr = '{0}.groups'.format(load['eauth'])
         if fstr not in self.auth:
             return False
         fcall = salt.utils.format_call(self.auth[fstr], load)
-        print(fcall)
         try:
             return self.auth[fstr](*fcall['args'])
         except IndexError:
-            return ''
+            return False
         except Exception as exc:
-            print(exc)
+            return None
 
 
     def mk_token(self, load):

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -101,6 +101,27 @@ class LoadAuth(object):
             time.sleep(0.001)
         return False
 
+    def get_groups(self, load):
+        '''
+        Read in a load and return the groups a user is a member of
+        by asking the appropriate provider
+        '''
+        print('GETTING GROUPS')
+        if 'eauth' not in load:
+            return False
+        fstr = '{0}.groups'.format(load['eauth'])
+        if fstr not in self.auth:
+            return False
+        fcall = salt.utils.format_call(self.auth[fstr], load)
+        print(fcall)
+        try:
+            return self.auth[fstr](*fcall['args'])
+        except IndexError:
+            return ''
+        except Exception as exc:
+            print(exc)
+
+
     def mk_token(self, load):
         '''
         Run time_auth and create a token. Return False or the token

--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -188,3 +188,6 @@ def auth(username, password):
         )
     )
     return True
+
+def groups(username, *args, **kwargs):
+    return None

--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -170,7 +170,7 @@ def auth(username, password, **kwargs):
 def groups(username, *args, **kwargs):
     '''
     Retreive groups for a given user for this auth provider
+
+    Uses system groups
     '''
-    print('CALLING GROUP')
-    print('USERNAME: {0}'.format(username))
     return get_group_list(username)

--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -23,6 +23,9 @@ from ctypes import CDLL, POINTER, Structure, CFUNCTYPE, cast, pointer, sizeof
 from ctypes import c_void_p, c_uint, c_char_p, c_char, c_int
 from ctypes.util import find_library
 
+# Import Salt libs
+from salt.utils import get_group_list
+
 LIBPAM = CDLL(find_library('pam'))
 LIBC = CDLL(find_library('c'))
 
@@ -163,3 +166,11 @@ def auth(username, password, **kwargs):
     Authenticate via pam
     '''
     return authenticate(username, password, kwargs.get('service', 'login'))
+
+def groups(username, *args, **kwargs):
+    '''
+    Retreive groups for a given user for this auth provider
+    '''
+    print('CALLING GROUP')
+    print('USERNAME: {0}'.format(username))
+    return get_group_list(username)

--- a/salt/master.py
+++ b/salt/master.py
@@ -2445,25 +2445,26 @@ class ClearFuncs(object):
                         'Authentication failure of type "eauth" occurred.'
                     )
                     return ''
-                # Auth has succeeded, get groups
-                groups = self.loadauth.get_groups(extra)
 
             except Exception as exc:
                 log.error(
                     'Exception occurred while authenticating: {0}'.format(exc)
                 )
                 return ''
+
             auth_list = self.opts['external_auth'][extra['eauth']][name] if name in self.opts['external_auth'][extra['eauth']] else self.opts['external_auth'][extra['eauth']]['*']
+
+            # Auth has succeeded, get groups this user is a member of
+            groups = self.loadauth.get_groups(extra)
+
             if groups:
-                gathered_groups = self.ckminions.gather_groups(self.opts['external_auth'][extra['eauth']])
-                for item in gathered_groups.values():
-                    auth_list.append(item)
+                auth_list = self.ckminions.gather_groups(self.opts['external_auth'][extra['eauth']], groups, auth_list)
             good = self.ckminions.auth_check(
                     auth_list,
                     clear_load['fun'],
                     clear_load['tgt'],
-                    clear_load.get('tgt_type', 'glob'),
-                    groups=groups)
+                    clear_load.get('tgt_type', 'glob')
+                    )
             if not good:
                 # Accept find_job so the CLI will function cleanly
                 if clear_load['fun'] != 'saltutil.find_job':

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -528,16 +528,17 @@ class CkMinions(object):
                 fun,
                 form)
 
-    def auth_check(self, auth_list, funs, tgt, tgt_type='glob'):
+    def auth_check(self, auth_list, funs, tgt, tgt_type='glob', groups=None):
         '''
         Returns a bool which defines if the requested function is authorized.
         Used to evaluate the standard structure under external master
         authentication interfaces, like eauth, peer, peer_run, etc.
         '''
         # compound commands will come in a list so treat everything as a list
+        import pprint
+        pprint.pprint(auth_list)
         if not isinstance(funs, list):
             funs = [funs]
-
         for fun in funs:
             for ind in auth_list:
                 if isinstance(ind, str):
@@ -563,6 +564,24 @@ class CkMinions(object):
                                 if self.match_check(regex, fun):
                                     return True
         return False
+
+    def gather_groups(self, auth_provider):
+        '''
+        Returns the list of groups, if any, for a given authentication provider type
+
+        Groups are defined as any dict in which a key has a trailing '%'
+        '''
+        print auth_provider
+        keys = filter(lambda(item): item.endswith('%'), auth_provider)
+        groups = {}
+        if keys:
+            for key in keys:
+                for matcher in auth_provider[key]:
+                    groups[key] = matcher
+            return groups
+        else:
+            return None
+        
 
     def wheel_check(self, auth_list, fun):
         '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -535,8 +535,6 @@ class CkMinions(object):
         authentication interfaces, like eauth, peer, peer_run, etc.
         '''
         # compound commands will come in a list so treat everything as a list
-        import pprint
-        pprint.pprint(auth_list)
         if not isinstance(funs, list):
             funs = [funs]
         for fun in funs:
@@ -565,20 +563,22 @@ class CkMinions(object):
                                     return True
         return False
 
-    def gather_groups(self, auth_provider):
+    def gather_groups(self, auth_provider, user_groups, auth_list):
         '''
         Returns the list of groups, if any, for a given authentication provider type
 
         Groups are defined as any dict in which a key has a trailing '%'
         '''
-        print auth_provider
-        keys = filter(lambda(item): item.endswith('%'), auth_provider)
+        group_perm_keys = filter(lambda(item): item.endswith('%'), auth_provider)
         groups = {}
-        if keys:
-            for key in keys:
-                for matcher in auth_provider[key]:
-                    groups[key] = matcher
-            return groups
+        if group_perm_keys:
+            for group_perm in group_perm_keys:
+                for matcher in auth_provider[group_perm]:
+                    if group_perm[:-1] in user_groups:
+                        groups[group_perm] = matcher
+        for item in groups.values():
+            auth_list.append(item)
+            return auth_list
         else:
             return None
         


### PR DESCRIPTION
This provides initial support for eauth groups for the PAM provider _only_.

There is no support for LDAP, etc. Providers other than PAM should simply no-op if a `groups` function is not found. 

The syntax for adding a group in a master configuration files is as follows:

```
my_group%:
  - '*':
    - test.echo
```

(Note the trailing '%', which indicates a group definition.)

The above block indicates that any user returned by PAM which is a member of the `my_group` group on the system should be authorized for the `test.echo` function on all minions in _addition_ to all functions granted to her by explicit user permission in the master configuration file for the given provider. 
