### PR TITLE
Fix for Windows filesystems without a SECURITY_DESCRIPTOR

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -337,9 +337,9 @@ def get_pgid(path, follow_symlinks=True):
         secdesc = win32security.GetFileSecurity(
             path, win32security.GROUP_SECURITY_INFORMATION
         )
-    # Not all filesystems mountable within windows 
+    # Not all filesystems mountable within windows
     # have SecurityDescriptor's.  For instance, some mounted
-    # SAMBA shares, or VirtualBox's shared folders.  If we 
+    # SAMBA shares, or VirtualBox's shared folders.  If we
     # can't load a file descriptor for the file, we default
     # to "Everyone" - http://support.microsoft.com/kb/243330
     except MemoryError:

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -342,7 +342,7 @@ def get_pgid(path, follow_symlinks=True):
     # SAMBA shares, or VirtualBox's shared folders.  If we 
     # can't load a file descriptor for the file, we default
     # to "Everyone" - http://support.microsoft.com/kb/243330
-    except MemoryError as e:
+    except MemoryError:
         return 'S-1-1-0'
     group_sid = secdesc.GetSecurityDescriptorGroup()
     return win32security.ConvertSidToStringSid(group_sid)


### PR DESCRIPTION
When hosting files on a VirtualBox shared folder, I was receiving:

```
[ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\state.py", line 1484, in call
    **cdata['kwargs'])
  File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\states\file.py", line 1533, in directory
    follow_symlinks)
  File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\modules\file.py", line 2417, in check_perms
    cur = stats(name, follow_symlinks=follow_symlinks)
  File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\modules\win_file.py", line 840, in stats
    ret['pgid'] = get_pgid(path, follow_symlinks)
  File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\modules\win_file.py", line 337, in get_pgid
    path, win32security.GROUP_SECURITY_INFORMATION
MemoryError: allocating SECURITY_DESCRIPTOR
```

VirtualBox shared folders (along with some SAMBA file shares) don't supply SecurityDescriptors, and cause this error.

Unfortunately, win32security.GetFileSecurity is raising a generic MemoryError in this case, so the exception handling is a little ugly.

The use-case is having masterless salt running in a Windows Vagrant box to allow automated provisioning of the guest VM.  In this situation, the salt repository is hosted on the VirtualBox shared folder.
