### PR TITLE
ansible inventories for salt-ssh rosters

### DIFF
--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -8,7 +8,6 @@ systems that cannot or should not host a minion agent.
 
 # Import salt libs
 import salt.loader
-import yaml.parser
 
 import logging
 log = logging.getLogger(__name__)
@@ -53,8 +52,6 @@ class Roster(object):
                 targets.update(self.rosters[f_str](tgt, tgt_type))
             except salt.exceptions.SaltRenderError as exc:
                 log.debug('Unable to render roster file: {0}'.format(exc.error))
-            except yaml.parser.ParserError as exc:
-                log.debug('Unable to render roster file: {0}'.format(exc.problem))
 
         if not targets:
             raise salt.exceptions.SaltRenderError('Unable to render any roster.')

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -9,6 +9,9 @@ systems that cannot or should not host a minion agent.
 # Import salt libs
 import salt.loader
 
+import logging
+log = logging.getLogger(__name__)
+
 
 class Roster(object):
     '''
@@ -45,5 +48,8 @@ class Roster(object):
             f_str = '{0}.targets'.format(back)
             if f_str not in self.rosters:
                 continue
-            targets.update(self.rosters[f_str](tgt, tgt_type))
+            try:
+                targets.update(self.rosters[f_str](tgt, tgt_type))
+            except salt.exceptions.SaltRenderError as exc:
+                log.debug('Unable to render roster file: {0}'.format(exc.error))
         return targets

--- a/salt/roster/__init__.py
+++ b/salt/roster/__init__.py
@@ -8,6 +8,7 @@ systems that cannot or should not host a minion agent.
 
 # Import salt libs
 import salt.loader
+import yaml.parser
 
 import logging
 log = logging.getLogger(__name__)
@@ -52,4 +53,9 @@ class Roster(object):
                 targets.update(self.rosters[f_str](tgt, tgt_type))
             except salt.exceptions.SaltRenderError as exc:
                 log.debug('Unable to render roster file: {0}'.format(exc.error))
+            except yaml.parser.ParserError as exc:
+                log.debug('Unable to render roster file: {0}'.format(exc.problem))
+
+        if not targets:
+            raise salt.exceptions.SaltRenderError('Unable to render any roster.')
         return targets

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -26,9 +26,9 @@ def targets(tgt, tgt_type='glob', **kwargs):
     Default: /etc/salt/hosts
     '''
     if tgt == 'all':
-        tgt = '*':
-    if __opts__.get('inventory_file', False) is not False:
-        hosts = __opts__.get('inventory_file')
+        tgt = '*'
+    if __opts__.get('roster_file', False) is not False:
+        hosts = __opts__.get('roster_file')
     elif os.path.isfile(__opts__['conf_file']) or not os.path.exists(__opts__['conf_file']):
         hosts = os.path.join(
                 os.path.dirname(__opts__['conf_file']),
@@ -37,7 +37,7 @@ def targets(tgt, tgt_type='glob', **kwargs):
         hosts = os.path.join(__opts__['conf_file'], 'hosts')
 
     if os.path.isfile(hosts) and os.access(hosts, os.X_OK):
-        imatcher = Script(tgt, tgt_type='glob', hosts=hosts)
+        imatcher = Script(tgt, tgt_type='glob', inventory_file=hosts)
     else:
         imatcher = Inventory(tgt, tgt_type='glob', inventory_file=hosts)
     return imatcher.targets()
@@ -56,7 +56,7 @@ class Inventory(object):
         blocks = re.compile('^\[.*\]$')
         hostvar = re.compile('^\[([^:]+):vars\]$')
         parents = re.compile('^\[([^:]+):children\]$')
-        with salt.utils.fopen(hosts) as config:
+        with salt.utils.fopen(inventory_file) as config:
             for line in config.read().split('\n'):
                 if not line or line.startswith('#'):
                     continue
@@ -150,7 +150,7 @@ class Script(Inventory):
     '''
     Matcher for Inventory scripts
     '''
-    def __init__(self, inventory_file='/etc/salt/hosts2'):
+    def __init__(self, tgt, tgt_type='glob', inventory_file='/etc/salt/hosts'):
         self.tgt = tgt
         self.tgt_type = tgt_type
         inventory, error = subprocess.Popen([inventory_file], shell=True, stdout=subprocess.PIPE).communicate()

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -1,0 +1,67 @@
+from __future__ import print_function
+import re
+import pprint
+
+CONVERSION = {
+    'ansible_ssh_host': 'host',
+    'ansible_ssh_port': 'port',
+    'ansible_ssh_user': 'user',
+    'ansible_ssh_pass': 'passwd',
+    'ansible_sudo_pass': 'passwd',
+    'ansible_ssh_private_key_file': 'priv'
+}
+
+class Inventory(object):
+    def __init__(self, hosts='hosts'):
+        self.groups = dict()
+        self.hostvars = dict()
+        blocks = re.compile('^\[.*\]$')
+        hostvar = re.compile('^\[.*:vars\]$')
+        with open(hosts) as config:
+            for line in config.read().split('\n'):
+                if not line or line.startswith('#'):
+                    continue
+                if blocks.match(line):
+                    if hostvar.match(line):
+                        hostvars = True
+                        groups = False
+                        varname = line[:-5].strip('[')
+                    else:
+                        hostvars = False
+                        groups = True
+                        varname = line.strip('[]')
+                    continue
+                if hostvars:
+                    key, value = self._parse_hostvars_line(line)
+                    if varname not in self.hostvars:
+                        self.hostvars[varname] = dict()
+                    self.hostvars[varname][key] = value
+                if groups:
+                    if varname in self.groups and self.groups[varname]:
+                        self.groups[varname].append(self._parse_host_line(line))
+                    else:
+                        self.groups[varname] = [self._parse_host_line(line)]
+
+    def _parse_host_line(self, line):
+        line_args = line.split(' ')
+        name = line_args[0]
+        host = {line_args[0]: dict()}
+        for arg in line_args[1:]:
+            key, value = arg.split('=')
+            host[name][CONVERSION[key]] = value
+        return host
+
+    def _parse_hostvars_line(self, line):
+        return line.split('=')
+
+    def get_groups(self):
+        return self.groups
+                
+    def get_hostvars(self):
+        return self.hostvars
+
+
+if __name__ == '__main__':
+    inventory = Inventory()
+    print(pprint.pformat(inventory.get_groups()))
+    print(pprint.pformat(inventory.get_hostvars()))

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -1,11 +1,12 @@
-from __future__ import print_function
+# -*- coding: utf-8 -*-
+'''
+Read in an Ansible inventory file or script
+'''
 import os
 import re
 import fnmatch
 import shlex
-import pprint
 import json
-import salt.loader
 import salt.utils
 import subprocess
 
@@ -19,10 +20,11 @@ CONVERSION = {
     'ansible_ssh_private_key_file': 'priv'
 }
 
-import logging
-log = logging.getLogger(__name__)
-
 def targets(tgt, tgt_type='glob', **kwargs):
+    '''
+    Return the targets from the ansible inventory_file
+    Default: /etc/salt/hosts
+    '''
     if tgt == 'all':
         tgt = '*':
     if __opts__.get('inventory_file', False) is not False:
@@ -34,7 +36,6 @@ def targets(tgt, tgt_type='glob', **kwargs):
     else:
         hosts = os.path.join(__opts__['conf_file'], 'hosts')
 
-    rend = salt.loader.render(__opts__, {})
     if os.path.isfile(hosts) and os.access(hosts, os.X_OK):
         imatcher = Script(tgt, tgt_type='glob', hosts=hosts)
     else:
@@ -43,6 +44,9 @@ def targets(tgt, tgt_type='glob', **kwargs):
 
 
 class Inventory(object):
+    '''
+    Matcher for static inventory files
+    '''
     def __init__(self, tgt, tgt_type='glob', inventory_file='/etc/salt/hosts'):
         self.tgt = tgt
         self.tgt_type = tgt_type
@@ -70,6 +74,9 @@ class Inventory(object):
                 getattr(self, proc)(line, varname)
 
     def _parse_group_line(self, line, varname):
+        '''
+        Parse lines in the inventory file that are under the same group block
+        '''
         line_args = shlex.split(line)
         name = line_args[0]
         host = {line_args[0]: dict()}
@@ -84,17 +91,26 @@ class Inventory(object):
             self.groups[varname] = host
 
     def _parse_hostvars_line(self, line, varname):
+        '''
+        Parse lines in the inventory file that are under the same [*:vars] block
+        '''
         key, value = line.split('=')
         if varname not in self.hostvars:
             self.hostvars[varname] = dict()
         self.hostvars[varname][key] = value
 
     def _parse_parents_line(self, line, varname):
+        '''
+        Parse lines in the inventory file that are under the same [*:children] block
+        '''
         if varname not in self.parents:
             self.parents[varname] = []
         self.parents[varname].append(line)
 
     def targets(self):
+        '''
+        Execute the correct tgt_type routine and return
+        '''
         try:
             return getattr(self, 'get_{0}'.format(self.tgt_type))()
         except AttributeError:
@@ -102,6 +118,9 @@ class Inventory(object):
 
 
     def get_glob(self):
+        '''
+        Return minions that match via glob
+        '''
         ret = dict()
         for key, value in self.groups.items():
             for host, info in value.items():
@@ -116,6 +135,9 @@ class Inventory(object):
         return ret
 
     def _get_parent(self, parent_nodegroup):
+        '''
+        Recursively resolve all [*:children] group blocks
+        '''
         ret = dict()
         for nodegroup in self.parents[parent_nodegroup]:
             if nodegroup in self.parents:
@@ -124,11 +146,10 @@ class Inventory(object):
                 ret.update(self.groups[nodegroup])
         return ret
                 
-    def get_hostvars(self):
-        return self.hostvars
-
-
 class Script(Inventory):
+    '''
+    Matcher for Inventory scripts
+    '''
     def __init__(self, inventory_file='/etc/salt/hosts2'):
         self.tgt = tgt
         self.tgt_type = tgt_type
@@ -149,6 +170,9 @@ class Script(Inventory):
                 self._parse_hostvars(key, value['hostvars'])
 
     def _parse_groups(self, key, value):
+        '''
+        Parse group data from inventory_file
+        '''
         host = dict()
         if key not in self.groups:
             self.groups[key] = dict()
@@ -165,11 +189,17 @@ class Script(Inventory):
         self.groups[key].update(host)
 
     def _parse_hostvars(self, key, value):
+        '''
+        Parse hostvars data from inventory_file
+        '''
         if key not in self.hostvars:
             self.hostvars[key] = dict()
         self.hostvars[key] = value
 
     def _parse_parents(self, key, value):
+        '''
+        Parse children data from inventory_file
+        '''
         if key not in self.parents:
             self.parents[key] = []
         self.parents[key].extend(value)

--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -38,9 +38,9 @@ class Inventory(object):
                     self.hostvars[varname][key] = value
                 if groups:
                     if varname in self.groups and self.groups[varname]:
-                        self.groups[varname].append(self._parse_host_line(line))
+                        self.groups[varname].update(self._parse_host_line(line))
                     else:
-                        self.groups[varname] = [self._parse_host_line(line)]
+                        self.groups[varname] = self._parse_host_line(line)
 
     def _parse_host_line(self, line):
         line_args = line.split(' ')

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -13,6 +13,9 @@ import salt.loader
 from salt.template import compile_template
 from salt._compat import string_types
 
+import logging
+log = logging.getLogger(__name__)
+
 
 def targets(tgt, tgt_type='glob', **kwargs):
     '''
@@ -62,6 +65,7 @@ class RosterMatcher(object):
                 data = self.get_data(minion)
                 if data:
                     minions[minion] = data
+        log.info('minions list: {0}'.format(minions))
         return minions
 
     def ret_pcre_minions(self):

--- a/salt/template.py
+++ b/salt/template.py
@@ -133,8 +133,8 @@ def template_shebang(template, renderers, default):
     with salt.utils.fopen(template, 'r') as ifile:
         line = ifile.readline()
 
-        # Check if it starts with a shebang
-        if line.startswith('#!'):
+        # Check if it starts with a shebang and not a path
+        if line.startswith('#!') and not line.startswith('#!/'):
 
             # pull out the shebang data
             render_pipe = check_render_pipe_str(line.strip()[2:], renderers)


### PR DESCRIPTION
This allows users to use their already made ansible inventories to run salt-ssh.

It also allows for the dynamic ansible inventories to be used as well.

It was @techhat 's idea

Thanks
Daniel
