### PR TITLE
Delete references to imported pip module so `reload(site)` works.

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -30,10 +30,18 @@ from salt.exceptions import CommandExecutionError, CommandNotFoundError
 # Import 3rd-party libs
 try:
     import pip
-    import pip.req
     HAS_PIP = True
 except ImportError:
     HAS_PIP = False
+
+if HAS_PIP is True:
+    try:
+        import pip.req
+    except ImportError:
+        HAS_PIP = False
+        # Remove references to the loaded pip module above so reloading works
+        import sys
+        del pip, sys.modules['pip']
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
When an older `pip` library is installed on the system, even if on a
state we upgrade it and reload modules, since we we're not removing all
references, the new module is not loaded and the old one is still used
instead.

Alternatively we could try and find out which modules were imported by a
module and explicitly remove them from `sys.modules` thus forcing a
reload, however, this can also cause bad behaviours, what if we
explicitly unload `salt`?

For now this works and it's simple.
