### PR TITLE
Consistency fixes for examples in documentation blocks

### DIFF
--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -162,7 +162,9 @@ def enable_term_protect(name, call=None):
     '''
     Enable termination protection on a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a enable_term_protect mymachine
     '''
@@ -178,7 +180,9 @@ def disable_term_protect(name, call=None):
     '''
     Disable termination protection on a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a disable_term_protect mymachine
     '''

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -632,7 +632,9 @@ def destroy(name, call=None):
     '''
     Destroy a node. Will check termination protection and warn if enabled.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2190,7 +2190,9 @@ def rename(name, kwargs, call=None):
     '''
     Properly rename a node. Pass in the new name as "new name".
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a rename mymachine newname=yourmachine
     '''
@@ -2212,7 +2214,9 @@ def destroy(name, call=None):
     '''
     Destroy a node. Will check termination protection and warn if enabled.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''
@@ -2294,7 +2298,9 @@ def reboot(name, call=None):
     '''
     Reboot a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a reboot mymachine
     '''
@@ -2565,7 +2571,9 @@ def enable_term_protect(name, call=None):
     '''
     Enable termination protection on a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a enable_term_protect mymachine
     '''
@@ -2582,7 +2590,9 @@ def disable_term_protect(name, call=None):
     '''
     Disable termination protection on a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a disable_term_protect mymachine
     '''
@@ -2599,7 +2609,9 @@ def _toggle_term_protect(name, value):
     '''
     Disable termination protection on a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a disable_term_protect mymachine
     '''
@@ -2618,7 +2630,9 @@ def show_delvol_on_destroy(name, kwargs=None, call=None):
     '''
     Do not delete all/specified EBS volumes upon instance termination
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a show_delvol_on_destroy mymachine
     '''
@@ -2676,7 +2690,9 @@ def keepvol_on_destroy(name, kwargs=None, call=None):
     '''
     Do not delete all/specified EBS volumes upon instance termination
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a keepvol_on_destroy mymachine
     '''
@@ -2699,7 +2715,9 @@ def delvol_on_destroy(name, kwargs=None, call=None):
     '''
     Delete all/specified EBS volumes upon instance termination
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a delvol_on_destroy mymachine
     '''

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -532,7 +532,9 @@ def create_network(kwargs=None, call=None):
     '''
     Create a GCE network.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f create_network gce name=mynet cidr=10.10.10.0/24
     '''
@@ -586,7 +588,9 @@ def delete_network(kwargs=None, call=None):
     '''
     Permanently delete a network.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f delete_network gce name=mynet
     '''
@@ -643,7 +647,9 @@ def show_network(kwargs=None, call=None):
     '''
     Show the details of an existing network.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f show_network gce name=mynet
     '''
@@ -665,7 +671,9 @@ def create_fwrule(kwargs=None, call=None):
     '''
     Create a GCE firewall rule. The 'default' network is used if not specified.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f create_fwrule gce name=allow-http allow=tcp:80
     '''
@@ -735,7 +743,9 @@ def delete_fwrule(kwargs=None, call=None):
     '''
     Permanently delete a firewall rule.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f delete_fwrule gce name=allow-http
     '''
@@ -792,7 +802,9 @@ def show_fwrule(kwargs=None, call=None):
     '''
     Show the details of an existing firewall rule.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f show_fwrule gce name=allow-http
     '''
@@ -814,7 +826,9 @@ def create_hc(kwargs=None, call=None):
     '''
     Create an HTTP health check configuration.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f create_hc gce name=hc path=/healthy port=80
     '''
@@ -886,7 +900,9 @@ def delete_hc(kwargs=None, call=None):
     '''
     Permanently delete a health check.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f delete_hc gce name=hc
     '''
@@ -943,7 +959,9 @@ def show_hc(kwargs=None, call=None):
     '''
     Show the details of an existing health check.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f show_hc gce name=hc
     '''
@@ -965,7 +983,9 @@ def create_lb(kwargs=None, call=None):
     '''
     Create a load-balancer configuration.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f create_lb gce name=lb region=us-central1 ports=80
     '''
@@ -1040,7 +1060,9 @@ def delete_lb(kwargs=None, call=None):
     '''
     Permanently delete a load-balancer.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f delete_lb gce name=lb
     '''
@@ -1097,7 +1119,9 @@ def show_lb(kwargs=None, call=None):
     '''
     Show the details of an existing load-balancer.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f show_lb gce name=lb
     '''
@@ -1119,7 +1143,9 @@ def attach_lb(kwargs=None, call=None):
     '''
     Add an existing node/member to an existing load-balancer configuration.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f attach_lb gce name=lb member=myinstance
     '''
@@ -1169,7 +1195,9 @@ def detach_lb(kwargs=None, call=None):
     '''
     Remove an existing node/member from an existing load-balancer configuration.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f detach_lb gce name=lb member=myinstance
     '''
@@ -1232,7 +1260,9 @@ def delete_snapshot(kwargs=None, call=None):
     '''
     Permanently delete a disk snapshot.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f delete_snapshot gce name=disk-snap-1
     '''
@@ -1289,7 +1319,9 @@ def delete_disk(kwargs=None, call=None):
     '''
     Permanently delete a persistent disk.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f delete_disk gce disk_name=pd
     '''
@@ -1351,7 +1383,9 @@ def create_disk(kwargs=None, call=None):
     Can also specify an `image` or `snapshot` but if neither of those are
     specified, a `size` (in GB) is required.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f create_disk gce disk_name=pd size=300 location=us-central1-b
     '''
@@ -1424,7 +1458,9 @@ def create_snapshot(kwargs=None, call=None):
     '''
     Create a new disk snapshot. Must specify `name` and  `disk_name`.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f create_snapshot gce name=snap1 disk_name=pd
     '''
@@ -1491,7 +1527,9 @@ def show_disk(name=None, kwargs=None, call=None):  # pylint: disable=W0613
     '''
     Show the details of an existing disk.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a show_disk myinstance disk_name=mydisk
         salt-cloud -f show_disk gce disk_name=mydisk
@@ -1510,7 +1548,9 @@ def show_snapshot(kwargs=None, call=None):
     '''
     Show the details of an existing snapshot.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f show_snapshot gce name=mysnapshot
     '''
@@ -1532,7 +1572,9 @@ def detach_disk(name=None, kwargs=None, call=None):
     '''
     Detach a disk from an instance.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a detach_disk myinstance disk_name=mydisk
     '''
@@ -1589,7 +1631,9 @@ def attach_disk(name=None, kwargs=None, call=None):
     '''
     Attach an existing disk to an existing instance.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a attach_disk myinstance disk_name=mydisk mode=READ_WRITE
     '''
@@ -1662,7 +1706,9 @@ def reboot(vm_name, call=None):
     '''
     Call GCE 'reset' on the instance.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a reboot myinstance
     '''
@@ -1680,7 +1726,9 @@ def destroy(vm_name, call=None):
     '''
     Call 'destroy' on the instance.  Can be called with "-a destroy" or -d
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a destroy myinstance1 myinstance2 ...
         salt-cloud -d myinstance1 myinstance2 ...

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -615,7 +615,9 @@ def set_tags(name, tags, call=None):
     '''
     Set tags for a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a set_tags mymachine tag1=somestuff tag2='Other stuff'
     '''
@@ -670,7 +672,9 @@ def del_tags(name, kwargs, call=None):
     '''
     Delete tags for a node
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a del_tags mymachine tag1,tag2,tag3
     '''
@@ -707,7 +711,9 @@ def rename(name, kwargs, call=None):
     '''
     Properly rename a node. Pass in the new name as "new name".
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a rename mymachine newname=yourmachine
     '''

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -548,7 +548,9 @@ def destroy(name, call=None):
     '''
     Destroy a node. Will check termination protection and warn if enabled.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -614,7 +614,9 @@ def destroy(name, call=None):
     '''
     Destroy a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''
@@ -662,7 +664,9 @@ def start(name, call=None):
     '''
     Start a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a start mymachine
     '''
@@ -683,7 +687,9 @@ def stop(name, call=None):
     '''
     Stop a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a stop mymachine
     '''

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -260,7 +260,9 @@ def _lookup_proxmox_task(upid):
 def get_resources_nodes(call=None, resFilter=None):
     '''
     Retrieve all hypervisors (nodes) available on this environment
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f get_resources_nodes my-proxmox-config
     '''
@@ -286,7 +288,9 @@ def get_resources_vms(call=None, resFilter=None, includeConfig=True):
     '''
     Retrieve all VMs available on this environment
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -f get_resources_vms my-proxmox-config
     '''
@@ -338,7 +342,9 @@ def avail_locations(call=None):
     '''
     Return a list of the hypervisors (nodes) which this Proxmox PVE machine manages
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --list-locations my-proxmox-config
     '''
@@ -363,7 +369,9 @@ def avail_images(call=None, location='local', img_type='vztpl'):
     '''
     Return a list of the images that are on the provider
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --list-images my-proxmox-config
     '''
@@ -384,7 +392,9 @@ def list_nodes(call=None):
     '''
     Return a list of the VMs that are managed by the provider
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -Q my-proxmox-config
     '''
@@ -427,7 +437,9 @@ def list_nodes_full(call=None):
     '''
     Return a list of the VMs that are on the provider
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -F my-proxmox-config
     '''
@@ -443,7 +455,9 @@ def list_nodes_select(call=None):
     '''
     Return a list of the VMs that are on the provider, with select fields
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -S my-proxmox-config
     '''
@@ -456,7 +470,9 @@ def create(vm_):
     '''
     Create a single VM from a data dict
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -p proxmox-ubuntu vmhostname
     '''
@@ -812,7 +828,9 @@ def destroy(name, call=None):
     '''
     Destroy a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''
@@ -910,7 +928,9 @@ def start(name, vmid=None, call=None):
     '''
     Start a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a start mymachine
     '''
@@ -933,7 +953,9 @@ def stop(name, vmid=None, call=None):
     '''
     Stop a node ("pulling the plug").
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a stop mymachine
     '''
@@ -955,7 +977,9 @@ def shutdown(name=None, vmid=None, call=None):
     '''
     Shutdown a node via ACPI.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud -a shutdown mymachine
     '''

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -599,7 +599,9 @@ def destroy(name, call=None):
     '''
     Destroy a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -759,7 +759,9 @@ def destroy(name, call=None):
     '''
     Destroy a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -481,7 +481,9 @@ def destroy(name, call=None):  # pylint: disable=W0613
     '''
     Destroy a node.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-cloud --destroy mymachine
     '''

--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -289,7 +289,9 @@ def get_cloud_init_mime(cloud_init):
     Get a mime multipart encoded string from a cloud-init dict. Currently
     supports scripts and cloud-config.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt myminion boto.get_cloud_init_mime <cloud init>
     '''

--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -157,7 +157,9 @@ def percent(args=None):
     '''
     Return partion information for volumes mounted on this minion
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' disk.percent /var
     '''
@@ -196,7 +198,9 @@ def blkid(device=None):
     '''
     Return block device attributes: UUID, LABEL, etc.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' disk.blkid
         salt '*' disk.blkid /dev/sda

--- a/salt/modules/groupadd.py
+++ b/salt/modules/groupadd.py
@@ -132,7 +132,9 @@ def adduser(name, username):
     '''
     Add a user in the group.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
          salt '*' group.adduser foo bar
 
@@ -148,7 +150,9 @@ def deluser(name, username):
     '''
     Remove a user from the group.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
          salt '*' group.deluser foo bar
 

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -203,7 +203,9 @@ def switch(cwd, remote, target=None, user=None, username=None,
     password : None
         Connect to the Subversion server with this password
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' svn.switch /path/to/repo svn://remote/repo
     '''

--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1098,7 +1098,9 @@ def get_profiles(hypervisor=None):
      - nic
      - disk
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' virt.get_profiles
         salt '*' virt.get_profiles hypervisor=esxi

--- a/salt/runners/mine.py
+++ b/salt/runners/mine.py
@@ -13,7 +13,9 @@ def get(tgt, fun, tgt_type='glob', output='yaml'):
     Gathers the data from the specified minions' mine, pass in the target,
     function to look up and the target type
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt-run mine.get '*' network.interfaces
     '''

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1331,7 +1331,9 @@ def directory(name,
     recurse
         Enforce user/group ownership and mode of directory recursively. Accepts
         a list of strings representing what you would like to recurse.
-        Example::
+        Example:
+
+        .. code-block:: yaml
 
             /var/log/httpd:
                 file.directory:
@@ -1622,7 +1624,9 @@ def recurse(name,
     include_pat
         When copying, include only this pattern from the source. Default
         is glob match; if prefixed with 'E@', then regexp match.
-        Example::
+        Example:
+
+        .. code-block:: yaml
 
           - include_pat: hello*       :: glob matches 'hello01', 'hello02'
                                          ... but not 'otherhello'
@@ -1637,7 +1641,9 @@ def recurse(name,
 
         Also, when 'clean=True', exclude this pattern from the removal
         list and preserve in the destination.
-        Example::
+        Example:
+
+        .. code-block:: yaml
 
           - exclude_pat: APPDATA*               :: glob matches APPDATA.01,
                                                    APPDATA.02,.. for exclusion
@@ -1647,7 +1653,9 @@ def recurse(name,
     maxdepth
         When copying, only copy paths which are of depth `maxdepth` from the
         source path.
-        Example::
+        Example:
+
+        .. code-block:: yaml
 
           - maxdepth: 0      :: Only include files located in the source
                                 directory

--- a/salt/states/modjk.py
+++ b/salt/states/modjk.py
@@ -66,7 +66,9 @@ def worker_stopped(name, workers=None, profile='default'):
     '''
     Stop all the workers in the modjk load balancer
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         loadbalancer:
           modjk.worker_stopped:
@@ -85,7 +87,9 @@ def worker_activated(name, workers=None, profile='default'):
     '''
     Activate all the workers in the modjk load balancer
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         loadbalancer:
           modjk.worker_activated:
@@ -104,7 +108,9 @@ def worker_disabled(name, workers=None, profile='default'):
     '''
     Disable all the workers in the modjk load balancer
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         loadbalancer:
           modjk.worker_disabled:
@@ -123,7 +129,9 @@ def worker_recover(name, workers=None, profile='default'):
     '''
     Recover all the workers in the modjk load balancer
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         loadbalancer:
           modjk.worker_recover:

--- a/salt/states/modjk_worker.py
+++ b/salt/states/modjk_worker.py
@@ -175,7 +175,9 @@ def stop(name, lbn, target, profile='default', expr_form='glob'):
     Stop the named worker from the lbn load balancers at the targeted minions
     The worker won't get any traffic from the lbn
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         disable-before-deploy:
           modjk_worker.stop:
@@ -193,7 +195,9 @@ def activate(name, lbn, target, profile='default', expr_form='glob'):
     Activate the named worker from the lbn load balancers at the targeted
     minions
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         disable-before-deploy:
           modjk_worker.activate:
@@ -213,7 +217,9 @@ def disable(name, lbn, target, profile='default', expr_form='glob'):
     The worker will get traffic only for current sessions and won't get new
     ones.
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         disable-before-deploy:
           modjk_worker.disable:

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -132,7 +132,9 @@ def installed(name,
         numbers here using the standard operators ``==, >=, <=``. If
         ``requirements`` is given, this parameter will be ignored.
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         django:
           pip.installed:
@@ -154,7 +156,9 @@ def installed(name,
         a pip executable. The example below assumes a virtual environment
         has been created at ``/foo/.virtualenvs/bar``.
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         django:
           pip.installed:
@@ -165,7 +169,9 @@ def installed(name,
 
     Or
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         django:
           pip.installed:

--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -34,7 +34,9 @@ def present(name, value, vtype='REG_DWORD', reflection=True):
     ``HKEY_CURRENT_USER\SOFTWARE\Wow6432Node\Salt\version``
 
     Example:
-        .. code:: yaml
+
+    .. code-block:: yaml
+
         HKEY_CURRENT_USER\SOFTWARE\Salt\version:
           reg.present:
             - value: 0.15.3

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -76,7 +76,9 @@ def war_deployed(name,
         use another location to temporarily copy to war file
         by default the system's temp directory is used
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         jenkins:
           tomcat.war_deployed:
@@ -178,7 +180,9 @@ def wait(name, url='http://localhost:8080/manager', timeout=180):
     timeout : 180
         timeout for HTTP request to the tomcat manager
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         tomcat-service:
           service:
@@ -244,7 +248,9 @@ def undeployed(name,
     timeout : 180
         timeout for HTTP request to the tomcat manager
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         jenkins:
           tomcat.undeployed:

--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -15,7 +15,9 @@ def dns_exists(name, servers=None, interface='Local Area Connection'):
     '''
     Configure the DNS server list in the specified interface
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         config_dns_servers:
           win_dns_client.dns_exists:

--- a/salt/states/win_path.py
+++ b/salt/states/win_path.py
@@ -27,7 +27,9 @@ def absent(name):
 
     index: where the directory should be placed in the PATH (default: 0)
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         'C:\\sysinternals':
           win_path.absent
@@ -60,7 +62,9 @@ def exists(name, index=None):
     [Note:  Providing no index will append directory to PATH and
     will not enforce its location within the PATH.]
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         'C:\\python27':
           win_path.exists

--- a/salt/states/win_update.py
+++ b/salt/states/win_update.py
@@ -14,7 +14,9 @@ install certain updates. default is all available updates.
 In the example below, will install all Security and Critical Updates,
 and download but not install standard updates.
 
-Example::
+Example:
+
+.. code-block:: yaml
     updates:
         win_update.installed:
             - categories:
@@ -38,7 +40,9 @@ features/states of updates available for configuring:
     'driver' - driver updates, skipped by default
 
 This example installs all driver updates that don't require a reboot:
-Example::
+Example:
+
+.. code-block:: yaml
     gryffindor:
         win_update.install:
             - includes:

--- a/salt/states/winrepo.py
+++ b/salt/states/winrepo.py
@@ -30,7 +30,9 @@ def genrepo(name, force=False, allow_empty=False):
     if force is True no checks will be made and the repository will be generated
     if allow_empty is True then the state will not return an error if there are 0 packages
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
         winrepo:
           winrepo.genrepo

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -789,7 +789,9 @@ def build_whitespace_split_regex(text):
     Create a regular expression at runtime which should match ignoring the
     addition or deletion of white space or line breaks, unless between commas
 
-    Example::
+    Example:
+
+    .. code-block:: yaml
 
     >>> import re
     >>> from salt.utils import *

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -702,7 +702,9 @@ class StateFire(object):
         '''
         Fire an event off on the master server
 
-        CLI Example::
+        CLI Example:
+
+        .. code-block:: bash
 
             salt '*' event.fire_master 'stuff to be in the event' 'tag'
         '''

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -41,7 +41,9 @@ def isportopen(host, port):
     '''
     Return status of a port
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' network.isportopen 127.0.0.1 22
     '''
@@ -59,7 +61,9 @@ def host_to_ip(host):
     '''
     Returns the IP address of a given hostname
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' network.host_to_ip example.com
     '''
@@ -253,7 +257,9 @@ def generate_minion_id():
     Returns a minion id after checking multiple sources for a FQDN.
     If no FQDN is found you may get an ip address
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' network.generate_minion_id
     '''
@@ -281,7 +287,9 @@ def get_fqhostname():
     '''
     Returns the fully qualified hostname
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' network.get_fqhostname
     '''
@@ -312,7 +320,9 @@ def ip_to_host(ip):
     '''
     Returns the hostname of a given IP
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' network.ip_to_host 8.8.8.8
     '''

--- a/tests/integration/files/file/base/_modules/runtests_decorators.py
+++ b/tests/integration/files/file/base/_modules/runtests_decorators.py
@@ -10,7 +10,9 @@ def _fallbackfunc():
 
 def working_function():
     '''
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
     '''
     return True
 


### PR DESCRIPTION
See the individual commits for what (and how it) has been done.

I have some further things in mind like:
- Ensure each `Example:` or `CLI Example:` has an empty line before and after it
- Ensure the `.. code-block` statement the same indentation as the previous line

Will create a new PR once I get around to take care of these further items. Feel free to review + merge this one for now.
