### PR TITLE
nest nodegroup match in nodegroups file

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1263,6 +1263,7 @@ class LocalClient(object):
                 )
             tgt = salt.utils.minions.nodegroup_comp(tgt,
                                                     self.opts['nodegroups'])
+            tgt = tgt[:-3]
             expr_form = 'compound'
 
         # Convert a range expression to a list of nodes and change expression

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1263,7 +1263,6 @@ class LocalClient(object):
                 )
             tgt = salt.utils.minions.nodegroup_comp(tgt,
                                                     self.opts['nodegroups'])
-            tgt = tgt[:-3]
             expr_form = 'compound'
 
         # Convert a range expression to a list of nodes and change expression

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -71,9 +71,9 @@ def nodegroup_comp(group, nodegroups, skip=None):
         return ''
     gstr = nodegroups[group]
     ret = ''
-    for comp in gstr.split(','):
+    for comp in gstr.split():
         if not comp.startswith('N@'):
-            ret += '{0} or '.format(comp)
+            ret += '{0} '.format(comp)
             continue
         ngroup = comp[2:]
         if ngroup in skip:

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -71,9 +71,9 @@ def nodegroup_comp(group, nodegroups, skip=None):
         return ''
     gstr = nodegroups[group]
     ret = ''
-    for comp in gstr.split():
+    for comp in gstr.split(','):
         if not comp.startswith('N@'):
-            ret += '{0} '.format(comp)
+            ret += '{0} or '.format(comp)
             continue
         ngroup = comp[2:]
         if ngroup in skip:


### PR DESCRIPTION
fix issue #12700
so we can use nest nodegroups in config
https://groups.google.com/forum/?fromgroups=#!topic/salt-users/xtnsqiadupk
for example
nodegroups:
  web: 'E@(server1,server2)'
  db: 'E@(server3, server4)'
  production: 'N@web,N@db'
  preproduction: 'L@server5' 
