### PR TITLE
Added exception message to module.run states comment in case of an exception

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -192,8 +192,8 @@ def run(name, **kwargs):
             mret = __salt__[name](*args, **nkwargs)
         else:
             mret = __salt__[name](*args)
-    except Exception:
-        ret['comment'] = 'Module function {0} threw an exception'.format(name)
+    except Exception as e:
+        ret['comment'] = 'Module function {0} threw an exception. Exception: {1}'.format(name, e)
         ret['result'] = False
         return ret
     else:


### PR DESCRIPTION
When using custom modules in highstates with module.run, you can get a message or return value with a success (green) or an Exception (red) without information about the exception. To be able to have red and information I added Exception as a string to the information line.
