### PR TITLE
avoid shadowing 'type' built-in in states.syslog_ng

### DIFF
--- a/salt/states/syslog_ng.py
+++ b/salt/states/syslog_ng.py
@@ -109,11 +109,11 @@ def _is_all_elements_simple_type(container):
     return all(map(_is_simple_type, container))
 
 
-def _is_all_element_has_type(container, type):
+def _is_all_element_has_type(container, type_):
     '''
     Returns True, if all elements in container are instances of the given type.
     '''
-    return all(map(lambda x: isinstance(x, type), container))
+    return all(map(lambda x: isinstance(x, type_), container))
 
 
 def _is_reference(parent, this, state_stack):


### PR DESCRIPTION
```
************* Module salt.states.syslog_ng
salt/states/syslog_ng.py:112: [W0622(redefined-builtin), _is_all_element_has_type] Redefining built-in 'type'
```
