### PR TITLE
Fix jinja unit tests

### DIFF
--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -11,7 +11,7 @@ import fnmatch
 
 # Import salt libs
 import salt.utils
-from salt.utils.network import remote_port_tcp
+from salt.utils.network import remote_port_tcp as _remote_port_tcp
 import salt.utils.event
 import salt.config
 
@@ -547,12 +547,20 @@ def version():
 
 def master():
     '''
-    Fire an event if the minion gets disconnected from its master
-    This function is meant to be run via a scheduled job from the minion
+    .. versionadded:: Helium
+
+    Fire an event if the minion gets disconnected from its master. This
+    function is meant to be run via a scheduled job from the minion
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' status.master
     '''
     ip = __salt__['config.option']('master')
     port = int(__salt__['config.option']('publish_port'))
-    ips = remote_port_tcp(port)
+    ips = _remote_port_tcp(port)
 
     if ip not in ips:
         event = salt.utils.event.get_event('minion', opts=__opts__, listen=False)

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -285,6 +285,8 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
         trace = traceback.extract_tb(sys.exc_info()[2])
         out = _get_jinja_error(trace, context=unicode_context)[1]
         tmplstr = ''
+        # Don't include the line number, since it is misreported
+        # https://github.com/mitsuhiko/jinja2/issues/276
         raise SaltRenderError(
             'Jinja variable {0}{1}'.format(
                 exc, out),

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -373,7 +373,7 @@ class TestGetTemplate(TestCase):
 
     def test_render_with_undefined_variable(self):
         template = "hello\n\n{{ foo }}\n\nfoo"
-        expected = r'Jinja variable \'foo\' is undefined;.*\n\n---\nhello\n\n{{ foo }}.*'
+        expected = r'Jinja variable \'foo\' is undefined'
         self.assertRaisesRegexp(
             SaltRenderError,
             expected,
@@ -384,7 +384,7 @@ class TestGetTemplate(TestCase):
 
     def test_render_with_undefined_variable_utf8(self):
         template = "hello\xed\x95\x9c\n\n{{ foo }}\n\nfoo"
-        expected = r'Jinja variable \'foo\' is undefined;.*\n\n---\nhello\xed\x95\x9c\n\n{{ foo }}.*'
+        expected = r'Jinja variable \'foo\' is undefined'
         self.assertRaisesRegexp(
             SaltRenderError,
             expected,
@@ -395,7 +395,7 @@ class TestGetTemplate(TestCase):
 
     def test_render_with_undefined_variable_unicode(self):
         template = u"hello\ud55c\n\n{{ foo }}\n\nfoo"
-        expected = r'Jinja variable \'foo\' is undefined;.*\n\n---\nhello\xed\x95\x9c\n\n{{ foo }}.*'
+        expected = r'Jinja variable \'foo\' is undefined'
         self.assertRaisesRegexp(
             SaltRenderError,
             expected,


### PR DESCRIPTION
Also fix another failing test caused by missing docstrings (see [here](http://jenkins.saltstack.com/job/salt-pr-rs-ubuntu12.04/4229/testReport/junit/integration.modules.sysmod/SysModuleTest/test_valid_docs/).
