### PR TITLE
Fix pepa shortcircuiting all scripts args at it'simport time...

### DIFF
--- a/salt/pillar/pepa.py
+++ b/salt/pillar/pepa.py
@@ -17,7 +17,7 @@ import sys
 
 
 log = None
-if sys.stdout.isatty():
+if __name__ == '__main__' and sys.stdout.isatty():
     import argparse
     from colorlog import ColoredFormatter
 


### PR DESCRIPTION
This kills salt-call & i think other salt scripts...
How can that hit develop !
