### PR TITLE
states.dockerio.running(): fix string formatting in error message

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -730,7 +730,7 @@ def running(name, container=None, port_bindings=None, binds=None,
             else:
                 return _invalid(
                     comment=(
-                        'Container {0!r} cannot be started\n{0!s}'
+                        'Container {0!r} cannot be started\n{1!s}'
                         .format(
                             container,
                             started['out'],


### PR DESCRIPTION
```
************* Module salt.states.dockerio
salt/states/dockerio.py:733: [E1305(too-many-format-args), running] Too many arguments for format string
```
