### PR TITLE
win_dns_client: fix get_dns_servers function

### DIFF
--- a/salt/modules/win_dns_client.py
+++ b/salt/modules/win_dns_client.py
@@ -41,9 +41,10 @@ def get_dns_servers(interface='Local Area Connection'):
 
     with salt.utils.winapi.Com():
         c = wmi.WMI()
-        for iface in c.Win32_NetworkAdapterConfiguration(IPEnabled=1):
-            if interface == iface.Description:
-                return list(iface.DNSServerSearchOrder)
+        for iface in c.Win32_NetworkAdapter(NetEnabled=True):
+            if interface == iface.NetConnectionID:
+                iface_config = c.Win32_NetworkAdapterConfiguration(Index=iface.Index).pop()
+                return list(iface_config.DNSServerSearchOrder)
     log.debug('Interface "{0}" not found'.format(interface))
     return False
 


### PR DESCRIPTION
the `get_dns_servers` should find the nic based on its name and not the driver
for some reason the Description of the interface in `Win32_NetworkAdapter` is the driver name .. =/
