### PR TITLE
Example should clean up after itself

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -21,7 +21,7 @@ no disk space:
 
     > /var/log/messages:
       cmd.run:
-        - unless: echo 'foo' > /tmp/.test
+        - unless: echo 'foo' > /tmp/.test && rm -f /tmp/.test
 
 Only run if the file specified by ``creates`` does not exist, in this case
 touch /tmp/foo if it does not exist.


### PR DESCRIPTION
This was pointed out by a student. If the file already exists (because this test has been run before, as it would be) then this command will just overwrite the file with the same data, and not perform a valid disk check.

Obviously, in production there should be a more solid way of performing both this test and the resolution (for instance, in an event reactor), but this should suffice for the example.
