### PR TITLE
Add extra handling to highstate outputter for 'Comment'

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -150,10 +150,17 @@ def _format_host(host, data):
                 comment = ret['comment'].strip().replace(
                     '\n',
                     '\n' + ' ' * 14)
-            except AttributeError:
-                comment = ret['comment'].join(' ').replace(
-                    '\n',
-                    '\n' + ' ' * 13)
+            except AttributeError:  # Assume comment is a list
+                try:
+                    comment = ret['comment'].join(' ').replace(
+                        '\n',
+                        '\n' + ' ' * 13)
+                except AttributeError:
+                    # Comment isn't a list either, just convert to string
+                    comment = str(ret['comment'])
+                    comment = comment.strip().replace(
+                        '\n',
+                        '\n' + ' ' * 14)
             for detail in ['start_time', 'duration']:
                 ret.setdefault(detail, '')
             if ret['duration'] != '':


### PR DESCRIPTION
Highstate outputter was handling strings in the comment, and lists, but wouldn't handle anything else.  (In this case, the fix is for dicts, but it should fix for any data structure, assuming it has a defined string representation)

Really, states should not be outputting comments as dicts, and this may not look especially pretty, but it will not stacktrace and fallback to the default outputter.  It will be up to the authors of those states to fix their comments to make them pretty.

Fixes #12840
