### PR TITLE
Add pillar get merge

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -39,10 +39,10 @@ def get(key, default='', merge=False):
 
         salt '*' pillar.get pkg:apache
     '''
-    if (merge):
-      return salt.utils.dictupdate.update(default,
-        salt.utils.traverse_dict(__pillar__, key, ''))
-      
+    if merge:
+        return salt.utils.dictupdate.update(default,
+            salt.utils.traverse_dict(__pillar__, key, ''))
+
     return salt.utils.traverse_dict(__pillar__, key, default)
 
 

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -13,12 +13,15 @@ import salt.utils
 __proxyenabled__ = ['*']
 
 
-def get(key, default=''):
+def get(key, default='', merge=False):
     '''
     .. versionadded:: 0.14
 
     Attempt to retrieve the named value from pillar, if the named value is not
     available return the passed default. The default return is an empty string.
+
+    If the merge parameter is set to `True`, the default will be recursively
+    merged into the returned pillar data.
 
     The value can also represent a value in a nested dict using a ":" delimiter
     for the dict. This means that if a dict in pillar looks like this::
@@ -36,6 +39,10 @@ def get(key, default=''):
 
         salt '*' pillar.get pkg:apache
     '''
+    if (merge):
+      return salt.utils.dictupdate.update(default,
+        salt.utils.traverse_dict(__pillar__, key, ''))
+      
     return salt.utils.traverse_dict(__pillar__, key, default)
 
 


### PR DESCRIPTION
Adds a boolean parameter and conditional to pillar.get() that enables an optional merge of the passed default value. Useful for situations where grains.filter_by() is an overly complex solution (eg, no grains actually need be filtered).
