### PR TITLE
Include dependency required for debconfmod

### DIFF
--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -3,6 +3,8 @@
 Management of debconf selections
 ================================
 
+:depends:   - debconf-utils package
+
 The debconfmod state module manages the enforcement of debconf selections,
 this state can set those selections prior to package installation.
 


### PR DESCRIPTION
The debconfmod module isn't available unless the the [test for debconf-get-selections](https://github.com/saltstack/salt/blob/develop/salt/modules/debconfmod.py#L32-L33) passes.  This isn't documented currently.
