### PR TITLE
Speed up highstate runs when all packages are already installed

### DIFF
--- a/salt/modules/rpm.py
+++ b/salt/modules/rpm.py
@@ -49,9 +49,9 @@ def list_pkgs(*packages):
     errors = []
     pkgs = {}
     if not packages:
-        cmd = 'rpm -qa --qf \'%{NAME} %{VERSION}\\n\''
+        cmd = 'rpm -qa --qf \'%{NAME} %{VERSION}-%{RELEASE}\\n\''
     else:
-        cmd = 'rpm -q --qf \'%{{NAME}} %{{VERSION}}\\n\' {0}'.format(
+        cmd = 'rpm -q --qf \'%{{NAME}} %{{VERSION}}-%{{RELEASE}}\\n\' {0}'.format(
             ' '.join(packages)
         )
     out = __salt__['cmd.run'](cmd, output_loglevel='trace')

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1517,7 +1517,7 @@ def _is_installed(name, pkgs, sources, version, allow_updates):
         if comparison in ['=', '']:
             comparison = '=='
         if allow_updates:
-           comparison = '>='
+            comparison = '>='
         if not _fulfills_version_spec([installed[pkgname]], comparison, verstr):
             return False
         if not __salt__['pkg_resource.check_extra_requirements'](pkgname, pkgver):

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1507,7 +1507,7 @@ def _is_installed(name, pkgs, sources, version, allow_updates):
 
     installed = __salt__['lowpkg.list_pkgs'](*names)
 
-    if len(names) != len(installed):
+    if names != installed.keys():
         return False
 
     for pkgname, pkgver in versioncheck:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -678,6 +678,26 @@ def installed(
     if not isinstance(version, string_types) and version is not None:
         version = str(version)
 
+    if not pkg_verify and _is_installed(name, pkgs, sources, version, allow_updates):
+        if version:
+            msg = ('Version {0} of package {1!r} is already '
+                   'installed'.format(version, name))
+        elif sources:
+            msg = 'All specified packages are already installed.'
+        elif pkgs:
+
+            version_spec = [p for p in pkgs if isinstance(p, dict)]
+
+            msg = ('All specified packages are already installed{0}.'
+            .format(' and are at the desired version' if version_spec else ''))
+        else:
+            msg = 'Package {0} is already installed'.format(name)
+
+        return {'name': name,
+                'changes': {},
+                'result': True,
+                'comment': msg}
+
     kwargs['allow_updates'] = allow_updates
     result = _find_install_targets(name, version, pkgs, sources,
                                    fromrepo=fromrepo,
@@ -1467,3 +1487,40 @@ def mod_aggregate(low, chunks, running):
         else:
             low['pkgs'] = pkgs
     return low
+
+
+def _is_installed(name, pkgs, sources, version, allow_updates):
+    '''
+    Determine if packages are already installed.
+    '''
+
+    if sources:
+        desired = __salt__['pkg_resource.pack_sources'](sources)
+    elif pkgs:
+        desired = _repack_pkgs(pkgs)
+    else:
+        desired = {name: version}
+
+    versioncheck = [] if sources else [(p, v) for p, v in desired.items() if v]
+
+    names = desired.keys()
+
+    installed = __salt__['lowpkg.list_pkgs'](*names)
+
+    for pkgname, pkgver in versioncheck:
+        match = re.match('^([<>])?(=)?([^<>=]+)$', pkgver)
+        gt_lt, eq, verstr = match.groups()
+        comparison = gt_lt or ''
+        comparison += eq or ''
+        # A comparison operator of "=" is redundant, but possible.
+        # Change it to "==" so that the version comparison works.
+        if comparison in ['=', '']:
+            comparison = '=='
+        if allow_updates:
+           comparison = '>='
+        if not _fulfills_version_spec([installed[pkgname]], comparison, verstr):
+            return False
+        if not __salt__['pkg_resource.check_extra_requirements'](pkgname, pkgver):
+            return False
+
+    return len(names) == len(installed)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -1507,6 +1507,9 @@ def _is_installed(name, pkgs, sources, version, allow_updates):
 
     installed = __salt__['lowpkg.list_pkgs'](*names)
 
+    if len(names) != len(installed):
+        return False
+
     for pkgname, pkgver in versioncheck:
         match = re.match('^([<>])?(=)?([^<>=]+)$', pkgver)
         gt_lt, eq, verstr = match.groups()
@@ -1523,4 +1526,4 @@ def _is_installed(name, pkgs, sources, version, allow_updates):
         if not __salt__['pkg_resource.check_extra_requirements'](pkgname, pkgver):
             return False
 
-    return len(names) == len(installed)
+    return True


### PR DESCRIPTION
Most of the time when we run a highstate there is nothing to change and all the packages we want are already installed. The slowest part of our runs is this part where Salt wants a list of all packages installed and all packages in the repos.

```
[INFO    ] Executing command 'repoquery --queryformat="%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}" --all --pkgnarrow=installed' in directory '/root'
[INFO    ] Executing command 'repoquery --queryformat="%{NAME}_|-%{ARCH}"  --pkgnarrow=all --all --plugins' in directory '/root'
```

This can be skipped if we check if the packages are already installed by asking the package manager. This patch speeds up our runs significantly, so hopefully we can get it cleaned up and added to Salt.
