### PR TITLE
Optimize auth

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1317,10 +1317,9 @@ class ClearFuncs(object):
                     'load': {'ret': False}}
         log.info('Authentication request from {id}'.format(**load))
 
-        minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
-
         # 0 is default which should be 'unlimited'
         if self.opts['max_minions'] > 0:
+            minions = salt.utils.minions.CkMinions(self.opts).connected_ids()
             if not len(minions) < self.opts['max_minions']:
                 # we reject new minions, minions that are already
                 # connected must be allowed for the mine, highstate, etc.


### PR DESCRIPTION
We were traversing the entire minion data cache on every auth
unnecessarily. This should speed auths up substantially, especially in large installations.
