### PR TITLE
Optimizations for saltutil.sync_all and state.highstate

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -56,6 +56,8 @@ def _get_top_file_envs():
             top = st_.get_top()
             if top:
                 envs = st_.top_matches(top).keys() or 'base'
+            else:
+                envs = 'base'
         except SaltRenderError as exc:
             raise CommandExecutionError(
                 'Unable to render top file(s): {0}'.format(exc)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 '''
-The Saltutil module is used to manage the state of the salt minion itself. It is used to manage minion modules as well as automate updates to the salt minion.
+The Saltutil module is used to manage the state of the salt minion itself. It
+is used to manage minion modules as well as automate updates to the salt
+minion.
 
 :depends:   - esky Python module for update functionality
 '''
@@ -42,24 +44,32 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 
+def _get_top_file_envs():
+    '''
+    Get all environments from the top file
+    '''
+    try:
+        return __context__['saltutil._top_file_envs']
+    except KeyError:
+        try:
+            st_ = salt.state.HighState(__opts__)
+            top = st_.get_top()
+            if top:
+                envs = st_.top_matches(top).keys() or 'base'
+        except SaltRenderError as exc:
+            raise CommandExecutionError(
+                'Unable to render top file(s): {0}'.format(exc)
+            )
+        __context__['saltutil._top_file_envs'] = envs
+        return envs
+
+
 def _sync(form, saltenv=None):
     '''
     Sync the given directory in the given environment
     '''
     if saltenv is None:
-        # No environment passed, detect them based on gathering the top files
-        # from the master
-        try:
-            st_ = salt.state.HighState(__opts__)
-            top = st_.get_top()
-            if top:
-                saltenv = st_.top_matches(top).keys()
-            if not saltenv:
-                saltenv = 'base'
-        except SaltRenderError as exc:
-            raise CommandExecutionError(
-                'Unable to render top file(s): {0}'.format(exc)
-            )
+        saltenv = _get_top_file_envs()
     if isinstance(saltenv, string_types):
         saltenv = saltenv.split(',')
     ret = []
@@ -135,7 +145,7 @@ def _sync(form, saltenv=None):
             if os.path.isfile(full):
                 touched = True
                 os.remove(full)
-        #cleanup empty dirs
+        # Cleanup empty dirs
         while True:
             emptydirs = _list_emptydirs(mod_dir)
             if not emptydirs:
@@ -143,7 +153,7 @@ def _sync(form, saltenv=None):
             for emptydir in emptydirs:
                 touched = True
                 os.rmdir(emptydir)
-    #dest mod_dir is touched? trigger reload if requested
+    # Dest mod_dir is touched? trigger reload if requested
     if touched:
         mod_file = os.path.join(__opts__['cachedir'], 'module_refresh')
         with salt.utils.fopen(mod_file, 'a+') as ofile:

--- a/salt/state.py
+++ b/salt/state.py
@@ -2173,9 +2173,11 @@ class BaseHighState(object):
         if not self.opts['autoload_dynamic_modules']:
             return
         if self.opts.get('local', False):
-            syncd = self.state.functions['saltutil.sync_all'](list(matches), refresh=False)
+            syncd = self.state.functions['saltutil.sync_all'](list(matches),
+                                                              refresh=False)
         else:
-            syncd = self.state.functions['saltutil.sync_all'](list(matches))
+            syncd = self.state.functions['saltutil.sync_all'](list(matches),
+                                                              refresh=False)
         if syncd['grains']:
             self.opts['grains'] = salt.loader.grains(self.opts)
             self.state.opts['pillar'] = self.state._gather_pillar()
@@ -2582,7 +2584,6 @@ class BaseHighState(object):
         err = []
         try:
             top = self.get_top()
-            self.state.functions['saltutil.sync_all'](saltenv=top.keys())
         except SaltRenderError as err:
             ret[tag_name]['comment'] = err.error
             return ret

--- a/salt/state.py
+++ b/salt/state.py
@@ -2559,7 +2559,7 @@ class BaseHighState(object):
         '''
         Run the sequence to execute the salt highstate for this minion
         '''
-        #Check that top file exists
+        # Check that top file exists
         tag_name = 'no_|-states_|-states_|-None'
         ret = {tag_name: {
                 'result': False,
@@ -2578,10 +2578,11 @@ class BaseHighState(object):
                 with salt.utils.fopen(cfn, 'rb') as fp_:
                     high = self.serial.load(fp_)
                     return self.state.call_high(high)
-        #File exists so continue
+        # File exists so continue
         err = []
         try:
             top = self.get_top()
+            self.state.functions['saltutil.sync_all'](saltenv=top.keys())
         except SaltRenderError as err:
             ret[tag_name]['comment'] = err.error
             return ret


### PR DESCRIPTION
This optimizes saltutil.sync_all by only reading the top file once, and storing the results in the `__context__` dict, rather than reading the top file again when each custom type is synced.

In addition, a redundant module refresh has been removed in `salt.state.BaseHighState.load_dynamic()`.
