### PR TITLE
Adding the ability to manage hosts in /etc/hosts will multiple IP addresses

### DIFF
--- a/salt/states/host.py
+++ b/salt/states/host.py
@@ -25,7 +25,19 @@ Or using the "names:" directive, you can put several names for the same IP.
 
 NOTE: changing the name(s) in the present() function does not cause an
 update to remove the old entry.
+
+    server1:
+      host.present:
+        - ip:
+          - 192.168.0.42
+          - 192.168.0.43
+          - 192.168.0.44
+        - names:
+          - server1
+
 '''
+
+import salt.utils.validate.net
 
 
 def present(name, ip):  # pylint: disable=C0103
@@ -36,31 +48,41 @@ def present(name, ip):  # pylint: disable=C0103
         The host to assign an ip to
 
     ip
-        The ip addr to apply to the host
+        The ip addr(s) to apply to the host
     '''
     ret = {'name': name,
            'changes': {},
            'result': None,
            'comment': ''}
-    if __salt__['hosts.has_pair'](ip, name):
-        ret['result'] = True
-        ret['comment'] = 'Host {0} already present'.format(name)
-        return ret
-    if __opts__['test']:
-        ret['comment'] = 'Host {0} needs to be added/updated'.format(name)
-        return ret
-    current_ip = __salt__['hosts.get_ip'](name)
-    if current_ip and current_ip != ip:
-        __salt__['hosts.rm_host'](current_ip, name)
-    if __salt__['hosts.add_host'](ip, name):
-        ret['changes'] = {'host': name}
-        ret['result'] = True
-        ret['comment'] = 'Added host {0}'.format(name)
-        return ret
-    else:
-        ret['result'] = False
-        ret['comment'] = 'Failed to set host'
-        return ret
+
+    if not isinstance(ip, list):
+        ip = [ip]
+
+    comments = []
+    for _ip in ip:
+        if __salt__['hosts.has_pair'](_ip, name):
+            ret['result'] = True
+            comments.append('Host {0} ({1}) already present'.format(name, _ip))
+        else:
+            if __opts__['test']:
+                comments.append('Host {0} ({1}) needs to be added/updated'.format(name, _ip))
+            else:
+                current_ip = __salt__['hosts.get_ip'](name)
+                if current_ip and current_ip not in ip:
+                    __salt__['hosts.rm_host'](current_ip, name)
+                if salt.utils.validate.net.ipv4_addr(_ip) or salt.utils.validate.net.ipv6_addr(_ip):
+                    if __salt__['hosts.add_host'](_ip, name):
+                        ret['changes'] = {'host': name}
+                        ret['result'] = True
+                        comments.append('Added host {0} ({1})'.format(name, _ip))
+                    else:
+                        ret['result'] = False
+                        comments.append('Failed to set host')
+                else:
+                    ret['result'] = False
+                    comments.append('Invalid IP Address for {0} ({1})'.format(name, _ip))
+    ret['comment'] = '\n'.join(comments)
+    return ret
 
 
 def absent(name, ip):  # pylint: disable=C0103
@@ -71,25 +93,31 @@ def absent(name, ip):  # pylint: disable=C0103
         The host to remove
 
     ip
-        The ip addr of the host to remove
+        The ip addr(s) of the host to remove
     '''
     ret = {'name': name,
            'changes': {},
            'result': None,
            'comment': ''}
-    if not __salt__['hosts.has_pair'](ip, name):
-        ret['result'] = True
-        ret['comment'] = 'Host {0} already absent'.format(name)
-        return ret
-    if __opts__['test']:
-        ret['comment'] = 'Host {0} needs to be removed'.format(name)
-        return ret
-    if __salt__['hosts.rm_host'](ip, name):
-        ret['changes'] = {'host': name}
-        ret['result'] = True
-        ret['comment'] = 'Removed host {0}'.format(name)
-        return ret
-    else:
-        ret['result'] = False
-        ret['comment'] = 'Failed to remove host'
-        return ret
+
+    if not isinstance(ip, list):
+        ip = [ip]
+
+    comments = []
+    for _ip in ip:
+        if not __salt__['hosts.has_pair'](_ip, name):
+            ret['result'] = True
+            comments.append('Host {0} ({1}) already absent'.format(name, _ip))
+        else:
+            if __opts__['test']:
+                comments.append('Host {0} ({1} needs to be removed'.format(name, _ip))
+            else:
+                if __salt__['hosts.rm_host'](_ip, name):
+                    ret['changes'] = {'host': name}
+                    ret['result'] = True
+                    comments.append('Removed host {0} ({1})'.format(name, _ip))
+                else:
+                    ret['result'] = False
+                    comments.append('Failed to remove host')
+    ret['comment'] = '\n'.join(comments)
+    return ret


### PR DESCRIPTION
Adding the ability to manage hosts in /etc/hosts will multiple IP addresses, eg. both IPv4 and IPv4.  Also added validation to ensure a valid IP address is only added. Per #13709
