### PR TITLE
Make lxc tests run!

### DIFF
--- a/tests/integration/modules/lxc.py
+++ b/tests/integration/modules/lxc.py
@@ -14,7 +14,7 @@ import integration
 import salt.utils
 
 
-@skipIf(salt.utils.which('lxc') is None, 'Skipping - lxc must be installed.')
+@skipIf(salt.utils.which('lxc-start') is None, 'Skipping - lxc must be installed.')
 class LXCModuleTest(integration.ModuleCase):
     '''
     Test the lxc module

--- a/tests/integration/modules/lxc.py
+++ b/tests/integration/modules/lxc.py
@@ -14,7 +14,7 @@ import integration
 import salt.utils
 
 
-@skipIf(salt.utils.which('lxc-start') is None, 'Skipping - lxc must be installed.')
+@skipIf(salt.utils.which('lxc-start') is None, 'LXC is not installed or minimal version not met')
 class LXCModuleTest(integration.ModuleCase):
     '''
     Test the lxc module


### PR DESCRIPTION
DO NOT MERGE YET - waiting to see test results and to make sure tests are running as intended.

Due to an improperly formed `skipIf`, lxc integration tests have not been running on Jenkins. This will make the tests run.
