### PR TITLE
added optional availability zones to openstack cloud driver

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -417,6 +417,12 @@ def request_instance(vm_=None, call=None):
             )
         )
 
+    avz = config.get_cloud_config_value(
+        'availability_zone', vm_, __opts__, default=None, search_global=False
+    )
+    if avz is not None:
+        kwargs['ex_availability_zone'] = avz
+
     kwargs['ex_keyname'] = config.get_cloud_config_value(
         'ssh_key_name', vm_, __opts__, search_global=False
     )


### PR DESCRIPTION
Depends on libcloud trunk at this time.
Expands on #12866, but does not check libcloud version.
Unfortunately, trunk is labeled 0.14.1 in `libcloud.__version__`, so I don't see any way to test for trunk.
