### PR TITLE
Add env support to npm

### DIFF
--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -183,7 +183,10 @@ def uninstall(pkg,
     return True
 
 
-def list_(pkg=None, dir=None):
+def list_(pkg=None,
+            dir=None,
+            runas=None,
+            env=None):
     '''
     List installed NPM packages.
 
@@ -196,6 +199,18 @@ def list_(pkg=None, dir=None):
     dir
         The directory whose packages will be listed, or None for global
         installation
+
+    runas
+        The user to run NPM with
+
+        .. versionadded:: 2014.7.0
+
+    env
+        Environment variables to set when invoking npm. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+        .. versionadded:: 2014.7.0
 
     CLI Example:
 
@@ -214,7 +229,8 @@ def list_(pkg=None, dir=None):
     if pkg:
         cmd += ' "{0}"'.format(pkg)
 
-    result = __salt__['cmd.run_all'](cmd, cwd=dir, ignore_retcode=True)
+    result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas, env=env,
+            ignore_retcode=True)
 
     # npm will return error code 1 for both no packages found and an actual
     # error. The only difference between the two cases are if stderr is empty

--- a/salt/modules/npm.py
+++ b/salt/modules/npm.py
@@ -50,7 +50,8 @@ def install(pkg=None,
             pkgs=None,
             dir=None,
             runas=None,
-            registry=None):
+            registry=None,
+            env=None):
     '''
     Install an NPM package.
 
@@ -65,7 +66,7 @@ def install(pkg=None,
     pkgs
         A list of package names in the same format as the ``name`` parameter
 
-        .. versionaddedd:: 2014.7
+        .. versionaddedd:: 2014.7.0
 
     dir
         The target directory in which to install the package, or None for
@@ -76,6 +77,13 @@ def install(pkg=None,
 
     registry
         The NPM registry to install the package from.
+
+        .. versionadded:: 2014.7.0
+
+    env
+        Environment variables to set when invoking npm. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
 
         .. versionadded:: 2014.7.0
 
@@ -103,7 +111,7 @@ def install(pkg=None,
     elif pkgs:
         cmd += ' "{0}"'.format('" "'.join(pkgs))
 
-    result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas)
+    result = __salt__['cmd.run_all'](cmd, cwd=dir, runas=runas, env=env)
 
     if result['retcode'] != 0:
         raise CommandExecutionError(result['stderr'])

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -37,7 +37,8 @@ def installed(name,
               runas=None,
               user=None,
               force_reinstall=False,
-              registry=None):
+              registry=None,
+              env=None):
     '''
     Verify that the given package is installed and is at the correct version
     (if specified).
@@ -60,7 +61,7 @@ def installed(name,
         A list of packages to install with a single npm invocation; specifying
         this argument will ignore the ``name`` argument
 
-        .. versionadded:: 2014.7
+        .. versionadded:: 2014.7.0
 
     dir
         The target directory in which to install the package, or None for
@@ -78,6 +79,13 @@ def installed(name,
 
     registry
         The NPM registry from which to install the package
+
+        .. versionadded:: 2014.7.0
+
+    env
+        A list of environment variables to be set prior to execution. The
+        format is the same as the :py:func:`cmd.run <salt.states.cmd.run>`.
+        state function.
 
         .. versionadded:: 2014.7.0
 
@@ -166,6 +174,7 @@ def installed(name,
             'dir': dir,
             'runas': user,
             'registry': registry,
+            'env': env,
         }
 
         if pkgs is not None:

--- a/salt/states/npm.py
+++ b/salt/states/npm.py
@@ -124,7 +124,7 @@ def installed(name,
         pkg_list = [name]
 
     try:
-        installed_pkgs = __salt__['npm.list'](dir=dir)
+        installed_pkgs = __salt__['npm.list'](dir=dir, runas=runas, env=env)
     except (CommandNotFoundError, CommandExecutionError) as err:
         ret['result'] = False
         ret['comment'] = 'Error looking up {0!r}: {1}'.format(name, err)


### PR DESCRIPTION
A lot of npm configuration can be done with env vars and there are no corresponding CLI switches so might as well just expose this.
