### PR TITLE
doc(pkgrepo/state): key_url doesn't have to be "web"

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -173,7 +173,7 @@ def managed(name, **kwargs):
        keyid option must also be set for this option to work.
 
     key_url
-       A web URL to retrieve the GPG key from.
+       URL to retrieve a GPG key from.
 
     consolidate
        If set to true, this will consolidate all sources definitions to


### PR DESCRIPTION
...with "web", I didn't think it supported `salt://` until I saw it in an example here: https://github.com/saltstack-formulas/docker-formula/blob/master/docker/init.sls
