### PR TITLE
Cloud provider unit tests

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1526,12 +1526,11 @@ def apply_cloud_providers_config(overrides, defaults=None):
                     details['extends'] = '{0}:{1}'.format(alias, provider)
                     # change provider details '-only-extendable-' to extended provider name
                     details['provider'] = provider
-                elif providers.get(extends) and len(providers[extends]) > 1:
+                elif providers.get(extends):
                     raise salt.cloud.exceptions.SaltCloudConfigError(
                         'The {0!r} cloud provider entry in {1!r} is trying '
-                        'to extend from {2!r} which has multiple entries '
-                        'and no provider is being specified. Not '
-                        'extending!'.format(
+                        'to extend from {2!r} and no provider was specified. '
+                        'Not extending!'.format(
                             details['provider'], provider_alias, extends
                         )
                     )
@@ -1547,7 +1546,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                 else:
                     if driver in providers.get(extends):
                         details['extends'] = '{0}:{1}'.format(extends, driver)
-                    elif providers.get(extends).startswith('-only-extendable-'):
+                    elif '-only-extendable-' in providers.get(extends):
                         details['extends'] = '{0}:{1}'.format(
                             extends, '-only-extendable-{0}'.format(ext_count)
                         )

--- a/salt/config.py
+++ b/salt/config.py
@@ -1524,7 +1524,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                             )
                         )
                     details['extends'] = '{0}:{1}'.format(alias, provider)
-                    # # change provider details '-only-extendable-' to extended provider name
+                    # change provider details '-only-extendable-' to extended provider name
                     details['provider'] = provider
                 elif providers.get(extends) and len(providers[extends]) > 1:
                     raise salt.cloud.exceptions.SaltCloudConfigError(

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -56,6 +56,7 @@ MOCK_ETC_HOSTNAME = '{0}\n'.format(MOCK_HOSTNAME)
 PATH = 'path/to/some/cloud/conf/file'
 DEFAULT = {'default_include': PATH}
 
+
 def _unhandled_mock_read(filename):
     '''
     Raise an error because we should not be calling salt.utils.fopen()

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -30,6 +30,7 @@ import salt.utils.network
 import integration
 from salt import config as sconfig, version as salt_version
 from salt.version import SaltStackVersion
+from salt.cloud.exceptions import SaltCloudConfigError
 
 log = logging.getLogger(__name__)
 
@@ -52,47 +53,8 @@ MOCK_ETC_HOSTS = (
     'ff00::0        ip6-mcastprefix\n'
 )
 MOCK_ETC_HOSTNAME = '{0}\n'.format(MOCK_HOSTNAME)
-
-MOCK_CLOUD_CONFIG = (
-    'my-dev-envs:\n'
-    '  - id: ABCDEFGHIJKLMNOP\n'
-    '    key: supersecretkeysupersecretkey\n'
-    '    keyname: test\n'
-    '    security-group: quick-start\n'
-    '    private_key: /root/test.pem\n'
-    '    location: ap-southeast-1\n'
-    '    provider: ec2\n'
-    '\n'
-    '  - apikey: abcdefghijklmnopqrstuvwxyz\n'
-    '    password: supersecret\n'
-    '    provider: linode\n'
-    '\n'
-    'my-production-envs:\n'
-    '  - extends: my-develop-envs:ec2\n'
-    '    location: us-east-1\n'
-    '    user: my-production-user@mycorp.com'
-)
-
-OVERRIDES = {'my-production-envs':
-                 [{'extends': 'my-dev-envs:ec2',
-                   'location': 'us-east-1',
-                   'user': 'my-production-user@mycorp.com'
-                  }],
-             'my-dev-envs':
-                 [{'private_key': '/root/test.pem',
-                   'security-group': 'quick-start',
-                   'keyname': 'test',
-                   'location': 'ap-southeast-1',
-                   'key': 'supersecretkeysupersecretkey',
-                   'provider': 'ec2',
-                   'id': 'ABCDEFGHIJKLMNOP',
-                   'user': 'user@mycorp.com'},
-                  {'apikey': 'abcdefghijklmnopqrstuvwxyz',
-                   'password': 'supersecret',
-                   'provider': 'linode'
-                  }],
-             'conf_file': MOCK_CLOUD_CONFIG}
-
+PATH = 'path/to/some/cloud/conf/file'
+DEFAULT = {'default_include': PATH}
 
 def _unhandled_mock_read(filename):
     '''
@@ -508,41 +470,196 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                 sconfig.get_id(cache=False), (MOCK_HOSTNAME, False)
             )
 
-    def test_apply_cloud_providers_config(self):
+    def test_apply_cloud_providers_config_same_providers(self):
+        '''
+        Tests when two providers are given with the same provider name
+        '''
+        overrides = {'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'ec2'},
+                          {'apikey': 'abcdefghijklmnopqrstuvwxyz',
+                           'password': 'supersecret',
+                           'provider': 'ec2'}],
+                     'conf_file': PATH}
+        self.assertRaises(SaltCloudConfigError,
+                          sconfig.apply_cloud_providers_config,
+                          overrides,
+                          DEFAULT)
+
+    def test_apply_cloud_providers_config_extend(self):
+        '''
+        Tests the successful extension of a cloud provider
+        '''
+        overrides = {'my-production-envs':
+                         [{'extends': 'my-dev-envs:ec2',
+                           'location': 'us-east-1',
+                           'user': 'ec2-user@mycorp.com'
+                          }],
+                     'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'user': 'user@mycorp.com',
+                           'location': 'ap-southeast-1',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'ec2'
+                          },
+                          {'apikey': 'abcdefghijklmnopqrstuvwxyz',
+                           'password': 'supersecret',
+                           'provider': 'linode'
+                          }],
+                     'conf_file': PATH}
         ret = {'my-production-envs':
                    {'ec2':
-                        {'private_key': '/root/test.pem',
-                         'security-group': 'quick-start',
-                         'profiles': {},
-                         'keyname': 'test',
+                        {'profiles': {},
                          'location': 'us-east-1',
                          'key': 'supersecretkeysupersecretkey',
                          'provider': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
-                         'user': 'my-production-user@mycorp.com'
-                        }
-                   },
+                         'user': 'ec2-user@mycorp.com'}},
                'my-dev-envs':
                    {'linode':
                         {'apikey': 'abcdefghijklmnopqrstuvwxyz',
                          'password': 'supersecret',
                          'profiles': {},
-                         'provider': 'linode'
-                        },
+                         'provider': 'linode'},
                     'ec2':
-                        {'private_key': '/root/test.pem',
-                         'security-group': 'quick-start',
-                         'profiles': {},
-                         'keyname': 'test',
+                        {'profiles': {},
                          'location': 'ap-southeast-1',
                          'key': 'supersecretkeysupersecretkey',
                          'provider': 'ec2',
                          'id': 'ABCDEFGHIJKLMNOP',
-                         'user': 'user@mycorp.com'
-                        }
-                   }}
-        self.assertEqual(ret, sconfig.apply_cloud_providers_config(OVERRIDES))
+                         'user': 'user@mycorp.com'}}}
+        self.assertEqual(ret, sconfig.apply_cloud_providers_config(overrides, defaults=DEFAULT))
 
+    def test_apply_cloud_providers_config_extend_multiple(self):
+        '''
+        Tests the successful extension of two cloud providers
+        '''
+        overrides = {'my-production-envs':
+                         [{'extends': 'my-dev-envs:ec2',
+                           'location': 'us-east-1',
+                           'user': 'ec2-user@mycorp.com'},
+                          {'password': 'new-password',
+                           'extends': 'my-dev-envs:linode',
+                           'location': 'Salt Lake City'
+                          }],
+                     'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'user': 'user@mycorp.com',
+                           'location': 'ap-southeast-1',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'ec2'},
+                          {'apikey': 'abcdefghijklmnopqrstuvwxyz',
+                           'password': 'supersecret',
+                           'provider': 'linode'}],
+                     'conf_file': PATH}
+        ret = {'my-production-envs':
+                   {'linode':
+                        {'apikey': 'abcdefghijklmnopqrstuvwxyz',
+                         'profiles': {},
+                         'location': 'Salt Lake City',
+                         'provider': 'linode',
+                         'password': 'new-password'},
+                    'ec2':
+                        {'user': 'ec2-user@mycorp.com',
+                         'key': 'supersecretkeysupersecretkey',
+                         'provider': 'ec2',
+                         'id': 'ABCDEFGHIJKLMNOP',
+                         'profiles': {},
+                         'location': 'us-east-1'}},
+               'my-dev-envs':
+                   {'linode':
+                        {'apikey': 'abcdefghijklmnopqrstuvwxyz',
+                         'password': 'supersecret',
+                         'profiles': {},
+                         'provider': 'linode'},
+                    'ec2':
+                        {'profiles': {},
+                         'user': 'user@mycorp.com',
+                         'key': 'supersecretkeysupersecretkey',
+                         'provider': 'ec2',
+                         'id': 'ABCDEFGHIJKLMNOP',
+                         'location': 'ap-southeast-1'}}}
+        self.assertEqual(ret, sconfig.apply_cloud_providers_config(
+            overrides,
+            defaults=DEFAULT))
+
+    def test_apply_cloud_providers_config_extends_bad_alias(self):
+        '''
+        Tests when the extension contains an alias not found in providers list
+        '''
+        overrides = {'my-production-envs':
+                         [{'extends': 'test-alias:ec2',
+                           'location': 'us-east-1',
+                           'user': 'ec2-user@mycorp.com'}],
+                     'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'user': 'user@mycorp.com',
+                           'location': 'ap-southeast-1',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'ec2'}],
+                     'conf_file': PATH}
+        self.assertRaises(SaltCloudConfigError,
+                          sconfig.apply_cloud_providers_config,
+                          overrides,
+                          DEFAULT)
+
+    def test_apply_cloud_providers_config_extends_bad_provider(self):
+        '''
+        Tests when the extension contains a provider not found in providers list
+        '''
+        overrides = {'my-production-envs':
+                         [{'extends': 'my-dev-envs:linode',
+                           'location': 'us-east-1',
+                           'user': 'ec2-user@mycorp.com'}],
+                     'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'user': 'user@mycorp.com',
+                           'location': 'ap-southeast-1',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'ec2'}],
+                     'conf_file': PATH}
+        self.assertRaises(SaltCloudConfigError,
+                          sconfig.apply_cloud_providers_config,
+                          overrides,
+                          DEFAULT)
+
+    def test_apply_cloud_providers_config_extends_no_provider(self):
+        overrides = {'my-production-envs':
+                         [{'extends': 'my-dev-envs',
+                           'location': 'us-east-1',
+                           'user': 'ec2-user@mycorp.com'}],
+                     'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'user': 'user@mycorp.com',
+                           'location': 'ap-southeast-1',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'linode'}],
+                     'conf_file': PATH}
+        self.assertRaises(SaltCloudConfigError,
+                          sconfig.apply_cloud_providers_config,
+                          overrides,
+                          DEFAULT)
+
+    def test_apply_cloud_providers_extends_not_in_providers(self):
+        '''
+        Tests when extends is not in the list of providers
+        '''
+        overrides = {'my-production-envs':
+                         [{'extends': 'my-dev-envs ec2',
+                           'location': 'us-east-1',
+                           'user': 'ec2-user@mycorp.com'}],
+                     'my-dev-envs':
+                         [{'id': 'ABCDEFGHIJKLMNOP',
+                           'user': 'user@mycorp.com',
+                           'location': 'ap-southeast-1',
+                           'key': 'supersecretkeysupersecretkey',
+                           'provider': 'linode'}],
+                     'conf_file': PATH}
+        self.assertRaises(SaltCloudConfigError,
+                          sconfig.apply_cloud_providers_config,
+                          overrides,
+                          DEFAULT)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Wrote unit tests for the `apply_cloud_providers_config` function in `salt.config.py`. Tests are particularly for extending cloud providers.

A couple couple of tweaks were necessary in `config.py` as discovered during testing. 

References #13512 and #13464.
