### PR TITLE
Added a _utils sync mechanism for distributing utility source files to minions (#12712)     

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -296,6 +296,7 @@
 #returner_dirs: []
 #states_dirs: []
 #render_dirs: []
+#utils_dirs: []
 #
 # A module provider can be statically overwritten or extended for the minion
 # via the providers option, in this case the default module will be

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -126,6 +126,7 @@ def prep_trans_tar(opts, chunks, file_refs):
             ['salt://_renderers'],
             ['salt://_returners'],
             ['salt://_outputters'],
+            ['salt://_utils'],
             ]
     with open(lowfn, 'w+') as fp_:
         fp_.write(json.dumps(chunks))

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -319,6 +319,25 @@ def sync_outputters(saltenv=None, refresh=True):
     return ret
 
 
+def sync_utils(saltenv=None, refresh=True):
+    '''
+    Sync utility source files from the _utils directory on the salt master file
+    server. This function is environment aware, pass the desired environment
+    to grab the contents of the _utils directory, base is the default
+    environment.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' saltutil.sync_utils
+    '''
+    ret = _sync('utils', saltenv)
+    if refresh:
+        refresh_modules()
+    return ret
+
+
 def sync_all(saltenv=None, refresh=True):
     '''
     Sync down all of the dynamic modules from the file server for a specific
@@ -338,6 +357,7 @@ def sync_all(saltenv=None, refresh=True):
     ret['renderers'] = sync_renderers(saltenv, False)
     ret['returners'] = sync_returners(saltenv, False)
     ret['outputters'] = sync_outputters(saltenv, False)
+    ret['utils'] = sync_utils(saltenv, False)
     if refresh:
         refresh_modules()
     return ret


### PR DESCRIPTION
Sync utility source files from the _utils directory on the salt master file
server. This function is environment aware, pass the desired environment
to grab the contents of the _utils directory, base is the default
environment.
