### PR TITLE
Now using new raet.nacling.uuid function to generate the yard names this...

### DIFF
--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -9,7 +9,7 @@ import time
 import logging
 
 # Import Salt libs
-from raet import raeting
+from raet import raeting, nacling
 from raet.lane.stacking import LaneStack
 from raet.lane.yarding import RemoteYard
 import salt.config
@@ -51,7 +51,7 @@ class LocalClient(salt.client.LocalClient):
                 jid=jid,
                 timeout=timeout,
                 **kwargs)
-        yid = salt.utils.gen_jid()
+        yid = nacling.uuid(size=18)
         basedirpath = os.path.join(self.opts['cachedir'], 'raet')
         stack = LaneStack(
                 name=('client' + yid),

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -118,7 +118,6 @@ class WorkerSetup(ioflo.base.deeding.Deed):
 
         self.stack.value = LaneStack(
                                      name=name,
-                                     #localname=localname,
                                      basedirpath=basedirpath,
                                      lanename=lanename,
                                      yid=self.yid.value,

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -13,7 +13,7 @@ import salt.payload
 import salt.auth
 import salt.utils
 try:
-    from raet import raeting
+    from raet import raeting, nacling
     from raet.road.stacking import RoadStack
     from raet.lane.stacking import LaneStack
     from raet.lane import yarding
@@ -60,13 +60,13 @@ class RAETChannel(Channel):
         '''
         Prepare the stack objects
         '''
-        id = self.opts.get('id', 'master')
-        yid = salt.utils.gen_jid()
-        stackname = id + yid
+        mid = self.opts.get('id', 'master')
+        yid = nacling.uuid(size=18)
+        stackname = 'raet' + yid
         dirpath = os.path.join(self.opts['cachedir'], 'raet')
         self.stack = LaneStack(
                 name=stackname,
-                lanename=id,
+                lanename=mid,
                 yid=yid,
                 basedirpath=dirpath,
                 sockdirpath=self.opts['sock_dir'])
@@ -74,10 +74,10 @@ class RAETChannel(Channel):
         self.router_yard = yarding.RemoteYard(
                 stack=self.stack,
                 yid=0,
-                lanename=id,
+                lanename=mid,
                 dirpath=self.opts['sock_dir'])
         self.stack.addRemote(self.router_yard)
-        src = (id, self.stack.local.name, None)
+        src = (mid, self.stack.local.name, None)
         dst = ('master', None, 'remote_cmd')
         self.route = {'src': src, 'dst': dst}
 

--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -17,7 +17,7 @@ import salt.loader
 import salt.state
 import salt.utils.event
 from salt import syspaths
-from raet import raeting
+from raet import raeting, nacling
 from raet.lane.stacking import LaneStack
 from raet.lane.yarding import RemoteYard
 
@@ -41,8 +41,7 @@ class SaltEvent(object):
         self.__prep_stack()
 
     def __prep_stack(self):
-        time.sleep(0.01)  # Make sure the event jids don't collide
-        self.yid = salt.utils.gen_jid()
+        self.yid = nacling.uuid(size=18)
         name = 'event' + self.yid
         cachedir = self.opts.get('cachedir', os.path.join(syspaths.CACHE_DIR, self.node))
         basedirpath = os.path.abspath(


### PR DESCRIPTION
... should prevent

any race conditions in yard names that were occuring with the old way of using gen_jid which was only microsecond rsolution
and therefore might generate two yards with the same name.

Needs RAET v 0.1.01
