### PR TITLE
modules.glusterfs.create(): avoid shadowing outer peer() function

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -113,7 +113,7 @@ def create(name, bricks, stripe=False, replica=False, device_vg=False,
     # Validate bricks syntax
     for brick in bricks:
         try:
-            peer, path = brick.split(':')
+            peer_name, path = brick.split(':')
             if not path.startswith('/'):
                 return 'Error: Brick paths must start with /'
         except ValueError:


### PR DESCRIPTION
```
************* Module salt.modules.glusterfs
salt/modules/glusterfs.py:116: [W0621(redefined-outer-name), create] Redefining name 'peer' from outer scope (line 43)
```
