### PR TITLE
Change binds documentation to correct syntax

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -555,7 +555,7 @@ def running(name, container=None, port_bindings=None, binds=None,
         .. code-block:: yaml
 
             - binds:
-                - /var/log/service: /var/log/service
+                "/var/log/service": "/var/log/service"
 
     publish_all_ports
 


### PR DESCRIPTION
According to issue #11873 the binds syntax need to be 
-binds:
 "var/log/service": "/var/log/service"
