### PR TITLE
Fix Issue: #12422 blockreplace adding blank lines

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1200,6 +1200,11 @@ def blockreplace(path,
                     # end of block detected
                     in_block = False
 
+                    # Check for multi-line '\n' terminated content as split will
+                    # introduce an unwanted additional new line.
+                    if content[-1] == '\n':
+                        content = content[:-1]
+
                     # push new block content in file
                     for cline in content.split("\n"):
                         new_file.append(cline + "\n")


### PR DESCRIPTION
file.blockreplace introduced an unwanted final new line when given
multi-line content due to split() behaviour.
