### PR TITLE
Fix top.sls compilation (#12483) so it matches the behaviour description in documentation section 21.24.15.3 exactly

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2022,7 +2022,7 @@ class BaseHighState(object):
         Cleanly merge the top files
         '''
         top = DefaultOrderedDict(OrderedDict)
-        preferred_base = 'base' # This should be made configurable
+        preferred_base = 'base'  # This should be made configurable
         locked = {}
         for ctops_key, ctops in tops.items():
             for ctop in ctops:

--- a/salt/state.py
+++ b/salt/state.py
@@ -2022,25 +2022,36 @@ class BaseHighState(object):
         Cleanly merge the top files
         '''
         top = DefaultOrderedDict(OrderedDict)
-        for ctops in tops.values():
+        preferred_base = 'base' # This should be made configurable
+        locked = {}
+        for ctops_key, ctops in tops.items():
             for ctop in ctops:
                 for saltenv, targets in ctop.items():
                     if saltenv == 'include':
                         continue
+                    # 21.24.15.3. HOW TOP FILES ARE COMPILED
+                    # [http://docs.saltstack.com/en/latest/ref/states/top.html#how-top-files-are-compiled]
+                    # If we load an environment from preferred_base, never overwrite it
+                    # When from the top.sls in the same environment, only overwrite if not from preferred_base
+                    # Otherwise overwrite in alphabetical order
+                    if saltenv in locked:
+                        if locked[saltenv] == 'pref':
+                            continue
+                        elif locked[saltenv] == 'env':
+                            if ctops_key == preferred_base:
+                                locked[saltenv] = 'pref'
+                            else:
+                                continue
+                    elif ctops_key == preferred_base:
+                        locked[saltenv] = 'pref'
+                    elif ctops_key == saltenv:
+                        locked[saltenv] = 'env'
+                    # Remove the old, we don't merge, we overwrite
+                    if saltenv in top:
+                        del top[saltenv]
                     try:
                         for tgt in targets:
-                            if tgt not in top[saltenv]:
-                                top[saltenv][tgt] = ctop[saltenv][tgt]
-                                continue
-                            matches = []
-                            states = set()
-                            for comp in top[saltenv][tgt]:
-                                if isinstance(comp, dict):
-                                    matches.append(comp)
-                                if isinstance(comp, string_types):
-                                    states.add(comp)
-                            top[saltenv][tgt] = matches
-                            top[saltenv][tgt].extend(list(states))
+                            top[saltenv][tgt] = ctop[saltenv][tgt]
                     except TypeError:
                         raise SaltRenderError('Unable to render top file. No targets found.')
         return top


### PR DESCRIPTION
Proposed fix for #12483

I found best way to debug was at end of merge_top put in a log.info that calls json.dumps( top ) (needed to import json) and it gave a nice pretty output to test things were working OK. Not sure if it worth putting that back in and keeping as a debugging option?

This **changes** the behaviour of top.sls compilation so it behaves exactly as the documentation describes at:
21.24.15.3. HOW TOP FILES ARE COMPILED
http://docs.saltstack.com/en/latest/ref/states/top.html#how-top-files-are-compiled

Specifcally, 'base' is king, then a top.sls in X environment is king of X environment (assuming 'base' isn't already kind). Then it's alphabetical order.

Currently, it's purely alphabetical order and does merging and stuff so nothing like what the documentation states.
