### PR TITLE
ScientificLinux : Use of correct grain value in modules/service.py

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -26,7 +26,7 @@ def __virtual__():
         'RedHat',
         'CentOS',
         'Amazon',
-        'Scientific',
+        'ScientificLinux',
         'CloudLinux',
         'Fedora',
         'Gentoo',


### PR DESCRIPTION
Small bug fix.
modules/service.py should use correct grain value for ScientificLinux
as reported below.

<pre>
# salt-call grains.item os
local:
  os: ScientificLinux
</pre>
