### PR TITLE
Fix regression in templating local files

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2426,6 +2426,10 @@ def get_managed(
         sfn = __salt__['cp.cache_file'](source, saltenv)
         if not os.path.exists(sfn):
             return sfn, {}, 'Source file {0} not found'.format(source)
+        if sfn == name:
+            raise SaltInvocationError(
+                'Source file cannot be the same as destination'
+            )
         if template in salt.utils.templates.TEMPLATE_REGISTRY:
             context_dict = defaults if defaults else {}
             if context:

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -225,7 +225,7 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         file.managed test interface
         '''
         name = os.path.join(integration.TMP, 'grail_not_scene33')
-        with open(name, 'wb') as fp_:
+        with salt.utils.fopen(name, 'wb') as fp_:
             fp_.write('test_managed_show_diff_false\n')
 
         ret = self.run_state(
@@ -444,10 +444,9 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             template='jinja', defaults={'spam': _ts})
         try:
             self.assertSaltTrueReturn(ret)
-            self.assertIn(
-                _ts,
-                salt.utils.fopen(os.path.join(name, 'scene33'), 'r').read()
-            )
+            with salt.utils.fopen(os.path.join(name, 'scene33'), 'r') as fp_:
+                contents = fp_.read()
+            self.assertIn(_ts, contents)
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
@@ -759,7 +758,8 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 'state.sls', mods='testappend.issue-2227'
             )
             self.assertSaltTrueReturn(ret)
-            contents = salt.utils.fopen(tmp_file_append, 'r').read()
+            with salt.utils.fopen(tmp_file_append, 'r') as fp_:
+                contents_pre = fp_.read()
 
             # It should not append text again
             ret = self.run_function(
@@ -767,10 +767,10 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             )
             self.assertSaltTrueReturn(ret)
 
-            self.assertEqual(
-                contents, salt.utils.fopen(tmp_file_append, 'r').read()
-            )
+            with salt.utils.fopen(tmp_file_append, 'r') as fp_:
+                contents_post = fp_.read()
 
+            self.assertEqual(contents_pre, contents_post)
         except AssertionError:
             shutil.copy(tmp_file_append, tmp_file_append + '.bak')
             raise
@@ -969,12 +969,15 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             "    - backup: '.bak2'",
             '    - show_changes: True',
             '']
-        open(template_path, 'w').write(
-            '\n'.join(sls_template).format(testcase_filedest))
+        with salt.utils.fopen(template_path, 'w') as fp_:
+            fp_.write('\n'.join(sls_template).format(testcase_filedest))
+
         try:
             ret = self.run_function('state.sls', mods='issue-8343')
             for name, step in ret.items():
                 self.assertSaltTrueReturn({name: step})
+            with salt.utils.fopen(testcase_filedest) as fp_:
+                contents = fp_.read().split('\n')
             self.assertEqual(
                 ['#-- start salt managed zonestart -- PLEASE, DO NOT EDIT',
                  'foo',
@@ -986,7 +989,7 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                  '',
                  '#-- end salt managed zoneend --',
                  ''],
-                open(testcase_filedest).read().split('\n')
+                contents
             )
         finally:
             if os.path.isdir(testcase_filedest):
@@ -1033,12 +1036,15 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             '    - show_changes: True'
         ]
 
-        open(template_path, 'w').write(
-            '\n'.join(sls_template).format(testcase_filedest))
+        with salt.utils.fopen(template_path, 'w') as fp_:
+            fp_.write('\n'.join(sls_template).format(testcase_filedest))
+
         try:
             ret = self.run_function('state.sls', mods='issue-11003')
             for name, step in ret.items():
                 self.assertSaltTrueReturn({name: step})
+            with salt.utils.fopen(testcase_filedest) as fp_:
+                contents = fp_.read().split('\n')
             self.assertEqual(
                 ['#',
                  '#-- start managed zone PLEASE, DO NOT EDIT',
@@ -1048,7 +1054,7 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                  '',
                  '#-- end managed zone',
                  ''],
-                open(testcase_filedest).read().split('\n')
+                contents
             )
         finally:
             if os.path.isdir(testcase_filedest):
@@ -1120,8 +1126,8 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             '    - require:',
             '      - cmd: some-utf8-file-content-remove',
         ]
-        open(template_path, 'w').write(
-                '\n'.join(template_lines))
+        with salt.utils.fopen(template_path, 'w') as fp_:
+            fp_.write('\n'.join(template_lines))
         try:
             ret = self.run_function('state.sls', mods='issue-8947')
             if not isinstance(ret, dict):
@@ -1301,19 +1307,22 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         '''
         source = tempfile.mkstemp()[-1]
         dest = tempfile.mkstemp()[-1]
-        with open(source, 'w') as fp_:
+        with salt.utils.fopen(source, 'w') as fp_:
             fp_.write('{{ foo }}\n')
 
-        for prefix in ('file://', ''):
-            self.assertSaltTrueReturn(
-                self.run_state(
-                    'file.managed', name=dest, source=prefix + source,
-                    template='jinja', context={'foo': 'Hello world!'}
+        try:
+            for prefix in ('file://', ''):
+                ret = self.run_state(
+                    'file.managed',
+                    name=dest,
+                    source=prefix + source,
+                    template='jinja',
+                    context={'foo': 'Hello world!'}
                 )
-            )
-
-        os.remove(source)
-        os.remove(dest)
+                self.assertSaltTrueReturn(ret)
+        finally:
+            os.remove(source)
+            os.remove(dest)
 
     def test_template_local_file_noclobber(self):
         '''
@@ -1321,20 +1330,25 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         and the source path is the same as the destination path.
         '''
         source = tempfile.mkstemp()[-1]
-        with open(source, 'w') as fp_:
+        with salt.utils.fopen(source, 'w') as fp_:
             fp_.write('{{ foo }}\n')
 
-        ret = self.run_state(
-            'file.managed', name=source, source=source, template='jinja',
-            context={'foo': 'Hello world!'}
-        )
-        self.assertSaltFalseReturn(ret)
-        self.assertEqual(
-            ret[next(iter(ret))]['comment'],
-            ('Unable to manage file: Source file cannot be the same as '
-             'destination')
-        )
-        os.remove(source)
+        try:
+            ret = self.run_state(
+                'file.managed',
+                name=source,
+                source=source,
+                template='jinja',
+                context={'foo': 'Hello world!'}
+            )
+            self.assertSaltFalseReturn(ret)
+            self.assertEqual(
+                ret[next(iter(ret))]['comment'],
+                ('Unable to manage file: Source file cannot be the same as '
+                    'destination')
+            )
+        finally:
+            os.remove(source)
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
This fixes a regression in file templating, in which files on the minion's local filesystem could no longer be used as template sources. It also cleans up usage of filehandles in the file state tests.

Resolves #13873.
