### PR TITLE
Expands fix for skipping loading security descriptors on filesystems where they aren't present to work on win2k8+ and Directories

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -343,7 +343,13 @@ def get_pgid(path, follow_symlinks=True):
     # can't load a file descriptor for the file, we default
     # to "Everyone" - http://support.microsoft.com/kb/243330
     except MemoryError:
+        # generic memory error (win2k3+)
         return 'S-1-1-0'
+    except pywinerror as exc:
+        # invalid function error (win2k8+)
+        if exc.winerror == 1:
+            return 'S-1-1-0'
+        raise
     group_sid = secdesc.GetSecurityDescriptorGroup()
     return win32security.ConvertSidToStringSid(group_sid)
 
@@ -533,7 +539,13 @@ def get_uid(path, follow_symlinks=True):
             path, win32security.OWNER_SECURITY_INFORMATION
         )
     except MemoryError:
+        # generic memory error (win2k3+)
         return 'S-1-1-0'
+    except pywinerror as exc:
+        # invalid function error (win2k8+)
+        if exc.winerror == 1:
+            return 'S-1-1-0'
+        raise
     owner_sid = secdesc.GetSecurityDescriptorOwner()
     return win32security.ConvertSidToStringSid(owner_sid)
 

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -346,7 +346,7 @@ def get_pgid(path, follow_symlinks=True):
         # generic memory error (win2k3+)
         return 'S-1-1-0'
     except pywinerror as exc:
-        # invalid function error (win2k8+)
+        # Incorrect function error (win2k8+)
         if exc.winerror == 1:
             return 'S-1-1-0'
         raise
@@ -542,7 +542,7 @@ def get_uid(path, follow_symlinks=True):
         # generic memory error (win2k3+)
         return 'S-1-1-0'
     except pywinerror as exc:
-        # invalid function error (win2k8+)
+        # Incorrect function error (win2k8+)
         if exc.winerror == 1:
             return 'S-1-1-0'
         raise


### PR DESCRIPTION
Previously would present with the error:

Unable to manage file: (1, 'GetFileSecurity', 'Incorrect function.')
