### PR TITLE
fix saltenv for aptpkg.mod_repo from pkgrepo state

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -264,7 +264,7 @@ def managed(name, **kwargs):
                           .format(name))
         return ret
     try:
-        __salt__['pkg.mod_repo'](**kwargs)
+        __salt__['pkg.mod_repo'](saltenv=__env__, **kwargs)
     except Exception as e:
         # This is another way to pass information back from the mod_repo
         # function.


### PR DESCRIPTION
so that when using key_url=salt://gpg.key, salt will get gpg.key from the correct environment instead of the 'base' environment.

Note that this is similar to #11173
