### PR TITLE
Allow minion_id to be specified for certain match functions

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -1,24 +1,9 @@
 # -*- coding: utf-8 -*-
 '''
 The match module allows for match routines to be run and determine target specs
-
-.. warning::
-
-    Since :doc:`Pillar </topics/pillar/index>` data is compiled on the master,
-    some of these functions require the minion ID to be overridden to
-    succesfully match them in Pillar SLS files. These functions are:
-
-    * :mod:`match.compound <salt.modules.match.compound>`
-    * :mod:`match.glob <salt.modules.match.glob>`
-    * :mod:`match.list <salt.modules.match.list_>`
-    * :mod:`match.pcre <salt.modules.match.pcre>`
-
-    This ability is new in the upcoming Helium release, and currently only
-    available in the development branch of Salt.
 '''
 
 # Import python libs
-import copy
 import logging
 
 # Import salt libs
@@ -47,12 +32,14 @@ def compound(tgt, minion_id=None):
 
         salt '*' match.compound 'L@cheese,foo and *'
     '''
-    opts = copy.deepcopy(__opts__)
+    opts = {}
     opts['grains'] = __grains__
     if minion_id is not None:
         if not isinstance(minion_id, string_types):
             minion_id = str(minion_id)
-        opts['id'] = minion_id
+    else:
+        minion_id = __grains__['id']
+    opts['id'] = minion_id
     matcher = salt.minion.Matcher(opts, __salt__)
     try:
         return matcher.compound_match(tgt)
@@ -181,12 +168,12 @@ def list_(tgt, minion_id=None):
 
         salt '*' match.list 'server1,server2'
     '''
-    opts = copy.deepcopy(__opts__)
     if minion_id is not None:
         if not isinstance(minion_id, string_types):
             minion_id = str(minion_id)
-        opts['id'] = minion_id
-    matcher = salt.minion.Matcher(opts, __salt__)
+    else:
+        minion_id = __grains__['id']
+    matcher = salt.minion.Matcher({'id': minion_id}, __salt__)
     try:
         return matcher.list_match(tgt)
     except Exception as exc:
@@ -209,12 +196,12 @@ def pcre(tgt, minion_id=None):
 
         salt '*' match.pcre '.*'
     '''
-    opts = copy.deepcopy(__opts__)
     if minion_id is not None:
         if not isinstance(minion_id, string_types):
             minion_id = str(minion_id)
-        opts['id'] = minion_id
-    matcher = salt.minion.Matcher(opts, __salt__)
+    else:
+        minion_id = __grains__['id']
+    matcher = salt.minion.Matcher({'id': minion_id}, __salt__)
     try:
         return matcher.pcre_match(tgt)
     except Exception as exc:
@@ -237,12 +224,12 @@ def glob(tgt, minion_id=None):
 
         salt '*' match.glob '*'
     '''
-    opts = copy.deepcopy(__opts__)
     if minion_id is not None:
         if not isinstance(minion_id, string_types):
             minion_id = str(minion_id)
-        opts['id'] = minion_id
-    matcher = salt.minion.Matcher(opts, __salt__)
+    else:
+        minion_id = __grains__['id']
+    matcher = salt.minion.Matcher({'id': minion_id}, __salt__)
     try:
         return matcher.glob_match(tgt)
     except Exception as exc:

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -1,13 +1,29 @@
 # -*- coding: utf-8 -*-
 '''
 The match module allows for match routines to be run and determine target specs
+
+.. warning::
+
+    Since :doc:`Pillar </topics/pillar/index>` data is compiled on the master,
+    some of these functions require the minion ID to be overridden to
+    succesfully match them in Pillar SLS files. These functions are:
+
+    * :mod:`match.compound <salt.modules.match.compound>`
+    * :mod:`match.glob <salt.modules.match.glob>`
+    * :mod:`match.list <salt.modules.match.list_>`
+    * :mod:`match.pcre <salt.modules.match.pcre>`
+
+    This ability is new in the upcoming Helium release, and currently only
+    available in the development branch of Salt.
 '''
 
 # Import python libs
+import copy
 import logging
 
 # Import salt libs
 import salt.minion
+from salt._compat import string_types
 
 __func_alias__ = {
     'list_': 'list'
@@ -16,9 +32,14 @@ __func_alias__ = {
 log = logging.getLogger(__name__)
 
 
-def compound(tgt):
+def compound(tgt, minion_id=None):
     '''
-    Return True if the minion matches the given compound target
+    Return True if the minion ID matches the given compound target
+
+    minion_id
+        Specify the minion ID to match against the target expression
+
+        .. versionadded:: Helium
 
     CLI Example:
 
@@ -26,8 +47,13 @@ def compound(tgt):
 
         salt '*' match.compound 'L@cheese,foo and *'
     '''
-    __opts__['grains'] = __grains__
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    opts = copy.deepcopy(__opts__)
+    opts['grains'] = __grains__
+    if minion_id is not None:
+        if not isinstance(minion_id, string_types):
+            minion_id = str(minion_id)
+        opts['id'] = minion_id
+    matcher = salt.minion.Matcher(opts, __salt__)
     try:
         return matcher.compound_match(tgt)
     except Exception as exc:
@@ -140,9 +166,14 @@ def grain(tgt, delim=':'):
         return False
 
 
-def list_(tgt):
+def list_(tgt, minion_id=None):
     '''
-    Return True if the minion matches the given list target
+    Return True if the minion ID matches the given list target
+
+    minion_id
+        Specify the minion ID to match against the target expression
+
+        .. versionadded:: Helium
 
     CLI Example:
 
@@ -150,7 +181,12 @@ def list_(tgt):
 
         salt '*' match.list 'server1,server2'
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    opts = copy.deepcopy(__opts__)
+    if minion_id is not None:
+        if not isinstance(minion_id, string_types):
+            minion_id = str(minion_id)
+        opts['id'] = minion_id
+    matcher = salt.minion.Matcher(opts, __salt__)
     try:
         return matcher.list_match(tgt)
     except Exception as exc:
@@ -158,9 +194,14 @@ def list_(tgt):
         return False
 
 
-def pcre(tgt):
+def pcre(tgt, minion_id=None):
     '''
-    Return True if the minion matches the given pcre target
+    Return True if the minion ID matches the given pcre target
+
+    minion_id
+        Specify the minion ID to match against the target expression
+
+        .. versionadded:: Helium
 
     CLI Example:
 
@@ -168,7 +209,12 @@ def pcre(tgt):
 
         salt '*' match.pcre '.*'
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    opts = copy.deepcopy(__opts__)
+    if minion_id is not None:
+        if not isinstance(minion_id, string_types):
+            minion_id = str(minion_id)
+        opts['id'] = minion_id
+    matcher = salt.minion.Matcher(opts, __salt__)
     try:
         return matcher.pcre_match(tgt)
     except Exception as exc:
@@ -176,9 +222,14 @@ def pcre(tgt):
         return False
 
 
-def glob(tgt):
+def glob(tgt, minion_id=None):
     '''
-    Return True if the minion matches the given glob target
+    Return True if the minion ID matches the given glob target
+
+    minion_id
+        Specify the minion ID to match against the target expression
+
+        .. versionadded:: Helium
 
     CLI Example:
 
@@ -186,7 +237,12 @@ def glob(tgt):
 
         salt '*' match.glob '*'
     '''
-    matcher = salt.minion.Matcher(__opts__, __salt__)
+    opts = copy.deepcopy(__opts__)
+    if minion_id is not None:
+        if not isinstance(minion_id, string_types):
+            minion_id = str(minion_id)
+        opts['id'] = minion_id
+    matcher = salt.minion.Matcher(opts, __salt__)
     try:
         return matcher.glob_match(tgt)
     except Exception as exc:

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -32,8 +32,7 @@ def compound(tgt, minion_id=None):
 
         salt '*' match.compound 'L@cheese,foo and *'
     '''
-    opts = {}
-    opts['grains'] = __grains__
+    opts = {'grains': __grains__}
     if minion_id is not None:
         if not isinstance(minion_id, string_types):
             minion_id = str(minion_id)


### PR DESCRIPTION
Rather than use the initial approach for this PR, I've updated it so that it grabs the minion ID from `__grains__` rather than expecting it to be overridden. This, in my opinion, is better than expecting users to manually override the minion_id in their Pillar SLS files. It still preserves the added functionality of overriding the minion ID, while operating as one would normally expect it to when not overridden (i.e. using the minion's ID by default, even when used from Pillar SLS files).

More detailed reasoning on this approach below, followed by the original commit msg.
### Detailed reasoning for grabbing minion ID from `__grains__`

The match functions which operate on the minion ID don't use anything from `__opts__` other than the minion ID, and they don't call any of the execution functions from `__salt__`, either. The match types that operate on the minion ID (which were the only ones that I modified in my pull request) just evaluate regexes, globs, etc.

Therefore, instead of passing `__opts__` when instantiating the Matcher class instance, instead a bare-bones dictionary containing just the ID is passed (aside from `match.compound` which also gets the grains). For example:

``` python
if minion_id is not None:
    if not isinstance(minion_id, string_types):
        minion_id = str(minion_id)
else:
    minion_id = __grains__['id']
opts['id'] = minion_id
matcher = salt.minion.Matcher(opts, __salt__)
```

So, the pull request still allows the minion ID to be passed in on the CLI to override the ID against which the match expression is evaluated, but if left out, it uses the value from `__grains__['id']`.
### Original commit message

This commit allows the minion ID to be specified for the functions in
salt/modules/match.py which operate on the minion ID (compound, list,
pcre, glob). Before, they would just use the value of `__opts__['id']`,
which makes these functions fail to work properly when run from within
Pillar SLS files, due to Pillar evaluation taking place on the master
(and thus `__opts__` referring to the master opts instead of the minion
opts).

By adding a `minion_id` argument to these functions, the ID can be
overridden, and thus be specified using the `id` grain in Pillar SLS
files.
