### PR TITLE
Remove unecessary (hopefully) sleep from highstate run (from #12137).

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1700,7 +1700,6 @@ class Minion(MinionBase):
 
         # On first startup execute a state run if configured to do so
         self._state_run()
-        time.sleep(.5)
 
         while self._running is True:
             try:


### PR DESCRIPTION
No mention in the ticket why a sleep was needed, and that shouldn't be-- if it is then we have a race condition somewhere :)
