### PR TITLE
Update useradd.py

### DIFF
--- a/salt/modules/useradd.py
+++ b/salt/modules/useradd.py
@@ -16,7 +16,8 @@ import copy
 # Import salt libs
 import salt.utils
 from salt._compat import string_types
-
+from salt.utils import get_group_list
+ 
 log = logging.getLogger(__name__)
 
 RETCODE_12_ERROR_REGEX = re.compile(


### PR DESCRIPTION
Fixes problem with get_group_list on Debian stable. 'import salt.utils' suddenly doesn't load it for me for some reason.

See: https://gist.github.com/oc/db8a564fb6eb6789e952
