### PR TITLE
list_nodes_min insufficent for map_providers_parallel

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -520,8 +520,6 @@ class Cloud(object):
         opts['providers'] = self._optimize_providers(opts['providers'])
         for alias, drivers in opts['providers'].iteritems():
             for driver, details in drivers.iteritems():
-                if '{0}.list_nodes_min'.format(driver) in self.clouds:
-                    query = 'list_nodes_min'
                 fun = '{0}.{1}'.format(driver, query)
                 if fun not in self.clouds:
                     log.error(


### PR DESCRIPTION
Addresses #11934 where salt-cloud can't create a machine with the same name as a terminated machine.
