### PR TITLE
Provide `env` to templates.

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -41,6 +41,16 @@ def compile_template(template,
     Take the path to a template and return the high data structure
     derived from the template.
     '''
+
+    # We "map" env to the same as saltenv until Boron is out in order to follow the same deprecation path
+    kwargs.setdefault('env', saltenv)
+    salt.utils.warn_until(
+        'Boron',
+        'We are only supporting \'env\' in the templating context until Boron comes out. '
+        'Once this warning is shown, please remove the above mapping',
+        _dont_call_warnings=True
+    )
+
     # Template was specified incorrectly
     if not isinstance(template, string_types):
         return {}

--- a/tests/integration/states/compiler.py
+++ b/tests/integration/states/compiler.py
@@ -4,12 +4,16 @@
 tests for host state
 '''
 
+# Import python libs
+import os
+
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils
 
 
 class CompileTest(integration.ModuleCase):
@@ -34,6 +38,40 @@ class CompileTest(integration.ModuleCase):
             ', in jinja_error' in ret[0].strip())
         self.assertTrue(
             ret[0].strip().endswith('Exception: hehehe'))
+
+    def test_env_in_jinja_context(self):
+        salt.utils.warn_until(
+            'Boron',
+            'We are only supporting \'env\' in the templating context until Boron comes out. '
+            'Once this warning is show, please remove the test case',
+            _dont_call_warnings=True
+        )
+        managed_file = os.path.join(integration.TMP, 'env-in-jinja-ctx.txt')
+        template = [
+            '{0}:'.format(managed_file),
+            '  file.managed:',
+            '    - contents: {{ saltenv }}'
+        ]
+        try:
+            ret = self.run_function('state.template_str', ['\n'.join(template)], timeout=120)
+            self.assertEqual('base', open(managed_file).read())
+        finally:
+            if os.path.isfile(managed_file):
+                os.unlink(managed_file)
+
+        template = [
+            '{0}:'.format(managed_file),
+            '  file.managed:',
+            '    - contents: {{ env }}'
+        ]
+        try:
+            ret = self.run_function('state.template_str', ['\n'.join(template)], timeout=120)
+            self.assertEqual('base', open(managed_file).read())
+        finally:
+            if os.path.isfile(managed_file):
+                os.unlink(managed_file)
+
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Map `env` to the same value of `saltenv` in the templating context until
`env` is fully deprecated in favor of `saltenv`.

Fixes #11480.
