### PR TITLE
states.file: avoid shadowing prepend() func

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2641,7 +2641,7 @@ def prepend(name,
 
     count = 0
 
-    prepend = []
+    preface = []
     for chunk in text:
 
         if __salt__['file.contains_regex_multiline'](
@@ -2663,10 +2663,10 @@ def prepend(name,
                 ret['comment'] = 'File {0} is set to be updated'.format(name)
                 ret['result'] = None
                 return ret
-            prepend.append(line)
+            preface.append(line)
             count += 1
 
-    __salt__['file.prepend'](name, *prepend)
+    __salt__['file.prepend'](name, *preface)
 
     with salt.utils.fopen(name, 'rb') as fp_:
         nlines = fp_.readlines()


### PR DESCRIPTION
```
************* Module salt.states.file
salt/states/file.py:2644: [W0621(redefined-outer-name), prepend] Redefining name 'prepend' from outer scope (line 2545)
```
