### PR TITLE
Insert missing safety check

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1278,7 +1278,7 @@ def request_instance(vm_=None, call=None):
         eni_devices = []
         for interface in network_interfaces:
             _new_eip = None
-            if interface['allocate_new_eip']:
+            if 'allocate_new_eip' in interface and interface['allocate_new_eip']:
                 _new_eip = _request_eip(interface)
             _new_eni = _create_eni(interface, _new_eip)
             eni_devices.append(_new_eni)


### PR DESCRIPTION
Without this check allocate_new_eip becomes required on every ENI allocation,
which is frustrating and breaks things for no reason.

```
[DEBUG   ] MasterEvent PUB socket URI: ipc:///var/run/salt/master/master_event_pub.ipc
[DEBUG   ] MasterEvent PULL socket URI: ipc:///var/run/salt/master/master_event_pull.ipc
[DEBUG   ] Sending event - data = {'profile': 'staging-util-ext', 'event': 'starting create', '_stamp': '2014-05-29T11:13:00.147826', 'name': 'staging-util01', 'provider': 'aws:ec2'}
[INFO    ] Creating Cloud VM staging-util01 in us-east-1
[ERROR   ] Failed to create VM staging-util01. Configuration value 'allocate_new_eip' needs to be set
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/salt/cloud/__init__.py", line 1162, in create
    output = self.clouds[func](vm_)
  File "/Library/Python/2.7/site-packages/salt/cloud/clouds/ec2.py", line 1819, in create
    data, vm_ = request_instance(vm_, location)
  File "/Library/Python/2.7/site-packages/salt/cloud/clouds/ec2.py", line 1281, in request_instance
    if interface['allocate_new_eip']:
KeyError: 'allocate_new_eip'
Error: There was a query error: Host for new master staging-util01 was not found, aborting map
```
