### PR TITLE
Remove references to pylint E8712

### DIFF
--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -178,8 +178,7 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
         'comment': comment
     }
 
-    # E8712 is disabled because this code is a LOT cleaner if we allow it.
-    if changes == "Random":
+    if changes == 'Random':
         if random.choice([True, False]):
             # Following the docs as written here
             # http://docs.saltstack.com/ref/states/writing.html#return-data
@@ -189,7 +188,7 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
                     'new': 'Something pretended to change'
                 }
             }
-    elif changes == True:  # pylint: disable=E8712
+    elif changes is True:
         # If changes is True we place our dummy change dictionary into it.
         # Following the docs as written here
         # http://docs.saltstack.com/ref/states/writing.html#return-data
@@ -199,7 +198,7 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
                 'new': 'Something pretended to change'
             }
         }
-    elif changes == False:  # pylint: disable=E8712
+    elif changes is False:
         ret['changes'] = {}
     else:
         err = ('You have specified the state option \'Changes\' with'
@@ -210,9 +209,9 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
     if result == 'Random':
         # since result is a boolean, if its random we just set it here,
         ret['result'] = random.choice([True, False])
-    elif result == True:  # pylint: disable=E8712
+    elif result is True:
         ret['result'] = True
-    elif result == False:  # pylint: disable=E8712
+    elif result is False:
         ret['result'] = False
     else:
         raise SaltInvocationError('You have specified the state option '


### PR DESCRIPTION
E8712 is not a thing, at least not according to pylint's docs:

http://docs.pylint.org/search.html?q=E8712

Also, a couple other fixes:
1. Double quotes to single quotes to follow style conventions
2. "is Bool", not "== Bool".
