### PR TITLE
Ignore retcode for yum refresh_db (2014.1 branch)

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -472,7 +472,9 @@ def refresh_db():
     }
 
     cmd = 'yum -q clean expire-cache && yum -q check-update'
-    ret = __salt__['cmd.retcode'](cmd)
+    ret = __salt__['cmd.retcode'](cmd,
+                                  output_loglevel='debug',
+                                  ignore_retcode=True)
     return retcodes.get(ret, False)
 
 


### PR DESCRIPTION
**This is #11645, cherrypicked for 2014.1**

'yum -q check_update' returns a retcode of 100 if there are updates to
install, so ignore the retcode and don't log an error if a nonzero
retcode is seen here.
