### PR TITLE
Add salt roles

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -901,6 +901,7 @@ def syndic_config(master_config_path,
     opts.update(master_opts)
     opts.update(minion_opts)
     syndic_opts = {
+        'role': 'syndic',
         'root_dir': opts.get('root_dir', salt.syspaths.ROOT_DIR),
         'pidfile': opts.get('syndic_pidfile', 'salt-syndic.pid'),
         'log_file': opts.get('syndic_log_file', 'salt-syndic.log'),
@@ -1916,6 +1917,7 @@ def apply_minion_config(overrides=None,
         defaults = DEFAULT_MINION_OPTS
 
     opts = defaults.copy()
+    opts['role'] = 'minion'
     if overrides:
         opts.update(overrides)
 
@@ -2021,6 +2023,7 @@ def apply_master_config(overrides=None, defaults=None):
         defaults = DEFAULT_MASTER_OPTS
 
     opts = defaults.copy()
+    opts['role'] = 'master'
     if overrides:
         opts.update(overrides)
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -901,7 +901,7 @@ def syndic_config(master_config_path,
     opts.update(master_opts)
     opts.update(minion_opts)
     syndic_opts = {
-        'role': 'syndic',
+        '__role': 'syndic',
         'root_dir': opts.get('root_dir', salt.syspaths.ROOT_DIR),
         'pidfile': opts.get('syndic_pidfile', 'salt-syndic.pid'),
         'log_file': opts.get('syndic_log_file', 'salt-syndic.log'),
@@ -1917,7 +1917,7 @@ def apply_minion_config(overrides=None,
         defaults = DEFAULT_MINION_OPTS
 
     opts = defaults.copy()
-    opts['role'] = 'minion'
+    opts['__role'] = 'minion'
     if overrides:
         opts.update(overrides)
 
@@ -2023,7 +2023,7 @@ def apply_master_config(overrides=None, defaults=None):
         defaults = DEFAULT_MASTER_OPTS
 
     opts = defaults.copy()
-    opts['role'] = 'master'
+    opts['__role'] = 'master'
     if overrides:
         opts.update(overrides)
 


### PR DESCRIPTION
Set a role for each class of machine (master/minion/syndic).

This would allow us to more easily determine the role of a machine
when examining the opts dict.

This can be useful for cases like logging, when we might want to 
print or surpress a particular type of message depending on the
role of the machine.
