### PR TITLE
Add support for pre_releases argument to the gem state

### DIFF
--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -32,7 +32,8 @@ def installed(name,          # pylint: disable=C0103
               user=None,
               version=None,
               rdoc=False,
-              ri=False):     # pylint: disable=C0103
+              ri=False,
+              pre_releases=False):     # pylint: disable=C0103
     '''
     Make sure that a gem is installed.
 
@@ -61,6 +62,9 @@ def installed(name,          # pylint: disable=C0103
 
     ri : False
         Generate RI documentation for the gem(s).
+
+    pre_releases : False
+        Install pre-release version of gem(s) if available.
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
@@ -106,7 +110,8 @@ def installed(name,          # pylint: disable=C0103
                                runas=user,
                                version=version,
                                rdoc=rdoc,
-                               ri=ri):
+                               ri=ri,
+                               pre_releases=pre_releases):
         ret['result'] = True
         ret['changes'][name] = 'Installed'
         ret['comment'] = 'Gem was successfully installed'

--- a/tests/unit/states/gem_test.py
+++ b/tests/unit/states/gem_test.py
@@ -29,8 +29,8 @@ class TestGemState(TestCase):
                 ret = gem.installed('quux')
                 self.assertEqual(True, ret['result'])
                 gem_install_succeeds.assert_called_once_with(
-                    'quux', ruby=None, runas=None, version=None, rdoc=False,
-                    ri=False
+                    'quux', pre_releases=False, ruby=None, runas=None,
+                    version=None, rdoc=False, ri=False
                 )
 
             with patch.dict(gem.__salt__,
@@ -38,8 +38,8 @@ class TestGemState(TestCase):
                 ret = gem.installed('quux')
                 self.assertEqual(False, ret['result'])
                 gem_install_fails.assert_called_once_with(
-                    'quux', ruby=None, runas=None, version=None, rdoc=False,
-                    ri=False
+                    'quux', pre_releases=False, ruby=None, runas=None,
+                    version=None, rdoc=False, ri=False
                 )
 
     def test_removed(self):


### PR DESCRIPTION
This should add support for pre_releases to the gem.installed state.
