### PR TITLE
Make ``recon_max`` 10 seconds, down from 59 seconds

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -333,7 +333,7 @@ DEFAULT_MINION_OPTS = {
     'update_url': False,
     'update_restart_services': [],
     'retry_dns': 30,
-    'recon_max': 59000,
+    'recon_max': 10000,
     'recon_default': 1000,
     'recon_randomize': True,
     'random_reauth_delay': 60,


### PR DESCRIPTION
Some large infrastructures will want a higher value here to prevent auth
floods, but a value of 59 seconds will result in up to a minute delay on
a master restart before minions come back.  10 seconds is a more
reasonable default here.
