### PR TITLE
Dont drop events during gather job info

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -207,7 +207,8 @@ class LocalClient(object):
 
         return self.get_returns(pub_data['jid'],
                                 minions,
-                                self._get_timeout(timeout))
+                                self._get_timeout(timeout),
+                                pending_tags=[jid])
 
     def _check_pub_data(self, pub_data):
         '''
@@ -909,7 +910,8 @@ class LocalClient(object):
             self,
             jid,
             minions,
-            timeout=None):
+            timeout=None,
+            pending_tags=None):
         '''
         Get the returns for the command line interface via the event system
         '''
@@ -935,7 +937,7 @@ class LocalClient(object):
         while True:
             time_left = timeout_at - int(time.time())
             wait = max(1, time_left)
-            raw = self.event.get_event(wait, jid)
+            raw = self.event.get_event(wait, jid, pending_tags=pending_tags)
             if raw is not None and 'return' in raw:
                 found.add(raw['id'])
                 ret[raw['id']] = raw['return']

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -138,11 +138,102 @@ def tagify(suffix='', prefix='', base=SALT):
     return TAGPARTER.join([part for part in parts if part])
 
 
-class SaltEvent(object):
+class PendingEventsBase(object):
+
+    def __init__(self):
+        super(PendingEventsBase, self).__init__()
+        self.pending_events = []
+
+    def _get_event_inner(self, wait):
+        """Wait for event. Don't do any filtering or retrying
+
+        :param wait: Max seconds to wait for event
+        :return:
+        """
+        raise NotImplementedError()
+
+    def _check_pending(self, tag, pending_tags):
+        """Check the pending_events list for events that match the tag
+
+        :param tag: The tag to search for
+        :type tag: str
+        :param pending_tags: List of tags to preserve
+        :type pending_tags: list[str]
+        :return:
+        """
+        old_events = self.pending_events
+        self.pending_events = []
+        ret = None
+        for evt in old_events:
+            if evt['tag'].startswith(tag):
+                if ret is None:
+                    ret = evt
+                else:
+                    self.pending_events.append(evt)
+            elif any(evt['tag'].startswith(ptag) for ptag in pending_tags):
+                self.pending_events.append(evt)
+        return ret
+
+    def _get_event(self, wait, tag, pending_tags):
+        start = time.time()
+        timeout_at = start + wait
+        while not wait or time.time() <= timeout_at:
+            ret = self._get_event_inner(wait)
+
+            log.trace('get_event() received = {0}'.format(ret))
+            if ret is not None:
+                if ret['tag'].startswith(tag):
+                    return ret
+                elif any(ret['tag'].startswith(ptag) for ptag in pending_tags):
+                    self.pending_events.append(ret)
+
+            wait = timeout_at - time.time()
+
+        return None
+
+    def get_event(self, wait=5, tag='', full=False, use_pending=False, pending_tags=None):
+        '''
+        Get a single publication.
+        IF no publication available THEN block for upto wait seconds
+        AND either return publication OR None IF no publication available.
+
+        IF wait is 0 then block forever.
+
+        New in Boron always checks the list of pending events
+
+        use_pending
+            Defines whether to keep all unconsumed events in a pending_events
+            list, or to discard events that don't match the requested tag.  If
+            set to True, MAY CAUSE MEMORY LEAKS.
+
+        pending_tags
+            Add any events matching the listed tags to the pending queue.
+            Still MAY CAUSE MEMORY LEAKS but less likely than use_pending
+            assuming you later get_event for the tags you've listed here
+
+            New in Boron
+        '''
+        if pending_tags is None:
+            pending_tags = []
+        if use_pending:
+            pending_tags = ['']
+
+        ret = self._check_pending(tag, pending_tags)
+        if ret is None:
+            ret = self._get_event(wait, tag, pending_tags)
+
+        if ret is None or full:
+            return ret
+        else:
+            return ret['data']
+
+
+class SaltEvent(PendingEventsBase):
     '''
     The base class used to manage salt events
     '''
     def __init__(self, node, sock_dir=None, opts=None):
+        super(SaltEvent, self).__init__()
         self.serial = salt.payload.Serial({'serial': 'msgpack'})
         self.context = zmq.Context()
         self.poller = zmq.Poller()
@@ -154,7 +245,6 @@ class SaltEvent(object):
         if sock_dir is None:
             sock_dir = opts.get('sock_dir', None)
         self.puburi, self.pulluri = self.__load_uri(sock_dir, node)
-        self.pending_events = []
 
     def __load_uri(self, sock_dir, node):
         '''
@@ -258,55 +348,19 @@ class SaltEvent(object):
         data = serial.loads(mdata)
         return mtag, data
 
-    def _check_pending(self, tag, pending_tags):
-        """Check the pending_events list for events that match the tag
+    def _get_event_inner(self, wait):
+        # convert to milliseconds
+        socks = dict(self.poller.poll(wait * 1000))
+        if socks.get(self.sub) != zmq.POLLIN:
+            return None
 
-        :param tag: The tag to search for
-        :type tag: str
-        :param pending_tags: List of tags to preserve
-        :type pending_tags: list[str]
-        :return:
-        """
-        old_events = self.pending_events
-        self.pending_events = []
-        ret = None
-        for evt in old_events:
-            if evt['tag'].startswith(tag):
-                if ret is None:
-                    ret = evt
-                else:
-                    self.pending_events.append(evt)
-            elif any(evt['tag'].startswith(ptag) for ptag in pending_tags):
-                self.pending_events.append(evt)
-        return ret
-
-    def _get_event(self, wait, tag, pending_tags):
-        start = time.time()
-        timeout_at = start + wait
-        while not wait or time.time() <= timeout_at:
-            # convert to milliseconds
-            socks = dict(self.poller.poll(wait * 1000))
-            if socks.get(self.sub) != zmq.POLLIN:
-                continue
-
-            try:
-                ret = self.get_event_noblock()
-            except zmq.ZMQError as ex:
-                if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
-                    continue
-                else:
-                    raise
-
-            if not ret['tag'].startswith(tag):  # tag not match
-                if any(ret['tag'].startswith(ptag) for ptag in pending_tags):
-                    self.pending_events.append(ret)
-                wait = timeout_at - time.time()
-                continue
-
-            log.trace('get_event() received = {0}'.format(ret))
-            return ret
-
-        return None
+        try:
+            return self.get_event_noblock()
+        except zmq.ZMQError as ex:
+            if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
+                return None
+            else:
+                raise
 
     def get_event(self, wait=5, tag='', full=False, use_pending=False, pending_tags=None):
         '''
@@ -332,19 +386,7 @@ class SaltEvent(object):
         '''
         self.subscribe()
 
-        if pending_tags is None:
-            pending_tags = []
-        if use_pending:
-            pending_tags = ['']
-
-        ret = self._check_pending(tag, pending_tags)
-        if ret is None:
-            ret = self._get_event(wait, tag, pending_tags)
-
-        if ret is None or full:
-            return ret
-        else:
-            return ret['data']
+        return super(SaltEvent, self).get_event(wait, tag, full, use_pending, pending_tags)
 
     def get_event_noblock(self):
         '''Get the raw event without blocking or any other niceties

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -235,7 +235,7 @@ class TestSaltEvent(TestCase):
             evt2 = me.get_event(tag='evt2')
             evt1 = me.get_event(tag='evt1')
             self.assertGotEvent(evt2, {'data': 'foo2'})
-            # This one will be None because we're dripping unrelated events
+            # This one will be None because we're dropping unrelated events
             self.assertIsNone(evt1)
 
             # Fire events again
@@ -247,6 +247,59 @@ class TestSaltEvent(TestCase):
             evt1 = me.get_event(tag='evt3', use_pending=True)
             self.assertGotEvent(evt2, {'data': 'foo4'})
             self.assertGotEvent(evt1, {'data': 'foo3'})
+
+    def test_event_nested_subs_explict_pending(self):
+        with eventpublisher_process():
+            me = event.MasterEvent(SOCK_DIR)
+            me.subscribe()
+
+            # Fire events
+            me.fire_event({'data': 'foo3'}, 'evt3')
+            me.fire_event({'data': 'foo4'}, 'evt4')
+
+            evt2 = me.get_event(tag='evt4', pending_tags=['evt3'])
+            evt1 = me.get_event(tag='evt3')
+            self.assertGotEvent(evt1, {'data': 'foo3'})
+            self.assertGotEvent(evt2, {'data': 'foo4'})
+            self.assertEqual(me.pending_events, [], "All pending events should be consumed")
+
+    def test_event_nested_subs_explict_pending3(self):
+        with eventpublisher_process():
+            me = event.MasterEvent(SOCK_DIR)
+            me.subscribe()
+
+            # Fire events
+            me.fire_event({'data': 'foo3'}, 'evt3')
+            me.fire_event({'data': 'foo4'}, 'evt4')
+            me.fire_event({'data': 'foo5'}, 'evt5')
+
+            evt2 = me.get_event(tag='evt4', pending_tags=['evt3'])
+            # Check that we keep the event whilst receiving a third
+            evt3 = me.get_event(tag='evt5', pending_tags=['evt3'])
+            evt1 = me.get_event(tag='evt3')
+            self.assertGotEvent(evt1, {'data': 'foo3'})
+            self.assertGotEvent(evt2, {'data': 'foo4'})
+            self.assertGotEvent(evt3, {'data': 'foo5'})
+            self.assertEqual(me.pending_events, [], "All pending events should be consumed")
+
+    def test_event_nested_subs_explict_pending_drop(self):
+        with eventpublisher_process():
+            me = event.MasterEvent(SOCK_DIR)
+            me.subscribe()
+
+            # Fire events
+            me.fire_event({'data': 'foo3'}, 'evt3')
+            me.fire_event({'data': 'foo4'}, 'evt4')
+            me.fire_event({'data': 'foo5'}, 'evt5')
+
+            evt3 = me.get_event(tag='evt5', pending_tags=['evt3'])
+            # Check that we keep the event whilst receiving a third
+            evt2 = me.get_event(tag='evt4', pending_tags=['evt3'])
+            evt1 = me.get_event(tag='evt3')
+            self.assertGotEvent(evt1, {'data': 'foo3'})
+            self.assertIsNone(evt2)
+            self.assertGotEvent(evt3, {'data': 'foo5'})
+            self.assertEqual(me.pending_events, [], "All pending events should be consumed")
 
     @expectedFailure
     def test_event_nested_sub_all(self):


### PR DESCRIPTION
Seen with syndic, but in theory affects all setups. When a we call gather_job_info if an event comes in for the main job we sometimes discard the event whilst we are looking for the gather_job_info event. To work around I've made gather_job_info add events for the main job to the pending_events list. get_event now always checks that list for events matching it's tag.

This was originally developed on my 2014.1 branch. Upon merging it I found the RAET stuff I've tried to standardise the interface across the two SaltEvent classes, but I've been unable to test the RAET version of this.
