### PR TITLE
Truncate id hash to 10 chars

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -297,9 +297,7 @@ class MinionBase(object):
         self._init_context_and_poller()
 
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
-        id_hash = hash_type(self.opts['id']).hexdigest()
-        if self.opts.get('hash_type', 'md5') == 'sha256':
-            id_hash = id_hash[:10]
+        id_hash = hash_type(self.opts['id']).hexdigest()[:10]
         epub_sock_path = os.path.join(
             self.opts['sock_dir'],
             'minion_event_{0}_pub.ipc'.format(id_hash)


### PR DESCRIPTION
This helps avoid the sock path being longer than the max length allowed
by the kernel. See the following comment for more information:

https://github.com/saltstack/salt/issues/12172#issuecomment-43903643

Fixes #12172.
