### PR TITLE
Add unicode supportting for client timeout arg.

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -25,6 +25,7 @@ import time
 import copy
 import logging
 from datetime import datetime
+from salt._compat import string_types
 
 # Import salt libs
 import salt.config
@@ -174,7 +175,7 @@ class LocalClient(object):
             return self.opts['timeout']
         if isinstance(timeout, int):
             return timeout
-        if isinstance(timeout, str):
+        if isinstance(timeout, string_types):
             try:
                 return int(timeout)
             except ValueError:


### PR DESCRIPTION
salt.client.LocalClient._get_timeout(self, timeout) only process with int and string type timeout value, it will be more in reason to process with unicode type timeout argument as well.
Also Salt-API passes unicode timeout argument to salt.client.LocalClient(), causing timeout argument passed being invalid. This will fix it.
