### PR TITLE
don't always overwrite the error_msg

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1335,11 +1335,9 @@ def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
 
 
 def _exec_ssh_cmd(cmd,
-                  error_msg='Failed to execute command {0!r}: {1}\n{2}',
+                  error_msg='A wrong password has been issued while establishing ssh session'
                   **kwargs):
     password_retries = kwargs.get('password_retries', 3)
-    error_msg = (
-        'A wrong password has been issued while establishing ssh session')
     try:
         stdout, stderr = None, None
         proc = vt.Terminal(

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1335,7 +1335,7 @@ def fire_event(key, msg, tag, args=None, sock_dir=None, transport='zeromq'):
 
 
 def _exec_ssh_cmd(cmd,
-                  error_msg='A wrong password has been issued while establishing ssh session'
+                  error_msg='A wrong password has been issued while establishing ssh session',
                   **kwargs):
     password_retries = kwargs.get('password_retries', 3)
     try:


### PR DESCRIPTION
error_msg='Failed to upload file {0!r}: {1}\n{2}', is in scp_file
