### PR TITLE
Remove unused argument

### DIFF
--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -88,7 +88,7 @@ def find_guest(name, quiet=False):
     return None
 
 
-def find_guests(names, quiet=False):
+def find_guests(names):
     '''
     Return a dict of hosts and named guests
     '''


### PR DESCRIPTION
This looks to have been the product of the function being copypasta'ed when it was added. Fixes #12359.
