### PR TITLE
Add support for additional, optional CLI arg to "salt-run thin.generate"...

### DIFF
--- a/salt/runners/thin.py
+++ b/salt/runners/thin.py
@@ -14,7 +14,7 @@ from __future__ import print_function
 import salt.utils.thin
 
 
-def generate(extra_mods='', overwrite=False):
+def generate(extra_mods='', overwrite=False, so_mods=''):
     '''
     Generate the salt-thin tarball and print the location of the tarball
     Optional additional mods to include (e.g. mako) can be supplied as a comma
@@ -29,4 +29,4 @@ def generate(extra_mods='', overwrite=False):
         salt-run thin.generate mako,wempy 1
         salt-run thin.generate overwrite=1
     '''
-    print(salt.utils.thin.gen_thin(__opts__['cachedir'], extra_mods, overwrite))
+    print(salt.utils.thin.gen_thin(__opts__['cachedir'], extra_mods, overwrite, so_mods))

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -60,7 +60,7 @@ if __name__ == '__main__':
 '''
 
 
-def gen_thin(cachedir, extra_mods='', overwrite=False):
+def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
     '''
     Generate the salt-thin tarball and print the location of the tarball
     Optional additional mods to include (e.g. mako) can be supplied as a comma
@@ -122,6 +122,12 @@ def gen_thin(cachedir, extra_mods='', overwrite=False):
                 # doesn't bail on import failure, so I followed that lead.
                 # And of course, any other failure still S/T's.
                 pass
+    for mod in [m for m in so_mods.split(',') if m]:
+        try:
+            locals()[mod] = __import__(mod)
+            tops.append(locals()[mod].__file__)
+        except ImportError:
+            pass   # As per comment above
     if HAS_MARKUPSAFE:
         tops.append(os.path.dirname(markupsafe.__file__))
     tfp = tarfile.open(thintar, 'w:gz', dereference=True)


### PR DESCRIPTION
... (which gets passed through to ssh_py_shim) to speciy comma separated list of _native_ python module names to be packaged up in the thin tar (ie: single-file python modules implemented as .so files). This type of module does not play well "normally" using the extra_mods functionality of thin.generate, and implicit defaults do not work for native extensions where the master/minion are in a heterogenous environment, ie: non-matching architectures.

This way, .so modules (native extensions) can be packaged into a thin tar even in the presence of a heterogeneous environment, assuming the master has available the correct binary .so module for the target minion architecture.

Addresses/solves/fixes issue #13769
