### PR TITLE
Add rest_cherrypy tests for the /run entrypoint; fix session reference when sessions are disabled

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -532,7 +532,8 @@ class LowDataAdapter(object):
         # Release the session lock before executing any potentially
         # long-running Salt commands. This allows different threads to execute
         # Salt commands concurrently without blocking.
-        cherrypy.session.release_lock()
+        if cherrypy.request.config.get('tools.sessions.on', False):
+            cherrypy.session.release_lock()
 
         # if the lowstate loaded isn't a list, lets notify the client
         if type(lowstate) != list:

--- a/tests/integration/netapi/rest_cherrypy/test_app.py
+++ b/tests/integration/netapi/rest_cherrypy/test_app.py
@@ -1,4 +1,6 @@
 # coding: utf-8
+import unittest
+import mock
 import urllib
 
 from tests.utils import BaseRestCherryPyTest
@@ -47,6 +49,13 @@ class TestLogin(BaseRestCherryPyTest):
             ('password', 'saltdev'),
             ('eauth', 'auto'))
 
+    @mock.patch('salt.auth.Resolver', autospec=True)
+    def setUp(self, Resolver, *args, **kwargs):
+        super(TestLogin, self).setUp(*args, **kwargs)
+
+        self.app.salt.auth.Resolver = Resolver
+        self.Resolver = Resolver
+
     def test_good_login(self):
         '''
         Test logging in
@@ -90,6 +99,15 @@ class TestWebhookDisableAuth(BaseRestCherryPyTest):
             'webhook_disable_auth': True,
         },
     }
+
+    @mock.patch('salt.utils.event.get_event', autospec=True)
+    def setUp(self, get_event, *args, **kwargs):
+        '''
+        '''
+        super(TestWebhookDisableAuth, self).setUp(*args, **kwargs)
+
+        self.app.salt.utils.event.get_event = get_event
+        self.get_event = get_event
 
     def test_webhook_noauth(self):
         '''

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -6,7 +6,6 @@ try:
 except ImportError:
     HAS_CHERRYPY = False
 
-import mock
 import os
 
 import salt.config
@@ -41,21 +40,9 @@ class BaseRestCherryPyTest(BaseCherryPyTestCase):
         master_conf = os.path.join(TMP_CONF_DIR, 'master')
         self.config = salt.config.client_config(master_conf)
 
-    @mock.patch('salt.netapi.NetapiClient', autospec=True)
-    @mock.patch('salt.auth.Resolver', autospec=True)
-    @mock.patch('salt.auth.LoadAuth', autospec=True)
-    @mock.patch('salt.utils.event.get_event', autospec=True)
-    def setUp(self, get_event, LoadAuth, Resolver, NetapiClient):  # pylint: disable=W0221
-        app.salt.netapi.NetapiClient = NetapiClient
-        app.salt.auth.Resolver = Resolver
-        app.salt.auth.LoadAuth = LoadAuth
-        app.salt.utils.event.get_event = get_event
-
-        # Make local references to mocked objects so individual tests can
-        # access and modify the mocked interfaces.
-        self.Resolver = Resolver
-        self.NetapiClient = NetapiClient
-        self.get_event = get_event
+    def setUp(self, *args, **kwargs):
+        # Make a local reference to the CherryPy app so we can mock attributes.
+        self.app = app
 
         __opts__ = self.config.copy()
         __opts__.update(self.__opts__ or {

--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -7,6 +7,10 @@ except ImportError:
     HAS_CHERRYPY = False
 
 import mock
+import os
+
+import salt.config
+from ..integration import TMP_CONF_DIR
 
 if HAS_CHERRYPY:
     from . cptestcase import BaseCherryPyTestCase
@@ -31,6 +35,12 @@ class BaseRestCherryPyTest(BaseCherryPyTestCase):
     '''
     __opts__ = None
 
+    def __init__(self, *args, **kwargs):
+        super(BaseRestCherryPyTest, self).__init__(*args, **kwargs)
+
+        master_conf = os.path.join(TMP_CONF_DIR, 'master')
+        self.config = salt.config.client_config(master_conf)
+
     @mock.patch('salt.netapi.NetapiClient', autospec=True)
     @mock.patch('salt.auth.Resolver', autospec=True)
     @mock.patch('salt.auth.LoadAuth', autospec=True)
@@ -47,7 +57,8 @@ class BaseRestCherryPyTest(BaseCherryPyTestCase):
         self.NetapiClient = NetapiClient
         self.get_event = get_event
 
-        __opts__ = self.__opts__ or {
+        __opts__ = self.config.copy()
+        __opts__.update(self.__opts__ or {
             'external_auth': {
                 'auto': {
                     'saltdev': [
@@ -61,7 +72,7 @@ class BaseRestCherryPyTest(BaseCherryPyTestCase):
                 'port': 8000,
                 'debug': True,
             },
-        }
+        })
 
         root, apiopts, conf = app.get_app(__opts__)
 


### PR DESCRIPTION
This also localizes some of the test mocks since we're in Salt core now we might not want to mock everything by default.  ^_^

Oh, c25e658 also fixes the failing netapi tests.
