### PR TITLE
Fix example code block in grains.filter_by

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -362,8 +362,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default'):
         {% set apache = salt['grains.filter_by']({
             'Debian': {'pkg': 'apache2', 'srv': 'apache2'},
             'RedHat': {'pkg': 'httpd', 'srv': 'httpd'},
-            'default': 'Debian',
-        }) %}
+        }), default='Debian' %}
 
         myapache:
           pkg:


### PR DESCRIPTION
The example code is incorrect. Default is a function parameter, not an attribute of the lookup_dict.
