### PR TITLE
Deprecate check_dns

### DIFF
--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -134,3 +134,4 @@ salt.modules.virturalenv_mod
 ----------------------------
 
 - Removed deprecated ``no_site_packages`` argument from ``create`` function (deprecated)
+- Removed deprecated ``check_dns`` argument from ``minion_config`` and ``apply_minion_config`` functions (deprecated)

--- a/salt/config.py
+++ b/salt/config.py
@@ -822,7 +822,6 @@ def insert_system_path(opts, paths):
 def minion_config(path,
                   env_var='SALT_MINION_CONFIG',
                   defaults=None,
-                  check_dns=None,
                   minion_id=False):
     '''
     Reads in the minion configuration file and sets up special options
@@ -836,19 +835,6 @@ def minion_config(path,
         import salt.client
         minion_opts = salt.config.minion_config('/etc/salt/minion')
     '''
-    if check_dns is not None:
-        # All use of the `check_dns` arg was removed in `598d715`. The keyword
-        # argument was then removed in `9d893e4` and `**kwargs` was then added
-        # in `5d60f77` in order not to break backwards compatibility.
-        #
-        # Showing a deprecation for 0.17.0 and 2014.1.0 should be enough for any
-        # api calls to be updated in order to stop its use.
-        salt.utils.warn_until(
-            'Helium',
-            'The functionality behind the \'check_dns\' keyword argument is '
-            'no longer required, as such, it became unnecessary and is now '
-            'deprecated. \'check_dns\' will be removed in Salt {version}.'
-        )
     if defaults is None:
         defaults = DEFAULT_MINION_OPTS
 
@@ -1896,25 +1882,10 @@ def get_id(opts, minion_id=False):
 
 def apply_minion_config(overrides=None,
                         defaults=None,
-                        check_dns=None,
                         minion_id=False):
     '''
     Returns minion configurations dict.
     '''
-    if check_dns is not None:
-        # All use of the `check_dns` arg was removed in `598d715`. The keyword
-        # argument was then removed in `9d893e4` and `**kwargs` was then added
-        # in `5d60f77` in order not to break backwards compatibility.
-        #
-        # Showing a deprecation for 0.17.0 and 2014.1.0 should be enough for any
-        # api calls to be updated in order to stop its use.
-        salt.utils.warn_until(
-            'Helium',
-            'The functionality behind the \'check_dns\' keyword argument is '
-            'no longer required, as such, it became unnecessary and is now '
-            'deprecated. \'check_dns\' will be removed in Salt {version}.'
-        )
-
     if defaults is None:
         defaults = DEFAULT_MINION_OPTS
 

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -12,7 +12,6 @@ import logging
 import os
 import shutil
 import tempfile
-import warnings
 from contextlib import contextmanager
 
 # Import Salt Testing libs
@@ -28,8 +27,7 @@ import salt.minion
 import salt.utils
 import salt.utils.network
 import integration
-from salt import config as sconfig, version as salt_version
-from salt.version import SaltStackVersion
+from salt import config as sconfig
 from salt.cloud.exceptions import SaltCloudConfigError
 
 # Import Third-Party Libs

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -365,65 +365,6 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         self.assertEqual(syndic_opts['_master_conf_file'], minion_conf_path)
         self.assertEqual(syndic_opts['_minion_conf_file'], syndic_conf_path)
 
-    def test_check_dns_deprecation_warning(self):
-        helium_version = SaltStackVersion.from_name('Helium')
-        if salt_version.__version_info__ >= helium_version:
-            raise AssertionError(
-                'Failing this test on purpose! Please delete this test case, '
-                'the \'check_dns\' keyword argument and the deprecation '
-                'warnings in `salt.config.minion_config` and '
-                'salt.config.apply_minion_config`'
-            )
-
-        # Let's force the warning to always be thrown
-        warnings.resetwarnings()
-        warnings.filterwarnings(
-            'always', '(.*)check_dns(.*)', DeprecationWarning, 'salt.config'
-        )
-        with warnings.catch_warnings(record=True) as w:
-            sconfig.minion_config(None, None, check_dns=True)
-            self.assertEqual(
-                'The functionality behind the \'check_dns\' keyword argument '
-                'is no longer required, as such, it became unnecessary and is '
-                'now deprecated. \'check_dns\' will be removed in Salt '
-                '{0}.'.format(helium_version.formatted_version),
-                str(w[-1].message)
-            )
-
-        with warnings.catch_warnings(record=True) as w:
-            sconfig.apply_minion_config(
-                overrides=None, defaults=None, check_dns=True
-            )
-            self.assertEqual(
-                'The functionality behind the \'check_dns\' keyword argument '
-                'is no longer required, as such, it became unnecessary and is '
-                'now deprecated. \'check_dns\' will be removed in Salt '
-                '{0}.'.format(helium_version.formatted_version),
-                str(w[-1].message)
-            )
-
-        with warnings.catch_warnings(record=True) as w:
-            sconfig.minion_config(None, None, check_dns=False)
-            self.assertEqual(
-                'The functionality behind the \'check_dns\' keyword argument '
-                'is no longer required, as such, it became unnecessary and is '
-                'now deprecated. \'check_dns\' will be removed in Salt '
-                '{0}.'.format(helium_version.formatted_version),
-                str(w[-1].message)
-            )
-
-        with warnings.catch_warnings(record=True) as w:
-            sconfig.apply_minion_config(
-                overrides=None, defaults=None, check_dns=False
-            )
-            self.assertEqual(
-                'The functionality behind the \'check_dns\' keyword argument '
-                'is no longer required, as such, it became unnecessary and is '
-                'now deprecated. \'check_dns\' will be removed in Salt '
-                '{0}.'.format(helium_version.formatted_version),
-                str(w[-1].message)
-            )
-
     def test_issue_6714_parsing_errors_logged(self):
         try:
             tempdir = tempfile.mkdtemp(dir=integration.SYS_TMP_DIR)


### PR DESCRIPTION
- Removed deprecated references to `check_dns` from `minion_config` and `apply_minion_config` functions
- Removed test checking for deprecation in `salt.tests.unit.config_test`
- Added deprecation notice to 2014.7 release notes
