### PR TITLE
remove incorrect comma in states.process.absent()

### DIFF
--- a/salt/states/process.py
+++ b/salt/states/process.py
@@ -39,7 +39,7 @@ def absent(name, user=None, signal=None):
         running = __salt__['ps.pgrep'](name, user=user)
         ret['result'] = None
         if running:
-            ret['comment'] = ('{0} processes will ',
+            ret['comment'] = ('{0} processes will '
                               'be killed').format(len(running))
         else:
             ret['comment'] = 'No matching processes running'


### PR DESCRIPTION
```
************* Module salt.states.process
salt/states/process.py:42: [E1101(no-member), absent] Instance of 'tuple' has no 'format' member
```
