### PR TITLE
Fixed AttributeError in _threaded_return caused when execution modules yield dicts.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -995,7 +995,7 @@ class Minion(MinionBase):
                     ind = 0
                     iret = {}
                     for single in return_data:
-                        if isinstance(single, dict) and isinstance(iret, list):
+                        if isinstance(single, dict) and isinstance(iret, dict):
                             iret.update(single)
                         else:
                             if not iret:


### PR DESCRIPTION
/var/log/salt/minion:

[salt.minion                                 ][WARNING ] The minion
function caused an exception
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/minion.py", line 803, in
  _thread_return
      iret.update(single)
