### PR TITLE
Add support for adding secondary IP addresses to network interfaces

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -864,4 +864,70 @@ This function removes the key pair from Amazon.
 
     salt-cloud -f delete_keypair ec2 keyname=mykeypair
 
+Launching instances into a VPC
+==============================
 
+Simple launching into a VPC
+---------------------------
+
+In the amazon web interface, identify the id of the subnet into which your
+image should be created. Then, edit your cloud.profiles file like so:-
+
+.. code-block:: yaml
+
+    profile-id:
+      provider: provider-name
+      subnetid: subnet-XXXXXXXX
+      image: ami-XXXXXXXX
+      size: m1.medium
+      ssh_username: ubuntu
+      securitygroupid:
+        - sg-XXXXXXXX
+
+Specifying interface properties
+-------------------------------
+
+Launching into a VPC allows you to specify more complex configurations for
+the network interfaces of your virtual machines, for example:-
+
+.. code-block:: yaml
+
+    profile-id:
+      provider: provider-name
+      image: ami-XXXXXXXX
+      size: m1.medium
+      ssh_username: ubuntu
+
+      # Do not include either 'subnetid' or 'securitygroupid' here if you are
+      # going to manually specify interface configuration
+      #
+      network_interfaces:
+        - DeviceIndex: 0
+          SubnetId: subnet-XXXXXXXX
+          SecurityGroupId:
+            - sg-XXXXXXXX
+
+          # Uncomment this to associate an existing Elastic IP Address with
+          # this network interface:
+          #
+          # associate_eip: eni-XXXXXXXX
+
+          # You can allocate more than one IP address to an interface. Use the
+          # 'ip addr list' command to see them.
+          #
+          # SecondaryPrivateIpAddressCount: 2
+
+          # Uncomment this to allocate a new Elastic IP Address to this
+          # interface (will be associated with the primary private ip address
+          # of the interface
+          #
+          # allocation_new_eip: True
+
+          # Uncomment this instead to allocate a new Elastic IP Address to
+          # both the primary private ip address and each of the secondary ones
+          #
+          allocate_new_eips: True
+
+Note that it is an error to assign a 'subnetid' or 'securitygroupid' to a
+profile where the interfaces are manually configured like this. These are both
+really properties of each network interface, not of the machine itself.

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -303,13 +303,14 @@ class Terminal(object):
         if not self.closed:
             if self.child_fd is not None:
                 os.close(self.child_fd)
+                self.child_fd = None
             if self.child_fde is not None:
                 os.close(self.child_fde)
+                self.child_fde = None
             time.sleep(0.1)
             if terminate:
                 if not self.terminate(kill):
                     raise TerminalException('Failed to terminate child process.')
-            self.child_fd = self.child_fde = None
             self.closed = True
 
     # <---- Common Public API ------------------------------------------------
@@ -393,7 +394,7 @@ class Terminal(object):
                 args = []
 
             if self.shell and self.args:
-                self.args = ['/bin/sh', '-c'] + args
+                self.args = ['/bin/sh', '-c', ' '.join(args)]
             elif self.shell:
                 self.args = ['/bin/sh']
             else:


### PR DESCRIPTION
when provisioning EC2 instances with salt-cloud. Also added some extra documentation on how to do this.
