### PR TITLE
npm state module: Add parameter to specify a custom NPM server

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -43,7 +43,8 @@ def _valid_version():
 
 def install(pkg=None,
             dir=None,
-            runas=None):
+            runas=None,
+            registry=None):
     '''
     Install an NPM package.
 
@@ -62,6 +63,9 @@ def install(pkg=None,
     runas
         The user to run NPM with
 
+    registry
+        The NPM registry to install the package from.
+
     CLI Example:
 
     .. code-block:: bash
@@ -78,6 +82,9 @@ def install(pkg=None,
 
     if dir is None:
         cmd += ' --global'
+
+    if registry:
+        cmd += ' --registry="{0}"'.format(registry)
 
     if pkg:
         cmd += ' "{0}"'.format(pkg)

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -35,7 +35,8 @@ def installed(name,
               dir=None,
               runas=None,
               user=None,
-              force_reinstall=False):
+              force_reinstall=False,
+              registry=None):
     '''
     Verify that the given package is installed and is at the correct version
     (if specified).
@@ -62,6 +63,9 @@ def installed(name,
 
     user
         The user to run NPM with
+
+    registry
+        The NPM registry to install the package from.
 
         .. versionadded:: 0.17.0
 
@@ -97,7 +101,9 @@ def installed(name,
     prefix = name.split('@')[0].strip()
 
     try:
-        installed_pkgs = __salt__['npm.list'](pkg=name, dir=dir)
+        installed_pkgs = __salt__['npm.list'](pkg=name,
+                                              dir=dir,
+                                              registry=registry)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error installing \'{0}\': {1}'.format(name, err)


### PR DESCRIPTION
The [pip-state](http://docs.saltstack.com/en/latest/ref/states/all/salt.states.pip_state.html) state module offers the parameters `index_url` and `extra_index_url` to pass a custom PyPI server to Salt.

The `npm` state module is lacking such an option, therefore I cannot use my companies NPM server to manage private NodeJS packages.

I think a parameter to specify a custom NPM server would greatly improve the `npm` state module.
