### PR TITLE
Fix timedatectl parsing for newer systemd releases (2014.1 branch)

### DIFF
--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -11,6 +11,7 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -7,6 +7,7 @@ Module for managing timezone on POSIX-like systems.
 import os
 import hashlib
 import logging
+import re
 
 # Import salt libs
 import salt.utils
@@ -34,9 +35,16 @@ def get_zone():
         salt '*' timezone.get_zone
     '''
     cmd = ''
-    if 'Arch' in __grains__['os_family']:
-        cmd = ('timedatectl | grep Timezone |'
-               'sed -e"s/: /=/" -e"s/^[ \t]*//" | cut -d" " -f1')
+    if salt.utils.which('timedatectl'):
+        out = __salt__['cmd.run']('timedatectl', output_loglevel='debug')
+        for line in (x.strip() for x in out.splitlines()):
+            try:
+                return re.match(r'Time ?zone:\s+(\S+)', line).group(1)
+            except AttributeError:
+                pass
+        raise CommandExecutionError(
+            'Failed to parse timedatectl output, this is likely a bug'
+        )
     elif 'RedHat' in __grains__['os_family']:
         cmd = 'grep ZONE /etc/sysconfig/clock | grep -vE "^#"'
     elif 'Suse' in __grains__['os_family']:
@@ -52,7 +60,7 @@ def get_zone():
                 'consider using timezone.get_zonecode or timezone.zonecompare')
     elif 'Solaris' in __grains__['os_family']:
         cmd = 'grep "TZ=" /etc/TIMEZONE'
-    out = __salt__['cmd.run'](cmd).split('=')
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug').split('=')
     ret = out[1].replace('"', '')
     return ret
 
@@ -68,7 +76,7 @@ def get_zonecode():
         salt '*' timezone.get_zonecode
     '''
     cmd = 'date +%Z'
-    out = __salt__['cmd.run'](cmd)
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug')
     return out
 
 
@@ -83,7 +91,7 @@ def get_offset():
         salt '*' timezone.get_offset
     '''
     cmd = 'date +%z'
-    out = __salt__['cmd.run'](cmd)
+    out = __salt__['cmd.run'](cmd, output_loglevel='debug')
     return out
 
 
@@ -176,23 +184,31 @@ def get_hwclock():
         salt '*' timezone.get_hwclock
     '''
     cmd = ''
-    if 'Arch' in __grains__['os_family']:
-        cmd = ('timedatectl | grep "RTC in local TZ" | '
-               'sed -e"s/^[ \t]*//" | cut -d" " -f5')
-        if __salt__['cmd.run'](cmd) == 'yes':
-            return 'localtime'
-        else:
-            return 'UTC'
+    if salt.utils.which('timedatectl'):
+        out = __salt__['cmd.run']('timedatectl', output_loglevel='debug')
+        for line in (x.strip() for x in out.splitlines()):
+            if 'rtc in local tz' in line.lower():
+                try:
+                    if line.split(':')[-1].strip().lower() == 'yes':
+                        return 'localtime'
+                    else:
+                        return 'UTC'
+                except IndexError:
+                    pass
+        raise CommandExecutionError(
+            'Failed to parse timedatectl output, this is likely a bug'
+        )
     elif 'RedHat' in __grains__['os_family']:
         cmd = 'tail -n 1 /etc/adjtime'
-        return __salt__['cmd.run'](cmd)
+        return __salt__['cmd.run'](cmd, output_loglevel='debug')
     elif 'Suse' in __grains__['os_family']:
         cmd = 'tail -n 1 /etc/adjtime'
-        return __salt__['cmd.run'](cmd)
+        return __salt__['cmd.run'](cmd, output_loglevel='debug')
     elif 'Debian' in __grains__['os_family']:
         #Original way to look up hwclock on Debian-based systems
         cmd = 'grep "UTC=" /etc/default/rcS | grep -vE "^#"'
-        out = __salt__['cmd.run'](cmd, ignore_retcode=True).split('=')
+        out = __salt__['cmd.run'](
+            cmd, output_loglevel='debug', ignore_retcode=True).split('=')
         if len(out) > 1:
             if out[1] == 'yes':
                 return 'UTC'
@@ -201,10 +217,10 @@ def get_hwclock():
         else:
             #Since Wheezy
             cmd = 'tail -n 1 /etc/adjtime'
-            return __salt__['cmd.run'](cmd)
+            return __salt__['cmd.run'](cmd, output_loglevel='debug')
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'grep "^clock=" /etc/conf.d/hwclock | grep -vE "^#"'
-        out = __salt__['cmd.run'](cmd).split('=')
+        out = __salt__['cmd.run'](cmd, output_loglevel='debug').split('=')
         return out[1].replace('"', '')
     elif 'Solaris' in __grains__['os_family']:
         if os.path.isfile('/etc/rtc_config'):
@@ -234,11 +250,11 @@ def set_hwclock(clock):
             return 'UTC is the only choice for SPARC architecture'
         if clock == 'localtime':
             cmd = 'rtc -z {0}'.format(timezone)
-            __salt__['cmd.run'](cmd)
+            __salt__['cmd.run'](cmd, output_loglevel='debug')
             return True
         elif clock == 'UTC':
             cmd = 'rtc -z GMT'
-            __salt__['cmd.run'](cmd)
+            __salt__['cmd.run'](cmd, output_loglevel='debug')
             return True
     else:
         zonepath = '/usr/share/zoneinfo/{0}'.format(timezone)
@@ -253,10 +269,10 @@ def set_hwclock(clock):
     if 'Arch' in __grains__['os_family']:
         if clock == 'localtime':
             cmd = 'timezonectl set-local-rtc true'
-            __salt__['cmd.run'](cmd)
+            __salt__['cmd.run'](cmd, output_loglevel='debug')
         else:
             cmd = 'timezonectl set-local-rtc false'
-            __salt__['cmd.run'](cmd)
+            __salt__['cmd.run'](cmd, output_loglevel='debug')
     elif 'RedHat' in __grains__['os_family']:
         __salt__['file.sed'](
             '/etc/sysconfig/clock', '^ZONE=.*', 'ZONE="{0}"'.format(timezone))


### PR DESCRIPTION
**This will likely have a merge conflict with #12725.  If that PR is merged first, ping me and I'll rebase and fix this one.**

This is #12728, backported for 2014.1.
