### PR TITLE
Replace socket.getfqdn with internal salt.utils.network.get_fqhostname

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1682,7 +1682,8 @@ def get_id(root_dir=None, minion_id=False, cache=True):
     Guess the id of the minion.
 
     - If CONFIG_DIR/minion_id exists, use the cached minion ID from that file
-    - If socket.getfqdn() returns us something other than localhost, use it
+    - If salt.utils.network.get_fqhostname returns us something other than
+      localhost, use it
     - Check /etc/hostname for a value other than localhost
     - Check /etc/hosts for something that isn't localhost that maps to 127.*
     - Look for a routeable / public IP
@@ -1720,10 +1721,10 @@ def get_id(root_dir=None, minion_id=False, cache=True):
     log.debug('Guessing ID. The id can be explicitly in set {0}'
               .format(os.path.join(salt.syspaths.CONFIG_DIR, 'minion')))
 
-    # Check socket.getfqdn()
-    fqdn = socket.getfqdn()
+    # Check salt.utils.network.get_fqhostname()
+    fqdn = salt.utils.network.get_fqhostname()
     if fqdn != 'localhost':
-        log.info('Found minion id from getfqdn(): {0}'.format(fqdn))
+        log.info('Found minion id from get_gqhostname(): {0}'.format(fqdn))
         if minion_id and cache:
             _cache_id(fqdn, id_cache)
         return fqdn, False

--- a/salt/config.py
+++ b/salt/config.py
@@ -7,7 +7,6 @@ All salt configuration loading and defaults should be in this module
 import glob
 import os
 import re
-import socket
 import logging
 import urlparse
 from copy import deepcopy
@@ -1724,7 +1723,7 @@ def get_id(root_dir=None, minion_id=False, cache=True):
     # Check salt.utils.network.get_fqhostname()
     fqdn = salt.utils.network.get_fqhostname()
     if fqdn != 'localhost':
-        log.info('Found minion id from get_gqhostname(): {0}'.format(fqdn))
+        log.info('Found minion id from get_fqhostname(): {0}'.format(fqdn))
         if minion_id and cache:
             _cache_id(fqdn, id_cache)
         return fqdn, False

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1067,10 +1067,7 @@ def hostname():
         return grains
 
     grains['localhost'] = socket.gethostname()
-    if '.' in socket.getfqdn():
-        grains['fqdn'] = socket.getfqdn()
-    else:
-        grains['fqdn'] = grains['localhost']
+    grains['fqdn'] = salt.utils.network.get_fqhostname()
     (grains['host'], grains['domain']) = grains['fqdn'].partition('.')[::2]
     return grains
 

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -157,7 +157,6 @@
 import os
 import zmq
 import json
-import socket
 import logging
 import logging.handlers
 import datetime

--- a/salt/log/handlers/logstash_mod.py
+++ b/salt/log/handlers/logstash_mod.py
@@ -166,6 +166,7 @@ import datetime
 from salt._compat import string_types
 from salt.log.setup import LOG_LEVELS
 from salt.log.mixins import NewStyleClassMixIn
+import salt.utils.network
 
 log = logging.getLogger(__name__)
 
@@ -267,7 +268,7 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
         return datetime.datetime.utcfromtimestamp(record.created).isoformat()[:-3] + 'Z'
 
     def format_v0(self, record):
-        host = socket.getfqdn()
+        host = salt.utils.network.get_fqhostname()
         message_dict = {
             '@timestamp': self.formatTime(record),
             '@fields': {
@@ -322,7 +323,7 @@ class LogstashFormatter(logging.Formatter, NewStyleClassMixIn):
         message_dict = {
             '@version': 1,
             '@timestamp': self.formatTime(record),
-            'host': socket.getfqdn(),
+            'host': salt.utils.network.get_fqhostname(),
             'levelname': record.levelname,
             'logger': record.name,
             'lineno': record.lineno,

--- a/salt/transport/road/raet/estating.py
+++ b/salt/transport/road/raet/estating.py
@@ -17,6 +17,9 @@ from . import nacling
 from ioflo.base.consoling import getConsole
 console = getConsole()
 
+# Import salt libs
+import salt.utils.network
+
 class Estate(object):
     '''
     RAET protocol endpoint estate object
@@ -50,7 +53,7 @@ class Estate(object):
             host = '127.0.0.1'
         else:
             host = self.host
-        self.fqdn = socket.getfqdn(host)
+        self.fqdn = salt.utils.network.get_fqhostname()
 
 
     @property

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -70,6 +70,22 @@ def host_to_ip(host):
     return ip
 
 
+def get_fqhostname(host):
+    '''
+    Returns the fully qualified hostname
+
+    CLI Example::
+
+        salt '*' network.get_fqhostname
+    '''
+    if socket.gethostname().find('.') >= 0:
+        return socket.gethostname()
+    else:
+        family, socktype, proto, canonname, sockaddr =  socket.getaddrinfo(
+                socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
+                socket.SOL_TCP, socket.AI_CANONNAME)[0]
+        return canonname
+
 def ip_to_host(ip):
     '''
     Returns the hostname of a given IP

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -70,7 +70,7 @@ def host_to_ip(host):
     return ip
 
 
-def get_fqhostname(host):
+def get_fqhostname():
     '''
     Returns the fully qualified hostname
 
@@ -81,10 +81,11 @@ def get_fqhostname(host):
     if socket.gethostname().find('.') >= 0:
         return socket.gethostname()
     else:
-        family, socktype, proto, canonname, sockaddr =  socket.getaddrinfo(
+        family, socktype, proto, canonname, sockaddr = socket.getaddrinfo(
                 socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
                 socket.SOL_TCP, socket.AI_CANONNAME)[0]
         return canonname
+
 
 def ip_to_host(ip):
     '''

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -28,6 +28,7 @@ ensure_in_syspath('../')
 # Import salt libs
 import salt.minion
 import salt.utils
+import salt.utils.network
 import integration
 from salt import config as sconfig, version as salt_version
 from salt.version import SaltStackVersion
@@ -442,11 +443,11 @@ class ConfigTestCase(TestCase):
             if os.path.isdir(tempdir):
                 shutil.rmtree(tempdir)
 
-    @patch('socket.getfqdn', MagicMock(return_value='foo.bar.org'))
-    def test_get_id_socket_getfqdn(self):
+    @patch('salt.utils.network.get_fqhostname', MagicMock(return_value='foo.bar.org'))
+    def test_get_id_socket_get_fqhostname(self):
         '''
         Test calling salt.config.get_id() and getting the hostname from
-        socket.getfqdn()
+        salt.utils.network.get_fqhostname()
         '''
         with patch('salt.utils.fopen',
                    MagicMock(side_effect=_unhandled_mock_read)):
@@ -454,7 +455,7 @@ class ConfigTestCase(TestCase):
                 sconfig.get_id(cache=False), ('foo.bar.org', False)
             )
 
-    @patch('socket.getfqdn', MagicMock(return_value='localhost'))
+    @patch('salt.utils.network.get_fqhostname', MagicMock(return_value='localhost'))
     def test_get_id_etc_hostname(self):
         '''
         Test calling salt.config.get_id() and falling back to looking at
@@ -465,7 +466,7 @@ class ConfigTestCase(TestCase):
                 sconfig.get_id(cache=False), ('foo.bar.com', False)
             )
 
-    @patch('socket.getfqdn', MagicMock(return_value='localhost'))
+    @patch('salt.utils.network.get_fqhostname', MagicMock(return_value='localhost'))
     def test_get_id_etc_hosts(self):
         '''
         Test calling salt.config.get_id() and falling back all the way to


### PR DESCRIPTION
See https://github.com/saltstack/salt/issues/11275 and http://bugs.python.org/issue5004

This replaces calls to socket.getfqdn with an internal one that offers more reliable behavior.  This could also be made more robust and move some of the abstraction around localhost handling into it.

Needs docs updates, but I want to get some feedback first.
