### PR TITLE
Don't report incorrect line from jinja exception

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -283,14 +283,12 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
                               tmplstr)
     except jinja2.exceptions.UndefinedError as exc:
         trace = traceback.extract_tb(sys.exc_info()[2])
-        line, out = _get_jinja_error(trace, context=unicode_context)
-        if not line:
-            tmplstr = ''
+        out = _get_jinja_error(trace, context=unicode_context)[1]
+        tmplstr = ''
         raise SaltRenderError(
             'Jinja variable {0}{1}'.format(
                 exc, out),
-            line,
-            tmplstr)
+            buf=tmplstr)
     except (SaltInvocationError, CommandExecutionError) as exc:
         trace = traceback.extract_tb(sys.exc_info()[2])
         line, out = _get_jinja_error(trace, context=unicode_context)


### PR DESCRIPTION
Jinja reports the wrong line for UndefinedError exceptions, which
results in a misleading comment in the state result. This commit removes
the line number and context string from the comment, leaving just the
error message telling the user which variable is undefined.

Resolves #13408.
