### PR TITLE
Don't set profile var as VM name when destroying

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -889,7 +889,7 @@ class Cloud(object):
 
             vm_ = {
                 'name': name,
-                'profile': name,
+                'profile': None,
                 'provider': ':'.join([alias, driver])
             }
             minion_dict = salt.config.get_cloud_config_value(


### PR DESCRIPTION
Setting profile as the VM's name in destroy() causes an error further down in `salt/cloud/__init__.py`:

```
[ERROR   ] There was an error destroying machines: u'test'
Traceback (most recent call last):
  File "/srv/salt-dev/salt/cloud/cli.py", line 162, in run
    ret = mapper.destroy(names, cached=True)
  File "/srv/salt-dev/salt/cloud/__init__.py", line 896, in destroy
    'minion', vm_, self.opts, default={}
  File "/srv/salt-dev/salt/config.py", line 1582, in get_cloud_config_value
    if name in opts['profiles'][vm_['profile']]:
KeyError: u'test'
```

It doesn't look to me like this should have any other impact, but I can't be 100%.. ;0

@techhat @s0undt3ch is anything happening wrt to test in salt cloud now? (also hi!)
