### PR TITLE
This corrects a syntax error for the sudo command,

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -112,7 +112,7 @@ fi
 
 SUDO=""
 if [ -n "{{SUDO}}" ]; then
-    SUDO="sudo root -c"
+    SUDO="sudo "
 fi
 
 EX_PYTHON_OLD={EX_THIN_PYTHON_OLD}    # Python interpreter is too old and incompatible


### PR DESCRIPTION
 normally the parameters 'username -c' is associated with 'su'
