### PR TITLE
Handle no roster file gracefully

### DIFF
--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -97,6 +97,7 @@ import shlex
 import json
 import salt.utils
 import subprocess
+from salt.roster import get_roster_file
 
 
 CONVERSION = {
@@ -116,19 +117,13 @@ def targets(tgt, tgt_type='glob', **kwargs):
     '''
     if tgt == 'all':
         tgt = '*'
-    if __opts__.get('roster_file', False) is not False:
-        hosts = __opts__.get('roster_file')
-    elif os.path.isfile(__opts__['conf_file']) or not os.path.exists(__opts__['conf_file']):
-        hosts = os.path.join(
-                os.path.dirname(__opts__['conf_file']),
-                'roster')
-    else:
-        hosts = os.path.join(__opts__['conf_file'], 'roster')
 
-    if os.path.isfile(hosts) and os.access(hosts, os.X_OK):
-        imatcher = Script(tgt, tgt_type='glob', inventory_file=hosts)
+    inventory_file = get_roster_file(__opts__)
+
+    if os.path.isfile(inventory_file) and os.access(inventory_file, os.X_OK):
+        imatcher = Script(tgt, tgt_type='glob', inventory_file=inventory_file)
     else:
-        imatcher = Inventory(tgt, tgt_type='glob', inventory_file=hosts)
+        imatcher = Inventory(tgt, tgt_type='glob', inventory_file=inventory_file)
     return imatcher.targets()
 
 

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -12,6 +12,7 @@ import re
 import salt.loader
 from salt.template import compile_template
 from salt._compat import string_types
+from salt.roster import get_roster_file
 
 import logging
 log = logging.getLogger(__name__)
@@ -22,14 +23,8 @@ def targets(tgt, tgt_type='glob', **kwargs):
     Return the targets from the flat yaml file, checks opts for location but
     defaults to /etc/salt/roster
     '''
-    if __opts__.get('roster_file'):
-        template = __opts__.get('roster_file')
-    elif os.path.isfile(__opts__['conf_file']) or not os.path.exists(__opts__['conf_file']):
-        template = os.path.join(
-                os.path.dirname(__opts__['conf_file']),
-                'roster')
-    else:
-        template = os.path.join(__opts__['conf_file'], 'roster')
+    template = get_roster_file(__opts__)
+
     rend = salt.loader.render(__opts__, {})
     raw = compile_template(template, rend, __opts__['renderer'], **kwargs)
     rmatcher = RosterMatcher(raw, tgt, tgt_type, 'ipv4')

--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -4,7 +4,6 @@ Read in the roster from a flat file using the renderer system
 '''
 
 # Import python libs
-import os
 import fnmatch
 import re
 


### PR DESCRIPTION
Before this PR:

```
salt-ssh -c /home/sontek/src/salttest/smstack/etc/ '127.0.0.1' test.ping
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
IOError: [Errno 2] No such file or directory: ''
Traceback (most recent call last):
  File "/home/sontek/venvs/salttest/bin/salt-ssh", line 9, in <module>
    load_entry_point('salt==2014.7.0-567-g6dae7e8', 'console_scripts', 'salt-ssh')()
  File "/home/sontek/src/salttest/salt/salt/scripts.py", line 252, in salt_ssh
    client.run()
  File "/home/sontek/src/salttest/salt/salt/cli/__init__.py", line 461, in run
    ssh = salt.client.ssh.SSH(self.config)
  File "/home/sontek/src/salttest/salt/salt/client/ssh/__init__.py", line 181, in __init__
    self.tgt_type)
  File "/home/sontek/src/salttest/salt/salt/roster/__init__.py", line 52, in targets
    targets.update(self.rosters[f_str](tgt, tgt_type))
  File "/home/sontek/src/salttest/salt/salt/roster/ansible.py", line 131, in targets
    imatcher = Inventory(tgt, tgt_type='glob', inventory_file=hosts)
  File "/home/sontek/src/salttest/salt/salt/roster/ansible.py", line 188, in __init__
    with salt.utils.fopen(inventory_file) as config:
  File "/home/sontek/src/salttest/salt/salt/utils/__init__.py", line 1110, in fopen
    fhandle = open(*args, **kwargs)
IOError: [Errno 2] No such file or directory: ''
```

and if you removed the ansible plugin:

```
salt-ssh -c /home/sontek/src/salttest/smstack/etc/ '*' test.ping
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
SaltRenderError: Unable to render any roster.
Traceback (most recent call last):
  File "/home/sontek/venvs/salttest/bin/salt-ssh", line 9, in <module>
    load_entry_point('salt==2014.7.0-567-g6dae7e8', 'console_scripts', 'salt-ssh')()
  File "/home/sontek/src/salttest/salt/salt/scripts.py", line 252, in salt_ssh
    client.run()
  File "/home/sontek/src/salttest/salt/salt/cli/__init__.py", line 461, in run
    ssh = salt.client.ssh.SSH(self.config)
  File "/home/sontek/src/salttest/salt/salt/client/ssh/__init__.py", line 181, in __init__
    self.tgt_type)
  File "/home/sontek/src/salttest/salt/salt/roster/__init__.py", line 61, in targets
    raise salt.exceptions.SaltRenderError('Unable to render any roster.')
SaltRenderError: Unable to render any roster.
Traceback (most recent call last):
  File "/home/sontek/venvs/salttest/bin/salt-ssh", line 9, in <module>
    load_entry_point('salt==2014.7.0-567-g6dae7e8', 'console_scripts', 'salt-ssh')()
  File "/home/sontek/src/salttest/salt/salt/scripts.py", line 252, in salt_ssh
    client.run()
  File "/home/sontek/src/salttest/salt/salt/cli/__init__.py", line 461, in run
    ssh = salt.client.ssh.SSH(self.config)
  File "/home/sontek/src/salttest/salt/salt/client/ssh/__init__.py", line 181, in __init__
    self.tgt_type)
  File "/home/sontek/src/salttest/salt/salt/roster/__init__.py", line 61, in targets
    raise salt.exceptions.SaltRenderError('Unable to render any roster.')
salt.exceptions.SaltRenderError: Unable to render any roster.
```

Now it returns:

```
salt-ssh -c /home/sontek/src/salttest/smstack/etc/ '*' test.ping
Unable to render any roster.
```

and

```
salt-ssh -c /home/sontek/src/salttest/smstack/etc/ '127.0.0.1' test.ping
Permission denied for host 127.0.0.1, do you want to deploy the salt-ssh key? (password required):
[Y/n] n
127.0.0.1:
    ----------
    retcode:
        255
    stderr:
        Permission denied (publickey,password).

    stdout:
```
