### PR TITLE
rm duplicate import of salt.utils.event in salt.client.ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -32,7 +32,6 @@ import salt.utils.event
 import salt.utils.atomicfile
 import salt.utils.thin
 import salt.utils.verify
-import salt.utils.event
 from salt._compat import string_types
 
 # This is just a delimiter to distinguish the beginning of salt STDOUT.  There


### PR DESCRIPTION
```
************* Module salt.client.ssh
salt/client/ssh/__init__.py:35: [W0404(reimported), ] Reimport 'salt.utils.event' (imported line 31)
```
