### PR TITLE
Fixes reference to ssh-id-wrapper script

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -37,7 +37,7 @@ def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):
     if identity:
         env = {
             'GIT_SSH': os.path.join(utils.templates.TEMPLATE_DIRNAME,
-                                    'ssh-id-wrapper'),
+                                    '/git/ssh-id-wrapper'),
             'GIT_IDENTITY': identity
         }
 


### PR DESCRIPTION
The ssh-id-wrapper script was moved to a sub directory. 

Fixes:

```
          ID: example.git
    Function: git.latest
        Name: git@example.com:group/example.git
      Result: False
     Comment: error: cannot run /usr/lib/pymodules/python2.7/salt/templates/ssh-id-wrapper: No such file or directory
              fatal: unable to fork
     Changes:
```
