### PR TITLE
Return empty set

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -398,7 +398,7 @@ class CkMinions(object):
         if self.opts.get('minion_data_cache', False):
             cdir = os.path.join(self.opts['cachedir'], 'minions')
             if not os.path.isdir(cdir):
-                return list(minions)
+                return minions
             addrs = salt.utils.network.local_port_tcp(int(self.opts['publish_port']))
             if '127.0.0.1' in addrs:
                 addrs.update(self.ip_addrs)


### PR DESCRIPTION
Fix for the following traceback. Occurs when starting the master if the minions cache folder hasn't been created yet. This function is only being called in one other place (manage runner) and that handles set objects just fine.

``` python
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/shouse/src/salt/salt/salt/master.py", line 309, in _clear_old_jobs
    new = present.difference(old_present)
AttributeError: 'list' object has no attribute 'difference'
```
