### PR TITLE
Fix failing state tests

### DIFF
--- a/tests/integration/files/file/base/master_tops_test.sls
+++ b/tests/integration/files/file/base/master_tops_test.sls
@@ -1,0 +1,1 @@
+# Empty to fix failing state tests.


### PR DESCRIPTION
The regression test for master_tops did not contain a reference SLS file in the base
env. This failure cascaded down and caused other state tests to fail.

cc: @pass_by_value and @cro
