### PR TITLE
Chocolatey.bat doesn't exist in 0.9.8.24

### DIFF
--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -45,7 +45,7 @@ def _find_chocolatey():
     choc_defaults = ['C:\\Chocolatey\\bin\\chocolatey.bat',
                      'C:\\ProgramData\\Chocolatey\\bin\\chocolatey.exe', ]
 
-    choc_path = __salt__['cmd.which']('chocolatey.bat')
+    choc_path = __salt__['cmd.which']('chocolatey.exe')
     if not choc_path:
         for choc_dir in choc_defaults:
             if __salt__['cmd.has_exec'](choc_dir):

--- a/salt/modules/chocolatey.py
+++ b/salt/modules/chocolatey.py
@@ -43,7 +43,7 @@ def _find_chocolatey():
     Returns the full path to chocolatey.bat on the host.
     '''
     choc_defaults = ['C:\\Chocolatey\\bin\\chocolatey.bat',
-                     'C:\\ProgramData\\Chocolatey\\bin\\chocolatey.bat', ]
+                     'C:\\ProgramData\\Chocolatey\\bin\\chocolatey.exe', ]
 
     choc_path = __salt__['cmd.which']('chocolatey.bat')
     if not choc_path:


### PR DESCRIPTION
Although we've covered the move to c:\ProgramData\Chocolatey, the batch file that Salt looks for is no longer provided.

Salt needs to support chocolatey.cmd in both folders also.
