### PR TITLE
RHEL 7 should use the systemd module

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -57,7 +57,7 @@ def __virtual__():
         if __grains__['os'] == 'Fedora':
             if __grains__.get('osrelease', 0) > 15:
                 return False
-    	if __grains__['os'] == 'RedHat':
+        if __grains__['os'] == 'RedHat':
             if __grains__.get('osrelease', 0) >= 7:
                 return False
         return __virtualname__

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -57,6 +57,9 @@ def __virtual__():
         if __grains__['os'] == 'Fedora':
             if __grains__.get('osrelease', 0) > 15:
                 return False
+    	if __grains__['os'] == 'RedHat':
+            if __grains__.get('osrelease', 0) >= 7:
+                return False
         return __virtualname__
     return False
 


### PR DESCRIPTION
Red Hat dropped the support for Upstart in RHEL7. On this OS, salt should now use the systemd module instead of rh_service.

(tested on RHEL7 RC)
