### PR TITLE
Fix the wrong keystone.tenant_update param

### DIFF
--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -591,7 +591,7 @@ def tenant_list(profile=None, **connection_args):
     return ret
 
 
-def tenant_update(tenant_id=None, name=None, email=None,
+def tenant_update(tenant_id=None, name=None, description=None,
                   enabled=None, profile=None, **connection_args):
     '''
     Update a tenant's information (keystone tenant-update)
@@ -617,11 +617,11 @@ def tenant_update(tenant_id=None, name=None, email=None,
     tenant = kstone.tenants.get(tenant_id)
     if not name:
         name = tenant.name
-    if not email:
-        email = tenant.email
+    if not description:
+        description = tenant.description
     if enabled is None:
         enabled = tenant.enabled
-    kstone.tenants.update(tenant_id, name, email, enabled)
+    kstone.tenants.update(tenant_id, name, description, enabled)
 
 
 def token_get(profile=None, **connection_args):

--- a/salt/states/keystone.py
+++ b/salt/states/keystone.py
@@ -245,16 +245,18 @@ def tenant_present(name, description=None, enabled=True, profile=None,
 
     if 'Error' not in tenant:
         if tenant[name]['description'] != description:
-            __salt__['keystone.tenant_update'](name, description,
-                                               enabled,
+            __salt__['keystone.tenant_update'](name=name,
+                                               description=description,
+                                               enabled=enabled,
                                                profile=profile,
                                                **connection_args)
             comment = 'Tenant "{0}" has been updated'.format(name)
             ret['comment'] = comment
             ret['changes']['Description'] = 'Updated'
         if tenant[name]['enabled'] != enabled:
-            __salt__['keystone.tenant_update'](name, description,
-                                               enabled,
+            __salt__['keystone.tenant_update'](name=name,
+                                               description=description,
+                                               enabled=enabled,
                                                profile=profile,
                                                **connection_args)
             comment = 'Tenant "{0}" has been updated'.format(name)


### PR DESCRIPTION
There is a description param rather than email param in keystone.tenant_update

See [1] to get more information. 

[1]  https://github.com/openstack/python-keystoneclient/blob/master/keystoneclient/v2_0/tenants.py#L39
