### PR TITLE
Append 'sqlite_queue_dir' prepend_root_dir for salt.Master.prepare, otherwise verify_env will complain no permission about default dir.

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1990,7 +1990,7 @@ def apply_master_config(overrides=None, defaults=None):
     # Prepend root_dir to other paths
     prepend_root_dirs = [
         'pki_dir', 'cachedir', 'pidfile', 'sock_dir', 'extension_modules',
-        'autosign_file', 'autoreject_file', 'token_dir'
+        'autosign_file', 'autoreject_file', 'token_dir', 'sqlite_queue_dir'
     ]
 
     # These can be set to syslog, so, not actual paths on the system


### PR DESCRIPTION
Append 'sqlite_queue_dir' prepend_root_dir for salt.Master.prepare, otherwise verify_env will complain no permission about default dir.

This issue happend while deploy development environment based on HACKING.rst
