### PR TITLE
Make cloud configuration unit tests more organized

### DIFF
--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -474,6 +474,10 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                 sconfig.get_id(cache=False), (MOCK_HOSTNAME, False)
             )
 
+# <---- Salt Cloud Configuration Tests ---------------------------------------------
+
+    # cloud_config tests
+
     def test_cloud_config_vm_profiles_config(self):
         '''
         Tests passing in vm_config and profiles_config.
@@ -546,88 +550,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         self.assertRaises(SaltCloudConfigError, sconfig.cloud_config, PATH,
                           providers_config_path='bar')
 
-    def test_load_cloud_config_from_environ_var(self):
-        original_environ = os.environ.copy()
-
-        tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
-        try:
-            env_root_dir = os.path.join(tempdir, 'foo', 'env')
-            os.makedirs(env_root_dir)
-            env_fpath = os.path.join(env_root_dir, 'config-env')
-
-            salt.utils.fopen(env_fpath, 'w').write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(env_root_dir, env_fpath)
-            )
-
-            os.environ['SALT_CLOUD_CONFIG'] = env_fpath
-            # Should load from env variable, not the default configuration file
-            config = sconfig.cloud_config('/etc/salt/cloud')
-            self.assertEqual(config['log_file'], env_fpath)
-            os.environ.clear()
-            os.environ.update(original_environ)
-
-            root_dir = os.path.join(tempdir, 'foo', 'bar')
-            os.makedirs(root_dir)
-            fpath = os.path.join(root_dir, 'config')
-            salt.utils.fopen(fpath, 'w').write(
-                'root_dir: {0}\n'
-                'log_file: {1}\n'.format(root_dir, fpath)
-            )
-            # Let's set the environment variable, yet, since the configuration
-            # file path is not the default one, ie, the user has passed an
-            # alternative configuration file form the CLI parser, the
-            # environment variable will be ignored.
-            os.environ['SALT_CLOUD_CONFIG'] = env_fpath
-            config = sconfig.cloud_config(fpath)
-            self.assertEqual(config['log_file'], fpath)
-        finally:
-            # Reset the environ
-            os.environ.clear()
-            os.environ.update(original_environ)
-
-            if os.path.isdir(tempdir):
-                shutil.rmtree(tempdir)
-
-    def test_deploy_search_path_as_string(self):
-        temp_conf_dir = os.path.join(integration.TMP, 'issue-8863')
-        config_file_path = os.path.join(temp_conf_dir, 'cloud')
-        deploy_dir_path = os.path.join(temp_conf_dir, 'test-deploy.d')
-        try:
-            for directory in (temp_conf_dir, deploy_dir_path):
-                if not os.path.isdir(directory):
-                    os.makedirs(directory)
-
-            default_config = sconfig.cloud_config(config_file_path)
-            default_config['deploy_scripts_search_path'] = deploy_dir_path
-            with salt.utils.fopen(config_file_path, 'w') as cfd:
-                cfd.write(yaml.dump(default_config))
-
-            default_config = sconfig.cloud_config(config_file_path)
-
-            # Our custom deploy scripts path was correctly added to the list
-            self.assertIn(
-                deploy_dir_path,
-                default_config['deploy_scripts_search_path']
-            )
-
-            # And it's even the first occurrence as it should
-            self.assertEqual(
-                deploy_dir_path,
-                default_config['deploy_scripts_search_path'][0]
-            )
-        finally:
-            if os.path.isdir(temp_conf_dir):
-                shutil.rmtree(temp_conf_dir)
-
-    def test_includes_load(self):
-        '''
-        Tests that cloud.{providers,profiles}.d directories are loaded, even if not
-        directly passed in through path
-        '''
-        config = sconfig.cloud_config(self.get_config_file_path('cloud'))
-        self.assertIn('ec2-config', config['providers'])
-        self.assertIn('Ubuntu-13.04-AMD64', config['profiles'])
+    # apply_cloud_providers_config tests
 
     def test_apply_cloud_providers_config_same_providers(self):
         '''
@@ -826,6 +749,8 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
                           overrides,
                           DEFAULT)
 
+    # is_provider_configured tests
+
     def test_is_provider_configured_no_alias(self):
         '''
         Tests when provider alias is not in opts
@@ -898,6 +823,93 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
             sconfig.is_provider_configured(opts,
                                            provider,
                                            required_keys=('api_key',)), ret)
+
+    # other cloud configuration tests
+
+    def test_load_cloud_config_from_environ_var(self):
+        original_environ = os.environ.copy()
+
+        tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)
+        try:
+            env_root_dir = os.path.join(tempdir, 'foo', 'env')
+            os.makedirs(env_root_dir)
+            env_fpath = os.path.join(env_root_dir, 'config-env')
+
+            salt.utils.fopen(env_fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(env_root_dir, env_fpath)
+            )
+
+            os.environ['SALT_CLOUD_CONFIG'] = env_fpath
+            # Should load from env variable, not the default configuration file
+            config = sconfig.cloud_config('/etc/salt/cloud')
+            self.assertEqual(config['log_file'], env_fpath)
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+            root_dir = os.path.join(tempdir, 'foo', 'bar')
+            os.makedirs(root_dir)
+            fpath = os.path.join(root_dir, 'config')
+            salt.utils.fopen(fpath, 'w').write(
+                'root_dir: {0}\n'
+                'log_file: {1}\n'.format(root_dir, fpath)
+            )
+            # Let's set the environment variable, yet, since the configuration
+            # file path is not the default one, ie, the user has passed an
+            # alternative configuration file form the CLI parser, the
+            # environment variable will be ignored.
+            os.environ['SALT_CLOUD_CONFIG'] = env_fpath
+            config = sconfig.cloud_config(fpath)
+            self.assertEqual(config['log_file'], fpath)
+        finally:
+            # Reset the environ
+            os.environ.clear()
+            os.environ.update(original_environ)
+
+            if os.path.isdir(tempdir):
+                shutil.rmtree(tempdir)
+
+    def test_deploy_search_path_as_string(self):
+        temp_conf_dir = os.path.join(integration.TMP, 'issue-8863')
+        config_file_path = os.path.join(temp_conf_dir, 'cloud')
+        deploy_dir_path = os.path.join(temp_conf_dir, 'test-deploy.d')
+        try:
+            for directory in (temp_conf_dir, deploy_dir_path):
+                if not os.path.isdir(directory):
+                    os.makedirs(directory)
+
+            default_config = sconfig.cloud_config(config_file_path)
+            default_config['deploy_scripts_search_path'] = deploy_dir_path
+            with salt.utils.fopen(config_file_path, 'w') as cfd:
+                cfd.write(yaml.dump(default_config))
+
+            default_config = sconfig.cloud_config(config_file_path)
+
+            # Our custom deploy scripts path was correctly added to the list
+            self.assertIn(
+                deploy_dir_path,
+                default_config['deploy_scripts_search_path']
+            )
+
+            # And it's even the first occurrence as it should
+            self.assertEqual(
+                deploy_dir_path,
+                default_config['deploy_scripts_search_path'][0]
+            )
+        finally:
+            if os.path.isdir(temp_conf_dir):
+                shutil.rmtree(temp_conf_dir)
+
+    def test_includes_load(self):
+        '''
+        Tests that cloud.{providers,profiles}.d directories are loaded, even if not
+        directly passed in through path
+        '''
+        config = sconfig.cloud_config(self.get_config_file_path('cloud'))
+        self.assertIn('ec2-config', config['providers'])
+        self.assertIn('Ubuntu-13.04-AMD64', config['profiles'])
+
+# <---- Salt Cloud Configuration Tests ---------------------------------------------
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
We are starting to get quite a few unit tests in `salt/tests/config_test.py`. This change makes things a little more organized so we can tell what is being tested in terms of testing the cloud configuration functions.
