### PR TITLE
Fix traceback in docker.running state

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -905,6 +905,10 @@ def start(container, binds=None, ports=None, port_bindings=None,
         binds = {}
     if not ports:
         ports = {}
+
+    if not isinstance(binds, dict):
+        raise SaltInvocationError('binds must be formatted as a dictionary')
+
     client = _get_client()
     status = base_status.copy()
     try:
@@ -912,9 +916,15 @@ def start(container, binds=None, ports=None, port_bindings=None,
         if not is_running(container):
             bindings = None
             if port_bindings is not None:
-                bindings = {}
-                for k, v in port_bindings.iteritems():
-                    bindings[k] = (v.get('HostIp', ''), v['HostPort'])
+                try:
+                    bindings = {}
+                    for k, v in port_bindings.iteritems():
+                        bindings[k] = (v.get('HostIp', ''), v['HostPort'])
+                except AttributeError:
+                    raise SaltInvocationError(
+                        'port_bindings must be formatted as a dictionary of '
+                        'dictionaries'
+                    )
             client.start(dcontainer, binds=binds, port_bindings=bindings,
                          lxc_conf=lxc_conf,
                          publish_all_ports=publish_all_ports, links=links,

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -555,7 +555,7 @@ def running(name, container=None, port_bindings=None, binds=None,
         .. code-block:: yaml
 
             - binds:
-                - /var/log/service: /var/log/service
+                /var/log/service: /var/log/service
 
     publish_all_ports
 


### PR DESCRIPTION
This improves error reporting when invalidly-formatted input is
submitted from the docker.running state to the docker.start execution
fucntion.
