### PR TITLE
(doc) : fix salt.minion_config to point to correct file in OS X walkthrough

### DIFF
--- a/doc/topics/tutorials/walkthrough_macosx.rst
+++ b/doc/topics/tutorials/walkthrough_macosx.rst
@@ -379,7 +379,7 @@ indentation level as the other properties):
     # salt-vagrant config
     config.vm.provision :salt do |salt|
         salt.run_highstate = true
-        salt.minion_config = "./minion.conf"
+        salt.minion_config = "/etc/salt/minion"
         salt.minion_key = "./minion1.pem"
         salt.minion_pub = "./minion1.pub"
     end


### PR DESCRIPTION
[This](https://github.com/saltstack/salt/blob/1026dbea61c2cf58015ddc9ba9911f5fb03f4a9c/doc/topics/tutorials/walkthrough_macosx.rst#creating-the-minion-configuration-file) section of the OS X walkthrough instructs the developer to create the minion config file at `/etc/salt/minion`. [Here](https://github.com/saltstack/salt/blob/1026dbea61c2cf58015ddc9ba9911f5fb03f4a9c/doc/topics/tutorials/walkthrough_macosx.rst#modify-vagrantfile-to-use-salt-provisioner) it asks to developer to point `salt.minion_config` to `./minion.conf`. This is inconsistent and gives the error `The specified minion_config file could not be found.` when provisioning. Fix the example to point to the already created `/etc/salt/minion` file
