### PR TITLE
2014.1

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -683,7 +683,7 @@ def _get_template_texts(source_list=None,
             source,
             '',
             template=template,
-            env=__env__,
+            saltenv=__env__,
             context=tmpctx,
             **kwargs
         )

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -433,6 +433,7 @@ fi
         }
         result = {}
         ret = self.run_function('state.sls', mods='requisites.mixed_simple')
+        self.assertReturnNonEmptySaltType(ret)
         for item, descr in ret.iteritems():
             result[item] = {
                 '__run_num__': descr['__run_num__'],
@@ -533,6 +534,7 @@ fi
         }
         result = {}
         ret = self.run_function('state.sls', mods='requisites.require')
+        self.assertReturnNonEmptySaltType(ret)
         for item, descr in ret.iteritems():
             result[item] = {
                 '__run_num__': descr['__run_num__'],
@@ -592,6 +594,7 @@ fi
         }
         result = {}
         ret = self.run_function('state.sls', mods='requisites.fullsls_require')
+        self.assertReturnNonEmptySaltType(ret)
         for item, descr in ret.iteritems():
             result[item] = {
                 '__run_num__': descr['__run_num__'],
@@ -683,6 +686,7 @@ fi
         }
         result = {}
         ret = self.run_function('state.sls', mods='requisites.prereq_simple')
+        self.assertReturnNonEmptySaltType(ret)
         for item, descr in ret.iteritems():
             result[item] = {
                 '__run_num__': descr['__run_num__'],
@@ -709,6 +713,7 @@ fi
 
         result = {}
         ret = self.run_function('state.sls', mods='requisites.prereq_simple2')
+        self.assertReturnNonEmptySaltType(ret)
         for item, descr in ret.iteritems():
             result[item] = {
                 '__run_num__': descr['__run_num__'],
@@ -725,6 +730,7 @@ fi
         #)
 
         ret = self.run_function('state.sls', mods='requisites.prereq_compile_error1')
+        self.assertReturnNonEmptySaltType(ret)
         self.assertEqual(
             ret['cmd_|-B_|-echo B_|-run']['comment'],
             'The following requisites were not found:\n'
@@ -733,6 +739,7 @@ fi
         )
 
         ret = self.run_function('state.sls', mods='requisites.prereq_compile_error2')
+        self.assertReturnNonEmptySaltType(ret)
         self.assertEqual(
             ret['cmd_|-B_|-echo B_|-run']['comment'],
             'The following requisites were not found:\n'
@@ -767,6 +774,7 @@ fi
         '''
         # TODO issue #8235 & #8774 some examples are still commented in the test file
         ret = self.run_function('state.sls', mods='requisites.use')
+        self.assertReturnNonEmptySaltType(ret)
         for item, descr in ret.iteritems():
             self.assertEqual(descr['comment'], 'onlyif execution failed')
 


### PR DESCRIPTION
- Assert proper return types from state calls
- Stop passing `env`. Use `saltenv`.
