### PR TITLE
Jinja renderer, timezone module/state fixes

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -10,6 +10,7 @@ import logging
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -156,11 +157,21 @@ def zone_compare(timezone):
         return 'Error: {0} does not exist.'.format(tzfile)
 
     hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
-    with salt.utils.fopen(zonepath, 'r') as fp_:
-        usrzone = hash_type(fp_.read()).hexdigest()
 
-    with salt.utils.fopen(tzfile, 'r') as fp_:
-        etczone = hash_type(fp_.read()).hexdigest()
+    try:
+        with salt.utils.fopen(zonepath, 'r') as fp_:
+            usrzone = hash_type(fp_.read()).hexdigest()
+    except IOError as exc:
+        raise SaltInvocationError('Invalid timezone {0!r}'.format(timezone))
+
+    try:
+        with salt.utils.fopen(tzfile, 'r') as fp_:
+            etczone = hash_type(fp_.read()).hexdigest()
+    except IOError as exc:
+        raise CommandExecutionError(
+            'Problem reading timezone file {0}: {1}'
+            .format(tzfile, exc.strerror)
+        )
 
     if usrzone == etczone:
         return True

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -28,6 +28,8 @@ it applies to systems that dual-boot with Windows. This is explained in greater
 detail here_.
 '''
 
+# Import salt libs
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 def __virtual__():
     '''
@@ -36,7 +38,7 @@ def __virtual__():
     return 'timezone.get_zone' in __salt__
 
 
-def system(name, utc=''):
+def system(name, utc=True):
     '''
     Set the timezone for the system.
 
@@ -53,7 +55,17 @@ def system(name, utc=''):
     # Set up metadata
     do_utc = False
     do_zone = False
-    compzone = __salt__['timezone.zone_compare'](name)
+
+    try:
+        compzone = __salt__['timezone.zone_compare'](name)
+    except (SaltInvocationError, CommandExecutionError) as exc:
+        ret['result'] = False
+        ret['comment'] = (
+            'Unable to compare desrired timezone {0!r} to system timezone: {1}'
+            .format(name, exc)
+        )
+        return ret
+
     myutc = True
     messages = []
     if __salt__['timezone.get_hwclock']() == 'localtime':
@@ -67,10 +79,10 @@ def system(name, utc=''):
         do_zone = True
 
     # If the user passed in utc, do a check
-    if utc != '' and utc != myutc:
+    if utc and utc != myutc:
         ret['result'] = None
         do_utc = True
-    elif utc != '' and utc == myutc:
+    elif utc and utc == myutc:
         messages.append('UTC already set to {0}'.format(name))
 
     if ret['result'] is True:
@@ -81,7 +93,7 @@ def system(name, utc=''):
         messages = []
         if compzone is False:
             messages.append('Timezone {0} needs to be set'.format(name))
-        if utc != '' and myutc != utc:
+        if utc and myutc != utc:
             messages.append('UTC needs to be set to {0}'.format(utc))
         ret['comment'] = ', '.join(messages)
         return ret

--- a/salt/states/timezone.py
+++ b/salt/states/timezone.py
@@ -31,6 +31,7 @@ detail here_.
 # Import salt libs
 from salt.exceptions import SaltInvocationError, CommandExecutionError
 
+
 def __virtual__():
     '''
     Only load if the timezone module is available in __salt__

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -20,7 +20,9 @@ import jinja2.ext
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import SaltRenderError
+from salt.exceptions import (
+    SaltRenderError, CommandExecutionError, SaltInvocationError
+)
 from salt.utils.jinja import ensure_sequence_filter
 from salt.utils.jinja import SaltCacheLoader as JinjaSaltCacheLoader
 from salt.utils.jinja import SerializerExtension as JinjaSerializerExtension
@@ -285,7 +287,17 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
                 exc, out),
             line,
             tmplstr)
-    except Exception, exc:
+    except (SaltInvocationError, CommandExecutionError) as exc:
+        trace = traceback.extract_tb(sys.exc_info()[2])
+        line, out = _get_jinja_error(trace, context=unicode_context)
+        if not line:
+            tmplstr = ''
+        raise SaltRenderError(
+            'Problem running salt function in Jinja template: {0}{1}'.format(
+                exc, out),
+            line,
+            tmplstr)
+    except Exception as exc:
         tracestr = traceback.format_exc()
         trace = traceback.extract_tb(sys.exc_info()[2])
         line, out = _get_jinja_error(trace, context=unicode_context)


### PR DESCRIPTION
**This will likely have a merge conflict with #12728. If that PR is merged first, ping me and I'll rebase and fix this one.**

This pull request does a couple things:
1. Improves jinja render error messages for `SaltInvocationError` and `CommandExecutionError` exceptions by catching them in the jinja renderer and suppressing the traceback.
2. Provides a useful error message instead of a traceback when an invalid timezone is passed. Refs #12696.
