### PR TITLE
Fix bug in _parse_key

### DIFF
--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -15,10 +15,10 @@ def _parse_key(key):
     '''
     split the full path in the registry to the key and the rest
     '''
-    splt = key.split('\\')
+    splt = key.split(r'\\')
     hive = splt.pop(0)
     key = splt.pop(-1)
-    path = '\\'.join(splt)
+    path = r'\\'.join(splt)
     return hive, path, key
 
 


### PR DESCRIPTION
According to the documentation, we should have double backslashes between the path segments in the key, however _parse_key split and joined on a single backslash which caused the resulting path to start and end with a backslash.

This fixes #11408.
