### PR TITLE
Fix broken core grains detection in localclient

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1365,7 +1365,13 @@ def is_linux():
     # This is a hack.  If a proxy minion is started by other
     # means, e.g. a custom script that creates the minion objects
     # then this will fail.
-    if 'salt-proxy-minion' in main.__file__:
+    is_proxy = False
+    try:
+        if 'salt-proxy-minion' in main.__file__:
+            is_proxy = True
+    except AttributeError:
+            pass
+    if is_proxy:
         return False
     else:
         return sys.platform.startswith('linux')

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1370,7 +1370,7 @@ def is_linux():
         if 'salt-proxy-minion' in main.__file__:
             is_proxy = True
     except AttributeError:
-            pass
+        pass
     if is_proxy:
         return False
     else:


### PR DESCRIPTION
A stacktrace was being thrown and swallowed in the core os detection
because there was no **file** attribute when run via localclient.

Refs #13920
