### PR TITLE
lack of ssh_py_shim.py breaks esky builds

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -151,7 +151,11 @@ EOF'''.format(
 )
 
 if not is_windows():
-    with open(os.path.join(os.path.dirname(__file__), 'ssh_py_shim.py')) as ssh_py_shim:
+    shim_file = os.path.join(os.path.dirname(__file__), 'ssh_py_shim.py')
+    if not os.path.exists(shim_file):
+        # On esky builds we only have the .pyc file
+        shim_file += "c"
+    with open(shim_file) as ssh_py_shim:
         SSH_PY_SHIM = ''.join(ssh_py_shim.readlines()).encode('base64')
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
I'm not 100% sure that this works correctly.
If someone else could test it, that would be helpful.
I don't use salt-ssh so I'm not certain exactly what I might be breaking...

I'm also open to other suggestions of how to fix this.
The error message I see without this change is:

```
[root@salt-build /opt]# ./salt/bin/salt-master 
Traceback (most recent call last):
  File "<string>", line 6, in <module>
  File "__main__.py", line 128, in <module>
  File "__main__salt-master__.py", line 9, in <module>
  File "salt/scripts.py", line 16, in <module>
  File "salt/cli/__init__.py", line 17, in <module>
  File "salt/client/ssh/__init__.py", line 154, in <module>
IOError: [Errno 2] No such file or directory: '/opt/salt/bin/appdata/salt-2014.7.0rc1-94-g2d0d6b5.solaris-2_11-i86pc_64bit/salt-2014.7.0rc1_94_g2d0d6b5-py2.7.egg/salt/client/ssh/ssh_py_shim.py'
```

Currently the master cannot start up if that file is missing even if there's a corresponding .pyc file.
