### PR TITLE
Fix traceback when syncing custom types

### DIFF
--- a/salt/utils/yamlloader.py
+++ b/salt/utils/yamlloader.py
@@ -77,7 +77,7 @@ class SaltYamlSafeLoader(yaml.SafeLoader, object):
                 raise ConstructorError(err)
             value = self.construct_object(value_node, deep=deep)
             if key in mapping:
-                raise ConstructorError('Conflicting ID "{0}"'.format(key))
+                raise ConstructorError('Conflicting ID {0!r}'.format(key))
             mapping[key] = value
         return mapping
 


### PR DESCRIPTION
This fixes a traceback which occurs when a rendering error occurs when
the top files are checked before custom types are synced.
