### PR TITLE
Make scripts hardcrashable

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -21,6 +21,17 @@ except ImportError:
     HAS_SALTCLOUD = False
 
 
+def _handle_interrupt(exc, original_exc, hardfail=False):
+    '''
+    if hardfalling raise the original exception
+    else just let salt exit gracefully
+    '''
+    if hardfail:
+        raise original_exc
+    else:
+        raise exc
+
+
 def salt_master():
     '''
     Start the salt-master.
@@ -65,11 +76,19 @@ def salt_key():
     '''
     Manage the authentication keys with salt-key.
     '''
+    client = None
     try:
-        saltkey = salt.cli.SaltKey()
-        saltkey.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+        client = salt.cli.SaltKey()
+        client.run()
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)
 
 
 def salt_cp():
@@ -77,11 +96,19 @@ def salt_cp():
     Publish commands to the salt system from the command line on the
     master.
     '''
+    client = None
     try:
-        cp_ = salt.cli.SaltCP()
-        cp_.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+        client = salt.cli.SaltCP()
+        client.run()
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)
 
 
 def salt_call():
@@ -91,11 +118,19 @@ def salt_call():
     '''
     if '' in sys.path:
         sys.path.remove('')
+    client = None
     try:
         client = salt.cli.SaltCall()
         client.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)
 
 
 def salt_run():
@@ -104,11 +139,19 @@ def salt_run():
     '''
     if '' in sys.path:
         sys.path.remove('')
+    client = None
     try:
         client = salt.cli.SaltRun()
         client.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)
 
 
 def salt_ssh():
@@ -117,13 +160,28 @@ def salt_ssh():
     '''
     if '' in sys.path:
         sys.path.remove('')
+    client = None
     try:
         client = salt.cli.SaltSSH()
         client.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)
     except salt.exceptions.SaltClientError as err:
-        raise SystemExit(err)
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit(err),
+            err,
+            hardcrash)
 
 
 def salt_cloud():
@@ -137,11 +195,19 @@ def salt_cloud():
         print('salt-cloud is not available in this system')
         sys.exit(os.EX_UNAVAILABLE)
 
+    client = None
     try:
-        cloud = salt.cloud.cli.SaltCloud()
-        cloud.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+        client = salt.cloud.cli.SaltCloud()
+        client.run()
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)
 
 
 def salt_main():
@@ -151,8 +217,16 @@ def salt_main():
     '''
     if '' in sys.path:
         sys.path.remove('')
+    client = None
     try:
         client = salt.cli.SaltCMD()
         client.run()
-    except KeyboardInterrupt:
-        raise SystemExit('\nExiting gracefully on Ctrl-c')
+    except KeyboardInterrupt, err:
+        try:
+            hardcrash = client.options.hard_crash
+        except (AttributeError, KeyError):
+            hardcrash = False
+        _handle_interrupt(
+            SystemExit('\nExiting gracefully on Ctrl-c'),
+            err,
+            hardcrash)

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -8,6 +8,8 @@ from __future__ import print_function
 import os
 import sys
 import time
+import traceback
+import logging
 
 # Import salt libs
 import salt
@@ -21,12 +23,22 @@ except ImportError:
     HAS_SALTCLOUD = False
 
 
-def _handle_interrupt(exc, original_exc, hardfail=False):
+log = logging.getLogger(__name__)
+
+
+def _handle_interrupt(exc, original_exc, hardfail=False, trace=''):
     '''
-    if hardfalling raise the original exception
+    if hardfalling:
+        If we got the original stacktrace, log it
+        If all cases, raise the original exception
+        but this is logically part the initial
+        stack.
     else just let salt exit gracefully
+
     '''
     if hardfail:
+        if trace:
+            log.error(trace)
         raise original_exc
     else:
         raise exc
@@ -81,6 +93,7 @@ def salt_key():
         client = salt.cli.SaltKey()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -88,7 +101,7 @@ def salt_key():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
 
 
 def salt_cp():
@@ -101,6 +114,7 @@ def salt_cp():
         client = salt.cli.SaltCP()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -108,7 +122,7 @@ def salt_cp():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
 
 
 def salt_call():
@@ -123,6 +137,7 @@ def salt_call():
         client = salt.cli.SaltCall()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -130,7 +145,7 @@ def salt_call():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
 
 
 def salt_run():
@@ -144,6 +159,7 @@ def salt_run():
         client = salt.cli.SaltRun()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -151,7 +167,7 @@ def salt_run():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
 
 
 def salt_ssh():
@@ -165,6 +181,7 @@ def salt_ssh():
         client = salt.cli.SaltSSH()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -172,8 +189,9 @@ def salt_ssh():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
     except salt.exceptions.SaltClientError as err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -181,7 +199,7 @@ def salt_ssh():
         _handle_interrupt(
             SystemExit(err),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
 
 
 def salt_cloud():
@@ -200,6 +218,7 @@ def salt_cloud():
         client = salt.cloud.cli.SaltCloud()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -207,7 +226,7 @@ def salt_cloud():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)
 
 
 def salt_main():
@@ -222,6 +241,7 @@ def salt_main():
         client = salt.cli.SaltCMD()
         client.run()
     except KeyboardInterrupt, err:
+        trace = traceback.format_exc()
         try:
             hardcrash = client.options.hard_crash
         except (AttributeError, KeyError):
@@ -229,4 +249,4 @@ def salt_main():
         _handle_interrupt(
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
-            hardcrash)
+            hardcrash, trace=trace)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -376,6 +376,20 @@ class SaltfileMixIn(object):
                             cli_config[option.dest])
 
 
+class HardCrashMixin(object):
+    __metaclass__ = MixInMeta
+    _mixin_prio_ = 40
+    _config_filename_ = None
+
+    def _mixin_setup(self):
+        hc = os.environ.get('SALT_HARD_CRASH', False)
+        self.add_option(
+            '--hard-crash', action='store_true', default=hc,
+            help=('Raise any original exception rather than exiting gracefully'
+                  ' Default: %default')
+        )
+
+
 class ConfigDirMixIn(object):
     __metaclass__ = MixInMeta
     _mixin_prio_ = -10
@@ -1518,7 +1532,7 @@ class SyndicOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                           TimeoutMixIn, ExtendedTargetOptionsMixIn,
-                          OutputOptionsMixIn, LogLevelMixIn):
+                          OutputOptionsMixIn, LogLevelMixIn, HardCrashMixin):
 
     __metaclass__ = OptionParserMeta
 
@@ -1724,7 +1738,8 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 
 class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
-                         TimeoutMixIn, TargetOptionsMixIn, LogLevelMixIn):
+                         TimeoutMixIn, TargetOptionsMixIn, LogLevelMixIn,
+                         HardCrashMixin):
     __metaclass__ = OptionParserMeta
 
     description = (
@@ -1766,7 +1781,8 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 
 class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
-                          LogLevelMixIn, OutputOptionsMixIn, RunUserMixin):
+                          LogLevelMixIn, OutputOptionsMixIn, RunUserMixin,
+                          HardCrashMixin):
 
     __metaclass__ = OptionParserMeta
 
@@ -1979,7 +1995,7 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 
 class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
-                           LogLevelMixIn, OutputOptionsMixIn):
+                           LogLevelMixIn, OutputOptionsMixIn, HardCrashMixin):
     __metaclass__ = OptionParserMeta
 
     description = ('Salt call is used to execute module functions locally '
@@ -2110,7 +2126,7 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 
 class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
-                          TimeoutMixIn, LogLevelMixIn):
+                          TimeoutMixIn, LogLevelMixIn, HardCrashMixin):
     __metaclass__ = OptionParserMeta
 
     default_timeout = 1
@@ -2172,7 +2188,7 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
 
 class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                           LogLevelMixIn, TargetOptionsMixIn,
-                          OutputOptionsMixIn, SaltfileMixIn):
+                          OutputOptionsMixIn, SaltfileMixIn, HardCrashMixin):
     __metaclass__ = OptionParserMeta
 
     usage = '%prog [options]'
@@ -2313,7 +2329,8 @@ class SaltCloudParser(OptionParser,
                       CloudQueriesMixIn,
                       ExecutionOptionsMixIn,
                       CloudProvidersListsMixIn,
-                  CloudCredentialsMixIn):
+                      CloudCredentialsMixIn,
+                      HardCrashMixin):
 
     __metaclass__ = OptionParserMeta
 


### PR DESCRIPTION
This add a --hard-crash cli switch to let the scripts hardcrash giving real stacktrace.
This is really helpful when it's time to investigate and debug without having to edit the runners code to let the exception raise up.
