### PR TITLE
Adding introspection methods for yum and apt-get

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -16,6 +16,7 @@ import yaml
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt._compat import string_types
 from salt.exceptions import (
     CommandExecutionError, MinionError, SaltInvocationError
@@ -1610,3 +1611,20 @@ def _resolve_deps(name, pkgs, **kwargs):
             except MinionError as exc:
                 raise CommandExecutionError(exc)
     return
+
+
+def owner(*paths):
+    '''
+    Return the name of the package that owns the specified file. Files may be
+    passed as a string (``path``) or as a list of strings (``paths``). If
+    ``path`` contains a comma, it will be converted to ``paths``. If a file
+    name legitimately contains a comma, pass it in via ``paths``.
+
+    CLI Example:
+
+        salt '*' pkg.owner /usr/bin/apachectl
+        salt '*' pkg.owner /usr/bin/apachectl /etc/httpd/conf/httpd.conf
+    '''
+    cmd = "dpkg -S {0} | cut -d':' -f1"
+    return salt.utils.pkg.find_owner(
+        __salt__['cmd.run'], cmd, *paths)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt._compat import string_types
 from salt.exceptions import CommandExecutionError, MinionError
 
@@ -533,7 +534,7 @@ def file_dict(*packages):
     return {'errors': errors, 'packages': ret}
 
 
-def owner(path=None, *paths):
+def owner(*paths):
     '''
     Return the name of the package that owns the specified file. Files may be
     passed as a string (``path``) or as a list of strings (``paths``). If
@@ -546,16 +547,5 @@ def owner(path=None, *paths):
         salt '*' pkg.owner /usr/bin/apachectl /etc/httpd/conf/httpd.conf
     '''
     cmd = 'pacman -Qqo {0}'
-    if path and isinstance(path, string_types):
-        if not ',' in path:
-            return {path: __salt__['cmd.run'](cmd.format(path)).strip()}
-        else:
-            paths = path.split(',')
-
-    if paths and isinstance(paths, list):
-        owners = {}
-        for fp_ in paths:
-            owners[fp_] = __salt__['cmd.run'](cmd.format(fp_)).strip()
-        return owners
-
-    return {'Error': 'Path must be passed in as a string or list'}
+    return salt.utils.pkg.find_owner(
+        __salt__['cmd.run'], cmd, *paths)

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -12,7 +12,6 @@ import re
 # Import salt libs
 import salt.utils
 import salt.utils.pkg
-from salt._compat import string_types
 from salt.exceptions import CommandExecutionError, MinionError
 
 log = logging.getLogger(__name__)

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+import salt.utils.pkg
 from salt._compat import string_types
 from salt.exceptions import (
     CommandExecutionError, MinionError, SaltInvocationError
@@ -1362,3 +1363,20 @@ def expand_repo_def(repokwargs):
     '''
     # YUM doesn't need the data massaged.
     return repokwargs
+
+
+def owner(*paths):
+    '''
+    Return the name of the package that owns the specified file. Files may be
+    passed as a string (``path``) or as a list of strings (``paths``). If
+    ``path`` contains a comma, it will be converted to ``paths``. If a file
+    name legitimately contains a comma, pass it in via ``paths``.
+
+    CLI Example:
+
+        salt '*' pkg.owner /usr/bin/apachectl
+        salt '*' pkg.owner /usr/bin/apachectl /etc/httpd/conf/httpd.conf
+    '''
+    cmd = "rpm -qf --queryformat '%{{NAME}}' {0}"
+    return salt.utils.pkg.find_owner(
+        __salt__['cmd.run'], cmd, *paths)

--- a/salt/utils/pkg.py
+++ b/salt/utils/pkg.py
@@ -1,0 +1,27 @@
+from salt._compat import string_types
+
+
+def find_owner(cmd_run, pkg_query_cmd, *paths):
+    '''
+    Takes in:
+    * a method that runs a command from the command line
+    * a command-line command to query the package manager for the package owning a file
+      (e.g. 'pacman -Qqo {0}')
+    * NOTE: if paths is one element, it will assume comma-delimited
+    * any number of additional arguments, which will be accepted as paths
+
+    return a dictionary of (filepath, package_name) pairs that show
+    files that correspond with a particular package.
+    '''
+    try:
+        assert len(paths) > 0, 'At least one argument required for paths!'
+        if len(paths) == 1:
+            assert isinstance(paths[0], string_types), '{0} is not a string or list!'.format(paths)
+            paths = paths[0].split(',')
+        owners = {}
+        for path_ in paths:
+            assert isinstance(path_, string_types), '{0} is not a string or list!'.format(path_)
+            owners[path_] = cmd_run(pkg_query_cmd.format(path_)).strip()
+        return owners
+    except AssertionError, e:
+        return {'Error': e.message}

--- a/salt/utils/pkg.py
+++ b/salt/utils/pkg.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from salt._compat import string_types
 
 

--- a/tests/unit/utils/pkg_test.py
+++ b/tests/unit/utils/pkg_test.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.utils.pkg_test
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test the salt package objects
+'''
+from salttesting import TestCase
+from salt.utils import pkg
+
+
+class PackageTestCase(TestCase):
+
+    def setUp(self):
+        super(PackageTestCase, self).setUp()
+        self.cmd_run = lambda x: x
+        self.pkg_query_cmd = 'test {0}'
+
+    def test_pkg_nonstring_input(self):
+        '''
+        a non-string input should result in test pkg failing
+        '''
+        output = pkg.find_owner(self.cmd_run,
+                                self.pkg_query_cmd,
+                                None)
+        assert 'Error' in output
+
+    def test_pkg_with_no_input(self):
+        '''
+        no paths should return an exception
+        '''
+        output = pkg.find_owner(self.cmd_run,
+                                self.pkg_query_cmd)
+        assert 'Error' in output
+
+    def test_pkg_with_valid_input(self):
+        '''
+        passing in a list of strings should return a valid dictionary of path->cmd_run result
+        '''
+        output = pkg.find_owner(self.cmd_run,
+                                self.pkg_query_cmd,
+                                'foo',
+                                'bar')
+        assert output == {
+            'foo': 'test foo',
+            'bar': 'test bar'
+        }
+
+    def test_pkg_with_valid_commadelimited_input(self):
+        '''
+        passing in a string of comma-delimited should return a valid dictionary of path->cmd_run result
+        '''
+        output = pkg.find_owner(self.cmd_run,
+                                self.pkg_query_cmd,
+                                'foo,bar')
+        assert output == {
+            'foo': 'test foo',
+            'bar': 'test bar'
+        }
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PackageTestCase, needs_daemon=False)


### PR DESCRIPTION
This is continuing @techhat's work on adding the introspect module to salt.
- adding yumpkg:owner
- adding aptpkg:owner
- refactoring owner method to utils.pkg library
