### PR TITLE
Adding the ability to schedule Salt jobs using cron like syntax

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -40,7 +40,8 @@ SCHEDULE_CONF = [
         'minutes',
         'hours',
         'days',
-        'enabled'
+        'enabled',
+        'cron'
         ]
 
 
@@ -203,9 +204,17 @@ def build_schedule_item(name, **kwargs):
         if item in kwargs and 'when' in kwargs:
             time_conflict = True
 
+        if item in kwargs and 'cron' in kwargs:
+            time_conflict = True
+
     if time_conflict:
         ret['result'] = False
-        ret['comment'] = 'Unable to use "seconds", "minutes", "hours", or "days" with "when" option.'
+        ret['comment'] = 'Unable to use "seconds", "minutes", "hours", or "days" with "when" or "cron" options.'
+        return ret
+
+    if 'when' in kwargs and 'cron' in kwargs:
+        ret['result'] = False
+        ret['comment'] = 'Unable to use "when" and "cron" options together.  Ignoring.'
         return ret
 
     for item in ['seconds', 'minutes', 'hours', 'days']:
@@ -240,7 +249,7 @@ def build_schedule_item(name, **kwargs):
         else:
             schedule[name]['splay'] = kwargs['splay']
 
-    for item in ['range', 'when', 'returner']:
+    for item in ['range', 'when', 'cron', 'returner']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 
@@ -278,10 +287,17 @@ def add(name, **kwargs):
     for item in ['seconds', 'minutes', 'hours', 'days']:
         if item in kwargs and 'when' in kwargs:
             time_conflict = True
+        if item in kwargs and 'cron' in kwargs:
+            time_conflict = True
 
     if time_conflict:
         ret['result'] = False
-        ret['comment'] = 'Error: Unable to use "seconds", "minutes", "hours", or "days" with "when" option.'
+        ret['comment'] = 'Error: Unable to use "seconds", "minutes", "hours", or "days" with "when" or "cron" options.'
+        return ret
+
+    if 'when' in kwargs and 'cron' in kwargs:
+        ret['result'] = False
+        ret['comment'] = 'Unable to use "when" and "cron" options together.  Ignoring.'
         return ret
 
     _new = build_schedule_item(name, **kwargs)
@@ -321,9 +337,17 @@ def modify(name, **kwargs):
         if item in kwargs and 'when' in kwargs:
             time_conflict = True
 
+        if item in kwargs and 'cron' in kwargs:
+            time_conflict = True
+
     if time_conflict:
         ret['result'] = False
         ret['comment'] = 'Error: Unable to use "seconds", "minutes", "hours", or "days" with "when" option.'
+        return ret
+
+    if 'when' in kwargs and 'cron' in kwargs:
+        ret['result'] = False
+        ret['comment'] = 'Unable to use "when" and "cron" options together.  Ignoring.'
         return ret
 
     current_schedule = __opts__['schedule'].copy()

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -42,10 +42,21 @@ Management of the Salt scheduler
     This will schedule the command: state.sls httpd test=True at 5pm on Monday,
     Wednesday and Friday, and 3pm on Tuesday and Thursday.
 
-'''
+    job1:
+      schedule.present:
+        - function: state.sls
+        - args:
+          - httpd
+        - kwargs:
+          test: True
+        - cron: '*/5 * * * *'
 
-import logging
-log = logging.getLogger(__name__)
+    Scheduled jobs can also be specified using the format used by cron.  This will
+    schedule the command: state.sls httpd test=True to run every 5 minutes.  Requires
+    that python-croniter is installed.
+
+
+'''
 
 
 def present(name,
@@ -76,6 +87,10 @@ def present(name,
         This will schedule the job at the specified time(s).
         The when parameter must be a single value or a dictionary
         with the date string(s) using the dateutil format.
+
+    cron
+        This will schedule the job at the specified time(s)
+        using the crontab format.
 
     function
         The function that should be executed by the scheduled job.


### PR DESCRIPTION
Adding the ability to schedule Salt jobs using cron like syntax for the time, using the excellent python-croniter module.  Also updated the module and state to be able to use this new functionality.  Some general cleanup in utils/schedule.py, modules/schedule.py and states/schedule.py
