### PR TITLE
Support various versions of python-zmq (fix for #13508)

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -178,8 +178,12 @@ class SREQ(object):
         delete socket if you have it
         '''
         if hasattr(self, '_socket'):
-            if self._socket in self.poller:
-                self.poller.unregister(self._socket)
+            if isinstance(self.poller.sockets, dict):
+                for socket in self.poller.sockets.keys():
+                    self.poller.unregister(socket)
+            else:
+                for socket in self.poller.sockets:
+                    self.poller.unregister(socket[0])
             del self._socket
 
     def send(self, enc, load, tries=1, timeout=60):


### PR DESCRIPTION
Looks like the api for determining if a socket is in a poller varies from python-zmq version to version. In my version (14.0.1) you cah do "socket in poller", it seems that older versions don't support that. So, to be compatible i've stolen the code from destroy()
