### PR TITLE
Fix typo in Type declaration of systemd unit

### DIFF
--- a/pkg/salt-master.service
+++ b/pkg/salt-master.service
@@ -3,7 +3,7 @@ Description=The Salt Master Server
 After=syslog.target network.target
 
 [Service]
-Type=Notify
+Type=notify
 ExecStart=/usr/bin/salt-master
 
 [Install]


### PR DESCRIPTION
The systemd service type must be declared in lower case, otherwise systemd generated a warning and ignores the declaration.
