### PR TITLE
Allow OSX to run tests with change to TMPDIR

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -69,8 +69,12 @@ except ImportError:
 # Import 3rd-party libs
 import yaml
 
+if os.uname()[0] == 'Darwin':
+    SYS_TMP_DIR = '/tmp'
+else:
+    SYS_TMP_DIR = os.environ.get('TMPDIR', tempfile.gettempdir())
+
 # Gentoo Portage prefers ebuild tests are rooted in ${TMPDIR}
-SYS_TMP_DIR = os.environ.get('TMPDIR', tempfile.gettempdir())
 TMP = os.path.join(SYS_TMP_DIR, 'salt-tests-tmpdir')
 FILES = os.path.join(INTEGRATION_TEST_DIR, 'files')
 PYEXEC = 'python{0}.{1}'.format(*sys.version_info)


### PR DESCRIPTION
Previously, the test suite could not run on OSX without either being `root` or adding `TMPDIR=/tmp` to the beginning of `./runtests.py`. This PR allows the test-suite to run without appending the TMPDIR variable change.
