### PR TITLE
fix indentation mistake in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -645,7 +645,7 @@ elif sys.platform.startswith('sunos'):
         from bbfreeze.modulegraph.modulegraph import ModuleGraph
         mf = ModuleGraph(sys.path[:])
         for arg in glob.glob('salt/modules/*.py'):
-                mf.run_script(arg)
+            mf.run_script(arg)
         for mod in mf.flatten():
             if type(mod).__name__ != 'Script' and mod.filename:
                 FREEZER_INCLUDES.append(str(os.path.basename(mod.identifier)))


### PR DESCRIPTION
```
************* Module setup
setup.py:648: [W0311(bad-indentation), ] Bad indentation. Found 16 spaces, expected 12
```
