### PR TITLE
Add state for managing YAML files.

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3164,6 +3164,44 @@ def accumulated(name, filename, text, **kwargs):
     return ret
 
 
+def _merge_dict(obj, k, v):
+    changes = {}
+    if k in obj:
+        if type(obj[k]) is list:
+            if type(v) is list:
+                for a in v:
+                    if not a in obj[k]:
+                        changes[k] = a
+                        obj[k].append(a)
+            else:
+                if obj[k] != v:
+                    changes[k] = v
+                    obj[k] = v
+        elif type(obj[k]) is dict:
+            if type(v) is dict:
+                for a, b in v.iteritems():
+                    if (type(b) is dict) or (type(b) is list):
+                        updates = _merge_dict(obj[k], a, b)
+                        for x, y in updates.iteritems():
+                            changes[k + "." + x] = y
+                    else:
+                        if obj[k][a] != b:
+                            changes[k + "." + a] = b
+                            obj[k][a] = b
+            else:
+                if obj[k] != v:
+                    changes[k] = v
+                    obj[k] = v
+        else:
+            if obj[k] != v:
+                changes[k] = v
+                obj[k] = v
+    else:
+        changes[k] = v
+        obj[k] = v
+    return changes
+
+
 def serialize(name,
               dataset,
               user=None,
@@ -3174,6 +3212,7 @@ def serialize(name,
               makedirs=False,
               show_diff=True,
               create=True,
+              merge_if_exists=False,
               **kwargs):
     '''
     Serializes dataset and store it into managed file. Useful for sharing
@@ -3218,6 +3257,10 @@ def serialize(name,
         Default is True, if create is set to False then the file will only be
         managed if the file already exists on the system.
 
+    merge_if_exists
+        Default is False, if merge_if_exists is True then the existing file will
+        be parsed and the dataset passed in will be merged with the existing
+        content
 
     For example, this state::
 
@@ -3271,6 +3314,30 @@ def serialize(name,
             return ret
 
     formatter = kwargs.pop('formatter', 'yaml').lower()
+
+    if merge_if_exists:
+        if os.path.isfile(name):
+            if formatter == 'yaml':
+                existing_data = yaml.load(file(name, 'r'))
+            elif formatter == 'json':
+                existing_data = json.load(file(name, 'r'))
+            else:
+                return {'changes': {},
+                        'comment': '{0} format is not supported for merging'.format(
+                            formatter.capitalized()),
+                        'name': name,
+                        'result': False
+                        }
+
+            if not existing_data is None:
+                for k, v in dataset.iteritems():
+                    if k in existing_data:
+                        ret['changes'].update(_merge_dict(existing_data, k, v))
+                    else:
+                        ret['changes'][k] = v
+                        existing_data[k] = v
+                dataset = existing_data
+
     if formatter == 'yaml':
         contents = yaml.dump(
             dataset,


### PR DESCRIPTION
This change enables the `file.serialize` state to merge existing content.

``` yaml
/etc/salt/minion:
  file.serialize:
    - merge_if_exists: True
    - dataset:
        startup_states: highstate
        mine_functions:
            dummy: []
```
