### PR TITLE
Documentation: Improve file.absent state

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -836,8 +836,9 @@ def symlink(
 
 def absent(name):
     '''
-    Verify that the named file or directory is absent. This will work to
-    reverse any of the functions in the file state module.
+    Make sure that the named file or directory is absent. If it exists, it will
+    be deleted. This will work to reverse any of the functions in the file
+    state module.
 
     name
         The path which should be deleted

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -836,7 +836,7 @@ def symlink(
 
 def absent(name):
     '''
-    Verify that the named file or directory is absent, this will work to
+    Verify that the named file or directory is absent. This will work to
     reverse any of the functions in the file state module.
 
     name


### PR DESCRIPTION
I've been annoyed by the fact that this piece of documentation is not being fully clear about the fact that it's actually _deleting_ a file/directory.
