### PR TITLE
Feature add grains support to master and roster

### DIFF
--- a/salt/key.py
+++ b/salt/key.py
@@ -883,7 +883,7 @@ class RaetKey(Key):
                 'device_id': device_id,
                 'pub': pub,
                 'verify': verify}
-        if self.opts['open_mode']: # always accept and overwrite
+        if self.opts['open_mode']:  # always accept and overwrite
             with salt.utils.fopen(acc_path, 'w+b') as fp_:
                 fp_.write(self.serial.dumps(keydata))
                 return 'accepted'


### PR DESCRIPTION
This adds the ability to specify custom grains on a salt-ssh target "minion".

In master conf:

```
ssh_grains:
  - somegrain
```

In roster:

```
testsrv:
  host: testsrv.local
  user: vagrant      
  sudo: True         
  grains:
    roles:
      - role1
      - role2
```

There is a preference order in play. The roster will overwrite master's conf, which in turn will overwrite grains on the target "minion".
