### PR TITLE
elasticsearch returner

### DIFF
--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -4,7 +4,7 @@ Return data to an elasticsearch server for indexing.
 
 :maintainer:    Jurnell Cockhren <jurnell.cockhren@sophicware.com>
 :maturity:      New
-:depends:       elasticsearch-py
+:depends:       `elasticsearch-py <http://elasticsearch-py.readthedocs.org/en/latest/>`_
 :platform:      all
 
 To enable this returner the elasticsearch python client must be installed

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -11,22 +11,22 @@ To enable this returner the elasticsearch python client must be installed
 on the desired minions (all or some subset).
 
 The required configuration is as follows:
-    
+
     elasticsearch:
         host: 'somehost.example.com:9200'
         index: 'salt'
         number_of_shards: 1 (optional)
         number_of_replicas: 0 (optional)
 
-The above configuration can be placed in a targeted pillar, minion or 
-master configurations. 
+The above configuration can be placed in a targeted pillar, minion or
+master configurations.
 
 To use the returner per salt call:
 
     salt '*' test.ping --return elasticsearch
 
 In order to have the returner apply to all minions:
-    
+
     ext_job_cache: elasticsearch
 '''
 

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -1,3 +1,35 @@
+#! -*- coding: utf-8 -*-
+'''
+Return data to an elasticsearch server for indexing.
+
+:maintainer:    Jurnell Cockhren <jurnell.cockhren@sophicware.com>
+:maturity:      New
+:depends:       elasticsearch-py
+:platform:      all
+
+To enable this returner the elasticsearch python client must be installed
+on the desired minions (all or some subset).
+
+The required configuration is as follows:
+    
+    elasticsearch:
+        host:
+        port:
+        number_of_shards: 1 (optional)
+        number_of_replicas: 0 (optional)
+
+The above configuration can be placed in a targeted pillar, minion or 
+master configurations. 
+
+To use the returner per salt call:
+
+    salt '*' test.ping --return elasticsearch
+
+In order to have the returner apply to all minions:
+    
+    ext_job_cache: elasticsearch
+'''
+
 import datetime
 
 __virtualname__ = 'elasticsearch'

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -13,8 +13,8 @@ on the desired minions (all or some subset).
 The required configuration is as follows:
     
     elasticsearch:
-        host:
-        port:
+        host: 'somehost.example.com:9200'
+        index: 'salt'
         number_of_shards: 1 (optional)
         number_of_replicas: 0 (optional)
 

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -1,0 +1,79 @@
+import datetime
+
+__virtualname__ = 'elasticsearch'
+
+try:
+    import elasticsearch
+    HAS_ELASTICSEARCH = True
+except ImportError:
+    HAS_ELASTICSEARCH = False
+
+try:
+    from jsonpickle.pickler import Pickler
+    HAS_PICKLER = True
+except ImportError:
+    HAS_PICKLER = False
+
+
+def _create_index(client, index):
+    # create empty index
+    client.indices.create(
+        index=index,
+        body={
+            'settings': {
+                'number_of_shards': __salt__['config.get']('elasticsearch:number_of_shards') or 1,
+                'number_of_replicas': __salt__['config.get']('elasticsearch:number_of_replicas') or 0,
+            },
+            'mappings': {
+                'returner': {
+                    'properties': {
+                        '@timestamp': {
+                            'type': 'date'
+                        },
+                        'success': {
+                            'type': 'boolean'
+                        },
+                        'id': {
+                            'type': 'string'
+                        },
+                        'retcode': {
+                            'type': 'integer'
+                        },
+                        'fun': {
+                            'type': 'string'
+                        },
+                        'jid': {
+                            'type': 'string'
+                        }
+                    }
+                }
+            }
+        },
+        ignore=400
+    )
+
+
+def __virtual__():
+    if HAS_ELASTICSEARCH and HAS_PICKLER:
+        return __virtualname__
+    return False
+
+
+def _get_pickler():
+    return Pickler(max_depth=5)
+
+
+def _get_instance():
+    return elasticsearch.Elasticsearch([__salt__['config.get']('elasticsearch:host')])
+
+
+def returner(ret):
+    es = _get_instance()
+    _create_index(es, __salt__['config.get']('elasticsearch:index'))
+    r = ret
+    the_time = datetime.datetime.now().isoformat()
+    r['@timestamp'] = the_time
+    es.index(index=__salt__['config.get']('elasticsearch:index'),
+             doc_type='returner',
+             body=_get_pickler().flatten(r),
+             )


### PR DESCRIPTION
Fixes #10678
Dependencies:
- [official elasticsearch python client](http://elasticsearch-py.readthedocs.org/)
- jsonpickler

configuration is defined in the master config file:

``` yaml
ext_job_cahe: elasticsearch

elasticsearch:
    host: 'some.host.com:9200'
    index: 'salt'
    number_of_shards: 1 (optional)
    number_of_replicas: 3 (optional)
```

**Note**: WIP in title will be removed once ready for merging. 
- [x] code
- [x] documentation
