### PR TITLE
Allow user to specify known_hosts_file

### DIFF
--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -273,4 +273,7 @@ file:
 If this is not set, it will default to ``/dev/null``, and strict host key
 checking will be turned off.
 
-At this time, only the EC2 driver supports this functionality.
+It is highly recommended that this option is *not* set, unless the user has
+verified that the provider supports this functionality, and that the image
+being used is capable of providing the necessary information. At this time,
+only the EC2 driver supports this functionality.

--- a/doc/topics/cloud/misc.rst
+++ b/doc/topics/cloud/misc.rst
@@ -249,3 +249,28 @@ salt/cloud/minionid/cache_node_diff
 One or more pieces of data in the cloud cachedir has changed on the cloud
 provider. A dict containing both the old and the new data will be contained in
 the event.
+
+
+SSH Known Hosts
+===============
+
+Normally when bootstrapping a VM, salt-cloud will ignore the SSH host key. This
+is because it does not know what the host key is before starting (because it
+doesn't exist yet). If strict host key checking is turned on without the key
+in the ``known_hosts`` file, then the host will never be available, and cannot
+be bootstrapped.
+
+If a provider is able to determine the host key before trying to bootstrap it,
+that provider's driver can add it to the ``known_hosts`` file, and then turn on
+strict host key checking. This can be set up in the main cloud configuration
+file (normally ``/etc/salt/cloud``) or in the provider-specific configuration
+file:
+
+.. code-block:: yaml
+
+    known_hosts_file: /path/to/.ssh/known_hosts
+
+If this is not set, it will default to ``/dev/null``, and strict host key
+checking will be turned off.
+
+At this time, only the EC2 driver supports this functionality.

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2347,7 +2347,6 @@ def _get_node(name, location=None):
     if location is None:
         location = get_location()
 
-    log.debug(list_nodes_full(location)[name])
     attempts = 10
     while attempts >= 0:
         try:
@@ -3195,8 +3194,6 @@ def get_console_output(
     By default, returns decoded data, not the Base64-encoded data that is
     actually returned from the EC2 API.
     '''
-    log.debug('*******************')
-
     if call != 'action':
         raise SaltCloudSystemExit(
             'The create_attach_volumes action must be called with '
@@ -3205,8 +3202,6 @@ def get_console_output(
 
     if not instance_id:
         instance_id = _get_node(name)['instanceId']
-
-    log.debug('instance_id is {0}'.format(instance_id))
 
     if kwargs is None:
         kwargs = {}

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -82,6 +82,7 @@ import urllib
 import requests
 
 # Import salt libs
+import salt.utils
 from salt._compat import ElementTree as ET
 
 # Import salt.cloud libs
@@ -1661,6 +1662,40 @@ def wait_for_instance(
                                         timeout=ssh_connect_timeout,
                                         gateway=ssh_gateway_config
                                         ):
+        # If a known_hosts_file is configured, this instance will not be
+        # accessable until it has a host key. Since this is provided on
+        # supported instances by cloud-init, and viewable to us only from the
+        # console output (which may take several minutes to become available,
+        # we have some more waiting to do here.
+        known_hosts_file = config.get_cloud_config_value(
+            'known_hosts_file', vm_, __opts__, default=None
+        )
+        if known_hosts_file:
+            console = {}
+            while not 'output_decoded' in console:
+                console = get_console_output(
+                    instance_id=vm_['instance_id'],
+                    call='action',
+                )
+                pprint.pprint(console)
+                time.sleep(5)
+            output = console['output_decoded']
+            comps = output.split('-----BEGIN SSH HOST KEY KEYS-----')
+            if len(comps) < 2:
+                # Fail; there are no host keys
+                return False
+
+            comps = comps[1].split('-----END SSH HOST KEY KEYS-----')
+            keys = ''
+            for line in comps[0].splitlines():
+                if not line:
+                    continue
+                keys += '\n{0} {1}'.format(ip_address, line)
+
+            with salt.utils.fopen(known_hosts_file, 'a') as fp_:
+                fp_.write(keys)
+            fp_.close()
+
         for user in vm_['usernames']:
             if salt.utils.cloud.wait_for_passwd(
                 host=ip_address,
@@ -3196,7 +3231,7 @@ def get_console_output(
     '''
     if call != 'action':
         raise SaltCloudSystemExit(
-            'The create_attach_volumes action must be called with '
+            'The get_console_output action must be called with '
             '-a or --action.'
         )
 
@@ -3214,15 +3249,12 @@ def get_console_output(
     params = {'Action': 'GetConsoleOutput',
               'InstanceId': instance_id}
 
-    ret = []
+    ret = {}
     data = query(params, return_root=True)
     for item in data:
-        pprint.pprint(item.keys())
         if item.keys()[0] == 'output':
-            ret.append(
-                {'output_decoded': binascii.a2b_base64(item.values()[0])}
-            )
+            ret['output_decoded'] = binascii.a2b_base64(item.values()[0])
         else:
-            ret.append(item)
+            ret[item.keys()[0]] = item.values()[0]
 
     return ret

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -427,8 +427,14 @@ def create(vm_):
                     username=user,
                     ssh_timeout=config.get_cloud_config_value(
                         'wait_for_passwd_timeout', vm_, __opts__,
-                        default=1 * 60),
-                    key_filename=key_filename):
+                        default=1 * 60
+                    ),
+                    key_filename=key_filename,
+                    known_hosts_file=config.get_cloud_config_value(
+                        'known_hosts_file', vm_, __opts__,
+                        default='/dev/null'
+                    ),
+                ):
                 username = user
                 break
         else:


### PR DESCRIPTION
By default, host key checking is turned off. This is because if it were turned on, and the key isn't in the known_hosts file, we would either have to do interactive verification (which isn't feasible in salt-cloud) or the host would just not be accessible (and would therefore be unable to be bootstrapped).
