### PR TITLE
Check for IPv6 address master_uri address

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -2016,8 +2016,11 @@ def client_config(path, env_var='SALT_CLIENT_CONFIG', defaults=None):
 
     # Make sure the master_uri is set
     if 'master_uri' not in opts:
-        opts['master_uri'] = 'tcp://{ip}:{port}'.format(ip=opts['interface'],
-                                                        port=opts['ret_port'])
+        opts['master_uri'] = 'tcp://{ip}:{port}'.format(
+            ip=salt.utils.ip_bracket(opts['interface']),
+            port=opts['ret_port']
+        )
+
     # Return the client options
     _validate_opts(opts)
     return opts


### PR DESCRIPTION
Using runnerClient.master_call via client/api.py in an IPv6 environment results in the following error:
  File "/usr/lib/python2.7/dist-packages/salt/payload.py", line 172, in **init**
    self.socket.connect(master)
  File "socket.pyx", line 459, in zmq.core.socket.Socket.connect (zmq/core/socket.c:4228)
ZMQError: Invalid argument

The reason for the error is the missing IPv6 brackets in master_uri as created within salt/config.py.
