### PR TITLE
Prevent a keyerror when cloud mapping

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1650,7 +1650,7 @@ class Map(Cloud):
                         overrides[setting] = overrides.pop(deprecated)
 
                 # merge minion grains from map file
-                if 'minion' in overrides:
+                if 'minion' in overrides and 'minion' in nodedata:
                     if 'grains' in overrides['minion']:
                         if 'grains' in nodedata['minion']:
                             nodedata['minion']['grains'].update(


### PR DESCRIPTION
removed the requirement that 'minion' must be in nodedata if 'minion' is in overrides. this requirement threw a keyerror on me.
