### PR TITLE
include trailing slash for slspath template var

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -64,6 +64,9 @@ def wrap_tmpl_func(render_str):
                 context['tplpath'] = tmplpath
                 if not tmplpath.lower().replace('\\', '/').endswith('/init.sls'):
                     slspath = os.path.dirname(slspath)
+            context['slspathdot'] = slspath.replace('/', '.')
+            if slspath:
+                slspath = slspath + '/'
             context['slspath'] = slspath
 
         if isinstance(tmplsrc, string_types):

--- a/tests/unit/stateconf_test.py
+++ b/tests/unit/stateconf_test.py
@@ -277,7 +277,7 @@ formula/woot.sls:
 ''', sls='formula.woot', argline='yaml . jinja')
 
         r = result['formula/woot.sls']['cmd.run'][0]['name']
-        self.assertEqual(r, 'echo formula/woot')
+        self.assertEqual(r, 'echo formula/woot/')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Include end slash so using join path is never required.

```
salt://{{ salt['file.join'](slspath,'ssl/my.key') }}
slspath = 'formula/woot/' # when not root of file system append a slash
slspath = '' # in root of filesystem no extra slash
# so this will always work!
salt://{{ slspath }}ssl/my.key
```

ref: https://github.com/saltstack/salt/pull/14535

It makes life more simple and reduces chance of error.
I also included slspathdot because I found a good place for it in formulas.
