### PR TITLE
Fix for "env" param in cmd state/module (2014.1 branch)

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -218,7 +218,7 @@ def _run(cmd,
          runas=None,
          shell=DEFAULT_SHELL,
          python_shell=True,
-         env=(),
+         env=None,
          clean_env=False,
          rstrip=True,
          template=None,
@@ -283,16 +283,13 @@ def _run(cmd,
 
     if not env:
         env = {}
-    elif isinstance(env, basestring):
-        try:
-            env = yaml.safe_load(env)
-        except yaml.parser.ParserError as err:
-            log.error(err)
-            env = {}
-    if not isinstance(env, dict):
-        log.error('Invalid input: {0}, must be a dict or '
-                  'string - yaml represented dict'.format(env))
-        env = {}
+    if isinstance(env, list):
+        env = salt.utils.repack_dictlist(env)
+
+    for bad_env_key in (x for x, y in env.iteritems() if y is None):
+        log.error('Environment variable {0!r} passed without a value. '
+                  'Setting value to an empty string'.format(bad_env_key))
+        env[bad_env_key] = ''
 
     if runas and salt.utils.is_windows():
         # TODO: Figure out the proper way to do this in windows
@@ -446,7 +443,7 @@ def _run_quiet(cmd,
                runas=None,
                shell=DEFAULT_SHELL,
                python_shell=True,
-               env=(),
+               env=None,
                template=None,
                umask=None,
                timeout=None,
@@ -477,7 +474,7 @@ def _run_all_quiet(cmd,
                    runas=None,
                    shell=DEFAULT_SHELL,
                    python_shell=True,
-                   env=(),
+                   env=None,
                    template=None,
                    umask=None,
                    timeout=None,
@@ -508,7 +505,7 @@ def run(cmd,
         runas=None,
         shell=DEFAULT_SHELL,
         python_shell=True,
-        env=(),
+        env=None,
         clean_env=False,
         template=None,
         rstrip=True,
@@ -591,7 +588,7 @@ def run_stdout(cmd,
                runas=None,
                shell=DEFAULT_SHELL,
                python_shell=True,
-               env=(),
+               env=None,
                clean_env=False,
                template=None,
                rstrip=True,
@@ -670,7 +667,7 @@ def run_stderr(cmd,
                runas=None,
                shell=DEFAULT_SHELL,
                python_shell=True,
-               env=(),
+               env=None,
                clean_env=False,
                template=None,
                rstrip=True,
@@ -749,7 +746,7 @@ def run_all(cmd,
             runas=None,
             shell=DEFAULT_SHELL,
             python_shell=True,
-            env=(),
+            env=None,
             clean_env=False,
             template=None,
             rstrip=True,
@@ -828,7 +825,7 @@ def retcode(cmd,
             runas=None,
             shell=DEFAULT_SHELL,
             python_shell=True,
-            env=(),
+            env=None,
             clean_env=False,
             template=None,
             umask=None,
@@ -904,7 +901,7 @@ def script(source,
            runas=None,
            shell=DEFAULT_SHELL,
            python_shell=True,
-           env=(),
+           env=None,
            template='jinja',
            umask=None,
            output_loglevel='info',
@@ -1008,7 +1005,7 @@ def script_retcode(source,
                    runas=None,
                    shell=DEFAULT_SHELL,
                    python_shell=True,
-                   env=(),
+                   env=None,
                    template='jinja',
                    umask=None,
                    timeout=None,

--- a/salt/state.py
+++ b/salt/state.py
@@ -1352,9 +1352,14 @@ class State(object):
             # that's not found in cdata, we look for what we're being passed in
             # the original data, namely, the special dunder __env__. If that's
             # not found we default to 'base'
-            if cdata['kwargs'].get('env', None) is not None:
+            if 'saltenv' in low:
+                inject_globals['__env__'] = low['saltenv']
+            elif isinstance(cdata['kwargs'].get('env', None), string_types):
                 # User is using a deprecated env setting which was parsed by
-                # format_call
+                # format_call.
+                # We check for a string type since module functions which
+                # allow setting the OS environ also make use of the "env"
+                # keyword argument, which is not a string
                 inject_globals['__env__'] = cdata['kwargs']['env']
             elif '__env__' in low:
                 # The user is passing an alternative environment using __env__

--- a/salt/state.py
+++ b/salt/state.py
@@ -2618,7 +2618,7 @@ class MasterHighState(HighState):
     def __init__(self, master_opts, minion_opts, grains, id_,
                  saltenv=None,
                  env=None):
-        if env is not None:
+        if isinstance(env, string_types):
             salt.utils.warn_until(
                 'Boron',
                 'Passing a salt environment should be done using \'saltenv\' '

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -574,7 +574,8 @@ def run(name,
     # Need the check for None here, if env is not provided then it falls back
     # to None and it is assumed that the environment is not being overridden.
     if env is not None and not isinstance(env, (list, dict)):
-        ret['comment'] = 'Invalidly-formatted \'env\' parameter'
+        ret['comment'] = ('Invalidly-formatted \'env\' parameter. See '
+                          'documentation.')
         return ret
 
     if HAS_GRP:
@@ -718,7 +719,8 @@ def script(name,
     # Need the check for None here, if env is not provided then it falls back
     # to None and it is assumed that the environment is not being overridden.
     if env is not None and not isinstance(env, (list, dict)):
-        ret['comment'] = 'Invalidly-formatted \'env\' parameter'
+        ret['comment'] = ('Invalidly-formatted \'env\' parameter. See '
+                          'documentation.')
         return ret
 
     if HAS_GRP:

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -738,7 +738,7 @@ def script(name,
                        'template': template,
                        'umask': umask,
                        'timeout': timeout,
-                       '__env__': __env__})
+                       'saltenv': __env__})
 
     run_check_cmd_kwargs = {
         'cwd': cwd,

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -707,10 +707,10 @@ def script(name,
         String of command line args to pass to the script.  Only used if no
         args are specified as part of the `name` argument.
     '''
-    ret = {'changes': {},
-           'comment': '',
-           'name': name,
-           'result': False}
+    ret = {'name': name,
+           'changes': {},
+           'result': False,
+           'comment': ''}
 
     if cwd and not os.path.isdir(cwd):
         ret['comment'] = 'Desired working directory "{0}" is not available'.format(cwd)

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -782,8 +782,7 @@ def script(name,
             ret['result'] = not bool(cmd_all['retcode'])
         if ret.get('changes', {}).get('cache_error'):
             ret['comment'] = 'Unable to cache script {0} from saltenv ' \
-                             '{1!r}'.format(source, kwargs.get('saltenv',
-                                                               'base'))
+                             '{1!r}'.format(source, __env__)
         else:
             ret['comment'] = 'Command {0!r} run'.format(name)
         return _reinterpreted_state(ret) if stateful else ret


### PR DESCRIPTION
This is #11422, cherrypicked for 2014.1.

@s0undt3ch should probably give this a look-over before it is merged, he was the one that wrote the saltenv stuff initially.
