### PR TITLE
Remove unused argument from boto_cloudwatch_alarm.absent

### DIFF
--- a/salt/states/boto_cloudwatch_alarm.py
+++ b/salt/states/boto_cloudwatch_alarm.py
@@ -168,7 +168,6 @@ def present(
 
 def absent(
         name,
-        attributes=None,
         region=None,
         key=None,
         keyid=None,


### PR DESCRIPTION
Fixes #14925
