### PR TITLE
Disk mounting improvements and bug fixes

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -211,7 +211,7 @@ def blkid(device=None):
         device = comps[0][:-1]
         info = {}
         device_attributes = re.split(('\"*\"'), line.partition(' ')[2])
-        for key,value in zip(*[iter(device_attributes)]*2):
+        for key, value in zip(*[iter(device_attributes)]*2):
             key = key.strip('=').strip(' ')
             info[key] = value.strip('"')
         ret[device] = info

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -6,6 +6,7 @@ Module for gathering disk information
 # Import python libs
 import logging
 import os
+import re
 
 # Import salt libs
 import salt.utils
@@ -209,8 +210,9 @@ def blkid(device=None):
         comps = line.split()
         device = comps[0][:-1]
         info = {}
-        for elem in comps[1:]:
-            key, value = elem.split('=')
+        device_attributes = re.split(('\"*\"'), line.partition(' ')[2])
+        for key,value in zip(*[iter(device_attributes)]*2):
+            key = key.strip('=').strip(' ')
             info[key] = value.strip('"')
         ret[device] = info
 

--- a/salt/states/disk.py
+++ b/salt/states/disk.py
@@ -15,7 +15,7 @@ __monitor__ = [
 
 def status(name, maximum=None, minimum=None):
     '''
-    Return the current disk usage stats for the named device
+    Return the current disk usage stats for the named mount point
     '''
     # Monitoring state, no changes will be made so no test interface needed
     ret = {'name': name,

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -109,9 +109,9 @@ def mounted(name,
     # Note the double-dash escaping.
     # So, let's call that the canonical device name
     # We should normalize names of the /dev/vg-name/lv-name type to the canonical name
-    m = re.match(r'^/dev/(?P<vg_name>[^/]+)/(?P<lv_name>[^/]+$)', device)
-    if m:
-        double_dash_escaped = dict((k, re.sub(r'-', '--', v)) for k, v in m.groupdict().iteritems())
+    lvs_match = re.match(r'^/dev/(?P<vg_name>[^/]+)/(?P<lv_name>[^/]+$)', device)
+    if lvs_match:
+        double_dash_escaped = dict((k, re.sub(r'-', '--', v)) for k, v in lvs_match.groupdict().iteritems())
         mapper_device = '/dev/mapper/{vg_name}-{lv_name}'.format(**double_dash_escaped)
         if os.path.exists(mapper_device):
             real_device = mapper_device

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -126,6 +126,14 @@ def mounted(name,
             device_list.append(alt_device)
         if uuid_device and uuid_device not in device_list:
             device_list.append(uuid_device)
+        if opts:
+            for opt in opts:
+                if opt not in active[real_name]['opts']:
+                    ret['changes']['umount'] = "Forced remount because " \
+                                                + "options changed"
+                    remount_result = __salt__['mount.remount'](real_name, device, mkmnt=mkmnt, fstype=fstype, opts=opts)
+                    ret['result'] = remount_result
+                    return ret
         if real_device not in device_list:
             # name matches but device doesn't - need to umount
             ret['changes']['umount'] = "Forced unmount because devices " \


### PR DESCRIPTION
- Fix error I found in blkids where spaces in a disk label will cause a stack trace.
- Rewrite doc string
- Detect changed mount options and remount if necessary. (Refs #6079) 
- Pylint a too-short variable name
