### PR TITLE
fix error introduced in 15c6aa829c

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -623,7 +623,7 @@ def create_self_signed_cert(tls_dir='tls',
     '''
     set_ca_path(cacert_path)
 
-    if not os.path.exists('{0}/{1}/certs/'.format(cert_base_path(tls_dir))):
+    if not os.path.exists('{0}/{1}/certs/'.format(cert_base_path(), tls_dir)):
         os.makedirs("{0}/{1}/certs/".format(cert_base_path(),
                                             tls_dir))
 


### PR DESCRIPTION
format is expecting two arguments, one of which was mistakenly merged with the other in [15c6aa829c](https://github.com/saltstack/salt/commit/15c6aa829c#diff-c9b8e2f5cfe6d13ed0f8bec1a08bd4b6L530)
