### PR TITLE
updating homebrew installation URL in Mac OS X Walkthrough TUT (doc)

### DIFF
--- a/doc/man/salt.7
+++ b/doc/man/salt.7
@@ -9234,7 +9234,7 @@ Or just type
 .sp
 .nf
 .ft C
-ruby \-e "$(curl \-fsSL https://raw.githubusercontent.com/mxcl/homebrew/go)"
+ruby \-e "$(curl \-fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
 .ft P
 .fi
 .UNINDENT
@@ -33555,7 +33555,7 @@ how to configure authenticated access.
 .B Parameters
 .INDENT 7.0
 .IP \(bu 2
-\fBrepo\fP (\fI\%string\fP) \-\- 
+\fBrepo\fP (\fI\%string\fP) \-\-
 .sp
 The repository to pull.         [registryurl://]REPOSITORY_NAME_image
 eg:
@@ -40327,7 +40327,7 @@ values for non\-standard package names such as when using a different
 Python version from the default Python version provided by the OS
 (e.g., \fBpython26\-mysql\fP instead of \fBpython\-mysql\fP).
 .IP \(bu 2
-\fBdefault\fP \-\- 
+\fBdefault\fP \-\-
 .sp
 default lookup_dict\(aqs key used if the grain does not exists
 or if the grain value has no match on lookup_dict.
@@ -91625,7 +91625,7 @@ used if no arguments are required.
 \fBtgt\fP (\fIstring or list\fP) \-\- Which minions to target for the execution. Default is shell
 glob. Modified by the \fBexpr_form\fP option.
 .IP \(bu 2
-\fBfun\fP (\fIstring or list of strings\fP) \-\- 
+\fBfun\fP (\fIstring or list of strings\fP) \-\-
 .sp
 The module and function to call on the specified minions of
 the form \fBmodule.function\fP\&. For example \fBtest.ping\fP or
@@ -91651,7 +91651,7 @@ executing a compound command.
 \fBtimeout\fP \-\- Seconds to wait after the last minion returns but
 before all minions return.
 .IP \(bu 2
-\fBexpr_form\fP \-\- 
+\fBexpr_form\fP \-\-
 .sp
 The type of \fBtgt\fP\&. Allowed values:
 .INDENT 2.0
@@ -91682,7 +91682,7 @@ on the minions
 .IP \(bu 2
 \fBkwarg\fP \-\- A dictionary with keyword arguments for the function.
 .IP \(bu 2
-\fBkwargs\fP \-\- 
+\fBkwargs\fP \-\-
 .sp
 Optional keyword arguments.
 .sp

--- a/doc/topics/tutorials/walkthrough_macosx.rst
+++ b/doc/topics/tutorials/walkthrough_macosx.rst
@@ -33,7 +33,7 @@ Here's a brief overview of a Salt cluster:
   , **on the master server**), and one for minions (default is
   /etc/salt/minion or /etc/salt/minion.conf, **on the minion servers**). Those
   files are used to determine things like the Salt Master IP, port, Salt
-  folder locations, etc.. If these are configured incorrectly, your minions 
+  folder locations, etc.. If these are configured incorrectly, your minions
   will probably be unable to receive orders from the master, or the master
   will not know which software a given minion should install.
 
@@ -44,7 +44,7 @@ Here's a brief overview of a Salt cluster:
   installed. These files should be created in the /srv/salt folder by default,
   but their location can be changed using ... /etc/salt/master configuration file!
 
-.. note:: 
+.. note::
 
     This tutorial contains a third important configuration file, not to
     be confused with the previous two: the virtual machine provisioning
@@ -53,7 +53,7 @@ Here's a brief overview of a Salt cluster:
     note that all configuration files are YAML files. So indentation matters.
 
 .. [#]
-       
+
     Salt also works with "masterless" configuration where a minion is
     autonomous (in which case salt can be seen as a local configuration tool),
     or in "multiple master" configuration. See the documentation for more on
@@ -94,17 +94,17 @@ have to do it all over again. It also lets you *uninstall* things easily.
     Brew is a Ruby program (Ruby is installed by default with your Mac). Brew
     downloads, compile and links software. The linking phase is when compiled
     software is deployed on your machine. It may conflict with manually
-    installed software, especially in the /usr/local directory. It's ok, 
+    installed software, especially in the /usr/local directory. It's ok,
     remove the manually installed version then refresh the link by typing
     ``brew link 'packageName'``. Brew has a ``brew doctor`` command that can
     help you troubleshoot. It's a great command, use it often. Brew requires
-    xcode command line tools. When you run brew the first time it asks you to 
+    xcode command line tools. When you run brew the first time it asks you to
     install them if they're not already on your system. Brew installs
     software in /usr/local/bin (system bins are in /usr/bin). In order to use
     those bins you need your $PATH to search there first. Brew tells you if
     your $PATH needs to be fixed.
 
-.. tip:: 
+.. tip::
 
     Use the keyboard shortcut ``cmd + shift + period`` in the "open" Mac OS X
     dialog box to display hidden files and folders, such as .profile.
@@ -117,7 +117,7 @@ Or just type
 
 .. code-block:: bash
 
-    ruby -e "$(curl -fsSL https://raw.githubusercontent.com/mxcl/homebrew/go)"
+    ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
 
 
 Now type the following commands in your terminal (you may want to type brew
@@ -129,7 +129,7 @@ doctor after each to make sure everything's fine):
     brew install swig
     brew install zmq
 
-.. note:: 
+.. note::
 
     zmq is ZeroMQ. It's a fantastic library used for server to server network
     communication and is at the core of Salt efficiency.
@@ -143,11 +143,11 @@ you should now have everything ready to launch this command:
 
     pip install salt
 
-.. note:: 
+.. note::
 
     There should be no need for ``sudo pip install salt``. Brew installed
     Python for your user, so you should have all the access. In case you
-    would like to check, type ``which python`` to ensure that it's 
+    would like to check, type ``which python`` to ensure that it's
     /usr/local/bin/python, and ``which pip`` which should be
     /usr/local/bin/pip.
 
@@ -161,8 +161,8 @@ If the default /etc/salt/master configuration file was not created,
 copy-paste it from here:
 http://docs.saltstack.com/ref/configuration/examples.html#configuration-examples-master
 
-.. note:: 
-       
+.. note::
+
     ``/etc/salt/master`` is a file, not a folder.
 
 Salt Master configuration changes. The Salt master needs a few customization
@@ -183,7 +183,7 @@ You should now be able to launch the Salt master:
 
 There should be no errors when running the above command.
 
-.. note:: 
+.. note::
 
     This command is supposed to be a daemon, but for toying around, we'll keep
     it running on a terminal to monitor the activity.
@@ -254,7 +254,7 @@ Import Precise64 Ubuntu Box
 
     vagrant box add precise64 http://files.vagrantup.com/precise64.box
 
-.. note:: 
+.. note::
 
     This box is added at the global Vagrant level. You only need to do it
     once as each VM will use this same file.
@@ -304,7 +304,7 @@ Now log inside the VM in ssh using Vagrant again:
 
     vagrant ssh
 
-You should see the shell prompt changing to something similar to 
+You should see the shell prompt changing to something similar to
 ``vagrant@precise64:~$`` meaning you're inside the VM. From there enter the
 following:
 
@@ -313,7 +313,7 @@ following:
     ping 10.0.2.2
 
 .. note::
-       
+
     That ip is the ip of your VM host (the Mac OS X OS). The number is a
     VirtualBox default and is displayed in the log after the Vagrant ssh
     command. We'll use that IP to tell the minion where the Salt master is.


### PR DESCRIPTION
https://raw.githubusercontent.com/mxcl/homebrew/go doesn't work anymore and http://brew.sh/ suggests to use https://raw.github.com/Homebrew/homebrew/go/install .
