### PR TITLE
openbsd services (openbsdservice.py): added reload(name), available(name...

### DIFF
--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -5,6 +5,9 @@ The service module for OpenBSD
 
 # Import python libs
 import os
+import logging
+
+log = logging.getLogger(__name__)
 
 # XXX enable/disable support would be nice
 
@@ -82,3 +85,186 @@ def status(name, sig=None):
         return bool(__salt__['status.pid'](sig))
     cmd = '/etc/rc.d/{0} -f check'.format(name)
     return not __salt__['cmd.retcode'](cmd)
+
+
+def reload(name):
+    '''
+    Reload the named service
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.reload <service name>
+    '''
+    cmd = '/etc/rc.d/{0} -f reload'.format(name)
+    return not __salt__['cmd.retcode'](cmd)
+
+
+import re
+service_flags_regex = re.compile(r'^\s*(\w[\d\w]*)_flags=(?:(NO)|.*)$')
+pkg_scripts_regex = re.compile(r'^\s*pkg_scripts=\'(.*)\'$')
+start_daemon_call_regex = re.compile(r'(\s*start_daemon(?!\(\)))')
+start_daemon_parameter_regex = re.compile(r'(?:\s+(\w[\w\d]*))')
+
+
+def _get_rc():
+    '''
+    Returns a dict where the key is the daemon's name and
+    the value a boolean indicating its status (True: enabled or False: disabled).
+    Check the daemons started by the system in /etc/rc and
+    configured in /etc/rc.conf and /etc/rc.conf.local.
+    Also add to the dict all the localy enabled daemons via $pkg_scripts.
+    '''
+    daemons_flags = {}
+
+    try:
+        # now read the system startup script /etc/rc
+        # to know what are the system enabled daemons
+        with open('/etc/rc', 'r') as handle:
+            lines = handle.readlines()
+    except:
+        log.error('Unable to read /etc/rc')
+    else:
+        for line in lines:
+            match = start_daemon_call_regex.match(line)
+            if match:
+                # the matched line is a call to start_daemon()
+                # we remove the function name
+                line = line[len(match.group(1)):]
+                # we retrieve each daemon name from the parameters of start_daemon()
+                for daemon in start_daemon_parameter_regex.findall(line):
+                    # mark it as enabled
+                    daemons_flags[daemon] = True
+
+    # this will execute rc.conf and rc.conf.local
+    # used in /etc/rc at boot to start the daemons
+    vars = __salt__['cmd.run']('(. /etc/rc.conf && set)', clean_env=True, output_loglevel='quiet').split('\n')
+    for var in vars:
+        match = service_flags_regex.match(var)
+        if match:
+            # the matched var look like daemon_name_flags=, we test its assigned value
+            # NO: disabled, everything else: enabled
+            # do not create a new key if the service hasn't been found in /etc/rc, see $pkg_scripts 
+            if match.group(2) == 'NO':
+                daemons_flags[match.group(1)] = False
+        else:
+            match = pkg_scripts_regex.match(var)
+            if match:
+                # the matched var is pkg_scripts
+                # we can retrieve the name of each localy enabled daemon that wasn't hand started via /etc/rc
+                for daemon in match.group(1).split():
+                    # create a new key and mark it as enabled
+                    daemons_flags[daemon] = True
+
+    return daemons_flags
+
+
+def available(name):
+    '''
+    Returns ``True`` if the specified service is available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.available sshd
+    '''
+    path = '/etc/rc.d/{0}'.format(name)
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def missing(name):
+    '''
+    The inverse of service.available.
+    Returns ``True`` if the specified service is not available, otherwise returns
+    ``False``.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.missing sshd
+    '''
+    return not available(name)
+
+
+def get_all():
+    '''
+    Return all available boot services
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.get_all
+    '''
+    services = []
+    if not os.path.isdir('/etc/rc.d'):
+        return services
+    for service in os.listdir('/etc/rc.d'):
+        # this will remove rc.subr and all non executable files
+        if available(service):
+            services.append(service)
+    return sorted(services)
+
+
+def get_enabled():
+    '''
+    Return a list of service that are enabled on boot
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.get_enabled
+    '''
+    services = []
+    for daemon, enabled in _get_rc().items():
+        if enabled:
+            services.append(daemon)
+    return sorted(set(get_all()) & set(services))
+
+
+def enabled(name):
+    '''
+    Return True if the named service is enabled, false otherwise
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.enabled <service name>
+    '''
+    return name in get_enabled()
+
+
+def get_disabled():
+    '''
+    Return a set of services that are installed but disabled
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.get_disabled
+    '''
+    services = []
+    for daemon, enabled in _get_rc().items():
+        if not enabled:
+            services.append(daemon)
+    return sorted(set(get_all()) & set(services))
+
+
+def disabled(name):
+    '''
+    Return True if the named service is disabled, false otherwise
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' service.disabled <service name>
+    '''
+    return name in get_disabled()

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -123,7 +123,7 @@ def _get_rc():
         # to know what are the system enabled daemons
         with open('/etc/rc', 'r') as handle:
             lines = handle.readlines()
-    except:
+    except IOError:
         log.error('Unable to read /etc/rc')
     else:
         for line in lines:
@@ -145,7 +145,7 @@ def _get_rc():
         if match:
             # the matched var look like daemon_name_flags=, we test its assigned value
             # NO: disabled, everything else: enabled
-            # do not create a new key if the service hasn't been found in /etc/rc, see $pkg_scripts 
+            # do not create a new key if the service hasn't been found in /etc/rc, see $pkg_scripts
             if match.group(2) == 'NO':
                 daemons_flags[match.group(1)] = False
         else:


### PR DESCRIPTION
...), missing(name), get_all(), get_enabled(), enabled(name), get_disabled(), disabled(name)

Add support for OpenBSD services.

Right now, declaring a service and applying state.hightstate will give the following result:
ID: sshd
Function: service.running
Result: False
Comment: The named service sshd is not available
Changes:

OpenBSD services are started via /etc/rc at boot.
This script load the system file /etc/rc.conf and the user override /etc/rc.conf.local to check wether or not a daemon should be started via the named variables 'daemon_flags'.
Non-builtin daemons are started only if the variable $pkg_scripts in /etc/rc.conf.local is set to their respective names.

This merge request provides the following functions:
- reload(): simply reloads the service via /etc/rc.d/daemon -f reload,
- available(): tests if a daemon is present in /etc/rc.d,
- missing(): tests if a daemon is absent of /etc/rc.d,
- get_all(): returns all the available services in /etc/rc.d,
- get_enabled(): returns the available daemons enabled in /etc/rc.conf or /etc/rc.conf.local,
- enabled(): tests if a daemon is enabled,
- get_disabled(): returns the available daemons disabled in /etc/rc.conf or /etc/rc.conf.local,
- disabled():  tests if a daemon is disabled.

With this patch, the state.highstate output is:
ID: sshd
Function: service.running
Result: True
Comment: The service sshd is already running
Changes:

However, the patch doesn't provide the ability to set the status of a deamon, since it requires to write in /etc/rc.conf.local file, which is possible via:
salt-master.rc.conf:
  file:
    - append
    - name: /etc/rc.conf.local
    - source: salt://openbsd-salt/daemons/salt/master/rc.conf.local
[...]

And salt://openbsd-salt/daemons/salt/master/rc.conf.local contents:
pkg_scripts="$pkg_scripts salt_master"
salt_master_flags="-d"
salt_master_user="" # root
