### PR TITLE
12839: Install specified version of gem if another version is already installed

### DIFF
--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -89,11 +89,11 @@ def installed(name,          # pylint: disable=C0103
         runas = None
 
     gems = __salt__['gem.list'](name, ruby, runas=user)
-    if name in gems and version and version in gems[name]:
+    if name in gems and version is not None and version in gems[name]:
         ret['result'] = True
         ret['comment'] = 'Gem is already installed.'
         return ret
-    elif name in gems:
+    elif name in gems and version is None:
         ret['result'] = True
         ret['comment'] = 'Gem is already installed.'
         return ret


### PR DESCRIPTION
Fixes #12839.

Before: If a gem is already installed, gem.installed always returns "True: Gem is already installed," even if the installed version is different than the specified version.

After: If a gem is already installed, but the installed gem is not of the specified version, gem.installed will install the specified version of the gem.
