### PR TITLE
Fix incorrect conditional in spec

### DIFF
--- a/pkg/rpm/salt.spec
+++ b/pkg/rpm/salt.spec
@@ -16,7 +16,7 @@
 
 Name: salt
 Version: 2014.1.10
-Release: 2%{?dist}
+Release: 4%{?dist}
 Summary: A parallel remote execution system
 
 Group:   System Environment/Daemons
@@ -125,7 +125,7 @@ servers, handle them quickly and through a simple and manageable interface.
 Summary: Management component for salt, a parallel remote execution system 
 Group:   System Environment/Daemons
 Requires: salt = %{version}-%{release}
-%if ! (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
+%if (0%{?rhel} >= 7 || 0%{?fedora} >= 15)
 Requires: systemd-python
 %endif
 
@@ -332,10 +332,13 @@ rm -rf %{buildroot}
 %endif
 
 %changelog
-* Tue Aug 5 2014 Erik Johnson <erik@saltstack.com> - 2014.1.10-2
+* Sun Aug 10 2014 Erik Johnson <erik@saltstack.com> - 2014.1.10-4
+- Fix incorrect conditional
+
+* Tue Aug  5 2014 Erik Johnson <erik@saltstack.com> - 2014.1.10-2
 - Deploy cachedir with package
 
-* Mon Aug 4 2014 Erik Johnson <erik@saltstack.com> - 2014.1.10-1
+* Mon Aug  4 2014 Erik Johnson <erik@saltstack.com> - 2014.1.10-1
 - Update to bugfix release 2014.1.10
 
 * Thu Jul 10 2014 Erik Johnson <erik@saltstack.com> - 2014.1.7-3
@@ -350,7 +353,7 @@ rm -rf %{buildroot}
 * Sun Jun 08 2014 Fedora Release Engineering <rel-eng@lists.fedoraproject.org> - 2014.1.4-2
 - Rebuilt for https://fedoraproject.org/wiki/Fedora_21_Mass_Rebuild
 
-* Tue May 6 2014 Erik Johnson <erik@saltstack.com> - 2014.1.4-1
+* Tue May  6 2014 Erik Johnson <erik@saltstack.com> - 2014.1.4-1
 - Update to bugfix release 2014.1.4
 
 * Fri Apr 18 2014 Erik Johnson <erik@saltstack.com> - 2014.1.3-1


### PR DESCRIPTION
The "!" here caused the dep on systemd-python to be assigned to the
opposite builds (EL5, EL6) from the ones which should have had it. New
builds have been made, this pull request updates the spec in git.
