### PR TITLE
dont fail if data.p is empty

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -418,9 +418,12 @@ class CkMinions(object):
                 datap = os.path.join(cdir, id_, 'data.p')
                 if not os.path.isfile(datap):
                     continue
-                grains = self.serial.load(
-                    salt.utils.fopen(datap, 'rb')
-                ).get('grains', {})
+                try:
+                    grains = self.serial.load(
+                        salt.utils.fopen(datap, 'rb')
+                    ).get('grains', {})
+                except AttributeError:
+                    pass
                 for ipv4 in grains.get('ipv4', []):
                     if ipv4 == '127.0.0.1' or ipv4 == '0.0.0.0':
                         continue


### PR DESCRIPTION
Not sure why my data.p is empty, but loading it fails anyway.

``` bash
[CRITICAL] Unexpected Error in Mworker
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.6/salt/master.py", line 613, in __bind
    ret = self.serial.dumps(self._handle_payload(payload))
  File "/usr/lib/pymodules/python2.6/salt/master.py", line 649, in _handle_payload
    'clear': self._handle_clear}[key](load)
  File "/usr/lib/pymodules/python2.6/salt/master.py", line 658, in _handle_clear
    return getattr(self.clear_funcs, load['cmd'])(load)
  File "/usr/lib/pymodules/python2.6/salt/master.py", line 1320, in _auth
    minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
  File "/usr/lib/pymodules/python2.6/salt/utils/minions.py", line 422, in connected_ids
    salt.utils.fopen(datap, 'rb')
AttributeError: 'NoneType' object has no attribute 'get'
```

This adds a safe-guard for opening an empty data.p.
