### PR TITLE
Add versionadded to new redis modules

### DIFF
--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -123,9 +123,10 @@ All of the fileserver backends have been overhauled to be faster, lighter and mo
 New Modules
 ===========
 
-Syslog-ng
-Oracle
-random
+- Syslog-ng
+- Oracle
+- Random
+- Redis
 
 Deprecations
 ============

--- a/salt/modules/redismod.py
+++ b/salt/modules/redismod.py
@@ -2,6 +2,8 @@
 '''
 Module to provide redis functionality to Salt
 
+.. versionadded:: 2014.7.0
+
 :configuration: This module requires the redis python module and uses the
     following defaults which may be overridden in the minion configuration:
 

--- a/salt/pillar/redismod.py
+++ b/salt/pillar/redismod.py
@@ -3,6 +3,8 @@
 Read pillar data from a Redis backend
 =====================================
 
+.. versionadded:: 2014.7.0
+
 :depends:   - redis Python module (on master)
 
 Salt Master Redis Configuration

--- a/salt/states/redismod.py
+++ b/salt/states/redismod.py
@@ -3,6 +3,8 @@
 Management of Redis server
 ==========================
 
+.. versionadded:: v2014.04
+
 :depends:   - redis Python module
 :configuration: See :py:mod:`salt.modules.redis` for setup instructions.
 

--- a/salt/states/redismod.py
+++ b/salt/states/redismod.py
@@ -3,7 +3,7 @@
 Management of Redis server
 ==========================
 
-.. versionadded:: v2014.04
+.. versionadded:: 2014.7.0
 
 :depends:   - redis Python module
 :configuration: See :py:mod:`salt.modules.redis` for setup instructions.


### PR DESCRIPTION
Fixes #14413
- Added `versionadded` directives to new redis modules
- Added redis to "new modules" category in release notes
