### PR TITLE
Add new configuration for salt-cloud to tweak connections to the VM

### DIFF
--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -173,6 +173,13 @@ The amount of time until an ssh connection can be established via password or
 ssh key. Default 15 seconds.
 
 
+wait_for_passwd_maxtries
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The number of attempts to connect to the VM until we abandon.
+Default 15 attempts
+
+
 wait_for_fun_timeout
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1669,7 +1669,9 @@ def wait_for_instance(
                     'wait_for_passwd_timeout', vm_, __opts__, default=1 * 60),
                 key_filename=vm_['key_filename'],
                 display_ssh_output=display_ssh_output,
-                gateway=ssh_gateway_config
+                gateway=ssh_gateway_config,
+                maxtries=config.get_cloud_config_value(
+                    'wait_for_passwd_maxtries', vm_, __opts__, default=15),
             ):
                 __opts__['ssh_username'] = user
                 vm_['ssh_username'] = user


### PR DESCRIPTION
because `wait_for_passwd_timeout` is never reached, thus prevent us to extend the time before salt-cloud can abandon.
