### PR TITLE
glusterfs.list_volumes should return the expected type

### DIFF
--- a/salt/modules/glusterfs.py
+++ b/salt/modules/glusterfs.py
@@ -159,7 +159,7 @@ def list_volumes():
 
     results = __salt__['cmd.run']('gluster volume list').splitlines()
     if results[0] == 'No volumes present in cluster':
-        return None
+        return []
     else:
         return results
 

--- a/salt/states/glusterfs.py
+++ b/salt/states/glusterfs.py
@@ -111,7 +111,7 @@ def created(name, bricks, stripe=False, replica=False, device_vg=False,
            'comment': '',
            'result': False}
     volumes = __salt__['glusterfs.list_volumes']()
-    if volumes and name in volumes:
+    if name in volumes:
         if start:
             if isinstance(__salt__['glusterfs.status'](name), dict):
                 ret['result'] = True


### PR DESCRIPTION
We are expecting a list, not a None.

```
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1517, in call
              **cdata['kwargs'])
            File "/usr/lib/python2.7/dist-packages/salt/states/glusterfs.py", line 178, in started
              if name not in volumes:
          TypeError: argument of type 'NoneType' is not iterable
```
