### PR TITLE
Fixes the problem where service module is unavailable on RedHat, CentOs 

### DIFF
--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -57,7 +57,7 @@ def __virtual__():
         if __grains__['os'] == 'Fedora':
             if int(__grains__.get('osrelease', 0).split('.')[0]) > 15:
                 return False
-        if __grains__['os'] in ('RedHat','CentOS','ScientificLinux'):
+        if __grains__['os'] in ('RedHat', 'CentOS', 'ScientificLinux'):
             if int(__grains__.get('osrelease', 0).split('.')[0]) >= 7:
                 return False
         return __virtualname__

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -55,10 +55,10 @@ def __virtual__():
     ))
     if __grains__['os'] in enable:
         if __grains__['os'] == 'Fedora':
-            if __grains__.get('osrelease', 0) > 15:
+            if int(__grains__.get('osrelease', 0).split('.')[0]) > 15:
                 return False
         if __grains__['os'] in ('RedHat','CentOS','ScientificLinux'):
-            if __grains__.get('osrelease', 0) >= 7:
+            if int(__grains__.get('osrelease', 0).split('.')[0]) >= 7:
                 return False
         return __virtualname__
     return False


### PR DESCRIPTION
Fixes the problem where service module is unavailable on RedHat, CentOs and Scientific Linux

Fixes: https://github.com/saltstack/salt/issues/13703

Earlier:

```
nitin-saltminion1:
----------
          ID: autofs
    Function: pkg.installed
      Result: True
     Comment: Package autofs is already installed.
     Started: 20:07:13.514544
     Duration: 390 ms
     Changes:   
----------
          ID: autofs
    Function: service.running
      Result: False
     Comment: State 'service.running' found in SLS 'curhel6.test' is unavailable
     Started: 
     Duration: 
     Changes:   

Summary
------------
Succeeded: 1
Failed:    1
------------
Total states run:     2
```

After Fixing:

```
nitin-saltminion1:
----------
          ID: autofs
    Function: pkg.installed
      Result: True
     Comment: Package autofs is already installed.
     Started: 13:59:51.288471
     Duration: 392 ms
     Changes:   
----------
          ID: autofs
    Function: service.running
      Result: None
     Comment: Service autofs is set to start
     Started: 13:59:51.681372
     Duration: 25 ms
     Changes:   

Summary
------------
Succeeded: 2 (unchanged=1)
Failed:    0
------------
Total states run:     2
```
