### PR TITLE
Return True for volume_detached if volume is absent

### DIFF
--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -418,6 +418,8 @@ def volume_attached(name, server_name, provider=None, **kwargs):
 def volume_detached(name, server_name=None, provider=None, **kwargs):
     '''
     Check if a block volume is attached.
+
+    Returns True if server or Volume do not exist.
     '''
     ret = _check_name(name)
     if not ret['result']:

--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -443,11 +443,11 @@ def volume_detached(name, server_name=None, provider=None, **kwargs):
         return ret
     elif not name in volumes.keys():
         ret['comment'] = 'Volume {0} does not exist'.format(name)
-        ret['result'] = False
+        ret['result'] = True
         return ret
     elif not instance and not server_name is None:
         ret['comment'] = 'Server {0} does not exist'.format(server_name)
-        ret['result'] = False
+        ret['result'] = True
         return ret
     elif __opts__['test']:
         ret['comment'] = 'Volume {0} will be will be detached.'.format(


### PR DESCRIPTION
Technically it is detached.

@techhat I think this is the more appropriate response for it being detached and not existing.

It may be better to have it return False if the server doesn't exist, but if the volume doesn't exist, I think it should definitely return True.

Let me know what you think.
