### PR TITLE
add test for npm.installed/removed

### DIFF
--- a/tests/integration/states/npm.py
+++ b/tests/integration/states/npm.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Erik Johnson (erik@saltstack.com)`
+    tests.integration.states.npm
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+'''
+
+# Import Salt Testing libs
+from salttesting import skipIf
+from salttesting.helpers import destructiveTest, ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+
+
+@skipIf(salt.utils.which('npm') is None, 'npm not installed')
+class NpmStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
+
+    @destructiveTest
+    def test_npm_installed_removed(self):
+        '''
+        Basic test to determine if NPM module was successfully installed and
+        removed.
+        '''
+        ret = self.run_state('npm.installed', name='pm2')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('npm.removed', name='pm2')
+        self.assertSaltTrueReturn(ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(NpmStateTest)


### PR DESCRIPTION
This is a simple test that would have caught the breakage I fixed in https://github.com/saltstack/salt/pull/13033. It will fail without that being merged, so this will need to be rebased before merging.

Also, it will be skipped if npm is not installed, so we'll need a way to ensure that it is installed before the test suite is run (or at least before this test is run). @s0undt3ch, what is the best way of doing this?
