### PR TITLE
Adding ability to force creation of a directory if a file with the same name exists

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1410,6 +1410,8 @@ def directory(name,
               require=None,
               exclude_pat=None,
               follow_symlinks=False,
+              force=False,
+              backupname=None,
               **kwargs):
     '''
     Ensure that a named directory is present and has the right perms
@@ -1475,6 +1477,24 @@ def directory(name,
         permissions of the directory/file to which the symlink points.
 
         .. versionadded:: 2014.1.4
+
+    force
+        If the name of the directory exists and is not a direcotry and
+        force is set to False, the state will fail. If force is set to
+        True, the file in the way of the directory will be deleted to
+        make room for the directory, unless backupname is set,
+        then it will be renamed.
+
+        .. versionadded:: Helium
+
+    backupname
+        If the name of the directory exists and is not a directory, it will be
+        renamed to the backupname. If the backupname already
+        exists and force is False, the state will fail. Otherwise, the
+        backupname will be removed first.
+
+        .. versionadded:: Helium
+
     '''
     # Remove trailing slash, if present
     if name[-1] == '/':
@@ -1511,8 +1531,33 @@ def directory(name,
         return _error(
             ret, 'Specified file {0} is not an absolute path'.format(name))
     if os.path.isfile(name):
-        return _error(
-            ret, 'Specified location {0} exists and is a file'.format(name))
+        if backupname is not None:
+            # Make a backup first
+            if os.path.lexists(backupname):
+                if not force:
+                    return _error(ret, ((
+                        'File exists where the backup target {0} should go'
+                    ).format(backupname)))
+                elif os.path.isfile(backupname):
+                    os.remove(backupname)
+                elif os.path.isdir(backupname):
+                    shutil.rmtree(backupname)
+                else:
+                    return _error(ret, ((
+                        'Something exists where the backup target {0}'
+                        'should go'
+                    ).format(backupname)))
+            os.rename(name, backupname)
+        elif force:
+            # Remove whatever is in the way
+            if os.path.isfile(name):
+                os.remove(name)
+                ret['changes']['forced'] = 'File was forcibly replaced'
+            else:
+                shutil.rmtree(name)
+        else:
+            return _error(
+                ret, 'Specified location {0} exists and is a file'.format(name))
     if __opts__['test']:
         ret['result'], ret['comment'] = _check_directory(
             name,


### PR DESCRIPTION
Adding ability to force creation of a directory if a file with the same name exists in place, with the ability to backup the existing file.  Fixes #13757.
