### PR TITLE
Handle sudo when re-deploying the shim

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -14,6 +14,7 @@ import tarfile
 import shutil
 import sys
 import os
+import stat
 
 THIN_ARCHIVE = 'salt-thin.tgz'
 
@@ -82,6 +83,13 @@ def need_deployment():
     old_umask = os.umask(0077)
     os.makedirs(OPTIONS.saltdir)
     os.umask(old_umask)
+    # If SUDOing then also give the super user group write permissions
+    sudo_gid = os.environ.get('SUDO_GID')
+    if sudo_gid:
+        os.chown(OPTIONS.saltdir, -1, int(sudo_gid))
+        st = os.stat(OPTIONS.saltdir)
+        os.chmod(OPTIONS.saltdir, st.st_mode | stat.S_IWGRP | stat.S_IRGRP | stat.S_IXGRP)
+
     # Delimeter emitted on stdout *only* to indicate shim message to master.
     sys.stdout.write("{0}\ndeploy\n".format(OPTIONS.delimeter))
     sys.exit(EX_THIN_DEPLOY)


### PR DESCRIPTION
This add permissions, when using SUDO, for the sudo user to the /tmp/.salt folder. If this is not done (disclaimer there might be better ways), the scp of the thin client will fail.
