### PR TITLE
Fix issue in aptpkg and yumpkg modules related to holding/unholding packages

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -640,7 +640,7 @@ def hold(name=None, pkgs=None, sources=None, *kwargs):
             ret[target]['comment'] = ('Package {0} not currently held.'
                                       .format(target))
         elif not salt.utils.is_true(state.get('hold', False)):
-            if 'test' in kwargs and kwargs['test']:
+            if 'test' in __opts__ and __opts__['test']:
                 ret[target].update(result=None)
                 ret[target]['comment'] = ('Package {0} is set to be held.'
                                           .format(target))
@@ -714,7 +714,7 @@ def unhold(name=None, pkgs=None, sources=None, **kwargs):
             ret[target]['comment'] = ('Package {0} does not have a state.'
                                       .format(target))
         elif salt.utils.is_true(state.get('hold', False)):
-            if 'test' in kwargs and kwargs['test']:
+            if 'test' in __opts__ and __opts__['test']:
                 ret[target].update(result=None)
                 ret['comment'] = ('Package {0} is set not to be held.'
                                   .format(target))

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1063,11 +1063,22 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
 
     targets = []
     if pkgs:
+        for pkg in pkgs:
+            ret = check_db(pkg)
+            if not ret[pkg]['found']:
+                raise SaltInvocationError(
+                    'Package {0} not available in repository.'.format(name)
+                )
         targets.extend(pkgs)
     elif sources:
         for source in sources:
             targets.append(next(iter(source)))
     else:
+        ret = check_db(name)
+        if not ret[name]['found']:
+            raise SaltInvocationError(
+                'Package {0} not available in repository.'.format(name)
+            )
         targets.append(name)
 
     current_locks = get_locked_packages(full=False)


### PR DESCRIPTION
Fixing issues where packages were being put on hold even when test=True.  Fixing issues related to listing and putting packages on hold using yumpkg, certain assumptions about the results of yum-versionlock were made which were false.
Adding some checks to ensure a package exists in the available repositories if not passed with a source URL, before allowing to be put on hold.
