### PR TITLE
Move dns and volumes_from from create_container() to start()

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -273,10 +273,9 @@ def _get_client(version=None, timeout=None):
         # only if defined by user.
         kwargs['timeout'] = timeout
     client = docker.Client(**kwargs)
-    # force 1..5 API for registry login
     if not version:
-        if client._version == '1.4':
-            client._version = '1.5'
+        # set version that match docker deamon
+        client._version = client.version()['ApiVersion']
     if getattr(client, '_cfg', None) is None:
         client._cfg = {
             'Configs': {},

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -589,8 +589,6 @@ def create_container(image,
         daemon mode
     environment
         environment variable mapping ({'foo':'BAR'})
-    dns
-        list of DNS servers
     ports
         ports redirections ({'222': {}})
     volumes
@@ -603,8 +601,6 @@ def create_container(image,
         attach ttys
     stdin_open
         let stdin open
-    volumes_from
-        container to get volumes definition from
     name
         name given to container
 
@@ -887,6 +883,7 @@ def restart(container, timeout=10, *args, **kwargs):
 def start(container, binds=None, port_bindings=None,
           lxc_conf=None, publish_all_ports=None, links=None,
           privileged=False,
+          dns=None, volumes_from=None,
           *args, **kwargs):
     '''
     restart the specified container
@@ -925,10 +922,25 @@ def start(container, binds=None, port_bindings=None,
                         'port_bindings must be formatted as a dictionary of '
                         'dictionaries'
                     )
-            client.start(dcontainer, binds=binds, port_bindings=bindings,
-                         lxc_conf=lxc_conf,
-                         publish_all_ports=publish_all_ports, links=links,
-                         privileged=privileged)
+            try:
+                client.start(dcontainer, binds=binds, port_bindings=bindings,
+                             lxc_conf=lxc_conf,
+                             publish_all_ports=publish_all_ports, links=links,
+                             privileged=privileged,
+                             dns=dns, volumes_from=volumes_from)
+            except TypeError:
+                # maybe older version of docker-py <= 0.3.1 dns and
+                # volumes_from are not accepted
+                # FIXME:
+                # Ideally we should write an explicit check based on
+                # version of docker-py package, but
+                # https://github.com/dotcloud/docker-py/issues/216
+                # prevents us to do it at the time I'm writing this.
+                client.start(dcontainer, binds=binds, port_bindings=bindings,
+                             lxc_conf=lxc_conf,
+                             publish_all_ports=publish_all_ports, links=links,
+                             privileged=privileged)
+
             if is_running(dcontainer):
                 valid(status,
                       comment='Container {0} was started'.format(container),

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -547,7 +547,7 @@ def script(*args, **kw):
 
 def running(name, container=None, port_bindings=None, binds=None,
             publish_all_ports=False, links=None, lxc_conf=None,
-            privileged=False):
+            privileged=False, dns=None, volumes_from=None):
     '''
     Ensure that a container is running. (`docker inspect`)
 
@@ -585,6 +585,21 @@ def running(name, container=None, port_bindings=None, binds=None,
                 "5000/tcp":
                     HostIp: ""
                     HostPort: "5000"
+    dns
+        List of DNS servers.
+
+        .. code-block:: yaml
+
+            - dns:
+                - 127.0.0.1
+
+    volumes_from
+        List of container names to get volumes definition from
+
+        .. code-block:: yaml
+
+            - dns:
+                - name_other_container
     '''
     is_running = __salt__['docker.is_running'](container)
     if is_running:
@@ -594,7 +609,9 @@ def running(name, container=None, port_bindings=None, binds=None,
         started = __salt__['docker.start'](
             container, binds=binds, port_bindings=port_bindings,
             lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
-            links=links, privileged=privileged)
+            links=links, privileged=privileged,
+            dns=dns, volumes_from=volumes_from,
+        )
         is_running = __salt__['docker.is_running'](container)
         if is_running:
             return _valid(

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -585,6 +585,19 @@ def running(name, container=None, port_bindings=None, binds=None,
                 "5000/tcp":
                     HostIp: ""
                     HostPort: "5000"
+    binds
+        List of volumes to mount
+
+        .. code-block:: yaml
+
+            - binds:
+                /home/user1:
+                    bind: /mnt/vol2
+                    ro: true
+                /var/www:
+                    bind: /mnt/vol1
+                    ro: false
+
     dns
         List of DNS servers.
 


### PR DESCRIPTION
Follow up for https://github.com/dotcloud/docker-py/pull/200

This change-set is still backward compatible, but it allows to deploy container with current version of docker v.0.10.

States should be modified accordingly.
