### PR TITLE
Make saltenv stripping more concise

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1461,11 +1461,11 @@ def mod_repo(repo, basedir=None, **kwargs):
         salt '*' pkg.mod_repo reponame basedir=/path/to/dir enabled=1
         salt '*' pkg.mod_repo reponame baseurl= mirrorlist=http://host.com/
     '''
-    # Filter out '__pub' arguments
-    repo_opts = dict((x, kwargs[x]) for x in kwargs if not x.startswith('__'))
-
-    if 'saltenv' in repo_opts:
-        del repo_opts['saltenv']
+    # Filter out '__pub' arguments, as well as saltenv
+    repo_opts = dict(
+        (x, kwargs[x]) for x in kwargs
+        if not x.startswith('__') and x not in ('saltenv',)
+    )
 
     if all(x in repo_opts for x in ('mirrorlist', 'baseurl')):
         raise SaltInvocationError(


### PR DESCRIPTION
We're already filtering __pub_\* arguments from the kwargs before using
them to write the key/value pairs in repo config files, no need to do
two extra dict lookups here. This commit excludes saltenv from the repo
args in the same list comprehension where __pub_\* arguments are
filtered.
