### PR TITLE
Clean up stale code and revert 59410a6db3a8e80cfd335bc633ab292a78042a19  which broke raet udp

### DIFF
--- a/salt/transport/road/raet/estating.py
+++ b/salt/transport/road/raet/estating.py
@@ -4,6 +4,9 @@ estating.py raet protocol estate classes
 '''
 # pylint: skip-file
 # pylint: disable=W0611
+
+import socket
+
 # Import ioflo libs
 from ioflo.base.odicting import odict
 from ioflo.base import aiding
@@ -14,8 +17,6 @@ from . import nacling
 from ioflo.base.consoling import getConsole
 console = getConsole()
 
-# Import salt libs
-import salt.utils.network
 
 class Estate(object):
     '''
@@ -44,7 +45,7 @@ class Estate(object):
 
         if ha:  # takes precedence
             host, port = ha
-        self.host = salt.utils.network.host_to_ip(host)
+        self.host = socket.gethostbyname(host)
         self.port = port
         if self.host == '0.0.0.0':
             host = '127.0.0.1'

--- a/salt/transport/road/raet/estating.py
+++ b/salt/transport/road/raet/estating.py
@@ -51,7 +51,7 @@ class Estate(object):
             host = '127.0.0.1'
         else:
             host = self.host
-        self.fqdn = salt.utils.network.get_fqhostname()
+        self.fqdn = socket.getfqdn(host)
 
     @property
     def ha(self):

--- a/salt/transport/road/raet/packeting.py
+++ b/salt/transport/road/raet/packeting.py
@@ -616,15 +616,9 @@ class RxPacket(Packet):
         data = self.data
         le = data['de']
         if le == 0:
-            #host = data['dh']
-            #if host == '0.0.0.0':
-                #host = '127.0.0.1'
             le = (data['dh'], data['dp'])
         re = data['se']
         if re == 0:
-            #host = data['sh']
-            #if host == '0.0.0.0':
-                #host = '127.0.0.1'
             re = (data['sh'], data['sp'])
         return ((not data['cf'], le, re, data['si'], data['ti'], data['bf']))
 


### PR DESCRIPTION
59410a6db3a8e80cfd335bc633ab292a78042a19  substituted 

salt.utils.network.get_fqhostname()
salt.utils.network.host_to_ip(host)

for

socket.gethostbyname(host)
and
socket.getfqdn(host)

This broke raet in two ways.

1)  It placed a hard dep on Salt in RAET. Raet is designed to be a standalone protocol so it can't have hard deps on Salt

2) salt.utils.network.get_fqhostname()  returns (None, Port) instead of ("",Port) as it should this breaks socket as it will not accept None for hostname
