### PR TITLE
`simple_types_filter` is only supposed to work for `dict`. Refs #9860.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1275,6 +1275,10 @@ def simple_types_filter(datadict):
     Convert the data dictionary into simple types, ie, int, float, string,
     bool, etc.
     '''
+    if not isinstance(datadict, dict):
+        # This function is only supposed to work on dictionaries
+        return datadict
+
     simpletypes_keys = (str, unicode, int, long, float, bool)
     simpletypes_values = tuple(list(simpletypes_keys) + [list, tuple])
     simpledict = {}


### PR DESCRIPTION
cherry-pick simple type filter so that salt-cloud -Pyd -m <mapfile> doesn't fail on doing an iteritems on an empty datadict.
