### PR TITLE
Move checking args for newlines from yamlify_arg into parse_input

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -29,11 +29,13 @@ def parse_input(args, condition=True):
     '''
     Parse out the args and kwargs from a list of input values. Optionally,
     return the args and kwargs without passing them to condition_input().
+
+    Don't pull args with key=val apart if it has a newline in it.
     '''
     _args = []
     _kwargs = {}
     for arg in args:
-        if isinstance(arg, string_types):
+        if isinstance(arg, string_types) and not r'\n' in arg:
             arg_name, arg_value = parse_kwarg(arg)
             if arg_name:
                 _kwargs[arg_name] = yamlify_arg(arg_value)
@@ -73,7 +75,7 @@ def parse_kwarg(string_):
 
 def yamlify_arg(arg):
     '''
-    yaml.safe_load the arg unless it has a newline in it.
+    yaml.safe_load the arg
     '''
     if not isinstance(arg, string_types):
         return arg
@@ -97,7 +99,7 @@ def yamlify_arg(arg):
             return arg
         if arg == 'None':
             arg = None
-        elif '\n' not in arg:
+        else:
             arg = yamlloader.load(arg, Loader=yamlloader.SaltYamlSafeLoader)
 
         if isinstance(arg, dict):


### PR DESCRIPTION
The key=val was getting split apart before getting passed to `yamlify_arg`. Also we're using raw strings now so we have to put the newline check in a raw string too.

@terminalmage please review?

Thanks to grrnotagain on IRC for the report!
