### PR TITLE
Improvement to nested output

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -69,14 +69,13 @@ class NestDisplay(object):
                         self.colors['ENDC'])
         elif isinstance(ret, list) or isinstance(ret, tuple):
             for ind in ret:
-                if isinstance(ind, (list, tuple)):
+                if isinstance(ind, (list, tuple, dict)):
                     out += '{0}{1}|_{2}\n'.format(
                             ' ' * indent,
                             self.colors['GREEN'],
                             self.colors['ENDC'])
-                    out = self.display(ind, indent + 2, '- ', out)
-                if isinstance(ind, dict):
-                    out = self.display(ind, indent, '',  out)
+                    prefix = '' if isinstance(ind, dict) else '- '
+                    out = self.display(ind, indent + 2, prefix, out)
                 else:
                     out = self.display(ind, indent, '- ', out)
         elif isinstance(ret, dict):

--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -75,6 +75,8 @@ class NestDisplay(object):
                             self.colors['GREEN'],
                             self.colors['ENDC'])
                     out = self.display(ind, indent + 2, '- ', out)
+                if isinstance(ind, dict):
+                    out = self.display(ind, indent, '',  out)
                 else:
                     out = self.display(ind, indent, '- ', out)
         elif isinstance(ret, dict):


### PR DESCRIPTION
Given this dictionary:

``` json
{
  "adict": {"a": 1, "b": 2, "c": 3}, 
  "alist": [{"a": 1, "b": 2, "c": 3}, [1, 2, 3], "abc"], 
  "astring": "abc"
}
```

`salt.output.nested` currently prints:

```
adict:
    ----------
    a:
        1
    b:
        2
    c:
        3
alist:
    ----------
    - a:
        1
    - b:
        2
    - c:
        3
    |_
      - 1
      - 2
      - 3
    - abc
astring:
    abc
```

Where the dictionary within the list looks very much like a list and not much like a dictionary.

This merge request changes the output to:

```
adict:
    ----------
    a:
        1
    b:
        2
    c:
        3
alist:
    |_
      ----------
      a:
          1
      b:
          2
      c:
          3
    |_
      - 1
      - 2
      - 3
    - abc
astring:
    abc
```

I believe this is more uniform behavior.
