### PR TITLE
Replace server, port for uri and fix deficiencies

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -62,13 +62,13 @@ def _render_template(param, username):
 
 class _LDAPConnection(object):
     '''
-    Setup a LDAP connection.
+    Setup an LDAP connection.
     '''
 
     def __init__(self, uri, tls, no_verify, binddn, bindpw,
                  anonymous):
         '''
-        Bind to a LDAP directory using passed credentials.
+        Bind to an LDAP directory using passed credentials.
         '''
         self.uri = uri
         self.tls = tls

--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -97,7 +97,7 @@ def _config(name, key=None, **kwargs):
 
 def _connect(**kwargs):
     '''
-    Instantiate LDAP Connection class and return a LDAP connection object
+    Instantiate LDAP Connection class and return an LDAP connection object
     '''
     connargs = {}
     for name in ['uri', 'tls', 'no_verify', 'anonymous', 'binddn', 'bindpw']:
@@ -179,13 +179,13 @@ def search(filter,      # pylint: disable=C0103
 
 class _LDAPConnection(object):
     '''
-    Setup a LDAP connection.
+    Setup an LDAP connection.
     '''
 
     def __init__(self, uri, tls, no_verify, anonymous,
                  binddn, bindpw):
         '''
-        Bind to a LDAP directory using passed credentials.
+        Bind to an LDAP directory using passed credentials.
         '''
         self.uri = uri
         self.tls = tls

--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -65,6 +65,7 @@ __defopts__ = {'ldap.uri': 'ldap://localhost:389',
                'ldap.attrs': []
                }
 
+
 def __virtual__():
     '''
     Only load this module if the ldap config is set
@@ -208,4 +209,3 @@ class _LDAPConnection(object):
                     self.uri, self.binddn, ldap_error
                 )
             )
-

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -117,7 +117,7 @@ def _do_search(conf):
     '''
     # Build LDAP connection args
     connargs = {}
-    for name in ['server', 'port', 'tls', 'binddn', 'bindpw']:
+    for name in ['uri', 'tls', 'no_verify', 'anonymous', 'binddn', 'bindpw']:
         connargs[name] = _config(name, conf)
     # Build search args
     try:


### PR DESCRIPTION
This pull request will fix any deficiencies between auth/ldap and modules/ldapmod, see #10998
Normally I will say keep the server, port options and add uri but why using server and port if you can use an uri?
The option tls will now trigger a start_tls like it already did in modules/ldapmod.
If you want to use ldaps just define that in the uri option like: ldaps://localhost:636
