### PR TITLE
Don't sleep if we don't need to

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1447,7 +1447,10 @@ class Minion(MinionBase):
 
         # On first startup execute a state run if configured to do so
         self._state_run()
-        time.sleep(.5)
+        if self.opts['startup_states']:
+            startup_sleep_length = 0.5
+            log.debug('Sleeping for {0}s before running startup states'.format(startup_sleep_length))
+            time.sleep(startup_sleep_length)
 
         loop_interval = int(self.opts['loop_interval'])
 


### PR DESCRIPTION
According to #5670, we added a sleep to let a startup_state run cleanly. This
only needs to happen if we have a startup state, otherwise let's keep our foot
on the gas.
