### PR TITLE
Better handling of floating IPs, pep8/pyflakes fixes

### DIFF
--- a/doc/topics/cloud/hpcloud.rst
+++ b/doc/topics/cloud/hpcloud.rst
@@ -8,6 +8,9 @@ uses is Havana. When an instance is booted, it must have a
 floating IP added to it in order to connect to it and further below 
 you will see an example that adds context to this statement.
 
+Set up a cloud provider configuration file
+==========================================
+
 To use the `openstack` driver for HP Cloud, set up the cloud 
 provider configuration file as in the example shown below: 
   ``/etc/salt/cloud.providers.d/hpcloud.conf``:
@@ -71,6 +74,9 @@ It is often named the same as ``user`` albeit with a ``-project1`` appended.
 The ``password`` is of course what you created your account with. The management
 UI also has other information such as being able to select US East or US West.
 
+Set up a cloud profile config file
+==================================
+
 The profile shown below is a know working profile for an Ubuntu instance. The
 profile configuration file is stored in the following location:
 
@@ -97,15 +103,17 @@ Some important things about the example above:
 
     # salt-cloud --list-images hp_ae1
 
-* The parameter ``ignore_cidr`` specifies a range of addresses to ignore when trying to connect to the instance. In this case, it's the range of IP addresses used for an internal IP of the instance. 
+* The parameter ``ignore_cidr`` specifies a range of addresses to ignore when trying to connect to the instance. In this case, it's the range of IP addresses used for an private IP of the instance. 
 
-* The parameter ``networks`` is very important to include. This is what makes it possible for salt-cloud to be able to attach a floating IP to the instance in order to connect to the instance and set up the minion
+* The parameter ``networks`` is very important to include. In previous versions of Salt Cloud, this is what made it possible for salt-cloud to be able to attach a floating IP to the instance in order to connect to the instance and set up the minion. The current version of salt-cloud doesn't require it, though having it is of no harm either. Newer versions of salt-cloud will use this, and without it, will attempt to find a list of floating IP addresses to use regardless. 
 
 * The ``ssh_key_file`` and ``ssh_key_name`` are the keys that will make it possible to connect to the instance to set up the minion
 
 * The ``ssh_username`` parameter, in this case, being that the image used will be ubuntu, will make it possible to not only log in but install the minion 
 
 
+Launch an instance 
+==================
 
 To instantiate a machine based on this profile (example):
 
@@ -118,6 +126,9 @@ After several minutes, this will create an instance named ubuntu_instance_1
 running in HP Cloud in the US East region and will set up the minion and then 
 return information about the instance once completed.
 
+Manage the instance 
+===================
+
 Once the instance has been created with salt-minion installed, connectivity to 
 it can be verified with Salt:
 
@@ -125,8 +136,31 @@ it can be verified with Salt:
 
     # salt ubuntu_instance_1 ping
 
+SSH to the instance
+===================
+
 Additionally, the instance can be acessed via SSH using the floating IP assigned to it
 
 .. code-block:: bash
 
     # ssh ubuntu@<floating ip>
+
+Using a private IP
+==================
+
+Alternatively, in the cloud profile, using the private IP to log into the instance to set up the minion is another option, paerticularly if salt-cloud is running within the cloud on an instance that is on the same network with all the other instances (minions)
+
+The example below is a modified version of the previous example. Note the use of ``ssh_interface``:
+
+.. code-block:: yaml
+
+    hp_ae1_ubuntu:
+        provider: hp_ae1 
+        image: 9302692b-b787-4b52-a3a6-daebb79cb498 
+        size: standard.small
+        ssh_key_file: /root/keys/test.key
+        ssh_key_name: test
+        ssh_username: ubuntu
+        ssh_interface: private_ips
+
+With this setup, salt-cloud will use the private IP address to ssh into the instance and set up the salt-minion

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -25,9 +25,9 @@ Set up in the cloud configuration at ``/etc/salt/cloud.providers`` or
 
     my-openstack-config:
       # The OpenStack identity service url
-      identity_url: https://region-a.geo-1.identity.hpcloudsvc.com:35357/v2.0/
+      identity_url: https://region-b.geo-1.identity.hpcloudsvc.com:35357/v2.0/
       # The OpenStack compute region
-      compute_region: az-1.region-a.geo-1
+      compute_region: region-b.geo-1
       # The OpenStack compute service name
       compute_name: Compute
       # The OpenStack tenant name (not tenant ID)
@@ -35,7 +35,9 @@ Set up in the cloud configuration at ``/etc/salt/cloud.providers`` or
       # The OpenStack user name
       user: myuser
       # The OpenStack keypair name
-      ssh_key_name
+      ssh_key_name: mykey
+      # The ssh key file
+      ssh_key_file: /path/to/keyfile/test.pem
       # The OpenStack network UUIDs
       networks:
           - fixed:
@@ -80,9 +82,9 @@ following option may be useful. Using the old syntax:
       ignore_cidr: 192.168.50.0/24
 
 It is possible to upload a small set of files (no more than 5, and nothing too
-large) to the remote server. Generally this should not be needed, as salt itself
-can upload to the server after it is spun up, with nowhere near the same
-restrictions.
+large) to the remote server. Generally this should not be needed, as salt
+itself can upload to the server after it is spun up, with nowhere near the
+same restrictions.
 
 .. code-block:: yaml
 
@@ -90,6 +92,15 @@ restrictions.
       files:
           /path/to/dest.txt:
               /local/path/to/src.txt
+
+Alternatively, one could use the private IP to connect by specifying:
+
+.. code-block:: yaml
+
+    my-openstack-config:
+      ssh_interface: private_ips
+
+
 '''
 
 # The import section is mostly libcloud boilerplate
@@ -205,11 +216,12 @@ def get_conn():
         'ex_tenant_name': config.get_cloud_config_value(
             'tenant', vm_, __opts__, search_global=False
         ),
-   }
+    }
 
-    service_type = config.get_cloud_config_value(
-            'service_type', vm_, __opts__, search_global=False
-        )
+    service_type = config.get_cloud_config_value('service_type',
+                                                 vm_,
+                                                 __opts__,
+                                                 search_global=False)
     if service_type:
         authinfo['ex_force_service_type'] = service_type
 
@@ -237,10 +249,12 @@ def get_conn():
     authinfo['ex_force_auth_version'] = '2.0_apikey'
     log.debug('OpenStack authenticating using apikey')
     return driver(
-        config.get_cloud_config_value('user', vm_, __opts__, search_global=False),
-        config.get_cloud_config_value('apikey', vm_, __opts__, search_global=False),
-        **authinfo
-    )
+        config.get_cloud_config_value('user',
+                                      vm_,
+                                      __opts__,
+                                      search_global=False),
+        config.get_cloud_config_value('apikey', vm_, __opts__,
+                                      search_global=False), **authinfo)
 
 
 def preferred_ip(vm_, ips):
@@ -418,36 +432,58 @@ def create(vm_):
     floating = []
 
     if HAS014:
+        # if there are networks defined, obtain IPs from each
         if networks is not None:
             for net in networks:
+                # try specific fixed network
                 if 'fixed' in net:
                     kwargs['networks'] = [
-                        OpenStackNetwork(n, None, None, None) for n in net['fixed']
+                        OpenStackNetwork(n, None, None, None)
+                        for n in net['fixed']
                     ]
+                # try specificly-named floating IP networks to build list
                 elif 'floating' in net:
                     pool = OpenStack_1_1_FloatingIpPool(
                         net['floating'], conn.connection
                     )
+
+                    # build up the list of floating IPs
+                    # from this floating IP pool
                     for idx in pool.list_floating_ips():
                         if idx.node_id is None:
                             floating.append(idx)
+                    # not floating IPs for this given pool
                     if not floating:
-                        # Note(pabelanger): We have no available floating IPs. For
-                        # now, we raise an exception and exit. A future enhancement
-                        # might be to allow salt-cloud to dynamically allocate new
-                        # address but that might be tricky to manage.
+                        # Note(pabelanger): We have no available floating IPs.
+                        # For now, we raise an exception and exit.
+                        # A future enhancement might be to allow salt-cloud
+                        # to dynamically allocate new address but that might
+                        # be tricky to manage.
                         raise SaltCloudSystemExit(
-                            'Floating pool {0!r} has not more address available, '
+                            'Floating pool {0!r} does not have any more '
+                            'addresses available, '
                             'please create some more or use a different '
                             'pool.'.format(net['floating'])
                         )
-        else:
-           pool = OpenStack_1_1_FloatingIpPool(
-               '', conn.connection
-           )
-           for idx in pool.list_floating_ips():
-               if idx.node_id is None:
-                   floating.append(idx)
+        # otherwise, attempt to obtain list without specifying pool
+        # this is the same as 'nova floating-ip-list'
+        elif ssh_interface(vm_) != 'private_ips':
+            pool = OpenStack_1_1_FloatingIpPool(
+                '', conn.connection
+            )
+            for idx in pool.list_floating_ips():
+                if idx.node_id is None:
+                    floating.append(idx)
+            if not floating:
+                # Note(pabelanger): We have no available floating IPs.
+                # For now, we raise an exception and exit.
+                # A future enhancement might be to allow salt-cloud to
+                # dynamically allocate new address but that might be
+                # tricky to manage.
+                raise SaltCloudSystemExit(
+                    'There are no more floating IP addresses '
+                    'available, please create some more'
+                )
 
     files = config.get_cloud_config_value(
         'files', vm_, __opts__, search_global=False
@@ -484,9 +520,7 @@ def create(vm_):
         'metadata', vm_, __opts__, default=default_profile, search_global=False
     )
     if not isinstance(kwargs['ex_metadata'], dict):
-        raise SaltCloudConfigError(
-                '\'metadata\' should be a dict.'
-        )
+        raise SaltCloudConfigError('\'metadata\' should be a dict.')
 
     try:
         data = conn.create_node(**kwargs)
@@ -676,7 +710,8 @@ def create(vm_):
         'script_args': config.get_cloud_config_value(
             'script_args', vm_, __opts__
         ),
-        'script_env': config.get_cloud_config_value('script_env', vm_, __opts__),
+        'script_env': config.get_cloud_config_value('script_env', vm_,
+                                                    __opts__),
         'minion_conf': salt.utils.cloud.minion_config(__opts__, vm_)
     }
 
@@ -723,7 +758,8 @@ def create(vm_):
         )
 
         # Check for Windows install params
-        win_installer = config.get_cloud_config_value('win_installer', vm_, __opts__)
+        win_installer = config.get_cloud_config_value('win_installer',
+                                                      vm_, __opts__)
         if win_installer:
             deploy_kwargs['win_installer'] = win_installer
             minion = salt.utils.cloud.minion_config(__opts__, vm_)


### PR DESCRIPTION
Ok! All in one, nice, clean changeset!

HP Cloud doesn't give one the ability (404) to obtain a network list and for me, I found that it took reading through salt source, openstack driver code to finally figure out how to get a cloud provider and profile to work properly particularly due to how with Havana, one has to manually assign a floating IP to an instance to access it. So, what I've added here is the functionality that if the floating ip pool is not defined, it will try to obtain a list of floating IPs anyway and use that. Also updated the document a bit. Lastly, I made the code pep8/pyflake copastetic :)
