### PR TITLE
Return proper results for 'test=True'

### DIFF
--- a/salt/states/rdp.py
+++ b/salt/states/rdp.py
@@ -25,7 +25,7 @@ def enabled(name):
         ret['changes'] = {'enabled rdp': True}
 
     if __opts__['test']:
-        ret['result'] = None
+        ret['result'] = stat
         return ret
 
     ret['result'] = __salt__['rdp.enable']()
@@ -46,6 +46,7 @@ def disabled(name):
         ret['changes'] = {'disable rdp': True}
 
     if __opts__['test']:
+        ret['result'] = stat
         return ret
 
     ret['result'] = __salt__['rdp.disable']()


### PR DESCRIPTION
`salt '*' state.highstate test=True` always reported `rdp` states as to be changed.

This PR makes the `rdp` state return proper results for `test=True`.
