### PR TITLE
fix get fqdn

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -101,15 +101,14 @@ def _get_fqhostname():
         return h_fqdn
     except socket.gaierror:
         return h_fqdn
-    else:
-        # Struct contanis the following elements:
-        #     family, socktype, proto, canonname, sockaddr
-        try:
-            # Prevent returning an empty string by falling back to
-            # socket.getfqdn()
-            return addrinfo[3] or h_fqdn
-        except IndexError:
-            return h_fqdn
+    # Struct contanis the following elements:
+    #     family, socktype, proto, canonname, sockaddr
+    try:
+        # Prevent returning an empty string by falling back to
+        # socket.getfqdn()
+        return addrinfo[3] or h_fqdn
+    except IndexError:
+        return h_fqdn
 
 
 def get_fqhostname():


### PR DESCRIPTION
you can not simple check if `socket.gethostname()` returns a string with a dot. 

A hostname can have a dot in its name and still not be FQDN!
This patch will return the socket.fqhostname() if it's longer then the socket.hostname().

I created this patch because my minions on first starting are resolving the /etc/salt/minion_id as the hostname not the FQDN.  Many of our hostnames have dots in them. 
