### PR TITLE
Added versionadded directives to shadow module

### DIFF
--- a/salt/modules/shadow.py
+++ b/salt/modules/shadow.py
@@ -137,6 +137,8 @@ def set_mindays(name, mindays):
 
 def gen_password(password, crypt_salt=None, algorithm='sha512'):
     '''
+    .. versionadded:: 2014.7.0
+
     Generate hashed password
 
     password
@@ -171,6 +173,8 @@ def gen_password(password, crypt_salt=None, algorithm='sha512'):
 
 def del_password(name):
     '''
+    .. versionadded:: 2014.7.0
+
     Delete the password from name user
 
     CLI Example:


### PR DESCRIPTION
Hi,

This is a minor fix, I've added missing `versionadded` directives on docstrings of the shadow module.
To see the changes in the module, I compared the branches with

```
$ git diff upstream/2014.1...upstream/2014.7 salt/modules/shadow.py
```
