### PR TITLE
Working salt-ssh test runner

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -735,7 +735,7 @@ class Single(object):
         else:
             # RSTR was found in stdout but not stderr - which means there
             # is a SHIM command for the master.
-            shim_command = re.split(r'\r?\n', stdout, 1)[1].strip()
+            shim_command = re.split(r'\r?\n', stdout, 1)[0].strip()
             if 'deploy' == shim_command and retcode == salt.exitcodes.EX_THIN_DEPLOY:
                 self.deploy()
                 stdout, stderr, retcode = self.shell.exec_cmd(cmd_str)

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -447,7 +447,6 @@ class TestDaemon(object):
         if keygen_ed25519_err:
             print('ssh-keygen had errors: {0}'.format(keygen_ed25519_err))
 
-
         with open(os.path.join(TMP_CONF_DIR, 'sshd_config'), 'a') as ssh_config:
             ssh_config.write('AuthorizedKeysFile {0}\n'.format(auth_key_file))
             ssh_config.write('HostKey {0}\n'.format(server_dsa_priv_key_file))

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1023,7 +1023,7 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
         '''
         Execute salt-ssh
         '''
-        arg_str = '-i --priv {0} --roster-file {1} localhost {2} --out=json'.format(os.path.join(TMP_CONF_DIR, 'key_test'), os.path.join(TMP_CONF_DIR, 'roster'), arg_str)
+        arg_str = '-c {0} -i --priv {1} --roster-file {2} localhost {3} --out=json'.format(self.get_config_dir(), os.path.join(TMP_CONF_DIR, 'key_test'), os.path.join(TMP_CONF_DIR, 'roster'), arg_str)
         return self.run_script('salt-ssh', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, raw=True)
 
     def run_run(self, arg_str, with_retcode=False, catch_stderr=False):

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1024,7 +1024,7 @@ class ShellCase(AdaptedConfigurationTestCaseMixIn, ShellTestCase):
         '''
         Execute salt-ssh
         '''
-        arg_str = '-c {0} --priv {1} --roster-file {2} localhost {3} --out=json'.format(TMP_CONF_DIR, os.path.join(TMP_CONF_DIR, 'test_key'), os.path.join(TMP_CONF_DIR, 'roster'), arg_str)
+        arg_str = '-i --priv {0} --roster-file {1} localhost {2} --out=json'.format(os.path.join(TMP_CONF_DIR, 'key_test'), os.path.join(TMP_CONF_DIR, 'roster'), arg_str)
         return self.run_script('salt-ssh', arg_str, with_retcode=with_retcode, catch_stderr=catch_stderr, raw=True)
 
     def run_run(self, arg_str, with_retcode=False, catch_stderr=False):

--- a/tests/integration/files/conf/_ssh/roster
+++ b/tests/integration/files/conf/_ssh/roster
@@ -1,3 +1,4 @@
 localhost:
   host: 127.0.0.1
   user: root
+  port: 2827

--- a/tests/integration/files/conf/_ssh/sshd_config
+++ b/tests/integration/files/conf/_ssh/sshd_config
@@ -1,0 +1,61 @@
+# Package generated configuration file
+# See the sshd_config(5) manpage for details
+
+Port 2827
+ListenAddress 127.0.0.1
+Protocol 2
+# HostKeys for protocol version 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_dsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+UsePrivilegeSeparation yes
+# Turn strict modes off so that we can operate in /tmp
+StrictModes no
+
+# Lifetime and size of ephemeral version 1 server key
+KeyRegenerationInterval 3600
+ServerKeyBits 1024
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Authentication:
+LoginGraceTime 120
+PermitRootLogin without-password
+StrictModes yes
+
+RSAAuthentication yes
+PubkeyAuthentication yes
+#AuthorizedKeysFile	%h/.ssh/authorized_keys
+#AuthorizedKeysFile	key_test.pub
+
+# Don't read the user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+# For this to work you will also need host keys in /etc/ssh_known_hosts
+RhostsRSAAuthentication no
+# similar for protocol version 2
+HostbasedAuthentication no
+#IgnoreUserKnownHosts yes
+
+# To enable empty passwords, change to yes (NOT RECOMMENDED)
+PermitEmptyPasswords no
+
+# Change to yes to enable challenge-response passwords (beware issues with
+# some PAM modules and threads)
+ChallengeResponseAuthentication no
+
+# Change to no to disable tunnelled clear text passwords
+PasswordAuthentication no
+
+X11Forwarding no
+X11DisplayOffset 10
+PrintMotd no
+PrintLastLog yes
+TCPKeepAlive yes
+#UseLogin no
+AcceptEnv LANG LC_*
+
+Subsystem sftp /usr/lib/openssh/sftp-server
+
+UsePAM yes

--- a/tests/integration/files/conf/_ssh/sshd_config
+++ b/tests/integration/files/conf/_ssh/sshd_config
@@ -5,9 +5,9 @@ Port 2827
 ListenAddress 127.0.0.1
 Protocol 2
 # HostKeys for protocol version 2
-HostKey /etc/ssh/ssh_host_rsa_key
-HostKey /etc/ssh/ssh_host_dsa_key
-HostKey /etc/ssh/ssh_host_ecdsa_key
+#HostKey /etc/ssh/ssh_host_rsa_key
+#HostKey /etc/ssh/ssh_host_dsa_key
+#HostKey /etc/ssh/ssh_host_ecdsa_key
 UsePrivilegeSeparation yes
 # Turn strict modes off so that we can operate in /tmp
 StrictModes no

--- a/tests/integration/files/conf/_ssh/sshd_config
+++ b/tests/integration/files/conf/_ssh/sshd_config
@@ -4,10 +4,6 @@
 Port 2827
 ListenAddress 127.0.0.1
 Protocol 2
-# HostKeys for protocol version 2
-#HostKey /etc/ssh/ssh_host_rsa_key
-#HostKey /etc/ssh/ssh_host_dsa_key
-#HostKey /etc/ssh/ssh_host_ecdsa_key
 UsePrivilegeSeparation yes
 # Turn strict modes off so that we can operate in /tmp
 StrictModes no
@@ -58,4 +54,4 @@ AcceptEnv LANG LC_*
 
 Subsystem sftp /usr/lib/openssh/sftp-server
 
-UsePAM yes
+#UsePAM yes

--- a/tests/integration/ssh/deploy.py
+++ b/tests/integration/ssh/deploy.py
@@ -1,1 +1,19 @@
 # -*- coding: utf-8 -*-
+'''
+salt-ssh testing
+'''
+import integration
+from salttesting import skipIf
+
+
+@skipIf(True, 'Not ready for production')
+class SSHTest(integration.SSHCase):
+    '''
+    Test general salt-ssh functionality
+    '''
+    def test_ping(self):
+        '''
+        Test a simple ping
+        '''
+        ret = self.run_function('test.ping')
+        self.assertTrue(ret, 'Ping did not return true')

--- a/tests/integration/ssh/deploy.py
+++ b/tests/integration/ssh/deploy.py
@@ -6,7 +6,7 @@ import integration
 from salttesting import skipIf
 
 
-#@skipIf(True, 'Not ready for production')
+@skipIf(True, 'Not ready for production')
 class SSHTest(integration.SSHCase):
     '''
     Test general salt-ssh functionality

--- a/tests/integration/ssh/deploy.py
+++ b/tests/integration/ssh/deploy.py
@@ -6,7 +6,7 @@ import integration
 from salttesting import skipIf
 
 
-@skipIf(True, 'Not ready for production')
+#@skipIf(True, 'Not ready for production')
 class SSHTest(integration.SSHCase):
     '''
     Test general salt-ssh functionality

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -122,7 +122,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             default=False,
             help='Run salt-ssh tests. These tests will spin up a temporary '
                  'SSH server on your machine. In certain environments, this '
-                 'may be insecure! Default: $default'
+                 'may be insecure! Default: False'
         )
         self.output_options_group.add_option(
             '--no-colors',


### PR DESCRIPTION
This rounds out initial (alpha) support for a salt-ssh test runner.

At present, one must manually specify the --ssh flag to ensure that
the ssh deamons are spun up properly.
