### PR TITLE
Added try/except to use old socket.get_gqdn if socket.getaddrinfo fails

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -89,9 +89,15 @@ def get_fqhostname():
     if h_name.find('.') >= 0:
         return h_name
     else:
-        family, socktype, proto, canonname, sockaddr = socket.getaddrinfo(
-                h_name, 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
-                socket.SOL_TCP, socket.AI_CANONNAME)[0]
+        try:
+            family, socktype, proto, canonname, sockaddr = socket.getaddrinfo(
+                    h_name, 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
+                    socket.SOL_TCP, socket.AI_CANONNAME)[0]
+        except IOError as exc:
+            msg = 'Command network.get_fqhostname failed with exception: ' \
+                  '{0}. Using socket.get_fqdn instead.'.format(exc)
+            log.warning(msg)
+            return socket.get_fqdn()
         return canonname
 
 


### PR DESCRIPTION
References #11660

Added a `try:except:` to `network.get_fqhostname` to handle the thrown exception in gethostbyname when `sockets.getaddrinfo` fails. 

Some basic tests are forthcoming. 
