### PR TITLE
use list comprehension instead of filter() to avoid pylint warning

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -244,8 +244,7 @@ def _refresh_buckets_cache_file(creds, cache_file, multiple_env, environment):
             # pull out the files for the environment
             for saltenv in environments:
                 # grab only files/dirs that match this saltenv.
-                env_files = filter(lambda k: k['Key'].startswith(saltenv),
-                                   files)
+                env_files = [k for k in files if k['Key'].startswith(saltenv)]
 
                 if saltenv not in metadata:
                     metadata[saltenv] = {}


### PR DESCRIPTION
```
************* Module salt.pillar.s3
salt/pillar/s3.py:247: [W0640(cell-var-from-loop), _refresh_buckets_cache_file.<lambda>] Cell variable saltenv defined in loop
```

More details: https://github.com/klen/pylama_pylint/blob/master/pylama_pylint/pylint/checkers/variables.py#L150
