### PR TITLE
chef integration

### DIFF
--- a/salt/modules/chef.py
+++ b/salt/modules/chef.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+'''
+Execute chef in server or solo mode
+'''
+
+import logging
+
+
+log = logging.getLogger(__name__) 
+
+CHEF_BINARIES = (
+   'chef-client',
+   'chef-solo',
+   'ohai',
+)
+
+# Import salt libs
+import salt.utils
+
+
+def __virtual__():
+    '''
+    Only load if chef is installed
+    '''
+    if salt.utils.which('chef-client'):
+        return 'chef'
+    return False
+
+
+def _check_chef():
+    '''
+    Checks if chef is installed
+    '''
+    for _ in CHEF_BINARIES:
+        salt.utils.check_or_die(_)
+
+
+def client(*args, **kwargs):
+    '''
+    Execute a chef client run and return a dict with the stderr, stdout,
+    return code, etc.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' chef.client server=https://localhost -l debug
+    '''
+    _check_chef()
+    args += ('chef-client',)
+    return __exec_cmd(*args, **kwargs)
+
+
+def solo(*args, **kwargs):
+    '''
+    Execute a chef solo run and return a dict with the stderr, stdout,
+    return code, etc.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' chef.solo config=/etc/chef/solo.rb -l debug
+    '''
+    _check_chef()
+    args += ('chef-solo',)
+    return __exec_cmd(*args, **kwargs)
+
+
+def ohai(*args, **kwargs):
+    '''
+    Execute a ohai and return a dict with the stderr, stdout,
+    return code, etc.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' chef.ohai
+    '''
+    _check_chef()
+    args += ('ohai',)
+    return __exec_cmd(*args, **kwargs)
+
+
+def __exec_cmd(*args, **kwargs): 
+    cmd = ''.join([arg for arg in args])
+    cmd_args = ''.join([
+         ' --{0} {1}'.format(k, v) for k, v in kwargs.items() if not k.startswith('__')]
+    )
+    cmd_exec = "{0} {1}".format(cmd, cmd_args)
+    log.debug("ChefCommand: %s" % cmd_exec)
+    return __salt__['cmd.run'](cmd_exec)


### PR DESCRIPTION
Hi,

Sending a module to integrate with Chef (opscode.com).
Currently supports runs with three binaries
- chef-client
- chef-solo
- ohai

I'm planing to add more functionality such as
- list cookbooks from local cache
- manage registration to chef server (hosted, enterprise, open source)
- manage config files into /etc/chef

thanks!

ps: chef supports different output formats, currently I don't serialize to anything in 
particular but can be easily added if need it 
