### PR TITLE
Truncate id hash to 10 chars

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -297,9 +297,9 @@ class MinionBase(object):
         self._init_context_and_poller()
 
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
-        id_hash = hash_type(self.opts['id']).hexdigest()
-        if self.opts.get('hash_type', 'md5') == 'sha256':
-            id_hash = id_hash[:10]
+        # Only use the first 10 chars to keep longer hashes from exceeding the
+        # max socket path length.
+        id_hash = hash_type(self.opts['id']).hexdigest()[:10]
         epub_sock_path = os.path.join(
             self.opts['sock_dir'],
             'minion_event_{0}_pub.ipc'.format(id_hash)

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -159,12 +159,9 @@ class SaltEvent(object):
         use for firing and listening to events
         '''
         hash_type = getattr(hashlib, self.opts.get('hash_type', 'md5'))
-        # Substr the first 10 chars off, because some algorithms produce
-        # longer hashes than others, and may exceed the IPC maximum length
-        # for UNIX sockets.
-        id_hash = hash_type(self.opts.get('id', '')).hexdigest()
-        if self.opts.get('hash_type', 'md5') == 'sha256':
-            id_hash = id_hash[:10]
+        # Only use the first 10 chars to keep longer hashes from exceeding the
+        # max socket path length.
+        id_hash = hash_type(self.opts.get('id', '')).hexdigest()[:10]
         if node == 'master':
             puburi = 'ipc://{0}'.format(os.path.join(
                     sock_dir,

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -107,7 +107,7 @@ class TestSaltEvent(TestCase):
 
     def test_minion_event(self):
         opts = dict(id='foo', sock_dir=SOCK_DIR)
-        id_hash = hashlib.md5(opts['id']).hexdigest()
+        id_hash = hashlib.md5(opts['id']).hexdigest()[:10]
         me = event.MinionEvent(opts)
         self.assertEqual(
             me.puburi,
@@ -134,7 +134,7 @@ class TestSaltEvent(TestCase):
 
     def test_minion_event_no_id(self):
         me = event.MinionEvent(dict(sock_dir=SOCK_DIR))
-        id_hash = hashlib.md5('').hexdigest()
+        id_hash = hashlib.md5('').hexdigest()[:10]
         self.assertEqual(
             me.puburi,
             'ipc://{0}'.format(


### PR DESCRIPTION
**This is take 2 of trying to fix this The first was reverted because it broke tests (see [here](https://github.com/saltstack/salt/commit/a39f3f6cbf1788a59f78dde5d7836c0cefe6ad7b#commitcomment-6423523)). Let's see if this works.**

This helps avoid the sock path being longer than the max length allowed
by the kernel. See the following comment for more information:

https://github.com/saltstack/salt/issues/12172#issuecomment-43903643
