### PR TITLE
Made many changes to get master and minion to bootup with external raet

### DIFF
--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -9,9 +9,9 @@ import time
 import logging
 
 # Import Salt libs
-from salt.transport.road.raet import stacking
-from salt.transport.road.raet import raeting
-from salt.transport.road.raet import yarding
+from raet import raeting
+from raet.lane.stacking import LaneStack
+from raet.lane.yarding import RemoteYard
 import salt.config
 import salt.client
 import salt.utils
@@ -51,18 +51,18 @@ class LocalClient(salt.client.LocalClient):
                 timeout=timeout,
                 **kwargs)
         yid = salt.utils.gen_jid()
-        stack = stacking.StackUxd(
+        stack = LaneStack(
                 yid=yid,
                 lanename='master',
-                dirpath=self.opts['sock_dir'])
+                sockdirpath=self.opts['sock_dir'])
         stack.Pk = raeting.packKinds.pack
-        router_yard = yarding.RemoteYard(
+        router_yard = RemoteYard(
                 prefix='master',
                 yid=0,
                 dirpath=self.opts['sock_dir'])
         stack.addRemote(router_yard)
         route = {'dst': (None, router_yard.name, 'local_cmd'),
-                 'src': (None, stack.yard.name, None)}
+                 'src': (None, stack.local.name, None)}
         msg = {'route': route, 'load': payload_kwargs}
         stack.transmit(msg)
         stack.serviceAll()

--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -62,7 +62,7 @@ class IofloMaster(object):
 
         port = self.opts['raet_port']
         '''
-        import wingdbstub
+        #import wingdbstub
 
         if behaviors is None:
             behaviors = []

--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -62,6 +62,8 @@ class IofloMaster(object):
 
         port = self.opts['raet_port']
         '''
+        import wingdbstub
+
         if behaviors is None:
             behaviors = []
         behaviors.extend(['salt.daemons.flo'])

--- a/salt/daemons/flo/master.flo
+++ b/salt/daemons/flo/master.flo
@@ -2,6 +2,7 @@
 
 house master
 
+init .raet.udp.stack.local to eid 1
 
 framer masterudpstack be active first setup
     frame setup
@@ -19,7 +20,7 @@ framer masterudpstack be active first setup
     frame start
         do salt raet udp stack per inode ".raet.udp.stack"
         exit
-            do raet udp stack closer per inode ".raet.udp.stack."
+            do salt raet udp stack closer per inode ".raet.udp.stack."
 
 framer inbound be active first start
     frame start

--- a/salt/daemons/flo/minion.flo
+++ b/salt/daemons/flo/minion.flo
@@ -13,7 +13,7 @@ framer minionudpstack be active first setup
     frame start
         do salt raet udp stack per inode ".raet.udp.stack"
         exit
-            do raet udp stack closer per inode ".raet.udp.stack."
+            do salt raet udp stack closer per inode ".raet.udp.stack."
 
 framer inbound be active first start
     frame start
@@ -25,7 +25,7 @@ framer bootstrap be active first join
         enter
             do salt raet udp stack joiner per inode ".raet.udp.stack."
         recur
-            do raet udp stack joined per inode ".raet.udp.stack."
+            do salt raet udp stack joined per inode ".raet.udp.stack."
 
         go next if joined in .raet.udp.stack.status
         go abort if elapsed >= 10
@@ -37,9 +37,9 @@ framer bootstrap be active first join
     frame allow
         print Allowing...
         enter
-            do raet udp stack allower per inode ".raet.udp.stack."
+            do salt raet udp stack allower per inode ".raet.udp.stack."
         recur
-            do raet udp stack allowed per inode ".raet.udp.stack."
+            do salt raet udp stack allowed per inode ".raet.udp.stack."
 
         go next if allowed in .raet.udp.stack.status
         go abort if elapsed >= 5

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -98,10 +98,10 @@ class SetupWorker(ioflo.base.deeding.Deed):
                 self.access_keys.value)
         init = {}
         init['route'] = {
-                'src': (None, self.uxd_stack.value.yard.name, None),
+                'src': (None, self.uxd_stack.value.local.name, None),
                 'dst': (None, 'yard0', 'worker_req')
                 }
-        self.uxd_stack.value.transmit(init, self.uxd_stack.value.uids['yard0'])
+        self.uxd_stack.value.transmit(init, self.uxd_stack.value.uids.get('yard0'))
         self.uxd_stack.value.serviceAll()
 
 
@@ -141,5 +141,5 @@ class RouterWorker(ioflo.base.deeding.Deed):
                         'src': (self.opts.value['id'], self.yid.value, None),
                         'dst': (msg['route']['src'][0], msg['route']['src'][1], r_share)
                         }
-                self.uxd_stack.value.transmit(ret, self.uxd_stack.value.uids['yard0'])
+                self.uxd_stack.value.transmit(ret, self.uxd_stack.value.uids.get('yard0'))
                 self.uxd_stack.value.serviceAll()

--- a/salt/daemons/salting.py
+++ b/salt/daemons/salting.py
@@ -24,7 +24,7 @@ class SaltSafe(object):
     Interface between Salt Key management and RAET keep key management
     '''
     Auto = False #auto accept
-    LocalFields = ['eid', 'name', 'sighex', 'prihex']
+    LocalFields = ['sighex', 'prihex']
     RemoteFields = ['eid', 'name', 'acceptance', 'verhex', 'pubhex']
 
     def __init__(self, opts=None, **kwa):
@@ -75,7 +75,7 @@ class SaltSafe(object):
         self.saltRaetKey.status(data['name'],
                                 data['eid'],
                                 data['pubhex'],
-                                data['verhex'])        
+                                data['verhex'])
 
     def loadAllRemoteData(self):
         '''
@@ -102,19 +102,17 @@ class SaltSafe(object):
         Remove all the remote estate files
         '''
         self.saltRaetKey.delete_all()
-        
+
     def dumpLocal(self, local):
         '''
         Dump the key data from the local estate
         '''
         data = odict([
-                        ('eid', local.eid),
-                        ('name', local.name),
                         ('sighex', local.signer.keyhex),
                         ('prihex', local.priver.keyhex),
                     ])
         if self.verifyLocalData(data):
-            self.dumpLocalData(data)  
+            self.dumpLocalData(data)
 
     def dumpRemote(self, remote):
         '''

--- a/salt/daemons/test/master.flo
+++ b/salt/daemons/test/master.flo
@@ -10,7 +10,7 @@ framer masterudpstack be active first start
    frame start
       do raet udp stack per inode ".raet.udp.stack"
       exit
-         do raet udp stack closer per inode ".raet.udp.stack."
+         do salt raet udp stack closer per inode ".raet.udp.stack."
 
 framer uxdrouter be active first start
    frame start

--- a/salt/daemons/test/minion.flo
+++ b/salt/daemons/test/minion.flo
@@ -10,7 +10,7 @@ framer minionudpstack be active first start
    frame start
       do raet udp stack per inode ".raet.udp.stack"
       exit
-         do raet udp stack closer per inode ".raet.udp.stack."
+         do salt raet udp stack closer per inode ".raet.udp.stack."
 
 framer bootstrap be active first join
    frame join
@@ -18,7 +18,7 @@ framer bootstrap be active first join
       enter
          do salt raet udp stack joiner per inode ".raet.udp.stack."
       recur
-         do raet udp stack joined per inode ".raet.udp.stack."
+         do salt raet udp stack joined per inode ".raet.udp.stack."
 
       go next if joined in .raet.udp.stack.status
       go abort if elapsed >= 10

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -168,16 +168,16 @@ def diff_mtime_map(map1, map2):
     '''
     # check if the file lists are different
     if cmp(sorted(map1.keys()), sorted(map2.keys())) != 0:
-        log.debug('diff_mtime_map: the keys are different')
+        #log.debug('diff_mtime_map: the keys are different')
         return True
 
     # check if the mtimes are the same
     if cmp(sorted(map1), sorted(map2)) != 0:
-        log.debug('diff_mtime_map: the maps are different')
+        #log.debug('diff_mtime_map: the maps are different')
         return True
 
     # we made it, that means we have no changes
-    log.debug('diff_mtime_map: the maps are the same')
+    #log.debug('diff_mtime_map: the maps are the same')
     return False
 
 
@@ -278,7 +278,7 @@ class Fileserver(object):
         for fsb in back:
             fstr = '{0}.update'.format(fsb)
             if fstr in self.servers:
-                log.debug('Updating fileserver cache')
+                #log.debug('Updating fileserver cache')
                 self.servers[fstr]()
 
     def envs(self, back=None, sources=False):

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -64,7 +64,7 @@ class RAETChannel(Channel):
                 prefix=self.opts['id'],
                 dirpath=self.opts['sock_dir'])
         self.stack.addRemote(self.router_yard)
-        src = (self.opts['id'], self.stack.yard.name, None)
+        src = (self.opts['id'], self.stack.local.name, None)
         dst = ('master', None, 'remote_cmd')
         self.route = {'src': src, 'dst': dst}
 

--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -69,7 +69,7 @@ class SaltEvent(object):
         if not self.connected and self.listen:
             try:
                 route = {'dst': (None, self.router_yard.name, 'event_req'),
-                         'src': (None, self.stack.yard.name, None)}
+                         'src': (None, self.stack.local.name, None)}
                 msg = {
                         'route': route,
                         'load': {'yid': self.yid, 'dirpath': self.sock_dir}}
@@ -156,7 +156,7 @@ class SaltEvent(object):
         if not isinstance(data, MutableMapping):  # data must be dict
             raise ValueError('Dict object expected, not "{0!r}".'.format(data))
         route = {'dst': (None, self.router_yard.name, 'event_fire'),
-                 'src': (None, self.stack.yard.name, None)}
+                 'src': (None, self.stack.local.name, None)}
         msg = {'route': route, 'tag': tag, 'data': data}
         self.stack.transmit(msg)
         self.stack.serviceAll()


### PR DESCRIPTION
Master and minion now boot and join with external raet.
client commands get lost (return does not come back)

Its a routing problem with worker naming.

next(self.workers.value)) does not return a name that belongs to a yard in stack.remotes so it gets dropped.
like yard1 but stack.remotes have names like yardjobid

self.uxd_stack.value.uids.get(next(self.workers.value)))

So something broke
