### PR TITLE
Detection of __salt__ in loader

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -778,8 +778,9 @@ class Loader(object):
         for mod in self.modules:
             if not hasattr(mod, '__salt__'):
                 mod.__salt__ = funcs
-            elif not in_pack(pack, '__salt__') and \
-                    str(mod.__name__).startswith('salt.loaded.int.grain'):
+            elif hasattr(mod, '__salt__') or (not in_pack(pack, '__salt__') and \
+                    str(mod.__name__).startswith('salt.loaded.int.grain')
+                ):
                 mod.__salt__.update(funcs)
             else:
                 mod.__salt__ = funcs

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -776,14 +776,15 @@ class Loader(object):
         # the available modules and inject the special __salt__ namespace that
         # contains these functions.
         for mod in self.modules:
-            if not hasattr(mod, '__salt__') and (
+            if not hasattr(mod, '__salt__') or (
                 not in_pack(pack, '__salt__') and
-                not str(mod.__name__).startswith('salt.loaded.int.grain')
+                (not str(mod.__name__).startswith('salt.loaded.int.grain') and
+                 not str(mod.__name__).startswith('salt.loaded.ext.grain'))
             ):
                 mod.__salt__ = funcs
-            elif hasattr(mod, '__salt__') and (not in_pack(pack, '__salt__' and \
-                    str(mod.__name__).startswith('salt.loaded.int.grain'))
-                ):
+            elif not in_pack(pack, '__salt__') and \
+                    (str(mod.__name__).startswith('salt.loaded.int.grain') or
+                     str(mod.__name__).startswith('salt.loaded.int.grain')):
                 mod.__salt__.update(funcs)
         return funcs
 

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -781,8 +781,8 @@ class Loader(object):
                 not str(mod.__name__).startswith('salt.loaded.int.grain')
             ):
                 mod.__salt__ = funcs
-            elif hasattr(mod, '__salt__') and (not in_pack(pack, '__salt__') and \
-                    str(mod.__name__).startswith('salt.loaded.int.grain')
+            elif hasattr(mod, '__salt__') and (not in_pack(pack, '__salt__' and \
+                    str(mod.__name__).startswith('salt.loaded.int.grain'))
                 ):
                 mod.__salt__.update(funcs)
         return funcs

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -776,14 +776,13 @@ class Loader(object):
         # the available modules and inject the special __salt__ namespace that
         # contains these functions.
         for mod in self.modules:
-            if not hasattr(mod, '__salt__') or (
-                not in_pack(pack, '__salt__') and
-                not str(mod.__name__).startswith('salt.loaded.int.grain')
-            ):
+            if not hasattr(mod, '__salt__'):
                 mod.__salt__ = funcs
             elif not in_pack(pack, '__salt__') and \
                     str(mod.__name__).startswith('salt.loaded.int.grain'):
                 mod.__salt__.update(funcs)
+            else:
+                mod.__salt__ = funcs
         return funcs
 
     def load_modules(self):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -776,14 +776,15 @@ class Loader(object):
         # the available modules and inject the special __salt__ namespace that
         # contains these functions.
         for mod in self.modules:
-            if not hasattr(mod, '__salt__'):
+            if not hasattr(mod, '__salt__') and (
+                not in_pack(pack, '__salt__') and
+                not str(mod.__name__).startswith('salt.loaded.int.grain')
+            ):
                 mod.__salt__ = funcs
-            elif hasattr(mod, '__salt__') or (not in_pack(pack, '__salt__') and \
+            elif hasattr(mod, '__salt__') and (not in_pack(pack, '__salt__') and \
                     str(mod.__name__).startswith('salt.loaded.int.grain')
                 ):
                 mod.__salt__.update(funcs)
-            else:
-                mod.__salt__ = funcs
         return funcs
 
     def load_modules(self):


### PR DESCRIPTION
This resolves #10275. Please see that issue for a thorough discussion of the problem.

It appears that there was an issue where in, `__salt__` defined outside
of a function in a custom grain would be overwritten by the loader
when the grain was loaded.

The old logic overwrote `__salt__` if it was not present in the pack,
regardless of whether or not it was an attribute of the module being
evaluated. I don't believe this is what was intended but there's
certainly a case I could be missing.

Should probably let tests run here before merging.
