### PR TITLE
updated documentation for salt.states.cmd concerning exit code handling.

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -76042,10 +76042,20 @@ no disk space:
 .UNINDENT
 .UNINDENT
 .sp
-Note that when executing a command or script, the state (i.e., changed or not)
+Salt determines whether the cmd state is successfully enforced based on the exit
+code returned by the command. If the command returns a zero exit code, then salt
+determines that the state was successfully enforced. If the script returns a non-zero
+exit code, then salt determines that it failed to successfully enforce the state.
+If a command returns a non-zero exit code but you wish to treat this as a success,
+then you must place the command in a script and explicitly set the exit code of
+the script to zero.
+.sp
+Please note that the success or failure of the state is not affected by whether a state 
+change occurred nor the stateful argument.
+.sp
+When executing a command or script, the state (i.e., changed or not)
 of the command is unknown to Salt\(aqs state system. Therefore, by default, the
 \fBcmd\fP state assumes that any command execution results in a changed state.
-.sp
 This means that if a \fBcmd\fP state is watched by another state then the
 state that\(aqs watching will always be executed due to the \fIchanged\fP state in
 the \fBcmd\fP state.

--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -76042,20 +76042,10 @@ no disk space:
 .UNINDENT
 .UNINDENT
 .sp
-Salt determines whether the cmd state is successfully enforced based on the exit
-code returned by the command. If the command returns a zero exit code, then salt
-determines that the state was successfully enforced. If the script returns a non-zero
-exit code, then salt determines that it failed to successfully enforce the state.
-If a command returns a non-zero exit code but you wish to treat this as a success,
-then you must place the command in a script and explicitly set the exit code of
-the script to zero.
-.sp
-Please note that the success or failure of the state is not affected by whether a state 
-change occurred nor the stateful argument.
-.sp
-When executing a command or script, the state (i.e., changed or not)
+Note that when executing a command or script, the state (i.e., changed or not)
 of the command is unknown to Salt\(aqs state system. Therefore, by default, the
 \fBcmd\fP state assumes that any command execution results in a changed state.
+.sp
 This means that if a \fBcmd\fP state is watched by another state then the
 state that\(aqs watching will always be executed due to the \fIchanged\fP state in
 the \fBcmd\fP state.

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -37,7 +37,18 @@ touch /tmp/foo if it does not exist.
     The ``creates`` option will be supported starting with the feature release
     codenamed Helium
 
-Note that when executing a command or script, the state (i.e., changed or not)
+Salt determines whether the ``cmd`` state is successfully enforced based on the exit
+code returned by the command. If the command returns a zero exit code, then salt
+determines that the state was successfully enforced. If the script returns a non-zero
+exit code, then salt determines that it failed to successfully enforce the state.
+If a command returns a non-zero exit code but you wish to treat this as a success,
+then you must place the command in a script and explicitly set the exit code of
+the script to zero.
+
+Please note that the success or failure of the state is not affected by whether a state
+change occurred nor the stateful argument.
+
+When executing a command or script, the state (i.e., changed or not)
 of the command is unknown to Salt's state system. Therefore, by default, the
 ``cmd`` state assumes that any command execution results in a changed state.
 


### PR DESCRIPTION
Fix for https://github.com/saltstack/salt/issues/12739
