### PR TITLE
SmartOS esky build: requirements files

### DIFF
--- a/pkg/smartos/esky/raet_requirements.txt
+++ b/pkg/smartos/esky/raet_requirements.txt
@@ -1,0 +1,2 @@
+-r ../../../raet-requirements.txt
+-r requirements.txt

--- a/pkg/smartos/esky/requirements.txt
+++ b/pkg/smartos/esky/requirements.txt
@@ -1,3 +1,4 @@
 GitPython==0.3.2.RC1
 halite
-cherrypy
+-r ../../../opt_requirements.txt
+-r ../../../cloud-requirements.txt

--- a/pkg/smartos/esky/zeromq_requirements.txt
+++ b/pkg/smartos/esky/zeromq_requirements.txt
@@ -1,0 +1,2 @@
+-r ../../../zeromq-requirements.txt
+-r requirements.txt


### PR DESCRIPTION
Mimicking the breakout of requirements files in the main project,
this allows me to keep a file of extra requirements that get put in the
esky (e.g. halite) while only needing to point the build process at
either the zeromq or raet requirements file.
