### PR TITLE
Add sync/async Runner calls & sync/async Wheel calls that all respect eauth

### DIFF
--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -94,7 +94,7 @@ WheelClient
 -----------
 
 .. autoclass:: salt.wheel.WheelClient
-    :members: call_func, cmd_sync, cmd_async
+    :members: cmd, async, cmd_sync, cmd_async
 
 CloudClient
 -----------

--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -88,7 +88,7 @@ RunnerClient
 ------------
 
 .. autoclass:: salt.runner.RunnerClient
-    :members:
+    :members: cmd, async, cmd_sync, cmd_async
 
 WheelClient
 -----------

--- a/doc/ref/clients/index.rst
+++ b/doc/ref/clients/index.rst
@@ -94,7 +94,7 @@ WheelClient
 -----------
 
 .. autoclass:: salt.wheel.WheelClient
-    :members:
+    :members: call_func, cmd_sync, cmd_async
 
 CloudClient
 -----------

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -1,0 +1,111 @@
+# coding: utf-8
+'''
+A collection of mixins useful for the various *Client interfaces
+'''
+from __future__ import print_function
+import datetime
+import logging
+import multiprocessing
+import time
+
+import salt.utils
+import salt.utils.event
+from salt.utils.event import tagify
+from salt.utils.doc import strip_rst as _strip_rst
+
+log = logging.getLogger(__name__)
+
+
+class SyncClientMixin(object):
+    '''
+    A mixin for *Client interfaces to abstract common function execution
+    '''
+    functions = ()
+
+    def _verify_fun(self, fun):
+        '''
+        Check that the function passed really exists
+        '''
+        if fun not in self.functions:
+            err = 'Function {0!r} is unavailable'.format(fun)
+            raise salt.exceptions.CommandExecutionError(err)
+
+    def low(self, fun, low):
+        '''
+        Execute a function from low data
+        '''
+        self._verify_fun(fun)
+        l_fun = self.functions[fun]
+        f_call = salt.utils.format_call(l_fun, low)
+        ret = l_fun(*f_call.get('args', ()), **f_call.get('kwargs', {}))
+        return ret
+
+    def get_docs(self, arg=None):
+        '''
+        Return a dictionary of functions and the inline documentation for each
+        '''
+        if arg:
+            target_mod = arg + '.' if not arg.endswith('.') else arg
+            docs = [(fun, self.functions[fun].__doc__)
+                    for fun in sorted(self.functions)
+                    if fun == arg or fun.startswith(target_mod)]
+        else:
+            docs = [(fun, self.functions[fun].__doc__)
+                    for fun in sorted(self.functions)]
+        docs = dict(docs)
+        return _strip_rst(docs)
+
+
+class AsyncClientMixin(object):
+    '''
+    A mixin for *Client interfaces to enable easy async function execution
+    '''
+    client = None
+    tag_prefix = None
+
+    def _proc_function(self, fun, low, user, tag, jid):
+        '''
+        Run this method in a multiprocess target to execute the function in a
+        multiprocess and fire the return data on the event bus
+        '''
+        salt.utils.daemonize()
+        event = salt.utils.event.get_event(
+                'master',
+                self.opts['sock_dir'],
+                self.opts['transport'],
+                listen=False)
+        data = {'fun': '{0}.{1}'.format(self.client, fun),
+                'jid': jid,
+                'user': user,
+                }
+        event.fire_event(data, tagify('new', base=tag))
+
+        try:
+            data['return'] = self.low(fun, low)
+            data['success'] = True
+        except Exception as exc:
+            data['return'] = 'Exception occurred in {0} {1}: {2}: {3}'.format(
+                            self.client,
+                            fun,
+                            exc.__class__.__name__,
+                            exc,
+                            )
+            data['success'] = False
+        data['user'] = user
+        event.fire_event(data, tagify('ret', base=tag))
+        # this is a workaround because process reaping is defeating 0MQ linger
+        time.sleep(2.0)  # delay so 0MQ event gets out before runner process reaped
+
+    def async(self, fun, low, user='UNKNOWN'):
+        '''
+        Execute the function in a multiprocess and return the event tag to use
+        to watch for the return
+        '''
+        jid = '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
+        tag = tagify(jid, prefix=self.tag_prefix)
+
+        proc = multiprocessing.Process(
+                target=self._proc_function,
+                args=(fun, low, user, tag, jid))
+        proc.start()
+        return {'tag': tag, 'jid': jid}

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -116,6 +116,17 @@ class SaltRenderError(SaltException):
         SaltException.__init__(self, exc_str)
 
 
+class SaltClientTimeout(SaltException):
+    '''
+    Thrown when a job sent through one of the *Client interfaces times out
+
+    Takes the ``jid`` as a parameter
+    '''
+    def __init__(self, msg, jid=None, *args, **kwargs):
+        super(SaltClientTimeout, self).__init__(msg, *args, **kwargs)
+        self.jid = jid
+
+
 class SaltReqTimeoutError(SaltException):
     '''
     Thrown when a salt master request call fails to return within the timeout

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -4,11 +4,14 @@ Make api awesomeness
 '''
 # Import Python libs
 import inspect
+import os
 
 # Import Salt libs
 import salt.log  # pylint: disable=W0611
 import salt.client
+import salt.config
 import salt.runner
+import salt.syspaths
 import salt.wheel
 import salt.utils
 from salt.exceptions import SaltException, EauthAuthenticationError
@@ -82,18 +85,31 @@ class NetapiClient(object):
 
     def runner(self, fun, **kwargs):
         '''
-        Run `runner modules <all-salt.runners>`
+        Run `runner modules <all-salt.runners>` synchronously
 
-        Wraps :py:meth:`salt.runner.RunnerClient.low`.
+        Wraps :py:meth:`salt.runner.RunnerClient.cmd_sync`.
 
         :return: Returns the result from the runner module
         '''
+        kwargs['fun'] = fun
         runner = salt.runner.RunnerClient(self.opts)
-        return runner.low(fun, kwargs)
+        return runner.cmd_sync(kwargs)
+
+    def runner_async(self, fun, **kwargs):
+        '''
+        Run `runner modules <all-salt.runners>` asynchronously
+
+        Wraps :py:meth:`salt.runner.RunnerClient.cmd_async`.
+
+        :return: event data and a job ID for the executed function.
+        '''
+        kwargs['fun'] = fun
+        runner = salt.runner.RunnerClient(self.opts)
+        return runner.cmd_sync(kwargs)
 
     def wheel(self, fun, **kwargs):
         '''
-        Run :ref:`wheel modules <all-salt.wheel>`
+        Run :ref:`wheel modules <all-salt.wheel>` synchronously
 
         Wraps :py:meth:`salt.wheel.WheelClient.master_call`.
 
@@ -102,3 +118,15 @@ class NetapiClient(object):
         kwargs['fun'] = fun
         wheel = salt.wheel.Wheel(self.opts)
         return wheel.master_call(**kwargs)
+
+    def wheel_async(self, fun, **kwargs):
+        '''
+        Run :ref:`wheel modules <all-salt.wheel>` asynchronously
+
+        Wraps :py:meth:`salt.wheel.WheelClient.master_call`.
+
+        :return: Returns the result from the wheel module
+        '''
+        kwargs['fun'] = fun
+        wheel = salt.wheel.Wheel(self.opts)
+        return wheel.cmd_async(kwargs)

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -87,7 +87,7 @@ class NetapiClient(object):
         local = salt.client.get_local_client(mopts=self.opts)
         return local.cmd_batch(*args, **kwargs)
 
-    def runner(self, fun, **kwargs):
+    def runner(self, fun, timeout=None, **kwargs):
         '''
         Run `runner modules <all-salt.runners>` synchronously
 
@@ -97,7 +97,7 @@ class NetapiClient(object):
         '''
         kwargs['fun'] = fun
         runner = salt.runner.RunnerClient(self.opts)
-        return runner.cmd_sync(kwargs)
+        return runner.cmd_sync(kwargs, timeout=timeout)
 
     def runner_async(self, fun, **kwargs):
         '''
@@ -109,7 +109,7 @@ class NetapiClient(object):
         '''
         kwargs['fun'] = fun
         runner = salt.runner.RunnerClient(self.opts)
-        return runner.cmd_sync(kwargs)
+        return runner.cmd_async(kwargs)
 
     def wheel(self, fun, **kwargs):
         '''

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -22,12 +22,16 @@ class NetapiClient(object):
     Provide a uniform method of accessing the various client interfaces in Salt
     in the form of low-data data structures. For example:
 
-    >>> client = NetapiClient(__opts__)
+    >>> client = NetapiClient()
     >>> lowstate = {'client': 'local', 'tgt': '*', 'fun': 'test.ping', 'arg': ''}
     >>> client.run(lowstate)
+
+    :param mopts: A copy of the client_config dictionary if already loaded into memory.
+    :param opts: Ignored; preserved for backward-compat
     '''
-    def __init__(self, opts):
-        self.opts = opts
+    def __init__(self, opts=None, mopts=None):
+        self.opts = mopts or salt.config.client_config(os.path.join(
+            salt.syspaths.CONFIG_DIR, 'master'))
 
     def run(self, low):
         '''
@@ -55,7 +59,7 @@ class NetapiClient(object):
 
         :return: job ID
         '''
-        local = salt.client.get_local_client(self.opts['conf_file'])
+        local = salt.client.get_local_client(mopts=self.opts)
         return local.run_job(*args, **kwargs)
 
     def local(self, *args, **kwargs):
@@ -66,7 +70,7 @@ class NetapiClient(object):
 
         :return: Returns the result from the execution module
         '''
-        local = salt.client.get_local_client(self.opts['conf_file'])
+        local = salt.client.get_local_client(mopts=self.opts)
         return local.cmd(*args, **kwargs)
 
     def local_batch(self, *args, **kwargs):
@@ -80,7 +84,7 @@ class NetapiClient(object):
         :return: Returns the result from the exeuction module for each batch of
             returns
         '''
-        local = salt.client.get_local_client(self.opts['conf_file'])
+        local = salt.client.get_local_client(mopts=self.opts)
         return local.cmd_batch(*args, **kwargs)
 
     def runner(self, fun, **kwargs):

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -120,7 +120,7 @@ class NetapiClient(object):
         :return: Returns the result from the wheel module
         '''
         kwargs['fun'] = fun
-        wheel = salt.wheel.Wheel(self.opts)
+        wheel = salt.wheel.WheelClient(self.opts)
         return wheel.master_call(**kwargs)
 
     def wheel_async(self, fun, **kwargs):
@@ -132,5 +132,5 @@ class NetapiClient(object):
         :return: Returns the result from the wheel module
         '''
         kwargs['fun'] = fun
-        wheel = salt.wheel.Wheel(self.opts)
+        wheel = salt.wheel.WheelClient(self.opts)
         return wheel.cmd_async(kwargs)

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -6,10 +6,7 @@ Execute salt convenience routines
 # Import python libs
 from __future__ import print_function
 import collections
-import datetime
 import logging
-import multiprocessing
-import time
 
 # Import salt libs
 import salt.exceptions
@@ -18,15 +15,15 @@ import salt.minion
 import salt.utils
 import salt.utils.args
 import salt.utils.event
+from salt.client import mixins
 from salt.output import display_output
-from salt.utils.doc import strip_rst as _strip_rst
 from salt.utils.error import raise_error
 from salt.utils.event import tagify
 
 log = logging.getLogger(__name__)
 
 
-class RunnerClient(object):
+class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
     '''
     The interface used by the :command:`salt-run` CLI tool on the Salt Master
 
@@ -41,64 +38,12 @@ class RunnerClient(object):
     eauth user must be authorized to execute runner modules: (``@runner``).
     Only the :py:meth:`master_call` below supports eauth.
     '''
+    client = 'runner'
+    tag_prefix = 'run'
+
     def __init__(self, opts):
         self.opts = opts
         self.functions = salt.loader.runner(opts)
-
-    def _proc_runner(self, fun, low, user, tag, jid):
-        '''
-        Run this method in a multiprocess target to execute the runner in a
-        multiprocess and fire the return data on the event bus
-        '''
-        salt.utils.daemonize()
-        event = salt.utils.event.get_event(
-                'master',
-                self.opts['sock_dir'],
-                self.opts['transport'],
-                listen=False)
-        data = {'fun': 'runner.{0}'.format(fun),
-                'jid': jid,
-                'user': user,
-                }
-        event.fire_event(data, tagify('new', base=tag))
-
-        try:
-            data['return'] = self.low(fun, low)
-            data['success'] = True
-        except Exception as exc:
-            data['return'] = 'Exception occurred in runner {0}: {1}: {2}'.format(
-                            fun,
-                            exc.__class__.__name__,
-                            exc,
-                            )
-            data['success'] = False
-        data['user'] = user
-        event.fire_event(data, tagify('ret', base=tag))
-        # this is a workaround because process reaping is defeating 0MQ linger
-        time.sleep(2.0)  # delay so 0MQ event gets out before runner process reaped
-
-    def _verify_fun(self, fun):
-        '''
-        Check that the function passed really exists
-        '''
-        if fun not in self.functions:
-            err = 'Function {0!r} is unavailable'.format(fun)
-            raise salt.exceptions.CommandExecutionError(err)
-
-    def get_docs(self, arg=None):
-        '''
-        Return a dictionary of functions and the inline documentation for each
-        '''
-        if arg:
-            target_mod = arg + '.' if not arg.endswith('.') else arg
-            docs = [(fun, self.functions[fun].__doc__)
-                    for fun in sorted(self.functions)
-                    if fun == arg or fun.startswith(target_mod)]
-        else:
-            docs = [(fun, self.functions[fun].__doc__)
-                    for fun in sorted(self.functions)]
-        docs = dict(docs)
-        return _strip_rst(docs)
 
     def cmd(self, fun, arg, pub_data=None, kwarg=None):
         '''
@@ -174,36 +119,6 @@ class RunnerClient(object):
             self.functions[fun], arglist, pub_data
         )
         return self.functions[fun](*args, **kwargs)
-
-    def low(self, fun, low):
-        '''
-        Pass in the runner function name and the low data structure
-
-        .. code-block:: python
-
-            runner.low({'fun': 'jobs.lookup_jid', 'jid': '20131219215921857715'})
-        '''
-        self._verify_fun(fun)
-        l_fun = self.functions[fun]
-        f_call = salt.utils.format_call(l_fun, low)
-        ret = l_fun(*f_call.get('args', ()), **f_call.get('kwargs', {}))
-        return ret
-
-    def async(self, fun, low, user='UNKNOWN'):
-        '''
-        Execute the runner in a multiprocess and return the event tag to use
-        to watch for the return
-        '''
-        jid = '{0:%Y%m%d%H%M%S%f}'.format(datetime.datetime.now())
-        tag = tagify(jid, prefix='run')
-        #low['tag'] = tag
-        #low['jid'] = jid
-
-        proc = multiprocessing.Process(
-                target=self._proc_runner,
-                args=(fun, low, user, tag, jid))
-        proc.start()
-        return {'tag': tag, 'jid': jid}
 
     def master_call(self, **kwargs):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -203,7 +203,7 @@ class RunnerClient(object):
                 target=self._proc_runner,
                 args=(fun, low, user, tag, jid))
         proc.start()
-        return {'tag': tag}
+        return {'tag': tag, 'jid': jid}
 
     def master_call(self, **kwargs):
         '''

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -208,18 +208,6 @@ class RunnerClient(object):
     def master_call(self, **kwargs):
         '''
         Execute a runner function through the master network interface (eauth).
-
-        This function requires that :conf_master:`external_auth` is configured
-        and the user is authorized to execute runner functions: (``@runner``).
-
-        .. code-block:: python
-
-            runner.master_call(
-                fun='jobs.list_jobs',
-                username='saltdev',
-                password='saltdev',
-                eauth='pam'
-            )
         '''
         load = kwargs
         load['cmd'] = 'runner'

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -107,4 +107,25 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             if ret['tag'] == ret_tag:
                 return ret['data']['return']
 
+    def cmd_async(self, low):
+        '''
+        Execute a wheel function asynchronously; eauth is respected
+
+        This function requires that :conf_master:`external_auth` is configured
+        and the user is authorized to execute runner functions: (``@wheel``).
+
+        .. code-block:: python
+
+            >>> wheel.cmd_async({
+                'fun': 'key.finger',
+                'match': 'jerry',
+                'eauth': 'auto',
+                'username': 'saltdev',
+                'password': 'saltdev',
+            })
+            {'jid': '20131219224744416681', 'tag': 'salt/wheel/20131219224744416681'}
+        '''
+        fun = low.pop('fun')
+        return self.async(fun, low)
+
 Wheel = WheelClient  # for backward-compat

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -45,7 +45,7 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         self.opts = opts
         self.functions = salt.loader.wheels(opts)
 
-    def call_func(self, fun, **kwargs):
+    def cmd(self, fun, **kwargs):
         '''
         Execute a wheel function
 
@@ -60,6 +60,8 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             'minions_rejected': []}
         '''
         return self.low(fun, kwargs)
+
+    call_func = cmd  # alias for backward-compat
 
     def master_call(self, **kwargs):
         '''

--- a/tests/integration/files/conf/master
+++ b/tests/integration/files/conf/master
@@ -35,6 +35,11 @@ external_auth:
       - '@wheel'
       - '@runner'
       - test.*
+  auto:
+    saltdev_auto:
+      - '@wheel'
+      - '@runner'
+      - test.*
 
 master_tops:
   master_tops_test: True

--- a/tests/integration/netapi/__init__.py
+++ b/tests/integration/netapi/__init__.py
@@ -1,1 +1,106 @@
 # encoding: utf-8
+
+# Import Python libs
+import os
+
+# Import Salt Testing libs
+from integration import TMP_CONF_DIR
+from salttesting import TestCase
+
+# Import Salt libs
+import salt.config
+import salt.netapi
+
+
+class NetapiClientTest(TestCase):
+    eauth_creds = {
+        'username': 'saltdev_auto',
+        'password': 'saltdev',
+        'eauth': 'auto',
+    }
+
+    def setUp(self):
+        '''
+        Set up a NetapiClient instance
+        '''
+        opts = salt.config.master_config(os.path.join(TMP_CONF_DIR, 'master'))
+        self.netapi = salt.netapi.NetapiClient(opts)
+
+    def test_local(self):
+        low = {'client': 'local', 'tgt': '*', 'fun': 'test.ping'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+        self.assertEqual(ret, {'minion': True, 'sub_minion': True})
+
+    def test_local_async(self):
+        low = {'client': 'local_async', 'tgt': '*', 'fun': 'test.ping'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+
+        # Remove all the volatile values before doing the compare.
+        self.assertIn('jid', ret)
+        ret.pop('jid', None)
+        self.assertEqual(ret, {'minions': ['minion', 'sub_minion']})
+
+    def test_wheel(self):
+        low = {'client': 'wheel', 'fun': 'key.list_all'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+
+        # Remove all the volatile values before doing the compare.
+        self.assertIn('tag', ret)
+        ret.pop('tag')
+
+        data = ret.get('data', {})
+        self.assertIn('jid', data)
+        data.pop('jid', None)
+
+        self.assertIn('tag', data)
+        data.pop('tag', None)
+
+        ret.pop('_stamp', None)
+        data.pop('_stamp', None)
+
+        self.maxDiff = None
+        self.assertEqual(ret, {
+            'data': {
+                'return': {
+                    'minions_pre': [],
+                    'minions_rejected': [],
+                    'local': [
+                        'master.pem', 'master.pub', 'minion.pem', 'minion.pub',
+                        'minion_master.pub', 'syndic_master.pub'
+                    ],
+                    'minions': ['minion', 'sub_minion']},
+                'success': True,
+                'user': 'saltdev_auto',
+                'fun': 'wheel.key.list_all'
+            }})
+
+    def test_wheel_async(self):
+        low = {'client': 'wheel_async', 'fun': 'key.list_all'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+        self.assertIn('jid', ret)
+        self.assertIn('tag', ret)
+
+    def test_runner(self):
+        low = {'client': 'runner', 'fun': 'cache.grains'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+
+    def test_runner_async(self):
+        low = {'client': 'runner', 'fun': 'cache.grains'}
+        low.update(self.eauth_creds)
+
+        ret = self.netapi.run(low)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(NetapiClientTest, needs_daemon=True)

--- a/tests/integration/netapi/__init__.py
+++ b/tests/integration/netapi/__init__.py
@@ -23,8 +23,8 @@ class NetapiClientTest(TestCase):
         '''
         Set up a NetapiClient instance
         '''
-        opts = salt.config.master_config(os.path.join(TMP_CONF_DIR, 'master'))
-        self.netapi = salt.netapi.NetapiClient(opts)
+        opts = salt.config.client_config(os.path.join(TMP_CONF_DIR, 'master'))
+        self.netapi = salt.netapi.NetapiClient(mopts=opts)
 
     def test_local(self):
         low = {'client': 'local', 'tgt': '*', 'fun': 'test.ping'}

--- a/tests/integration/runner/__init__.py
+++ b/tests/integration/runner/__init__.py
@@ -59,6 +59,24 @@ class RunnerModuleTest(integration.ClientCase):
             'token': token['token'],
         })
 
+    def test_cmd_sync(self):
+        low = {
+            'client': 'runner',
+            'fun': 'error.error',
+        }
+        low.update(self.eauth_creds)
+
+        self.runner.cmd_sync(low)
+
+    def test_cmd_async(self):
+        low = {
+            'client': 'runner',
+            'fun': 'error.error',
+        }
+        low.update(self.eauth_creds)
+
+        self.runner.cmd_async(low)
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/runner/__init__.py
+++ b/tests/integration/runner/__init__.py
@@ -11,6 +11,12 @@ import salt.runner
 
 
 class RunnerModuleTest(integration.ClientCase):
+    eauth_creds = {
+        'username': 'saltdev_auto',
+        'password': 'saltdev',
+        'eauth': 'auto',
+    }
+
     def setUp(self):
         '''
         Configure an eauth user to test with
@@ -24,13 +30,13 @@ class RunnerModuleTest(integration.ClientCase):
         The choice of using error.error for this is arbitrary and should be
         changed to some mocked function that is more testing friendly.
         '''
-        self.runner.master_call(**{
+        low = {
             'client': 'runner',
             'fun': 'error.error',
-            'eauth': 'auto',
-            'username': 'saltdev',
-            'password': 'saltdev',
-        })
+        }
+        low.update(self.eauth_creds)
+
+        self.runner.master_call(**low)
 
     def test_token(self):
         '''
@@ -45,11 +51,7 @@ class RunnerModuleTest(integration.ClientCase):
         self.mkdir_p(os.path.join(opts['root_dir'], 'cache', 'tokens'))
 
         auth = salt.auth.LoadAuth(opts)
-        token = auth.mk_token({
-            'username': 'saltdev',
-            'password': 'saltdev',
-            'eauth': 'auto',
-        })
+        token = auth.mk_token(self.eauth_creds)
 
         self.runner.master_call(**{
             'client': 'runner',


### PR DESCRIPTION
Re-opening #13961 against 2014.7.

This pull request addresses #9324 and sets up the fix for #13930.

These changes are all additive and are backward compatible. (Unless I missed something of course.)

Fix 1: this adds a synchronous function to RunnerClient() that goes through the master_call interface. (It does this by watching the event bus.)

Fix 2: this adds an asynchronous function to WheelClient() that goes through the master_call interface. (It does this by copying the RunnerClient() async code.)

Fix: 3: this adds two methods, cmd_sync and cmd_async, that present a consistent interface between RunnerClient() and WheelClient() for executing both sync and async commands that both respect eauth.

Fix 4: this moves some of the duplicate code between RunnerClient() and WheelClient() into mixin classes so fixes and additions can be made to both. Other *Client interfaces can easily get sync/async methods by inheriting these. Future changes to how the async behavior works can be made in a single place. (ioflo-centric worker management, anyone?)
