### PR TITLE
Let os.path.join do it's job.

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -37,7 +37,7 @@ def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):
     if identity:
         env = {
             'GIT_SSH': os.path.join(utils.templates.TEMPLATE_DIRNAME,
-                                    '/git/ssh-id-wrapper'),
+                                    'git/ssh-id-wrapper'),
             'GIT_IDENTITY': identity
         }
 


### PR DESCRIPTION
Remove forward slash so that the path will be built
correctly.
