### PR TITLE
Fixes to returners.

### DIFF
--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -152,13 +152,20 @@ def returner(ret):
 
     '''
 
-    cfg = __salt__['config.option']
-    c_cfg = cfg('carbon', {})
+    if 'config.option' in __salt__:
+        cfg = __salt__['config.option']
+        c_cfg = cfg('carbon', {})
 
-    host = c_cfg.get('host', cfg('carbon.host', None))
-    port = c_cfg.get('port', cfg('carbon.port', None))
-    skip = c_cfg.get('skip_on_error', cfg('carbon.skip_on_error', False))
-    mode = c_cfg.get('mode', cfg('carbon.mode', 'text')).lower()
+        host = c_cfg.get('host', cfg('carbon.host', None))
+        port = c_cfg.get('port', cfg('carbon.port', None))
+        skip = c_cfg.get('skip_on_error', cfg('carbon.skip_on_error', False))
+        mode = c_cfg.get('mode', cfg('carbon.mode', 'text')).lower()
+    else:
+        cfg = __opts__
+        host = cfg.get('cabon.host', None)
+        port = cfg.get('cabon.port', None)
+        skip = cfg.get('carbon.skip_on_error', False)
+        mode = cfg.get('carbon.mode', 'text').lower()
 
     log.debug('Carbon minion configured with host: {0}:{1}'.format(host, port))
     log.debug('Using carbon protocol: {0}'.format(mode))

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -30,12 +30,18 @@ def _get_options():
     Get the couchdb options from salt. Apply defaults
     if required.
     '''
-    server_url = __salt__['config.option']('couchdb.url')
+    if 'config.option' in __salt__:
+        server_url = __salt__['config.option']('couchdb.url')
+        db_name = __salt__['config.option']('couchdb.db')
+    else:
+        cfg = __opts__
+        server_url = cfg.get('couchdb.url', None)
+        db_name = cfg.get('couchdb.db', None)
+
     if not server_url:
         log.debug("Using default url.")
         server_url = "http://salt:5984/"
 
-    db_name = __salt__['config.option']('couchdb.db')
     if not db_name:
         log.debug("Using default database.")
         db_name = "salt"

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -39,8 +39,13 @@ def _get_serv():
     '''
     Return a memcache server object
     '''
-    host = __salt__['config.option']('memcache.host')
-    port = __salt__['config.option']('memcache.port')
+    if 'config.option' in __salt__:
+        host = __salt__['config.option']('memcache.host')
+        port = __salt__['config.option']('memcache.port')
+    else:
+        cfg = __opts__
+        host = cfg.get('memcache.host', None)
+        port = cfg.get('memcache.port', None)
     log.debug('memcache server: {0}:{1}'.format(host, port))
     if not host or not port:
         log.error('Host or port not defined in salt config')

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -58,13 +58,22 @@ def _get_conn():
     '''
     Return a mongodb connection object
     '''
-    conn = pymongo.Connection(
-            __salt__['config.option']('mongo.host'),
-            __salt__['config.option']('mongo.port'))
-    mdb = conn[__salt__['config.option']('mongo.db')]
+    if 'config.option' in __salt__:
+        host = __salt__['config.option']('mongo.host')
+        port = __salt__['config.option']('mongo.port')
+        db = __salt__['config.option']('mongo.db')
+        user = __salt__['config.option']('mongo.user')
+        password = __salt__['config.option']('mongo.password')
+    else:
+        cfg = __opts__
+        host = cfg.get('mongo.host', None)
+        port = cfg.get('mongo.port', None)
+        db = cfg.get('mongo.db', None)
+        user = cfg.get('mongo.user', None)
+        password = cfg.get('mongo.password', None)
 
-    user = __salt__['config.option']('mongo.user')
-    password = __salt__['config.option']('mongo.password')
+    conn = pymongo.Connection(host, port)
+    mdb = conn[db]
 
     if user and password:
         mdb.authenticate(user, password)

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -53,13 +53,22 @@ def _get_conn():
     '''
     Return a mongodb connection object
     '''
-    conn = pymongo.Connection(
-            __salt__['config.option']('mongo.host'),
-            __salt__['config.option']('mongo.port'))
-    mdb = conn[__salt__['config.option']('mongo.db')]
+    if 'config.option' in __salt__:
+        host = __salt__['config.option']('mongo.host')
+        port = __salt__['config.option']('mongo.port')
+        db = __salt__['config.option']('mongo.db')
+        user = __salt__['config.option']('mongo.user')
+        password = __salt__['config.option']('mongo.password')
+    else:
+        cfg = __opts__
+        host = cfg.get('mongo.host', None)
+        port = cfg.get('mongo.port', None)
+        db = cfg.get('mongo.db', None)
+        user = cfg.get('mongo.user', None)
+        password = cfg.get('mongo.password', None)
 
-    user = __salt__['config.option']('mongo.user')
-    password = __salt__['config.option']('mongo.password')
+    conn = pymongo.Connection(host, port)
+    mdb = conn[db]
 
     if user and password:
         mdb.authenticate(user, password)

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -96,7 +96,11 @@ def _get_options():
                 'port': 3306}
     _options = {}
     for attr in defaults:
-        _attr = __salt__['config.option']('mysql.{0}'.format(attr))
+        if 'config.option' in __salt__:
+            _attr = __salt__['config.option']('mysql.{0}'.format(attr))
+        else:
+            cfg = __opts__
+            _attr = cfg.get('mysql.{0}'.format(attr), None)
         if not _attr:
             log.debug('Using default for MySQL {0}'.format(attr))
             _options[attr] = defaults[attr]

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -121,10 +121,17 @@ def _get_conn():
     '''
     Return a MSSQL connection.
     '''
-    return pyodbc.connect('DSN={0};UID={1};PWD={2}'.format(
-            __salt__['config.option']('returner.odbc.dsn'),
-            __salt__['config.option']('returner.odbc.user'),
-            __salt__['config.option']('returner.odbc.passwd')))
+    if 'config.option' in __salt__:
+        return pyodbc.connect('DSN={0};UID={1};PWD={2}'.format(
+                __salt__['config.option']('returner.odbc.dsn'),
+                __salt__['config.option']('returner.odbc.user'),
+                __salt__['config.option']('returner.odbc.passwd')))
+    else:
+        cfg = __opts__
+        return pyodbc.connect('DSN={0};UID={1};PWD={2}'.format(
+                cfg.get('returner.odbc.dsn', None),
+                cfg.get('returner.odbc.user', None),
+                cfg.get('returner.odbc.passwd', None)))
 
 
 def _close_conn(conn):

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -85,12 +85,21 @@ def _get_conn():
     '''
     Return a postgres connection.
     '''
-    return psycopg2.connect(
-            host=__salt__['config.option']('returner.postgres.host'),
-            user=__salt__['config.option']('returner.postgres.user'),
-            password=__salt__['config.option']('returner.postgres.passwd'),
-            database=__salt__['config.option']('returner.postgres.db'),
-            port=__salt__['config.option']('returner.postgres.port'))
+    if 'config.option' in __salt__:
+        return psycopg2.connect(
+                host=__salt__['config.option']('returner.postgres.host'),
+                user=__salt__['config.option']('returner.postgres.user'),
+                password=__salt__['config.option']('returner.postgres.passwd'),
+                database=__salt__['config.option']('returner.postgres.db'),
+                port=__salt__['config.option']('returner.postgres.port'))
+    else:
+        cfg = __opts__
+        return psycopg2.connect(
+                host=cfg.get('returner.postgres.host', None),
+                user=cfg.get('returner.postgres.user', None),
+                password=cfg.get('returner.postgres.passwd', None),
+                database=cfg.get('returner.postgres.db', None),
+                port=cfg.get('returner.postgres.port', None))
 
 
 def _close_conn(conn):

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -39,10 +39,17 @@ def _get_serv():
     '''
     Return a redis server object
     '''
-    return redis.Redis(
-            host=__salt__['config.option']('redis.host'),
-            port=__salt__['config.option']('redis.port'),
-            db=__salt__['config.option']('redis.db'))
+    if 'config.option' in __salt__:
+        return redis.Redis(
+                host=__salt__['config.option']('redis.host'),
+                port=__salt__['config.option']('redis.port'),
+                db=__salt__['config.option']('redis.db'))
+    else:
+        cfg = __opts__
+        return redis.Redis(
+                host=cfg.get('redis.host', None),
+                port=cfg.get('redis.port', None),
+                db=cfg.get('redis.db', None))
 
 
 def returner(ret):

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -72,19 +72,33 @@ def returner(ret):
     Send an email with the data
     '''
 
-    from_addr = __salt__['config.option']('smtp.from')
-    to_addrs = __salt__['config.option']('smtp.to')
-    host = __salt__['config.option']('smtp.host')
-    port = __salt__['config.option']('smtp.port')
+    if 'config.option' in __salt__:
+        from_addr = __salt__['config.option']('smtp.from')
+        to_addrs = __salt__['config.option']('smtp.to')
+        host = __salt__['config.option']('smtp.host')
+        port = __salt__['config.option']('smtp.port')
+        user = __salt__['config.option']('smtp.username')
+        passwd = __salt__['config.option']('smtp.password')
+        subject = __salt__['config.option']('smtp.subject')
+        gpgowner = __salt__['config.option']('smtp.gpgowner')
+        fields = __salt__['config.option']('smtp.fields').split(',')
+        smtp_tls = __salt__['config.option']('smtp.tls')
+    else:
+        cfg = __opts__
+        from_addr = cfg.get('smtp.from', None)
+        to_addrs = cfg.get('smtp.to', None)
+        host = cfg.get('smtp.host', None)
+        port = cfg.get('smtp.port', None)
+        user = cfg.get('smtp.username', None)
+        passwd = cfg.get('smtp.password', None)
+        subject = cfg.get('smtp.subject', None)
+        gpgowner = cfg.get('smtp.gpgowner', None)
+        fields = cfg.get('smtp.fields', '').split(',')
+        smtp_tls = cfg('smtp.tls', False)
+
     if not port:
         port = 25
     log.debug('SMTP port has been set to {0}'.format(port))
-    user = __salt__['config.option']('smtp.username')
-    passwd = __salt__['config.option']('smtp.password')
-    subject = __salt__['config.option']('smtp.subject')
-    gpgowner = __salt__['config.option']('smtp.gpgowner')
-
-    fields = __salt__['config.option']('smtp.fields').split(',')
     for field in fields:
         if field in ret.keys():
             subject += ' {0}'.format(ret[field])
@@ -124,7 +138,7 @@ def returner(ret):
 
     log.debug('smtp_return: Connecting to the server...')
     server = smtplib.SMTP(host, int(port))
-    if __salt__['config.option']('smtp.tls') is True:
+    if smtp_tls is True:
         server.starttls()
         log.debug('smtp_return: TLS enabled')
     if user and passwd:

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -79,18 +79,24 @@ def _get_conn():
     '''
     # Possible todo: support detect_types, isolation_level, check_same_thread,
     # factory, cached_statements. Do we really need to though?
-    if not __salt__['config.option']('returner.sqlite3.database'):
+    if 'config.option' in __salt__:
+        database = __salt__['config.option']('returner.sqlite3.database')
+        timeout = __salt__['config.option']('returner.sqlite3.timeout')
+    else:
+        cfg = __opts__
+        database = cfg.get('returner.sqlite3.database', None)
+        timeout = cfg.get('returner.sqlite3.timeout', None)
+
+    if not database:
         raise Exception(
                 'sqlite3 config option "returner.sqlite3.database" is missing')
-    if not __salt__['config.option']('returner.sqlite3.timeout'):
+    if not timeout:
         raise Exception(
                 'sqlite3 config option "returner.sqlite3.timeout" is missing')
     log.debug('Connecting the sqlite3 database: {0} timeout: {1}'.format(
-              __salt__['config.option']('returner.sqlite3.database'),
-              __salt__['config.option']('returner.sqlite3.timeout')))
-    conn = sqlite3.connect(
-                  __salt__['config.option']('returner.sqlite3.database'),
-        timeout=float(__salt__['config.option']('returner.sqlite3.timeout')))
+              database,
+              timeout))
+    conn = sqlite3.connect(database, timeout=float(timeout))
     return conn
 
 


### PR DESCRIPTION
Fixing returners that use configuration options from config.options to work as returners for the salt schedulers.  The **salt** variable is unavailable when the returner is run from a scheduled job so we pull the configuration values out of **opts** instead.
