### PR TITLE
Added support for config option  "ioflo_console_logdir"

### DIFF
--- a/salt/daemons/flo/__init__.py
+++ b/salt/daemons/flo/__init__.py
@@ -16,6 +16,7 @@ opts['ioflo_period']
 opts['ioflo_realtime']
 opts['ioflo_verbose']
 '''
+import os
 
 # Import modules
 from . import core
@@ -66,6 +67,12 @@ class IofloMaster(object):
             behaviors = []
         behaviors.extend(['salt.daemons.flo'])
 
+        console_logdir = self.opts.get('ioflo_console_logdir', '')
+        if console_logdir:
+            consolepath = os.path.join(console_logdir, 'master.log')
+        else: # empty means log to std out
+            consolepath = ''
+
         ioflo.app.run.start(
                 name='master',
                 period=float(self.opts['ioflo_period']),
@@ -80,6 +87,7 @@ class IofloMaster(object):
                 metas=None,
                 preloads=self.preloads,
                 verbose=int(self.opts['ioflo_verbose']),
+                consolepath=consolepath,
                 )
 
 
@@ -105,6 +113,12 @@ class IofloMinion(object):
 
         preloads = explode_opts(self.opts)
 
+        console_logdir = self.opts.get('ioflo_console_logdir', '')
+        if console_logdir:
+            consolepath = os.path.join(console_logdir, 'minion.log')
+        else: # empty means log to std out
+            consolepath = ''
+
         ioflo.app.run.start(
                 name=self.opts['id'],
                 period=float(self.opts['ioflo_period']),
@@ -119,6 +133,7 @@ class IofloMinion(object):
                 metas=None,
                 preloads=preloads,
                 verbose=int(self.opts['ioflo_verbose']),
+                consolepath=consolepath,
                 )
 
     start = tune_in  # alias

--- a/salt/daemons/flo/maint.py
+++ b/salt/daemons/flo/maint.py
@@ -4,6 +4,7 @@ Define the behaviors used in the maintinance process
 '''
 # Import python libs
 import multiprocessing
+import os
 
 # Import ioflo libs
 import ioflo.base.deeding
@@ -38,6 +39,13 @@ class ForkMaint(ioflo.base.deeding.Deed):
         '''
         behaviors = ['salt.daemons.flo']
         preloads = [('.salt.opts', dict(value=self.opts.value))]
+
+        console_logdir = self.opts.value.get('ioflo_console_logdir', '')
+        if console_logdir:
+            consolepath = os.path.join(console_logdir, 'maintenance.log')
+        else: # empty means log to std out
+            consolepath = ''
+
         ioflo.app.run.start(
                 name='maintenance',
                 period=float(self.opts.value['loop_interval']),
@@ -52,6 +60,7 @@ class ForkMaint(ioflo.base.deeding.Deed):
                 metas=None,
                 preloads=preloads,
                 verbose=int(self.opts.value['ioflo_verbose']),
+                consolepath=consolepath,
                 )
 
     def action(self):

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -44,7 +44,7 @@ class WorkerFork(ioflo.base.deeding.Deed):
 
     def _worker(self, yid):
         '''
-        Spin up a worker, do this in s multiprocess
+        Spin up a worker, do this in  multiprocess
         '''
         self.opts.value['__worker'] = True
         behaviors = ['salt.daemons.flo']
@@ -52,6 +52,13 @@ class WorkerFork(ioflo.base.deeding.Deed):
         preloads.append(('.salt.yid', dict(value=yid)))
         preloads.append(
                 ('.salt.access_keys', dict(value=self.access_keys.value)))
+
+        console_logdir = self.opts.value.get('ioflo_console_logdir', '')
+        if console_logdir:
+            consolepath = os.path.join(console_logdir, "worker_{0}.log".format(yid))
+        else: # empty means log to std out
+            consolepath = ''
+
         ioflo.app.run.start(
                 name='worker{0}'.format(yid),
                 period=float(self.opts.value['ioflo_period']),
@@ -66,6 +73,7 @@ class WorkerFork(ioflo.base.deeding.Deed):
                 metas=None,
                 preloads=preloads,
                 verbose=int(self.opts.value['ioflo_verbose']),
+                consolepath=consolepath,
                 )
 
     def action(self):


### PR DESCRIPTION
This allows sending all the ioflo console logs to files in the directory specified by ioflo_console_logdir

These are
master.log
minion.log
maintenance.log
worker_x.log etc

Requires  ioflo v0.9.37
