### PR TITLE
service.available should also use chkconfig, to support xinetd services

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -306,7 +306,7 @@ def available(name, limit=''):
     elif limit == 'sysvinit':
         return _service_is_sysv(name)
     else:
-        return _service_is_upstart(name) or _service_is_sysv(name)
+        return _service_is_upstart(name) or _service_is_sysv(name) or _service_is_chkconfig(name)
 
 
 def missing(name, limit=''):


### PR DESCRIPTION
Given this sls, enabling rsync as a service in xinetd

```
rsync:
  pkg:
    - installed
    - name: rsync
  file:
    - managed
    - name: /etc/rsyncd.conf
    - source: salt://rsync/files/etc/rsyncd.conf
    - require:
      - pkg: rsync
  service:
    - enabled
```

service.available will fail for xinetd services because it only checks for upstart and sysvinit scripts in /etc/init.d/

```
[INFO    ] Package rsync is already installed
[INFO    ] Completed state [rsync] at time 14:23:04.706557
[INFO    ] Running state [/etc/rsyncd.conf] at time 14:23:04.707115
[INFO    ] Executing state file.managed for /etc/rsyncd.conf
[INFO    ] File /etc/rsyncd.conf is in the correct state
[INFO    ] Completed state [/etc/rsyncd.conf] at time 14:23:04.713597
[INFO    ] Running state [rsync] at time 14:23:04.713822
[INFO    ] Executing state service.enabled for rsync
[ERROR   ] The named service rsync is not available
[INFO    ] Completed state [rsync] at time 14:23:04.714946
[DEBUG   ] Loaded no_out as virtual quiet
[DEBUG   ] Loaded json_out as virtual json
[DEBUG   ] Loaded yaml_out as virtual yaml
[DEBUG   ] Loaded pprint_out as virtual pprint
local:
----------
          ID: rsync
    Function: pkg.installed
      Result: True
     Comment: Package rsync is already installed
     Changes:   
----------
          ID: rsync
    Function: file.managed
        Name: /etc/rsyncd.conf
      Result: True
     Comment: File /etc/rsyncd.conf is in the correct state
     Changes:   
----------
          ID: rsync
    Function: service.enabled
      Result: False
     Comment: The named service rsync is not available
     Changes:   

Summary
------------
Succeeded: 2
Failed:    1
------------
```

Add _service_is_chkconfig to the list of service checks, as it checks the output of chkconfig --list which shows all xinetd services, as well as all added sysvinit services.
