### PR TITLE
Improve the salt-ssh error handling 

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -749,10 +749,10 @@ class Single(object):
         return stdout, stderr, retcode
 
     def categorize_shim_errors(self, stdout, stderr, retcode):
-        if re.search(RSTR_RE, stdout):
+        if re.search(RSTR_RE, stdout) and stdout != RSTR+'\n':
             # RSTR was found in stdout which means that the shim
             # functioned without *errors* . . . but there may be shim
-            # commands
+            # commands, unless the only thing we found is RSTR
             return None
 
         if re.search(RSTR_RE, stderr):

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -6,6 +6,7 @@ Create ssh executor system
 import os
 import copy
 import json
+import logging
 
 # Import salt libs
 import salt.client.ssh.shell
@@ -16,6 +17,9 @@ import salt.roster
 import salt.state
 import salt.loader
 import salt.minion
+import salt.log
+
+log = logging.getLogger(__name__)
 
 
 def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
@@ -183,7 +187,12 @@ def highstate(test=None, **kwargs):
             trans_tar,
             '/tmp/.salt/salt_state.tgz')
     stdout, stderr, _ = single.cmd_block()
-    return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    try:
+        stdout = json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception, e:
+        log.error("JSON Render failed for: {0}".format(stdout))
+        log.error(str(e))
+    return stdout
 
 
 def top(topfn, test=None, **kwargs):


### PR DESCRIPTION
This is an attempt to try and stop JSON rendering errors from halting the salt-ssh run entirely.
