### PR TITLE
move restart code to salt.Minion().Start()

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -162,63 +162,65 @@ class Minion(parsers.MinionOptionParser):
 
             super(YourSubClass, self).prepare()
         '''
-        self.parse_args()
+        
+        if not hasattr(self, 'config'):
+            self.parse_args()
 
-        try:
-            if self.config['verify_env']:
-                confd = self.config.get('default_include')
-                if confd:
-                    # If 'default_include' is specified in config, then use it
-                    if '*' in confd:
-                        # Value is of the form "minion.d/*.conf"
-                        confd = os.path.dirname(confd)
-                    if not os.path.isabs(confd):
-                        # If configured 'default_include' is not an absolute
-                        # path, consider it relative to folder of 'conf_file'
-                        # (/etc/salt by default)
+            try:
+                if self.config['verify_env']:
+                    confd = self.config.get('default_include')
+                    if confd:
+                        # If 'default_include' is specified in config, then use it
+                        if '*' in confd:
+                            # Value is of the form "minion.d/*.conf"
+                            confd = os.path.dirname(confd)
+                        if not os.path.isabs(confd):
+                            # If configured 'default_include' is not an absolute
+                            # path, consider it relative to folder of 'conf_file'
+                            # (/etc/salt by default)
+                            confd = os.path.join(
+                                os.path.dirname(self.config['conf_file']), confd
+                            )
+                    else:
                         confd = os.path.join(
-                            os.path.dirname(self.config['conf_file']), confd
+                            os.path.dirname(self.config['conf_file']), 'minion.d'
                         )
-                else:
-                    confd = os.path.join(
-                        os.path.dirname(self.config['conf_file']), 'minion.d'
+                    v_dirs = [
+                            self.config['pki_dir'],
+                            self.config['cachedir'],
+                            self.config['sock_dir'],
+                            self.config['extension_modules'],
+                            confd,
+                        ]
+                    if self.config.get('transport') == 'raet':
+                        v_dirs.append(os.path.join(self.config['pki_dir'], 'accepted'))
+                        v_dirs.append(os.path.join(self.config['pki_dir'], 'pending'))
+                        v_dirs.append(os.path.join(self.config['pki_dir'], 'rejected'))
+                    verify_env(
+                        v_dirs,
+                        self.config['user'],
+                        permissive=self.config['permissive_pki_access'],
+                        pki_dir=self.config['pki_dir'],
                     )
-                v_dirs = [
-                        self.config['pki_dir'],
-                        self.config['cachedir'],
-                        self.config['sock_dir'],
-                        self.config['extension_modules'],
-                        confd,
-                    ]
-                if self.config.get('transport') == 'raet':
-                    v_dirs.append(os.path.join(self.config['pki_dir'], 'accepted'))
-                    v_dirs.append(os.path.join(self.config['pki_dir'], 'pending'))
-                    v_dirs.append(os.path.join(self.config['pki_dir'], 'rejected'))
-                verify_env(
-                    v_dirs,
-                    self.config['user'],
-                    permissive=self.config['permissive_pki_access'],
-                    pki_dir=self.config['pki_dir'],
-                )
-                logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith(('tcp://',
-                                                                   'udp://',
-                                                                   'file://')):
-                    # Logfile is not using Syslog, verify
-                    current_umask = os.umask(0077)
-                    verify_files([logfile], self.config['user'])
-                    os.umask(current_umask)
-        except OSError as err:
-            logger.exception('Failed to prepare salt environment')
-            sys.exit(err.errno)
+                    logfile = self.config['log_file']
+                    if logfile is not None and not logfile.startswith(('tcp://',
+                                                                    'udp://',
+                                                                    'file://')):
+                        # Logfile is not using Syslog, verify
+                        current_umask = os.umask(0077)
+                        verify_files([logfile], self.config['user'])
+                        os.umask(current_umask)
+            except OSError as err:
+                logger.exception('Failed to prepare salt environment')
+                sys.exit(err.errno)
 
-        self.setup_logfile_logger()
-        logger.info(
-            'Setting up the Salt Minion "{0}"'.format(
-                self.config['id']
+            self.setup_logfile_logger()
+            logger.info(
+                'Setting up the Salt Minion "{0}"'.format(
+                    self.config['id']
+                )
             )
-        )
-        migrations.migrate_paths(self.config)
+            migrations.migrate_paths(self.config)
         if self.config['transport'].lower() == 'zeromq':
             # Late import so logging works correctly
             import salt.minion
@@ -249,26 +251,29 @@ class Minion(parsers.MinionOptionParser):
 
         NOTE: Run any required code before calling `super()`.
         '''
-        try:
-            self.prepare()
-            if check_user(self.config['user']):
-                self.minion.tune_in()
-        except (KeyboardInterrupt, SaltSystemExit) as exc:
-            logger.warn('Stopping the Salt Minion')
-            if isinstance(exc, KeyboardInterrupt):
-                logger.warn('Exiting on Ctrl-c')
-            else:
-                logger.error(str(exc))
-        except SaltClientError as exc:
-            logger.error(exc)
-            if self.config.get('restart_on_error'):
-                logger.warn('** Restarting minion **')
-                s = randint(0, self.config.get('random_reauth_delay', 10))
-                logger.info('Sleeping random_reauth_delay of {0} seconds'.format(s))
-                time.sleep(s)
-                return 'reconnect'
-        finally:
-            self.shutdown()
+        reconnect = True
+        while reconnect:
+            reconnect = False
+            try:
+                self.prepare()
+                if check_user(self.config['user']):
+                    self.minion.tune_in()
+            except (KeyboardInterrupt, SaltSystemExit) as exc:
+                logger.warn('Stopping the Salt Minion')
+                if isinstance(exc, KeyboardInterrupt):
+                    logger.warn('Exiting on Ctrl-c')
+                else:
+                    logger.error(str(exc))
+            except SaltClientError as exc:
+                logger.error(exc)
+                if self.config.get('restart_on_error'):
+                    logger.warn('** Restarting minion **')
+                    s = randint(0, self.config.get('random_reauth_delay', 10))
+                    logger.info('Sleeping random_reauth_delay of {0} seconds'.format(s))
+                    time.sleep(s)
+                    reconnect = True
+            finally:
+                self.shutdown()
 
     def shutdown(self):
         '''

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -46,7 +46,7 @@ def _handle_interrupt(exc, original_exc, hardfail=False, trace=''):
 
 def salt_master():
     '''
-    Start the salt-master.
+    Start the salt master.
     '''
     master = salt.Master()
     master.start()
@@ -54,27 +54,18 @@ def salt_master():
 
 def salt_minion():
     '''
-    Kick off a salt minion daemon.
+    Start the salt minion.
     '''
     if '' in sys.path:
         sys.path.remove('')
 
-    reconnect = True
-    while reconnect:
-        reconnect = False
-        minion = salt.Minion()
-        ret = minion.start()
-        if ret == 'reconnect':
-            del minion
-            minion = None
-            # give extra time for resources like ZMQ to close.
-            time.sleep(10)
-            reconnect = True
+    minion = salt.Minion()
+    minion.start()
 
 
 def salt_syndic():
     '''
-    Kick off a salt syndic daemon.
+    Start the salt syndic.
     '''
     pid = os.getpid()
     try:


### PR DESCRIPTION
move the restart minion code into, minion start method because we need to prevent the minion from
preforming a full restart. /or some objects get appended to an array and build up large over time/ /mem leak/

this patch will only run self.parse_args() and self.setup_logfile_logger() once.
