### PR TITLE
Fix apache state

### DIFF
--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -51,24 +51,12 @@ def __virtual__():
     return 'apache.config' in __salt__
 
 
-def _check_name(name):
+def configfile(name, config):
     ret = {'name': name,
            'changes': {},
            'result': None,
            'comment': ''}
-    if salt.utils.cloud.check_name(
-        name, ' a-zA-Z0-9.,_/\[\]\(\)\<\>\'*+:-'  # pylint: disable=W1401
-    ):
-        ret['comment'] = 'Invalid characters in name.'
-        ret['result'] = False
-        return ret
-    else:
-        ret['result'] = True
-        return ret
 
-
-def configfile(name, config):
-    ret = _check_name(str(config))
     configs = __salt__['apache.config'](name, config, edit=False)
     current_configs = ''
     if os.path.exists(name):

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -43,9 +43,6 @@ from __future__ import with_statement, print_function
 # Import python libs
 import os.path
 
-# Import salt libs
-import salt.utils.cloud
-
 
 def __virtual__():
     return 'apache.config' in __salt__

--- a/salt/states/apache.py
+++ b/salt/states/apache.py
@@ -13,17 +13,17 @@ the above word between angle brackets (<>).
 .. code-block:: yaml
 
     /etc/httpd/conf.d/website.com.conf:
-      apache.config:
+      apache.configfile:
         - config:
           - VirtualHost:
               this: '*:80'
               ServerName:
-                -website.com
+                - website.com
               ServerAlias:
                 - www.website.com
                 - dev.website.com
               ErrorLog: logs/website.com-error_log
-              CustomLog: logs/website.com-access_log combinded
+              CustomLog: logs/website.com-access_log combined
               DocumentRoot: /var/www/vhosts/website.com
               Directory:
                 this: /var/www/vhosts/website.com


### PR DESCRIPTION
A few changes to the apache state:
- Fixed a typo and cleaned up space in example usage.
- Fixed the name of the state (apache.config vs apache.configfile) in example usage.
- Eliminated _check_name function, which seems unnecessary (and was incorrectly checking the config instead of the name, anyway).
