### PR TITLE
Change how salt-ssh connects with sshpass.

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -109,7 +109,7 @@ class Shell(object):
 
         if self.passwd:
             options.extend(['PasswordAuthentication=yes',
-                            'PubkeyAuthentication=no'])
+                            'PubkeyAuthentication=yes'])
         else:
             options.extend(['PasswordAuthentication=no',
                             'PubkeyAuthentication=yes',


### PR DESCRIPTION
When the 'passwd' option is set in the rooster file for a host, then salt won't use PubkeyAuthentication even if it is already set up.
Solves: #15062
But #12807 is still there with #12808 as sudo is not supported without NOPASSWD #8882
