### PR TITLE
Missing case for show_timeout 

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1025,6 +1025,7 @@ class LocalClient(object):
             tgt='*',
             tgt_type='glob',
             verbose=False,
+            show_timeout=False,
             show_jid=False):
         '''
         Get the returns for the command line interface via the event system
@@ -1074,7 +1075,7 @@ class LocalClient(object):
                 # All minions have returned, break out of the loop
                 break
             if int(time.time()) > timeout_at:
-                if verbose:
+                if verbose or show_timeout:
                     if self.opts.get('minion_data_cache', False) \
                             or tgt_type in ('glob', 'pcre', 'list'):
                         if len(found) < len(minions):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1582,13 +1582,13 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             '--show-timeout',
             default=False,
             action='store_true',
-            help=('Display minions that timeout')
+            help=('Display minions that timeout without the additional output of --verbose')
         )
         self.add_option(
             '--show-jid',
             default=False,
             action='store_true',
-            help=('Displays jid without the additional output of --verbose')
+            help=('Display jid without the additional output of --verbose')
         )
         self.add_option(
             '-b', '--batch',


### PR DESCRIPTION
--show-timeout was missing from get_cli_static_event_returns.  Also added additional explanation to the option's help because I was seeing people unnecessarily use it in addition to --verbose.
