### PR TITLE
IMPROVEMENT: Use Python for the thin shim instead of /bin/sh @thatch45

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+'''
+This is a shim that handles checking and updating salt thin and
+then invoking thin.
+
+This is not intended to be instantiated as a module, rather it is a
+helper script used by salt.client.ssh.Single.  It is here, in a
+seperate file, for convenience of development.
+'''
+
+import optparse
+import hashlib
+import tarfile
+import shutil
+import sys
+import os
+
+THIN_ARCHIVE = 'salt-thin.tgz'
+
+# FIXME - it would be ideal if these could be obtained directly from
+#         salt.exitcodes rather than duplicated.
+EX_THIN_DEPLOY = 11
+EX_THIN_CHECKSUM = 12
+
+
+OPTIONS = None
+ARGS = None
+
+
+def parse_argv(argv):
+    global OPTIONS
+    global ARGS
+
+    oparser = optparse.OptionParser(usage="%prog -- [SHIM_OPTIONS] -- [SALT_OPTIONS]")
+    oparser.add_option(
+        "-d", "--delimeter",
+        help="Delimeter string (viz. magic string) to indicate beginning of salt output",
+    )
+    oparser.add_option(
+        "-s", "--saltdir",
+        help="Directory where salt thin is or will be installed.",
+    )
+    oparser.add_option(
+        "--sum", "--checksum",
+        dest="checksum",
+        help="Salt thin checksum",
+    )
+    oparser.add_option(
+        "--hashfunc",
+        default='sha1',
+        help="Hash function for computing checksum",
+    )
+    oparser.add_option(
+        "-v", "--version",
+        help="Salt thin version to be deployed/verified",
+    )
+
+    if argv and '--' not in argv:
+        oparser.error('A "--" argument must be the initial argument indicating the start of options to this script')
+
+    (OPTIONS, ARGS) = oparser.parse_args(argv[argv.index('--')+1:])
+
+    for option in (
+            'delimeter',
+            'saltdir',
+            'checksum',
+            'version',
+    ):
+        if getattr(OPTIONS, option, None):
+            continue
+        oparser.error('Option "--{0}" is required.'.format(option))
+
+
+def need_deployment():
+    if os.path.exists(OPTIONS.saltdir):
+        shutil.rmtree(OPTIONS.saltdir)
+    old_umask = os.umask(0077)
+    os.makedirs(OPTIONS.saltdir)
+    os.umask(old_umask)
+    sys.stdout.write("%s\ndeploy\n" % OPTIONS.delimeter)
+    sys.exit(EX_THIN_DEPLOY)
+
+
+# Adapted from salt.utils.get_hash()
+def get_hash(path, form='md5', chunk_size=4096):
+    try:
+        hash_type = getattr(hashlib, form)
+    except AttributeError:
+        raise ValueError('Invalid hash type: {0}'.format(form))
+    with open(path, 'rb') as ifile:
+        hash_obj = hash_type()
+        # read the file in in chunks, not the entire file
+        for chunk in iter(lambda: ifile.read(chunk_size), b''):
+            hash_obj.update(chunk)
+        return hash_obj.hexdigest()
+
+
+def unpack_thin(thin_path):
+    tfile = tarfile.TarFile.gzopen(thin_path)
+    tfile.extractall(path=OPTIONS.saltdir)
+    tfile.close()
+    os.unlink(thin_path)
+
+
+def main(argv):
+    parse_argv(argv)
+
+    thin_path = os.path.join(OPTIONS.saltdir, THIN_ARCHIVE)
+    if os.path.exists(thin_path):
+        if OPTIONS.checksum != get_hash(thin_path, OPTIONS.hashfunc):
+            sys.stderr.write('WARNING: checksum mismatch for "{0}"\n'.format(thin_path))
+            sys.exit(EX_THIN_CHECKSUM)
+        unpack_thin(thin_path)
+        # Salt thin now is available to use
+    else:
+        if not os.path.exists(OPTIONS.saltdir):
+            need_deployment()
+
+        if not os.path.isdir(OPTIONS.saltdir):
+            sys.stderr.write('ERROR: salt path "{0}" exists but is not a directory\n'.format(OPTIONS.saltdir))
+            sys.exit(os.EX_CANTCREAT)
+
+        version_path = os.path.join(OPTIONS.saltdir, 'version')
+        if not os.path.exists(version_path) or not os.path.isfile(version_path):
+            sys.stderr.write('WARNING: Unable to locate current thin version.\n')
+            need_deployment()
+        with open(version_path, 'r') as vpo:
+            cur_version = vpo.readline().strip()
+        if cur_version != OPTIONS.version:
+            sys.stderr.write('WARNING: current thin version is not up-to-date.\n')
+            need_deployment()
+        # Salt thin exists and is up-to-date - fall through and use it
+
+    salt_call_path = os.path.join(OPTIONS.saltdir, 'salt-call')
+    if not os.path.isfile(salt_call_path):
+        sys.stderr.write('ERROR: thin is missing "{0}"\n'.format(salt_call_path))
+        sys.exit(os.EX_SOFTWARE)
+
+    sys.stdout.write(OPTIONS.delimeter + '\n')
+    sys.stderr.write(OPTIONS.delimeter + '\n')
+    # echo "{{4}}" > /tmp/.salt/minion
+    os.execv(
+        salt_call_path,
+        [
+            'salt-call',
+            '--local',
+            '--out', 'json',
+            '-l', 'quiet',
+            '-c', OPTIONS.saltdir,
+        ]
+        + ARGS
+    )
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/salt/exitcodes.py
+++ b/salt/exitcodes.py
@@ -8,3 +8,8 @@ prefix or in `sysexits.h`).
 # Too many situations use "exit 1" - try not to use it when something
 # else is more appropriate.
 EX_GENERIC = 1
+
+# Salt SSH "Thin" deployment failures
+EX_THIN_PYTHON_OLD = 10
+EX_THIN_DEPLOY = 11
+EX_THIN_CHECKSUM = 12


### PR DESCRIPTION
DO NOT MERGE - for review only @thatch45

This is not complete.  It has only been tested piece-meal and has not
had full integration testing.  I'm hoping for some feedback prior to
completion.
- /bin/sh is, unfortunately, not very portable
- Additional commands (tar, md5sum, etc.) are not uniform
- Python _already_ must be there to run salt and is very predictable
  and portable
- All of the tools necessary to deploy thin are in Python stdlibs
