### PR TITLE
Fix misplaced parens in cmd.run

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -255,7 +255,10 @@ def _run(cmd,
         )
 
     if not _is_valid_shell(shell):
-        log.warning('Attempt to run a shell command with what may be an invalid shell! Check to ensure that she shell <{0}> is valid for this user.').format(shell)
+        log.warning(
+            'Attempt to run a shell command with what may be an invalid shell! '
+            'Check to ensure that she shell <{0}> is valid for this user.'
+            .format(shell))
 
     # Set the default working directory to the home directory of the user
     # salt-minion is running as. Defaults to home directory of user under which


### PR DESCRIPTION
From log.warning('snip').format(shell) to
log.warning('snip'.format(shell)).

Also broke up very long line which probably contributed to this being hard
to spot.
