### PR TITLE
Honor lack of user/group recurse in file.directory

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1413,6 +1413,8 @@ def directory(name,
                     ret['comment'] = 'user not specified, but configured as ' \
                                      'a target for recursive ownership ' \
                                      'management'
+            else:
+                user = None
             if 'group' in recurse:
                 if group:
                     gid = __salt__['file.group_to_gid'](group)
@@ -1426,6 +1428,8 @@ def directory(name,
                     ret['comment'] = 'group not specified, but configured ' \
                                      'as a target for recursive ownership ' \
                                      'management'
+            else:
+                group = None
 
             if 'mode' not in recurse:
                 file_mode = None


### PR DESCRIPTION
PR  #10939 wrongly assumed it already honored other recurse directives.

Current stable version (2014.1.1) does not honor any information in file.directory recurse list, and just recurse everything it can.

Along with #10939, that should fix the state to behave like the documentation describes.
