### PR TITLE
Fix for 13793 postgres

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -74,7 +74,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None,
     kwargs = {
         'reset_system_locale': False,
         'clean_env': True,
-    }
+        }
     if runas is None:
         if not host:
             host = __salt__['config.option']('postgres.host')
@@ -100,7 +100,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None,
                 port if port else '*',
                 user if user else '*',
                 password,
-            ))
+                ))
             __salt__['file.chown'](pgpassfile, runas, '')
             kwargs['env'] = {'PGPASSFILE': pgpassfile}
 
@@ -156,7 +156,7 @@ def _parsed_version(user=None, host=None, port=None, maintenance_db=None,
         maintenance_db=maintenance_db,
         password=password,
         runas=runas,
-    )
+        )
 
     if psql_version:
         return distutils.version.LooseVersion(psql_version)
@@ -372,7 +372,7 @@ def db_create(name,
         'LC_COLLATE': lc_collate and '{0!r}'.format(lc_collate),
         'LC_CTYPE': lc_ctype and '{0!r}'.format(lc_ctype),
         'TABLESPACE': tablespace,
-    }
+        }
     with_chunks = []
     for key, value in with_args.iteritems():
         if value is not None:
@@ -656,15 +656,15 @@ def _role_cmd_args(name,
     skip_passwd = False
     escaped_password = ''
     if not (
-        rolepassword is not None
-        # first is passwd set
-        # second is for handling NOPASSWD
-        and (
-            isinstance(rolepassword, string_types) and bool(rolepassword)
-        )
-        or (
-            isinstance(rolepassword, bool)
-        )
+                        rolepassword is not None
+                # first is passwd set
+                # second is for handling NOPASSWD
+                and (
+                            isinstance(rolepassword, string_types) and bool(rolepassword)
+                )
+            or (
+                    isinstance(rolepassword, bool)
+            )
     ):
         skip_passwd = True
     if isinstance(rolepassword, string_types) and bool(rolepassword):
@@ -1145,17 +1145,17 @@ def create_metadata(name,
     if installed_ext:
         ret = [_EXTENSION_INSTALLED]
         if (
-            ext_version is not None
-            and _pg_is_older_ext_ver(
-                installed_ext.get('extversion', ext_version),
-                ext_version
-            )
+                        ext_version is not None
+                and _pg_is_older_ext_ver(
+                        installed_ext.get('extversion', ext_version),
+                        ext_version
+                )
         ):
             ret.append(_EXTENSION_TO_UPGRADE)
         if (
-            schema is not None
-            and installed_ext.get('extrelocatable', 'f') == 't'
-            and installed_ext.get('schema_name', schema) != schema
+                            schema is not None
+                    and installed_ext.get('extrelocatable', 'f') == 't'
+                and installed_ext.get('schema_name', schema) != schema
         ):
             ret.append(_EXTENSION_TO_MOVE)
     return ret

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -74,7 +74,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None,
     kwargs = {
         'reset_system_locale': False,
         'clean_env': True,
-        }
+    }
     if runas is None:
         if not host:
             host = __salt__['config.option']('postgres.host')
@@ -100,7 +100,7 @@ def _run_psql(cmd, runas=None, password=None, host=None, port=None, user=None,
                 port if port else '*',
                 user if user else '*',
                 password,
-                ))
+            ))
             __salt__['file.chown'](pgpassfile, runas, '')
             kwargs['env'] = {'PGPASSFILE': pgpassfile}
 
@@ -156,7 +156,7 @@ def _parsed_version(user=None, host=None, port=None, maintenance_db=None,
         maintenance_db=maintenance_db,
         password=password,
         runas=runas,
-        )
+    )
 
     if psql_version:
         return distutils.version.LooseVersion(psql_version)
@@ -372,7 +372,7 @@ def db_create(name,
         'LC_COLLATE': lc_collate and '{0!r}'.format(lc_collate),
         'LC_CTYPE': lc_ctype and '{0!r}'.format(lc_ctype),
         'TABLESPACE': tablespace,
-        }
+    }
     with_chunks = []
     for key, value in with_args.iteritems():
         if value is not None:
@@ -656,15 +656,15 @@ def _role_cmd_args(name,
     skip_passwd = False
     escaped_password = ''
     if not (
-                        rolepassword is not None
-                # first is passwd set
-                # second is for handling NOPASSWD
-                and (
-                            isinstance(rolepassword, string_types) and bool(rolepassword)
-                )
-            or (
-                    isinstance(rolepassword, bool)
-            )
+        rolepassword is not None
+        # first is passwd set
+        # second is for handling NOPASSWD
+        and (
+            isinstance(rolepassword, string_types) and bool(rolepassword)
+        )
+        or (
+            isinstance(rolepassword, bool)
+        )
     ):
         skip_passwd = True
     if isinstance(rolepassword, string_types) and bool(rolepassword):
@@ -1145,17 +1145,17 @@ def create_metadata(name,
     if installed_ext:
         ret = [_EXTENSION_INSTALLED]
         if (
-                        ext_version is not None
-                and _pg_is_older_ext_ver(
-                        installed_ext.get('extversion', ext_version),
-                        ext_version
-                )
+            ext_version is not None
+            and _pg_is_older_ext_ver(
+                installed_ext.get('extversion', ext_version),
+                ext_version
+            )
         ):
             ret.append(_EXTENSION_TO_UPGRADE)
         if (
-                            schema is not None
-                    and installed_ext.get('extrelocatable', 'f') == 't'
-                and installed_ext.get('schema_name', schema) != schema
+            schema is not None
+            and installed_ext.get('extrelocatable', 'f') == 't'
+            and installed_ext.get('schema_name', schema) != schema
         ):
             ret.append(_EXTENSION_TO_MOVE)
     return ret

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -639,7 +639,8 @@ def _role_cmd_args(name,
                    superuser=None,
                    groups=None,
                    replication=None,
-                   rolepassword=None):
+                   rolepassword=None,
+                   db_role=None):
     if createuser is not None and superuser is None:
         superuser = createuser
     if inherit is None:
@@ -672,11 +673,15 @@ def _role_cmd_args(name,
             _maybe_encrypt_password(name,
                                     rolepassword.replace('\'', '\'\''),
                                     encrypted=encrypted))
+    skip_superuser = False
+    if bool(db_role) and bool(superuser) == bool(db_role['superuser']):
+        skip_superuser = True
     flags = (
         {'flag': 'INHERIT', 'test': inherit},
         {'flag': 'CREATEDB', 'test': createdb},
         {'flag': 'CREATEROLE', 'test': createroles},
-        {'flag': 'SUPERUSER', 'test': superuser},
+        {'flag': 'SUPERUSER', 'test': superuser,
+         'skip': skip_superuser},
         {'flag': 'REPLICATION', 'test': replication},
         {'flag': 'LOGIN', 'test': login},
         {'flag': 'ENCRYPTED',
@@ -820,9 +825,17 @@ def _role_update(name,
     Updates a postgres role.
     '''
 
+    role = role_get(name,
+         user=user,
+         host=host,
+         port=port,
+         maintenance_db=maintenance_db,
+         password=password,
+         runas=runas,
+         return_password=False)
+
     # check if user exists
-    if not user_exists(name, user, host, port, maintenance_db, password,
-                       runas=runas):
+    if bool(role):
         log.info('{0} {1!r} could not be found'.format(typ_.capitalize(), name))
         return False
 
@@ -838,7 +851,8 @@ def _role_update(name,
         superuser=superuser,
         groups=groups,
         replication=replication,
-        rolepassword=rolepassword
+        rolepassword=rolepassword,
+        db_role=role
     ))
     ret = _psql_prepare_and_run(['-c', sub_cmd],
                                 runas=runas, host=host, user=user, port=port,

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -485,7 +485,7 @@ def user_list(user=None, host=None, port=None, maintenance_db=None,
     # will return empty string if return_password = False
     _x = lambda s: s if return_password else ''
 
-    query = ([
+    query = (''.join([
         'SELECT '
         'pg_roles.rolname as "name",'
         'pg_roles.rolsuper as "superuser", '
@@ -497,13 +497,12 @@ def user_list(user=None, host=None, port=None, maintenance_db=None,
         '{0} as "replication", '
         'pg_roles.rolconnlimit as "connections", '
         'pg_roles.rolvaliduntil::timestamp(0) as "expiry time", '
-        'pg_roles.rolconfig  as "defaults variables", '
-        , _x('COALESCE(pg_shadow.passwd, pg_authid.rolpassword) as "password" '),
+        'pg_roles.rolconfig  as "defaults variables" '
+        , _x(', COALESCE(pg_shadow.passwd, pg_authid.rolpassword) as "password" '),
         'FROM pg_roles '
         , _x('LEFT JOIN pg_authid ON pg_roles.oid = pg_authid.oid ')
         , _x('LEFT JOIN pg_shadow ON pg_roles.oid = pg_shadow.usesysid')
-        .format(replication_column)
-    ].join(''))
+    ]).format(replication_column))
 
     rows = psql_query(query,
                       runas=runas,
@@ -824,18 +823,17 @@ def _role_update(name,
     '''
     Updates a postgres role.
     '''
-
     role = role_get(name,
-         user=user,
-         host=host,
-         port=port,
-         maintenance_db=maintenance_db,
-         password=password,
-         runas=runas,
-         return_password=False)
+                    user=user,
+                    host=host,
+                    port=port,
+                    maintenance_db=maintenance_db,
+                    password=password,
+                    runas=runas,
+                    return_password=False)
 
     # check if user exists
-    if bool(role):
+    if not bool(role):
         log.info('{0} {1!r} could not be found'.format(typ_.capitalize(), name))
         return False
 

--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -482,7 +482,10 @@ def user_list(user=None, host=None, port=None, maintenance_db=None,
         log.error('Could not retrieve Postgres version. Is Postgresql server running?')
         return False
 
-    query = (
+    # will return empty string if return_password = False
+    _x = lambda s: s if return_password else ''
+
+    query = ([
         'SELECT '
         'pg_roles.rolname as "name",'
         'pg_roles.rolsuper as "superuser", '
@@ -495,12 +498,12 @@ def user_list(user=None, host=None, port=None, maintenance_db=None,
         'pg_roles.rolconnlimit as "connections", '
         'pg_roles.rolvaliduntil::timestamp(0) as "expiry time", '
         'pg_roles.rolconfig  as "defaults variables", '
-        'COALESCE(pg_shadow.passwd, pg_authid.rolpassword) as "password" '
+        , _x('COALESCE(pg_shadow.passwd, pg_authid.rolpassword) as "password" '),
         'FROM pg_roles '
-        'LEFT JOIN pg_authid ON pg_roles.oid = pg_authid.oid '
-        'LEFT JOIN pg_shadow ON pg_roles.oid = pg_shadow.usesysid'
+        , _x('LEFT JOIN pg_authid ON pg_roles.oid = pg_authid.oid ')
+        , _x('LEFT JOIN pg_shadow ON pg_roles.oid = pg_shadow.usesysid')
         .format(replication_column)
-    )
+    ].join(''))
 
     rows = psql_query(query,
                       runas=runas,
@@ -589,7 +592,7 @@ def user_exists(name,
                  maintenance_db=maintenance_db,
                  password=password,
                  runas=runas,
-                 return_password=True))
+                 return_password=False))
 
 
 def _add_role_flag(string,

--- a/salt/states/postgres_user.py
+++ b/salt/states/postgres_user.py
@@ -41,6 +41,7 @@ def present(name,
             inherit=None,
             login=None,
             password=None,
+            refresh_password=None,
             groups=None,
             runas=None,
             user=None,
@@ -91,6 +92,18 @@ def present(name,
         If encrypted is None or True, the password will be automatically
         encrypted to the previous
         format if it is not already done.
+
+    refresh_password
+        Password refresh flag
+
+        Boolean attribute to specify whether to password comparison check
+        should be performed.
+
+        If refresh_password is None or False, the password will be automatically
+        updated without extra password change check.
+
+        This behaviour allows to execute in environments without superuser access
+        available, e.g. Amazon RDS for PostgreSQL
 
     groups
         A string of comma separated groups the user should be in
@@ -168,7 +181,7 @@ def present(name,
     # check if user exists
     mode = 'create'
     user_attr = __salt__['postgres.role_get'](
-        name, return_password=True, **db_args)
+        name, return_password=not refresh_password, **db_args)
     if user_attr is not None:
         mode = 'update'
 
@@ -200,7 +213,7 @@ def present(name,
             update['replication'] = replication
         if superuser is not None and user_attr['superuser'] != superuser:
             update['superuser'] = superuser
-        if password is not None and user_attr['password'] != password:
+        if password is not None and (refresh_password or user_attr['password'] != password):
             update['password'] = True
 
     if mode == 'create' or (mode == 'update' and update):

--- a/tests/unit/modules/postgres_test.py
+++ b/tests/unit/modules/postgres_test.py
@@ -205,7 +205,8 @@ class PostgresTestCase(TestCase):
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
-    @patch('salt.modules.postgres.user_exists', Mock(return_value=True))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
     def test_group_update(self):
         postgres.group_update(
             'testgroup',
@@ -357,7 +358,8 @@ class PostgresTestCase(TestCase):
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
-    @patch('salt.modules.postgres.user_exists', Mock(return_value=True))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
     def test_user_update(self):
         postgres.user_update(
             'test_username',
@@ -382,7 +384,7 @@ class PostgresTestCase(TestCase):
                 '/usr/bin/pgsql --no-align --no-readline --no-password --username test_user '
                 '--host test_host --port test_port --dbname test_maint '
                 '-c [\'"]{0,1}ALTER ROLE test_username WITH  INHERIT NOCREATEDB '
-                'NOCREATEROLE NOSUPERUSER NOREPLICATION LOGIN '
+                'NOCREATEROLE NOREPLICATION LOGIN '
                 'UNENCRYPTED PASSWORD [\'"]{0,5}test_role_pass[\'"]{0,5};'
                 ' GRANT test_groups TO test_username[\'"]{0,1}',
                 postgres._run_psql.call_args[0][0])
@@ -390,7 +392,8 @@ class PostgresTestCase(TestCase):
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
-    @patch('salt.modules.postgres.user_exists', Mock(return_value=True))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
     def test_user_update2(self):
         postgres.user_update(
             'test_username',
@@ -414,14 +417,15 @@ class PostgresTestCase(TestCase):
                 '/usr/bin/pgsql --no-align --no-readline --no-password --username test_user '
                 '--host test_host --port test_port --dbname test_maint '
                 '-c \'ALTER ROLE test_username WITH  INHERIT NOCREATEDB '
-                'CREATEROLE NOSUPERUSER NOREPLICATION LOGIN;'
+                'CREATEROLE NOREPLICATION LOGIN;'
                 ' GRANT test_groups TO test_username\'',
                 postgres._run_psql.call_args[0][0])
         )
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
-    @patch('salt.modules.postgres.user_exists', Mock(return_value=True))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
     def test_user_update3(self):
         postgres.user_update(
             'test_username',
@@ -446,14 +450,15 @@ class PostgresTestCase(TestCase):
                 '/usr/bin/pgsql --no-align --no-readline --no-password --username test_user '
                 '--host test_host --port test_port --dbname test_maint '
                 '-c \'ALTER ROLE test_username WITH  INHERIT NOCREATEDB '
-                'CREATEROLE NOSUPERUSER NOREPLICATION LOGIN NOPASSWORD;'
+                'CREATEROLE NOREPLICATION LOGIN NOPASSWORD;'
                 ' GRANT test_groups TO test_username\'',
                 postgres._run_psql.call_args[0][0])
         )
 
     @patch('salt.modules.postgres._run_psql',
            Mock(return_value={'retcode': None}))
-    @patch('salt.modules.postgres.user_exists', Mock(return_value=True))
+    @patch('salt.modules.postgres.role_get',
+           Mock(return_value={'superuser': False}))
     def test_user_update_encrypted_passwd(self):
         postgres.user_update(
             'test_username',
@@ -478,7 +483,7 @@ class PostgresTestCase(TestCase):
                 '/usr/bin/pgsql --no-align --no-readline --no-password --username test_user '
                 '--host test_host --port test_port --dbname test_maint '
                 '-c [\'"]{0,1}ALTER ROLE test_username WITH  INHERIT NOCREATEDB '
-                'CREATEROLE NOSUPERUSER NOREPLICATION LOGIN '
+                'CREATEROLE NOREPLICATION LOGIN '
                 'ENCRYPTED PASSWORD '
                 '[\'"]{0,5}md531c27e68d3771c392b52102c01be1da1[\'"]{0,5}'
                 '; GRANT test_groups TO test_username[\'"]{0,1}',


### PR DESCRIPTION
Fixes #13793
1. Extends [postgres_user.present](http://docs.saltstack.com/en/latest/ref/states/all/salt.states.postgres_user.html#salt.states.postgres_user.present) and [postgres_group.present](http://docs.saltstack.com/en/latest/ref/states/all/salt.states.postgres_group.html#salt.states.postgres_group.present) with `refresh_password` attribute
2. skips `SUPERUSER` and `NOSUPERUSER` on user/group updates if no changes are to be expected (otherwise it fails with `must be a superuser to alter super..`)

@basepi Please take a look.
