### PR TITLE
Fix support for allow-hotplug statement in debian_ip network module

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -907,6 +907,9 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     if enabled:
         adapters[iface]['enabled'] = True
 
+    if opts.get('hotplug', False):
+        adapters[iface]['hotplug'] = True
+
     adapters[iface]['data']['inet']['inet_type'] = 'inet'
 
     if iface_type not in ['bridge']:


### PR DESCRIPTION
When an existing interface was configured with `allow-hotplug` or when setting
`hotplug: True` in network.managed state, this was not taken into account and
the `allow-hotplug` setting would be removed from /etc/network/interfaces.

This patch fixes this issue.
