### PR TITLE
Add wrapper function for total_seconds()

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -301,7 +301,7 @@ class Master(SMaster):
                                                          'remove an entry from the '
                                                          'job cache!  {0}'.format(exc))
                                     difference = cur - jidtime
-                                    hours_difference = difference.total_seconds() / 3600.0
+                                    hours_difference = salt.utils.total_seconds(difference) / 3600.0
                                     if hours_difference > self.opts['keep_jobs']:
                                         try:
                                             shutil.rmtree(f_path)

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2050,3 +2050,11 @@ def get_gid_list(user=None, include_default=True):
         return []
     gid_list = [gid for (group, gid) in salt.utils.get_group_dict(user, include_default=include_default).items()]
     return sorted(set(gid_list))
+
+def total_seconds(td):
+    '''
+    Takes a timedelta and returns the total number of seconds
+    represented by the object. Wrapper for the total_seconds()
+    method which does not exist in versions of Python < 2.7.
+    '''
+    return (td.microseconds + (td.seconds + td.days * 24 * 3600) * 10**6) / 10**6


### PR DESCRIPTION
Fixes an issue related to #10443. Proposed fix doesn't work on Python <= 2.6 because they don't support total_seconds(). Added a wrapper function to salt.utils.

Pull request is for the 2014.1 branch since it looks like the job cache code has changed radically on develop.
