### PR TITLE
Add unit tests and function doc strings to gpg renderer

### DIFF
--- a/opt_requirements.txt
+++ b/opt_requirements.txt
@@ -2,3 +2,4 @@ mysql-python
 timelib
 yappi >= 0.8.2
 python-novaclient
+python-gnupg

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -85,6 +85,11 @@ DEFAULT_GPG_KEYDIR = '/etc/salt/gpgkeys'
 
 
 def decrypt_ciphertext(c, gpg):
+    '''
+    Given a block of ciphertext as a string, and a gpg object, try to decrypt
+    the cipher and return the decrypted string. If the cipher cannot be
+    decrypted, log the error, and return the ciphertext back out.
+    '''
     decrypted_data = gpg.decrypt(c)
     if not decrypted_data.ok:
         log.info("Could not decrypt cipher {0}, received {1}".format(
@@ -95,6 +100,11 @@ def decrypt_ciphertext(c, gpg):
 
 
 def decrypt_object(o, gpg):
+    '''
+    Recursively try to decrypt any object. If the object is a string, and
+    it contains a valid GPG header, decrypt it, otherwise keep going until
+    a string is found.
+    '''
     if isinstance(o, str):
         if GPG_HEADER.search(o):
             return decrypt_ciphertext(o, gpg)
@@ -111,6 +121,10 @@ def decrypt_object(o, gpg):
 
 
 def render(data, saltenv='base', sls='', argline='', **kwargs):
+    '''
+    Create a gpg object given a gpg_keydir, and then use it to try to decrypt
+    the data to be rendered.
+    '''
     if not HAS_GPG:
         raise SaltRenderError('GPG unavailable')
     if isinstance(__salt__, dict):

--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -11,7 +11,8 @@ The typical use-case would be to use ciphers in your pillar data, and keep a
 secret key on your master. You can put the public key in source control so that
 developers can add new secrets quickly and easily.
 
-This renderer requires the gnupg package.
+This renderer requires the python-gnupg package. Be careful to install the
+``python-gnupg`` package, not the ``gnupg`` package, or you will get errors.
 
 To set things up, you will first need to generate a keypair. On your master,
 run:

--- a/tests/unit/gpg_test.py
+++ b/tests/unit/gpg_test.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+
+# Import Python libs
+import os
+from collections import OrderedDict
+
+# Import Salt Testing libs
+from salttesting import TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import patch, Mock
+
+ensure_in_syspath('../')
+
+# Import Salt libs
+import salt.loader
+import salt.config
+from salt.state import HighState
+
+OPTS = salt.config.minion_config(None)
+OPTS['state_events'] = False
+OPTS['id'] = 'whatever'
+OPTS['file_client'] = 'local'
+OPTS['file_roots'] = dict(base=['/tmp'])
+OPTS['test'] = False
+OPTS['grains'] = salt.loader.grains(OPTS)
+OPTS['gpg_keydir'] = os.getcwd()
+
+ENCRYPTED_STRING = """
+-----BEGIN PGP MESSAGE-----
+I AM SO SECRET!
+-----END PGP MESSAGE-----
+"""
+DECRYPTED_STRING = "I am not a secret anymore"
+
+
+class PyDSLRendererTestCase(TestCase):
+
+    def setUp(self):
+        self.HIGHSTATE = HighState(OPTS)
+        self.HIGHSTATE.push_active()
+
+    def tearDown(self):
+        self.HIGHSTATE.pop_active()
+
+    def render_sls(self, data, sls='', env='base', **kws):
+        return self.HIGHSTATE.state.rend['gpg'](
+            data, env=env, sls=sls, **kws
+        )
+
+    def make_decryption_mock(self, gpg_mock, decrypted_string):
+        decrypted_data_mock = Mock()
+        decrypted_data_mock.ok = True
+        decrypted_data_mock.__str__ = lambda x: DECRYPTED_STRING
+
+        decrypt_mock = Mock(return_value=decrypted_data_mock)
+        gpg_mock.decrypt = decrypt_mock
+
+        return gpg_mock
+
+    def make_nested_object(self, s):
+        return OrderedDict([
+            ('array_key', [1, False, s])
+            ('string_key', "A Normal String"),
+            ('dict_key', {1: None}),
+            ('obj_key', object()),
+        ])
+
+    @patch('gnupg.GPG')
+    def test_homedir_is_passed_to_gpg(self, gpg_mock):
+        self.render_sls({})
+        gpg_mock.assert_called_with(OPTS['gpg_keydir'])
+
+    def test_normal_string_is_unchanged(self):
+        s = 'I am just another string'
+        new_s = self.render_sls(s)
+        self.assertEqual(s, new_s)
+
+    @patch('gnupg.GPG')
+    def test_encrypted_string_is_decrypted(self, gpg_mock):
+        gpg_mock = self.make_decryption_mock(gpg_mock)
+
+        new_s = self.render_sls(ENCRYPTED_STRING)
+        self.assertEqual(new_s, DECRYPTED_STRING)
+
+    @patch('gnupg.GPG')
+    def test_encrypted_string_is_unchanged_when_gpg_fails(self, gpg_mock):
+        decrypted_data_mock = Mock()
+        decrypted_data_mock.ok = False
+
+        decrypt_mock = Mock(return_value=decrypted_data_mock)
+        gpg_mock.decrypt = decrypt_mock
+
+        new_s = self.render_sls(ENCRYPTED_STRING)
+        self.assertEqual(new_s, ENCRYPTED_STRING)
+
+    @patch('gnupg.GPG')
+    def test_nested_object_is_decrypted(self, gpg_mock):
+        gpg_mock = self.make_decryption_mock(gpg_mock)
+
+        encrypted_o = self.make_nested_object(ENCRYPTED_STRING)
+        decrypted_o = self.make_nested_object(DECRYPTED_STRING)
+
+        new_o = self.render_sls(encrypted_o)
+        self.assertEqual(new_o, decrypted_o)


### PR DESCRIPTION
Also some general cleanup.

One thing I wasn't sure of: will putting `python-gnupg` into `opt_requirements.txt` pull it in during automated test runs? Do I need to add it someplace else?
