### PR TITLE
Add CLI Example to augeas.execute

### DIFF
--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -89,6 +89,8 @@ def execute(context=None, lens=None, commands=()):
     '''
     Execute Augeas commands
 
+    .. versionadded:: 2014.7.0
+
     CLI Example:
 
     .. code-block:: bash

--- a/salt/modules/augeas_cfg.py
+++ b/salt/modules/augeas_cfg.py
@@ -88,6 +88,12 @@ def _lstrip_word(word, prefix):
 def execute(context=None, lens=None, commands=()):
     '''
     Execute Augeas commands
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' augeas.execute commands='["set bind 0.0.0.0", "set maxmemory 1G"]'
     '''
     ret = {'retval': False}
 


### PR DESCRIPTION
RHEL 7 tests were failing due to missing CLI Example in the `augeas.execute` function.

@pkruithof - Since you wrote the original function, does that look correct for your implementation?
