### PR TITLE
Missing versionadded in user_keys for ssh module

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -760,7 +760,10 @@ def set_known_host(user, hostname,
 
 def user_keys(user=None, pubfile=None, prvfile=None):
     '''
+
     Return the user's ssh keys on the minion
+
+    .. versionadded:: Helium
 
     CLI Example:
 


### PR DESCRIPTION
Adding the versionadded string to user_keys in ssh module
