### PR TITLE
Randomize minion reconnects by default

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -297,7 +297,7 @@ DEFAULT_MINION_OPTS = {
     'retry_dns': 30,
     'recon_max': 5000,
     'recon_default': 100,
-    'recon_randomize': False,
+    'recon_randomize': True,
     'win_repo_cachefile': 'salt://win/repo/winrepo.p',
     'pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-minion.pid'),
     'range_server': 'range:80',


### PR DESCRIPTION
I've opened this pull req to open a discussion.

By setting recon_randomize: True   the salt-minions reconnect at a random time between the recon_default and the recon_max. Since recon_max is set to 5000 milliseconds, all minions should connect within 5 seconds.

On larger deployments having recon_randomize: False was causing unrecoverable minion floods. Does anyone have any objections to making recon_randomiz: True the default?
