### PR TITLE
restart salt-minion after salt-cloud deployment on windows

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -858,6 +858,9 @@ def deploy_windows(host,
                 creds,
             ))
         # Shell out to winexe to ensure salt-minion service started
+        win_cmd('winexe {0} "sc stop salt-minion"'.format(
+            creds,
+        ))
         win_cmd('winexe {0} "sc start salt-minion"'.format(
             creds,
         ))


### PR DESCRIPTION
changing the windows deployment function to restart the salt-minion after installation instead of only starting it.
this will enable fixing issues if salt-minion was improperly installed before the salt-cloud deployment
