### PR TITLE
salt/client/raet/__init__.py: fix spacing per pylint

### DIFF
--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -53,7 +53,7 @@ class LocalClient(salt.client.LocalClient):
                 **kwargs)
         yid = salt.utils.gen_jid()
         stack = LaneStack(
-                name = 'client' + yid,
+                name=('client' + yid),
                 yid=yid,
                 lanename='master',
                 sockdirpath=self.opts['sock_dir'])


### PR DESCRIPTION
```
************* Module salt.client.raet.__init__
salt/client/raet/__init__.py:56: [C0326(bad-whitespace), ] No space allowed around keyword argument assignment
                name = 'client' + yid,
```
