### PR TITLE
Changes to pkg related modules and pkg state

### DIFF
--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -212,11 +212,17 @@ def refresh_db():
     cmd = 'brew update'
     user = __salt__['file.get_user'](_homebrew_bin())
 
-    if __salt__['cmd.retcode'](cmd, runas=user):
-        log.error('Failed to update')
-        return False
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace', runas=user)
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
 
-    return True
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        return True
 
 
 def install(name=None, pkgs=None, taps=None, options=None, **kwargs):
@@ -334,8 +340,19 @@ def list_upgrades():
         salt '*' pkg.list_upgrades
     '''
     cmd = 'brew outdated'
-
-    return __salt__['cmd.run'](cmd, output_loglevel='trace').splitlines()
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        out = call['stdout']
+    return out.splitlines()
 
 
 def upgrade_available(pkg):
@@ -369,6 +386,11 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
+
     old = list_pkgs()
 
     if salt.utils.is_true(refresh):
@@ -376,12 +398,20 @@ def upgrade(refresh=True):
 
     cmd = 'brew upgrade'
     user = __salt__['file.get_user'](_homebrew_bin())
-    __salt__['cmd.run'](
+    call = __salt__['cmd.run_all'](
         cmd,
         runas=user if user != __opts__['user'] else __opts__['user'],
         output_loglevel='trace'
     )
 
-    __context__.pop('pkg.list_pkgs', None)
-    new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    if call['retcode'] != 0:
+        ret['result'] = False
+        if 'stderr' in call:
+            ret['comment'] += call['stderr']
+        if 'stdout' in call:
+            ret['comment'] += call['stdout']
+    else:
+        __context__.pop('pkg.list_pkgs', None)
+        new = list_pkgs()
+        ret['changes'] = salt.utils.compare_dicts(old, new)
+    return ret

--- a/salt/modules/brew.py
+++ b/salt/modules/brew.py
@@ -212,17 +212,11 @@ def refresh_db():
     cmd = 'brew update'
     user = __salt__['file.get_user'](_homebrew_bin())
 
-    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace', runas=user)
-    if call['retcode'] != 0:
-        comment = ''
-        if 'stderr' in call:
-            comment += call['stderr']
+    if __salt__['cmd.retcode'](cmd, runas=user):
+        log.error('Failed to update')
+        return False
 
-        raise CommandExecutionError(
-            '{0}'.format(comment)
-        )
-    else:
-        return True
+    return True
 
 
 def install(name=None, pkgs=None, taps=None, options=None, **kwargs):

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -251,7 +251,19 @@ def _get_upgradable():
     '''
 
     cmd = 'emerge --pretend --update --newuse --deep --ask n world'
-    out = __salt__['cmd.run_stdout'](cmd, output_loglevel='trace')
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        out = call['stdout']
 
     rexp = re.compile(r'(?m)^\[.+\] '
                       r'([^ ]+/[^ ]+)'    # Package string
@@ -653,17 +665,28 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
+
     if salt.utils.is_true(refresh):
         refresh_db()
 
     old = list_pkgs()
     cmd = 'emerge --update --newuse --deep --ask n --quiet world'
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
-    __context__.pop('pkg.list_pkgs', None)
     if call['retcode'] != 0:
-        return _process_emerge_err(call['stdout'], call['stderr'])
-    new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+        ret['result'] = False
+        if 'stderr' in call:
+            ret['comment'] += call['stderr']
+        if 'stdout' in call:
+            ret['comment'] += call['stdout']
+    else:
+        __context__.pop('pkg.list_pkgs', None)
+        new = list_pkgs()
+        ret['changes'] = salt.utils.compare_dicts(old, new)
+    return ret
 
 
 def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):

--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -10,6 +10,9 @@ import re
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import (
+    CommandExecutionError
+)
 
 log = logging.getLogger(__name__)
 
@@ -31,7 +34,20 @@ def __virtual__():
 def _list(query=''):
     ret = {}
     cmd = 'port list {0}'.format(query)
-    out = __salt__['cmd.run'](cmd, output_loglevel='trace')
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        out = call['stdout']
+
     for line in out.splitlines():
         try:
             name, version_num, category = re.split(r'\s+', line.lstrip())[0:3]
@@ -323,7 +339,15 @@ def refresh_db():
     '''
     Update ports with ``port selfupdate``
     '''
-    __salt__['cmd.run_all']('port selfupdate', output_loglevel='trace')
+    call = __salt__['cmd.run_all']('port selfupdate', output_loglevel='trace')
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
 
 
 def upgrade(refresh=True):
@@ -346,6 +370,10 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
 
     old = list_pkgs()
 

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -970,6 +970,11 @@ def upgrade(jail=None, chroot=None, force=False, local=False, dryrun=False):
 
             salt '*' pkg.upgrade dryrun=True
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
+
     opts = ''
     if force:
         opts += 'f'
@@ -982,10 +987,23 @@ def upgrade(jail=None, chroot=None, force=False, local=False, dryrun=False):
     if opts:
         opts = '-' + opts
 
-    return __salt__['cmd.run'](
+    old = list_pkgs()
+    call = __salt__['cmd.run_all'](
         '{0} upgrade {1}'.format(_pkg(jail, chroot), opts),
         output_loglevel='trace'
     )
+    if call['retcode'] != 0:
+        ret['result'] = False
+        if 'stderr' in call:
+            ret['comment'] += call['stderr']
+        if 'stdout' in call:
+            ret['comment'] += call['stdout']
+    else:
+        __context__.pop('pkg.list_pkgs', None)
+        new = list_pkgs()
+        ret['changes'] = salt.utils.compare_dicts(old, new)
+    return ret
+
 
 
 def clean(jail=None, chroot=None):

--- a/salt/modules/pkgng.py
+++ b/salt/modules/pkgng.py
@@ -1005,7 +1005,6 @@ def upgrade(jail=None, chroot=None, force=False, local=False, dryrun=False):
     return ret
 
 
-
 def clean(jail=None, chroot=None):
     '''
     Cleans the local cache of fetched remote packages

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -108,8 +108,19 @@ def _repoquery(repoquery_args, query_format=__QUERYFORMAT):
     cmd = 'repoquery --plugins --queryformat="{0}" {1}'.format(
         query_format, repoquery_args
     )
-    out = __salt__['cmd.run_stdout'](cmd, output_loglevel='trace')
-    return out.splitlines()
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        out = call['stdout']
+        return out.splitlines()
 
 
 def _get_repo_options(**kwargs):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -56,9 +56,21 @@ def list_upgrades(refresh=True):
     if salt.utils.is_true(refresh):
         refresh_db()
     ret = {}
-    out = __salt__['cmd.run_stdout'](
+    call = __salt__['cmd.run_stdout'](
         'zypper list-updates', output_loglevel='trace'
     )
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+        if 'stdout' in call:
+            comment += call['stdout']
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        out = call['stdout']
+
     for line in out.splitlines():
         if not line:
             continue
@@ -524,7 +536,18 @@ def refresh_db():
     '''
     cmd = 'zypper refresh'
     ret = {}
-    out = __salt__['cmd.run'](cmd, output_loglevel='trace')
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+    if call['retcode'] != 0:
+        comment = ''
+        if 'stderr' in call:
+            comment += call['stderr']
+
+        raise CommandExecutionError(
+            '{0}'.format(comment)
+        )
+    else:
+        out = call['stdout']
+
     for line in out.splitlines():
         if not line:
             continue
@@ -712,14 +735,27 @@ def upgrade(refresh=True):
 
         salt '*' pkg.upgrade
     '''
+    ret = {'changes': {},
+           'result': True,
+           'comment': '',
+           }
+
     if salt.utils.is_true(refresh):
         refresh_db()
     old = list_pkgs()
     cmd = 'zypper --non-interactive update --auto-agree-with-licenses'
-    __salt__['cmd.run'](cmd, output_loglevel='trace')
-    __context__.pop('pkg.list_pkgs', None)
-    new = list_pkgs()
-    return salt.utils.compare_dicts(old, new)
+    call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
+    if call['retcode'] != 0:
+        ret['result'] = False
+        if 'stderr' in call:
+            ret['comment'] += call['stderr']
+        if 'stdout' in call:
+            ret['comment'] += call['stdout']
+    else:
+        __context__.pop('pkg.list_pkgs', None)
+        new = list_pkgs()
+        ret['changes'] = salt.utils.compare_dicts(old, new)
+    return ret
 
 
 def _uninstall(action='remove', name=None, pkgs=None):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1372,7 +1372,11 @@ def uptodate(name, refresh=False):
         return ret
 
     if isinstance(refresh, bool):
-        packages = __salt__['pkg.list_upgrades'](refresh=refresh)
+        try:
+            packages = __salt__['pkg.list_upgrades'](refresh=refresh)
+        except Exception, e:
+            ret['comment'] = str(e)
+            return ret
     else:
         ret['comment'] = 'refresh must be a boolean.'
         return ret
@@ -1388,7 +1392,9 @@ def uptodate(name, refresh=False):
 
     updated = __salt__['pkg.upgrade'](refresh=refresh)
 
-    if updated:
+    if updated.get('result') is False:
+        ret.update(updated)
+    elif updated:
         ret['changes'] = updated
         ret['comment'] = 'Upgrade successful.'
         ret['result'] = True


### PR DESCRIPTION
Ensuring that failed calls to packaging tools raise an exception, eg.  if the apt-get database is locked and salt tried to update the database.  @terminalmage  can you review this, make sure I didn't miss anything obvious.
