### PR TITLE
block_device_mappings support for CloudStack

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -35,6 +35,7 @@ from salt.cloud.exceptions import SaltCloudSystemExit
 # CloudStackNetwork will be needed during creation of a new node
 try:
     from libcloud.compute.drivers.cloudstack import CloudStackNetwork
+    from libcloud.common.cloudstack import CloudStackConnection
     HASLIBS = True
 except ImportError:
     HASLIBS = False
@@ -49,7 +50,6 @@ avail_locations = namespaced_function(avail_locations, globals())
 avail_images = namespaced_function(avail_images, globals())
 avail_sizes = namespaced_function(avail_sizes, globals())
 script = namespaced_function(script, globals())
-destroy = namespaced_function(destroy, globals())
 list_nodes = namespaced_function(list_nodes, globals())
 list_nodes_full = namespaced_function(list_nodes_full, globals())
 list_nodes_select = namespaced_function(list_nodes_select, globals())
@@ -240,6 +240,37 @@ def create(vm_):
         transport=__opts__['transport']
     )
 
+    volumes = {}
+    ex_blockdevicemappings = block_device_mappings(vm_)
+    if ex_blockdevicemappings:
+        for ex_blockdevicemapping in ex_blockdevicemappings:
+            if 'VirtualName' not in ex_blockdevicemapping:
+                ex_blockdevicemapping['VirtualName'] = '{0}-{1}'.format(vm_['name'], len(volumes))
+            salt.utils.cloud.fire_event(
+              'event',
+              'requesting volume',
+              'salt/cloud/{0}/requesting'.format(ex_blockdevicemapping['VirtualName']),
+              {'kwargs': {'name': ex_blockdevicemapping['VirtualName'],
+                          'device': ex_blockdevicemapping['DeviceName'],
+                          'size': ex_blockdevicemapping['VolumeSize']}},
+            )
+            try:
+                volumes[ex_blockdevicemapping['DeviceName']] = conn.create_volume(
+                        ex_blockdevicemapping['VolumeSize'],
+                        ex_blockdevicemapping['VirtualName']
+                    )
+            except Exception as exc:
+                log.error(
+                    'Error creating volume {0} on CLOUDSTACK\n\n'
+                    'The following exception was thrown by libcloud when trying to '
+                    'requesting a volume: \n{1}'.format(
+                        ex_blockdevicemapping['VirtualName'], exc.message
+                    ),
+                    # Show the traceback if the debug logging level is enabled
+                    exc_info_on_loglevel=logging.DEBUG
+                )
+                return False
+
     try:
         data = conn.create_node(**kwargs)
     except Exception as exc:
@@ -253,6 +284,21 @@ def create(vm_):
             exc_info_on_loglevel=logging.DEBUG
         )
         return False
+
+    for device_name in volumes.keys():
+        try:
+            conn.attach_volume(data, volumes[device_name], device_name)
+        except Exception as exc:
+            log.error(
+                'Error attaching volume {0} on CLOUDSTACK\n\n'
+                'The following exception was thrown by libcloud when trying to '
+                'attach a volume: \n{1}'.format(
+                    ex_blockdevicemapping['VirtualName'], exc.message
+                ),
+                # Show the traceback if the debug logging level is enabled
+                exc_info=log.isEnabledFor(logging.DEBUG)
+            )
+            return False
 
     ssh_username = config.get_cloud_config_value(
         'ssh_username', vm_, __opts__, default='root'
@@ -388,3 +434,104 @@ def create(vm_):
     )
 
     return ret
+
+
+def destroy(name, conn=None, call=None):
+    '''
+    Delete a single VM, and all of its volumes
+    '''
+    if call == 'function':
+        raise SaltCloudSystemExit(
+            'The destroy action must be called with -d, --destroy, '
+            '-a or --action.'
+        )
+
+    salt.utils.cloud.fire_event(
+        'event',
+        'destroying instance',
+        'salt/cloud/{0}/destroying'.format(name),
+        {'name': name},
+    )
+
+    if not conn:
+        conn = get_conn()   # pylint: disable=E0602
+
+    node = get_node(conn, name)
+    if node is None:
+        log.error('Unable to find the VM {0}'.format(name))
+    volumes = conn.list_volumes(node)
+    if volumes is None:
+        log.error('Unable to find volumes of the VM {0}'.format(name))
+    # TODO add an option like 'delete_sshkeys' below
+    for volume in volumes:
+        if  volume.extra['volume_type'] != 'DATADISK':
+            log.info('Ignoring volume type {0}: {1}'.format(
+                volume.extra['volume_type'],volume.name)
+            )
+            continue
+        log.info('Detaching volume: {0}'.format(volume.name))
+        salt.utils.cloud.fire_event(
+            'event',
+            'detaching volume',
+            'salt/cloud/{0}/detaching'.format(volume.name),
+            {'name': volume.name},
+        )
+        if not conn.detach_volume(volume):
+            log.error('Failed to Detach volume: {0}'.format(volume.name))
+            return False
+        log.info('Detached volume: {0}'.format(volume.name))
+        salt.utils.cloud.fire_event(
+            'event',
+            'detached volume',
+            'salt/cloud/{0}/detached'.format(volume.name),
+            {'name': volume.name},
+        )
+
+        log.info('Destroying volume: {0}'.format(volume.name))
+        salt.utils.cloud.fire_event(
+            'event',
+            'destroying volume',
+            'salt/cloud/{0}/destroying'.format(volume.name),
+            {'name': volume.name},
+        )
+        if not conn.destroy_volume(volume):
+            log.error('Failed to Destroy volume: {0}'.format(volume.name))
+            return False
+        log.info('Destroyed volume: {0}'.format(volume.name))
+        salt.utils.cloud.fire_event(
+            'event',
+            'destroyed volume',
+            'salt/cloud/{0}/destroyed'.format(volume.name),
+            {'name': volume.name},
+        )
+    log.info('Destroying VM: {0}'.format(name))
+    ret = conn.destroy_node(node)
+    if not ret:
+        log.error('Failed to Destroy VM: {0}'.format(name))
+        return False
+    log.info('Destroyed VM: {0}'.format(name))
+    # Fire destroy action
+    event = salt.utils.event.SaltEvent('master', __opts__['sock_dir'])
+    salt.utils.cloud.fire_event(
+        'event',
+        'destroyed instance',
+        'salt/cloud/{0}/destroyed'.format(name),
+        {'name': name},
+    )
+    if __opts__['delete_sshkeys'] is True:
+        salt.utils.cloud.remove_sshkey(node.public_ips[0])
+    return True
+
+
+def block_device_mappings(vm_):
+    '''
+    Return the block device mapping:
+
+    ::
+
+        [{'DeviceName': '/dev/sdb', 'VirtualName': 'ephemeral0'},
+          {'DeviceName': '/dev/sdc', 'VirtualName': 'ephemeral1'}]
+    '''
+    return config.get_cloud_config_value(
+        'block_device_mappings', vm_, __opts__, search_global=True
+    )


### PR DESCRIPTION
block_device_mappings can be used with CloudStack the same way as Amazon. It will remove any disks attached to a machine when destroying it.
