### PR TITLE
Add function to delete a minion cache with relative safety.

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -440,6 +440,30 @@ def running():
     return ret
 
 
+def clear_cache():
+    '''
+    Forcibly removes all caches on a minion.
+
+    WARNING: The safest way to clear a minion cache is by first stopping
+    the minion and then deleting the cache files before restarting it.
+    
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.clear_cache
+    '''
+    
+    for root, dirs, files in salt.utils.safe_walk(__opts__['cachedir'], followlinks=False):
+        for name in files:
+            try:
+                os.remove(os.path.join(root, name)) 
+            except OSError as exc:
+                log.error('Attempt to clear cache with saltutil.clear_cache FAILED with: {0}'.format(exc))
+                return False
+    return True
+
+
 def cached():
     '''
     Return the data on all cached salt jobs on the minion

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -446,18 +446,18 @@ def clear_cache():
 
     WARNING: The safest way to clear a minion cache is by first stopping
     the minion and then deleting the cache files before restarting it.
-    
+ 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' saltutil.clear_cache
     '''
-    
+ 
     for root, dirs, files in salt.utils.safe_walk(__opts__['cachedir'], followlinks=False):
         for name in files:
             try:
-                os.remove(os.path.join(root, name)) 
+                os.remove(os.path.join(root, name))
             except OSError as exc:
                 log.error('Attempt to clear cache with saltutil.clear_cache FAILED with: {0}'.format(exc))
                 return False


### PR DESCRIPTION
This closes #6947.

While a minion will most certainly become unstable if the directory structure for its cache is pulled out from under it, removing only the files is relatively safe in my testing and made available via saltutil because it's often useful to have, if only for debugging. 

Regardless, this function includes a warning about the safest way to accomplish this task in production.
