### PR TITLE
Fix salt-ssh handling of python os.execv

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -146,6 +146,12 @@ def main(argv):
     with open(os.path.join(OPTIONS.saltdir, 'minion'), 'w') as config:
         config.write(OPTIONS.config + '\n')
 
+    #Fix parameter passing issue
+    if len(ARGS) == 1:
+        argv_prepared = ARGS[0].split()
+    else:
+        argv_prepared = ARGS
+
     salt_argv = [
         sys.executable,
         salt_call_path,
@@ -154,7 +160,8 @@ def main(argv):
         '-l', 'quiet',
         '-c', OPTIONS.saltdir,
         '--',
-    ] + ARGS
+    ] + argv_prepared
+
     sys.stderr.write('SALT_ARGV: {0}\n'.format(salt_argv))
 
     # Only emit the delimiter on *both* stdout and stderr when completely successful.


### PR DESCRIPTION
This fix addresses an issue where the ssh_py_shim.py file attempts to run arguments with multiple parameters stuffed into index 0 of ARGV. This results in an error similar to:

`Function state.pkg /tmp/.salt/salt_state.tgz test=None pkg_sum=6dec40943712befb30b8e200fe5465dc hash_type=md5 is not available`

This is because the command line is effectively (note the last parameter):
`python /tmp/.salt/salt-call --local -l debug -c /tmp/.salt -- 'state.pkg /tmp/.salt/salt_state.tgz test=None pkg_sum=6dec40943712befb30b8e200fe5465dc hash_type=md5'`
