### PR TITLE
Fix issue #12370

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -690,7 +690,7 @@ class State(object):
             # order for the newly installed package to be importable.
             reload(site)
         self.load_modules()
-        if not self.opts.get('local', False):
+        if not self.opts.get('local', False) and self.opts.get('multiprocessing', True):
             self.functions['saltutil.refresh_modules']()
 
     def check_refresh(self, data, ret):


### PR DESCRIPTION
Fix issue #12370.

In a multithreaded minion (i.e. windows) the modules have already been reloaded at line 692.

Calling `saltutil.refresh_modules` is unnecessary and causes a race condition. It sends an event on the minion bus to reload the modules. At some time in the future the main minion loop, which is a different thread in the same process, receives this event and reloads the modules again. This occurs while the other thread is using the modules to apply a state.
