### PR TITLE
remove _has_check and just check iptables --help

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -13,7 +13,7 @@ import shlex
 import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
-HAS_CHECK=False
+HAS_CHECK = False
 
 
 def __virtual__():
@@ -22,7 +22,7 @@ def __virtual__():
     '''
     global HAS_CHECK
     if __salt__['cmd.run']('iptables --help').find('--check'):
-        HAS_CHECK=True
+        HAS_CHECK = True
 
     if salt.utils.which('iptables'):
         return True
@@ -483,8 +483,7 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
     if not rule:
         return 'Error: Rule needs to be specified'
 
-    global HAS_CHECK
-    if not HAS_CHECK:
+    if HAS_CHECK is False:
         cmd = '{0}-save' . format(_iptables_cmd(family))
         out = __salt__['cmd.run'](cmd).find('-A {1} {2}'.format(
             table,

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -13,12 +13,17 @@ import shlex
 import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
+HAS_CHECK=False
 
 
 def __virtual__():
     '''
     Only load the module if iptables is installed
     '''
+    global HAS_CHECK
+    if __salt__['cmd.run']('iptables --help').find('--check'):
+        HAS_CHECK=True
+
     if salt.utils.which('iptables'):
         return True
     return False
@@ -452,34 +457,6 @@ def save(filename=None, family='ipv4'):
     return out
 
 
-def _has_check():
-    '''
-    Check if the iptables on has --check function
-    '''
-
-    if __grains__['os_family'] == 'RedHat':
-        if __grains__['osfullname'] == 'Fedora':
-            return False
-        elif __grains__['osrelease'] <= 6:
-            return True
-        else:
-            return False
-    elif __grains__['os'] == 'Ubuntu':
-        if __grains__['osrelease'] == '10.04':
-            return True
-        else:
-            return False
-    elif __grains__['os'] == 'Debian':
-        if __grains__['osrelease'].split('.')[0] == '6':
-            return True
-        else:
-            return False
-    elif __salt__['cmd.run']('iptables -h').find('--check') == -1:
-        return True
-    else:
-        return False
-
-
 def check(table='filter', chain=None, rule=None, family='ipv4'):
     '''
     Check for the existence of a rule in the table and chain
@@ -506,7 +483,8 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
     if not rule:
         return 'Error: Rule needs to be specified'
 
-    if _has_check():
+    global HAS_CHECK
+    if not HAS_CHECK:
         cmd = '{0}-save' . format(_iptables_cmd(family))
         out = __salt__['cmd.run'](cmd).find('-A {1} {2}'.format(
             table,


### PR DESCRIPTION
I just got rid of the _has_check function #13091

not sure why I didn't think of just doing this when I was expanding the _has_check function... but this makes more sense and works better IMO.

just a regular

```
__salt__['cmd.run']('iptables --help').find('--check')
```

Thanks,
Daniel
