### PR TITLE
Use salt's master `clean_proc` routine.

### DIFF
--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -25,6 +25,7 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+from salt.master import clean_proc
 from salt.utils import event
 
 SOCK_DIR = os.path.join(integration.TMP, 'test-socks')
@@ -46,8 +47,7 @@ def eventpublisher_process():
             time.sleep(2)
         yield
     finally:
-        proc.terminate()
-        proc.join()
+        clean_proc(proc)
 
 
 class EventSender(Process):
@@ -76,8 +76,7 @@ def eventsender_process(data, tag, wait=0):
     try:
         yield
     finally:
-        proc.terminate()
-        proc.join()
+        clean_proc(proc)
 
 
 @skipIf(NO_LONG_IPC, "This system does not support long IPC paths. Skipping event tests!")


### PR DESCRIPTION
On Fedora 20, we hit an issue, at least, similar to #3618.
While debugging it, I've found that the runtests process keeps eating
memory.

Using `clean_proc` has at least, allowed the runtests to finish without
triggering #3618.
