### PR TITLE
Multi-master start race condition

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -465,8 +465,9 @@ class MultiMinion(MinionBase):
             s_opts['master'] = master
             try:
                 minions.append(Minion(s_opts, 5, False))
-            except SaltClientError:
-                minions.append(s_opts)
+            except SaltClientError as exc:
+                log.error('Error while bring up minion for multi-master. Is master responding?')
+                raise(exc)
         return minions
 
     def minions(self):


### PR DESCRIPTION
Don't explode in most unsual ways if we start a multi-master minion before a
master is ready.

Closes #13546
