### PR TITLE
gnomedesktop typo: clock_format instead of clock_show_format

### DIFF
--- a/salt/states/gnomedesktop.py
+++ b/salt/states/gnomedesktop.py
@@ -22,7 +22,7 @@ Control the GNOME settings
         gnomedesktop.desktop_interface:
             - user: username
             - clock_show_date: true
-            - clock_show_format: 12h
+            - clock_format: 12h
 '''
 # Import python libs
 import logging


### PR DESCRIPTION
In the documentation there is a typo in this example: http://docs.saltstack.com/en/latest/ref/states/all/salt.states.gnomedesktop.html#configuration-of-the-gnome-desktop

'clock_show_format' should be 'clock_format'

This fixes issue https://github.com/saltstack/salt/issues/13759
