### PR TITLE
states.dockerio.running: fix bad indentation

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -629,7 +629,7 @@ def running(name, container=None, port_bindings=None, binds=None,
         e.g. nginx <- static-files
     '''
     if not container and name:
-       container = name
+        container = name
     is_running = __salt__['docker.is_running'](container)
     if is_running:
         return _valid(


### PR DESCRIPTION
```
************* Module salt.states.dockerio
salt/states/dockerio.py:632: [W0311(bad-indentation), ] Bad indentation. Found 7 spaces, expected 8
```
