### PR TITLE
Additions to docstrings for aptpkg module and pkgrepo state.

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
 Support for APT (Advanced Packaging Tool)
+
+.. note::
+
+    The ``python-apt`` package is required to be installed.
+
 '''
 
 # Import python libs

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -56,6 +56,11 @@ these states. Here is some example SLS:
     ``python-software-properties`` package, a missing dependency on pycurl, so
     ``python-pycurl`` will need to be manually installed if it is not present
     once ``python-software-properties`` is installed.
+
+    On Ubuntu & Debian systems, the ```python-apt`` package is required to be installed.
+    To check if this package is installed, run ``dpkg -l python-software-properties``.
+    ``python-apt`` will need to be manually installed if it is not present.
+
 '''
 
 # Import python libs


### PR DESCRIPTION
Adding information to docstrings to indicate that the python-apt package needs to be installed for the aptpkg module to work and pkgrepo state to manage apt repositories.  #14180
