### PR TITLE
Only log/display exceptions in debug mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Vagrantfile
 
 # Allow a user to set their own _version.py for testing
 _version.py
+
+# Ignore files that may be created during testing
+tests/integration/files/conf/grains

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -544,7 +544,7 @@ class Cloud(object):
                         'running nodes: {1}'.format(fun, err),
                         # Show the traceback if the debug logging level is
                         # enabled
-                        exc_info=log.isEnabledFor(logging.DEBUG)
+                        exc_info=self.opts.get('log_level', False) == 'debug'
                     )
                     # Failed to communicate with the provider, don't list any
                     # nodes
@@ -741,7 +741,7 @@ class Cloud(object):
                         fun, err
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info=self.opts.get('log_level', False) == 'debug'
                 )
         return data
 
@@ -784,7 +784,7 @@ class Cloud(object):
                         fun, err
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info=self.opts.get('log_level', False) == 'debug'
                 )
         return data
 
@@ -827,7 +827,7 @@ class Cloud(object):
                         fun, err
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info=self.opts.get('log_level', False) == 'debug'
                 )
         return data
 
@@ -1576,7 +1576,7 @@ class Map(Cloud):
                 'Rendering map {0} failed, render error:\n{1}'.format(
                     self.opts['map'], exc
                 ),
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=self.opts.get('log_level', False) == 'debug'
             )
             return {}
 
@@ -2017,7 +2017,7 @@ class Map(Cloud):
                         name, exc
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info=self.opts.get('log_level', False) == 'debug'
                 )
                 output[name] = {'Error': str(exc)}
 
@@ -2172,7 +2172,7 @@ def run_parallel_map_providers_query(data, queue=None):
             'nodes: {1}'.format(data['fun'], err),
             # Show the traceback if the debug logging level is
             # enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=self.opts.get('log_level', False) == 'debug'
         )
         # Failed to communicate with the provider, don't list any nodes
         return (data['alias'], data['driver'], ())

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -40,7 +40,6 @@ class SaltCloud(parsers.SaltCloudParser):
         '''
         # Parse shell arguments
         self.parse_args()
-
         salt_master_user = self.config.get('user', salt.utils.get_user())
         if salt_master_user is not None and not check_user(salt_master_user):
             self.error(
@@ -348,6 +347,6 @@ class SaltCloud(parsers.SaltCloudParser):
             msg.format(exc),
             # Show the traceback if the debug logging level is
             # enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=self.options('log_level', False) == 'debug'
         )
         self.exit(salt.exitcodes.EX_GENERIC)

--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -589,7 +589,7 @@ def create(vm_):
                 exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -250,7 +250,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -322,7 +322,7 @@ def create(vm_):
                 exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1443,7 +1443,7 @@ def request_instance(vm_=None, call=None):
                 'Error getting root device name for image id {0} for '
                 'VM {1}: \n{2}'.format(image_id, vm_['name'], exc),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=__opts__.get('log_level', False) == 'debug'
             )
             raise
 
@@ -1518,7 +1518,7 @@ def request_instance(vm_=None, call=None):
                 vm_['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         raise
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -629,7 +629,7 @@ def delete_network(kwargs=None, call=None):
             'Nework {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -784,7 +784,7 @@ def delete_fwrule(kwargs=None, call=None):
             'Rule {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -941,7 +941,7 @@ def delete_hc(kwargs=None, call=None):
             'Health check {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -1101,7 +1101,7 @@ def delete_lb(kwargs=None, call=None):
             'Load balancer {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -1301,7 +1301,7 @@ def delete_snapshot(kwargs=None, call=None):
             'Snapshot {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -1361,7 +1361,7 @@ def delete_disk(kwargs=None, call=None):
             'Disk {0} is in use and must be detached before deleting.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 disk.name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -1495,7 +1495,7 @@ def create_snapshot(kwargs=None, call=None):
             'Disk {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 disk_name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -1751,7 +1751,7 @@ def destroy(vm_name, call=None):
             'run the initial deployment: \n{1}'.format(
                 vm_name, exc
             ),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         raise SaltCloudSystemExit(
             'Could not find instance {0}.'.format(vm_name)
@@ -1789,7 +1789,7 @@ def destroy(vm_name, call=None):
             'run the initial deployment: \n{1}'.format(
                 vm_name, exc
             ),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         raise SaltCloudSystemExit(
             'Could not destroy instance {0}.'.format(vm_name)
@@ -1826,7 +1826,7 @@ def destroy(vm_name, call=None):
                 'to run the initial deployment: \n{1}'.format(
                     vm_name, exc
                 ),
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=__opts__.get('log_level', False) == 'debug'
             )
         salt.utils.cloud.fire_event(
             'event',
@@ -1894,7 +1894,7 @@ def create(vm_=None, call=None):
             'run the initial deployment: \n{1}'.format(
                 vm_['name'], exc
             ),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -145,7 +145,7 @@ def create(vm_):
                 vm_['name']
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -217,7 +217,7 @@ def create(vm_):
                 vm_['name'], str(exc)
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -577,7 +577,7 @@ def take_action(name=None, call=None, command=None, data=None, method='GET',
             log.error(
                 'Failed to invoke {0} node {1}: {2}'.format(caller, name, exc),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=__opts__.get('log_level', False) == 'debug'
             )
             ret = [100, {}]
 

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -369,7 +369,7 @@ def create(vm_):
                 vm_['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -744,7 +744,7 @@ def rename(name, kwargs, call=None):
                 name, kwargs['newname'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
     return kwargs['newname']
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -200,7 +200,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -497,7 +497,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -590,7 +590,7 @@ def create(vm_):
                     err
                 ),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=__opts__.get('log_level', False) == 'debug'
             )
             # Trigger a failure in the wait for IP function
             return False

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -338,7 +338,7 @@ def create(vm_):
                 exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -644,7 +644,7 @@ def create(vm_):
                     err
                 ),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=__opts__.get('log_level', False) == 'debug'
             )
             # Trigger a failure in the wait for IP function
             return False

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -289,7 +289,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -508,7 +508,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -240,7 +240,7 @@ def create(vm_):
                 vm_['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 
@@ -261,7 +261,7 @@ def create(vm_):
                     err
                 ),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info=__opts__.get('log_level', False) == 'debug'
             )
             # Trigger a failure in the wait for IP function
             return False

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -311,7 +311,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -492,7 +492,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -229,7 +229,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info=__opts__.get('log_level', False) == 'debug'
         )
         return False
 


### PR DESCRIPTION
This commit stems from the complaints that salt-cloud is too liberal
when displaying stacktraces.

I think this this may stem from a mis-use of the logger.isEnabledFor() method.

The old behaviour was to log/display an exception if the logger
_supports_ debug mode, with no regard to what logging mode the user
actually requested.

This swaps that behaviour out for a check against opts to see which log
level the user has requested.

It's completely possible, of course, that this _was_ the intended behaviour, in which case this PR should be shot into the flaming sun.

cc: @techhat
