### PR TITLE
Fix salt-ssh highstate rendering

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -647,8 +647,10 @@ class Single(object):
         result = self.wfuncs[self.fun](*self.args, **self.kwargs)
         # Mimic the json data-structure that "salt-call --local" will
         # emit (as seen in ssh_py_shim.py)
-        ret = json.dumps({'local': result})
-        return ret
+        if 'local' in result:
+            return json.dumps(result)
+        else:
+            return json.dumps({'local': result})
 
     def _cmd_str(self):
         '''


### PR DESCRIPTION
This patch addresses an issue where the ssh wrapper functions introduced a 'local' dictionary key to (probably) compensate for how the thin client used to render results. This extra 'local' key breaks the --out highstate rendering of salt-ssh as illustrated below.

```
[DEBUG   ] Traceback (most recent call last):
  File "/Users/stephanbuys/Documents/Coding/github/salt/salt/output/__init__.py", line 36, in display_output
    display_data = get_printout(out, opts)(data).rstrip()
  File "/Users/stephanbuys/Documents/Coding/github/salt/salt/output/highstate.py", line 67, in output
    return _format_host(host, hostdata)[0]
  File "/Users/stephanbuys/Documents/Coding/github/salt/salt/output/highstate.py", line 107, in _format_host
    rcounts.setdefault(ret['result'], 0)
KeyError: 'result'
```
