### PR TITLE
Handle missing roster

### DIFF
--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -125,12 +125,14 @@ def targets(tgt, tgt_type='glob', **kwargs):
     else:
         hosts = os.path.join(__opts__['conf_file'], 'roster')
 
-    if os.path.isfile(hosts) and os.access(hosts, os.X_OK):
-        imatcher = Script(tgt, tgt_type='glob', inventory_file=hosts)
-    else:
-        imatcher = Inventory(tgt, tgt_type='glob', inventory_file=hosts)
-    return imatcher.targets()
-
+    try:
+        if os.path.isfile(hosts) and os.access(hosts, os.X_OK):
+            imatcher = Script(tgt, tgt_type='glob', inventory_file=hosts)
+        else:
+            imatcher = Inventory(tgt, tgt_type='glob', inventory_file=hosts)
+            return imatcher.targets()
+    except IOError:
+        return []
 
 class Target(object):
     def targets(self):


### PR DESCRIPTION
If you don't have a roster setup the ansible inventory script currently fails with an IOError
