### PR TITLE
Fix for #13008

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -167,7 +167,7 @@ def save_load(jid, clear_load):
     '''
     Save the load to the specified jid
     '''
-    jid_dir = _jid_dir(clear_load['jid'])
+    jid_dir = _jid_dir(jid)
 
     serial = salt.payload.Serial(__opts__)
 


### PR DESCRIPTION
This is a somewhat silly fix since everywhere that calls "save_load" does something like:

```
save_load(load['jid'], load)
```

Fix for #13008
