### PR TITLE
copy and rename should pass name instead of dname when makedirs is true

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3251,7 +3251,7 @@ def copy(name, source, force=False, makedirs=False):
     dname = os.path.dirname(name)
     if not os.path.isdir(dname):
         if makedirs:
-            __salt__['file.makedirs'](dname)
+            __salt__['file.makedirs'](name)
         else:
             return _error(
                 ret,
@@ -3337,7 +3337,7 @@ def rename(name, source, force=False, makedirs=False):
     dname = os.path.dirname(name)
     if not os.path.isdir(dname):
         if makedirs:
-            __salt__['file.makedirs'](dname)
+            __salt__['file.makedirs'](name)
         else:
             return _error(
                 ret,


### PR DESCRIPTION
makedirs_ already calls os.path.dirname on the path provided, and so cuts off the lowest level directory when dname is passed in copy and rename. This fixes that.
