### PR TITLE
Do not throw errors for supervisor when success

### DIFF
--- a/salt/states/supervisord.py
+++ b/salt/states/supervisord.py
@@ -27,8 +27,13 @@ def _check_error(result, success_message):
     ret = {}
 
     if 'ERROR' in result:
-        ret['comment'] = result
-        ret['result'] = False
+        if 'already running' in result:
+            ret['comment'] = success_message
+        elif 'not running' in result:
+            ret['comment'] = success_message
+        else:
+            ret['comment'] = result
+            ret['result'] = False
     else:
         ret['comment'] = success_message
 


### PR DESCRIPTION
Sometimes when a new service is added to supervisord it'll automatically start the service and it'll occur before supervisord state detects it, causing a race condition that makes supervisor try to start it, resulting in an error of already running. This change ignores common errors for stop/start.
