### PR TITLE
modules.lxc: don't clobber lxc.network.type setting

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -393,6 +393,11 @@ def _get_network_conf(conf_tuples=None, **kwargs):
             nmac = ndata.get('lxc.network.hwaddr', '')
             if omac and not nmac:
                 new[iface]['lxc.network.hwaddr'] = omac
+            otype = odata.get('lxc.network.type', '')
+            ntype = ndata.get('lxc.network.type', '')
+            if otype:
+                new[iface]['lxc.network.type'] = otype
+
     ret = []
     for v in new.values():
         for row in v:


### PR DESCRIPTION
This fixes a regression which causes the network type specified in the lxc profile to be overwritten.

@kiorky, is this going to break anything for you?
