### PR TITLE
are in the enum of the users. this was used also to know when to

### DIFF
--- a/salt/modules/win_useradd.py
+++ b/salt/modules/win_useradd.py
@@ -8,6 +8,9 @@ NOTE: This currently only works with local user accounts, not domain accounts
 # Import salt libs
 import salt.utils
 from salt._compat import string_types
+import logging
+
+log = logging.getLogger(__name__)
 
 try:
     import win32net
@@ -379,11 +382,13 @@ def list_users():
     '''
     Return a list of users on Windows
     '''
-    res = 1
+    res = 0
     users = []
     user_list = []
+    dowhile = True
     try:
-        while res:
+        while res or dowhile:
+            dowhile = False
             (users, _, res) = win32net.NetUserEnum(
                 'localhost',
                 3,
@@ -393,6 +398,7 @@ def list_users():
             )
             for user in users:
                 user_list.append(user['name'])
+                log.debug('User: {0}'.format(str(user)))
         return user_list
     except win32net.error:
         pass


### PR DESCRIPTION
Figured it out. The variable 'res' is used to keep track of where you
are in the enum of the users. this was used also to know when to
kick out of the while loop. This is one of those moments where you
wish that python had a "do while" feature. So I pieced something
together that allows res to start at 0 instead of 1. This solved the
problem of the first user being dropped from the list of users.

This fixes #12071
