### PR TITLE
Fallback to stored funcs in LazyLoader

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1270,7 +1270,10 @@ class LazyLoader(MutableMapping):
             # until we have a better way, we have to load them all to know
             # TODO: maybe do a load until, with some glob match first?
             self.load_all()
-            return self._dict[key]
+            if key in self._dict:
+                return self._dict[key]
+            elif key in self.functions:
+                return self.functions[key]
         else:
             patched = []
             # be sure that the global __salt__ dict is able of loading
@@ -1304,6 +1307,11 @@ class LazyLoader(MutableMapping):
             # load the item
             self._load(key)
             log.debug('LazyLoaded {0}'.format(key))
+            if key in self._dict:
+                return self._dict[key]
+            elif key in self.functions:
+                log.debug('Could not LazyLoad {0}. Using stored function'.format(key))
+                return self.functions[key]
         return self._dict[key]
 
     def __len__(self):


### PR DESCRIPTION
This corrects issues wherein some functions are not available inside
the context of certain modules.

This is a pretty simple fix, so by all means please let me know if
it's too naieve. I'm simply falling back to a stored functions if
we try to LazyLoad a function that's not a part of the loader owned
by LL in question. (i.e., trying to load an exec module into a
returner.)

Closes #12641

This needs careful review from @jacksontj and @thatch45 
