### PR TITLE
More granular master job targeting

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -249,6 +249,7 @@ VALID_OPTS = {
     'max_minions': int,
     'username': str,
     'password': str,
+    'zmq_filtering': bool,
 }
 
 # default configurations
@@ -373,6 +374,7 @@ DEFAULT_MINION_OPTS = {
     'ping_interval': 0,
     'username': None,
     'password': None,
+    'zmq_filtering': True,
 }
 
 DEFAULT_MASTER_OPTS = {
@@ -529,6 +531,7 @@ DEFAULT_MASTER_OPTS = {
     'master_sign_pubkey': False,
     'master_pubkey_signature': 'master_pubkey_signature',
     'master_use_pubkey_signature': False,
+    'zmq_filtering': True,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -25,6 +25,12 @@ class SaltMasterError(SaltException):
     '''
 
 
+class SaltSyndicMasterError(SaltException):
+    '''
+    Problem while proxying a request in the syndication master
+    '''
+
+
 class MasterExit(SystemExit):
     '''
     Rise when the master exits

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -55,7 +55,7 @@ except ImportError:
 from salt.exceptions import (
     AuthenticationError, CommandExecutionError, CommandNotFoundError,
     SaltInvocationError, SaltReqTimeoutError, SaltClientError,
-    SaltSystemExit
+    SaltSystemExit, SaltSyndicMasterError
 )
 import salt.client
 import salt.crypt
@@ -623,6 +623,10 @@ class Minion(MinionBase):
             })
 
         self.grains_cache = self.opts['grains']
+
+        # store your hexid to subscribe to zmq, hash since zmq filters are prefix
+        # matches this way we can avoid collisions
+        self.hexid = hashlib.sha1(self.opts['id']).hexdigest()
 
         if 'proxy' in self.opts['pillar']:
             log.debug('I am {0} and I need to start some proxies for {0}'.format(self.opts['id'],
@@ -1302,7 +1306,13 @@ class Minion(MinionBase):
         )
 
     def _setsockopts(self):
-        self.socket.setsockopt(zmq.SUBSCRIBE, '')
+        if self.opts['zmq_filtering']:
+            # TODO: constants file for "broadcast"
+            self.socket.setsockopt(zmq.SUBSCRIBE, 'broadcast')
+            self.socket.setsockopt(zmq.SUBSCRIBE, self.hexid)
+        else:
+            self.socket.setsockopt(zmq.SUBSCRIBE, '')
+
         self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
         self._set_ipv4only()
         self._set_reconnect_ivl_max()
@@ -1715,7 +1725,19 @@ class Minion(MinionBase):
 
     def _do_socket_recv(self, socks):
         if socks.get(self.socket) == zmq.POLLIN:
-            payload = self.serial.loads(self.socket.recv(zmq.NOBLOCK))
+            # topic filtering is done at the zmq level, so we just strip it
+            messages = self.socket.recv_multipart(zmq.NOBLOCK)
+            messages_len = len(messages)
+            # if it was one message, then its old style
+            if messages_len == 1:
+                payload = self.serial.loads(messages[0])
+            # 2 includes a header which says who should do it
+            elif messages_len == 2:
+                payload = self.serial.loads(messages[1])
+            else:
+                raise Exception(('Invalid number of messages ({0}) in zeromq pub'
+                                 'message from master').format(len(messages_len)))
+
             log.trace('Handling payload')
             self._handle_payload(payload)
 
@@ -1835,6 +1857,8 @@ class Syndic(Minion):
         # Share the poller with the event object
         self.poller = self.local.event.poller
         self.socket = self.context.socket(zmq.SUB)
+        # no filters for syndication masters, unless we want to maintain a
+        # list of all connected minions and update the filter
         self.socket.setsockopt(zmq.SUBSCRIBE, '')
         self.socket.setsockopt(zmq.IDENTITY, self.opts['id'])
 
@@ -1899,7 +1923,17 @@ class Syndic(Minion):
 
     def _process_cmd_socket(self):
         try:
-            payload = self.serial.loads(self.socket.recv(zmq.NOBLOCK))
+            messages = self.socket.recv_multipart(zmq.NOBLOCK)
+            messages_len = len(messages)
+            idx = None
+            if messages_len == 1:
+                idx = 0
+            elif messages_len == 2:
+                idx = 1
+            else:
+                raise SaltSyndicMasterError('Syndication master recieved message of invalid len ({0}/2)'.format(messages_len))
+
+            payload = self.serial.loads(messages[idx])
         except zmq.ZMQError as e:
             # Swallow errors for bad wakeups or signals needing processing
             if e.errno != errno.EAGAIN and e.errno != errno.EINTR:


### PR DESCRIPTION
Please DO NOT MERGE IMMEDIATELY.

Salt targeting is done using the zmq pub/sub mechanism. No filtering is done so all requests go to all minions. This is an attempt to make the requests more target-able. ZeroMQ supports filters on these sockets which are processed publisher side. So the thought is to set it to the minion id and a shared "broadcast" one. Only requests of tgt_type == list will use this. The thought is if we like this we can use other data (mine etc) to determine a more specific target on the master (such as a list) from a glob match etc.

This is more or less backwards compatible, during my testing it still works but the old minion will throw an exception like:

[CRITICAL] An exception occurred while polling the minion
Traceback (most recent call last):
File "/home/thjackso/src/salt/salt/minion.py", line 1324, in tune_in
payload = self.serial.loads(self.socket.recv(zmq.NOBLOCK))
File "/home/thjackso/src/salt/salt/payload.py", line 95, in loads
return msgpack.loads(msg, use_list=True)
File "_unpacker.pyx", line 114, in msgpack._unpacker.unpackb (msgpack/_unpacker.cpp:114)
ExtraData: unpack(b) recieved extra data.

The new minion (in this PR) will work with both configurations-- although once a minion has enabled targeting it will no longer receive old-style messages.

This is another attempt of #10374.
And exactly the same as #13154
