### PR TITLE
Removing logging from __virtual__ in cloud modules

### DIFF
--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -68,10 +68,6 @@ def __virtual__():
     except ImportError:
         # Botocore is not available, the Libcloud AWS module will be loaded
         # instead.
-        log.debug(
-            'The \'botocore\' library is not installed. The libcloud AWS '
-            'support will be loaded instead.'
-        )
         return False
 
     # "Patch" the imported libcloud_aws to have the current __opts__
@@ -79,10 +75,6 @@ def __virtual__():
     libcloudfuncs.__opts__ = __opts__
 
     if get_configured_provider() is False:
-        log.debug(
-            'There is no AWS cloud provider configuration available. Not '
-            'loading module'
-        )
         return False
 
     for provider, details in __opts__['providers'].iteritems():
@@ -145,7 +137,6 @@ def __virtual__():
         list_nodes_select, globals(), (conn,)
     )
 
-    log.debug('Loading AWS botocore cloud module')
     return 'aws'
 
 

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -62,13 +62,8 @@ def __virtual__():
     Set up the libcloud functions and check for CloudStack configurations.
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no CloudStack cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading CloudStack cloud module')
     return True
 
 

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -51,13 +51,8 @@ def __virtual__():
     Check for Digital Ocean configurations
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Digital Ocean cloud provider configuration '
-            'available. Not loading module.'
-        )
         return False
 
-    log.debug('Loading Digital Ocean cloud module')
     return True
 
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -150,10 +150,6 @@ def __virtual__():
     Set up the libcloud functions and check for EC2 configurations
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no EC2 cloud provider configuration available. Not '
-            'loading module'
-        )
         return False
 
     for provider, details in __opts__['providers'].iteritems():
@@ -181,7 +177,6 @@ def __virtual__():
                 )
             )
 
-    log.debug('Loading EC2 cloud compute module')
     return True
 
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -171,10 +171,6 @@ def __virtual__():
     Set up the libcloud functions and check for GCE configurations.
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no GCE cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
 
     for provider, details in __opts__['providers'].iteritems():
@@ -201,7 +197,6 @@ def __virtual__():
                 )
             )
 
-    log.debug('Loading GCE cloud module')
     return True
 
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -62,13 +62,8 @@ def __virtual__():
     Set up the libcloud functions and check for GOGRID configs
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no GoGrid cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
 
-    log.debug('Loading GoGrid cloud module')
     return True
 
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -97,13 +97,7 @@ def __virtual__():
     Set up the libcloud functions and check for JOYENT configs
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Joyent cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
-
-    log.debug('Loading Joyent cloud module')
 
     global script
     conn = None

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -67,19 +67,11 @@ def __virtual__():
     try:
         import botocore
         # Since we have botocore, we won't load the libcloud AWS module
-        log.debug(
-            'The \'botocore\' library is installed. The libcloud AWS support '
-            'will not be loaded.'
-        )
         return False
     except ImportError:
         pass
 
     if get_configured_provider() is False:
-        log.debug(
-            'There is no AWS cloud provider configuration available. Not '
-            'loading module'
-        )
         return False
 
     for provider, details in __opts__['providers'].iteritems():
@@ -131,7 +123,6 @@ def __virtual__():
     )
     show_instance = namespaced_function(show_instance, globals())
 
-    log.debug('Loading Libcloud AWS cloud module')
     return __virtualname__
 
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -58,13 +58,8 @@ def __virtual__():
     Set up the libcloud functions and check for Linode configurations.
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Linode cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
 
-    log.debug('Loading Linode cloud module')
     return True
 
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -60,13 +60,8 @@ def __virtual__():
         return False
 
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Azure cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
 
-    log.debug('Loading Azure cloud module')
     return __virtualname__
 
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -156,13 +156,8 @@ def __virtual__():
     Check for Nova configurations
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Nova cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading Openstack Nova cloud module')
     return True
 
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -176,13 +176,8 @@ def __virtual__():
     Set up the libcloud functions and check for OPENSTACK configurations
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Openstack cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading Openstack cloud module')
     return True
 
 

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -52,13 +52,8 @@ def __virtual__():
     Check for PARALLELS configurations
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Parallels cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading Parallels cloud module')
     return True
 
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -68,13 +68,8 @@ def __virtual__():
         return False
 
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Proxmox cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading Proxmox cloud module')
     return True
 
 

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -83,13 +83,8 @@ def __virtual__():
     Set up the libcloud functions and check for Rackspace configuration.
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no Rackspace cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading Rackspace cloud module')
     return True
 
 

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -19,6 +19,10 @@ configuration at:
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
       provider: softlayer
 
+The SoftLayer Python Library needs to be installed in ordere to use the
+SoftLayer salt.cloud modules. See: https://pypi.python.org/pypi/SoftLayer
+
+:depends: softlayer
 '''
 # pylint: disable=E0102
 
@@ -54,21 +58,11 @@ def __virtual__():
     Set up the libcloud functions and check for SoftLayer configurations.
     '''
     if not HAS_SLLIBS:
-        log.debug(
-            'The SoftLayer Python Library needs to be installed in ordere to '
-            'use the SoftLayer salt.cloud module. See: '
-            'https://pypi.python.org/pypi/SoftLayer'
-        )
         return False
 
     if get_configured_provider() is False:
-        log.debug(
-            'There is no SoftLayer cloud provider configuration available. '
-            'Not loading module.'
-        )
         return False
 
-    log.debug('Loading SoftLayer cloud module')
     return True
 
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -19,6 +19,10 @@ configuration at:
       apikey: JVkbSJDGHSDKUKSDJfhsdklfjgsjdkflhjlsdfffhgdgjkenrtuinv
       provider: softlayer_hw
 
+The SoftLayer Python Library needs to be installed in ordere to use the
+SoftLayer salt.cloud modules. See: https://pypi.python.org/pypi/SoftLayer
+
+:depends: softlayer
 '''
 # pylint: disable=E0102
 
@@ -55,21 +59,11 @@ def __virtual__():
     Set up the libcloud functions and check for SoftLayer configurations.
     '''
     if not HAS_SLLIBS:
-        log.debug(
-            'The SoftLayer Python Library needs to be installed in ordere to '
-            'use the SoftLayer HW salt.cloud module. See: '
-            'https://pypi.python.org/pypi/SoftLayer'
-        )
         return False
 
     if get_configured_provider() is False:
-        log.debug(
-            'There is no SoftLayer cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
 
-    log.debug('Loading SoftLayer cloud module')
     return True
 
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -72,13 +72,8 @@ def __virtual__():
     Set up the libcloud functions and check for vSphere configurations.
     '''
     if get_configured_provider() is False:
-        log.debug(
-            'There is no vSphere cloud provider configuration available. Not '
-            'loading module.'
-        )
         return False
 
-    log.debug('Loading vSphere cloud module')
     return True
 
 


### PR DESCRIPTION
This brings all of the cloud modules in compliance with Salt's policy of not logging in `__virtual__()`. It's messy, confusing to users, and hard to debug.
