### PR TITLE
Allow dots in kwarg names (2014.1 branch)

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -107,8 +107,8 @@ DEFAULT_COLOR = '\033[00m'
 RED_BOLD = '\033[01;31m'
 ENDC = '\033[0m'
 
-#KWARG_REGEX = re.compile(r'^([^\d\W][\w-]*)=(?!=)(.*)$', re.UNICODE)  # python 3
-KWARG_REGEX = re.compile(r'^([^\d\W][\w-]*)=(?!=)(.*)$')
+#KWARG_REGEX = re.compile(r'^([^\d\W][\w.-]*)=(?!=)(.*)$', re.UNICODE)  # python 3
+KWARG_REGEX = re.compile(r'^([^\d\W][\w.-]*)=(?!=)(.*)$')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
This is the same fix from https://github.com/saltstack/salt/pull/11863, only for the 2014.1 branch.
