### PR TITLE
auth_tries should be repeated

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -134,7 +134,7 @@
 #auth_timeout: 60
 
 # Number of consecutive SaltReqTimeoutError that are acceptable when trying to authenticate.
-#auth_tries: 1
+#auth_tries: 7
 
 # If authentication failes due to SaltReqTimeoutError during a ping_interval,
 # cause sub minion proccess to restart.

--- a/salt/config.py
+++ b/salt/config.py
@@ -364,7 +364,7 @@ DEFAULT_MINION_OPTS = {
     'keysize': 4096,
     'transport': 'zeromq',
     'auth_timeout': 60,
-    'auth_tries': 1,
+    'auth_tries': 7,
     'auth_safemode': False,
     'random_master': False,
     'minion_floscript': os.path.join(FLO_DIR, 'minion.flo'),


### PR DESCRIPTION
auth_tries should be repeated because its possible the master just missed the auth request.
7 tries is a good number, because most systems reboot in under 6min.
