### PR TITLE
salt.client: rm duplicate import of string_types

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -41,7 +41,6 @@ import salt.syspaths as syspaths
 from salt.exceptions import (
     EauthAuthenticationError, SaltInvocationError, SaltReqTimeoutError
 )
-from salt._compat import string_types
 
 # Try to import range from https://github.com/ytoolshed/range
 HAS_RANGE = False


### PR DESCRIPTION
```
************* Module salt.client
salt/client/__init__.py:44: [W0404(reimported), ] Reimport 'string_types' (imported line 28)
```
