### PR TITLE
Add test for shadow.gen_password

### DIFF
--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -135,20 +135,26 @@ def gen_password(password, crypt_salt=None, algorithm='sha512'):
     Generate hashed password
 
     password
-        Clear text password
+        Plaintext password to be hashed.
 
     crypt_salt
-        Crpytographic salt. If not given, will generate random 8-characters
+        Crpytographic salt. If not given, a random 8-character salt will be
+        generated.
 
     algorithm
-        Hashing algorithm. Support ``md5``, ``blowfish``, ``sha256``, ``sha512``(default).
+        The following hash algorithms are supported:
+
+        * md5
+        * blowfish (not in mainline glibc, only available in distros that add it)
+        * sha256
+        * sha512 (default)
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' shadow.gen_password 'I_am_password'
-        salt '*' shadow.gen_password 'I_am_password' 'I_am_salt' sha256
+        salt '*' shadow.gen_password 'I_am_password' crypt_salt'I_am_salt' algorithm=sha256
     '''
     return salt.utils.pycrypto.gen_hash(crypt_salt, password, algorithm)
 

--- a/salt/utils/pycrypto.py
+++ b/salt/utils/pycrypto.py
@@ -16,7 +16,7 @@ import string
 import random
 
 # Import salt libs
-import salt.exceptions
+from salt.exceptions import SaltInvocationError
 
 def secure_password(length=20):
     '''
@@ -35,9 +35,13 @@ def gen_hash(crypt_salt=None, password=None, algorithm='sha512'):
     '''
     Generate /etc/shadow hash
     '''
-    hash_algorithms = {'md5':'$1$', 'blowfish':'$2a$', 'sha256':'$5$', 'sha512':'$6$'}
+    hash_algorithms = dict(
+        md5='$1$', blowfish='$2a$', sha256='$5$', sha512='$6$'
+    )
     if algorithm not in hash_algorithms:
-        raise salt.exceptions.SaltInvocationError('Not support {0} algorithm'.format(algorithm))
+        raise SaltInvocationError(
+            'Algorithm {0!r} is not supported'.format(algorithm)
+        )
 
     if password is None:
         password = secure_password()

--- a/tests/unit/modules/shadow_test.py
+++ b/tests/unit/modules/shadow_test.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+'''
+    :codauthor: :email:`Erik Johnson <erik@saltstack.com>`
+'''
+
+# Import Salt Testing libs
+from salt.utils import is_linux
+from salttesting import TestCase, skipIf
+from salttesting.helpers import ensure_in_syspath
+
+# Import salt libs
+try:
+    import salt.modules.shadow as shadow
+    HAS_SHADOW = True
+except ImportError:
+    HAS_SHADOW = False
+
+ensure_in_syspath('../../')
+
+_PASSWORD = 'lamepassword'
+
+# Not testing blowfish as it is not available on most Linux distros
+_HASHES = dict(
+    md5=dict(
+        pw_salt='TgIp9OTu',
+        pw_hash='$1$TgIp9OTu$.d0FFP6jVi5ANoQmk6GpM1'
+    ),
+    sha256=dict(
+        pw_salt='3vINbSrC',
+        pw_hash='$5$3vINbSrC$hH8A04jAY3bG123yU4FQ0wvP678QDTvWBhHHFbz6j0D'
+    ),
+    sha512=dict(
+        pw_salt='PiGA3V2o',
+        pw_hash='$6$PiGA3V2o$/PrntRYufz49bRV/V5Eb1V6DdHaS65LB0fu73Tp/xxmDFr6HWJKptY2TvHRDViXZugWpnAcOnrbORpOgZUGTn.'
+    ),
+)
+
+@skipIf(not is_linux(), 'minion is not Linux')
+class LinuxShadowTest(TestCase):
+
+    def test_gen_password(self):
+        '''
+        Test shadow.gen_password
+        '''
+        self.assertTrue(HAS_SHADOW)
+        for algorithm, hash_info in _HASHES.iteritems():
+            self.assertEqual(
+                shadow.gen_password(
+                    _PASSWORD,
+                    crypt_salt=hash_info['pw_salt'],
+                    algorithm=algorithm
+                ),
+                hash_info['pw_hash']
+            )
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(LinuxShadowTest, needs_daemon=False)


### PR DESCRIPTION
This addresses some breakage in this function. For more info, see
https://github.com/saltstack/salt/pull/12941.
