### PR TITLE
Clean environment before calling psql

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -72,7 +72,8 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None,
     makes this too much code to be repeated in each function below
     '''
     kwargs = {
-        'reset_system_locale': False
+        'reset_system_locale': False,
+        'clean_env': True,
     }
     if runas is None:
         if not host:


### PR DESCRIPTION
If environment variables are not cleaned, the psql execution can be
affected by variables like PGHOST, and induce unwanted behaviours or
failures.  Especially on Linux if one launches salt-minion by invoking
directly the init script instead of using the "service" command (the
former does not clean the environment).
