### PR TITLE
Changes to aptpkg module and pkg state

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -392,6 +392,11 @@ def install(name=None,
 
         .. versionadded:: 0.17.4
 
+    install_recommends
+        Whether to install the packages marked as recommended.  Default is True.
+
+        .. versionadded:: Lithium
+
     Returns a dict containing the new package names and versions::
 
         {'<package>': {'old': '<old-version>',
@@ -474,6 +479,8 @@ def install(name=None,
             cmd.append('--force-yes')
         cmd = cmd + ['-o', 'DPkg::Options::=--force-confold']
         cmd = cmd + ['-o', 'DPkg::Options::=--force-confdef']
+        if 'install_recommends' in kwargs and not kwargs['install_recommends']:
+            cmd.append('--no-install-recommends')
         if skip_verify:
             cmd.append('--allow-unauthenticated')
         if fromrepo:

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -660,6 +660,20 @@ def installed(
               - bar: http://somesite.org/bar.rpm
               - baz: ftp://someothersite.org/baz.rpm
               - qux: /minion/path/to/qux.rpm
+
+    install_recommends
+        Whether to install the packages marked as recommended.  Default is True.
+        Currently only works with APT based systems.
+
+        .. versionadded:: Lithium
+
+    .. code-block:: yaml
+
+        httpd:
+          pkg.installed:
+            - install_recommends: False
+
+
     '''
     kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
@@ -1040,6 +1054,19 @@ def latest(
               - foo
               - bar
               - baz
+
+    install_recommends
+        Whether to install the packages marked as recommended.  Default is True.
+        Currently only works with APT based systems.
+
+        .. versionadded:: Lithium
+
+    .. code-block:: yaml
+
+        httpd:
+          pkg.latest:
+            - install_recommends: False
+
     '''
     rtag = __gen_rtag()
     refresh = bool(


### PR DESCRIPTION
Adding the ability for apt based pkg installs to not install packages that have been marked as recommended.  By default these packages are installed but passing install_recommends as False will cause these not to be installed. #15049
