### PR TITLE
Check for pki_dir's master/minions before chdir into it

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -101,7 +101,13 @@ class CkMinions(object):
         Return the minions found by looking via globs
         '''
         cwd = os.getcwd()
-        os.chdir(os.path.join(self.opts['pki_dir'], self.acc))
+        pki_dir = os.path.join(self.opts['pki_dir'], self.acc)
+        
+        # If there is no directory return an empty list
+        if os.path.isdir(pki_dir) is False:
+            return list()
+
+        os.chdir(pki_dir)
         ret = set(glob.glob(expr))
         try:
             os.chdir(cwd)

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -105,7 +105,7 @@ class CkMinions(object):
         
         # If there is no directory return an empty list
         if os.path.isdir(pki_dir) is False:
-            return list()
+            return []
 
         os.chdir(pki_dir)
         ret = set(glob.glob(expr))


### PR DESCRIPTION
When using salt-ssh, it is possible that you do not have an `pki/master/minions` directory. This is common if you specify your own configuration directory. When this happens you get an exception like this:

```
salt-ssh '*' pkg.install htop
[ERROR   ] Failed matching available minions with glob pattern: *
Traceback (most recent call last):
  File "/Users/jcarmony/git/projects/salt/salt/salt/utils/minions.py", line 450, in check_minions
    }[expr_form](expr)
  File "/Users/jcarmony/git/projects/salt/salt/salt/utils/minions.py", line 104, in _check_glob_minions
    os.chdir(os.path.join(self.opts['pki_dir'], self.acc))
OSError: [Errno 2] No such file or directory: '/Users/jcarmony/salt/test_ssh/config/etc/salt/pki/master/minions'
```

salt-ssh will continue to run and match against the roster. This patch is simply to prevent this error by having it check before the chdir.
