### PR TITLE
Don't try to set brew cmd user if we're already the correct user

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -315,7 +315,7 @@ def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
 
     __salt__['cmd.run'](
         cmd,
-        runas=user if user != __opts__['user'] else __opts__['user'],
+        runas=user if user != __opts__['user'] else None,
         output_loglevel='trace'
     )
     __context__.pop('pkg.list_pkgs', None)


### PR DESCRIPTION
If we define a user for this command, we will try to call os.setgroups which requires privileges, which breaks brew use if you're using an unprivileged user who is also the brew user.  If we're already running salt as the correct user, just don't try to set the user at all for the brew command.

Fixes #13097
