### PR TITLE
Change install package to help Arch tests pass

### DIFF
--- a/tests/integration/states/pkg.py
+++ b/tests/integration/states/pkg.py
@@ -23,7 +23,7 @@ import integration
 import salt.utils
 
 _PKG_TARGETS = {
-    'Arch': ['python2-django', 'finch'],
+    'Arch': ['python2-django', 'libpng'],
     'Debian': ['python-plist', 'apg'],
     'RedHat': ['xz-devel', 'zsh-html'],
     'FreeBSD': ['aalib', 'pth'],


### PR DESCRIPTION
Two tests in `integration.states.pkg` were failing because one of the packages' dependencies in the list wasn't found. Changed the package to help the tests.
