### PR TITLE
Fixes exception in states.git.config()

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -484,7 +484,7 @@ def config(name,
                                           cwd=repo,
                                           user=user)
     except CommandExecutionError:
-        oval = 'None'
+        oval = None
 
     if value == oval:
         ret['comment'] = 'No changes made'
@@ -503,6 +503,9 @@ def config(name,
             nval = __salt__['git.config_get'](setting_name=name,
                                               cwd=repo,
                                               user=user)
+
+        if oval is None:
+            oval = 'None'
 
         ret['changes'][name] = '{0} => {1}'.format(oval, nval)
 


### PR DESCRIPTION
Fixes an exception that can occur when user has no .gitconfig which apparently causes salt.modules.git.config_get to throw an exception. Not sure I like that behavior but it traces all the way back through to `git config` which returns exit code `1`. Workaround isn't great but it'll serve for the time being.
