### PR TITLE
Minion restart if master is not responding

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -323,12 +323,15 @@ DEFAULT_MINION_OPTS = {
     'keysize': 4096,
     'transport': 'zeromq',
     'auth_timeout': 60,
+    'auth_timeout_count_max': None,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),
     'ioflo_verbose': 0,
     'ioflo_period': 0.01,
     'ioflo_realtime': True,
     'raet_port': 4510,
+    'restart_on_error': False,
+    'hartbeat_wait_time': None,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -345,10 +345,9 @@ class Auth(object):
                 timeout=timeout
             )
         except SaltReqTimeoutError as e:
-            self.opts.update(salt.minion.resolve_dns(self.opts))
             if safe:
                 log.warning('SaltReqTimeoutError: {0}'.format(e))
-                return 'retry'
+                return 'timeout'
             raise SaltClientError
 
         if 'load' in payload:
@@ -521,7 +520,7 @@ class SAuth(Auth):
                 self.opts['auth_timeout'],
                 self.opts.get('_safe_auth', True)
             )
-            if creds == 'retry':
+            if creds == 'retry' or creds == 'timeout':
                 if self.opts.get('caller'):
                     print('Minion failed to authenticate with the master, '
                           'has the minion key been accepted?')


### PR DESCRIPTION
if master is not responding, its possible it has changed IP addresses.
this fix causes the minion to restart after the minion is offline, leading to the resolved master dns ip address being used throughout the minion.

minion config should have something like:
auth_timeout_count_max= 10
restart_on_error=True
hartbeat_wait_time=600

these settings will have minions reconnecting to master after a DDNS change in about ~10min
