### PR TITLE
Fix salt.utils.chugid group_list filtering on OS X

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2419,8 +2419,8 @@ def chugid(runas):
     # this does not appear to be strictly true.
     group_list = get_group_dict(runas, include_default=True)
     if sys.platform == 'darwin':
-        group_list = [a for a in group_list
-                      if not a.startswith('_')]
+        group_list = dict((k, v) for k, v in group_list.iteritems()
+                          if not k.startswith('_'))
     for group_name in group_list:
         gid = group_list[group_name]
         if (gid not in supgroups_seen


### PR DESCRIPTION
This should fix #13990, which is not a `salt.utils.vt` issue like I thought it was (I confused commenting out similar lines in `salt.utils.vt` for lines in `salt.utils.__init__`). As a result, the error I was seeing, `list indices must be integers, not str`, makes a lot more sense now.
