### PR TITLE
Replace instances of "basestring" with salt._compat.string_types

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -40,6 +40,7 @@ import salt.syspaths as syspaths
 from salt.exceptions import (
     EauthAuthenticationError, SaltInvocationError, SaltReqTimeoutError
 )
+from salt._compat import string_types
 
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False
@@ -846,7 +847,7 @@ class LocalClient(object):
         :returns: all of the information for the JID
         '''
         if not isinstance(minions, set):
-            if isinstance(minions, basestring):
+            if isinstance(minions, string_types):
                 minions = set([minions])
             elif isinstance(minions, (list, tuple)):
                 minions = set(list(minions))
@@ -1174,7 +1175,7 @@ class LocalClient(object):
         Get the returns for the command line interface via the event system
         '''
         if not isinstance(minions, set):
-            if isinstance(minions, basestring):
+            if isinstance(minions, string_types):
                 minions = set([minions])
             elif isinstance(minions, (list, tuple)):
                 minions = set(list(minions))

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -30,6 +30,7 @@ import salt.loader
 import salt.minion
 import salt.exceptions
 import salt.config
+from salt._compat import string_types
 
 # This is just a delimiter to distinguish the beginning of salt STDOUT.  There
 # is no special meaning
@@ -256,7 +257,7 @@ class SSH(object):
         '''
         Deploy the SSH key if the minions don't auth
         '''
-        if not isinstance(ret[host], basestring):
+        if not isinstance(ret[host], string_types):
             if self.opts.get('ssh_key_deploy'):
                 target = self.targets[host]
                 if 'passwd' in target:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -31,6 +31,7 @@ import salt.loader
 import salt.utils
 import salt.utils.cloud
 from salt.utils import context
+from salt._compat import string_types
 
 # Import third party libs
 import yaml
@@ -551,7 +552,7 @@ class Cloud(object):
 
     def get_running_by_names(self, names, query='list_nodes', cached=False,
                              profile=None):
-        if isinstance(names, basestring):
+        if isinstance(names, string_types):
             names = [names]
 
         matches = {}
@@ -1507,7 +1508,7 @@ class Map(Cloud):
             if isinstance(mapped, (list, tuple)):
                 entries = {}
                 for mapping in mapped:
-                    if isinstance(mapping, basestring):
+                    if isinstance(mapping, string_types):
                         # Foo:
                         #   - bar1
                         #   - bar2
@@ -1539,7 +1540,7 @@ class Map(Cloud):
                 map_[profile] = entries
                 continue
 
-            if isinstance(mapped, basestring):
+            if isinstance(mapped, string_types):
                 # If it's a single string entry, let's make iterable because of
                 # the next step
                 mapped = [mapped]

--- a/salt/config.py
+++ b/salt/config.py
@@ -28,6 +28,7 @@ import salt.utils
 import salt.utils.network
 import salt.pillar
 import salt.syspaths
+from salt._compat import string_types
 
 import sys
 #can't use salt.utils.is_windows, because config.py is included from salt.utils
@@ -923,7 +924,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
         'deploy_scripts_search_path',
         defaults.get('deploy_scripts_search_path', 'cloud.deploy.d')
     )
-    if isinstance(deploy_scripts_search_path, basestring):
+    if isinstance(deploy_scripts_search_path, string_types):
         deploy_scripts_search_path = [deploy_scripts_search_path]
 
     # Check the provided deploy scripts search path removing any non existing

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -29,6 +29,7 @@ _supported_dists += ('arch', 'mageia', 'meego', 'vmware', 'bluewhite64',
 import salt.log
 import salt.utils
 import salt.utils.network
+from salt._compat import string_types
 
 # Solve the Chicken and egg problem where grains need to run before any
 # of the modules are loaded and are generally available for any usage.
@@ -293,7 +294,7 @@ def _bsd_cpudata(osdata):
 
     grains = dict([(k, __salt__['cmd.run'](v)) for k, v in cmds.items()])
 
-    if 'cpu_flags' in grains and isinstance(grains['cpu_flags'], basestring):
+    if 'cpu_flags' in grains and isinstance(grains['cpu_flags'], string_types):
         grains['cpu_flags'] = grains['cpu_flags'].split(' ')
 
     if osdata['kernel'] == 'NetBSD':

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -35,6 +35,7 @@ QUIET = logging.QUIET = 1000
 # Import salt libs
 from salt.log.handlers import TemporaryLoggingHandler
 from salt.log.mixins import LoggingMixInMeta, NewStyleClassMixIn
+from salt._compat import string_types
 
 LOG_LEVELS = {
     'all': logging.NOTSET,
@@ -166,7 +167,7 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS, NewStyleClassMixIn):
     def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None,
                    extra=None):
         # Let's try to make every logging message unicode
-        if isinstance(msg, basestring) and not isinstance(msg, unicode):
+        if isinstance(msg, string_types) and not isinstance(msg, unicode):
             try:
                 return LOGGING_LOGGER_CLASS.makeRecord(
                     self, name, level, fn, lno,

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -285,7 +285,7 @@ def _run(cmd,
 
     if not env:
         env = {}
-    elif isinstance(env, basestring):
+    elif isinstance(env, string_types):
         try:
             env = yaml.safe_load(env)
         except yaml.parser.ParserError as err:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2330,7 +2330,7 @@ def check_perms(name, ret, user, group, mode):
         elif 'cgroup' in perms:
             ret['changes']['group'] = group
 
-    if isinstance(orig_comment, basestring):
+    if isinstance(orig_comment, salt._compat.string_types):
         if orig_comment:
             ret['comment'].insert(0, orig_comment)
         ret['comment'] = '; '.join(ret['comment'])

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -9,6 +9,7 @@ import yaml
 # Import salt libs
 import salt.pillar
 import salt.utils
+from salt._compat import string_types
 
 __proxyenabled__ = ['*']
 
@@ -128,7 +129,7 @@ def ext(external):
 
         salt '*' pillar.ext '{libvirt: _}'
     '''
-    if isinstance(external, basestring):
+    if isinstance(external, string_types):
         external = yaml.safe_load(external)
     pillar = salt.pillar.get_pillar(
         __opts__,

--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -16,6 +16,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
+from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 __SUFFIX_NOT_NEEDED = ('x86_64', 'noarch')
@@ -168,7 +169,7 @@ def pack_sources(sources):
         salt '*' pkg_resource.pack_sources '[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
     '''
     _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
-    if isinstance(sources, basestring):
+    if isinstance(sources, string_types):
         try:
             sources = yaml.safe_load(sources)
         except yaml.parser.ParserError as err:

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -35,6 +35,7 @@ except ImportError:
 
 # Import salt libs
 import salt.utils
+from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
@@ -640,14 +641,14 @@ def _role_cmd_args(name,
         # first is passwd set
         # second is for handling NOPASSWD
         and (
-            isinstance(rolepassword, basestring) and bool(rolepassword)
+            isinstance(rolepassword, string_types) and bool(rolepassword)
         )
         or (
             isinstance(rolepassword, bool)
         )
     ):
         skip_passwd = True
-    if isinstance(rolepassword, basestring) and bool(rolepassword):
+    if isinstance(rolepassword, string_types) and bool(rolepassword):
         escaped_password = '{0!r}'.format(
             _maybe_encrypt_password(name,
                                     rolepassword.replace('\'', '\'\''),

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -13,6 +13,7 @@ import os.path
 # Import salt libs
 import salt.utils
 import salt.exceptions
+from salt._compat import string_types
 
 KNOWN_BINARY_NAMES = frozenset(
     ['virtualenv',
@@ -204,7 +205,7 @@ def create(path,
                 )
             cmd.append('--python={0}'.format(python))
         if extra_search_dir is not None:
-            if isinstance(extra_search_dir, basestring) and \
+            if isinstance(extra_search_dir, string_types) and \
                     extra_search_dir.strip() != '':
                 extra_search_dir = [
                     e.strip() for e in extra_search_dir.split(',')

--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -7,6 +7,7 @@ from numbers import Number
 
 # Import salt libs
 import salt.utils
+from salt._compat import string_types
 
 
 class NestDisplay(object):
@@ -35,7 +36,7 @@ class NestDisplay(object):
                     prefix,
                     ret,
                     self.colors['ENDC'])
-        elif isinstance(ret, basestring):
+        elif isinstance(ret, string_types):
             lines = ret.split('\n')
             for line in lines:
                 out += '{0}{1}{2}{3}{4}\n'.format(

--- a/salt/renderers/json.py
+++ b/salt/renderers/json.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 # Import python libs
 import json
 
+# Import salt libs
+from salt._compat import string_types
+
 
 def render(json_data, saltenv='base', sls='', **kws):
     '''
@@ -12,7 +15,7 @@ def render(json_data, saltenv='base', sls='', **kws):
 
     :rtype: A Python data structure
     '''
-    if not isinstance(json_data, basestring):
+    if not isinstance(json_data, string_types):
         json_data = json_data.read()
 
     if json_data.startswith('#!'):

--- a/salt/renderers/msgpack.py
+++ b/salt/renderers/msgpack.py
@@ -4,6 +4,9 @@ from __future__ import absolute_import
 # Import third party libs
 import msgpack
 
+# Import salt libs
+from salt._compat import string_types
+
 
 def render(msgpack_data, saltenv='base', sls='', **kws):
     '''
@@ -18,7 +21,7 @@ def render(msgpack_data, saltenv='base', sls='', **kws):
 
     :rtype: A Python data structure
     '''
-    if not isinstance(msgpack_data, basestring):
+    if not isinstance(msgpack_data, string_types):
         msgpack_data = msgpack_data.read()
 
     if msgpack_data.startswith('#!'):

--- a/salt/renderers/stateconf.py
+++ b/salt/renderers/stateconf.py
@@ -37,6 +37,7 @@ from cStringIO import StringIO
 # Import salt libs
 import salt.utils
 from salt.exceptions import SaltRenderError
+from salt._compat import string_types
 
 __all__ = ['render']
 
@@ -201,7 +202,7 @@ def render(input, saltenv='base', sls='', argline='', **kws):
         except IndexError:
             raise INVALID_USAGE_ERROR
 
-        if isinstance(input, basestring):
+        if isinstance(input, string_types):
             with salt.utils.fopen(input, 'r') as ifile:
                 sls_templ = ifile.read()
         else:  # assume file-like
@@ -256,7 +257,7 @@ def rewrite_single_shorthand_state_decl(data):  # pylint: disable=C0103
         state.func: []
     '''
     for sid, states in data.items():
-        if isinstance(states, basestring):
+        if isinstance(states, string_types):
             data[sid] = {states: []}
 
 

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -11,6 +11,7 @@ from yaml.constructor import ConstructorError
 from salt.utils.yamlloader import CustomLoader, load
 from salt.utils.odict import OrderedDict
 from salt.exceptions import SaltRenderError
+from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
@@ -36,7 +37,7 @@ def render(yaml_data, saltenv='base', sls='', argline='', **kws):
 
     :rtype: A Python data structure
     '''
-    if not isinstance(yaml_data, basestring):
+    if not isinstance(yaml_data, string_types):
         yaml_data = yaml_data.read()
     with warnings.catch_warnings(record=True) as warn_list:
         try:

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -11,6 +11,7 @@ import re
 # Import Salt libs
 import salt.loader
 from salt.template import compile_template
+from salt._compat import string_types
 
 
 def targets(tgt, tgt_type='glob', **kwargs):
@@ -79,7 +80,7 @@ class RosterMatcher(object):
         '''
         Return the configured ip
         '''
-        if isinstance(self.raw[minion], basestring):
+        if isinstance(self.raw[minion], string_types):
             return {'host': self.raw[minion]}
         if isinstance(self.raw[minion], dict):
             return self.raw[minion]

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -583,7 +583,7 @@ def run(name,
         return ret
 
     if env:
-        if isinstance(env, basestring):
+        if isinstance(env, string_types):
             try:
                 env = yaml.safe_load(env)
             except Exception:
@@ -604,7 +604,7 @@ def run(name,
             _env = {}
             for comp in env:
                 try:
-                    if isinstance(comp, basestring):
+                    if isinstance(comp, string_types):
                         _env.update(yaml.safe_load(comp))
                     if isinstance(comp, dict):
                         _env.update(comp)
@@ -872,7 +872,7 @@ def call(name,
             'name': name
             'changes': {'retval': result},
             'result': True if result is None else bool(result),
-            'comment': result if isinstance(result, basestring) else ''
+            'comment': result if isinstance(result, string_types) else ''
         }
     '''
     ret = {'name': name,
@@ -905,7 +905,7 @@ def call(name,
         # result must be JSON serializable else we get an error
         ret['changes'] = {'retval': result}
         ret['result'] = True if result is None else bool(result)
-        if isinstance(result, basestring):
+        if isinstance(result, string_types):
             ret['comment'] = result
         return ret
 

--- a/salt/states/disk.py
+++ b/salt/states/disk.py
@@ -5,6 +5,9 @@ Disk monitoring state
 Monitor the state of disk resources
 '''
 
+# Import salt libs
+from salt._compat import string_types
+
 __monitor__ = [
         'status',
         ]
@@ -28,13 +31,13 @@ def status(name, maximum=None, minimum=None):
         return ret
     if maximum:
         try:
-            if isinstance(maximum, basestring):
+            if isinstance(maximum, string_types):
                 maximum = int(maximum.strip('%'))
         except Exception:
             ret['comment'] += 'Max argument must be an integer '
     if minimum:
         try:
-            if isinstance(minimum, basestring):
+            if isinstance(minimum, string_types):
                 minimum = int(minimum.strip('%'))
         except Exception:
             ret['comment'] += 'Min argument must be an integer '

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1403,7 +1403,7 @@ def directory(name,
                     # file.user_to_uid returns '' if user does not exist. Above
                     # check for user is not fatal, so we need to be sure user
                     # exists.
-                    if isinstance(uid, basestring):
+                    if isinstance(uid, string_types):
                         ret['result'] = False
                         ret['comment'] = 'Failed to enforce ownership for ' \
                                          'user {0} (user does not ' \
@@ -1417,7 +1417,7 @@ def directory(name,
                 if group:
                     gid = __salt__['file.group_to_gid'](group)
                     # As above with user, we need to make sure group exists.
-                    if isinstance(gid, basestring):
+                    if isinstance(gid, string_types):
                         ret['result'] = False
                         ret['comment'] = 'Failed to enforce group ownership ' \
                                          'for group {0}'.format(group, user)
@@ -1689,7 +1689,7 @@ def recurse(name,
 
     def add_comment(path, comment):
         comments = ret['comment'].setdefault(path, [])
-        if isinstance(comment, basestring):
+        if isinstance(comment, string_types):
             comments.append(comment)
         else:
             comments.extend(comment)
@@ -1904,7 +1904,7 @@ def recurse(name,
     # Flatten comments until salt command line client learns
     # to display structured comments in a readable fashion
     ret['comment'] = '\n'.join('\n#### {0} ####\n{1}'.format(
-        k, v if isinstance(v, basestring) else '\n'.join(v)
+        k, v if isinstance(v, string_types) else '\n'.join(v)
     ) for (k, v) in ret['comment'].iteritems()).strip()
 
     if not ret['comment']:

--- a/salt/states/pecl.py
+++ b/salt/states/pecl.py
@@ -19,6 +19,9 @@ requisite to a pkg.installed state for the package which provides pecl
           - pkg: php-pear
 '''
 
+# Import salt libs
+from salt._compat import string_types
+
 
 def __virtual__():
     '''
@@ -57,7 +60,7 @@ def installed(name,
         The ``defaults`` option will be available in version 0.17.0.
     '''
     # Check to see if we have a designated version
-    if not isinstance(version, basestring) and version is not None:
+    if not isinstance(version, string_types) and version is not None:
         version = str(version)
 
     ret = {'name': name,

--- a/salt/transport/road/raet/transacting.py
+++ b/salt/transport/road/raet/transacting.py
@@ -18,6 +18,7 @@ except ImportError:
 # Import ioflo libs
 from ioflo.base.odicting import odict
 from ioflo.base import aiding
+from salt._compat import string_types
 
 from . import raeting
 from . import nacling
@@ -1026,7 +1027,7 @@ class Allower(Initiator):
         data = self.rxPacket.data
         body = self.rxPacket.body.data
 
-        if not isinstance(body, basestring):
+        if not isinstance(body, string_types):
             emsg = "Invalid format of cookie packet body\n"
             console.terse(emsg)
             self.stack.incStat('invalid_cookie')
@@ -1285,7 +1286,7 @@ class Allowent(Correspondent):
         data = self.rxPacket.data
         body = self.rxPacket.body.data
 
-        if not isinstance(body, basestring):
+        if not isinstance(body, string_types):
             emsg = "Invalid format of hello packet body\n"
             console.terse(emsg)
             self.stack.incStat('invalid_hello')
@@ -1358,7 +1359,7 @@ class Allowent(Correspondent):
         data = self.rxPacket.data
         body = self.rxPacket.body.data
 
-        if not isinstance(body, basestring):
+        if not isinstance(body, string_types):
             emsg = "Invalid format of initiate packet body\n"
             console.terse(emsg)
             self.stack.incStat('invalid_initiate')

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -534,7 +534,7 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         '''
         log.debug('Gathering reactors for tag {0}'.format(tag))
         reactors = []
-        if isinstance(self.opts['reactor'], basestring):
+        if isinstance(self.opts['reactor'], string_types):
             try:
                 with salt.utils.fopen(self.opts['reactor']) as fp_:
                     react_map = yaml.safe_load(fp_.read())

--- a/salt/utils/pydsl.py
+++ b/salt/utils/pydsl.py
@@ -90,6 +90,7 @@ from uuid import uuid4 as _uuid
 from salt.utils.odict import OrderedDict
 from salt.utils import warn_until
 from salt.state import HighState
+from salt._compat import string_types
 
 
 REQUISITES = set('require watch use require_in watch_in use_in'.split())
@@ -255,7 +256,7 @@ class Sls(object):
                     modname, funcname = modname.rsplit('.', 1)
                 else:
                     funcname = (
-                        x for x in args if isinstance(x, basestring)
+                        x for x in args if isinstance(x, string_types)
                     ).next()
                     args.remove(funcname)
                 mod = getattr(s, modname)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -25,6 +25,7 @@ from salt.utils.jinja import ensure_sequence_filter
 from salt.utils.jinja import SaltCacheLoader as JinjaSaltCacheLoader
 from salt.utils.jinja import SerializerExtension as JinjaSerializerExtension
 from salt import __path__ as saltpath
+from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
@@ -54,7 +55,7 @@ def wrap_tmpl_func(render_str):
         assert 'opts' in context
         assert 'saltenv' in context
 
-        if isinstance(tmplsrc, basestring):
+        if isinstance(tmplsrc, string_types):
             if from_str:
                 tmplstr = tmplsrc
             else:
@@ -251,7 +252,7 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     unicode_context = {}
     for key, value in context.iteritems():
-        if not isinstance(value, basestring):
+        if not isinstance(value, string_types):
             unicode_context[key] = value
             continue
 


### PR DESCRIPTION
We should be using `salt._compat.string_types` when checking if a variable is a string, instead of `basestring`. This is because Python 3 does not have a `basestring` class. This would have to be done eventually to support Python 3.
