### PR TITLE
Added convert to list functionality to append in grains module

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -256,11 +256,23 @@ def setval(key, val, destructive=False):
     return setvals({key: val}, destructive)
 
 
-def append(key, val):
+def append(key, val, convert=False):
     '''
     .. versionadded:: 0.17.0
 
-    Append a value to a list in the grains config file
+    Append a value to a list in the grains config file. If the grain doesn't
+    exist, the grain key is added and the value is appended to the new grain
+    as a list item.
+
+    key
+        The grain key to be appended to
+
+    val
+        The value to append to the grain key
+
+    :param convert: If convert is True, convert non-list contents into a
+    list. If convert is False and the grain contains non-list contents, an
+    error is given. Defaults to False.
 
     CLI Example:
 
@@ -268,7 +280,9 @@ def append(key, val):
 
         salt '*' grains.append key val
     '''
-    grains = get(key, [])
+    grains = get(key)
+    if not isinstance(grains, list) and convert is True:
+        grains = [grains]
     if not isinstance(grains, list):
         return 'The key {0} is not a valid list'.format(key)
     if val in grains:


### PR DESCRIPTION
The grains states append function contains `convert=False` kwarg that converts grain values to a list when set to True. I added this same functionality to the append function in the grains module to match. 
