### PR TITLE
Fix error when /etc/hostname contains a short hostname on Debian

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1504,7 +1504,7 @@ def build_network_settings(**settings):
     _write_file_network(hostname, _DEB_HOSTNAME_FILE)
 
     # Write domainname to /etc/resolv.conf
-    if len(sline) > 0:
+    if len(sline) > 1:
         domainname = sline[1]
 
         contents = _parse_resolve()


### PR DESCRIPTION
This pull request fix an error which occurs when /etc/hostname contains a short hostname (no domain name) on Debian.

```
$ cat /etc/hostname
salt-master
```

Error returned: 

```
          ID: hostname
    Function: network.system
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1371, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.7/dist-packages/salt/states/network.py", line 380, in system
                  new = __salt__['ip.build_network_settings'](**kwargs)
                File "/usr/lib/python2.7/dist-packages/salt/modules/debian_ip.py", line 1487, in build_network_settings
                  domainname = sline[1]
              IndexError: list index out of range
     Changes:   
```

I didn't find where to add tests for network module.
