### PR TITLE
Fixing #14778 - When mount is True we need to ensure the directory exists

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -140,7 +140,7 @@ def mounted(name,
                             return ret
                         else:
                             ret['changes']['umount'] = "Forced remount because " \
-                                                        + "options changed"
+                                                       + "options changed"
                             remount_result = __salt__['mount.remount'](real_name, device, mkmnt=mkmnt, fstype=fstype, opts=opts)
                             ret['result'] = remount_result
                             return ret
@@ -165,8 +165,14 @@ def mounted(name,
             # The mount is not present! Mount it
             if __opts__['test']:
                 ret['result'] = None
-                ret['comment'] = '{0} would be mounted'.format(name)
+                if os.path.exists(name):
+                    ret['comment'] = '{0} would be mounted'.format(name)
+                else:
+                    ret['comment'] = '{0} will be created and mounted'.format(name)
                 return ret
+
+            if not os.path.exists(name):
+                __salt__['file.mkdir'](name)
 
             out = __salt__['mount.mount'](name, device, mkmnt, fstype, opts)
             active = __salt__['mount.active']()


### PR DESCRIPTION
When mount is True we need to ensure that the mount point exists otherwise the mount command will fail.
