### PR TITLE
Change user salt configs to .saltrc from .salt to prevent conflicts

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -2058,9 +2058,9 @@ def client_config(path, env_var='SALT_CLIENT_CONFIG', defaults=None):
     # Update with the users salt dot file or with the environment variable
     opts.update(
         load_config(
-            os.path.expanduser('~/.salt'),
+            os.path.expanduser('~/.saltrc'),
             env_var,
-            os.path.expanduser('~/.salt')
+            os.path.expanduser('~/.saltrc')
         )
     )
     # Make sure we have a proper and absolute path to the token file


### PR DESCRIPTION
Fixes #12169

As stated in #12169, LocalClient will sometimes look for a local salt config.  It was looking for the file `~/.salt`.  However, client_acl can also result in salt looking for (and creating) a directory of the same name.  Now we use `~/.saltrc` instead for the file, so we don't conflict.
