### PR TITLE
Bypass the missing jid files

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -241,30 +241,33 @@ class Master(SMaster):
                             f_path = os.path.join(t_path, final)
                             jid_file = os.path.join(f_path, 'jid')
                             if not os.path.isfile(jid_file):
-                                # No jid file means corrupted cache entry, scrub it
-                                shutil.rmtree(f_path)
-                            with salt.utils.fopen(jid_file, 'r') as fn_:
-                                jid = fn_.read()
-                            if len(jid) < 18:
-                                # Invalid jid, scrub the dir
+                                # No jid file means corrupted cache entry,
+                                # scrub it
                                 shutil.rmtree(f_path)
                             else:
-                                # Parse the jid into a proper datetime object.  We only
-                                # parse down to the minute, since keep_jobs is measured
-                                # in hours, so a minute difference is not important
-                                try:
-                                    jidtime = datetime.datetime(int(jid[0:4]),
-                                                                int(jid[4:6]),
-                                                                int(jid[6:8]),
-                                                                int(jid[8:10]),
-                                                                int(jid[10:12]))
-                                except ValueError as e:
+                                with salt.utils.fopen(jid_file, 'r') as fn_:
+                                    jid = fn_.read()
+                                if len(jid) < 18:
                                     # Invalid jid, scrub the dir
                                     shutil.rmtree(f_path)
-                                difference = cur - jidtime
-                                hours_difference = difference.seconds / 3600.0
-                                if hours_difference > self.opts['keep_jobs']:
-                                    shutil.rmtree(f_path)
+                                else:
+                                    # Parse the jid into a proper datetime
+                                    # object. We only parse down to the minute,
+                                    # since keep_jobs is measured in hours, so
+                                    # a minute difference is not important
+                                    try:
+                                        jidtime = datetime.datetime(int(jid[0:4]),
+                                                                    int(jid[4:6]),
+                                                                    int(jid[6:8]),
+                                                                    int(jid[8:10]),
+                                                                    int(jid[10:12]))
+                                    except ValueError as e:
+                                        # Invalid jid, scrub the dir
+                                        shutil.rmtree(f_path)
+                                    difference = cur - jidtime
+                                    hours_difference = difference.seconds / 3600.0
+                                    if hours_difference > self.opts['keep_jobs']:
+                                        shutil.rmtree(f_path)
 
             if self.opts.get('publish_session'):
                 if now - rotate >= self.opts['publish_session']:


### PR DESCRIPTION
[Re-submitted for the broken PR #11376]

The most recent release 2014.1.1 has a little logic issue while cleaning old jobs.
At exactly 65 seconds after the master started, one of the master processes get defunct.

Process Process-1:
Traceback (most recent call last):
File "/usr/lib64/python2.7/multiprocessing/process.py", line 258, in bootstrap
self.run()
File "/usr/lib64/python2.7/multiprocessing/process.py", line 114, in run
self._target(_self._args, *_self._kwargs)
File "/usr/lib64/python2.7/site-packages/salt/master.py", line 246, in _clear_old_jobs
with salt.utils.fopen(jid_file, 'r') as fn:
File "/usr/lib64/python2.7/site-packages/salt/utils/init.py", line 1037, in fopen
fhandle = open(_args, *_kwargs)
IOError: [Errno 2] No such file or directory: '/var/cache/salt/master/jobs/44/9e352281c9938b05de853cdfb96ea0/jid'

This PR fixes this issue.
