### PR TITLE
Fix iptables checking on RedHat

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -479,20 +479,8 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
     if not rule:
         return 'Error: Rule needs to be specified'
 
-    if __grains__['os_family'] == 'RedHat':
-        cmd = '{0}-save' . format(_iptables_cmd(family))
-        out = __salt__['cmd.run'](cmd).find('-A {1} {2}'.format(
-            table,
-            chain,
-            rule,
-        ))
-        if out != -1:
-            out = ''
-        else:
-            return False
-    else:
-        cmd = '{0} -t {1} -C {2} {3}'.format(_iptables_cmd(family), table, chain, rule)
-        out = __salt__['cmd.run'](cmd)
+    cmd = '{0} -t {1} -C {2} {3}'.format(_iptables_cmd(family), table, chain, rule)
+    out = __salt__['cmd.run'](cmd)
 
     if not out:
         return True


### PR DESCRIPTION
This is not working as it was envisioned it appears.  It does not
correctly take into account all of the different ways you could set an
iptables rule, from --in-interface or -i, to whatever you want.  It is
better to just use the built in iptables -C to check the chain for the
rule that it renders.

With this iptables-save stuff in place, it is currently giving me
duplicate rules for everything on RedHat distributions.
