### PR TITLE
Do not do a list_nodes_min for --query commands

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -574,8 +574,9 @@ class Cloud(object):
                 # If driver has function list_nodes_min, just replace it
                 # with query param to check existing vms on this driver
                 # for minimum information, Othwise still use query param.
-                if '{0}.list_nodes_min'.format(driver) in self.clouds:
-                    this_query = 'list_nodes_min'
+                if not 'selected_query_option' in opts:
+                    if '{0}.list_nodes_min'.format(driver) in self.clouds:
+                        this_query = 'list_nodes_min'
                 fun = '{0}.{1}'.format(driver, this_query)
                 if fun not in self.clouds:
                     log.error(

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -574,7 +574,7 @@ class Cloud(object):
                 # If driver has function list_nodes_min, just replace it
                 # with query param to check existing vms on this driver
                 # for minimum information, Othwise still use query param.
-                if not 'selected_query_option' in opts:
+                if 'selected_query_option' not in opts:
                     if '{0}.list_nodes_min'.format(driver) in self.clouds:
                         this_query = 'list_nodes_min'
                 fun = '{0}.{1}'.format(driver, this_query)


### PR DESCRIPTION
This has been pretty obnoxious. Basically, `list_nodes_min()` is designed to optimize name lookups for everything except for `--query`, `--full-query` and `--select-query`, but it was doing it for them too. This should take care of that.
