### PR TITLE
fix #14011 - self_signed_cert also need the correct ssl version set

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -620,7 +620,7 @@ def create_self_signed_cert(tls_dir='tls',
 
     # create certificate
     cert = OpenSSL.crypto.X509()
-    cert.set_version(3)
+    cert.set_version(2)
 
     cert.gmtime_adj_notBefore(0)
     cert.gmtime_adj_notAfter(int(days) * 24 * 60 * 60)


### PR DESCRIPTION
this sets the default ssl version for self-signed certs to version 3 (just like the CA)
