### PR TITLE
Give rhel5 a chance to pass the cache tests

### DIFF
--- a/tests/unit/utils/cache_test.py
+++ b/tests/unit/utils/cache_test.py
@@ -38,7 +38,7 @@ class CacheDictTestCase(TestCase):
         cd['foo'] = 'bar'
         self.assertIn('foo', cd)
         self.assertEqual(cd['foo'], 'bar')
-        time.sleep(0.1)
+        time.sleep(0.2)
         self.assertNotIn('foo', cd)
 
         # make sure that a get would get a regular old key error


### PR DESCRIPTION
Fixed in develop with #14410, but it's also a problem on 2014.7. Now it's not.
