### PR TITLE
Remove OutputOptionsWithTextMixIn as it is deprecated

### DIFF
--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -135,3 +135,4 @@ salt.modules.virturalenv_mod
 
 - Removed deprecated ``no_site_packages`` argument from ``create`` function (deprecated)
 - Removed deprecated ``check_dns`` argument from ``minion_config`` and ``apply_minion_config`` functions (deprecated)
+- Removed deprecated ``OutputOptionsWithTextMixIn`` class from ``salt/utils/parsers.py`` (deprecated)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1045,23 +1045,6 @@ class OutputOptionsMixIn(object):
         self.config['selected_output_option'] = self.selected_output_option
 
 
-class OutputOptionsWithTextMixIn(OutputOptionsMixIn):
-    # This should also be removed
-    _include_text_out_ = True
-
-    def __new__(cls, *args, **kwargs):
-        instance = super(OutputOptionsWithTextMixIn, cls).__new__(
-            cls, *args, **kwargs
-        )
-        utils.warn_until(
-            'Helium',
-            '\'OutputOptionsWithTextMixIn\' has been deprecated. Please '
-            'start using \'OutputOptionsMixIn\'; your code should not need '
-            'any further changes.'
-        )
-        return instance
-
-
 class CloudConfigMixIn(object):
     __metaclass__ = MixInMeta
     _mixin_prio_ = -11    # Evaluate before ConfigDirMixin


### PR DESCRIPTION
- removed deprecated OutputOptionsWithTextMixIn class
- updated release notes with news of deprecation
