### PR TITLE
skip portsnap interactive check

### DIFF
--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -36,6 +36,16 @@ def __virtual__():
     return __virtualname__ if __grains__.get('os', '') == 'FreeBSD' else False
 
 
+def _portsnap():
+    '''
+    Return 'portsnap --interactive' for FreeBSD 10, otherwise 'portsnap'
+    '''
+    return 'portsnap{0}'.format(
+        ' --interactive' if float(__grains__['osrelease']) >= 10
+        else ''
+    )
+
+
 def _check_portname(name):
     '''
     Check if portname is valid and whether or not the directory exists in the
@@ -359,7 +369,7 @@ def update(extract=False):
 
         salt '*' ports.update
     '''
-    result = __salt__['cmd.run_all']('portsnap --interactive fetch')
+    result = __salt__['cmd.run_all']('{0} fetch'.format(_portsnap()))
     if not result['retcode'] == 0:
         raise CommandExecutionError(
             'Unable to fetch ports snapshot: {0}'.format(result['stderr'])
@@ -384,13 +394,13 @@ def update(extract=False):
     ret.append('Fetched {0} new ports or files'.format(new_port_count))
 
     if extract:
-        result = __salt__['cmd.run_all']('portsnap --interactive extract')
+        result = __salt__['cmd.run_all']('{0} extract'.format(_portsnap()))
         if not result['retcode'] == 0:
             raise CommandExecutionError(
                 'Unable to extract ports snapshot {0}'.format(result['stderr'])
             )
 
-    result = __salt__['cmd.run_all']('portsnap --interactive update')
+    result = __salt__['cmd.run_all']('{0} update'.format(_portsnap()))
     if not result['retcode'] == 0:
         raise CommandExecutionError(
             'Unable to apply ports snapshot: {0}'.format(result['stderr'])

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -359,7 +359,7 @@ def update(extract=False):
 
         salt '*' ports.update
     '''
-    result = __salt__['cmd.run_all']('portsnap fetch')
+    result = __salt__['cmd.run_all']('portsnap --interactive fetch')
     if not result['retcode'] == 0:
         raise CommandExecutionError(
             'Unable to fetch ports snapshot: {0}'.format(result['stderr'])
@@ -384,13 +384,13 @@ def update(extract=False):
     ret.append('Fetched {0} new ports or files'.format(new_port_count))
 
     if extract:
-        result = __salt__['cmd.run_all']('portsnap extract')
+        result = __salt__['cmd.run_all']('portsnap --interactive extract')
         if not result['retcode'] == 0:
             raise CommandExecutionError(
                 'Unable to extract ports snapshot {0}'.format(result['stderr'])
             )
 
-    result = __salt__['cmd.run_all']('portsnap update')
+    result = __salt__['cmd.run_all']('portsnap --interactive update')
     if not result['retcode'] == 0:
         raise CommandExecutionError(
             'Unable to apply ports snapshot: {0}'.format(result['stderr'])


### PR DESCRIPTION
This is the error i got running `ports.update`:

```
[INFO    ] Executing command '/sbin/zfs help || :' in directory '/root'
[INFO    ] Executing command '/sbin/zfs help || :' in directory '/root'
[INFO    ] Executing command 'portsnap fetch' in directory '/root'
[ERROR   ] Command 'portsnap fetch' failed with return code: 1
[ERROR   ] stdout: portsnap fetch should not be run non-interactively.
Run portsnap cron instead
Error running 'ports.update': Unable to fetch ports snapshot:
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

chmod +x /tmp/vagrant-shell && /tmp/vagrant-shell

Stdout from the command:



Stderr from the command:

[INFO    ] Executing command '/sbin/zfs help || :' in directory '/root'
[INFO    ] Executing command '/sbin/zfs help || :' in directory '/root'
[INFO    ] Executing command 'portsnap fetch' in directory '/root'
[ERROR   ] Command 'portsnap fetch' failed with return code: 1
[ERROR   ] stdout: portsnap fetch should not be run non-interactively.
Run portsnap cron instead
Error running 'ports.update': Unable to fetch ports snapshot:
```

On FreeBSD 10 which im running, portsnap has a `--interactive` flag, that can be used in this case. This is what i have provided in the pull request.

In FreeBSD 9 portsnap has to be patched, but im not quite sure how to implement this.
Looking at this implementation - https://github.com/opscode-cookbooks/freebsd/blob/master/recipes/portsnap.rb#L25 - They are replacing `[ ! -t 0 ]` with `false` in the following section of portsnap:

```
cmd_fetch() {
    if [ ! -t 0 ]; then
        echo -n "`basename $0` fetch should not "
        echo "be run non-interactively."
        echo "Run `basename $0` cron instead."
        exit 1
    fi
    fetch_check_params
    fetch_run || exit 1
}
```
