### PR TITLE
Switching the _get_virtual function to use pure python instead of a call to grep-available

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -48,6 +48,12 @@ try:
 except ImportError:
     resolve_dep_support = False
 
+try:
+    import apt.cache  # pylint: disable=E0611
+    apt_cache_support = True
+except ImportError:
+    apt_cache_support = False
+
 # Source format for urllib fallback on PPA handling
 LP_SRC_FORMAT = 'deb http://ppa.launchpad.net/{0}/{1}/ubuntu {2} main'
 LP_PVT_SRC_FORMAT = 'deb https://{0}private-ppa.launchpad.net/{1}/{2}/ubuntu' \
@@ -128,12 +134,15 @@ def _get_virtual():
     '''
     if 'pkg._get_virtual' not in __context__:
         __context__['pkg._get_virtual'] = {}
-        if __salt__['cmd.has_exec']('grep-available'):
-            cmd = 'grep-available -F Provides -s Package,Provides -e "^.+$"'
-            out = __salt__['cmd.run_stdout'](cmd, output_loglevel='trace')
-            virtpkg_re = re.compile(r'Package: (\S+)\nProvides: ([\S, ]+)')
-            for realpkg, provides in virtpkg_re.findall(out):
-                __context__['pkg._get_virtual'][realpkg] = provides.split(', ')
+        apt_cache = apt.cache.Cache()
+        pkgs = apt_cache._cache.packages
+        for pkg in pkgs:
+            if pkg.provides_list:
+                for item in pkg.provides_list:
+                    realpkg = item[2].parent_pkg.name
+                    if realpkg not in __context__['pkg._get_virtual']:
+                        __context__['pkg._get_virtual'][realpkg] = []
+                    __context__['pkg._get_virtual'][realpkg].append(pkg.name)
     return __context__['pkg._get_virtual']
 
 
@@ -191,6 +200,11 @@ def latest_version(*names, **kwargs):
     # Refresh before looking for the latest version available
     if refresh:
         refresh_db()
+
+    if not apt_cache_support:
+        msg = 'Error: apt.cache python module not found'
+        log.error(msg)
+        return msg
 
     virtpkgs = _get_virtual()
     all_virt = set()
@@ -863,8 +877,13 @@ def list_pkgs(versions_as_list=False,
                                                  name,
                                                  version_num)
 
+    if not apt_cache_support:
+        msg = 'Error: apt.cache python module not found'
+        log.error(msg)
+        return msg
+
     # Check for virtual packages. We need dctrl-tools for this.
-    if not removed and __salt__['cmd.has_exec']('grep-available'):
+    if not removed:
         virtpkgs_all = _get_virtual()
         virtpkgs = set()
         for realpkg, provides in virtpkgs_all.iteritems():


### PR DESCRIPTION
Switching the _get_virtual function to use pure python instead of a call to grep-available.  
The issue with grep-available is that it doesn't know about virtual packages until they've been installed, if you're installing a virtual package via Salt which hasn't been installed before then the process will fail because the virtual package won't be in the list of available packages.  
Using the apt.cache module instead ensure that _get_virtual shows _all_ virtual packages.
Per #14426 
