### PR TITLE
FreeBSD jail.conf and jls

### DIFF
--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -122,6 +122,21 @@ def show_config(jail):
                         continue
                     key, value = line.split('=')
                     ret[key.split('_', 2)[2]] = value.split('"')[1]
+    for jconf in ('/etc/jail.conf', '/usr/local/etc/jail.conf'):
+        if os.access(jconf, os.R_OK):
+            with salt.utils.fopen(jconf, 'r') as _fp:
+                for line in _fp:
+                    if line.split()[0:2] == [jail, '{']:
+                        break
+                for line in _fp:
+                    if line.split()[-1] == '}':
+                        break
+                    if '=' not in line:
+                        ret[line.strip().rstrip(";")] = 'true'
+                    else:
+                        key = line.split('=')[0].strip()
+                        value = line.split('=')[-1].strip().strip(";'\"")
+                        ret[key] = value
     return ret
 
 
@@ -140,7 +155,12 @@ def fstab(jail):
     config = show_config(jail)
     if 'fstab' in config:
         c_fstab = config['fstab']
+    elif 'mount.fstab' in config:
+        c_fstab = config['mount.fstab']
+    if 'fstab' in config or 'mount.fstab' in config:
+        print config['mount.fstab']
         if os.access(c_fstab, os.R_OK):
+            print '158'
             with salt.utils.fopen(c_fstab, 'r') as _fp:
                 for line in _fp:
                     line = line.strip()
@@ -196,3 +216,5 @@ def sysctl():
         key, value = line.split(':', 1)
         ret[key.strip()] = value.strip()
     return ret
+
+

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -158,9 +158,7 @@ def fstab(jail):
     elif 'mount.fstab' in config:
         c_fstab = config['mount.fstab']
     if 'fstab' in config or 'mount.fstab' in config:
-        print config['mount.fstab']
         if os.access(c_fstab, os.R_OK):
-            print '158'
             with salt.utils.fopen(c_fstab, 'r') as _fp:
                 for line in _fp:
                     line = line.strip()

--- a/salt/modules/freebsdjail.py
+++ b/salt/modules/freebsdjail.py
@@ -5,6 +5,8 @@ The jail module for FreeBSD
 
 # Import python libs
 import os
+import subprocess
+import shlex
 
 # Import salt libs
 import salt.utils
@@ -112,31 +114,48 @@ def show_config(jail):
         salt '*' jail.show_config <jail name>
     '''
     ret = {}
-    for rconf in ('/etc/rc.conf', '/etc/rc.conf.local'):
-        if os.access(rconf, os.R_OK):
-            with salt.utils.fopen(rconf, 'r') as _fp:
-                for line in _fp:
-                    if not line.strip():
-                        continue
-                    if not line.startswith('jail_{0}_'.format(jail)):
-                        continue
-                    key, value = line.split('=')
-                    ret[key.split('_', 2)[2]] = value.split('"')[1]
-    for jconf in ('/etc/jail.conf', '/usr/local/etc/jail.conf'):
-        if os.access(jconf, os.R_OK):
-            with salt.utils.fopen(jconf, 'r') as _fp:
-                for line in _fp:
-                    if line.split()[0:2] == [jail, '{']:
-                        break
-                for line in _fp:
-                    if line.split()[-1] == '}':
-                        break
-                    if '=' not in line:
-                        ret[line.strip().rstrip(";")] = 'true'
-                    else:
-                        key = line.split('=')[0].strip()
-                        value = line.split('=')[-1].strip().strip(";'\"")
-                        ret[key] = value
+    if subprocess.call(["jls", "-nq", "-j", jail]) == 0:
+        jls = subprocess.check_output(["jls", "-nq", "-j", jail])
+        jailopts = shlex.split(jls)
+        for jailopt in jailopts:
+            if '=' not in jailopt:
+                ret[jailopt.strip().rstrip(";")] = '1'
+            else:
+                key = jailopt.split('=')[0].strip()
+                value = jailopt.split('=')[-1].strip().strip("\"")
+                ret[key] = value
+    else:
+        for rconf in ('/etc/rc.conf', '/etc/rc.conf.local'):
+            if os.access(rconf, os.R_OK):
+                with salt.utils.fopen(rconf, 'r') as _fp:
+                    for line in _fp:
+                        if not line.strip():
+                            continue
+                        if not line.startswith('jail_{0}_'.format(jail)):
+                            continue
+                        key, value = line.split('=')
+                        ret[key.split('_', 2)[2]] = value.split('"')[1]
+        for jconf in ('/etc/jail.conf', '/usr/local/etc/jail.conf'):
+            if os.access(jconf, os.R_OK):
+                with salt.utils.fopen(jconf, 'r') as _fp:
+                    for line in _fp:
+                        line = line.partition('#')[0].strip()
+                        if line:
+                            if line.split()[-1] == '{':
+                                if line.split()[0] != jail and line.split()[0] != '*':
+                                    while line.split()[-1] != '}':
+                                        line = _fp.next()
+                                        line = line.partition('#')[0].strip()
+                                else:
+                                    continue
+                            if line.split()[-1] == '}':
+                                continue
+                            if '=' not in line:
+                                ret[line.strip().rstrip(";")] = '1'
+                            else:
+                                key = line.split('=')[0].strip()
+                                value = line.split('=')[-1].strip().strip(";'\"")
+                                ret[key] = value
     return ret
 
 


### PR DESCRIPTION
This updates jail.show_config. If the jail is currently running, show_config will get all properties from the jls command. If it is not, show_config will get properties from either rc.conf or jail.conf.
