### PR TITLE
Add IPv6 support to auth Resolver

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -312,7 +312,8 @@ class Resolver(object):
 
     def _send_token_request(self, load):
         sreq = salt.payload.SREQ(
-            'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
+            'tcp://' + salt.utils.ip_bracket(self.opts['interface']) + \
+            ':{0[ret_port]}'.format(self.opts),
             )
         tdata = sreq.send('clear', load)
         return tdata


### PR DESCRIPTION
Auth Resolver is missing the IPv6 brackets around the IP address.
See: https://github.com/saltstack/salt/issues/9286
