### PR TITLE
Don't stacktrace with old versions of psutil on certain functions

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -12,7 +12,7 @@ import time
 import datetime
 
 # Import salt libs
-from salt.exceptions import SaltInvocationError
+from salt.exceptions import SaltInvocationError, CommandExecutionError
 
 # Import third party libs
 try:
@@ -347,12 +347,19 @@ def virtual_memory():
 
     Return a dict that describes statistics about system memory usage.
 
+    .. note::
+
+        This function is only available in psutil version 0.6.0 and above.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' ps.virtual_memory
     '''
+    if psutil.version_info < (0, 6, 0):
+        msg = 'virtual_memory is only available in psutil 0.6.0 or greater'
+        raise CommandExecutionError(msg)
     return dict(psutil.virtual_memory()._asdict())
 
 
@@ -362,12 +369,19 @@ def swap_memory():
 
     Return a dict that describes swap memory statistics.
 
+    .. note::
+
+        This function is only available in psutil version 0.6.0 and above.
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' ps.swap_memory
     '''
+    if psutil.version_info < (0, 6, 0):
+        msg = 'swap_memory is only available in psutil 0.6.0 or greater'
+        raise CommandExecutionError(msg)
     return dict(psutil.swap_memory()._asdict())
 
 

--- a/tests/unit/modules/ps_test.py
+++ b/tests/unit/modules/ps_test.py
@@ -56,6 +56,10 @@ try:
 except ImportError:
     HAS_UTMP = False
 
+HAS_PSUTIL_VERSION = False
+if psutil.version_info >= (0, 6, 0):
+    HAS_PSUTIL_VERSION = True
+
 
 def _get_proc_name(proc):
     return proc.name() if PSUTIL2 else proc.name
@@ -104,11 +108,13 @@ class PsTestCase(TestCase):
     def test_cpu_times(self):
         self.assertDictEqual({'idle': 4, 'nice': 2, 'system': 3, 'user': 1}, ps.cpu_times())
 
+    @skipIf(HAS_PSUTIL_VERSION is False, 'psutil 0.6.0 or greater is required for this test')
     @patch('psutil.virtual_memory', new=MagicMock(return_value=STUB_VIRT_MEM))
     def test_virtual_memory(self):
         self.assertDictEqual({'used': 500, 'total': 1000, 'available': 500, 'percent': 50, 'free': 500},
                              ps.virtual_memory())
 
+    @skipIf(HAS_PSUTIL_VERSION is False, 'psutil 0.6.0 or greater is required for this test')
     @patch('psutil.swap_memory', new=MagicMock(return_value=STUB_SWAP_MEM))
     def test_swap_memory(self):
         self.assertDictEqual({'used': 500, 'total': 1000, 'percent': 50, 'free': 500, 'sin': 0, 'sout': 0},

--- a/tests/unit/modules/ps_test.py
+++ b/tests/unit/modules/ps_test.py
@@ -35,6 +35,10 @@ if HAS_PSUTIL:
         1000, 2000, 500, 600, 2000, 3000)
     STUB_USER = psutil._compat.namedtuple('user', 'name, terminal, host, started')('bdobbs', 'ttys000', 'localhost',
                                                                                    0.0)
+    HAS_PSUTIL_VERSION = False
+    if psutil.version_info >= (0, 6, 0):
+        HAS_PSUTIL_VERSION = True
+
 else:
     (STUB_CPU_TIMES,
      STUB_VIRT_MEM,
@@ -55,10 +59,6 @@ try:
     HAS_UTMP = True
 except ImportError:
     HAS_UTMP = False
-
-HAS_PSUTIL_VERSION = False
-if psutil.version_info >= (0, 6, 0):
-    HAS_PSUTIL_VERSION = True
 
 
 def _get_proc_name(proc):

--- a/tests/unit/modules/ps_test.py
+++ b/tests/unit/modules/ps_test.py
@@ -13,6 +13,7 @@ ensure_in_syspath('../../')
 from salt.modules import ps
 
 HAS_PSUTIL = ps.__virtual__()
+HAS_PSUTIL_VERSION = False
 
 if HAS_PSUTIL:
     import psutil
@@ -35,7 +36,6 @@ if HAS_PSUTIL:
         1000, 2000, 500, 600, 2000, 3000)
     STUB_USER = psutil._compat.namedtuple('user', 'name, terminal, host, started')('bdobbs', 'ttys000', 'localhost',
                                                                                    0.0)
-    HAS_PSUTIL_VERSION = False
     if psutil.version_info >= (0, 6, 0):
         HAS_PSUTIL_VERSION = True
 


### PR DESCRIPTION
If you install psutil from apt-get, it's a very old version (0.5.0), which doesn't support the `virtual_memory` and `swap_memory` functions, and stacktraces on those function. This PR adds some version checks for those functions to not stacktrace and skips the affected unit tests.
