### PR TITLE
Add proxy argument to virtualenv state which is passed to pip install

### DIFF
--- a/salt/states/virtualenv_mod.py
+++ b/salt/states/virtualenv_mod.py
@@ -42,7 +42,8 @@ def managed(name,
             index_url=None,
             extra_index_url=None,
             pre_releases=False,
-            no_deps=False):
+            no_deps=False,
+            proxy=None):
     '''
     Create a virtualenv and optionally manage it with pip
 
@@ -57,6 +58,8 @@ def managed(name,
         Prefer wheel archives (requires pip>=1.4)
     no_deps: False
         Pass `--no-deps` to `pip`.
+    proxy: None
+        Proxy address which is passed to "pip install"
 
     Also accepts any kwargs that the virtualenv module will.
 
@@ -203,6 +206,7 @@ def managed(name,
             no_chown=no_chown,
             pre_releases=pre_releases,
             no_deps=no_deps,
+            proxy=proxy,
         )
         ret['result'] &= _ret['retcode'] == 0
         if _ret['retcode'] > 0:


### PR DESCRIPTION
It's usefull to have ability to set proxy for environments which do not have direct access to internet. Proxy argument is supported by pip module so it's needed only to be passed from virtualenv state.
