### PR TITLE
Additions to ssh module

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -195,6 +195,7 @@ def _fingerprint(public_key):
     return ':'.join(chunks)
 
 
+
 def host_keys(keydir=None):
     '''
     Return the minion's host keys
@@ -690,6 +691,7 @@ def rm_known_host(user=None, hostname=None, config='.ssh/known_hosts'):
 def set_known_host(user=None,
                    hostname=None,
                    fingerprint=None,
+                   key=None,
                    port=None,
                    enc=None,
                    hash_hostname=True,
@@ -719,22 +721,25 @@ def set_known_host(user=None,
         update_required = True
     elif fingerprint and fingerprint != stored_host['fingerprint']:
         update_required = True
+    elif key and key != stored_host['key']:
+        update_required = True
 
     if not update_required:
         return {'status': 'exists', 'key': stored_host}
 
-    remote_host = recv_known_host(hostname,
-                                  enc=enc,
-                                  port=port,
-                                  hash_hostname=hash_hostname)
-    if not remote_host:
-        return {'status': 'error',
-                'error': 'Unable to receive remote host key'}
+    if not key:
+        remote_host = recv_known_host(hostname,
+                                      enc=enc,
+                                      port=port,
+                                      hash_hostname=hash_hostname)
+        if not remote_host:
+            return {'status': 'error',
+                    'error': 'Unable to receive remote host key'}
 
-    if fingerprint and fingerprint != remote_host['fingerprint']:
-        return {'status': 'error',
-                'error': ('Remote host public key found but its fingerprint '
-                          'does not match one you have provided')}
+        if fingerprint and fingerprint != remote_host['fingerprint']:
+            return {'status': 'error',
+                    'error': ('Remote host public key found but its fingerprint '
+                              'does not match one you have provided')}
 
     # remove everything we had in the config so far
     rm_known_host(user, hostname, config=config)
@@ -747,7 +752,11 @@ def set_known_host(user=None,
         full = os.path.join(uinfo['home'], config)
     else:
         full = '/etc/ssh/ssh_known_hosts'
-    line = '{hostname} {enc} {key}\n'.format(**remote_host)
+    if not key:
+        line = '{hostname} {enc} {key}\n'.format(**remote_host)
+    else:
+        remote_host = {'hostname': hostname, 'enc': enc, 'key': key}
+        line = '{hostname} {enc} {key}\n'.format(**remote_host)
 
     # ensure ~/.ssh exists
     ssh_dir = os.path.dirname(full)
@@ -766,6 +775,9 @@ def set_known_host(user=None,
         if user:
             os.chown(ssh_dir, uinfo['uid'], uinfo['gid'])
             os.chmod(ssh_dir, 0700)
+
+    if key:
+        cmd_result = __salt__['ssh.hash_known_hosts'](user=user, config=full)
 
     # write line to known_hosts file
     try:
@@ -857,3 +869,37 @@ def user_keys(user=None, pubfile=None, prvfile=None):
         if keys[key]:
             _keys[key] = keys[key]
     return _keys
+
+
+@decorators.which('ssh-keygen')
+def hash_known_hosts(user=None, config='.ssh/known_host'):
+    '''
+
+    Hash all the hostnames in the known hosts file.
+
+    .. versionadded:: Helium
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' ssh.hash_known_hosts
+
+    '''
+    if user:
+        uinfo = __salt__['user.info'](user)
+        if not uinfo:
+            return {'status': 'error',
+                    'error': 'User {0} does not exist'.format(user)}
+        full = os.path.join(uinfo.get('home', ''), config)
+    else:
+        full = '/etc/ssh/ssh_known_hosts'
+    if not os.path.isfile(full):
+        return {'status': 'error',
+                'error': 'Known hosts file {0} does not exist'.format(full)}
+    cmd = 'ssh-keygen -H -f "{0}"'.format(full)
+    cmd_result = __salt__['cmd.run'](cmd)
+    # ssh-keygen creates a new file, thus a chown is required.
+    if os.geteuid() == 0 and user:
+        os.chown(full, uinfo['uid'], uinfo['gid'])
+    return {'status': 'updated', 'comment': cmd_result}

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -195,7 +195,6 @@ def _fingerprint(public_key):
     return ':'.join(chunks)
 
 
-
 def host_keys(keydir=None):
     '''
     Return the minion's host keys

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -751,11 +751,9 @@ def set_known_host(user=None,
         full = os.path.join(uinfo['home'], config)
     else:
         full = '/etc/ssh/ssh_known_hosts'
-    if not key:
-        line = '{hostname} {enc} {key}\n'.format(**remote_host)
-    else:
+    if key:
         remote_host = {'hostname': hostname, 'enc': enc, 'key': key}
-        line = '{hostname} {enc} {key}\n'.format(**remote_host)
+    line = '{hostname} {enc} {key}\n'.format(**remote_host)
 
     # ensure ~/.ssh exists
     ssh_dir = os.path.dirname(full)

--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -24,6 +24,7 @@ def present(
         name,
         user=None,
         fingerprint=None,
+        key=None,
         port=None,
         enc=None,
         config='.ssh/known_hosts',
@@ -69,9 +70,26 @@ def present(
         config = '/etc/ssh/ssh_known_hosts'
 
     if __opts__['test']:
-        result = __salt__['ssh.check_known_host'](user=user, hostname=name,
-                                                  fingerprint=fingerprint,
-                                                  config=config)
+        if key and fingerprint:
+            comment = 'Specify either "key" or "fingerprint", not both.'
+            ret['result'] = False
+            return dict(ret, comment=comment)
+        elif key:
+            if not enc:
+                comment = 'Required argument "enc" if using "key" argument.'
+                ret['result'] = False
+                return dict(ret, comment=comment)
+            result = __salt__['ssh.check_known_host'](user, name,
+                                                      key=key,
+                                                      config=config)
+        elif fingerprint:
+            result = __salt__['ssh.check_known_host'](user, name,
+                                                      fingerprint=fingerprint,
+                                                      config=config)
+        else:
+            comment = 'Arguments key or fingerprint required.'
+            ret['result'] = False
+            return dict(ret, comment=comment)
         if result == 'exists':
             comment = 'Host {0} is already in {1}'.format(name, config)
             ret['result'] = True
@@ -87,6 +105,7 @@ def present(
 
     result = __salt__['ssh.set_known_host'](user=user, hostname=name,
                 fingerprint=fingerprint,
+                key=key,
                 port=port,
                 enc=enc,
                 config=config,
@@ -97,11 +116,18 @@ def present(
     elif result['status'] == 'error':
         return dict(ret, result=False, comment=result['error'])
     else:  # 'updated'
-        fingerprint = result['new']['fingerprint']
-        return dict(ret,
-                changes={'old': result['old'], 'new': result['new']},
-                comment='{0}\'s key saved to {1} (fingerprint: {2})'.format(
-                         name, config, fingerprint))
+        if key:
+            new_key = result['new']['key']
+            return dict(ret,
+                    changes={'old': result['old'], 'new': result['new']},
+                    comment='{0}\'s key saved to {1} (key: {2})'.format(
+                             name, config, new_key))
+        else:
+            fingerprint = result['new']['fingerprint']
+            return dict(ret,
+                    changes={'old': result['old'], 'new': result['new']},
+                    comment='{0}\'s key saved to {1} (fingerprint: {2})'.format(
+                             name, config, fingerprint))
 
 
 def absent(name, user=None, config='.ssh/known_hosts'):


### PR DESCRIPTION
Adding the ability to specify the ssh key instead of a fingerprint when adding to known_hosts.  Does not require connecting to host to gather key information.  Per #11936 
