### PR TITLE
return only one url

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -378,7 +378,7 @@ class _RepoInfo(object):
 
     @property
     def url(self):
-        return [url.asCompleteString() for url in self.zypp.baseUrls()]
+        return self.zypp.url().asCompleteString()
 
     @url.setter
     def url(self, value):


### PR DESCRIPTION
get url should return only one url.
We can set only one URL so with get we should expect only one too.

Otherwise in states/pkgrepo test=True compare failed, when comparing a string with an array.
