### PR TITLE
Set proper fallback CONFIG_DIR for NetBSD

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -48,6 +48,8 @@ except ImportError:
         ROOT_DIR = '/'
         if 'freebsd' in __platform:
             CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
+        elif 'netbsd' in __platform:
+            CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'pkg', 'etc', 'salt')
         else:
             CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
     CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')


### PR DESCRIPTION
This is not a critical fix since the official package for NetBSD uses
`--salt-config-dir` to set the config dir. But, since NetBSD uses pkgsrc,
which defaults to /usr/pkg/etc, a NetBSD-specific fallback should be
set.

See https://github.com/saltstack/salt/issues/11889#issuecomment-40500747 for more information.
