### PR TITLE
Fixes #12348 by updating rvm url

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -75,7 +75,7 @@ def install(runas=None):
     '''
     # RVM dependencies on Ubuntu 10.04:
     #   bash coreutils gzip bzip2 gawk sed curl git-core subversion
-    installer = 'https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
+    installer = 'https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
     ret = __salt__['cmd.run_all'](
         # the RVM installer automatically does a multi-user install when it is
         # invoked with root privileges


### PR DESCRIPTION
Per
https://developer.github.com/changes/2014-04-25-user-content-security/
raw.github.com is now served from raw.githubusercontent.com.
