### PR TITLE
Avoid traceback for unexpected pkgin/pkg_info output

### DIFF
--- a/salt/modules/pkgin.py
+++ b/salt/modules/pkgin.py
@@ -229,9 +229,10 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
     out = __salt__['cmd.run'](pkg_command, output_loglevel='debug')
     for line in out.splitlines():
-        if not line:
+        try:
+            pkg, ver = line.split(' ')[0].rsplit('-', 1)
+        except ValueError:
             continue
-        pkg, ver = line.split(' ')[0].rsplit('-', 1)
         __salt__['pkg_resource.add_pkg'](ret, pkg, ver)
 
     __salt__['pkg_resource.sort_pkglist'](ret)


### PR DESCRIPTION
I'm pretty sure this is the correct fix here for #10981, but I need more information from that report to know for certain.
