### PR TITLE
salt.state: fix an edge case of inclusion for error reporting

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2397,9 +2397,13 @@ class BaseHighState(object):
                         self.merge_included_states(highstate, state, errors)
                     for i, error in enumerate(errors[:]):
                         if 'is not available on the salt master' in error:
-                            errors[i] = (
-                                'No matching sls found for {0!r} '
-                                'in env {1!r}'.format(sls_match, saltenv))
+                            # match SLS foobar in environment
+                            this_sls = 'SLS {0} in environment'.format(
+                                sls_match)
+                            if this_sls in error:
+                                errors[i] = (
+                                    'No matching sls found for {0!r} '
+                                    'in env {1!r}'.format(sls_match, saltenv))
                     all_errors.extend(errors)
 
         self.clean_duplicate_extends(highstate)


### PR DESCRIPTION
/cc @thatch45

There is an edge case on the fix we provide last week for the error reporting.

If in a sls, we include another (missing) sls which is under the same prefix, the error will be misleading replacing the missing sls by the loaded one.
The error is good in the first place but point to the wrong sls.

An exemple will be more meaningful

```
foo/a.sls
include:
 - foo.b
```

if foo.b is absent, and without this PR, it will report that foo.a is missing :)
