### PR TITLE
Don't decrypt twice

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -745,13 +745,9 @@ class Minion(MinionBase):
         channel = salt.transport.Channel.factory(self.opts)
         try:
             result = channel.send(load)
-            try:
-                data = self.crypticle.loads(result)
-            except AuthenticationError:
-                log.info("AES key changed, re-authenticating")
-                # We can't decode the master's response to our event,
-                # so we will need to re-authenticate.
-                self.authenticate()
+        except AuthenticationError:
+            log.info("AES key changed, re-authenticating")
+            self.authenticate()
         except SaltReqTimeoutError:
             log.info("Master failed to respond. Preforming re-authenticating")
             self.authenticate()


### PR DESCRIPTION
According to #13328, the minion was stacktracing on state but operating
normally after that.

I believe this problem may have originated in the channel-reuse changes in
functionality into the transport, which would make it unecessary in the minion
method itself. (Please correct me if I'm wrong, of course. I'm making an
assumption here.)

At any rate, this removes that duplicate functionality, thus eliminating the
stack trace.

Closes #13328 
