### PR TITLE
remove any trailing comments in hosts file lines, fixing issue with GCE

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -38,6 +38,8 @@ def _list_hosts():
                 continue
             if line.startswith('#'):
                 continue
+            if '#' in line:
+                line = line[:line.index('#')].strip()
             comps = line.split()
             ip = comps.pop(0)
             ret.setdefault(ip, []).extend(comps)


### PR DESCRIPTION
When using the hosts module for Google Compute Engine it is not possible to modify the nodes own entry, because Google adds a trainling comment. Example below

[snip]
10.240.178.205 gc-attivio-ie01.c.foo-matching-prod.internal gc-attivio-ie01  # Added by Google
[snap]

Adding a second name to this line ends up with the name appended after the comment and rendering the entry useless. This patch should fix the issue.
