### PR TITLE
should use password provided by API if it isn't specified in the configu...

### DIFF
--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -407,7 +407,7 @@ def create(vm_):
                 'win_username', vm_, __opts__, default='Administrator'
             )
             deploy_kwargs['password'] = config.get_cloud_config_value(
-                'win_password', vm_, __opts__, default=''
+                'win_password', vm_, __opts__, default=data.extra['password']
             )
 
         # Store what was used to the deploy the VM


### PR DESCRIPTION
...ration file.

When provisioning Windows Servers with salt-cloud, they should attempt to login using the password returned by the API, not a hard coded value from the configuration file.

This is my attempt at fixing this issue for the Rackspace Cloud. I'm not 100% on the testing process for this change, so please examine carefully the impact of my small change.
