### PR TITLE
Revert "Add master local ip mapping to minion id checking"

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -90,7 +90,6 @@ class CkMinions(object):
     def __init__(self, opts):
         self.opts = opts
         self.serial = salt.payload.Serial(opts)
-        self.ip_addrs = salt.utils.network.ip_addrs()
         if self.opts['transport'] == 'zeromq':
             self.acc = 'minions'
         else:
@@ -406,8 +405,6 @@ class CkMinions(object):
             if not os.path.isdir(cdir):
                 return minions
             addrs = salt.utils.network.local_port_tcp(int(self.opts['publish_port']))
-            if '127.0.0.1' in addrs:
-                addrs.update(self.ip_addrs)
             if subset:
                 search = subset
             else:


### PR DESCRIPTION
This reverts commit 1f890ea9592e6237b831306a4376a19dec8fb682 and fixes #13665. Please read the discussion in that bug report as I am, as of now, not entirely sure if this fix might introduce regressions.
