### PR TITLE
Removed check for RHN optional repo

### DIFF
--- a/Contributing.rst
+++ b/Contributing.rst
@@ -66,8 +66,8 @@ salt's code.
 
 
 .. _`report an issue`: https://github.com/saltstack/salt/issues
-.. _`Salt's documentation`: http://docs.saltstack.org/en/latest/index.html
-.. _`Developing Salt`: http://docs.saltstack.com/topics/hacking.html
-.. _`pull request`: http://docs.saltstack.com/topics/hacking.html#sending-a-github-pull-request
+.. _`Salt's documentation`: http://docs.saltstack.com/en/latest/index.html
+.. _`Developing Salt`: http://docs.saltstack.com/en/latest/topics/development/hacking.html
+.. _`pull request`: http://docs.saltstack.com/en/latest/topics/development/contributing.html#sending-a-github-pull-request
 
 .. vim: fenc=utf-8 spell spl=en

--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -2484,10 +2484,6 @@ install_red_hat_linux_stable_deps() {
     else
         OPTIONAL_ARCH=$CPU_ARCH_L
     fi
-    if [ $DISTRO_MAJOR_VERSION -eq 6 ] && case "X$(rhn-channel -l | grep optional)" in Xrhel-${OPTIONAL_ARCH}-server-optional-${DISTRO_MAJOR_VERSION}* ) false ;; * ) true ;; esac ; then
-      echoerror "Failed to find RHN optional repo, please enable it using the GUI or rhn-channel command."
-      return 1
-    fi
     install_centos_stable_deps || return 1
     return 0
 }


### PR DESCRIPTION
It is no longer required and causes the bootstrap script to fail if the system isn't registered with Red Hat. Tested it to work without these lines. 
