### PR TITLE
starting to cleanup minion id generation and resolving fqdn

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1746,6 +1746,16 @@ def get_id(root_dir=None, minion_id=False, cache=True):
     log.debug('Guessing ID. The id can be explicitly in set {0}'
               .format(os.path.join(salt.syspaths.CONFIG_DIR, 'minion')))
 
+    ## TODO: config option
+    #if opts['use_generate_minion_id']:
+    newid = salt.utils.network.generate_minion_id()
+    log.info('Found minion id from generate_minion_id(): {0}'.format(newid))
+    if minion_id and cache:
+        _cache_id(newid, id_cache)
+    is_ipv4 = newid.count('.') == 3 and not any(c.isalpha() for c in newid)
+    return newid, is_ipv4
+    
+
     # Check salt.utils.network.get_fqhostname()
     fqdn = salt.utils.network.get_fqhostname()
     if fqdn != 'localhost':

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -137,7 +137,7 @@ def _sort_hostnames(hostname_list):
         # favor longest fqdn
         return len(b) - len(a)
     
-    sorted(hostname_list, cmp=_cmp_hostname)
+    return sorted(hostname_list, cmp=_cmp_hostname)
 
 def get_hostnames():
     '''

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -216,7 +216,8 @@ def _get_minion_ids():
                         entry = line.split()
                         if entry[0].startswith('127.'):
                             for name in entry[1:]:  # try each name in the row
-                                l.append(name)
+                                if name != 'localhost':
+                                    l.append(name.replace(' ',''))
                     except IndexError:
                         pass  # could not split line (malformed entry?)
         except (IOError, OSError):

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -84,6 +84,7 @@ def _sort_hostnames(hostname_list):
     # punish matches in order of preference
     punish = [
         'localhost.localdomain',
+        'localhost.my.domain',
         'localhost',
         'ip6-localhost',
         'ip6-loopback',

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -77,6 +77,180 @@ def host_to_ip(host):
     return ip
 
 
+def _sort_hostnames(hostname_list):
+    '''
+    sort hostnames in order of preference
+    '''
+    # punish matches in order of preference
+    punish = [
+        'localhost.localdomain',
+        'localhost',
+        'ip6-localhost',
+        'ip6-loopback',
+        '127.0.2.1',
+        '127.0.1.1',
+        '127.0.0.1',
+        '0.0.0.0',
+        '::1',
+        'fe00::',
+        'fe02::',
+    ]
+    
+    def _cmp_hostname(a, b):
+        # should never have a space in hostname
+        if ' ' in a:
+            return 1
+        if ' ' in b:
+            return -1
+        
+        # punish list    
+        if a in punish:
+            if b in punish:
+                return punish.index(a) - punish.index(b)
+            return 1
+        if b in punish:
+            return -1
+        
+        # punish ipv6
+        if ':' in a or ':' in b:
+            return a.count(':') - b.count(':')
+        
+        # punish ipv4
+        a_is_ipv4 = a.count('.') == 3 and not any(c.isalpha() for c in a)
+        b_is_ipv4 = b.count('.') == 3 and not any(c.isalpha() for c in b)
+        if a_is_ipv4 and a.startswith('127.'):
+            return 1
+        if b_is_ipv4 and b.startswith('127.'):
+            return -1
+        if a_is_ipv4 and not b_is_ipv4:
+            return 1
+        if a_is_ipv4 and b_is_ipv4:
+            return 0
+        if not a_is_ipv4 and b_is_ipv4:
+            return -1
+            
+        # favor hosts with more dots
+        diff = b.count('.') - a.count('.')
+        if diff != 0:
+            return diff
+        
+        # favor longest fqdn
+        return len(b) - len(a)
+    
+    sorted(hostname_list, cmp=_cmp_hostname)
+
+def get_hostnames():
+    '''
+    Get list of hostnames using multiple strategies
+    '''
+    l = []
+    l.append(socket.gethostname())
+    l.append(socket.getfqdn())
+    
+    # try socket.getaddrinfo
+    try:
+        addrinfo = socket.getaddrinfo(
+            socket.gethostname(), 0, socket.AF_UNSPEC, socket.SOCK_STREAM,
+            socket.SOL_TCP, socket.AI_CANONNAME
+        )
+        for info in addrinfo:
+            # info struct [family, socktype, proto, canonname, sockaddr]
+            if len(info) >= 4:
+                l.append(info[3])
+    except socket.gaierror:
+        pass
+    
+    # remove duplicates
+    l = list(set(l))
+    return l
+
+def _get_minion_ids():
+    '''
+    Get list of hostnames and ip addresses using multiple strategies
+    '''
+    l = get_hostnames()
+
+    # try /etc/hostname
+    try:
+        with salt.utils.fopen('/etc/hostname') as hfl:
+            name = hfl.read().strip()
+        l.append(name.replace(' ',''))
+    except (IOError, OSError):
+        pass
+
+    # try hostname --fqdn
+    #try:
+    #    fqdn = salt.utils.run('hostname --fqdn')
+    #    l.append(fqdn)
+    #except Exception:
+    #    pass
+
+    # try /etc/hosts
+    try:
+        with salt.utils.fopen('/etc/hosts') as hfl:
+            for line in hfl:
+                names = line.split()
+                try:
+                    ip_ = names.pop(0)
+                except IndexError:
+                    continue
+                if ip_.startswith('127.'):
+                    for name in names:
+                        if name != 'localhost':
+                            l.append(name.replace(' ',''))
+    except (IOError, OSError):
+        pass
+    
+    if salt.utils.is_windows():
+        # Try Windows 'hosts'
+        try:
+            windir = os.getenv('WINDIR')
+            with salt.utils.fopen(windir + r'\system32\drivers\etc\hosts') as hfl:
+                for line in hfl:
+                    # skip commented or blank lines
+                    if line[0] == '#' or len(line) <= 1:
+                        continue
+                    # process lines looking for '127.' in first column
+                    try:
+                        entry = line.split()
+                        if entry[0].startswith('127.'):
+                            for name in entry[1:]:  # try each name in the row
+                                l.append(name)
+                    except IndexError:
+                        pass  # could not split line (malformed entry?)
+        except (IOError, OSError):
+            pass
+    
+    # include ipaddresses
+    ip_addresses = [IPv4Address(addr) for addr
+                    in salt.utils.network.ip_addrs(include_loopback=True)
+                    if not addr.startswith('127.')]
+
+    for addr in ip_addresses:
+        if not addr.is_private:
+            l.append(str(addr))
+    
+    if len(l) == 0:
+        l.append('noname')
+
+    # remove duplicates
+    l = list(set(l))
+    return l
+
+def generate_minion_id():
+    '''
+    Returns a minion id after checking multiple sources for a FQDN.
+    If no FQDN is found you may get an ip address
+
+    CLI Example::
+
+        salt '*' network.generate_minion_id
+    '''
+    host_list = _get_minion_ids()
+    hosts = _sort_hostnames(host_list)
+    return hosts[0]
+
+
 def get_fqhostname():
     '''
     Returns the fully qualified hostname


### PR DESCRIPTION
attempt 2 at a patch for resolving FQDN for the minion id.

This patch is a WIP and not tested... could have syntex and logic errors..
What this patch does is 
- migrate logic from salt/config.py for resolving hostname to salt/utils/network.py
- create a list of possible minion id
- sorts the list of minion ids so FQDNs float to the top

This patch still needs some work but looks kinda cool to me.
