### PR TITLE
PEP8/PEP20: use kwargs.get instead of one line if/else

### DIFF
--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -101,7 +101,7 @@ class ZeroMQChannel(Channel):
         self.ttype = 'zeromq'
 
         # crypt defaults to 'aes'
-        self.crypt = kwargs['crypt'] if 'crypt' in kwargs else 'aes'
+        self.crypt = kwargs.get('crypt', 'aes')
 
         self.serial = salt.payload.Serial(opts)
         if self.crypt != 'clear':


### PR DESCRIPTION
I was poking around in the transport code thinking about an idea and noticed this simplification.
