### PR TITLE
add: new config option for virt module

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -127,11 +127,16 @@ def __get_conn():
         '''
         return [[libvirt.VIR_CRED_EXTERNAL], lambda: 0, None]
 
+    if 'virt.connect' in __opts__:
+        conn_str = __opts__['virt.connect']
+    else:
+        conn_str = 'qemu:///system'
+
     conn_func = {
         'esxi': [libvirt.openAuth, [__esxi_uri(),
                                     __esxi_auth(),
                                     0]],
-        'qemu': [libvirt.open, ['qemu:///system']],
+        'qemu': [libvirt.open, [conn_str]],
         }
 
     hypervisor = __salt__['config.get']('libvirt:hypervisor', 'qemu')


### PR DESCRIPTION
Hi,

I am using XEN as a dom0 on some of my servers and the _virt_ module wasn't able to retrieve some informations like the running VM.

Although I set the `uri_default` option in my `/etc/libvirt/libvirt.conf` this parameter did not seem to be used by the module.

So I wrote this little patch that allows us to set the proper _connect string_ in the minion's configuration file.

This new option is named `virt.connect`

Cheers
