### PR TITLE
Add a bug fix plus tests for calling functions in Jinja via dot-lookup notation

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -432,7 +432,7 @@ public keys from minions.
 ``autosign_timeout``
 --------------------
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``120``
 
@@ -462,7 +462,7 @@ that trust is based on just the requesting minion id.
 ``autoreject_file``
 -------------------
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 Default: ``not defined``
 
@@ -944,8 +944,7 @@ translated into salt environments.
 
 .. note::
 
-    As of the upcoming **Helium** release (and right now in the development
-    branch), it is possible to have per-repo versions of the
+    As of 2014.7.0, it is possible to have per-repo versions of the
     :conf_master:`gitfs_base`, :conf_master:`gitfs_root`, and
     :conf_master:`gitfs_mountpoint` parameters. For example:
 
@@ -968,7 +967,7 @@ For more information on GitFS remotes, see the :ref:`GitFS Backend Walkthrough
 ``gitfs_provider``
 ******************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``gitpython``
 
@@ -1008,7 +1007,7 @@ is a security concern, you may want to try using the ssh transport.
 ``gitfs_mountpoint``
 ********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``''``
 
@@ -1042,7 +1041,7 @@ available to the Salt fileserver. Can be used in conjunction with
 
     gitfs_root: somefolder/otherfolder
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
 
    Ability to specify gitfs roots on a per-remote basis was added. See
    :conf_master:`here <gitfs_remotes>` for more info.
@@ -1056,7 +1055,7 @@ Default: ``master``
 
 Defines which branch/tag should be used as the ``base`` environment.
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
     Can also be configured on a per-remote basis, see :conf_master:`here
     <gitfs_remotes>` for more info.
 
@@ -1069,7 +1068,7 @@ Defines which branch/tag should be used as the ``base`` environment.
 ``gitfs_env_whitelist``
 ***********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1097,7 +1096,7 @@ blacklist will be exposed as fileserver environments.
 ``gitfs_env_blacklist``
 ***********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1147,8 +1146,7 @@ translated into salt environments, as defined by the
 
 .. note::
 
-    As of the upcoming **Helium** release (and right now in the development
-    branch), it is possible to have per-repo versions of the
+    As of 2014.7.0, it is possible to have per-repo versions of the
     :conf_master:`hgfs_root`, :conf_master:`hgfs_mountpoint`,
     :conf_master:`hgfs_base`, and :conf_master:`hgfs_branch_method` parameters.
     For example:
@@ -1186,10 +1184,10 @@ Defines the objects that will be used as fileserver environments.
 
 .. note::
 
-    Starting in version 2014.1.0 (Hydrogen), the value of the
-    :conf_master:`hgfs_base` parameter defines which branch is used as the
-    ``base`` environment, allowing for a ``base`` environment to be used with
-    an :conf_master:`hgfs_branch_method` of ``bookmarks``.
+    Starting in version 2014.1.0, the value of the :conf_master:`hgfs_base`
+    parameter defines which branch is used as the ``base`` environment,
+    allowing for a ``base`` environment to be used with an
+    :conf_master:`hgfs_branch_method` of ``bookmarks``.
 
     Prior to this release, the ``default`` branch will be used as the ``base``
     environment.
@@ -1199,7 +1197,7 @@ Defines the objects that will be used as fileserver environments.
 ``hgfs_mountpoint``
 *******************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``''``
 
@@ -1235,7 +1233,7 @@ available to the Salt fileserver. Can be used in conjunction with
 
     hgfs_root: somefolder/otherfolder
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
 
    Ability to specify hgfs roots on a per-remote basis was added. See
    :conf_master:`here <hgfs_remotes>` for more info.
@@ -1245,7 +1243,7 @@ available to the Salt fileserver. Can be used in conjunction with
 ``hgfs_base``
 *************
 
-.. versionadded:: 2014.1.0 (Hydrogen)
+.. versionadded:: 2014.1.0
 
 Default: ``default``
 
@@ -1262,7 +1260,7 @@ bookmark should be used as the ``base`` environment.
 ``hgfs_env_whitelist``
 **********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1290,7 +1288,7 @@ blacklist will be exposed as fileserver environments.
 ``hgfs_env_blacklist``
 **********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1340,8 +1338,7 @@ become environments, with the trunk being the ``base`` environment.
 
 .. note::
 
-    As of the upcoming **Helium** release (and right now in the development
-    branch), it is possible to have per-repo versions of the following
+    As of 2014.7.0, it is possible to have per-repo versions of the following
     configuration parameters:
 
     * :conf_master:`svnfs_root`
@@ -1369,7 +1366,7 @@ become environments, with the trunk being the ``base`` environment.
 ``svnfs_mountpoint``
 ********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``''``
 
@@ -1405,7 +1402,7 @@ available to the Salt fileserver. Can be used in conjunction with
 
     svnfs_root: somefolder/otherfolder
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
 
    Ability to specify svnfs roots on a per-remote basis was added. See
    :conf_master:`here <svnfs_remotes>` for more info.
@@ -1415,7 +1412,7 @@ available to the Salt fileserver. Can be used in conjunction with
 ``svnfs_trunk``
 ***************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``trunk``
 
@@ -1432,7 +1429,7 @@ also be configured on a per-remote basis, see :conf_master:`here
 ``svnfs_branches``
 ******************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``branches``
 
@@ -1449,7 +1446,7 @@ also be configured on a per-remote basis, see :conf_master:`here
 ``svnfs_tags``
 **************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``tags``
 
@@ -1466,7 +1463,7 @@ for more info.
 ``svnfs_env_whitelist``
 ***********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1494,7 +1491,7 @@ will be exposed as fileserver environments.
 ``svnfs_env_blacklist``
 ***********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1525,7 +1522,7 @@ minion: MinionFS Remote File Server Backend
 ``minionfs_env``
 ****************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``base``
 
@@ -1540,7 +1537,7 @@ Environment from which MinionFS files are made available.
 ``minionfs_mountpoint``
 ***********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``''``
 
@@ -1560,7 +1557,7 @@ Specifies a path on the salt fileserver from which minionfs files are served.
 ``minionfs_whitelist``
 **********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 
@@ -1586,7 +1583,7 @@ exposed.
 ``minionfs_blacklist``
 **********************
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``[]``
 

--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -48,7 +48,7 @@ The option can can also be set to a list of masters, enabling
       - address1
       - address2
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
 
     The master can be dynamically configured. The :conf_minion:`master` value
     can be set to an module function which will be executed and will assume
@@ -80,7 +80,7 @@ The option can can also be set to a list of masters, enabling
 ``master_type``
 ---------------
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``str``
 
@@ -110,7 +110,7 @@ in the list until it successfully connects.
 ``master_shuffle``
 ------------------
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Default: ``False``
 
@@ -753,7 +753,7 @@ Enables verification of the master-public-signature returned by the master in
 auth-replies. Please see the tutorial on how to configure this properly
 `Multimaster-PKI with Failover Tutorial <http://docs.saltstack.com/en/latest/topics/tutorials/multimaster_pki.html>`_
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 
@@ -774,7 +774,7 @@ The filename without the *.pub-suffix of the public that should be used for
 verifying the signature from the master. The file must be located in the minions
 pki-directory.
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 
@@ -791,7 +791,7 @@ If :conf_minion:`verify_master_pubkey_sign` is enabled, the signature is only ve
 if the public-key of the master changes. If the signature should always be verified,
 this can be set to ``True``.
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 

--- a/doc/ref/states/aggregate.rst
+++ b/doc/ref/states/aggregate.rst
@@ -2,9 +2,9 @@
 Mod Aggregate State Runtime Modifications
 =========================================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
-The mod_aggregate system was added in the Helium release of Salt and allows for
+The mod_aggregate system was added in the 2014.7.0 release of Salt and allows for
 runtime modification of the executing state data. Simply put, it allows for the
 data used by Salt's state system to be changed on the fly at runtime, kind of
 like a configuration management JIT compiler or a runtime import system. All in

--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -240,7 +240,7 @@ successfully.
 onfail
 ~~~~~~
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The ``onfail`` requisite allows for reactions to happen strictly as a response
 to the failure of another state. This can be used in a number of ways, such as
@@ -270,7 +270,7 @@ The ``onfail`` requisite is applied in the same way as ``require`` as ``watch``:
 onchanges
 ~~~~~~~~~
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The ``onchanges`` requisite makes a state only apply if the required states
 generate changes, and if the watched state's "result" is ``True``. This can be
@@ -401,11 +401,6 @@ be installed. Thus allowing for a requisite to be defined "after the fact".
 Altering States
 ===============
 
-.. note::
-
-    The ``unless``, ``onlyif``, and ``check_cmd`` options will be supported
-    starting with the feature release codenamed Helium
-
 The state altering system is used to make sure that states are evaluated exactly
 as the user expects.  It can be used to double check that a state preformed
 exactly how it was expected to, or to make 100% sure that a state only runs
@@ -415,6 +410,8 @@ state is evaluated correctly.
 
 Unless
 ~~~~~~
+
+.. versionadded:: 2014.7.0
 
 Use unless to only run if any of the specified commands return False.
 
@@ -432,6 +429,8 @@ run.
 
 Onlyif
 ~~~~~~
+
+.. versionadded:: 2014.7.0
 
 Onlyif is the opposite of Unless.  If all of the commands in onlyif return True,
 then the state is run.
@@ -460,6 +459,8 @@ gluster commands return back a 0 ret value.
 
 Check_Cmd
 ~~~~~~~~~
+
+.. versionadded:: 2014.7.0
 
 Check Command is used for determining that a state did or did not run as
 expected.

--- a/doc/topics/development/conventions/documentation.rst
+++ b/doc/topics/development/conventions/documentation.rst
@@ -112,7 +112,7 @@ denotes what Salt release will be affected. For example:
         '''
         Upper-case the given value
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
         <...snip...>
         '''

--- a/doc/topics/jobs/schedule.rst
+++ b/doc/topics/jobs/schedule.rst
@@ -66,7 +66,7 @@ This will schedule the command: state.sls httpd test=True every 3600 seconds
 This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour) splaying the time between 10 and 15 seconds
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Frequency of jobs can also be specified using date strings supported by
 the python dateutil library.
@@ -122,7 +122,7 @@ This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour) between the hours of 8am and 5pm.  The range parameter must be a
 dictionary with the date strings using the dateutil format.
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The scheduler also supports ensuring that there are no more than N copies of
 a particular routine running.  Use this for jobs that may be long-running

--- a/doc/topics/netapi/index.rst
+++ b/doc/topics/netapi/index.rst
@@ -27,7 +27,7 @@ Communication with Salt and Salt satellite projects is done using Salt's own
 
 .. admonition:: salt-api
 
-    Prior to Salt's Helium release, netapi modules lived in the separate sister
+    Prior to Salt's 2014.7.0 release, netapi modules lived in the separate sister
     projected ``salt-api``. That project has been merged into the main Salt
     project.
 

--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -126,3 +126,11 @@ New Modules
 Syslog-ng
 Oracle
 random
+
+Deprecations
+============
+
+salt.modules.virturalenv_mod
+----------------------------
+
+- Removed deprecated ``no_site_packages`` argument from ``create`` function (deprecated)

--- a/doc/topics/releases/saltapi/0.8.4.rst
+++ b/doc/topics/releases/saltapi/0.8.4.rst
@@ -7,7 +7,7 @@ enhancements in the :py:mod:`rest_cherrypy <salt.netapi.rest_cherrypy.app>`
 netapi module.
 
 Work to merge :program:`salt-api` into the main Salt distribution continues and
-it is likely to be included in Salt's Helium release.
+it is likely to be included in Salt's 2014.7.0 release.
 
 :py:mod:`rest_cherrypy <salt.netapi.rest_cherrypy.app>` changes
 ==================================================================

--- a/doc/topics/sdb/index.rst
+++ b/doc/topics/sdb/index.rst
@@ -9,7 +9,7 @@ allow passwords to be stored in a secure database, such as one managed by the
 keyring package, rather than as plain-text files. However, as a generic database
 interface, it could conceptually be used for a number of other purposes.
 
-SDB was added to Salt in version Helium. SDB is currently experimental, and
+SDB was added to Salt in version 2014.7.0. SDB is currently experimental, and
 should probably not be used in production.
 
 

--- a/doc/topics/transports/raet/index.rst
+++ b/doc/topics/transports/raet/index.rst
@@ -9,7 +9,7 @@ The RAET Transport
 
     This document is also not yet complete
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The Reliable Asynchronous Event Transport, or RAET, is an alternative transport
 medium developed specifically with Salt in mind. It has been developed to

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -370,7 +370,7 @@ pillar, add a section like the following to the salt master config file:
     ext_pillar:
       - git: <branch> <repo> [root=<gitroot>]
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
     The optional ``root`` parameter will be added.
 
 The ``<branch>`` param is the branch containing the pillar SLS tree. The

--- a/doc/topics/tutorials/intro_scale.rst
+++ b/doc/topics/tutorials/intro_scale.rst
@@ -238,5 +238,5 @@ If no job history is needed, the job cache can be disabled:
 If the job cache is necessary there are (currently) 2 options:
 - ext_job_cache: this will have the minions store their return data directly
     into a returner (not sent through the master)
-- master_job_cache (New in `Helium`): this will make the master store the job
+- master_job_cache (New in `2014.7.0`): this will make the master store the job
     data using a returner (instead of the local job cache on disk).

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -58,7 +58,7 @@ def get_local_client(
         mopts=None,
         skip_perm_errors=False):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Read in the config and return the correct LocalClient object based on
     the configured transport
@@ -1587,7 +1587,7 @@ class Caller(object):
     Instantiate a new Caller() instance using a dictionary of the minion
     config:
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
         Pass the minion config as a dictionary.
 
     .. code-block:: python

--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -3,7 +3,7 @@
 AliYun ECS Cloud Module
 ==========================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The Aliyun cloud module is used to control access to the aliyun ECS.
 http://www.aliyun.com/

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -3,7 +3,7 @@
 Install Salt on an LXC Container
 ================================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Please read :ref:`core config documentation <config_lxc>`.
 '''

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -3,7 +3,7 @@
 Proxmox Cloud Module
 ======================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The Proxmox cloud module is used to control access to cloud providers using
 the Proxmox system (KVM / OpenVZ).

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -3,7 +3,7 @@
 vSphere Cloud Module
 ====================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 The vSphere cloud module is used to control access to VMWare vSphere.
 

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -14,7 +14,7 @@ This backend assumes a standard svn layout with directories for ``branches``,
             - pysvn
 
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
     The paths to the trunk, branches, and tags have been made configurable, via
     the config options :conf_master:`svnfs_trunk`,
     :conf_master:`svnfs_branches`, and :conf_master:`svnfs_tags`.

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -369,7 +369,7 @@ def install(name=None,
         architecture designation (``:i386``, etc.) to the end of the package
         name.
 
-        .. versionchanged:: Helium
+        .. versionchanged:: 2014.7.0
 
         CLI Example:
 
@@ -592,7 +592,7 @@ def upgrade(refresh=True, dist_upgrade=True, **kwargs):
         Whether to perform the upgrade using dist-upgrade vs upgrade.  Default
         is to use dist-upgrade.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -618,7 +618,7 @@ def upgrade(refresh=True, dist_upgrade=True, **kwargs):
 
 def hold(name=None, pkgs=None, sources=None, *kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Set package in 'hold' state, meaning it will not be upgraded.
 
@@ -691,7 +691,7 @@ def hold(name=None, pkgs=None, sources=None, *kwargs):
 
 def unhold(name=None, pkgs=None, sources=None, **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Set package current in 'hold' state to install state,
     meaning it will be upgraded.
@@ -1756,7 +1756,7 @@ def _resolve_deps(name, pkgs, **kwargs):
     Installs missing dependencies and marks them as auto installed so they
     are removed when no more manually installed packages depend on them.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     :depends:   - python-apt module
     '''
@@ -1798,7 +1798,7 @@ def _resolve_deps(name, pkgs, **kwargs):
 
 def owner(*paths):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return the name of the package that owns the file. Multiple file paths can
     be passed. Like :mod:`pkg.version <salt.modules.aptpkg.version`, if a

--- a/salt/modules/aws_sqs.py
+++ b/salt/modules/aws_sqs.py
@@ -90,7 +90,7 @@ def receive_message(queue, region, num=1, opts=None, user=None):
         salt '*' aws_sqs.receive_message <sqs queue> <region>
         salt '*' aws_sqs.receive_message <sqs queue> <region> num=10
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     '''
     ret = {
@@ -134,7 +134,7 @@ def delete_message(queue, region, receipthandle, opts=None, user=None):
 
         salt '*' aws_sqs.delete_message <sqs queue> <region> receipthandle='<sqs ReceiptHandle>'
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     '''
     queues = list_queues(region, opts, user)

--- a/salt/modules/blockdev.py
+++ b/salt/modules/blockdev.py
@@ -2,7 +2,7 @@
 '''
 Module for managing block devices
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 '''
 
 # Import python libs

--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Autoscale Groups
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit autoscale credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Elasticache
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit elasticache credentials but can
     also utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon ELB
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit elb credentials but can also utilize
     IAM roles assigned to the instance trough Instance Profiles. Dynamic

--- a/salt/modules/boto_iam.py
+++ b/salt/modules/boto_iam.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon IAM
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit iam credentials but can also utilize
     IAM roles assigned to the instance trough Instance Profiles. Dynamic

--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Route53
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit route53 credentials but can also
     utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon Security Groups
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit ec2 credentials but can
     also utilize IAM roles assigned to the instance trough Instance Profiles.

--- a/salt/modules/boto_sqs.py
+++ b/salt/modules/boto_sqs.py
@@ -2,7 +2,7 @@
 '''
 Connection module for Amazon SQS
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :configuration: This module accepts explicit sqs credentials but can also utilize
     IAM roles assigned to the instance trough Instance Profiles. Dynamic

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1230,7 +1230,7 @@ def exec_code(lang, code, cwd=None):
 
 def run_chroot(root, cmd):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     This function runs :mod:`cmd.run_all <salt.modules.cmdmod.run_all>` wrapped
     within a chroot, with dev and proc mounted in the chroot

--- a/salt/modules/cp.py
+++ b/salt/modules/cp.py
@@ -371,7 +371,7 @@ def cache_dir(path, saltenv='base', include_empty=False, include_pat=None,
         matching with a regex, the regex must be prefixed with ``E@``,
         otherwise the expression will be interpreted as a glob.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     exclude_pat : None
         Glob or regex to exclude certain files from being cached from the given
@@ -383,7 +383,7 @@ def cache_dir(path, saltenv='base', include_empty=False, include_pat=None,
             If used with ``include_pat``, files matching this pattern will be
             excluded from the subset of files defined by ``include_pat``.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
 
     CLI Examples:
@@ -676,7 +676,7 @@ def push_dir(path, glob=None):
     ``/var/cache/salt/master/minions/minion-id/files``).  It also has a glob
     for matching specific files using globbing.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Since this feature allows a minion to push files up to the master server it
     is disabled by default for security purposes. To enable, set ``file_recv``

--- a/salt/modules/etcd_mod.py
+++ b/salt/modules/etcd_mod.py
@@ -57,7 +57,7 @@ def __virtual__():
 
 def get_(key, recurse=False, profile=None):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Get a value from etcd, by direct path
 
@@ -86,7 +86,7 @@ def get_(key, recurse=False, profile=None):
 
 def set_(key, value, profile=None):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Set a value in etcd, by direct path
 
@@ -111,7 +111,7 @@ def set_(key, value, profile=None):
 
 def ls_(path='/', profile=None):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return all keys and dirs inside a specific path
 
@@ -144,7 +144,7 @@ def ls_(path='/', profile=None):
 
 def rm_(key, recurse=False, profile=None):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Delete a key from etcd
 
@@ -172,7 +172,7 @@ def rm_(key, recurse=False, profile=None):
 
 def tree(path='/', profile=None):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Recurse through etcd and return all values
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1051,16 +1051,16 @@ def replace(path,
     :param append_if_not_found: If pattern is not found and set to ``True``
         then, the content will be appended to the file.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
     :param prepend_if_not_found: If pattern is not found and set to ``True``
         then, the content will be appended to the file.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
     :param not_found_content: Content to use for append/prepend if not found. If
         None (default), uses repl. Useful when repl uses references to group in
         pattern.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
     :param backup: The file extension to use for a backup of the file before
         editing. Set to ``False`` to skip making a backup.
     :param dry_run: Don't make any edits to the file
@@ -1618,7 +1618,7 @@ def append(path, *args):
 
 def prepend(path, *args):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Prepend text to the beginning of a file
 
@@ -1653,7 +1653,7 @@ def prepend(path, *args):
 
 def write(path, *args):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Write text to a file, overwriting any existing contents.
 
@@ -2938,7 +2938,7 @@ def manage_file(name,
 
         salt '*' file.manage_file /etc/httpd/conf.d/httpd.conf '' '{}' salt://http/httpd.conf '{hash_type: 'md5', 'hsum': <md5sum>}' root root '755' base ''
 
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
         ``follow_symlinks`` option added
 
     '''
@@ -3878,7 +3878,7 @@ def pardir():
     '''
     Return the relative parent directory path symbol for underlying OS
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     This can be useful when constructing Salt Formulas.
 
@@ -3900,7 +3900,7 @@ def join(*args):
     '''
     Return a normalized file system path for the underlying OS
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     This can be useful at the CLI but is frequently useful when scripting
     combining path variables:

--- a/salt/modules/genesis.py
+++ b/salt/modules/genesis.py
@@ -2,7 +2,7 @@
 '''
 Module for managing container and VM images
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 '''
 
 # Import python libs

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -814,7 +814,7 @@ def config_set(cwd=None, setting_name=None, setting_value=None, user=None, is_gl
     cwd : None
         Options path to the Git repository
 
-        .. versionchanged:: Helium
+        .. versionchanged:: 2014.7.0
             Made ``cwd`` optional
 
     user : None
@@ -855,7 +855,7 @@ def config_get(cwd=None, setting_name=None, user=None):
     cwd : None
         Optional path to a Git repository
 
-        .. versionchanged:: Helium
+        .. versionchanged:: 2014.7.0
             Made ``cwd`` optional
 
     user : None

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -80,7 +80,7 @@ def get(key, default='', delim=':'):
     delim
         Specify an alternate delimiter to use when traversing a nested dict
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -5,7 +5,7 @@ InfluxDB - A distributed time series database
 Module to provide InfluxDB compatibility to Salt
 (compatible with InfluxDB version 0.5+)
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :depends:    - influxdb Python module
 

--- a/salt/modules/ipset.py
+++ b/salt/modules/ipset.py
@@ -121,7 +121,7 @@ def version():
 
 def new_set(set=None, set_type=None, family='ipv4', comment=False, **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Create new custom set
 
@@ -174,7 +174,7 @@ def new_set(set=None, set_type=None, family='ipv4', comment=False, **kwargs):
 
 def delete_set(set=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Delete ipset set.
 
@@ -201,7 +201,7 @@ def delete_set(set=None, family='ipv4'):
 
 def rename_set(set=None, new_set=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Delete ipset set.
 
@@ -239,7 +239,7 @@ def rename_set(set=None, new_set=None, family='ipv4'):
 
 def list_sets(family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List all ipset sets.
 
@@ -270,7 +270,7 @@ def list_sets(family='ipv4'):
 
 def check_set(set=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Check that given ipset set exists.
 

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -26,7 +26,7 @@ def compound(tgt, minion_id=None):
     minion_id
         Specify the minion ID to match against the target expression
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -161,7 +161,7 @@ def list_(tgt, minion_id=None):
     minion_id
         Specify the minion ID to match against the target expression
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -189,7 +189,7 @@ def pcre(tgt, minion_id=None):
     minion_id
         Specify the minion ID to match against the target expression
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -217,7 +217,7 @@ def glob(tgt, minion_id=None):
     minion_id
         Specify the minion ID to match against the target expression
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -242,7 +242,7 @@ def filter_by(lookup, expr_form='compound', minion_id=None):
     '''
     Return the first match in a dictionary of target patterns
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -152,7 +152,7 @@ def create(name,
     '''
     Create a RAID device.
 
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
 
     .. warning::
         Use with CAUTION, as this function can be very destructive if not used

--- a/salt/modules/mod_random.py
+++ b/salt/modules/mod_random.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Provides access to randomness generators.
 '''
@@ -24,7 +24,7 @@ def __virtual__():
 
 def hash(value, algorithm='sha512'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Encodes a value with the specified encoder.
 
@@ -53,7 +53,7 @@ def hash(value, algorithm='sha512'):
 
 def str_encode(value, encoder='base64'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     value
         The value to be encoded.
@@ -79,7 +79,7 @@ def str_encode(value, encoder='base64'):
 
 def get_str(length=20):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Returns a random string of the specified length.
 

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -515,7 +515,7 @@ def swapoff(name):
 
 def is_mounted(name):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Provide information if the path is mounted
 

--- a/salt/modules/nftables.py
+++ b/salt/modules/nftables.py
@@ -437,7 +437,7 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
 
 def check_chain(table='filter', chain=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Check for the existence of a chain in the table
 
@@ -495,7 +495,7 @@ def check_table(table=None, family='ipv4'):
 
 def new_table(table, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Create new custom table.
 
@@ -527,7 +527,7 @@ def new_table(table, family='ipv4'):
 
 def delete_table(table, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Create new custom table.
 
@@ -558,7 +558,7 @@ def delete_table(table, family='ipv4'):
 
 def new_chain(table='filter', chain=None, table_type=None, hook=None, priority=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Create new chain to the specified table.
 
@@ -614,7 +614,7 @@ def new_chain(table='filter', chain=None, table_type=None, hook=None, priority=N
 
 def delete_chain(table='filter', chain=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Delete the chain from the specified table.
 

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -71,7 +71,7 @@ def install(pkg=None,
     registry
         The NPM registry to install the package from.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -93,7 +93,7 @@ def status(name, sig=None):
 
 def reload_(name):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Reload the named service
 
@@ -168,7 +168,7 @@ def _get_rc():
 
 def available(name):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Returns ``True`` if the specified service is available, otherwise returns
     ``False``.
@@ -185,7 +185,7 @@ def available(name):
 
 def missing(name):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     The inverse of service.available.
     Returns ``True`` if the specified service is not available, otherwise returns
@@ -202,7 +202,7 @@ def missing(name):
 
 def get_all():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return all available boot services
 
@@ -224,7 +224,7 @@ def get_all():
 
 def get_enabled():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return a list of service that are enabled on boot
 
@@ -243,7 +243,7 @@ def get_enabled():
 
 def enabled(name):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return True if the named service is enabled, false otherwise
 
@@ -258,7 +258,7 @@ def enabled(name):
 
 def get_disabled():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return a set of services that are installed but disabled
 
@@ -277,7 +277,7 @@ def get_disabled():
 
 def disabled(name):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return True if the named service is disabled, false otherwise
 

--- a/salt/modules/pacman.py
+++ b/salt/modules/pacman.py
@@ -531,7 +531,7 @@ def file_dict(*packages):
 
 def owner(*paths):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return the name of the package that owns the file. Multiple file paths can
     be passed. Like :mod:`pkg.version <salt.modules.yumpkg.version`, if a

--- a/salt/modules/parted.py
+++ b/salt/modules/parted.py
@@ -743,7 +743,7 @@ def get_block_device():
     '''
     Retrieve a list of disk devices
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -41,12 +41,12 @@ def get(key, default='', merge=False, delim=':'):
         Specify whether or not the retrieved values should be recursively
         merged into the passed default.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     delim
         Specify an alternate delimiter to use when traversing a nested dict
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -662,7 +662,7 @@ def install(name=None,
 
             salt '*' pkg.install <package name> reinstall_requires=True force=True
 
-        .. versionchanged:: Helium
+        .. versionchanged:: 2014.7.0
             ``require`` kwarg renamed to ``reinstall_requires``
 
     fromrepo

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -344,7 +344,7 @@ def cpu_times(per_cpu=False):
 
 def virtual_memory():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return a dict that describes statistics about system memory usage.
 
@@ -359,7 +359,7 @@ def virtual_memory():
 
 def swap_memory():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return a dict that describes swap memory statistics.
 
@@ -374,7 +374,7 @@ def swap_memory():
 
 def physical_memory_usage():
     '''
-    .. deprecated:: Helium
+    .. deprecated:: 2014.7.0
         Use :mod:`ps.virtual_memory <salt.modules.ps.virtual_memory>` instead.
 
     Return a dict that describes free and available physical memory.
@@ -396,7 +396,7 @@ def physical_memory_usage():
 
 def virtual_memory_usage():
     '''
-    .. deprecated:: Helium
+    .. deprecated:: 2014.7.0
         Use :mod:`ps.virtual_memory <salt.modules.ps.virtual_memory>` instead.
 
     Return a dict that describes free and available memory, both physical
@@ -419,7 +419,7 @@ def virtual_memory_usage():
 
 def cached_physical_memory():
     '''
-    .. deprecated:: Helium
+    .. deprecated:: 2014.7.0
         Use :mod:`ps.virtual_memory <salt.modules.ps.virtual_memory>` instead.
 
     Return the amount cached memory.
@@ -441,7 +441,7 @@ def cached_physical_memory():
 
 def physical_memory_buffers():
     '''
-    .. deprecated:: Helium
+    .. deprecated:: 2014.7.0
         Use :mod:`ps.virtual_memory <salt.modules.ps.virtual_memory>` instead.
 
     Return the amount of physical memory buffers.

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -190,7 +190,7 @@ def noop(*args, **kwargs):
 
 def enable():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Enable the puppet agent
 
@@ -218,7 +218,7 @@ def enable():
 
 def disable():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Disable the puppet agent
 
@@ -249,7 +249,7 @@ def disable():
 
 def status():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Display puppet agent status
 
@@ -290,7 +290,7 @@ def status():
 
 def summary():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Show a summary of the last puppet agent run
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -500,7 +500,7 @@ def clear_cache():
     '''
     Forcibly removes all caches on a minion.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     WARNING: The safest way to clear a minion cache is by first stopping
     the minion and then deleting the cache files before restarting it.

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -2,7 +2,7 @@
 '''
 Module for manging the Salt schedule on a minion
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 '''
 

--- a/salt/modules/serverdensity_device.py
+++ b/salt/modules/serverdensity_device.py
@@ -3,7 +3,7 @@
 Wrapper around Server Density API
 =================================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 '''
 import requests
 import json

--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -279,7 +279,7 @@ def set_date(name, date):
 
 def set_expire(name, expire):
     '''
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
 
     Sets the value for the date the account expires as days since the epoch
     (January 1, 1970). Using a value of -1 will clear expiration. See man

--- a/salt/modules/smtp.py
+++ b/salt/modules/smtp.py
@@ -2,7 +2,7 @@
 '''
 Module for Sending Messages via SMTP
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :depends:   - smtplib python module
 :configuration: This module can be used by either passing a jid and password

--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -834,7 +834,7 @@ def user_keys(user=None, pubfile=None, prvfile=None):
 
     Return the user's ssh keys on the minion
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -913,7 +913,7 @@ def hash_known_hosts(user=None, config=None):
 
     Hash all the hostnames in the known hosts file.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -559,7 +559,7 @@ def sls_id(
     '''
     Call a single ID from the named module(s) and handle all requisites
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     CLI Example:
 

--- a/salt/modules/status.py
+++ b/salt/modules/status.py
@@ -547,7 +547,7 @@ def version():
 
 def master(master_ip=None, connected=True):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Fire an event if the minion gets disconnected from its master. This
     function is meant to be run via a scheduled job from the minion

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -65,7 +65,7 @@ def doc(*args):
 
 def state_doc(*args):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return the docstrings for all states. Optionally, specify a state or a
     function to narrow the selection.
@@ -115,7 +115,7 @@ def state_doc(*args):
 
 def runner_doc(*args):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return the docstrings for all runners. Optionally, specify a runner or a
     function to narrow the selection.
@@ -156,7 +156,7 @@ def runner_doc(*args):
 
 def returner_doc(*args):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return the docstrings for all returners. Optionally, specify a returner or a
     function to narrow the selection.
@@ -279,7 +279,7 @@ def argspec(module=''):
 
 def list_state_functions(*args, **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List the functions for all state modules. Optionally, specify a state
     module or modules from which to list.
@@ -314,7 +314,7 @@ def list_state_functions(*args, **kwargs):
 
 def list_state_modules():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List the modules loaded on the minion
 
@@ -336,7 +336,7 @@ def list_state_modules():
 
 def list_runners():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List the runners loaded on the minion
 
@@ -358,7 +358,7 @@ def list_runners():
 
 def list_runner_functions(*args, **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List the functions for all runner modules. Optionally, specify a runner
     module or modules from which to list.
@@ -393,7 +393,7 @@ def list_runner_functions(*args, **kwargs):
 
 def list_returners():
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List the runners loaded on the minion
 
@@ -415,7 +415,7 @@ def list_returners():
 
 def list_returner_functions(*args, **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     List the functions for all returner modules. Optionally, specify a returner
     module or modules from which to list.

--- a/salt/modules/twilio_notify.py
+++ b/salt/modules/twilio_notify.py
@@ -2,7 +2,7 @@
 '''
 Module for notifications via Twilio
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :depends:   - twilio python module
 :configuration: Configure this module by specifying the name of a configuration

--- a/salt/modules/varnish.py
+++ b/salt/modules/varnish.py
@@ -2,7 +2,7 @@
 '''
 Support for Varnish
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. note::
 

--- a/salt/modules/virtualenv_mod.py
+++ b/salt/modules/virtualenv_mod.py
@@ -41,7 +41,6 @@ def __virtual__():
 
 def create(path,
            venv_bin=None,
-           no_site_packages=None,
            system_site_packages=False,
            distribute=False,
            clear=False,
@@ -63,9 +62,6 @@ def create(path,
     venv_bin : None (default 'virtualenv')
         The name (and optionally path) of the virtualenv command. This can also
         be set globally in the minion config file as ``virtualenv.venv_bin``.
-    no_site_packages : None
-        Passthrough argument given to virtualenv if True. Deprecated since
-        ``salt>=0.17.0``. Use ``system_site_packages=False`` instead.
     system_site_packages : False
         Passthrough argument given to virtualenv or pyvenv
     distribute : False
@@ -107,16 +103,6 @@ def create(path,
     # raise CommandNotFoundError if venv_bin is missing
     salt.utils.check_or_die(venv_bin)
 
-    if no_site_packages is not None:
-        # Show a deprecation warning
-        salt.utils.warn_until(
-            'Helium',
-            '\'no_site_packages\' has been deprecated. Please start using '
-            '\'system_site_packages=False\' which means exactly the same '
-            'as \'no_site_packages=True\'. This warning and respective '
-            'workaround will be removed in Salt {version}'
-        )
-
     if runas is not None:
         # The user is using a deprecated argument, warn!
         salt.utils.warn_until(
@@ -135,14 +121,6 @@ def create(path,
     # Support deprecated 'runas' arg
     elif runas is not None and not user:
         user = str(runas)
-
-    if no_site_packages is True and system_site_packages is True:
-        raise salt.exceptions.CommandExecutionError(
-            '\'no_site_packages\' and \'system_site_packages\' are mutually '
-            'exclusive options. Please use only one, and prefer '
-            '\'system_site_packages\' since \'no_site_packages\' has been '
-            'deprecated.'
-        )
 
     cmd = [venv_bin]
 
@@ -184,8 +162,6 @@ def create(path,
                  ret['stdout'].strip().split('rc')[0].split('.')]
             )
 
-        if no_site_packages is True:
-            cmd.append('--no-site-packages')
         if distribute:
             if virtualenv_version_info >= (1, 10):
                 log.info(
@@ -230,12 +206,7 @@ def create(path,
         # ----- Stop the user if virtualenv only options are being used ----->
         # If any of the following values are not None, it means that the user
         # is actually passing a True or False value. Stop Him!
-        if no_site_packages is not None:
-            raise salt.exceptions.CommandExecutionError(
-                'The `no_site_packages`(`--no-site-packages`) option is not '
-                'supported by {0!r}'.format(venv_bin)
-            )
-        elif python is not None and python.strip() != '':
+        if python is not None and python.strip() != '':
             raise salt.exceptions.CommandExecutionError(
                 'The `python`(`--python`) option is not supported '
                 'by {0!r}'.format(venv_bin)

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -7,7 +7,7 @@ Module for running windows updates.
         - win32api
         - pywintypes
 
-.. versionadded:: (Helium)
+.. versionadded:: 2014.7.0
 
 '''
 

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -244,7 +244,7 @@ def latest_version(*names, **kwargs):
     A specific repo can be requested using the ``fromrepo`` keyword argument,
     and the ``disableexcludes`` option is also supported.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
         Support for the ``disableexcludes`` option
 
     CLI Example:
@@ -448,7 +448,7 @@ def list_upgrades(refresh=True, **kwargs):
     supported, as used in pkg states, and the ``disableexcludes`` option is
     also supported.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
         Support for the ``disableexcludes`` option
 
     CLI Example:
@@ -484,7 +484,7 @@ def check_db(*names, **kwargs):
     supported, as used in pkg states, and the ``disableexcludes`` option is
     also supported.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
         Support for the ``disableexcludes`` option
 
     CLI Examples:
@@ -714,7 +714,7 @@ def install(name=None,
         Works with sources when the package header of the source can be
         matched to the name and version of an installed package.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     skip_verify
         Skip the GPG verification check (e.g., ``--nogpgcheck``)
@@ -742,7 +742,7 @@ def install(name=None,
         Disable exclude from main, for a repo or for everything.
         (e.g., ``yum --disableexcludes='main'``)
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
 
     Multiple Package Installation Options:
@@ -905,7 +905,7 @@ def upgrade(refresh=True, fromrepo=None, skip_verify=False, **kwargs):
     '''
     Run a full system upgrade, a yum upgrade
 
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
 
     Return a dict containing the new package names and versions::
 
@@ -936,7 +936,7 @@ def upgrade(refresh=True, fromrepo=None, skip_verify=False, **kwargs):
         Disable exclude from main, for a repo or for everything.
         (e.g., ``yum --disableexcludes='main'``)
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
     '''
     if salt.utils.is_true(refresh):
         refresh_db(**kwargs)
@@ -1040,7 +1040,7 @@ def purge(name=None, pkgs=None, **kwargs):  # pylint: disable=W0613
 
 def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Hold packages with ``yum -q versionlock``.
 
@@ -1133,7 +1133,7 @@ def hold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
 
 def unhold(name=None, pkgs=None, sources=None, **kwargs):  # pylint: disable=W0613
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Hold packages with ``yum -q versionlock``.
 
@@ -1727,7 +1727,7 @@ def expand_repo_def(repokwargs):
 
 def owner(*paths):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return the name of the package that owns the file. Multiple file paths can
     be passed. Like :mod:`pkg.version <salt.modules.yumpkg.version`, if a

--- a/salt/modules/znc.py
+++ b/salt/modules/znc.py
@@ -2,7 +2,7 @@
 '''
 znc - An advanced IRC bouncer
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Provides an interface to basic ZNC functionality
 '''

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -3,7 +3,7 @@
 A REST API for Salt
 ===================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. py:currentmodule:: salt.netapi.rest_cherrypy.app
 

--- a/salt/pillar/etcd_pillar.py
+++ b/salt/pillar/etcd_pillar.py
@@ -2,7 +2,7 @@
 '''
 Use etcd data as a Pillar source
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :depends:  - python-etcd
 

--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -13,7 +13,7 @@ so:
 The `root=` parameter is optional and used to set the subdirectory from where
 to look for Pillar files (such as ``top.sls``).
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
     The optional ``root`` parameter will be added.
 
 Note that this is not the same thing as configuring pillar data using the

--- a/salt/pillar/svn_pillar.py
+++ b/salt/pillar/svn_pillar.py
@@ -13,7 +13,7 @@ so:
 The `root=` parameter is optional and used to set the subdirectory from where
 to look for Pillar files (such as ``top.sls``).
 
-.. versionchanged:: Helium
+.. versionchanged:: 2014.7.0
     The optional ``root`` parameter will be added.
 
 Note that this is not the same thing as configuring pillar data using the

--- a/salt/queues/sqlite_queue.py
+++ b/salt/queues/sqlite_queue.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 This is the default local master event queue built on sqlite.  By default, an
 sqlite3 database file is created in the `sqlite_queue_dir` which is found at::

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -186,7 +186,7 @@ Calling Salt Functions
 The Jinja renderer provides a shorthand lookup syntax for the ``salt``
 dictionary of :term:`execution function <Execution Function>`.
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 
@@ -200,7 +200,7 @@ Debugging
 The ``show_full_context`` function can be used to output all variables present
 in the current Jinja context.
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -237,10 +237,11 @@ def _split_module_dicts(__salt__):
 
         {{ salt.cmd.run('uptime') }}
     '''
-    mod_dict = {}
+    mod_dict = SaltDotLookup()
     for module_func_name in __salt__.keys():
         mod, _, fun = module_func_name.partition('.')
-        mod_dict.setdefault(mod, {})[fun] = __salt__[module_func_name]
+        mod_dict.setdefault(mod,
+                SaltDotLookup())[fun] = __salt__[module_func_name]
     return mod_dict
 
 
@@ -258,9 +259,8 @@ def render(template_file, saltenv='base', sls='', argline='',
                 'Unknown renderer option: {opt}'.format(opt=argline)
         )
 
-    salt_dict = {}
-    salt_dict.update(_split_module_dicts(__salt__))
-    salt_dict.update(__salt__)
+    salt_dict = SaltDotLookup(**__salt__)
+    salt_dict.__dict__.update(_split_module_dicts(__salt__))
 
     tmp_data = salt.utils.templates.JINJA(template_file,
                                           to_str=True,

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -221,6 +221,12 @@ import salt.utils.templates
 log = logging.getLogger(__name__)
 
 
+class SaltDotLookup(dict):
+    def __init__(self, *args, **kwargs):
+        dict.__init__(self, *args, **kwargs)
+        self.__dict__ = self
+
+
 def _split_module_dicts(__salt__):
     '''
     Create a dictionary from module.function as module[function]

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -84,7 +84,7 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
 
         Runner renamed from ``state.sls`` to ``state.orchestrate``
 
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
 
         Runner uses the pillar variable
     '''
@@ -134,7 +134,7 @@ def event(tagmatch='*', count=1, quiet=False, sock_dir=None):
     '''
     Watch Salt's event bus and block until the given tag is matched
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     This is useful for taking some simple action after an event is fired via
     the CLI without having to use Salt's Reactor.

--- a/salt/runners/survey.py
+++ b/salt/runners/survey.py
@@ -3,7 +3,7 @@
 A general map/reduce style salt runner for aggregating results
 returned by several different minions.
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Aggregated results are sorted by the size of the minion pools which returned
 matching results.
@@ -20,7 +20,7 @@ def hash(*args, **kwargs):
     Return the MATCHING minion pools from the aggregated and sorted results of
     a salt command
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     This command is submitted via a salt runner using the
     general form:
@@ -64,7 +64,7 @@ def diff(*args, **kwargs):
     Return the DIFFERENCE of the result sets returned by each matching minion
     pool
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     These pools are determined from the aggregated and sorted results of
     a salt command.

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -2,7 +2,7 @@
 '''
 Apache state
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Allows for inputting a yaml dictionary into a file for apache configuration
 files.

--- a/salt/states/apache_module.py
+++ b/salt/states/apache_module.py
@@ -3,7 +3,7 @@
 Manage Apache Modules
 =====================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Enable and disable apache modules.
 

--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -3,7 +3,7 @@
 Manage Autoscale Groups
 =======================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create and destroy autoscale groups. Be aware that this interacts with Amazon's
 services, and so may incur charges.

--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -3,7 +3,7 @@
 Manage Elasticache
 ==================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create, destroy and update Elasticache clusters. Be aware that this interacts
 with Amazon's services, and so may incur charges.

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -3,7 +3,7 @@
 Manage ELBs
 =================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create and destroy ELBs. Be aware that this interacts with Amazon's
 services, and so may incur charges.

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -3,7 +3,7 @@
 Manage IAM roles.
 =================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 This module uses ``boto``, which can be installed via package, or pip.
 

--- a/salt/states/boto_lc.py
+++ b/salt/states/boto_lc.py
@@ -3,7 +3,7 @@
 Manage Launch Configurations
 ============================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create and destroy Launch Configurations. Be aware that this interacts with
 Amazon's services, and so may incur charges.

--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -3,7 +3,7 @@
 Manage Route53 records
 ======================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create and delete Route53 records. Be aware that this interacts with Amazon's
 services, and so may incur charges.

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -3,7 +3,7 @@
 Manage Security Groups
 ======================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create and destroy Security Groups. Be aware that this interacts with Amazon's
 services, and so may incur charges.

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -3,7 +3,7 @@
 Manage SQS Queues
 =================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Create and destroy SQS queues. Be aware that this interacts with Amazon's
 services, and so may incur charges.

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -34,8 +34,7 @@ touch /tmp/foo if it does not exist.
 
 .. note::
 
-    The ``creates`` option will be supported starting with the feature release
-    codenamed Helium
+    The ``creates`` option was added to version 2014.7.0
 
 Salt determines whether the ``cmd`` state is successfully enforced based on the exit
 code returned by the command. If the command returns a zero exit code, then salt
@@ -421,7 +420,7 @@ def wait(name,
     creates
         Only run if the file specified by ``creates`` does not exist.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     output_loglevel
         Control the loglevel at which the output from the command is logged.
@@ -634,7 +633,7 @@ def run(name,
     creates
         Only run if the file specified by ``creates`` does not exist.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     use_vt
         Use VT utils (saltstack) to stream the command output more
@@ -821,7 +820,7 @@ def script(name,
     creates
         Only run if the file specified by ``creates`` does not exist.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     use_vt
         Use VT utils (saltstack) to stream the command output more

--- a/salt/states/event.py
+++ b/salt/states/event.py
@@ -8,7 +8,7 @@ def fire_master(name, data):
     '''
     Fire an event on the Salt master event bus
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     name
         The tag for the event
@@ -47,7 +47,7 @@ def wait(name, sfun=None):
     '''
     Fire an event on the Salt master event bus if called from a watch statement
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Example:
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1157,25 +1157,25 @@ def managed(name,
             spaces.
 
     contents_grains
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
         Same as contents_pillar, but with grains
 
     contents_newline
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
         When using contents, contents_pillar, or contents_grains, a newline is
         inserted into the data. When loading some data this newline is better
         left off.  Setting contents_newline to False will omit this newline.
 
     follow_symlinks : True
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
         If the desired path is a symlink follow it and make changes to the
         file to which the symlink points.
 
     check_cmd
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
         Do run the state only if the check_cmd succeeds
 
@@ -1491,7 +1491,7 @@ def directory(name,
         make room for the directory, unless backupname is set,
         then it will be renamed.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     backupname
         If the name of the directory exists and is not a directory, it will be
@@ -1499,7 +1499,7 @@ def directory(name,
         exists and force is False, the state will fail. Otherwise, the
         backupname will be removed first.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     '''
     # Remove trailing slash, if present
@@ -2983,7 +2983,7 @@ def prepend(name,
                   - salt://motd/hr-messages.tmpl
                   - salt://motd/general-messages.tmpl
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
     '''
     ret = {'name': name, 'changes': {}, 'result': False, 'comment': ''}
 
@@ -3646,7 +3646,7 @@ def serialize(name,
         be parsed and the dataset passed in will be merged with the existing
         content
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     For example, this state:
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -433,7 +433,7 @@ def config(name,
            user=None,
            is_global=False):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Manage a git config setting for a user or repository
 

--- a/salt/states/grains.py
+++ b/salt/states/grains.py
@@ -168,7 +168,7 @@ def list_absent(name, value):
 
 def absent(name, destructive=False):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Delete a grain from the grains config file
 
@@ -216,7 +216,7 @@ def absent(name, destructive=False):
 
 def append(name, value, convert=False):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Append a value to a list in the grains config file
 

--- a/salt/states/htpasswd.py
+++ b/salt/states/htpasswd.py
@@ -2,7 +2,7 @@
 '''
 Support for htpasswd module
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 .. code-block:: yaml
 

--- a/salt/states/influxdb_database.py
+++ b/salt/states/influxdb_database.py
@@ -5,7 +5,7 @@ Management of InfluxDB databases
 
 (compatible with InfluxDB version 0.5+)
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 '''
 

--- a/salt/states/influxdb_user.py
+++ b/salt/states/influxdb_user.py
@@ -5,7 +5,7 @@ Management of InfluxDB users
 
 (compatible with InfluxDB version 0.5+)
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 '''
 

--- a/salt/states/ipset.py
+++ b/salt/states/ipset.py
@@ -66,7 +66,7 @@ def __virtual__():
 
 def set_present(name, set_type, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Verify the chain is exist.
 
@@ -116,7 +116,7 @@ def set_present(name, set_type, family='ipv4', **kwargs):
 
 def set_absent(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Verify the set is absent.
 
@@ -164,7 +164,7 @@ def set_absent(name, family='ipv4', **kwargs):
 
 def present(name, entry=None, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Append a entry to a set
 
@@ -233,7 +233,7 @@ def present(name, entry=None, family='ipv4', **kwargs):
 
 def absent(name, entry=None, entries=None, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Remove a entry or entries from a chain
 
@@ -304,7 +304,7 @@ def absent(name, entry=None, entries=None, family='ipv4', **kwargs):
 
 def flush(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Flush current ipset set
 

--- a/salt/states/mdadm.py
+++ b/salt/states/mdadm.py
@@ -44,7 +44,7 @@ def present(name,
     '''
     Verify that the raid is present
 
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
 
     name
         The name of raid device to be created

--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -3,7 +3,7 @@
 Execution of MySQL queries
 ==========================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :depends:   - MySQLdb Python module
 :configuration: See :py:mod:`salt.modules.mysql` for setup instructions.

--- a/salt/states/nftables.py
+++ b/salt/states/nftables.py
@@ -115,7 +115,7 @@ def __virtual__():
 
 def chain_present(name, table='filter', table_type=None, hook=None, priority=None, family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Verify the chain is exist.
 
@@ -169,7 +169,7 @@ def chain_present(name, table='filter', table_type=None, hook=None, priority=Non
 
 def chain_absent(name, table='filter', family='ipv4'):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Verify the chain is absent.
 
@@ -281,7 +281,7 @@ def append(name, family='ipv4', **kwargs):
 
 def insert(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Insert a rule into a chain
 
@@ -347,7 +347,7 @@ def insert(name, family='ipv4', **kwargs):
 
 def delete(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Delete a rule to a chain
 
@@ -426,7 +426,7 @@ def delete(name, family='ipv4', **kwargs):
 
 def flush(name, family='ipv4', **kwargs):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Flush current nftables state
 

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -69,7 +69,7 @@ def installed(name,
     registry
         The NPM registry from which to install the package
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     force_reinstall
         Install the package even if it is already installed

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -514,14 +514,14 @@ def installed(
         Force the package to be held at the current installed version.
         Currently works with YUM & APT based systems.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     allow_updates
         Allow the package to be updated outside Salt's control (e.g. auto updates on Windows).
         This means a package on the Minion can have a newer version than the latest available
         in the repository without enforcing a re-installation of the package.
 
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
     Example:
 
@@ -537,7 +537,7 @@ def installed(
             - hold: False
 
     pkg_verify
-        .. versionadded:: Helium
+        .. versionadded:: 2014.7.0
 
         For requested packages that are already installed and would not be targeted for
         upgrade or downgrade, use pkg.verify to determine if any of the files installed
@@ -1351,7 +1351,7 @@ def purged(name, pkgs=None, **kwargs):
 
 def uptodate(name, refresh=False):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Verify that the system is completely up to date.
 

--- a/salt/states/serverdensity_device.py
+++ b/salt/states/serverdensity_device.py
@@ -3,7 +3,7 @@
 Monitor Server with Server Density
 ==================================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 `Server Density <https://www.serverdensity.com/>`_
 Is a hosted monitoring service.

--- a/salt/states/smtp.py
+++ b/salt/states/smtp.py
@@ -3,7 +3,7 @@
 Sending Messages via SMTP
 ==========================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 This state is useful for firing messages during state runs, using the XMPP
 protocol

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -45,7 +45,7 @@ def succeed_without_changes(name):
     '''
     Returns successful.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     name
         A unique string.
@@ -66,7 +66,7 @@ def fail_without_changes(name):
     '''
     Returns failure.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     name:
         A unique string.
@@ -89,7 +89,7 @@ def succeed_with_changes(name):
     '''
     Returns successful and changes is not empty
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     name:
         A unique string.
@@ -122,7 +122,7 @@ def fail_with_changes(name):
     '''
     Returns failure and changes is not empty.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     name:
         A unique string.
@@ -155,7 +155,7 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
     '''
     A configurable test state which determines its output based on the inputs.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     name:
         A unique string.

--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -71,7 +71,7 @@ def _changes(name,
     Return a dict of the changes required for a user if the user is present,
     otherwise return False.
 
-    Updated in Helium to include support for shadow attributes, all
+    Updated in 2014.7.0 to include support for shadow attributes, all
     attributes supported as integers only.
     '''
 
@@ -264,7 +264,7 @@ def present(name,
         The user's home phone number (not supported in MacOS)
 
 
-    .. versionchanged:: Helium
+    .. versionchanged:: 2014.7.0
        Shadow attribute support added.
 
     Shadow attributes support (currently Linux only):

--- a/salt/states/win_dns_client.py
+++ b/salt/states/win_dns_client.py
@@ -101,7 +101,7 @@ def primary_suffix(name,
         suffix=None,
         updates=False):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Configure the global primary DNS suffix of a DHCP client.
 

--- a/salt/states/win_update.py
+++ b/salt/states/win_update.py
@@ -3,7 +3,7 @@
 Management of the windows update agent.
 =======================================
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 Set windows updates to run by category. Default behavior is to install
 all updates that do not require user interaction to complete.

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2097,7 +2097,7 @@ def cache_node_list(nodes, provider, opts):
     If configured to do so, update the cloud cachedir with the current list of
     nodes. Also fires configured events pertaining to the node list.
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
     '''
     if 'update_cachedir' not in opts or not opts['update_cachedir']:
         return
@@ -2122,7 +2122,7 @@ def cache_node(node, provider, opts):
     '''
     Cache node individually
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
     '''
     if 'update_cachedir' not in opts or not opts['update_cachedir']:
         return
@@ -2152,7 +2152,7 @@ def missing_node_cache(prov_dir, node_list, provider, opts):
 
         diff_cache_events: True
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
     '''
     cached_nodes = []
     for node in os.listdir(prov_dir):
@@ -2185,7 +2185,7 @@ def diff_node_cache(prov_dir, node, new_data, opts):
 
         diff_cache_events: True
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
     '''
     if 'diff_cache_events' not in opts or not opts['diff_cache_events']:
         return
@@ -2241,7 +2241,7 @@ def _strip_cache_events(data, opts):
           - password
           - priv_key
 
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
     '''
     event_data = copy.deepcopy(data)
     strip_fields = opts.get('cache_event_strip_fields', [])

--- a/salt/utils/etcd_util.py
+++ b/salt/utils/etcd_util.py
@@ -2,7 +2,7 @@
 '''
 Utilities for working with etcd
 
-.. versionadded:: Helium
+.. versionadded:: 2014.7.0
 
 :depends:  - python-etcd
 
@@ -53,7 +53,7 @@ log = logging.getLogger(__name__)
 
 def get_conn(opts, profile=None):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Return a client object for accessing etcd
     '''
@@ -84,7 +84,7 @@ def get_conn(opts, profile=None):
 
 def tree(client, path):
     '''
-    .. versionadded:: Helium
+    .. versionadded:: 2014.7.0
 
     Recurse through etcd and return all values
     '''

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -46,7 +46,7 @@ This will schedule the command: state.sls httpd test=True every 3600 seconds
 This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour) splaying the time between 10 and 15 seconds
 
-    ... versionadded:: Helium
+    ... versionadded:: 2014.7.0
 
 Frequency of jobs can also be specified using date strings supported by
 the python dateutil library.
@@ -96,7 +96,7 @@ This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour) between the hours of 8am and 5pm.  The range parameter must be a
 dictionary with the date strings using the dateutil format.
 
-    ... versionadded:: Helium
+    ... versionadded:: 2014.7.0
 
     schedule:
       job1:

--- a/tests/unit/modules/virtualenv_test.py
+++ b/tests/unit/modules/virtualenv_test.py
@@ -8,7 +8,6 @@
 '''
 
 # Import python libraries
-import warnings
 import sys
 
 # Import Salt Testing libs

--- a/tests/unit/modules/virtualenv_test.py
+++ b/tests/unit/modules/virtualenv_test.py
@@ -163,26 +163,6 @@ class VirtualenvTestCase(TestCase):
                 system_site_packages=True
             )
 
-    def test_no_site_packages_deprecation(self):
-        # We *always* want *all* warnings thrown on this module
-        warnings.resetwarnings()
-        warnings.filterwarnings('always', '', DeprecationWarning, __name__)
-
-        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
-        with patch.dict(virtualenv_mod.__salt__, {'cmd.run_all': mock}):
-            with warnings.catch_warnings(record=True) as w:
-                virtualenv_mod.create(
-                    '/tmp/foo', no_site_packages=True
-                )
-                self.assertEqual(
-                    '\'no_site_packages\' has been deprecated. Please '
-                    'start using \'system_site_packages=False\' which '
-                    'means exactly the same as \'no_site_packages=True\'. '
-                    'This warning and respective workaround will be removed '
-                    'in Salt Helium (Unreleased)',
-                    str(w[-1].message)
-                )
-
     def test_unapplicable_options(self):
         # ----- Virtualenv using pyvenv options ----------------------------->
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})

--- a/tests/unit/templates/jinja_test.py
+++ b/tests/unit/templates/jinja_test.py
@@ -8,11 +8,13 @@ import datetime
 import pprint
 
 # Import Salt Testing libs
+from tests.integration import ModuleCase
 from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
+import salt.loader
 import salt.utils
 from salt.exceptions import SaltRenderError
 from salt.utils import get_context
@@ -631,7 +633,53 @@ class TestCustomExtensions(TestCase):
     #     return
 
 
+class TestDotNotationLookup(ModuleCase):
+    '''
+    Tests to call Salt functions via Jinja with various lookup syntaxes
+    '''
+    def __init__(self, *args, **kwargs):
+        super(TestDotNotationLookup, self).__init__(*args, **kwargs)
+
+        pack = {
+            'test.ping': lambda: True,
+            'grains.get': lambda x: 'jerry',
+        }
+        render = salt.loader.render(self.minion_opts, pack)
+        self.jinja = render.get('jinja')
+
+    def render(self, tmpl_str, context=None):
+        return self.jinja(tmpl_str, context=context or {}, from_str=True).read()
+
+    def test_normlookup(self):
+        '''
+        Sanity-check the normal dictionary-lookup syntax for our stub function
+        '''
+        tmpl_str = '''Hello, {{ salt['test.ping']() }}.'''
+
+        ret = self.render(tmpl_str)
+        self.assertEqual(ret, 'Hello, True.')
+
+    def test_dotlookup(self):
+        '''
+        Check calling a stub function using awesome dot-notation
+        '''
+        tmpl_str = '''Hello, {{ salt.test.ping() }}.'''
+
+        ret = self.render(tmpl_str)
+        self.assertEqual(ret, 'Hello, True.')
+
+    def test_shadowed_dict_method(self):
+        '''
+        Check calling a stub function with a name that shadows a ``dict``
+        method name
+        '''
+        tmpl_str = '''Hello, {{ salt.grains.get('id') }}.'''
+
+        ret = self.render(tmpl_str)
+        self.assertEqual(ret, 'Hello, jerry.')
+
 if __name__ == '__main__':
     from integration import run_tests
     run_tests(TestSaltCacheLoader, TestGetTemplate, TestCustomExtensions,
+            TestDotNotationLookup,
               needs_daemon=False)


### PR DESCRIPTION
@thatch45 does the `abspath` change in loader.py tickle you the wrong way? This fixes I problem I see occasionally when invoking Salt's loader at the Python-level. It is due to `self.module_dirs` in the loader class being set to `salt/modules` or `salt/renderers` instead of `/path/to/salt/modules` or `/path/to/salt/renderers`.
