### PR TITLE
Fixed enable_gpu_grains option by validate the option before the lspci c...

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -136,18 +136,14 @@ def _linux_gpu_data():
       - vendor: nvidia|amd|ati|...
         model: string
     '''
+    if __opts__.get('enable_gpu_grains', True) is False:
+        return {}
+
     lspci = salt.utils.which('lspci')
     if not lspci:
         log.info(
             'The `lspci` binary is not available on the system. GPU grains '
             'will not be available.'
-        )
-        return {}
-
-    elif __opts__.get('enable_gpu_grains', None) is False:
-        log.info(
-            'Skipping lspci call because enable_gpu_grains was set to False '
-            'in the config. GPU grains will not be available.'
         )
         return {}
 


### PR DESCRIPTION
Fixed for the issue #12073 The "enable_gpu_grains" minion option don't disable lspci check

I didn't wrote the unit and integration tests because of my Windows setup and I'm not sure on how to write it (deep in the minion configuration)
