### PR TITLE
Refine gitfs tests

### DIFF
--- a/tests/integration/fileserver/gitfs_test.py
+++ b/tests/integration/fileserver/gitfs_test.py
@@ -11,6 +11,7 @@ from salttesting.mock import patch, NO_MOCK, NO_MOCK_REASON
 ensure_in_syspath('../..')
 
 # Import Python libs
+import copy
 import os
 import shutil
 
@@ -20,7 +21,7 @@ from salt.fileserver import gitfs
 
 gitfs.__opts__ = {'gitfs_remotes': [''],
                   'gitfs_root': '',
-                  'fileserver_backend': 'gitfs',
+                  'fileserver_backend': ['git'],
                   'gitfs_base': 'master',
                   'fileserver_events': True,
                   'transport': 'zeromq',
@@ -52,7 +53,6 @@ class GitFSTest(integration.ModuleCase):
         '''
         We don't want to check in another .git dir into GH because that just gets messy.
         Instead, we'll create a temporary repo on the fly for the tests to examine.
-        :return:
         '''
         self.integration_base_files = os.path.join(integration.FILES, 'file', 'base')
         self.tmp_repo_dir = os.path.join(integration.TMP, 'gitfs_root')
@@ -61,7 +61,7 @@ class GitFSTest(integration.ModuleCase):
 
         try:
             shutil.copytree(self.integration_base_files, self.tmp_repo_dir + '/')
-        except OSError as e:
+        except OSError:
             # We probably caught an error because files already exist. Ignore
             pass
 
@@ -79,6 +79,14 @@ class GitFSTest(integration.ModuleCase):
                                          'sock_dir': self.master_opts['sock_dir']}):
             gitfs.update()
 
+    def tearDown(self):
+        '''
+        Remove the temporary git repository and gitfs cache directory to ensure
+        a clean environment for each test.
+        '''
+        shutil.rmtree(self.tmp_repo_dir)
+        shutil.rmtree(os.path.join(self.master_opts['cachedir'], 'gitfs'))
+
     def test_file_list(self):
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
@@ -90,14 +98,14 @@ class GitFSTest(integration.ModuleCase):
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
                                          'sock_dir': self.master_opts['sock_dir']}):
-            ret = gitfs.find_file('testfile')
-            expected_ret = {'path': os.path.join(self.master_opts['cachedir'],
-                                                 'gitfs',
-                                                 'refs',
-                                                 'base',
-                                                 'testfile'),
-                            'rel': 'testfile'}
 
+            path = os.path.join(self.master_opts['cachedir'],
+                                'gitfs/refs',
+                                LOAD['saltenv'],
+                                'testfile')
+
+            ret = gitfs.find_file('testfile')
+            expected_ret = {'path': path, 'rel': 'testfile'}
             self.assertDictEqual(ret, expected_ret)
 
     def test_dir_list(self):
@@ -122,20 +130,29 @@ class GitFSTest(integration.ModuleCase):
             ret = gitfs.envs()
             self.assertIn('base', ret)
 
-    def test_sha1_file_hash(self):
+    def test_file_hash_sha1(self):
         '''
-        NOTE: this test must be named in such a way that it comes later,
-        lexicographically, than test_find_file, otherwise the file in the local
-        minion cache referred to by fnd['path'] will not exist.
+        NOTE: This test requires that gitfs.find_file is executed to ensure
+        that the file exists in the gitfs cache.
         '''
+        target = 'testfile'
+        with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
+                                         'gitfs_remotes': ['file://' + self.tmp_repo_dir],
+                                         'sock_dir': self.master_opts['sock_dir']}):
+            # This needs to be in its own patch because we are using a
+            # different hash_type for this test (sha1) from the one the master
+            # is using (md5), which will cause the find_file to fail when the
+            # repo URI is hashed to determine the cachedir.
+            gitfs.find_file(target)
+
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
                                          'sock_dir': self.master_opts['sock_dir'],
                                          'hash_type': 'sha1'}):
-            tmp_load = LOAD.copy()
+            tmp_load = copy.deepcopy(LOAD)
             tmp_load['loc'] = 0
-            tmp_load['path'] = 'testfile'
-            fnd = {'rel': 'testfile',
+            tmp_load['path'] = target
+            fnd = {'rel': target,
                    'path': os.path.join(gitfs.__opts__['cachedir'],
                                         'gitfs/refs',
                                         tmp_load['saltenv'],
@@ -149,36 +166,40 @@ class GitFSTest(integration.ModuleCase):
 
     def test_serve_file(self):
         '''
-        NOTE: this test must be named in such a way that it comes later,
-        lexigraphically, than test_find_file, otherwise the file in the local
-        minion cache referred to by fnd['path'] will not exist.
+        NOTE: This test requires that gitfs.find_file is executed to ensure
+        that the file exists in the gitfs cache.
         '''
+        target = 'testfile'
         with patch.dict(gitfs.__opts__, {'cachedir': self.master_opts['cachedir'],
                                          'gitfs_remotes': ['file://' + self.tmp_repo_dir],
                                          'sock_dir': self.master_opts['sock_dir'],
                                          'file_buffer_size': 262144}):
-            tmp_load = LOAD.copy()
+            tmp_load = copy.deepcopy(LOAD)
             tmp_load['loc'] = 0
-            tmp_load['path'] = 'testfile'
-            fnd = {'rel': 'testfile',
+            tmp_load['path'] = target
+            fnd = {'rel': target,
                    'path': os.path.join(gitfs.__opts__['cachedir'],
                                         'gitfs/refs',
                                         tmp_load['saltenv'],
                                         tmp_load['path'])}
 
+            gitfs.find_file(tmp_load['path'])
             ret = gitfs.serve_file(tmp_load, fnd)
             self.assertDictEqual({
-                'data': 'Scene 24\n\n \n  OLD MAN:  Ah, hee he he ha!\n  ARTHUR:  '
-                        'And this enchanter of whom you speak, he has seen the grail?\n  '
-                        'OLD MAN:  Ha ha he he he he!\n  ARTHUR:  Where does he live?  '
-                        'Old man, where does he live?\n  OLD MAN:  He knows of a cave, '
-                        'a cave which no man has entered.\n  ARTHUR:  And the Grail... '
-                        'The Grail is there?\n  OLD MAN:  Very much danger, for beyond '
-                        'the cave lies the Gorge\n      of Eternal Peril, which no man '
-                        'has ever crossed.\n  ARTHUR:  But the Grail!  Where is the Grail!?\n  '
-                        'OLD MAN:  Seek you the Bridge of Death.\n  ARTHUR:  The Bridge of '
-                        'Death, which leads to the Grail?\n  OLD MAN:  Hee hee ha ha!\n\n',
-                'dest': 'testfile'},
+                'data': 'Scene 24\n\n \n  OLD MAN:  Ah, hee he he ha!\n  '
+                        'ARTHUR:  And this enchanter of whom you speak, he '
+                        'has seen the grail?\n  OLD MAN:  Ha ha he he he '
+                        'he!\n  ARTHUR:  Where does he live?  Old man, where '
+                        'does he live?\n  OLD MAN:  He knows of a cave, a '
+                        'cave which no man has entered.\n  ARTHUR:  And the '
+                        'Grail... The Grail is there?\n  OLD MAN:  Very much '
+                        'danger, for beyond the cave lies the Gorge\n      of '
+                        'Eternal Peril, which no man has ever crossed.\n  '
+                        'ARTHUR:  But the Grail!  Where is the Grail!?\n  OLD '
+                        'MAN:  Seek you the Bridge of Death.\n  ARTHUR:  The '
+                        'Bridge of Death, which leads to the Grail?\n  OLD '
+                        'MAN:  Hee hee ha ha!\n\n',
+                'dest': target},
                 ret)
 
 


### PR DESCRIPTION
This adds a tearDown to ensure a clean copy of the repo for each test.
In addition, it removes the dependency on lexicographical order by
running a find_file() inside the two tests which require it in order to
ensure that the file exists in the gitfs cache.
