### PR TITLE
Clarify version numbering scheme

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -64,7 +64,7 @@ help:
 
 clean:
 	rm -rf $(BUILDDIR)/*
-	find locale/ -name *.mo -exec rm {} \;
+	test -d 'locale' && find locale/ -name *.mo -exec rm {} \;
 
 html: translations
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/topics/releases/2014.1.0.rst
+++ b/doc/topics/releases/2014.1.0.rst
@@ -18,7 +18,8 @@ testing making roughly double the coverage in the Salt tests, and comes with
 many new features.
 
 2014.1.0 is the first release to follow the new date-based release naming
-system.
+system. See the :doc:`version numbers</topics/releases/version_numbers>`
+page for more details.
 
 Major Features
 ==============

--- a/doc/topics/releases/index.rst
+++ b/doc/topics/releases/index.rst
@@ -2,6 +2,9 @@
 Release notes
 =============
 
+See the :doc:`version numbers</topics/releases/version_numbers>` page for more
+information about the version numbering scheme.
+
 .. releasestree::
     :maxdepth: 1
 
@@ -14,7 +17,7 @@ Archive
     :maxdepth: 1
     :glob:
 
-    *
+    [0-9]*
 
 .. seealso:: :doc:`Legacy salt-cloud release docs <../cloud/releases/index>`
 

--- a/doc/topics/releases/version_numbers.rst
+++ b/doc/topics/releases/version_numbers.rst
@@ -1,0 +1,33 @@
+===============
+Version Numbers
+===============
+
+Salt uses a date based system for version numbers. Version numbers are in the
+format ``YYYY.MM.R``. The year (``YYYY``) and month (``MM``) reflect when the
+release was created. The bugfix release number (``R``) increments within that
+feature release.
+
+.. note:: Prior to the ``2014.1.0`` release, the typical semantic versioning was
+   still being used. Because of the rolling nature of the project, this did not
+   make sense. The ``0.17`` release was the last of that style.
+
+Code Names
+----------
+
+To distinguish future releases from the current release, code names are used.
+The periodic table is used to derive the next codename. The first release in
+the date based system was code named ``Hydrogen``, each subsequent release will
+go to the next atomic number.
+
+Example
+-------
+
+An example might help clarify how this all works.
+
+It is the year ``2020`` and the current code name is ``Iodine``. A release is ready
+to be cut and the month is ``June``. This would make the new release number
+``2020.6.0``. After three bug fix releases, the release number would be
+``2020.6.3``.
+
+After the release is cut, new features would be worked on under the ``Xenon``
+code name and the process repeats itself.


### PR DESCRIPTION
Clarify the version numbering scheme based on the blog post on the subject.
http://www.saltstack.com/salt-blog/2013/10/27/salt-version-numbers
Reference the new document on the releases page and from the first date based release.
Also a minor fix for the docs make clean command so that it does not error out.
