### PR TITLE
Make git rev-parse check fail if SHA not found

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -213,7 +213,7 @@ def latest(name,
                                           identity=identity)
                 elif rev:
 
-                    cmd = 'git rev-parse {0}'.format(rev)
+                    cmd = 'git rev-parse {0}^{{commit}}'.format(rev)
                     retcode = __salt__['cmd.retcode'](cmd,
                                                       cwd=target,
                                                       runas=user)


### PR DESCRIPTION
This reinstates the change in 51d18a495e68b1812a58e3a2f03eeee1cfc34bf5.

That change was first broken by 091a5515fefc6ba69be2507aaace5e5d685a1618 (by introducing a space, which breaks the `<rev>^{<type>}` syntax being used, see `git rev-parse` documentation) ... and then fully removed by ef48008bbc7e641edb2f4f304f749d5378c3de2e. The commit message in the latter commit does not suggest an intent or a reason to revert the 51d18a495e68b1812a58e3a2f03eeee1cfc34bf5 change, so it was probably just trying to resolve the immediate problem that the git rev-parse call was broken.

NOTE: this should be reviewed by someone more familiar with the code; I am proposing this reinstated change because the two latter changes seem to me to have clearly been unintended regressions. This came to my attention because the 2014.1.0 and 2014.1.1 releases have 091a5515fefc6ba69be2507aaace5e5d685a1618 (actually its rewritten counterpart d5083f31031d2b0e85273a558344703f232576a2) but not ef48008bbc7e641edb2f4f304f749d5378c3de2e, and so the git rev-parse call fails with “Command 'git rev-parse master ^{commit}' failed with return code: 128”)
