### PR TITLE
Add a quiet retcode wrapper for grain executions.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -36,6 +36,7 @@ import salt.modules.cmdmod
 
 __salt__ = {
     'cmd.run': salt.modules.cmdmod._run_quiet,
+    'cmd.retcode': salt.modules.cmdmod._retcode_quiet,
     'cmd.run_all': salt.modules.cmdmod._run_all_quiet
 }
 log = logging.getLogger(__name__)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -926,6 +926,45 @@ def retcode(cmd,
     return ret['retcode']
 
 
+def _retcode_quiet(cmd,
+                   cwd=None,
+                   stdin=None,
+                   runas=None,
+                   shell=DEFAULT_SHELL,
+                   python_shell=True,
+                   env=(),
+                   clean_env=False,
+                   template=None,
+                   umask=None,
+                   output_loglevel='quiet',
+                   quiet=True,
+                   timeout=None,
+                   reset_system_locale=True,
+                   ignore_retcode=False,
+                   saltenv='base',
+                   **kwargs):
+    '''
+    Helper for running commands quietly for minion startup.
+    Returns same as retcode
+    '''
+    return retcode(cmd,
+                   cwd=cwd,
+                   stdin=stdin,
+                   runas=runas,
+                   shell=shell,
+                   python_shell=python_shell,
+                   env=env,
+                   clean_env=clean_env,
+                   template=template,
+                   umask=umask,
+                   output_loglevel=output_loglevel,
+                   timeout=timeout,
+                   reset_system_locale=reset_system_locale,
+                   ignore_retcode=ignore_retcode,
+                   saltenv=saltenv,
+                   **kwargs)
+
+
 def script(source,
            args=None,
            cwd=None,


### PR DESCRIPTION
This fixes #11361 regression introduced by c341c0ebc4978ccdb75b22a1f2eec012b558980b.

/cc @gtmanfred @thatch45  @s0undt3ch
