### PR TITLE
Update smf.py to fix availability check on SmartOS

### DIFF
--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -87,9 +87,9 @@ def get_stopped():
 def available(name):
     '''
     Returns ``True`` if the specified service is available, otherwise returns
-    ``False``. 
-    
-    The SmartOS if statement uses svcs to return the service name from the 
+    ``False``.
+
+    The SmartOS if statement uses svcs to return the service name from the
     package name.
 
     CLI Example:
@@ -104,7 +104,7 @@ def available(name):
         return name in get_all()
     else:
         return name in get_all()
-        
+
 
 def missing(name):
     '''
@@ -124,7 +124,7 @@ def missing(name):
         return name not in get_all()
     else:
         return name not in get_all()
-        
+
 
 def get_all():
     '''

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -87,7 +87,10 @@ def get_stopped():
 def available(name):
     '''
     Returns ``True`` if the specified service is available, otherwise returns
-    ``False``.
+    ``False``. 
+    
+    The SmartOS if statement uses svcs to return the service name from the 
+    package name.
 
     CLI Example:
 
@@ -95,8 +98,13 @@ def available(name):
 
         salt '*' service.available net-snmp
     '''
-    return name in get_all()
-
+    if 'SmartOS' in __grains__['os']:
+        cmd = '/usr/bin/svcs -H -o SVC {0}'.format(name)
+        name = __salt__['cmd.run'](cmd)
+        return name in get_all()
+    else:
+        return name in get_all()
+        
 
 def missing(name):
     '''
@@ -110,8 +118,13 @@ def missing(name):
 
         salt '*' service.missing net-snmp
     '''
-    return name not in get_all()
-
+    if 'SmartOS' in __grains__['os']:
+        cmd = '/usr/bin/svcs -H -o SVC {0}'.format(name)
+        name = __salt__['cmd.run'](cmd)
+        return name not in get_all()
+    else:
+        return name not in get_all()
+        
 
 def get_all():
     '''


### PR DESCRIPTION
This addresses issue #13983.

Checking availability uses the services name, not the package name. The get_all function (which is used by available and missing functions) returns the service name. While to install the package, you need the package name. For example, for nginx, you have pkgsrc/nginx for the service name and nginx for the package name.

`/usr/bin/svcs -H -o SVC <packagename>` will take the package name and return abbreviated service name which can then be compared against the service list returned by the get_all function.

This fix works on SmartOS, but it was not compared to other SMF distributions. Therefore, the fix was confined to SmartOS.
