### PR TITLE
Minion restart if master is not responding

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -127,7 +127,22 @@
 # in seconds, for each individual attempt. After this timeout expires, the minion
 # will wait for acceptance_wait_time seconds before trying again.
 # Unless your master is under unusually heavy load, this should be left at the default.
-#auth_timeout: 3
+#auth_timeout: 60
+
+# Fail after consecutive SaltReqTimeoutError when trying to authenticate with the master.
+# Using this setting with restart_on_error will help recover if the Master
+# changed ip address (DDNS).  A value of 10 is reasonable.
+#auth_timeout_count_max: None
+
+# If the minion hits an issue that causes SaltSystemExit then reconnect the minion
+# When using auth_timeout_count_max and hartbeat_wait_time you will want to enable this,
+#restart_on_error: False
+
+# Number of seconds the minion should wait after not receving anything from the master
+# before sending a ping to the Master to ensure there is an active connection.
+# This is required if you want your minion to recover if the Master changes IP addresses.
+# In production 21600 (6 hours) is reasonable.
+#hartbeat_wait_time: None
 
 
 # If you don't have any problems with syn-floods, dont bother with the

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -241,23 +241,20 @@ class Minion(parsers.MinionOptionParser):
 
         NOTE: Run any required code before calling `super()`.
         '''
-        reconnect = True
-        while reconnect:
-            reconnect = False
-            try:
-                self.prepare()
-                if check_user(self.config['user']):
-                    self.minion.tune_in()
-            except KeyboardInterrupt as exc:
-                logger.warn('Stopping the Salt Minion')
-                logger.warn('Exiting on Ctrl-c')
-            except SaltSystemExit as exc:
-                logger.error(exc)
-                if self.config.get('restart_on_error'):
-                    logger.warn('** Restarting minion **')
-                    reconnect = True
-            finally:
-                self.shutdown()
+        try:
+            self.prepare()
+            if check_user(self.config['user']):
+                self.minion.tune_in()
+        except KeyboardInterrupt as exc:
+            logger.warn('Stopping the Salt Minion')
+            logger.warn('Exiting on Ctrl-c')
+        except SaltSystemExit as exc:
+            logger.error(exc)
+            if self.config.get('restart_on_error'):
+                logger.warn('** Restarting minion **')
+                raise exc
+        finally:
+            self.shutdown()
 
     def shutdown(self):
         '''

--- a/salt/config.py
+++ b/salt/config.py
@@ -323,12 +323,15 @@ DEFAULT_MINION_OPTS = {
     'keysize': 4096,
     'transport': 'zeromq',
     'auth_timeout': 60,
+    'auth_timeout_count_max': None,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),
     'ioflo_verbose': 0,
     'ioflo_period': 0.01,
     'ioflo_realtime': True,
     'raet_port': 4510,
+    'restart_on_error': False,
+    'hartbeat_wait_time': None,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -345,10 +345,9 @@ class Auth(object):
                 timeout=timeout
             )
         except SaltReqTimeoutError as e:
-            self.opts.update(salt.minion.resolve_dns(self.opts))
             if safe:
                 log.warning('SaltReqTimeoutError: {0}'.format(e))
-                return 'retry'
+                return 'timeout'
             raise SaltClientError
 
         if 'load' in payload:
@@ -521,7 +520,7 @@ class SAuth(Auth):
                 self.opts['auth_timeout'],
                 self.opts.get('_safe_auth', True)
             )
-            if creds == 'retry':
+            if creds == 'retry' or creds == 'timeout':
                 if self.opts.get('caller'):
                     print('Minion failed to authenticate with the master, '
                           'has the minion key been accepted?')

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -7,6 +7,7 @@ This module contains the function calls to execute command line scripts
 from __future__ import print_function
 import os
 import sys
+import time
 
 # Import salt libs
 import salt
@@ -33,8 +34,19 @@ def salt_minion():
     '''
     if '' in sys.path:
         sys.path.remove('')
-    minion = salt.Minion()
-    minion.start()
+    
+    reconnect = True
+    while reconnect:
+        reconnect = False
+        try:
+            minion = salt.Minion()
+            minion.start()
+        except SaltSystemExit as exc:
+            minion = None
+            # I dont truest the minion to shutdown... perhaps ZMQ issue
+            # give system some time to shutdown
+            time.sleep(10)
+            reconnect = True
 
 
 def salt_syndic():


### PR DESCRIPTION
if master is not responding to minion, it could be because the master changed IP addresses.
this fix alows the minion to restart if the master is not accessible after a /somewhat/ configurable amount of time.
restarting the minion will cause the master dns ip address to be resolved and eventual successful connection.

minion config should have something like:
auth_timeout_count_max: 10
restart_on_error: True
hartbeat_wait_time: 2400

these settings will have minions reconnecting to master after a DDNS change in about ~30min avg.
