### PR TITLE
tomcat module: adding temp_war_location argument to war_deployed

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -440,7 +440,8 @@ def deploy_war(war,
                url='http://localhost:8080/manager',
                saltenv='base',
                timeout=180,
-               env=None):
+               env=None,
+               temp_war_location=None):
     '''
     Deploy a WAR file
 
@@ -458,6 +459,9 @@ def deploy_war(war,
         function
     timeout : 180
         timeout for HTTP request
+    temp_war_location : None
+        use another location to temporarily  copy to war file
+        by default the system's temp directory is used
 
     CLI Examples:
 
@@ -486,13 +490,19 @@ def deploy_war(war,
         # Backwards compatibility
         saltenv = env
 
+    # Decide the location to copy the war for the deployment
+    tfile = 'salt.{0}'.format(os.path.basename(war))
+    if temp_war_location is not None:
+        if not os.path.isdir(temp_war_location):
+            return 'Error - "{0}" is not a directory'.format(temp_war_location)
+        tfile = os.path.join(temp_war_location, tfile)
+    else:
+        tfile = os.path.join(tempfile.gettempdir(), tfile)
+
     # Copy file name if needed
-    tfile = war
     cache = False
     if not os.path.isfile(war):
         cache = True
-        tfile = os.path.join(tempfile.gettempdir(), 'salt.' +
-                os.path.basename(war))
         cached = __salt__['cp.get_url'](war, tfile, saltenv)
         if not cached:
             return 'FAIL - could not cache the WAR file'

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -54,7 +54,8 @@ def __virtual__():
 def war_deployed(name,
                  war,
                  url='http://localhost:8080/manager',
-                 timeout=180):
+                 timeout=180,
+                 temp_war_location=None):
     '''
     Enforce that the WAR will be deployed and started in the context path
     it will make use of WAR versions
@@ -71,6 +72,9 @@ def war_deployed(name,
         the URL of the server manager webapp
     timeout : 180
         timeout for HTTP request to the tomcat manager
+    temp_war_location : None
+        use another location to temporarily  copy to war file
+        by default the system's temp directory is used
 
     Example::
 
@@ -144,7 +148,8 @@ def war_deployed(name,
                                                'yes',
                                                url,
                                                __env__,
-                                               timeout)
+                                               timeout,
+                                               temp_war_location=temp_war_location)
 
     # Return
     if deploy_res.startswith('OK'):


### PR DESCRIPTION
adding an argument to set the location of the temp directory which will be used to copy the war before to actual deployment to tomcat
this is useful to eliminate file-system permission issues (mainly on windows minions)
