### PR TITLE
Prep ipv4/6 socket for syndic

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1856,6 +1856,7 @@ class Syndic(Minion):
 
         self._set_reconnect_ivl_max()
         self._set_tcp_keepalive()
+        self._set_ipv4only()
 
         self.socket.connect(self.master_pub)
         self.poller.register(self.socket, zmq.POLLIN)


### PR DESCRIPTION
Otherwise, ipv6 on syndics is a no-go.

Resolves #14736

@rallytime It would be a good idea to think about ipv6 testing.
