### PR TITLE
digital ocean requires an ssh key file

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -281,6 +281,12 @@ def create(vm_):
             )
         )
 
+    if key_filename is None:
+        raise SaltCloudConfigError(
+            'The Digital Ocean driver requires a ssh_key_file because it does not supply a root password '
+            'upon building the server'
+        )
+
     private_networking = config.get_cloud_config_value(
         'private_networking', vm_, __opts__, search_global=False, default=None,
     )


### PR DESCRIPTION
The api does not return a root password via the api, and it also does
not return one when calling for a root password reset.  The password is
only sent via email to the user.

closes #13232
