### PR TITLE
Fixed example usage in docstring for grains.filter_by

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -362,7 +362,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default'):
         {% set apache = salt['grains.filter_by']({
             'Debian': {'pkg': 'apache2', 'srv': 'apache2'},
             'RedHat': {'pkg': 'httpd', 'srv': 'httpd'},
-        }), default='Debian' %}
+        }, default='Debian') %}
 
         myapache:
           pkg:


### PR DESCRIPTION
Simple syntax fix for example grains.filter_by docstring example.  Fixes #14988.
