### PR TITLE
Sort the list of available versions in 'pkg.list_available()'

### DIFF
--- a/salt/modules/win_pkg.py
+++ b/salt/modules/win_pkg.py
@@ -176,6 +176,7 @@ def list_available(*names):
             if not pkginfo:
                 continue
             versions[name] = pkginfo.keys() if pkginfo else []
+    versions = sorted(versions, cmp=_reverse_cmp_pkg_versions)
     return versions
 
 


### PR DESCRIPTION
Improves readability of `pkg.list_available`'s output. Previously it was hard to determine the latest available version because the list was not sorted. Now it is sorted ascending.

**Before:**

``` YAML
MN1221-C0007:
    - 28.0
    - 25.0
    - 24.0
    - 29.0
    - 27.0.1
```

**After:**

``` YAML
MN1221-C0007:
    - 24.0
    - 25.0
    - 27.0.1
    - 28.0
    - 29.0
```
