### PR TITLE
Fix problem with socket path length when using SHA256.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -292,8 +292,10 @@ class MinionBase(object):
         # Start with the publish socket
         self._init_context_and_poller()
 
-        id_hash = hashlib.md5(self.opts['id']).hexdigest()
-
+        hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
+        id_hash = hash_type(self.opts['id']).hexdigest()
+        if self.opts.get('hash_type', 'md5') == 'sha256':
+            id_hash = id_hash[:10]
         epub_sock_path = os.path.join(
             self.opts['sock_dir'],
             'minion_event_{0}_pub.ipc'.format(id_hash)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -158,7 +158,12 @@ class SaltEvent(object):
         use for firing and listening to events
         '''
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
+        # Substr the first 10 chars off, because some algorithms produce
+        # longer hashes than others, and may exceed the IPC maximum length
+        # for UNIX sockets.
         id_hash = hash_type(self.opts.get('id', '')).hexdigest()
+        if hash_type == 'sha256':
+            id_hash = id_hash[:10]
         if node == 'master':
             puburi = 'ipc://{0}'.format(os.path.join(
                     sock_dir,

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -162,7 +162,7 @@ class SaltEvent(object):
         # longer hashes than others, and may exceed the IPC maximum length
         # for UNIX sockets.
         id_hash = hash_type(self.opts.get('id', '')).hexdigest()
-        if hash_type == 'sha256':
+        if self.opts.get('hash_type', 'md5') == 'sha256':
             id_hash = id_hash[:10]
         if node == 'master':
             puburi = 'ipc://{0}'.format(os.path.join(


### PR DESCRIPTION
Note here that I only trim the length if we're using SHA256. Otherewise, we end up with an extra set of sockets when the minion doesn't change for most installs which are using MD5.
