### PR TITLE
git_pillar: removed unnecessary loops, moved configuration check responsibility to runner

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -50,6 +50,7 @@ section in it, like this:
 # Import python libs
 from copy import deepcopy
 import logging
+import hashlib
 import os
 
 # Import third party libs
@@ -102,48 +103,46 @@ class GitPillar(object):
         self.working_dir = ''
         self.repo = None
 
-        for idx, opts_dict in enumerate(self.opts['ext_pillar']):
-            lopts = opts_dict.get('git', '').split()
-            if len(lopts) >= 2 and lopts[:2] == [self.branch, self.rp_location]:
-                rp_ = os.path.join(self.opts['cachedir'],
-                                   'pillar_gitfs', str(idx))
+        hash_type = getattr(hashlib, opts.get('hash_type', 'md5'))
+        hash_str = '{} {}'.format(self.branch, self.rp_location)
+        repo_hash = hash_type(hash_str).hexdigest()
+        rp_ = os.path.join(self.opts['cachedir'], 'pillar_gitfs', repo_hash)
 
-                if not os.path.isdir(rp_):
-                    os.makedirs(rp_)
+        if not os.path.isdir(rp_):
+            os.makedirs(rp_)
 
+        try:
+            self.repo = git.Repo.init(rp_)
+        except (git.exc.NoSuchPathError,
+                git.exc.InvalidGitRepositoryError) as exc:
+            log.error('GitPython exception caught while '
+                      'initializing the repo: {0}. Maybe '
+                      'git is not available.'.format(exc))
+
+        # Git directory we are working on
+        # Should be the same as self.repo.working_dir
+        self.working_dir = rp_
+
+        if isinstance(self.repo, git.Repo):
+            if not self.repo.remotes:
                 try:
-                    self.repo = git.Repo.init(rp_)
-                except (git.exc.NoSuchPathError,
-                        git.exc.InvalidGitRepositoryError) as exc:
-                    log.error('GitPython exception caught while '
-                              'initializing the repo: {0}. Maybe '
-                              'git is not available.'.format(exc))
-
-                # Git directory we are working on
-                # Should be the same as self.repo.working_dir
-                self.working_dir = rp_
-
-                if isinstance(self.repo, git.Repo):
-                    if not self.repo.remotes:
-                        try:
-                            self.repo.create_remote('origin', self.rp_location)
-                            # ignore git ssl verification if requested
-                            if self.opts.get('pillar_gitfs_ssl_verify', True):
-                                self.repo.git.config('http.sslVerify', 'true')
-                            else:
-                                self.repo.git.config('http.sslVerify', 'false')
-                        except os.error:
-                            # This exception occurs when two processes are
-                            # trying to write to the git config at once, go
-                            # ahead and pass over it since this is the only
-                            # write.
-                            # This should place a lock down.
-                            pass
+                    self.repo.create_remote('origin', self.rp_location)
+                    # ignore git ssl verification if requested
+                    if self.opts.get('pillar_gitfs_ssl_verify', True):
+                        self.repo.git.config('http.sslVerify', 'true')
                     else:
-                        if self.repo.remotes.origin.url != self.rp_location:
-                            self.repo.remotes.origin.config_writer.set('url', self.rp_location)
+                        self.repo.git.config('http.sslVerify', 'false')
+                except os.error:
+                    # This exception occurs when two processes are
+                    # trying to write to the git config at once, go
+                    # ahead and pass over it since this is the only
+                    # write.
+                    # This should place a lock down.
+                    pass
+            else:
+                if self.repo.remotes.origin.url != self.rp_location:
+                    self.repo.remotes.origin.config_writer.set('url', self.rp_location)
 
-                break
 
     def update(self):
         '''

--- a/salt/runners/git_pillar.py
+++ b/salt/runners/git_pillar.py
@@ -5,6 +5,7 @@ Directly manage the salt git_pillar plugin
 
 # Import salt libs
 import salt.pillar.git_pillar
+from salt.exceptions import SaltRunnerError
 
 
 def update(branch, repo):
@@ -17,5 +18,10 @@ def update(branch, repo):
 
         salt-run git_pillar.update branch='branch' repo='location'
     '''
-    fileserver = salt.pillar.git_pillar.GitPillar(branch, repo, __opts__)
-    fileserver.update()
+    for opts_dict in __opts__.get('ext_pillar', []):
+	parts = opts_dict.get('git', '').split()
+	if len(parts) >= 2 and parts[:2] == [branch, repo]:
+            salt.pillar.git_pillar.GitPillar(branch, repo, __opts__).update()
+            break
+    else:
+        raise SaltRunnerError('git repo/branch not found in ext_pillar config')


### PR DESCRIPTION
When you have multiple "git"-type ext_pillar lines in your configuration, the GitPillar object is instantiated for each line. The previous behavior of the object was to rescan the configuration, try to match itself in it, and do its work, leading to an unoptimized lookup. It also used its index in the list to compute its cache directory path.

This patch
- removes the unnecessary loop in the GitPillar object **init** function
- relies on hashlib to generate the cache path
- gives the runner the responsibility to check if the repo/branch is in the configuration
- improves the verbosity of the runner if the repo/branch does not exist

The cache path is safe from duplicates as long as the repo/branch is unique in the configuration, which is not a problem, because if you do a duplicate, you still get what you want. If the repo/branch is a duplicate except the "root" option, it will share the same repository cache directory, which, i think, should not cause any trouble.
