### PR TITLE
avoid shadowing outer clone() func in modules.lxc.init()

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -224,14 +224,14 @@ def init(name,
     seed_cmd = select('seed_cmd')
     config = select('config')
     approve_key = select('approve_key', True)
-    clone = select('clone')
+    clone_from = select('clone')
 
     with tempfile.NamedTemporaryFile() as cfile:
         cfile.write(_gen_config(cpuset=cpuset, cpushare=cpushare,
                                 memory=memory, nicp=nicp, nic_opts=nic_opts))
         cfile.flush()
-        if clone:
-            ret = __salt__['lxc.clone'](name, clone, config=cfile.name,
+        if clone_from:
+            ret = __salt__['lxc.clone'](name, clone_from, config=cfile.name,
                                         profile=profile, **kwargs)
         else:
             ret = __salt__['lxc.create'](name, config=cfile.name,


### PR DESCRIPTION
```
************* Module salt.modules.lxc
salt/modules/lxc.py:227: [W0621(redefined-outer-name), init] Redefining name 'clone' from outer scope (line 355)
```
