### PR TITLE
Remove "su -c" from upstart scripts

### DIFF
--- a/pkg/salt-master.upstart
+++ b/pkg/salt-master.upstart
@@ -13,6 +13,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  # invoke salt-master via su so that /etc/environment is read
-  exec su -c salt-master
+  exec salt-master
 end script

--- a/pkg/salt-master.upstart.rhel6
+++ b/pkg/salt-master.upstart.rhel6
@@ -11,6 +11,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  # invoke salt-master via su so that /etc/environment is read
-  exec su -c salt-master
+  exec salt-master
 end script

--- a/pkg/salt-minion.upstart
+++ b/pkg/salt-minion.upstart
@@ -19,6 +19,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  # invoke salt-minion via su so that /etc/environment is read
-  exec su -c salt-minion
+  exec salt-minion
 end script

--- a/pkg/salt-minion.upstart.rhel6
+++ b/pkg/salt-minion.upstart.rhel6
@@ -17,6 +17,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  # invoke salt-minion via su so that /etc/environment is read
-  exec su -c salt-minion
+  exec salt-minion
 end script

--- a/pkg/salt-syndic.upstart
+++ b/pkg/salt-syndic.upstart
@@ -12,6 +12,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  # invoke salt-syndic via su so that /etc/environment is read
-  exec su -c salt-syndic
+  exec salt-syndic
 end script

--- a/pkg/salt-syndic.upstart.rhel6
+++ b/pkg/salt-syndic.upstart.rhel6
@@ -10,6 +10,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  # invoke salt-syndic via su so that /etc/environment is read
-  exec su -c salt-syndic
+  exec salt-syndic
 end script


### PR DESCRIPTION
Starting salt via su should be avoided. The original reason to exec via su was to read in /etc/environment - if this is needed then it should be done by adding ". /etc/environment" to the appropriate defaults file (/etc/default/salt-{minion,master,syndic}.
