### PR TITLE
Fix crash when launching an EC2 instance.

### DIFF
--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -528,7 +528,7 @@ def create(vm_):
         else:
             log.error('Failed to start Salt on Cloud VM {name}'.format(**vm_))
 
-    ret.update(data)
+    ret.update(data.__dict__)
 
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
     log.debug(


### PR DESCRIPTION
Fixes the following exception when trying to launch an EC2 instance via salt-cloud:

```
[INFO    ] Salt installed on test
[ERROR   ] There was a profile error: 'Node' object is not iterable
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/cli.py", line 331, in run
    self.config.get('names')
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 942, in run_profile
    ret[name] = self.create(vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 856, in create
    output = self.clouds[func](vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/libcloud_aws.py", line 515, in create
    ret.update(data)
TypeError: 'Node' object is not iterable
```
