### PR TITLE
Interactively acquire the SSH password with no echo.

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -15,6 +15,7 @@
 from __future__ import print_function
 import os
 import sys
+import getpass
 import logging
 import optparse
 import traceback
@@ -2263,6 +2264,14 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                  'authenticating'
         )
         auth_group.add_option(
+            '--askpass',
+            dest='ssh_askpass',
+            default=False,
+            action='store_true',
+            help='Interactively ask for the SSH password with no echo - avoids '
+                 'password in process args and stored in history'
+        )
+        auth_group.add_option(
             '--key-deploy',
             dest='ssh_key_deploy',
             default=False,
@@ -2287,6 +2296,9 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             self.config['tgt'] = self.args[0]
         if len(self.args) > 0:
             self.config['arg_str'] = ' '.join(self.args[1:])
+
+        if self.options.ssh_askpass:
+            self.options.ssh_passwd = getpass.getpass('Password: ')
 
     def setup_config(self):
         return config.master_config(self.get_config_file_path())


### PR DESCRIPTION
This avoids specifying the password as a command argument that can be
discovered in the shell history or through ps(1).

Fixes existing bug (if you feel that exposing a password is a bug)
