### PR TITLE
Adding a trailing slash after path if not present when using salt.modules.file.makedirs

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3062,7 +3062,7 @@ def makedirs_(path,
     '''
     # walk up the directory structure until we find the first existing
     # directory
-    dirname = os.path.normpath(os.path.dirname(os.path.join(path, '')))
+    dirname = os.path.normpath(os.path.join(os.path.dirname(path), ''))
 
     if os.path.isdir(dirname):
         # There's nothing for us to do

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -3062,7 +3062,7 @@ def makedirs_(path,
     '''
     # walk up the directory structure until we find the first existing
     # directory
-    dirname = os.path.normpath(os.path.dirname(path))
+    dirname = os.path.normpath(os.path.dirname(os.path.join(path, '')))
 
     if os.path.isdir(dirname):
         # There's nothing for us to do


### PR DESCRIPTION
Fixes: https://github.com/saltstack/salt/issues/14019
