### PR TITLE
Include grains_dirs in loader

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -370,8 +370,7 @@ def grains(opts, force_refresh=False):
             opts['grains'] = {}
     else:
         opts['grains'] = {}
-
-    load = _create_loader(opts, 'grains', 'grain')
+    load = _create_loader(opts, 'grains', 'grain', ext_type_dirs='grains_dirs')
     grains_info = load.gen_grains(force_refresh)
     grains_info.update(opts['grains'])
     return grains_info


### PR DESCRIPTION
It is unclear to me why this was missing to begin with. This does correctly
load grains specified by grains_dirs in a minion config in my testing.

Closes #13436
