### PR TITLE
Minion restart if master is not responding

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -127,7 +127,32 @@
 # in seconds, for each individual attempt. After this timeout expires, the minion
 # will wait for acceptance_wait_time seconds before trying again.
 # Unless your master is under unusually heavy load, this should be left at the default.
-#auth_timeout: 3
+#auth_timeout: 60
+
+
+# Number of consecutive SaltReqTimeoutError that are acceptable when trying to authenticate.
+#auth_tries: 1
+
+# If authentication failes due to SaltReqTimeoutError, continue without ending minion.
+#auth_safemode: True
+
+# If the minion hits an error that is recoverable, restart the minion.
+#restart_on_error: False
+
+# Ping Master to ensure connection is alive (minutes).
+# TODO: perhaps could update the scheduler to raise Exception in main thread after /mine_interval (60 minutes)/ fails
+#ping_interval: 0
+
+# To auto recover Minions if Master changes IP address (DDNS)
+#
+#    auth_tries: 10
+#    auth_safemode: False
+#    ping_interval: 90
+#    restart_on_error: True
+#
+# Minions wont know master is missing untill a ping fails.  After the ping fail,
+# the minion will attempt authentication and likly fails out and cause a restart.
+# When the minion restarts it will resolve the Masters IP and attempt to reconnect.
 
 
 # If you don't have any problems with syn-floods, dont bother with the

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -7,6 +7,8 @@ Make me some salt!
 import os
 import sys
 import warnings
+import time
+from random import randint
 
 # All salt related deprecation warnings should be shown once each!
 warnings.filterwarnings(
@@ -41,7 +43,7 @@ try:
 except ImportError as exc:
     if exc.args[0] != 'No module named _msgpack':
         raise
-from salt.exceptions import SaltSystemExit, MasterExit
+from salt.exceptions import SaltSystemExit, MasterExit, SaltClientError
 
 
 # Let's instantiate logger using salt.log.setup.logging.getLogger() so pylint
@@ -241,8 +243,8 @@ class Minion(parsers.MinionOptionParser):
 
         NOTE: Run any required code before calling `super()`.
         '''
-        self.prepare()
         try:
+            self.prepare()
             if check_user(self.config['user']):
                 self.minion.tune_in()
         except (KeyboardInterrupt, SaltSystemExit) as exc:
@@ -251,6 +253,14 @@ class Minion(parsers.MinionOptionParser):
                 logger.warn('Exiting on Ctrl-c')
             else:
                 logger.error(str(exc))
+        except SaltClientError as exc:
+            logger.error(exc)
+            if self.config.get('restart_on_error'):
+                logger.warn('** Restarting minion **')
+                s = randint(0, self.config.get('random_reauth_delay',10))
+                logger.info('Sleeping random_reauth_delay of {0} seconds'.format(s))
+                time.sleep(s)
+                return 'reconnect'
         finally:
             self.shutdown()
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -213,6 +213,8 @@ VALID_OPTS = {
     'enumerate_proxy_minions': bool,
     'gather_job_timeout': int,
     'auth_timeout': int,
+    'auth_tries': int,
+    'auth_safemode': bool,
     'random_master': bool,
     'syndic_event_forward_timeout': float,
     'syndic_max_event_process_time': float,
@@ -222,6 +224,8 @@ VALID_OPTS = {
     'ssh_timeout': float,
     'ssh_user': str,
     'raet_port': int,
+    'restart_on_error': bool,
+    'ping_interval': int,
 }
 
 # default configurations
@@ -323,12 +327,16 @@ DEFAULT_MINION_OPTS = {
     'keysize': 4096,
     'transport': 'zeromq',
     'auth_timeout': 60,
+    'auth_tries': 1,
+    'auth_safemode': False,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),
     'ioflo_verbose': 0,
     'ioflo_period': 0.01,
     'ioflo_realtime': True,
     'raet_port': 4510,
+    'restart_on_error': False,
+    'ping_interval': 0,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -679,6 +679,9 @@ class Minion(MinionBase):
                 # We can't decode the master's response to our event,
                 # so we will need to re-authenticate.
                 self.authenticate()
+        except SaltReqTimeoutError:
+            log.info("Master failed to respond. Preforming re-authenticating")
+            self.authenticate()
         except Exception:
             log.info("fire_master failed: {0}".format(traceback.format_exc()))
 
@@ -1181,8 +1184,11 @@ class Minion(MinionBase):
         acceptance_wait_time_max = self.opts['acceptance_wait_time_max']
         if not acceptance_wait_time_max:
             acceptance_wait_time_max = acceptance_wait_time
+        
+        tries = self.opts.get('auth_tries', 1)
+        safe = self.opts.get('auth_safemode', safe)
         while True:
-            creds = auth.sign_in(timeout, safe)
+            creds = auth.sign_in(timeout, safe, tries)
             if creds != 'retry':
                 log.info('Authentication with master successful!')
                 break
@@ -1193,6 +1199,7 @@ class Minion(MinionBase):
             if acceptance_wait_time < acceptance_wait_time_max:
                 acceptance_wait_time += acceptance_wait_time
                 log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))
+                
         self.aes = creds['aes']
         if self.opts.get('syndic_master_publish_port'):
             self.publish_port = self.opts.get('syndic_master_publish_port')
@@ -1340,10 +1347,21 @@ class Minion(MinionBase):
                     exc)
             )
 
+        ping_interval = self.opts.get('ping_interval', 0) * 60
+        ping_at = None
         while self._running is True:
             loop_interval = self.process_schedule(self, loop_interval)
             try:
                 socks = self._do_poll(loop_interval)
+              
+                if ping_interval > 0:
+                    if socks or not ping_at:
+                        ping_at = time.time() + ping_interval
+                    if ping_at < time.time():
+                        log.debug('Ping master')
+                        self._fire_master('ping', 'minion_ping')
+                        ping_at = time.time() + ping_interval
+
                 self._do_socket_recv(socks)
 
                 # Check the event system
@@ -1382,6 +1400,8 @@ class Minion(MinionBase):
                     log.critical('Unexpected ZMQError while polling minion',
                                  exc_info=True)
                 continue
+            except SaltClientError:
+                raise
             except Exception:
                 log.critical(
                     'An exception occurred while polling the minion',

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -177,11 +177,12 @@ class SREQ(object):
             tried += 1
             if polled:
                 break
-            elif tried >= tries:
+            if tries > 1:
+                log.info('SaltReqTimeoutError: after {0} seconds. (Try {1} of {2})'.format(
+                  timeout, tried, tries))
+            if tried >= tries:
                 raise SaltReqTimeoutError(
-                    'Waited {0} seconds'.format(
-                        timeout * tried
-                    )
+                    'SaltReqTimeoutError: after {0} seconds, ran {1} tries'.format(timeout * tried, tried)
                 )
         return self.serial.loads(self.socket.recv())
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -7,6 +7,7 @@ This module contains the function calls to execute command line scripts
 from __future__ import print_function
 import os
 import sys
+import time
 
 # Import salt libs
 import salt
@@ -33,8 +34,18 @@ def salt_minion():
     '''
     if '' in sys.path:
         sys.path.remove('')
-    minion = salt.Minion()
-    minion.start()
+    
+    reconnect = True
+    while reconnect:
+        reconnect = False
+        minion = salt.Minion()
+        ret = minion.start()
+        if ret == 'reconnect':
+            del minion
+            minion = None
+            # give extra time for resources like ZMQ to close.
+            time.sleep(10)
+            reconnect = True
 
 
 def salt_syndic():


### PR DESCRIPTION
Adds config options so minion can ping master to ensure a connection. If the ping fails the minion has the option to restart. This solves the issue of a master that changes IP addresses (DDNS/CNAME)

/perhaps worth investigating/
- instead of using a ping_interval, the scheduler could be updated to throw exceptions outside the thread into the main thread.
- instead of restarting the minion for a new IP address to take effect.  Perhaps could update all the sockets to use the new IP address.
