### PR TITLE
Fixes to ipset state and iptables module

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -198,6 +198,13 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         rule += '--comment "{0}" '.format(kwargs['comment'])
         del kwargs['comment']
 
+    # --set is deprecated, works but returns error.
+    # rewrite to --match-set
+    if 'set' in kwargs:
+        rule += '--match-set {0} '.format(kwargs['set'])
+        del kwargs['set']
+
+    # Jumps should appear last, except for any arguments that are passed to
     # Jumps should appear last, except for any arguments that are passed to
     # jumps, which of course need to follow.
     after_jump = []

--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -197,7 +197,7 @@ def present(name, entry=None, family='ipv4', **kwargs):
 
     for entry in entries:
         _entry = '{0}'.format(entry)
-        if kwargs['comment']:
+        if 'comment' in kwargs:
             _entry = '{0} comment "{1}"'.format(entry, kwargs['comment'])
 
         if __salt__['ipset.check'](kwargs['set_name'],
@@ -264,7 +264,7 @@ def absent(name, entry=None, entries=None, family='ipv4', **kwargs):
     for entry in entries:
         _entry = '{0}'.format(entry)
 
-        if kwargs['comment']:
+        if 'comment' in kwargs:
             _entry = '{0} comment "{1}"'.format(entry, kwargs['comment'])
 
         log.debug('_entry {0}'.format(_entry))


### PR DESCRIPTION
Fixing a bug in ipset.py state.  Adding a check for iptables in the build_rule for the --set argument to rewrite it to --match-set.  The --set argument is still supported but is being deprecated and returns an error when used, suggesting using the --match-set instead.
