### PR TITLE
GitPython may raise a bad AssertionError

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -736,8 +736,14 @@ def update():
         with salt.utils.fopen(lk_fn, 'w+') as fp_:
             fp_.write(str(pid))
         try:
+            log.debug("Fetching from {0}".format(origin.url))
             if provider == 'gitpython':
-                for fetch in origin.fetch():
+                _f = []
+                try:
+                    _f = origin.fetch()
+                except AssertionError:
+                    _f = origin.fetch()
+                for fetch in _f:
                     if fetch.old_commit is not None:
                         data['changed'] = True
             elif provider == 'pygit2':


### PR DESCRIPTION
GitPython may raise an AssertionError during a successful fetch due to
poorly grepping the fetch output for success. If this is the case, a
second fetch will be a no-op. If the second fetch also raises the error,
then the error is legit.

Fixes  #11473 
