### PR TITLE
Remove grep from git.current_branch

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -107,8 +107,7 @@ def current_branch(cwd, user=None):
 
         salt '*' git.current_branch /path/to/repo
     '''
-    cmd = r'git branch | grep "^*\ " | cut -d " " -f 2 | ' + \
-        'grep -v "(detached"'
+    cmd = r'git rev-parse --abbrev-ref HEAD'
 
     return __salt__['cmd.run_stdout'](cmd, cwd=cwd, runas=user)
 

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -237,21 +237,22 @@ def latest(name,
                                              force=force_checkout,
                                              user=user)
 
-                    current_remote = __salt__['git.config_get'](target,
-                                                         'branch.{0}.remote'.format(rev),
-                                                         user=user)
-                    if current_remote != remote_name:
-                        if __opts__['test']:
-                            ret['changes'] = {'old': current_remote, 'new': remote_name}
-                            return _neutral_test(ret,
-                                                 ('Repository {0} update is probably required.'
-                                                  'Current remote is {1} should be {2}'.format(target, current_remote, remote_name)))
-                        log.debug('Setting branch {0} to upstream {1}'.format(rev, remote_name))
-                        __salt__['git.branch'](target,
-                                               rev,
-                                               opts='--set-upstream {0}/{1}'.format(remote_name, rev),
-                                               user=user)
-                        ret['changes']['remote/{0}/{1}'.format(remote_name, rev)] = '{0} => {1}'.format(current_remote, remote_name)
+                    if branch != 'HEAD':
+                        current_remote = __salt__['git.config_get'](target,
+                                                             'branch.{0}.remote'.format(rev),
+                                                             user=user)
+                        if current_remote != remote_name:
+                            if __opts__['test']:
+                                ret['changes'] = {'old': current_remote, 'new': remote_name}
+                                return _neutral_test(ret,
+                                                     ('Repository {0} update is probably required.'
+                                                      'Current remote is {1} should be {2}'.format(target, current_remote, remote_name)))
+                            log.debug('Setting branch {0} to upstream {1}'.format(rev, remote_name))
+                            __salt__['git.branch'](target,
+                                                   rev,
+                                                   opts='--set-upstream {0}/{1}'.format(remote_name, rev),
+                                                   user=user)
+                            ret['changes']['remote/{0}/{1}'.format(remote_name, rev)] = '{0} => {1}'.format(current_remote, remote_name)
 
                 # check if we are on a branch to merge changes
                 cmd = "git symbolic-ref -q HEAD"

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -172,7 +172,7 @@ def latest(name,
             branch = __salt__['git.current_branch'](target, user=user)
             # We're only interested in the remote branch if a branch
             # (instead of a hash, for example) was provided for rev.
-            if len(branch) > 0 and branch == rev:
+            if branch != 'HEAD' and branch == rev:
                 remote_rev = __salt__['git.ls_remote'](target,
                                                        repository=name,
                                                        branch=branch, user=user,


### PR DESCRIPTION
Was there a reason that this did all the greps and the cut instead of using git's builtin rev-parse?

If not, then this works.

Daniel
