### PR TITLE
Normalized where RAET keep files are stored. So use consistent path

### DIFF
--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -52,10 +52,12 @@ class LocalClient(salt.client.LocalClient):
                 timeout=timeout,
                 **kwargs)
         yid = salt.utils.gen_jid()
+        basedirpath = os.path.join(self.opts['cachedir'],  'raet')
         stack = LaneStack(
                 name=('client' + yid),
                 yid=yid,
                 lanename='master',
+                basedirpath=basedirpath,
                 sockdirpath=self.opts['sock_dir'])
         stack.Pk = raeting.packKinds.pack
         router_yard = RemoteYard(

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -111,7 +111,7 @@ class SaltRaetRoadStack(ioflo.base.deeding.Deed):
                 localname=localname,
                 auto=auto,
                 main=main,
-                dirpath=dirpath,
+                basedirpath=dirpath,
                 safe=safe,
                 txMsgs=txMsgs,
                 rxMsgs=rxMsgs)
@@ -720,13 +720,13 @@ class NixExecutor(ioflo.base.deeding.Deed):
         Send the return data back via the uxd socket
         '''
         stackname = self.opts['id'] + ret['jid']
-        dirpath = os.path.join(self.opts['cachedir'], stackname)
+        dirpath = os.path.join(self.opts['cachedir'], 'raet')
         ret_stack = LaneStack(
                 name=stackname,
                 lanename=self.opts['id'],
                 yid=ret['jid'],
                 sockdirpath=self.opts['sock_dir'],
-                dirpath=dirpath)
+                basedirpath=dirpath)
 
         ret_stack.Pk = raeting.packKinds.pack
         main_yard = RemoteYard(

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -57,12 +57,12 @@ class RAETChannel(Channel):
         '''
         yid = salt.utils.gen_jid()
         stackname = self.opts['id'] + yid
-        dirpath = os.path.join(self.opts['cachedir'], stackname)
+        dirpath = os.path.join(self.opts['cachedir'], 'raet')
         self.stack = LaneStack(
                 name=stackname,
                 lanename=self.opts['id'],
                 yid=yid,
-                dirpath=dirpath,
+                basedirpath=dirpath,
                 sockdirpath=self.opts['sock_dir'])
         self.stack.Pk = raeting.packKinds.pack
         self.router_yard = yarding.RemoteYard(


### PR DESCRIPTION
This merge is behind develop since current develop is broken so I did not include latest develop fetch in this commit.

With this commit the keep caches for Master and Minion are as follows below;

Everything is now in the same place and uses the opts['cachedir'] as the prefix for the path

cachedir/raet/stackname

where the default cachedir is
/var/cache/salt/master 
or
/var/cache/salt/minion

Keep Caches

salt master:

/var/cache/salt/master/raet/
    master/
        local/
          estate.json
          yard.json
        remote/
          estate2.json

```
eventstackname/
    local/
        yard.json
    remote/

masterworkerstackname/
    local/
        yard.json
    remote/

clientstackname/
    local/
        yard.json
    remote/
```

salt minion: (where minion id is alpha)

/var/cache/salt/minion/raet/
    alpha/
        local/
            estate.json
            yard.json
        remote/
            estate1.json

```
alphajobstackname/
    local/
        yard.json
    remote/
```
