### PR TITLE
in openstack topic, appended tokes the auth url which the driver require...

### DIFF
--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -20,7 +20,7 @@ OpenStack instances.
 
       # Configure the OpenStack driver
       #
-      identity_url: http://identity.youopenstack.com/v2.0/
+      identity_url: http://identity.youopenstack.com/v2.0/tokens
       compute_name: nova
       protocol: ipv4
 


### PR DESCRIPTION
In the openstack topic, it gives a sample cloud provider configuration file. This example is flawed because the identity url does not have tokens appended to the end. Without the /tokes in the identity URL, the keystone server rejects salt-cloud's authz request.
