### PR TITLE
Tweaks to salt-ssh error handling

### DIFF
--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -14,7 +14,7 @@ import salt.utils
 import salt.client.ssh
 
 
-class FunctionWrapper(object):
+class FunctionWrapper(dict):
     '''
     Create an object that acts like the salt function dict and makes function
     calls remotely via the SSH shell system

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -80,7 +80,12 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
             trans_tar,
             '/tmp/.salt/salt_state.tgz')
     stdout, stderr, _ = single.cmd_block()
-    return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    try:
+        return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception, e:
+        log.error("JSON Render failed for: {0}".format(stdout))
+        log.error(str(e))
+    return stdout
 
 
 def low(data, **kwargs):


### PR DESCRIPTION
Running states through salt-ssh is currently broken. This does not fix that issue but gets us closer to the real problem. Two problems:
1. Running states through salt-ssh is returning: `ERROR: Undefined SHIM state`.
2. The `__salt__` object in salt-ssh is not a dictionary-like object. It is missing `in` support, `.keys()` support, `.update()` support,
