### PR TITLE
cleanup string formatting in modules.tls.create_ca()

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -428,10 +428,10 @@ def create_ca(ca_name,
 
     _write_cert_to_database(ca_name, ca)
 
-    ret = ('Created Private Key: "{1}/{2}/{3}_ca_cert.key." ').format(
-        ca_name, cert_base_path(), ca_name, ca_name)
-    ret += ('Created CA "{0}": "{1}/{2}/{3}_ca_cert.crt."').format(
-        ca_name, cert_base_path(), ca_name, ca_name)
+    ret = ('Created Private Key: "{0}/{1}/{1}_ca_cert.key." ').format(
+        cert_base_path(), ca_name)
+    ret += ('Created CA "{0}": "{1}/{0}/{0}_ca_cert.crt."').format(
+        ca_name, cert_base_path())
 
     return ret
 


### PR DESCRIPTION
```
************* Module salt.modules.tls
salt/modules/tls.py:431: [E1305(too-many-format-args), create_ca] Too many arguments for format string
```
