### PR TITLE
Misc fixes to stuff found while debugging / working on salt-ssh:

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -110,9 +110,9 @@ if [ -n "$DEBUG" ]; then
     set -x
 fi
 
-SUDO=""
-if [ -n "{{SUDO}}" ]; then
-    SUDO="sudo root -c"
+SUDO="{{SUDO}}"
+if [ -n "$SUDO" ]; then
+    SUDO="sudo -u root"
 fi
 
 EX_PYTHON_OLD={EX_THIN_PYTHON_OLD}    # Python interpreter is too old and incompatible

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -74,7 +74,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
             __opts__,
-            cmd,
+            cmd.split(' '),
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
@@ -112,7 +112,7 @@ def low(data):
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
             __opts__,
-            cmd,
+            cmd.split(' '),
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
@@ -147,7 +147,7 @@ def high(data):
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
             __opts__,
-            cmd,
+            cmd.split(' '),
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
@@ -185,7 +185,7 @@ def highstate(test=None, **kwargs):
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
             __opts__,
-            cmd,
+            cmd.split(' '),
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,
@@ -232,7 +232,7 @@ def top(topfn, test=None, **kwargs):
             __opts__['hash_type'])
     single = salt.client.ssh.Single(
             __opts__,
-            cmd,
+            cmd.split(' '),
             **__salt__.kwargs)
     single.shell.send(
             trans_tar,

--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -3,6 +3,8 @@
 Generate the salt thin tarball from the installed python files
 '''
 
+from __future__ import absolute_import
+
 # Import python libs
 import os
 import tarfile
@@ -10,6 +12,7 @@ import tarfile
 # Import third party libs
 import jinja2
 import yaml
+import backports
 import msgpack
 import requests
 try:
@@ -92,6 +95,7 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
             os.path.dirname(salt.__file__),
             os.path.dirname(jinja2.__file__),
             os.path.dirname(yaml.__file__),
+            os.path.dirname(backports.__file__),
             os.path.dirname(msgpack.__file__),
             os.path.dirname(requests.__file__)
             ]


### PR DESCRIPTION
UPDATED: after rebase: removed pre-existing salt/modules/iptables.py fix as it's already upstream...
- SUDO command string/logic for salt-ssh fixed
- command & args (list) now passed to Single properly/as it expects w.r.t. current implementation (vs. one big string)
- added absolute imports to utils/thin.py - this does not break any existing imports untouched, but fixes case where extra mods are being included with "salt-run thin.generate", as mako (as an example) will not be imported properly without absolute imports since there exists a mako.py file inside the utils/ dir, etc.
- also added "backports" module to thin tar generation, since it is required by other stuff in the core "thin" modules in some setups
