### PR TITLE
modules.schedule: avoid shadowing built-in list type

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -17,6 +17,10 @@ __proxyenabled__ = ['*']
 import logging
 log = logging.getLogger(__name__)
 
+__func_alias__ = {
+    'list_': 'list'
+}
+
 SCHEDULE_CONF = [
         'function',
         'splay',
@@ -35,7 +39,7 @@ SCHEDULE_CONF = [
         ]
 
 
-def list(show_all=False):
+def list_(show_all=False):
     '''
     List the jobs currently scheduled on the minion
 


### PR DESCRIPTION
```
************* Module salt.modules.schedule
salt/modules/schedule.py:38: [W0622(redefined-builtin), list] Redefining built-in 'list'
```
