### PR TITLE
Fix bad docstrings

### DIFF
--- a/salt/modules/lvs.py
+++ b/salt/modules/lvs.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 '''
-
 Support for LVS (Linux Virtual Server)
 '''
 

--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
-''' Module for running ZFS command
+'''
+Salt interface to ZFS commands
 '''
 
 # Import Python libs

--- a/salt/renderers/json.py
+++ b/salt/renderers/json.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+'''
+JSON Renderer for Salt
+'''
+
 from __future__ import absolute_import
 
 # Import python libs

--- a/salt/renderers/mako.py
+++ b/salt/renderers/mako.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+'''
+Mako Renderer for Salt
+'''
+
 from __future__ import absolute_import
 
 # Import python libs

--- a/salt/renderers/yaml.py
+++ b/salt/renderers/yaml.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
+'''
+YAML Renderer for Salt
+'''
+
 from __future__ import absolute_import
 
 # Import python libs

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -1,10 +1,9 @@
 # -*- coding: utf-8 -*-
-
-"""
+'''
 Archive states.
 
 .. versionadded:: 2014.1.0 (Hydrogen)
-"""
+'''
 
 import logging
 import os

--- a/salt/states/lvs_server.py
+++ b/salt/states/lvs_server.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-
-Management of LVS(Linux Virtual Server) Real Server.
-=====================================================
-
-This lvs_server module is used to add and manage LVS Real Server in the specified service. Server can be set as either absent or present.
+Management of LVS (Linux Virtual Server) Real Server
+====================================================
 '''
 
 
 def __virtual__():
     '''
-
     Only load if the lvs module is available in __salt__
     '''
     return 'lvs_server' if 'lvs.get_rules' in __salt__ else False
@@ -117,7 +113,6 @@ def present(name,
 
 def absent(name, protocol=None, service_address=None, server_address=None):
     '''
-
     Ensure the LVS Real Server in specified service is absent.
 
     name

--- a/salt/states/lvs_service.py
+++ b/salt/states/lvs_service.py
@@ -1,16 +1,12 @@
 # -*- coding: utf-8 -*-
 '''
-
-Management of LVS(Linux Virtual Server) Service.
+Management of LVS (Linux Virtual Server) Service
 ================================================
-
-This lvs_service module is used to create and manage LVS Service. Service can be set as either absent or present.
 '''
 
 
 def __virtual__():
     '''
-
     Only load if the lvs module is available in __salt__
     '''
     return 'lvs_service' if 'lvs.get_rules' in __salt__ else False
@@ -99,7 +95,6 @@ def present(name,
 
 def absent(name, protocol=None, service_address=None):
     '''
-
     Ensure the LVS service is absent.
 
     name

--- a/salt/states/zcbuildout.py
+++ b/salt/states/zcbuildout.py
@@ -1,8 +1,7 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 '''
 Management of zc.buildout
-===========================
+=========================
 
 This module is inspired from minitage's buildout maker
 (https://github.com/minitage/minitage/blob/master/src/minitage/core/makers/buildout.py)


### PR DESCRIPTION
Sphinx autosummary uses the top line of the module's docstring to populate the TOC, among other parts of the docs. A blank line at the top of the docstring results in a blank space in those areas of the documentation.

Also, I removed a shebang line from the top of salt/states/zcbuildout.py, because it is not required in Salt code, and added docstrings to a few modules that lacked them.
