### PR TITLE
Hook fileserver tests into test runner

### DIFF
--- a/tests/integration/fileserver/gitfs_test.py
+++ b/tests/integration/fileserver/gitfs_test.py
@@ -39,7 +39,8 @@ if not gitfs.__virtual__():
     GITFS_AVAILABLE = False
 
 
-# @skipIf(not GITFS_AVAILABLE, "GitFS could not be loaded. Skipping GitFS tests!")
+@skipIf(True, 'GitFS tests not yet ready')
+@skipIf(not GITFS_AVAILABLE, "GitFS could not be loaded. Skipping GitFS tests!")
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class GitFSTest(integration.ModuleCase):
     def setUp(self):
@@ -100,7 +101,6 @@ class GitFSTest(integration.ModuleCase):
             ret = gitfs.dir_list(load)
             self.assertIn('grail', ret)
 
-    @skipIf(True, 'This test is failing and for good reason! See #9193')
     def test_file_list_emptydirs(self):
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_git],

--- a/tests/integration/fileserver/roots_test.py
+++ b/tests/integration/fileserver/roots_test.py
@@ -30,6 +30,7 @@ class RootsTest(integration.ModuleCase):
                                          'fileserver_ignoresymlinks': False,
                                          'fileserver_followsymlinks': False,
                                          'file_ignore_regex': False,
+                                         'cachedir': self.master_opts['cachedir'],
                                          'file_ignore_glob': False}):
             ret = roots.file_list({'saltenv': 'base'})
             self.assertIn('testfile', ret)
@@ -106,6 +107,7 @@ class RootsTest(integration.ModuleCase):
                                          'fileserver_ignoresymlinks': False,
                                          'fileserver_followsymlinks': False,
                                          'file_ignore_regex': False,
+                                         'cachedir': self.master_opts['cachedir'],
                                          'file_ignore_glob': False}):
             ret = roots.file_list_emptydirs({'saltenv': 'base'})
             self.assertIn('empty_dir', ret)
@@ -115,6 +117,7 @@ class RootsTest(integration.ModuleCase):
                                  'fileserver_ignoresymlinks': False,
                                  'fileserver_followsymlinks': False,
                                  'file_ignore_regex': False,
+                                 'cachedir': self.master_opts['cachedir'],
                                  'file_ignore_glob': False}):
             ret = roots.dir_list({'saltenv': 'base'})
             self.assertIn('empty_dir', ret)

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -101,6 +101,14 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             help='Run loader tests'
         )
         self.test_selection_group.add_option(
+                '-f',
+                '--fileserver',
+                dest='fileserver',
+                default=False,
+                action='store_true',
+                help='Run fileserver tests'
+        )
+        self.test_selection_group.add_option(
             '-u',
             '--unit',
             '--unit-tests',
@@ -122,8 +130,8 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         if self.options.coverage and any((
                 self.options.module, self.options.client, self.options.shell,
                 self.options.unit, self.options.state, self.options.runner,
-                self.options.loader, self.options.name, os.geteuid() != 0,
-                not self.options.run_destructive)):
+                self.options.loader, self.options.name, self.options.fileserver,
+                os.geteuid() != 0, not self.options.run_destructive)):
             self.error(
                 'No sense in generating the tests coverage report when '
                 'not running the full test suite, including the '
@@ -135,7 +143,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         if not any((self.options.module, self.options.client,
                     self.options.shell, self.options.unit, self.options.state,
                     self.options.runner, self.options.loader,
-                    self.options.name)):
+                    self.options.fileserver, self.options.name)):
             self.options.module = True
             self.options.client = True
             self.options.shell = True
@@ -143,6 +151,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             self.options.runner = True
             self.options.state = True
             self.options.loader = True
+            self.options.fileserver = True
 
         self.start_coverage(
             branch=True,
@@ -176,6 +185,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
                  self.options.module or
                  self.options.client or
                  self.options.loader or
+                 self.options.fileserver or
                  named_tests):
             # We're either not running any of runner, state, module and client
             # tests, or, we're only running unittests by passing --unit or by
@@ -224,7 +234,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         if not any([self.options.client, self.options.module,
                     self.options.runner, self.options.shell,
                     self.options.state, self.options.loader,
-                    self.options.name]):
+                    self.options.fileserver, self.options.name]):
             return status
 
         with TestDaemon(self):
@@ -246,6 +256,8 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
                 status.append(self.run_integration_suite('client', 'Client'))
             if self.options.shell:
                 status.append(self.run_integration_suite('shell', 'Shell'))
+            if self.options.fileserver:
+                status.append(self.run_integration_suite('fileserver', 'Fileserver'))
         return status
 
     def run_unit_tests(self):


### PR DESCRIPTION
This should have been done when these tests were first created but I wasn't aware that subdirectories weren't automatically picked up by the test runner. This commit sets the appropriate options for the test runner to be able to run the fileserver tests. 

There have also been some changes to the back-end fileservers inside salt. For the time being, I have disabled the gitfs tests and made some small changes to the `roots` integration test to re-align it with current code in develop.
