### PR TITLE
Allow EC2's list_nodes_full() to cache node data

### DIFF
--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -193,3 +193,11 @@ wait_for_spot_timeout
 
 The amount of time Salt Cloud should wait before an EC2 Spot instance is 
 available. This setting is only available for the EC2 cloud driver.
+
+
+update_cachedir
+~~~~~~~~~~~~~~~
+
+On supported cloud providers, whether or not to maintain a cache of nodes
+returned from a --full-query. The data will be stored in ``json`` format under
+``<SALT_CACHEDIR>/cloud/active/<DRIVER>/<PROVIDER>/<NODE_NAME>.json``.

--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -195,6 +195,13 @@ The amount of time Salt Cloud should wait before an EC2 Spot instance is
 available. This setting is only available for the EC2 cloud driver.
 
 
+Salt Cloud Cache
+================
+
+Salt Cloud can maintain a cache of node data, for supported providers. The
+following options manage this functionality.
+
+
 update_cachedir
 ~~~~~~~~~~~~~~~
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2449,6 +2449,8 @@ def _list_nodes_full(location=None):
                     public_ips=item.get('ipAddress', [])
                 )
             )
+
+    salt.utils.cloud.cache_node_list(ret, __opts__)
     return ret
 
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2041,6 +2041,8 @@ def cache_node_list(nodes, opts):
     '''
     If configured to do so, update the cloud cachedir with the current list of
     nodes. Also fires configured events pertaining to the node list.
+
+    .. versionadded:: Helium
     '''
     if not 'update_cachedir' in opts or not opts['update_cachedir']:
         return

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1820,6 +1820,8 @@ def init_cachedir(base=None):
             os.makedirs(dir_)
         os.chmod(base, 0755)
 
+    return base
+
 
 def request_minion_cachedir(
         minion_id,
@@ -2033,6 +2035,27 @@ def update_bootstrap(config):
             continue
 
     return {'Success': {'Files updated': finished_full}}
+
+
+def cache_node_list(nodes, opts):
+    '''
+    If configured to do so, update the cloud cachedir with the current list of
+    nodes. Also fires configured events pertaining to the node list.
+    '''
+    if not 'update_cachedir' in opts or not opts['update_cachedir']:
+        return
+
+    base = os.path.join(init_cachedir(), 'active')
+    provider = opts['function'][1]
+    driver = opts['providers'][provider].keys()[0]
+    prov_dir = os.path.join(base, driver, provider)
+    if not os.path.exists(prov_dir):
+        os.makedirs(prov_dir)
+
+    for node in nodes:
+        path = os.path.join(prov_dir, '{0}.json'.format(node))
+        with salt.utils.fopen(path, 'w') as fh_:
+            json.dump(nodes[node], fh_)
 
 
 def _salt_cloud_force_ascii(exc):


### PR DESCRIPTION
This gets the ball rolling on this functionality, and makes it available for other devs to start calling this functionality.

A future pull request will add more intelligence to the cloud cachedir.

Ping @gtmanfred.
