### PR TITLE
Allow schedules to work in multimaster.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -459,7 +459,7 @@ class MultiMinion(object):
         while True:
             for minion in minions.values():
                 if isinstance(minion, dict):
-                    continue
+                    minion = minion['minion']
                 if not hasattr(minion, 'schedule'):
                     continue
                 try:


### PR DESCRIPTION
This change allows schedules to work in multimaster. I've had to revert to a single master config for now since 2014.1.4 (the latest EPEL version) contains this bug.

I did try this with a single master setup. It does appear to work.

The code in the develop version looks very similar and may be similarly broken.
