### PR TITLE
fix typo in modules.file.replace() docstring

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1030,7 +1030,7 @@ def replace(path,
 
     .. code-block:: bash
 
-        salt '*' file.replace /path/to/file pattern="bind-address\s*=" repl='bind-address:'
+        salt '*' file.replace /path/to/file pattern="bind-address\\s*=" repl='bind-address:'
 
     :param repl: The replacement text
     :param count: Maximum number of pattern occurrences to be replaced


### PR DESCRIPTION
```
************* Module salt.modules.file
salt/modules/file.py:1020: [W1401(anomalous-backslash-in-string), ] Anomalous backslash in string: '\s'. String constant might be missing an r prefix.
```
