### PR TITLE
Nova openstack cloud adapter improvements

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -386,8 +386,6 @@ def destroy(name, conn=None, call=None):
             {'name': name},
             transport=__opts__['transport']
         )
-        print __opts__.get('ssh_interface')
-        print str(node)
         if __opts__.get('delete_sshkeys', False) is True:
             salt.utils.cloud.remove_sshkey(getattr(node, __opts__.get('ssh_interface', 'public_ips'))[0])
         if __opts__.get('update_cachedir', False) is True:

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -820,12 +820,12 @@ def volume_create(name, size=100, snapshot=None, voltype=None, **kwargs):
     Create block storage device
     '''
     conn = get_conn()
-    return conn.volume_create(
-        name,
-        size,
-        snapshot,
-        voltype
-    )
+    create_kwargs = {'name': name,
+                     'size': size,
+                     'snapshot': snapshot,
+                     'voltype': voltype}
+    create_kwargs['availability_zone'] = kwargs.get('availability_zone', None)
+    return conn.volume_create(**create_kwargs)
 
 
 def volume_delete(name, **kwargs):

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -293,7 +293,8 @@ class SaltNova(object):
 
         return volume
 
-    def volume_create(self, name, size=100, snapshot=None, voltype=None):
+    def volume_create(self, name, size=100, snapshot=None, voltype=None,
+                      availability_zone=None):
         '''
         Create a block device
         '''
@@ -302,7 +303,8 @@ class SaltNova(object):
             size=size,
             display_name=name,
             volume_type=voltype,
-            snapshot_id=snapshot
+            snapshot_id=snapshot,
+            availability_zone=availability_zone
         )
 
         return self._volume_get(response.id)


### PR DESCRIPTION
This adds availability_zone to some nova cloud adapter functions.
Documentation is not included, I'll add a separate issue that it should probably be documented somewhere what features are available for the different cloud adapters etc.

It also fixes an issue with security groups in the nova driver, ie. they work now.

Finally, the NeCTAR cloud (aka Australian research cloud) does not use floating IPs (wish they did) and so in order to get any IP address I added a condition to use the 'access_ip' metadata if no other IP address can be found.
This is also used for Rackspace, I think, so maybe the Rackspace knowledgable person can make their code more generic instead? I'm happy to split up the pull requests if necessary, just let me know.
