### PR TITLE
avoid using test.ping on a non-existent minion

### DIFF
--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -219,7 +219,14 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         for name in names:
             seeds[name] = kwargs.get('seed', True)
             skey = salt.key.Key(__opts__)
-            if name in skey.list_all():
+            seed = True
+            if name in skey.all_keys().get('minions', []):
+                try:
+                    if client.cmd(name, 'test.ping', timeout=20).get(name, None):
+                        seed = False
+                except (TypeError, KeyError):
+                    pass
+            if not seed:
                 seeds[name] = False
             kv = salt.utils.virt.VirtKey(host, name, __opts__)
             if kv.authorize():

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -216,18 +216,17 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     approve_key = kw.get('approve_key', True)
     seeds = {}
     if approve_key and not explicit_auth:
+        skey = salt.key.Key(__opts__)
+        all_minions = skey.all_keys().get('minions', [])
         for name in names:
-            seeds[name] = kwargs.get('seed', True)
-            skey = salt.key.Key(__opts__)
-            seed = True
-            if name in skey.all_keys().get('minions', []):
+            seed = kwargs.get('seed', True)
+            if name in all_minions:
                 try:
                     if client.cmd(name, 'test.ping', timeout=20).get(name, None):
                         seed = False
                 except (TypeError, KeyError):
                     pass
-            if not seed:
-                seeds[name] = False
+            seeds[name] = seed
             kv = salt.utils.virt.VirtKey(host, name, __opts__)
             if kv.authorize():
                 log.info('Container key will be preauthorized')

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -218,13 +218,8 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     if approve_key and not explicit_auth:
         for name in names:
             seeds[name] = kwargs.get('seed', True)
-            try:
-                ping = client.cmd(name, 'test.ping', timeout=20).get(name, None)
-            except (TypeError, KeyError):
-                ping = False
-            curkey = os.path.join(__opts__['pki_dir'], 'minions', name)
-            # be sure not to seed an alrady seeded host
-            if ping or os.path.exists(curkey):
+            skey = salt.key.Key(__opts__)
+            if name in skey.list_all():
                 seeds[name] = False
             kv = salt.utils.virt.VirtKey(host, name, __opts__)
             if kv.authorize():


### PR DESCRIPTION
test.ping in this case generally prints a confusing error message: "No minions matched the target."

I believe this commit will accomplish the same goal without actually calling test.ping. 

attn: @kiorky
