### PR TITLE
Fixed "previous releases" docs link

### DIFF
--- a/doc/_templates/version.html
+++ b/doc/_templates/version.html
@@ -5,7 +5,7 @@
 {% endif %}
 
 <p class="muted">Docs for previous releases are available on
-    <a href="http://salt.readthedocs.org">salt.rtfd.org</a>.</p>
+    <a href="https://readthedocs.org/projects/salt/">readthedocs.org</a>.</p>
 
 <p>Latest Salt release: <a href="{{ pathto('topics/releases/{0}'.format(release)) }}">{{ release }}</a></p>
 


### PR DESCRIPTION
The link to previous docs releases was a redirect to the latest index page. Fixed.

I would argue the de facto docs version should be "latest stable", but this is an in-place fix for the status quo.
