### PR TITLE
Add template files to manifest so they get included

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -16,4 +16,6 @@ recursive-include scripts *
 include conf/*
 recursive-include pkg *
 recursive-include salt *.jinja
-include salt/templates/git/ssh-id-wrapper
+recursive-include salt *.flo
+include salt/templates/git/*
+include salt/templates/lxc/*


### PR DESCRIPTION
in python 2.6 builds because package_data was changed in 2.7
