### PR TITLE
Automatic OpenSSL CA implementation

### DIFF
--- a/salt/modules/openssl.py
+++ b/salt/modules/openssl.py
@@ -1,0 +1,85 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    return 'openssl'
+
+
+def _get_subj(CN, **kwargs):
+    fields = ['CN=' + CN]
+    map = {
+        'C': 'country',
+        'L': 'city',
+        'O': 'company'
+    }
+
+    for var, field in map.items():
+        if field in kwargs:
+            fields.append('{0}={1}'.format(var, kwargs[field]))
+
+    subj = '/' + '/'.join(fields)
+
+    return subj
+
+
+def generate(file, **kwargs):
+    '''
+    Generate a private key that can be used to request a certificate.
+    '''
+    algo = kwargs.pop('algorithm', 'RSA')
+    len = kwargs.pop('length', 4096)
+
+    if algo not in ['RSA', 'DSA']:
+        return False
+
+    if algo == 'RSA':
+        opts = 'rsa_keygen_bits:{0}'.format(len)
+    elif algo == 'DSA':
+        opts = 'dsa_paramgen_bits:{0}'.format(len)
+
+    cmd = "openssl genpkey -algorithm {0} -out {1} -pkeyopt {2}".format(
+        algo, file, opts
+    )
+    out = __salt__['cmd.run'](cmd)
+    return cmd + "\n" + out
+
+
+def gen_req(file, req_file, CN, **kwargs):
+    '''
+    Generate a csr (certificate signing request) file to be able to get a
+    signed certificate from a certificate authority.
+    '''
+    subj = _get_subj(CN, **kwargs)
+    cmd = "openssl req -new -key {0} -subj '{1}' -out {2}".format(
+        file, subj, req_file
+    )
+    out = __salt__['cmd.run'](cmd)
+    # TODO: Error handling...
+    return cmd + "\n" + out
+
+
+def gen_pem(file, private_key, certificate):
+    '''
+    Merge a certificate file and a private key file into a single pem file.
+    '''
+    cmd = '{0} {1} > {2}'.format(private_key, certificate, file)
+    # TODO: Check for existence of file first.
+    out = __salt__['cmd.run'](cmd)
+    return out
+
+
+def sign(config, csr, crt, passfile=None):
+    '''
+    Create a certificate based on a certificate signing request. Optionally
+    accepts a passfile which contains the password for the certificate
+    authority specified in the config file.
+    '''
+    if passfile:
+        passfile = '-passin file:{0}'.format(passfile)
+    cmd = 'openssl ca -config {0} -batch -in {1} -out {2} {3}'.format(
+        config, csr, crt, passfile
+    )
+    out = __salt__['cmd.run'](cmd)
+    return out

--- a/salt/pillar/crt.py
+++ b/salt/pillar/crt.py
@@ -1,0 +1,52 @@
+import logging
+import os
+import glob
+import shutil
+import salt.utils
+
+log = logging.getLogger(__name__)
+
+def __virtual__():
+    # TODO: Check if openssl is installed.
+    return 'crt'
+
+
+def ext_pillar(minion_id, pillar, crtdir=None, cacrtbundle=None, autosign=False, config=None, passfile=None):
+    if not crtdir:
+        crtdir = '/var/lib/openssl/ca/certs'
+
+    d = crtdir + minion_id
+
+    ret = {'crt': {}}
+    if not __salt__['file.directory_exists'](d):
+        __salt__['file.mkdir'](d)
+        return ret
+
+    if autosign and config:
+        csr_dir = os.path.join('/var/cache/salt/master/minions', minion_id, 'files')
+        csr = None
+        for dirpath, dirnames, files in os.walk(csr_dir, topdown=False):
+            for name in files:
+                if name.lower().endswith('csr'):
+                    csr = os.path.join(dirpath, name)
+
+        if csr:
+            crt = os.path.join(d, os.path.splitext(os.path.basename(csr))[0] + '.crt')
+            out = __salt__['openssl.sign'](config, csr, crt, passfile)
+
+            if __salt__['file.file_exists'](crt):
+                shutil.rmtree(csr_dir)
+
+    cacrt = None
+    if cacrtbundle:
+        with salt.utils.fopen(cacrtbundle, 'r') as fp_:
+            cacrt = fp_.read()
+
+    for f in glob.glob(d + '/*.crt'):
+        crt = os.path.splitext(os.path.basename(f))[0]
+        with salt.utils.fopen(f, 'r') as fp_:
+            ret['crt'][crt] = fp_.read()
+        if cacrt:
+            ret['crt']['ca_chain'] = {crt: cacrt}
+
+    return ret

--- a/salt/states/pk.py
+++ b/salt/states/pk.py
@@ -1,0 +1,126 @@
+'''
+State for making sure a private key is generated and optionally signed
+by a CA specified.
+'''
+
+import logging
+import os.path
+import salt.utils
+import time
+
+log = logging.getLogger(__name__)
+
+def __virtual__():
+    '''
+    Only work on POSIX-like systems
+    '''
+    if salt.utils.is_windows():
+        return False
+    return 'pk'
+
+def generated(name, pk_dir, length=4096, algorithm='RSA', **kwargs):
+    '''
+    Ensures that a private key is generated.
+    '''
+    ret = {
+            'name': name,
+            'result': False,
+            'comment': '',
+            'changes': {}
+    }
+    pk = os.path.join(pk_dir, name + '.key')
+
+    # TODO: Failure conditions on key size, etc.
+    if __salt__['file.file_exists'](pk):
+        ret['result'] = True
+        ret['comment'] = 'Key {0} is already generated.'.format(pk)
+        return ret
+
+    ret['comment'] = 'Generating private key at: %s'.format(pk)
+    out = __salt__['openssl.generate'](pk, length=length, algorithm=algorithm, **kwargs)
+    if not out:
+        ret['comment'] = 'SOMETHING FAILED HORRIBLY!'
+        return ret
+
+    ret['changes']['pk'] = {'old': '', 'new': out}
+    ret['result'] = True
+    return ret
+
+
+def signed(name, bundle_ca = True, base_dir=None, length=4096, algorithm='RSA', gen_pem=True, **kwargs):
+    '''
+    Ensures that the certificate is signed by a CA.
+    It does however not actually sign the certificate,
+    that is a manual step on the CA itself because you
+    probably want the CA root certificate encrypted.
+
+    If you don't supply a CN, it will be the same as
+    the file name without .pem.
+    You can pass in country, city and company for
+    inclusion in the certificate in the PK as well.
+    '''
+    pk_dir = kwargs.pop('pk_dir', base_dir)
+    base_dir = base_dir if base_dir else pk_dir
+    crt_dir = kwargs.pop('crt_dir', base_dir)
+    cacrt_dir = kwargs.pop('cacrt_dir', base_dir)
+
+    if not pk_dir or not crt_dir:
+        return {'result': False,
+                'comment': 'You need to specify either base_dir or pk_dir AND crt_dir'
+                }
+    # create file paths
+    crt = os.path.join(crt_dir, name + '.crt')
+    pk = os.path.join(pk_dir, name + '.key')
+    csr = os.path.join(pk_dir, name + '.csr')
+    pem = os.path.join(base_dir, name + '.pem')
+    cacrt = os.path.join(cacrt_dir, name + '-chain.crt')
+
+    # Check if PK is generated
+    ret = generated(name, pk_dir, length=length, algorithm=algorithm, **kwargs)
+    if not ret['result']:
+        return ret
+
+    crt_file = pem if gen_pem else crt
+    if __salt__['file.file_exists'](crt_file):
+        # TODO: Verify certificate authenticity
+        ret['comment'] = 'Key {0} is already signed.'
+        return ret
+
+    # Check if CSR exists
+    if not __salt__['file.file_exists'](csr):
+        out = __salt__['openssl.gen_req'](pk, csr, name, **kwargs)
+        ret['changes']['csr'] = {'old': '', 'new': out}
+    # Copy CSR to Master
+    out = __salt__['cp.push'](csr)
+    if out:
+        ret['changes']['csr_push'] = {'old': '', 'new': 'Pushed!'}
+
+    # We'll give the master 5 seconds to generate the certificate.
+    # There might be a large problem with the fact that pillars might be read
+    # in at script start and not when it is requested, but we will see.
+    time.sleep(5)
+
+    # Check if CRT exists
+    if 'crt' in __pillar__ and name in __pillar__['crt']:
+        ca_chain = __pillar__['crt']['ca_chain'][name]
+        if not __salt__['file.file_exists'](cacrt) and not bundle_ca:
+            with salt.utils.fopen(cacrt, 'w') as fp_:
+                fp_.write(ca_chain)
+
+        if not __salt__['file.file_exists'](crt):
+            crt_data = __pillar__['crt'][name]
+            if bundle_ca: crt_data += "\n" + ca_chain
+            with salt.utils.fopen(crt, 'w') as fp_:
+                fp_.write(crt_data)
+
+            ret['changes']['crt'] = {'old': '', 'new': 'CRT Received'}
+        # Merge PK + CRT
+        if gen_pem:
+            __salt__['openssl.gen_pem'](name, pk, crt)
+
+        ret['result'] = True
+    else:
+        ret['comment'] = 'Did not receive CRT from pillar. It probably is not accepted by master yet.'
+        ret['result'] = False
+
+    return ret


### PR DESCRIPTION
Not ready for merge!

This is a rather crude and in its current state poorly documented CA implementation for Salt. The idea is to enable minions to request certificates which are automatically signed by a central CA which Salt administers.

Right now it requires two state runs to be able to pick up a certificate, which is not ideal. But if we refresh the pillars during the state run after we've sent the CRL from the minion, we should be able to do it in one go.

The reason I'm putting this up as a pull request was to let other people help me finish this up as I'm rather pressed on time, and from the chatter in #salt on IRC, I figured that there's plenty of people that would like something like this.

It has a couple dependencies too, you need to allow minion to master file uploads and you must create the CA yourself.
