### PR TITLE
Moved write cache before sending to master. 

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1013,6 +1013,17 @@ class Minion(MinionBase):
             else:
                 if isinstance(oput, string_types):
                     load['out'] = oput
+        if self.opts['cache_jobs']:
+            # Local job cache has been enabled
+            fn_ = os.path.join(
+                self.opts['cachedir'],
+                'minion_jobs',
+                load['jid'],
+                'return.p')
+            jdir = os.path.dirname(fn_)
+            if not os.path.isdir(jdir):
+                os.makedirs(jdir)
+            salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
         try:
             ret_val = sreq.send('aes', self.crypticle.dumps(load))
         except SaltReqTimeoutError:
@@ -1026,17 +1037,6 @@ class Minion(MinionBase):
             # The master AES key has changed, reauth
             self.authenticate()
             ret_val = sreq.send('aes', self.crypticle.dumps(load))
-        if self.opts['cache_jobs']:
-            # Local job cache has been enabled
-            fn_ = os.path.join(
-                self.opts['cachedir'],
-                'minion_jobs',
-                load['jid'],
-                'return.p')
-            jdir = os.path.dirname(fn_)
-            if not os.path.isdir(jdir):
-                os.makedirs(jdir)
-            salt.utils.fopen(fn_, 'w+b').write(self.serial.dumps(ret))
         log.trace('ret_val = {0}'.format(ret_val))
         return ret_val
 


### PR DESCRIPTION
This allows for the master to go down during a job and not have the job results lost if cache is enabled.
