### PR TITLE
Added Ec2 Placement Group support

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -943,6 +943,13 @@ def securitygroupid(vm_):
         'securitygroupid', vm_, __opts__, search_global=False
     )
 
+def get_placementgroup(vm_):
+    '''
+    Returns the PlacementGroup to use
+    '''
+    return config.get_cloud_config_value(
+        'placementgroup', vm_, __opts__, search_global=False
+    )
 
 def get_spot_config(vm_):
     '''
@@ -1248,6 +1255,10 @@ def request_instance(vm_=None, call=None):
                 params[
                     spot_prefix + 'SecurityGroupId.{0}'.format(counter)
                 ] = sg_
+
+    placementgroup_ = get_placementgroup(vm_)
+    if placementgroup_ is not None:
+        params[spot_prefix + 'Placement.GroupName'] = placementgroup_
 
     ex_blockdevicemappings = block_device_mappings(vm_)
     if ex_blockdevicemappings:

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -943,6 +943,7 @@ def securitygroupid(vm_):
         'securitygroupid', vm_, __opts__, search_global=False
     )
 
+
 def get_placementgroup(vm_):
     '''
     Returns the PlacementGroup to use
@@ -950,6 +951,7 @@ def get_placementgroup(vm_):
     return config.get_cloud_config_value(
         'placementgroup', vm_, __opts__, search_global=False
     )
+
 
 def get_spot_config(vm_):
     '''


### PR DESCRIPTION
Added support for EC2 Placement Groups by following the pattern for added support of VPC subnets and security group Id's (https://github.com/saltstack/salt-cloud/pull/585/files#r4282815).

Info on Ec2 Placement Groups: http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html

Placement Group API reference: http://docs.aws.amazon.com/AWSEC2/latest/APIReference/ApiReference-query-RunInstances.html
