### PR TITLE
Fix quoting problem in git.clone

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -173,7 +173,7 @@ def clone(cwd, repository, opts=None, user=None, identity=None):
 
     if not opts:
         opts = ''
-    cmd = 'git clone {0} {1} {2}'.format(repository, cwd, opts)
+    cmd = 'git clone {0} {1!r} {2}'.format(repository, cwd, opts)
 
     return _git_run(cmd, runas=user, identity=identity)
 


### PR DESCRIPTION
`git.clone` fails if `cwd` contains space.

```
$ salt-call git.clone '/Users/lendar/Library/Application Support/Sublime Text 2/Packages/sublime-text' https://github.com/saltstack/sublime-text
[INFO    ] Executing command 'git clone https://github.com/saltstack/sublime-text /Users/lendar/Library/Application Support/Sublime Text 2/Packages/sublime-text ' in directory '/Users/lendar'
[ERROR   ] Command 'git clone https://github.com/saltstack/sublime-text /Users/lendar/Library/Application Support/Sublime Text 2/Packages/sublime-text ' failed with return code: 129
[ERROR   ] stderr: Too many arguments.
```

Similar merged fixes:
- https://github.com/saltstack/salt/pull/9865 (via @s0undt3ch)
- https://github.com/saltstack/salt/commit/d4bf456e29d73a7c92bf1a04e773fd1f27166cda (via @garethgreenaway) that fix is OK, but fails on weird filenames like `foo".tar` 
