### PR TITLE
Fixed statements in omapi module

### DIFF
--- a/salt/modules/omapi.py
+++ b/salt/modules/omapi.py
@@ -78,9 +78,9 @@ def add_host(mac, name=None, ip=None, ddns=False, group=None,
     if group:
         msg.obj.append(('group', group))
     if supersede_host:
-        statements += 'option host-name {0}; '.format(name)
+        statements += 'option host-name "{0}"; '.format(name)
     if ddns and name:
-        statements += 'ddns-hostname {0}; '.format(name)
+        statements += 'ddns-hostname "{0}"; '.format(name)
     if statements:
         msg.obj.append(('statements', statements))
     response = o.query_server(msg)


### PR DESCRIPTION
Those particular statements need quotes around the arguments or else ISC dhcpd will ignore them.
