### PR TITLE
Fix error in cache detection time

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -298,6 +298,6 @@ def clean_old_jobs():
                             # Invalid jid, scrub the dir
                             shutil.rmtree(f_path)
                         difference = cur - jidtime
-                        hours_difference = difference.seconds / 3600.0
+                        hours_difference = difference.total_seconds() / 3600.0
                         if hours_difference > __opts__['keep_jobs']:
                             shutil.rmtree(f_path)


### PR DESCRIPTION
Master job caches were not being cleaned because we were incorrectly detecting
the age of the cache file. To wit:

[DEBUG ] Cache cleaner evaluating jid file at time 2014-05-23 11:53:00
[DEBUG ] Cache cleaner thinks that the current time is: 2014-05-29 
09:23:38.740181
[DEBUG ] Cache cleaner sees the difference as: 5 days, 21:30:38.740181
[DEBUG ] Cache cleaner sees the HOURS difference as: 21.5105555556
[DEBUG ] Cache cleaner is set to only clean jobs after 24 hours

Closes #12396

Please note that in order to backport this fix into previous releases,
this change should be made in master.py.
