### PR TITLE
Fix pillar mysql tests

### DIFF
--- a/tests/unit/pillar/mysql_test.py
+++ b/tests/unit/pillar/mysql_test.py
@@ -14,7 +14,8 @@ class MysqlPillarTestCase(TestCase):
         args, kwargs = [], {'mysql_query': 'SELECT blah'}
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
-            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False, 'with_lists': None}]
+            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}]
         ], qbuffer)
 
     def test_002_extract_queries_list(self):
@@ -32,15 +33,24 @@ class MysqlPillarTestCase(TestCase):
         ], {}
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
-            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah2', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah4', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah5', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah6', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah7', 'depth': 0, 'as_list': True, 'with_lists': None}],
-            [None, {'query': 'SELECT blah8', 'depth': 0, 'as_list': False, 'with_lists': [1]}],
-            [None, {'query': 'SELECT blah9', 'depth': 0, 'as_list': False, 'with_lists': [1, 2]}]
+            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah4', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah5', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah6', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah7', 'depth': 0, 'as_list': True,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah8', 'depth': 0, 'as_list': False,
+                    'with_lists': [1], 'ignore_null': False}],
+            [None, {'query': 'SELECT blah9', 'depth': 0, 'as_list': False,
+                    'with_lists': [1, 2], 'ignore_null': False}]
         ], qbuffer)
 
     def test_003_extract_queries_kwarg(self):
@@ -56,13 +66,20 @@ class MysqlPillarTestCase(TestCase):
         }
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
-            ['1', {'query': 'SELECT blah', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            ['2', {'query': 'SELECT blah2', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            ['3', {'query': 'SELECT blah3', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            ['4', {'query': 'SELECT blah4', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            ['5', {'query': 'SELECT blah5', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            ['6', {'query': 'SELECT blah6', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            ['7', {'query': 'SELECT blah7', 'depth': 0, 'as_list': True, 'with_lists': None}]
+            ['1', {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['2', {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['3', {'query': 'SELECT blah3', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['4', {'query': 'SELECT blah4', 'depth': 2, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['5', {'query': 'SELECT blah5', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['6', {'query': 'SELECT blah6', 'depth': 2, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['7', {'query': 'SELECT blah7', 'depth': 0, 'as_list': True,
+                   'with_lists': None, 'ignore_null': False}]
         ], qbuffer)
 
     def test_004_extract_queries_mixed(self):
@@ -79,13 +96,20 @@ class MysqlPillarTestCase(TestCase):
         }
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
-            [None, {'query': 'SELECT blahm', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah1', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah2', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': True, 'with_lists': None}],
-            ['1', {'query': 'SELECT blah1', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            ['2', {'query': 'SELECT blah2', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            ['3', {'query': 'SELECT blah3', 'depth': 0, 'as_list': True, 'with_lists': None}]
+            [None, {'query': 'SELECT blahm', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah1', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah2', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': True,
+                    'with_lists': None, 'ignore_null': False}],
+            ['1', {'query': 'SELECT blah1', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['2', {'query': 'SELECT blah2', 'depth': 2, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['3', {'query': 'SELECT blah3', 'depth': 0, 'as_list': True,
+                   'with_lists': None, 'ignore_null': False}]
         ], qbuffer)
 
     def test_005_extract_queries_bogus_list(self):
@@ -108,14 +132,22 @@ class MysqlPillarTestCase(TestCase):
         ], {}
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
-            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah2', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah4', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah5', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah6', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah7', 'depth': 2, 'as_list': False, 'with_lists': None}],
-            [None, {'query': 'SELECT blah8', 'depth': 0, 'as_list': True, 'with_lists': None}]
+            [None, {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah3', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah4', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah5', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah6', 'depth': 0, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah7', 'depth': 2, 'as_list': False,
+                    'with_lists': None, 'ignore_null': False}],
+            [None, {'query': 'SELECT blah8', 'depth': 0, 'as_list': True,
+                    'with_lists': None, 'ignore_null': False}]
         ], qbuffer)
 
     def test_006_extract_queries_bogus_kwargs(self):
@@ -128,8 +160,10 @@ class MysqlPillarTestCase(TestCase):
         }
         qbuffer = return_data.extract_queries(args, kwargs)
         self.assertEqual([
-            ['1', {'query': 'SELECT blah', 'depth': 0, 'as_list': False, 'with_lists': None}],
-            ['3', {'query': 'SELECT blah2', 'depth': 0, 'as_list': False, 'with_lists': None}]
+            ['1', {'query': 'SELECT blah', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}],
+            ['3', {'query': 'SELECT blah2', 'depth': 0, 'as_list': False,
+                   'with_lists': None, 'ignore_null': False}]
         ], qbuffer)
 
     def test_011_enter_root(self):

--- a/tests/unit/pillar/mysql_test.py
+++ b/tests/unit/pillar/mysql_test.py
@@ -1,11 +1,17 @@
 # -*- coding: utf-8 -*-
 
 # Import Salt Testing libs
-from salttesting import TestCase
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
 
+ensure_in_syspath('../../')
+
+# Import Salt Libs
 from salt.pillar import mysql
 
 
+@skipIf(NO_MOCK, NO_MOCK_REASON)
 class MysqlPillarTestCase(TestCase):
     maxDiff = None
 


### PR DESCRIPTION
Formatting for test returns changed with https://github.com/saltstack/salt/commit/4c42ca6a69b6d285e85d825d69d492c92636bf4b commit.

Make the tests blue!
