### PR TITLE
Adding the ability to invert rules in the iptables module and state.

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -14,6 +14,7 @@ import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
 
+
 def __virtual__():
     '''
     Only load the module if iptables is installed

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -14,10 +14,6 @@ import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
 
-import logging
-log = logging.getLogger(__name__)
-
-
 def __virtual__():
     '''
     Only load the module if iptables is installed

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -5,6 +5,7 @@ Support for iptables
 
 # Import python libs
 import os
+import re
 import sys
 import shlex
 
@@ -12,6 +13,9 @@ import shlex
 import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
+
+import logging
+log = logging.getLogger(__name__)
 
 
 def __virtual__():
@@ -102,8 +106,22 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
 
         salt '*' iptables.build_rule match=state \\
             connstate=RELATED,ESTABLISHED jump=ACCEPT
+
         salt '*' iptables.build_rule filter INPUT command=I position=3 \\
             full=True match=state state=RELATED,ESTABLISHED jump=ACCEPT
+
+        salt '*' iptables.build_rule filter INPUT command=A \\
+            full=True match=state state=RELATED,ESTABLISHED \\
+            source='127.0.0.1' jump=ACCEPT
+
+        .. Invert Rules
+        salt '*' iptables.build_rule filter INPUT command=A \\
+            full=True match=state state=RELATED,ESTABLISHED \\
+            source='! 127.0.0.1' jump=ACCEPT
+
+        salt '*' iptables.build_rule filter INPUT command=A \\
+            full=True match=state state=RELATED,ESTABLISHED \\
+            destination='not 127.0.0.1' jump=ACCEPT
 
         IPv6:
         salt '*' iptables.build_rule match=state \\
@@ -123,12 +141,29 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
             del kwargs[ignore]
 
     rule = ''
+    bang_not_pat = re.compile(r'[!,not]\s?')
 
     if 'if' in kwargs:
+        if kwargs['if'].startswith('!') or kwargs['if'].startswith('not'):
+            kwargs['if'] = re.sub(bang_not_pat, '', kwargs['if'])
+            rule += '! '
+
         rule += '-i {0} '.format(kwargs['if'])
         del kwargs['if']
 
+    if 'of' in kwargs:
+        if kwargs['of'].startswith('!') or kwargs['of'].startswith('not'):
+            kwargs['of'] = re.sub(bang_not_pat, '', kwargs['of'])
+            rule += '! '
+
+        rule += '-i {0} '.format(kwargs['of'])
+        del kwargs['of']
+
     if 'proto' in kwargs:
+        if kwargs['proto'].startswith('!') or kwargs['proto'].startswith('not'):
+            kwargs['proto'] = re.sub(bang_not_pat, '', kwargs['proto'])
+            rule += '! '
+
         rule += '-p {0} '.format(kwargs['proto'])
 
     if 'match' in kwargs:
@@ -147,18 +182,34 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         del kwargs['state']
 
     if 'connstate' in kwargs:
+        if kwargs['connstate'].startswith('!') or kwargs['connstate'].startswith('not'):
+            kwargs['connstate'] = re.sub(bang_not_pat, '', kwargs['connstate'])
+            rule += '! '
+
         rule += '--state {0} '.format(kwargs['connstate'])
         del kwargs['connstate']
 
     if 'proto' in kwargs:
+        if kwargs['proto'].startswith('!') or kwargs['proto'].startswith('not'):
+            kwargs['proto'] = re.sub(bang_not_pat, '', kwargs['proto'])
+            rule += '! '
+
         rule += '-m {0} '.format(kwargs['proto'])
         del kwargs['proto']
 
     if 'dport' in kwargs:
+        if kwargs['dport'].startswith('!') or kwargs['dport'].startswith('not'):
+            kwargs['dport'] = re.sub(bang_not_pat, '', kwargs['dport'])
+            rule += '! '
+
         rule += '--dport {0} '.format(kwargs['dport'])
         del kwargs['dport']
 
     if 'sport' in kwargs:
+        if kwargs['sport'].startswith('!') or kwargs['sport'].startswith('not'):
+            kwargs['sport'] = re.sub(bang_not_pat, '', kwargs['sport'])
+            rule += '! '
+
         rule += '--sport {0} '.format(kwargs['sport'])
         del kwargs['sport']
 
@@ -167,9 +218,16 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
             rule += '-m multiport '
 
         if isinstance(kwargs['dports'], list):
+            if [item for item in kwargs['dports'] if item.startswith('!') or item.startswith('not')]:
+                kwargs['dports'] = [re.sub(bang_not_pat, '', item) for item in kwargs['dports']]
+                rule += '! '
             dports = ','.join(kwargs['dports'])
         else:
-            dports = kwargs['dports']
+            if kwargs['dports'].startswith('!') or kwargs['dports'].startswith('not'):
+                dports = re.sub(bang_not_pat, '', kwargs['dports'])
+                rule += '! '
+            else:
+                dports = kwargs['dports']
 
         rule += '--dports {0} '.format(dports)
         del kwargs['dports']
@@ -179,9 +237,16 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
             rule += '-m multiport '
 
         if isinstance(kwargs['sports'], list):
+            if [item for item in kwargs['sports'] if item.startswith('!') or item.startswith('not')]:
+                kwargs['sports'] = [re.sub(bang_not_pat, '', item) for item in kwargs['sports']]
+                rule += '! '
             sports = ','.join(kwargs['sports'])
         else:
-            sports = kwargs['dports']
+            if kwargs['sports'].startswith('!') or kwargs['sports'].startswith('not'):
+                sports = re.sub(bang_not_pat, '', kwargs['sports'])
+                rule += '! '
+            else:
+                sports = kwargs['sports']
 
         rule += '--sports {0} '.format(sports)
         del kwargs['sports']
@@ -193,6 +258,10 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
     # --set in ipset is deprecated, works but returns error.
     # rewrite to --match-set if not empty, otherwise treat as recent option
     if 'set' in kwargs and kwargs['set']:
+        if kwargs['set'].startswith('!') or kwargs['set'].startswith('not'):
+            kwargs['set'] = re.sub(bang_not_pat, '', kwargs['set'])
+            rule += '! '
+
         rule += '--match-set {0} '.format(kwargs['set'])
         del kwargs['set']
 
@@ -225,6 +294,10 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         del kwargs['reject-with']
 
     for item in kwargs:
+        if kwargs[item].startswith('!') or kwargs[item].startswith('not'):
+            kwargs[item] = re.sub(bang_not_pat, '', kwargs[item])
+            rule += '! '
+
         if len(item) == 1:
             rule += '-{0} {1} '.format(item, kwargs[item])
         else:

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -39,6 +39,55 @@ at some point be deprecated in favor of a more generic `firewall` state.
     httpd:
       iptables.append:
         - table: filter
+        - chain: INPUT
+        - jump: ACCEPT
+        - match:
+            - state
+            - comment
+        - comment: "Allow HTTP"
+        - connstate: NEW
+        - source: '127.0.0.1'
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    .. Invert Rule
+    httpd:
+      iptables.append:
+        - table: filter
+        - chain: INPUT
+        - jump: ACCEPT
+        - match:
+            - state
+            - comment
+        - comment: "Allow HTTP"
+        - connstate: NEW
+        - source: '! 127.0.0.1'
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    httpd:
+      iptables.append:
+        - table: filter
+        - chain: INPUT
+        - jump: ACCEPT
+        - match:
+            - state
+            - comment
+        - comment: "Allow HTTP"
+        - connstate: NEW
+        - source: 'not 127.0.0.1'
+        - dport: 80
+        - proto: tcp
+        - sport: 1025:65535
+        - save: True
+
+    httpd:
+      iptables.append:
+        - table: filter
         - family: ipv6
         - chain: INPUT
         - jump: ACCEPT


### PR DESCRIPTION
The rules can be inverted by placing a ! or the word not before the contents of the kwarg argument in either the module call from the CLI or the state file.
