### PR TITLE
Increase timeout for grains test

### DIFF
--- a/tests/integration/modules/grains.py
+++ b/tests/integration/modules/grains.py
@@ -81,7 +81,7 @@ class TestModulesGrains(integration.ModuleCase):
                     'grains.setval',
                     ['setgrain', 'grainval']),
                 {'setgrain': 'grainval'})
-        time.sleep(1)
+        time.sleep(5)
         ret = self.run_function('grains.item', ['setgrain'])
         if not ret:
             # Sleep longer, sometimes test systems get bogged down


### PR DESCRIPTION
RAET needs a little more time or it hangs. This _seems_ to just be a side-effect of it being under test as I cannot replicate this behaviour by hand. 
