### PR TITLE
Removed the term "Hydrogen" from versionadded notation

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -231,9 +231,8 @@
 # no signature, it will still be accepted, and a warning message will be logged.
 # Conversely, if sign_pub_messages is False, but a minion receives a signed
 # message it will be accepted, the signature will not be checked, and a warning message
-# will be logged.  This behavior will go away in Salt 0.17.6 (or Hydrogen RC1, whichever
-# comes first) and these two situations will cause minion to throw an exception and
-# drop the message.
+# will be logged. This behavior went away in Salt 2014.1.0 and these two situations
+# will cause minion to throw an exception and drop the message.
 #
 # sign_pub_messages: False
 

--- a/doc/ref/cli/salt-ssh.rst
+++ b/doc/ref/cli/salt-ssh.rst
@@ -36,7 +36,7 @@ Options
     default roster file is called ``roster`` and is found in the same directory
     as the master config file.
 
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
 .. option:: --refresh, --refresh-cache
 

--- a/doc/topics/cloud/releases/index.rst
+++ b/doc/topics/cloud/releases/index.rst
@@ -4,8 +4,8 @@
 Legacy salt-cloud Release Notes
 ===============================
 
-.. versionchanged:: 2014.1.0 (Hydrogen)
-    As of Salt's 2014.1.0 (Hydrogen) release salt-cloud is part of mainline
+.. versionchanged:: 2014.1.0
+    As of Salt's 2014.1.0 release salt-cloud is part of mainline
     Salt. Future salt-cloud release notes will be included in Salt's regular
     release notes.
 

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -133,7 +133,7 @@ If the ``gitfs_remotes`` option specifies three remotes:
 
 .. warning::
 
-    Salt versions prior to 2014.1.0 (Hydrogen) are not tolerant of changing the
+    Salt versions prior to 2014.1.0 are not tolerant of changing the
     order of remotes or modifying the URI of existing remotes. In those
     versions, when modifying remotes it is a good idea to remove the gitfs
     cache directory (``/var/cache/salt/master/gitfs``) before restarting the

--- a/doc/topics/tutorials/halite.rst
+++ b/doc/topics/tutorials/halite.rst
@@ -4,7 +4,7 @@ Installing and Configuring Halite
 
 In this tutorial, we'll walk through installing and setting up Halite.  The
 current version of Halite is considered pre-alpha and is supported only in Salt
-``v2014.1.0 (Hydrogen)`` or greater. Additional information is available on GitHub:
+``v2014.1.0`` or greater. Additional information is available on GitHub:
 https://github.com/saltstack/halite
 
 Before beginning this tutorial, ensure that the salt-master is installed. To
@@ -13,7 +13,7 @@ http://docs.saltstack.com/topics/installation/index.html
 
 .. note::
 
-    Halite only works with Salt versions greater than 2014.1.0 (Hydrogen).
+    Halite only works with Salt versions greater than 2014.1.0:.
 
 Installing Halite Via Package
 =============================

--- a/doc/topics/tutorials/halite.rst
+++ b/doc/topics/tutorials/halite.rst
@@ -13,7 +13,7 @@ http://docs.saltstack.com/topics/installation/index.html
 
 .. note::
 
-    Halite only works with Salt versions greater than 2014.1.0:.
+    Halite only works with Salt versions greater than 2014.1.0.
 
 Installing Halite Via Package
 =============================

--- a/doc/topics/tutorials/minionfs.rst
+++ b/doc/topics/tutorials/minionfs.rst
@@ -4,7 +4,7 @@
 MinionFS Backend Walkthrough
 ============================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 Sometimes, you might need to propagate files that are generated on a minion.
 Salt already has a feature to send files from a minion to the master:

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -16,7 +16,7 @@ will set the desired branch method. Possible values are: ``branches``,
 ``default`` branch will be mapped to ``base``.
 
 
-.. versionchanged:: 2014.1.0:
+.. versionchanged:: 2014.1.0
     The :conf_master:`hgfs_base` master config parameter was added, allowing
     for a branch other than ``default`` to be used for the ``base``
     environment, and allowing for a ``base`` environment to be specified when

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -16,7 +16,7 @@ will set the desired branch method. Possible values are: ``branches``,
 ``default`` branch will be mapped to ``base``.
 
 
-.. versionchanged:: 2014.1.0 (Hydrogen)
+.. versionchanged:: 2014.1.0:
     The :conf_master:`hgfs_base` master config parameter was added, allowing
     for a branch other than ``default`` to be used for the ``base``
     environment, and allowing for a ``base`` environment to be specified when

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -2,7 +2,7 @@
 '''
 A module to wrap archive calls
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 '''
 
 # Import salt libs

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -3,7 +3,7 @@
 A dead simple module wrapping calls to the Chocolatey package manager
 (http://chocolatey.org)
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 '''
 
 import logging

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -3,7 +3,7 @@
 Management of dockers
 =====================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 .. note::
 

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -170,7 +170,7 @@ def ex_mod_init(low):
     .. versionadded:: 0.17.0
        Initial automatic enforcement added when pkg is used on a Gentoo system.
 
-    .. versionchanged:: 2014.1.0-Hydrogen
+    .. versionchanged:: 2014.1.0
        Configure option added to make this behaviour optional, defaulting to
        off.
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1118,7 +1118,7 @@ def blockreplace(path,
         show_changes=True,
         ):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Replace content of a text block in a file, delimited by line markers
 
@@ -1625,7 +1625,7 @@ def touch(name, atime=None, mtime=None):
 
 def seek_read(path, size, offset):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Seek to a position on a file and write to it
 
@@ -1646,7 +1646,7 @@ def seek_read(path, size, offset):
 
 def seek_write(path, data, offset):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Seek to a position on a file and write to it
 
@@ -1668,7 +1668,7 @@ def seek_write(path, data, offset):
 
 def truncate(path, length):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Seek to a position on a file and delete everything after that point
 
@@ -1687,7 +1687,7 @@ def truncate(path, length):
 
 def link(src, path):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Create a hard link to a file
 
@@ -1823,7 +1823,7 @@ def copy(src, dst, recurse=False, remove_existing=False):
 
 def lstat(path):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Returns the lstat attributes for the given file or dir. Does not support
     symbolic links.
@@ -1847,7 +1847,7 @@ def lstat(path):
 
 def access(path, mode):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Test whether the Salt process has the specified access to the file. One of
     the following modes must be specified:
@@ -1882,7 +1882,7 @@ def access(path, mode):
 
 def readlink(path):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Return the path that a symlink points to
 
@@ -1903,7 +1903,7 @@ def readlink(path):
 
 def readdir(path):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Return a list containing the contents of a directory
 
@@ -1926,7 +1926,7 @@ def readdir(path):
 
 def statvfs(path):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Perform a statvfs call against the filesystem that the file resides on
 
@@ -2006,7 +2006,7 @@ def stats(path, hash_type=None, follow_symlinks=True):
 
 def rmdir(path):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Remove the specified directory. Fails if a directory is not empty.
 

--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -192,7 +192,7 @@ def version(*names, **kwargs):
         Return a nested dictionary containing both the origin name and version
         for each specified package.
 
-        .. versionadded:: 2014.1.0 (Hydrogen)
+        .. versionadded:: 2014.1.0
 
 
     CLI Example:
@@ -240,7 +240,7 @@ def list_pkgs(versions_as_list=False, with_origin=False, **kwargs):
         Return a nested dictionary containing both the origin name and version
         for each installed package.
 
-        .. versionadded:: 2014.1.0 (Hydrogen)
+        .. versionadded:: 2014.1.0
 
     CLI Example:
 

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -2,7 +2,7 @@
 '''
 Install software from the FreeBSD ``ports(7)`` system
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This module allows you to install ports using ``BATCH=yes`` to bypass
 configuration prompts. It is recommended to use the the :mod:`ports state

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -407,7 +407,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default'):
     :param default: default lookup_dict's key used if the grain does not exists
          or if the grain value has no match on lookup_dict.
 
-         .. versionadded:: 2014.1.0 (Hydrogen)
+         .. versionadded:: 2014.1.0
 
     CLI Example:
 

--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -2,7 +2,7 @@
 '''
 Support for htpasswd command
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 The functions here will load inside the webutil module. This allows other
 functions that don't use htpasswd to use the webutil module name.

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -506,7 +506,7 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
 
 def check_chain(table='filter', chain=None, family='ipv4'):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Check for the existence of a chain in the table
 
@@ -536,7 +536,7 @@ def check_chain(table='filter', chain=None, family='ipv4'):
 
 def new_chain(table='filter', chain=None, family='ipv4'):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Create new custom chain to the specified table.
 
@@ -563,7 +563,7 @@ def new_chain(table='filter', chain=None, family='ipv4'):
 
 def delete_chain(table='filter', chain=None, family='ipv4'):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Delete custom chain to the specified table.
 

--- a/salt/modules/memcached.py
+++ b/salt/modules/memcached.py
@@ -3,7 +3,7 @@
 Module for Management of Memcached Keys
 =======================================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 '''
 
 # Import python libs

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -25,7 +25,7 @@ Module to provide MySQL compatibility to salt.
 
         mysql.default_file: '/etc/mysql/debian.cnf'
 
-.. versionchanged:: 2014.1.0 (Hydrogen)
+.. versionchanged:: 2014.1.0
     charset connection argument added. This is a MySQL charset, not a python one
 .. versionchanged:: 0.16.2
     Connection arguments from the minion config file can be overridden on the

--- a/salt/modules/nova.py
+++ b/salt/modules/nova.py
@@ -114,7 +114,7 @@ def boot(name, flavor_id=0, image_id=0, profile=None, timeout=300):
         How long to wait, after creating the instance, for the provider to
         return information about it (default 300 seconds).
 
-        .. versionadded:: 2014.1.0 (Hydrogen)
+        .. versionadded:: 2014.1.0
 
     CLI Example:
 

--- a/salt/modules/pagerduty.py
+++ b/salt/modules/pagerduty.py
@@ -2,7 +2,7 @@
 '''
 Module for Firing Events via PagerDuty
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 :depends:   - pygerduty python module
 :configuration: This module can be used by either passing a jid and password

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -147,7 +147,7 @@ def version(*names, **kwargs):
         Return a nested dictionary containing both the origin name and version
         for each specified package.
 
-        .. versionadded:: 2014.1.0 (Hydrogen)
+        .. versionadded:: 2014.1.0
 
 
     CLI Example:
@@ -295,7 +295,7 @@ def list_pkgs(versions_as_list=False,
         Return a nested dictionary containing both the origin name and version
         for each installed package.
 
-        .. versionadded:: 2014.1.0 (Hydrogen)
+        .. versionadded:: 2014.1.0
 
     CLI Example:
 

--- a/salt/modules/rsync.py
+++ b/salt/modules/rsync.py
@@ -2,7 +2,7 @@
 '''
 Wrapper for rsync
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This data can also be passed into :doc:`pillar </topics/tutorials/pillar>`.
 Options passed into opts will overwrite options passed into pillar.

--- a/salt/modules/supervisord.py
+++ b/salt/modules/supervisord.py
@@ -352,7 +352,7 @@ def _read_config(conf_file=None):
 
 def options(name, conf_file=None):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Read the config file and return the config options for a given process
 

--- a/salt/modules/svn.py
+++ b/salt/modules/svn.py
@@ -179,7 +179,7 @@ def checkout(cwd,
 def switch(cwd, remote, target=None, user=None, username=None,
            password=None, *opts):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Switch a working copy of a remote Subversion repository
     directory

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -93,7 +93,7 @@ def create(path,
         Set ownership for the virtualenv
 
     .. note::
-        The ``runas`` argument is deprecated as of Hydrogen. ``user`` should be
+        The ``runas`` argument is deprecated as of 2014.1.0. ``user`` should be
         used instead.
 
     CLI Example:

--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -2,7 +2,7 @@
 '''
 Management of NTP servers on Windows
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 '''
 
 # Import python libs

--- a/salt/modules/xmpp.py
+++ b/salt/modules/xmpp.py
@@ -2,7 +2,7 @@
 '''
 Module for Sending Messages via XMPP (a.k.a. Jabber)
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 :depends:   - sleekxmpp python module
 :configuration: This module can be used by either passing a jid and password

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -386,7 +386,7 @@ def list_pkgs(versions_as_list=False, **kwargs):
 
 def list_repo_pkgs(*args, **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Returns all available packages. Optionally, package names can be passed and
     the results will be filtered to packages matching those names. This can be
@@ -563,7 +563,7 @@ def refresh_db(**kwargs):
 
 def clean_metadata(**kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Cleans local yum metadata. Functionally identical to :mod:`refresh_db()
     <salt.modules.yumpkg.refresh_db>`.
@@ -582,7 +582,7 @@ def group_install(name,
                   include=(),
                   **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Install the passed package group(s). This is basically a wrapper around
     pkg.install, which performs package group resolution for the user. This
@@ -1259,7 +1259,7 @@ def get_locked_packages(pattern=None, full=True):
 
 def verify(*names, **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Runs an rpm -Va on a system, and returns the results in a dict
 
@@ -1280,7 +1280,7 @@ def verify(*names, **kwargs):
 
 def group_list():
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Lists all groups known by yum on this system
 
@@ -1325,7 +1325,7 @@ def group_list():
 
 def group_info(name):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Lists packages belonging to a certain group
 
@@ -1377,7 +1377,7 @@ def group_info(name):
 
 def group_diff(name):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Lists packages belonging to a certain group, and which are installed
 
@@ -1677,7 +1677,7 @@ def _parse_repo_file(filename):
 
 def file_list(*packages):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     List the files that belong to a package. Not specifying any packages will
     return a list of *every* file on the system's rpm database (not generally
@@ -1696,7 +1696,7 @@ def file_list(*packages):
 
 def file_dict(*packages):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     List the files that belong to a package, grouped by package. Not
     specifying any packages will return a list of *every* file on the system's

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -3,7 +3,7 @@
 Management of zc.buildout
 =========================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 .. _`minitage's buildout maker`: https://github.com/minitage/minitage/blob/master/src/minitage/core/makers/buildout.py
 

--- a/salt/sdb/keyring_db.py
+++ b/salt/sdb/keyring_db.py
@@ -42,7 +42,7 @@ examples and documentation, see keyring:
 
 https://pypi.python.org/pypi/keyring
 
-.. versionadded:: 2014.1.4 (Hydrogen)
+.. versionadded:: 2014.1.4
 '''
 
 # import python libs

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -2,7 +2,7 @@
 '''
 Archive states.
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 '''
 
 import logging
@@ -21,7 +21,7 @@ def extracted(name,
               if_missing=None,
               keep=False):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     State that make sure an archive is extracted in a directory.
     The downloaded archive is erased if successfully extracted.

--- a/salt/states/at.py
+++ b/salt/states/at.py
@@ -36,12 +36,12 @@ def present(name, timespec, tag=None, runas=None, user=None, job=None):
     runas
         Users run the job.
 
-        .. deprecated:: 2014.1.4 (Hydrogen)
+        .. deprecated:: 2014.1.4
 
     user
         The user to run the at job
 
-        .. versionadded:: 2014.1.4 (Hydrogen)
+        .. versionadded:: 2014.1.4
 
     .. code-block:: yaml
 
@@ -64,7 +64,7 @@ def present(name, timespec, tag=None, runas=None, user=None, job=None):
     salt.utils.warn_until(
         'Lithium',
         'Please remove \'runas\' support at this stage. \'user\' support was '
-        'added in 2014.1.4 (Hydrogen). Support will be removed in {version}.',
+        'added in 2014.1.4. Support will be removed in {version}.',
         _dont_call_warnings=True
     )
     if runas:

--- a/salt/states/cloud.py
+++ b/salt/states/cloud.py
@@ -3,7 +3,7 @@
 Using states instead of maps to deploy clouds
 =============================================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 Use this minion to spin up a cloud instance:
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -616,7 +616,7 @@ def run(name,
     quiet
         The command will be executed quietly, meaning no log entries of the
         actual command or its return data. This is deprecated as of the
-        **2014.1.0 (Hydrogen)** release, and is being replaced with
+        **2014.1.0** release, and is being replaced with
         ``output_loglevel: quiet``.
 
     timeout

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -81,12 +81,12 @@ def installed(name,
     runas
         Which system user to run composer as.
 
-        .. deprecated:: 2014.1.4 (Hydrogen)
+        .. deprecated:: 2014.1.4
 
     user
         Which system user to run composer as.
 
-        .. versionadded:: 2014.1.4 (Hydrogen)
+        .. versionadded:: 2014.1.4
 
     prefer_source
         --prefer-source option of composer.
@@ -117,7 +117,7 @@ def installed(name,
     salt.utils.warn_until(
         'Lithium',
         'Please remove \'runas\' support at this stage. \'user\' support was '
-        'added in 2014.1.4 (Hydrogen).',
+        'added in 2014.1.4.',
         _dont_call_warnings=True
     )
     if runas:

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -63,7 +63,7 @@ def present(name, value):
 
 def list_present(name, value):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Ensure the value is present in the list type grain
 

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -194,7 +194,7 @@ def __virtual__():
 
 def chain_present(name, table='filter', family='ipv4'):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Verify the chain is exist.
 
@@ -246,7 +246,7 @@ def chain_present(name, table='filter', family='ipv4'):
 
 def chain_absent(name, table='filter', family='ipv4'):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Verify the chain is absent.
 
@@ -367,7 +367,7 @@ def append(name, family='ipv4', **kwargs):
 
 def insert(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Insert a rule into a chain
 
@@ -434,7 +434,7 @@ def insert(name, family='ipv4', **kwargs):
 
 def delete(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Delete a rule to a chain
 
@@ -514,7 +514,7 @@ def delete(name, family='ipv4', **kwargs):
 
 def set_policy(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Sets the default policy for iptables firewall tables
 
@@ -576,7 +576,7 @@ def set_policy(name, family='ipv4', **kwargs):
 
 def flush(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: 2014.1.0 (Hydrogen)
+    .. versionadded:: 2014.1.0
 
     Flush current iptables state
 

--- a/salt/states/memcached.py
+++ b/salt/states/memcached.py
@@ -3,7 +3,7 @@
 States for Management of Memcached Keys
 =======================================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 '''
 from salt.modules.memcached import (
     DEFAULT_HOST,

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -9,7 +9,7 @@ all interfaces are ignored unless specified.
 
 .. note::
 
-    Prior to version 2014.1.0 (Hydrogen), only RedHat-based systems (RHEL,
+    Prior to version 2014.1.0, only RedHat-based systems (RHEL,
     CentOS, Scientific Linux, etc.) are supported. Support for Debian/Ubuntu is
     new in 2014.1.0 and should be considered experimental.
 

--- a/salt/states/ntp.py
+++ b/salt/states/ntp.py
@@ -3,7 +3,7 @@
 Management of NTP servers
 =========================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This state is used to manage NTP servers. Currently only Windows is supported.
 

--- a/salt/states/pagerduty.py
+++ b/salt/states/pagerduty.py
@@ -3,7 +3,7 @@
 Create an Event in PagerDuty
 ============================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This state is useful for creating events on the PagerDuty service during state
 runs.

--- a/salt/states/ports.py
+++ b/salt/states/ports.py
@@ -2,7 +2,7 @@
 '''
 Manage software from FreeBSD ports
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 .. note::
 

--- a/salt/states/rabbitmq_plugin.py
+++ b/salt/states/rabbitmq_plugin.py
@@ -3,7 +3,7 @@
 Manage RabbitMQ Plugins
 =======================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 Example:
 

--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -3,7 +3,7 @@
 Configuration of network interfaces on Windows hosts
 ====================================================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This module provides the ``network`` state(s) on Windows hosts. DNS servers, IP
 addresses and default gateways can currently be managed.

--- a/salt/states/win_system.py
+++ b/salt/states/win_system.py
@@ -3,7 +3,7 @@
 Management of Windows system information
 ========================================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This state is used to manage system information such as the computer name and
 description.

--- a/salt/states/xmpp.py
+++ b/salt/states/xmpp.py
@@ -3,7 +3,7 @@
 Sending Messages over XMPP
 ==========================
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 This state is useful for firing messages during state runs, using the XMPP
 protocol

--- a/salt/states/zcbuildout.py
+++ b/salt/states/zcbuildout.py
@@ -157,12 +157,12 @@ def installed(name,
     runas
         user used to run buildout as
 
-        .. deprecated:: 2014.1.4 (Hydrogen)
+        .. deprecated:: 2014.1.4
 
     user
         user used to run buildout as
 
-        .. versionadded:: 2014.1.4 (Hydrogen)
+        .. versionadded:: 2014.1.4
 
     env
         environment variables to set when running
@@ -212,7 +212,7 @@ def installed(name,
     salt.utils.warn_until(
         'Lithium',
         'Please remove \'runas\' support at this stage. \'user\' support was '
-        'added in 2014.1.4 (Hydrogen).',
+        'added in 2014.1.4.',
         _dont_call_warnings=True
     )
     if runas:


### PR DESCRIPTION
Now that Hydrogen has a version number, the codename shouldn't be referenced, as per #12672.
