### PR TITLE
Update all raw.github.com references to raw.githubusercontent.com

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -6189,7 +6189,7 @@ passed):
 .sp
 .nf
 .ft C
-wget https://raw.github.com/saltstack/salt\-bootstrap/develop/bootstrap\-salt.sh
+wget https://raw.githubusercontent.com/saltstack/salt\-bootstrap/develop/bootstrap\-salt.sh
 .ft P
 .fi
 .UNINDENT
@@ -9234,7 +9234,7 @@ Or just type
 .sp
 .nf
 .ft C
-ruby \-e "$(curl \-fsSL https://raw.github.com/mxcl/homebrew/go)"
+ruby \-e "$(curl \-fsSL https://raw.githubusercontent.com/mxcl/homebrew/go)"
 .ft P
 .fi
 .UNINDENT
@@ -20682,7 +20682,7 @@ Example usage:
 .sp
 .nf
 .ft C
-wget https://raw.github.com/saltstack/salt/develop/tests/eventlisten.py
+wget https://raw.githubusercontent.com/saltstack/salt/develop/tests/eventlisten.py
 python eventlisten.py
 
 # OR
@@ -87536,7 +87536,7 @@ CLI Example:
 .ft C
 salt\-run manage.bootstrap hosts="host1,host2"
 salt\-run manage.bootstrap hosts="host1,host2" version="v0.17"
-salt\-run manage.bootstrap hosts="host1,host2" version="v0.17" script="https://raw.github.com/saltstack/salt\-bootstrap/develop/bootstrap\-salt.sh"
+salt\-run manage.bootstrap hosts="host1,host2" version="v0.17" script="https://raw.githubusercontent.com/saltstack/salt\-bootstrap/develop/bootstrap\-salt.sh"
 .ft P
 .fi
 .UNINDENT

--- a/doc/topics/reactor/index.rst
+++ b/doc/topics/reactor/index.rst
@@ -120,7 +120,7 @@ Example usage:
 
 .. code-block:: bash
 
-    wget https://raw.github.com/saltstack/salt/develop/tests/eventlisten.py
+    wget https://raw.githubusercontent.com/saltstack/salt/develop/tests/eventlisten.py
     python eventlisten.py
 
     # OR

--- a/doc/topics/tutorials/salt_bootstrap.rst
+++ b/doc/topics/tutorials/salt_bootstrap.rst
@@ -299,7 +299,7 @@ passed):
 
 .. code-block:: bash
 
-    wget https://raw.github.com/saltstack/salt-bootstrap/develop/bootstrap-salt.sh
+    wget https://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.sh
 
 Command Line Options
 --------------------

--- a/doc/topics/tutorials/walkthrough_macosx.rst
+++ b/doc/topics/tutorials/walkthrough_macosx.rst
@@ -117,7 +117,7 @@ Or just type
 
 .. code-block:: bash
 
-    ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/mxcl/homebrew/go)"
 
 
 Now type the following commands in your terminal (you may want to type brew

--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -3316,11 +3316,11 @@ install_smartos_deps() {
         # Let's download, since they were not provided, the default configuration files
         if [ ! -f $_SALT_ETC_DIR/minion ] && [ ! -f $_TEMP_CONFIG_DIR/minion ]; then
             curl $_CURL_ARGS -s -o $_TEMP_CONFIG_DIR/minion -L \
-                https://raw.github.com/saltstack/salt/develop/conf/minion || return 1
+                https://raw.githubusercontent.com/saltstack/salt/develop/conf/minion || return 1
         fi
         if [ ! -f $_SALT_ETC_DIR/master ] && [ ! -f $_TEMP_CONFIG_DIR/master ]; then
             curl $_CURL_ARGS -s -o $_TEMP_CONFIG_DIR/master -L \
-                https://raw.github.com/saltstack/salt/develop/conf/master || return 1
+                https://raw.githubusercontent.com/saltstack/salt/develop/conf/master || return 1
         fi
     fi
 
@@ -3372,7 +3372,7 @@ install_smartos_post() {
         if [ $? -eq 1 ]; then
             if [ ! -f $_TEMP_CONFIG_DIR/salt-$fname.xml ]; then
                 curl $_CURL_ARGS -s -o $_TEMP_CONFIG_DIR/salt-$fname.xml -L \
-                    https://raw.github.com/saltstack/salt/develop/pkg/smartos/salt-$fname.xml
+                    https://raw.githubusercontent.com/saltstack/salt/develop/pkg/smartos/salt-$fname.xml
             fi
             svccfg import $_TEMP_CONFIG_DIR/salt-$fname.xml
             if [ "${VIRTUAL_TYPE}" = "global" ]; then
@@ -3668,7 +3668,7 @@ install_suse_11_stable_deps() {
                 # Let's download, since they were not provided, the default configuration files
                 if [ ! -f $_SALT_ETC_DIR/$fname ] && [ ! -f $_TEMP_CONFIG_DIR/$fname ]; then
                     curl $_CURL_ARGS -s -o $_TEMP_CONFIG_DIR/$fname -L \
-                        https://raw.github.com/saltstack/salt/develop/conf/$fname || return 1
+                        https://raw.githubusercontent.com/saltstack/salt/develop/conf/$fname || return 1
                 fi
             done
         fi

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -276,7 +276,7 @@ def bootstrap(version="develop",
 
         salt-run manage.bootstrap hosts="host1,host2"
         salt-run manage.bootstrap hosts="host1,host2" version="v0.17"
-        salt-run manage.bootstrap hosts="host1,host2" version="v0.17" script="https://raw.github.com/saltstack/salt-bootstrap/develop/bootstrap-salt.sh"
+        salt-run manage.bootstrap hosts="host1,host2" version="v0.17" script="https://raw.githubusercontent.com/saltstack/salt-bootstrap/develop/bootstrap-salt.sh"
 
     '''
     for host in hosts.split(","):


### PR DESCRIPTION
Submitted separated pull requests for virtualenv and rvm module usage of raw.github.com.  This pull request covers docs and salt cloud deploy scripts.

Per
https://developer.github.com/changes/2014-04-25-user-content-security/
raw.github.com is now served from raw.githubusercontent.com.
