### PR TITLE
Specifying apache2

### DIFF
--- a/doc/topics/tutorials/quickstart.rst
+++ b/doc/topics/tutorials/quickstart.rst
@@ -82,7 +82,7 @@ ensures that the server has the Apache webserver installed.
 
 .. code-block:: yaml
 
-    apache:               # ID declaration
+    apache2               # ID declaration
       pkg:                # state declaration
         - installed       # function declaration
 


### PR DESCRIPTION
When using the quickstart on Ubuntu 13.10 I noticed that the salt-call would fail because `apache` was not a recognized package. Changing this to `apache2` allowed the install to happen.
