### PR TITLE
Make sure LDAP filter strings are properly escaped.

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -19,6 +19,7 @@ from jinja2 import Environment
 try:
     import ldap
     import ldap.modlist
+    import ldap.filter
     HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
@@ -135,6 +136,7 @@ def auth(username, password):
         paramvalues['binddn'] = _render_template(paramvalues['binddn'], username)
 
     if paramvalues['filter']:
+        paramvalues['filter'] = ldap.filter.escape_filter_chars(paramvalues['filter'])
         paramvalues['filter'] = _render_template(paramvalues['filter'], username)
 
     # Only add binddn/bindpw to the connargs when they're set, as they're not

--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -22,6 +22,7 @@ import yaml
 from jinja2 import Environment, FileSystemLoader
 try:
     import ldap
+    import ldap.filter
     HAS_LDAP = True
 except ImportError:
     HAS_LDAP = False
@@ -132,6 +133,7 @@ def _do_search(conf):
         attrs = None
     # Perform the search
     try:
+        _filter = __salt__['ldap.filter.escape_filter_chars'](_filter)
         result = __salt__['ldap.search'](_filter, _dn, scope, attrs,
                                          **connargs)['results'][0][1]
         log.debug(


### PR DESCRIPTION
Use python LDAP module's built-in escape function.
