### PR TITLE
Fix esky breaking

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -35,6 +35,7 @@ import salt.utils.atomicfile
 import salt.utils.thin
 import salt.utils.verify
 from salt._compat import string_types
+from salt.utils import is_windows
 
 try:
     import zmq
@@ -149,8 +150,9 @@ EOF'''.format(
     EX_THIN_PYTHON_OLD=salt.exitcodes.EX_THIN_PYTHON_OLD,
 )
 
-with open(os.path.join(os.path.dirname(__file__), 'ssh_py_shim.py')) as ssh_py_shim:
-    SSH_PY_SHIM = ''.join(ssh_py_shim.readlines()).encode('base64')
+if not is_windows():
+    with open(os.path.join(os.path.dirname(__file__), 'ssh_py_shim.py')) as ssh_py_shim:
+        SSH_PY_SHIM = ''.join(ssh_py_shim.readlines()).encode('base64')
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
All CLI commands import salt.ssh. Windows esky builds seem to have a problem with resolving `__name__` correctly and so all salt commands were broken as a result because the import failed.

This is more of a temporary fix. I don't really like the fact that we're essentially forcing this file to be opened and encoded on every single salt command (even non-ssh commands). I'd like to discuss refactoring this to avoid it in the future.

cc: @plastikos 
