### PR TITLE
git module: support windows

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -15,7 +15,7 @@ def __virtual__():
     '''
     Only load if git exists on the system
     '''
-    return utils.which('git')
+    return True if utils.which('git') else False
 
 
 def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -5,11 +5,7 @@ Support for the Git SCM
 
 # Import python libs
 import os
-try:
-    import pipes
-    HAS_PIPES = True
-except ImportError:
-    HAS_PIPES = False
+import subprocess
 
 # Import salt libs
 from salt import utils, exceptions
@@ -19,9 +15,7 @@ def __virtual__():
     '''
     Only load if git exists on the system
     '''
-    if not all((utils.which('git'), HAS_PIPES)):
-        return False
-    return True
+    return utils.which('git')
 
 
 def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):
@@ -597,9 +591,10 @@ def commit(cwd, message, user=None, opts=None):
         salt '*' git.commit /path/to/git/repo 'The commit message'
     '''
 
-    if not opts:
-        opts = ''
-    cmd = 'git commit -m {0} {1}'.format(pipes.quote(message), opts)
+    cmd = subprocess.list2cmdline(['git', 'commit', '-m', message])
+    # add opts separately; they don't need to be quoted
+    if opts:
+        cmd = cmd + ' ' + opts
     return _git_run(cmd, cwd=cwd, runas=user)
 
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -231,7 +231,7 @@ def latest(name,
                                              user=user)
 
                 # check if we are on a branch to merge changes
-                cmd = "git symbolic-ref -q HEAD > /dev/null"
+                cmd = "git symbolic-ref -q HEAD"
                 retcode = __salt__['cmd.retcode'](cmd, cwd=target, runas=user)
                 if 0 == retcode:
                     __salt__['git.fetch' if bare else 'git.pull'](target,
@@ -374,9 +374,9 @@ def present(name, bare=True, runas=None, user=None, force=False):
 
     # If the named directory is a git repo return True
     if os.path.isdir(name):
-        if bare and os.path.isfile('{0}/HEAD'.format(name)):
+        if bare and os.path.isfile(os.path.join(name, 'HEAD')):
             return ret
-        elif not bare and os.path.isdir('{0}/.git'.format(name)):
+        elif not bare and os.path.isdir(os.path.join(name, '.git')):
             return ret
         # Directory exists and is not a git repo, if force is set destroy the
         # directory and recreate, otherwise throw an error

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -18,6 +18,7 @@ authentication, it is also possible to pass private keys to use explicitly.
 # Import python libs
 import logging
 import os
+import os.path
 import shutil
 
 # Import salt libs
@@ -156,9 +157,8 @@ def latest(name,
 
     bare = bare or mirror
     check = 'refs' if bare else '.git'
-
-    if os.path.isdir(target) and os.path.isdir('{0}/{1}'.format(target,
-                                                                check)):
+    checkdir = os.path.join(target, check)
+    if os.path.isdir(target) and os.path.isdir(checkdir):
         # git pull is probably required
         log.debug(('target {0} is found, "git pull" '
                    'is probably required'.format(target)))


### PR DESCRIPTION
remove dependence on `pipes.quote` in favor of
`subprocess.list2cmdline`, which is cross-platform. This permits the
git module to be used by windows minions.

`list2cmdline` quotes a little differently than `pipes.quote`, but
produces a safe result:

```
>>> x = 'A & "B"'
>>> print pipes.quote(x)
'A & "B"'
>>> print subprocess.list2cmdline([x])
"A & \"B\""
```

Discussed awhile back at: https://groups.google.com/forum/#!topic/salt-users/N_E4Y4mfp7k
