### PR TITLE
Fixed issues with Yard persistence

### DIFF
--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -345,9 +345,10 @@ class Schedule(ioflo.base.deeding.Deed):
         self.schedule.eval()
 
 
-class Setup(ioflo.base.deeding.Deed):
+class SaltManorLaneSetup(ioflo.base.deeding.Deed):
     '''
-    Only intended to be called once at the top of the house
+    Only intended to be called once at the top of the manor house
+    Sets of the LaneStack for the main yard
     FloScript:
 
     do setup at enter
@@ -362,19 +363,33 @@ class Setup(ioflo.base.deeding.Deed):
                'event': '.salt.event.events',
                'event_req': '.salt.event.event_req',
                'workers': '.salt.track.workers',
-               'uxd_stack': '.salt.uxd.stack.stack'}
+               'inode': '.salt.uxd.stack.',
+               'stack': 'stack',
+               'local': {'ipath': 'local',
+                          'ival': {'name': 'master',
+                                   'localname': 'master',
+                                   'yid': 0,
+                                   'lanename': 'master'}}
+            }
 
     def postinitio(self):
         '''
         Set up required objects and queues
         '''
-        self.uxd_stack.value = LaneStack(
-                name='yard',
-                lanename=self.opts.value.get('id', 'master'),
-                yid=0,
-                sockdirpath=self.opts.value['sock_dir'],
-                dirpath=self.opts.value['cachedir'])
-        self.uxd_stack.value.Pk = raeting.packKinds.pack
+        name = self.opts.value.get('id', self.local.data.name)
+        localname = self.opts.value.get('id', self.local.data.localname)
+        lanename = self.opts.value.get('id', self.local.data.lanename)
+        yid = self.local.data.yid
+        basedirpath = os.path.abspath(
+                os.path.join(self.opts.value['cachedir'], 'raet'))
+        self.stack.value = LaneStack(
+                                    name=name,
+                                    #localname=localname,
+                                    lanename=lanename,
+                                    yid=0,
+                                    sockdirpath=self.opts.value['sock_dir'],
+                                    basedirpath=basedirpath)
+        self.stack.value.Pk = raeting.packKinds.pack
         self.event_yards.value = set()
         self.local_cmd.value = deque()
         self.remote_cmd.value = deque()
@@ -387,6 +402,25 @@ class Setup(ioflo.base.deeding.Deed):
             for ind in range(self.opts.value['worker_threads']):
                 worker_seed.append('yard{0}'.format(ind + 1))
             self.workers.value = itertools.cycle(worker_seed)
+
+class SaltRaetLaneStackCloser(ioflo.base.deeding.Deed):  # pylint: disable=W0232
+    '''
+    Closes lane stack server socket connection
+    FloScript:
+
+    do raet lane stack closer at exit
+
+    '''
+    Ioinits = odict(
+        inode=".salt.uxd.stack",
+        stack='stack',)
+
+    def action(self, **kwa):
+        '''
+        Close uxd socket
+        '''
+        if self.stack.value and isinstance(self.stack.value, LaneStack):
+            self.stack.value.server.close()
 
 
 class SaltRoadService(ioflo.base.deeding.Deed):

--- a/salt/daemons/flo/master.flo
+++ b/salt/daemons/flo/master.flo
@@ -4,10 +4,14 @@ house master
 
 init .raet.udp.stack.local to eid 1 main true name "master" localname "master"
 
+init .salt.uxd.stack.local to yid 0 name "master" localname "master" lanename "master"
+
 framer masterudpstack be active first setup
     frame setup
         enter
-            do setup
+            do salt manor lane setup
+
+
 #        go spawnmaint
 #    frame spawnmaint
 #        enter
@@ -21,6 +25,7 @@ framer masterudpstack be active first setup
         do salt raet road stack per inode ".raet.udp.stack"
         exit
             do salt raet road stack closer per inode ".raet.udp.stack."
+            do salt raet lane stack closer per inode ".salt.uxd.stack."
 
 framer inbound be active first start
     frame start

--- a/salt/daemons/flo/minion.flo
+++ b/salt/daemons/flo/minion.flo
@@ -5,16 +5,18 @@ house minion
 init name in .raet.udp.stack.local from value in .salt.etc.id
 init localname in .raet.udp.stack.local from value in .salt.etc.id
 
+init .salt.uxd.stack.local to yid 0 name "minion" localname "minion" lanename "minion"
 
 framer minionudpstack be active first setup
     frame setup
         enter
-            do setup
+            do salt manor lane setup
         go start
     frame start
         do salt raet road stack per inode ".raet.udp.stack"
         exit
             do salt raet road stack closer per inode ".raet.udp.stack."
+            do salt raet lane stack closer per inode ".salt.uxd.stack."
 
 framer inbound be active first start
     frame start

--- a/salt/daemons/flo/worker.flo
+++ b/salt/daemons/flo/worker.flo
@@ -10,3 +10,5 @@ framer uxdrouter be active first setup
       go start
    frame start
       do worker router
+      exit
+         do salt raet lane stack closer per inode ".salt.uxd.stack."

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -5,6 +5,7 @@ The core bahaviuors ued by minion and master
 # pylint: disable=W0232
 
 # Import python libs
+import os
 import multiprocessing
 
 # Import salt libs
@@ -80,40 +81,57 @@ class WorkerSetup(ioflo.base.deeding.Deed):
 
     '''
     Ioinits = {
-            'uxd_stack': '.salt.uxd.stack.stack',
             'opts': '.salt.opts',
             'yid': '.salt.yid',
             'access_keys': '.salt.access_keys',
             'remote': '.salt.loader.remote',
             'local': '.salt.loader.local',
+            'inode': '.salt.uxd.stack.',
+            'stack': 'stack',
+            'main': {'ipath': 'main',
+                       'ival': {'name': 'master',
+                                'localname': 'master',
+                                'yid': 0,
+                                'lanename': 'master'}}
             }
 
     def action(self):
         '''
         Set up the uxd stack and behaviors
         '''
-        self.uxd_stack.value = LaneStack(
-                lanename=self.opts.value.get('id', 'master'),
-                yid=self.yid.value,
-                sockdirpath=self.opts.value['sock_dir'])
-        self.uxd_stack.value.Pk = raeting.packKinds.pack
+        name = "{0}{1}{2}".format(self.opts.value.get('id', self.main.data.name),
+                                  'worker',
+                                  self.yid.value)
+        localname = name
+        lanename = self.opts.value.get('id', self.main.data.lanename)
+        basedirpath = os.path.abspath(
+                os.path.join(self.opts.value['cachedir'], 'raet'))
+
+        self.stack.value = LaneStack(
+                                     name=name,
+                                     #localname=localname,
+                                     basedirpath=basedirpath,
+                                     lanename=lanename,
+                                     yid=self.yid.value,
+                                     sockdirpath=self.opts.value['sock_dir'])
+        self.stack.value.Pk = raeting.packKinds.pack
         manor_yard = RemoteYard(
-                stack=self.uxd_stack.value,
-                yid=0,
-                lanename=self.opts.value.get('id', 'master'),
-                dirpath=self.opts.value['sock_dir'])
-        self.uxd_stack.value.addRemote(manor_yard)
+                                 stack=self.stack.value,
+                                 yid=0,
+                                 lanename=lanename,
+                                 dirpath=self.opts.value['sock_dir'])
+        self.stack.value.addRemote(manor_yard)
         self.remote.value = salt.daemons.masterapi.RemoteFuncs(self.opts.value)
         self.local.value = salt.daemons.masterapi.LocalFuncs(
                 self.opts.value,
                 self.access_keys.value)
         init = {}
         init['route'] = {
-                'src': (None, self.uxd_stack.value.local.name, None),
-                'dst': (None, 'yard0', 'worker_req')
+                'src': (None, self.stack.value.local.name, None),
+                'dst': (None, manor_yard.name, 'worker_req')
                 }
-        self.uxd_stack.value.transmit(init, self.uxd_stack.value.uids.get('yard0'))
-        self.uxd_stack.value.serviceAll()
+        self.stack.value.transmit(init, self.stack.value.uids.get(manor_yard.name))
+        self.stack.value.serviceAll()
 
 
 class WorkerRouter(ioflo.base.deeding.Deed):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -112,7 +112,10 @@ def get_event(node, sock_dir=None, transport='zeromq', opts=None, listen=True):
         return SaltEvent(node, sock_dir, opts)
     elif transport == 'raet':
         import salt.utils.raetevent
-        return salt.utils.raetevent.SaltEvent(node, sock_dir, listen)
+        return salt.utils.raetevent.SaltEvent(node,
+                                              sock_dir=sock_dir,
+                                              listen=listen,
+                                              opts=opts)
 
 
 def tagify(suffix='', prefix='', base=SALT):

--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -6,6 +6,7 @@ This module is used to manage events via RAET
 '''
 
 # Import python libs
+import os
 import logging
 import time
 from collections import MutableMapping
@@ -26,21 +27,30 @@ class SaltEvent(object):
     '''
     The base class used to manage salt events
     '''
-    def __init__(self, node, sock_dir=None, listen=True):
+    def __init__(self, node, sock_dir=None, listen=True, opts=None):
         '''
         Set up the stack and remote yard
         '''
         self.node = node
         self.sock_dir = sock_dir
         self.listen = listen
+        if opts is None:
+            opts =  {}
+        self.opts = opts
         self.__prep_stack()
 
     def __prep_stack(self):
         self.yid = salt.utils.gen_jid()
+        name = 'event' + self.yid
+        cachedir = self.opts.get('cachedir', os.path.join('/var/cache/salt', self.node))
+        basedirpath = os.path.abspath(
+                os.path.join(cachedir, 'raet'))
         self.connected = False
         self.stack = LaneStack(
+                name=name,
                 yid=self.yid,
                 lanename=self.node,
+                basedirpath=basedirpath,
                 sockdirpath=self.sock_dir)
         self.stack.Pk = raeting.packKinds.pack
         self.router_yard = RemoteYard(


### PR DESCRIPTION
All LaneStacks in SaltRaet now have unique names so there are no namespace collisons when persisting Yard data.

Added support for basedirpath to Stacks to provide default way to ensure stack name is part of dirpath for keep files

Added closer behaviors to close lane stacks opened by Master miniion and workers.
Still not closing event lanestacks

Still not closing for sure workers depending on how the process shutsdown.

Fixed the problem with stacktrace for race condition opening lane stacks. This is solved by the unique keeep names
