### PR TITLE
Remove hard-coded MD5 wherever possible.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -318,6 +318,10 @@
 # The hash_type is the hash to use when discovering the hash of a file on
 # the master server. The default is md5, but sha1, sha224, sha256, sha384
 # and sha512 are also supported.
+#
+# Prior to changing this value, the master should be stopped and all Salt 
+# caches should be cleared.
+#
 #hash_type: md5
 
 # The buffer size in the file server can be adjusted here:

--- a/conf/minion
+++ b/conf/minion
@@ -385,6 +385,10 @@
 # The hash_type is the hash to use when discovering the hash of a file in
 # the local fileserver. The default is md5, but sha1, sha224, sha256, sha384
 # and sha512 are also supported.
+#
+# Warning: Prior to changing this value, the minion should be stopped and all
+# Salt caches should be cleared.
+#
 #hash_type: md5
 
 # The Salt pillar is searched for locally if file_client is set to local. If

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -127,10 +127,11 @@ class LoadAuth(object):
         if ret is False:
             return {}
         fstr = '{0}.auth'.format(load['eauth'])
-        tok = str(hashlib.md5(os.urandom(512)).hexdigest())
+        hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
+        tok = str(hash_type(os.urandom(512)).hexdigest())
         t_path = os.path.join(self.opts['token_dir'], tok)
         while os.path.isfile(t_path):
-            tok = hashlib.md5(os.urandom(512)).hexdigest()
+            tok = str(hash_type(os.urandom(512)).hexdigest())
             t_path = os.path.join(self.opts['token_dir'], tok)
         fcall = salt.utils.format_call(self.auth[fstr], load)
         tdata = {'start': time.time(),

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -812,9 +812,11 @@ class LocalClient(Client):
                 log.warning(err.format(path))
                 return ret
             else:
+                opts_hash_type = self.opts.get('hash_type', 'md5')
+                hash_type = getattr(hashlib, opts_hash_type) 
                 with salt.utils.fopen(path, 'rb') as ifile:
-                    ret['hsum'] = hashlib.md5(ifile.read()).hexdigest()
-                ret['hash_type'] = 'md5'
+                    ret['hsum'] = hash_type(ifile.read()).hexdigest()
+                ret['hash_type'] = opts_hash_type
                 return ret
         path = self._find_file(path, saltenv)['path']
         if not path:
@@ -1134,7 +1136,7 @@ class RemoteClient(Client):
                 hash_type = self.opts.get('hash_type', 'md5')
                 ret['hsum'] = salt.utils.get_hash(
                     path, form=hash_type, chunk_size=4096)
-                ret['hash_type'] = 'md5'
+                ret['hash_type'] = hash_type
                 return ret
         load = {'path': path,
                 'saltenv': saltenv,

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -554,7 +554,8 @@ def init():
             # mountpoint not specified
             pass
 
-        repo_hash = hashlib.md5(repo_uri).hexdigest()
+        hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
+        repo_hash = hash_type(repo_uri).hexdigest()
         rp_ = os.path.join(bp_, repo_hash)
         if not os.path.isdir(rp_):
             os.makedirs(rp_)

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -189,7 +189,8 @@ def init():
             # mountpoint not specified
             pass
 
-        repo_hash = hashlib.md5(repo_uri).hexdigest()
+        hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
+        repo_hash = hash_type(repo_uri).hexdigest()
         rp_ = os.path.join(bp_, repo_hash)
         if not os.path.isdir(rp_):
             os.makedirs(rp_)

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -58,6 +58,9 @@ A multiple-environment bucket must adhere to the following root directory
 structure::
 
     s3://<bucket name>/<environment>/<files>
+
+.. note:: This fileserver back-end requires the use of the MD5 hashing algorightm.
+    MD5 may not be compliant with all security policies. 
 '''
 
 # Import python libs

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -133,7 +133,8 @@ def init():
             # mountpoint not specified
             pass
 
-        repo_hash = hashlib.md5(repo_uri).hexdigest()
+        hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
+        repo_hash = hash_type(repo_uri).hexdigest()
         rp_ = os.path.join(bp_, repo_hash)
         if not os.path.isdir(rp_):
             os.makedirs(rp_)

--- a/salt/modules/guestfs.py
+++ b/salt/modules/guestfs.py
@@ -48,7 +48,8 @@ def mount(location, access='rw'):
     while True:
         if os.listdir(root):
             # Stuf is in there, don't use it
-            rand = hashlib.md5(str(random.randint(1, 1000000))).hexdigest()
+            hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
+            rand = hash_type(str(random.randint(1, 1000000))).hexdigest()
             root = os.path.join(
                 tempfile.gettempdir(),
                 'guest',

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -16,6 +16,9 @@ Module to provide Postgres compatibility to salt.
     be left at the default setting.
     This data can also be passed into pillar. Options passed into opts will
     overwrite options passed into pillar
+
+:note: This module uses MD5 hashing which may not be compliant with certain
+    security audits.
 '''
 
 # Import python libs

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -102,10 +102,11 @@ def _sync(form, saltenv=None):
             log.info('Copying {0!r} to {1!r}'.format(fn_, dest))
             if os.path.isfile(dest):
                 # The file is present, if the sum differs replace it
-                srch = hashlib.md5(
+                hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
+                srch = hash_type(
                     salt.utils.fopen(fn_, 'r').read()
                 ).hexdigest()
-                dsth = hashlib.md5(
+                dsth = hash_type(
                     salt.utils.fopen(dest, 'r').read()
                 ).hexdigest()
                 if srch != dsth:

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -1,6 +1,10 @@
 # -*- coding: utf-8 -*-
 '''
 Manage client ssh components
+
+.. note:: This module requires the use of MD5 hashing. Certain 
+    secruity audits may not permit the use of MD5. For those cases,
+    this module should be disabled or removed.
 '''
 
 # Import python libs

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -136,7 +136,7 @@ def set_zone(timezone):
 
 def zone_compare(timezone):
     '''
-    Checks the md5sum between the given timezone, and the one set in
+    Checks the hash sum between the given timezone, and the one set in
     /etc/localtime. Returns True if they match, and False if not. Mostly useful
     for running state checks.
 
@@ -155,11 +155,12 @@ def zone_compare(timezone):
     if not os.path.exists(tzfile):
         return 'Error: {0} does not exist.'.format(tzfile)
 
+    hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
     with salt.utils.fopen(zonepath, 'r') as fp_:
-        usrzone = hashlib.md5(fp_.read()).hexdigest()
+        usrzone = hashtype(fp_.read()).hexdigest()
 
     with salt.utils.fopen(tzfile, 'r') as fp_:
-        etczone = hashlib.md5(fp_.read()).hexdigest()
+        etczone = hashtype(fp_.read()).hexdigest()
 
     if usrzone == etczone:
         return True

--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -59,8 +59,10 @@ def _new_serial(ca_name, CN):
     CN
         common name in the request
     '''
+    opts_hash_type = __opts__.get('hash_type', 'md5')
+    hash_type = getattr(hashlib, opts_hash_type) 
     hashnum = int(
-            hashlib.md5(
+            hashtype(
                 '{0}_{1}_{2}'.format(
                     ca_name,
                     CN,


### PR DESCRIPTION
Doing so helps Salt to achieve FIPS compliance. Closes #11486 and #7318.
