### PR TITLE
Properly pre-parse args and kwargs (2014.1 branch)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -178,7 +178,10 @@ def parse_args_and_kwargs(func, args, data=None):
             for key, val in arg.iteritems():
                 if key == '__kwarg__':
                     continue
-                kwargs[key] = val
+                if isinstance(val, string_types):
+                    kwargs[key] = yamlify_arg(val)
+                else:
+                    kwargs[key] = val
             continue
         _args.append(yamlify_arg(arg))
     if argspec.keywords and isinstance(data, dict):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -66,7 +66,7 @@ import salt.payload
 import salt.utils.schedule
 import salt.utils.event
 
-from salt._compat import string_types
+from salt._compat import integer_types, string_types
 from salt.utils.debug import enable_sigusr1_handler
 from salt.utils.event import tagify
 import salt.syspaths
@@ -204,22 +204,27 @@ def yamlify_arg(arg):
     if not isinstance(arg, string_types):
         return arg
     try:
-        original_arg = str(arg)
-        if isinstance(arg, string_types):
-            if '#' in arg:
-                # Don't yamlify this argument or the '#' and everything after
-                # it will be interpreted as a comment.
-                return arg
-            if '\n' not in arg:
-                arg = yaml.safe_load(arg)
+        # Explicit late import to avoid circular import. DO NOT MOVE THIS.
+        import salt.utils.yamlloader as yamlloader
+        original_arg = arg
+        if '#' in arg:
+            # Don't yamlify this argument or the '#' and everything after
+            # it will be interpreted as a comment.
+            return arg
+        if arg == 'None':
+            arg = None
+        elif '\n' not in arg:
+            arg = yamlloader.load(arg, Loader=yamlloader.CustomLoader)
+
         if isinstance(arg, dict):
             # dicts must be wrapped in curly braces
-            if (isinstance(original_arg, string_types) and
-                    not original_arg.startswith('{')):
+            if not original_arg.startswith('{'):
                 return original_arg
             else:
                 return arg
-        elif isinstance(arg, (int, list, string_types)):
+
+        elif arg is None \
+                or isinstance(arg, (list, float, integer_types, string_types)):
             # yaml.safe_load will load '|' as '', don't let it do that.
             if arg == '' and original_arg in ('|',):
                 return original_arg

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -159,7 +159,6 @@ def parse_args_and_kwargs(func, args, data=None):
     invalid_kwargs = []
 
     for arg in args:
-        # support old yamlify syntax
         if isinstance(arg, string_types):
             arg_name, arg_value = salt.utils.parse_kwarg(arg)
             if arg_name:

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -7,8 +7,9 @@ Execute overstate functions
 from __future__ import print_function
 
 # Import salt libs
-import salt.overstate
 import salt.output
+import salt.overstate
+from salt.exceptions import CommandExecutionError
 
 
 def over(saltenv='base', os_fn=None):
@@ -25,7 +26,12 @@ def over(saltenv='base', os_fn=None):
         salt-run state.over base /path/to/myoverstate.sls
     '''
     stage_num = 0
-    overstate = salt.overstate.OverState(__opts__, saltenv, os_fn)
+    try:
+        overstate = salt.overstate.OverState(__opts__, saltenv, os_fn)
+    except IOError as exc:
+        raise CommandExecutionError(
+            '{0}: {1!r}'.format(exc.strerror, exc.filename)
+        )
     for stage in overstate.stages_iter():
         if isinstance(stage, dict):
             # This is highstate data

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -29,9 +29,27 @@ import salt.version as version
 import salt.syspaths as syspaths
 import salt.log.setup as log
 from salt.utils.validate.path import is_writeable
+from salt._compat import string_types
 
 if not utils.is_windows():
     import salt.cloud.exceptions
+
+
+def parse_args_kwargs(args):
+    '''
+    Parse out the args and kwargs from an args string
+    '''
+    _args = []
+    _kwargs = {}
+    for arg in args:
+        if isinstance(arg, string_types):
+            arg_name, arg_value = utils.parse_kwarg(arg)
+            if arg_name:
+                _kwargs[arg_name] = arg_value
+            else:
+                _args.append(arg)
+
+    return _args, _kwargs
 
 
 def _sorted(mixins_or_funcs):
@@ -1560,6 +1578,9 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                 else:
                     self.config['fun'] = self.args[1]
                     self.config['arg'] = self.args[2:]
+
+                # parse the args and kwargs before sending to the publish interface
+                self.config['arg'] = salt.client.condition_kwarg(*parse_args_kwargs(self.config['arg']))
             except IndexError:
                 self.exit(42, '\nIncomplete options passed.\n\n')
 


### PR DESCRIPTION
**Hold off on merging, I'm working on additional commits to develop that I will cherrypick here.**

This adds in some fixes from develop, as well as some missing commits that didn't make their way into 2014.1.0, that change how kwargs are parsed. This will likely still be refactored a bit in the coming weeks.
