### PR TITLE
Set a variable if we're building for the live docs site or not

### DIFF
--- a/doc/_themes/saltstack/layout.html
+++ b/doc/_themes/saltstack/layout.html
@@ -275,11 +275,13 @@
 
         <script src="{{ pathto('_static/js/main.js', 1) }}"></script>
 
+        {% if html_docs_saltstack_org %}
         <script>
             var _gaq=[['_setAccount','UA-26984928-1'],['_trackPageview']];
             (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
             g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
             s.parentNode.insertBefore(g,s)}(document,'script'));
         </script>
+        {% endif %}
     </body>
 </html>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,8 +179,11 @@ html_logo = None # specfied in the theme layout.html
 html_favicon = 'favicon.ico'
 html_use_smartypants = False
 
+# Set a var if we're building docs for the live site or not
+html_docs_saltstack_org = 'SALT_GOOGLE_SEARCH' in os.environ
+
 # Use Google customized search or use Sphinx built-in JavaScript search
-if 'SALT_GOOGLE_SEARCH' in os.environ:
+if html_docs_saltstack_org:
     html_search_template = 'googlesearch.html'
 else:
     html_search_template = 'searchbox.html'
@@ -208,6 +211,7 @@ html_sidebars = {
 }
 
 html_context = {
+    'docs_saltstack_org': html_docs_saltstack_org,
     'html_default_sidebars': html_default_sidebars,
     'github_base': 'https://github.com/saltstack/salt',
     'github_issues': 'https://github.com/saltstack/salt/issues',


### PR DESCRIPTION
This is useful to customize online / offline search and whether to
include things like Google Analytics.

Fixes #9875
