### PR TITLE
Performance enhancement for Issues/#11877

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -523,8 +523,8 @@ def _virtual(osdata):
         # Provide additional detection for OpenVZ
         if os.path.isfile('/proc/self/status'):
             with salt.utils.fopen('/proc/self/status') as status_file:
+                vz_re = re.compile(r'^envID:\s+(\d+)$')
                 for line in status_file:
-                    vz_re = re.compile(r'^envID:\s+(\d+)$')
                     vz_match = vz_re.match(line.rstrip('\n'))
                     if vz_match and int(vz_match.groups()[0]) != 0:
                         grains['virtual'] = 'openvzve'


### PR DESCRIPTION
There is no need to recompile the pattern for every line in the file. This version behaves identically, but moves the re.compile(pat) call out of the line comparison loop.
