### PR TITLE
Initial commit of boto_route53 module and state

### DIFF
--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -4,10 +4,10 @@ Connection module for Amazon Route53
 
 .. versionadded:: Helium
 
-:configuration: This module accepts explicit route53 credentials but can also utilize
-    IAM roles assigned to the instance trough Instance Profiles. Dynamic
-    credentials are then automatically obtained from AWS API and no further
-    configuration is necessary. More Information available at::
+:configuration: This module accepts explicit route53 credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at::
 
        http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
 
@@ -221,7 +221,7 @@ def _wait_for_sync(status, conn):
             return True
         i = i + 1
         time.sleep(10)
-    log.error('Timed out waiting for route53 status update.')
+    log.error('Timed out waiting for Route53 status update.')
     return False
 
 

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -62,7 +62,7 @@ def __virtual__():
     return True
 
 
-def get_record(name, zone, type, fetch_all=False, region=None, key=None,
+def get_record(name, zone, record_type, fetch_all=False, region=None, key=None,
                keyid=None, profile=None):
     '''
     Get a record from a zone.
@@ -79,39 +79,37 @@ def get_record(name, zone, type, fetch_all=False, region=None, key=None,
         msg = 'Failed to retrieve zone {0}'.format(zone)
         log.error(msg)
         return None
-    _type = type.upper()
+    _type = record_type.upper()
     ret = odict.OrderedDict()
     if _type == 'A':
         _record = _zone.get_a(name, fetch_all)
         if _record:
             ret['name'] = _record.name
             ret['value'] = _record.to_print()
-            ret['type'] = _record.type
+            ret['record_type'] = _record.type
             ret['ttl'] = _record.ttl
     elif _type == 'CNAME':
         _record = _zone.get_cname(name, fetch_all)
         if _record:
             ret['name'] = _record.name
             ret['value'] = _record.to_print()
-            ret['type'] = _record.type
+            ret['record_type'] = _record.type
             ret['ttl'] = _record.ttl
     elif _type == 'MX':
         _record = _zone.get_mx(name, fetch_all)
         if _record:
             ret['name'] = _record.name
             ret['value'] = _record.to_print()
-            ret['type'] = _record.type
+            ret['record_type'] = _record.type
             ret['ttl'] = _record.ttl
     else:
         msg = '{0} is an unsupported resource type.'.format(_type)
         log.error(msg)
         return None
-    if not ret:
-        log.error('Failed to find record {0} in zone {1}.'.format(name, zone))
     return ret
 
 
-def add_record(name, value, zone, type, identifier=None, ttl=None, comment='',
+def add_record(name, value, zone, record_type, identifier=None, ttl=None,
                region=None, key=None, keyid=None, profile=None):
     '''
     Add a record to a zone.
@@ -128,15 +126,15 @@ def add_record(name, value, zone, type, identifier=None, ttl=None, comment='',
         msg = 'Failed to retrieve zone {0}'.format(zone)
         log.error(msg)
         return False
-    _type = type.upper()
+    _type = record_type.upper()
     if _type == 'A':
-        status = _zone.add_a(name, value, ttl, identifier, comment)
+        status = _zone.add_a(name, value, ttl, identifier)
         return _wait_for_sync(status.id, conn)
     elif _type == 'CNAME':
-        status = _zone.add_cname(name, value, ttl, identifier, comment)
+        status = _zone.add_cname(name, value, ttl, identifier)
         return _wait_for_sync(status.id, conn)
     elif _type == 'MX':
-        status = _zone.add_mx(name, value, ttl, identifier, comment)
+        status = _zone.add_mx(name, value, ttl, identifier)
         return _wait_for_sync(status.id, conn)
     else:
         msg = '{0} is an unsupported resource type.'.format(_type)
@@ -145,8 +143,8 @@ def add_record(name, value, zone, type, identifier=None, ttl=None, comment='',
     return False
 
 
-def update_record(name, value, zone, type, identifier=None, ttl=None,
-                  comment='', region=None, key=None, keyid=None, profile=None):
+def update_record(name, value, zone, record_type, identifier=None, ttl=None,
+                  region=None, key=None, keyid=None, profile=None):
     '''
     Modify a record in a zone.
 
@@ -162,15 +160,15 @@ def update_record(name, value, zone, type, identifier=None, ttl=None,
         msg = 'Failed to retrieve zone {0}'.format(zone)
         log.error(msg)
         return False
-    _type = type.upper()
+    _type = record_type.upper()
     if _type == 'A':
-        status = _zone.update_a(name, value, ttl, identifier, comment)
+        status = _zone.update_a(name, value, ttl, identifier)
         return _wait_for_sync(status.id, conn)
     elif _type == 'CNAME':
-        status = _zone.update_cname(name, value, ttl, identifier, comment)
+        status = _zone.update_cname(name, value, ttl, identifier)
         return _wait_for_sync(status.id, conn)
     elif _type == 'MX':
-        status = _zone.update_mx(name, value, ttl, identifier, comment)
+        status = _zone.update_mx(name, value, ttl, identifier)
         return _wait_for_sync(status.id, conn)
     else:
         msg = '{0} is an unsupported resource type.'.format(_type)
@@ -179,7 +177,7 @@ def update_record(name, value, zone, type, identifier=None, ttl=None,
     return False
 
 
-def delete_record(name, zone, type, identifier=None, all_records=False,
+def delete_record(name, zone, record_type, identifier=None, all_records=False,
                   region=None, key=None, keyid=None, profile=None):
     '''
     Modify a record in a zone.
@@ -196,7 +194,7 @@ def delete_record(name, zone, type, identifier=None, all_records=False,
         msg = 'Failed to retrieve zone {0}'.format(zone)
         log.error(msg)
         return False
-    _type = type.upper()
+    _type = record_type.upper()
     if _type == 'A':
         status = _zone.delete_a(name, identifier, all_records)
         return _wait_for_sync(status.id, conn)

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -1,0 +1,261 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon Route53
+
+.. versionadded:: Helium
+
+:configuration: This module accepts explicit route53 credentials but can also utilize
+    IAM roles assigned to the instance trough Instance Profiles. Dynamic
+    credentials are then automatically obtained from AWS API and no further
+    configuration is necessary. More Information available at::
+
+       http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file::
+
+        route53.keyid: GKTADJGHEIQSXMKKRBJ08H
+        route53.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration::
+
+        route53.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto
+'''
+
+# Import Python libs
+import logging
+import time
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+try:
+    import boto
+    import boto.route53
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+from salt._compat import string_types
+import salt.utils.odict as odict
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist.
+    '''
+    if not HAS_BOTO:
+        return False
+    return True
+
+
+def get_record(name, zone, type, fetch_all=False, region=None, key=None,
+               keyid=None, profile=None):
+    '''
+    Get a record from a zone.
+
+    CLI example::
+
+        salt myminion boto_route53.get_record test.example.org example.org A
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return None
+    _zone = conn.get_zone(zone)
+    if not _zone:
+        msg = 'Failed to retrieve zone {0}'.format(zone)
+        log.error(msg)
+        return None
+    _type = type.upper()
+    ret = odict.OrderedDict()
+    if _type == 'A':
+        _record = _zone.get_a(name, fetch_all)
+        if _record:
+            ret['name'] = _record.name
+            ret['value'] = _record.to_print()
+            ret['type'] = _record.type
+            ret['ttl'] = _record.ttl
+    elif _type == 'CNAME':
+        _record = _zone.get_cname(name, fetch_all)
+        if _record:
+            ret['name'] = _record.name
+            ret['value'] = _record.to_print()
+            ret['type'] = _record.type
+            ret['ttl'] = _record.ttl
+    elif _type == 'MX':
+        _record = _zone.get_mx(name, fetch_all)
+        if _record:
+            ret['name'] = _record.name
+            ret['value'] = _record.to_print()
+            ret['type'] = _record.type
+            ret['ttl'] = _record.ttl
+    else:
+        msg = '{0} is an unsupported resource type.'.format(_type)
+        log.error(msg)
+        return None
+    if not ret:
+        log.error('Failed to find record {0} in zone {1}.'.format(name, zone))
+    return ret
+
+
+def add_record(name, value, zone, type, identifier=None, ttl=None, comment='',
+               region=None, key=None, keyid=None, profile=None):
+    '''
+    Add a record to a zone.
+
+    CLI example::
+
+        salt myminion boto_route53.add_record test.example.org 1.1.1.1 example.org A
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    _zone = conn.get_zone(zone)
+    if not _zone:
+        msg = 'Failed to retrieve zone {0}'.format(zone)
+        log.error(msg)
+        return False
+    _type = type.upper()
+    if _type == 'A':
+        status = _zone.add_a(name, value, ttl, identifier, comment)
+        return _wait_for_sync(status.id, conn)
+    elif _type == 'CNAME':
+        status = _zone.add_cname(name, value, ttl, identifier, comment)
+        return _wait_for_sync(status.id, conn)
+    elif _type == 'MX':
+        status = _zone.add_mx(name, value, ttl, identifier, comment)
+        return _wait_for_sync(status.id, conn)
+    else:
+        msg = '{0} is an unsupported resource type.'.format(_type)
+        log.error(msg)
+    log.error('Failed to add route53 record {0}.'.format(name))
+    return False
+
+
+def update_record(name, value, zone, type, identifier=None, ttl=None,
+                  comment='', region=None, key=None, keyid=None, profile=None):
+    '''
+    Modify a record in a zone.
+
+    CLI example::
+
+        salt myminion boto_route53.modify_record test.example.org 1.1.1.1 example.org A
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    _zone = conn.get_zone(zone)
+    if not _zone:
+        msg = 'Failed to retrieve zone {0}'.format(zone)
+        log.error(msg)
+        return False
+    _type = type.upper()
+    if _type == 'A':
+        status = _zone.update_a(name, value, ttl, identifier, comment)
+        return _wait_for_sync(status.id, conn)
+    elif _type == 'CNAME':
+        status = _zone.update_cname(name, value, ttl, identifier, comment)
+        return _wait_for_sync(status.id, conn)
+    elif _type == 'MX':
+        status = _zone.update_mx(name, value, ttl, identifier, comment)
+        return _wait_for_sync(status.id, conn)
+    else:
+        msg = '{0} is an unsupported resource type.'.format(_type)
+        log.error(msg)
+    log.error('Failed to update route53 record {0}.'.format(name))
+    return False
+
+
+def delete_record(name, zone, type, identifier=None, all_records=False,
+                  region=None, key=None, keyid=None, profile=None):
+    '''
+    Modify a record in a zone.
+
+    CLI example::
+
+        salt myminion boto_route53.delete_record test.example.org example.org A
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    _zone = conn.get_zone(zone)
+    if not _zone:
+        msg = 'Failed to retrieve zone {0}'.format(zone)
+        log.error(msg)
+        return False
+    _type = type.upper()
+    if _type == 'A':
+        status = _zone.delete_a(name, identifier, all_records)
+        return _wait_for_sync(status.id, conn)
+    elif _type == 'CNAME':
+        status = _zone.delete_cname(name, identifier, all_records)
+        return _wait_for_sync(status.id, conn)
+    elif _type == 'MX':
+        status = _zone.delete_mx(name, identifier, all_records)
+        return _wait_for_sync(status.id, conn)
+    else:
+        msg = '{0} is an unsupported resource type.'.format(_type)
+        log.error(msg)
+    log.error('Failed to delete route53 record {0}.'.format(name))
+    return False
+
+
+def _wait_for_sync(status, conn):
+    retry = 10
+    i = 0
+    while i < retry:
+        log.info('Getting route53 status (attempt {0})'.format(i + 1))
+        change = conn.get_change(status)
+        if change.GetChangeResponse.ChangeInfo.Status == 'INSYNC':
+            return True
+        i = i + 1
+        time.sleep(10)
+    log.error('Timed out waiting for route53 status update.')
+    return False
+
+
+def _get_conn(region, key, keyid, profile):
+    '''
+    Get a boto connection to Route53.
+    '''
+    if profile:
+        if isinstance(profile, string_types):
+            _profile = __salt__['config.option'](profile)
+        elif isinstance(profile, dict):
+            _profile = profile
+        key = _profile.get('key', None)
+        keyid = _profile.get('keyid', None)
+        region = _profile.get('region', None)
+
+    if not region and __salt__['config.option']('route53.region'):
+        region = __salt__['config.option']('route53.region')
+
+    if not region:
+        region = 'us-east-1'
+
+    if not key and __salt__['config.option']('route53.key'):
+        key = __salt__['config.option']('route53.key')
+    if not keyid and __salt__['config.option']('route53.keyid'):
+        keyid = __salt__['config.option']('route53.keyid')
+
+    try:
+        conn = boto.route53.connect_to_region(region, aws_access_key_id=keyid,
+                                              aws_secret_access_key=key)
+    except boto.exception.NoAuthHandlerFound:
+        log.error('No authentication credentials found when attempting to'
+                  ' make boto route53 connection.')
+        return None
+    return conn

--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -33,27 +33,40 @@ as a passed in dict, or as a string to pull from pillars or minion config:
 
 .. code-block:: yaml
 
-    myqueue:
+    mycnamerecord:
         boto_route53.present:
+            - name: test.example.com.
+            - value: my-elb.us-east-1.elb.amazonaws.com.
+            - zone: example.com.
+            - ttl: 60
+            - type: CNAME
             - region: us-east-1
-            - key: GKTADJGHEIQSXMKKRBJ08H
-            - keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
-            - attributes:
-                ReceiveMessageWaitTimeSeconds: 20
+            - keyid: GKTADJGHEIQSXMKKRBJ08H
+            - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
 
     # Using a profile from pillars
-    myqueue:
+    myarecord:
         boto_route53.present:
+            - name: test.example.com.
+            - value: 1.1.1.1
+            - zone: example.com.
+            - ttl: 60
+            - type: A
             - region: us-east-1
             - profile: myprofile
 
     # Passing in a profile
-    myqueue:
+    myarecord:
         boto_route53.present:
+            - name: test.example.com.
+            - value: 1.1.1.1
+            - zone: example.com.
+            - ttl: 60
+            - type: A
             - region: us-east-1
             - profile:
-                key: GKTADJGHEIQSXMKKRBJ08H
-                keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+                keyid: GKTADJGHEIQSXMKKRBJ08H
+                key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
 '''
 
 
@@ -88,7 +101,7 @@ def present(
         The zone to create the record in.
 
     record_type
-        The record type. Current supported values: A, CNAME, MX
+        The record type. Currently supported values: A, CNAME, MX
 
     ttl
         The time to live for the record.
@@ -97,7 +110,7 @@ def present(
         The unique identifier to use for this record.
 
     region
-        Region to create the queue
+        The region to connect to.
 
     key
         Secret key to be used.
@@ -148,12 +161,9 @@ def present(
         _r_values.sort()
         if _values != _r_values:
             need_to_update = True
-            print 'Value does not match'
         if identifier and identifier != record['identifier']:
-            print 'Identifier does not match'
             need_to_update = True
         if ttl and str(ttl) != str(record['ttl']):
-            print 'ttl does not match'
             need_to_update = True
         if need_to_update:
             if __opts__['test']:
@@ -192,7 +202,7 @@ def absent(
         keyid=None,
         profile=None):
     '''
-    Ensure the named sqs queue is deleted.
+    Ensure the Route53 record is deleted.
 
     name
         Name of the record.

--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -1,0 +1,245 @@
+# -*- coding: utf-8 -*-
+'''
+Manage Route53 records
+======================
+
+.. versionadded:: Helium
+
+Create and delete Route53 records. Be aware that this interacts with Amazon's
+services, and so may incur charges.
+
+This module uses boto, which can be installed via package, or pip.
+
+This module accepts explicit route53 credentials but can also utilize
+IAM roles assigned to the instance trough Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More Information available at::
+
+   http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+If IAM roles are not used you need to specify them either in a pillar or
+in the minion's config file::
+
+    route53.keyid: GKTADJGHEIQSXMKKRBJ08H
+    route53.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify key, keyid and region via a profile, either
+as a passed in dict, or as a string to pull from pillars or minion config:
+
+    myprofile:
+        keyid: GKTADJGHEIQSXMKKRBJ08H
+        key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+.. code-block:: yaml
+
+    myqueue:
+        boto_route53.present:
+            - region: us-east-1
+            - key: GKTADJGHEIQSXMKKRBJ08H
+            - keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            - attributes:
+                ReceiveMessageWaitTimeSeconds: 20
+
+    # Using a profile from pillars
+    myqueue:
+        boto_route53.present:
+            - region: us-east-1
+            - profile: myprofile
+
+    # Passing in a profile
+    myqueue:
+        boto_route53.present:
+            - region: us-east-1
+            - profile:
+                key: GKTADJGHEIQSXMKKRBJ08H
+                keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+'''
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    return 'boto_route53' if 'boto_route53.get_record' in __salt__ else False
+
+
+def present(
+        name,
+        value,
+        zone,
+        record_type,
+        ttl=None,
+        identifier=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    '''
+    Ensure the Route53 record is present.
+
+    name
+        Name of the record.
+
+    value
+        Value of the record.
+
+    zone
+        The zone to create the record in.
+
+    record_type
+        The record type. Current supported values: A, CNAME, MX
+
+    ttl
+        The time to live for the record.
+
+    identifier
+        The unique identifier to use for this record.
+
+    region
+        Region to create the queue
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    record = __salt__['boto_route53.get_record'](name, zone, record_type,
+                                                 False, region, key, keyid,
+                                                 profile)
+
+    if isinstance(record, dict) and not record:
+        if __opts__['test']:
+            ret['comment'] = 'Route53 record {0} set to be added.'.format(name)
+            return ret
+        added = __salt__['boto_route53.add_record'](name, value, zone,
+                                                    record_type, identifier,
+                                                    ttl, region, key, keyid,
+                                                    profile)
+        if added:
+            ret['result'] = True
+            ret['changes']['old'] = None
+            ret['changes']['new'] = {'name': name,
+                                     'value': value,
+                                     'record_type': record_type,
+                                     'ttl': ttl}
+            ret['comment'] = 'Added {0} Route53 record.'.format(name)
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to add {0} Route53 record.'.format(name)
+            return ret
+    elif record:
+        need_to_update = False
+        # Values can be a comma separated list and some values will end with a
+        # period (even if we set it without one). To easily check this we need
+        # to split and check with the period stripped from the input and what's
+        # in route53.
+        # TODO: figure out if this will cause us problems with some records.
+        _values = [x.rstrip('.') for x in value.split(',')]
+        _r_values = [x.rstrip('.') for x in record['value'].split(',')]
+        _values.sort()
+        _r_values.sort()
+        if _values != _r_values:
+            need_to_update = True
+            print 'Value does not match'
+        if identifier and identifier != record['identifier']:
+            print 'Identifier does not match'
+            need_to_update = True
+        if ttl and str(ttl) != str(record['ttl']):
+            print 'ttl does not match'
+            need_to_update = True
+        if need_to_update:
+            if __opts__['test']:
+                msg = 'Route53 record {0} set to be updated.'.format(name)
+                ret['comment'] = msg
+                return ret
+            updated = __salt__['boto_route53.update_record'](name, value, zone,
+                                                             record_type,
+                                                             identifier, ttl,
+                                                             region, key,
+                                                             keyid, profile)
+            if updated:
+                ret['result'] = True
+                ret['changes']['old'] = record
+                ret['changes']['new'] = {'name': name,
+                                         'value': value,
+                                         'record_type': record_type,
+                                         'ttl': ttl}
+                ret['comment'] = 'Updated {0} Route53 record.'.format(name)
+            else:
+                ret['result'] = False
+                msg = 'Failed to update {0} Route53 record.'.format(name)
+                ret['comment'] = msg
+        else:
+            ret['comment'] = '{0} exists.'.format(name)
+    return ret
+
+
+def absent(
+        name,
+        zone,
+        record_type,
+        identifier=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    '''
+    Ensure the named sqs queue is deleted.
+
+    name
+        Name of the record.
+
+    zone
+        The zone to delete the record from.
+
+    identifier
+        An identifier to match for deletion.
+
+    region
+        The region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    record = __salt__['boto_route53.get_record'](name, zone, record_type,
+                                                 False, region, key, keyid,
+                                                 profile)
+    if record:
+        if __opts__['test']:
+            msg = 'Route53 record {0} set to be deleted.'.format(name)
+            ret['comment'] = msg
+            return ret
+        deleted = __salt__['boto_route53.delete_record'](name, zone,
+                                                         record_type,
+                                                         identifier, False,
+                                                         region, key, keyid,
+                                                         profile)
+        if deleted:
+            ret['result'] = True
+            ret['changes']['old'] = record
+            ret['changes']['new'] = None
+            ret['comment'] = 'Deleted {0} Route53 record.'.format(name)
+        else:
+            ret['result'] = False
+            msg = 'Failed to delete {0} Route53 record.'.format(name)
+            ret['comment'] = msg
+    else:
+        ret['comment'] = '{0} does not exist.'.format(name)
+    return ret


### PR DESCRIPTION
This change adds support for adding, deleting and updating route53 records in AWS via boto. Currently it only support A, CNAME and MX records.
