### PR TITLE
Fix os grains for OpenSolaris/OpenIndiana Development

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -969,7 +969,7 @@ def os_data():
                     grains['osrelease'] = ''
                 else:
                     if development is not None:
-                        osname = ''.join((osname, development))
+                        osname = ' '.join((osname, development))
                     grains['os'] = grains['osfullname'] = osname
                     grains['osrelease'] = osrelease
 


### PR DESCRIPTION
The lack of a space in the OS grain breaks os_family resolution.

Fixes #11907
