### PR TITLE
add finger_master to key module

### DIFF
--- a/salt/modules/key.py
+++ b/salt/modules/key.py
@@ -15,6 +15,7 @@ def finger():
     Return the minion's public key fingerprint
 
     CLI Example:
+    dfasdf
 
     .. code-block:: bash
 
@@ -22,4 +23,19 @@ def finger():
     '''
     return salt.utils.pem_finger(
             os.path.join(__opts__['pki_dir'], 'minion.pub')
+            )
+
+
+def finger_master():
+    '''
+    Return the fingerprint of the master's public key on the minion.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' key.finger_master
+    '''
+    return salt.utils.pem_finger(
+            os.path.join(__opts__['pki_dir'], 'minion_master.pub')
             )


### PR DESCRIPTION
This would help us because we need to validate the master key is up to
date.

The plan is to expose the finger prints on the master (via salt-api).
The minion will periodically check. If it's master finger print is
wrong, then the minion will delete and start the auth process again.
