### PR TITLE
Fix to rh_ip.py to allow the networking enabled code to function.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -49,6 +49,7 @@ Erik Nolte <enolte@beyondoblivion.com>
 Evan Borgstrom <evan@fatbox.ca>
 Forrest Alvarez <forrest.alvarez@gmail.com>
 Henrik Holmboe <henrik@holmboe.se>
+Gareth J. Greenaway <gareth@wiked.org>
 Jacob Albretsen <jakea@xmission.com>
 Jed Glazner <jglazner@coldcrow.com>
 Jeff Bauer <jbauer@rubic.com>

--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -689,12 +689,14 @@ def _parse_network_settings(opts, current):
     result = {}
 
     valid = _CONFIG_TRUE + _CONFIG_FALSE
-    if not 'networking' in opts:
+    if not 'enabled' in opts:
         try:
             opts['networking'] = current['networking']
             _log_default_network('networking', current['networking'])
-        except Exception:
+        except ValueError:
             _raise_error_network('networking', valid)
+    else:
+        opts['networking'] = opts['enabled']
 
     if opts['networking'] in valid:
         if opts['networking'] in _CONFIG_TRUE:


### PR DESCRIPTION
Fix to rh_ip.py to allow the networking enabled code to function.  Similar fix made in the debian_ip module where the if statement was expecting networking as the value in the array but the value was enabled.
