### PR TITLE
Change in FreeBSD user add() home parameter handling.

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -8,7 +8,6 @@ try:
     import pwd
 except ImportError:
     pass
-import os
 import logging
 import copy
 

--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -95,7 +95,7 @@ def add(name,
     if groups:
         cmd += '-G {0} '.format(','.join(groups))
     if home is not None:
-        cmd += '-b {0} '.format(os.path.dirname(home))
+        cmd += '-d {0} '.format(home)
     if createhome is True:
         cmd += '-m '
     if shell:


### PR DESCRIPTION
Previously the module used -b to create a home directory that caused
some bugs. Change the module to use -d argument. This will fix the
issues when salt user defines a unusual home parameter and will also
fulfill the requirement that home directory's base directory should not
be created automatically.
