### PR TITLE
Refactor mdadm module/state to support all options on create.

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -214,7 +214,7 @@ def create(name,
     opts = ''
     for key in kwargs:
         if not key.startswith('__'):
-            if kwargs[key] == True:
+            if kwargs[key] is True:
                 opts += '--{0} '.format(key)
             else:
                 opts += '--{0}={1} '.format(key, kwargs[key])

--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -143,80 +143,89 @@ def destroy(device):
         return False
 
 
-def create(*args):
+def create(name,
+           level,
+           devices,
+           raid_devices=None,
+           test_mode=False,
+           **kwargs):
     '''
     Create a RAID device.
+
+    .. versionchanged:: Helium
 
     .. warning::
         Use with CAUTION, as this function can be very destructive if not used
         properly!
 
-    Use this module just as a regular mdadm command.
-
-    For more info, read the ``mdadm(8)`` manpage
-
-    NOTE: It takes time to create a RAID array. You can check the progress in
-    "resync_status:" field of the results from the following command:
-
-    .. code-block:: bash
-
-        salt '*' raid.detail /dev/md0
-
     CLI Examples:
 
     .. code-block:: bash
 
-        salt '*' raid.create /dev/md0 level=1 chunk=256 raid-devices=2 /dev/xvdd /dev/xvde test_mode=True
+        salt '*' raid.create /dev/md0 level=1 chunk=256 raid_devices=2 ['/dev/xvdd', '/dev/xvde'] test_mode=True
 
-    .. note:: Test mode
+    .. note::
 
         Adding ``test_mode=True`` as an argument will print out the mdadm
         command that would have been run.
 
-    :param args: The arguments u pass to this function.
-    :param arguments:
-        arguments['new_array']: The name of the new RAID array that will be created.
-        arguments['opt_val']: Option with Value. Example: raid-devices=2
-        arguments['opt_raw']: Option without Value. Example: force
-        arguments['disks_to_array']: The disks that will be added to the new raid.
-    :return:
+    name
+        The name of the array to create.
+
+    level
+        The RAID level to use when creating the raid.
+
+    devices
+        A list of devices used to build the array.
+
+    raid_devices
+        The number of devices in the array.  If not specified, the number of devices will be counted.
+
+    kwargs
+        Optional arguments to be passed to mdadm.
+
+    returns
         test_mode=True:
             Prints out the full command.
         test_mode=False (Default):
             Executes command on remote the host(s) and
             Prints out the mdadm output.
+
+    .. note::
+
+        It takes time to create a RAID array. You can check the progress in
+        "resync_status:" field of the results from the following command:
+
+        .. code-block:: bash
+
+            salt '*' raid.detail /dev/md0
+
+    For more info, read the ``mdadm(8)`` manpage
     '''
-    test_mode = False
-    arguments = {'new_array': '', 'opt_val': {}, 'opt_raw': [], "disks_to_array": []}
+    cmd_args = {}
 
-    for arg in args:
-        if arg.startswith('test_mode'):
-            test_mode = bool(arg.split('=')[-1])
-        elif arg.startswith('/dev/') is True:
-            if arg.startswith('/dev/md') is True:
-                arguments['new_array'] = arg
+    cmd_args['name'] = name
+    cmd_args['level'] = level
+    cmd_args['devices'] = ' '.join(devices)
+
+    if raid_devices is None:
+        cmd_args['raid-devices'] = len(devices)
+
+    opts = ''
+    for key in kwargs:
+        if not key.startswith('__'):
+            if kwargs[key] == True:
+                opts += '--{0} '.format(key)
             else:
-                arguments['disks_to_array'].append(arg)
-        elif '=' in arg:
-            opt, val = arg.split('=')
-            arguments['opt_val'][opt] = val
-        elif str(arg) in ['readonly', 'run', 'force']:
-            arguments['opt_raw'].append(arg)
-        elif str(arg) in ['missing']:
-            arguments['disks_to_array'].append(arg)
-        else:
-            msg = "Invalid argument - {0} !"
-            raise CommandExecutionError(msg.format(arg))
+                opts += '--{0}={1} '.format(key, kwargs[key])
 
-    cmd = "echo y | mdadm --create --verbose {new_array}{opts_raw}{opts_val} {disks_to_array}"
-    cmd = cmd.format(new_array=arguments['new_array'],
-                     opts_raw=(' --' + ' --'.join(arguments['opt_raw'])
-                               if len(arguments['opt_raw']) > 0
-                               else ''),
-                     opts_val=(' --' + ' --'.join(key + '=' + arguments['opt_val'][key] for key in arguments['opt_val'])
-                               if len(arguments['opt_val']) > 0
-                               else ''),
-                     disks_to_array=' '.join(arguments['disks_to_array']))
+    cmd_args['raw_args'] = opts
+
+    cmd = "mdadm -C {0} -v {1}-l {2} -n {3} {4}".format(cmd_args['name'],
+            cmd_args['raw_args'],
+            cmd_args['level'],
+            cmd_args['raid-devices'],
+            cmd_args['devices'])
 
     if test_mode is True:
         return cmd

--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -36,47 +36,46 @@ def __virtual__():
     return __virtualname__
 
 
-def present(name, opts=None):
+def present(name,
+            level,
+            devices,
+            raid_devices=None,
+            **kwargs):
     '''
     Verify that the raid is present
+
+    .. versionchanged:: Helium
 
     name
         The name of raid device to be created
 
-    opts
-        The mdadm options to use to create the raid. See
-        :mod:`mdadm <salt.modules.mdadm>` for more information.
-        Opts can be expressed as a single string of options.
+    level
+                The RAID level to use when creating the raid.
 
-        .. code-block:: yaml
+    devices
+        A list of devices used to build the array.
 
-            /dev/md0:
-              raid.present:
-                - opts: level=1 chunk=256 raid-devices=2 /dev/xvdd /dev/xvde
+    raid_devices
+        The number of devices in the array.  If not specified, the number of devices will be counted.
 
-        Or as a list of options.
+    Example:
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
-            /dev/md0:
-              raid.present:
-                - opts:
-                  - level=1
-                  - chunk=256
-                  - raid-devices=2
-                  - /dev/xvdd
-                  - /dev/xvde
+        /dev/md0:
+          raid.present:
+            - level: 5
+            - devices:
+              - /dev/xvdd
+              - /dev/xvde
+              - /dev/xvdf
+            - chunk: 256
+            - run: True
     '''
     ret = {'changes': {},
            'comment': '',
            'name': name,
            'result': True}
-
-    args = [name]
-    if isinstance(opts, str):
-        opts = opts.split()
-
-    args.extend(opts)
 
     # Device exists
     raids = __salt__['raid.list']()
@@ -86,14 +85,22 @@ def present(name, opts=None):
 
     # If running with test use the test_mode with create
     if __opts__['test']:
-        args.extend(['test_mode=True'])
-        res = __salt__['raid.create'](*args)
+        res = __salt__['raid.create'](name,
+                                      level,
+                                      devices,
+                                      raid_devices,
+                                      test_mode=True,
+                                      **kwargs)
         ret['comment'] = 'Raid will be created with: {0}'.format(res)
         ret['result'] = None
         return ret
 
     # Attempt to create the array
-    __salt__['raid.create'](*args)
+    __salt__['raid.create'](name,
+                            level,
+                            devices,
+                            raid_devices,
+                            **kwargs)
 
     raids = __salt__['raid.list']()
     changes = raids.get(name)

--- a/tests/unit/modules/mdadm_test.py
+++ b/tests/unit/modules/mdadm_test.py
@@ -52,7 +52,6 @@ class MdadmTestCase(TestCase):
                     ['/dev/sdb1',
                      '/dev/sdc1',
                      '/dev/sdd1'],
-                    test_mode=False,
                     force=True,
                     chunk=256,
                     test_mode=True

--- a/tests/unit/modules/mdadm_test.py
+++ b/tests/unit/modules/mdadm_test.py
@@ -17,7 +17,6 @@ ensure_in_syspath('../../')
 
 # Import salt libs
 from salt.modules import mdadm
-from salt.exceptions import CommandNotFoundError
 
 mdadm.__salt__ = {}
 

--- a/tests/unit/modules/mdadm_test.py
+++ b/tests/unit/modules/mdadm_test.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Ted Strzalkowski (tedski@gmail.com)`
+    :copyright: © 2013 by the SaltStack Team, see AUTHORS for more details
+    :license: Apache 2.0, see LICENSE for more details.
+
+
+    tests.unit.modules.mdadm_test
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+ensure_in_syspath('../../')
+
+# Import salt libs
+from salt.modules import mdadm
+from salt.exceptions import CommandNotFoundError
+
+mdadm.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class MdadmTestCase(TestCase):
+
+    @patch('salt.utils.which', lambda exe: exe)
+    def test_create(self):
+        mock = MagicMock(return_value='salt')
+        with patch.dict(mdadm.__salt__, {'cmd.run': mock}):
+            ret = mdadm.create(
+                    '/dev/md0', 5,
+                    ['/dev/sdb1',
+                     '/dev/sdc1',
+                     '/dev/sdd1'],
+                    test_mode=False,
+                    force=True,
+                    chunk=256
+            )
+            self.assertEqual('salt', ret)
+            mock.assert_called_once_with(
+                    'mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -n 3 '
+                    '/dev/sdb1 /dev/sdc1 /dev/sdd1'
+            )
+
+    def test_create_test_mode(self):
+        mock = MagicMock()
+        with patch.dict(mdadm.__salt__, {'cmd.run': mock}):
+            ret = mdadm.create(
+                    '/dev/md0', 5,
+                    ['/dev/sdb1',
+                     '/dev/sdc1',
+                     '/dev/sdd1'],
+                    test_mode=False,
+                    force=True,
+                    chunk=256,
+                    test_mode=True
+            )
+            self.assertEqual('mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -n 3 '
+                    '/dev/sdb1 /dev/sdc1 /dev/sdd1', ret)
+            assert not mock.called, 'test mode failed, cmd.run called'
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(MdadmTestCase, needs_daemon=False)


### PR DESCRIPTION
- Utilize kwargs to support all mdadm options.
- Auto-count number of devices if left out.
- Use YAML data structure in state instead of args.
- Removes forceful array creation (moves it to arguments)
