### PR TITLE
sometimes /proc/1/cgroup is not readable

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -515,8 +515,11 @@ def _virtual(osdata):
     sysctl = salt.utils.which('sysctl')
     if osdata['kernel'] in choices:
         if os.path.isfile('/proc/1/cgroup'):
-            if ':/lxc/' in salt.utils.fopen('/proc/1/cgroup', 'r').read():
-                grains['virtual_subtype'] = 'LXC'
+            try:
+                if ':/lxc/' in salt.utils.fopen('/proc/1/cgroup', 'r').read():
+                    grains['virtual_subtype'] = 'LXC'
+            except IOError:
+                pass
         if isdir('/proc/vz'):
             if os.path.isfile('/proc/vz/version'):
                 grains['virtual'] = 'openvzhn'


### PR DESCRIPTION
Prevent the code from throwing fatal exceptions when /proc/1/cgroup
exists but is not readable (which can happen in VPS systems).

Pull request to follow up issue #11619.
