### PR TITLE
Adds support for extra_filerefs=salt://path1,salt://path2 CLI arg to inc...

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -70,7 +70,7 @@ class SSHHighState(salt.state.BaseHighState):
         return
 
 
-def lowstate_file_refs(chunks):
+def lowstate_file_refs(chunks, extras=''):
     '''
     Create a list of file ref objects to reconcile
     '''
@@ -90,6 +90,12 @@ def lowstate_file_refs(chunks):
             if saltenv not in refs:
                 refs[saltenv] = []
             refs[saltenv].append(crefs)
+    if extras:
+        extra_refs = extras.split(',')
+        if extra_refs:
+            for env in refs:
+                [refs[env].append([x]) for x in extra_refs]
+
     return refs
 
 

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -61,7 +61,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
         return errors
     # Compile and verify the raw chunks
     chunks = st_.state.compile_high_data(high_data)
-    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
@@ -100,7 +100,7 @@ def low(data):
     err = st_.verify_data(data)
     if err:
         return err
-    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
@@ -135,7 +135,7 @@ def high(data):
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
     chunks = st_.state.compile_high_data(high)
-    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
@@ -172,7 +172,7 @@ def highstate(test=None, **kwargs):
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
     chunks = st_.compile_low_chunks()
-    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,
@@ -219,7 +219,7 @@ def top(topfn, test=None, **kwargs):
     st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
     st_.opts['state_top'] = os.path.join('salt://', topfn)
     chunks = st_.compile_low_chunks()
-    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks)
+    file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
             __opts__,
             chunks,


### PR DESCRIPTION
...lude _template_-referenced files (ie: includes) in thin data package sent to minion during salt-ssh.

Fixes issue #9878
