### PR TITLE
Fix KeyError in schedule.delete and more schedule unit tests

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -195,19 +195,20 @@ class Schedule(object):
             return self.functions['config.merge'](opt, {}, omit_master=True)
         return self.opts.get(opt, {})
 
-    def delete_job(self, name):
+    def delete_job(self, name, where=None):
         '''
         Deletes a job from the scheduler.
         '''
 
-        # ensure job exists, then delete it
-        if name in self.opts['schedule']:
-            del self.opts['schedule'][name]
-
-        # If job is in pillar, delete it there too
-        if 'schedule' in self.opts['pillar']:
-            if name in self.opts['pillar']['schedule']:
-                del self.opts['pillar']['schedule'][name]
+        if where is None or where != 'pillar':
+            # ensure job exists, then delete it
+            if name in self.opts['schedule']:
+                del self.opts['schedule'][name]
+        else:
+            # If job is in pillar, delete it there too
+            if 'schedule' in self.opts['pillar']:
+                if name in self.opts['pillar']['schedule']:
+                    del self.opts['pillar']['schedule'][name]
 
         # remove from self.intervals
         if name in self.intervals:
@@ -262,11 +263,11 @@ class Schedule(object):
         '''
         if where == 'pillar':
             if name in self.opts['pillar']['schedule']:
-                self.delete_job(name)
+                self.delete_job(name, where=where)
             self.opts['pillar']['schedule'][name] = schedule
         else:
             if name in self.opts['schedule']:
-                self.delete_job(name)
+                self.delete_job(name, where=where)
             self.opts['schedule'][name] = schedule
 
     def run_job(self, name, where):

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -270,7 +270,7 @@ class Schedule(object):
                 self.delete_job(name, where=where)
             self.opts['schedule'][name] = schedule
 
-    def run_job(self, name, where):
+    def run_job(self, name, where=None):
         '''
         Run a schedule job now
         '''
@@ -498,7 +498,8 @@ class Schedule(object):
                     time_conflict = True
 
             if time_conflict:
-                log.error('Unable to use "seconds", "minutes", "hours", or "days" with "when" or "cron" options.  Ignoring.')
+                log.error('Unable to use "seconds", "minutes", "hours", or "days" with '
+                          '"when" or "cron" options.  Ignoring.')
                 continue
 
             if 'when' in data and 'cron' in data:

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -328,10 +328,11 @@ class Schedule(object):
         # Remove all jobs from self.intervals
         self.intervals = {}
 
-        if 'schedule' in self.opts and 'schedule' in schedule:
-            self.opts['schedule'].update(schedule['schedule'])
-        elif 'schedule' in self.opts:
-            self.opts['schedule'].update(schedule)
+        if 'schedule' in self.opts:
+            if 'schedule' in schedule:
+                self.opts['schedule'].update(schedule['schedule'])
+            else:
+                self.opts['schedule'].update(schedule)
         else:
             self.opts['schedule'] = schedule
 

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -102,6 +102,28 @@ class ScheduleTestCase(TestCase):
         Schedule.disable_job(self.schedule, 'name', where='pillar')
         self.assertFalse(self.schedule.opts['pillar']['schedule']['name']['enabled'])
 
+    # modify_job tests
+
+    def test_modify_job(self):
+        '''
+        Tests modifying a job in the scheduler
+        '''
+        schedule = {'schedule': {'foo': 'bar'}}
+        ret = {'schedule': {'foo': 'bar', 'name': {'schedule': {'foo': 'bar'}}}}
+        self.schedule.opts = {'schedule': {'foo': 'bar'}}
+        Schedule.modify_job(self.schedule, 'name', schedule)
+        self.assertEqual(self.schedule.opts, ret)
+
+    def test_modify_job_pillar(self):
+        '''
+        Tests modifying a job in the scheduler in pillar
+        '''
+        schedule = {'foo': 'bar'}
+        ret = {'pillar': {'schedule': {'name': {'foo': 'bar'}}}}
+        self.schedule.opts = {'pillar': {'schedule': {'name': {'foo': 'bar'}}}}
+        Schedule.modify_job(self.schedule, 'name', schedule, where='pillar')
+        self.assertEqual(self.schedule.opts, ret)
+
     # enable_schedule tests
 
     def test_enable_schedule(self):

--- a/tests/unit/utils/schedule_test.py
+++ b/tests/unit/utils/schedule_test.py
@@ -66,6 +66,16 @@ class ScheduleTestCase(TestCase):
         data = {'key1': 'value1', 'key2': 'value2'}
         self.assertRaises(ValueError, Schedule.add_job, self.schedule, data)
 
+    def test_add_job(self):
+        '''
+        Tests adding a job to the schedule
+        '''
+        data = {'foo': 'bar'}
+        ret = {'schedule': {'foo': 'bar', 'hello': 'world'}}
+        self.schedule.opts = {'schedule': {'hello': 'world'}}
+        Schedule.add_job(self.schedule, data)
+        self.assertEqual(self.schedule.opts, ret)
+
     # enable_job tests
 
     def test_enable_job(self):


### PR DESCRIPTION
- Wrote unit tests for `salt.utils.schedule.modify_job`
- Fixed KeyError in `schedule.delete` found from tests
- Reformatted changes to `schedule.reload` to reduce if statement checks
- Fixed `where=None` bug
