### PR TITLE
Fix region key fetching from profiles in boto_sqs

### DIFF
--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -178,7 +178,7 @@ def _get_conn(region, key, keyid, profile):
             _profile = profile
         key = _profile.get('key', None)
         keyid = _profile.get('keyid', None)
-        region = _profile.get('keyid', None)
+        region = _profile.get('region', None)
 
     if not region and __salt__['config.option']('sqs.region'):
         region = __salt__['config.option']('sqs.region')


### PR DESCRIPTION
I was pulling the wrong key in profiles for regions in boto_sqs.
This change addresses that.
