### PR TITLE
Tweak wording for successful orch w/no changes

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -209,7 +209,7 @@ def state(
         if changes:
             ret['comment'] += ' Updating {0}.'.format(', '.join(changes))
         if no_change:
-            ret['comment'] += ' Without changing {0}.'.format(', '.join(no_change))
+            ret['comment'] += ' No changes made to {0}.'.format(', '.join(no_change))
     if failures:
         ret['comment'] += '\nFailures:\n'
         for minion, failure in failures.iteritems():


### PR DESCRIPTION
This changes an awkwardly-worded comment when the state.orchestrate
runner is executed and there are no changes to be made.
## Old

```
saltmine:
----------
          ID: test.txt
    Function: salt.state
      Result: True
     Comment: States ran successfully. Without changing saltmine.
     Changes:

Summary
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
```
## New

```
saltmine:
----------
          ID: test.txt
    Function: salt.state
      Result: True
     Comment: States ran successfully. No changes made to saltmine.
     Changes:

Summary
------------
Succeeded: 1
Failed:    0
------------
Total states run:     1
```
