### PR TITLE
salt.wheel: rm redundant import of salt.exceptions

### DIFF
--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -10,7 +10,6 @@ import time
 # Import salt libs
 from salt import syspaths
 import salt.config
-import salt.exceptions
 import salt.loader
 import salt.payload
 import salt.utils


### PR DESCRIPTION
```
************* Module salt.wheel
salt/wheel/__init__.py:17: [W0404(reimported), ] Reimport 'salt.exceptions' (imported line 13)
```
