### PR TITLE
quote the password string

### DIFF
--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -62,7 +62,7 @@ def _run_svn(cmd, cwd, user, username, password, opts, **kwargs):
     if username:
         opts += ('--username', username)
     if password:
-        opts += ('--password', password)
+        opts += ('--password', '\'{0}\''.format(password))
     if opts:
         cmd += subprocess.list2cmdline(opts)
 


### PR DESCRIPTION
handle the case where passwords contain [ or ] or : characters which the shell doesn't like.
this changes --password [0:]foo   to be --password '[0:]foo'
