### PR TITLE
Use pwd (where available) to get username

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -24,7 +24,6 @@ import os
 import glob
 import time
 import copy
-import getpass
 import logging
 from datetime import datetime
 
@@ -144,7 +143,7 @@ class LocalClient(object):
         '''
         Determine the current user running the salt command
         '''
-        user = getpass.getuser()
+        user = salt.utils.get_user()
         # if our user is root, look for other ways to figure out
         # who we are
         if (user == 'root' or user == self.opts['user']) and 'SUDO_USER' in os.environ:

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -15,7 +15,6 @@ Primary interfaces for the salt-cloud system
 from __future__ import print_function
 import os
 import sys
-import getpass
 import logging
 
 # Import salt libs
@@ -43,7 +42,7 @@ class SaltCloud(parsers.SaltCloudParser):
         # Parse shell arguments
         self.parse_args()
 
-        salt_master_user = self.config.get('user', getpass.getuser())
+        salt_master_user = self.config.get('user', salt.utils.get_user())
         if salt_master_user is not None and not check_user(salt_master_user):
             self.error(
                 'salt-cloud needs to run as the same user as salt-master, '

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -8,7 +8,6 @@ involves preparing the three listeners and the workers needed by the master.
 import os
 import re
 import logging
-import getpass
 import shutil
 import datetime
 try:
@@ -120,7 +119,7 @@ def access_keys(opts):
     acl_users = set(opts['client_acl'].keys())
     if opts.get('user'):
         acl_users.add(opts['user'])
-    acl_users.add(getpass.getuser())
+    acl_users.add(salt.utils.get_user())
     for user in pwd.getpwall():
         users.append(user.pw_name)
     for user in acl_users:
@@ -1235,7 +1234,7 @@ class LocalFuncs(object):
                         'Authentication failure of type "user" occurred.'
                     )
                     return ''
-            elif load['user'] == getpass.getuser():
+            elif load['user'] == salt.utils.get_user():
                 if load.pop('key') != self.key.get(load['user']):
                     log.warning(
                         'Authentication failure of type "user" occurred.'
@@ -1273,7 +1272,7 @@ class LocalFuncs(object):
                     )
                     return ''
         else:
-            if load.pop('key') != self.key[getpass.getuser()]:
+            if load.pop('key') != self.key[salt.utils.get_user()]:
                 log.warning(
                     'Authentication failure of type "other" occurred.'
                 )

--- a/salt/master.py
+++ b/salt/master.py
@@ -18,7 +18,6 @@ try:
     import pwd
 except ImportError:  # This is in case windows minion is importing
     pass
-import getpass
 import resource
 import subprocess
 import multiprocessing
@@ -326,7 +325,7 @@ class Master(SMaster):
         '''
         self._pre_flight()
         log.info(
-            'salt-master is starting as user {0!r}'.format(getpass.getuser())
+            'salt-master is starting as user {0!r}'.format(salt.utils.get_user())
         )
 
         enable_sigusr1_handler()
@@ -2498,7 +2497,7 @@ class ClearFuncs(object):
                         'Authentication failure of type "user" occurred.'
                     )
                     return ''
-            elif clear_load['user'] == getpass.getuser():
+            elif clear_load['user'] == salt.utils.get_user():
                 if clear_load.pop('key') != self.key.get(clear_load['user']):
                     log.warning(
                         'Authentication failure of type "user" occurred.'
@@ -2536,7 +2535,7 @@ class ClearFuncs(object):
                     )
                     return ''
         else:
-            if clear_load.pop('key') != self.key[getpass.getuser()]:
+            if clear_load.pop('key') != self.key[salt.utils.get_user()]:
                 log.warning(
                     'Authentication failure of type "other" occurred.'
                 )

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import copy
 import errno
 import fnmatch
-import getpass
 import hashlib
 import logging
 import multiprocessing
@@ -1252,7 +1251,7 @@ class Minion(MinionBase):
             log.info(
                 '{0} is starting as user \'{1}\''.format(
                     self.__class__.__name__,
-                    getpass.getuser()
+                    salt.utils.get_user()
                 )
             )
         except Exception as err:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -17,7 +17,6 @@ import difflib
 import errno
 import fileinput
 import fnmatch
-import getpass
 import hashlib
 import itertools
 import logging
@@ -220,7 +219,7 @@ def user_to_uid(user):
         salt '*' file.user_to_uid root
     '''
     if not user:
-        user = getpass.getuser()
+        user = salt.utils.get_user()
     try:
         return pwd.getpwnam(user).pw_uid
     except KeyError:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -34,6 +34,13 @@ import warnings
 import yaml
 from calendar import month_abbr as months
 
+# Try to load pwd, fallback to getpass if unsuccessful
+try:
+    import pwd
+except ImportError:
+    import getpass
+    pwd = None
+
 try:
     import timelib
     HAS_TIMELIB = True
@@ -236,6 +243,16 @@ def get_context(template, line, num_lines=5, marker=None):
     buf = [i.encode('UTF-8') if isinstance(i, unicode) else i for i in buf]
 
     return '---\n{0}\n---'.format('\n'.join(buf))
+
+
+def get_user():
+    '''
+    Get the current user
+    '''
+    if pwd is not None:
+        return pwd.getpwuid(os.geteuid()).pw_name
+    else:
+        return getpass.getuser()
 
 
 def daemonize(redirect_out=True):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -15,7 +15,6 @@
 from __future__ import print_function
 import os
 import sys
-import getpass
 import logging
 import optparse
 import traceback
@@ -643,7 +642,7 @@ class LogLevelMixIn(object):
             # Since we're not be able to write to the log file or it's parent
             # directory(if the log file does not exit), are we the same user
             # as the one defined in the configuration file?
-            current_user = getpass.getuser()
+            current_user = salt.utils.get_user()
             if self.config['user'] != current_user:
                 # Yep, not the same user!
                 # Is the current user in ACL?

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -11,7 +11,6 @@ import re
 import sys
 import stat
 import socket
-import getpass
 import logging
 
 # Import third party libs
@@ -284,7 +283,7 @@ def check_user(user):
     '''
     if salt.utils.is_windows():
         return True
-    if user == getpass.getuser():
+    if user == salt.utils.get_user():
         return True
     import pwd  # after confirming not running Windows
     try:
@@ -353,7 +352,7 @@ def check_path_traversal(path, user='root'):
             if not os.path.exists(tpath):
                 msg += ' Path does not exist.'
             else:
-                current_user = getpass.getuser()
+                current_user = salt.utils.get_user()
                 # Make the error message more intelligent based on how
                 # the user invokes salt-call or whatever other script.
                 if user != current_user:


### PR DESCRIPTION
This fixes an issue with username detection on FreeBSD. See [here](https://github.com/saltstack/salt/issues/11628#issuecomment-39245443) for more information.

Resolves #11628.
