### PR TITLE
Job cache

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -118,9 +118,9 @@ class LocalClient(object):
                 self.opts['transport'],
                 listen=not self.opts.get('__worker', False))
 
-        self.returners = salt.loader.returner(self.opts['master_job_cache'],
-                                                      self.opts,
-                                                      {})
+        self.returner = salt.loader.returner(self.opts['master_job_cache'],
+                                             self.opts,
+                                             {})
 
     def __read_master_key(self):
         '''
@@ -795,7 +795,7 @@ class LocalClient(object):
         timeout_at = start + timeout
         found = set()
         # Check to see if the jid is real, if not return the empty dict
-        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returner['get_load'](jid) != {}:
             log.warning("jid does not exist")
             yield {}
             # stop the iteration, since the jid is invalid
@@ -898,7 +898,7 @@ class LocalClient(object):
         found = set()
         ret = {}
         # Check to see if the jid is real, if not return the empty dict
-        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returner['get_load'](jid) != {}:
             log.warning("jid does not exist")
             return ret
 
@@ -939,7 +939,7 @@ class LocalClient(object):
         # create the iterator-- since we want to get anyone in the middle
         event_iter = self.get_event_iter_returns(jid, minions, timeout=timeout)
 
-        data = self.returners['{0}.get_jid'.format(self.opts['master_job_cache'])](jid)
+        data = self.returner['get_jid'](jid)
         for minion in data:
             m_data = {}
             if u'return' in data[minion]:
@@ -982,7 +982,7 @@ class LocalClient(object):
         '''
         ret = {}
 
-        data = self.returners['{0}.get_jid'.format(self.opts['master_job_cache'])](jid)
+        data = self.returner['get_jid'](jid)
         for minion in data:
             m_data = {}
             if u'return' in data[minion]:
@@ -1027,7 +1027,7 @@ class LocalClient(object):
         found = set()
         ret = {}
         # Check to see if the jid is real, if not return the empty dict
-        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returner['get_load'](jid) != {}:
             log.warning("jid does not exist")
             return ret
         # Wait for the hosts to check in
@@ -1104,7 +1104,7 @@ class LocalClient(object):
         timeout_at = start + timeout
         found = set()
         # Check to see if the jid is real, if not return the empty dict
-        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returner['get_load'](jid) != {}:
             log.warning("jid does not exist")
             yield {}
             # stop the iteration, since the jid is invalid
@@ -1202,7 +1202,7 @@ class LocalClient(object):
 
         found = set()
         # Check to see if the jid is real, if not return the empty dict
-        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returner['get_load'](jid) != {}:
             log.warning("jid does not exist")
             yield {}
             # stop the iteration, since the jid is invalid

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -31,6 +31,7 @@ from datetime import datetime
 import salt.config
 import salt.payload
 import salt.transport
+import salt.loader
 import salt.utils
 import salt.utils.args
 import salt.utils.event
@@ -73,6 +74,8 @@ def get_local_client(
     elif opts['transport'] == 'zeromq':
         return LocalClient(mopts=opts)
 
+class Foo(object):
+    pass
 
 class LocalClient(object):
     '''
@@ -117,7 +120,9 @@ class LocalClient(object):
                 self.opts['transport'],
                 listen=not self.opts.get('__worker', False))
 
-        self.mminion = salt.minion.MasterMinion(self.opts)
+        self.returners = salt.loader.returner(self.opts['master_job_cache'],
+                                                      self.opts,
+                                                      {})
 
     def __read_master_key(self):
         '''
@@ -792,7 +797,7 @@ class LocalClient(object):
         timeout_at = start + timeout
         found = set()
         # Check to see if the jid is real, if not return the empty dict
-        if not self.mminion.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
             log.warning("jid does not exist")
             yield {}
             # stop the iteration, since the jid is invalid
@@ -895,7 +900,7 @@ class LocalClient(object):
         found = set()
         ret = {}
         # Check to see if the jid is real, if not return the empty dict
-        if not self.mminion.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
             log.warning("jid does not exist")
             return ret
 
@@ -936,7 +941,7 @@ class LocalClient(object):
         # create the iterator-- since we want to get anyone in the middle
         event_iter = self.get_event_iter_returns(jid, minions, timeout=timeout)
 
-        data = self.mminion.returners['{0}.get_jid'.format(self.opts['master_job_cache'])](jid)
+        data = self.returners['{0}.get_jid'.format(self.opts['master_job_cache'])](jid)
         for minion in data:
             m_data = {}
             if u'return' in data[minion]:
@@ -979,7 +984,7 @@ class LocalClient(object):
         '''
         ret = {}
 
-        data = self.mminion.returners['{0}.get_jid'.format(self.opts['master_job_cache'])](jid)
+        data = self.returners['{0}.get_jid'.format(self.opts['master_job_cache'])](jid)
         for minion in data:
             m_data = {}
             if u'return' in data[minion]:
@@ -1024,7 +1029,7 @@ class LocalClient(object):
         found = set()
         ret = {}
         # Check to see if the jid is real, if not return the empty dict
-        if not self.mminion.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
             log.warning("jid does not exist")
             return ret
         # Wait for the hosts to check in
@@ -1101,7 +1106,7 @@ class LocalClient(object):
         timeout_at = start + timeout
         found = set()
         # Check to see if the jid is real, if not return the empty dict
-        if not self.mminion.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
             log.warning("jid does not exist")
             yield {}
             # stop the iteration, since the jid is invalid
@@ -1199,7 +1204,7 @@ class LocalClient(object):
 
         found = set()
         # Check to see if the jid is real, if not return the empty dict
-        if not self.mminion.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
+        if not self.returners['{0}.get_load'.format(self.opts['master_job_cache'])](jid) != {}:
             log.warning("jid does not exist")
             yield {}
             # stop the iteration, since the jid is invalid

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -74,8 +74,6 @@ def get_local_client(
     elif opts['transport'] == 'zeromq':
         return LocalClient(mopts=opts)
 
-class Foo(object):
-    pass
 
 class LocalClient(object):
     '''

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -176,6 +176,15 @@ def returners(opts, functions, whitelist=None):
             'value': functions}
     return load.gen_functions(pack, whitelist=whitelist)
 
+def returner(name, opts, functions):
+    '''
+    Returns a single returner module
+    '''
+    load = _create_loader(opts, 'returners', 'returner')
+    pack = {'name': '__salt__',
+            'value': functions}
+    return load.gen_module(name, functions, pack)
+
 
 def pillars(opts, functions):
     '''
@@ -546,11 +555,15 @@ class Loader(object):
             fn_ = os.path.join(mod_dir, name)
             if os.path.isdir(fn_):
                 full = fn_
+                break
             else:
                 for ext in ('.py', '.pyo', '.pyc', '.so'):
                     full_test = '{0}{1}'.format(fn_, ext)
                     if os.path.isfile(full_test):
                         full = full_test
+                        break
+                if full:
+                    break
         if not full:
             return None
 
@@ -655,7 +668,7 @@ class Loader(object):
             context = sys.modules[
                 functions[functions.keys()[0]].__module__
             ].__context__
-        except AttributeError:
+        except (AttributeError, IndexError):
             context = {}
         mod.__context__ = context
         return funcs

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -183,7 +183,15 @@ def returner(name, opts, functions):
     load = _create_loader(opts, 'returners', 'returner')
     pack = {'name': '__salt__',
             'value': functions}
-    return load.gen_module(name, functions, pack)
+
+    tmp = load.gen_module(name, functions, pack)
+    # TODO: maybe don't do this in the gen_module?
+    for key, val in tmp.items():
+        new_key = key.replace('{0}.'.format(name), '')
+        tmp[new_key] = val
+        del tmp[key]
+
+    return tmp
 
 
 def pillars(opts, functions):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -398,7 +398,6 @@ class MinionBase(object):
             )
         return loop_interval
 
-
 class MasterMinion(object):
     '''
     Create a fully loaded minion function object for generic use on the


### PR DESCRIPTION
Make the master_job_cache not load the grains/modules (since they are slow). I'll need to add some mechanism to lazy load them or something if people want them... but since this is still undocumented its probably better to be fast ;)
