### PR TITLE
Causing problems for boolean values from config

### DIFF
--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -76,9 +76,6 @@ def _config(name, key=None, **kwargs):
         value = kwargs[name]
     else:
         value = __salt__['config.option']('ldap.{0}'.format(key))
-        if not value:
-            msg = 'missing ldap.{0} in config or {1} in args'.format(key, name)
-            raise SaltInvocationError(msg)
     return value
 
 


### PR DESCRIPTION
I just don't know how I didn't see this but really.....
Value could be a boolean i.e. ldap.tls which is false by default, so using "not" in the if statement isn't correct.
And value will always be filled anyway.
