### PR TITLE
Adjust get_time function for salt api

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -174,7 +174,7 @@ class LocalClient(object):
             return self.opts['timeout']
         if isinstance(timeout, int):
             return timeout
-        if isinstance(timeout, str):
+        if isinstance(timeout, str) or isinstance(timeout, unicode):
             try:
                 return int(timeout)
             except ValueError:


### PR DESCRIPTION
Timeout is unicode type in salt rest api by POST data.
The issue in salt-api: https://github.com/saltstack/salt-api/issues/148
