### PR TITLE
Correct salt-ssh cache_job() data structure to match master+minion.

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -466,7 +466,7 @@ class SSH(object):
             print('')
         for ret in self.handle_ssh():
             host = ret.keys()[0]
-            self.cache_job(jid, host, ret)
+            self.cache_job(jid, host, ret[host])
             ret = self.key_deploy(host, ret)
             salt.output.display_output(
                     ret,


### PR DESCRIPTION
Prior to this the return data structure had a gratuitous "host" level.

Fixes existing bug.
