### PR TITLE
fixes #12801

### DIFF
--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -384,7 +384,7 @@ def destroy(name, conn=None, call=None):
             transport=__opts__['transport']
         )
         if __opts__['delete_sshkeys'] is True:
-            salt.utils.cloud.remove_sshkey(node.public_ips[0])
+            salt.utils.cloud.remove_sshkey(getattr(node, __opts__.get('ssh_interface', 'public_ips'))[0])
         return True
 
     log.error('Failed to Destroy VM: {0}'.format(name))


### PR DESCRIPTION
get ssh_interface if it is set, otherwise just use public_ips

@grischa can you double check that this one fixes your problem?

It should use whatever value you set in ssh_interfaces, and if nothing is set fall back to using the public_ips
