### PR TITLE
Backport #13278 to 2014.1 branch

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -631,7 +631,7 @@ class ReactWrap(object):
         Wrap RunnerClient for executing :ref:`runner modules <all-salt.runners>`
         '''
         runner = salt.runner.RunnerClient(self.opts)
-        return runner.low(fun, kwargs)
+        return runner.async(fun, kwargs)
 
     def wheel(self, fun, **kwargs):
         '''


### PR DESCRIPTION
Execute runner functions asynchronously via the Reactor

Closes #13277

Conflicts:
    salt/utils/event.py
