### PR TITLE
fix for issue #14655

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1560,7 +1560,8 @@ class State(object):
         self.check_refresh(low, ret)
         finish_time = datetime.datetime.now()
         ret['start_time'] = start_time.time().isoformat()
-        ret['duration'] = (finish_time - start_time).microseconds / 1000
+        #duration in milliseconds.microseconds
+        ret['duration'] = (finish_time - start_time).total_seconds() * 1000
         log.info('Completed state [{0}] at time {1}'.format(low['name'], finish_time.time().isoformat()))
         return ret
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -1560,8 +1560,9 @@ class State(object):
         self.check_refresh(low, ret)
         finish_time = datetime.datetime.now()
         ret['start_time'] = start_time.time().isoformat()
+        delta = (finish_time - start_time)
         #duration in milliseconds.microseconds
-        ret['duration'] = (finish_time - start_time).total_seconds() * 1000
+        ret['duration'] = (delta.seconds * 1000000 + delta.microseconds)/1000.0
         log.info('Completed state [{0}] at time {1}'.format(low['name'], finish_time.time().isoformat()))
         return ret
 


### PR DESCRIPTION
Fix for issue #14655

timedelta.microseconds returns the microseconds portion of the timestamp. Instead we call total_seconds() and the multiple by 1000.

```
>>> start_time = datetime.datetime.now()
>>> finish_time = datetime.datetime.now()
>>> (finish_time-start_time).total_seconds() * 1000
14567.464
>>>
```
