### PR TITLE
Fix url for git-pip.py

### DIFF
--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -305,7 +305,7 @@ def create(path,
     # Install pip
     if pip and not os.path.exists(venv_pip):
         _ret = _install_script(
-            'https://raw.github.com/pypa/pip/master/contrib/get-pip.py',
+            'https://raw.githubusercontent.com/pypa/pip/master/contrib/get-pip.py',
             path, venv_python, user, saltenv=saltenv
         )
         # Let's update the return dictionary with the details from the pip


### PR DESCRIPTION
Per
https://developer.github.com/changes/2014-04-25-user-content-security/
raw.github.com is now served from raw.githubusercontent.com.
