### PR TITLE
Added mount.active functionality for Solaris.

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -103,6 +103,18 @@ def _active_mounts_freebsd(ret):
     return ret
 
 
+def _active_mounts_solaris(ret):
+    '''
+    List active mounts on Solaris systems
+    '''
+    for line in __salt__['cmd.run_stdout']('mount -v').split('\n'):
+        comps = re.sub(r"\s+", " ", line).split()
+        ret[comps[2]] = {'device': comps[0],
+                         'fstype': comps[4],
+                         'opts': comps[5].split(',')}
+    return ret
+
+
 def active():
     '''
     List the active mounts.
@@ -116,6 +128,8 @@ def active():
     ret = {}
     if __grains__['os'] == 'FreeBSD':
         _active_mounts_freebsd(ret)
+    elif __grains__['os'] == 'Solaris':
+        _active_mounts_solaris(ret)
     else:
         try:
             _active_mountinfo(ret)


### PR DESCRIPTION
Without this change, 2014.1.3 on Solaris 10 reports

```
$ sudo salt 'sandbox-solaris*' mount.active
sandbox-solaris.example.com:
    The minion function caused an exception: Traceback (most recent call last):
      File "/opt/csw/lib/python2.6/site-packages/salt/minion.py", line 793, in _thread_return
        return_data = func(*args, **kwargs)
      File "/opt/csw/lib/python2.6/site-packages/salt/modules/mount.py", line 94, in active
        _active_mountinfo(ret)
      File "/opt/csw/lib/python2.6/site-packages/salt/modules/mount.py", line 30, in _active_mountinfo
        _list = _list_mounts()
      File "/opt/csw/lib/python2.6/site-packages/salt/modules/mount.py", line 25, in _list_mounts
        ret[comps[2]] = comps[0]
    IndexError: list index out of range
```
