### PR TITLE
Remove unused import

### DIFF
--- a/salt/modules/ldapmod.py
+++ b/salt/modules/ldapmod.py
@@ -39,7 +39,7 @@ import time
 import logging
 
 # Import salt libs
-from salt.exceptions import CommandExecutionError, SaltInvocationError
+from salt.exceptions import CommandExecutionError
 
 # Import third party libs
 try:


### PR DESCRIPTION
30d9675 removed the only reference to `SaltInvocationError`, but left the
import. This removes it.
