### PR TITLE
Fix pillar overlay bug

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -272,8 +272,8 @@ class Pillar(object):
         '''
         Cleanly merge the top files
         '''
-        top = collections.defaultdict(dict)
-        orders = collections.defaultdict(dict)
+        top = collections.defaultdict(OrderedDict)
+        orders = collections.defaultdict(OrderedDict)
         for ctops in tops.values():
             for ctop in ctops:
                 for saltenv, targets in ctop.items():


### PR DESCRIPTION
This was the underlying cause of that most confusing issue outlined in #12098 where we saw pillar overrides rendered in seemingly random ways.

@thatch45 Please give this careful consideration. I believe this is the intended behaviour but it may dramatically change the way pillars are applied for people who are used to the original behaviour. 

If approved, this will need to be forward merged.

Closes #12098
