### PR TITLE
Minion is not always defined in the profile

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1924,7 +1924,7 @@ class Map(Cloud):
                 # Already deployed, it's the master's minion
                 continue
 
-            if profile['minion'].get('local_master', False) and \
+            if 'minion' in profile and profile['minion'].get('local_master', False) and \
                     profile['minion'].get('master', None) is not None:
                 # The minion is explicitly defining a master and it's
                 # explicitely saying it's the local one


### PR DESCRIPTION
```
[INFO    ] Since parallel deployment is in use, ssh console output is disabled. All ssh output will be logged though
[ERROR   ] There was a query error: 'minion'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/cli.py", line 284, in run
    ret = mapper.run_map(dmap)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1927, in run_map
    if profile['minion'].get('local_master', False) and \
KeyError: 'minion'
```
