### PR TITLE
salt-cloud/linode: Allow arbitrary libcloud create_node args in salt cloud profile

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -171,6 +171,9 @@ def create(vm_):
         'ex_rsize': get_disk_size(vm_, get_size(conn, vm_), get_swap(vm_)),
         'ex_swap': get_swap(vm_)
     }
+    
+    if 'libcloud_args' in vm_:
+        kwargs.update(vm_['libcloud_args'])
 
     salt.utils.cloud.fire_event(
         'event',

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -171,7 +171,7 @@ def create(vm_):
         'ex_rsize': get_disk_size(vm_, get_size(conn, vm_), get_swap(vm_)),
         'ex_swap': get_swap(vm_)
     }
-    
+
     if 'libcloud_args' in vm_:
         kwargs.update(vm_['libcloud_args'])
 


### PR DESCRIPTION
libcloud create_node for linode has a lot of special arguments, many of which come in really handy. This commit allows you to override those args in the salt cloud profile.

Case in point, labelling the linode or its disk is limited to 50 characters, but libcloud sticks 38 characters on the end, severely limiting what names you can use. By overriding these labels in the salt-cloud profile, we can have more freedom.

Here's my extra libcloud args:

``` yaml
production:
    libcloud_args:
        ex_private: True
        ex_payment: 1
        ex_swap: 256
        lroot: Ubuntu SSD Image
        lconfig: Configuration Profile
        lswap: Swap Space
```
