### PR TITLE
Fix link to AWS credential distribution blog post

### DIFF
--- a/doc/topics/tutorials/preseed_key.rst
+++ b/doc/topics/tutorials/preseed_key.rst
@@ -33,7 +33,7 @@ master config file.
 There is no single method to get the keypair to your minion.  The difficulty is
 finding a distribution method which is secure. For Amazon EC2 only, an AWS best
 practice is to use IAM Roles to pass credentials. (See blog post, 
-http://blogs.aws.amazon.com/php/post/Tx1F82CR0ANO3ZI/Providing-credentials-to-the-AWS-SDK-for-PHP )
+http://blogs.aws.amazon.com/security/post/Tx610S2MLVZWEA/Using-IAM-roles-to-distribute-non-AWS-credentials-to-your-EC2-instances )
 
 .. admonition:: Security Warning
 


### PR DESCRIPTION
The existing link left me feeling confused and unfulfilled. I think that's possibly because it accidentally linked to the previous post in the series. I found the "correct" post by googling for it.
