### PR TITLE
Fix virtual module loading (for now)

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1272,6 +1272,7 @@ class LazyLoader(MutableMapping):
         if mod_funcs is None:
             # if we couldn't find it, then it could be a virtual or we don't have it
             # until we have a better way, we have to load them all to know
+            # TODO: maybe do a load until, with some glob match first?
             self.load_all()
             return self._dict[key]
         self._dict.update(mod_funcs)
@@ -1342,6 +1343,7 @@ class LazyFilterLoader(LazyLoader):
         if mod_funcs is None:
             # if we couldn't find it, then it could be a virtual or we don't have it
             # until we have a better way, we have to load them all to know
+            # TODO: maybe do a load until, with some glob match first?
             self.load_all()
             return self._dict[key]
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -225,8 +225,7 @@ def outputters(opts):
         'output',
         'output',
         ext_type_dirs='outputter_dirs')
-#    return LazyFilterLoader(load, 'output')
-    return load.filter_func('output')
+    return LazyFilterLoader(load, 'output')
 
 
 def auth(opts, whitelist=None):
@@ -1271,7 +1270,10 @@ class LazyLoader(MutableMapping):
                                            )
         # if you loaded nothing, then we don't have it
         if mod_funcs is None:
-            raise KeyError
+            # if we couldn't find it, then it could be a virtual or we don't have it
+            # until we have a better way, we have to load them all to know
+            self.load_all()
+            return self._dict[key]
         self._dict.update(mod_funcs)
 
     def load_all(self):
@@ -1338,7 +1340,10 @@ class LazyFilterLoader(LazyLoader):
                                            )
         # if you loaded nothing, then we don't have it
         if mod_funcs is None:
-            raise KeyError
+            # if we couldn't find it, then it could be a virtual or we don't have it
+            # until we have a better way, we have to load them all to know
+            self.load_all()
+            return self._dict[key]
 
         # if we got one, now lets check if we have the function name we want
         for mod_key, mod_fun in mod_funcs.iteritems():

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -90,6 +90,7 @@ def get_printout(out, opts=None, **kwargs):
             opts['color'] = True
 
     outputters = salt.loader.outputters(opts)
+    # TODO: raise an exception? This means if you do --out foobar you get nested
     if out not in outputters:
         return outputters['nested']
     return outputters[out]


### PR DESCRIPTION
Fix for #12462

The lazy loading was only trying to load the name of the module you passed, which doesn't work if the module you asked for (json) is actually called json_out. For now I have it loading all modules if  you can't find the one you were looking for. To do anything nicer we'll have to come up with some way of either saving a map (filename -> mod_name) or just drop the lazyloader stuff alltogether :/

TLDR; now if theres a miss we load all-- this means you only get a benefit if you don't miss (still seems helpful, for the case where you never even call a specific module type)
