### PR TITLE
Do not ensure a trailing newline when using contents_pillar

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1159,9 +1159,6 @@ def managed(name,
     # If contents_pillar was used, get the pillar data
     if contents_pillar:
         contents = __salt__['pillar.get'](contents_pillar)
-        # Make sure file ends in newline
-        if not contents.endswith('\n'):
-            contents += '\n'
 
     if not replace and os.path.exists(name):
         # Check and set the permissions if necessary


### PR DESCRIPTION
Using `contents_pillar` on a managed file causes Salt to append a newline if the file would not end with a newline.  This is problematic if you don't want trailing newlines, e.g. in the case of a binary file.

In my case, I wanted to distribute Kerberos keytabs.  I was keeping the keytab itself in Pillar using YAML's `!!binary` tag (see http://yaml.org/type/binary.html).

Futhermore, `contents` and `contents_pillar` are inconsistent in this behavior.  Using `contents` will not cause a newline to be appended, but `contents_pillar` will.  This small pull request will fix the inconsistency.

For those interested, I was able to work the issue by storing the base64 encoded data directly in a Pillar variable (_without_ the `!!binary` tag).  See the example below (and no, that's not my keytab file, it's random data :-p).

Pillar file:

```
host-keytab: |
    lnHZJdKmMXFhtXnZarm8oLh4qU5qWcccY84rDjg/xgsq9j5Gj5S5zC2JxT3RvK4y63qrkFWqfpEv
    4pizH68XCGhu5KfDhU55fIrw2aC2K+Mr1UHUvlm8Fb0hXdFjUd0serB7BLiXeHbzPVIPdrdDpGHT
    37Qd3wYf9og3GArfnRDnO7jf+jTSkpZ7xjX+Ps0Nwuttds9MN3OsrruaaCsMyIfQDQNySJeyrz3N
    fSx1l5QzcjjTzy3Fck7OVKseIHR02dT7bkjChFxMXa7MXwAkLtEjPOvDJrWiw33jgQvQxDglZ3aI
    fQhhcRBpt95uS17XAyhgH8jGIpNtSW6pavdnoSEeO9xubMzqsDtqSDhCprb2+PTC8kcxB8r9d6cc
    nXKUuMuXywEYi/zUqFPGMJAJ31UTM3+fc/9cyuNty2FsxWpugWiffljoufFbUZDv2o0jSKIWrMwz
    JDQ1jv0Lnb3TaU7noUdiwUpoXGRBJBxaag1DlAeg3r/BKi8tDeTdxAe/tDF1jwEi6wHrteJvRm66
    HhRoXzoHsGxTGnsmgmqnCUNnW2OoWb0Ev6tmf+qafuX1KqzFWrLRuOH5fpl6+rGLI2OBAQouVys/
    Bk58dlDmTAKsDe/t3cF2xKvnOm1fILfDjTPi6IdQXcBmglkz0bS4kSrxHE5nZ+E07A45qLnlXHQ=
```

State file:

```
kerberos-keytab:
    file.managed:
         - name:  /etc/krb5.keytab
         - user:  root
         - group: root
         - mode:  400
         - contents: !!binary |
            {{ pillar['host_keytab'] | indent(12) }}
```
