### PR TITLE
Temporary fix for broken outputters with LazyLoader

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -225,7 +225,8 @@ def outputters(opts):
         'output',
         'output',
         ext_type_dirs='outputter_dirs')
-    return LazyFilterLoader(load, 'output')
+#    return LazyFilterLoader(load, 'output')
+    return load.filter_func('output')
 
 
 def auth(opts, whitelist=None):


### PR DESCRIPTION
This is a temporary reversal of the new LazyLoader approach for loaders to fix the test suite while the true source of the problem can be debugged.

The root of the issue is that it would appear that `__virtual__` names are not being respected for outputters when they are loaded by the LazyLoader. This results in the key in the loader dict for the JSON outputter being set to `json_out` (derived from the name of module on the filesystem) instead of `json` as the module requests in its `__virtual` function.

cc: @jacksontj 
