### PR TITLE
Salt cloud master host

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1947,7 +1947,7 @@ class Map(Cloud):
                 out.pop('deploy_kwargs', {})
             )
 
-            master_host = deploy_kwargs.get('host', None)
+            master_host = deploy_kwargs.get('salt_host', None)
             if master_host is None:
                 raise SaltCloudSystemExit(
                     'Host for new master {0} was not found, '

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1947,7 +1947,7 @@ class Map(Cloud):
                 out.pop('deploy_kwargs', {})
             )
 
-            master_host = deploy_kwargs.get('salt_host', None)
+            master_host = deploy_kwargs.get('salt_host', deploy_kwargs.get('host', None))
             if master_host is None:
                 raise SaltCloudSystemExit(
                     'Host for new master {0} was not found, '

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -789,6 +789,16 @@ def ssh_interface(vm_):
         search_global=False
     )
 
+def salt_interface(vm_):
+    '''
+    Return the salt_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'salt_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
+
 
 def get_ssh_gateway_config(vm_):
     '''
@@ -2008,6 +2018,14 @@ def create(vm_=None, call=None):
         ip_address = instance['ipAddress']
         log.info('Salt node data. Public_ip: {0}'.format(ip_address))
     vm_['ssh_host'] = ip_address
+
+    if salt_interface(vm_) == 'private_ips':
+        salt_ip_address = instance['privateIpAddress']
+        log.info('Salt interface set to: {0}'.format(salt_ip_address))
+    else:
+        salt_ip_address = instance['ipAddress']
+        log.debug('Salt interface set to: {0}'.format(salt_ip_address))
+    vm_['salt_host'] = salt_ip_address
 
     display_ssh_output = config.get_cloud_config_value(
         'display_ssh_output', vm_, __opts__, default=True

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -277,11 +277,14 @@ def create(vm_):
         host = data['public_ips'][0]
         if ssh_interface(vm_) == 'private_ips':
             host = data['private_ips'][0]
+        if salt_interface(vm_) == 'private_ips':
+            salt_host = data['private_ips'][0]
 
         deploy_script = script(vm_)
         deploy_kwargs = {
             'opts': __opts__,
             'host': host,
+            'salt_host': salt_host,
             'username': ssh_username,
             'key_filename': key_filename,
             'script': deploy_script.script,
@@ -591,6 +594,16 @@ def ssh_interface(vm_):
     '''
     return config.get_cloud_config_value(
         'ssh_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
+
+def salt_interface(vm_):
+    '''
+    Return the salt_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'salt_interface', vm_, __opts__, default='public_ips',
         search_global=False
     )
 

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -264,6 +264,16 @@ def ssh_interface(vm_):
         search_global=False
     )
 
+def salt_interface(vm_):
+    '''
+    Return the salt_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'salt_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
+
 
 def get_location(vm_=None):
     '''
@@ -416,6 +426,13 @@ def create(vm_):
         log.info('Salt node data. Public_ip: {0}'.format(data.public_ips[0]))
         ip_address = data.public_ips[0]
 
+    if salt_interface(vm_) == 'private_ips':
+        salt_ip_address = instance['privateIpAddress']
+        log.info('Salt interface set to: {0}'.format(salt_ip_address))
+    else:
+        salt_ip_address = instance['ipAddress']
+        log.debug('Salt interface set to: {0}'.format(salt_ip_address))
+
     username = 'ec2-user'
     ssh_connect_timeout = config.get_cloud_config_value(
         'ssh_connect_timeout', vm_, __opts__, 900   # 15 minutes
@@ -448,6 +465,7 @@ def create(vm_):
         deploy_kwargs = {
             'opts': __opts__,
             'host': ip_address,
+            'salt_host': salt_ip_address,
             'username': username,
             'key_filename': key_filename,
             'tmp_dir': config.get_cloud_config_value(

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -310,6 +310,16 @@ def ssh_interface(vm_):
         search_global=False
     )
 
+def salt_interface(vm_):
+    '''
+    Return the salt_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'salt_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
+
 
 def rackconnect(vm_):
     '''
@@ -696,10 +706,19 @@ def create(vm_):
         ip_address = preferred_ip(vm_, data.public_ips)
     log.debug('Using IP address {0}'.format(ip_address))
 
+    if salt_interface(vm_) == 'private_ips':
+        salt_ip_address = instance['privateIpAddress']
+        log.info('Salt interface set to: {0}'.format(salt_ip_address))
+    else:
+        salt_ip_address = instance['ipAddress']
+        log.debug('Salt interface set to: {0}'.format(salt_ip_address))
+
     if not ip_address:
         raise SaltCloudSystemExit('A valid IP address was not found')
 
     vm_['ssh_host'] = ip_address
+    vm_['salt_host'] = salt_ip_address
+
     ret = salt.utils.cloud.bootstrap(vm_, __opts__)
 
     ret.update(data.__dict__)

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -357,6 +357,16 @@ def ssh_interface(vm_):
         search_global=False
     )
 
+def salt_interface(vm_):
+    '''
+    Return the salt_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'salt_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
+
 
 def rackconnect(vm_):
     '''
@@ -767,6 +777,14 @@ def create(vm_):
     else:
         ip_address = preferred_ip(vm_, data.public_ips)
     log.debug('Using IP address {0}'.format(ip_address))
+
+    if salt_interface(vm_) == 'private_ips':
+        salt_ip_address = instance['privateIpAddress']
+        log.info('Salt interface set to: {0}'.format(salt_ip_address))
+    else:
+        salt_ip_address = instance['ipAddress']
+        log.debug('Salt interface set to: {0}'.format(salt_ip_address))
+    vm_['salt_host'] = salt_ip_address
 
     if not ip_address:
         raise SaltCloudSystemExit('A valid IP address was not found')

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -188,6 +188,15 @@ def ssh_interface(vm_):
         search_global=False
     )
 
+def salt_interface(vm_):
+    '''
+    Return the salt_interface type to connect to. Either 'public_ips' (default)
+    or 'private_ips'.
+    '''
+    return config.get_cloud_config_value(
+        'salt_interface', vm_, __opts__, default='public_ips',
+        search_global=False
+    )
 
 def create(vm_):
     '''
@@ -328,6 +337,14 @@ def create(vm_):
     else:
         ip_address = preferred_ip(vm_, data.public_ips)
     log.debug('Using IP address {0}'.format(ip_address))
+
+    if salt_interface(vm_) == 'private_ips':
+        salt_ip_address = instance['privateIpAddress']
+        log.info('Salt interface set to: {0}'.format(salt_ip_address))
+    else:
+        salt_ip_address = instance['ipAddress']
+        log.debug('Salt interface set to: {0}'.format(salt_ip_address))
+    vm_['salt_host'] = salt_ip_address
 
     if not ip_address:
         raise SaltCloudSystemExit(

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -95,6 +95,7 @@ def create(vm_):
     deploy_kwargs = {
         'opts': __opts__,
         'host': vm_['ssh_host'],
+        'salt_host': vm_['salt_host'],
         'username': ssh_username,
         'script': deploy_script,
         'name': vm_['name'],

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -316,6 +316,7 @@ def bootstrap(vm_, opts):
     deploy_kwargs = {
         'opts': opts,
         'host': vm_['ssh_host'],
+        'salt_host': vm_['salt_host'],
         'username': ssh_username,
         'script': deploy_script_code,
         'name': vm_['name'],


### PR DESCRIPTION
Scenario cloud map:

```
ubuntu_small:
  - master:
    make_master: True
    securitygroup: ['ssh-external', 'salt-internal']
  - web:
    securitygroup: ['ssh-external', 'salt-internal']
```

To run this from my local machine I must set `ssh_interface: public_ips` but this means the minions are configured to talk to the master on the public_ip which I don't allow with these security groups.

Proposed solution:
Also add `salt_interface: private_ips`. Then I can provision over ssh to the public interface but let the new master and minions communicate internally only.

Tested with ec2, would appreciate any thoughts or testing of the other providers which I've updated too. This could well break the clouds I haven't updated.
