### PR TITLE
Update to tomcat.py

### DIFF
--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -53,6 +53,7 @@ def __virtual__():
 # Functions
 def war_deployed(name,
                  war,
+                 force,
                  url='http://localhost:8080/manager',
                  timeout=180,
                  temp_war_location=None):
@@ -68,6 +69,8 @@ def war_deployed(name,
     war
         absolute path to WAR file (should be accessible by the user running
         tomcat) or a path supported by the salt.modules.cp.get_url function
+	force: 
+		force deploy even if version strings are the same, False by default.	
     url : http://localhost:8080/manager
         the URL of the server manager webapp
     timeout : 180
@@ -102,7 +105,7 @@ def war_deployed(name,
 
     # Determine what to do
     try:
-        if version != webapps[name]['version']:
+        if (version != webapps[name]['version']) or force:
             deploy = True
             undeploy = True
             ret['changes']['undeploy'] = ('undeployed {0} in version {1}'.
@@ -147,16 +150,16 @@ def war_deployed(name,
     # Deploy
     deploy_res = __salt__['tomcat.deploy_war'](war,
                                                name,
-                                               'yes',
+                                               force,
                                                url,
                                                __env__,
                                                timeout,
-                                               temp_war_location=temp_war_location)
+                                               temp_war_location)
 
     # Return
     if deploy_res.startswith('OK'):
         ret['result'] = True
-        ret['comment'] = __salt__['tomcat.ls'](url, timeout)[name]
+        ret['comment'] = str(__salt__['tomcat.ls'](url, timeout)[name])
         ret['changes']['deploy'] = 'deployed {0} in version {1}'.format(name,
                 version)
     else:

--- a/salt/states/tomcat.py
+++ b/salt/states/tomcat.py
@@ -53,7 +53,7 @@ def __virtual__():
 # Functions
 def war_deployed(name,
                  war,
-                 force,
+                 force=False,
                  url='http://localhost:8080/manager',
                  timeout=180,
                  temp_war_location=None):
@@ -69,8 +69,8 @@ def war_deployed(name,
     war
         absolute path to WAR file (should be accessible by the user running
         tomcat) or a path supported by the salt.modules.cp.get_url function
-	force: 
-		force deploy even if version strings are the same, False by default.	
+    force: 
+        force deploy even if version strings are the same, False by default.	
     url : http://localhost:8080/manager
         the URL of the server manager webapp
     timeout : 180
@@ -150,7 +150,7 @@ def war_deployed(name,
     # Deploy
     deploy_res = __salt__['tomcat.deploy_war'](war,
                                                name,
-                                               force,
+                                               'yes',
                                                url,
                                                __env__,
                                                timeout,


### PR DESCRIPTION
-Added "force" (default false) option commensurate with force option in salt.modules.tomcat.deploy_war to allow forced deployment of a .war even if the version strings match.  
-Forced successful deploy comment to be a string instead of dict to compensate for https://github.com/saltstack/salt/issues/12840
