### PR TITLE
Restart minion if master is not responding

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -127,7 +127,32 @@
 # in seconds, for each individual attempt. After this timeout expires, the minion
 # will wait for acceptance_wait_time seconds before trying again.
 # Unless your master is under unusually heavy load, this should be left at the default.
-#auth_timeout: 3
+#auth_timeout: 60
+
+
+# Number of consecutive SaltReqTimeoutError that are acceptable when trying to authenticate.
+#auth_tries: 1
+
+# If authentication failes due to SaltReqTimeoutError, continue without ending minion.
+#auth_safemode: True
+
+# If the minion hits an error that is recoverable, restart the minion.
+#restart_on_error: False
+
+# Ping Master to ensure connection is alive.
+#ping_interval: 0
+
+# To recover the minions if master uses DDNS/CNAME and changes IP address:
+#
+#    auth_tries: 10
+#    auth_safemode: False
+#    ping_interval: 90
+#    restart_on_error: True
+#
+# Minions wont know master is missing untill a ping fails.
+# TODO: perhaps could update the scheduler to raise Exception in main thread after /mine_interval (60 minutes)/ fails
+# After the fail, the minion will attempt authentication and likly fails out and cause the restart.
+# When the minion restarts it will resolve the Masters IP and attempt to reconnect.
 
 
 # If you don't have any problems with syn-floods, dont bother with the

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -7,6 +7,8 @@ Make me some salt!
 import os
 import sys
 import warnings
+import time
+from random import randrange
 
 # All salt related deprecation warnings should be shown once each!
 warnings.filterwarnings(
@@ -41,7 +43,7 @@ try:
 except ImportError as exc:
     if exc.args[0] != 'No module named _msgpack':
         raise
-from salt.exceptions import SaltSystemExit, MasterExit
+from salt.exceptions import SaltSystemExit, MasterExit, SaltClientError
 
 
 # Let's instantiate logger using salt.log.setup.logging.getLogger() so pylint
@@ -241,8 +243,8 @@ class Minion(parsers.MinionOptionParser):
 
         NOTE: Run any required code before calling `super()`.
         '''
-        self.prepare()
         try:
+            self.prepare()
             if check_user(self.config['user']):
                 self.minion.tune_in()
         except (KeyboardInterrupt, SaltSystemExit) as exc:
@@ -251,6 +253,14 @@ class Minion(parsers.MinionOptionParser):
                 logger.warn('Exiting on Ctrl-c')
             else:
                 logger.error(str(exc))
+        except SaltClientError as exc:
+            logger.error(exc)
+            if self.config.get('restart_on_error'):
+                logger.warn('** Restarting minion **')
+                s = randrange(0, self.config.get('random_reauth_delay',10))
+                logger.info('Sleeping random_reauth_delay of {0} seconds'.format(s))
+                time.sleep(s)
+                return 'reconnect'
         finally:
             self.shutdown()
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -213,6 +213,8 @@ VALID_OPTS = {
     'enumerate_proxy_minions': bool,
     'gather_job_timeout': int,
     'auth_timeout': int,
+    'auth_tries': int,
+    'auth_safemode': bool,
     'random_master': bool,
     'syndic_event_forward_timeout': float,
     'syndic_max_event_process_time': float,
@@ -222,6 +224,8 @@ VALID_OPTS = {
     'ssh_timeout': float,
     'ssh_user': str,
     'raet_port': int,
+    'restart_on_error': bool,
+    'ping_interval': int,
 }
 
 # default configurations
@@ -323,12 +327,16 @@ DEFAULT_MINION_OPTS = {
     'keysize': 4096,
     'transport': 'zeromq',
     'auth_timeout': 60,
+    'auth_tries': 1,
+    'auth_safemode': False,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),
     'ioflo_verbose': 0,
     'ioflo_period': 0.01,
     'ioflo_realtime': True,
     'raet_port': 4510,
+    'restart_on_error': False,
+    'ping_interval': 0,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -327,7 +327,7 @@ class Auth(object):
             aes, token = self.decrypt_aes(payload, False)
             return aes
 
-    def sign_in(self, timeout=60, safe=True):
+    def sign_in(self, timeout=60, safe=True, tries=1):
         '''
         Send a sign in request to the master, sets the key information and
         returns a dict containing the master publish interface to bind to
@@ -339,17 +339,18 @@ class Auth(object):
         sreq = salt.payload.SREQ(
             self.opts['master_uri'],
         )
+        
         try:
             payload = sreq.send_auto(
                 self.minion_sign_in_payload(),
+                tries=tries,
                 timeout=timeout
             )
         except SaltReqTimeoutError as e:
-            self.opts.update(salt.minion.resolve_dns(self.opts))
             if safe:
                 log.warning('SaltReqTimeoutError: {0}'.format(e))
                 return 'retry'
-            raise SaltClientError
+            raise SaltClientError('Failed sign in request to the master')
 
         if 'load' in payload:
             if 'ret' in payload['load']:
@@ -518,8 +519,9 @@ class SAuth(Auth):
         '''
         while True:
             creds = self.sign_in(
-                self.opts['auth_timeout'],
-                self.opts.get('_safe_auth', True)
+                self.opts.get('auth_timeout', 60),
+                self.opts.get('auth_safemode', self.opts.get('_safe_auth', True)),
+                self.opts.get('auth_tries', 1)
             )
             if creds == 'retry':
                 if self.opts.get('caller'):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1400,6 +1400,13 @@ class Minion(MinionBase):
                     log.critical('Unexpected ZMQError while polling minion',
                                  exc_info=True)
                 continue
+            except SaltClientError:
+                if self.opts.get('restart_on_error'):
+                    raise
+                else:
+                    log.critical('An exception occurred while polling the minion',
+                                 exc_info=True
+                    )
             except Exception:
                 log.critical(
                     'An exception occurred while polling the minion',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -679,6 +679,9 @@ class Minion(MinionBase):
                 # We can't decode the master's response to our event,
                 # so we will need to re-authenticate.
                 self.authenticate()
+        except SaltReqTimeoutError:
+            log.info("Master failed to respond. Preforming re-authenticating")
+            self.authenticate()
         except Exception:
             log.info("fire_master failed: {0}".format(traceback.format_exc()))
 
@@ -1181,8 +1184,11 @@ class Minion(MinionBase):
         acceptance_wait_time_max = self.opts['acceptance_wait_time_max']
         if not acceptance_wait_time_max:
             acceptance_wait_time_max = acceptance_wait_time
+        
+        tries = self.opts.get('auth_tries', 1)
+        safe = self.opts.get('auth_safemode', safe)
         while True:
-            creds = auth.sign_in(timeout, safe)
+            creds = auth.sign_in(timeout, safe, tries)
             if creds != 'retry':
                 log.info('Authentication with master successful!')
                 break
@@ -1193,6 +1199,7 @@ class Minion(MinionBase):
             if acceptance_wait_time < acceptance_wait_time_max:
                 acceptance_wait_time += acceptance_wait_time
                 log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))
+                
         self.aes = creds['aes']
         if self.opts.get('syndic_master_publish_port'):
             self.publish_port = self.opts.get('syndic_master_publish_port')
@@ -1340,10 +1347,21 @@ class Minion(MinionBase):
                     exc)
             )
 
+        ping_interval = self.opts.get('ping_interval', 0)
+        ping_at = None
         while self._running is True:
             loop_interval = self.process_schedule(self, loop_interval)
             try:
                 socks = self._do_poll(loop_interval)
+              
+                if ping_interval > 0:
+                    if socks or not ping_at:
+                        ping_at = time.time() + (ping_interval * 60)
+                    if ping_at < time.time():
+                        log.debug('Ping master')
+                        self._fire_master('ping', 'minion_ping')
+                        ping_at = time.time() + (ping_interval * 60)
+
                 self._do_socket_recv(socks)
 
                 # Check the event system

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -177,11 +177,12 @@ class SREQ(object):
             tried += 1
             if polled:
                 break
-            elif tried >= tries:
+            if tries > 1:
+                log.info('SaltReqTimeoutError: after {0} seconds. (Try {1} of {2})'.format(
+                  timeout, tried, tries))
+            if tried >= tries:
                 raise SaltReqTimeoutError(
-                    'Waited {0} seconds'.format(
-                        timeout * tried
-                    )
+                    'SaltReqTimeoutError: after {0} seconds, ran {1} tries'.format(timeout * tried, tried)
                 )
         return self.serial.loads(self.socket.recv())
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -7,6 +7,7 @@ This module contains the function calls to execute command line scripts
 from __future__ import print_function
 import os
 import sys
+import time
 
 # Import salt libs
 import salt
@@ -33,8 +34,18 @@ def salt_minion():
     '''
     if '' in sys.path:
         sys.path.remove('')
-    minion = salt.Minion()
-    minion.start()
+    
+    reconnect = True
+    while reconnect:
+        reconnect = False
+        minion = salt.Minion()
+        ret = minion.start()
+        if ret == 'reconnect':
+            del minion
+            minion = None
+            # give extra time for resources like ZMQ to close.
+            time.sleep(10)
+            reconnect = True
 
 
 def salt_syndic():

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -101,15 +101,14 @@ def _get_fqhostname():
         return h_fqdn
     except socket.gaierror:
         return h_fqdn
-    else:
-        # Struct contanis the following elements:
-        #     family, socktype, proto, canonname, sockaddr
-        try:
-            # Prevent returning an empty string by falling back to
-            # socket.getfqdn()
-            return addrinfo[3] or h_fqdn
-        except IndexError:
-            return h_fqdn
+    # Struct contanis the following elements:
+    #     family, socktype, proto, canonname, sockaddr
+    try:
+        # Prevent returning an empty string by falling back to
+        # socket.getfqdn()
+        return addrinfo[3] or h_fqdn
+    except IndexError:
+        return h_fqdn
 
 
 def get_fqhostname():


### PR DESCRIPTION
Restart minion if master is not responding.

Adds config options so minion can ping master to ensure a connection.  If the ping fails the minion has the option to restart.  This solves the issue of a master that changes IP addresses (DDNS/CNAME)
