### PR TITLE
Since docker is using multiple driver extend its attach support.

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -148,6 +148,7 @@ __docformat__ = 'restructuredtext en'
 
 import datetime
 import json
+import logging
 import os
 import re
 import traceback
@@ -165,7 +166,8 @@ try:
 except ImportError:
     HAS_DOCKER = False
 
-import logging
+HAS_NSENTER = bool(salt.utils.which('nsenter'))
+
 
 log = logging.getLogger(__name__)
 
@@ -1763,42 +1765,59 @@ def _run_wrapper(status, container, func, cmd, *args, **kwargs):
     '''
     Wrapper to a cmdmod function
 
-    Idea is to prefix the call to cmdrun with the relevant lxc-attach to
+    Idea is to prefix the call to cmdrun with the relevant driver to
     execute inside a container context
+
+    .. note::
+
+        Only lxc and native drivers are implemented.
 
     status
         status object
     container
-        container id or grain to execute in
+        container id to execute in
     func
         cmd function to execute
     cmd
-        command to execute in container
+        command to execute in the container
     '''
+
+    client = _get_client()
+    # For old version of docker. lxc was the only supported driver.
+    # We can safely hardcode it
+    driver = client.info().get('ExecutionDriver', 'lxc-')
+    container_info = _get_container_infos(container)
+    container_id = container_info['id']
+    if driver.startswith('lxc-'):
+        full_cmd = 'lxc-attach -n {0} -- {1}'.format(container_id, cmd)
+    elif driver.startswith('native-') and HAS_NSENTER:
+        # http://jpetazzo.github.io/2014/03/23/lxc-attach-nsinit-nsenter-docker-0-9/
+        container_pid = container_info['State']['Pid']
+        if container_pid == 0:
+            invalid(status, id=container, comment='Container is not running')
+            return status
+        full_cmd = ('nsenter --target {pid} --mount --uts --ipc --net --pid'
+                    ' {cmd}'.format(pid=container_pid, cmd=cmd))
+    else:
+        raise NotImplementedError(
+            'Unknown docker ExecutionDriver {0!r}. Or didn\'t found command'
+            ' to attach to the container'.format(driver))
+
+    # now execute the command
+    comment = 'Executed {0}'.format(full_cmd)
     try:
-        cid = _get_container_infos(container)['id']
-        dcmd = 'lxc-attach -n {0} -- {1}'.format(cid, cmd)
-        comment = 'Executed {0}'.format(dcmd)
-        try:
-            f = __salt__[func]
-            ret = f(dcmd, *args, **kwargs)
-            if (
-                (
-                    isinstance(ret, dict)
-                    and (
-                        ('retcode' in ret)
-                        and (ret['retcode'] != 0)
-                    )
-                )
-                or (func == 'cmd.retcode' and ret != 0)
-            ):
-                return invalid(status, id=container, out=ret, comment=comment)
-            valid(status, id=container, out=ret, comment=comment,)
-        except Exception:
-            invalid(status, id=container,
-                    comment=comment, out=traceback.format_exc())
+        f = __salt__[func]
+        ret = f(full_cmd, *args, **kwargs)
+        if ((isinstance(ret, dict) and
+                ('retcode' in ret) and
+                (ret['retcode'] != 0))
+                or (func == 'cmd.retcode' and ret != 0)):
+            return invalid(status, id=container, out=ret,
+                            comment=comment)
+        valid(status, id=container, out=ret, comment=comment,)
     except Exception:
-        invalid(status, id=container, out=traceback.format_exc())
+        invalid(status, id=container,
+                comment=comment, out=traceback.format_exc())
     return status
 
 


### PR DESCRIPTION
Add support for attaching processes to a container driven by `libcontainer`.
`lxc` is still supported.

reference implementation http://jpetazzo.github.io/2014/03/23/lxc-attach-nsinit-nsenter-docker-0-9/
