### PR TITLE
Update imports and skipIfs on boto unit tests

### DIFF
--- a/tests/unit/modules/boto_secgroup.py
+++ b/tests/unit/modules/boto_secgroup.py
@@ -6,15 +6,19 @@ import string
 from collections import OrderedDict
 from copy import deepcopy
 
+HAS_BOTO = True
+HAS_MOTO = True
+
 # import Python Third Party Libs
 try:
     import boto
-    from moto import mock_ec2
-    missing_requirements = False
-    missing_requirements_msg = ''
 except ImportError:
-    missing_requirements = True
-    missing_requirements_msg = 'boto and moto modules required for test.'
+    HAS_BOTO = False
+
+try:
+    from moto import mock_ec2
+except ImportError:
+    HAS_MOTO = False
 
     def mock_ec2(self):
         '''
@@ -32,6 +36,10 @@ from salt.modules import boto_secgroup
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
 
 vpc_id = 'vpc-mjm05d27'
 region = 'us-east-1'
@@ -50,6 +58,10 @@ def _random_group_name():
     return group_name
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(HAS_MOTO is False, 'The moto module must be installed.')
+@mock_ec2
 class Boto_SecgroupTestCase(TestCase):
     '''
     TestCase for salt.modules.boto_secgroup module
@@ -64,8 +76,6 @@ class Boto_SecgroupTestCase(TestCase):
                        {'to_port': 80, 'from_port': 80, 'ip_protocol': u'tcp', 'cidr_ip': u'0.0.0.0/0'}]
         self.assertEqual(boto_secgroup._split_rules(rules), split_rules)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_create_ec2_classic(self):
         '''
         test of creation of an EC2-Classic security group. The test ensures
@@ -85,8 +95,6 @@ class Boto_SecgroupTestCase(TestCase):
         secgroup_create_result = [secgroup_created_group[0].name, secgroup_created_group[0].description]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_create_ec2_vpc(self):
         '''
         test of creation of an EC2-VPC security group. The test ensures that a
@@ -104,10 +112,8 @@ class Boto_SecgroupTestCase(TestCase):
         secgroup_create_result = [secgroup_created_group[0].name, secgroup_created_group[0].description, secgroup_created_group[0].vpc_id]
         self.assertEqual(expected_create_result, secgroup_create_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
     @skipIf(True, 'test skipped due to error in moto return - fixed in'
                   ' https://github.com/spulec/moto/commit/cc0166964371f7b5247a49d45637a8f936ccbe6f')
-    @mock_ec2
     def test_get_group_id_ec2_classic(self):
         '''
         tests that given a name of a group in EC2-Classic that the correct
@@ -127,10 +133,8 @@ class Boto_SecgroupTestCase(TestCase):
                                                         **conn_parameters)
         self.assertEqual(group_classic.id, retreived_group_id)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
     def test_get_group_id_ec2_vpc(self):
         '''
         tests that given a name of a group in EC2-VPC that the correct
@@ -150,8 +154,6 @@ class Boto_SecgroupTestCase(TestCase):
                                                         **conn_parameters)
         self.assertEqual(group_vpc.id, retreived_group_id)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_get_config_single_rule_group_name(self):
         '''
         tests return of 'config' when given group name. get_config returns an OrderedDict.
@@ -172,10 +174,8 @@ class Boto_SecgroupTestCase(TestCase):
         secgroup_get_config_result = boto_secgroup.get_config(group_id=group.id, **conn_parameters)
         self.assertEqual(expected_get_config_result, secgroup_get_config_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
     @skipIf(False, 'test skipped due to error in moto return - fixed in'
                   ' https://github.com/spulec/moto/commit/cc0166964371f7b5247a49d45637a8f936ccbe6f')
-    @mock_ec2
     def test_exists_true_name_classic(self):
         '''
         tests 'true' existence of a group in EC2-Classic when given name
@@ -188,15 +188,11 @@ class Boto_SecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(name=group_name, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
     def test_exists_false_name_classic(self):
         pass
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_exists_true_name_vpc(self):
         '''
         tests 'true' existence of a group in EC2-VPC when given name and vpc_id
@@ -208,8 +204,6 @@ class Boto_SecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(name=group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_exists_false_name_vpc(self):
         '''
         tests 'false' existence of a group in vpc when given name and vpc_id
@@ -218,8 +212,6 @@ class Boto_SecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(group_name, vpc_id=vpc_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_exists_true_group_id(self):
         '''
         tests 'true' existence of a group when given group_id
@@ -231,8 +223,6 @@ class Boto_SecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(group_id=group.id, **conn_parameters)
         self.assertTrue(salt_exists_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_exists_false_group_id(self):
         '''
         tests 'false' existence of a group when given group_id
@@ -241,10 +231,8 @@ class Boto_SecgroupTestCase(TestCase):
         salt_exists_result = boto_secgroup.exists(group_id=group_id, **conn_parameters)
         self.assertFalse(salt_exists_result)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
     @skipIf(True, 'test skipped due to error in moto return - fixed in'
                   ' https://github.com/spulec/moto/commit/cc0166964371f7b5247a49d45637a8f936ccbe6f')
-    @mock_ec2
     def test_delete_group_ec2_classic(self):
         '''
         test deletion of a group in EC2-Classic. Test does the following:
@@ -270,15 +258,11 @@ class Boto_SecgroupTestCase(TestCase):
         actual_groups = [group.id for group in conn.get_all_security_groups()]
         self.assertEqual(expected_groups, actual_groups)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
     @skipIf(True, 'test skipped because moto does not yet support group'
                   ' filters https://github.com/spulec/moto/issues/154')
-    @mock_ec2
     def test_delete_group_name_ec2_vpc(self):
         pass
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test__get_conn_true(self):
         '''
         tests ensures that _get_conn returns an boto.ec2.connection.EC2Connection object.

--- a/tests/unit/modules/boto_secgroup.py
+++ b/tests/unit/modules/boto_secgroup.py
@@ -6,17 +6,16 @@ import string
 from collections import OrderedDict
 from copy import deepcopy
 
-HAS_BOTO = True
-HAS_MOTO = True
-
 # import Python Third Party Libs
 try:
     import boto
+    HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
 
 try:
     from moto import mock_ec2
+    HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 

--- a/tests/unit/modules/boto_vpc.py
+++ b/tests/unit/modules/boto_vpc.py
@@ -1,14 +1,18 @@
 # -*- coding: utf-8 -*-
 
+HAS_BOTO = True
+HAS_MOTO = True
+
 # import Python Third Party Libs
 try:
     import boto
-    from moto import mock_ec2
-    missing_requirements = False
-    missing_requirements_msg = ''
 except ImportError:
-    missing_requirements = True
-    missing_requirements_msg = 'boto and moto modules required for test.'
+    HAS_BOTO = False
+
+try:
+    from moto import mock_ec2
+except ImportError:
+    HAS_MOTO = False
 
     def mock_ec2(self):
         '''
@@ -26,6 +30,10 @@ from salt.modules import boto_vpc
 
 # Import Salt Testing Libs
 from salttesting import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
 
 region = 'us-east-1'
 access_key = 'GKTADJGHEIQSXMKKRBJ08H'
@@ -33,12 +41,14 @@ secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
 conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(HAS_MOTO is False, 'The moto module must be installed.')
+@mock_ec2
 class Boto_VpcTestCase(TestCase):
     '''
     TestCase for salt.modules.boto_vpc module
     '''
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_get_subnet_association_single_subnet(self):
         '''
         tests that given multiple subnet ids in the same VPC that the VPC ID is
@@ -52,8 +62,6 @@ class Boto_VpcTestCase(TestCase):
                                                             **conn_parameters)
         self.assertEqual(vpc.id, subnet_assocation)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_get_subnet_association_multiple_subnets_same_vpc(self):
         '''
         tests that given multiple subnet ids in the same VPC that the VPC ID is
@@ -67,8 +75,6 @@ class Boto_VpcTestCase(TestCase):
                                                             **conn_parameters)
         self.assertEqual(vpc.id, subnet_assocation)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_get_subnet_association_multiple_subnets_different_vpc(self):
         '''
         tests that given multiple subnet ids in different VPCs that False is
@@ -83,8 +89,6 @@ class Boto_VpcTestCase(TestCase):
                                                             **conn_parameters)
         self.assertFalse(subnet_assocation)
 
-    @skipIf(missing_requirements, missing_requirements_msg)
-    @mock_ec2
     def test_exists_true(self):
         '''
         tests True existence of a VPC.

--- a/tests/unit/modules/boto_vpc.py
+++ b/tests/unit/modules/boto_vpc.py
@@ -1,16 +1,15 @@
 # -*- coding: utf-8 -*-
 
-HAS_BOTO = True
-HAS_MOTO = True
-
 # import Python Third Party Libs
 try:
     import boto
+    HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
 
 try:
     from moto import mock_ec2
+    HAS_MOTO = True
 except ImportError:
     HAS_MOTO = False
 


### PR DESCRIPTION
- Make third-party import failures independent
- Added `NO_MOCK` and `NO_MOCK_REASON` skips
- Added `ensure_in_syspath`
- Moved skipIfs from individual functions to entire class, since each function had the same repeated skipIfs

@s0undt3ch ping
