### PR TITLE
Fix doc typos about s3.verify_ssl flag

### DIFF
--- a/salt/modules/s3.py
+++ b/salt/modules/s3.py
@@ -32,7 +32,7 @@ Connection module for Amazon S3
 
     s3.verify_ssl: False
 
-    This is required if using S3 bucketnames that have a period in them due, as
+    This is required if using S3 bucket names that contain a period, as
     these will not match Amazon's S3 wildcard certificates. Certificate
     verification is enabled by default.
 

--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -51,7 +51,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
 
     s3.verify_ssl: False
 
-    This is required if using S3 bucketnames that have a period in them due, as
+    This is required if using S3 bucket names that contain a period, as
     these will not match Amazon's S3 wildcard certificates. Certificate
     verification is enabled by default.
     '''


### PR DESCRIPTION
Fixing typos in the docs for the s3.verify_ssl flag. Addresses comment by @cvrebert in PR #12273 and issue #12200.
