### PR TITLE
fix set autorefresh in zypper module

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -269,7 +269,7 @@ class _RepoInfo(object):
 
     @autorefresh.setter
     def autorefresh(self, value):
-        self.zypp.setAlias(value)
+        self.zypp.setAutorefresh(value)
 
     @property
     def enabled(self):


### PR DESCRIPTION
fix set autorefresh in zypper module

fixes:
"Failed to configure repo '<reponame>': in method
'RepoInfoBase_setAlias', argument 2 of type 'std::string const &'"
