### PR TITLE
Skip lxc tests if no lxc and skip failing vt_test if running osx

### DIFF
--- a/tests/integration/modules/lxc.py
+++ b/tests/integration/modules/lxc.py
@@ -5,14 +5,16 @@ Test the lxc module
 '''
 
 # Import Salt Testing libs
-from salttesting.helpers import ensure_in_syspath, requires_salt_modules
+from salttesting import skipIf
+from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
+import salt.utils
 
 
-@requires_salt_modules('lxc.list')
+@skipIf(salt.utils.which('lxc') is None, 'Skipping - lxc must be installed.')
 class LXCModuleTest(integration.ModuleCase):
     '''
     Test the lxc module

--- a/tests/unit/utils/vt_test.py
+++ b/tests/unit/utils/vt_test.py
@@ -10,11 +10,12 @@
 '''
 
 # Import python libs
+import os
 import sys
 import random
 
 # Import Salt Testing libs
-from salttesting import TestCase
+from salttesting import TestCase, skipIf
 from salttesting.helpers import ensure_in_syspath
 ensure_in_syspath('../../')
 
@@ -45,6 +46,7 @@ class VTTestCase(TestCase):
         terminal.wait()
         terminal.close()
 
+    @skipIf(os.uname()[0] == 'Darwin', 'OS X does not support procfs - skipping!')
     def test_issue_10404_ptys_not_released(self):
         n_executions = 15
         # Get current number of PTY's


### PR DESCRIPTION
Clean up some failing tests:
- If `lxc` hasn't been installed, skip all lxc tests
- One of the `vt_tests` relies on `procfs`, which is not supported in OS X - skipped now mac
