### PR TITLE
rm seemingly-redundant logging import in modules.aws_sqs

### DIFF
--- a/salt/modules/aws_sqs.py
+++ b/salt/modules/aws_sqs.py
@@ -218,7 +218,6 @@ def delete_queue(name, region, opts=None, user=None):
     queues = list_queues(region, opts, user)
     url_map = _parse_queue_list(queues)
 
-    import logging
     logger = logging.getLogger(__name__)
     logger.debug('map ' + unicode(url_map))
     if name in url_map:


### PR DESCRIPTION
```
************* Module salt.modules.aws_sqs
salt/modules/aws_sqs.py:221: [W0621(redefined-outer-name), delete_queue] Redefining name 'logging' from outer scope (line 5)
salt/modules/aws_sqs.py:221: [W0404(reimported), delete_queue] Reimport 'logging' (imported line 5)
```
