### PR TITLE
Implemented win_dns_client.primary_suffix

### DIFF
--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -94,10 +94,9 @@ def dns_dhcp(name, interface='Local Area Connection'):
 
     return ret
 
-def suffix(name,
+def primary_suffix(name,
         suffix=None,
-        updates=False,
-        **kwargs):
+        updates=False):
     '''
     .. versionadded:: TODO
 
@@ -123,7 +122,6 @@ def suffix(name,
             'changes': {},
             'result': True,
             'comment': 'No changes needed'
-            # TODO: REMOVE: 'comment': 'Global primary DNS suffix is set to {0!r}.'.format(suffix)
     }
 
     suffix = str(suffix)
@@ -143,7 +141,7 @@ def suffix(name,
     reg_data = {
             'suffix': {
                 'hkey': 'HKEY_LOCAL_MACHINE',
-                'path': 'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'path': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
                 'key':  'NV Domain',
                 'type': 'REG_SZ',
                 'old':  None,
@@ -151,7 +149,7 @@ def suffix(name,
             },
             'updates': {
                 'hkey': 'HKEY_LOCAL_MACHINE',
-                'path': 'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'path': r'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
                 'key':  'SyncDomainWithMembership',
                 'type': 'REG_DWORD',
                 'old':  None,
@@ -168,7 +166,7 @@ def suffix(name,
             reg_data['updates']['hkey'],
             reg_data['updates']['path'],
             reg_data['updates']['key'],))
- 
+
     updates_operation = 'enabled' if reg_data['updates']['new'] else 'disabled'
 
     # No changes to suffix needed

--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -112,7 +112,7 @@ def primary_suffix(name,
     .. code-block:: yaml
 
         primary_dns_suffix:
-            win_dns_client.suffix:
+            win_dns_client.primary_suffix:
                 - suffix: sub.domain.tld
                 - updates: True
     '''

--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -93,3 +93,134 @@ def dns_dhcp(name, interface='Local Area Connection'):
                 ).format(interface)
 
     return ret
+
+def suffix(name,
+        suffix=None,
+        updates=False,
+        **kwargs):
+    '''
+    .. versionadded:: TODO
+
+    Configure the global primary DNS suffix of a DHCP client.
+
+    suffix : None
+        The suffix which is advertised for this client when acquiring a DHCP lease
+        When none is set, the explicitely configured DNS suffix will be removed.
+
+    updates : False
+        Allow syncing the DNS suffix with the AD domain when the client's AD domain membership changes
+
+    .. code-block:: yaml
+
+        primary_dns_suffix:
+            win_dns_client.suffix:
+                - suffix: sub.domain.tld
+                - updates: True
+    '''
+
+    ret = {
+            'name': name,
+            'changes': {},
+            'result': True,
+            'comment': 'No changes needed'
+            # TODO: REMOVE: 'comment': 'Global primary DNS suffix is set to {0!r}.'.format(suffix)
+    }
+
+    suffix = str(suffix)
+
+    errors = []
+
+    if not isinstance(updates, bool):
+        ret['result'] = False
+        ret['comment'] = '\'updates\' must be a boolean value'
+        return ret
+
+    # TODO: waiting for an implementation of
+    # https://github.com/saltstack/salt/issues/6792 to be able to handle the
+    # requirement for a reboot to actually apply this state.
+    # Until then, this method will only be able to verify that the required
+    # value has been written to the registry and rebooting needs to be handled
+    # manually
+
+    reg_data = {
+            'suffix': {
+                'hkey': 'HKEY_LOCAL_MACHINE',
+                'path': 'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'key':  'NV Domain',
+                'type': 'REG_SZ',
+                'old':  None,
+                'new':  suffix
+            },
+            'updates': {
+                'hkey': 'HKEY_LOCAL_MACHINE',
+                'path': 'SYSTEM\CurrentControlSet\services\Tcpip\Parameters',
+                'key':  'SyncDomainWithMembership',
+                'type': 'REG_DWORD',
+                'old':  None,
+                'new':  updates
+            }
+    }
+
+    reg_data['suffix']['old'] = __salt__['reg.read_key'](
+            reg_data['suffix']['hkey'],
+            reg_data['suffix']['path'],
+            reg_data['suffix']['key'],)
+
+    reg_data['updates']['old'] = bool(__salt__['reg.read_key'](
+            reg_data['updates']['hkey'],
+            reg_data['updates']['path'],
+            reg_data['updates']['key'],))
+ 
+    updates_operation = 'enabled' if reg_data['updates']['new'] else 'disabled'
+
+    # No changes to suffix needed
+    if reg_data['suffix']['new'] == reg_data['suffix']['old']:
+        # No changes to updates policy needed
+        if reg_data['updates']['new'] == reg_data['updates']['old']:
+            return ret
+        # Changes to update policy needed
+        else:
+            ret['comment'] = '{0} suffix updates'.format(updates_operation)
+            ret['changes'] = {
+                    'old': {
+                        'updates': reg_data['updates']['old']},
+                    'new': {
+                        'updates': reg_data['updates']['new']}}
+    # Changes to suffix needed
+    else:
+        # Changes to updates policy needed
+        if reg_data['updates']['new'] != reg_data['updates']['old']:
+            ret['comment'] = 'Updated primary DNS suffix ({0}) and {1} suffix updates'.format(suffix, updates_operation)
+            ret['changes'] = {
+                    'old': {
+                        'suffix': reg_data['suffix']['old'],
+                        'updates': reg_data['updates']['old']},
+                    'new': {
+                        'suffix': reg_data['suffix']['new'],
+                        'updates': reg_data['updates']['new']}}
+        # No changes to updates policy needed
+        else:
+            ret['comment'] = 'Updated primary DNS suffix ({0})'.format(suffix)
+            ret['changes'] = {
+                    'old': {
+                        'suffix': reg_data['suffix']['old']},
+                    'new': {
+                        'suffix': reg_data['suffix']['new']}}
+
+    suffix_result = __salt__['reg.set_key'](
+            reg_data['suffix']['hkey'],
+            reg_data['suffix']['path'],
+            reg_data['suffix']['key'],
+            reg_data['suffix']['new'],
+            reg_data['suffix']['type'])
+
+    updates_result = __salt__['reg.set_key'](
+            reg_data['updates']['hkey'],
+            reg_data['updates']['path'],
+            reg_data['updates']['key'],
+            reg_data['updates']['new'],
+            reg_data['updates']['type'])
+
+    ret['result'] = suffix_result & updates_result
+
+    return ret

--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -128,8 +128,6 @@ def suffix(name,
 
     suffix = str(suffix)
 
-    errors = []
-
     if not isinstance(updates, bool):
         ret['result'] = False
         ret['comment'] = '\'updates\' must be a boolean value'


### PR DESCRIPTION
This allows to set the primary DNS suffix on Windows clients. It is advertised to DHCP servers to be used for dynamic DNS updates.

The 'updates' option defines, whether the primary DNS suffix will be kept in sync when the domain of the client changes or not.

Tested it on Win7 x64 Enterprise so far.
