### PR TITLE
winrepo state

### DIFF
--- a/salt/states/winrepo.py
+++ b/salt/states/winrepo.py
@@ -1,0 +1,95 @@
+'''
+Manage Windows Package Repository
+'''
+
+# Python Libs
+import logging
+import os
+import stat
+import itertools
+
+# Salt Modules
+import salt.runner
+import salt.config
+
+# Settings
+log = logging.getLogger(__name__)
+
+
+def __virtual__():
+    '''
+    Load this state if this is the salt-master
+    '''
+
+    return 'winrepo' if 'salt-master' in __grains__['roles'] else False
+
+
+def _get_runner_client():
+    '''
+    Create the runner client
+    '''
+    return salt.runner.RunnerClient(
+        salt.config.master_config(__pillar__['master']['conf_file'])
+    )
+
+
+def genrepo(name, force=False, allow_empty=False):
+    '''
+    Refresh the winrepo.p file of the repository (salt-run winrepo.genrepo)
+
+    if force is True no checks will be made and the repository will be generated
+    if allow_empty is True then the state will not return an error if there are 0 packages
+
+    Example::
+
+        winrepo:
+          winrepo.genrepo
+    '''
+
+    ret = {'name': name,
+           'result': True,
+           'changes': {},
+           'comment': ''}
+
+    # TODO - get from salt.config without the need of pillar
+    win_repo = __pillar__['master']['win_repo']
+    win_repo_mastercachefile = __pillar__['master']['win_repo_mastercachefile']
+
+    # Check if the win_repo directory exists
+    # if not search for a file with a newer mtime than the win_repo_mastercachefile file
+    execute = False
+    if not force:
+        if not os.path.exists(win_repo):
+            ret['result'] = False
+            ret['comment'] = 'missing {0}'.format(win_repo)
+            return ret
+        elif not os.path.exists(win_repo_mastercachefile):
+            execute = True
+            ret['comment'] = 'missing {0}'.format(win_repo_mastercachefile)
+        else:
+            win_repo_mastercachefile_mtime = os.stat(win_repo_mastercachefile)[stat.ST_MTIME]
+            for root, dirs, files in os.walk(win_repo):
+                for name in itertools.chain(files, dirs):
+                    full_path = os.path.join(root, name)
+                    if os.stat(full_path)[stat.ST_MTIME] > win_repo_mastercachefile_mtime:
+                        ret['comment'] = 'mtime({0}) < mtime({1})'.format(win_repo_mastercachefile, full_path)
+                        execute = True
+                        break
+
+    if __opts__['test']:
+        ret['result'] = None
+        return ret
+
+    if not execute and not force:
+        return ret
+
+    runner = _get_runner_client()
+    runner_ret = runner.cmd('winrepo.genrepo', [])
+    ret['changes'] = {'winrepo': runner_ret}
+    if isinstance(runner_ret, dict) and runner_ret == {} and not allow_empty:
+        os.remove(win_repo_mastercachefile)
+        ret['result'] = False
+        ret['comment'] = 'winrepo.genrepo returned empty'
+
+    return ret
+


### PR DESCRIPTION
STILL NOT READY TO MERGE

I wrote this state mainly to be used via state.orch
the idea is to check the timestamp of `win_repo_mastercachefile` against all the files under the repository
if there is one file/directory with a newer timestamp it's a sign to execute `genrepo`

also I noticed that there is a `win_repo` state that should be executed on a windows standalone minion,
I thought about naming this state `win_repo` as well but this could cause a confusion with all the `win_*` modules ...

I'll be happy to hear your input about the 2 notes I've marked below

cheers
