### PR TITLE
remove duplicated code and warn when master IP changes

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -126,6 +126,11 @@ def resolve_dns(opts):
     else:
         ret['master_ip'] = '127.0.0.1'
 
+    if 'master_ip' in ret and 'master_ip' in opts:
+        if ret['master_ip'] != opts['master_ip']:
+            log.warning('Master ip address changed from {0} to {1}'.format(opts['master_ip'],
+                                                                          ret['master_ip'])
+            )
     ret['master_uri'] = 'tcp://{ip}:{port}'.format(ip=ret['master_ip'],
                                                    port=opts['master_port'])
     return ret


### PR DESCRIPTION
remove duplicated code and warn when master IP address changes.

only try and preform extra DNS resolves after an error.  This solution is better because often times when using DDNS the ip address will flop between the old and the new address because DNS servers are often  load-balanced and not updated in sync.
