### PR TITLE
Allow packages to be updated on their own

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -245,7 +245,7 @@ def _find_install_targets(name=None,
                     if kwargs['allow_updates']:
                         comparison = '>='
                 if not _fulfills_version_spec(cver, comparison, verstr):
-                    log.debug('Current version ({0} did not match ({1}) desired ({2}), add to targets'.format(cver,comparison,verstr))
+                    log.debug('Current version ({0} did not match ({1}) desired ({2}), add to targets'.format(cver, comparison, verstr))
                     targets[pkgname] = pkgver
 
         if problems:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -241,8 +241,11 @@ def _find_install_targets(name=None,
                 # Change it to "==" so that the version comparison works
                 if comparison in ['=', '']:
                     comparison = '=='
+                if 'allow_updates' in kwargs:
+                    if kwargs['allow_updates']:
+                        comparison = '>='
                 if not _fulfills_version_spec(cver, comparison, verstr):
-                    # Current version did not match desired, add to targets
+                    log.debug('Current version ({0} did not match ({1}) desired ({2}), add to targets'.format(cver,comparison,verstr))
                     targets[pkgname] = pkgver
 
         if problems:
@@ -337,6 +340,7 @@ def installed(
         skip_suggestions=False,
         pkgs=None,
         sources=None,
+        allow_updates=False,
         **kwargs):
     '''
     Verify that the package is installed, and that it is the correct version
@@ -425,6 +429,13 @@ def installed(
     hold
         Force the package to be held at the current installed version.
         Currently works with YUM & APT based systems.
+
+        .. versionadded:: Helium
+
+    allow_updates
+        Allow the package to be updated outside Salt's control (e.g. auto updates on Windows).
+        This means a package on the Minion can have a newer version than the latest available
+        in the repository without enforcing a re-installation of the package.
 
         .. versionadded:: Helium
 
@@ -546,6 +557,7 @@ def installed(
     if not isinstance(version, string_types) and version is not None:
         version = str(version)
 
+    kwargs['allow_updates'] = allow_updates
     result = _find_install_targets(name, version, pkgs, sources,
                                    fromrepo=fromrepo,
                                    skip_suggestions=skip_suggestions,


### PR DESCRIPTION
In some cases, it is required to let packages update themselves:
- Some Windows updates increase the version number of installed packages
  while this version cannot be deployed standalone through a regular
  win_repo package
- Allow users to apply timely critical updates on their own so they
  don't have to wait for the admins to provide the newest version (e.g
  auto updates of software such as Mozilla Firefox which allows to
  install updates through regular users without administrative
  permissions)

Fixes #11602
