### PR TITLE
Fix #11493

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -77,10 +77,10 @@ def dropfile(cachedir, user=None):
             import pwd
             uid = pwd.getpwnam(user).pw_uid
             os.chown(dfnt, uid, -1)
-            shutil.move(dfnt, dfn)
         except (KeyError, ImportError, OSError, IOError):
             pass
 
+    shutil.move(dfnt, dfn)
     os.umask(mask)
 
 


### PR DESCRIPTION
crypt.dropfile was failing to emplace the .dfn file
when user was None, as is the case in the periodic
call based on the publish_session config setting.
