### PR TITLE
Fix refs to with_system_account decorator

### DIFF
--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -20,7 +20,7 @@ from salttesting import skipIf
 from salttesting.helpers import (
     destructiveTest,
     ensure_in_syspath,
-    with_system_account
+    with_system_user
 )
 ensure_in_syspath('../../')
 
@@ -177,7 +177,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
-    @with_system_account('issue-6912', on_existing='delete', delete=True)
+    @with_system_user('issue-6912', on_existing='delete', delete=True)
     def test_issue_6912_wrong_owner(self, username):
         venv_dir = os.path.join(
             integration.SYS_TMP_DIR, '6912-wrong-owner'

--- a/tests/integration/states/ssh.py
+++ b/tests/integration/states/ssh.py
@@ -13,7 +13,7 @@ from salttesting import skipIf
 from salttesting.helpers import (
     destructiveTest,
     ensure_in_syspath,
-    with_system_account
+    with_system_user
 )
 ensure_in_syspath('../../')
 
@@ -158,7 +158,7 @@ class SSHAuthStateTests(integration.ModuleCase,
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
-    @with_system_account('issue_7409', on_existing='delete', delete=True)
+    @with_system_user('issue_7409', on_existing='delete', delete=True)
     def test_issue_7409_no_linebreaks_between_keys(self, username):
 
         userdetails = self.run_function('user.info', [username])
@@ -193,7 +193,7 @@ class SSHAuthStateTests(integration.ModuleCase,
 
     @destructiveTest
     @skipIf(os.geteuid() != 0, 'you must be root to run this test')
-    @with_system_account('issue_10198', on_existing='delete', delete=True)
+    @with_system_user('issue_10198', on_existing='delete', delete=True)
     def test_issue_10198_keyfile_from_another_env(self, username=None):
         userdetails = self.run_function('user.info', [username])
         user_ssh_dir = os.path.join(userdetails['home'], '.ssh')


### PR DESCRIPTION
**This should not be merged until the corresponding pull request described below has been merged. These tests will fail, and the issue should be closed and re-opened after the corresponding pull request has been merged, in order to re-test with the new salt-testing code.**

This renames this decorator to with_system_user, to go along with
changes in https://github.com/saltstack/salt-testing/pull/14.
