### PR TITLE
sources and dest are not mutually exclusive

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -81,19 +81,16 @@ def tar(options, tarfile, sources=None, dest=None, cwd=None, template=None):
         salt '*' archive.tar foo.tar xf dest=/target/directory
 
     '''
-    if sources is not None and dest is not None:
-        raise SaltInvocationError(
-            'The \'sources\' and \'dest\' arguments are mutually exclusive'
-        )
-
     if isinstance(sources, salt._compat.string_types):
         sources = [s.strip() for s in sources.split(',')]
+
+    if dest:
+        options = 'C {0} -{1}'.format(dest, options)
 
     cmd = 'tar -{0} {1}'.format(options, tarfile)
     if sources:
         cmd += ' {0}'.format(' '.join(sources))
-    elif dest:
-        cmd += ' -C {0}'.format(dest)
+
     return __salt__['cmd.run'](cmd, cwd=cwd, template=template).splitlines()
 
 


### PR DESCRIPTION
Pinging @s0undt3ch, since I'm removing some changes he made.

It's _extremely_ helpful to be able to use `-C` while creating an archive.
