### PR TITLE
avoid shadowing in salt.utils.xdg_config_dir()

### DIFF
--- a/salt/utils/xdg.py
+++ b/salt/utils/xdg.py
@@ -10,9 +10,9 @@ def xdg_config_dir(config_dir=None):
     Check xdg locations for config files
     '''
     xdg_config = os.getenv('XDG_CONFIG_HOME', os.path.expanduser('~/.config'))
-    xdg_config_dir = os.path.join(xdg_config, 'salt')
-    if os.path.isdir(xdg_config_dir):
-        return xdg_config_dir
+    xdg_config_directory = os.path.join(xdg_config, 'salt')
+    if os.path.isdir(xdg_config_directory):
+        return xdg_config_directory
     else:
         if config_dir is None:
             return os.path.expanduser('~/.')


### PR DESCRIPTION
```
************* Module salt.utils.xdg
salt/utils/xdg.py:13: [W0621(redefined-outer-name), xdg_config_dir] Redefining name 'xdg_config_dir' from outer scope (line 8)
```
