### PR TITLE
Salt-cloud: Fix URL for VSphere

### DIFF
--- a/conf/cloud.providers.d/vsphere.conf
+++ b/conf/cloud.providers.d/vsphere.conf
@@ -2,4 +2,4 @@
 #  provider: vsphere
 #  user: myuser
 #  password: verybadpass
-#  url: 'https://10.1.1.1:443'
+#  url: 'https://10.1.1.1:443/sdk'

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -20,7 +20,7 @@ configuration at:
       provider: vsphere
       user: myuser
       password: verybadpass
-      url: 'https://10.1.1.1:443'
+      url: 'https://10.1.1.1:443/sdk'
 
 folder: Name of the folder that will contain the new VM. If not set, the VM will
         be added to the folder the original VM belongs to.


### PR DESCRIPTION
Without the "/sdk" suffix requests to it will fail and raises errors about the response being text rather than text/xml.
