### PR TITLE
Updating the iptables module to allow specifying states as a list in additional to a comma delimited string

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -132,9 +132,13 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         rule += '-p {0} '.format(kwargs['proto'])
 
     if 'match' in kwargs:
-        kwargs['match'].replace(' ', '')
-        for match in kwargs['match'].split(','):
-            rule += '-m {0} '.format(match)
+        if isinstance(kwargs['match'], list):
+            for match in kwargs['match']:
+                rule += '-m {0} '.format(match)
+        else:
+            kwargs['match'].replace(' ', '')
+            for match in kwargs['match'].split(','):
+                rule += '-m {0} '.format(match)
         del kwargs['match']
 
     if 'state' in kwargs:
@@ -167,6 +171,10 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
             rule += '-m multiport '
         rule += '--sports {0} '.format(kwargs['sports'])
         del kwargs['sports']
+
+    if 'comment' in kwargs:
+        rule += '--comment "{0}" '.format(kwargs['comment'])
+        del kwargs['comment']
 
     # Jumps should appear last, except for any arguments that are passed to
     # jumps, which of course need to follow.

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -24,6 +24,21 @@ at some point be deprecated in favor of a more generic `firewall` state.
     httpd:
       iptables.append:
         - table: filter
+        - chain: INPUT
+        - jump: ACCEPT
+        - match:
+            - state
+            - comment
+        - comment: "Allow HTTP"
+        - connstate: NEW
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    httpd:
+      iptables.append:
+        - table: filter
         - family: ipv6
         - chain: INPUT
         - jump: ACCEPT


### PR DESCRIPTION
Updating the iptables module to allow specifying states as a list in additional to a comma delimited string.  Also added a code to ensure that the argument to --comment is surrounded by quotes.  #11763
