### PR TITLE
Correct quoting/code block of documentation for 'salt.states.reg.present()'

### DIFF
--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -27,14 +27,15 @@ def present(name, value, vtype='REG_DWORD', reflection=True):
     Set a registry entry
 
     Optionally set ``reflection`` to ``False`` to disable reflection.
-    ``reflection`` has no effect on 32-bit os.
+    ``reflection`` has no effect on a 32-bit OS.
 
     In the example below, this will prevent Windows from silently creating
-    the key in::
-    'HKEY_CURRENT_USER\\SOFTWARE\\Wow6432Node\\Salt\\version'
+    the key in:
+    ``HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Salt\version``
 
-    Example::
-        'HKEY_CURRENT_USER\\SOFTWARE\\Salt\\version':
+    Example:
+        .. code:: yaml
+        HKEY_CURRENT_USER\SOFTWARE\Salt\version:
           reg.present:
             - value: 0.15.3
             - vtype: REG_SZ


### PR DESCRIPTION
Currently, [this renders](http://docs.saltstack.com/en/latest/ref/states/all/salt.states.reg.html) a bit wrong (no backslashes, code rendered a RST instead of plain YAML etc.).

This PR should fix this.

Thanks @tedski for suggestions on how to handle backslashes correctly.
