### PR TITLE
Close file handle before returning

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -999,6 +999,7 @@ def replace(path,
             result = re.search(cpattern, line)
 
             if result:
+                fi_file.close() # close file handle before returning
                 return True
         else:
             result, nrepl = re.subn(cpattern, repl, line, count)


### PR DESCRIPTION
Not closing the file handle here was causing Salt to keep a lock on the
file on Windows minions since the minion thread is long-lived.
