### PR TITLE
Update salt-minion

### DIFF
--- a/pkg/rpm/salt-minion
+++ b/pkg/rpm/salt-minion
@@ -81,6 +81,7 @@ stop() {
     if [ -f $SUSE_RELEASE ]; then
         killproc -TERM $SALTMINION
         rc_status -v
+        RETVAL=$?
     elif [ -f $DEBIAN_VERSION ]; then
         # Added this since Debian's start-stop-daemon doesn't support spawned processes
         if ps -ef | grep "$PYTHON $SALTMINION" | grep -v grep | awk '{print $2}' | xargs kill &> /dev/null; then
@@ -92,8 +93,18 @@ stop() {
         fi
     else
         killproc $PROCESS
+        RETVAL=$?
+        # tidy up any rogue processes:
+        PROCS=`ps -ef | grep "$SALTMINION" | grep -v grep | awk '{print $2}'`
+        if [ -n "$PROCS" ]; then
+            kill $PROCS &> /dev/null
+            sleep 1
+            PROCS=`ps -ef | grep "$SALTMINION" | grep -v grep | awk '{print $2}'`
+            if [ -n "$PROCS" ]; then
+                kill -9 $PROCS &> /dev/null
+            fi
+        fi
     fi
-    RETVAL=$?
     echo
 }
 


### PR DESCRIPTION
On our RHEL5 systems we're getting 2 and sometimes 3 or more salt-minions started. Somehow the check on /var/run/salt-minion.pid doesn't prevent this.

This patch stops the registered process and kills any further salt-minion processes, first trying -TERM and then -KILL signals.

It may be that other distros would like to use this same logic to tidy up, in which case the new code can be moved into place as appropriate.
