### PR TITLE
salt-ssh should use argv rather than using join/split/join on command

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1423,7 +1423,7 @@ class SSHClient(object):
         opts.update(kwargs)
         opts['timeout'] = timeout
         arg = salt.utils.args.condition_input(arg, kwarg)
-        opts['arg_str'] = '{0} {1}'.format(fun, ' '.join(arg))
+        opts['argv'] = [fun] + arg
         opts['selected_target_option'] = expr_form
         opts['tgt'] = tgt
         opts['arg'] = arg

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -44,14 +44,12 @@ class FunctionWrapper(object):
             '''
             The remote execution function
             '''
-            arg_str = ['{0} '.format(cmd)]
-            for arg in args:
-                arg_str.append('{0} '.format(arg))
-            for key, val in kwargs.items():
-                arg_str.append('{0}={1} '.format(key, val))
+            args = [cmd]
+            args.extend([str(arg) for arg in args])
+            args.extend(['{0}={1}'.format(key, val) for key, val in kwargs.items()])
             single = salt.client.ssh.Single(
                     self.opts,
-                    ''.join(arg_str),
+                    ' '.join(args),
                     **self.kwargs
             )
             stdout, _, _ = single.cmd_block()

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2295,8 +2295,8 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                 self.config['tgt'] = self.args[0].split()
         else:
             self.config['tgt'] = self.args[0]
-        if len(self.args) > 0:
-            self.config['arg_str'] = ' '.join(self.args[1:])
+
+        self.config['argv'] = self.args[1:]
 
         if self.options.ssh_askpass:
             self.options.ssh_passwd = getpass.getpass('Password: ')


### PR DESCRIPTION
strings.  The latter can be quite dangerous for detecting appropriate
word boundaries and may not be identical to shell arg parsing.

The argv use should be carried into ssh.Single, but that is a future exercise.
