### PR TITLE
Give warning about using grains as pillar matches

### DIFF
--- a/doc/topics/best_practices.rst
+++ b/doc/topics/best_practices.rst
@@ -15,6 +15,8 @@ General rules
 2. Create clear relations between pillars and states.
 3. Use variables when it makes sense but don't overuse them.
 4. Store sensitive data in pillar.
+5. Don't use grains for matching in your pillar top file for any sensitive
+   pillars.
 
 
 Structuring States and Formulas


### PR DESCRIPTION
If you use grains to match for pillar top files, any sensitive data
in the pillars is no longer protected, as any minion could modify its
grains to access the sensitive pillars.
