### PR TITLE
fix rbenv module UnboundLocalError

### DIFF
--- a/salt/modules/rbenv.py
+++ b/salt/modules/rbenv.py
@@ -175,11 +175,9 @@ def install_ruby(ruby, runas=None):
         env_list.append('MAKE=gmake')
 
     if __salt__['config.get']('rbenv:build_env'):
-        build_env = __salt__['config.get']('rbenv:build_env')
+        env_list.append(__salt__['config.get']('rbenv:build_env'))
     elif __salt__['config.option']('rbenv.build_env'):
         env_list.append(__salt__['config.option']('rbenv.build_env'))
-    if build_env:
-        env_list.append(build_env)
 
     if env_list:
         env = ' '.join(env_list)


### PR DESCRIPTION
This commit fixes the error of the rbenv module below :

```
2014-07-23 15:48:42,068 [salt.state       ][ERROR   ] An exception occurred in this state: Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/state.py", line 1517, in call
    **cdata['kwargs'])
  File "/usr/lib/python2.7/dist-packages/salt/states/rbenv.py", line 162, in installed
    return _check_and_install_ruby(ret, name, default, user=user)
  File "/usr/lib/python2.7/dist-packages/salt/states/rbenv.py", line 83, in _check_and_install_ruby
    if __salt__['rbenv.install_ruby'](ruby, runas=user):
  File "/usr/lib/python2.7/dist-packages/salt/modules/rbenv.py", line 181, in install_ruby
    if build_env:
UnboundLocalError: local variable 'build_env' referenced before assignment
```
