### PR TITLE
disable confusing [ERROR] printing on retcode!=0 where not relevant

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -119,7 +119,7 @@ def _service_is_chkconfig(name):
     Return True if the service is managed by chkconfig.
     '''
     cmdline = '/sbin/chkconfig --list {0}'.format(name)
-    return __salt__['cmd.retcode'](cmdline) == 0
+    return __salt__['cmd.retcode'](cmdline, ignore_retcode=True) == 0
 
 
 def _sysv_is_enabled(name, runlevel=None):
@@ -419,7 +419,7 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = '/sbin/service {0} status'.format(name)
-    return __salt__['cmd.retcode'](cmd) == 0
+    return __salt__['cmd.retcode'](cmd, ignore_retcode=True) == 0
 
 
 def enable(name, **kwargs):


### PR DESCRIPTION
This is a small addition to make the output look clearer.

```
[ERROR  ] Command '/sbin/service nrpe status' failed with return code: 3
[ERROR  ] output: nrpe is stopped
[ERROR  ] Command '/sbin/service xinetd status' failed with return code: 3
[ERROR  ] output: xinetd is stopped
[ERROR  ] Command '/sbin/service haproxy status' failed with return code: 3
[ERROR  ] output: haproxy is stopped
```

on the `service.status nrpe` it will give:

```
[INFO    ] Executing command '/sbin/service nrpe status' in directory '/root'
[INFO    ] output: nrpe is stopped
local:
    False
```

vs

```
[INFO    ] Executing command '/sbin/service nrpe status' in directory '/root'
[ERROR   ] Command '/sbin/service nrpe status' failed with return code: 3
[ERROR   ] output: nrpe is stopped
local:
    False
```

it also affects `service.enable` making it easier to read where the error is.

```
[INFO    ] Executing command '/sbin/chkconfig --list haproxya' in directory '/root'
[INFO    ] output: error reading information on service haproxya: No such file or directory
[INFO    ] Executing command '/sbin/chkconfig --add haproxya' in directory '/root'
[ERROR   ] Command '/sbin/chkconfig --add haproxya' failed with return code: 1
[ERROR   ] output: error reading information on service haproxya: No such file or directory
[ERROR   ] Unable to add initscript "haproxya" to chkconfig
local:
    False
```

vs

```
[INFO    ] Executing command '/sbin/chkconfig --list haproxya' in directory '/root'
[ERROR   ] Command '/sbin/chkconfig --list haproxya' failed with return code: 1
[ERROR   ] output: error reading information on service haproxya: No such file or directory
[INFO    ] Executing command '/sbin/chkconfig --add haproxya' in directory '/root'
[ERROR   ] Command '/sbin/chkconfig --add haproxya' failed with return code: 1
[ERROR   ] output: error reading information on service haproxya: No such file or directory
[ERROR   ] Unable to add initscript "haproxya" to chkconfig
local:
    False
```
