### PR TITLE
Make ec2 create() more reactor friendly

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1753,7 +1753,7 @@ def create(vm_=None, call=None):
                 salt.config.get_cloud_config_value(
                     'keysize',
                     vm_,
-                    self.opts
+                    __opts__
                 )
             )
     else:

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -380,6 +380,7 @@ def bootstrap(vm_, opts):
 
     # Store what was used to the deploy the VM
     event_kwargs = copy.deepcopy(deploy_kwargs)
+    del event_kwargs['opts']
     del event_kwargs['minion_pem']
     del event_kwargs['minion_pub']
     del event_kwargs['sudo_password']

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -297,7 +297,7 @@ def bootstrap(vm_, opts):
 
     ssh_username = salt.config.get_cloud_config_value(
         'ssh_username', vm_, opts, default='root'
-    ),
+    )
 
     deploy_kwargs = {
         'opts': opts,

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -293,7 +293,12 @@ def bootstrap(vm_, opts):
 
     ret = {}
 
-    deploy_script_code = os_script('script', vm_, opts)
+    deploy_script_code = os_script(
+        salt.config.get_cloud_config_value(
+            'os', vm_, opts, default='bootstrap-salt'
+        ),
+        vm_, opts
+    )
 
     ssh_username = salt.config.get_cloud_config_value(
         'ssh_username', vm_, opts, default='root'


### PR DESCRIPTION
This allows create() to be called on an instance which already exists; it skips the request portion and moves onto waiting for it to be available, so that it can bootstrap it.

Also fixes a regression with a misplaced comma in a previous commit today.
