### PR TITLE
fix up cache problems

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -668,6 +668,6 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return node

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -668,6 +668,6 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return node

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -546,8 +546,9 @@ def show_instance(name, call=None):
         raise SaltCloudSystemExit(
             'The show_instance action must be called with -a or --action.'
         )
-
-    return _get_node(name)
+    node = _get_node(name)
+    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    return node
 
 
 def _get_node(name):

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2384,7 +2384,9 @@ def show_instance(name, call=None):
             'The show_instance action must be called with -a or --action.'
         )
 
-    return _get_node(name)
+    node = _get_node(name)
+    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    return node
 
 
 def _get_node(name, location=None):

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2333,7 +2333,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return ret
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2333,7 +2333,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return ret
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -1835,7 +1835,7 @@ def destroy(vm_name, call=None):
         )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return inst_deleted
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -334,7 +334,9 @@ def show_instance(vm_name, call=None):
             'The show_instance action must be called with -a or --action.'
         )
     conn = get_conn()
-    return _expand_node(conn.ex_get_node(vm_name))
+    node = _expand_node(conn.ex_get_node(vm_name))
+    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    return node
 
 
 def avail_sizes(conn=None):

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -1835,7 +1835,7 @@ def destroy(vm_name, call=None):
         )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return inst_deleted
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -475,7 +475,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return ret[0] in VALID_RESPONSE_CODES
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -475,7 +475,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return ret[0] in VALID_RESPONSE_CODES
 

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -785,6 +785,6 @@ def destroy(name):
         )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return ret

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -785,6 +785,6 @@ def destroy(name):
         )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return ret

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -281,6 +281,7 @@ def show_instance(name, call=None):
     if not call:
         call = 'action'
     nodes = list_nodes_full(call=call)
+    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -354,7 +354,7 @@ def destroy(vm_, call=None):
                 transport=__opts__['transport']
             )
             if __opts__.get('update_cachedir', False) is True:
-                salt.utils.cloud.delete_minion_cachedir(vm_, __opts__)
+                salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -354,7 +354,7 @@ def destroy(vm_, call=None):
                 transport=__opts__['transport']
             )
             if __opts__.get('update_cachedir', False) is True:
-                salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+                salt.utils.cloud.delete_minion_cachedir(vm_, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -677,7 +677,7 @@ def destroy(name, conn=None, call=None):
         'request_id': del_vm.request_id,
     }
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -393,6 +393,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
+    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -677,7 +677,7 @@ def destroy(name, conn=None, call=None):
         'request_id': del_vm.request_id,
     }
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -237,7 +237,9 @@ def show_instance(name, call=None):
         )
 
     conn = get_conn()
-    return conn.show_instance(name).__dict__
+    node = conn.show_instance(name).__dict__
+    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    return node
 
 
 def get_size(conn, vm_):

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -389,7 +389,7 @@ def destroy(name, conn=None, call=None):
         if __opts__.get('delete_sshkeys', False) is True:
             salt.utils.cloud.remove_sshkey(node.public_ips[0])
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
         return True
 
     log.error('Failed to Destroy VM: {0}'.format(name))

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -389,7 +389,7 @@ def destroy(name, conn=None, call=None):
         if __opts__.get('delete_sshkeys', False) is True:
             salt.utils.cloud.remove_sshkey(node.public_ips[0])
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
         return True
 
     log.error('Failed to Destroy VM: {0}'.format(name))

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -580,6 +580,6 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return node

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -522,8 +522,9 @@ def show_instance(name, call=None):
         raise SaltCloudSystemExit(
             'The show_instance action must be called with -a or --action.'
         )
-
-    return _get_node(name)
+    node = _get_node(name)
+    salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
+    return node
 
 
 def _get_node(name):

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -580,6 +580,6 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return node

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -658,7 +658,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return {'Destroyed': '{0} was destroyed.'.format(name)}
 

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -658,7 +658,7 @@ def destroy(name, call=None):
     )
 
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return {'Destroyed': '{0} was destroyed.'.format(name)}
 

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -592,6 +592,8 @@ def show_instance(name, call=None):
             children = item._children
             for child in children:
                 ret[item.tag][child.tag] = child.attrib
+
+    salt.utils.cloud.cache_node(item, __active_provider_name__, __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -861,7 +861,7 @@ def destroy(name, call=None):
             transport=__opts__['transport']
         )
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
         return {'Destroyed': '{0} was destroyed.'.format(name)}
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -756,6 +756,7 @@ def show_instance(name, call=None, instance_type=None):
         )
 
     nodes = list_nodes_full()
+    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -861,7 +861,7 @@ def destroy(name, call=None):
             transport=__opts__['transport']
         )
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
         return {'Destroyed': '{0} was destroyed.'.format(name)}
 

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -631,7 +631,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return response
 

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -631,7 +631,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return response
 

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -592,6 +592,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
+    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -799,7 +799,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return response
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -752,6 +752,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
+    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -799,7 +799,7 @@ def destroy(name, call=None):
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return response
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -474,6 +474,7 @@ def show_instance(name, call=None):
     ret = instance.get_properties()
     ret['status'] = instance.get_status()
     ret['tools_status'] = instance.get_tools_status()
+    salt.utils.cloud.cache_node(ret, __active_provider_name__, __opts__)
     return ret
 
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -512,7 +512,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
     return True
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -512,7 +512,7 @@ def destroy(name, call=None):  # pylint: disable=W0613
         transport=__opts__['transport']
     )
     if __opts__.get('update_cachedir', False) is True:
-        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+        salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
     return True
 

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -386,7 +386,7 @@ def destroy(name, conn=None, call=None):
         if __opts__['delete_sshkeys'] is True:
             salt.utils.cloud.remove_sshkey(getattr(node, __opts__.get('ssh_interface', 'public_ips'))[0])
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
+            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0], __opts__)
 
         return True
 

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -495,6 +495,7 @@ def show_instance(name, call=None):
         )
 
     nodes = list_nodes_full()
+    salt.utils.cloud.cache_node(nodes[name], __active_provider_name__, __opts__)
     return nodes[name]
 
 

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -386,7 +386,7 @@ def destroy(name, conn=None, call=None):
         if __opts__['delete_sshkeys'] is True:
             salt.utils.cloud.remove_sshkey(getattr(node, __opts__.get('ssh_interface', 'public_ips'))[0])
         if __opts__.get('update_cachedir', False) is True:
-            salt.utils.cloud.delete_minion_cachedir(name, __opts__)
+            salt.utils.cloud.delete_minion_cachedir(name, __active_provider_name__.split(':')[0],  __opts__)
 
         return True
 

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2084,6 +2084,23 @@ def cache_node_list(nodes, provider, opts):
             json.dump(nodes[node], fh_)
 
 
+def cache_node(node, provider, opts):
+    '''
+    Cache node individually
+
+    .. versionadded:: Helium
+    '''
+    if not 'update_cachedir' in opts or not opts['update_cachedir']:
+        return
+
+    base = os.path.join(syspaths.CACHE_DIR, 'cloud', 'active')
+    provider, driver = provider.split(':')
+    prov_dir = os.path.join(base, driver, provider)
+    path = os.path.join(prov_dir, '{0}.json'.format(node['name']))
+    with salt.utils.fopen(path, 'w') as fh_:
+        json.dump(node, fh_)
+
+
 def missing_node_cache(prov_dir, node_list, opts):
     '''
     Check list of nodes to see if any nodes which were previously known about


### PR DESCRIPTION
The first patch just starts caching the servers each time we do a show_instance on them. We do this several times in the build process anyway, and the extra step to just dump the contents to the file shouldn't be taxing.

The second one is to fix up the usage of delete_minion_cachedir, so that it actually goes all the way to where the file will be to clean it up.

Before it was just hitting /var/cache/salt/cloud/{active,requested}/<name>.json, now it adds the driver/provider top the directory tree as well.

Thanks,
Daniel
