### PR TITLE
Remove binary package verification

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -6,10 +6,7 @@ Resources needed by pkg providers
 # Import python libs
 import fnmatch
 import logging
-import os
 import pprint
-import re
-import sys
 
 # Import third party libs
 import yaml

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -19,8 +19,6 @@ from salt.exceptions import (
 
 log = logging.getLogger(__name__)
 
-# This is imported in salt.modules.pkg_resource._parse_pkg_meta. Don't change
-# it without considering its impact there.
 __QUERYFORMAT = '%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}'
 
 # These arches compiled from the rpmUtils.arch python module source
@@ -64,8 +62,6 @@ def __virtual__():
     return False
 
 
-# This is imported in salt.modules.pkg_resource._parse_pkg_meta. Don't change
-# it without considering its impact there.
 def _parse_pkginfo(line):
     '''
     A small helper to parse a repoquery; returns a namedtuple


### PR DESCRIPTION
This code has been the source of several nagging issues over the last
several releases. It is also unnecessary, since a package installed
using the "sources" argument will still fail if the package's real name
doesn't match the desired name, since the list_pkgs output will show the
true name of the installed package (which will not match what was
specified).

Fixes #12177.
