### PR TITLE
#13224

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -141,7 +141,7 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
 
     rule = ''
     proto = False
-    bang_not_pat = re.compile(r'[!,not]\s?')
+    bang_not_pat = re.compile(r'[!|not]\s?')
 
     if 'if' in kwargs:
         if kwargs['if'].startswith('!') or kwargs['if'].startswith('not'):


### PR DESCRIPTION
Hi
(r'[!,not]\s?') match '!' as well as ',' and will remove commas from added options to tcp-flags.
(r'[!|not]\s?') should only match not or ! as intended by bang_not_pat.
