### PR TITLE
Change password for cloud servers if instance already exists

### DIFF
--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -90,3 +90,12 @@ Here is an example of a profile:
 
 ``image`` can be one of the options listed in the output of ``nova image-list``.
 
+
+change_password
+~~~~~~~~~~~~~~~
+If no ssh_key_file is provided, and the server already exists, change_password
+will use the api to change the root password of the server so that it can be
+bootstrapped.
+
+.. code-block:: yaml
+    change_password: True

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -498,6 +498,7 @@ def request_instance(vm_=None, call=None):
             exc_info=log.isEnabledFor(logging.DEBUG)
         )
         return False, vm_
+    vm_['password'] = data.extra.get('password', '')
 
     return data, vm_
 
@@ -553,7 +554,7 @@ def create(vm_):
                 )
             )
         vm_['password'] = sup.secure_password()
-        conn.root_password(vm_['instance_id'], vm_['secure_password'])
+        conn.root_password(vm_['instance_id'], vm_['password'])
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it
@@ -688,8 +689,8 @@ def create(vm_):
 
     ret.update(data.__dict__)
 
-    if 'password' in data.extra:
-        del data.extra['password']
+    if 'password' in ret['extra']:
+        del ret['extra']['password']
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
     log.debug(

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -111,6 +111,7 @@ import salt.client
 
 # Import salt.cloud libs
 import salt.utils.cloud
+import salt.utils.pycrypto as sup
 import salt.config as config
 from salt.utils import namespaced_function
 from salt.cloud.exceptions import (
@@ -551,6 +552,8 @@ def create(vm_):
                     __opts__
                 )
             )
+        vm_['password'] = sup.secure_password()
+        conn.root_password(vm_['instance_id'], vm_['secure_password'])
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -553,8 +553,9 @@ def create(vm_):
                     __opts__
                 )
             )
-        vm_['password'] = sup.secure_password()
-        conn.root_password(vm_['instance_id'], vm_['password'])
+        if vm_['key_filename'] is None and 'change_password' in __opts__ and __opts__['change_password'] is True:
+            vm_['password'] = sup.secure_password()
+            conn.root_password(vm_['instance_id'], vm_['password'])
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -569,7 +569,7 @@ def create(vm_):
                 'Loaded node data for {0}:\n{1}'.format(
                     vm_['name'],
                     pprint.pformat(
-                        nodelist[vm_['name']].__dict__
+                        nodelist[vm_['name']]
                     )
                 )
             )
@@ -584,7 +584,7 @@ def create(vm_):
             # Trigger a failure in the wait for IP function
             return False
 
-        running = nodelist[vm_['name']].state == 'ACTIVE'
+        running = nodelist[vm_['name']]['state'] == 'ACTIVE'
         if not running:
             # Still not running, trigger another iteration
             return
@@ -601,7 +601,7 @@ def create(vm_):
 
         if managedcloud(vm_) is True:
             extra = conn.server_show_libcloud(
-                nodelist[vm_['name']].id
+                nodelist[vm_['name']]['id']
             ).extra
             mc_status = extra.get('metadata', {}).get(
                 'rax_service_level_automation', '')
@@ -611,8 +611,8 @@ def create(vm_):
                 return
 
         result = []
-        private = nodelist[vm_['name']].private_ips
-        public = nodelist[vm_['name']].public_ips
+        private = nodelist[vm_['name']]['private_ips']
+        public = nodelist[vm_['name']]['public_ips']
         if private and not public:
             log.warn(
                 'Private IPs returned, but not public... Checking for '

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -610,8 +610,9 @@ def create(vm_):
                     __opts__
                 )
             )
-        vm_['password'] = sup.secure_password()
-        conn.ex_set_password(vm_['instance_id'], vm_['password'])
+        if vm_['key_filename'] is None and 'change_password' in __opts__ and __opts__['change_password'] is True:
+            vm_['password'] = sup.secure_password()
+            conn.root_password(vm_['instance_id'], vm_['password'])
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -146,6 +146,7 @@ import salt.utils
 
 # Import salt.cloud libs
 import salt.utils.cloud
+import salt.utils.pycrypto as sup
 import salt.config as config
 from salt.utils import namespaced_function
 from salt.cloud.exceptions import (
@@ -610,7 +611,7 @@ def create(vm_):
                 )
             )
         vm_['password'] = sup.secure_password()
-        conn.ex_set_password(vm_['instance_id'], vm['password'])
+        conn.ex_set_password(vm_['instance_id'], vm_['password'])
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -609,6 +609,8 @@ def create(vm_):
                     __opts__
                 )
             )
+        vm_['password'] = sup.secure_password()
+        conn.ex_set_password(vm_['instance_id'], vm['password'])
     else:
         # Put together all of the information required to request the instance,
         # and then fire off the request for it

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -298,8 +298,6 @@ def bootstrap(vm_, opts):
             'Check your provider for the \'change_password\' option.'
         )
 
-
-
     ret = {}
 
     deploy_script_code = os_script(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -291,6 +291,15 @@ def bootstrap(vm_, opts):
             'system for the password.'
         )
 
+    if key_filename is None and ('password' not in vm_ or not vm_['password']):
+        raise SaltCloudSystemExit(
+            'Cannot deploy salt in a VM if the \'ssh_keyfile\' setting '
+            'is not set and there is no password set for the vm. '
+            'Check your provider for the \'change_password\' option.'
+        )
+
+
+
     ret = {}
 
     deploy_script_code = os_script(

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -229,6 +229,13 @@ class SaltNova(object):
         '''
         return self.server_list().get(name, {})
 
+    def root_password(self, server_id, password):
+        '''
+        Change server(uuid's) root password
+        '''
+        nt_ks = self.compute.conn
+        nt_ks.servers.change_password(server_id, password)
+
     def server_by_name(self, name):
         '''
         Find a server by its name


### PR DESCRIPTION
@techhat, please double check that I am using these functions correctly.

The idea is... if the instance already exists, and you don't have ssh_key_file specified, it will just use the api to change the root password using the salt.utils.pycrypto's secure_password that I made at some point in the past, so that it can ssh to the root user and then bootstrap the servers.

Thanks!
Daniel
