### PR TITLE
Linux ACL: default mask and default other

### DIFF
--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -95,7 +95,12 @@ def getfacl(*args):
             for entity in ('other', 'mask'):
                 if entity in vals.keys():
                     del vals[entity]
-                    ret[dentry][entity] = vals
+                    if acl_type == 'acl':
+                        ret[dentry][entity] = vals
+                    elif acl_type == 'default':
+                        if 'defaults' not in ret[dentry].keys():
+                            ret[dentry]['defaults'] = {}
+                        ret[dentry]['defaults'][entity] = vals
     return ret
 
 


### PR DESCRIPTION
If an ACL has default values for `other` and `mask` these values will overwrite the non-default `other` and `mask` values.

E.g.:

```
# file: t
# owner: root
# group: root
user::rwx
user:www-data:rwx       #effective:---
group::r-x          #effective:---
mask::---
other::---
default:user::rwx
default:user:www-data:rwx
default:group::r-x
default:mask::rwx
default:other::---
```

Here the default `mask`/`other` values would overwrite the `mask`/`other` value.

This commit fixes that.
