### PR TITLE
More scheduler unit tests and fixed keyerror possibility

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -327,8 +327,10 @@ class Schedule(object):
         # Remove all jobs from self.intervals
         self.intervals = {}
 
-        if 'schedule' in self.opts:
+        if 'schedule' in self.opts and 'schedule' in schedule:
             self.opts['schedule'].update(schedule['schedule'])
+        elif 'schedule' in self.opts:
+            self.opts['schedule'].update(schedule)
         else:
             self.opts['schedule'] = schedule
 

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -90,8 +90,8 @@ class ScheduleTestCase(TestCase):
 
     def test_reload_update_schedule_key(self):
         '''
-        Tests reloading and updating the schedule from saved schedule file that
-        contains a schedule key
+        Tests reloading the schedule from saved schedule where both the
+        saved schedule and self.schedule.opts contain a schedule key
         '''
         saved = {'schedule': {'foo': 'bar'}}
         ret = {'schedule': {'foo': 'bar', 'hello': 'world'}}
@@ -101,8 +101,8 @@ class ScheduleTestCase(TestCase):
 
     def test_reload_update_schedule_no_key(self):
         '''
-        Tests reloading and updating the schedule from saved schedule file that
-        contains a schedule key
+        Tests reloading the schedule from saved schedule that does not
+        contain a schedule key but self.schedule.opts does not
         '''
         saved = {'foo': 'bar'}
         ret = {'schedule': {'foo': 'bar', 'hello': 'world'}}
@@ -112,7 +112,8 @@ class ScheduleTestCase(TestCase):
 
     def test_reload_no_schedule_in_opts(self):
         '''
-        Tests reloading the schedule
+        Tests reloading the schedule from saved schedule that does not
+        contain a schedule key and neither does self.schedule.opts
         '''
         saved = {'foo': 'bar'}
         ret = {'schedule': {'foo': 'bar'}}
@@ -121,7 +122,8 @@ class ScheduleTestCase(TestCase):
 
     def test_reload_schedule_in_saved_but_not_opts(self):
         '''
-        Tests reloading the schedule
+        Tests reloading the schedule from saved schedule that contains
+        a schedule key, but self.schedule.opts does not
         '''
         saved = {'schedule': {'foo': 'bar'}}
         ret = {'schedule': {'schedule': {'foo': 'bar'}}}

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -66,6 +66,68 @@ class ScheduleTestCase(TestCase):
         data = {'key1': 'value1', 'key2': 'value2'}
         self.assertRaises(ValueError, Schedule.add_job, self.schedule, data)
 
+    # enabled_schedule tests
+
+    def test_enable_schedule(self):
+        '''
+        Tests enabling the scheduler
+        '''
+        self.schedule.opts = {'schedule': {'enabled': 'foo'}}
+        Schedule.enable_schedule(self.schedule)
+        self.assertTrue(self.schedule.opts['schedule']['enabled'])
+
+    # disable_schedule tests
+
+    def test_disable_schedule(self):
+        '''
+        Tests disabling the scheduler
+        '''
+        self.schedule.opts = {'schedule': {'enabled': 'foo'}}
+        Schedule.disable_schedule(self.schedule)
+        self.assertFalse(self.schedule.opts['schedule']['enabled'])
+
+    # reload tests
+
+    def test_reload_update_schedule_key(self):
+        '''
+        Tests reloading and updating the schedule from saved schedule file that
+        contains a schedule key
+        '''
+        saved = {'schedule': {'foo': 'bar'}}
+        ret = {'schedule': {'foo': 'bar', 'hello': 'world'}}
+        self.schedule.opts = {'schedule': {'hello': 'world'}}
+        Schedule.reload(self.schedule, saved)
+        self.assertEqual(self.schedule.opts, ret)
+
+    def test_reload_update_schedule_no_key(self):
+        '''
+        Tests reloading and updating the schedule from saved schedule file that
+        contains a schedule key
+        '''
+        saved = {'foo': 'bar'}
+        ret = {'schedule': {'foo': 'bar', 'hello': 'world'}}
+        self.schedule.opts = {'schedule': {'hello': 'world'}}
+        Schedule.reload(self.schedule, saved)
+        self.assertEqual(self.schedule.opts, ret)
+
+    def test_reload_no_schedule_in_opts(self):
+        '''
+        Tests reloading the schedule
+        '''
+        saved = {'foo': 'bar'}
+        ret = {'schedule': {'foo': 'bar'}}
+        Schedule.reload(self.schedule, saved)
+        self.assertEqual(self.schedule.opts, ret)
+
+    def test_reload_schedule_in_saved_but_not_opts(self):
+        '''
+        Tests reloading the schedule
+        '''
+        saved = {'schedule': {'foo': 'bar'}}
+        ret = {'schedule': {'schedule': {'foo': 'bar'}}}
+        Schedule.reload(self.schedule, saved)
+        self.assertEqual(self.schedule.opts, ret)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -66,7 +66,43 @@ class ScheduleTestCase(TestCase):
         data = {'key1': 'value1', 'key2': 'value2'}
         self.assertRaises(ValueError, Schedule.add_job, self.schedule, data)
 
-    # enabled_schedule tests
+    # enable_job tests
+
+    def test_enable_job(self):
+        '''
+        Tests enabling a job
+        '''
+        self.schedule.opts = {'schedule': {'name': {'enabled': 'foo'}}}
+        Schedule.enable_job(self.schedule, 'name')
+        self.assertTrue(self.schedule.opts['schedule']['name']['enabled'])
+
+    def test_enable_job_pillar(self):
+        '''
+        Tests enabling a job in pillar
+        '''
+        self.schedule.opts = {'pillar': {'schedule': {'name': {'enabled': 'foo'}}}}
+        Schedule.enable_job(self.schedule, 'name', where='pillar')
+        self.assertTrue(self.schedule.opts['pillar']['schedule']['name']['enabled'])
+
+    # disable_job tests
+
+    def test_disable_job(self):
+        '''
+        Tests disabling a job
+        '''
+        self.schedule.opts = {'schedule': {'name': {'enabled': 'foo'}}}
+        Schedule.disable_job(self.schedule, 'name')
+        self.assertFalse(self.schedule.opts['schedule']['name']['enabled'])
+
+    def test_disable_job_pillar(self):
+        '''
+        Tests disabling a job in pillar
+        '''
+        self.schedule.opts = {'pillar': {'schedule': {'name': {'enabled': 'foo'}}}}
+        Schedule.disable_job(self.schedule, 'name', where='pillar')
+        self.assertFalse(self.schedule.opts['pillar']['schedule']['name']['enabled'])
+
+    # enable_schedule tests
 
     def test_enable_schedule(self):
         '''


### PR DESCRIPTION
Wrote a few more unit tests for `salt.utils.schedule` and fixed a KeyError that could potentially occur in `salt.utils.schedule.reload`.
