### PR TITLE
Add trace output for EC2 API calls.

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -325,6 +325,11 @@ def query(params=None, setname=None, requesturl=None, location=None,
                     result.status_code
                 )
             )
+            log.trace(
+                'EC2 Response Text: {0}'.format(
+                    result.text
+                )
+            )
             break
         except requests.exceptions.HTTPError as exc:
             root = ET.fromstring(exc.read())


### PR DESCRIPTION
This will help with debugging salt-cloud calls. The status code
only provides limited information. Amazon will post back what
actually happened. This will output the body of the response
in TRACE output.
