### PR TITLE
Add a method context environment PATH

### DIFF
--- a/pkg/smartos/salt-minion.xml
+++ b/pkg/smartos/salt-minion.xml
@@ -31,7 +31,12 @@
         <service_fmri value="svc:/system/filesystem/local"/>
       </dependency>
 
-      <method_context/>
+      <method_context>
+       <method_environment>
+        <envvar name='PATH'
+                value='/usr/local/sbin:/usr/local/bin:/opt/local/sbin:/opt/local/bin:/usr/sbin:/usr/bin:/sbin'/>
+       </method_environment>
+      </method_context>
 
       <exec_method type="method"
                    name="start"


### PR DESCRIPTION
Some modules are referring to PATH env variable which do not contains /opt/local/.. paths by default. This fix provides correct PATH handling
