### PR TITLE
Don't load module if zypp is not present

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -17,10 +17,13 @@ from salt.exceptions import (
 
 log = logging.getLogger(__name__)
 
+HAS_ZYPP = False
+
 try:
     import zypp
-except ImportError as e:
-    log.trace('Failed to import zypp: {0}'.format(e))
+    HAS_ZYPP = True
+except ImportError:
+    pass
 
 # Define the module's virtual name
 __virtualname__ = 'pkg'
@@ -30,6 +33,8 @@ def __virtual__():
     '''
     Set the virtual pkg module if the os is openSUSE
     '''
+    if not HAS_ZYPP:
+        return False
     if __grains__.get('os_family', '') != 'Suse':
         return False
     # Not all versions of Suse use zypper, check that it is available
@@ -214,12 +219,15 @@ class _RepoInfo(object):
     Incapsulate all properties that are dumped in zypp._RepoInfo.dumpOn:
     http://doc.opensuse.org/projects/libzypp/HEAD/classzypp_1_1RepoInfo.html#a2ba8fdefd586731621435428f0ec6ff1
     '''
-    repo_types = {
-        zypp.RepoType.NONE_e: 'NONE',
-        zypp.RepoType.RPMMD_e: 'rpm-md',
-        zypp.RepoType.YAST2_e: 'yast2',
-        zypp.RepoType.RPMPLAINDIR_e: 'plaindir',
-    }
+    repo_types = {}
+    
+    if HAS_ZYPP:
+        repo_types = {
+            zypp.RepoType.NONE_e: 'NONE',
+            zypp.RepoType.RPMMD_e: 'rpm-md',
+            zypp.RepoType.YAST2_e: 'yast2',
+            zypp.RepoType.RPMPLAINDIR_e: 'plaindir',
+        }
 
     def __init__(self, zypp_repo_info=None):
         self.zypp = zypp_repo_info if zypp_repo_info else zypp.RepoInfo()


### PR DESCRIPTION
@rominf - fyi (Since SUSE Salt packages are depping on zypp, we're not going to load this module at all unless zypp is present.)
