### PR TITLE
use sudo correctly

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -112,7 +112,7 @@ fi
 
 SUDO=""
 if [ -n "{{SUDO}}" ]; then
-    SUDO="sudo root -c"
+    SUDO="sudo"
 fi
 
 EX_PYTHON_OLD={EX_THIN_PYTHON_OLD}    # Python interpreter is too old and incompatible


### PR DESCRIPTION
This command is formatted as if it was su.

So, this is the first part.

I have no idea how to fix the second part, which is it cann't find the thin version.

```
    """.decode("base64")' -- --config '{id: salt.gtmanfred.com, root_dir: /tmp/.salt/running_data}' --delimeter _edbc7885e4f9aac9b83b35999b68d015148caf467b78fa39c05f669c0ff89878 --saltdir /tmp/.salt --checksum 21f94b789530963312905c3c6f5185c2daf326fd --hashfunc sha1 --version 2014.7.0-244-gf26ee84 -- test.ping
    WARNING: Unable to locate current thin version.

stdout:
    ERROR: Failure deploying thin: _edbc7885e4f9aac9b83b35999b68d015148caf467b78fa39c05f669c0ff89878
    deploy
```
