### PR TITLE
Additions to yumpkg.py, aptpkg.py and pkg.py

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -574,6 +574,128 @@ def upgrade(refresh=True, **kwargs):
     return salt.utils.compare_dicts(old, new)
 
 
+def hold(name=None, pkgs=None, **kwargs):
+    '''
+    Set package in 'hold' state, meaning it will not be upgraded.
+
+    name
+        The name of the package, e.g., 'tmux'
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' pkg.hold <package name>
+
+    pkgs
+        A list of packages to hold. Must be passed as a python list.
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' pkg.hold pkgs='["foo", "bar"]'
+
+    .. versionadded:: Helium
+
+    '''
+
+    if not name and not pkgs:
+        return 'Error: name or pkgs needs to be specified.'
+
+    if name and not pkgs:
+        pkgs = []
+        pkgs.append(name)
+
+    ret = {}
+    for pkg in pkgs:
+
+        if isinstance(pkg, dict):
+            pkg = pkg.keys()[0]
+
+        ret[pkg] = {'name': pkg, 'changes': {}, 'result': False, 'comment': ''}
+        state = get_selections(pattern=pkg, state=hold)
+        if not state:
+            ret[pkg]['comment'] = 'Package {0} not currently held.'.format(pkg)
+        elif not salt.utils.is_true(state.get('hold', False)):
+            if 'test' in kwargs and kwargs['test']:
+                ret[pkg].update(result=None)
+                ret[pkg]['comment'] = 'Package {0} is set to be held.'.format(pkg)
+            else:
+                result = set_selections(
+                    selection={'hold': [pkg]}
+                )
+                ret[pkg].update(changes=result[pkg], result=True)
+                ret[pkg]['comment'] = 'Package {0} is now being held.'.format(pkg)
+        else:
+            ret[pkg].update(result=True)
+            ret[pkg]['comment'] = 'Package {0} is already set to be held.'.format(pkg)
+    return ret
+
+
+def unhold(name=None, pkgs=None, **kwargs):
+    '''
+    Set package current in 'hold' state to install state,
+    meaning it will be upgraded.
+
+    name
+        The name of the package, e.g., 'tmux'
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' pkg.unhold <package name>
+
+    pkgs
+        A list of packages to hold. Must be passed as a python list.
+
+        CLI Example:
+
+        .. code-block:: bash
+
+            salt '*' pkg.unhold pkgs='["foo", "bar"]'
+
+    .. versionadded:: Helium
+
+    '''
+
+    log.debug('calling unhold {0}')
+    if not name and not pkgs:
+        return 'Error: name or pkgs needs to be specified.'
+
+    if name and not pkgs:
+        pkgs = []
+        pkgs.append(name)
+
+    ret = {}
+    for pkg in pkgs:
+
+        if isinstance(pkg, dict):
+            pkg = pkg.keys()[0]
+
+        ret[pkg] = {'changes': {}, 'result': False, 'comment': ''}
+        state = get_selections(pattern=pkg)
+        if not state:
+            ret[pkg]['comment'] = 'Package {0} does not have a state.'.format(pkg)
+        elif salt.utils.is_true(state.get('hold', False)):
+            if 'test' in kwargs and kwargs['test']:
+                ret[pkg].update(result=None)
+                ret['comment'] = 'Package {0} is set not to be held.'.format(pkg)
+            else:
+                result = set_selections(
+                    selection={'install': [pkg]}
+                )
+                ret[pkg].update(changes=result[pkg], result=True)
+                ret[pkg]['comment'] = 'Package {0} is no longer being held.'.format(pkg)
+        else:
+            ret[pkg].update(result=True)
+            ret[pkg]['comment'] = 'Package {0} is already set not to be held.'.format(pkg)
+
+    log.debug('in unhold {0}'.format(ret))
+    return ret
+
+
 def _clean_pkglist(pkgs):
     '''
     Go through package list and, if any packages have more than one virtual

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -905,6 +905,165 @@ def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
     return remove(name=name, pkgs=pkgs)
 
 
+def hold(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
+    '''
+    Hold packages with ``yum -q versionlock``.
+
+    name
+        The name of the package to be deleted.
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to hold. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: Helium
+
+
+    Returns a dict containing the changes.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.hold <package name>
+        salt '*' pkg.hold pkgs='["foo", "bar"]'
+    '''
+    if not name and not pkgs:
+        return 'Error: name or pkgs needs to be specified.'
+
+    if name and not pkgs:
+        pkgs = []
+        pkgs.append(name)
+
+    current_pkgs = list_pkgs()
+    if not 'yum-plugin-versionlock' in current_pkgs:
+        return 'Error: Package yum-plugin-versionlock needs to be installed.'
+
+    current_locks = get_locked_packages()
+    ret = {}
+    for pkg in pkgs:
+        if isinstance(pkg, dict):
+            pkg = pkg.keys()[0]
+
+        ret[pkg] = {'name': pkg, 'changes': {}, 'result': False, 'comment': ''}
+        if not pkg in current_locks:
+            if 'test' in kwargs and kwargs['test']:
+                ret[pkg].update(result=None)
+                ret[pkg]['comment'] = 'Package {0} is set to be held.'.format(pkg)
+            else:
+                cmd = 'yum -q versionlock {0}'.format(pkg)
+                out = __salt__['cmd.run_all'](cmd)
+
+                if out['retcode'] == 0:
+                    ret[pkg].update(result=True)
+                    ret[pkg]['comment'] = 'Package {0} is now being held.'.format(pkg)
+                    ret[pkg]['changes']['new'] = 'hold'
+                    ret[pkg]['changes']['old'] = ''
+                else:
+                    ret[pkg]['comment'] = 'Package {0} was unable to be held.'.format(pkg)
+        else:
+            ret[pkg].update(result=True)
+            ret[pkg]['comment'] = 'Package {0} is already set to be held.'.format(pkg)
+    return ret
+
+
+def unhold(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
+    '''
+    Hold packages with ``yum -q versionlock``.
+
+    name
+        The name of the package to be deleted.
+
+    Multiple Package Options:
+
+    pkgs
+        A list of packages to unhold. Must be passed as a python list. The
+        ``name`` parameter will be ignored if this option is passed.
+
+    .. versionadded:: Helium
+
+
+    Returns a dict containing the changes.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.unhold <package name>
+        salt '*' pkg.unhold pkgs='["foo", "bar"]'
+    '''
+    if not name and not pkgs:
+        return 'Error: name or pkgs needs to be specified.'
+
+    if name and not pkgs:
+        pkgs = []
+        pkgs.append(name)
+
+    current_pkgs = list_pkgs()
+    if not 'yum-plugin-versionlock' in current_pkgs:
+        return 'Error: Package yum-plugin-versionlock needs to be installed.'
+
+    current_locks = get_locked_packages(full=True)
+    ret = {}
+    for pkg in pkgs:
+        if isinstance(pkg, dict):
+            pkg = pkg.keys()[0]
+
+        ret[pkg] = {'name': pkg, 'changes': {}, 'result': False, 'comment': ''}
+
+        search_locks = [lock for lock in current_locks if lock.startswith(pkg)]
+        if search_locks:
+            if 'test' in kwargs and kwargs['test']:
+                ret[pkg].update(result=None)
+                ret[pkg]['comment'] = 'Package {0} is set to be unheld.'.format(pkg)
+            else:
+                _pkgs = ' '.join('"0:' + item + '"' for item in search_locks)
+                cmd = 'yum -q versionlock delete {0}'.format(_pkgs)
+                out = __salt__['cmd.run_all'](cmd)
+
+                if out['retcode'] == 0:
+                    ret[pkg].update(result=True)
+                    ret[pkg]['comment'] = 'Package {0} is no longer held.'.format(pkg)
+                    ret[pkg]['changes']['new'] = ''
+                    ret[pkg]['changes']['old'] = 'hold'
+                else:
+                    ret[pkg]['comment'] = 'Package {0} was unable to be unheld.'.format(pkg)
+        else:
+            ret[pkg].update(result=True)
+            ret[pkg]['comment'] = 'Package {0} is not being held.'.format(pkg)
+    return ret
+
+
+def get_locked_packages(pattern=None, full=False):
+    '''
+    Get packages that are currently locked
+    ``yum -q versionlock list``.
+    '''
+    cmd = 'yum -q versionlock list'
+    ret = __salt__['cmd.run'](cmd).split('\n')
+
+    if pattern:
+        if full:
+            _pat = r'\d\:({0}\-\S+)'.format(pattern)
+        else:
+            _pat = r'\d\:({0})\-\S+'.format(pattern)
+    else:
+        if full:
+            _pat = r'\d\:(\w+\-\S+)'
+        else:
+            _pat = r'\d\:(\w+)\-\S+'
+    pat = re.compile(_pat)
+
+    current_locks = []
+    for item in ret:
+        match = pat.search(item)
+        if match:
+            current_locks.append(match.group(1))
+    return current_locks
+
+
 def verify(*names):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -422,6 +422,12 @@ def installed(
         Update the repo database of available packages prior to installing the
         requested package.
 
+    hold
+        Force the package to be held at the current installed version.
+        Currently works with YUM & APT based systems.
+
+        .. versionadded:: Helium
+
     Example:
 
     .. code-block:: yaml
@@ -433,6 +439,7 @@ def installed(
             - skip_suggestions: True
             - version: 2.0.6~ubuntu3
             - refresh: True
+            - hold: False
 
     Multiple Package Installation Options: (not supported in Windows or pkgng)
 
@@ -450,6 +457,7 @@ def installed(
               - foo
               - bar
               - baz
+            - hold: True
 
     ``NOTE:`` For :mod:`apt <salt.modules.aptpkg>`,
     :mod:`ebuild <salt.modules.ebuild>`,
@@ -542,10 +550,40 @@ def installed(
                                    fromrepo=fromrepo,
                                    skip_suggestions=skip_suggestions,
                                    **kwargs)
+
     try:
         desired, targets, to_unpurge = result
     except ValueError:
         # _find_install_targets() found no targets or encountered an error
+
+        # check that the hold function is available
+        if 'pkg.hold' in __salt__:
+            if 'hold' in kwargs:
+                if kwargs['hold']:
+                    hold_ret = __salt__['pkg.hold'](name=name, pkgs=pkgs)
+                else:
+                    hold_ret = __salt__['pkg.unhold'](name=name, pkgs=pkgs)
+
+            modified_hold = [hold_ret[x] for x in hold_ret.keys() if hold_ret[x]['changes']]
+            not_modified_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['changes'] and hold_ret[x]['result']]
+            failed_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['result']]
+
+            if modified_hold:
+                for i in modified_hold:
+                    result['comment'] += ' {0}'.format(i['comment'])
+                    result['result'] = i['result']
+                    change_name = i['name']
+                    result['changes'][change_name] = i['changes']
+
+            if not_modified_hold:
+                for i in not_modified_hold:
+                    result['comment'] += ' {0}'.format(i['comment'])
+                    result['result'] = i['result']
+
+            if failed_hold:
+                for i in failed_hold:
+                    result['comment'] += ' {0}'.format(i['comment'])
+                    result['result'] = i['result']
         return result
 
     if to_unpurge and 'lowpkg.unpurge' not in __salt__:
@@ -602,6 +640,20 @@ def installed(
                     'comment': 'An error was encountered while installing '
                             'package(s): {0}'.format(exc)}
 
+        modified_hold = None
+        not_modified_hold = None
+        failed_hold = None
+        if 'pkg.hold' in __salt__:
+            if 'hold' in kwargs:
+                if kwargs['hold']:
+                    hold_ret = __salt__['pkg.hold'](name=name, pkgs=pkgs)
+                else:
+                    hold_ret = __salt__['pkg.unhold'](name=name, pkgs=pkgs)
+
+                modified_hold = [hold_ret[x] for x in hold_ret.keys() if hold_ret[x]['changes']]
+                not_modified_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['changes'] and hold_ret[x]['result']]
+                failed_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['result']]
+
         if isinstance(pkg_ret, dict):
             changes['installed'].update(pkg_ret)
         elif isinstance(pkg_ret, string_types):
@@ -647,6 +699,17 @@ def installed(
                 )
             )
 
+    if modified_hold:
+        for i in modified_hold:
+            comment.append(i['comment'])
+            change_name = i['name']
+            if len(changes[change_name]['new']) > 0:
+                changes[change_name]['new'] += '\n'
+            changes[change_name]['new'] += '{0}'.format(i['changes']['new'])
+            if len(changes[change_name]['old']) > 0:
+                changes[change_name]['old'] += '\n'
+            changes[change_name]['old'] += '{0}'.format(i['changes']['old'])
+
     if not_modified:
         if sources:
             summary = ', '.join(not_modified)
@@ -665,6 +728,10 @@ def installed(
                 )
             )
 
+    if not_modified_hold:
+        for i in not_modified_hold:
+            comment.append(i['comment'])
+
     if failed:
         if sources:
             summary = ', '.join(failed)
@@ -673,6 +740,11 @@ def installed(
                                  for x in failed])
         comment.insert(0, 'The following packages failed to '
                           'install/update: {0}.'.format(summary))
+
+    if failed_hold:
+        for i in failed_hold:
+            comment.append(i['comment'])
+
         return {'name': name,
                 'changes': changes,
                 'result': False,


### PR DESCRIPTION
Adding hold and unhold functions to both aptpkg and yumpkg, these can be used to set the packages in a hold state so the versions are locked.  Adding initial support to be able to put packages on hold from states.  Per #11076 
