### PR TITLE
Include the private port in the get_docker mine

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -343,11 +343,11 @@ def get_docker(interfaces=None, cidrs=None):
                     # If port is 0.0.0.0, then we must get the docker host IP
                     if dock_port['IP'] == '0.0.0.0':
                         for ip_ in host_ips:
-                            proxy_lists[container['Image']].setdefault('ipv4', []).append(
+                            proxy_lists[container['Image']].setdefault('ipv4', {}).setdefault(dock_port['PrivatePort'], []).append(
                                 '{0}:{1}'.format(ip_, dock_port['PublicPort']))
-                            proxy_lists[container['Image']]['ipv4'] = list(set(proxy_lists[container['Image']]['ipv4']))
+                            proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']] = list(set(proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']]))
                     elif dock_port['IP']:
-                        proxy_lists[container['Image']].setdefault('ipv4', []).append(
+                        proxy_lists[container['Image']].setdefault('ipv4', {}).setdefault(dock_port['PrivatePort'], []).append(
                             '{0}:{1}'.format(dock_port['IP'], dock_port['PublicPort']))
-                        proxy_lists[container['Image']]['ipv4'] = list(set(proxy_lists[container['Image']]['ipv4']))
+                        proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']] = list(set(proxy_lists[container['Image']]['ipv4'][dock_port['PrivatePort']]))
     return proxy_lists


### PR DESCRIPTION
If your docker containers listen on multiple ports the current output is not very useful. I've updated this to show the private port the ip addresses map to for these instances.

Before:

```
docker1.:
    ----------
    node-demo:jenkins-29:
        ----------
        ipv4:
            - 172.17.0.5:49156
    static-demo:TEST_LATEST:
        ----------
        ipv4:
            - 172.17.0.5:49159
            - 172.17.0.5:49160
    static-demo:jenkins-22:
        ----------
        ipv4:
            - 172.17.0.5:49158
            - 172.17.0.5:49157
```

After:

```
    ----------
    node-demo:jenkins-29:
        ----------
        ipv4:
            ----------
            3000:
                - 172.17.0.5:49156
    static-demo:TEST_LATEST:
        ----------
        ipv4:
            ----------
            22:
                - 172.17.0.5:49159
            80:
                - 172.17.0.5:49160
    static-demo:jenkins-22:
        ----------
        ipv4:
            ----------
            22:
                - 172.17.0.5:49157
            80:
                - 172.17.0.5:49158
```
