### PR TITLE
Add Service Introspection

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3480,12 +3480,7 @@ def open_files(by_pid=False):
             fd_.append('{0}/fd/{1}'.format(ppath, fpath))
 
         for tid in tids:
-            try:
-                fd_.append(
-                    os.path.realpath('{0}/task/{1}/exe'.format(ppath, tid))
-                )
-            except:
-                pass
+            fd_.append(os.path.realpath('{0}/task/{1}/exe'.format(ppath, tid)))
 
             for tpath in os.listdir('{0}/task/{1}/fd'.format(ppath, tid)):
                 fd_.append('{0}/task/{1}/fd/{2}'.format(ppath, tid, tpath))

--- a/salt/modules/introspect.py
+++ b/salt/modules/introspect.py
@@ -6,6 +6,7 @@ usable by Salt States
 
 import os
 
+
 def running_service_owners(
         exclude=('/dev', '/home', '/media', '/proc', '/run', '/sys/', '/tmp',
                  '/var')

--- a/salt/modules/introspect.py
+++ b/salt/modules/introspect.py
@@ -96,3 +96,41 @@ def enabled_service_owners():
         ret[service] = pkg.values()[0]
 
     return ret
+
+
+def service_highstate(requires=True):
+    '''
+    Return running and enabled services in a lowstate structure.
+
+    CLI Example:
+
+        salt myminion introspect.service_lowstate
+    '''
+    ret = {}
+    running = running_service_owners()
+    for service in running:
+        ret[service] = {'service': ['running']}
+
+        if requires:
+            ret[service]['service'].append(
+                {'require': {'pkg': running[service]}}
+            )
+
+    enabled = enabled_service_owners()
+    for service in enabled:
+        if service in ret:
+            ret[service]['service'].append({'enabled': True})
+        else:
+            ret[service] = {'service': [{'enabled': True}]}
+
+        if requires:
+            exists = False
+            for item in ret[service]['service']:
+                if type(item) is dict and item.keys()[0] == 'require':
+                    exists = True
+            if not exists:
+                ret[service]['service'].append(
+                    {'require': {'pkg': enabled[service]}}
+                )
+
+    return ret

--- a/salt/modules/introspect.py
+++ b/salt/modules/introspect.py
@@ -100,11 +100,15 @@ def enabled_service_owners():
 
 def service_highstate(requires=True):
     '''
-    Return running and enabled services in a highstate structure.
+    Return running and enabled services in a highstate structure. By default
+    also returns package dependencies for those services, which means that
+    package definitions must be created outside this function. To drop the
+    package dependencies, set ``requires`` to False.
 
     CLI Example:
 
         salt myminion introspect.service_highstate
+        salt myminion introspect.service_highstate requires=False
     '''
     ret = {}
     running = running_service_owners()

--- a/salt/modules/introspect.py
+++ b/salt/modules/introspect.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+'''
+Functions to perform introspection on a minion, and return data in a format
+usable by Salt States
+'''
+
+import os
+
+def running_service_owners(
+        exclude=('/dev', '/home', '/media', '/proc', '/run', '/sys/', '/tmp',
+                 '/var')
+    ):
+    '''
+    Determine which packages own the currently running services. By default,
+    excludes files whose full path starts with ``/dev``, ``/home``, ``/media``,
+    ``/proc``, ``/run``, ``/sys``, ``/tmp`` and ``/var``. This can be
+    overridden by passing in a new list to ``exclude``.
+
+    CLI Example:
+
+        salt myminion introspect.running_service_owners
+    '''
+    error = {}
+    if not 'pkg.owner' in __salt__:
+        error['Unsupported Package Manager'] = (
+            'The module for the package manager on this system does not '
+            'support looking up which package(s) owns which file(s)'
+        )
+
+    if not 'file.open_files' in __salt__:
+        error['Unsupported File Module'] = (
+            'The file module on this system does not '
+            'support looking up open files on the system'
+        )
+
+    if error:
+        return {'Error': error}
+
+    ret = {}
+    open_files = __salt__['file.open_files']()
+
+    execs = __salt__['service.execs']()
+    for path in open_files:
+        ignore = False
+        for bad_dir in exclude:
+            if path.startswith(bad_dir):
+                ignore = True
+
+        if ignore:
+            continue
+
+        if not os.access(path, os.X_OK):
+            continue
+
+        for service in execs:
+            if path == execs[service]:
+                pkg = __salt__['pkg.owner'](path)
+                ret[service] = pkg.values()[0]
+
+    return ret

--- a/salt/modules/introspect.py
+++ b/salt/modules/introspect.py
@@ -100,11 +100,11 @@ def enabled_service_owners():
 
 def service_highstate(requires=True):
     '''
-    Return running and enabled services in a lowstate structure.
+    Return running and enabled services in a highstate structure.
 
     CLI Example:
 
-        salt myminion introspect.service_lowstate
+        salt myminion introspect.service_highstate
     '''
     ret = {}
     running = running_service_owners()

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -530,3 +530,31 @@ def file_dict(*packages):
                 ret[comps[0]] = []
             ret[comps[0]].append((' '.join(comps[1:])))
     return {'errors': errors, 'packages': ret}
+
+
+def owner(path=None, *paths):
+    '''
+    Return the name of the package that owns the specified file. Files may be
+    passed as a string (``path``) or as a list of strings (``paths``). If
+    ``path`` contains a comma, it will be converted to ``paths``. If a file
+    name legitimately contains a comma, pass it in via ``paths``.
+
+    CLI Example:
+
+        salt '*' pkg.owner /usr/bin/apachectl
+        salt '*' pkg.owner /usr/bin/apachectl /etc/httpd/conf/httpd.conf
+    '''
+    cmd = 'pacman -Qqo {0}'
+    if path and isinstance(path, string_types):
+        if not ',' in path:
+            return {path: __salt__['cmd.run'](cmd.format(path)).strip()}
+        else:
+            paths = path.split(',')
+
+    if paths and isinstance(paths, list):
+        owners = {}
+        for fp_ in paths:
+            owners[fp_] = __salt__['cmd.run'](cmd.format(fp_)).strip()
+        return owners
+
+    return {'Error': 'Path must be passed in as a string or list'}

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt._compat import string_types
 from salt.exceptions import CommandExecutionError, MinionError
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
Short version: this allows us to return high data that describes the services that are running and the services that are enabled on a machine.

Currently only systems running pacman and systemd are supported. However, this lays out an example of how to do other package managers and init systems. At this point only systemd matters going forward (as far as Linux init systems are concerned), but I expect people will still have a need to introspect legacy upstart and sysv init systems. I will likely add rpm support in the very near future, but somebody else will need to do support for dpkg and any others. Likewise, I'm probably not going to write sysv or upstart myself.
