### PR TITLE
Change fileclient from urllib2 to requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ PyYAML
 pyzmq >= 2.2.0
 MarkupSafe
 apache-libcloud >= 0.14.0
+requests

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -10,6 +10,7 @@ import hashlib
 import os
 import shutil
 import subprocess
+import requests
 
 # Import third party libs
 import yaml
@@ -554,9 +555,9 @@ class Client(object):
         else:
             fixed_url = url
         try:
-            with contextlib.closing(url_open(fixed_url)) as srcfp:
-                with salt.utils.fopen(dest, 'wb') as destfp:
-                    shutil.copyfileobj(srcfp, destfp)
+            req = requests.get(fixed_url)
+            with salt.utils.fopen(dest, 'wb') as destfp:
+                destfp.write(req.content)
             return dest
         except HTTPError as ex:
             raise MinionError('HTTP error {0} reading {1}: {3}'.format(


### PR DESCRIPTION
This makes `requests` a hard dependency for Salt.

This should only be merged by @thatch45.

@basepi, please do not cherry pick.
