### PR TITLE
Add refresh_db flag to pkgrepo.managed

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1415,7 +1415,8 @@ def mod_repo(repo, saltenv='base', **kwargs):
             setattr(mod_source, key, kwargs[key])
     sources.save()
     # on changes, explicitly refresh
-    refresh_db()
+    if kwargs.get('refresh_db', True):
+        refresh_db()
     return {
         repo: {
             'architectures': getattr(mod_source, 'architectures', []),

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1218,7 +1218,8 @@ def mod_repo(repo, saltenv='base', **kwargs):
                         cmd = 'apt-add-repository -y {0}'.format(repo)
                     out = __salt__['cmd.run_stdout'](cmd, **kwargs)
                     # explicit refresh when a repo is modified.
-                    refresh_db()
+                    if kwargs.get('refresh_db', True):
+                        refresh_db()
                     return {repo: out}
             else:
                 if not ppa_format_support:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -184,10 +184,15 @@ def managed(name, **kwargs):
        file.  The consolidate will run every time the state is processed. The
        option only needs to be set on one repo managed by salt to take effect.
 
+    refresh_db
+       If set to false, this will skip calling aptpkg.refresh_db on Debian
+       based systems.
+
+
     require_in
-        Set this to a list of pkg.installed or pkg.latest to trigger the
-        running of apt-get update prior to attempting to install these
-        packages. Setting a require in the pkg will not work for this.
+       Set this to a list of pkg.installed or pkg.latest to trigger the
+       running of apt-get update prior to attempting to install these
+       packages. Setting a require in the pkg will not work for this.
     '''
     ret = {'name': name,
            'changes': {},
@@ -279,7 +284,8 @@ def managed(name, **kwargs):
     else:
         # Repo was modified, refresh the pkg db if on an apt-based OS. Other
         # package managers do this sort of thing automatically.
-        if __grains__['os_family'] == 'Debian':
+        if (kwargs.get('refresh_db', False) and
+             __grains__['os_family'] == 'Debian'):
             __salt__['pkg.refresh_db']()
 
     try:

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -185,9 +185,8 @@ def managed(name, **kwargs):
        option only needs to be set on one repo managed by salt to take effect.
 
     refresh_db
-       If set to false, this will skip calling aptpkg.refresh_db on Debian
-       based systems.
-
+       If set to false this will skip refreshing the apt package database on
+       debian based systems.
 
     require_in
        Set this to a list of pkg.installed or pkg.latest to trigger the
@@ -281,12 +280,6 @@ def managed(name, **kwargs):
         ret['comment'] = \
             'Failed to configure repo {0!r}: {1}'.format(name, exc)
         return ret
-    else:
-        # Repo was modified, refresh the pkg db if on an apt-based OS. Other
-        # package managers do this sort of thing automatically.
-        if (kwargs.get('refresh_db', False) and
-             __grains__['os_family'] == 'Debian'):
-            __salt__['pkg.refresh_db']()
 
     try:
         repodict = __salt__['pkg.get_repo'](


### PR DESCRIPTION
Though it's nice for the pkgrepo.managed to run apt-get update when
it adds a ppa, adding multiple ppa will cause it to be run multiple
times, which is slow. The refresh_db allows users to disable automatic
updates of the apt database, so that they can do so based on a wait
condition.
