### PR TITLE
modules.openbsdservice: avoid shadowing outer enabled() func

### DIFF
--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -231,8 +231,8 @@ def get_enabled():
         salt '*' service.get_enabled
     '''
     services = []
-    for daemon, enabled in _get_rc().items():
-        if enabled:
+    for daemon, is_enabled in _get_rc().items():
+        if is_enabled:
             services.append(daemon)
     return sorted(set(get_all()) & set(services))
 
@@ -265,8 +265,8 @@ def get_disabled():
         salt '*' service.get_disabled
     '''
     services = []
-    for daemon, enabled in _get_rc().items():
-        if not enabled:
+    for daemon, is_enabled in _get_rc().items():
+        if not is_enabled:
             services.append(daemon)
     return sorted(set(get_all()) & set(services))
 


### PR DESCRIPTION
```
************* Module salt.modules.openbsdservice
salt/modules/openbsdservice.py:234: [W0621(redefined-outer-name), get_enabled] Redefining name 'enabled' from outer scope (line 240)
salt/modules/openbsdservice.py:268: [W0621(redefined-outer-name), get_disabled] Redefining name 'enabled' from outer scope (line 240)
```
