### PR TITLE
Change dmidecode notification to loglevel WARNING

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1286,7 +1286,7 @@ def _dmidecode_data(regex_dict):
     elif salt.utils.which('smbios'):
         out = __salt__['cmd.run']('smbios')
     else:
-        log.info(
+        log.warning(
             'The `dmidecode` binary is not available on the system. GPU '
             'grains will not be available.'
         )


### PR DESCRIPTION
This mitigates the following noise in salt-call runs:

```
[INFO    ] The `dmidecode` binary is not available on the system. GPU
grains will not be available.
```
