### PR TITLE
pass in data type check_libcloud_version expects

### DIFF
--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -651,7 +651,7 @@ def create(vm_):
             return
 
         if rackconnect(vm_) is True:
-            check_libcloud_version('0.14.0'), why='rackconnect: True')
+            check_libcloud_version('0.14.0', why='rackconnect: True')
             extra = node.get('extra')
             rc_status = extra.get('metadata', {}).get(
                 'rackconnect_automation_status', '')

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -651,7 +651,7 @@ def create(vm_):
             return
 
         if rackconnect(vm_) is True:
-            check_libcloud_version((0, 14, 0), why='rackconnect: True')
+            check_libcloud_version('0.14.0'), why='rackconnect: True')
             extra = node.get('extra')
             rc_status = extra.get('metadata', {}).get(
                 'rackconnect_automation_status', '')


### PR DESCRIPTION
The function check_libcloud_version expects a string, not a tuple. When it calls .replace() on the passed-in version, an exception is thrown since tuples have no .replace function.
