### PR TITLE
Fix adding tenant to keystone user with no previous tenant assigned

### DIFF
--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -138,7 +138,8 @@ def user_present(name,
                                              **connection_args)
             ret['comment'] = 'User "{0}" has been updated'.format(name)
             ret['changes']['Enabled'] = 'Now {0}'.format(enabled)
-        if tenant and user[name]['tenant_id'] != tenant_id:
+        if tenant and ('tenant_id' not in user[name] or
+                       user[name]['tenant_id'] != tenant_id):
             __salt__['keystone.user_update'](name=name, tenant=tenant,
                                              profile=profile,
                                              **connection_args)


### PR DESCRIPTION
Applying a keystone.user_present state on a user without a tenant currently raises the following exception:

```
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/lib/python2.7/site-packages/salt/state.py", line 1371, in call                                                 
              **cdata['kwargs'])                                                                                                      
            File "/usr/lib/python2.7/site-packages/salt/states/keystone.py", line 141, in user_present                                
              if tenant and user[name]['tenant_id'] != tenant_id:                                                                     
          KeyError: 'tenant_id'
```

This commit applies the required key check.
