### PR TITLE
Actually pass the args in salt.function state

### DIFF
--- a/salt/states/saltmod.py
+++ b/salt/states/saltmod.py
@@ -222,7 +222,7 @@ def function(
            'changes': {},
            'comment': '',
            'result': True}
-    cmd_kw = {'arg': []}
+    cmd_kw = {'arg': arg or []}
     if 'expr_form' in kwargs and not tgt_type:
         tgt_type = kwargs['expr_form']
     if not tgt_type:


### PR DESCRIPTION
**This is against the 2014.1 branch**

Fixes one small problem with the 2014.1 version of salt/states/saltmod.function

Args were not being passed to the function, now they are.

However, saltmod.py is very behind the `develop` version.  It doesn't handle kwargs, it doesn't handle returns correctly, it's missing _a lot_ of functionality compared to `develop`'s orchestrate capabilities.  However, at the same time I'm not sure it's a drop-in replacement from `develop`, since we've done so much kwarg work.  In any case, I think because we're so close to the release candidate for the next feature release, we should probably not expend the time/effort required to get it up to standard.

Fixes #12451
