### PR TITLE
Remove redundant mkdirs argument

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2670,8 +2670,7 @@ def manage_file(name,
                 template=None,   # pylint: disable=W0613
                 show_diff=True,
                 contents=None,
-                dir_mode=None,
-                mkdirs=False):
+                dir_mode=None):
     '''
     Checks the destination against what was retrieved with get_managed and
     makes the appropriate modifications (if necessary).
@@ -2816,7 +2815,7 @@ def manage_file(name,
                     ret['result'] = False
                     return ret
             if not os.path.isdir(os.path.dirname(name)):
-                if makedirs and mkdirs:
+                if makedirs:
                     # check for existence of windows drive letter
                     if salt.utils.is_windows():
                         drive, _ = os.path.splitdrive(name)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1280,9 +1280,7 @@ def managed(name,
                 template,
                 show_diff,
                 contents,
-                dir_mode,
-                makedirs
-            )
+                dir_mode)
         except Exception as exc:
             ret['changes'] = {}
             log.debug(traceback.format_exc())


### PR DESCRIPTION
This was obsoleted when we renamed makedirs() to makedirs_() and made a
func_alias for it. It does not exist in any officially released code, so
no need to deprecate it.
