### PR TITLE
Minion alert disconnect

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -56,6 +56,7 @@ VALID_OPTS = {
     'master_type': str,
     'master_finger': str,
     'master_shuffle': bool,
+    'master_alive_interval': int,
     'syndic_finger': str,
     'user': str,
     'root_dir': str,
@@ -249,6 +250,7 @@ DEFAULT_MINION_OPTS = {
     'master_port': '4506',
     'master_finger': '',
     'master_shuffle': False,
+    'master_alive_interval': 0,
     'syndic_finger': '',
     'user': 'root',
     'root_dir': salt.syspaths.ROOT_DIR,
@@ -1880,18 +1882,10 @@ def apply_minion_config(overrides=None,
             prepend_root_dirs.append(config_key)
 
     prepend_root_dir(opts, prepend_root_dirs)
-    if '__mine_interval' not in opts.get('schedule', {}):
-        if 'schedule' not in opts:
-            opts['schedule'] = {}
-        opts['schedule'].update({
-            '__mine_interval':
-            {
-                'function': 'mine.update',
-                'minutes': opts['mine_interval'],
-                'jid_include': True,
-                'maxrunning': 2
-            }
-        })
+
+    # if there is no schedule option yet, add an empty scheduler
+    if 'schedule' not in opts:
+        opts['schedule'] = {}
     return opts
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -665,6 +665,29 @@ class Minion(MinionBase):
             self.functions,
             self.returners)
 
+        # add default scheduling jobs to the minions scheduler
+        self.schedule.add_job({
+            '__mine_interval':
+            {
+                'function': 'mine.update',
+                'minutes': opts['mine_interval'],
+                'jid_include': True,
+                'maxrunning': 2
+            }
+        })
+    
+        # add master_alive job if enabled
+        if self.opts['master_alive_interval'] > 0:
+            self.schedule.add_job({
+                '__master_alive':
+                {
+                    'function': 'status.master',
+                    'seconds': opts['master_alive_interval'],
+                    'jid_include': True,
+                    'maxrunning': 2
+                }
+            })
+
         self.grains_cache = self.opts['grains']
 
         if 'proxy' in self.opts['pillar']:
@@ -1488,6 +1511,8 @@ class Minion(MinionBase):
                             tag, data = salt.utils.event.MinionEvent.unpack(package)
                             log.debug('Forwarding master event tag={tag}'.format(tag=data['tag']))
                             self._fire_master(data['data'], data['tag'], data['events'], data['pretag'])
+                        elif package.startswith('__master_disconnect'):
+                            log.debug('handling master disconnect')
 
                         self.epub_sock.send(package)
                     except Exception:

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -868,6 +868,25 @@ def local_port_tcp(port):
         ret = remotes_on_local_tcp_port(port)
     return ret
 
+def remote_port_tcp(port):
+    '''
+    Return a set of ip addrs the current host is connected to on given port
+    '''
+    ret = set()
+    if os.path.isfile('/proc/net/tcp'):
+        with open('/proc/net/tcp', 'rb') as fp_:
+            for line in fp_:
+                if line.strip().startswith('sl'):
+                    continue
+                iret = _parse_tcp_line(line)
+                sl = iter(iret).next()
+                if iret[sl]['remote_port'] == port:
+                    ret.add(iret[sl]['remote_addr'])
+        return ret
+    else:  # Fallback to use 'lsof' if /proc not available
+        ret = remotes_on_remote_tcp_port(port)
+    return ret
+
 
 def _parse_tcp_line(line):
     '''
@@ -930,6 +949,51 @@ def remotes_on_local_tcp_port(port):
         remotes.add(rhost)
 
     return remotes
+
+def remotes_on_remote_tcp_port(port):
+    '''
+    Returns set of ipv4 host addresses which the current host is connected
+    to on given port
+
+    Parses output of shell 'lsof' to get connections
+
+    $ sudo lsof -i4TCP:4505 -n
+    COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
+    Python   9971 root   35u  IPv4 0x18a8464a29ca329d      0t0  TCP *:4505 (LISTEN)
+    Python   9971 root   37u  IPv4 0x18a8464a29b2b29d      0t0  TCP 127.0.0.1:4505->127.0.0.1:55703 (ESTABLISHED)
+    Python  10152 root   22u  IPv4 0x18a8464a29c8cab5      0t0  TCP 127.0.0.1:55703->127.0.0.1:4505 (ESTABLISHED)
+
+    '''
+    port = int(port)
+    remotes = set()
+
+    try:
+        data = subprocess.check_output(['lsof', '-i4TCP:{0:d}'.format(port), '-n'])
+    except subprocess.CalledProcessError as ex:
+        log.error('Failed "lsof" with returncode = {0}'.format(ex.returncode))
+        raise
+
+    lines = data.split('\n')
+    for line in lines:
+        chunks = line.split()
+        if not chunks:
+            continue
+        # ['Python', '9971', 'root', '37u', 'IPv4', '0x18a8464a29b2b29d', '0t0',
+        # 'TCP', '127.0.0.1:4505->127.0.0.1:55703', '(ESTABLISHED)']
+        #print chunks
+        if 'COMMAND' in chunks[0]:
+            continue  # ignore header
+        if 'ESTABLISHED' not in chunks[-1]:
+            continue  # ignore if not ESTABLISHED
+        # '127.0.0.1:4505->127.0.0.1:55703'
+        local, remote = chunks[8].split('->')
+        rhost, rport = remote.split(':')
+        if int(rport) != port:  # ignore if local port not port
+            continue
+        rhost, rport = remote.split(':')
+        remotes.add(rhost)
+
+    return remotes 
 
 
 class IPv4Address(object):


### PR DESCRIPTION
Enables the minion to detect if the connection to the master is still alive. If the connection is down, an event is fired which is caught in the minion main loop. It has to be explicitly enabled in the minions config.

Handling the __master_disconnect event is only POC for now. I'm not sure yet how to make it as flexible as possible to enable everyone to configure it to their needs later. Its primary goal is to make the minion able to work with multiple master and have the minion jump to the next master if the current master dies.
