### PR TITLE
Query rpm to determine arch on Fedora. Fixes #14850

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1018,6 +1018,8 @@ def os_data():
     # architecture.
     if grains.get('os_family') == 'Debian':
         osarch = __salt__['cmd.run']('dpkg --print-architecture').strip()
+    elif grains.get('os') == 'Fedora':
+        osarch = __salt__['cmd.run']('rpm --eval %{_host_cpu}').strip()
     else:
         osarch = grains['cpuarch']
     grains['osarch'] = osarch


### PR DESCRIPTION
uname for my Fedora arm vm is 

```
Linux arm-builder 3.11.10-301.fc20.armv7hl #1 SMP Thu Dec 5 15:21:22 UTC 2013 armv7l armv7l armv7l GNU/Linux
```

RPM package names are:

```
kernel-3.11.10-301.fc20.armv7hl
```

Because armv7hl != armv7l package handling in Salt is broken. This pull request is to ask rpm for the build arch instead of using uname.

This has the side effect of returning i686 instead of x86_64 for the case of '64 bit kernel + 32 bit userland'. If this is not desired I can adjust the patch to be arm specific.
