### PR TITLE
Adds git config management features to git state module

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -8,7 +8,8 @@ import os
 import subprocess
 
 # Import salt libs
-from salt import utils, exceptions
+from salt import utils
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 
 def __virtual__():
@@ -58,7 +59,7 @@ def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):
                 stderrs.append(result['stderr'])
 
         # we've tried all IDs and still haven't passed, so error out
-        raise exceptions.CommandExecutionError("\n\n".join(stderrs))
+        raise CommandExecutionError("\n\n".join(stderrs))
 
     else:
         result = __salt__['cmd.run_all'](cmd,
@@ -71,7 +72,7 @@ def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):
         if retcode == 0:
             return result['stdout']
         else:
-            raise exceptions.CommandExecutionError(result['stderr'])
+            raise CommandExecutionError(result['stderr'])
 
 
 def _git_getdir(cwd, user=None):
@@ -688,7 +689,7 @@ def remote_get(cwd, remote='origin', user=None):
             return res
         else:
             return None
-    except exceptions.CommandExecutionError:
+    except CommandExecutionError:
         return None
 
 
@@ -799,19 +800,22 @@ def stash(cwd, opts=None, user=None):
     return _git_run('git stash {0}'.format(opts), cwd=cwd, runas=user)
 
 
-def config_set(cwd, setting_name, setting_value, user=None, is_global=False):
+def config_set(setting_name, setting_value, cwd=None, user=None, is_global=False):
     '''
     Set a key in the git configuration file (.git/config) of the repository or
     globally.
-
-    cwd
-        The path to the Git repository
 
     setting_name
         The name of the configuration key to set
 
     setting_value
         The (new) value to set
+
+    cwd : None
+        Options path to the Git repository
+
+        .. versionchanged:: Helium
+            Made ``cwd`` optional
 
     user : None
         Run git as a user other than what the minion runs as
@@ -823,26 +827,34 @@ def config_set(cwd, setting_name, setting_value, user=None, is_global=False):
 
     .. code-block:: bash
 
-        salt '*' git.config_set /path/to/repo user.email me@example.com
+        salt '*' git.config_set user.email me@example.com /path/to/repo
     '''
+    if cwd is None and not is_global:
+        raise SaltInvocationError('Either `is_global` must be set to True or '
+                                  'you must provide `cwd`')
+
     scope = '--local'
     if is_global:
         scope = '--global'
 
     _check_git()
 
-    return _git_run('git config {0} {1} {2}'.format(scope, setting_name, setting_value), cwd=cwd, runas=user)
+    return _git_run('git config {0} {1} {2}'.format(scope, setting_name, setting_value),
+                    cwd=cwd, runas=user)
 
 
-def config_get(cwd, setting_name, user=None):
+def config_get(setting_name, cwd=None, user=None):
     '''
-    Get a key from the git configuration file (.git/config) of the repository.
-
-    cwd
-        The path to the Git repository
+    Get a key or keys from the git configuration file (.git/config).
 
     setting_name
         The name of the configuration key to get
+
+    cwd : None
+        Optional path to a Git repository
+
+        .. versionchanged:: Helium
+            Made ``cwd`` optional
 
     user : None
         Run git as a user other than what the minion runs as
@@ -851,7 +863,8 @@ def config_get(cwd, setting_name, user=None):
 
     .. code-block:: bash
 
-        salt '*' git.config_get /path/to/repo user.email
+        salt '*' git.config_get user.email
+        salt '*' git.config_get user.name cwd=/path/to/repo user=arthur
     '''
     _check_git()
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -426,6 +426,83 @@ def present(name, bare=True, runas=None, user=None, force=False):
     return ret
 
 
+def config(name,
+           value,
+           repo=None,
+           user=None,
+           is_global=False):
+    '''
+    .. versionadded:: Helium
+
+    Manage a git config setting for a user or repository
+
+    name
+        Name of the git config value to set
+
+    value
+        Value to set
+
+    repo : None
+        An optional location of a git repository for local operations
+
+    user : None
+        Optional name of a user as whom `git config` will be run
+
+    is_global : False
+        Whether or not to pass the `--global` option to `git config`
+
+    Local config example:
+
+    .. code-block:: yaml
+
+        mylocalrepo:
+          git.config:
+            - name: user.email
+            - value: fester@bestertester.net
+            - repo: file://my/path/to/repo
+
+    Global config example:
+
+    .. code-block:: yaml
+
+        mylocalrepo:
+          git.config:
+            - name: user.name
+            - value: Esther Bestertester
+            - user: ebestertester
+            - is_global: True
+    '''
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    # get old value
+    oval = __salt__['git.config_get'](setting_name=name, cwd=repo, user=user)
+
+    if value == oval:
+        ret['comment'] = 'No changes made'
+    else:
+        if __opts__['test']:
+            nval = value
+        else:
+            # set new value
+            __salt__['git.config_set'](setting_name=name,
+                                       setting_value=value,
+                                       cwd=repo,
+                                       user=user,
+                                       is_global=is_global)
+
+            # get new value
+            nval = __salt__['git.config_get'](setting_name=name,
+                                              cwd=repo,
+                                              user=user)
+
+        ret['changes'][name] = '{0} => {1}'.format(oval, nval)
+
+    return ret
+
+
 def _fail(ret, comment):
     ret['result'] = False
     ret['comment'] = comment

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -23,6 +23,7 @@ import shutil
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
@@ -478,7 +479,12 @@ def config(name,
            'comment': ''}
 
     # get old value
-    oval = __salt__['git.config_get'](setting_name=name, cwd=repo, user=user)
+    try:
+        oval = __salt__['git.config_get'](setting_name=name,
+                                          cwd=repo,
+                                          user=user)
+    except CommandExecutionError:
+        oval = 'None'
 
     if value == oval:
         ret['comment'] = 'No changes made'


### PR DESCRIPTION
Also applies some fixes to the git exec module that removes an unnecessary requirement to always have a repository, even when operating globally.

Note: I made some changes to the order of parameters in `modules.git.config_set()` and `modules.git.config_get`. I'm not in love with this because some people might have scripts that rely on positional parameters and this would break backwards compat with that but, otherwise, this would fail lint'ing as PEP8 requires that arguments with defaults always appear after arguments without defaults. I can change it either way.
