### PR TITLE
remove hard-coded script path in vsphere provider

### DIFF
--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -265,7 +265,6 @@ def create(vm_):
             'password': template_password,
             'script': deploy_script,
             'name': vm_['name'],
-            'deploy_command': '/tmp/deploy.sh',
             'start_action': __opts__['start_action'],
             'parallel': __opts__['parallel'],
             'sock_dir': __opts__['sock_dir'],


### PR DESCRIPTION
before removing this deploy script path it was attempting to run the script at this path instead of the one the scripts were uploaded to in /tmp/.saltcloud/.  i guess the location in salt/utils/cloud.py was updated since?
