### PR TITLE
Adds support for sending the pillar data downstream to the minion during...

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -110,7 +110,7 @@ def salt_refs(data):
     return ret
 
 
-def prep_trans_tar(opts, chunks, file_refs):
+def prep_trans_tar(opts, chunks, file_refs, pillar=None):
     '''
     Generate the execution package from the saltenv file refs and a low state
     data structure
@@ -119,6 +119,7 @@ def prep_trans_tar(opts, chunks, file_refs):
     trans_tar = salt.utils.mkstemp()
     file_client = salt.fileclient.LocalClient(opts)
     lowfn = os.path.join(gendir, 'lowstate.json')
+    pillarfn = os.path.join(gendir, 'pillar.json')
     sync_refs = [
             ['salt://_modules'],
             ['salt://_states'],
@@ -130,6 +131,9 @@ def prep_trans_tar(opts, chunks, file_refs):
             ]
     with open(lowfn, 'w+') as fp_:
         fp_.write(json.dumps(chunks))
+    if pillar:
+        with open(pillarfn, 'w+') as fp_:
+            fp_.write(json.dumps(pillar))
     for saltenv in file_refs:
         file_refs[saltenv].extend(sync_refs)
         env_root = os.path.join(gendir, saltenv)

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -65,7 +65,8 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
-            file_refs)
+            file_refs,
+            __pillar__)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg /tmp/.salt/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
             test,
@@ -103,7 +104,8 @@ def low(data):
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
-            file_refs)
+            file_refs,
+            __pillar__)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg /tmp/.salt/salt_state.tgz pkg_sum={0} hash_type={1}'.format(
             trans_tar_sum,
@@ -137,7 +139,8 @@ def high(data):
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
-            file_refs)
+            file_refs,
+            __pillar__)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg /tmp/.salt/salt_state.tgz pkg_sum={0} hash_type={1}'.format(
             trans_tar_sum,
@@ -173,7 +176,8 @@ def highstate(test=None, **kwargs):
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
-            file_refs)
+            file_refs,
+            __pillar__)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg /tmp/.salt/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
             test,
@@ -219,7 +223,8 @@ def top(topfn, test=None, **kwargs):
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
-            file_refs)
+            file_refs,
+            __pillar__)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
     cmd = 'state.pkg /tmp/.salt/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
             test,

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -888,6 +888,12 @@ def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
     lowstate_json = os.path.join(root, 'lowstate.json')
     with salt.utils.fopen(lowstate_json, 'r') as fp_:
         lowstate = json.load(fp_, object_hook=salt.utils.decode_dict)
+    pillar_json = os.path.join(root, 'pillar.json')
+    if os.path.isfile(pillar_json):
+        with salt.utils.fopen(pillar_json, 'r') as fp_:
+            pillar = json.load(fp_)
+    else:
+        pillar = None
     popts = copy.deepcopy(__opts__)
     popts['fileclient'] = 'local'
     popts['file_roots'] = {}
@@ -901,7 +907,7 @@ def pkg(pkg_path, pkg_sum, hash_type, test=False, **kwargs):
         if not os.path.isdir(full):
             continue
         popts['file_roots'][fn_] = [full]
-    st_ = salt.state.State(popts)
+    st_ = salt.state.State(popts, pillar=pillar)
     st_.functions['saltutil.sync_all'](envs)
     st_.module_refresh()
     ret = st_.call_chunks(lowstate)


### PR DESCRIPTION
... a salt-ssh run so that it is available in _file_ templates (not SLS templates) on minion while executing state.<thing> via salt-ssh... Fixes #10421 , #11650
