### PR TITLE
Link directly to bootstrap repo

### DIFF
--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -11,7 +11,8 @@ Installation
 Quick Install
 -------------
 
-On most distributions, you can set up a **Salt Minion** with the bootstrap script:
+On most distributions, you can set up a **Salt Minion** with the
+`Salt Bootstrap`_.
 
 .. _`Salt Bootstrap`: https://github.com/saltstack/salt-bootstrap
 


### PR DESCRIPTION
As I found no link to salt bootstrap in doc homepage.

Error introduced in ec7dec55f72e493675d99c1a9b836cd0644aa639

Try to fix this as far as I understand what @cachedout want to do 
