### PR TITLE
Fix to make setup.py work

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -389,7 +389,10 @@ class InstallLib(install_lib):
         inp = self.get_inputs()
         out = self.get_outputs()
 
-        idx = inp.index('build/lib/salt/templates/git/ssh-id-wrapper')
+        #idx = inp.index('build/lib/salt/templates/git/ssh-id-wrapper')
+        for i, word in enumerate(inp):
+            if word.endswith('salt/templates/git/ssh-id-wrapper'):
+                idx = i
         filename = out[idx]
 
         os.chmod(filename, 0755)


### PR DESCRIPTION
change in InstallLib assumes build/lib/salt and looks for a file based on that assumption.  on certain platforms this fails and causes the setup.py to fail.
