### PR TITLE
Tweak comment message formatting so that it doesn't outwit pylint

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -895,8 +895,8 @@ def script(name,
 
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Command {0!r} would have been executed'
-            ret['comment'] = ret['comment'].format(name)
+            ret['comment'] = 'Command {0!r} would have been ' \
+                             'executed'.format(name)
             return _reinterpreted_state(ret) if stateful else ret
 
         # Wow, we passed the test, run this sucker!

--- a/salt/states/kmod.py
+++ b/salt/states/kmod.py
@@ -92,8 +92,7 @@ def absent(name, persist=False, comment=True):
         # Found the module, unload it!
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'Module {0} is set to be unloaded'
-            ret['comment'] = ret['comment'].format(name)
+            ret['comment'] = 'Module {0} is set to be unloaded'.format(name)
             return ret
         for mod in __salt__['kmod.remove'](name, persist, comment):
             ret['changes'][mod] = 'removed'

--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -240,8 +240,8 @@ def absent(name,
 
         if __opts__['test']:
             ret['result'] = None
-            ret['comment'] = 'MySQL grant {0} is set to be revoked'
-            ret['comment'] = ret['comment'].format(name)
+            ret['comment'] = 'MySQL grant {0} is set to be ' \
+                             'revoked'.format(name)
             return ret
         if __salt__['mysql.grant_revoke'](
                 grant,
@@ -250,9 +250,8 @@ def absent(name,
                 host,
                 grant_option,
                 **connection_args):
-            ret['comment'] = 'Grant {0} on {1} for {2}@{3} has been revoked'
-            ret['comment'] = ret['comment'].format(grant, database, user,
-                                                   host)
+            ret['comment'] = 'Grant {0} on {1} for {2}@{3} has been ' \
+                             'revoked'.format(grant, database, user, host)
             ret['changes'][name] = 'Absent'
             return ret
         else:


### PR DESCRIPTION
Also, this is marginally more efficient due to removing unnecessary dict accesses.
X-Ref: https://bitbucket.org/logilab/pylint/issue/287/e1305-false-positive-involving-dicts
