### PR TITLE
Audit error reporting in states, fix traceback in state.template

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -29,6 +29,8 @@ __outputter__ = {
     'top': 'highstate',
     'single': 'highstate',
     'highstate': 'highstate',
+    'template': 'highstate',
+    'template_str': 'highstate',
 }
 
 log = logging.getLogger(__name__)

--- a/salt/state.py
+++ b/salt/state.py
@@ -281,10 +281,10 @@ class Compiler(object):
             if name.startswith('__'):
                 continue
             if not isinstance(name, string_types):
-                err = ('The name {0} in sls {1} is not formed as a '
-                       'string but is a {2}').format(
-                               name, body['__sls__'], type(name))
-                errors.append(err)
+                errors.append(
+                    'ID {0!r} in SLS {1!r} is not formed as a string, but is '
+                    'a {2}'.format(name, body['__sls__'], type(name).__name__)
+                )
             if not isinstance(body, dict):
                 err = ('The type {0} in {1} is not formatted as a dictionary'
                        .format(name, body))
@@ -294,9 +294,10 @@ class Compiler(object):
                 if state.startswith('__'):
                     continue
                 if not isinstance(body[state], list):
-                    err = ('The state "{0}" in sls {1} is not formed as a list'
-                           .format(name, body['__sls__']))
-                    errors.append(err)
+                    errors.append(
+                        'State {0!r} in SLS {1!r} is not formed as a list'
+                        .format(name, body['__sls__'])
+                    )
                 else:
                     fun = 0
                     if '.' in state:
@@ -323,7 +324,7 @@ class Compiler(object):
                             if argfirst in ('require', 'watch', 'prereq'):
                                 if not isinstance(arg[argfirst], list):
                                     errors.append(('The {0}'
-                                    ' statement in state "{1}" in sls "{2}" '
+                                    ' statement in state {1!r} in SLS {2!r} '
                                     'needs to be formed as a list').format(
                                         argfirst,
                                         name,
@@ -388,19 +389,20 @@ class Compiler(object):
                                 # dict
                                 if len(list(arg)) != 1:
                                     errors.append(('Multiple dictionaries '
-                                    'defined in argument of state "{0}" in sls'
-                                    ' {1}').format(
+                                    'defined in argument of state {0!r} in SLS'
+                                    ' {1!r}').format(
                                         name,
                                         body['__sls__']))
                     if not fun:
                         if state == 'require' or state == 'watch':
                             continue
-                        errors.append(('No function declared in state "{0}" in'
-                            ' sls {1}').format(state, body['__sls__']))
+                        errors.append(('No function declared in state {0!r} in'
+                            ' SLS {1!r}').format(state, body['__sls__']))
                     elif fun > 1:
-                        errors.append(('Too many functions declared in state'
-                            ' "{0}" in sls {1}').format(
-                                state, body['__sls__']))
+                        errors.append(
+                            'Too many functions declared in state {0!r} in '
+                            'SLS {1!r}'.format(state, body['__sls__'])
+                        )
         return errors
 
     def order_chunks(self, chunks):
@@ -671,24 +673,25 @@ class State(object):
         if 'name' not in data:
             errors.append('Missing "name" data')
         if data['name'] and not isinstance(data['name'], string_types):
-            err = ('The name {0} in sls {1} is not formed as a '
-                   'string but is a {2}').format(
-                           data['name'], data['__sls__'], type(data['name']))
-            errors.append(err)
+            errors.append(
+                'ID {0!r} in SLS {1!r} is not formed as a string, but is '
+                'a {2}'.format(
+                    data['name'], data['__sls__'], type(data['name']).__name__)
+            )
         if errors:
             return errors
         full = data['state'] + '.' + data['fun']
         if full not in self.states:
             if '__sls__' in data:
                 errors.append(
-                    'State {0} found in sls {1} is unavailable'.format(
+                    'State {0!r} found in SLS {1!r} is unavailable'.format(
                         full,
                         data['__sls__']
                         )
                     )
             else:
                 errors.append(
-                        'Specified state {0} is unavailable.'.format(
+                        'Specified state {0!r} is unavailable.'.format(
                             full
                             )
                         )
@@ -754,10 +757,11 @@ class State(object):
             if name.startswith('__'):
                 continue
             if not isinstance(name, string_types):
-                err = ('The name {0} in sls {1} is not formed as a '
-                       'string but is a {2}').format(
-                               name, body['__sls__'], type(name))
-                errors.append(err)
+                errors.append(
+                    'ID {0!r} in SLS {1!r} is not formed as a string, but '
+                    'is a {2}'.format(
+                        name, body['__sls__'], type(name).__name__)
+                )
             if not isinstance(body, dict):
                 err = ('The type {0} in {1} is not formatted as a dictionary'
                        .format(name, body))
@@ -766,10 +770,19 @@ class State(object):
             for state in body:
                 if state.startswith('__'):
                     continue
+                if body[state] is None:
+                    errors.append(
+                        'ID {0!r} in SLS {1!r} contains a short declaration '
+                        '({2}) with a trailing colon. When not passing any '
+                        'arguments to a state, the colon must be omitted.'
+                        .format(name, body['__sls__'], state)
+                    )
+                    continue
                 if not isinstance(body[state], list):
-                    err = ('The state "{0}" in sls {1} is not formed as a list'
-                           .format(name, body['__sls__']))
-                    errors.append(err)
+                    errors.append(
+                        'State {0!r} in SLS {1!r} is not formed as a list'
+                        .format(name, body['__sls__'])
+                    )
                 else:
                     fun = 0
                     if '.' in state:
@@ -795,20 +808,21 @@ class State(object):
                             argfirst = next(iter(arg))
                             if argfirst == 'names':
                                 if not isinstance(arg[argfirst], list):
-                                    errors.append(('Names statement in state '
-                                    '"{0}" in sls "{1}" needs to be formed as'
-                                    'a list').format(
-                                        name,
-                                        body['__sls__']))
+                                    errors.append(
+                                        'The \'names\' argument in state '
+                                        '{0!r} in SLS {1!r} needs to be '
+                                        'formed as a list'
+                                        .format(name, body['__sls__'])
+                                    )
                             if argfirst in ('require', 'watch', 'prereq'):
                                 if not isinstance(arg[argfirst], list):
-                                    errors.append(('The {0}'
-                                    ' statement in state "{1}" in sls "{2}" '
-                                    'needs to be formed as a list').format(
-                                        argfirst,
-                                        name,
-                                        body['__sls__']
-                                        ))
+                                    errors.append(
+                                        'The {0} statement in state {1!r} in '
+                                        'SLS {2!r} needs to be formed as a '
+                                        'list'.format(argfirst,
+                                                      name,
+                                                      body['__sls__'])
+                                    )
                                 # It is a list, verify that the members of the
                                 # list are all single key dicts.
                                 else:
@@ -865,20 +879,23 @@ class State(object):
                                 # Make sure that there is only one key in the
                                 # dict
                                 if len(list(arg)) != 1:
-                                    errors.append(('Multiple dictionaries '
-                                    'defined in argument of state "{0}" in sls'
-                                    ' {1}').format(
-                                        name,
-                                        body['__sls__']))
+                                    errors.append(
+                                        'Multiple dictionaries defined in '
+                                        'argument of state {0!r} in SLS {1!r}'
+                                        .format(name, body['__sls__'])
+                                    )
                     if not fun:
                         if state == 'require' or state == 'watch':
                             continue
-                        errors.append(('No function declared in state "{0}" in'
-                            ' sls {1}').format(state, body['__sls__']))
+                        errors.append(
+                            'No function declared in state {0!r} in SLS {1!r}'
+                            .format(state, body['__sls__'])
+                        )
                     elif fun > 1:
-                        errors.append(('Too many functions declared in state'
-                            ' "{0}" in sls {1}').format(
-                                state, body['__sls__']))
+                        errors.append(
+                            'Too many functions declared in state {0!r} in '
+                            'SLS {1!r}'.format(state, body['__sls__'])
+                        )
         return errors
 
     def verify_chunks(self, chunks):
@@ -1755,7 +1772,7 @@ class State(object):
                         continue
 
                     errors.append(
-                        'Name {0} in template {1} is not a dictionary'.format(
+                        'ID {0} in template {1} is not a dictionary'.format(
                             name, template
                         )
                     )
@@ -1763,6 +1780,14 @@ class State(object):
             skeys = set()
             for key in sorted(high[name]):
                 if key.startswith('_'):
+                    continue
+                if high[name][key] is None:
+                    errors.append(
+                        'ID {0!r} in template {1} contains a short '
+                        'declaration ({2}) with a trailing colon. When not '
+                        'passing any arguments to a state, the colon must be '
+                        'omitted.'.format(name, template, key)
+                    )
                     continue
                 if not isinstance(high[name][key], list):
                     continue
@@ -1779,10 +1804,9 @@ class State(object):
                     #     - regex: ^requirepass
                     if comps[0] in skeys:
                         errors.append(
-                            'Name \'{0}\' in template \'{1}\' contains '
-                            'multiple state decs of the same type'.format(
-                                name, template
-                            )
+                            'ID {0!r} in template {1!r} contains multiple '
+                            'state declarations of the same type'
+                            .format(name, template)
                         )
                         continue
                     high[name][comps[0]] = high[name].pop(key)
@@ -2303,7 +2327,7 @@ class BaseHighState(object):
                                        comps[0]: [comps[1]]}
                         continue
                 errors.append(
-                    'Name {0} in sls {1} is not a dictionary'.format(name, sls)
+                    'ID {0} in SLS {1} is not a dictionary'.format(name, sls)
                 )
                 continue
             skeys = set()
@@ -2325,10 +2349,10 @@ class BaseHighState(object):
                     #       file.comment:
                     #           - regex: ^requirepass
                     if comps[0] in skeys:
-                        err = ('Name "{0}" in sls "{1}" contains '
-                               'multiple state decs of the same type'
-                              ).format(name, sls)
-                        errors.append(err)
+                        errors.append(
+                            'ID {0!r} in SLS {1!r} contains multiple state '
+                            'declarationss of the same type'.format(name, sls)
+                        )
                         continue
                     state[name][comps[0]] = state[name].pop(key)
                     state[name][comps[0]].append(comps[1])
@@ -2348,12 +2372,12 @@ class BaseHighState(object):
         if 'extend' in state:
             ext = state.pop('extend')
             if not isinstance(ext, dict):
-                errors.append(('Extension value in sls {0} is not a '
+                errors.append(('Extension value in SLS {0!r} is not a '
                                'dictionary').format(sls))
                 return
             for name in ext:
                 if not isinstance(ext[name], dict):
-                    errors.append(('Extension name {0} in sls {1} is '
+                    errors.append(('Extension name {0!r} in SLS {1!r} is '
                                    'not a dictionary'
                                    .format(name, sls)))
                     continue

--- a/salt/state.py
+++ b/salt/state.py
@@ -2351,7 +2351,7 @@ class BaseHighState(object):
                     if comps[0] in skeys:
                         errors.append(
                             'ID {0!r} in SLS {1!r} contains multiple state '
-                            'declarationss of the same type'.format(name, sls)
+                            'declarations of the same type'.format(name, sls)
                         )
                         continue
                     state[name][comps[0]] = state[name].pop(key)

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -362,7 +362,7 @@ fi
         ])
         ret = self.run_function('state.sls', mods='syntax.badlist2')
         self.assertEqual(ret, [
-            'The state "C" in sls syntax.badlist2 is not formed as a list'
+            'State \'C\' in SLS \'syntax.badlist2\' is not formed as a list'
         ])
 
     def test_requisites_mixed_require_prereq_use(self):

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -127,8 +127,8 @@ fi
         testfile = os.path.join(integration.TMP, 'issue-1876')
         sls = self.run_function('state.sls', mods='issue-1876')
         self.assertIn(
-            'Name "{0}" in sls "issue-1876" contains multiple state decs of '
-            'the same type'.format(testfile),
+            'ID {0!r} in SLS \'issue-1876\' contains multiple state '
+            'declarations of the same type'.format(testfile),
             sls
         )
 
@@ -358,7 +358,7 @@ fi
         '''
         ret = self.run_function('state.sls', mods='syntax.badlist')
         self.assertEqual(ret, [
-            'The state "A" in sls syntax.badlist is not formed as a list'
+            'State \'A\' in SLS \'syntax.badlist\' is not formed as a list'
         ])
         ret = self.run_function('state.sls', mods='syntax.badlist2')
         self.assertEqual(ret, [
@@ -554,8 +554,8 @@ fi
         result = {}
         ret = self.run_function('state.sls', mods='requisites.require_simple_nolist')
         self.assertEqual(ret, [
-            'The require statement in state "B" in sls '
-          + '"requisites.require_simple_nolist" needs to be formed as a list'
+            'The require statement in state \'B\' in SLS '
+          + '\'requisites.require_simple_nolist\' needs to be formed as a list'
         ])
 
         # commented until a fix is made for issue #8772


### PR DESCRIPTION
**NOTE: Because this pull request changes error messages, there is likely to be test breakage, which will need to be addressed before this is merged. I'd like @thatch45 to sign off on this first though, as it involves changing the wording for several error messages.**

This pull request normalizes error reporting quite a bit. The ID declaration was referred to both as "Name" and "ID", and "SLS" was both capitalized and uncapitalized.

In addition, this fixes #11359 by identifying short declarations with no arguments which contain a trailing colon, and providing a meaningful error message. See [here](https://github.com/saltstack/salt/issues/11359#issuecomment-40983833) for an example of the error message.

This also catches the same behavior when state.highstate/state.sls are invoked, and provides a similar error message.

Finally, this pull request sets the correct outputter for both state.template and state.template_str. Before, it was displaying output using the default (nested) outputter, when it should have been run through the highstate outputter.
