### PR TITLE
Add new styles for code blocks

### DIFF
--- a/doc/_themes/saltstack/static/css/main.css
+++ b/doc/_themes/saltstack/static/css/main.css
@@ -476,3 +476,67 @@ SaltStack custom styles
     overflow-x:auto;
     position:relative;
 }
+
+/* Code blocks */
+
+pre {
+    position: relative;
+}
+
+.highlight-bash,
+.highlight-jinja,
+.highlight-python,
+.highlight-yaml {
+    position: relative;
+}
+.highlight-bash:before,
+.highlight-jinja:before,
+.highlight-python:before,
+.highlight-yaml:before {
+    z-index: 10;
+    font-size: 9px;
+    padding: 0.3em 0.8em;
+    text-align: center;
+    color: #999;
+    display: block;
+    position: absolute;
+    border-radius: 0 0 0 4px;
+    border-top: none;
+    border-right: none;
+    background-color: #f1f1f1;
+    top: 0;
+    right: 0;
+}
+.highlight-bash pre {
+    /* bit more subdued ... */
+    border-color: #999;
+}
+.highlight-jinja pre {
+    border-color: #e00a1b;
+}
+.highlight-python pre {
+    border-color: #3377b0;
+}
+.highlight-yaml pre {
+    border-color: #ccc;
+}
+.highlight-bash:before {
+    content: 'BASH';
+    background-color: #444;
+    color: white;
+}
+.highlight-jinja:before {
+    content: 'JINJA';
+    background-color: #e00a1b;
+    color: white;
+}
+.highlight-python:before {
+    content: 'PYTHON';
+    background-color: #3377b0;
+    color: #ffe243;
+}
+.highlight-yaml:before {
+    content: 'YAML';
+    background-color: #ccc;
+    color: black;
+}


### PR DESCRIPTION
This adds some small indicators for different types of code blocks, which helps distinguish each section. Addresses issue #13215

![screen shot 2014-06-24 at 10 23 07 pm](https://cloud.githubusercontent.com/assets/410839/3381826/de74430e-fc29-11e3-9430-22fd21f7fbd1.png)
