### PR TITLE
cli/caller.py: rm duplicate import of logging module

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -24,7 +24,6 @@ from salt._compat import string_types
 from salt.log import LOG_LEVELS
 from salt.utils import print_cli
 
-import logging
 log = logging.getLogger(__name__)
 
 try:


### PR DESCRIPTION
```
************* Module salt.cli.caller
salt/cli/caller.py:27: [W0404(reimported), ] Reimport 'logging' (imported line 11)
```
