### PR TITLE
Fix for unit tests for file state, fix related to symlinks in file module.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2702,7 +2702,7 @@ def manage_file(name,
                'result': True}
 
     # Check changes if the target file exists
-    if os.path.isfile(name):
+    if os.path.isfile(name) or os.path.islink(name):
         if os.path.islink(name) and follow_symlinks:
             real_name = os.path.realpath(name)
         else:

--- a/tests/unit/states/file_test.py
+++ b/tests/unit/states/file_test.py
@@ -108,7 +108,7 @@ class TestFileState(TestCase):
         self.assertEqual(None, ret)
 
         # make sure the value is correct
-        self.assertEqual(expected, returner.call_args[0][-2])
+        self.assertEqual(expected, returner.call_args[0][-3])
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Unit tests for file state broke after adding the follow_symlnks argument.  Tests were looking for a value in a specific position in a dictionary which has been pushed back one value.  Also fixing an issue that happened if the file being managed by the module is a symlink, file would be treated as a new file.
