### PR TITLE
Switch openstack drivers to useing show_instance

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -777,9 +777,12 @@ def list_nodes_full(call=None, **kwargs):
     if not server_list:
         return {}
     for server in server_list.keys():
-        ret[server] = conn.server_show_libcloud(
-            server_list[server]['id']
-        ).__dict__
+        try:
+            ret[server] = conn.server_show_libcloud(
+                server_list[server]['id']
+            ).__dict__
+        except IndexError as exc:
+            ret = {}
 
     salt.utils.cloud.cache_node_list(ret, __active_provider_name__.split(':')[0], __opts__)
     return ret

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -130,6 +130,7 @@ except ImportError:
 
 # Get logging started
 log = logging.getLogger(__name__)
+request_log = logging.getLogger('requests')
 
 
 # Some of the libcloud functions need to be in the same namespace as the
@@ -144,6 +145,7 @@ def __virtual__():
     '''
     Check for Nova configurations
     '''
+    request_log.setLevel(getattr(logging, __opts__.get('requests_log_level', 'warning').upper()))
     return nova.HAS_NOVA
 
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -235,7 +235,7 @@ def show_instance(name, call=None):
         )
 
     conn = get_conn()
-    return conn.show_instance(name)
+    return conn.show_instance(name).__dict__
 
 
 def get_size(conn, vm_):
@@ -565,13 +565,11 @@ def create(vm_):
 
     def __query_node_data(vm_, data):
         try:
-            node = show_instance(vm_['name'])
+            node = show_instance(vm_['name'], 'action')
             log.debug(
                 'Loaded node data for {0}:\n{1}'.format(
                     vm_['name'],
-                    pprint.pformat(
-                        nodelist[vm_['name']]
-                    )
+                    pprint.pformat(node)
                 )
             )
         except Exception as err:
@@ -585,7 +583,7 @@ def create(vm_):
             # Trigger a failure in the wait for IP function
             return False
 
-        running = node['state'] == 'ACTIVE'
+        running = node['status'] == 'ACTIVE'
         if not running:
             # Still not running, trigger another iteration
             return
@@ -751,7 +749,7 @@ def list_nodes(call=None, **kwargs):
             'id': server_tmp['id'],
             'image': server_tmp['image']['id'],
             'size': server_tmp['flavor']['id'],
-            'state': server_tmp['status'],
+            'status': server_tmp['status'],
             'private_ips': [addrs['addr'] for addrs in server_tmp['addresses']['private']],
             'public_ips': [server_tmp['accessIPv4'], server_tmp['accessIPv6']],
         }

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -565,7 +565,7 @@ def create(vm_):
 
     def __query_node_data(vm_, data):
         try:
-            nodelist = list_nodes_full()
+            node = show_instance(vm_['name'])
             log.debug(
                 'Loaded node data for {0}:\n{1}'.format(
                     vm_['name'],
@@ -585,13 +585,13 @@ def create(vm_):
             # Trigger a failure in the wait for IP function
             return False
 
-        running = nodelist[vm_['name']]['state'] == 'ACTIVE'
+        running = node['state'] == 'ACTIVE'
         if not running:
             # Still not running, trigger another iteration
             return
 
         if rackconnect(vm_) is True:
-            extra = nodelist[vm_['name']].get('extra', {})
+            extra = node.get('extra', {})
             rc_status = extra.get('metadata', {}).get(
                 'rackconnect_automation_status', '')
             access_ip = extra.get('access_ip', '')
@@ -602,7 +602,7 @@ def create(vm_):
 
         if managedcloud(vm_) is True:
             extra = conn.server_show_libcloud(
-                nodelist[vm_['name']]['id']
+                node['id']
             ).extra
             mc_status = extra.get('metadata', {}).get(
                 'rax_service_level_automation', '')
@@ -612,8 +612,8 @@ def create(vm_):
                 return
 
         result = []
-        private = nodelist[vm_['name']]['private_ips']
-        public = nodelist[vm_['name']]['public_ips']
+        private = node['private_ips']
+        public = node['public_ips']
         if private and not public:
             log.warn(
                 'Private IPs returned, but not public... Checking for '

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -583,7 +583,7 @@ def create(vm_):
             # Trigger a failure in the wait for IP function
             return False
 
-        running = node['status'] == 'ACTIVE'
+        running = node['state'] == 'ACTIVE'
         if not running:
             # Still not running, trigger another iteration
             return
@@ -749,7 +749,7 @@ def list_nodes(call=None, **kwargs):
             'id': server_tmp['id'],
             'image': server_tmp['image']['id'],
             'size': server_tmp['flavor']['id'],
-            'status': server_tmp['status'],
+            'state': server_tmp['state'],
             'private_ips': [addrs['addr'] for addrs in server_tmp['addresses']['private']],
             'public_ips': [server_tmp['accessIPv4'], server_tmp['accessIPv6']],
         }

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -621,13 +621,11 @@ def create(vm_):
 
     def __query_node_data(vm_, data, floating):
         try:
-            nodelist = list_nodes_full()
+            node = show_instance(vm_['name'], 'action')
             log.debug(
                 'Loaded node data for {0}:\n{1}'.format(
                     vm_['name'],
-                    pprint.pformat(
-                        nodelist[vm_['name']]
-                    )
+                    pprint.pformat(node)
                 )
             )
         except Exception as err:
@@ -641,14 +639,14 @@ def create(vm_):
             # Trigger a failure in the wait for IP function
             return False
 
-        running = nodelist[vm_['name']]['state'] == NodeState.RUNNING
+        running = node['state'] == NodeState.RUNNING
         if not running:
             # Still not running, trigger another iteration
             return
 
         if rackconnect(vm_) is True:
             check_libcloud_version((0, 14, 0), why='rackconnect: True')
-            extra = nodelist[vm_['name']].get('extra')
+            extra = node.get('extra')
             rc_status = extra.get('metadata', {}).get(
                 'rackconnect_automation_status', '')
             access_ip = extra.get('access_ip', '')
@@ -658,7 +656,7 @@ def create(vm_):
                 return
 
         if managedcloud(vm_) is True:
-            extra = nodelist[vm_['name']].get('extra')
+            extra = node.get('extra')
             mc_status = extra.get('metadata', {}).get(
                 'rax_service_level_automation', '')
 
@@ -683,8 +681,8 @@ def create(vm_):
                 pass
 
         result = []
-        private = nodelist[vm_['name']]['private_ips']
-        public = nodelist[vm_['name']]['public_ips']
+        private = node['private_ips']
+        public = node['public_ips']
         if private and not public:
             log.warn(
                 'Private IPs returned, but not public... Checking for '

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -40,7 +40,7 @@ class NovaServer(object):
         self.id = server['id']
         self.image = server['image']['id']
         self.size = server['flavor']['id']
-        self.state = server['status']
+        self.status = server['status']
         self._uuid = None
         self.extra = {
             'metadata': server['metadata'],
@@ -227,7 +227,7 @@ class SaltNova(object):
         '''
         Find a server by its name (libcloud)
         '''
-        return self.server_list().get(name, {})
+        return self.server_by_name(name)
 
     def root_password(self, server_id, password):
         '''

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -40,7 +40,7 @@ class NovaServer(object):
         self.id = server['id']
         self.image = server['image']['id']
         self.size = server['flavor']['id']
-        self.status = server['status']
+        self.state = server['state']
         self._uuid = None
         self.extra = {
             'metadata': server['metadata'],
@@ -616,7 +616,7 @@ class SaltNova(object):
             ret[item.name] = {
                 'id': item.id,
                 'name': item.name,
-                'status': item.status,
+                'state': item.status,
                 'accessIPv4': item.accessIPv4,
                 'accessIPv6': item.accessIPv6,
                 'flavor': {'id': item.flavor['id'],
@@ -650,7 +650,7 @@ class SaltNova(object):
                 'links': item.links,
                 'metadata': item.metadata,
                 'name': item.name,
-                'status': item.status,
+                'state': item.status,
                 'tenant_id': item.tenant_id,
                 'updated': item.updated,
                 'user_id': item.user_id,


### PR DESCRIPTION
there isn't a reason to use list_node_full directly if we can just use the show_instance function.

If show_instance also uses list_node_full, then so be it, but we could always make it more efficient for 
some of the other drivers that aren't using libcloud.

This cuts down on the number of connections that the nova driver uses why querying server information because it doesn't have to do a new query for ever each server when doing a server_list_detailed.

@techhat ping
