### PR TITLE
Adding verify_ssl flag to S3 filesystem

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -102,8 +102,6 @@ def update():
     metadata = _init()
 
     if _s3_sync_on_update:
-        key, keyid, service_url = _get_s3_key()
-
         # sync the buckets to the local cache
         log.info('Syncing local cache from S3...')
         for saltenv, env_meta in metadata.iteritems():
@@ -318,8 +316,11 @@ def _get_s3_key():
     service_url = __opts__['s3.service_url'] \
         if 's3.service_url' in __opts__ \
         else None
+    verify_ssl = __opts__['s3.verify_ssl'] \
+        if 's3.verify_ssl' in __opts__ \
+        else None
 
-    return key, keyid, service_url
+    return key, keyid, service_url, verify_ssl
 
 
 def _init():
@@ -383,7 +384,7 @@ def _refresh_buckets_cache_file(cache_file):
 
     log.debug('Refreshing buckets cache file')
 
-    key, keyid, service_url = _get_s3_key()
+    key, keyid, service_url, verify_ssl = _get_s3_key()
     metadata = {}
 
     # helper s3 query function
@@ -393,6 +394,7 @@ def _refresh_buckets_cache_file(cache_file):
                 keyid=keyid,
                 bucket=bucket,
                 service_url=service_url,
+                verify_ssl=verify_ssl,
                 return_bin=False)
 
     if _is_env_per_bucket():
@@ -524,12 +526,13 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
             return
 
     # ... or get the file from S3
-    key, keyid, service_url = _get_s3_key()
+    key, keyid, service_url, verify_ssl = _get_s3_key()
     s3.query(
         key=key,
         keyid=keyid,
         bucket=bucket_name,
         service_url=service_url,
+        verify_ssl=verify_ssl,
         path=urllib.quote(path),
         local_file=cached_file_path
     )


### PR DESCRIPTION
This is related to issue #12200. One more PR relating to allowing period separated names to work with Requests. 

I simply added the flag to s3fs so it can be properly passed down to utils/s3.py.
