### PR TITLE
Fix the rest of the double-colons in docs

### DIFF
--- a/doc/topics/cloud/gce.rst
+++ b/doc/topics/cloud/gce.rst
@@ -61,10 +61,12 @@ Google Compute Engine Setup
    libcloud.  The original Google-generated private key was encrypted using
    *notasecret* as a passphrase.  Use the following command and record the
    location of the converted private key and record the location for use
-   in the ``service_account_private_key`` of your ``/etc/salt/cloud`` file::
+   in the ``service_account_private_key`` of your ``/etc/salt/cloud`` file:
 
-     openssl pkcs12 -in ORIG.pkey -passin pass:notasecret \
-     -nodes -nocerts | openssl rsa -out NEW.pem
+   .. code-block:: bash
+
+       openssl pkcs12 -in ORIG.pkey -passin pass:notasecret \
+       -nodes -nocerts | openssl rsa -out NEW.pem
 
 
 

--- a/doc/topics/cloud/lxc.rst
+++ b/doc/topics/cloud/lxc.rst
@@ -54,7 +54,9 @@ Here is a simple provider configuration:
 Profile configuration
 ---------------------
 
-Here are the options to configure your containers::
+Here are the options to configure your containers:
+
+.. code-block:: text
 
     ``target``
         Host minion id to install the lxc Container into

--- a/doc/topics/cloud/releases/0.8.0.rst
+++ b/doc/topics/cloud/releases/0.8.0.rst
@@ -32,7 +32,7 @@ Increased Formatting Options
 Additional options have been added to salt-cloud -Q, to support the same kinds
 of formatting already available in Salt:
 
-::
+.. code-block:: bash
 
   --raw-out
   --text-out

--- a/doc/topics/installation/freebsd.rst
+++ b/doc/topics/installation/freebsd.rst
@@ -7,7 +7,9 @@ Salt was added to the FreeBSD ports tree Dec 26th, 2011 by Christer Edwards
 releases.
 
 Salt is dependent on the following additional ports. These will be installed as
-dependencies of the ``sysutils/py-salt`` port. ::
+dependencies of the ``sysutils/py-salt`` port:
+
+.. code-block:: text
 
    /devel/py-yaml
    /devel/py-pyzmq

--- a/doc/topics/installation/solaris.rst
+++ b/doc/topics/installation/solaris.rst
@@ -24,15 +24,15 @@ following working well:
 7.   shadow password management modules/states
 
 Salt is dependent on the following additional packages. These will
-automatically be installed as dependencies of the ``py_salt`` package.::
+automatically be installed as dependencies of the ``py_salt`` package:
 
-   py_yaml
-   py_pyzmq
-   py_jinja2
-   py_msgpack_python
-   py_m2crypto
-   py_crypto
-   python
+- py_yaml
+- py_pyzmq
+- py_jinja2
+- py_msgpack_python
+- py_m2crypto
+- py_crypto
+- python
 
 Installation
 ============

--- a/doc/topics/installation/ubuntu.rst
+++ b/doc/topics/installation/ubuntu.rst
@@ -16,7 +16,9 @@ key in one step:
 .. admonition:: add-apt-repository: command not found?
 
     The ``add-apt-repository`` command is not always present on Ubuntu systems.
-    This can be fixed by installing `python-software-properties`::
+    This can be fixed by installing `python-software-properties`:
+
+    .. code-block:: bash
 
         sudo apt-get install python-software-properties
 

--- a/doc/topics/releases/saltapi/0.8.0.rst
+++ b/doc/topics/releases/saltapi/0.8.0.rst
@@ -65,7 +65,9 @@ Authentication information on login
     Changes such as this will be rare.
 
 New in this release is displaying information about the current session and the
-current user. For example::
+current user. For example:
+
+.. code-block:: bash
 
     % curl -sS localhost:8000/login \
         -H 'Accept: application/x-yaml'
@@ -74,18 +76,18 @@ current user. For example::
         -d eauth='pam'
 
     return:
-    - eauth: pam
-      expire: 1365508324.359403
-      perms:
-      - '@wheel'
-      - grains.*
-      - state.*
-      - status.*
-      - sys.*
-      - test.*
-      start: 1365465124.359402
-      token: caa7aa2b9dbc4a8adb6d2e19c3e52be68995ef4b
-      user: saltdev
+      - eauth: pam
+        expire: 1365508324.359403
+        perms:
+          - '@wheel'
+          - grains.*
+          - state.*
+          - status.*
+          - sys.*
+          - test.*
+        start: 1365465124.359402
+        token: caa7aa2b9dbc4a8adb6d2e19c3e52be68995ef4b
+        user: saltdev
 
 Bypass session handling
 -----------------------
@@ -106,7 +108,9 @@ then automatically added to the lowstate for subsequent requests that match the
 current session.
 
 It is sometimes useful to handle authentication or token management manually
-from another program or script. For example::
+from another program or script. For example:
+
+.. code-block:: bash
 
     curl -sS localhost:8000/run \
         -d client='local' \
@@ -139,7 +143,9 @@ The WSGI application entry point has been factored out into a stand-alone file
 in this release suitable for calling from an external server.
 :program:`salt-api` does not need to be running in this scenario.
 
-For example, an Apache virtual host configuration::
+For example, an Apache virtual host configuration:
+
+.. code-block:: text
 
     <VirtualHost *:80>
         ServerName example.com

--- a/doc/topics/troubleshooting/master.rst
+++ b/doc/topics/troubleshooting/master.rst
@@ -77,7 +77,9 @@ As with any change to resource limits, it is best to stay logged into your
 current shell and open another shell to run ``ulimit -n`` again and verify that
 the changes were applied correctly. Additionally, if your master is running
 upstart, it may be necessary to specify the ``nofile`` limit in
-``/etc/default/salt-master`` if upstart isn't respecting your resource limits::
+``/etc/default/salt-master`` if upstart isn't respecting your resource limits:
+
+.. code-block:: text
 
     limit nofile 4096 4096
 

--- a/doc/topics/tutorials/salt_bootstrap.rst
+++ b/doc/topics/tutorials/salt_bootstrap.rst
@@ -133,8 +133,9 @@ Installing via an Insecure One-Liner
 The following examples illustrate how to install Salt via a one-liner.
 
 .. note::
-    Warning! These methods do not involve a verification step and assume that the delivered file
-    is trustworthy.
+
+    Warning! These methods do not involve a verification step and assume that
+    the delivered file is trustworthy.
 
 
 Examples
@@ -231,7 +232,9 @@ passed):
 Command Line Options
 --------------------
 
-Here's a summary of the command line options::
+Here's a summary of the command line options:
+
+.. code-block:: bash
 
     $ sh bootstrap-salt.sh -h
     

--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -167,7 +167,9 @@ The SLS files are laid out in a directory structure on the Salt master; an
 SLS is just a file and files to download are just files.
 
 The Apache example would be laid out in the root of the Salt file server like
-this::
+this:
+
+.. code-block:: text
 
     apache/init.sls
     apache/httpd.conf
@@ -241,7 +243,9 @@ the toolkit. Consider this SSH example:
     produce an identical result; the first way -- using `file.managed` --
     is merely a shortcut.
 
-Now our State Tree looks like this::
+Now our State Tree looks like this:
+
+.. code-block:: text
 
     apache/init.sls
     apache/httpd.conf
@@ -342,6 +346,7 @@ gives you a `"Pythonic"`_ interface to building state data.
 .. _`"Pythonic"`: http://legacy.python.org/dev/peps/pep-0008/
 
 .. note::
+
     The templating engines described above aren't just available in SLS files.
     They can also be used in :mod:`file.managed <salt.states.file.managed>`
     states, making file management much more dynamic and flexible. Some

--- a/doc/topics/tutorials/states_pt2.rst
+++ b/doc/topics/tutorials/states_pt2.rst
@@ -4,12 +4,12 @@ States tutorial, part 2 - More Complex States, Requisites
 
 .. note:: 
 
-  This tutorial builds on topics covered in :doc:`part 1 <states_pt1>`. It is
-  recommended that you begin there.
+    This tutorial builds on topics covered in :doc:`part 1 <states_pt1>`. It is
+    recommended that you begin there.
 
-In the :doc:`last part <states_pt1>` of the Salt States tutorial we covered
-the basics of installing a package. We will now modify our ``webserver.sls``
-file to have requirements, and use even more Salt States.
+In the :doc:`last part <states_pt1>` of the Salt States tutorial we covered the
+basics of installing a package. We will now modify our ``webserver.sls`` file
+to have requirements, and use even more Salt States.
 
 Call multiple States
 ====================
@@ -32,29 +32,6 @@ You can specify multiple :ref:`state-declaration` under an
 
 Try stopping Apache before running ``state.highstate`` once again and observe
 the output.
-
-Expand the SLS module
-=====================
-
-As you have seen, SLS modules are appended with the file extension ``.sls`` and
-are referenced by name starting at the root of the state tree. An SLS module
-can be also defined as a directory. Demonstrate that now by creating a
-directory named ``webserver`` and moving and renaming ``webserver.sls`` to
-``webserver/init.sls``. Your state directory should now look like this::
-
-    |- top.sls
-    `- webserver/
-       `- init.sls
-
-.. admonition:: Organizing SLS modules
-
-    You can place additional ``.sls`` files in a state file directory. This
-    affords much cleaner organization of your state tree on the filesystem. For
-    example, if we created a ``webserver/django.sls`` file that module would be
-    referenced as ``webserver.django``.
-
-    In addition, States provide powerful includes and extending functionality
-    which we will cover in :doc:`Part 3 <states_pt3>`.
 
 Require other states
 ====================


### PR DESCRIPTION
This completes an audit of the doc files, which converts indented code blocks preceded by a line ending in a double-colon to a code-block using the relevant block type. In our new sphinx theme, these double-colon blocks are incorrectly identified as python blocks.

Note that the docstrings in the states and execution modules still need to be audited, this only completes an audit of the documentation RST files.
