### PR TITLE
Avoid IOError tracebacks for broken pipes

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -21,7 +21,7 @@ import salt.runner
 import salt.auth
 import salt.key
 
-from salt.utils import parsers
+from salt.utils import parsers, print_cli
 from salt.utils.verify import check_user, verify_env, verify_files
 from salt.exceptions import (
     SaltInvocationError,
@@ -133,7 +133,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
             if self.config['async']:
                 jid = local.cmd_async(**kwargs)
-                print('Executed command with job ID: {0}'.format(jid))
+                print_cli('Executed command with job ID: {0}'.format(jid))
                 return
             retcodes = []
             try:
@@ -199,17 +199,17 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 not_return_minions.append(each_minion)
             else:
                 return_counter += 1
-        print('\n')
-        print('-------------------------------------------')
-        print('Summary')
-        print('-------------------------------------------')
+        print_cli('\n')
+        print_cli('-------------------------------------------')
+        print_cli('Summary')
+        print_cli('-------------------------------------------')
         if self.options.verbose:
-            print('# of Minions Targeted: {0}'.format(return_counter + not_return_counter))
-        print('# of Minions Returned: {0}'.format(return_counter))
+            print_cli('# of Minions Targeted: {0}'.format(return_counter + not_return_counter))
+        print_cli('# of Minions Returned: {0}'.format(return_counter))
         if self.options.verbose:
-            print('# of Minions Did Not Return: {0}'.format(not_return_counter))
-            print('Minions Which Did Not Return: {0}'.format(" ".join(not_return_minions)))
-        print('-------------------------------------------')
+            print_cli('# of Minions Did Not Return: {0}'.format(not_return_counter))
+            print_cli('Minions Which Did Not Return: {0}'.format(" ".join(not_return_minions)))
+        print_cli('-------------------------------------------')
 
     def _output_ret(self, ret, out):
         '''
@@ -255,8 +255,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                         docs[fun] = ret[host][fun]
         for fun in sorted(docs):
             salt.output.display_output(fun + ':', 'text', self.config)
-            print(docs[fun])
-            print('')
+            print_cli(docs[fun])
+            print_cli('')
 
 
 class SaltCP(parsers.SaltCPOptionParser):

--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -12,6 +12,7 @@ import copy
 # Import salt libs
 import salt.client
 import salt.output
+from salt.utils import print_cli
 
 
 class Batch(object):
@@ -45,7 +46,7 @@ class Batch(object):
         for ret in self.local.cmd_iter(*args, **self.eauth):
             for minion in ret:
                 if not self.quiet:
-                    print('{0} Detected for this batch run'.format(minion))
+                    print_cli('{0} Detected for this batch run'.format(minion))
                 fret.append(minion)
         return sorted(fret)
 
@@ -65,8 +66,8 @@ class Batch(object):
                 return int(self.opts['batch'])
         except ValueError:
             if not self.quiet:
-                print(('Invalid batch data sent: {0}\nData must be in the form'
-                       'of %10, 10% or 3').format(self.opts['batch']))
+                print_cli('Invalid batch data sent: {0}\nData must be in the '
+                          'form of %10, 10% or 3'.format(self.opts['batch']))
 
     def run(self):
         '''
@@ -109,7 +110,7 @@ class Batch(object):
 
             if next_:
                 if not self.quiet:
-                    print('\nExecuting run on {0}\n'.format(next_))
+                    print_cli('\nExecuting run on {0}\n'.format(next_))
                 # create a new iterator for this batch of minions
                 new_iter = self.local.cmd_iter_no_block(
                                 *args,

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -22,6 +22,7 @@ import salt.transport
 import salt.utils.args
 from salt._compat import string_types
 from salt.log import LOG_LEVELS
+from salt.utils import print_cli
 
 # Custom exceptions
 from salt.exceptions import (
@@ -169,7 +170,7 @@ class Caller(object):
                     docs[name] = func.__doc__
         for name in sorted(docs):
             if name.startswith(self.opts.get('fun', '')):
-                print('{0}:\n{1}\n'.format(name, docs[name]))
+                print_cli('{0}:\n{1}\n'.format(name, docs[name]))
 
     def print_grains(self):
         '''

--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -14,6 +14,7 @@ import pprint
 
 # Import salt libs
 import salt.client
+from salt.utils import print_cli
 
 
 class SaltCP(object):
@@ -60,7 +61,7 @@ class SaltCP(object):
             if os.path.isfile(fn_):
                 files.update(self._file_dict(fn_))
             elif os.path.isdir(fn_):
-                print(fn_ + ' is a directory, only files are supported.')
+                print_cli(fn_ + ' is a directory, only files are supported.')
                 #files.update(self._recurse_dir(fn_))
         return files
 

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -15,6 +15,7 @@ import traceback
 # Import salt libs
 import salt.loader
 import salt.utils
+from salt.utils import print_cli
 
 
 log = logging.getLogger(__name__)
@@ -47,7 +48,7 @@ def display_output(data, out=None, opts=None):
                 ofh.write('\n')
             return
         if display_data:
-            print(display_data)
+            print_cli(display_data)
     except IOError as exc:
         # Only raise if it's NOT a broken pipe
         if exc.errno != errno.EPIPE:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -10,6 +10,7 @@ import copy
 import collections
 import datetime
 import distutils.version  # pylint: disable=E0611
+import errno
 import fnmatch
 import hashlib
 import imp
@@ -1646,6 +1647,18 @@ def parse_docstring(docstring):
         deps = dep_list[0].replace(txt, '').strip().split(', ')
         ret['deps'] = deps
         return ret
+
+
+def print_cli(msg):
+    '''
+    Wrapper around print() that suppresses tracebacks on broken pipes (i.e.
+    when salt output is piped to less and less is stopped prematurely).
+    '''
+    try:
+        print(msg)
+    except IOError as exc:
+        if exc.errno != errno.EPIPE:
+            raise
 
 
 def safe_walk(top, topdown=True, onerror=None, followlinks=True, _seen=None):


### PR DESCRIPTION
This pull request suppresses an `IOError` when there is a broken pipe (i.e. when salt output is piped to less and less is exited prematurely). It uses a wrapper function in salt.utils, and (for now) has only been applied to the CLI frontend bits and salt.output.display_output().

Resolves #13721.
