### PR TITLE
Pass --all when invoking `systemctl list-units`

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -82,7 +82,7 @@ def _get_all_units():
                       r')\s+loaded\s+(?P<active>[^\s]+)')
 
     out = __salt__['cmd.run_stdout'](
-        'systemctl --full --no-legend --no-pager list-units | col -b'
+        'systemctl --all --full --no-legend --no-pager list-units | col -b'
     )
 
     ret = {}


### PR DESCRIPTION
`systemctl list-units` without --all won't list services that aren't actually running.  See https://github.com/saltstack/salt/issues/13788 for some further discussion.
