### PR TITLE
Continue if master in multi-master is down

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -467,7 +467,7 @@ class MultiMinion(MinionBase):
             try:
                 minions.append(Minion(s_opts, 5, False))
             except SaltClientError as exc:
-                log.error('Error while bring up minion for multi-master. Is master responding?')
+                log.error('Error while bringing up minion for multi-master. Is master at {0} responding?'.format(master))
                 raise
         return minions
 
@@ -1349,7 +1349,7 @@ class Minion(MinionBase):
             if creds == 'full':
                 return creds
             elif creds != 'retry':
-                log.info('Authentication with master successful!')
+                log.info('Authentication with master at {0} successful!'.format(self.opts['master_ip']))
                 break
             log.info('Waiting for minion key to be accepted by the master.')
             if acceptance_wait_time:


### PR DESCRIPTION
This addresses the main concern in #14099 and #14128.

This is a quick-fix. I think we need to write some functionality to retry against failed masters on a schedule but this will at least a minion to startup if one or more masters do not respond.
