### PR TITLE
restart minion if master is not responding

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -345,10 +345,9 @@ class Auth(object):
                 timeout=timeout
             )
         except SaltReqTimeoutError as e:
-            self.opts.update(salt.minion.resolve_dns(self.opts))
             if safe:
                 log.warning('SaltReqTimeoutError: {0}'.format(e))
-                return 'retry'
+                return 'timeout'
             raise SaltClientError
 
         if 'load' in payload:
@@ -521,7 +520,7 @@ class SAuth(Auth):
                 self.opts['auth_timeout'],
                 self.opts.get('_safe_auth', True)
             )
-            if creds == 'retry':
+            if creds == 'retry' or creds == 'timeout':
                 if self.opts.get('caller'):
                     print('Minion failed to authenticate with the master, '
                           'has the minion key been accepted?')

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1082,6 +1082,24 @@ class Minion(MinionBase):
                         'minutes': refresh_interval_in_minutes
                     }
             })
+                    
+                    
+    def _alive_test_watcher(self, interval_in_minutes = 10):
+        '''
+        Create a loop that will fire a ping test
+        '''
+        if '__alive_test' not in self.opts.get('schedule', {}):
+            if not 'schedule' in self.opts:
+                self.opts['schedule'] = {}
+            self.opts['schedule'].update({
+                '__alive_test':
+                    {
+                        'function': 'event.fire',
+                        'args': [{}, 'ping'],
+                        'minutes': interval_in_minutes
+                    }
+            })
+
 
     def _set_tcp_keepalive(self):
         if hasattr(zmq, 'TCP_KEEPALIVE'):
@@ -1348,7 +1366,10 @@ class Minion(MinionBase):
                 'Exception occurred in attempt to initialize grain refresh routine during minion tune-in: {0}'.format(
                     exc)
             )
-
+        
+        # start a ping test to run every 10 min
+        self._alive_test_watcher(10)
+        
         while self._running is True:
             loop_interval = self.process_schedule(self, loop_interval)
             try:


### PR DESCRIPTION
restart minion if master is not responding.

This patch is not complete.
One or two variables should be added to the minion config.
- onerror_auto_restart (hard coded as True)
- max SaltReqTimeoutError timeouts before restarting minion (hard coded as 10)
