### PR TITLE
Check if api_key is set in kwargs instead of checking for key

### DIFF
--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -119,7 +119,7 @@ class SaltNova(object):
             self.kwargs['auth_plugin'] = auth_plugin
             self.kwargs['auth_system'] = os_auth_plugin
 
-        if 'api_key' not in self.kwargs.keys():
+        if not self.kwargs.get('api_key', None):
             self.kwargs['api_key'] = password
         extensions = []
         if 'extensions' in kwargs:


### PR DESCRIPTION
This fixes an issue when trying to connect to OpenStack using the nova module with a password. The nova module always adds 'api_key' to kwargs, but sets it to None if it isn't specified. This would result in the old check always being false and not setting the password to 'api_key'.
