### PR TITLE
Fix IPv6 sockaddr unpacking in utils.network.host_to_ip()

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -70,7 +70,7 @@ def host_to_ip(host):
         if family == socket.AF_INET:
             ip, port = sockaddr
         elif family == socket.AF_INET6:
-            ip, port, flow, info, scope, id = sockaddr
+            ip, port, flow_info, scope_id = sockaddr
 
     except Exception:
         ip = None


### PR DESCRIPTION
Per http://docs.python.org/2/library/socket.html#socket.getaddrinfo :

> sockaddr is [...] a (address, port, flow info, scope id) `4`-tuple for AF_INET6
