### PR TITLE
Support for Openstack Swift

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2179,7 +2179,7 @@ def get_managed(
                 if not source_sum:
                     return '', {}, 'Source file {0} not found'.format(source)
             elif source_hash:
-                protos = ['salt', 'http', 'https', 'ftp']
+                protos = ['salt', 'http', 'https', 'ftp', 'swift']
                 if salt._compat.urlparse(source_hash).scheme in protos:
                     # The source_hash is a file on a server
                     hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)

--- a/salt/modules/swift.py
+++ b/salt/modules/swift.py
@@ -106,7 +106,7 @@ def delete(cont, path=None, profile=None):
     '''
     swift_conn = _auth(profile)
 
-    if path == None:
+    if path is None:
         return swift_conn.delete_container(cont)
     else:
         return swift_conn.delete_object(cont, path)
@@ -145,16 +145,16 @@ def get(cont=None, path=None, local_file=None, return_bin=False, profile=None):
     '''
     swift_conn = _auth(profile)
 
-    if cont == None:
+    if cont is None:
         return swift_conn.get_account()
 
-    if path == None:
+    if path is None:
         return swift_conn.get_container(cont)
 
-    if return_bin == True:
+    if return_bin is True:
         return swift_conn.get_object(cont, path, return_bin)
 
-    if local_file != None:
+    if local_file is not None:
         return swift_conn.get_object(cont, path, local_file)
 
     return False
@@ -182,9 +182,9 @@ def put(cont, path=None, local_file=None, profile=None):
     '''
     swift_conn = _auth(profile)
 
-    if path == None:
+    if path is not None:
         return swift_conn.put_container(cont)
-    elif local_file != None:
+    elif local_file is not None:
         return swift_conn.put_object(cont, path, local_file)
     else:
         return False

--- a/salt/modules/swift.py
+++ b/salt/modules/swift.py
@@ -47,12 +47,14 @@ import salt.utils.openstack.swift as suos
 # Get logging started
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     '''
     Only load this module if swift
     is installed on this minion.
     '''
     return suos.check_swift()
+
 
 __opts__ = {}
 
@@ -89,6 +91,7 @@ def _auth(profile=None):
 
     return suos.SaltSwift(**kwargs)
 
+
 def delete(cont, path=None, profile=None):
     '''
     Delete a container, or delete an object from a container.
@@ -104,9 +107,10 @@ def delete(cont, path=None, profile=None):
     swift_conn = _auth(profile)
 
     if path == None:
-      return swift_conn.delete_container(cont)
+        return swift_conn.delete_container(cont)
     else:
-      return swift_conn.delete_object(cont, path)
+        return swift_conn.delete_object(cont, path)
+
 
 def get(cont=None, path=None, local_file=None, return_bin=False, profile=None):
     '''
@@ -143,7 +147,7 @@ def get(cont=None, path=None, local_file=None, return_bin=False, profile=None):
 
     if cont == None:
         return swift_conn.get_account()
-        
+
     if path == None:
         return swift_conn.get_container(cont)
 
@@ -155,8 +159,10 @@ def get(cont=None, path=None, local_file=None, return_bin=False, profile=None):
 
     return False
 
+
 def head():
     pass
+
 
 def put(cont, path=None, local_file=None, profile=None):
     '''

--- a/salt/modules/swift.py
+++ b/salt/modules/swift.py
@@ -188,5 +188,3 @@ def put(cont, path=None, local_file=None, profile=None):
         return swift_conn.put_object(cont, path, local_file)
     else:
         return False
-
-

--- a/salt/modules/swift.py
+++ b/salt/modules/swift.py
@@ -14,8 +14,6 @@ Inspired by the S3 and Nova modules
         keystone.password: verybadpass
         keystone.tenant: admin
         keystone.auth_url: 'http://127.0.0.1:5000/v2.0/'
-        # Optional
-        keystone.region_name: 'regionOne'
 
     If configuration for multiple OpenStack accounts is required, they can be
     set up as different configuration profiles:
@@ -33,11 +31,11 @@ Inspired by the S3 and Nova modules
           keystone.tenant: admin
           keystone.auth_url: 'http://127.0.0.2:5000/v2.0/'
 
-    With this configuration in place, any of the nova functions can make use of
+    With this configuration in place, any of the swift functions can make use of
     a configuration profile by declaring it explicitly.
     For example::
 
-        salt '*' nova.flavor_list profile=openstack1
+        salt '*' swift.get mycontainer myfile /tmp/file profile=openstack1
 '''
 
 # Import python libs
@@ -46,26 +44,15 @@ import logging
 # Import salt libs
 import salt.utils.openstack.swift as suos
 
-
 # Get logging started
 log = logging.getLogger(__name__)
-
-# Function alias to not shadow built-ins
-__func_alias__ = {
-    'list_': 'list'
-}
-
 
 def __virtual__():
     '''
     Only load this module if swift
     is installed on this minion.
     '''
-    if suos.check_swift():
-        return 'swift'
-    else:
-        return False
-
+    return suos.check_swift()
 
 __opts__ = {}
 
@@ -106,11 +93,11 @@ def delete(cont, path=None, profile=None):
     '''
     Delete a container, or delete an object from a container.
 
-    CLI Example to delete a bucket::
+    CLI Example to delete a container::
 
         salt myminion swift.delete mycontainer
 
-    CLI Example to delete an object from a bucket::
+    CLI Example to delete an object from a container::
 
         salt myminion swift.delete mycontainer remoteobject
     '''
@@ -123,33 +110,33 @@ def delete(cont, path=None, profile=None):
 
 def get(cont=None, path=None, local_file=None, return_bin=False, profile=None):
     '''
-    List the contents of a bucket, or return an object from a bucket. Set
+    List the contents of a container, or return an object from a container. Set
     return_bin to True in order to retrieve an object wholesale. Otherwise,
     Salt will attempt to parse an XML response.
 
-    CLI Example to list buckets:
+    CLI Example to list containers:
 
     .. code-block:: bash
 
-        salt myminion s3.get
+        salt myminion swift.get
 
-    CLI Example to list the contents of a bucket:
+    CLI Example to list the contents of a container:
 
     .. code-block:: bash
 
-        salt myminion s3.get mybucket
+        salt myminion swift.get mycontainer
 
     CLI Example to return the binary contents of an object:
 
     .. code-block:: bash
 
-        salt myminion s3.get mybucket myfile.png return_bin=True
+        salt myminion swift.get mycontainer myfile.png return_bin=True
 
     CLI Example to save the binary contents of an object to a local file:
 
     .. code-block:: bash
 
-        salt myminion s3.get mybucket myfile.png local_file=/tmp/myfile.png
+        salt myminion swift.get mycontainer myfile.png local_file=/tmp/myfile.png
 
     '''
     swift_conn = _auth(profile)
@@ -173,19 +160,19 @@ def head():
 
 def put(cont, path=None, local_file=None, profile=None):
     '''
-    Create a new bucket, or upload an object to a bucket.
+    Create a new container, or upload an object to a container.
 
-    CLI Example to create a bucket:
-
-    .. code-block:: bash
-
-        salt myminion s3.put mybucket
-
-    CLI Example to upload an object to a bucket:
+    CLI Example to create a container:
 
     .. code-block:: bash
 
-        salt myminion s3.put mybucket remotepath local_path=/path/to/file
+        salt myminion swift.put mycontainer
+
+    CLI Example to upload an object to a container:
+
+    .. code-block:: bash
+
+        salt myminion swift.put mycontainer remotepath local_file=/path/to/file
     '''
     swift_conn = _auth(profile)
 
@@ -197,17 +184,3 @@ def put(cont, path=None, local_file=None, profile=None):
         return False
 
 
-
-#The following is a list of functions that need to be incorporated in the
-#swift module. This list should be updated as functions are added.
-#
-#    delete               Delete a container or objects within a container.
-#    download             Download objects from containers.
-#    list                 Lists the containers for the account or the objects
-#                         for a container.
-#    post                 Updates meta information for the account, container,
-#                         or object; creates containers if not present.
-#    stat                 Displays information for the account, container,
-#                         or object.
-#    upload               Uploads files or directories to the given container
-#    capabilities         List cluster capabilities.

--- a/salt/modules/swift.py
+++ b/salt/modules/swift.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+'''
+Module for handling OpenStack Swift calls
+Author: Anthony Stanton <anthony.stanton@gmail.com>
+
+Inspired by the S3 and Nova modules
+
+:depends:   - swiftclient Python module
+:configuration: This module is not usable until the user, password, tenant, and
+    auth URL are specified either in a pillar or in the minion's config file.
+    For example::
+
+        keystone.user: admin
+        keystone.password: verybadpass
+        keystone.tenant: admin
+        keystone.auth_url: 'http://127.0.0.1:5000/v2.0/'
+        # Optional
+        keystone.region_name: 'regionOne'
+
+    If configuration for multiple OpenStack accounts is required, they can be
+    set up as different configuration profiles:
+    For example::
+
+        openstack1:
+          keystone.user: admin
+          keystone.password: verybadpass
+          keystone.tenant: admin
+          keystone.auth_url: 'http://127.0.0.1:5000/v2.0/'
+
+        openstack2:
+          keystone.user: admin
+          keystone.password: verybadpass
+          keystone.tenant: admin
+          keystone.auth_url: 'http://127.0.0.2:5000/v2.0/'
+
+    With this configuration in place, any of the nova functions can make use of
+    a configuration profile by declaring it explicitly.
+    For example::
+
+        salt '*' nova.flavor_list profile=openstack1
+'''
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.utils.openstack.swift as suos
+
+
+# Get logging started
+log = logging.getLogger(__name__)
+
+# Function alias to not shadow built-ins
+__func_alias__ = {
+    'list_': 'list'
+}
+
+
+def __virtual__():
+    '''
+    Only load this module if swift
+    is installed on this minion.
+    '''
+    if suos.check_swift():
+        return 'swift'
+    else:
+        return False
+
+
+__opts__ = {}
+
+
+def _auth(profile=None):
+    '''
+    Set up openstack credentials
+    '''
+    if profile:
+        credentials = __salt__['config.option'](profile)
+        user = credentials['keystone.user']
+        password = credentials['keystone.password']
+        tenant = credentials['keystone.tenant']
+        auth_url = credentials['keystone.auth_url']
+        region_name = credentials.get('keystone.region_name', None)
+        api_key = credentials.get('keystone.api_key', None)
+        os_auth_system = credentials.get('keystone.os_auth_system', None)
+    else:
+        user = __salt__['config.option']('keystone.user')
+        password = __salt__['config.option']('keystone.password')
+        tenant = __salt__['config.option']('keystone.tenant')
+        auth_url = __salt__['config.option']('keystone.auth_url')
+        region_name = __salt__['config.option']('keystone.region_name')
+        api_key = __salt__['config.option']('keystone.api_key')
+        os_auth_system = __salt__['config.option']('keystone.os_auth_system')
+    kwargs = {
+        'user': user,
+        'password': password,
+        'api_key': api_key,
+        'tenant_name': tenant,
+        'auth_url': auth_url,
+        'region_name': region_name
+    }
+
+    return suos.SaltSwift(**kwargs)
+
+def delete(cont, path=None, profile=None):
+    '''
+    Delete a container, or delete an object from a container.
+
+    CLI Example to delete a bucket::
+
+        salt myminion swift.delete mycontainer
+
+    CLI Example to delete an object from a bucket::
+
+        salt myminion swift.delete mycontainer remoteobject
+    '''
+    swift_conn = _auth(profile)
+
+    if path == None:
+      return swift_conn.delete_container(cont)
+    else:
+      return swift_conn.delete_object(cont, path)
+
+def get(cont=None, path=None, local_file=None, return_bin=False, profile=None):
+    '''
+    List the contents of a bucket, or return an object from a bucket. Set
+    return_bin to True in order to retrieve an object wholesale. Otherwise,
+    Salt will attempt to parse an XML response.
+
+    CLI Example to list buckets:
+
+    .. code-block:: bash
+
+        salt myminion s3.get
+
+    CLI Example to list the contents of a bucket:
+
+    .. code-block:: bash
+
+        salt myminion s3.get mybucket
+
+    CLI Example to return the binary contents of an object:
+
+    .. code-block:: bash
+
+        salt myminion s3.get mybucket myfile.png return_bin=True
+
+    CLI Example to save the binary contents of an object to a local file:
+
+    .. code-block:: bash
+
+        salt myminion s3.get mybucket myfile.png local_file=/tmp/myfile.png
+
+    '''
+    swift_conn = _auth(profile)
+
+    if cont == None:
+        return swift_conn.get_account()
+        
+    if path == None:
+        return swift_conn.get_container(cont)
+
+    if return_bin == True:
+        return swift_conn.get_object(cont, path, return_bin)
+
+    if local_file != None:
+        return swift_conn.get_object(cont, path, local_file)
+
+    return False
+
+def head():
+    pass
+
+def put(cont, path=None, local_file=None, profile=None):
+    '''
+    Create a new bucket, or upload an object to a bucket.
+
+    CLI Example to create a bucket:
+
+    .. code-block:: bash
+
+        salt myminion s3.put mybucket
+
+    CLI Example to upload an object to a bucket:
+
+    .. code-block:: bash
+
+        salt myminion s3.put mybucket remotepath local_path=/path/to/file
+    '''
+    swift_conn = _auth(profile)
+
+    if path == None:
+        return swift_conn.put_container(cont)
+    elif local_file != None:
+        return swift_conn.put_object(cont, path, local_file)
+    else:
+        return False
+
+
+
+#The following is a list of functions that need to be incorporated in the
+#swift module. This list should be updated as functions are added.
+#
+#    delete               Delete a container or objects within a container.
+#    download             Download objects from containers.
+#    list                 Lists the containers for the account or the objects
+#                         for a container.
+#    post                 Updates meta information for the account, container,
+#                         or object; creates containers if not present.
+#    stat                 Displays information for the account, container,
+#                         or object.
+#    upload               Uploads files or directories to the given container
+#    capabilities         List cluster capabilities.

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -956,6 +956,8 @@ def managed(name,
         Both HTTPS and HTTP are supported as well as downloading directly
         from Amazon S3 compatible URLs with both pre-configured and automatic
         IAM credentials. (see s3.get state documentation)
+        File retrieval from Openstack Swift object storage is supported via
+        swift://container/object_path URLs, see swift.get documentation.
         For files hosted on the salt file server, if the file is located on
         the master in the directory named spam, and is called eggs, the source
         string is salt://spam/eggs. If source is left blank or None

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -22,6 +22,7 @@ log = logging.getLogger(__name__)
 HAS_SWIFT = False
 try:
     from swiftclient import client
+
     HAS_SWIFT = True
 except ImportError:
     pass
@@ -30,6 +31,7 @@ except ImportError:
 def check_swift():
     return HAS_SWIFT
 
+
 def mkdirs(path):
     try:
         makedirs(path)
@@ -37,11 +39,12 @@ def mkdirs(path):
         if err.errno != EEXIST:
             raise
 
+
 # we've been playing fast and loose with kwargs, but the swiftclient isn't
 # going to accept any old thing
 def _sanitize(kwargs):
     variables = (
-        'user', 'key', 'authurl', 
+        'user', 'key', 'authurl',
         'retries', 'preauthurl', 'preauthtoken', 'snet',
         'starting_backoff', 'max_backoff', 'tenant_name',
         'os_options', 'auth_version', 'cacert',
@@ -54,19 +57,20 @@ def _sanitize(kwargs):
 
     return ret
 
+
 class SaltSwift(object):
     '''
     Class for all swiftclient functions
     '''
 
     def __init__(
-        self,
-        user,
-        tenant_name,
-        auth_url,
-        password=None,
-        auth_version=2,
-        **kwargs
+            self,
+            user,
+            tenant_name,
+            auth_url,
+            password=None,
+            auth_version=2,
+            **kwargs
     ):
         '''
         Set up openstack credentials
@@ -123,7 +127,7 @@ class SaltSwift(object):
         try:
             self.conn.put_container(cont)
             return True
-        except Exception as exc:      
+        except Exception as exc:
             log.error('There was an error::')
             if hasattr(exc, 'code') and hasattr(exc, 'msg'):
                 log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
@@ -183,7 +187,7 @@ class SaltSwift(object):
 
         # ClientException
         # file/dir exceptions
-        except Exception as exc:      
+        except Exception as exc:
             log.error('There was an error::')
             if hasattr(exc, 'code') and hasattr(exc, 'msg'):
                 log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
@@ -199,7 +203,7 @@ class SaltSwift(object):
             self.conn.put_object(cont, obj, fp)
             fp.close()
             return True
-        except Exception as exc:      
+        except Exception as exc:
             log.error('There was an error::')
             if hasattr(exc, 'code') and hasattr(exc, 'msg'):
                 log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
@@ -214,7 +218,7 @@ class SaltSwift(object):
         try:
             self.conn.delete_object(cont, obj)
             return True
-        except Exception as exc:      
+        except Exception as exc:
             log.error('There was an error::')
             if hasattr(exc, 'code') and hasattr(exc, 'msg'):
                 log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -24,7 +24,6 @@ try:
     from swiftclient import client
     HAS_SWIFT = True
 except ImportError:
-    log.error('Error:: unable to find swiftclient. Try installing it from the appropriate repository.')
     pass
 
 
@@ -73,6 +72,7 @@ class SaltSwift(object):
         Set up openstack credentials
         '''
         if not HAS_SWIFT:
+            log.error('Error:: unable to find swiftclient. Try installing it from the appropriate repository.')
             return None
 
         self.kwargs = kwargs.copy()

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -6,15 +6,11 @@ Author: Anthony Stanton <anthony.stanton@gmail.com>
 '''
 
 # Import python libs
-import time
 import logging
 from sys import stdout
 from os import makedirs
 from os.path import dirname, isdir
 from errno import EEXIST
-
-# Import salt libs
-import salt.utils
 
 # Get logging started
 log = logging.getLogger(__name__)

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -5,7 +5,7 @@ Swift utility class
 Author: Anthony Stanton <anthony.stanton@gmail.com>
 '''
 
-# Import third party libs
+# Import Swift client libs
 HAS_SWIFT = False
 try:
     from swiftclient import client
@@ -37,6 +37,8 @@ def mkdirs(path):
         if err.errno != EEXIST:
             raise
 
+# we've been playing fast and loose with kwargs, but the swiftclient isn't
+# going to accept any old thing
 def _sanitize(kwargs):
     variables = (
         'user', 'key', 'authurl', 
@@ -52,7 +54,6 @@ def _sanitize(kwargs):
 
     return ret
 
-# Function alias to not shadow built-ins
 class SaltSwift(object):
     '''
     Class for all swiftclient functions
@@ -102,7 +103,7 @@ class SaltSwift(object):
 
     def get_container(self, cont):
         '''
-        List files in a new Swift container
+        List files in a Swift container
         '''
         try:
             listing = self.conn.get_container(cont)
@@ -143,9 +144,15 @@ class SaltSwift(object):
             return False
 
     def post_container(self, cont, metadata=None):
+        '''
+        Update container metadata
+        '''
         pass
 
     def head_container(self, cont):
+        '''
+        Get container metadata
+        '''
         pass
 
     def get_object(self, cont, obj, local_file=None, return_bin=False):
@@ -201,7 +208,7 @@ class SaltSwift(object):
 
     def delete_object(self, cont, obj):
         '''
-        Upload a file to Swift
+        Delete a file from Swift
         '''
         try:
             self.conn.delete_object(cont, obj)
@@ -214,23 +221,15 @@ class SaltSwift(object):
             return False
 
     def head_object(self, cont, obj):
+        '''
+        Get object metadata
+        '''
         pass
 
     def post_object(self, cont, obj, metadata):
+        '''
+        Update object metadata
+        '''
         pass
 
 
-
-#The following is a list of functions that need to be incorporated in the
-#swift module. This list should be updated as functions are added.
-#
-#    delete               Delete a container or objects within a container.
-#    download             Download objects from containers.
-#    list                 Lists the containers for the account or the objects
-#                         for a container.
-#    post                 Updates meta information for the account, container,
-#                         or object; creates containers if not present.
-#    stat                 Displays information for the account, container,
-#                         or object.
-#    upload               Uploads files or directories to the given container
-#    capabilities         List cluster capabilities.

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+'''
+Swift utility class
+===================
+Author: Anthony Stanton <anthony.stanton@gmail.com>
+'''
+
+# Import third party libs
+HAS_SWIFT = False
+try:
+    from swiftclient import client
+    HAS_SWIFT = True
+except ImportError:
+    pass
+
+# Import python libs
+import time
+import logging
+from sys import stdout
+from os import makedirs
+from os.path import dirname, isdir
+
+# Import salt libs
+import salt.utils
+
+# Get logging started
+log = logging.getLogger(__name__)
+
+
+def check_swift():
+    return HAS_SWIFT
+
+def mkdirs(path):
+    try:
+        makedirs(path)
+    except OSError as err:
+        if err.errno != EEXIST:
+            raise
+
+def _sanitize(kwargs):
+    variables = (
+        'user', 'key', 'authurl', 
+        'retries', 'preauthurl', 'preauthtoken', 'snet',
+        'starting_backoff', 'max_backoff', 'tenant_name',
+        'os_options', 'auth_version', 'cacert',
+        'insecure', 'ssl_compression'
+    )
+    ret = {}
+    for var in kwargs.keys():
+        if var in variables:
+            ret[var] = kwargs[var]
+
+    return ret
+
+# Function alias to not shadow built-ins
+class SaltSwift(object):
+    '''
+    Class for all swiftclient functions
+    '''
+
+    def __init__(
+        self,
+        user,
+        tenant_name,
+        auth_url,
+        password=None,
+        auth_version=2,
+        **kwargs
+    ):
+        '''
+        Set up openstack credentials
+        '''
+        if not HAS_SWIFT:
+            return None
+
+        self.kwargs = kwargs.copy()
+        self.kwargs['user'] = user
+        self.kwargs['password'] = password
+        self.kwargs['tenant_name'] = tenant_name
+        self.kwargs['authurl'] = auth_url
+        self.kwargs['auth_version'] = auth_version
+        if not 'key' in self.kwargs.keys():
+            self.kwargs['key'] = password
+
+        self.kwargs = _sanitize(self.kwargs)
+
+        self.conn = client.Connection(**self.kwargs)
+
+    def get_account(self):
+        '''
+        List Swift containers
+        '''
+        try:
+            listing = self.conn.get_account()
+            return listing
+        except Exception as exc:
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+    def get_container(self, cont):
+        '''
+        List files in a new Swift container
+        '''
+        try:
+            listing = self.conn.get_container(cont)
+            return listing
+        except Exception as exc:
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+    def put_container(self, cont, metadata=None):
+        '''
+        Create a new Swift container
+        '''
+        try:
+            self.conn.put_container(cont)
+            return True
+        except Exception as exc:      
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+    def delete_container(self, cont):
+        '''
+        Delete a Swift container
+        '''
+        try:
+            self.conn.delete_container(cont)
+            return True
+        except Exception as exc:
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+    def post_container(self, cont, metadata=None):
+        pass
+
+    def head_container(self, cont):
+        pass
+
+    def get_object(self, cont, obj, local_file=None, return_bin=False):
+        '''
+        Retrieve a file from Swift
+        '''
+        try:
+            if local_file == None and return_bin == False:
+                return False
+
+            headers, body = self.conn.get_object(cont, obj, resp_chunk_size=65536)
+
+            if return_bin == True:
+                fp = stdout
+            else:
+                dirpath = dirname(local_file)
+                if dirpath and not isdir(dirpath):
+                    mkdirs(dirpath)
+                fp = open(local_file, 'wb')
+
+            read_length = 0
+            for chunk in body:
+                read_length += len(chunk)
+                fp.write(chunk)
+            fp.close()
+            return True
+
+        # ClientException
+        # file/dir exceptions
+        except Exception as exc:      
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+    def put_object(self, cont, obj, local_file, content_type=None, metadata=None):
+        '''
+        Upload a file to Swift
+        '''
+        try:
+            fp = open(local_file, 'rb')
+            self.conn.put_object(cont, obj, fp)
+            fp.close()
+            return True
+        except Exception as exc:      
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+
+    def delete_object(self, cont, obj):
+        '''
+        Upload a file to Swift
+        '''
+        try:
+            self.conn.delete_object(cont, obj)
+            return True
+        except Exception as exc:      
+            log.error('There was an error::')
+            if hasattr(exc, 'code') and hasattr(exc, 'msg'):
+                log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
+            log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
+            return False
+
+    def head_object(self, cont, obj):
+        pass
+
+    def post_object(self, cont, obj, metadata):
+        pass
+
+
+
+#The following is a list of functions that need to be incorporated in the
+#swift module. This list should be updated as functions are added.
+#
+#    delete               Delete a container or objects within a container.
+#    download             Download objects from containers.
+#    list                 Lists the containers for the account or the objects
+#                         for a container.
+#    post                 Updates meta information for the account, container,
+#                         or object; creates containers if not present.
+#    stat                 Displays information for the account, container,
+#                         or object.
+#    upload               Uploads files or directories to the given container
+#    capabilities         List cluster capabilities.

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -120,7 +120,7 @@ class SaltSwift(object):
             log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
             return False
 
-    def put_container(self, cont, metadata=None):
+    def put_container(self, cont):
         '''
         Create a new Swift container
         '''
@@ -165,12 +165,12 @@ class SaltSwift(object):
         Retrieve a file from Swift
         '''
         try:
-            if local_file == None and return_bin == False:
+            if local_file is None and return_bin == False:
                 return False
 
             headers, body = self.conn.get_object(cont, obj, resp_chunk_size=65536)
 
-            if return_bin == True:
+            if return_bin is True:
                 fp = stdout
             else:
                 dirpath = dirname(local_file)
@@ -194,7 +194,7 @@ class SaltSwift(object):
             log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
             return False
 
-    def put_object(self, cont, obj, local_file, content_type=None, metadata=None):
+    def put_object(self, cont, obj, local_file):
         '''
         Upload a file to Swift
         '''
@@ -209,7 +209,6 @@ class SaltSwift(object):
                 log.error('    Code: {0}: {1}'.format(exc.code, exc.msg))
             log.error('    Content: \n{0}'.format(getattr(exc, 'read', lambda: str(exc))()))
             return False
-
 
     def delete_object(self, cont, obj):
         '''

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -5,14 +5,6 @@ Swift utility class
 Author: Anthony Stanton <anthony.stanton@gmail.com>
 '''
 
-# Import Swift client libs
-HAS_SWIFT = False
-try:
-    from swiftclient import client
-    HAS_SWIFT = True
-except ImportError:
-    pass
-
 # Import python libs
 import time
 import logging
@@ -25,6 +17,15 @@ import salt.utils
 
 # Get logging started
 log = logging.getLogger(__name__)
+
+# Import Swift client libs
+HAS_SWIFT = False
+try:
+    from swiftclient import client
+    HAS_SWIFT = True
+except ImportError:
+    log.error('Error:: unable to find swiftclient. Try installing it from the appropriate repository.')
+    pass
 
 
 def check_swift():

--- a/salt/utils/openstack/swift.py
+++ b/salt/utils/openstack/swift.py
@@ -11,6 +11,7 @@ import logging
 from sys import stdout
 from os import makedirs
 from os.path import dirname, isdir
+from errno import EEXIST
 
 # Import salt libs
 import salt.utils
@@ -165,7 +166,7 @@ class SaltSwift(object):
         Retrieve a file from Swift
         '''
         try:
-            if local_file is None and return_bin == False:
+            if local_file is None and return_bin is False:
                 return False
 
             headers, body = self.conn.get_object(cont, obj, resp_chunk_size=65536)
@@ -235,5 +236,3 @@ class SaltSwift(object):
         Update object metadata
         '''
         pass
-
-


### PR DESCRIPTION
Hi,

We are running an environment based on Openstack, and the need arose to use Openstack Swift object storage with Salt as a repository for files (Java WARs, installation tarballs, etc).

Basing myself on the existing S3 and Openstack Nova support I've added the functionality required for basic operations with Openstack swift - an execution module, a utility module that calls the Swift library (python-swiftclient in Ubuntu Cloud Archive), and patches to fileclient.py and modules/file.py to support a swift://container/object URL format. As far as I know this is a scheme I just made up, analogous to the "de facto" s3://bucket/object format.

I hope this can be of use and integrated in Salt, please let me know if there's anything you'd rather have done differently.

NB: currently this only supports the Keystone-based (2.0) Openstack authentication, so it's only for fully fledged Openstack deployments, not stand-alone Swift.

Cheers
Anthony
