### PR TITLE
Wrapper func return.

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -576,7 +576,7 @@ class Single(object):
             stdout, stderr, retcode = self.shell.exec_cmd(cmd_str)
 
         elif self.fun in self.wfuncs:
-            stdout, stderr, retcode = self.run_wfunc()
+            stdout = self.run_wfunc()
 
         else:
             stdout, stderr, retcode = self.cmd_block()


### PR DESCRIPTION
Not sure why were expecting a tuple here. Looks like a single dict to me unless I'm missing something.

This fixes things like grains.items, which were stacktracing prior to this change.

Closes #12809
