### PR TITLE
Added an example for using states.git.latest

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -112,6 +112,44 @@ def latest(name,
     unless
         A command to run as a check, only run the named command if the command
         passed to the ``unless`` option returns false
+
+    .. note::
+
+        Clashing ID declarations can be avoided when including different
+        branches from the same git repository in the same sls file by using the
+        ``name`` declaration.  The example below checks out the ``gh-pages``
+        and ``gh-pages-prod`` branches from the same repository into separate
+        directories.  The example also sets up the ``ssh_known_hosts`` ssh key
+        required to perform the git checkout.
+
+    .. code-block:: yaml
+
+        gitlab.example.com:
+          ssh_known_hosts:
+            - present
+            - user: root
+            - enc: ecdsa
+            - fingerprint: 4e:94:b0:54:c1:5b:29:a2:70:0e:e1:a3:51:ee:ee:e3
+
+        git-website-staging:
+          git.latest:
+            - name: git@gitlab.example.com:user/website.git
+            - rev: gh-pages
+            - target: /usr/share/nginx/staging
+            - identity: /root/.ssh/website_id_rsa
+            - require:
+                - pkg: git
+                - ssh_known_hosts: gitlab.example.com
+
+        git-website-prod:
+          git.latest:
+            - name: git@gitlab.example.com:user/website.git
+            - rev: gh-pages-prod
+            - target: /usr/share/nginx/prod
+            - identity: /root/.ssh/website_id_rsa
+            - require:
+                - pkg: git
+                - ssh_known_hosts: gitlab.example.com
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 


### PR DESCRIPTION
I added example of checking out two branches in the same git repo using the name declaration to avoid clashing ID declarations.
