### PR TITLE
[RFC] Allow names to override chunk variables.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -477,9 +477,14 @@ class Compiler(object):
                                 chunk.update(arg)
                 if names:
                     name_order = 1
-                    for low_name in names:
+                    for entry in names:
                         live = copy.deepcopy(chunk)
-                        live['name'] = low_name
+                        if isinstance(entry, dict):
+                            low_name = entry.keys()[0]
+                            live['name'] = low_name
+                            live.update(entry[low_name])
+                        else:
+                            live['name'] = entry 
                         live['name_order'] = name_order
                         name_order = name_order + 1
                         for fun in funcs:
@@ -1059,9 +1064,14 @@ class State(object):
                                 chunk[key] = val
                 if names:
                     name_order = 1
-                    for low_name in names:
+                    for entry in names:
                         live = copy.deepcopy(chunk)
-                        live['name'] = low_name
+                        if isinstance(entry, dict):
+                            low_name = entry.keys()[0]
+                            live['name'] = low_name
+                            live.update(entry[low_name])
+                        else:
+                            live['name'] = entry 
                         live['name_order'] = name_order
                         name_order = name_order + 1
                         for fun in funcs:

--- a/salt/state.py
+++ b/salt/state.py
@@ -73,6 +73,13 @@ STATE_INTERNAL_KEYWORDS = frozenset([
 ])
 
 
+def _odict_hashable(self):
+    return id(self)
+
+
+OrderedDict.__hash__ = _odict_hashable
+
+
 def split_low_tag(tag):
     '''
     Take a low tag and split it back into the low dict that it came from
@@ -482,9 +489,9 @@ class Compiler(object):
                         if isinstance(entry, dict):
                             low_name = entry.keys()[0]
                             live['name'] = low_name
-                            live.update(entry[low_name])
+                            live.update(entry[low_name][0])
                         else:
-                            live['name'] = entry 
+                            live['name'] = entry
                         live['name_order'] = name_order
                         name_order = name_order + 1
                         for fun in funcs:
@@ -1069,9 +1076,9 @@ class State(object):
                         if isinstance(entry, dict):
                             low_name = entry.keys()[0]
                             live['name'] = low_name
-                            live.update(entry[low_name])
+                            live.update(entry[low_name][0])
                         else:
-                            live['name'] = entry 
+                            live['name'] = entry
                         live['name_order'] = name_order
                         name_order = name_order + 1
                         for fun in funcs:


### PR DESCRIPTION
This feels gross and I haven't thought of a better way of doing this
besides adding **hash** to OrderedDict (if it is decided that is the
best way, then probably needs to be moved into it's own class) but I
would be interested in other peoples opinions on how to achieve these
results?

```
ius:
  pkgrepo.managed:
    - humanname: IUS Community Packages for Enterprise Linux 6 - $basearch
    - gpgcheck: 1
    - baseurl: http://mirror.rackspace.com/ius/stable/CentOS/6/$basearch
    - gpgkey: http://dl.iuscommunity.org/pub/ius/IUS-COMMUNITY-GPG-KEY
    - names:
        - ius
        - ius-devel:
            - baseurl: http://mirror.rackspace.com/ius/development/CentOS/6/$basearch
```

Thanks
Daniel
