### PR TITLE
Fix argument order in RunnerClient.cmd()

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -189,7 +189,7 @@ def load_args_and_kwargs(func, args, data=None):
                     # **kwargs not in argspec and parsed argument name not in
                     # list of positional arguments. This keyword argument is
                     # invalid.
-                    invalid_kwargs.append(arg)
+                    invalid_kwargs.append('{0}'.format(arg))
                 continue
 
         # if the arg is a dict with __kwarg__ == True, then its a kwarg
@@ -203,7 +203,7 @@ def load_args_and_kwargs(func, args, data=None):
                     # **kwargs not in argspec and parsed argument name not in
                     # list of positional arguments. This keyword argument is
                     # invalid.
-                    invalid_kwargs.append(arg)
+                    invalid_kwargs.append('{0}'.format(arg))
             continue
 
         else:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -101,7 +101,7 @@ class RunnerClient(object):
         docs = dict(docs)
         return _strip_rst(docs)
 
-    def cmd(self, fun, arg, kwarg=None, pub_data=None):
+    def cmd(self, fun, arg, pub_data=None, kwarg=None):
         '''
         Execute a runner function
 


### PR DESCRIPTION
Also fix how invalid args are aggregated. Resolves #11576.
