### PR TITLE
Increased default auth_timeout value from 3 to 60

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -310,7 +310,7 @@ DEFAULT_MINION_OPTS = {
     'minion_id_caching': True,
     'keysize': 4096,
     'transport': 'zeromq',
-    'auth_timeout': 3,
+    'auth_timeout': 60,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),
     'ioflo_verbose': 3,


### PR DESCRIPTION
Fixes #11806

The default value for `auth_timeout` got set to 3 somewhere. This increases it to 60.
