### PR TITLE
fixes potential ext_pillar line mismatches

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -102,9 +102,9 @@ class GitPillar(object):
         self.working_dir = ''
         self.repo = None
 
-        needle = '{0} {1}'.format(self.branch, self.rp_location)
         for idx, opts_dict in enumerate(self.opts['ext_pillar']):
-            if opts_dict.get('git', '').startswith(needle):
+            lopts = opts_dict.get('git', '').split()
+            if len(lopts) >= 2 and lopts[:2] == [self.branch, self.rp_location]:
                 rp_ = os.path.join(self.opts['cachedir'],
                                    'pillar_gitfs', str(idx))
 


### PR DESCRIPTION
The previous matching method could lead to mismatches.
Let's assume the following variables :

<pre>
self.branch = "master"
self.rp_location = "http://github.com/xyz/project/pillar1"
</pre>

and the following configuration :

<pre>
ext_pillar:
  - git: master     http://github.com/xyz/project/pillar1
  - git: master http://github.com/xyz/project/pillar10
  - git: master http://github.com/xyz/project/pillar1
</pre>


The current code :
- would not match the first line, because there is more than 1 space
- would erroneously match the second line
