### PR TITLE
Fixes to module yumpkg.py and state pkg.py

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1058,7 +1058,9 @@ def hold(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
 
     current_pkgs = list_pkgs()
     if 'yum-plugin-versionlock' not in current_pkgs:
-        return 'Error: Package yum-plugin-versionlock needs to be installed.'
+        ret = {}
+        ret['result'] = False
+        ret['comment'] = 'Packages cannot be held, yum-plugin-versionlock needs to be installed.'
 
     current_locks = get_locked_packages()
     ret = {}
@@ -1122,7 +1124,9 @@ def unhold(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
 
     current_pkgs = list_pkgs()
     if 'yum-plugin-versionlock' not in current_pkgs:
-        return 'Error: Package yum-plugin-versionlock needs to be installed.'
+        ret = {}
+        ret['result'] = False
+        ret['comment'] = 'Error: Package yum-plugin-versionlock needs to be installed.'
 
     current_locks = get_locked_packages(full=True)
     ret = {}

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -576,26 +576,33 @@ def installed(
                 else:
                     hold_ret = __salt__['pkg.unhold'](name=name, pkgs=pkgs)
 
-                modified_hold = [hold_ret[x] for x in hold_ret.keys() if hold_ret[x]['changes']]
-                not_modified_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['changes'] and hold_ret[x]['result']]
-                failed_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['result']]
+                if 'result' in hold_ret and not hold_ret['result']:
+                    return {'name': name,
+                            'changes': {},
+                            'result': False,
+                            'comment': 'An error was encountered while holding/unholding '
+                                       'package(s): {0}'.format(hold_ret['comment'])}
+                else:
+                    modified_hold = [hold_ret[x] for x in hold_ret.keys() if hold_ret[x]['changes']]
+                    not_modified_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['changes'] and hold_ret[x]['result']]
+                    failed_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['result']]
 
-                if modified_hold:
-                    for i in modified_hold:
-                        result['comment'] += ' {0}'.format(i['comment'])
-                        result['result'] = i['result']
-                        change_name = i['name']
-                        result['changes'][change_name] = i['changes']
+                    if modified_hold:
+                        for i in modified_hold:
+                            result['comment'] += ' {0}'.format(i['comment'])
+                            result['result'] = i['result']
+                            change_name = i['name']
+                            result['changes'][change_name] = i['changes']
 
-                if not_modified_hold:
-                    for i in not_modified_hold:
-                        result['comment'] += ' {0}'.format(i['comment'])
-                        result['result'] = i['result']
+                    if not_modified_hold:
+                        for i in not_modified_hold:
+                            result['comment'] += ' {0}'.format(i['comment'])
+                            result['result'] = i['result']
 
-                if failed_hold:
-                    for i in failed_hold:
-                        result['comment'] += ' {0}'.format(i['comment'])
-                        result['result'] = i['result']
+                    if failed_hold:
+                        for i in failed_hold:
+                            result['comment'] += ' {0}'.format(i['comment'])
+                            result['result'] = i['result']
         return result
 
     if to_unpurge and 'lowpkg.unpurge' not in __salt__:
@@ -662,9 +669,16 @@ def installed(
                 else:
                     hold_ret = __salt__['pkg.unhold'](name=name, pkgs=pkgs)
 
-                modified_hold = [hold_ret[x] for x in hold_ret.keys() if hold_ret[x]['changes']]
-                not_modified_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['changes'] and hold_ret[x]['result']]
-                failed_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['result']]
+                if 'result' in hold_ret and not hold_ret['result']:
+                    return {'name': name,
+                            'changes': {},
+                            'result': False,
+                            'comment': 'An error was encountered while holding/unholding '
+                                       'package(s): {0}'.format(hold_ret['comment'])}
+                else:
+                    modified_hold = [hold_ret[x] for x in hold_ret.keys() if hold_ret[x]['changes']]
+                    not_modified_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['changes'] and hold_ret[x]['result']]
+                    failed_hold = [hold_ret[x] for x in hold_ret.keys() if not hold_ret[x]['result']]
 
         if isinstance(pkg_ret, dict):
             changes['installed'].update(pkg_ret)


### PR DESCRIPTION
Fixes to module yumpkg.py and state pkg.py to prevent exceptions when yum-plugin-versionlock is not installed and packages are attempted to be held. #13293 
