### PR TITLE
resolve master dns name when trying to reconnect. (DDNS)

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1173,6 +1173,11 @@ class Minion(MinionBase):
                 log.info('Authentication with master successful!')
                 break
             log.info('Waiting for minion key to be accepted by the master.')
+            
+            if self.opts.get('check_dns'):
+                log.info('Resolve master dns name.')
+                self.opts.update(resolve_dns(self.opts))
+            
             time.sleep(acceptance_wait_time)
             if acceptance_wait_time < acceptance_wait_time_max:
                 acceptance_wait_time += acceptance_wait_time


### PR DESCRIPTION
since minion config dns_check don't seems to do anything? I'm using that config option.

if the master is a ddns address or the ip address needs to change, this small fix keeps the minion running.
