### PR TITLE
Adding the ability for the file manage module and state to handle symlinks.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2690,6 +2690,10 @@ def manage_file(name,
     .. code-block:: bash
 
         salt '*' file.manage_file /etc/httpd/conf.d/httpd.conf '{}' salt://http/httpd.conf '{hash_type: 'md5', 'hsum': <md5sum>}' root root '755' base ''
+
+    .. versionchanged:: Helium
+        ``follow_symlinks`` option added
+
     '''
     if not ret:
         ret = {'name': name,

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2679,7 +2679,8 @@ def manage_file(name,
                 template=None,   # pylint: disable=W0613
                 show_diff=True,
                 contents=None,
-                dir_mode=None):
+                dir_mode=None,
+                follow_symlinks=True):
     '''
     Checks the destination against what was retrieved with get_managed and
     makes the appropriate modifications (if necessary).
@@ -2698,9 +2699,14 @@ def manage_file(name,
 
     # Check changes if the target file exists
     if os.path.isfile(name):
+        if os.path.islink(name) and follow_symlinks:
+            real_name = os.path.realpath(name)
+        else:
+            real_name = name
+
         # Only test the checksums on files with managed contents
         if source:
-            name_sum = get_hash(name, source_sum['hash_type'])
+            name_sum = get_hash(real_name, source_sum['hash_type'])
 
         # Check if file needs to be replaced
         if source and source_sum['hsum'] != name_sum:
@@ -2729,13 +2735,13 @@ def manage_file(name,
                 ret['changes']['diff'] = '<show_diff=False>'
             else:
                 # Check to see if the files are bins
-                bdiff = _binary_replace(name, sfn)
+                bdiff = _binary_replace(real_name, sfn)
                 if bdiff:
                     ret['changes']['diff'] = bdiff
                 else:
                     with contextlib.nested(
                             salt.utils.fopen(sfn, 'rb'),
-                            salt.utils.fopen(name, 'rb')) as (src, name_):
+                            salt.utils.fopen(real_name, 'rb')) as (src, name_):
                         slines = src.readlines()
                         nlines = name_.readlines()
                     ret['changes']['diff'] = \
@@ -2744,7 +2750,7 @@ def manage_file(name,
             # Pre requisites are met, and the file needs to be replaced, do it
             try:
                 salt.utils.copyfile(sfn,
-                                    name,
+                                    real_name,
                                     __salt__['config.backup_mode'](backup),
                                     __opts__['cachedir'])
             except IOError:
@@ -2761,7 +2767,7 @@ def manage_file(name,
             # Compare contents of files to know if we need to replace
             with contextlib.nested(
                     salt.utils.fopen(tmp, 'rb'),
-                    salt.utils.fopen(name, 'rb')) as (src, name_):
+                    salt.utils.fopen(real_name, 'rb')) as (src, name_):
                 slines = src.readlines()
                 nlines = name_.readlines()
                 different = ''.join(slines) != ''.join(nlines)
@@ -2772,7 +2778,7 @@ def manage_file(name,
                 elif not show_diff:
                     ret['changes']['diff'] = '<show_diff=False>'
                 else:
-                    if salt.utils.istextfile(name):
+                    if salt.utils.istextfile(real_name):
                         ret['changes']['diff'] = \
                             ''.join(difflib.unified_diff(nlines, slines))
                     else:
@@ -2782,7 +2788,7 @@ def manage_file(name,
                 # Pre requisites are met, the file needs to be replaced, do it
                 try:
                     salt.utils.copyfile(tmp,
-                                        name,
+                                        real_name,
                                         __salt__['config.backup_mode'](backup),
                                         __opts__['cachedir'])
                 except IOError:
@@ -2791,7 +2797,40 @@ def manage_file(name,
                         ret, 'Failed to commit change, permission error')
             __clean_tmp(tmp)
 
-        ret, _ = check_perms(name, ret, user, group, mode)
+        # check for changing symlink to regular file here
+        if os.path.islink(name) and not follow_symlinks:
+            if not sfn:
+                sfn = __salt__['cp.cache_file'](source, saltenv)
+            if not sfn:
+                return _error(
+                    ret, 'Source file {0} not found'.format(source))
+            # If the downloaded file came from a non salt server source verify
+            # that it matches the intended sum value
+            if salt._compat.urlparse(source).scheme != 'salt':
+                dl_sum = get_hash(sfn, source_sum['hash_type'])
+                if dl_sum != source_sum['hsum']:
+                    ret['comment'] = ('File sum set for file {0} of {1} does '
+                                      'not match real sum of {2}'
+                                      ).format(name,
+                                               source_sum['hsum'],
+                                               dl_sum)
+                    ret['result'] = False
+                    return ret
+
+            try:
+                salt.utils.copyfile(sfn,
+                                    name,
+                                    __salt__['config.backup_mode'](backup),
+                                    __opts__['cachedir'])
+            except IOError:
+                __clean_tmp(sfn)
+                return _error(
+                    ret, 'Failed to commit change, permission error')
+
+            ret['changes']['diff'] = \
+                'Replace symbolic link with regular file'
+
+        ret, _ = check_perms(name, ret, user, group, mode, follow_symlinks)
 
         if ret['changes']:
             ret['comment'] = 'File {0} updated'.format(name)

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -964,6 +964,7 @@ def managed(name,
             contents=None,
             contents_pillar=None,
             contents_pillar_newline=True,
+            follow_symlinks=True,
             **kwargs):
     '''
     Manage a given file, this function allows for a file to be downloaded from
@@ -1205,7 +1206,7 @@ def managed(name,
 
     if not replace and os.path.exists(name):
         # Check and set the permissions if necessary
-        ret, _ = __salt__['file.check_perms'](name, ret, user, group, mode)
+        ret, _ = __salt__['file.check_perms'](name, ret, user, group, mode, follow_symlinks)
         if __opts__['test']:
             ret['comment'] = 'File {0} not updated'.format(name)
         elif not ret['changes'] and ret['result']:
@@ -1286,7 +1287,8 @@ def managed(name,
                 template,
                 show_diff,
                 contents,
-                dir_mode)
+                dir_mode,
+                follow_symlinks)
         except Exception as exc:
             ret['changes'] = {}
             log.debug(traceback.format_exc())

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1140,6 +1140,13 @@ def managed(name,
         When using content_pillar, a newline is inserted into the data gathered
         from pillar. When loading some data this newline is better left off.
         Setting contents_pillar_newline to False will omit this newline.
+
+    follow_symlinks : True
+        .. versionadded:: Helium
+
+        If the desired path is a symlink follow it and make changes to the
+        file to which the symlink points.
+
     '''
     # Make sure that leading zeros stripped by YAML loader are added back
     mode = __salt__['config.manage_mode'](mode)


### PR DESCRIPTION
Adding the ability for the manage_file and manage state to properly handle symlinks.  This change adds the ability to specify if symlinks should be followed of not by the manage state and manage_file module, by default they are followed.  When follow_symlinks is True, the target file of the symbolic link is updated.  If follow_symlinks is set to False then the symlink is replaced with a real file with any updates that are required. Per #12582 
