### PR TITLE
Tweak error wording

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -535,7 +535,7 @@ def run(name,
                         _env[key] = val
                     except ValueError:
                         ret['comment'] = \
-                            'Invalid environmental var: "{0}"'.format(var)
+                            'Invalid environment var: {0!r}'.format(var)
                         return ret
                 env = _env
         elif isinstance(env, dict):
@@ -551,7 +551,7 @@ def run(name,
                         _env.update(comp)
                     else:
                         ret['comment'] = \
-                            'Invalid environmental var: "{0}"'.format(env)
+                            'Invalid environment var: {0!r}'.format(env)
                         return ret
                 except Exception:
                     _env = {}
@@ -561,7 +561,7 @@ def run(name,
                             _env[key] = val
                         except ValueError:
                             ret['comment'] = \
-                                'Invalid environmental var: "{0}"'.format(var)
+                                'Invalid environment var: {0!r}'.format(var)
                             return ret
             env = _env
 
@@ -757,7 +757,7 @@ def script(name,
         else:
             ret['result'] = not bool(cmd_all['retcode'])
         if ret.get('changes', {}).get('cache_error'):
-            ret['comment'] = 'Unable to cache script {0} from env ' \
+            ret['comment'] = 'Unable to cache script {0} from saltenv ' \
                              '{1!r}'.format(source, env)
         else:
             ret['comment'] = 'Command {0!r} run'.format(name)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1713,7 +1713,7 @@ def recurse(name,
         ret['result'] = False
         ret['comment'] = (
             'The directory {0!r} does not exist on the salt fileserver '
-            'in environment {1!r}'.format(source, __env__)
+            'in saltenv {1!r}'.format(source, __env__)
         )
         return ret
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2644,7 +2644,7 @@ def patch(name,
     # get cached file or copy it to cache
     cached_source_path = __salt__['cp.cache_file'](source, __env__)
     if not cached_source_path:
-        ret['comment'] = ('Unable to cache {0} from environment {1!r}'
+        ret['comment'] = ('Unable to cache {0} from saltenv {1!r}'
                           .format(source, __env__))
         return ret
 


### PR DESCRIPTION
**Note: this pull is for 2014.1 and includes cherrypicked wording fixes**

These commits fix some issues with how we are wording our error messages, and also make the use of the term `saltenv` more visible in them.
