### PR TITLE
Salt cloud openstack availability zone

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -541,7 +541,7 @@ def request_instance(vm_=None, call=None):
     if not isinstance(kwargs['ex_metadata'], dict):
         raise SaltCloudConfigError('\'metadata\' should be a dict.')
 
-    kwargs['availability_zone'] = config.get_cloud_config_value(
+    kwargs['ex_availability_zone'] = config.get_cloud_config_value(
         'availability_zone', vm_, __opts__, search_global=False
     )
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -541,6 +541,10 @@ def request_instance(vm_=None, call=None):
     if not isinstance(kwargs['ex_metadata'], dict):
         raise SaltCloudConfigError('\'metadata\' should be a dict.')
 
+    kwargs['availability_zone'] = config.get_cloud_config_value(
+        'availability_zone', vm_, __opts__, search_global=False
+    )
+
     try:
         data = conn.create_node(**kwargs)
         return data, vm_


### PR DESCRIPTION
Added support for setting node availability zone in openstack
This feature depends on apache/libcloud#295:
https://issues.apache.org/jira/browse/LIBCLOUD-555
