### PR TITLE
LaneStack rxMsgs queue now returns duple (msg, sender) 

### DIFF
--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -73,7 +73,7 @@ class LocalClient(salt.client.LocalClient):
         while True:
             time.sleep(0.01)
             stack.serviceAll()
-            for msg in stack.rxMsgs:
+            for msg, sender in stack.rxMsgs:
                 ret = msg.get('return', {})
                 if 'ret' in ret:
                     stack.server.close()

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -510,7 +510,7 @@ class LoadPillar(ioflo.base.deeding.Deed):
         while True:
             time.sleep(0.01)
             if self.udp_stack.value.rxMsgs:
-                for msg, rnmid in self.udp_stack.value.rxMsgs:
+                for msg, sender in self.udp_stack.value.rxMsgs:
                     self.pillar.value = msg.get('return', {})
                     self.opts.value['pillar'] = self.pillar.value
                     return
@@ -717,11 +717,11 @@ class Router(ioflo.base.deeding.Deed):
                'uxd_stack': '.salt.uxd.stack.stack',
                'udp_stack': '.raet.udp.stack.stack'}
 
-    def _process_udp_rxmsg(self, msg, rnmid):
+    def _process_udp_rxmsg(self, msg, sender):
         '''
         Send to the right queue
         msg is the message body dict
-        rnmid is the unique name identifyer of the remote estate that sent the message
+        sender is the unique name of the remote estate that sent the message
         '''
         try:
             d_estate = msg['route']['dst'][0]
@@ -757,10 +757,13 @@ class Router(ioflo.base.deeding.Deed):
         elif d_share == 'fun':
             self.fun.value.append(msg)
 
-    def _process_uxd_rxmsg(self, msg):
+    def _process_uxd_rxmsg(self, msg, sender):
         '''
         Send uxd messages tot he right queue or forward them to the correct
         yard etc.
+
+        msg is message body dict
+        sender is unique name  of remote that sent the message
         '''
         try:
             d_estate = msg['route']['dst'][0]
@@ -803,10 +806,11 @@ class Router(ioflo.base.deeding.Deed):
         Process the messages!
         '''
         while self.udp_stack.value.rxMsgs:
-            msg, name = self.udp_stack.value.rxMsgs.popleft()
-            self._process_udp_rxmsg(msg=msg, rnmid=name)
+            msg, sender = self.udp_stack.value.rxMsgs.popleft()
+            self._process_udp_rxmsg(msg=msg, sender=sender)
         while self.uxd_stack.value.rxMsgs:
-            self._process_uxd_rxmsg(self.uxd_stack.value.rxMsgs.popleft())
+            msg, sender = self.uxd_stack.value.rxMsgs.popleft()
+            self._process_uxd_rxmsg(msg=msg, sender=sender)
 
 
 class Eventer(ioflo.base.deeding.Deed):

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -755,7 +755,7 @@ class Router(ioflo.base.deeding.Deed):
         elif d_share == 'remote_cmd':
             # Send it to a remote worker
             if 'load' in msg:
-                msg['load']['id'] = rnmid
+                msg['load']['id'] = sender
                 self.uxd_stack.value.transmit(msg,
                         self.uxd_stack.value.uids.get(next(self.workers.value)))
         elif d_share == 'fun':

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -164,7 +164,7 @@ class WorkerRouter(ioflo.base.deeding.Deed):
         '''
         self.uxd_stack.value.serviceAll()
         while self.uxd_stack.value.rxMsgs:
-            msg = self.uxd_stack.value.rxMsgs.popleft()
+            msg, sender = self.uxd_stack.value.rxMsgs.popleft()
             if 'load' in msg:
                 cmd = msg['load'].get('cmd')
                 if not cmd:

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -106,7 +106,7 @@ class RAETChannel(Channel):
             time.sleep(0.01)
             self.stack.serviceAll()
             if self.stack.rxMsgs:
-                for msg in self.stack.rxMsgs:
+                for msg, sender in self.stack.rxMsgs:
                     return msg.get('return', {})
             if time.time() - start > timeout:
                 if tried >= tries:

--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -115,7 +115,7 @@ class SaltEvent(object):
         while True:
             self.stack.serviceAll()
             if self.stack.rxMsgs:
-                msg = self.stack.rxMsgs.popleft()
+                msg, sender = self.stack.rxMsgs.popleft()
                 event = msg.get('event', {})
                 if 'tag' not in event and 'data' not in event:
                     # Invalid event, how did this get here?
@@ -138,7 +138,7 @@ class SaltEvent(object):
         self.connect_pub()
         self.stack.serviceAll()
         if self.stack.rxMsgs:
-            event = self.stack.rxMsgs.popleft()
+            event, sender = self.stack.rxMsgs.popleft()
             if 'tag' not in event and 'data' not in event:
                 # Invalid event, how did this get here?
                 return None


### PR DESCRIPTION
where 
msg is message body dict
sender is unique name of remote yard that sent the message
