### PR TITLE
Add suffix 'd' or 'ed' depending on last letter

### DIFF
--- a/salt/states/postgres_extension.py
+++ b/salt/states/postgres_extension.py
@@ -123,7 +123,11 @@ def present(name,
             from_version=from_version,
             **db_args)
     if cret:
-        ret['comment'] = 'The extension {0} has been {1}ed'.format(name, mode)
+        if mode.endswith('e'):
+            suffix = 'd'
+        else:
+            suffix = 'ed'
+        ret['comment'] = 'The extension {0} has been {1}{2}'.format(name, mode, suffix)
     elif cret is not None:
         ret['comment'] = 'Failed to {1} extension {0}'.format(name, mode)
         ret['result'] = False


### PR DESCRIPTION
Spelling changes in the test suite exposed this needed change, which fixes the tests. If the mode (install or upgrade) ends with an 'e', then only append a 'd'. If not, append 'ed' to the end of mode:
- The extension foo has been installed.
- The extension foo has been upgraded. (not upgradeed)
