### PR TITLE
Allow multiple instances to be spun up at once

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2533,7 +2533,7 @@ def show_instance(name=None, instance_id=None, call=None, kwargs=None):
             'The show_instance action requires a name.'
         )
 
-    if instance_id and call == 'function':
+    if call == 'function':
         name = kwargs.get('name', None)
         instance_id = kwargs.get('instance_id', None)
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2555,14 +2555,17 @@ def _get_node(name=None, instance_id=None, location=None):
     params = {'Action': 'DescribeInstances'}
     if instance_id:
         params['InstanceId.1'] = instance_id
-        instances = query(params, location=location)
-        return _extract_instance_info(instances)
+    else:
+        params['Filter.1.Name'] = 'tag:Name'
+        params['Filter.1.Value.1'] = name
+
     log.trace(params)
 
     attempts = 10
     while attempts >= 0:
         try:
-            return list_nodes_full(location)[name]
+            instances = query(params, location=location)
+            return _extract_instance_info(instances)
         except KeyError:
             attempts -= 1
             log.debug(

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1277,6 +1277,12 @@ def request_instance(vm_=None, call=None):
 
     # regular EC2 instance
     else:
+        # WARNING! EXPERIMENTAL!
+        # This allows more than one instance to be spun up in a single call.
+        # The first instance will be called by the name provided, but all other
+        # instances will be nameless (or more specifically, they will use the
+        # InstanceId as the name). This interface is expected to change, so
+        # use at your own risk.
         min_instance = config.get_cloud_config_value(
             'min_instance', vm_, __opts__, search_global=False, default=1
         )


### PR DESCRIPTION
Also optimizes show_instance(), so that when it is called as a function, with an instance_id, it does not have to run a full_query() in order to return data for a single instance.

Also, allows show_instance() to be called as a function.
