### PR TITLE
chmod ssh known hosts file in set_ssh_known_host (salt.modules.ssh)

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -824,6 +824,8 @@ def set_known_host(user=None,
 
     if os.geteuid() == 0 and user:
         os.chown(full, uinfo['uid'], uinfo['gid'])
+    os.chmod(full, 0644)
+
     return {'status': 'updated', 'old': stored_host, 'new': remote_host}
 
 


### PR DESCRIPTION
#12437 implemented management of gobal ssh known hosts file (e.g. /etc/ssh/ssh_known_hosts). Unfortunately this file isn't world-readable yet.

This change always sets 0644 for known hosts regardless whether there are global or user-specific since those files contain public data. I also haven't seen an user-specific known_hosts file which is not world-readable so far anyway.

See also http://www.openbsd.org/cgi-bin/man.cgi?query=ssh&sektion=1 (File: /etc/ssh/ssh_known_hosts)
