### PR TITLE
Allow association of exiting EIP

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1280,6 +1280,8 @@ def request_instance(vm_=None, call=None):
             _new_eip = None
             if 'allocate_new_eip' in interface and interface['allocate_new_eip']:
                 _new_eip = _request_eip(interface)
+            elif 'associate_eip' in interface and interface['associate_eip']:
+                _new_eip = interface['associate_eip']
             _new_eni = _create_eni(interface, _new_eip)
             eni_devices.append(_new_eni)
         params.update(_param_from_config(spot_prefix + 'NetworkInterface',


### PR DESCRIPTION
This will allow the user to specify an EIP allocation identifier in a map file, and have that EIP be associated with the created ENI when creating a new instance. Sadly it will not work on an EIP that is currently allocated, but I'll try to make another request for that in the future (once I have a better understanding of appropriate default behaviour).
