### PR TITLE
Allow multi-master minions to start even if a master is currently unavailable

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -461,16 +461,16 @@ class MultiMinion(object):
 
         while True:
             for minion in minions.values():
-                if isinstance(minion, dict):
-                    continue
-                if not hasattr(minion, 'schedule'):
+                # See the minions function above for the contents of a minions value
+                minionObj = minion.get('minion')
+                if not hasattr(minionObj, 'schedule'):
                     continue
                 try:
-                    minion.schedule.eval()
+                    minionObj.schedule.eval()
                     # Check if scheduler requires lower loop interval than
                     # the loop_interval setting
-                    if minion.schedule.loop_interval < loop_interval:
-                        loop_interval = minion.schedule.loop_interval
+                    if minionObj.schedule.loop_interval < loop_interval:
+                        loop_interval = minionObj.schedule.loop_interval
                         log.debug(
                             'Overriding loop_interval because of scheduled jobs.'
                         )

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -368,9 +368,8 @@ class MultiMinion(object):
             s_opts['master'] = master
             try:
                 minions.append(Minion(s_opts, 5, False))
-            except SaltClientError as exc:
-                log.error('Error while bring up minion for multi-master. Is master responding?')
-                raise exc
+            except SaltClientError:
+                minions.append(s_opts)
         return minions
 
     def minions(self):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -462,7 +462,7 @@ class MultiMinion(object):
         while True:
             for minion in minions.values():
                 if isinstance(minion, dict):
-                    minion = minion['minion']
+                    continue
                 if not hasattr(minion, 'schedule'):
                     continue
                 try:


### PR DESCRIPTION
N.B. this pull request is against the 2014.1 branch see below.

Between 2014.1.4 and 2014.1.7 the behaviour of multi-master minions changed to prevent the minion starting unless it could connect to all the masters. This kind of defied the point of multi-master as I saw it, which was to allow for continued operation of minions when a master is unavailable. This seems to have come in response to a couple of issues firstly schedules were not working which was fixed by @wt in PR #13189 unfortunately this fix stopped the multi-minion from starting if connecting to one of the master's failed and caused issue #13546 @cachedout fixed that in PR #13549 but didn't allow the minion to start if one of the masters are not responding.

I've reverted both of those changes and have tried to fix the original bug with schedules in multi-master mode in a way such that the minion can still start if one of the masters is unavailable. Hopefully this makes everyone happy.

This is against 2014.1 because the code has changed in both the 2014.7 branch and the develop branch. Giving them both a quick scan develop looks completely fine. 2014.7 looks like it has a subtly different bug. The exception raise introduced by PR #13549 has been removed but the handling of uncontactable masters hasn't been restored so no errors will occur but a master that couldn't been contacted at startup will never be re-tried (like it would be in 2014.1.4 or develop) 
