### PR TITLE
Move mine_interval example to a minion conf file

### DIFF
--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -65,6 +65,10 @@ to add them to the pool of load balanced servers.
     mine_functions:
       network.ip_addrs: [eth0]
 
+:file:`/etc/salt/minion.d/mine.conf`:
+
+.. code-block:: yaml
+
     mine_interval: 5
 
 :file:`/srv/salt/haproxy.sls`:


### PR DESCRIPTION
`mine_interval` has no effect when added in a pillar, so this can be misleading to those who are trying the example and expecting a mine update in 5 minutes (or whatever value they used).
