### PR TITLE
If interface type is slave, not auto set hwaddr

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -582,9 +582,11 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
             else:
                 _raise_error_iface(iface, opts['addr'], ['AA:BB:CC:DD:EE:FF'])
         else:
-            ifaces = __salt__['network.interfaces']()
-            if iface in ifaces and 'hwaddr' in ifaces[iface]:
-                result['addr'] = ifaces[iface]['hwaddr']
+            # If interface type is slave for bond, not setting hwaddr
+            if iface_type != 'slave':
+                ifaces = __salt__['network.interfaces']()
+                if iface in ifaces and 'hwaddr' in ifaces[iface]:
+                    result['addr'] = ifaces[iface]['hwaddr']
 
     if iface_type == 'bridge':
         result['devtype'] = 'Bridge'


### PR DESCRIPTION
If auto set hwaddr for bond, it will use the true hwaddr for the first time. It's correct.
But interfaces will display same hwaddr in a bond by use 'ifconfig' or 'ip link show' when bond running,
Then they will reset to same hwaddr when execute state again, os will prompt like:

```
Bringing up interface bond0:  Device eth2 has different MAC address than expected, ignoring.
                                                       [  OK  ]
```

eth2 interface in this example will eliminate from bond0. It's incorrect.
