### PR TITLE
Also validate 'defaults' in states.file.managed

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1243,6 +1243,9 @@ def managed(name,
     elif not isinstance(context, dict):
         return _error(
             ret, 'Context must be formed as a dict')
+    if defaults and not isinstance(defaults, dict):
+        return _error(
+            ret, 'Defaults must be formed as a dict')
 
     if len(filter(None, [contents, contents_pillar, contents_grains])) > 1:
         return _error(


### PR DESCRIPTION
Prevents ugly backtraces which don't really point out the actual issue like this one:

```
        Comment: An exception occurred in this state: Traceback (most recent call last):
                   File "salt/state.py", line 1379, in call
                    File "salt/states/file.py", line 1246, in managed
                    File "salt/modules/file.py", line 2363, in check_managed
                    File "salt/modules/file.py", line 2099, in get_managed
                    File "salt/utils/templates.py", line 53, in render_tmpl
                  ValueError: dictionary update sequence element #0 has length 1; 2 is required
```
