### PR TITLE
Add version of Master to manage.versions output.

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -229,6 +229,7 @@ def versions():
         -1: 'Minion requires update',
         0: 'Up to date',
         1: 'Minion newer than master',
+        2: 'Master',
     }
 
     version_status = {}
@@ -249,11 +250,17 @@ def versions():
         if ver_diff not in version_status:
             version_status[ver_diff] = {}
         version_status[ver_diff][minion] = minion_version
+    # Add version of Master to output
+    version_status[2] = salt.__version__
 
     ret = {}
     for key in version_status:
-        for minion in sorted(version_status[key]):
-            ret.setdefault(labels[key], {})[minion] = version_status[key][minion]
+        if key == 2:
+            ret[labels[key]] = version_status[2]
+        else:
+            for minion in sorted(version_status[key]):
+                ret.setdefault(labels[key], {})[minion] = version_status[key][minion]
+
 
     salt.output.display_output(ret, '', __opts__)
     return ret


### PR DESCRIPTION
Adds the version of the master to the output of the `manage.versions` runner:
![manage versions-show-master-version](https://cloud.githubusercontent.com/assets/48491/3670511/ad7fc4a4-1244-11e4-893e-c72c43630724.png)
