### PR TITLE
Module does not rename itself, no need to define `__virtualname__`, simply return `True`

### DIFF
--- a/salt/pillar/pepa.py
+++ b/salt/pillar/pepa.py
@@ -15,6 +15,7 @@ __version__ = '0.6.2'
 import logging
 import sys
 
+
 log = None
 if sys.stdout.isatty():
     import argparse
@@ -45,8 +46,6 @@ if sys.stdout.isatty():
 else:
     log = logging.getLogger(__name__)
 
-# Name
-__virtualname__ = 'pepa'
 
 # Options
 __opts__ = {
@@ -104,7 +103,7 @@ def __virtual__():
         log.error('Failed to load "jinja2" library')
         return False
 
-    return __virtualname__
+    return True
 
 
 def key_value_to_tree(data):


### PR DESCRIPTION
There's lot's more to clean up, but I'll leave that to @mickep76 since he coded it and I don't want to break an functionality.

Basically, I think salt's logging should be used and all external libraries for which salt does not hard depend should be in a `try/except` and the module should not load without these.
