### PR TITLE
Unresolvable master dns entry should not result in 127.0.0.1 if retry_dns not set.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -115,7 +115,11 @@ def resolve_dns(opts):
                     except SaltClientError:
                         pass
             else:
-                ret['master_ip'] = '127.0.0.1'
+                err = 'Master address: {0} could not be resolved and retry_dns is not set.  Invalid or unresolveable address.'.format(
+                    opts.get('master', 'Unknown'))
+                log.error(err)
+                raise SaltSystemExit(code=42, msg=err)
+                # ret['master_ip'] = '127.0.0.1'
         except SaltSystemExit:
             err = 'Master address: {0} could not be resolved. Invalid or unresolveable address.'.format(
                 opts.get('master', 'Unknown'))

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -119,7 +119,6 @@ def resolve_dns(opts):
                     opts.get('master', 'Unknown'))
                 log.error(err)
                 raise SaltSystemExit(code=42, msg=err)
-                # ret['master_ip'] = '127.0.0.1'
         except SaltSystemExit:
             err = 'Master address: {0} could not be resolved. Invalid or unresolveable address.'.format(
                 opts.get('master', 'Unknown'))


### PR DESCRIPTION
Die off with log message in this case.
