### PR TITLE
minion tries to resolve master DNS after ip change (DDNS)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1037,6 +1037,11 @@ class Minion(object):
                 break
             log.info('Waiting for minion key to be accepted by the master.')
             time.sleep(acceptance_wait_time)
+            
+            if self.opts.get('check_dns'):
+              log.info('Recheck master dns')
+              self.opts.update(resolve_dns(self.opts))
+              
             if acceptance_wait_time < acceptance_wait_time_max:
                 acceptance_wait_time += acceptance_wait_time
                 log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))


### PR DESCRIPTION
since minion config option.. dns_check dont seems to do anything? ..

if the master is a dns address and ip address changes, minions will try to resolve dns to new ip address.
