### PR TITLE
BUG: ssh.wrapper.FunctionWrapper was missed in move to argv

### DIFF
--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -44,18 +44,15 @@ class FunctionWrapper(object):
             '''
             The remote execution function
             '''
-            args = [cmd]
-            args.extend([str(arg) for arg in args])
-            args.extend(['{0}={1}'.format(key, val) for key, val in kwargs.items()])
+            argv = [cmd]
+            argv.extend([str(arg) for arg in args])
+            argv.extend(['{0}={1}'.format(key, val) for key, val in kwargs.items()])
             single = salt.client.ssh.Single(
                     self.opts,
-                    ' '.join(args),
+                    argv,
                     **self.kwargs
             )
             stdout, _, _ = single.cmd_block()
-            if stdout.startswith('deploy'):
-                single.deploy()
-                stdout, _, _ = single.cmd_block()
             try:
                 ret = json.loads(stdout, object_hook=salt.utils.decode_dict)
             except ValueError:


### PR DESCRIPTION
FunctionWrapper is still using an arg string rather than an argv.  Additionally there is an incorrect re-use of "args" for what should be two different variables - which causes an ugly bug.
