### PR TITLE
fix: cloud.absent thow error when vm doesn't exist

### DIFF
--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -154,7 +154,9 @@ def absent(name, onlyif=None, unless=None):
            'comment': ''}
     retcode = __salt__['cmd.retcode']
     instance = __salt__['cloud.action'](fun='show_instance', names=[name])
-    if not instance:
+    if not instance or \
+            ('Not Actioned/Not Running' in ret \
+            and name in ret['Not Actioned/Not Running']):
         ret['result'] = True
         ret['comment'] = 'Instance {0} already absent'.format(name)
         return ret


### PR DESCRIPTION
The state cloud.absent return an error if the vm does not exist.

```
states/cloud.py:
instance = __salt__['cloud.action'](fun='show_instance', names=[name])
if not instance:
        ret['result'] = True
        ret['comment'] = 'Instance {0} already absent'.format(name)
        return ret 
```

But with some providers like openstack the variable instance exist whereas the vm does not exist:

```
instance = {'Not Actioned/Not Running': ['vpn2']}
```

This is due to do_action method of Cloud class :

```
cloud/__init__.py:L

ret['Not Actioned/Not Running'] = list(names)
```

VMs not found by show_instance (that use list_nodes_full) are put this list so salt try to delete them.

A fixed that with this trivial patch :

```
diff --git a/salt/states/cloud.py b/salt/states/cloud.py
index 749b45a..bb77a1b 100644
--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -154,7 +154,7 @@ def absent(name, onlyif=None, unless=None):
            'comment': ''}
     retcode = __salt__['cmd.retcode']
     instance = __salt__['cloud.action'](fun='show_instance', names=[name])
-    if not instance:
+    if not instance or ('Not Actioned/Not Running' in ret and name in ret['Not Actioned/Not Running']):
         ret['result'] = True
         ret['comment'] = 'Instance {0} already absent'.format(name)
         return ret
```

If the  'Not Actioned/Not Running' state is used by others providers, stopped VMs are not deleted. grep show me that no provider use this state so I think it is not an issue.
