### PR TITLE
Adding network and virtual_interface commands to the cloud module

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -983,9 +983,9 @@ def virtual_interface_list(name, **kwargs):
     return conn.virtual_interface_list(name)
 
 
-def virtual_interface_create(name, netname, **kwargs):
+def virtual_interface_create(name, net_name, **kwargs):
     '''
     Create private networks
     '''
     conn = get_conn()
-    return conn.virtual_interface_create(name, netname)
+    return conn.virtual_interface_create(name, net_name)

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -957,3 +957,10 @@ def volume_list(**kwargs):
     '''
     conn = get_conn()
     return conn.volume_list()
+
+def network_list(call=None, **kwargs):
+    '''
+    Attach block volume
+    '''
+    conn = get_conn()
+    return conn.network_list()

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -960,7 +960,14 @@ def volume_list(**kwargs):
 
 def network_list(call=None, **kwargs):
     '''
-    Attach block volume
+    List private networks
     '''
     conn = get_conn()
     return conn.network_list()
+
+def network_create(name, **kwargs):
+    '''
+    Create private networks
+    '''
+    conn = get_conn()
+    return conn.network_create(name, **kwargs)

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -958,6 +958,7 @@ def volume_list(**kwargs):
     conn = get_conn()
     return conn.volume_list()
 
+
 def network_list(call=None, **kwargs):
     '''
     List private networks
@@ -965,9 +966,26 @@ def network_list(call=None, **kwargs):
     conn = get_conn()
     return conn.network_list()
 
+
 def network_create(name, **kwargs):
     '''
     Create private networks
     '''
     conn = get_conn()
     return conn.network_create(name, **kwargs)
+
+
+def virtual_interface_list(name, **kwargs):
+    '''
+    Create private networks
+    '''
+    conn = get_conn()
+    return conn.virtual_interface_list(name)
+
+
+def virtual_interface_create(name, netname, **kwargs):
+    '''
+    Create private networks
+    '''
+    conn = get_conn()
+    return conn.virtual_interface_create(name, netname)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -297,7 +297,7 @@ def network_list(provider):
 
     '''
     client = _get_client()
-    return client.extra_action(action='network_list', provider=provider)
+    return client.extra_action(action='network_list', provider=provider, names='names')
 
 
 def network_create(provider, names, **kwargs):

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -283,3 +283,7 @@ def volume_detach(provider, names, **kwargs):
     client = _get_client()
     info = client.volume_action(provider, names, action='detach', **kwargs)
     return info
+
+def network_list(provider):
+    client = _get_client()
+    return action(fun='network_list', provider=provider)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -289,8 +289,7 @@ def network_list(provider):
     '''
     List private networks
     '''
-    client = _get_client()
-    return action(fun='network_list', provider=provider)
+    return client.network_action(action='network_list', provider=provider)
 
 
 def network_create(provider, names, **kwargs):
@@ -298,4 +297,4 @@ def network_create(provider, names, **kwargs):
     Create private network
     '''
     client = _get_client()
-    return action(fun='network_create', provider=provider, names=names)
+    return client.network_action(provider=provider, names=names, action='network_create', **kwargs)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -296,6 +296,7 @@ def network_list(provider):
         salt minionname cloud.network_list my-nova
 
     '''
+    client = _get_client()
     return client.extra_action(action='network_list', provider=provider)
 
 

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -298,3 +298,19 @@ def network_create(provider, names, **kwargs):
     '''
     client = _get_client()
     return client.extra_action(provider=provider, names=names, action='network_create', **kwargs)
+
+
+def virtual_interface_list(provider, names, **kwargs):
+    '''
+    Create private network
+    '''
+    client = _get_client()
+    return client.extra_action(provider=provider, names=names, action='virtual_interface_list', **kwargs)
+
+
+def virtual_interface_create(provider, names, **kwargs):
+    '''
+    Create private network
+    '''
+    client = _get_client()
+    return client.extra_action(provider=provider, names=names, action='virtual_interface_list', **kwargs)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -213,7 +213,7 @@ def volume_list(provider):
 
     '''
     client = _get_client()
-    info = client.volume_action(provider, 'name', action='list')
+    info = client.extra_action(provider, 'name', action='volume_list')
     return info['name']
 
 
@@ -229,7 +229,7 @@ def volume_delete(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.volume_action(provider, names, action='delete', **kwargs)
+    info = client.extra_action(provider, names, action='volume_delete', **kwargs)
     return info
 
 
@@ -246,7 +246,7 @@ def volume_create(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.volume_action(provider, names, action='create', **kwargs)
+    info = client.extra_action(provider, names, action='volume_create', **kwargs)
     return info
 
 
@@ -264,7 +264,7 @@ def volume_attach(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.volume_action(provider, names, action='attach', **kwargs)
+    info = client.extra_action(provider, names, action='volume_attach', **kwargs)
     return info
 
 
@@ -281,7 +281,7 @@ def volume_detach(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.volume_action(provider, names, action='detach', **kwargs)
+    info = client.extra_action(provider, names, action='volume_detach', **kwargs)
     return info
 
 
@@ -289,7 +289,7 @@ def network_list(provider):
     '''
     List private networks
     '''
-    return client.network_action(action='network_list', provider=provider)
+    return client.extra_action(action='network_list', provider=provider)
 
 
 def network_create(provider, names, **kwargs):
@@ -297,4 +297,4 @@ def network_create(provider, names, **kwargs):
     Create private network
     '''
     client = _get_client()
-    return client.network_action(provider=provider, names=names, action='network_create', **kwargs)
+    return client.extra_action(provider=provider, names=names, action='network_create', **kwargs)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -284,6 +284,18 @@ def volume_detach(provider, names, **kwargs):
     info = client.volume_action(provider, names, action='detach', **kwargs)
     return info
 
+
 def network_list(provider):
+    '''
+    List private networks
+    '''
     client = _get_client()
     return action(fun='network_list', provider=provider)
+
+
+def network_create(provider, names, **kwargs):
+    '''
+    Create private network
+    '''
+    client = _get_client()
+    return action(fun='network_create', provider=provider, names=names)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -313,4 +313,4 @@ def virtual_interface_create(provider, names, **kwargs):
     Create private network
     '''
     client = _get_client()
-    return client.extra_action(provider=provider, names=names, action='virtual_interface_list', **kwargs)
+    return client.extra_action(provider=provider, names=names, action='virtual_interface_create', **kwargs)

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -288,6 +288,13 @@ def volume_detach(provider, names, **kwargs):
 def network_list(provider):
     '''
     List private networks
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt minionname cloud.network_list my-nova
+
     '''
     return client.extra_action(action='network_list', provider=provider)
 
@@ -295,6 +302,13 @@ def network_list(provider):
 def network_create(provider, names, **kwargs):
     '''
     Create private network
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt minionname cloud.network_create my-nova names=['salt'] cidr='192.168.100.0/24'
+
     '''
     client = _get_client()
     return client.extra_action(provider=provider, names=names, action='network_create', **kwargs)
@@ -302,7 +316,14 @@ def network_create(provider, names, **kwargs):
 
 def virtual_interface_list(provider, names, **kwargs):
     '''
-    Create private network
+    List virtual interfaces on a server
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt minionname cloud.virtual_interface_list my-nova names=['salt-master']
+
     '''
     client = _get_client()
     return client.extra_action(provider=provider, names=names, action='virtual_interface_list', **kwargs)
@@ -310,7 +331,14 @@ def virtual_interface_list(provider, names, **kwargs):
 
 def virtual_interface_create(provider, names, **kwargs):
     '''
-    Create private network
+    Attach private interfaces to a server
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt minionname cloud.virtual_interface_create my-nova names=['salt-master'] net_name='salt'
+
     '''
     client = _get_client()
     return client.extra_action(provider=provider, names=names, action='virtual_interface_create', **kwargs)

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -124,7 +124,7 @@ class SaltNova(object):
         if 'extensions' in kwargs:
             exts = []
             for key, item in self.kwargs['extensions'].items():
-                mod = __import__(item.replace('-','_'))
+                mod = __import__(item.replace('-', '_'))
                 exts.append(
                     novaclient.extension.Extension(key, mod)
                 )
@@ -759,7 +759,6 @@ class SaltNova(object):
             if variable not in params:
                 del kwargs[variable]
         return kwargs
-
 
     def network_create(self, name, **kwargs):
         '''

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -9,6 +9,7 @@ try:
     from novaclient.v1_1 import client
     import novaclient.auth_plugin
     import novaclient.exceptions
+    import novaclient.extension
     HAS_NOVA = True
 except ImportError:
     pass
@@ -119,6 +120,15 @@ class SaltNova(object):
 
         if not 'api_key' in self.kwargs.keys():
             self.kwargs['api_key'] = password
+        extensions = []
+        if 'extensions' in kwargs:
+            exts = []
+            for key, item in self.kwargs['extensions'].items():
+                mod = __import__(item.replace('-','_'))
+                exts.append(
+                    novaclient.extension.Extension(key, mod)
+                )
+            self.kwargs['extensions'] = exts
 
         self.kwargs = sanatize_novaclient(self.kwargs)
 
@@ -710,6 +720,13 @@ class SaltNova(object):
         for item in nt_ks.items.list():
             ret.append(item.__dict__)
         return ret
+
+    def network_list(self):
+        '''
+        List extra private networks
+        '''
+        nt_ks = self.compute_conn
+        return [network.__dict__ for network in nt_ks.networks.list()]
 
 #The following is a list of functions that need to be incorporated in the
 #nova module. This list should be updated as functions are added.

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -791,9 +791,8 @@ class SaltNova(object):
         '''
         nt_ks = self.compute_conn
         serverid = self._server_uuid_from_name(name)
-        networkid = self.network_show(name).get('id', '')
-        nets = nt_ks.virtual_interface.create(networkid, serverid)
-        log.debug('Nets: \n{0}'.format(nets))
+        networkid = self.network_show(net_name).get('id', '')
+        nets = nt_ks.virtual_interfaces.create(networkid, serverid)
         return nets
 
 #The following is a list of functions that need to be incorporated in the

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -728,6 +728,33 @@ class SaltNova(object):
         nt_ks = self.compute_conn
         return [network.__dict__ for network in nt_ks.networks.list()]
 
+    def _sanatize_network_params(kwargs):
+        '''
+        Sanatize novaclient network parameters
+        '''
+        params = [
+            'label', 'bridge', 'bridge_interface', 'cidr', 'cidr_v6', 'dns1',
+            'dns2', 'fixed_cidr', 'gateway', 'gateway_v6', 'multi_host',
+            'priority', 'project_id', 'vlan_start', 'vpn_start'
+        ]
+
+        for variable in kwargs.keys():
+            if variable not in params:
+                del kwargs[variable]
+        return kwargs
+
+
+    def network_create(self, name, **kwargs):
+        '''
+        Create extra private network
+        '''
+        nt_ks = self.compute_conn
+        kwargs['label'] = name
+        kwargs = _sanatize_network_params(kwargs)
+        net = nt_ks.networks.create(**kwargs)
+        log.debug('Network: \n{0}'.format(net))
+        return net
+
 #The following is a list of functions that need to be incorporated in the
 #nova module. This list should be updated as functions are added.
 #

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -771,6 +771,31 @@ class SaltNova(object):
         net = nt_ks.networks.create(**kwargs)
         return net.__dict__
 
+    def _server_uuid_from_name(self, name):
+        '''
+        Get server uuid from name
+        '''
+        return self.server_list().get(name, {}).get('id', '')
+
+    def virtual_interface_list(self, name):
+        '''
+        Get virtual interfaces on slice
+        '''
+        nt_ks = self.compute_conn
+        nets = nt_ks.virtual_interfaces.list(self._server_uuid_from_name(name))
+        return [network.__dict__ for network in nets]
+
+    def virtual_interface_create(self, name, net_name):
+        '''
+        Add an interfaces to a slice
+        '''
+        nt_ks = self.compute_conn
+        serverid = self._server_uuid_from_name(name)
+        networkid = self.network_show(name).get('id', '')
+        nets = nt_ks.virtual_interface.create(networkid, serverid)
+        log.debug('Nets: \n{0}'.format(nets))
+        return nets
+
 #The following is a list of functions that need to be incorporated in the
 #nova module. This list should be updated as functions are added.
 #

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -721,6 +721,23 @@ class SaltNova(object):
             ret.append(item.__dict__)
         return ret
 
+    def _network_show(self, name, network_lst):
+        '''
+        Parse the returned network list
+        '''
+        for net in network_lst:
+            if net.label == name:
+                return net.__dict__
+        return False
+
+    def network_show(self, name):
+        '''
+        Show network information
+        '''
+        nt_ks = self.compute_conn
+        net_list = nt_ks.networks.list()
+        return self._network_show(name, net_list)
+
     def network_list(self):
         '''
         List extra private networks
@@ -728,7 +745,7 @@ class SaltNova(object):
         nt_ks = self.compute_conn
         return [network.__dict__ for network in nt_ks.networks.list()]
 
-    def _sanatize_network_params(kwargs):
+    def _sanatize_network_params(self, kwargs):
         '''
         Sanatize novaclient network parameters
         '''
@@ -750,10 +767,9 @@ class SaltNova(object):
         '''
         nt_ks = self.compute_conn
         kwargs['label'] = name
-        kwargs = _sanatize_network_params(kwargs)
+        kwargs = self._sanatize_network_params(kwargs)
         net = nt_ks.networks.create(**kwargs)
-        log.debug('Network: \n{0}'.format(net))
-        return net
+        return net.__dict__
 
 #The following is a list of functions that need to be incorporated in the
 #nova module. This list should be updated as functions are added.


### PR DESCRIPTION
If you use things like rackspace, the extensions will need to be specified in
in the extensions.

```
my-nova: 
  minion:
    mine_functions:
      network.ip_addrs: []
    startup_states: sls
    sls_list:
      - cloud.novaclient
  identity_url: 'https://identity.api.rackspacecloud.com/v2.0/'
  extensions:
    networks: os_networksv2_python_novaclient_ext
    virtual_interfaces: os_virtual_interfacesv2_python_novaclient_ext
  protocol: ipv4
  compute_region: DFW
  user: USER
  tenant: TENANT
  provider: nova
  api_key: APIKEY
  os_auth_plugin: rackspace
  wait_for_ip_timeout: 6000
```
