### PR TITLE
fix issue #12192 to return {} or error message

### DIFF
--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -561,7 +561,12 @@ def show_image(kwargs, call=None):
     items = query(action='template', command=kwargs['image'])
     if 'error' in items:
         return items['error']
-    return {items.attrib['name']: items.attrib}
+
+    ret = {}
+    for item in items:
+        ret.update({item.attrib['name']: item.attrib})
+
+    return ret
 
 
 def show_instance(name, call=None):


### PR DESCRIPTION
This is the rework version for issue #12192. when query return {}, we also simply return {}
