### PR TITLE
Raise exception when pillar data is non-dict

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -19,6 +19,7 @@ import salt.utils
 import salt.state
 import salt.payload
 from salt._compat import string_types
+from salt.exceptions import SaltInvocationError
 
 
 __proxyenabled__ = ['*']
@@ -268,6 +269,10 @@ def highstate(test=None, queue=False, **kwargs):
         opts['environment'] = kwargs['saltenv']
 
     pillar = kwargs.get('pillar')
+    if pillar is not None and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary'
+        )
 
     st_ = salt.state.HighState(opts, pillar, kwargs.get('__pub_jid'))
     st_.push_active()
@@ -368,6 +373,10 @@ def sls(mods,
         opts['test'] = __opts__.get('test', None)
 
     pillar = kwargs.get('pillar')
+    if pillar is not None and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary'
+        )
 
     serial = salt.payload.Serial(__opts__)
     cfn = os.path.join(
@@ -466,7 +475,14 @@ def top(topfn, test=None, queue=False, **kwargs):
         opts['test'] = True
     else:
         opts['test'] = __opts__.get('test', None)
-    st_ = salt.state.HighState(opts)
+
+    pillar = kwargs.get('pillar')
+    if pillar is not None and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary'
+        )
+
+    st_ = salt.state.HighState(opts, pillar)
     st_.push_active()
     st_.opts['state_top'] = os.path.join('salt://', topfn)
     try:
@@ -716,7 +732,14 @@ def single(fun, name, test=None, queue=False, **kwargs):
         opts['test'] = True
     else:
         opts['test'] = __opts__.get('test', None)
-    st_ = salt.state.State(opts)
+
+    pillar = kwargs.get('pillar')
+    if pillar is not None and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary'
+        )
+
+    st_ = salt.state.State(opts, pillar)
     err = st_.verify_data(kwargs)
     if err:
         __context__['retcode'] = 1

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -14,7 +14,7 @@ import salt.output
 import salt.overstate
 import salt.syspaths
 import salt.utils.event
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import SaltInvocationError
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +36,7 @@ def over(saltenv='base', os_fn=None):
     try:
         overstate = salt.overstate.OverState(__opts__, saltenv, os_fn)
     except IOError as exc:
-        raise CommandExecutionError(
+        raise SaltInvocationError(
             '{0}: {1!r}'.format(exc.strerror, exc.filename)
         )
     for stage in overstate.stages_iter():
@@ -83,6 +83,10 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
 
         Runner renamed from ``state.sls`` to ``state.orchestrate``
     '''
+    if pillar is not None and not isinstance(pillar, dict):
+        raise SaltInvocationError(
+            'Pillar data must be formatted as a dictionary'
+        )
     __opts__['file_client'] = 'local'
     minion = salt.minion.MasterMinion(__opts__)
     running = minion.functions['state.sls'](


### PR DESCRIPTION
This adds some checks to the pillar data passed into the functions in
the state execution module, which raise a SaltInvocationError when the
pillar data is not a dictionary.

It also adds the ability to pass pillar data to state.top and
state.single, as this functionality was missing before.

Additionally, the same check is added to the state.sls runner to prevent
bad pillar data from being passed to it.
