### PR TITLE
Fix an error in examples

### DIFF
--- a/doc/topics/best_practices.rst
+++ b/doc/topics/best_practices.rst
@@ -332,7 +332,7 @@ modification of static values:
             'service': 'httpd',
             'conf': '/etc/httpd/httpd.conf',
         },
-    }, merge=salt['pillar.get']('apache:lookup')) %}
+    }, grain='os', merge=salt['pillar.get']('apache:lookup')) %}
 
 /srv/pillar/apache.sls:
 
@@ -391,7 +391,7 @@ to be broken into two states.
             'service': 'httpd',
             'conf': '/etc/httpd/httpd.conf',
         },
-    }, merge=salt['pillar.get']('apache:lookup')) %}
+    }, grain='os', merge=salt['pillar.get']('apache:lookup')) %}
 
 /srv/pillar/apache.sls:
 


### PR DESCRIPTION
Add the grain='os' parameter into map.jinja.
Refer to https://github.com/saltstack-formulas/samba-formula/blob/2727dfb0922768bdea6669e37782919ad9c4c545/samba/map.jinja
Unfortunately https://github.com/saltstack-formulas/apache-formula/blob/2db91119af17f780f5901e5d72f9d9dfc891658b/apache/map.jinja has the same error.
Maybe author of apache-formula has some custom configuration or modules hacked.
