### PR TITLE
fix for #12947

### DIFF
--- a/salt/states/zk_concurrency.py
+++ b/salt/states/zk_concurrency.py
@@ -52,6 +52,7 @@ try:
     )
     import kazoo.recipe.lock
     from kazoo.exceptions import CancelledError
+    from kazoo.exceptions import NoNodeError
 
     # TODO: use the kazoo one, waiting for pull req:
     # https://github.com/python-zk/kazoo/pull/206


### PR DESCRIPTION
remove zk_hosts from unlock, since we already fail if we don't have the lease.
Also, adding logic into the semaphore class when it is not ephemeral to load its own previous lease (to avoid deadlocks)
