### PR TITLE
Add swap option

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -108,6 +108,13 @@ def get_password(vm_):
         ), search_global=False
     )
 
+def get_swap(vm_):
+    '''
+    Return the amount of swap space to use
+    '''
+    return config.get_cloud_config_value(
+        'swap', vm_, __opts__, default=128
+    )
 
 def create(vm_):
     '''
@@ -132,7 +139,8 @@ def create(vm_):
         'image': get_image(conn, vm_),
         'size': get_size(conn, vm_),
         'location': get_location(conn, vm_),
-        'auth': NodeAuthPassword(get_password(vm_))
+        'auth': NodeAuthPassword(get_password(vm_)),
+        'ex_swap': get_swap(vm_)
     }
 
     salt.utils.cloud.fire_event(
@@ -142,7 +150,8 @@ def create(vm_):
         {'kwargs': {'name': kwargs['name'],
                     'image': kwargs['image'].name,
                     'size': kwargs['size'].name,
-                    'location': kwargs['location'].name}},
+                    'location': kwargs['location'].name,
+                    'ex_swap': kwargs['ex_swap']}},
         transport=__opts__['transport']
     )
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -108,6 +108,7 @@ def get_password(vm_):
         ), search_global=False
     )
 
+
 def get_swap(vm_):
     '''
     Return the amount of swap space to use
@@ -115,6 +116,7 @@ def get_swap(vm_):
     return config.get_cloud_config_value(
         'swap', vm_, __opts__, default=128
     )
+
 
 def create(vm_):
     '''


### PR DESCRIPTION
This adds support for specifying the size of the swap disk when using salt-cloud to create a Linode. It's mainly a copy/paste job, but hopefully it's ok.
