### PR TITLE
Backport Fix for #12348 to 0.16

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -70,7 +70,7 @@ def install(runas=None):
     '''
     # RVM dependencies on Ubuntu 10.04:
     #   bash coreutils gzip bzip2 gawk sed curl git-core subversion
-    installer = 'https://raw.github.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
+    installer = 'https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer'
     ret = __salt__['cmd.run_all'](
         # the RVM installer automatically does a multi-user install when it is
         # invoked with root privileges


### PR DESCRIPTION
This backports the fix for #12348 to the 0.16 branch. I know that's super old, but I'm not going to be able to update my environment within the next 6 weeks and I'd really love to have my provisioning not be broken. I just cherry-picked the fixing commit out of dev.

---

Per https://developer.github.com/changes/2014-04-25-user-content-security/
raw.github.com is now served from raw.githubusercontent.com.
