### PR TITLE
Deprecate "delim" argument in favor of "delimiter"

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -671,7 +671,7 @@ class Single(object):
 
         ssh_py_shim_args = [
             '--config', self.minion_config,
-            '--delimeter', RSTR,
+            '--delimiter', RSTR,
             '--saltdir', DEFAULT_THIN_DIR,
             '--checksum', thin_sum,
             '--hashfunc', 'sha1',

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -39,7 +39,7 @@ def parse_argv(argv):
         help="YAML configuration for salt thin",
     )
     oparser.add_option(
-        "-d", "--delimeter",
+        "-d", "--delimiter",
         help="Delimeter string (viz. magic string) to indicate beginning of salt output",
     )
     oparser.add_option(
@@ -67,7 +67,7 @@ def parse_argv(argv):
     (OPTIONS, ARGS) = oparser.parse_args(argv[argv.index('--')+1:])
 
     for option in (
-            'delimeter',
+            'delimiter',
             'saltdir',
             'checksum',
             'version',
@@ -91,7 +91,7 @@ def need_deployment():
         os.chmod(OPTIONS.saltdir, st.st_mode | stat.S_IWGRP | stat.S_IRGRP | stat.S_IXGRP)
 
     # Delimeter emitted on stdout *only* to indicate shim message to master.
-    sys.stdout.write("{0}\ndeploy\n".format(OPTIONS.delimeter))
+    sys.stdout.write("{0}\ndeploy\n".format(OPTIONS.delimiter))
     sys.exit(EX_THIN_DEPLOY)
 
 
@@ -174,9 +174,9 @@ def main(argv):
 
     # Only emit the delimiter on *both* stdout and stderr when completely successful.
     # Yes, the flush() is necessary.
-    sys.stdout.write(OPTIONS.delimeter + '\n')
+    sys.stdout.write(OPTIONS.delimiter + '\n')
     sys.stdout.flush()
-    sys.stderr.write(OPTIONS.delimeter + '\n')
+    sys.stderr.write(OPTIONS.delimiter + '\n')
     sys.stderr.flush()
     os.execv(sys.executable, salt_argv)
 

--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -61,7 +61,7 @@ _SANITIZERS = {
 }
 
 
-def get(key, default='', delim=':'):
+def get(key, default='', delimiter=':'):
     '''
     Attempt to retrieve the named value from grains, if the named value is not
     available return the passed default. The default return is an empty string.
@@ -77,7 +77,7 @@ def get(key, default='', delim=':'):
         pkg:apache
 
 
-    delim
+    delimiter
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 2014.7.0
@@ -88,7 +88,10 @@ def get(key, default='', delim=':'):
 
         salt '*' grains.get pkg:apache
     '''
-    return salt.utils.traverse_dict_and_list(__grains__, key, default, delim)
+    return salt.utils.traverse_dict_and_list(__grains__,
+                                             key,
+                                             default,
+                                             delimiter)
 
 
 def has_value(key):
@@ -439,7 +442,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default'):
     return ret
 
 
-def _dict_from_path(path, val, delim=':'):
+def _dict_from_path(path, val, delimiter=':'):
     '''
     Given a lookup string in the form of 'foo:bar:baz" return a nested
     dictionary of the appropriate depth with the final segment as a value.
@@ -448,7 +451,7 @@ def _dict_from_path(path, val, delim=':'):
     {"foo": {"bar": {"baz": "somevalue"}}
     '''
     nested_dict = _infinitedict()
-    keys = path.rsplit(delim)
+    keys = path.rsplit(delimiter)
     lastplace = reduce(operator.getitem, keys[:-1], nested_dict)
     lastplace[keys[-1]] = val
 

--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -10,6 +10,7 @@ import sys
 
 # Import salt libs
 import salt.minion
+import salt.utils
 from salt._compat import string_types
 
 __func_alias__ = {
@@ -67,24 +68,41 @@ def ipcidr(tgt):
         return False
 
 
-def pillar(tgt, delim=':'):
+def pillar(tgt, delimiter=':', delim=None):
     '''
     Return True if the minion matches the given pillar target. The
-    ``delim`` argument can be used to specify a different delimiter.
+    ``delimiter`` argument can be used to specify a different delimiter.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' match.pillar 'cheese:foo'
-        salt '*' match.pillar 'clone_url|https://github.com/saltstack/salt.git' delim='|'
+        salt '*' match.pillar 'clone_url|https://github.com/saltstack/salt.git' delimiter='|'
 
-    .. versionchanged:: 0.16.4
-        ``delim`` argument added
+    delimiter
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 2014.7.0
+
+    delim
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 0.16.4
+        .. deprecated:: 2014.7.0
     '''
+    if delim is not None:
+        salt.utils.warn_until(
+            'Beryllium',
+            'The \'delim\' argument to match.pillar has been deprecated and '
+            'will be removed in a future release. Please use \'delimiter\' '
+            'instead.'
+        )
+        delimiter = delim
+
     matcher = salt.minion.Matcher({'pillar': __pillar__}, __salt__)
     try:
-        return matcher.pillar_match(tgt, delim=delim)
+        return matcher.pillar_match(tgt, delim=delimiter)
     except Exception as exc:
         log.exception(exc)
         return False
@@ -108,32 +126,49 @@ def data(tgt):
         return False
 
 
-def grain_pcre(tgt, delim=':'):
+def grain_pcre(tgt, delimiter=':', delim=None):
     '''
     Return True if the minion matches the given grain_pcre target. The
-    ``delim`` argument can be used to specify a different delimiter.
+    ``delimiter`` argument can be used to specify a different delimiter.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' match.grain_pcre 'os:Fedo.*'
-        salt '*' match.grain_pcre 'ipv6|2001:.*' delim='|'
+        salt '*' match.grain_pcre 'ipv6|2001:.*' delimiter='|'
 
-    .. versionchanged:: 0.16.4
-        ``delim`` argument added
+    delimiter
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 2014.7.0
+
+    delim
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 0.16.4
+        .. deprecated:: 2014.7.0
     '''
+    if delim is not None:
+        salt.utils.warn_until(
+            'Beryllium',
+            'The \'delim\' argument to match.grain_pcre has been deprecated '
+            'and will be removed in a future release. Please use '
+            '\'delimiter\' instead.'
+        )
+        delimiter = delim
+
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
-        return matcher.grain_pcre_match(tgt, delim=delim)
+        return matcher.grain_pcre_match(tgt, delim=delimiter)
     except Exception as exc:
         log.exception(exc)
         return False
 
 
-def grain(tgt, delim=':'):
+def grain(tgt, delimiter=':', delim=None):
     '''
-    Return True if the minion matches the given grain target. The ``delim``
+    Return True if the minion matches the given grain target. The ``delimiter``
     argument can be used to specify a different delimiter.
 
     CLI Example:
@@ -141,14 +176,31 @@ def grain(tgt, delim=':'):
     .. code-block:: bash
 
         salt '*' match.grain 'os:Ubuntu'
-        salt '*' match.grain_pcre 'ipv6|2001:db8::ff00:42:8329' delim='|'
+        salt '*' match.grain 'ipv6|2001:db8::ff00:42:8329' delimiter='|'
 
-    .. versionchanged:: 0.16.4
-        ``delim`` argument added
+    delimiter
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 2014.7.0
+
+    delim
+        Specify an alternate delimiter to use when traversing a nested dict
+
+        .. versionadded:: 0.16.4
+        .. deprecated:: 2014.7.0
     '''
+    if delim is not None:
+        salt.utils.warn_until(
+            'Beryllium',
+            'The \'delim\' argument to match.grain has been deprecated and '
+            'will be removed in a future release. Please use \'delimiter\' '
+            'instead.'
+        )
+        delimiter = delim
+
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:
-        return matcher.grain_match(tgt, delim=delim)
+        return matcher.grain_match(tgt, delim=delimiter)
     except Exception as exc:
         log.exception(exc)
         return False

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -17,7 +17,7 @@ from salt._compat import string_types
 __proxyenabled__ = ['*']
 
 
-def get(key, default='', merge=False, delim=':'):
+def get(key, default='', merge=False, delimiter=':'):
     '''
     .. versionadded:: 0.14
 
@@ -43,7 +43,7 @@ def get(key, default='', merge=False, delim=':'):
 
         .. versionadded:: 2014.7.0
 
-    delim
+    delimiter
         Specify an alternate delimiter to use when traversing a nested dict
 
         .. versionadded:: 2014.7.0
@@ -55,12 +55,15 @@ def get(key, default='', merge=False, delim=':'):
         salt '*' pillar.get pkg:apache
     '''
     if merge:
-        ret = salt.utils.traverse_dict_and_list(__pillar__, key, {}, delim)
+        ret = salt.utils.traverse_dict_and_list(__pillar__, key, {}, delimiter)
         if isinstance(ret, collections.Mapping) and \
                 isinstance(default, collections.Mapping):
             return salt.utils.dictupdate.update(default, ret)
 
-    return salt.utils.traverse_dict_and_list(__pillar__, key, default, delim)
+    return salt.utils.traverse_dict_and_list(__pillar__,
+                                             key,
+                                             default,
+                                             delimiter)
 
 
 def items(*args):


### PR DESCRIPTION
This makes the argument more user-friendly and intuitive.

This pull request also makes the following changes to code exclusive to
the 2014.7 branch:
- The `delim` argument in both `pillar.get` and `grains.get` has
  been renamed to `delimiter`.
- Misspelled salt-ssh CLI argument `--delimeter` has been corrected to
  `--delimiter`.
