### PR TITLE
Add returns summary

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -199,11 +199,11 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         print('Summary')
         print('-------------------------------------------')
         if self.options.verbose:
-            print('Target minions counter: %d' %(return_counter + not_return_counter))
-        print('Recived returns counter: %d' %return_counter)
+            print('Target minions counter: {0}'.format(return_counter + not_return_counter))
+        print('Recived returns counter: {0}'.format(return_counter))
         if self.options.verbose:
-            print('Not returns counter: %d' %not_return_counter)
-            print('Not return minions: %s' % " ".join(not_return_minions))
+            print('Not returns counter: {0}'.format(not_return_counter))
+            print('Not return minions: {0}'.format(" ".join(not_return_minions)))
         print('-------------------------------------------')
 
     def _output_ret(self, ret, out):

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -166,7 +166,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
                     # Returns summary
                     if self.config['fun'] != 'sys.doc':
-                        self._print_returns_summary(ret)
+                        if self.options.output is None:
+                            self._print_returns_summary(ret)
 
                     # NOTE: Return code is set here based on if all minions
                     # returned 'ok' with a retcode of 0.

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -157,10 +157,36 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                     else:
                         if self.options.verbose:
                             kwargs['verbose'] = True
+                        ret = {}
                         for full_ret in cmd_func(**kwargs):
-                            ret, out, retcode = self._format_ret(full_ret)
+                            ret_, out, retcode = self._format_ret(full_ret)
                             retcodes.append(retcode)
-                            self._output_ret(ret, out)
+                            self._output_ret(ret_, out)
+                            ret.update(ret_)
+
+                    # Returns summary
+                    if self.config['fun'] != 'sys.doc':
+                        return_counter = 0
+                        not_return_counter = 0
+                        not_return_minions = []
+                        for each_minion in ret:
+                             if ret[each_minion] == "Minion did not return":
+                                 not_return_counter += 1
+                                 not_return_minions.append(each_minion)
+                             else:
+                                 return_counter += 1
+                        # Display returns summary
+                        print('\n')
+                        print('-------------------------------------------')
+                        print('Summary')
+                        print('-------------------------------------------')
+                        if self.options.verbose:
+                            print('Target minions counter: %d' %(return_counter + not_return_counter))
+                        print('Recived returns counter: %d' %return_counter)
+                        if self.options.verbose:
+                            print('Not returns counter: %d' %not_return_counter)
+                            print('Not return minions: %s' % "".join(not_return_minions))
+                        print('-------------------------------------------')
 
                     # NOTE: Return code is set here based on if all minions
                     # returned 'ok' with a retcode of 0.

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -166,27 +166,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
                     # Returns summary
                     if self.config['fun'] != 'sys.doc':
-                        return_counter = 0
-                        not_return_counter = 0
-                        not_return_minions = []
-                        for each_minion in ret:
-                             if ret[each_minion] == "Minion did not return":
-                                 not_return_counter += 1
-                                 not_return_minions.append(each_minion)
-                             else:
-                                 return_counter += 1
-                        # Display returns summary
-                        print('\n')
-                        print('-------------------------------------------')
-                        print('Summary')
-                        print('-------------------------------------------')
-                        if self.options.verbose:
-                            print('Target minions counter: %d' %(return_counter + not_return_counter))
-                        print('Recived returns counter: %d' %return_counter)
-                        if self.options.verbose:
-                            print('Not returns counter: %d' %not_return_counter)
-                            print('Not return minions: %s' % "".join(not_return_minions))
-                        print('-------------------------------------------')
+                        self._print_returns_summary(ret)
 
                     # NOTE: Return code is set here based on if all minions
                     # returned 'ok' with a retcode of 0.
@@ -199,6 +179,31 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 ret = str(exc)
                 out = ''
                 self._output_ret(ret, out)
+
+    def _print_returns_summary(self, ret):
+        '''
+        Display returns summary
+        '''
+        return_counter = 0
+        not_return_counter = 0
+        not_return_minions = []
+        for each_minion in ret:
+            if ret[each_minion] == "Minion did not return":
+                not_return_counter += 1
+                not_return_minions.append(each_minion)
+            else:
+                return_counter += 1
+        print('\n')
+        print('-------------------------------------------')
+        print('Summary')
+        print('-------------------------------------------')
+        if self.options.verbose:
+            print('Target minions counter: %d' %(return_counter + not_return_counter))
+        print('Recived returns counter: %d' %return_counter)
+        if self.options.verbose:
+            print('Not returns counter: %d' %not_return_counter)
+            print('Not return minions: %s' % " ".join(not_return_minions))
+        print('-------------------------------------------')
 
     def _output_ret(self, ret, out):
         '''


### PR DESCRIPTION
Add returns summary for salt cmd, Example:

<pre>
# salt '*' test.ping
salt-minion-02.example.com:
    True


-------------------------------------------
Summary
-------------------------------------------
Recived returns counter: 1
-------------------------------------------
</pre>


verbose:

<pre>
# salt '*' test.ping -v
Executing job with jid 20140429084534201775
-------------------------------------------

salt-minion-02.example.com:
    True
salt-minion-01.example.com:
    Minion did not return


-------------------------------------------
Summary
-------------------------------------------
Target minions counter: 2
Recived returns counter: 1
Not returns counter: 1
Not return minions: salt-minion-01.example.com
-------------------------------------------
</pre>
