### PR TITLE
Keystore abstraction

### DIFF
--- a/salt/keystores/mysql.py
+++ b/salt/keystores/mysql.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+'''
+A Mysql-Keystore that manages salt-keys in a mysql-database
+'''
+import re
+
+minions = [ 'minion' + str(x)  for x in xrange(5) ]
+minions_pre = [ 'minion' + str(x)  for x in xrange(6,10) ]
+minions_rej = [ 'minion' + str(x)  for x in xrange(11,15) ]
+
+def name_match(match, full=False):
+    '''
+    Accept a glob which to match the of a key and return the key's location
+    '''
+
+    matches = list_keys()
+    ret = {}
+    for status, keys in matches.items():
+        for key in sorted(keys):
+            yes = re.match(match + '$', key)
+            if yes:
+                if status not in ret:
+                    ret[status] = []
+                ret[status].append(yes.group(0))
+    return ret
+
+
+def dict_match(match_dict):
+    '''
+    Accept a dictionary of keys and return the current state of the
+    specified keys
+    '''
+    print("dict_match")
+
+def local_keys():
+    minions = [ 'minion' + str(x)  for x in xrange(10) ]
+    return {'local': minions }
+
+def list_keys():
+    '''
+    Return a dict of managed keys and what the key status are
+    '''
+    return {'minions' : minions,
+            'minions_pre' : minions_pre,
+            'minions_rejected' : minions_rej}
+
+
+def all_keys():
+    '''
+    Merge managed keys with local keys
+    '''
+    return list_keys()
+
+def list_status(match):
+    '''
+    Return a dict of managed keys under a named status
+    '''
+
+    if match.startswith('acc'):
+        return minions
+    elif match.startswith('pre') or match.startswith('un'):
+        return minions_pre
+    elif match.startswith('rej'):
+        return minions_rej
+    elif match.startswith('all'):
+        return self.all_keys()
+
+def key_str(match):
+    '''
+    Return the specified public key or keys based on a glob
+    '''
+    ret = {}
+    minions = name_match(match)
+
+    for status, minion_list in minions.items():
+        ret[status] = {}
+        for minion in minion_list:
+            ret[status][minion] = 'ABCSAMPLE_PUBKEY'
+    return ret
+
+
+def key_str_all(self):
+    '''
+    Return all managed key strings
+    '''
+    print("key_str_all")
+
+def accept(match=None, match_dict=None, include_rejected=False):
+    '''
+    Accept public keys. If "match" is passed, it is evaluated as a glob.
+    Pre-gathered matches can also be passed via "match_dict".
+    '''
+    print("accept")
+
+def accept_all():
+    '''
+    Accept all keys in pre
+    '''
+    print("accept_all")
+
+def delete_key(match=None, match_dict=None):
+    '''
+    Delete public keys. If "match" is passed, it is evaluated as a glob.
+    Pre-gathered matches can also be passed via "match_dict".
+    '''
+    print("delete_key")
+
+def delete_all(self):
+    '''
+    Delete all keys
+    '''
+    print("delete_all")
+
+def reject(match=None, match_dict=None, include_accepted=False):
+    '''
+    Reject public keys. If "match" is passed, it is evaluated as a glob.
+    Pre-gathered matches can also be passed via "match_dict".
+    '''
+    print("reject")
+
+def reject_all(self):
+    '''
+    Reject all keys in pre
+    '''
+    print("reject_all")
+
+def finger(match):
+    '''
+    Return the fingerprint for a specified key
+    '''
+    print("finger")
+
+
+def finger_all(self):
+    '''
+    Return fingerprins for all keys
+    '''
+    print("finger_all")
+
+if __name__ == '__main__':
+    name_match('minion1')

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -387,12 +387,18 @@ def call(fun, **kwargs):
     load = Loader(module_dirs)
     return load.call(fun, args)
 
-def keystores(opts, name):
+def keystore(opts, name):
     '''
-    load all available keystores
+    try loading the given keystore by name
     '''
     load = _create_loader(opts, 'keystores', 'rawmodule')
-    return load.gen_module(name, None)
+    mod_funcs = load.gen_module(name, None)
+    ret_funcs = {}
+    for func in mod_funcs.keys():
+        mod, func_name = func.split('.')
+        ret_funcs[func_name] = mod_funcs[func]
+    return ret_funcs
+
 
 
 def runner(opts):

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -387,6 +387,13 @@ def call(fun, **kwargs):
     load = Loader(module_dirs)
     return load.call(fun, args)
 
+def keystores(opts, name):
+    '''
+    load all available keystores
+    '''
+    load = _create_loader(opts, 'keystores', 'rawmodule')
+    return load.gen_module(name, None)
+
 
 def runner(opts):
     '''


### PR DESCRIPTION
Currently salt stores its keys on the salt-master in the pki-directories. In Mutlimaster-(PKI)-Modes, that requires a shared keystore over all salt-masters to have the keystore always in sync. A shared-storage for multiple servers adds a lot of complexity and also requires even more complex failover-strategies for desaster-scenarios.
A keystore abstracted from the salt-master-service and implemented (for example) in a redis-database would make such a setup a lot easier. 

This is a first approach to abstract the keystore from the master itself and make it more modular. The goal is to have various keystores like redis, mysql, etc. while still keeping the default local file-keystore for zeromq and raet (which could of course also be moved to a keystore-module). 

While this PR only extends salt-key to query a sample mysql-keystore-module, the salt-master would of course also be extended to query the same keystore for auth-requests, etc. 

This is not intended as a real PR yet. Its more a request for comments, if this is something that would be welcomed by the salt-developers and if the approach is in a way thats acceptable.
