### PR TITLE
Add no_use_wheel option to pip.install

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -94,6 +94,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             env=None,
             bin_env=None,
             use_wheel=False,
+            no_use_wheel=False,
             log=None,
             proxy=None,
             timeout=None,
@@ -150,6 +151,8 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         Deprecated, use bin_env now
     use_wheel
         Prefer wheel archives (requires pip>=1.4)
+    no_use_wheel
+        Force to not use wheel archives (requires pip>=1.4)
     log
         Log file where a complete (maximum verbosity) record will be kept
     proxy
@@ -351,6 +354,19 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             )
         else:
             cmd.append('--use-wheel')
+            
+    if no_use_wheel:
+        min_version = '1.4'
+        cur_version = __salt__['pip.version'](bin_env)
+        if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
+                                           ver2=min_version):
+            log.error(
+                ('The --use-wheel option is only supported in pip {0} and '
+                 'newer. The version of pip detected is {1}. This option '
+                 'will be ignored.'.format(min_version, cur_version))
+            )
+        else:
+            cmd.append('--no-use-wheel')
 
     if log:
         try:

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -354,7 +354,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             )
         else:
             cmd.append('--use-wheel')
-            
+
     if no_use_wheel:
         min_version = '1.4'
         cur_version = __salt__['pip.version'](bin_env)

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -361,7 +361,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
                                            ver2=min_version):
             log.error(
-                ('The --use-wheel option is only supported in pip {0} and '
+                ('The --no-use-wheel option is only supported in pip {0} and '
                  'newer. The version of pip detected is {1}. This option '
                  'will be ignored.'.format(min_version, cur_version))
             )

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -160,7 +160,7 @@ def installed(name,
 
     use_wheel : False
         Prefer wheel archives (requires pip>=1.4)
-        
+
     no_use_wheel : False
         Force to not use wheel archives (requires pip>=1.4)
 

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -94,6 +94,7 @@ def installed(name,
               env=None,
               bin_env=None,
               use_wheel=False,
+              no_use_wheel=False,
               log=None,
               proxy=None,
               timeout=None,
@@ -159,6 +160,9 @@ def installed(name,
 
     use_wheel : False
         Prefer wheel archives (requires pip>=1.4)
+        
+    no_use_wheel : False
+        Force to not use wheel archives (requires pip>=1.4)
 
     bin_env : None
         Absolute path to a virtual environment directory or absolute path to
@@ -254,6 +258,17 @@ def installed(name,
                                            ver2=min_version):
             ret['result'] = False
             ret['comment'] = ('The \'use_wheel\' option is only supported in '
+                              'pip {0} and newer. The version of pip detected '
+                              'was {1}.').format(min_version, cur_version)
+            return ret
+
+    if no_use_wheel:
+        min_version = '1.4'
+        cur_version = __salt__['pip.version'](bin_env)
+        if not salt.utils.compare_versions(ver1=cur_version, oper='>=',
+                                           ver2=min_version):
+            ret['result'] = False
+            ret['comment'] = ('The \'no_use_wheel\' option is only supported in '
                               'pip {0} and newer. The version of pip detected '
                               'was {1}.').format(min_version, cur_version)
             return ret
@@ -403,6 +418,7 @@ def installed(name,
         requirements=requirements,
         bin_env=bin_env,
         use_wheel=use_wheel,
+        no_use_wheel=no_use_wheel,
         log=log,
         proxy=proxy,
         timeout=timeout,


### PR DESCRIPTION
Some packages like cherrypy do not work well if you do `pip install cherrypy` since hey use the wheel version you need to specify the `--no-use-wheel` argument. See [here](http://www.chronicles.no/2014/04/cherrypy-no-module-named-wsgiserver2.html) for someone who had that problem.
