### PR TITLE
Corrected typo (Verion → Version).

### DIFF
--- a/doc/topics/releases/2014.1.10.rst
+++ b/doc/topics/releases/2014.1.10.rst
@@ -6,7 +6,7 @@ Salt 2014.1.10 Release Notes
 
 .. note::
 
-    Verion 2014.1.9 contained a regression which caused inaccurate Salt version
+    Version 2014.1.9 contained a regression which caused inaccurate Salt version
     detection, and thus was never packaged for general release.  This version
     contains the version detection fix, but is otherwise identical to 2014.1.9.
 

--- a/doc/topics/releases/2014.1.9.rst
+++ b/doc/topics/releases/2014.1.9.rst
@@ -12,7 +12,7 @@ Salt 2014.1.9 Release Notes
 
 .. note::
 
-    Verion 2014.1.8 contained a regression which caused inaccurate Salt version
+    Version 2014.1.8 contained a regression which caused inaccurate Salt version
     detection, and thus was never packaged for general release.  This version
     contains the version detection fix, but is otherwise identical to 2014.1.8.
 


### PR DESCRIPTION
Needs to be cherry-picked into `2014.1` and merged into `develop`.
