### PR TITLE
Initial commit of boto_sqs state and module

### DIFF
--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon SQS
+
+:configuration: This module accepts explicit sqs credentials but can also utilize
+    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    credentials are then automatically obtained from AWS API and no further
+    configuration is necessary. More Information available at::
+
+       http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file::
+
+        sqs.keyid: GKTADJGHEIQSXMKKRBJ08H
+        sqs.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration::
+
+        sqs.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+:depends: boto
+'''
+
+# Import Python libs
+import logging
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+try:
+    import boto
+    import boto.sqs
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist.
+    '''
+    if not HAS_BOTO:
+        return False
+    return True
+
+
+def exists(name, region=None, key=None, keyid=None):
+    '''
+    Check to see if a queue exists.
+
+    CLI example::
+
+        salt myminion sqs.exists myqueue region=us-east-1
+    '''
+    conn = _get_conn(region, key, keyid)
+    if not conn:
+        return False
+    if conn.get_queue(name):
+        return True
+    else:
+        return False
+
+
+def create(name, region=None, key=None, keyid=None):
+    '''
+    Create an SQS queue.
+
+    CLI example to create a queue::
+
+        salt myminion sqs.create myqueue region=us-east-1
+    '''
+    conn = _get_conn(region, key, keyid)
+    if not conn:
+        return False
+    if not conn.get_queue(name):
+        try:
+            conn.create_queue(name)
+        except boto.exception.SQSError:
+            msg = 'Failed to create queue {0}'.format(name)
+            log.error(msg)
+            return False
+    log.info('Created queue {0}'.format(name))
+    return True
+
+
+def delete(name, region=None, key=None, keyid=None):
+    '''
+    Delete an SQS queue.
+
+    CLI example to delete a queue::
+
+        salt myminion sqs.delete myqueue region=us-east-1
+    '''
+    conn = _get_conn(region, key, keyid)
+    if not conn:
+        return False
+    queue_obj = conn.get_queue(name)
+    if queue_obj:
+        deleted_queue = conn.delete_queue(queue_obj)
+        if not deleted_queue:
+            msg = 'Failed to delete queue {0}'.format(name)
+            log.error(msg)
+            return False
+    return True
+
+
+def get_attributes(name, region=None, key=None, keyid=None):
+    '''
+    Check to see if attributes are set on an SQS queue.
+
+    CLI example::
+
+        salt myminion sqs.get_attributes myqueue
+    '''
+    conn = _get_conn(region, key, keyid)
+    if not conn:
+        return {}
+    queue_obj = conn.get_queue(name)
+    if not queue_obj:
+        log.error('Queue {0} does not exist.'.format(name))
+        return {}
+    return conn.get_queue_attributes(queue_obj)
+
+
+def set_attributes(name, attributes, region=None, key=None, keyid=None):
+    '''
+    Set attributes on an SQS queue.
+
+    CLI example to set attributes on a queue::
+
+        salt myminion sqs.set_attributes myqueue '{ReceiveMessageWaitTimeSeconds: 20}' region=us-east-1
+    '''
+    ret = True
+    conn = _get_conn(region, key, keyid)
+    if not conn:
+        return False
+    queue_obj = conn.get_queue(name)
+    if not queue_obj:
+        log.error('Queue {0} does not exist.'.format(name))
+        ret = False
+    for attr, val in attributes.iteritems():
+        attr_set = queue_obj.set_attribute(attr, val)
+        if not attr_set:
+            msg = 'Failed to set attribute {0} = {1} on queue {2}'
+            log.error(msg.format(attr, val, name))
+            ret = False
+        else:
+            msg = 'Set attribute {0} = {1} on queue {2}'
+            log.info(msg.format(attr, val, name))
+    return ret
+
+
+def _get_conn(region, key, keyid):
+    '''
+    Get a boto connection to SQS.
+    '''
+    if not region and __salt__['config.option']('sqs.region'):
+        region = __salt__['config.option']('sqs.region')
+
+    if not region:
+        region = 'us-east-1'
+
+    if not key and __salt__['config.option']('sqs.key'):
+        key = __salt__['config.option']('sqs.key')
+    if not keyid and __salt__['config.option']('sqs.keyid'):
+        keyid = __salt__['config.option']('sqs.keyid')
+
+    try:
+        conn = boto.sqs.connect_to_region(region, aws_access_key_id=keyid,
+                                          aws_secret_access_key=key)
+    except boto.exception.NoAuthHandlerFound:
+        log.error('No authentication credentials found when attempting to'
+                  ' make boto sqs connection.')
+        return None
+    return conn

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -66,7 +66,7 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
 
     CLI example::
 
-        salt myminion sqs.exists myqueue region=us-east-1
+        salt myminion boto_sqs.exists myqueue region=us-east-1
     '''
     conn = _get_conn(region, key, keyid, profile)
     if not conn:
@@ -83,7 +83,7 @@ def create(name, region=None, key=None, keyid=None, profile=None):
 
     CLI example to create a queue::
 
-        salt myminion sqs.create myqueue region=us-east-1
+        salt myminion boto_sqs.create myqueue region=us-east-1
     '''
     conn = _get_conn(region, key, keyid, profile)
     if not conn:
@@ -105,7 +105,7 @@ def delete(name, region=None, key=None, keyid=None, profile=None):
 
     CLI example to delete a queue::
 
-        salt myminion sqs.delete myqueue region=us-east-1
+        salt myminion boto_sqs.delete myqueue region=us-east-1
     '''
     conn = _get_conn(region, key, keyid, profile)
     if not conn:
@@ -126,7 +126,7 @@ def get_attributes(name, region=None, key=None, keyid=None, profile=None):
 
     CLI example::
 
-        salt myminion sqs.get_attributes myqueue
+        salt myminion boto_sqs.get_attributes myqueue
     '''
     conn = _get_conn(region, key, keyid, profile)
     if not conn:
@@ -145,7 +145,7 @@ def set_attributes(name, attributes, region=None, key=None, keyid=None,
 
     CLI example to set attributes on a queue::
 
-        salt myminion sqs.set_attributes myqueue '{ReceiveMessageWaitTimeSeconds: 20}' region=us-east-1
+        salt myminion boto_sqs.set_attributes myqueue '{ReceiveMessageWaitTimeSeconds: 20}' region=us-east-1
     '''
     ret = True
     conn = _get_conn(region, key, keyid, profile)

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -173,7 +173,7 @@ def _get_conn(region, key, keyid, profile):
     '''
     if profile:
         if isinstance(profile, string_types):
-            log.error(_profile)
+            _profile = __salt__['config.option'](profile)
         elif isinstance(profile, dict):
             _profile = profile
         key = _profile.get('key', None)

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -66,7 +66,7 @@ def __virtual__():
 
 def created(
         name,
-        attributes={},
+        attributes=None
         region=None,
         key=None,
         keyid=None,
@@ -113,10 +113,11 @@ def created(
     attrs_to_set = {}
     _attributes = __salt__['boto_sqs.get_attributes'](name, region, key, keyid,
                                                       profile)
-    for attr, val in attributes.iteritems():
-        _val = _attributes.get(attr, None)
-        if str(_val) != str(val):
-            attrs_to_set[attr] = val
+    if attributes:
+        for attr, val in attributes.iteritems():
+            _val = _attributes.get(attr, None)
+            if str(_val) != str(val):
+                attrs_to_set[attr] = val
     attr_names = ','.join(attrs_to_set.keys())
     if attrs_to_set:
         if __opts__['test']:

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+'''
+Manage SQS Queues
+=================
+
+Create and destroy SQS queues. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses boto, which can be installed via package, or pip.
+
+This module accepts explicit sqs credentials but can also utilize
+IAM roles assigned to the instance trough Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More Information available at::
+
+   http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+If IAM roles are not used you need to specify them either in a pillar or
+in the minion's config file::
+
+    sqs.keyid: GKTADJGHEIQSXMKKRBJ08H
+    sqs.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+.. code-block:: yaml
+
+    myqueue:
+        aws_sqs.exists:
+            - region: us-east-1
+            - key: GKTADJGHEIQSXMKKRBJ08H
+            - keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            - attributes:
+                ReceiveMessageWaitTimeSeconds: 20
+'''
+
+
+def __virtual__():
+    '''
+    Only load if aws is available.
+    '''
+    return 'boto_sqs' if 'boto_sqs.exists' in __salt__ else False
+
+
+def created(
+        name,
+        attributes=None,
+        region=None,
+        key=None,
+        keyid=None):
+    '''
+    Ensure the SQS queue exists.
+
+    name
+        Name of the SQS queue.
+
+    region
+        Region to create the queue
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+    '''
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+
+    is_created = __salt__['boto_sqs.exists'](name, region, key, keyid)
+
+    if not is_created:
+        ret['comment'] = 'AWS SQS queue {0} is set to be created.'.format(name)
+        if __opts__['test']:
+            ret['result'] = None
+            return ret
+        created = __salt__['boto_sqs.create'](name, region, key, keyid)
+        if created:
+            ret['changes']['old'] = None
+            ret['changes']['new'] = {'queue': name}
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} AWS queue'.format(name)
+            return ret
+    else:
+        ret['comment'] = '{0} present.'.format(name)
+    attrs_to_set = {}
+    _attributes = __salt__['boto_sqs.get_attributes'](name, region, key, keyid)
+    for attr, val in attributes.iteritems():
+        _val = _attributes.get(attr, None)
+        if str(_val) != str(val):
+            attrs_to_set[attr] = val
+    if attrs_to_set:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Attributes {0} to be set on {1}'.format(
+                attrs_to_set.keys(), name)
+            return ret
+        attr_names = ','.join(attrs_to_set.keys())
+        msg = (' Setting {0} attributes.'.format(attr_names))
+        ret['comment'] = ret['comment'] + msg
+        ret['result'] = True
+        if 'new' in ret['changes']:
+            ret['changes']['new']['attributes_set'] = []
+        else:
+            ret['changes']['new'] = {'attributes_set': []}
+        for attr, val in attrs_to_set.iteritems():
+            set_attr = __salt__['boto_sqs.set_attributes'](name, {attr: val},
+                                                           region, key, keyid)
+            if not set_attr:
+                ret['result'] = False
+            msg = 'Set attribute {0}.'.format(attr)
+            ret['changes']['new']['attributes_set'].append(attr)
+    else:
+        ret['comment'] = ret['comment'] + ' Attributes set.'
+    return ret
+
+
+def deleted(
+        name,
+        region=None,
+        key=None,
+        keyid=None):
+    '''
+    Delete the named SQS queue if it exists.
+
+    name
+        Name of the SQS queue.
+
+    region
+        Region to remove the queue from
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    is_created = __salt__['boto_sqs.exists'](name, region, key, keyid)
+
+    if is_created:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'AWS SQS queue {0} is set to be removed'.format(
+                    name)
+            return ret
+        deleted = __salt__['boto_sqs.delete'](name, region, key, keyid)
+        if deleted:
+            ret['result'] = True
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to remove {0} sqs queue.'.format(name)
+    else:
+        ret['comment'] = u'{0} does not exist in {1}'.format(name, region)
+
+    return ret

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -42,7 +42,7 @@ def __virtual__():
 
 def created(
         name,
-        attributes=None,
+        attributes={},
         region=None,
         key=None,
         keyid=None):
@@ -86,14 +86,14 @@ def created(
         _val = _attributes.get(attr, None)
         if str(_val) != str(val):
             attrs_to_set[attr] = val
+    attr_names = ','.join(attrs_to_set.keys())
     if attrs_to_set:
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Attributes {0} to be set on {1}'.format(
-                attrs_to_set.keys(), name)
+            ret['comment'] = 'Attribute(s) {0} to be set on {1}.'.format(
+                attr_names, name)
             return ret
-        attr_names = ','.join(attrs_to_set.keys())
-        msg = (' Setting {0} attributes.'.format(attr_names))
+        msg = (' Setting {0} attribute(s).'.format(attr_names))
         ret['comment'] = ret['comment'] + msg
         ret['result'] = True
         if 'new' in ret['changes']:
@@ -139,7 +139,7 @@ def deleted(
     if is_created:
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'AWS SQS queue {0} is set to be removed'.format(
+            ret['comment'] = 'AWS SQS queue {0} is set to be removed.'.format(
                     name)
             return ret
         deleted = __salt__['boto_sqs.delete'](name, region, key, keyid)
@@ -151,6 +151,6 @@ def deleted(
             ret['result'] = False
             ret['comment'] = 'Failed to remove {0} sqs queue.'.format(name)
     else:
-        ret['comment'] = u'{0} does not exist in {1}'.format(name, region)
+        ret['comment'] = '{0} does not exist in {1}.'.format(name, region)
 
     return ret

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -34,7 +34,7 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 .. code-block:: yaml
 
     myqueue:
-        aws_sqs.exists:
+        aws_sqs.present:
             - region: us-east-1
             - key: GKTADJGHEIQSXMKKRBJ08H
             - keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
@@ -43,13 +43,13 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 
     # Using a profile from pillars
     myqueue:
-        aws_sqs.exists:
+        aws_sqs.present:
             - region: us-east-1
             - profile: mysqsprofile
 
     # Passing in a profile
     myqueue:
-        aws_sqs.exists:
+        aws_sqs.present:
             - region: us-east-1
             - profile:
                 key: GKTADJGHEIQSXMKKRBJ08H
@@ -64,9 +64,9 @@ def __virtual__():
     return 'boto_sqs' if 'boto_sqs.exists' in __salt__ else False
 
 
-def created(
+def present(
         name,
-        attributes=None
+        attributes=None,
         region=None,
         key=None,
         keyid=None,
@@ -92,9 +92,9 @@ def created(
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
-    is_created = __salt__['boto_sqs.exists'](name, region, key, keyid, profile)
+    is_present = __salt__['boto_sqs.exists'](name, region, key, keyid, profile)
 
-    if not is_created:
+    if not is_present:
         ret['comment'] = 'AWS SQS queue {0} is set to be created.'.format(name)
         if __opts__['test']:
             ret['result'] = None
@@ -145,14 +145,14 @@ def created(
     return ret
 
 
-def deleted(
+def absent(
         name,
         region=None,
         key=None,
         keyid=None,
         profile=None):
     '''
-    Delete the named SQS queue if it exists.
+    Ensure the named sqs queue is deleted.
 
     name
         Name of the SQS queue.
@@ -172,9 +172,9 @@ def deleted(
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
-    is_created = __salt__['boto_sqs.exists'](name, region, key, keyid, profile)
+    is_present = __salt__['boto_sqs.exists'](name, region, key, keyid, profile)
 
-    if is_created:
+    if is_present:
         if __opts__['test']:
             ret['result'] = None
             ret['comment'] = 'AWS SQS queue {0} is set to be removed.'.format(
@@ -188,7 +188,7 @@ def deleted(
             ret['changes']['new'] = None
         else:
             ret['result'] = False
-            ret['comment'] = 'Failed to remove {0} sqs queue.'.format(name)
+            ret['comment'] = 'Failed to delete {0} sqs queue.'.format(name)
     else:
         ret['comment'] = '{0} does not exist in {1}.'.format(name, region)
 

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -34,7 +34,7 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 .. code-block:: yaml
 
     myqueue:
-        aws_sqs.present:
+        boto_sqs.present:
             - region: us-east-1
             - key: GKTADJGHEIQSXMKKRBJ08H
             - keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
@@ -43,13 +43,13 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 
     # Using a profile from pillars
     myqueue:
-        aws_sqs.present:
+        boto_sqs.present:
             - region: us-east-1
             - profile: mysqsprofile
 
     # Passing in a profile
     myqueue:
-        aws_sqs.present:
+        boto_sqs.present:
             - region: us-east-1
             - profile:
                 key: GKTADJGHEIQSXMKKRBJ08H
@@ -59,7 +59,7 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 
 def __virtual__():
     '''
-    Only load if aws is available.
+    Only load if boto is available.
     '''
     return 'boto_sqs' if 'boto_sqs.exists' in __salt__ else False
 


### PR DESCRIPTION
This state and module manage SQS queues via boto, rather than the
aws commands. Since it's using boto, it supports IAM instance profile
credentials natively. The module and state also support the ability
to accept key/keyid credentials as parameters, through pillars or
through minion configuration.

In addition, the state and module supports managing queue attributes.
In the state this is added as an argument. In the module it's a separate
function. The module also has support for fetching the attributes for a
queue.
