### PR TITLE
Use an absolute path when using SALT_BASE_PATH

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -28,7 +28,7 @@ __salt__ = {
 }
 log = logging.getLogger(__name__)
 
-SALT_BASE_PATH = os.path.dirname(salt.__file__)
+SALT_BASE_PATH = os.path.abspath(os.path.dirname(salt.__file__))
 LOADED_BASE_NAME = 'salt.loaded'
 
 # Because on the cloud drivers we do `from salt.cloud.libcloudfuncs import *`


### PR DESCRIPTION
Salt's loader will skip non-absolute paths and relative paths are
generated with certain kinds of light Salt invocations such as in the
Python shell or in unit tests.
