### PR TITLE
prevent gitfs.py from changing load variable

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -1168,6 +1168,7 @@ def _file_lists(load, form):
     '''
     Return a dict containing the file lists for files and dirs
     '''
+    load = copy.deepcopy(load)
     if 'env' in load:
         salt.utils.warn_until(
             'Boron',


### PR DESCRIPTION
Gitfs.py sometimes changes 'load' variable (for example to 'master') and it breaks work of all next fs modules. It breaks, for example, module 'cp.list_master_dirs', and all states that depends on this module.
