### PR TITLE
Multi syndic

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -61,6 +61,20 @@ The network port to set up the publication interface
 
     publish_port: 4505
 
+.. conf_master:: master_id
+
+``master_id``
+----------------
+
+Default: ``None``
+
+The id to be passed in the publish job to minions. This is used for MultiSyndics
+to return the job to the requesting master. Note, this must be the same string
+as the syndic is configured with.
+
+.. code-block:: yaml
+
+    master_id: MasterOfMaster
 
 .. conf_master:: user
 

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -420,7 +420,11 @@ class Syndic(parsers.SyndicOptionParser):
         # Late import so logging works correctly
         import salt.minion
         self.daemonize_if_required()
-        self.syndic = salt.minion.Syndic(self.config)
+        # if its a multisyndic, do so
+        if isinstance(self.config.get('master'), list):
+            self.syndic = salt.minion.MultiSyndic(self.config)
+        else:
+            self.syndic = salt.minion.Syndic(self.config)
         self.set_pidfile()
 
     def start(self):

--- a/salt/master.py
+++ b/salt/master.py
@@ -2195,6 +2195,11 @@ class ClearFuncs(object):
             'jid': clear_load['jid'],
             'ret': clear_load['ret'],
         }
+        # if you specified a master id, lets put that in the load
+        if 'master_id' in self.opts:
+            load['master_id'] = self.opts['master_id']
+        elif 'master_id' in extra:
+            load['master_id'] = extra['master_id']
 
         if 'id' in extra:
             load['id'] = extra['id']

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2020,6 +2020,7 @@ class Syndic(Minion):
         if hasattr(self, 'local'):
             del self.local
 
+
 class MultiSyndic(Syndic):
     '''
     Make a Syndic minion, this minion will handle relaying jobs and returns from

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2028,7 +2028,12 @@ class MultiSyndic(Syndic):
     Note: jobs will be returned best-effort to the requesting master. This also means
     (since we are using zmq) that if a job was fired and the master disconnects
     between the publish and return, that the return will end up in a zmq buffer
-    in this Syndic headed to that original master
+    in this Syndic headed to that original master.
+
+    In addition, since these classes all seem to use a mix of blocking and non-blocking
+    calls (with varying timeouts along the way) this daemon does not handle failure well,
+    it will (under most circumstances) stall the daemon for ~60s attempting to re-auth
+    with the down master
     '''
     # timeout for one of the connections to an upstream master
     MASTER_MINION_CONNECT_TIMEOUT = 5


### PR DESCRIPTION
Implementation to allow for a syndic master to connect to multiple masters. This can be done by setting syndic_master's value to a list. What this will do is create a MultiSyndic object which acts similar to MultiMinion-- with a few caveats:
- jobs are returned to the master who originated the request in a best-effort fashion, assuming "master_id" is set in the master config.
- Down masters cause blocking of the syndic process-- this is somewhat avoided using the acceptance_wait_time, but it still blocks
- Events/jobs without a "master_id" in them get sent back to a random master
