### PR TITLE
modules.dockerio.port(): fix typo

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -728,7 +728,7 @@ def port(container, private_port, *args, **kwargs):
     try:
         port_info = client.port(
             _get_container_infos(container)['id'],
-            port)
+            private_port)
         valid(status, id=container, out=port_info)
     except Exception:
         invalid(status, id=container, out=traceback.format_exc())


### PR DESCRIPTION
```
************* Module salt.modules.dockerio
salt/modules/dockerio.py:708: [W0613(unused-argument), port] Unused argument 'private_port'
```

I believe you're currently passing the `port()` function into `client.port()`, which is unlikely to be what was intended.
