### PR TITLE
Drop duplicated versions in salt.modules.pkg_resource.sort_pkglist()

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -207,7 +207,7 @@ def sort_pkglist(pkgs):
     # so long as the sorting is consistent.
     try:
         for key in pkgs.keys():
-            pkgs[key].sort()
+            pkgs[key] = sorted(set(pkgs[key]))
     except AttributeError as e:
         log.exception(e)
 


### PR DESCRIPTION
This prevents having packages which report the same version multiple times such as

```
microsoft.office = ["15.0.4569.1506","15.0.4569.1506"]
```

Duplicated version will be dropped to a result like this:

```
microsoft.office = ["15.0.4569.1506"]
```

This is a result of software being registered in 2 places (registry + MSI) at the same time on Windows.
I implemented this in `salt.modules.pkg_resource.sort_pkglist()` as a general safety measure to prevent this from happening in other situations again as it lead to quite some unstable behaviour in other modules here.
