### PR TITLE
Clarify cloud configuration extends behaviors

### DIFF
--- a/doc/topics/cloud/config.rst
+++ b/doc/topics/cloud/config.rst
@@ -702,6 +702,18 @@ files, i.e. ``/etc/salt/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/*.conf``.
 
 
+.. note::
+
+    Extending cloud profiles and providers is not recursive. For example, a
+    profile that is extended by a second profile is possible, but the second
+    profile cannot be extended by a third profile.
+
+    Also, if a profile (or provider) is extending another profile and each
+    contains a list of values, the lists from the extending profile will
+    override the list from the original profile. The lists are not merged
+    together.
+
+
 Extending Profiles
 ------------------
 


### PR DESCRIPTION
In `cloud.config` the extend functionality does not merge lists or extend cloud providers/profiles recursively. This clarifies those behaviors in the docs.

Refs #12033
