### PR TITLE
output.compact.output(): fix ref to output.highstate.output()

### DIFF
--- a/salt/output/compact.py
+++ b/salt/output/compact.py
@@ -31,4 +31,4 @@ def output(data):
                 else:
                     tmp[min_][process] = {process: data[min_][process]}
 
-    return salt.output.highstate._output(tmp)
+    return salt.output.highstate.output(tmp)


### PR DESCRIPTION
Seems to have been accidentally broken when adjusting the style of the module's imports.

```
************* Module salt.output.compact
salt/output/compact.py:34: [E1101(no-member), output] Module 'salt.output.highstate' has no '_output' member
```
