### PR TITLE
[2014.7] Allow the inclusion of `exc_info` on a per handler basis.

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -544,7 +544,7 @@ class Cloud(object):
                         'running nodes: {1}'.format(fun, err),
                         # Show the traceback if the debug logging level is
                         # enabled
-                        exc_info=log.isEnabledFor(logging.DEBUG)
+                        exc_info_on_loglevel=logging.DEBUG
                     )
                     # Failed to communicate with the provider, don't list any
                     # nodes
@@ -741,7 +741,7 @@ class Cloud(object):
                         fun, err
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
         return data
 
@@ -784,7 +784,7 @@ class Cloud(object):
                         fun, err
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
         return data
 
@@ -827,7 +827,7 @@ class Cloud(object):
                         fun, err
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
         return data
 
@@ -1576,7 +1576,7 @@ class Map(Cloud):
                 'Rendering map {0} failed, render error:\n{1}'.format(
                     self.opts['map'], exc
                 ),
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             return {}
 
@@ -2017,7 +2017,7 @@ class Map(Cloud):
                         name, exc
                     ),
                     # Show the traceback if the debug logging level is enabled
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
                 output[name] = {'Error': str(exc)}
 
@@ -2092,7 +2092,7 @@ def create_multiprocessing(parallel_data, queue=None):
                 parallel_data, exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return {parallel_data['name']: {'Error': str(exc)}}
 
@@ -2129,7 +2129,7 @@ def destroy_multiprocessing(parallel_data, queue=None):
                 parallel_data['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return {parallel_data['name']: {'Error': str(exc)}}
 
@@ -2172,7 +2172,7 @@ def run_parallel_map_providers_query(data, queue=None):
             'nodes: {1}'.format(data['fun'], err),
             # Show the traceback if the debug logging level is
             # enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         # Failed to communicate with the provider, don't list any nodes
         return (data['alias'], data['driver'], ())

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -348,6 +348,6 @@ class SaltCloud(parsers.SaltCloudParser):
             msg.format(exc),
             # Show the traceback if the debug logging level is
             # enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         self.exit(salt.exitcodes.EX_GENERIC)

--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -589,7 +589,7 @@ def create(vm_):
                 exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -250,7 +250,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -322,7 +322,7 @@ def create(vm_):
                 exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1443,7 +1443,7 @@ def request_instance(vm_=None, call=None):
                 'Error getting root device name for image id {0} for '
                 'VM {1}: \n{2}'.format(image_id, vm_['name'], exc),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             raise
 
@@ -1518,7 +1518,7 @@ def request_instance(vm_=None, call=None):
                 vm_['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         raise
 

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -629,7 +629,7 @@ def delete_network(kwargs=None, call=None):
             'Nework {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -784,7 +784,7 @@ def delete_fwrule(kwargs=None, call=None):
             'Rule {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -941,7 +941,7 @@ def delete_hc(kwargs=None, call=None):
             'Health check {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -1101,7 +1101,7 @@ def delete_lb(kwargs=None, call=None):
             'Load balancer {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -1301,7 +1301,7 @@ def delete_snapshot(kwargs=None, call=None):
             'Snapshot {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -1361,7 +1361,7 @@ def delete_disk(kwargs=None, call=None):
             'Disk {0} is in use and must be detached before deleting.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 disk.name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -1495,7 +1495,7 @@ def create_snapshot(kwargs=None, call=None):
             'Disk {0} could not be found.\n'
             'The following exception was thrown by libcloud:\n{1}'.format(
                 disk_name, exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -1751,7 +1751,7 @@ def destroy(vm_name, call=None):
             'run the initial deployment: \n{1}'.format(
                 vm_name, exc
             ),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         raise SaltCloudSystemExit(
             'Could not find instance {0}.'.format(vm_name)
@@ -1789,7 +1789,7 @@ def destroy(vm_name, call=None):
             'run the initial deployment: \n{1}'.format(
                 vm_name, exc
             ),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         raise SaltCloudSystemExit(
             'Could not destroy instance {0}.'.format(vm_name)
@@ -1826,7 +1826,7 @@ def destroy(vm_name, call=None):
                 'to run the initial deployment: \n{1}'.format(
                     vm_name, exc
                 ),
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
         salt.utils.cloud.fire_event(
             'event',
@@ -1894,7 +1894,7 @@ def create(vm_=None, call=None):
             'run the initial deployment: \n{1}'.format(
                 vm_['name'], exc
             ),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -145,7 +145,7 @@ def create(vm_):
                 vm_['name']
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -217,7 +217,7 @@ def create(vm_):
                 vm_['name'], str(exc)
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -577,7 +577,7 @@ def take_action(name=None, call=None, command=None, data=None, method='GET',
             log.error(
                 'Failed to invoke {0} node {1}: {2}'.format(caller, name, exc),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             ret = [100, {}]
 

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -369,7 +369,7 @@ def create(vm_):
                 vm_['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -744,7 +744,7 @@ def rename(name, kwargs, call=None):
                 name, kwargs['newname'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
     return kwargs['newname']
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -200,7 +200,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -497,7 +497,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -590,7 +590,7 @@ def create(vm_):
                     err
                 ),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             # Trigger a failure in the wait for IP function
             return False

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -338,7 +338,7 @@ def create(vm_):
                 exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -644,7 +644,7 @@ def create(vm_):
                     err
                 ),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             # Trigger a failure in the wait for IP function
             return False

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -289,7 +289,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -508,7 +508,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -240,7 +240,7 @@ def create(vm_):
                 vm_['name'], exc
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 
@@ -261,7 +261,7 @@ def create(vm_):
                     err
                 ),
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             # Trigger a failure in the wait for IP function
             return False

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -311,7 +311,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -492,7 +492,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -229,7 +229,7 @@ def create(vm_):
                 vm_['name'], exc.message
             ),
             # Show the traceback if the debug logging level is enabled
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
         return False
 

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -1071,7 +1071,7 @@ class NixExecutor(ioflo.base.deeding.Deed):
                         function_name,
                         exc
                     ),
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
                 ret['return'] = 'ERROR: {0}'.format(exc)
             except SaltInvocationError as exc:
@@ -1080,7 +1080,7 @@ class NixExecutor(ioflo.base.deeding.Deed):
                         function_name,
                         exc
                     ),
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
                 ret['return'] = 'ERROR executing {0!r}: {1}'.format(
                     function_name, exc
@@ -1094,11 +1094,11 @@ class NixExecutor(ioflo.base.deeding.Deed):
                        'arguments issue:  {2}').format(function_name,
                                                        exc,
                                                        aspec)
-                log.warning(msg, exc_info=log.isEnabledFor(logging.DEBUG))
+                log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
                 ret['return'] = msg
             except Exception:
                 msg = 'The minion function caused an exception'
-                log.warning(msg, exc_info=log.isEnabledFor(logging.DEBUG))
+                log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
         else:
             ret['return'] = '{0!r} is not available.'.format(function_name)

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -217,7 +217,7 @@ def fileserver_update(fileserver):
     except Exception as exc:
         log.error(
             'Exception {0} occurred in file server update'.format(exc),
-            exc_info=log.isEnabledFor(logging.DEBUG)
+            exc_info_on_loglevel=logging.DEBUG
         )
 
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -829,7 +829,7 @@ def update():
             log.error(
                 'Exception {0} caught while fetching gitfs remote {1}'
                 .format(exc, repo['uri']),
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
         try:
             os.remove(lk_fn)

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -324,7 +324,7 @@ def update():
             log.error(
                 'Exception {0} caught while updating hgfs remote {1}'
                 .format(exc, repo['uri']),
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
         else:
             newtip = repo['repo'].tip()

--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -87,26 +87,26 @@ class TemporaryLoggingHandler(logging.NullHandler):
                 handler.handle(record)
 
 
-class StreamHandler(ExcInfoOnLogLevelFormatMixIn, logging.StreamHandler):
+class StreamHandler(ExcInfoOnLogLevelFormatMixIn, logging.StreamHandler, NewStyleClassMixIn):
     '''
     Stream handler which properly handles exc_info on a per handler basis
     '''
 
 
-class FileHandler(ExcInfoOnLogLevelFormatMixIn, logging.FileHandler):
+class FileHandler(ExcInfoOnLogLevelFormatMixIn, logging.FileHandler, NewStyleClassMixIn):
     '''
     File handler which properly handles exc_info on a per handler basis
     '''
 
 
-class SysLogHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.SysLogHandler):
+class SysLogHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.SysLogHandler, NewStyleClassMixIn):
     '''
     Syslog handler which properly handles exc_info on a per handler basis
     '''
 
 
 if sys.version_info > (2, 6):
-    class WatchedFileHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.WatchedFileHandler):
+    class WatchedFileHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.WatchedFileHandler, NewStyleClassMixIn):
         '''
         Watched file handler which properly handles exc_info on a per handler basis
         '''

--- a/salt/log/handlers/__init__.py
+++ b/salt/log/handlers/__init__.py
@@ -13,10 +13,11 @@ import sys
 import atexit
 import logging
 import threading
+import logging.handlers
 
 # Import salt libs
 from salt._compat import Queue
-from salt.log.mixins import NewStyleClassMixIn
+from salt.log.mixins import NewStyleClassMixIn, ExcInfoOnLogLevelFormatMixIn
 
 log = logging.getLogger(__name__)
 
@@ -84,3 +85,28 @@ class TemporaryLoggingHandler(logging.NullHandler):
                     # it should not handle the log record
                     continue
                 handler.handle(record)
+
+
+class StreamHandler(ExcInfoOnLogLevelFormatMixIn, logging.StreamHandler):
+    '''
+    Stream handler which properly handles exc_info on a per handler basis
+    '''
+
+
+class FileHandler(ExcInfoOnLogLevelFormatMixIn, logging.FileHandler):
+    '''
+    File handler which properly handles exc_info on a per handler basis
+    '''
+
+
+class SysLogHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.SysLogHandler):
+    '''
+    Syslog handler which properly handles exc_info on a per handler basis
+    '''
+
+
+if sys.version_info > (2, 6):
+    class WatchedFileHandler(ExcInfoOnLogLevelFormatMixIn, logging.handlers.WatchedFileHandler):
+        '''
+        Watched file handler which properly handles exc_info on a per handler basis
+        '''

--- a/salt/log/mixins.py
+++ b/salt/log/mixins.py
@@ -98,6 +98,8 @@ class ExcInfoOnLogLevelFormatMixIn(object):
 
         if record.exc_info_on_loglevel_formatted is None:
             # Let's cache the formatted exception to avoid recurring conversions and formatting calls
+            if self.formatter is None:
+                self.formatter = logging._defaultFormatter
             record.exc_info_on_loglevel_formatted = self.formatter.formatException(
                 record.exc_info_on_loglevel_instance
             )

--- a/salt/log/mixins.py
+++ b/salt/log/mixins.py
@@ -12,6 +12,7 @@
 '''
 
 # Import python libs
+import sys
 import logging
 
 
@@ -67,3 +68,56 @@ class NewStyleClassMixIn(object):
 
         'Cannot create a consistent method resolution order (MRO) for bases'
     '''
+
+
+class ExcInfoOnLogLevelFormatMixIn(object):
+    '''
+    Logging handler class mixin to properly handle including exc_info on a pre logging handler basis
+    '''
+
+    def format(self, record):
+        '''
+        Format the log record to include exc_info if the handler is enabled for a specific log level
+        '''
+        formatted_record = super(ExcInfoOnLogLevelFormatMixIn, self).format(record)
+        exc_info_on_loglevel = getattr(record, 'exc_info_on_loglevel', None)
+        if exc_info_on_loglevel is None:
+            return formatted_record
+
+        # If we reached this far it means the log record was created with exc_info_on_loglevel
+        # If this specific handler is enabled for that record, then we should format it to
+        # include the exc_info details
+        if self.level > exc_info_on_loglevel:
+            # This handler is not enabled for the desired exc_info_on_loglevel, don't include exc_info
+            return formatted_record
+
+        # If we reached this far it means we should include exc_info
+        if not record.exc_info_on_loglevel_instance:
+            # This should actually never occur
+            return formatted_record
+
+        if record.exc_info_on_loglevel_formatted is None:
+            # Let's cache the formatted exception to avoid recurring conversions and formatting calls
+            record.exc_info_on_loglevel_formatted = self.formatter.formatException(
+                record.exc_info_on_loglevel_instance
+            )
+
+        # Let's format the record to include exc_info just like python's logging formatted does
+        if formatted_record[-1:] != '\n':
+            formatted_record += '\n'
+
+        try:
+            formatted_record += record.exc_info_on_loglevel_formatted
+        except UnicodeError:
+            # According to the standard library logging formatter comments:
+            #
+            #     Sometimes filenames have non-ASCII chars, which can lead
+            #     to errors when s is Unicode and record.exc_text is str
+            #     See issue 8924.
+            #     We also use replace for when there are multiple
+            #     encodings, e.g. UTF-8 for the filesystem and latin-1
+            #     for a script. See issue 13232.
+            formatted_record += record.record.exc_info_on_loglevel_formatted.decode(sys.getfilesystemencoding(),
+                                                                                    'replace')
+
+        return formatted_record

--- a/salt/log/mixins.py
+++ b/salt/log/mixins.py
@@ -98,7 +98,7 @@ class ExcInfoOnLogLevelFormatMixIn(object):
 
         if record.exc_info_on_loglevel_formatted is None:
             # Let's cache the formatted exception to avoid recurring conversions and formatting calls
-            if self.formatter is None:
+            if self.formatter is None:  # pylint: disable=access-member-before-definition
                 self.formatter = logging._defaultFormatter
             record.exc_info_on_loglevel_formatted = self.formatter.formatException(
                 record.exc_info_on_loglevel_instance

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -31,7 +31,7 @@ GARBAGE = logging.GARBAGE = 1
 QUIET = logging.QUIET = 1000
 
 # Import salt libs
-from salt.log.handlers import TemporaryLoggingHandler
+from salt.log.handlers import TemporaryLoggingHandler, StreamHandler, SysLogHandler, WatchedFileHandler
 from salt.log.mixins import LoggingMixInMeta, NewStyleClassMixIn
 from salt._compat import string_types
 
@@ -87,7 +87,7 @@ def is_extended_logging_configured():
 LOGGING_NULL_HANDLER = TemporaryLoggingHandler(logging.WARNING)
 
 # Store a reference to the temporary console logger
-LOGGING_TEMP_HANDLER = logging.StreamHandler(sys.stderr)
+LOGGING_TEMP_HANDLER = StreamHandler(sys.stderr)
 
 # Store a reference to the "storing" logging handler
 LOGGING_STORE_HANDLER = TemporaryLoggingHandler()
@@ -161,26 +161,66 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS, NewStyleClassMixIn):
             pass
         return instance
 
+    def _log(self, level, msg, args, exc_info=None, extra=None, exc_info_on_loglevel=None):
+        # If both exc_info and exc_info_on_loglevel are both passed, let's fail.
+        if exc_info and exc_info_on_loglevel:
+            raise RuntimeError(
+                'Please only use one of \'exc_info\' and \'exc_info_on_loglevel\', not both'
+            )
+        if exc_info_on_loglevel is not None:
+            if isinstance(exc_info_on_loglevel, string_types):
+                exc_info_on_loglevel = LOG_LEVELS.get(exc_info_on_loglevel, logging.ERROR)
+            elif not isinstance(exc_info_on_loglevel, int):
+                raise RuntimeError(
+                    'The value of \'exc_info_on_loglevel\' needs to be a logging level or '
+                    'a logging level name, not {0!r}'.format(exc_info_on_loglevel)
+                )
+        if extra is None:
+            extra = {'exc_info_on_loglevel': exc_info_on_loglevel}
+        else:
+            extra['exc_info_on_loglevel'] = exc_info_on_loglevel
+
+        LOGGING_LOGGER_CLASS._log(
+            self, level, msg, args, exc_info=exc_info, extra=extra
+        )
+
     # pylint: disable=C0103
-    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None,
-                   extra=None):
+    def makeRecord(self, name, level, fn, lno, msg, args, exc_info, func=None, extra=None):
+        # Let's remove exc_info_on_loglevel from extra
+        exc_info_on_loglevel = extra.pop('exc_info_on_loglevel')
+        if not extra:
+            # If nothing else is in extra, make it None
+            extra = None
+
         # Let's try to make every logging message unicode
         if isinstance(msg, string_types) and not isinstance(msg, unicode):
             try:
-                return LOGGING_LOGGER_CLASS.makeRecord(
+                logrecord = LOGGING_LOGGER_CLASS.makeRecord(
                     self, name, level, fn, lno,
                     msg.decode('utf-8', 'replace'),
                     args, exc_info, func, extra
                 )
             except UnicodeDecodeError:
-                return LOGGING_LOGGER_CLASS.makeRecord(
+                logrecord = LOGGING_LOGGER_CLASS.makeRecord(
                     self, name, level, fn, lno,
                     msg.decode('utf-8', 'ignore'),
                     args, exc_info, func, extra
                 )
-        return LOGGING_LOGGER_CLASS.makeRecord(
-            self, name, level, fn, lno, msg, args, exc_info, func, extra
-        )
+        else:
+            logrecord = LOGGING_LOGGER_CLASS.makeRecord(
+                self, name, level, fn, lno, msg, args, exc_info, func, extra
+            )
+
+        if exc_info_on_loglevel is not None:
+            # Let's add some custom attributes to the LogRecord class in order to include the exc_info on a per
+            # handler basis. This will allow showing tracebacks on logfiles but not on console if the logfile
+            # handler is enabled for the log level "exc_info_on_loglevel" and console handler is not.
+            logrecord.exc_info_on_loglevel_instance = sys.exc_info()
+            logrecord.exc_info_on_loglevel_formatted = None
+
+        logrecord.exc_info_on_loglevel = exc_info_on_loglevel
+        return logrecord
+
     # pylint: enable=C0103
 
 
@@ -301,7 +341,7 @@ def setup_console_logger(log_level='error', log_format=None, date_format=None):
             # There's already a logging handler outputting to sys.stderr
             break
     else:
-        handler = logging.StreamHandler(sys.stderr)
+        handler = StreamHandler(sys.stderr)
     handler.setLevel(level)
 
     # Set the default console formatter config
@@ -371,7 +411,7 @@ def setup_logfile_logger(log_path, log_level='error', log_format=None,
 
     if parsed_log_path.scheme in ('tcp', 'udp', 'file'):
         syslog_opts = {
-            'facility': logging.handlers.SysLogHandler.LOG_USER,
+            'facility': SysLogHandler.LOG_USER,
             'socktype': socket.SOCK_DGRAM
         }
 
@@ -403,7 +443,7 @@ def setup_logfile_logger(log_path, log_level='error', log_format=None,
             facility_name = 'LOG_USER'      # Syslog default
 
         facility = getattr(
-            logging.handlers.SysLogHandler, facility_name, None
+            SysLogHandler, facility_name, None
         )
         if facility is None:
             # This python syslog version does not know about the user provided
@@ -436,7 +476,7 @@ def setup_logfile_logger(log_path, log_level='error', log_format=None,
 
         try:
             # Et voilá! Finally our syslog handler instance
-            handler = logging.handlers.SysLogHandler(**syslog_opts)
+            handler = SysLogHandler(**syslog_opts)
         except socket.error as err:
             logging.getLogger(__name__).error(
                 'Failed to setup the Syslog logging handler: {0}'.format(
@@ -450,9 +490,7 @@ def setup_logfile_logger(log_path, log_level='error', log_format=None,
             # Since salt uses YAML and YAML uses either UTF-8 or UTF-16, if a
             # user is not using plain ASCII, their system should be ready to
             # handle UTF-8.
-            handler = getattr(
-                logging.handlers, 'WatchedFileHandler', logging.FileHandler
-            )(log_path, mode='a', encoding='utf-8', delay=0)
+            handler = WatchedFileHandler(log_path, mode='a', encoding='utf-8', delay=0)
         except (IOError, OSError):
             logging.getLogger(__name__).warning(
                 'Failed to open log file, do you have permission to write to '

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -161,7 +161,8 @@ class SaltLoggingClass(LOGGING_LOGGER_CLASS, NewStyleClassMixIn):
             pass
         return instance
 
-    def _log(self, level, msg, args, exc_info=None, extra=None, exc_info_on_loglevel=None):
+    def _log(self, level, msg, args, exc_info=None, extra=None,  # pylint: disable=arguments-differ
+             exc_info_on_loglevel=None):
         # If both exc_info and exc_info_on_loglevel are both passed, let's fail.
         if exc_info and exc_info_on_loglevel:
             raise RuntimeError(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1022,7 +1022,7 @@ class Minion(MinionBase):
                         function_name,
                         exc
                     ),
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
                 ret['return'] = 'ERROR: {0}'.format(exc)
                 ret['out'] = 'nested'
@@ -1032,7 +1032,7 @@ class Minion(MinionBase):
                         function_name,
                         exc
                     ),
-                    exc_info=log.isEnabledFor(logging.DEBUG)
+                    exc_info_on_loglevel=logging.DEBUG
                 )
                 ret['return'] = 'ERROR executing {0!r}: {1}'.format(
                     function_name, exc
@@ -1048,12 +1048,12 @@ class Minion(MinionBase):
                        'arguments issue:  {2}').format(function_name,
                                                        exc,
                                                        aspec)
-                log.warning(msg, exc_info=log.isEnabledFor(logging.DEBUG))
+                log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
                 ret['return'] = msg
                 ret['out'] = 'nested'
             except Exception:
                 msg = 'The minion function caused an exception'
-                log.warning(msg, exc_info=log.isEnabledFor(logging.DEBUG))
+                log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'
         else:

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -432,7 +432,7 @@ def _run(cmd,
                 except vt.TerminalException as exc:
                     log.error(
                         'VT: {0}'.format(exc),
-                        exc_info=log.isEnabledFor(logging.DEBUG))
+                        exc_info_on_loglevel=logging.DEBUG)
                     ret = {'retcode': 1, 'pid': '2'}
                     break
                 # only set stdout on sucess as we already mangled in other

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1247,7 +1247,7 @@ def tty(device, echo=None):
         return {'Error': 'The specified device is not a valid TTY'}
 
     ret = subprocess.call(['echo', echo, '>', teletype], shell=False, stdout=open(os.devnull, 'wb'))
-    if ret == 0: 
+    if ret == 0:
         return {
             'Success': 'Message was successfully echoed to {0}'.format(teletype)
         }

--- a/salt/state.py
+++ b/salt/state.py
@@ -2364,7 +2364,7 @@ class BaseHighState(object):
             log.critical(
                 msg,
                 # Show the traceback if the debug logging level is enabled
-                exc_info=log.isEnabledFor(logging.DEBUG)
+                exc_info_on_loglevel=logging.DEBUG
             )
             errors.append('{0}\n{1}'.format(msg, traceback.format_exc()))
         mods.add('{0}:{1}'.format(saltenv, sls))

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -78,7 +78,7 @@ def wrap_tmpl_func(render_str):
                         'Exception occurred while reading file '
                         '{0}: {1}'.format(tmplsrc, exc),
                         # Show full traceback if debug logging is enabled
-                        exc_info=log.isEnabledFor(logging.DEBUG)
+                        exc_info_on_loglevel=logging.DEBUG
                     )
                     raise exc
         else:  # assume tmplsrc is file-like.

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -210,7 +210,7 @@ class Terminal(object):
             # exception type
             log.warning(
                 'Failed to spawn the VT: {0}'.format(err),
-                 exc_info=log.isEnabledFor(logging.DEBUG)
+                 exc_info_on_loglevel=logging.DEBUG
             )
             raise TerminalException(
                 'Failed to spawn the VT. Error: {0}'.format(err)
@@ -431,7 +431,7 @@ class Terminal(object):
                             'Failed to set the VT terminal size: {0}'.format(
                                 err
                             ),
-                            exc_info=log.isEnabledFor(logging.DEBUG)
+                            exc_info_on_loglevel=logging.DEBUG
                         )
 
                 # Do not allow child to inherit open file descriptors from

--- a/tests/unit/log_test.py
+++ b/tests/unit/log_test.py
@@ -74,7 +74,7 @@ class TestLog(TestCase):
 
     def test_exc_info_on_loglevel(self):
         def raise_exception_on_purpose():
-            1/0
+            1/0  # pylint: disable=pointless-statement
 
         log = saltlog.SaltLoggingClass(__name__)
 

--- a/tests/unit/log_test.py
+++ b/tests/unit/log_test.py
@@ -9,18 +9,27 @@
     Test salt's "hacked" logging
 '''
 
+# Import python libs
+import logging
+from cStringIO import StringIO
+
 # Import Salt Testing libs
-from salttesting import TestCase
+from salttesting.case import TestCase
 from salttesting.helpers import ensure_in_syspath, TestsLoggingHandler
 
 ensure_in_syspath('../')
 
+# Import Salt libs
+from salt.log import setup as saltlog
+from salt.log.handlers import StreamHandler
+
 
 class TestLog(TestCase):
-    '''Test several logging settings'''
+    '''
+    Test several logging settings
+    '''
 
     def test_issue_2853_regex_TypeError(self):
-        from salt.log import setup as saltlog
         # Now, python's logging logger class is ours.
         # Let's make sure we have at least one instance
         log = saltlog.SaltLoggingClass(__name__)
@@ -62,6 +71,111 @@ class TestLog(TestCase):
 
             # Remove the testing handler
             log.removeHandler(handler)
+
+    def test_exc_info_on_loglevel(self):
+        def raise_exception_on_purpose():
+            1/0
+
+        log = saltlog.SaltLoggingClass(__name__)
+
+        # Only stream2 should contain the traceback
+        stream1 = StringIO()
+        stream2 = StringIO()
+        handler1 = StreamHandler(stream1)
+        handler2 = StreamHandler(stream2)
+
+        handler1.setLevel(logging.INFO)
+        handler2.setLevel(logging.DEBUG)
+
+        log.addHandler(handler1)
+        log.addHandler(handler2)
+
+        try:
+            raise_exception_on_purpose()
+        except ZeroDivisionError as exc:
+            log.error('Exception raised on purpose caught: {0}'.format(exc),
+                      exc_info_on_loglevel=logging.DEBUG)
+
+        try:
+            self.assertIn(
+                'Exception raised on purpose caught: integer division or modulo by zero\n',
+                stream1.getvalue()
+            )
+            self.assertNotIn('Traceback (most recent call last)', stream1.getvalue())
+            self.assertIn(
+                'Exception raised on purpose caught: integer division or modulo by zero\n',
+                stream2.getvalue()
+            )
+            self.assertIn('Traceback (most recent call last)', stream2.getvalue())
+        finally:
+            log.removeHandler(handler1)
+            log.removeHandler(handler2)
+
+        # Both streams should contain the traceback
+        stream1 = StringIO()
+        stream2 = StringIO()
+        handler1 = StreamHandler(stream1)
+        handler2 = StreamHandler(stream2)
+
+        handler1.setLevel(logging.INFO)
+        handler2.setLevel(logging.DEBUG)
+
+        log.addHandler(handler1)
+        log.addHandler(handler2)
+
+        try:
+            raise_exception_on_purpose()
+        except ZeroDivisionError as exc:
+            log.error('Exception raised on purpose caught: {0}'.format(exc),
+                      exc_info_on_loglevel=logging.INFO)
+
+        try:
+            self.assertIn(
+                'Exception raised on purpose caught: integer division or modulo by zero\n',
+                stream1.getvalue()
+            )
+            self.assertIn('Traceback (most recent call last)', stream1.getvalue())
+            self.assertIn(
+                'Exception raised on purpose caught: integer division or modulo by zero\n',
+                stream2.getvalue()
+            )
+            self.assertIn('Traceback (most recent call last)', stream2.getvalue())
+        finally:
+            log.removeHandler(handler1)
+            log.removeHandler(handler2)
+
+        # No streams should contain the traceback
+        stream1 = StringIO()
+        stream2 = StringIO()
+        handler1 = StreamHandler(stream1)
+        handler2 = StreamHandler(stream2)
+
+        handler1.setLevel(logging.ERROR)
+        handler2.setLevel(logging.INFO)
+
+        log.addHandler(handler1)
+        log.addHandler(handler2)
+
+        try:
+            raise_exception_on_purpose()
+        except ZeroDivisionError as exc:
+            log.error('Exception raised on purpose caught: {0}'.format(exc),
+                      exc_info_on_loglevel=logging.DEBUG)
+
+        try:
+            self.assertIn(
+                'Exception raised on purpose caught: integer division or modulo by zero',
+                stream1.getvalue()
+            )
+            self.assertNotIn('Traceback (most recent call last)', stream1.getvalue())
+            self.assertIn(
+                'Exception raised on purpose caught: integer division or modulo by zero',
+                stream2.getvalue()
+            )
+            self.assertNotIn('Traceback (most recent call last)', stream2.getvalue())
+        finally:
+            log.removeHandler(handler1)
+            log.removeHandler(handler2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This allows showing the `exc_info` if a specific log level or lower is
enabled, but, on a per logging handler basis.
For example, if the console hander is at info level and the file log
handler is on debug level and we pass `exc_info_on_loglevel` to a log
call, the traceback will be included in the log message of the file
handler but not on the log message of the console handler.

Closes #14870
Closes #14859
