### PR TITLE
Initial commit of boto_elasticache execution module and state

### DIFF
--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -180,9 +180,10 @@ def create(name, num_cache_nodes, engine, cache_node_type,
                 return True
             time.sleep(2)
         log.info('Created cache cluster {0}.'.format(name))
-    except boto.exception.BotoServerError:
+    except boto.exception.BotoServerError as e:
         msg = 'Failed to create cache cluster {0}.'.format(name)
         log.error(msg)
+        log.debug(e)
         return False
 
 
@@ -211,9 +212,10 @@ def delete(name, wait=False, region=None, key=None, keyid=None, profile=None):
             time.sleep(2)
         log.info('Deleted cache cluster {0}.'.format(name))
         return True
-    except boto.exception.BotoServerError:
+    except boto.exception.BotoServerError as e:
         msg = 'Failed to delete cache cluster {0}.'.format(name)
         log.error(msg)
+        log.debug(e)
         return False
 
 

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+'''
+Connection module for Amazon Elasticache
+
+.. versionadded:: Helium
+
+:configuration: This module accepts explicit elasticache credentials but can
+    also utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at::
+
+       http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file::
+
+        elasticache.keyid: GKTADJGHEIQSXMKKRBJ08H
+        elasticache.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration::
+
+        elasticache.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+:depends: boto
+'''
+
+# Import Python libs
+import logging
+
+log = logging.getLogger(__name__)
+
+# Import third party libs
+try:
+    import boto
+    import boto.elasticache
+    import boto.utils
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+from salt._compat import string_types
+import salt.utils.odict as odict
+
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist.
+    '''
+    if not HAS_BOTO:
+        return False
+    return True
+
+
+def exists(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Check to see if a cache cluster exists.
+
+    CLI example::
+
+        salt myminion boto_elasticache.exists myelasticache
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    try:
+        conn.describe_cache_clusters(name)
+        return True
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        return False
+
+
+def get_config(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Get the configuration for a cache cluster.
+
+    CLI example::
+
+        salt myminion boto_elasticache.get_config myelasticache
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return None
+    try:
+        cc = conn.describe_cache_clusters(name)
+    except boto.exception.BotoServerError as e:
+        msg = 'Failed to get config for cache cluster {0}.'.format(name)
+        log.error(msg)
+        log.debug(e)
+        return {}
+    cc = cc['DescribeCacheClustersResponse']['DescribeCacheClustersResult']
+    cc = cc['CacheClusters'][0]
+    ret = odict.OrderedDict()
+    attrs = ['engine', 'cache_parameter_group', 'cache_cluster_id',
+             'cache_security_groups', 'replication_group_id',
+             'auto_minor_version_upgrade', 'num_cache_nodes',
+             'preferred_availability_zone', 'security_groups',
+             'cache_subnet_group_name', 'engine_version', 'cache_node_type',
+             'notification_configuration', 'preferred_maintenance_window',
+             'cache_nodes']
+    for key, val in cc.iteritems():
+        _key = boto.utils.pythonize_name(key)
+        if _key not in attrs:
+            continue
+        if _key == 'cache_parameter_group':
+            ret[_key] = val['CacheParameterGroupName']
+        elif _key == 'cache_security_groups':
+            ret[_key] = [k['CacheSecurityGroupName'] for k in val]
+        else:
+            ret[_key] = val
+    return ret
+
+
+def create(name, num_cache_nodes=None, cache_node_type=None, engine=None,
+           replication_group_id=None, engine_version=None,
+           cache_parameter_group_name=None, cache_subnet_group_name=None,
+           cache_security_group_names=None, security_group_ids=None,
+           snapshot_arns=None, preferred_availability_zone=None,
+           preferred_maintenance_window=None, port=None,
+           notification_topic_arn=None, auto_minor_version_upgrade=True,
+           region=None, key=None, keyid=None, profile=None):
+    '''
+    Create a cache cluster.
+
+    CLI example::
+
+        salt myminion boto_elasticache.create myelasticache 1 redis cache_security_group_names='["myelasticachesg"]'
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    created = conn.create_cache_cluster(
+        name, num_cache_nodes, cache_node_type, engine, replication_group_id,
+        engine_version, cache_parameter_group_name, cache_subnet_group_name,
+        cache_security_group_names, security_group_ids, snapshot_arns,
+        preferred_availability_zone, preferred_maintenance_window, port,
+        notification_topic_arn, auto_minor_version_upgrade)
+    if created:
+        log.info('Created cache cluster {0}.'.format(name))
+        return True
+    else:
+        msg = 'Failed to create cache cluster {0}.'.format(name)
+        log.error(msg)
+        return False
+
+
+def delete(name, region=None, key=None, keyid=None, profile=None):
+    '''
+    Delete a cache cluster.
+
+    CLI example::
+
+        salt myminion boto_elasticache.delete myelasticache
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    deleted = conn.delete_cache_cluster(name)
+    if deleted:
+        log.info('Deleted cache cluster {0}.'.format(name))
+        return True
+    else:
+        msg = 'Failed to delete cache cluster {0}.'.format(name)
+        log.error(msg)
+        return False
+
+
+def create_cache_security_group(name, description, region=None, key=None,
+                                keyid=None, profile=None):
+    '''
+    Create a cache security group.
+
+    CLI example::
+
+        salt myminion boto_elasticache.create_cache_security_group myelasticachesg 'My Cache Security Group'
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    created = conn.create_cache_security_group(name, description)
+    if created:
+        log.info('Created cache security group {0}.'.format(name))
+        return True
+    else:
+        msg = 'Failed to create cache security group {0}.'.format(name)
+        log.error(msg)
+        return False
+
+
+def delete_cache_security_group(name, region=None, key=None, keyid=None,
+                                profile=None):
+    '''
+    Delete a cache security group.
+
+    CLI example::
+
+        salt myminion boto_elasticache.delete_cache_security_group myelasticachesg 'My Cache Security Group'
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    deleted = conn.delete_cache_security_group(name)
+    if deleted:
+        log.info('Deleted cache security group {0}.'.format(name))
+        return True
+    else:
+        msg = 'Failed to delete cache security group {0}.'.format(name)
+        log.error(msg)
+        return False
+
+
+def authorize_cache_security_group_ingress(name, ec2_security_group_name,
+                                           ec2_security_group_owner_id,
+                                           region=None, key=None, keyid=None,
+                                           profile=None):
+    '''
+    Authorize network ingress from an ec2 security group to a cache security
+    group.
+
+    CLI example::
+
+        salt myminion boto_elasticache.authorize_cache_security_group_ingress myelasticachesg myec2sg 879879
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    try:
+        added = conn.authorize_cache_security_group_ingress(
+            name, ec2_security_group_name, ec2_security_group_owner_id)
+        if added:
+            msg = 'Added {0} to cache security group {1}.'
+            msg = msg.format(name, ec2_security_group_name)
+            log.info(msg)
+            return True
+        else:
+            msg = 'Failed to add {0} to cache security group {1}.'
+            msg = msg.format(name, ec2_security_group_name)
+            log.error(msg)
+            return False
+    except boto.exception.EC2ResponseError as e:
+        log.debug(e)
+        msg = 'Failed to add {0} to cache security group {1}.'
+        msg = msg.format(name, ec2_security_group_name)
+        log.error(msg)
+        return False
+
+
+def revoke_cache_security_group_ingress(name, ec2_security_group_name,
+                                        ec2_security_group_owner_id,
+                                        region=None, key=None, keyid=None,
+                                        profile=None):
+    '''
+    Revoke network ingress from an ec2 security group to a cache security
+    group.
+
+    CLI example::
+
+        salt myminion boto_elasticache.revoke_cache_security_group_ingress myelasticachesg myec2sg 879879
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    try:
+        removed = conn.revoke_cache_security_group_ingress(
+            name, ec2_security_group_name, ec2_security_group_owner_id)
+        if removed:
+            msg = 'Removed {0} from cache security group {1}.'
+            msg = msg.format(name, ec2_security_group_name)
+            log.info(msg)
+            return True
+        else:
+            msg = 'Failed to remove {0} from cache security group {1}.'
+            msg = msg.format(name, ec2_security_group_name)
+            log.error(msg)
+            return False
+    except boto.exception.EC2ResponseError as e:
+        log.debug(e)
+        msg = 'Failed to remove {0} from cache security group {1}.'
+        msg = msg.format(name, ec2_security_group_name)
+        log.error(msg)
+        return False
+
+
+def _get_conn(region, key, keyid, profile):
+    '''
+    Get a boto connection to ec2.
+    '''
+    if profile:
+        if isinstance(profile, string_types):
+            _profile = __salt__['config.option'](profile)
+        elif isinstance(profile, dict):
+            _profile = profile
+        key = _profile.get('key', None)
+        keyid = _profile.get('keyid', None)
+        region = _profile.get('region', None)
+
+    if not region and __salt__['config.option']('elasticache.region'):
+        region = __salt__['config.option']('elasticache.region')
+
+    if not region:
+        region = 'us-east-1'
+
+    if not key and __salt__['config.option']('elasticache.key'):
+        key = __salt__['config.option']('elasticache.key')
+    if not keyid and __salt__['config.option']('elasticache.keyid'):
+        keyid = __salt__['config.option']('elasticache.keyid')
+
+    try:
+        conn = boto.elasticache.connect_to_region(region,
+                                                  aws_access_key_id=keyid,
+                                                  aws_secret_access_key=key)
+    except boto.exception.NoAuthHandlerFound:
+        log.error('No authentication credentials found when attempting to'
+                  ' make elasticache connection.')
+        return None
+    return conn

--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -1,0 +1,287 @@
+'''
+Manage Elasticache
+==================
+
+.. versionadded:: Helium
+
+Create, destroy and update Elasticache clusters. Be aware that this interacts
+with Amazon's services, and so may incur charges.
+
+Note: This module currently only supports creation and deletion of
+elasticache resources and will not modify clusters when their configuration
+changes in your state files.
+
+This module uses boto, which can be installed via package, or pip.
+
+This module accepts explicit elasticache credentials but can also utilize
+IAM roles assigned to the instance trough Instance Profiles. Dynamic
+credentials are then automatically obtained from AWS API and no further
+configuration is necessary. More Information available at::
+
+   http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+If IAM roles are not used you need to specify them either in a pillar or
+in the minion's config file::
+
+    elasticache.keyid: GKTADJGHEIQSXMKKRBJ08H
+    elasticache.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+It's also possible to specify key, keyid and region via a profile, either
+as a passed in dict, or as a string to pull from pillars or minion config:
+
+    myprofile:
+      keyid: GKTADJGHEIQSXMKKRBJ08H
+      key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+        region: us-east-1
+
+.. code-block:: yaml
+
+    Ensure myelasticache exists:
+      boto_elasticache.present:
+        - name: myelasticache
+        - engine: redis
+        - cache_node_type: cache.t1.micro
+        - num_cache_nodes: 1
+        - notification_topic_arn: arn:aws:sns:us-east-1:879879:my-sns-topic
+        - region: us-east-1
+        - keyid: GKTADJGHEIQSXMKKRBJ08H
+        - key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    # Using a profile from pillars
+    Ensure myelasticache exists:
+      boto_elasticache.present:
+        - name: myelasticache
+        - engine: redis
+        - cache_node_type: cache.t1.micro
+        - num_cache_nodes: 1
+        - notification_topic_arn: arn:aws:sns:us-east-1:879879:my-sns-topic
+        - region: us-east-1
+        - profile: myprofile
+
+    # Passing in a profile
+    Ensure myelasticache exists:
+      boto_elasticache.present:
+        - name: myelasticache
+        - engine: redis
+        - cache_node_type: cache.t1.micro
+        - num_cache_nodes: 1
+        - notification_topic_arn: arn:aws:sns:us-east-1:879879:my-sns-topic
+        - region: us-east-1
+        - profile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+'''
+
+
+def __virtual__():
+    '''
+    Only load if boto is available.
+    '''
+    if 'boto_elasticache.exists' in __salt__:
+        return 'boto_elasticache'
+    else:
+        return False
+
+
+def present(
+        name,
+        engine,
+        cache_node_type,
+        num_cache_nodes=1,
+        preferred_availability_zone=None,
+        port=None,
+        cache_parameter_group_name=None,
+        cache_security_group_names=None,
+        replication_group_id=None,
+        auto_minor_version_upgrade=True,
+        security_group_ids=None,
+        cache_subnet_group_name=None,
+        engine_version=None,
+        notification_topic_arn=None,
+        preferred_maintenance_window=None,
+        wait=True,
+        cache_nodes=None,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    '''
+    Ensure the cache cluster exists.
+
+    name
+        Name of the cache cluster (cache cluster id).
+
+    engine
+        The name of the cache engine to be used for this cache cluster. Valid
+        values are memcached or redis.
+
+    cache_node_type
+        The compute and memory capacity of the nodes in the cache cluster.
+        cache.t1.micro, cache.m1.small, etc. See: http://boto.readthedocs.org/en/latest/ref/elasticache.html#boto.elasticache.layer1.ElastiCacheConnection.create_cache_cluster
+
+    num_cache_nodes
+        The number of cache nodes that the cache cluster will have.
+
+    preferred_availability_zone
+        The EC2 Availability Zone in which the cache cluster will be created.
+        All cache nodes belonging to a cache cluster are placed in the
+        preferred availability zone.
+
+    port
+        The port number on which each of the cache nodes will accept
+        connections.
+
+    cache_parameter_group_name
+        The name of the cache parameter group to associate with this cache
+        cluster. If this argument is omitted, the default cache parameter group
+        for the specified engine will be used.
+
+    cache_security_group_names
+        A list of cache security group names to associate with this cache
+        cluster. Use this parameter only when you are creating a cluster
+        outside of a VPC.
+
+    replication_group_id
+        The replication group to which this cache cluster should belong. If
+        this parameter is specified, the cache cluster will be added to the
+        specified replication group as a read replica; otherwise, the cache
+        cluster will be a standalone primary that is not part of any
+        replication group.
+
+    auto_minor_version_upgrade
+        Determines whether minor engine upgrades will be applied automatically
+        to the cache cluster during the maintenance window. A value of True
+        allows these upgrades to occur; False disables automatic upgrades.
+
+    security_groups_ids
+        One or more VPC security groups associated with the cache cluster. Use
+        this parameter only when you are creating a cluster in a VPC.
+
+    cache_subnet_group_name
+        The name of the cache subnet group to be used for the cache cluster.
+        Use this parameter only when you are creating a cluster in a VPC.
+
+    engine_version
+        The version number of the cache engine to be used for this cluster.
+
+    notification_topic_arn
+        The Amazon Resource Name (ARN) of the Amazon Simple Notification
+        Service (SNS) topic to which notifications will be sent. The Amazon SNS
+        topic owner must be the same as the cache cluster owner.
+
+    preferred_maintenance_window
+        The weekly time range (in UTC) during which system maintenance can
+        occur. Example: sun:05:00-sun:09:00
+
+    wait
+        Boolean. Wait for confirmation from boto that the cluster is in the
+        creating state.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    config = __salt__['boto_elasticache.get_config'](name, region, key, keyid,
+                                                     profile)
+    if config is None:
+        msg = 'Failed to retrive cache cluster info from AWS.'.format(name)
+        ret['comment'] = msg
+        return ret
+    elif not config:
+        if __opts__['test']:
+            msg = 'Cache cluster {0} is set to be created.'.format(name)
+            ret['comment'] = msg
+            return ret
+        created = __salt__['boto_elasticache.create'](
+            name=name, num_cache_nodes=num_cache_nodes,
+            cache_node_type=cache_node_type, engine=engine,
+            replication_group_id=replication_group_id,
+            engine_version=engine_version,
+            cache_parameter_group_name=cache_parameter_group_name,
+            cache_subnet_group_name=cache_subnet_group_name,
+            cache_security_group_names=cache_security_group_names,
+            security_group_ids=security_group_ids,
+            preferred_availability_zone=preferred_availability_zone,
+            preferred_maintenance_window=preferred_maintenance_window,
+            port=port, notification_topic_arn=notification_topic_arn,
+            auto_minor_version_upgrade=auto_minor_version_upgrade,
+            wait=wait, region=region, key=key, keyid=keyid, profile=profile)
+        if created:
+            ret['result'] = True
+            ret['changes']['old'] = None
+            config = __salt__['boto_elasticache.get_config'](name, region, key,
+                                                             keyid, profile)
+            ret['changes']['new'] = config
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create {0} cache cluster.'.format(name)
+            return ret
+    # TODO: support modification of existing elasticache clusters
+    else:
+        ret['comment'] = 'Cache cluster {0} is present.'.format(name)
+    return ret
+
+
+def absent(
+        name,
+        wait=True,
+        region=None,
+        key=None,
+        keyid=None,
+        profile=None):
+    '''
+    Ensure the named elasticache cluster is deleted.
+
+    name
+        Name of the cache cluster.
+
+    wait
+        Boolean. Wait for confirmation from boto that the cluster is in the
+        deleting state.
+
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string)
+        that contains a dict with region, key and keyid.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    is_present = __salt__['boto_elasticache.exists'](name, region, key, keyid,
+                                                     profile)
+
+    if is_present:
+        if __opts__['test']:
+            ret['comment'] = 'Cache cluster {0} is set to be removed.'.format(
+                name)
+            return ret
+        deleted = __salt__['boto_elasticache.delete'](name, wait, region, key,
+                                                      keyid, profile)
+        if deleted:
+            ret['result'] = True
+            ret['changes']['old'] = name
+            ret['changes']['new'] = None
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to delete {0} cache cluster.'.format(name)
+    else:
+        ret['comment'] = '{0} does not exist in {1}.'.format(name, region)
+
+    return ret


### PR DESCRIPTION
This change adds support for creation and deletion of elasticache clusters and cache security groups. Cache security groups are currently only supported through the execution module and creation/deletion and authorization/revocation of ingress rules. In the state module only creation and deletion of elasticache clusters is currently supported.
