### PR TITLE
Pylint zcbuildout

### DIFF
--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -738,8 +738,7 @@ def run_buildout(directory='.',
                  runas=None,
                  env=(),
                  verbose=False,
-                 debug=False,
-                 python=sys.executable):
+                 debug=False):
     '''
     Run a buildout in a directory.
 

--- a/tests/unit/modules/zcbuildout_test.py
+++ b/tests/unit/modules/zcbuildout_test.py
@@ -410,7 +410,7 @@ class BuildoutOnlineTestCase(Base):
         ret = buildout.bootstrap(b_dir, buildout_ver=2, python=self.py_st)
         self.assertTrue(ret['status'])
         ret = buildout.run_buildout(b_dir,
-                                    parts=['a', 'b'], python=self.py_st)
+                                    parts=['a', 'b'])
         out = ret['out']
         self.assertTrue('Installing a' in out)
         self.assertTrue('Installing b' in out)


### PR DESCRIPTION
I see no evidence of this argument in use. Removed and modified test.

Closes #9556
