### PR TITLE
Fix stactrace with sys.reload modules.

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -97,8 +97,11 @@ class Caller(object):
                 if active_level <= logging.DEBUG:
                     sys.stderr.write(trace)
                 sys.exit(salt.exitcodes.EX_GENERIC)
-            ret['retcode'] = sys.modules[
-                func.__module__].__context__.get('retcode', 0)
+            try:
+                ret['retcode'] = sys.modules[
+                    func.__module__].__context__.get('retcode', 0)
+            except AttributeError:
+                ret['retcode'] = 1 
         except (CommandExecutionError) as exc:
             msg = 'Error running \'{0}\': {1}\n'
             active_level = LOG_LEVELS.get(


### PR DESCRIPTION
Before this fix, sys.reload_modules would stacktrace:

```
[ERROR   ] An un-handled exception was caught by salt's global exception
handler:
AttributeError: 'module' object has no attribute '__context__'
Traceback (most recent call last):
  File "/home/mp/Devel/salt/scripts/salt-call", line 11, in <module>
    salt_call()
  File "/home/mp/Devel/salt/salt/scripts.py", line 95, in salt_call
    client.run()
  File "/home/mp/Devel/salt/salt/cli/__init__.py", line 353, in run
    caller.run()
  File "/home/mp/Devel/salt/salt/cli/caller.py", line 183, in run
    ret = self.call()
  File "/home/mp/Devel/salt/salt/cli/caller.py", line 101, in call
    func.__module__].__context__.get('retcode', 0)
AttributeError: 'module' object has no attribute '__context__'
Traceback (most recent call last):
  File "/home/mp/Devel/salt/scripts/salt-call", line 11, in <module>
    salt_call()
  File "/home/mp/Devel/salt/salt/scripts.py", line 95, in salt_call
    client.run()
  File "/home/mp/Devel/salt/salt/cli/__init__.py", line 353, in run
    caller.run()
  File "/home/mp/Devel/salt/salt/cli/caller.py", line 183, in run
    ret = self.call()
  File "/home/mp/Devel/salt/salt/cli/caller.py", line 101, in call
    func.__module__].__context__.get('retcode', 0)
AttributeError: 'module' object has no attribute '__context__'

```

I'm returning `1` here out of an abudence of caution but I think a pretty good case could be made just to set this to `0` since the 'error' is really of no concern.
