### PR TITLE
Add repo managing functionality to the zypper module

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -236,6 +236,9 @@ class RepoInfo(object):
             raise ValueError(
                 'Only one of \'mirrorlist\' and \'url\' can be specified')
 
+    def _zypp_url(self, url):
+        return zypp.Url(url) if url else zypp.Url()
+
     @options.setter
     def options(self, value):
         log.garbage('Setting options {} for RepoInfo'.format(value))
@@ -283,7 +286,7 @@ class RepoInfo(object):
 
     @gpgkey.setter
     def gpgkey(self, value):
-        self.zypp.setGpgKeyUrl(value)
+        self.zypp.setGpgKeyUrl(self._zypp_url(value))
 
     @property
     def keeppackages(self):
@@ -307,7 +310,7 @@ class RepoInfo(object):
 
     @mirrorlist.setter
     def mirrorlist(self, value):
-        self.zypp.setMirrorListUrl(zypp.Url(value))
+        self.zypp.setMirrorListUrl(self._zypp_url(value))
         # self._check_only_mirrorlist_or_url()
 
     @property
@@ -324,7 +327,7 @@ class RepoInfo(object):
 
     @packagesPath.setter
     def packagesPath(self, value):
-        self.zypp.setPackagesPath(zypp.Url(value))
+        self.zypp.setPackagesPath(self._zypp_url(value))
 
     @property
     def path(self):
@@ -332,7 +335,7 @@ class RepoInfo(object):
 
     @path.setter
     def path(self, value):
-        self.zypp.setPath(zypp.Url(value))
+        self.zypp.setPath(self._zypp_url(value))
 
     @property
     def priority(self):
@@ -372,7 +375,7 @@ class RepoInfo(object):
 
     @url.setter
     def url(self, value):
-        self.zypp.setBaseUrl(zypp.Url(value) if value else zypp.Url())
+        self.zypp.setBaseUrl(self._zypp_url(value))
         # self._check_only_mirrorlist_or_url()
 
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -209,9 +209,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
     return ret
 
 
-class RepoInfo(object):
+class _RepoInfo(object):
     '''
-    Incapsulate all properties that are dumped in zypp.RepoInfo.dumpOn:
+    Incapsulate all properties that are dumped in zypp._RepoInfo.dumpOn:
     http://doc.opensuse.org/projects/libzypp/HEAD/classzypp_1_1RepoInfo.html#a2ba8fdefd586731621435428f0ec6ff1
     '''
     repo_types = {
@@ -241,7 +241,6 @@ class RepoInfo(object):
 
     @options.setter
     def options(self, value):
-        log.garbage('Setting options {} for RepoInfo'.format(value))
         for k, v in value.iteritems():
             setattr(self, k, v)
 
@@ -396,7 +395,7 @@ def _try_zypp():
 @depends('zypp')
 def _get_zypp_repo(repo, **kwargs):
     '''
-    Get zypp.RepoInfo object by repo alias.
+    Get zypp._RepoInfo object by repo alias.
     '''
     with _try_zypp():
         return zypp.RepoManager().getRepositoryInfo(repo)
@@ -413,7 +412,7 @@ def get_repo(repo, **kwargs):
 
         salt '*' pkg.get_repo alias
     '''
-    r = RepoInfo(_get_zypp_repo(repo))
+    r = _RepoInfo(_get_zypp_repo(repo))
     return r.options
 
 
@@ -481,10 +480,10 @@ def mod_repo(repo, **kwargs):
 
     repo_manager = zypp.RepoManager()
     try:
-        r = RepoInfo(repo_manager.getRepositoryInfo(repo))
+        r = _RepoInfo(repo_manager.getRepositoryInfo(repo))
         new_repo = False
     except RuntimeError:
-        r = RepoInfo()
+        r = _RepoInfo()
         r.alias = repo
         new_repo = True
     try:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -393,7 +393,7 @@ def _try_zypp():
 @depends('zypp')
 def _get_zypp_repo(repo, **kwargs):
     '''
-    Get zypp.RepoInfo object by repo name.
+    Get zypp.RepoInfo object by repo alias.
     '''
     with _try_zypp():
         return zypp.RepoManager().getRepositoryInfo(repo)
@@ -457,11 +457,7 @@ def mod_repo(repo, **kwargs):
 
     repo
         alias by which the zypper refers to the repo
-    name
-        a human-readable name for the repo
-    url
-        the URL for zypper to reference
-    mirrorlist
+    url or mirrorlist
         the URL for zypper to reference
 
     Key/Value pairs may also be removed from a repo's configuration by setting

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -275,6 +275,27 @@ def list_repos():
             for r in zypp.RepoManager().knownRepositories()}
 
 
+@depends('zypp')
+def del_repo(repo, **kwargs):
+    '''
+    Delete a repo.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt '*' pkg.del_repo alias
+        salt '*' pkg.del_repo alias
+    '''
+    r = _get_repo(repo)
+    try:
+        zypp.RepoManager().removeRepository(r)
+    except RuntimeError as e:
+        raise CommandExecutionError(re.sub('\[.*\] ', '', e.message))
+    return 'File {1} containing repo {0!r} has been removed.\n'.format(
+        repo, r.path().c_str())
+
+
 def refresh_db():
     '''
     Just run a ``zypper refresh``, return a dict::

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -227,9 +227,9 @@ class _RepoInfo(object):
     @property
     def options(self):
         class_items = self.__class__.__dict__.iteritems()
-        return {k: getattr(self, k) for k, v in class_items
-                if isinstance(v, property) and k != 'options'
-                and getattr(self, k) not in (None, '')}
+        return dict([(k, getattr(self, k)) for k, v in class_items
+                     if isinstance(v, property) and k != 'options'
+                     and getattr(self, k) not in (None, '')])
 
     def _check_only_mirrorlist_or_url(self):
         if all(x in self.options for x in ('mirrorlist', 'url')):


### PR DESCRIPTION
I've added functions `get_repo, list_repo, del_repo and mod_repo` into `modules.zypper`.

I've found 3 ways to manage repositories:
1. Manually handling .repo files (like in `yumpkg`)
2. Using `zypper`.
3. Using `libzypp` python binding.

First method requires writing lot's of code and I'm not sure that my "yet another rpm package manager" would be as stable as zypper is.

Second method requires to convert arguments into the format the zypper wants to read and parse zypper output. Moreover, zypper is simple command oriented, not dictionary oriented (for example, it uses `--enable` and `--disable` flags, but not `--enabled=True` and `--enabled=False`).

libzypp, in contrast is very convenient to wrap. So I've decided to use the latter method.

Dictionary keys are the same as in the `zypper lr repo` output, but keys are more Pythonic (`True`/`False` but not `1`/`0`).

Sorry for the lack of unittests. I wanted to write them but I didn't find any for the analogous `aptpkg` and `yumpkg` modules (see #14161), so I did not dare to write my own infrastructure for testing.
