### PR TITLE
Fixes to debian_ip.py and friends.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1676,17 +1676,23 @@ def get_network_settings():
 
         salt '*' ip.get_network_settings
     '''
+    skip_etc_default_networking = (
+        __grains__['osfullname'] == 'Ubuntu' and
+        int(__grains__['osrelease'].split('.')[0]) >= 12)
 
-    settings = _parse_current_network_settings()
-
-    try:
-        template = JINJA.get_template('network.jinja')
-    except jinja2.exceptions.TemplateNotFound:
-        log.error('Could not load template network.jinja')
+    if skip_etc_default_networking:
         return ''
+    else:
+        settings = _parse_current_network_settings()
 
-    network = template.render(settings)
-    return _read_temp(network)
+        try:
+            template = JINJA.get_template('network.jinja')
+        except jinja2.exceptions.TemplateNotFound:
+            log.error('Could not load template network.jinja')
+            return ''
+
+        network = template.render(settings)
+        return _read_temp(network)
 
 
 def get_routes(iface):

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -30,7 +30,7 @@ iface {{name}} {{interface.addrfam}} {{interface.proto}}
 {%endif%}{% if interface.provider %}    provider {{interface.provider}}
 {%endif%}{% if interface.unit %}    unit {{interface.unit}}
 {%endif%}{% if interface.options %}    options {{interface.options}}
-{%endif%}{% if interface.dns %}    dns-nameservers {%for item in interface.dns %}{{item}} {%endfor%}
+{%endif%}{% if interface.dns_nameservers %}    dns-nameservers {%for item in interface.dns_nameservers %}{{item}} {%endfor%}
 {%endif%}{% if interface.dns_search %}    dns-search {% for item in interface.dns_search %}{{item}} {%endfor%}
 {%endif%}{% if interface.ethtool %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}
 {%endfor%}{%endif%}{% if interface.bonding %}{%for item in interface.bonding_keys %}    bond_{{item}} {{interface.bonding[item]}}


### PR DESCRIPTION
Fixing an issue in the debian networking template related to DNS servers.  Since Ubuntu has moved away from /etc/default/networking since the 12.04 release, the build_network_settings doesn't create this file on Ubuntu systems higher than 12.04, the get_network_settings shouldn't return anything including defaults.
