### PR TITLE
Fixes #11966, clearer interface for files.copy

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1670,25 +1670,23 @@ def rename(src, dst):
     return False
 
 
-def copy(src, dst, recurse=False, merge_existing=False, remove_existing=False):
+def copy(src, dst, recurse=False, remove_existing=False):
     '''
     Copy a file or directory from source to dst
 
-    In order to copy a directory, the recurse flag is required, along
-    with one of the merge_existing or remove_existing flags.
-
-    merge_existing will keep files in the target directory,
-    overwriting files from the source.
+    In order to copy a directory, the recurse flag is required, and
+    will by default overwrite files in the destination with the same path,
+    and retain all other existing files. (similar to cp -r on unix)
 
     remove_existing will remove all files in the target directory,
-    and copy files from the source.
+    and then copy files from the source.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' file.copy /path/to/src /path/to/dst
-        salt '*' file.copy /path/to/src_dir /path/to/dst_dir recurse=True merge_existing=True
+        salt '*' file.copy /path/to/src_dir /path/to/dst_dir recurse=True
         salt '*' file.copy /path/to/src_dir /path/to/dst_dir recurse=True remove_existing=True
 
     '''
@@ -1705,17 +1703,11 @@ def copy(src, dst, recurse=False, merge_existing=False, remove_existing=False):
             if not recurse:
                 raise SaltInvocationError(
                     "Cannot copy overwriting a directory without recurse flag set to true!")
-            if not (merge_existing or remove_existing):
-                raise SaltInvocationError(
-                    "one of merge_existing and remove_existing must be set!")
-            if merge_existing and remove_existing:
-                raise SaltInvocationError(
-                    "only one of merge_existing and remove_existing can be set!")
             if remove_existing:
                 if os.path.exists(dst):
                     shutil.rmtree(dst)
                 shutil.copytree(src, dst)
-            elif merge_existing:
+            else:
                 salt.utils.files.recursive_copy(src, dst)
         else:
             shutil.copyfile(src, dst)

--- a/salt/utils/files.py
+++ b/salt/utils/files.py
@@ -1,0 +1,21 @@
+# -*- coding: utf-8 -*-
+import os
+import shutil
+
+
+def recursive_copy(source, dest):
+    '''
+    Recursively copy the source directory to the destination,
+    leaving files with the source does not explicitly overwrite.
+
+    (identical to cp -r on a unix machine)
+    '''
+    for root, dirs, files in os.walk(source):
+        path_from_source = root.replace(source, '').lstrip('/')
+        target_directory = os.path.join(dest, path_from_source)
+        if not os.path.exists(target_directory):
+            os.makedirs(target_directory)
+        for name in files:
+            file_path_from_source = os.path.join(source, path_from_source, name)
+            target_path = os.path.join(target_directory, name)
+            shutil.copyfile(file_path_from_source, target_path)

--- a/tests/unit/files_test.py
+++ b/tests/unit/files_test.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+'''
+    tests.unit.file_test
+    ~~~~~~~~~~~~~~~~~~~~
+'''
+import copy
+import os
+import shutil
+import tempfile
+from salt.utils import files
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+
+class FilesTestCase(TestCase):
+
+    STRUCTURE = {
+        'foo': {
+            'foofile.txt': 'fooSTRUCTURE'
+        },
+        'bar': {
+            'barfile.txt': 'barSTRUCTURE'
+        }
+    }
+
+    def _create_temp_structure(self, temp_directory, structure):
+        for folder, files in structure.items():
+            current_directory = os.path.join(temp_directory, folder)
+            os.makedirs(current_directory)
+            for name, content in files.items():
+                path = os.path.join(temp_directory, folder, name)
+                with open(path, 'w+') as fh:
+                    fh.write(content)
+
+    def _validate_folder_structure_and_contents(self, target_directory,
+                                                desired_structure):
+        for folder, files in desired_structure.items():
+            for name, content in files.items():
+                path = os.path.join(target_directory, folder, name)
+                with open(path) as fh:
+                    assert fh.read().strip() == content
+
+    def setUp(self):
+        super(FilesTestCase, self).setUp()
+        self.temp_dir = tempfile.mkdtemp()
+        self._create_temp_structure(self.temp_dir,
+                                    self.STRUCTURE)
+
+    def tearDown(self):
+        super(FilesTestCase, self).tearDown()
+        shutil.rmtree(self.temp_dir)
+
+    def test_recursive_copy(self):
+        test_target_directory = tempfile.mkdtemp()
+        TARGET_STRUCTURE = {
+            'foo': {
+                'foo.txt': 'fooTARGET_STRUCTURE'
+            },
+            'baz': {
+                'baz.txt': 'bazTARGET_STRUCTURE'
+            }
+        }
+        self._create_temp_structure(test_target_directory, TARGET_STRUCTURE)
+        try:
+            files.recursive_copy(self.temp_dir, test_target_directory)
+            DESIRED_STRUCTURE = copy.copy(TARGET_STRUCTURE)
+            DESIRED_STRUCTURE.update(self.STRUCTURE)
+            self._validate_folder_structure_and_contents(
+                test_target_directory,
+                DESIRED_STRUCTURE
+            )
+        finally:
+            shutil.rmtree(test_target_directory)


### PR DESCRIPTION
- adds recurse flag (required when copying directories)
- adds (merge|remove)_existing, to choose whether to keep existing files, or delete the target directory entirely.

fixes #11966 
