### PR TITLE
Cron comments should be optional

### DIFF
--- a/salt/modules/cron.py
+++ b/salt/modules/cron.py
@@ -358,7 +358,7 @@ def set_job(user,
             month,
             dayweek,
             cmd,
-            comment,
+            comment=None,
             identifier=None):
     '''
     Sets a cron job up for a specified user.


### PR DESCRIPTION
My custom modules suddenly broke when the mandatory comment parameter was added to cron.set_job.
Having such a parameter is fine but given its marginal benefit I think it should at least be optional.
