### PR TITLE
By popular demand, switch from urllib2 to requests

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -10,6 +10,17 @@ has been deprecated in favor of the ``ec2`` provider. Configuration using the
 old ``aws`` provider will still function, but that driver is no longer in
 active development.
 
+
+Dependencies
+============
+This driver requires the Python ``requests`` library to be installed.
+
+
+Configuration
+=============
+The following example illustrates some of the options that can be set. These
+parameters are discussed in more detail below.
+
 .. code-block:: yaml
 
     # Note: This example is for /etc/salt/cloud.providers or any file in the

--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -7,7 +7,7 @@ Digital Ocean is a public cloud provider that specializes in Linux instances.
 
 Dependencies
 ============
-The Digital Ocean driver requires no special dependencies outside of Salt.
+This driver requires the Python ``requests`` library to be installed.
 
 
 Configuration

--- a/doc/topics/cloud/joyent.rst
+++ b/doc/topics/cloud/joyent.rst
@@ -8,8 +8,7 @@ Windows.
 
 Dependencies
 ============
-The Joyent driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
-installed.
+This driver requires the Python ``requests`` library to be installed.
 
 
 Configuration

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -72,10 +72,16 @@ class SaltCloud(parsers.SaltCloudParser):
 
         if self.options.update_bootstrap:
             log.debug('Updating the bootstrap-salt.sh script to latest stable')
-            import urllib2
+            try:
+                import requests
+            except ImportError:
+                self.error (
+                    'Updating the bootstrap-salt.sh script requires the '
+                    'Python requests library to be installed'
+                )
             url = 'http://bootstrap.saltstack.org'
-            req = urllib2.urlopen(url)
-            if req.getcode() != 200:
+            req = requests.get(url)
+            if req.status_code != 200:
                 self.error(
                     'Failed to download the latest stable version of the '
                     'bootstrap-salt.sh script from {0}. HTTP error: '

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -71,112 +71,12 @@ class SaltCloud(parsers.SaltCloudParser):
         self.setup_logfile_logger()
 
         if self.options.update_bootstrap:
-            log.debug('Updating the bootstrap-salt.sh script to latest stable')
-            try:
-                import requests
-            except ImportError:
-                self.error (
-                    'Updating the bootstrap-salt.sh script requires the '
-                    'Python requests library to be installed'
-                )
-            url = 'http://bootstrap.saltstack.org'
-            req = requests.get(url)
-            if req.status_code != 200:
-                self.error(
-                    'Failed to download the latest stable version of the '
-                    'bootstrap-salt.sh script from {0}. HTTP error: '
-                    '{1}'.format(
-                        url, req.getcode()
-                    )
-                )
-
-            # Get the path to the built-in deploy scripts directory
-            builtin_deploy_dir = os.path.join(
-                os.path.dirname(__file__),
-                'deploy'
+            ret = salt.utils.cloud.update_bootstrap(self.config)
+            display_output = salt.output.get_printout(
+                self.options.output, self.config
             )
-
-            # Compute the search path from the current loaded opts conf_file
-            # value
-            deploy_d_from_conf_file = os.path.join(
-                os.path.dirname(self.config['conf_file']),
-                'cloud.deploy.d'
-            )
-
-            # Compute the search path using the install time defined
-            # syspaths.CONF_DIR
-            deploy_d_from_syspaths = os.path.join(
-                syspaths.CONFIG_DIR,
-                'cloud.deploy.d'
-            )
-
-            # Get a copy of any defined search paths, flagging them not to
-            # create parent
-            deploy_scripts_search_paths = []
-            for entry in self.config.get('deploy_scripts_search_path', []):
-                if entry.startswith(builtin_deploy_dir):
-                    # We won't write the updated script to the built-in deploy
-                    # directory
-                    continue
-
-                if entry in (deploy_d_from_conf_file, deploy_d_from_syspaths):
-                    # Allow parent directories to be made
-                    deploy_scripts_search_paths.append((entry, True))
-                else:
-                    deploy_scripts_search_paths.append((entry, False))
-
-            # In case the user is not using defaults and the computed
-            # 'cloud.deploy.d' from conf_file and syspaths is not included, add
-            # them
-            if deploy_d_from_conf_file not in deploy_scripts_search_paths:
-                deploy_scripts_search_paths.append(
-                    (deploy_d_from_conf_file, True)
-                )
-            if deploy_d_from_syspaths not in deploy_scripts_search_paths:
-                deploy_scripts_search_paths.append(
-                    (deploy_d_from_syspaths, True)
-                )
-
-            for entry, makedirs in deploy_scripts_search_paths:
-                if makedirs and not os.path.isdir(entry):
-                    try:
-                        os.makedirs(entry)
-                    except (OSError, IOError) as err:
-                        log.info(
-                            'Failed to create directory {0!r}'.format(entry)
-                        )
-                        continue
-
-                if not is_writeable(entry):
-                    log.debug(
-                        'The {0!r} is not writeable. Continuing...'.format(
-                            entry
-                        )
-                    )
-                    continue
-
-                deploy_path = os.path.join(entry, 'bootstrap-salt.sh')
-                try:
-                    print(
-                        '\nUpdating \'bootstrap-salt.sh\':'
-                        '\n\tSource:      {0}'
-                        '\n\tDestination: {1}'.format(
-                            url,
-                            deploy_path
-                        )
-                    )
-                    with salt.utils.fopen(deploy_path, 'w') as fp_:
-                        fp_.write(req.read())
-                    # We were able to update, no need to continue trying to
-                    # write up the search path
-                    self.exit(0)
-                except (OSError, IOError) as err:
-                    log.debug(
-                        'Failed to write the updated script: {0}'.format(err)
-                    )
-                    continue
-
-            self.error('Failed to update the bootstrap script')
+            print(display_output(ret))
+            self.exit(0)
 
         log.info('salt-cloud starting')
         mapper = salt.cloud.Map(self.config)

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -18,6 +18,7 @@ cloud configuration at ``/etc/salt/cloud.providers`` or
       api_key: GDE43t43REGTrkilg43934t34qT43t4dgegerGEgg
       provider: digital_ocean
 
+:depends: requests
 '''
 
 # Import python libs

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -26,8 +26,7 @@ import copy
 import time
 import json
 import pprint
-import urllib
-import urllib2
+import requests
 import logging
 
 # Import salt cloud libs
@@ -504,22 +503,20 @@ def query(method='droplets', droplet_id=None, command=None, args=None):
         'api_key', get_configured_provider(), __opts__, search_global=False
     )
 
-    path += '?%s'
-    params = urllib.urlencode(args)
-    request = urllib2.urlopen(path % params)
-    if request.getcode() != 200:
+    request = requests.get(path, params=args)
+    if request.status_code != 200:
         raise SaltCloudSystemExit(
             'An error occurred while querying Digital Ocean. HTTP Code: {0}  '
             'Error: {1!r}'.format(
                 request.getcode(),
-                request.read()
+                #request.read()
+                request.text
             )
         )
 
-    log.debug(request.geturl())
+    log.debug(request.url)
 
-    content = request.read()
-    request.close()
+    content = request.text
 
     result = json.loads(content)
     if result.get('status', '').lower() == 'error':

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -59,6 +59,7 @@ To use the EC2 cloud module, set up the cloud configuration at
 
       provider: ec2
 
+:depends: requests
 '''
 # pylint: disable=E0102
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -79,7 +79,7 @@ import hashlib
 import binascii
 import datetime
 import urllib
-import urllib2
+import requests
 
 # Import salt libs
 from salt._compat import ElementTree as ET
@@ -318,19 +318,19 @@ def query(params=None, setname=None, requesturl=None, location=None,
             sig = binascii.b2a_base64(hashed.digest())
             params['Signature'] = sig.strip()
 
-            querystring = urllib.urlencode(params)
-            requesturl = 'https://{0}/?{1}'.format(endpoint, querystring)
+            requesturl = 'https://{0}/'.format(endpoint)
 
         log.debug('EC2 Request: {0}'.format(requesturl))
         try:
-            result = urllib2.urlopen(requesturl)
+            result = requests.get(requesturl, params=params)
             log.debug(
                 'EC2 Response Status Code: {0}'.format(
-                    result.getcode()
+                    #result.getcode()
+                    result.status_code
                 )
             )
             break
-        except urllib2.URLError as exc:
+        except requests.exceptions.HTTPError as exc:
             root = ET.fromstring(exc.read())
             data = _xml_to_dict(root)
 
@@ -366,7 +366,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
             return {'error': data}, requesturl
         return {'error': data}
 
-    response = result.read()
+    response = result.text
     result.close()
 
     root = ET.fromstring(response)

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -40,7 +40,7 @@ import os
 import copy
 import urllib
 import httplib
-import urllib2
+import requests
 import json
 import logging
 import base64
@@ -229,7 +229,7 @@ def create(vm_):
     ret = {}
 
     def __query_node_data(vm_id, vm_location):
-        rcode, data = query2(
+        rcode, data = query(
             command='my/machines/{0}'.format(vm_id),
             method='GET',
             location=vm_location
@@ -425,7 +425,7 @@ def create_node(**kwargs):
     })
 
     try:
-        ret = query2(command='/my/machines', data=data, method='POST',
+        ret = query(command='/my/machines', data=data, method='POST',
                      location=location)
         if ret[0] in VALID_RESPONSE_CODES:
             return ret[1]
@@ -468,7 +468,7 @@ def destroy(name, call=None):
     )
 
     node = get_node(name)
-    ret = query2(command='my/machines/{0}'.format(node['id']),
+    ret = query(command='my/machines/{0}'.format(node['id']),
                  location=node['location'], method='DELETE')
 
     salt.utils.cloud.fire_event(
@@ -569,7 +569,7 @@ def take_action(name=None, call=None, command=None, data=None, method='GET',
     ret = []
     try:
 
-        ret = query2(command=command, data=data, method=method,
+        ret = query(command=command, data=data, method=method,
                      location=location)
         log.info('Success {0} for node {1}'.format(caller, name))
     except Exception as exc:
@@ -637,7 +637,7 @@ def avail_locations(call=None):
     # corrected, currently only the european dc (new api) returns the correct
     # values
     # ret = {}
-    # rcode, datacenters = query2(
+    # rcode, datacenters = query(
     #     command='my/datacenters', location=DEFAULT_LOCATION, method='GET'
     # )
     # if rcode in VALID_RESPONSE_CODES and isinstance(datacenters, dict):
@@ -775,7 +775,7 @@ def list_nodes(full=False, call=None):
     ret = {}
     if POLL_ALL_LOCATIONS:
         for location in JOYENT_LOCATIONS.keys():
-            result = query2(command='my/machines', location=location,
+            result = query(command='my/machines', location=location,
                             method='GET')
             nodes = result[1]
             for node in nodes:
@@ -784,7 +784,7 @@ def list_nodes(full=False, call=None):
                     ret[node['name']] = reformat_node(item=node, full=full)
 
     else:
-        result = query2(command='my/machines', location=DEFAULT_LOCATION,
+        result = query(command='my/machines', location=DEFAULT_LOCATION,
                         method='GET')
         nodes = result[1]
         for node in nodes:
@@ -838,23 +838,13 @@ def avail_images(call=None):
         )
 
     img_url = 'https://images.joyent.com/images'
-    request = urllib2.Request(img_url)
-    request.get_method = lambda: 'GET'
-    result = urllib2.urlopen(request)
-    content = result.read()
-    result.close()
+    result = requests.get(img_url)
+    content = result.text
 
     ret = {}
     for image in yaml.safe_load(content):
         ret[image['name']] = image
     return ret
-
-    # It appears the API has changed on us again
-    #rcode, items = query2(command='/my/datasets')
-    #log.debug(rcode)
-    #if rcode not in VALID_RESPONSE_CODES:
-    #    return {}
-    #return key_list(items=items)
 
 
 def avail_sizes(call=None):
@@ -873,7 +863,7 @@ def avail_sizes(call=None):
             '-f or --function, or with the --list-sizes option'
         )
 
-    rcode, items = query2(command='/my/packages')
+    rcode, items = query(command='/my/packages')
     if rcode not in VALID_RESPONSE_CODES:
         return {}
     return key_list(items=items)
@@ -893,7 +883,7 @@ def list_keys(kwargs=None, call=None):
         kwargs = {}
 
     ret = {}
-    data = query(action='keys')
+    rcode, data = query(command='my/keys', method='GET')
     for pair in data:
         ret[pair['name']] = pair['key']
     return {'keys': ret}
@@ -916,7 +906,10 @@ def show_key(kwargs=None, call=None):
         log.error('A keyname is required.')
         return False
 
-    data = query(action='keys/{0}'.format(kwargs['keyname']))
+    rcode, data = query(
+        command='my/keys/{0}'.format(kwargs['keyname']),
+        method='GET',
+    )
     return {'keys': {data['name']: data['key']}}
 
 
@@ -959,8 +952,12 @@ def import_key(kwargs=None, call=None):
     send_data = {'name': kwargs['keyname'], 'key': kwargs['key']}
     kwargs['data'] = json.dumps(send_data)
 
-    data = query(action='keys', method='POST', data=kwargs['data'],
-                 headers={'Content-Type': 'application/json'})
+    rcode, data = query(
+        command='my/keys',
+        method='POST',
+        data=kwargs['data'],
+    )
+    log.debug(pprint.pformat(data))
     return {'keys': {data['name']: data['key']}}
 
 
@@ -987,96 +984,11 @@ def delete_key(kwargs=None, call=None):
         log.error('A keyname is required.')
         return False
 
-    data = query(action='keys/{0}'.format(kwargs['keyname']), method='DELETE')
+    rcode, data = query(
+        command='my/keys/{0}'.format(kwargs['keyname']),
+        method='DELETE',
+    )
     return data
-
-
-def query(action=None, command=None, args=None, method='GET', data=None,
-          headers=None):
-    '''
-    Make a web call to Joyent
-    '''
-    location = get_location()
-    path = 'https://{0}.api.joyentcloud.com/{1}/'.format(
-        location,
-        config.get_cloud_config_value(
-            'user', get_configured_provider(), __opts__, search_global=False
-        ),
-    )
-    auth_handler = urllib2.HTTPBasicAuthHandler()
-    auth_handler.add_password(
-        realm='SmartDataCenter',
-        uri=path,
-        user=config.get_cloud_config_value(
-            'user', get_configured_provider(), __opts__, search_global=False
-        ),
-        passwd=config.get_cloud_config_value(
-            'password', get_configured_provider(), __opts__,
-            search_global=False
-        )
-    )
-    opener = urllib2.build_opener(auth_handler)
-    urllib2.install_opener(opener)
-
-    if action:
-        path += action
-
-    if command:
-        path += '/{0}'.format(command)
-
-    if type(args) is not dict:
-        args = {}
-
-    kwargs = {'data': data}
-    kwargs['headers'] = {
-        'Accept': 'application/json',
-        'X-Api-Version': '~6.5',
-    }
-    if type(headers) is dict:
-        for header in headers.keys():
-            kwargs['headers'][header] = headers[header]
-
-    log.debug(
-        'Request headers: {0}'.format(
-            pprint.pformat(kwargs['headers'])
-        )
-    )
-
-    if args:
-        path += '?%s'
-        params = urllib.urlencode(args)
-        req = urllib2.Request(url=path % params, **kwargs)
-    else:
-        req = urllib2.Request(url=path, **kwargs)
-
-    req.get_method = lambda: method
-
-    log.debug('{0} {1}'.format(method, req.get_full_url()))
-    if data:
-        log.debug(data)
-
-    try:
-        result = urllib2.urlopen(req)
-        log.debug(
-            'Joyent Response Status Code: {0}'.format(
-                result.getcode()
-            )
-        )
-
-        content = result.read()
-        result.close()
-
-        data = yaml.safe_load(content)
-        return data
-    except urllib2.URLError as exc:
-        log.error(
-            'Joyent Response Status Code: {0} {1}'.format(
-                exc.code,
-                exc.msg
-            )
-        )
-        log.error(exc)
-        return {'error': exc}
 
 
 def get_location_path(location=DEFAULT_LOCATION):
@@ -1088,12 +1000,11 @@ def get_location_path(location=DEFAULT_LOCATION):
     return 'https://{0}{1}'.format(location, JOYENT_API_HOST_SUFFIX)
 
 
-def query2(action=None, command=None, args=None, method='GET', location=None,
+def query(action=None, command=None, args=None, method='GET', location=None,
            data=None):
     '''
     Make a web call to Joyent
     '''
-
     user = config.get_cloud_config_value(
         'user', get_configured_provider(), __opts__, search_global=False
     )
@@ -1126,40 +1037,26 @@ def query2(action=None, command=None, args=None, method='GET', location=None,
     if not isinstance(args, dict):
         args = {}
 
-    request = None
-    if args:
-        params = urllib.urlencode(args)
-        path = '{0}?{1}'.format(path, params)
-
-    request = urllib2.Request(path)
-    request.get_method = lambda: method
-
     # post form data
     if not data:
         data = json.dumps({})
 
-    request.add_data(data)
-
-    for key, value in headers.items():
-        request.add_header(key, value)
-
     return_content = None
     try:
 
-        result = urllib2.urlopen(request)
+        result = requests.request(method, path, params=args, headers=headers, data=data)
         log.debug(
             'Joyent Response Status Code: {0}'.format(
-                result.getcode()
+                result.status_code
             )
         )
         if 'content-length' in result.headers:
-            content = result.read()
-            result.close()
+            content = result.text
             return_content = yaml.safe_load(content)
 
-        return [result.getcode(), return_content]
+        return [result.status_code, return_content]
 
-    except urllib2.URLError as exc:
+    except requests.exceptions.HTTPError as exc:
         log.error(
             'Joyent Response Status Code: {0}'.format(
                 str(exc)

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -30,6 +30,8 @@ associated with that vm. An example profile might look like:
         size: Extra Small 512 MB
         image: centos-6
         location: us-east-1
+
+:depends: requests
 '''
 # pylint: disable=E0102
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -258,20 +258,17 @@ def dot_vals(value):
     return ret
 
 
-def gather_bootstrap_script(replace=False):
+def gather_bootstrap_script():
     '''
-    Download the salt-bootstrap script, set replace to True to refresh the
-    script if it has already been downloaded
+    Download the salt-bootstrap script, and return the first location
+    downloaded to.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' config.gather_bootstrap_script True
+        salt '*' config.gather_bootstrap_script
     '''
-    fn_ = os.path.join(__opts__['cachedir'], 'bootstrap.sh')
-    if not replace and os.path.isfile(fn_):
-        return fn_
-    with salt.utils.fopen(fn_, 'w+') as fp_:
-        fp_.write(urllib2.urlopen('http://bootstrap.saltstack.org').read())
-    return fn_
+    ret = salt.utils.cloud.update_bootstrap(__opts__)
+    if 'Success' in ret and len(ret['Success']['Files updated']) > 0:
+        return ret['Success']['Files updated'][0]

--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -30,6 +30,8 @@ Connection module for Amazon S3
 
     This module should be usable to query other S3-like services, such as
     Eucalyptus.
+
+:depends: requests
 '''
 
 # Import Python libs

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
 Connection library for Amazon S3
+
+:depends: requests
 '''
 
 # Import Python libs


### PR DESCRIPTION
Take note that EC2 and S3 still use urllib, because requests does not seem to provide a URL encoding method, and we need to use that to set up the headers.
