### PR TITLE
Replace POST to GET for logout

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1092,7 +1092,7 @@ class Logout(LowDataAdapter):
         'tools.salt_auth.on': True,
     })
 
-    def POST(self):
+    def GET(self):
         '''
         Destroy the currently active session and expire the session cookie
         '''


### PR DESCRIPTION
Any post data don't required in logout api, and some tools like 'curl'  couldn't use 'POST' method whitout post data. So the method should be 'GET'.
