### PR TITLE
minions auto recover after DNS ip address change. [DDNS]

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -241,18 +241,24 @@ class Minion(parsers.MinionOptionParser):
 
         NOTE: Run any required code before calling `super()`.
         '''
-        self.prepare()
-        try:
-            if check_user(self.config['user']):
-                self.minion.tune_in()
-        except (KeyboardInterrupt, SaltSystemExit) as exc:
-            logger.warn('Stopping the Salt Minion')
-            if isinstance(exc, KeyboardInterrupt):
-                logger.warn('Exiting on Ctrl-c')
-            else:
-                logger.error(str(exc))
-        finally:
-            self.shutdown()
+        reconnect = True
+        while reconnect:
+            reconnect = True
+            self.prepare()
+            try:
+                if check_user(self.config['user']):                    
+                    self.minion.tune_in()
+            except (KeyboardInterrupt, SaltSystemExit) as exc:
+                logger.warn('Stopping the Salt Minion')
+                if isinstance(exc, KeyboardInterrupt):
+                    logger.warn('Exiting on Ctrl-c')
+                else:
+                    logger.error(str(exc))
+            except Exception, exc:
+                if exc == 'reconnect':
+                    reconnect = True
+            finally:
+                self.shutdown()
 
     def shutdown(self):
         '''


### PR DESCRIPTION
DO NOT PULL.  USE AS REF.

Minions currently don't seem to support Masters changing ip address.  I did some previous work in the authenticate method but there is still issues... https://github.com/saltstack/salt/pull/11663

This patch causes the minion to restart after 500 seconds if the master 'seems' to be gone.
Once the minion restarts it will resolve its DNS again and have the correct IP address.

This commit is not to be pulled!  Someone more in tune with the minion tune_in code should handle this.

Thanks
