### PR TITLE
Fixing docstrings for archive.tar to be consistent. 

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -70,14 +70,14 @@ def tar(options, tarfile, sources=None, dest=None, cwd=None, template=None):
 
     .. code-block:: bash
 
-        salt '*' archive.tar template=jinja cjvf /tmp/salt.tar.bz2 {{grains.saltpath}}
+        salt '*' archive.tar cjvf /tmp/salt.tar.bz2 {{grains.saltpath}} template=jinja 
 
 
     To unpack a tarfile, for example:
 
     .. code-block:: bash
 
-        salt '*' archive.tar foo.tar xf dest=/target/directory
+        salt '*' archive.tar xf foo.tar dest=/target/directory
 
     '''
     if isinstance(sources, salt._compat.string_types):


### PR DESCRIPTION
Fixing docstrings for archive.tar to be consistent.  Per #14308.
