### PR TITLE
archive.py state throws AttributeError when the 'f' flag is passed as a tar_option

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -155,7 +155,7 @@ def extracted(name,
                     tar_options = '-{0} {1}'.format(opt, tar_options)
             # Want to ensure -f is the last argument before the filename
             if 'f' in tar_options:
-                tar_options.remove('f')
+                tar_options = tar_options.replace('f', '')
             results = __salt__['cmd.run_all']('tar {0} -f "{1}"'.format(
                 tar_options, filename), cwd=name)
             if results['retcode'] != 0:


### PR DESCRIPTION
[Line 158 of archive.py](https://github.com/saltstack/salt/blob/develop/salt/states/archive.py#L158) calls remove on an str object (as indicated by line 155) and throws an AttributeError when using an options string that contains 'f':

```
Traceback (most recent call last):
  File "/root/salt/salt/state.py", line 1401, in call
    **cdata['kwargs'])
  File "/root/salt/salt/states/archive.py", line 159, in extracted
    tar_options.remove('f')
AttributeError: 'str' object has no attribute 'remove'
```

My HSD looks like this (it is written for the python renderer):

```
  generated_hsd[full_local_path] = {
    'archive': [
      'extracted',
      { 'name': app['deploy']['path'] },
      { 'user': 'myuser' },
      { 'group': 'mygroup' },
      { 'mode': 400 },
      { 'source': 's3://{0}/{1}'.format(bucket, build_archive) },
      { 'source_hash': 'md5={0}'.format(build_hash) },
      { 'tar_options': 'xvf' },
      { 'archive_format': 'tar' },
      { 'if_missing': '{0}/{1}'.format(local_path, build) },
      { 'require': [
        { 'user': 'myuser' },
        { 'file': local_path }
      ]
      }
    ]
  }
```

This PR fixes the issue for me.
