### PR TITLE
Use /usr/local/etc/salt as fallback CONFIG_DIR only on FreeBSD

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -46,7 +46,7 @@ except ImportError:
         CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
     else:
         ROOT_DIR = '/'
-        if 'bsd' in __platform:
+        if 'freebsd' in __platform:
             CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
         else:
             CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')


### PR DESCRIPTION
Fixes #11889.
