### PR TITLE
Convert cloud related relative paths to absolute paths(if they exist)

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -34,7 +34,7 @@ import salt.utils.xdg
 from salt._compat import string_types
 
 import sys
-#can't use salt.utils.is_windows, because config.py is included from salt.utils
+# can't use salt.utils.is_windows, because config.py is included from salt.utils
 if not sys.platform.lower().startswith('win'):
     import salt.cloud.exceptions
 
@@ -651,6 +651,27 @@ def _read_conf_file(path):
         return conf_opts
 
 
+def _absolute_path(path, relative_to=None):
+    '''
+    Return an absolute path. In case ``relative_to`` is passed and ``path`` is
+    not an absolute path, we try to prepend ``relative_to`` to ``path``and if
+    that path exists, return that one
+    '''
+
+    if path and os.path.isabs(path):
+        return path
+    if path and relative_to is not None:
+        _abspath = os.path.join(relative_to, path)
+        if os.path.isfile(_abspath):
+            log.debug(
+                'Relative path {0!r} converted to existing absolute path {1!r}'.format(
+                    path, _abspath
+                )
+            )
+            return _abspath
+    return path
+
+
 def load_config(path, env_var, default_path=None):
     '''
     Returns configuration dict from parsing either the file described by
@@ -1017,6 +1038,9 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
         # configuration file, and
         master_config_path = os.path.join(config_dir, 'master')
 
+    # Convert relative to absolute paths if necessary
+    master_config_path = _absolute_path(master_config_path, config_dir)
+
     if 'providers_config' in overrides and providers_config_path is None:
         # The configuration setting is being specified in the main cloud
         # configuration file
@@ -1025,6 +1049,9 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
                                                 and not providers_config_path:
         providers_config_path = os.path.join(config_dir, 'cloud.providers')
 
+    # Convert relative to absolute paths if necessary
+    providers_config_path = _absolute_path(providers_config_path, config_dir)
+
     if 'profiles_config' in overrides and profiles_config_path is None:
         # The configuration setting is being specified in the main cloud
         # configuration file
@@ -1032,6 +1059,9 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     elif 'profiles_config' not in overrides and not profiles_config \
             and not profiles_config_path:
         profiles_config_path = os.path.join(config_dir, 'cloud.profiles')
+
+    # Convert relative to absolute paths if necessary
+    profiles_config_path = _absolute_path(profiles_config_path, config_dir)
 
     # Prepare the deploy scripts search path
     deploy_scripts_search_path = overrides.get(


### PR DESCRIPTION
The cloud configuration file can point to a relative master file:

``` yaml
master_config: another/dir
```

We just convert those into `<cloud-config-dir>/another/dir` if the path  exists.
This also works for `providers_config` and `profiles_config`
