### PR TITLE
Refinement on salt-ssh master conf grains, should always overwrite

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -603,12 +603,13 @@ class Single(object):
             if passed_time > self.opts.get('cache_life', 60):
                 refresh = True
 
-        conf_grains = {}
         if self.opts.get('refresh_cache'):
             refresh = True
-            #Save conf file grains before they get clobbered
-            if 'ssh_grains' in self.opts:
-                conf_grains = self.opts['ssh_grains']
+
+        conf_grains = {}
+        #Save conf file grains before they get clobbered
+        if 'ssh_grains' in self.opts:
+            conf_grains = self.opts['ssh_grains']
 
         if refresh:
             # Make the datap


### PR DESCRIPTION
This patch ensures that grains from a local source is always included, not just during refresh (otherwise certain refreshes that depend on templates with grains variables might fail).
