### PR TITLE
The MOCK_HOSTNAME is not sufficiently long

### DIFF
--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -36,7 +36,7 @@ from salt.version import SaltStackVersion
 log = logging.getLogger(__name__)
 
 # mock hostname should be more complex than the systems FQDN
-MOCK_HOSTNAME = 'vary.long.complex.fqdn.com'
+MOCK_HOSTNAME = 'vary.long.complex.fqdn.that.is.crazy.extra.long.example.com'
 
 MOCK_ETC_HOSTS = (
     '##\n'


### PR DESCRIPTION
 Make it longer to make it more likely that it will be longer than the hostname on the current host.  Make it crazy long.
