### PR TITLE
Use the silent option when listing npm packages

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -190,7 +190,7 @@ def list_(pkg=None, dir=None):
     '''
     _check_valid_version()
 
-    cmd = 'npm list --json'
+    cmd = 'npm list --silent --json'
 
     if dir is None:
         cmd += ' --global'


### PR DESCRIPTION
If warnings are output it can't be parsed as JSON.
