### PR TITLE
salt.key: rm duplicate import of salt.crypt

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -18,7 +18,6 @@ import salt.utils
 import salt.utils.event
 import salt.daemons.masterapi
 from salt.utils.event import tagify
-import salt.crypt
 
 
 class KeyCLI(object):


### PR DESCRIPTION
```
************* Module salt.key
salt/key.py:21: [W0404(reimported), ] Reimport 'salt.crypt' (imported line 16)
```
