### PR TITLE
Use cloud profile to determine key on delete

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -887,8 +887,16 @@ class Cloud(object):
             if not ret:
                 continue
 
+            vm_ = {
+                'name': name,
+                'profile': name,
+                'provider': ':'.join([alias, driver])
+            }
+            minion_dict = salt.config.get_cloud_config_value(
+                'minion', vm_, self.opts, default={}
+            )
             key_file = os.path.join(
-                self.opts['pki_dir'], 'minions', name
+                self.opts['pki_dir'], 'minions', minion_dict.get('id', name)
             )
             globbed_key_file = glob.glob('{0}.*'.format(key_file))
 


### PR DESCRIPTION
On a cloud create it is allowed to search the profiles to override the minion id and thus the key file name that is created.

Currently, on delete only the name is checked and if the name differs from the minion id then the key file is not removed.

This merge causes the key file to be derived from the profile as it is during creation so that the key files will be removed correctly.
