### PR TITLE
Update sentry_mod.py

### DIFF
--- a/salt/log/handlers/sentry_mod.py
+++ b/salt/log/handlers/sentry_mod.py
@@ -170,7 +170,10 @@ def setup_handlers():
         # processors: A list of processors to apply to events before sending
         # them to the Sentry server. Useful for sending additional global state
         # data or sanitizing data that you want to keep off of the server.
-        'processors': get_config_value('processors')
+        'processors': get_config_value('processors'),
+        
+        # dsn: Ensure the DSN is passed into the client
+        'dsn': dsn
     })
 
     client = raven.Client(**options)


### PR DESCRIPTION
Pass DSN to raven client. fix for issue 13172. Thanks cachedout
