### PR TITLE
Added cert option to pip.installed.

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -120,6 +120,7 @@ def install(pkgs=None,
             cwd=None,
             activate=False,
             pre_releases=False,
+            cert=None,
             __env__=None,
             saltenv='base'):
     '''
@@ -221,7 +222,8 @@ def install(pkgs=None,
         before running install.
     pre_releases
         Include pre-releases in the available versions
-
+    cert
+        Provide a path to an alternate CA bundle
 
     CLI Example:
 
@@ -447,6 +449,9 @@ def install(pkgs=None,
         # From pip v1.4 the --pre flag is available
         if salt.utils.compare_versions(ver1=pip_version, oper='>=', ver2='1.4'):
             cmd.append('--pre')
+
+    if cert:
+        cmd.append('--cert={0}'.format(cert))
 
     if global_options:
         if isinstance(global_options, string_types):

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -123,7 +123,8 @@ def installed(name,
               no_chown=False,
               cwd=None,
               activate=False,
-              pre_releases=False):
+              pre_releases=False,
+              cert=None):
     '''
     Make sure the package is installed
 
@@ -422,6 +423,7 @@ def installed(name,
         cwd=cwd,
         activate=activate,
         pre_releases=pre_releases,
+        cert=cert,
         saltenv=__env__
     )
 


### PR DESCRIPTION
I had a need for pip's --cert option and, as far as I could tell, the pip.installed state has no way of specifying it. I did this to try and fix that. It works for me, for my own purposes, but I'm not all that well versed in salt's internals, so I'm not sure if there's more places that need altering. 
