### PR TITLE
Master type failover

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -365,7 +365,7 @@ Default: 0
 
 The number of minions the master should allow to connect. Use this to accomodate
 the number of minions per master if you have different types of hardware serving
-your minions. The default of ``0`` mean unlimited connections. Please note, that
+your minions. The default of ``0`` means unlimited connections. Please note, that
 this can slow down the authentication process a bit in large setups.
 
 .. code-block:: yaml

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -358,6 +358,20 @@ only the cache for the mine system.
 
     enforce_mine_cache: False
 
+``max_minions``
+---------------
+
+Default: 0
+
+The number of minions the master should allow to connect. Use this to accomodate
+the number of minions per master if you have different types of hardware serving
+your minions. The default of ``0`` mean unlimited connections. Please note, that
+this can slow down the authentication process a bit in large setups.
+
+.. code-block:: yaml
+
+    max_minions: 100
+
 
 Master Security Settings
 ========================

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -37,7 +37,7 @@ Default: ``salt``
 
 The master is, by default, staticaly configured by the `master` setting, but
 if desired, the master can be dynamically configured. The `master` value can
-be set to a module function will will be executed and will assume that the
+be set to a module function which will be executed and will assume that the
 returning value is the ip or hostname of the desired master. In addition to
 specifying the function to execute to detect the master the
 :conf_minion:`master_type`, option must be set to 'func'.
@@ -45,6 +45,19 @@ specifying the function to execute to detect the master the
 .. code-block:: yaml
 
     master: module.function
+
+The `master` can also be a list of masters the minion should try to connect
+to. If the first master fails or rejects the minions connection (for example
+when too many minions are already connected), the minion will try the next
+master in the given list. For this to work, :conf_minion:`master_type` must
+be set to 'failover'. If `master_type` is not set, the minion will be in
+multimaster mode: :ref:`multi master <topics-tutorials-multimaster>`
+
+.. code-block:: yaml
+
+    master: 
+        - address1
+        - address2
 
 
 .. conf_minion:: master_type
@@ -54,16 +67,26 @@ specifying the function to execute to detect the master the
 
 Default: ``str``
 
-The type of the :conf_minion:`master` variable. If the master needs to be
-dynamically assigned by executing a function instead of reading in the static
-master value, set this  to 'func'. This can be used to manage the minion's
-master setting from an execution module. By simply changeing the algorithm
-in the module to return a new master ip/fqdn, restart the minion and it will
-connect to the new master.
+The type of the :conf_minion:`master` variable. Can be either 'func' or
+'failover'.
+
+If the master needs to be dynamically assigned by executing a function 
+instead of reading in the static master value, set this  to 'func'. 
+This can be used to manage the minion's master setting from an execution 
+module. By simply changing the algorithm in the module to return a new 
+master ip/fqdn, restart the minion and it will connect to the new master.
 
 .. code-block:: yaml
 
-    master_type: str
+    master_type: 'func'
+
+If it is set to 'failover', :conf_minion:`master` has to be a list of master
+addresses. The minion will then try one master after the other, until it 
+successfully connects.
+
+.. code-block:: yaml
+
+    master_type: 'failover'
 
 .. conf_minion:: master_port
 

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -229,7 +229,10 @@ class Minion(parsers.MinionOptionParser):
             self.daemonize_if_required()
             self.set_pidfile()
             if isinstance(self.config.get('master'), list):
-                self.minion = salt.minion.MultiMinion(self.config)
+                if self.config.get('master_type') == 'failover':
+                    self.minion = salt.minion.Minion(self.config)
+                else:
+                    self.minion = salt.minion.MultiMinion(self.config)
             else:
                 self.minion = salt.minion.Minion(self.config)
         else:

--- a/salt/config.py
+++ b/salt/config.py
@@ -234,6 +234,7 @@ VALID_OPTS = {
     'restart_on_error': bool,
     'ping_interval': int,
     'cli_summary': bool,
+    'max_minion': int,
 }
 
 # default configurations
@@ -500,6 +501,7 @@ DEFAULT_MASTER_OPTS = {
     'sqlite_queue_dir': os.path.join(salt.syspaths.CACHE_DIR, 'master', 'queues'),
     'queue_dirs': [],
     'cli_summary': False,
+    'max_minions': 0,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/config.py
+++ b/salt/config.py
@@ -234,7 +234,7 @@ VALID_OPTS = {
     'restart_on_error': bool,
     'ping_interval': int,
     'cli_summary': bool,
-    'max_minion': int,
+    'max_minions': int,
 }
 
 # default configurations

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -372,6 +372,11 @@ class Auth(object):
                             'clean out the keys. The Salt Minion will now exit.'
                         )
                         sys.exit(os.EX_OK)
+                # has the master returned that its maxed out with minions?
+                elif payload['load']['ret'] == 'full':
+                        msg = ('master {0} is full, trying next master'.format(self.opts['master']))
+                        log.info(msg)
+                        return 'full'
                 else:
                     log.error(
                         'The Salt Master has cached the public key for this '

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -374,8 +374,6 @@ class Auth(object):
                         sys.exit(os.EX_OK)
                 # has the master returned that its maxed out with minions?
                 elif payload['load']['ret'] == 'full':
-                        msg = ('master {0} is full, trying next master'.format(self.opts['master']))
-                        log.info(msg)
                         return 'full'
                 else:
                     log.error(

--- a/salt/master.py
+++ b/salt/master.py
@@ -1747,7 +1747,7 @@ class ClearFuncs(object):
                     'load': {'ret': False}}
         log.info('Authentication request from {id}'.format(**load))
 
-        minions = salt.utils.minions.CkMinions(opts)
+        minions = salt.utils.minions.CkMinions(self.opts)
 
         if not len(minions) < self.opts['max_minions']:
             msg = ('Too many minions connected. Rejecting connection '

--- a/salt/master.py
+++ b/salt/master.py
@@ -1747,6 +1747,14 @@ class ClearFuncs(object):
                     'load': {'ret': False}}
         log.info('Authentication request from {id}'.format(**load))
 
+        minions = salt.utils.minions.CkMinions(opts)
+
+        if not len(minions) < self.opts['max_minions']:
+            msg = ('Too many minions connected. Rejecting connection '
+                   ' from id {0}'.format(load['id']))
+            log.debug(msg)
+
+
         # Check if key is configured to be auto-rejected/signed
         auto_reject = self.__check_autoreject(load['id'])
         auto_sign = self.__check_autosign(load['id'])

--- a/salt/master.py
+++ b/salt/master.py
@@ -1747,7 +1747,8 @@ class ClearFuncs(object):
                     'load': {'ret': False}}
         log.info('Authentication request from {id}'.format(**load))
 
-        minions = salt.utils.minions.CkMinions(self.opts)
+        minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
+        print minions
 
         if not len(minions) < self.opts['max_minions']:
             msg = ('Too many minions connected. Rejecting connection '

--- a/salt/master.py
+++ b/salt/master.py
@@ -1749,16 +1749,17 @@ class ClearFuncs(object):
 
         minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
 
-        log.debug(minions)
-
         # 0 is default which should be 'unlimited'
         if self.opts['max_minions'] > 0:
             if not len(minions) < self.opts['max_minions']:
                 # we reject new minions, minions that are already
                 # connected must be allowed for the mine, highstate, etc.
                 if load['id'] not in minions:
-                    msg = ('Too many minions connected. Rejecting connection '
-                           'from id {0}'.format(load['id']))
+                    msg = ('Too many minions connected (max_minions={0}). '
+                           'Rejecting connection from id '
+                           '{1}'.format(self.opts['max_minions'],
+                                        load['id'])
+                          )
                     log.info(msg)
                     eload = {'result': False,
                              'act': 'full',

--- a/salt/master.py
+++ b/salt/master.py
@@ -1748,12 +1748,20 @@ class ClearFuncs(object):
         log.info('Authentication request from {id}'.format(**load))
 
         minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
-        print minions
 
         if not len(minions) < self.opts['max_minions']:
             msg = ('Too many minions connected. Rejecting connection '
-                   ' from id {0}'.format(load['id']))
+                   'from id {0}'.format(load['id']))
             log.debug(msg)
+            eload = {'result': False,
+                     'act': 'full',
+                     'id': load['id'],
+                     'pub': load['pub']}
+ 
+            self.event.fire_event(eload, tagify(prefix='auth'))
+            return {'enc': 'clear',
+                    'load': {'ret': 'full'}}
+ 
 
 
         # Check if key is configured to be auto-rejected/signed

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -621,6 +621,10 @@ class Minion(MinionBase):
                 super(Minion, self).__init__(opts)
                 if self.authenticate(timeout, safe) != 'full':
                     break
+            msg = ('No master could be reached or all masters denied '
+                   'the minions connection attempt.')
+            log.error(msg)
+            sys,exit(1)
         else:
             opts.update(resolve_dns(opts))
             super(Minion, self).__init__(opts)

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -624,11 +624,15 @@ class Minion(MinionBase):
             msg = ('No master could be reached or all masters denied '
                    'the minions connection attempt.')
             log.error(msg)
-            sys,exit(1)
+            sys.exit(1)
         else:
             opts.update(resolve_dns(opts))
             super(Minion, self).__init__(opts)
-            self.authenticate(timeout, safe)
+            if self.authenticate(timeout, safe) == 'full':
+                msg = ('master {0} rejected the minions connection because too '
+                       'many minions are already connected.'.format(opts['master']))
+                log.error(msg)
+                sys.exit(1)
 
         self.opts['pillar'] = salt.pillar.get_pillar(
             opts,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -575,8 +575,7 @@ class Minion(MinionBase):
         # module
         opts['grains'] = salt.loader.grains(opts)
 
-        # if master_type was changed, we might want to load our
-        # master-variable from a user defined modules function
+        # check if master_type was altered from its default
         if opts['master_type'] != 'str':
             # check for a valid keyword
             if opts['master_type'] == 'func':
@@ -593,16 +592,40 @@ class Minion(MinionBase):
                            'module \'{0}\''.format(opts['master']))
                     log.error(msg)
                     sys.exit(1)
-                log.info('Evaluated master from module: {0}'.format(opts['master']))
+                log.info('Evaluated master from module: {0}'.format(mod_master))
+
+            # if failover is set, master has to be of type list
+            elif opts['master_type'] == 'failover':
+                if type(opts['master']) is list:
+                    log.info('Got list of available master addresses:'
+                             ' {0}'.format(opts['master']))
+                else:
+                    msg = ('master_type set to \'failover\' but \'master\' '
+                           'is not of type list but of type '
+                           '{0}'.format(type(opts['master'])))
+                    log.error(msg)
+                    sys.exit(1)
             else:
                 msg = ('Invalid keyword \'{0}\' for variable '
                        '\'master_type\''.format(opts['master_type']))
                 log.error(msg)
                 sys.exit(1)
 
-        opts.update(resolve_dns(opts))
-        super(Minion, self).__init__(opts)
-        self.authenticate(timeout, safe)
+        # if we have a list of masters, loop through them and be
+        # happy with the first one that allows us to connect
+        if type(opts['master']) is list:
+            local_masters = copy.copy(opts['master'])
+            for master in local_masters:
+                opts['master'] = master
+                opts.update(resolve_dns(opts))
+                super(Minion, self).__init__(opts)
+                if self.authenticate(timeout, safe) != 'full':
+                    break
+        else:
+            opts.update(resolve_dns(opts))
+            super(Minion, self).__init__(opts)
+            self.authenticate(timeout, safe)
+
         self.opts['pillar'] = salt.pillar.get_pillar(
             opts,
             opts['grains'],
@@ -1217,8 +1240,7 @@ class Minion(MinionBase):
         while True:
             creds = auth.sign_in(timeout, safe, tries)
             if creds == 'full':
-                log.debug('master full, exit')
-                sys.exit(1)
+                return creds
             elif creds != 'retry':
                 log.info('Authentication with master successful!')
                 break

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1216,7 +1216,10 @@ class Minion(MinionBase):
         safe = self.opts.get('auth_safemode', safe)
         while True:
             creds = auth.sign_in(timeout, safe, tries)
-            if creds != 'retry':
+            if creds == 'full':
+                log.debug('master full, exit')
+                sys.exit(1)
+            elif creds != 'retry':
                 log.info('Authentication with master successful!')
                 break
             log.info('Waiting for minion key to be accepted by the master.')


### PR DESCRIPTION
Enables the master to only accept a limited amount of minions. If a minion connects that is already connected, it is allowed, else its denied by sending it the string 'full'.

Enables the minion to connect to a single master from a list of masters (not all masters like in multimaster mode). If it is denied by a master because the master has maxed out its minions, it acts on the returned string 'full'  and tries the next master in the list until it is accepted by one (caching the minions key counts as accepted) or all masters have rejected the connection. If no master accepts it, the minion exits.
