### PR TITLE
Added ignore_types option to pkg.verify ...

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -64,15 +64,21 @@ def list_pkgs(*packages):
     return pkgs
 
 
-def verify(*package):
+def verify(*package, **kwargs):
     '''
     Runs an rpm -Va on a system, and returns the results in a dict
+
+    Files with an attribute of config, doc, ghost, license or readme in the
+    package header can be ignored using the ``ignore_types`` keyword argument
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' lowpkg.verify
+        salt '*' lowpkg.verify httpd
+        salt '*' lowpkg.verify 'httpd postfix'
+        salt '*' lowpkg.verify 'httpd postfix' ignore_types=['config','doc']
     '''
     ftypes = {'c': 'config',
               'd': 'doc',
@@ -80,6 +86,9 @@ def verify(*package):
               'l': 'license',
               'r': 'readme'}
     ret = {}
+    ignore_types = {}
+    if 'ignore_types' in kwargs:
+        ignore_types = kwargs.get('ignore_types')
     if package:
         packages = ' '.join(package)
         cmd = 'rpm -V {0}'.format(packages)
@@ -95,25 +104,26 @@ def verify(*package):
         fname = line[13:]
         if line[11:12] in ftypes:
             fdict['type'] = ftypes[line[11:12]]
-        if line[0:1] == 'S':
-            fdict['mismatch'].append('size')
-        if line[1:2] == 'M':
-            fdict['mismatch'].append('mode')
-        if line[2:3] == '5':
-            fdict['mismatch'].append('md5sum')
-        if line[3:4] == 'D':
-            fdict['mismatch'].append('device major/minor number')
-        if line[4:5] == 'L':
-            fdict['mismatch'].append('readlink path')
-        if line[5:6] == 'U':
-            fdict['mismatch'].append('user')
-        if line[6:7] == 'G':
-            fdict['mismatch'].append('group')
-        if line[7:8] == 'T':
-            fdict['mismatch'].append('mtime')
-        if line[8:9] == 'P':
-            fdict['mismatch'].append('capabilities')
-        ret[fname] = fdict
+        if not 'type' in fdict.keys() or not fdict['type'] in ignore_types:
+          if line[0:1] == 'S':
+              fdict['mismatch'].append('size')
+          if line[1:2] == 'M':
+              fdict['mismatch'].append('mode')
+          if line[2:3] == '5':
+              fdict['mismatch'].append('md5sum')
+          if line[3:4] == 'D':
+              fdict['mismatch'].append('device major/minor number')
+          if line[4:5] == 'L':
+              fdict['mismatch'].append('readlink path')
+          if line[5:6] == 'U':
+              fdict['mismatch'].append('user')
+          if line[6:7] == 'G':
+              fdict['mismatch'].append('group')
+          if line[7:8] == 'T':
+              fdict['mismatch'].append('mtime')
+          if line[8:9] == 'P':
+              fdict['mismatch'].append('capabilities')
+          ret[fname] = fdict
     return ret
 
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1073,19 +1073,25 @@ def get_locked_packages(pattern=None, full=False):
     return current_locks
 
 
-def verify(*names):
+def verify(*names, **kwargs):
     '''
     .. versionadded:: 2014.1.0 (Hydrogen)
 
     Runs an rpm -Va on a system, and returns the results in a dict
+
+    Files with an attribute of config, doc, ghost, license or readme in the
+    package header can be ignored using the ``ignore_types`` keyword argument
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' pkg.verify
+        salt '*' pkg.verify httpd
+        salt '*' pkg.verify 'httpd postfix'
+        salt '*' pkg.verify 'httpd postfix' ignore_types=['config','doc']
     '''
-    return __salt__['lowpkg.verify'](*names)
+    return __salt__['lowpkg.verify'](*names, **kwargs)
 
 
 def group_list():


### PR DESCRIPTION
...which can be used to omit files of a given type such as config or doc from the returned dict
