### PR TITLE
modules.varnish.purge(): avoid shadowing

### DIFF
--- a/salt/modules/varnish.py
+++ b/salt/modules/varnish.py
@@ -71,10 +71,10 @@ def purge():
     ver = version()
     log.debug('Purging varnish cache')
     if ver.startswith('4'):
-        purge = 'ban .'
+        purge_cmd = 'ban .'
     elif ver.startswith('3'):
-        purge = 'ban.url .'
+        purge_cmd = 'ban.url .'
     elif ver.startswith('2'):
-        purge = 'url.purge .'
-    cmd = 'varnishadm {0}'.format(purge)
+        purge_cmd = 'url.purge .'
+    cmd = 'varnishadm {0}'.format(purge_cmd)
     return __salt__['cmd.retcode'](cmd) == 0


### PR DESCRIPTION
```
************* Module salt.modules.varnish
salt/modules/varnish.py:74: [W0621(redefined-outer-name), purge] Redefining name 'purge' from outer scope (line 61)
```
