### PR TITLE
Fixing debian_ip.py per #14530.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -626,9 +626,10 @@ def _parse_interfaces(interface_files=None):
     # ensure a consistent order
     for iface_name in adapters:
         for opt in ['ethtool', 'bonding', 'bridging']:
-            if opt in adapters[iface_name]['data']['inet']:
-                opt_keys = sorted(adapters[iface_name]['data']['inet'][opt].keys())
-                adapters[iface_name]['data']['inet'][opt + '_keys'] = opt_keys
+            if 'inet' in adapters[iface_name]['data']:
+                if opt in adapters[iface_name]['data']['inet']:
+                    opt_keys = sorted(adapters[iface_name]['data']['inet'][opt].keys())
+                    adapters[iface_name]['data']['inet'][opt + '_keys'] = opt_keys
 
     return adapters
 

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -1,9 +1,9 @@
 {% if data.enabled %}auto {{name}}
 {%endif%}{% if data.hotplug %}allow-hotplug {{name}}
-{%endif%}{% if data.data['inet'] %}
+{%endif%}{%- if data.data['inet'] -%}
 {%- set interface = data.data['inet'] -%}
-iface {{name}} {{interface.addrfam}} {{interface.proto}}
-{%endif%}{% if interface.hwaddress %}    hwaddress {{interface.hwaddress}}
+{% if interface.proto %}iface {{name}} {{interface.addrfam}} {{interface.proto}}
+{%endif %}{% if interface.hwaddress %}    hwaddress {{interface.hwaddress}}
 {%endif%}{% if interface.vlan_raw_device %}    vlan-raw-device {{interface.vlan_raw_device}}
 {%endif%}{% if interface.address %}    address {{interface.address}}
 {%endif%}{% if interface.netmask %}    netmask {{interface.netmask}}
@@ -59,7 +59,8 @@ iface {{name}} {{interface.addrfam}} {{interface.proto}}
 {%endfor-%}
 {%endif%}{% if interface.post_down_cmds %}{% for cmd in interface.post_down_cmds %}    post-down {{ cmd }}
 {%endfor-%}{%endif%}
-{% if data.data['inet6'] %}
+{%endif%}
+{%- if data.data['inet6'] -%}
 {%- set interface = data.data['inet6'] -%}
 iface {{name}} {{interface.addrfam}} {{interface.proto}}
 {% if interface.hwaddress %}    hwaddress {{interface.hwaddress}}


### PR DESCRIPTION
Setting ipv6 only options resulted in a malformed interfaces file, mostly cleanup in the template to ensure that ipv4 options are only added when ipv4 networking is included.
