### PR TITLE
Fix the iptables save file location on Debian family

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -49,9 +49,9 @@ def _conf(family='ipv4'):
             return '/etc/iptables/iptables.rules'
     elif __grains__['os_family'] == 'Debian':
         if family == 'ipv6':
-            return '/etc/iptables/rules.v4'
-        else:
             return '/etc/iptables/rules.v6'
+        else:
+            return '/etc/iptables/rules.v4'
     elif __grains__['os'] == 'Gentoo':
         if family == 'ipv6':
             return '/var/lib/ip6tables/rules-save'


### PR DESCRIPTION
The file selector is backwards, so it was saving the rules in the wrong file.
