### PR TITLE
Raise a 401 reponse instead of redirecting to the login page

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -267,7 +267,7 @@ def salt_auth_tool():
     '''
     # Redirect to the login page if the session hasn't been authed
     if not cherrypy.session.has_key('token'):  # pylint: disable=W8601
-        raise cherrypy.InternalRedirect('/login')
+        raise cherrypy.HTTPError(401)
 
     # Session is authenticated; inform caches
     cherrypy.response.headers['Cache-Control'] = 'private'
@@ -298,7 +298,7 @@ def hypermedia_handler(*args, **kwargs):
         cherrypy.response.processors = dict(ct_out_map)
         ret = cherrypy.serving.request._hypermedia_inner_handler(*args, **kwargs)
     except salt.exceptions.EauthAuthenticationError:
-        raise cherrypy.InternalRedirect('/login')
+        raise cherrypy.HTTPError(401)
     except cherrypy.CherryPyException:
         raise
     except Exception as exc:
@@ -1238,7 +1238,7 @@ class Events(object):
 
         # Manually verify the token
         if not salt_token or not self.auth.get_tok(salt_token):
-            raise cherrypy.InternalRedirect('/login')
+            raise cherrypy.HTTPError(401)
 
         # Release the session lock before starting the long-running response
         cherrypy.session.release_lock()

--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -23,8 +23,8 @@ class TestAuth(BaseRestCherryPyTest):
         '''
         POST requests to the root URL redirect to login
         '''
-        self.assertRaisesRegexp(cherrypy.InternalRedirect, '/login',
-                self.request, '/', method='POST', data={})
+        request, response = self.request('/', method='POST', data={})
+        self.assertEqual(response.status, '401 Unauthorized')
 
     def test_login_noauth(self):
         '''
@@ -37,8 +37,8 @@ class TestAuth(BaseRestCherryPyTest):
         '''
         Requests to the webhook URL require auth by default
         '''
-        self.assertRaisesRegexp(cherrypy.InternalRedirect, '/login',
-                self.request, '/hook', method='POST', data={})
+        request, response = self.request('/hook', method='POST', data={})
+        self.assertEqual(response.status, '401 Unauthorized')
 
 
 class TestLogin(BaseRestCherryPyTest):


### PR DESCRIPTION
Also fixed bad tests that should have caught this.

Fixes saltstack/salt-api#155.
