### PR TITLE
Do not unnecessarily recompile OpenVZ envId pattern

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -530,8 +530,8 @@ def _virtual(osdata):
         # Provide additional detection for OpenVZ
         if os.path.isfile('/proc/self/status'):
             with salt.utils.fopen('/proc/self/status') as status_file:
+                vz_re = re.compile(r'^envID:\s+(\d+)$')
                 for line in status_file:
-                    vz_re = re.compile(r'^envID:\s+(\d+)$')
                     vz_match = vz_re.match(line.rstrip('\n'))
                     if vz_match and int(vz_match.groups()[0]) != 0:
                         grains['virtual'] = 'openvzve'


### PR DESCRIPTION
The pattern against which lines in /proc/self/status are matched is static and
therefore does not have to be (re-)compiled for every line in the file.

(This is a cherry-pick from the 2014.1 branch)
