### PR TITLE
Update Arch Linux Installation Documentation

### DIFF
--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -11,34 +11,11 @@ currently stable and -git packages available.
 Stable Release
 --------------
 
-Install Salt stable releases from the Arch Linux AUR as follows:
+Install Salt stable releases from the Arch Linux Official repositories as follows:
 
 .. code-block:: bash
 
-    wget https://aur.archlinux.org/packages/sa/salt/salt.tar.gz
-    tar xf salt.tar.gz
-    cd salt/
-    makepkg -is
-
-A few of Salt's dependencies are currently only found within the AUR, so it is
-necessary to download and run ``makepkg -is`` on these as well. As a reference, Salt
-currently relies on the following packages which are only available via the AUR:
-
-* https://aur.archlinux.org/packages/py/python2-msgpack/python2-msgpack.tar.gz
-* https://aur.archlinux.org/packages/py/python2-psutil/python2-psutil.tar.gz
-
-.. note:: yaourt
-
-    If a tool such as Yaourt_ is used, the dependencies will be
-    gathered and built automatically.
-
-    The command to install salt using the yaourt tool is:
-
-    .. code-block:: bash
-
-        yaourt salt
-
-.. _Yaourt: https://aur.archlinux.org/packages.php?ID=5863
+    pacman -S salt
 
 Tracking develop
 ----------------
@@ -53,7 +30,18 @@ use the -git package. Installing the -git package as follows:
     cd salt-git/
     makepkg -is
 
-See the note above about Salt's dependencies.
+.. note:: yaourt
+
+    If a tool such as Yaourt_ is used, the dependencies will be
+    gathered and built automatically.
+
+    The command to install salt using the yaourt tool is:
+
+    .. code-block:: bash
+
+        yaourt salt-git
+
+.. _Yaourt: https://aur.archlinux.org/packages.php?ID=5863
 
 Post-installation tasks
 =======================

--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -5,8 +5,9 @@ Arch Linux
 Installation
 ============
 
-Salt is currently available via the Arch User Repository (AUR). There are
-currently stable and -git packages available.
+Salt (stable) is currently available via the Arch Linux Official repositories.
+There are currently -git packages available in the Arch User repositories (AUR)
+as well.
 
 Stable Release
 --------------


### PR DESCRIPTION
Arch Linux has official support for the `salt` package (including
dependencies), update installation instructions to reflect this change.

Related, restructure notes about installing development builds from AUR.
