### PR TITLE
Add registry argument to call to npm.install

### DIFF
--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -127,7 +127,8 @@ def installed(name,
         call = __salt__['npm.install'](
             pkg=name,
             dir=dir,
-            runas=user
+            runas=user,
+            registry=registry
         )
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False


### PR DESCRIPTION
In #13033, I removed this argument from the call to npm.list, it appears
it was mistakenly put there instead of npm.install. Removing the
argument triggered a lint failure: https://github.com/saltstack/salt/issues/13065

This commit adds the argument to the call to npm.install, which should
allow the state to work as originally intended.

Fixes #13065.
