### PR TITLE
Use the service_catalog, auth_token, and bypass_url in order to decrease authentications

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -148,6 +148,7 @@ avail_locations = namespaced_function(avail_locations, globals())
 script = namespaced_function(script, globals())
 destroy = namespaced_function(destroy, globals())
 reboot = namespaced_function(reboot, globals())
+conn = False
 
 
 # Only load in this module is the OPENSTACK configurations are in place
@@ -175,6 +176,9 @@ def get_conn():
     '''
     Return a conn object for the passed VM data
     '''
+    if not conn is False:
+        return conn
+
     vm_ = get_configured_provider()
 
     kwargs = vm_.copy()  # pylint: disable=E1103
@@ -187,7 +191,9 @@ def get_conn():
     if 'password' in vm_:
         kwargs['password'] = vm_['password']
 
-    return nova.SaltNova(**kwargs)
+    conn = nova.SaltNova(**kwargs)
+
+    return conn
 
 
 def get_image(conn, vm_):

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -176,9 +176,6 @@ def get_conn():
     '''
     Return a conn object for the passed VM data
     '''
-    if not conn is False:
-        return conn
-
     vm_ = get_configured_provider()
 
     kwargs = vm_.copy()  # pylint: disable=E1103

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -1004,7 +1004,6 @@ def _item_list(profile=None, **connection_args):
         #        }
     return ret
 
-
     #The following is a list of functions that need to be incorporated in the
     #keystone module. This list should be updated as functions are added.
     #


### PR DESCRIPTION
If you set the region you want to work in, these patches will decrease the number of times you are actually authenticating.  Before it would authenticate on every call to SaltNova, but now, by specifying bypass_url and the auth_token on the first authentication, the api only has to query the auth_token on the first try.

Instead of doing almost 20 authentications, it now only does 2.
The first one is to send the boot a server command, and the second one is for during the watch_ip potion of the create function in salt-cloud.
