### PR TITLE
fixes to debian_ip

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1794,7 +1794,7 @@ def build_network_settings(**settings):
 
     # Write domainname to /etc/resolv.conf
     # TODO: how does this work with resolvconf?
-    if len(sline) > 0:
+    if len(sline) > 1:
         domainname = sline[1]
 
         contents = _parse_resolve()


### PR DESCRIPTION
fixing the debian_ip to allow setting a hostname that is not a FQDN per #15085
