### PR TITLE
fix for incorrect string split character in windows registry keys

### DIFF
--- a/salt/states/reg.py
+++ b/salt/states/reg.py
@@ -15,7 +15,7 @@ def _parse_key(key):
     '''
     split the full path in the registry to the key and the rest
     '''
-    splt = key.split(r'\\')
+    splt = key.split("\\")
     hive = splt.pop(0)
     key = splt.pop(-1)
     path = r'\\'.join(splt)


### PR DESCRIPTION
Was receiving:

```
Comment: An exception occurred in this state: Traceback (most recent call last):
           File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\state.py", line 1484, in call
             **cdata['kwargs'])
           File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\states\reg.py", line 52, in present
             hive, path, key = _parse_key(name)
           File "c:\salt\salt-2014.1.4.win32\salt-2014.1.4-py2.7.egg\salt\states\reg.py", line 20, in _parse_key
             key = splt.pop(-1)
         IndexError: pop from empty list
```

Whenever using reg.present

Python interprets r'\' as "\\", and we want to match on a single \ rather than a double, so we need to use "\".
