### PR TITLE
SmartOS: run salt minion in an audit context

### DIFF
--- a/pkg/smartos/esky/salt-minion.xml
+++ b/pkg/smartos/esky/salt-minion.xml
@@ -28,7 +28,7 @@
 
       <exec_method type="method"
                    name="start"
-                   exec="SALT_PREFIX/bin/salt-minion"
+                   exec="auditconfig -setaudit 0 lo 0,0,localhost 5417 SALT_PREFIX/bin/salt-minion"
                    timeout_seconds="60">
         <method_context>
           <method_environment>


### PR DESCRIPTION
This fixes an issue @njones11 was having with
multiple cron.present states.

"crontab -l <username>" would fail, so the temp file
would be empty, a given cronjob would go in
and then the "su - <username> crontab <temp file>" would
succeed.

This evaded debugging attempts because if you invoked the salt
minion manually from a login shell, an audit context would
already exist and the "crontab -l <username>" would succeed.

The hint was a message in the debug log of:
[ERROR   ] Command 'crontab -l legion' failed with return code: 1
[ERROR   ] stderr: crontab: The audit context for your shell has not
been set.

We explicitly set up an audit context when launching the salt minion
which allows "crontab -l <username>" to succeed.

This may fix other issues and something similar
should perhaps be applied to pkg/smartos/salt-minion.xml

"5417" was chosen arbitrarily
