### PR TITLE
Add sync/async Runner calls & sync/async Wheel calls that all respect eauth

### DIFF
--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -94,7 +94,7 @@ WheelClient
 -----------
 
 .. autoclass:: salt.wheel.WheelClient
-    :members: call_func, cmd_sync, cmd_async
+    :members: cmd, async, cmd_sync, cmd_async
 
 CloudClient
 -----------

--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -88,7 +88,7 @@ RunnerClient
 ------------
 
 .. autoclass:: salt.runner.RunnerClient
-    :members:
+    :members: cmd, async, cmd_sync, cmd_async
 
 WheelClient
 -----------

--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -94,7 +94,7 @@ WheelClient
 -----------
 
 .. autoclass:: salt.wheel.WheelClient
-    :members:
+    :members: call_func, cmd_sync, cmd_async
 
 CloudClient
 -----------

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+'''
+A collection of mixins useful for the various *Client interfaces
+'''
+from __future__ import print_function
+import datetime
+import logging
+import multiprocessing
+import time
+
+import salt.utils
+import salt.utils.event
+from salt.utils.event import tagify
+from salt.utils.doc import strip_rst as _strip_rst
+
+log = logging.getLogger(__name__)
+
+
+class SyncClientMixin(object):
+    '''
+    A mixin for *Client interfaces to abstract common function execution
+    '''
+    functions = ()
+
+    def _verify_fun(self, fun):
+        '''
+        Check that the function passed really exists
+        '''
+        if fun not in self.functions:
+            err = 'Function {0!r} is unavailable'.format(fun)
+            raise salt.exceptions.CommandExecutionError(err)
+
+    def low(self, fun, low):
+        '''
+        Execute a function from low data
+        '''
+        self._verify_fun(fun)
+        l_fun = self.functions[fun]
+        f_call = salt.utils.format_call(l_fun, low)
+        ret = l_fun(*f_call.get('args', ()), **f_call.get('kwargs', {}))
+        return ret
+
+    def get_docs(self, arg=None):
+        '''
+        Return a dictionary of functions and the inline documentation for each
+        '''
+        if arg:
+            target_mod = arg + '.' if not arg.endswith('.') else arg
+            docs = [(fun, self.functions[fun].__doc__)
+                    for fun in sorted(self.functions)
+                    if fun == arg or fun.startswith(target_mod)]
+        else:
+            docs = [(fun, self.functions[fun].__doc__)
+                    for fun in sorted(self.functions)]
+        docs = dict(docs)
+        return _strip_rst(docs)
+
+
+class AsyncClientMixin(object):
+    '''
+    A mixin for *Client interfaces to enable easy async function execution
+    '''
+    client = None
+    tag_prefix = None
+
+    def _proc_function(self, fun, low, user, tag, jid):
+        '''
+        Run this method in a multiprocess target to execute the function in a
+        multiprocess and fire the return data on the event bus
+        '''
+        salt.utils.daemonize()
+        event = salt.utils.event.get_event(
+                'master',
+                self.opts['sock_dir'],
+                self.opts['transport'],
+                listen=False)
+        data = {'fun': '{0}.{1}'.format(self.client, fun),
+                'jid': jid,
+                'user': user,
+                }
+        event.fire_event(data, tagify('new', base=tag))
+
+        try:
+            data['return'] = self.low(fun, low)
+            data['success'] = True
+        except Exception as exc:
+            data['return'] = 'Exception occurred in {0} {1}: {2}: {3}'.format(
+                            self.client,
+                            fun,
+                            exc.__class__.__name__,
+                            exc,
+                            )
+            data['success'] = False
+        data['user'] = user
+        event.fire_event(data, tagify('ret', base=tag))
+        # this is a workaround because process reaping is defeating 0MQ linger
+        time.sleep(2.0)  # delay so 0MQ event gets out before runner process reaped
+
+    def async(self, fun, low, user='UNKNOWN'):
+        '''
+        Execute the function in a multiprocess and return the event tag to use
+        to watch for the return
+        '''
+        jid = '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
+        tag = tagify(jid, prefix=self.tag_prefix)
+
+        proc = multiprocessing.Process(
+                target=self._proc_function,
+                args=(fun, low, user, tag, jid))
+        proc.start()
+        return {'tag': tag, 'jid': jid}

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -6,10 +6,7 @@ Execute salt convenience routines
 # Import python libs
 from __future__ import print_function
 import collections
-import datetime
 import logging
-import multiprocessing
-import time
 
 # Import salt libs
 import salt.exceptions
@@ -18,15 +15,15 @@ import salt.minion
 import salt.utils
 import salt.utils.args
 import salt.utils.event
+from salt.client import mixins
 from salt.output import display_output
-from salt.utils.doc import strip_rst as _strip_rst
 from salt.utils.error import raise_error
 from salt.utils.event import tagify
 
 log = logging.getLogger(__name__)
 
 
-class RunnerClient(object):
+class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
     '''
     The interface used by the :command:`salt-run` CLI tool on the Salt Master
 
@@ -41,64 +38,12 @@ class RunnerClient(object):
     eauth user must be authorized to execute runner modules: (``@runner``).
     Only the :py:meth:`master_call` below supports eauth.
     '''
+    client = 'runner'
+    tag_prefix = 'run'
+
     def __init__(self, opts):
         self.opts = opts
         self.functions = salt.loader.runner(opts)
-
-    def _proc_runner(self, fun, low, user, tag, jid):
-        '''
-        Run this method in a multiprocess target to execute the runner in a
-        multiprocess and fire the return data on the event bus
-        '''
-        salt.utils.daemonize()
-        event = salt.utils.event.get_event(
-                'master',
-                self.opts['sock_dir'],
-                self.opts['transport'],
-                listen=False)
-        data = {'fun': 'runner.{0}'.format(fun),
-                'jid': jid,
-                'user': user,
-                }
-        event.fire_event(data, tagify('new', base=tag))
-
-        try:
-            data['return'] = self.low(fun, low)
-            data['success'] = True
-        except Exception as exc:
-            data['return'] = 'Exception occurred in runner {0}: {1}: {2}'.format(
-                            fun,
-                            exc.__class__.__name__,
-                            exc,
-                            )
-            data['success'] = False
-        data['user'] = user
-        event.fire_event(data, tagify('ret', base=tag))
-        # this is a workaround because process reaping is defeating 0MQ linger
-        time.sleep(2.0)  # delay so 0MQ event gets out before runner process reaped
-
-    def _verify_fun(self, fun):
-        '''
-        Check that the function passed really exists
-        '''
-        if fun not in self.functions:
-            err = 'Function {0!r} is unavailable'.format(fun)
-            raise salt.exceptions.CommandExecutionError(err)
-
-    def get_docs(self, arg=None):
-        '''
-        Return a dictionary of functions and the inline documentation for each
-        '''
-        if arg:
-            target_mod = arg + '.' if not arg.endswith('.') else arg
-            docs = [(fun, self.functions[fun].__doc__)
-                    for fun in sorted(self.functions)
-                    if fun == arg or fun.startswith(target_mod)]
-        else:
-            docs = [(fun, self.functions[fun].__doc__)
-                    for fun in sorted(self.functions)]
-        docs = dict(docs)
-        return _strip_rst(docs)
 
     def cmd(self, fun, arg, pub_data=None, kwarg=None):
         '''
@@ -174,36 +119,6 @@ class RunnerClient(object):
             self.functions[fun], arglist, pub_data
         )
         return self.functions[fun](*args, **kwargs)
-
-    def low(self, fun, low):
-        '''
-        Pass in the runner function name and the low data structure
-
-        .. code-block:: python
-
-            runner.low({'fun': 'jobs.lookup_jid', 'jid': '20131219215921857715'})
-        '''
-        self._verify_fun(fun)
-        l_fun = self.functions[fun]
-        f_call = salt.utils.format_call(l_fun, low)
-        ret = l_fun(*f_call.get('args', ()), **f_call.get('kwargs', {}))
-        return ret
-
-    def async(self, fun, low, user='UNKNOWN'):
-        '''
-        Execute the runner in a multiprocess and return the event tag to use
-        to watch for the return
-        '''
-        jid = '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
-        tag = tagify(jid, prefix='run')
-        #low['tag'] = tag
-        #low['jid'] = jid
-
-        proc = multiprocessing.Process(
-                target=self._proc_runner,
-                args=(fun, low, user, tag, jid))
-        proc.start()
-        return {'tag': tag, 'jid': jid}
 
     def master_call(self, **kwargs):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -203,7 +203,7 @@ class RunnerClient(object):
                 target=self._proc_runner,
                 args=(fun, low, user, tag, jid))
         proc.start()
-        return {'tag': tag}
+        return {'tag': tag, 'jid': jid}
 
     def master_call(self, **kwargs):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -208,18 +208,6 @@ class RunnerClient(object):
     def master_call(self, **kwargs):
         '''
         Execute a runner function through the master network interface (eauth).
-
-        This function requires that :conf_master:`external_auth` is configured
-        and the user is authorized to execute runner functions: (``@runner``).
-
-        .. code-block:: python
-
-            runner.master_call(
-                fun='jobs.list_jobs',
-                username='saltdev',
-                password='saltdev',
-                eauth='pam'
-            )
         '''
         load = kwargs
         load['cmd'] = 'runner'

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -107,4 +107,25 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             if ret['tag'] == ret_tag:
                 return ret['data']['return']
 
+    def cmd_async(self, low):
+        '''
+        Execute a wheel function asynchronously; eauth is respected
+
+        This function requires that :conf_master:`external_auth` is configured
+        and the user is authorized to execute runner functions: (``@wheel``).
+
+        .. code-block:: python
+
+            >>> wheel.cmd_async({
+                'fun': 'key.finger',
+                'match': 'jerry',
+                'eauth': 'auto',
+                'username': 'saltdev',
+                'password': 'saltdev',
+            })
+            {'jid': '20131219224744416681', 'tag': 'salt/wheel/20131219224744416681'}
+        '''
+        fun = low.pop('fun')
+        return self.async(fun, low)
+
 Wheel = WheelClient  # for backward-compat

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -45,7 +45,7 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         self.opts = opts
         self.functions = salt.loader.wheels(opts)
 
-    def call_func(self, fun, **kwargs):
+    def cmd(self, fun, **kwargs):
         '''
         Execute a wheel function
 
@@ -60,6 +60,8 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             'minions_rejected': []}
         '''
         return self.low(fun, kwargs)
+
+    call_func = cmd  # alias for backward-compat
 
     def master_call(self, **kwargs):
         '''


### PR DESCRIPTION
This pull request addresses #9324 and sets up the fix for #13930.

These changes are all additive and are backward compatible. (Unless I missed something of course.)

Fix 1: this adds a synchronous function to `RunnerClient()` that goes through the `master_call` interface. (It does this by watching the event bus.)

Fix 2: this adds an asynchronous function to `WheelClient()` that goes through the `master_call` interface. (It does this by copying the `RunnerClient()` async code.)

Fix: 3: this adds two methods, `cmd_sync` and `cmd_async`, that present a consistent interface between `RunnerClient()` and `WheelClient()` for executing both sync and async commands that both respect eauth.

Fix 4: this moves some of the duplicate code between `RunnerClient()` and `WheelClient()` into mixin classes so fixes and additions can be made to both. Other *Client interfaces can easily get sync/async methods by inheriting these. Future changes to how the async behavior works can be made in a single place. (ioflo-centric worker management, anyone?)
