### PR TITLE
fix nodegroup_comp func

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1263,7 +1263,6 @@ class LocalClient(object):
                 )
             tgt = salt.utils.minions.nodegroup_comp(tgt,
                                                     self.opts['nodegroups'])
-            tgt = tgt[:-3]
             expr_form = 'compound'
 
         # Convert a range expression to a list of nodes and change expression

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -65,8 +65,10 @@ def nodegroup_comp(group, nodegroups, skip=None):
     '''
     Take the nodegroup and the nodegroups and fill in nodegroup refs
     '''
+    k = 1
     if skip is None:
         skip = set([group])
+        k = 0
     if group not in nodegroups:
         return ''
     gstr = nodegroups[group]
@@ -80,7 +82,10 @@ def nodegroup_comp(group, nodegroups, skip=None):
             continue
         skip.add(ngroup)
         ret += nodegroup_comp(ngroup, nodegroups, skip)
-    return ret
+    if k == 1:
+        return ret
+    else:
+        return ret[:-3]
 
 
 class CkMinions(object):


### PR DESCRIPTION
fix bug in pull request #13587

There are function calls using getattr.
So I made some change for the same output in function nodegroup_comp.
for example
  production: 'N@web'

call function nodegroup_comp origin get "web"
after pull request #13587 get "web or "
at this version will get "web"

  production: 'N@web,N@db'

call function nodegroup_comp origin get web db
after pull request #13587 get web or db or
at this version will get web or db

So other module  which direct call the function nodegroup_comp will get correct result.

Thanks.
