### PR TITLE
Ensuring the order of options for tar in the archive state.

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -147,10 +147,13 @@ def extracted(name,
         else:
             # this is needed until merging PR 2651
             log.debug("Untar %s in %s", filename, name)
-            for opt in ['x', 'f']:
+            for opt in ['x']:
                 if not opt in tar_options:
                     tar_options = '-{0} {1}'.format(opt, tar_options)
-            results = __salt__['cmd.run_all']('tar {0} "{1}"'.format(
+            # Want to ensure -f is the last argument before the filename
+            if 'f' in tar_options:
+                tar_options.remove('f')
+            results = __salt__['cmd.run_all']('tar {0} -f "{1}"'.format(
                 tar_options, filename), cwd=name)
             if results['retcode'] != 0:
                 ret['result'] = False


### PR DESCRIPTION
Ensuring the order of options for tar, need to make sure -f is last and right before the filename
