### PR TITLE
Fix up some cloud stuff

### DIFF
--- a/opt_requirements.txt
+++ b/opt_requirements.txt
@@ -1,5 +1,5 @@
 mysql-python
 timelib
 yappi >= 0.8.2
-python-novaclient
+python-novaclient > 2.17.0
 python-gnupg

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -953,7 +953,7 @@ def volume_attach(name, server_name, device='/dev/xvdb', **kwargs):
 
 def volume_list(**kwargs):
     '''
-    Attach block volume
+    List block devices
     '''
     conn = get_conn()
     return conn.volume_list()

--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -213,7 +213,7 @@ def volume_list(provider):
 
     '''
     client = _get_client()
-    info = client.extra_action(provider, 'name', action='volume_list')
+    info = client.extra_action(action='volume_list', provider=provider, names='name')
     return info['name']
 
 
@@ -229,7 +229,7 @@ def volume_delete(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.extra_action(provider, names, action='volume_delete', **kwargs)
+    info = client.extra_action(provider=provider, names=names, action='volume_delete', **kwargs)
     return info
 
 
@@ -246,7 +246,7 @@ def volume_create(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.extra_action(provider, names, action='volume_create', **kwargs)
+    info = client.extra_action(action='volume_create', names=names, provider=provider, **kwargs)
     return info
 
 
@@ -264,7 +264,7 @@ def volume_attach(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.extra_action(provider, names, action='volume_attach', **kwargs)
+    info = client.extra_action(provider=provider, names=names, action='volume_attach', **kwargs)
     return info
 
 
@@ -281,7 +281,7 @@ def volume_detach(provider, names, **kwargs):
 
     '''
     client = _get_client()
-    info = client.extra_action(provider, names, action='volume_detach', **kwargs)
+    info = client.extra_action(provider=provider, names=names, action='volume_detach', **kwargs)
     return info
 
 

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -301,11 +301,17 @@ class SaltNova(object):
         Delete a block device
         '''
         nt_ks = self.volume_conn
-        volume = self.volume_show(name)
+        try:
+            volume = self.volume_show(name)
+        except:
+            raise SaltCloudSystemExit('Unable to find {0} volume.'.format(name))
         if volume['status'] == 'deleted':
             return volume
-        response = nt_ks.volumes.delete(volume['id'])
-        return self.volume_show(name)
+        try:
+            response = nt_ks.volumes.delete(volume['id'])
+            return volume
+        except:
+            return False
 
     def volume_detach(self,
                       name,

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -676,7 +676,10 @@ class SaltNova(object):
         Show details of one server
         '''
         ret = {}
-        servers = self.server_list_detailed()
+        try:
+            servers = self.server_list_detailed()
+        except AttributeError as exc:
+            raise SaltCloudSystemExit('Corrupt server in server_list_detailed. Remove corrupt servers.')
         for server_name, server in servers.iteritems():
             if str(server['id']) == server_id:
                 ret[server_name] = server

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -304,15 +304,12 @@ class SaltNova(object):
         nt_ks = self.volume_conn
         try:
             volume = self.volume_show(name)
-        except:
-            raise SaltCloudSystemExit('Unable to find {0} volume.'.format(name))
+        except KeyError as exc:
+            raise SaltCloudSystemExit('Unable to find {0} volume: {1}'.format(name, exc))
         if volume['status'] == 'deleted':
             return volume
-        try:
-            response = nt_ks.volumes.delete(volume['id'])
-            return volume
-        except:
-            return False
+        response = nt_ks.volumes.delete(volume['id'])
+        return volume
 
     def volume_detach(self,
                       name,
@@ -320,7 +317,10 @@ class SaltNova(object):
         '''
         Detach a block device
         '''
-        volume = self.volume_show(name)
+        try:
+            volume = self.volume_show(name)
+        except KeyError as exc:
+            raise SaltCloudSystemExit('Unable to find {0} volume: {1}'.format(name, exc))
         if not volume['attachments']:
             return True
         response = self.compute_conn.volumes.delete_server_volume(
@@ -355,7 +355,10 @@ class SaltNova(object):
         '''
         Attach a block device
         '''
-        volume = self.volume_show(name)
+        try:
+            volume = self.volume_show(name)
+        except keyerror as exc:
+            raise saltcloudsystemexit('unable to find {0} volume: {1}'.format(name, exc))
         server = self.server_by_name(server_name)
         response = self.compute_conn.volumes.create_server_volume(
             server.id,

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -2,6 +2,7 @@
 '''
 Nova class
 '''
+from __future__ import with_statement
 
 # Import third party libs
 HAS_NOVA = False

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -132,42 +132,42 @@ class SaltNova(object):
 
         self.kwargs = sanatize_novaclient(self.kwargs)
 
-        conn = client.Client(**self.kwargs)
-        try:
-            conn.client.authenticate()
-        except novaclient.exceptions.AmbiguousEndpoints:
-            raise SaltCloudSystemExit(
-                "Nova provider requires a 'region_name' to be specified"
-            )
+        with client.Client(**self.kwargs) as conn:
+            try:
+                conn.client.authenticate()
+            except novaclient.exceptions.AmbiguousEndpoints:
+                raise SaltCloudSystemExit(
+                    "Nova provider requires a 'region_name' to be specified"
+                )
 
-        self.kwargs['auth_token'] = conn.client.auth_token
-        self.catalog = \
-            conn.client.service_catalog.catalog['access']['serviceCatalog']
+            self.kwargs['auth_token'] = conn.client.auth_token
+            self.catalog = \
+                conn.client.service_catalog.catalog['access']['serviceCatalog']
 
-        if not region_name is None:
-            servers_endpoints = get_entry(self.catalog, 'type', 'compute')['endpoints']
-            self.kwargs['bypass_url'] = get_entry(
-                servers_endpoints,
-                'region',
-                region_name.upper()
-            )['publicURL']
+            if not region_name is None:
+                servers_endpoints = get_entry(self.catalog, 'type', 'compute')['endpoints']
+                self.kwargs['bypass_url'] = get_entry(
+                    servers_endpoints,
+                    'region',
+                    region_name.upper()
+                )['publicURL']
 
-        self.compute_conn = client.Client(**self.kwargs)
+            self.compute_conn = client.Client(**self.kwargs)
 
-        if not region_name is None:
-            servers_endpoints = get_entry(
-                self.catalog,
-                'type',
-                'volume'
-            )['endpoints']
-            self.kwargs['bypass_url'] = get_entry(
-                servers_endpoints,
-                'region',
-                region_name.upper()
-            )['publicURL']
+            if not region_name is None:
+                servers_endpoints = get_entry(
+                    self.catalog,
+                    'type',
+                    'volume'
+                )['endpoints']
+                self.kwargs['bypass_url'] = get_entry(
+                    servers_endpoints,
+                    'region',
+                    region_name.upper()
+                )['publicURL']
 
-        self.kwargs['service_type'] = 'volume'
-        self.volume_conn = client.Client(**self.kwargs)
+            self.kwargs['service_type'] = 'volume'
+            self.volume_conn = client.Client(**self.kwargs)
 
     def get_catalog(self):
         '''

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -133,6 +133,9 @@ class SaltNova(object):
 
         self.kwargs = sanatize_novaclient(self.kwargs)
 
+        if not hasattr(client.Client, '__exit__'):
+            raise SaltCloudSystemExit("Newer version of novaclient required for __exit__.")
+
         with client.Client(**self.kwargs) as conn:
             try:
                 conn.client.authenticate()

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -144,30 +144,30 @@ class SaltNova(object):
             self.catalog = \
                 conn.client.service_catalog.catalog['access']['serviceCatalog']
 
-            if not region_name is None:
-                servers_endpoints = get_entry(self.catalog, 'type', 'compute')['endpoints']
-                self.kwargs['bypass_url'] = get_entry(
-                    servers_endpoints,
-                    'region',
-                    region_name.upper()
-                )['publicURL']
+        if not region_name is None:
+            servers_endpoints = get_entry(self.catalog, 'type', 'compute')['endpoints']
+            self.kwargs['bypass_url'] = get_entry(
+                servers_endpoints,
+                'region',
+                region_name.upper()
+            )['publicURL']
 
-            self.compute_conn = client.Client(**self.kwargs)
+        self.compute_conn = client.Client(**self.kwargs)
 
-            if not region_name is None:
-                servers_endpoints = get_entry(
-                    self.catalog,
-                    'type',
-                    'volume'
-                )['endpoints']
-                self.kwargs['bypass_url'] = get_entry(
-                    servers_endpoints,
-                    'region',
-                    region_name.upper()
-                )['publicURL']
+        if not region_name is None:
+            servers_endpoints = get_entry(
+                self.catalog,
+                'type',
+                'volume'
+            )['endpoints']
+            self.kwargs['bypass_url'] = get_entry(
+                servers_endpoints,
+                'region',
+                region_name.upper()
+            )['publicURL']
 
-            self.kwargs['service_type'] = 'volume'
-            self.volume_conn = client.Client(**self.kwargs)
+        self.kwargs['service_type'] = 'volume'
+        self.volume_conn = client.Client(**self.kwargs)
 
     def get_catalog(self):
         '''

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -357,8 +357,8 @@ class SaltNova(object):
         '''
         try:
             volume = self.volume_show(name)
-        except keyerror as exc:
-            raise saltcloudsystemexit('unable to find {0} volume: {1}'.format(name, exc))
+        except KeyError as exc:
+            raise SaltCloudSystemExit('Unable to find {0} volume: {1}'.format(name, exc))
         server = self.server_by_name(server_name)
         response = self.compute_conn.volumes.create_server_volume(
             server.id,


### PR DESCRIPTION
Fix novaclient to stop being dumb and close the authentication connection when it is done with it.

Also, reorganize the flags for client.extra_actions in the cloud module.

These changes also require novaclient straight out of git, so that it actually has the functions to close the Requests connection.

@techhat this is the one that I messaged you would break novaclient.  Do you want me to add a check for the type and force the use of the new novaclient?(again, not available yet... :/ )
