### PR TITLE
Remove apparent debugging lines

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -86,11 +86,8 @@ class KeyCLI(object):
 
         matches = self.key.name_match(match)
         keys = {}
-        print(matches)
-        print(self.pend)
         if self.pend in matches:
             keys[self.pend] = matches[self.pend]
-            print(keys)
         if include_rejected and bool(matches.get(self.rej)):
             keys[self.rej] = matches[self.rej]
         if not keys:


### PR DESCRIPTION
When accepting a key, extraneous lines appear in the terminal:

```
root@saltmine:~erik/saltdev#  salt-key -A
{'minions_pre': ['saltmine']}
minions_pre
{'minions_pre': ['saltmine']}
The following keys are going to be accepted:
Unaccepted Keys:
saltmine
Proceed? [n/Y]
```

This appears to have been introduced in 7b03382, and only appears in develop.
