### PR TITLE
Make salt.states.target behave correctly with list of targets

### DIFF
--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -12,6 +12,7 @@ import tempfile
 # Import salt libs
 import salt.utils
 from salt.utils import which as _which
+from salt.exceptions import SaltInvocationError
 
 
 __outputter__ = {
@@ -139,6 +140,8 @@ def has_target(alias, target):
 
         salt '*' aliases.has_target alias target
     '''
+    if target == '':
+        raise SaltInvocationError('target can not be an empty string')
     aliases = list_aliases()
     if alias in aliases and isinstance(target, list):
         for item in target:
@@ -160,6 +163,12 @@ def set_target(alias, target):
 
         salt '*' aliases.set_target alias target
     '''
+
+    if alias == '':
+        raise SaltInvocationError('alias can not be an empty string')
+
+    if target == '':
+        raise SaltInvocationError('target can not be an empty string')
 
     if get_target(alias) == target:
         return True

--- a/salt/modules/aliases.py
+++ b/salt/modules/aliases.py
@@ -75,6 +75,8 @@ def __write_aliases_file(lines):
             os.chown(out.name, 0, 0)
 
     for (line_alias, line_target, line_comment) in lines:
+        if isinstance(line_target, list):
+            line_target = ', '.join(line_target)
         if not line_comment:
             line_comment = ''
         if line_alias and line_target:
@@ -138,7 +140,12 @@ def has_target(alias, target):
         salt '*' aliases.has_target alias target
     '''
     aliases = list_aliases()
-    return alias in aliases and target == aliases[alias]
+    if alias in aliases and isinstance(target, list):
+        for item in target:
+            if item not in aliases[alias]:
+                return False
+        target = ', '.join(target)
+    return alias in aliases and target in aliases[alias]
 
 
 def set_target(alias, target):

--- a/salt/states/alias.py
+++ b/salt/states/alias.py
@@ -16,7 +16,10 @@ aliases:
 
 def present(name, target):
     '''
-    Ensures that the named alias is present with the given target
+    Ensures that the named alias is present with the given target or list of
+    targets. If the alias exists but the target differs from the previous
+    entry, the target(s) will be overwritten. If the alias does not exist, the
+    alias will be created.
 
     name
         The local user/address to assign an alias to

--- a/tests/integration/modules/aliases.py
+++ b/tests/integration/modules/aliases.py
@@ -12,7 +12,7 @@ class AliasesTest(integration.ModuleCase):
     '''
     Validate aliases module
     '''
-    def not_test_set_target(self):
+    def test_set_target(self):
         '''
         aliases.set_target and aliases.get_target
         '''
@@ -24,9 +24,9 @@ class AliasesTest(integration.ModuleCase):
         tgt_ret = self.run_function(
                 'aliases.get_target',
                 alias='fred')
-        self.assertEqual(tgt_ret, 'target=bob')
+        self.assertEqual(tgt_ret, 'bob')
 
-    def not_test_has_target(self):
+    def test_has_target(self):
         '''
         aliases.set_target and aliases.has_target
         '''
@@ -41,7 +41,7 @@ class AliasesTest(integration.ModuleCase):
                 target='bob')
         self.assertTrue(tgt_ret)
 
-    def not_test_list_aliases(self):
+    def test_list_aliases(self):
         '''
         aliases.list_aliases
         '''
@@ -53,7 +53,7 @@ class AliasesTest(integration.ModuleCase):
         tgt_ret = self.run_function(
                 'aliases.list_aliases')
         self.assertIsInstance(tgt_ret, dict)
-        self.assertIn('alias=fred', tgt_ret)
+        self.assertIn('fred', tgt_ret)
 
     def test_rm_alias(self):
         '''
@@ -64,9 +64,9 @@ class AliasesTest(integration.ModuleCase):
                 alias='frank',
                 target='greg')
         self.assertTrue(set_ret)
-        set_ret = self.run_function(
-                'aliases.rm_alias',
-                alias='frank')
+        self.run_function(
+            'aliases.rm_alias',
+            alias='frank')
         tgt_ret = self.run_function(
                 'aliases.list_aliases')
         self.assertIsInstance(tgt_ret, dict)

--- a/tests/unit/modules/aliases_test.py
+++ b/tests/unit/modules/aliases_test.py
@@ -9,7 +9,7 @@ from salt.exceptions import SaltInvocationError
 
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
-from salttesting.mock import MagicMock, mock_open, patch, NO_MOCK, NO_MOCK_REASON
+from salttesting.mock import MagicMock, patch, NO_MOCK, NO_MOCK_REASON
 from salttesting.helpers import ensure_in_syspath
 
 ensure_in_syspath('../../')

--- a/tests/unit/modules/aliases_test.py
+++ b/tests/unit/modules/aliases_test.py
@@ -1,0 +1,170 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Nicole Thomas <nicole@satlstack.com>`
+'''
+
+# Import Salt Libs
+from salt.modules import aliases
+from salt.exceptions import SaltInvocationError
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import MagicMock, mock_open, patch, NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class AliasesTestCase(TestCase):
+    '''
+    TestCase for salt.modules.aliases module
+    '''
+
+    mock_alias = [('foo', 'bar@example.com', '')]
+    mock_alias_mult = [('foo', 'bar@example.com', ''),
+                       ('hello', 'world@earth.com, earth@world.com', '')]
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias))
+    def test_list_aliases(self):
+        '''
+        Tests the return of a file containing one alias
+        '''
+        ret = {'foo': 'bar@example.com'}
+        self.assertEqual(aliases.list_aliases(), ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias_mult))
+    def test_list_aliases_mult(self):
+        '''
+        Tests the return of a file containing multiple aliases
+        '''
+        ret = {'foo': 'bar@example.com',
+               'hello': 'world@earth.com, earth@world.com'}
+        self.assertEqual(aliases.list_aliases(), ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias))
+    def test_get_target(self):
+        '''
+        Tests the target returned by an alias with one target
+        '''
+        ret = 'bar@example.com'
+        self.assertEqual(aliases.get_target('foo'), ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias_mult))
+    def test_get_target_mult(self):
+        '''
+        Tests the target returned by an alias with multiple targets
+        '''
+        ret = 'world@earth.com, earth@world.com'
+        self.assertEqual(aliases.get_target('hello'), ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias))
+    def test_get_target_no_alias(self):
+        '''
+        Tests return of an alias doesn't exist
+        '''
+        self.assertEqual(aliases.get_target('pizza'), '')
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias))
+    def test_has_target(self):
+        '''
+        Tests simple return known alias and target
+        '''
+        ret = aliases.has_target('foo', 'bar@example.com')
+        self.assertTrue(ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias))
+    def test_has_target_no_alias(self):
+        '''
+        Tests return of empty alias and known target
+        '''
+        ret = aliases.has_target('', 'bar@example.com')
+        self.assertFalse(ret)
+
+    def test_has_target_no_target(self):
+        '''
+        Tests return of known alias and empty target
+        '''
+        self.assertRaises(SaltInvocationError, aliases.has_target, 'foo', '')
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias_mult))
+    def test_has_target_mult(self):
+        '''
+        Tests return of multiple targets to one alias
+        '''
+        ret = aliases.has_target('hello',
+                                 'world@earth.com, earth@world.com')
+        self.assertTrue(ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias_mult))
+    def test_has_target_mult_differs(self):
+        '''
+        Tests return of multiple targets to one alias in opposite order
+        '''
+        ret = aliases.has_target('hello',
+                                 'earth@world.com, world@earth.com')
+        self.assertFalse(ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias_mult))
+    def test_has_target_list_mult(self):
+        '''
+        Tests return of target as same list to know alias
+        '''
+        ret = aliases.has_target('hello', ['world@earth.com',
+                                           'earth@world.com'])
+        self.assertTrue(ret)
+
+    @patch('salt.modules.aliases.__parse_aliases',
+           MagicMock(return_value=mock_alias_mult))
+    def test_has_target_list_mult_differs(self):
+        '''
+        Tests return of target as differing list to known alias
+        '''
+        ret = aliases.has_target('hello', ['world@earth.com',
+                                           'mars@space.com'])
+        self.assertFalse(ret)
+
+    @patch('salt.modules.aliases.get_target', MagicMock(return_value='bar@example.com'))
+    def test_set_target_equal(self):
+        '''
+        Tests return when target is already present
+        '''
+        alias = 'foo'
+        target = 'bar@example.com'
+        ret = aliases.set_target(alias, target)
+        self.assertTrue(ret)
+
+    def test_set_target_empty_alias(self):
+        '''
+        Tests return of empty alias
+        '''
+        self.assertRaises(SaltInvocationError, aliases.set_target, '', 'foo')
+
+    def test_set_target_empty_target(self):
+        '''
+        Tests return of known alias and empty target
+        '''
+        self.assertRaises(SaltInvocationError, aliases.set_target, 'foo', '')
+
+    @patch('salt.modules.aliases.get_target', MagicMock(return_value=''))
+    def test_rm_alias_absent(self):
+        '''
+        Tests return when alias is not present
+        '''
+        ret = aliases.rm_alias('foo')
+        self.assertTrue(ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(AliasesTestCase, needs_daemon=False)


### PR DESCRIPTION
References: #12730

/etc/aliases should now be listed as `username: user@example.com, another_user@example.com` instead of `username: ['user@example.com', 'user2@example.com']`.

I also added some small changes to `salt/tests/integration/modules/aliases.py` so the tests will run.
