### PR TITLE
Previsouly this would run even if no proc matched.

### DIFF
--- a/salt/roster/ansible.py
+++ b/salt/roster/ansible.py
@@ -194,8 +194,10 @@ class Inventory(Target):
                     else:
                         proc = '_parse_group_line'
                         varname = line.strip('[]')
-                    continue
-                getattr(self, proc)(line, varname)
+
+                    getattr(self, proc)(line, varname)
+
+                continue
 
     def _parse_group_line(self, line, varname):
         '''


### PR DESCRIPTION
With this fix:

```
salt-ssh '*' test.ping
The authenticity of host '10.128.40.44 (10.128.40.44)' can't be established.
```

without:

```
$ salt-ssh '*' test.ping
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
UnboundLocalError: local variable 'proc' referenced before assignment
Traceback (most recent call last):
  File "/home/sontek/venvs/salttest/bin/salt-ssh", line 9, in <module>
    load_entry_point('salt==2014.7.0-567-g6dae7e8', 'console_scripts', 'salt-ssh')()
  File "/home/sontek/src/salttest/salt/salt/scripts.py", line 252, in salt_ssh
    client.run()
  File "/home/sontek/src/salttest/salt/salt/cli/__init__.py", line 461, in run
    ssh = salt.client.ssh.SSH(self.config)
  File "/home/sontek/src/salttest/salt/salt/client/ssh/__init__.py", line 181, in __init__
    self.tgt_type)
  File "/home/sontek/src/salttest/salt/salt/roster/__init__.py", line 69, in targets
    targets.update(self.rosters[f_str](tgt, tgt_type))
  File "/home/sontek/src/salttest/salt/salt/roster/ansible.py", line 126, in targets
    imatcher = Inventory(tgt, tgt_type='glob', inventory_file=inventory_file)
  File "/home/sontek/src/salttest/salt/salt/roster/ansible.py", line 198, in __init__
    getattr(self, proc)(line, varname)
UnboundLocalError: local variable 'proc' referenced before assignment

```
