### PR TITLE
some fixes for the nova cloud adapter

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -758,7 +758,8 @@ def list_nodes(call=None, **kwargs):
             'image': server_tmp['image']['id'],
             'size': server_tmp['flavor']['id'],
             'state': server_tmp['state'],
-            'private_ips': [addrs['addr'] for addrs in server_tmp['addresses']['private']],
+            'private_ips': [addrs['addr'] for addrs in
+                            server_tmp['addresses'].get('private', [])],
             'public_ips': [server_tmp['accessIPv4'], server_tmp['accessIPv6']],
         }
     return ret

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -153,7 +153,7 @@ class SaltNova(object):
             self.kwargs['bypass_url'] = get_entry(
                 servers_endpoints,
                 'region',
-                region_name.upper()
+                region_name
             )['publicURL']
 
         self.compute_conn = client.Client(**self.kwargs)
@@ -167,7 +167,7 @@ class SaltNova(object):
             self.kwargs['bypass_url'] = get_entry(
                 servers_endpoints,
                 'region',
-                region_name.upper()
+                region_name
             )['publicURL']
 
         self.kwargs['service_type'] = 'volume'


### PR DESCRIPTION
Using the NeCTAR Australian Research Cloud (OpenStack) I found these issues.
1. the `private` key does not appear, so I made it optional.
2. the `region_name` here is `"Melbourne"`, ie. mixed case. I suggest whoever has uppercase requirements can specify the `region_name` as uppercase in the provider settings, or `get_entry` is modified to be case insensitive.
