### PR TITLE
add -g to ebuild.py

### DIFF
--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -170,8 +170,8 @@ def ex_mod_init(low):
     .. versionadded:: 0.17.0
        Initial automatic enforcement added when pkg is used on a Gentoo system.
 
-    .. versionchanged:: 2014.1.0
-       Configure option added to make this behavior optional, defaulting to
+    .. versionchanged:: 2014.1.0-Hydrogen
+       Configure option added to make this behaviour optional, defaulting to
        off.
 
     .. seealso::
@@ -407,6 +407,7 @@ def install(name=None,
             slot=None,
             fromrepo=None,
             uses=None,
+            binhost=None,
             **kwargs):
     '''
     Install the passed package(s), add refresh=True to sync the portage tree
@@ -488,7 +489,10 @@ def install(name=None,
         .. code-block:: bash
 
             salt '*' pkg.install sources='[{"foo": "salt://foo.tbz2"},{"bar": "salt://bar.tbz2"}]'
-
+    binhost
+        has two options try and force.
+        try - tells emerge to try and install the package from a configured binhost.
+        force - forces emerge to install the package from a binhost otherwise it fails out.
 
     Returns a dict containing the new package names and versions::
 
@@ -501,7 +505,8 @@ def install(name=None,
             'refresh': refresh,
             'pkgs': pkgs,
             'sources': sources,
-            'kwargs': kwargs
+            'kwargs': kwargs,
+            'binhost' : binhost
         }
     ))
     if salt.utils.is_true(refresh):
@@ -535,6 +540,13 @@ def install(name=None,
         emerge_opts = 'tbz2file'
     else:
         emerge_opts = ''
+
+    if binhost == 'try':
+        bin_opts = '-g'
+    elif binhost == 'force':
+        bin_opts = '-G'
+    else:
+        bin_opts = ''
 
     changes = {}
 
@@ -582,7 +594,7 @@ def install(name=None,
                 targets.append(target)
     else:
         targets = pkg_params
-    cmd = 'emerge --quiet --ask n {0} {1}'.format(emerge_opts, ' '.join(targets))
+    cmd = 'emerge --quiet {0} --ask n {1} {2}'.format(bin_opts,emerge_opts, ' '.join(targets))
 
     old = list_pkgs()
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
@@ -594,17 +606,20 @@ def install(name=None,
     return changes
 
 
-def update(pkg, slot=None, fromrepo=None, refresh=False):
+def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
     '''
     Updates the passed package (emerge --update package)
 
-    slot
-        Restrict the update to a particular slot. It will update to the
+
         latest version within the slot.
 
     fromrepo
         Restrict the update to a particular repository. It will update to the
         latest version within the repository.
+    binhost
+        has two options try and force.
+        try - tells emerge to try and install the package from a configured binhost.
+        force - forces emerge to install the package from a binhost otherwise it fails out.
 
     Return a dict containing the new package names and versions::
 
@@ -628,8 +643,15 @@ def update(pkg, slot=None, fromrepo=None, refresh=False):
     if fromrepo is not None:
         full_atom = '{0}::{1}'.format(full_atom, fromrepo)
 
+    if binhost == 'try':
+        bin_opts = '-g'
+    elif binhost == 'force':
+        bin_opts = '-G'
+    else:
+        bin_opts = ''
+
     old = list_pkgs()
-    cmd = 'emerge --update --newuse --oneshot --ask n --quiet {0}'.format(full_atom)
+    cmd = 'emerge --update --newuse --oneshot --ask n --quiet {0} {1}'.format(bin_opts,full_atom)
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     __context__.pop('pkg.list_pkgs', None)
     if call['retcode'] != 0:
@@ -638,9 +660,14 @@ def update(pkg, slot=None, fromrepo=None, refresh=False):
     return salt.utils.compare_dicts(old, new)
 
 
-def upgrade(refresh=True):
+def upgrade(refresh=True,binhost=None):
     '''
     Run a full system upgrade (emerge --update world)
+
+    binhost
+        has two options try and force.
+        try - tells emerge to try and install the package from a configured binhost.
+        force - forces emerge to install the package from a binhost otherwise it fails out.
 
     Return a dict containing the new package names and versions::
 
@@ -656,8 +683,15 @@ def upgrade(refresh=True):
     if salt.utils.is_true(refresh):
         refresh_db()
 
+    if binhost == 'try':
+        bin_opts = '-g'
+    elif binhost == 'force':
+        bin_opts = '-G'
+    else:
+        bin_opts = ''
+
     old = list_pkgs()
-    cmd = 'emerge --update --newuse --deep --ask n --quiet world'
+    cmd = 'emerge --update --newuse --deep --ask n --quiet {0} world'.format(bin_opts)
     call = __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     __context__.pop('pkg.list_pkgs', None)
     if call['retcode'] != 0:
@@ -716,7 +750,7 @@ def remove(name=None, slot=None, fromrepo=None, pkgs=None, **kwargs):
 
     if not targets:
         return {}
-    cmd = 'emerge --unmerge --quiet --quiet-unmerge-warn --ask n ' \
+    cmd = 'emerge --unmerge --quiet --quiet-unmerge-warn --ask n' \
           '{0}'.format(' '.join(targets))
     __salt__['cmd.run_all'](cmd, output_loglevel='trace')
     __context__.pop('pkg.list_pkgs', None)

--- a/salt/modules/ebuild.py
+++ b/salt/modules/ebuild.py
@@ -610,7 +610,8 @@ def update(pkg, slot=None, fromrepo=None, refresh=False, binhost=None):
     '''
     Updates the passed package (emerge --update package)
 
-
+    slot
+        Restrict the update to a particular slot. It will update to the
         latest version within the slot.
 
     fromrepo


### PR DESCRIPTION
Added the option binhost= so that ebuild.py can support a binhost. The params are ehtere try or force. Try has emerge attempted to get the package from the binhost. While force makes it, if it can't it will fail.
