### PR TITLE
Tweak loglevel for dmidecode warning

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -141,7 +141,7 @@ def _linux_gpu_data():
 
     lspci = salt.utils.which('lspci')
     if not lspci:
-        log.info(
+        log.debug(
             'The `lspci` binary is not available on the system. GPU grains '
             'will not be available.'
         )
@@ -1286,7 +1286,7 @@ def _dmidecode_data(regex_dict):
     elif salt.utils.which('smbios'):
         out = __salt__['cmd.run']('smbios')
     else:
-        log.warning(
+        log.debug(
             'The `dmidecode` binary is not available on the system. GPU '
             'grains will not be available.'
         )


### PR DESCRIPTION
In 18056a3 I changed the loglevel to WARNING, in my brain that was the
next _less_ verbose loglevel, when in reality this should have been
changed to DEBUG.

Since the change, now all salt CLI commands show this warning since the
default CLI loglevel is warning. This is obviously not what I intended.

Also, this changes the warning about lspci to loglevel DEBUG.
