### PR TITLE
show_timeouts, new default

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -90,6 +90,9 @@
 # Set the default outputter used by the salt command. The default is "nested"
 #output: nested
 
+# Return minions that timeout when running commands like test.ping
+#show_timeout: True
+
 # By default output is colored, to disable colored output set the color value
 # to False
 #color: True

--- a/doc/ref/cli/salt.rst
+++ b/doc/ref/cli/salt.rst
@@ -60,10 +60,10 @@ Options
     Turn on verbosity for the salt call, this will cause the salt command to
     print out extra data like the job id.
 
-.. option:: --show-timeout
+.. option:: --hide-timeout
 
-    Instead of only showing the return data from the online minions this option
-    also prints the names of the minions which could not be reached.
+    Instead of showing the return data for all minions. This option
+    prints only the online minions which could be reached.
 
 .. option:: -b BATCH, --batch-size=BATCH
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -410,7 +410,7 @@ DEFAULT_MASTER_OPTS = {
     'hgfs_branch_method': 'branches',
     'hgfs_env_whitelist': [],
     'hgfs_env_blacklist': [],
-    'show_timeout': False,
+    'show_timeout': True,
     'show_jid': False,
     'svnfs_remotes': [],
     'svnfs_mountpoint': '',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1437,10 +1437,11 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'queries')
         )
         self.add_option(
-            '--show-timeout',
-            default=False,
-            action='store_true',
-            help=('Display minions that timeout without the additional output of --verbose')
+            '--hide-timeout',
+            dest='show_timeout',
+            default=True,
+            action='store_false',
+            help=('Hide minions that timeout')
         )
         self.add_option(
             '--show-jid',

--- a/scripts/completion/zsh_completion.zsh
+++ b/scripts/completion/zsh_completion.zsh
@@ -49,7 +49,7 @@ _master_options=(
     '(--state-output --state_output)'{--state-output,--state_output}'[Override the configured state_output value for minion output. Default: full]:Outputs:(full terse mixed changes)'
     '--subset[Execute the routine on a random subset of the targeted minions]:Subset:'
     '(-v --verbose)'{-v,--verbose}'[Turn on command verbosity, display jid and active job queries]'
-    '--show-timeout[Display minions that timeout]'
+    '--hide-timeout[Hide minions that timeout]'
     '(-b --batch --batch-size)'{-b,--batch,--batch-size}'[Execute the salt job in batch mode, pass number or percentage to batch.]:Batch Size:'
     '(-a --auth --eauth --extrenal-auth)'{-a,--auth,--eauth,--external-auth}'[Specify an external authentication system to use.]:eauth:'
     '(-T --make-token)'{-T,--make-token}'[Generate and save an authentication token for re-use.]'


### PR DESCRIPTION
add a referance to the show_timeout var in the master config file.
change the default to enabled. !! this should not be merged yet untill some comments.

I feel this should be the default because I for one found this confusing when I first started using salt
test.ping... dont return fails... :(

when running highstate on a cluster of systems that need to work togeather, I must ensure all the selected minions are responding to the request.... 
