### PR TITLE
Update error message for `cmd.script` on cache fail to use saltenv

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -824,8 +824,9 @@ def script(name,
         else:
             ret['result'] = not bool(cmd_all['retcode'])
         if ret.get('changes', {}).get('cache_error'):
-            ret['comment'] = 'Unable to cache script {0} from env ' \
-                             '{1!r}'.format(source, env)
+            ret['comment'] = 'Unable to cache script {0} from saltenv ' \
+                             '{1!r}'.format(source, kwargs.get('saltenv',
+                                                               'base'))
         else:
             ret['comment'] = 'Command {0!r} run'.format(name)
         return _reinterpreted_state(ret) if stateful else ret


### PR DESCRIPTION
Fixes #11189
