### PR TITLE
Fix #12137 where minions fail to perform a highstate on startup

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1408,6 +1408,11 @@ class Minion(MinionBase):
         self._fire_master_minion_start()
 
         loop_interval = int(self.opts['loop_interval'])
+
+        # On first startup execute a state run if configured to do so
+        self._state_run()
+        time.sleep(.5)
+
         while self._running is True:
             try:
                 socks = self._do_poll(loop_interval)


### PR DESCRIPTION
This will allow minions to run a highstate if specified in the minion's configuration file.
