### PR TITLE
Remove libcloud as a hard dep for salt-cloud

### DIFF
--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -38,17 +38,22 @@ import logging
 # Import salt.cloud libs
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.cloud.libcloudfuncs import *        # pylint: disable=W0614,W0401
 from salt.cloud.exceptions import SaltCloudException, SaltCloudSystemExit
 
 # Import libcloudfuncs and libcloud_aws, required to latter patch __opts__
-from salt.cloud import libcloudfuncs
-from salt.cloud.clouds import libcloud_aws
-# Import libcloud_aws, storing pre and post locals so we can namespace any
-# callable to this module.
-PRE_IMPORT_LOCALS_KEYS = locals().copy()
-from salt.cloud.clouds.libcloud_aws import *  # pylint: disable=W0614,W0401
-POST_IMPORT_LOCALS_KEYS = locals().copy()
+try:
+    from libcloud.compute.types import Provider
+    from salt.cloud.libcloudfuncs import *  # pylint: disable=W0614,W0401
+    from salt.cloud import libcloudfuncs
+    from salt.cloud.clouds import libcloud_aws
+    # Import libcloud_aws, storing pre and post locals so we can namespace any
+    # callable to this module.
+    PRE_IMPORT_LOCALS_KEYS = locals().copy()
+    from salt.cloud.clouds.libcloud_aws import *  # pylint: disable=W0614,W0401
+    POST_IMPORT_LOCALS_KEYS = locals().copy()
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 
 # Get logging started
 log = logging.getLogger(__name__)
@@ -62,6 +67,9 @@ def __virtual__():
     '''
     Set up the libcloud funcstions and check for AWS configs
     '''
+    if not HAS_LIBCLOUD:
+        return False
+
     try:
         # Import botocore
         import botocore.session

--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -42,7 +42,6 @@ from salt.cloud.exceptions import SaltCloudException, SaltCloudSystemExit
 
 # Import libcloudfuncs and libcloud_aws, required to latter patch __opts__
 try:
-    from libcloud.compute.types import Provider
     from salt.cloud.libcloudfuncs import *  # pylint: disable=W0614,W0401
     from salt.cloud import libcloudfuncs
     from salt.cloud.clouds import libcloud_aws

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -88,7 +88,6 @@ from salt._compat import ElementTree as ET
 # Import salt.cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
 from salt.cloud.exceptions import (
     SaltCloudException,
     SaltCloudSystemExit,
@@ -119,20 +118,18 @@ SIZE_MAP = {
 
 
 EC2_LOCATIONS = {
-    'ap-northeast-1': Provider.EC2_AP_NORTHEAST,
-    'ap-southeast-1': Provider.EC2_AP_SOUTHEAST,
-    'eu-west-1': Provider.EC2_EU_WEST,
-    'sa-east-1': Provider.EC2_SA_EAST,
-    'us-east-1': Provider.EC2_US_EAST,
-    'us-west-1': Provider.EC2_US_WEST,
-    'us-west-2': Provider.EC2_US_WEST_OREGON
+    'ap-northeast-1': 'ec2_ap_northeast',
+    'ap-southeast-1': 'ec2_ap_southeast',
+    'ap-southeast-2': 'ec2_ap_southeast_2',
+    'eu-west-1': 'ec2_eu_west',
+    'sa-east-1': 'ec2_sa_east',
+    'us-east-1': 'ec2_us_east',
+    'us-west-1': 'ec2_us_west',
+    'us-west-2': 'ec2_us_west_oregon',
 }
 DEFAULT_LOCATION = 'us-east-1'
 
 DEFAULT_EC2_API_VERSION = '2013-10-01'
-
-if hasattr(Provider, 'EC2_AP_SOUTHEAST2'):
-    EC2_LOCATIONS['ap-southeast-2'] = Provider.EC2_AP_SOUTHEAST2
 
 EC2_RETRY_CODES = [
     'RequestLimitExceeded',
@@ -1999,6 +1996,7 @@ def get_tags(name=None,
              instance_id=None,
              call=None,
              location=None,
+             kwargs=None,
              resource_id=None):  # pylint: disable=W0613
     '''
     Retrieve tags for a resource. Normally a VM name or instance_id is passed
@@ -2010,14 +2008,19 @@ def get_tags(name=None,
         salt-cloud -a get_tags mymachine
         salt-cloud -a get_tags resource_id=vol-3267ab32
     '''
-    if instance_id is None:
-        if location is None:
-            location = get_location()
+    if location is None:
+        location = get_location()
 
+    if instance_id is None:
         if resource_id is None:
-            instances = list_nodes_full(location)
-            if name in instances:
-                instance_id = instances[name]['instanceId']
+            if name:
+                instances = list_nodes_full(location)
+                if name in instances:
+                    instance_id = instances[name]['instanceId']
+            elif 'instance_id' in kwargs:
+                instance_id = kwargs['instance_id']
+            elif 'resource_id' in kwargs:
+                instance_id = kwargs['resource_id']
         else:
             instance_id = resource_id
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -122,14 +122,18 @@ _UA_PRODUCT = 'salt-cloud'
 _UA_VERSION = '0.2.0'
 
 # The import section is mostly libcloud boilerplate
-from libcloud.compute.types import Provider
-from libcloud.compute.providers import get_driver
-from libcloud.loadbalancer.types import Provider as Provider_lb
-from libcloud.loadbalancer.providers import get_driver as get_driver_lb
-from libcloud.common.google import (
-    ResourceInUseError,
-    ResourceNotFoundError,
-    )
+try:
+    from libcloud.compute.types import Provider
+    from libcloud.compute.providers import get_driver
+    from libcloud.loadbalancer.types import Provider as Provider_lb
+    from libcloud.loadbalancer.providers import get_driver as get_driver_lb
+    from libcloud.common.google import (
+        ResourceInUseError,
+        ResourceNotFoundError,
+        )
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 
 # Import python libs
 import copy
@@ -170,6 +174,9 @@ def __virtual__():
     '''
     Set up the libcloud functions and check for GCE configurations.
     '''
+    if not HAS_LIBCLOUD:
+        return False
+
     if get_configured_provider() is False:
         return False
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -26,7 +26,11 @@ import pprint
 import logging
 
 # Import libcloud
-from libcloud.compute.base import NodeAuthPassword
+try:
+    from libcloud.compute.base import NodeAuthPassword
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 
 # Import salt cloud libs
 import salt.config as config
@@ -57,6 +61,9 @@ def __virtual__():
     '''
     Set up the libcloud functions and check for Linode configurations.
     '''
+    if not HAS_LIBCLOUD:
+        return False
+
     if get_configured_provider() is False:
         return False
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -113,7 +113,11 @@ import socket
 import pprint
 
 # Import libcloud
-from libcloud.compute.base import NodeState
+try:
+    from libcloud.compute.base import NodeState
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 
 # These functions requre libcloud trunk or >= 0.14.0
 HAS014 = False
@@ -175,6 +179,9 @@ def __virtual__():
     '''
     Set up the libcloud functions and check for OPENSTACK configurations
     '''
+    if not HAS_LIBCLOUD:
+        return False
+
     if get_configured_provider() is False:
         return False
 

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -39,7 +39,11 @@ import socket
 import pprint
 
 # Import libcloud
-from libcloud.compute.base import NodeState
+try:
+    from libcloud.compute.base import NodeState
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 
 # Import generic libcloud functions
 from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
@@ -82,6 +86,9 @@ def __virtual__():
     '''
     Set up the libcloud functions and check for Rackspace configuration.
     '''
+    if not HAS_LIBCLOUD:
+        return False
+
     if get_configured_provider() is False:
         return False
 

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -11,13 +11,17 @@ import logging
 
 # pylint: disable=W0611
 # Import libcloud
-from libcloud.compute.types import Provider
-from libcloud.compute.providers import get_driver
-from libcloud.compute.deployment import (
-    MultiStepDeployment,
-    ScriptDeployment,
-    SSHKeyDeployment
-)
+try:
+    from libcloud.compute.types import Provider
+    from libcloud.compute.providers import get_driver
+    from libcloud.compute.deployment import (
+        MultiStepDeployment,
+        ScriptDeployment,
+        SSHKeyDeployment
+    )
+    HAS_LIBCLOUD = True
+except ImportError:
+    HAS_LIBCLOUD = False
 # pylint: enable=W0611
 
 
@@ -52,6 +56,9 @@ def check_libcloud_version(reqver=LIBCLOUD_MINIMAL_VERSION, why=None):
     '''
     Compare different libcloud versions
     '''
+    if not HAS_LIBCLOUD:
+        return False
+
     if not isinstance(reqver, (list, tuple)):
         raise RuntimeError(
             '\'reqver\' needs to passed as a tuple or list, ie, (0, 14, 0)'


### PR DESCRIPTION
This removes the hard dependency on libcloud. Now only providers which actually use libcloud will need it installed.
