### PR TITLE
Fix CLI arg parsing

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -27,15 +27,14 @@ import salt.utils as utils
 import salt.version as version
 import salt.syspaths as syspaths
 import salt.log.setup as log
-from salt.utils import yamlloader
 from salt.utils.validate.path import is_writeable
 from salt._compat import string_types
+from salt.minion import yamlify_arg
 
 if not utils.is_windows():
     import salt.cloud.exceptions
 
 # Import 3rd-party libs
-import yaml
 from yaml.scanner import ScannerError as YAMLScannerError
 
 
@@ -59,7 +58,7 @@ def parse_args_kwargs(args):
                     _kwargs[arg_name] = arg_value
                     continue
                 try:
-                    _kwargs[arg_name] = yaml.load(arg_value, Loader=yamlloader.CustomLoader)
+                    _kwargs[arg_name] = yamlify_arg(arg_value)
                 except YAMLScannerError:
                     _kwargs[arg_name] = arg_value
             else:
@@ -73,7 +72,7 @@ def parse_args_kwargs(args):
                     _args.append(arg)
                     continue
                 try:
-                    _args.append(yaml.load(arg, Loader=yamlloader.CustomLoader))
+                    _args.append(yamlify_arg(arg))
                 except YAMLScannerError:
                     _args.append(arg)
     return _args, _kwargs


### PR DESCRIPTION
This fixes an issue only present in the 2014.1 branch, where the yaml
loader is invoked directly to parse CLI args, instead of passing it
through yamlify_arg(), which has logic to mitigate some of the
idiosyncrasies of PyYAML.

Fixes #12185.
