### PR TITLE
kmod. Replace dash from available kernel modules by underscores

### DIFF
--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -129,7 +129,7 @@ def available():
     for root, dirs, files in os.walk(mod_dir):
         for fn_ in files:
             if '.ko' in fn_:
-                ret.append(fn_[:fn_.index('.ko')])
+                ret.append(fn_[:fn_.index('.ko')].replace('-', '_'))
     return sorted(list(ret))
 
 


### PR DESCRIPTION
Pull request to fix issue #13239

Replace dash by underscore from available kernel modules, so salt does not fail to check if a module containing a dash is loaded.
