### PR TITLE
Adds support for separate default & shim CLI arg for thin/thin data pack...

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -45,6 +45,7 @@ except ImportError:
 
 # The directory where salt thin is deployed
 DEFAULT_THIN_DIR = '/tmp/.salt'
+DEFAULT_THIN_PKG_DIR = '/tmp'
 
 # RSTR is just a delimiter to distinguish the beginning of salt STDOUT
 # and STDERR.  There is no special meaning.  Messages prior to RSTR in
@@ -553,7 +554,7 @@ class Single(object):
         thin = salt.utils.thin.gen_thin(self.opts['cachedir'])
         self.shell.send(
             thin,
-            os.path.join(DEFAULT_THIN_DIR, 'salt-thin.tgz'),
+            os.path.join(DEFAULT_THIN_PKG_DIR, 'salt-thin.tgz'),
         )
         return True
 
@@ -664,6 +665,7 @@ class Single(object):
             '--config', self.minion_config,
             '--delimeter', RSTR,
             '--saltdir', DEFAULT_THIN_DIR,
+            '--saltpkgdir', DEFAULT_THIN_PKG_DIR,
             '--checksum', thin_sum,
             '--hashfunc', 'sha1',
             '--version', salt.__version__,
@@ -874,7 +876,7 @@ class Single(object):
         trans_tar = prep_trans_tar(self.opts, chunks, file_refs)
         self.shell.send(
             trans_tar,
-            os.path.join(DEFAULT_THIN_DIR, 'salt_state.tgz'),
+            os.path.join(DEFAULT_THIN_PKG_DIR, 'salt_state.tgz'),
         )
         self.argv = ['state.pkg', '/tmp/salt_state.tgz', 'test={0}'.format(test)]
 

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -46,6 +46,11 @@ def parse_argv(argv):
         help="Directory where salt thin is or will be installed.",
     )
     oparser.add_option(
+        "--sp", "--saltpkgdir",
+        dest="saltpkgdir",
+        help="Directory where salt thin tarball is or will be copied.",
+    )
+    oparser.add_option(
         "--sum", "--checksum",
         dest="checksum",
         help="Salt thin checksum",
@@ -68,6 +73,7 @@ def parse_argv(argv):
     for option in (
             'delimeter',
             'saltdir',
+            'saltpkgdir',
             'checksum',
             'version',
     ):
@@ -111,7 +117,7 @@ def unpack_thin(thin_path):
 def main(argv):
     parse_argv(argv)
 
-    thin_path = os.path.join(OPTIONS.saltdir, THIN_ARCHIVE)
+    thin_path = os.path.join(OPTIONS.saltpkgdir, THIN_ARCHIVE)
     if os.path.exists(thin_path):
         if OPTIONS.checksum != get_hash(thin_path, OPTIONS.hashfunc):
             os.unlink(thin_path)

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -10,6 +10,7 @@ import json
 # Import salt libs
 import salt.client.ssh.shell
 import salt.client.ssh.state
+from salt.client.ssh import DEFAULT_THIN_PKG_DIR
 import salt.utils
 import salt.utils.thin
 import salt.roster
@@ -63,17 +64,18 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
             chunks,
             file_refs)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
-    cmd = 'state.pkg /tmp/.salt/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
+    cmd = 'state.pkg {3}/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
             test,
             trans_tar_sum,
-            __opts__['hash_type'])
+            __opts__['hash_type'],
+            DEFAULT_THIN_PKG_DIR)
     single = salt.client.ssh.Single(
             __opts__,
             cmd,
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
-            '/tmp/.salt/salt_state.tgz')
+            '{0}/salt_state.tgz'.format(DEFAULT_THIN_PKG_DIR))
     stdout, stderr, _ = single.cmd_block()
     return json.loads(stdout, object_hook=salt.utils.decode_dict)
 
@@ -101,16 +103,17 @@ def low(data):
             chunks,
             file_refs)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
-    cmd = 'state.pkg /tmp/.salt/salt_state.tgz pkg_sum={0} hash_type={1}'.format(
+    cmd = 'state.pkg {2}/salt_state.tgz pkg_sum={0} hash_type={1}'.format(
             trans_tar_sum,
-            __opts__['hash_type'])
+            __opts__['hash_type'],
+            DEFAULT_THIN_PKG_DIR)
     single = salt.client.ssh.Single(
             __opts__,
             cmd,
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
-            '/tmp/.salt/salt_state.tgz')
+            '{0}/salt_state.tgz'.format(DEFAULT_THIN_PKG_DIR))
     stdout, stderr, _ = single.cmd_block()
     return json.loads(stdout, object_hook=salt.utils.decode_dict)
 
@@ -135,16 +138,17 @@ def high(data):
             chunks,
             file_refs)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
-    cmd = 'state.pkg /tmp/.salt/salt_state.tgz pkg_sum={0} hash_type={1}'.format(
+    cmd = 'state.pkg {2}/salt_state.tgz pkg_sum={0} hash_type={1}'.format(
             trans_tar_sum,
-            __opts__['hash_type'])
+            __opts__['hash_type'],
+            DEFAULT_THIN_PKG_DIR)
     single = salt.client.ssh.Single(
             __opts__,
             cmd,
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
-            '/tmp/.salt/salt_state.tgz')
+            '{0}/salt_state.tgz'.format(DEFAULT_THIN_PKG_DIR))
     stdout, stderr, _ = single.cmd_block()
     return json.loads(stdout, object_hook=salt.utils.decode_dict)
 
@@ -171,17 +175,18 @@ def highstate(test=None, **kwargs):
             chunks,
             file_refs)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
-    cmd = 'state.pkg /tmp/.salt/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
+    cmd = 'state.pkg {3}/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
             test,
             trans_tar_sum,
-            __opts__['hash_type'])
+            __opts__['hash_type'],
+            DEFAULT_THIN_PKG_DIR)
     single = salt.client.ssh.Single(
             __opts__,
             cmd,
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
-            '/tmp/.salt/salt_state.tgz')
+            '{0}/salt_state.tgz'.format(DEFAULT_THIN_PKG_DIR))
     stdout, stderr, _ = single.cmd_block()
     return json.loads(stdout, object_hook=salt.utils.decode_dict)
 
@@ -212,17 +217,18 @@ def top(topfn, test=None, **kwargs):
             chunks,
             file_refs)
     trans_tar_sum = salt.utils.get_hash(trans_tar, __opts__['hash_type'])
-    cmd = 'state.pkg /tmp/.salt/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
+    cmd = 'state.pkg {3}/salt_state.tgz test={0} pkg_sum={1} hash_type={2}'.format(
             test,
             trans_tar_sum,
-            __opts__['hash_type'])
+            __opts__['hash_type'],
+            DEFAULT_THIN_PKG_DIR)
     single = salt.client.ssh.Single(
             __opts__,
             cmd,
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
-            '/tmp/.salt/salt_state.tgz')
+            '{0}/salt_state.tgz'.format(DEFAULT_THIN_PKG_DIR))
     stdout, stderr, _ = single.cmd_block()
     return json.loads(stdout, object_hook=salt.utils.decode_dict)
 


### PR DESCRIPTION
...age _copy dir_, ie: via scp, vs. regular salt-thin dir (/tmp/.salt).

Fixes issue #13770 , related to issue #9473
