### PR TITLE
Issue 14304: add proxy parameter to gem.installed state

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -36,7 +36,8 @@ def install(gems,           # pylint: disable=C0103
             version=None,
             rdoc=False,
             ri=False,
-            pre_releases=False):      # pylint: disable=C0103
+            pre_releases=False,
+            proxy=None):      # pylint: disable=C0103
     '''
     Installs one or several gems.
 
@@ -55,6 +56,9 @@ def install(gems,           # pylint: disable=C0103
         Generate RI documentation for the gem(s).
     pre_releases
         Include pre-releases in the available versions
+    proxy : None
+        Use the specified HTTP proxy server for all outgoing traffic.
+        Format: http://hostname[:port]
 
     CLI Example:
 
@@ -71,6 +75,8 @@ def install(gems,           # pylint: disable=C0103
         options.append('--no-ri')
     if pre_releases:
         options.append('--pre')
+    if proxy:
+        options.append('-p {0}'.format(proxy))
 
     cmdline_args = ' '.join(options)
     return _gem('install {gems} {options}'.format(gems=gems,

--- a/salt/states/gem.py
+++ b/salt/states/gem.py
@@ -33,7 +33,8 @@ def installed(name,          # pylint: disable=C0103
               version=None,
               rdoc=False,
               ri=False,
-              pre_releases=False):     # pylint: disable=C0103
+              pre_releases=False,
+              proxy=None):     # pylint: disable=C0103
     '''
     Make sure that a gem is installed.
 
@@ -65,6 +66,10 @@ def installed(name,          # pylint: disable=C0103
 
     pre_releases : False
         Install pre-release version of gem(s) if available.
+
+    proxy : None
+        Use the specified HTTP proxy server for all outgoing traffic.
+        Format: http://hostname[:port]
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
@@ -111,7 +116,8 @@ def installed(name,          # pylint: disable=C0103
                                version=version,
                                rdoc=rdoc,
                                ri=ri,
-                               pre_releases=pre_releases):
+                               pre_releases=pre_releases,
+                               proxy=proxy):
         ret['result'] = True
         ret['changes'][name] = 'Installed'
         ret['comment'] = 'Gem was successfully installed'

--- a/tests/unit/states/gem_test.py
+++ b/tests/unit/states/gem_test.py
@@ -30,7 +30,7 @@ class TestGemState(TestCase):
                 self.assertEqual(True, ret['result'])
                 gem_install_succeeds.assert_called_once_with(
                     'quux', pre_releases=False, ruby=None, runas=None,
-                    version=None, rdoc=False, ri=False
+                    version=None, proxy=None, rdoc=False, ri=False
                 )
 
             with patch.dict(gem.__salt__,
@@ -39,7 +39,7 @@ class TestGemState(TestCase):
                 self.assertEqual(False, ret['result'])
                 gem_install_fails.assert_called_once_with(
                     'quux', pre_releases=False, ruby=None, runas=None,
-                    version=None, rdoc=False, ri=False
+                    version=None, proxy=None, rdoc=False, ri=False
                 )
 
     def test_removed(self):


### PR DESCRIPTION
Fix  #14304 by adding a "proxy" parameter to the gem.installed state.
