### PR TITLE
Return True by default in boto states

### DIFF
--- a/salt/states/boto_asg.py
+++ b/salt/states/boto_asg.py
@@ -225,7 +225,7 @@ def present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     if vpc_zone_identifier:
         vpc_id = __salt__['boto_vpc.get_subnet_association'](vpc_zone_identifier, region, key, keyid, profile)
         log.debug('Auto Scaling Group {0} is associated with VPC ID {1}'
@@ -278,6 +278,7 @@ def present(
         if __opts__['test']:
             msg = 'Autoscale group set to be created.'
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         created = __salt__['boto_asg.create'](name, launch_config_name,
                                               availability_zones, min_size,
@@ -292,7 +293,6 @@ def present(
                                               scaling_policies, region,
                                               key, keyid, profile)
         if created:
-            ret['result'] = True
             ret['changes']['old'] = None
             asg = __salt__['boto_asg.get_config'](name, region, key, keyid,
                                                   profile)
@@ -345,6 +345,7 @@ def present(
             if __opts__['test']:
                 msg = 'Autoscale group set to be updated.'
                 ret['comment'] = msg
+                ret['result'] = None
                 return ret
             updated = __salt__['boto_asg.update'](name, launch_config_name,
                                                   availability_zones, min_size,
@@ -367,7 +368,6 @@ def present(
                         ret["changes"]["launch_config"] = {}
                     ret["changes"]["launch_config"]["deleted"] = asg["launch_config_name"]
             if updated:
-                ret['result'] = True
                 ret['changes']['old'] = asg
                 asg = __salt__['boto_asg.get_config'](name, region, key, keyid,
                                                       profile)
@@ -456,20 +456,19 @@ def absent(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     asg = __salt__['boto_asg.get_config'](name, region, key, keyid, profile)
     if asg is None:
         ret['result'] = False
         ret['comment'] = 'Failed to check autoscale group existence.'
     elif asg:
         if __opts__['test']:
-            ret['result'] = None
             ret['comment'] = 'Autoscale group set to be deleted.'
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_asg.delete'](name, force, region, key, keyid,
                                               profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = asg
             ret['changes']['new'] = None
             ret['comment'] = 'Deleted autoscale group.'

--- a/salt/states/boto_cloudwatch_alarm.py
+++ b/salt/states/boto_cloudwatch_alarm.py
@@ -141,6 +141,7 @@ def present(
         if __opts__['test']:
             msg = 'alarm {0} is to be created/updated.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         result = __salt__['boto_cloudwatch.create_or_update_alarm'](
             **create_or_update_alarm_args
@@ -154,6 +155,7 @@ def present(
         if __opts__['test']:
             msg = 'alarm {0} is to be created/updated.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         result = __salt__['boto_cloudwatch.create_or_update_alarm'](
             **create_or_update_alarm_args
@@ -199,6 +201,7 @@ def absent(
     if is_present:
         if __opts__['test']:
             ret['comment'] = 'alarm {0} is set to be removed.'.format(name)
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_cloudwatch.delete_alarm'](name, region, key,
                                                            keyid, profile)

--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -193,17 +193,19 @@ def present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     config = __salt__['boto_elasticache.get_config'](name, region, key, keyid,
                                                      profile)
     if config is None:
         msg = 'Failed to retrieve cache cluster info from AWS.'
         ret['comment'] = msg
+        ret['result'] = None
         return ret
     elif not config:
         if __opts__['test']:
             msg = 'Cache cluster {0} is set to be created.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         created = __salt__['boto_elasticache.create'](
             name=name, num_cache_nodes=num_cache_nodes,
@@ -220,7 +222,6 @@ def present(
             auto_minor_version_upgrade=auto_minor_version_upgrade,
             wait=wait, region=region, key=key, keyid=keyid, profile=profile)
         if created:
-            ret['result'] = True
             ret['changes']['old'] = None
             config = __salt__['boto_elasticache.get_config'](name, region, key,
                                                              keyid, profile)
@@ -265,7 +266,7 @@ def absent(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     is_present = __salt__['boto_elasticache.exists'](name, region, key, keyid,
                                                      profile)
@@ -274,11 +275,11 @@ def absent(
         if __opts__['test']:
             ret['comment'] = 'Cache cluster {0} is set to be removed.'.format(
                 name)
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_elasticache.delete'](name, wait, region, key,
                                                       keyid, profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = name
             ret['changes']['new'] = None
         else:

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -153,19 +153,19 @@ def present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _elb_present(name, availability_zones, listeners, subnets,
                         security_groups, scheme, region, key, keyid, profile)
     ret['changes'] = _ret['changes']
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _attributes_present(name, attributes, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
@@ -173,14 +173,14 @@ def present(
                                  profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _cnames_present(name, cnames, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
@@ -198,7 +198,7 @@ def _elb_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     if not (availability_zones or subnets):
         raise SaltInvocationError('Either availability_zones or subnets must'
                                   ' be provided as arguments.')
@@ -241,13 +241,13 @@ def _elb_present(
     if not exists:
         if __opts__['test']:
             ret['comment'] = 'ELB {0} is set to be created.'.format(name)
+            ret['result'] = None
             return ret
         created = __salt__['boto_elb.create'](name, availability_zones,
                                               _listeners, subnets,
                                               security_groups, scheme, region,
                                               key, keyid, profile)
         if created:
-            ret['result'] = True
             ret['changes']['old'] = {'elb': None}
             ret['changes']['new'] = {'elb': name}
             ret['comment'] = 'ELB {0} created.'.format(name)
@@ -260,7 +260,7 @@ def _elb_present(
                                   profile)
         ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
         ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-        if _ret['result'] is not None:
+        if not _ret['result']:
             ret['result'] = _ret['result']
             if ret['result'] is False:
                 return ret
@@ -269,7 +269,7 @@ def _elb_present(
                                   profile)
             ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
             ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-            if _ret['result'] is not None:
+            if not _ret['result']:
                 ret['result'] = _ret['result']
                 if ret['result'] is False:
                     return ret
@@ -278,7 +278,7 @@ def _elb_present(
                                     profile)
             ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
             ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-            if _ret['result'] is not None:
+            if not _ret['result']:
                 ret['result'] = _ret['result']
     return ret
 
@@ -290,7 +290,7 @@ def _listeners_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     lb = __salt__['boto_elb.get_elb_config'](name, region, key, keyid, profile)
     if not lb:
         msg = '{0} ELB configuration could not be retrieved.'.format(name)
@@ -311,6 +311,7 @@ def _listeners_present(
         if __opts__['test']:
             msg = 'ELB {0} set to have listeners modified.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         if to_delete:
             deleted = __salt__['boto_elb.delete_listeners'](name, to_delete,
@@ -318,7 +319,6 @@ def _listeners_present(
                                                             profile)
             if deleted:
                 ret['comment'] = 'Deleted listeners on {0} ELB.'.format(name)
-                ret['result'] = True
             else:
                 msg = 'Failed to delete listeners on {0} ELB.'.format(name)
                 ret['comment'] = msg
@@ -330,8 +330,6 @@ def _listeners_present(
             if created:
                 msg = 'Created listeners on {0} ELB.'
                 ret['comment'] = ' '.join([ret['comment'], msg.format(name)])
-                if ret['result'] is not False:
-                    ret['result'] = True
             else:
                 msg = 'Failed to create listeners on {0} ELB.'
                 ret['comment'] = ' '.join([ret['comment'], msg.format(name)])
@@ -350,7 +348,7 @@ def _attributes_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     _attributes = __salt__['boto_elb.get_attributes'](name, region, key, keyid,
                                                       profile)
     if not _attributes:
@@ -377,12 +375,12 @@ def _attributes_present(
     if attrs_to_set:
         if __opts__['test']:
             ret['comment'] = 'ELB {0} set to have attributes set.'.format(name)
+            ret['result'] = None
             return ret
         was_set = __salt__['boto_elb.set_attributes'](name, attributes,
                                                       region, key, keyid,
                                                       profile)
         if was_set:
-            ret['result'] = True
             ret['changes']['old'] = {'attributes': _attributes}
             ret['changes']['new'] = {'attributes': attributes}
             ret['comment'] = 'Set attributes on ELB {0}.'.format(name)
@@ -402,7 +400,7 @@ def _health_check_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     if not health_check:
         health_check = {}
     _health_check = __salt__['boto_elb.get_health_check'](name, region, key,
@@ -420,13 +418,13 @@ def _health_check_present(
     if need_to_set:
         if __opts__['test']:
             msg = 'ELB {0} set to have health check set.'.format(name)
+            ret['result'] = True
             ret['comment'] = msg
             return ret
         was_set = __salt__['boto_elb.set_health_check'](name, health_check,
                                                         region, key, keyid,
                                                         profile)
         if was_set:
-            ret['result'] = True
             ret['changes']['old'] = {'health_check': _health_check}
             _health_check = __salt__['boto_elb.get_health_check'](name, region,
                                                                   key, keyid,
@@ -449,7 +447,7 @@ def _zones_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     lb = __salt__['boto_elb.get_elb_config'](name, region, key, keyid, profile)
     if not lb:
         if not __opts__['test']:
@@ -470,6 +468,7 @@ def _zones_present(
         if __opts__['test']:
             msg = 'ELB {0} to have availability zones set.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         if to_enable:
             enabled = __salt__['boto_elb.enable_availability_zones'](name,
@@ -481,7 +480,6 @@ def _zones_present(
             if enabled:
                 msg = 'Enabled availability zones on {0} ELB.'.format(name)
                 ret['comment'] = msg
-                ret['result'] = True
             else:
                 msg = 'Failed to enable availability zones on {0} ELB.'
                 ret['comment'] = msg.format(name)
@@ -496,7 +494,6 @@ def _zones_present(
             if disabled:
                 msg = 'Disabled availability zones on {0} ELB.'
                 ret['comment'] = ' '.join([ret['comment'], msg.format(name)])
-                ret['result'] = True
             else:
                 msg = 'Failed to disable availability zones on {0} ELB.'
                 ret['comment'] = ' '.join([ret['comment'], msg.format(name)])
@@ -520,7 +517,7 @@ def _subnets_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     if not subnets:
         subnets = []
     lb = __salt__['boto_elb.get_elb_config'](name, region, key, keyid, profile)
@@ -543,6 +540,7 @@ def _subnets_present(
         if __opts__['test']:
             msg = 'ELB {0} to have subnets set.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         if to_enable:
             attached = __salt__['boto_elb.attach_subnets'](name, to_enable,
@@ -551,7 +549,6 @@ def _subnets_present(
             if attached:
                 msg = 'Attached subnets on {0} ELB.'.format(name)
                 ret['comment'] = msg
-                ret['result'] = True
             else:
                 msg = 'Failed to attach subnets on {0} ELB.'
                 ret['comment'] = msg.format(name)
@@ -563,7 +560,6 @@ def _subnets_present(
             if detached:
                 msg = 'Detached subnets on {0} ELB.'
                 ret['comment'] = ' '.join([ret['comment'], msg.format(name)])
-                ret['result'] = True
             else:
                 msg = 'Failed to detach subnets on {0} ELB.'
                 ret['comment'] = ' '.join([ret['comment'], msg.format(name)])
@@ -585,7 +581,7 @@ def _cnames_present(
         key,
         keyid,
         profile):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     if not cnames:
         cnames = []
     lb = __salt__['boto_elb.get_elb_config'](name, region, key, keyid, profile)
@@ -614,6 +610,7 @@ def _cnames_present(
         if __opts__['test']:
             msg = 'ELB {0} to have cnames modified.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         if to_create:
             created = []
@@ -633,7 +630,6 @@ def _cnames_present(
             if created:
                 msg = 'Created cnames {0}.'.format(','.join(created))
                 ret['comment'] = msg
-                ret['result'] = True
             if not_created:
                 msg = 'Failed to create cnames {0}.'
                 msg = msg.format(','.join(not_created))
@@ -663,8 +659,6 @@ def _cnames_present(
                     ret['comment'] = ret['comment'] + ' ' + msg
                 else:
                     ret['comment'] = msg
-                if ret['result'] is not False:
-                    ret['result'] = True
             if not_updated:
                 msg = 'Failed to update cnames {0}.'
                 msg = msg.format(','.join(not_updated))
@@ -688,18 +682,17 @@ def absent(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     exists = __salt__['boto_elb.exists'](name, region, key, keyid, profile)
     if exists:
         if __opts__['test']:
-            ret['result'] = None
             ret['comment'] = 'ELB {0} is set to be removed.'.format(name)
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_elb.delete'](name, region, key, keyid,
                                               profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = {'elb': name}
             ret['changes']['new'] = {'elb': None}
             ret['comment'] = 'ELB {0} deleted.'.format(name)

--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -119,33 +119,33 @@ def present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _role_present(name, policy_document, path, region, key, keyid,
                          profile)
     ret['changes'] = _ret['changes']
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _instance_profile_present(name, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _instance_profile_associated(name, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _policies_present(name, policies, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
     return ret
 
@@ -158,18 +158,18 @@ def _role_present(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     exists = __salt__['boto_iam.role_exists'](name, region, key, keyid,
                                               profile)
     if not exists:
-        ret['comment'] = 'IAM role {0} is set to be created.'.format(name)
         if __opts__['test']:
+            ret['comment'] = 'IAM role {0} is set to be created.'.format(name)
+            ret['result'] = None
             return ret
         created = __salt__['boto_iam.create_role'](name, policy_document,
                                                    path, region, key,
                                                    keyid, profile)
         if created:
-            ret['result'] = True
             ret['changes']['old'] = {'role': None}
             ret['changes']['new'] = {'role': name}
             ret['comment'] = 'IAM role {0} created.'.format(name)
@@ -187,13 +187,13 @@ def _instance_profile_present(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     exists = __salt__['boto_iam.instance_profile_exists'](name, region, key,
                                                           keyid, profile)
     if not exists:
-        msg = 'Instance profile {0} is set to be created.'
-        ret['comment'] = msg.format(name)
         if __opts__['test']:
+            msg = 'Instance profile {0} is set to be created.'
+            ret['comment'] = msg.format(name)
             ret['result'] = None
             return ret
         created = __salt__['boto_iam.create_instance_profile'](name, region,
@@ -216,14 +216,14 @@ def _instance_profile_associated(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     is_associated = __salt__['boto_iam.profile_associated'](name, name, region,
                                                             key, keyid,
                                                             profile)
     if not is_associated:
-        msg = 'Instance profile {0} is set to be associated.'
-        ret['comment'] = msg.format(name)
         if __opts__['test']:
+            msg = 'Instance profile {0} is set to be associated.'
+            ret['comment'] = msg.format(name)
             ret['result'] = None
             return ret
         associated = __salt__['boto_iam.associate_profile_to_role'](name, name,
@@ -248,7 +248,7 @@ def _policies_present(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     if not policies:
         policies = {}
     policies_to_create = {}
@@ -265,15 +265,14 @@ def _policies_present(
         if policy_name not in policies:
             policies_to_delete.append(policy_name)
     if policies_to_create or policies_to_delete:
-        msg = '{0} policies to be modified on role {1}.'
         _to_modify = list(policies_to_delete)
         _to_modify.extend(policies_to_create)
-        ret['comment'] = msg.format(', '.join(_to_modify), name)
         if __opts__['test']:
+            msg = '{0} policies to be modified on role {1}.'
+            ret['comment'] = msg.format(', '.join(_to_modify), name)
             ret['result'] = None
             return ret
         ret['changes']['old'] = {'policies': _list}
-        ret['result'] = True
         for policy_name, policy in policies_to_create.iteritems():
             policy_set = __salt__['boto_iam.create_role_policy'](name,
                                                                  policy_name,
@@ -338,32 +337,32 @@ def absent(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     _ret = _policies_absent(name, region, key, keyid, profile)
     ret['changes'] = _ret['changes']
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _instance_profile_disassociated(name, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _instance_profile_absent(name, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
         if ret['result'] is False:
             return ret
     _ret = _role_absent(name, region, key, keyid, profile)
     ret['changes'] = dictupdate.update(ret['changes'], _ret['changes'])
     ret['comment'] = ' '.join([ret['comment'], _ret['comment']])
-    if _ret['result'] is not None:
+    if not _ret['result']:
         ret['result'] = _ret['result']
     return ret
 
@@ -374,20 +373,19 @@ def _role_absent(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
 
     exists = __salt__['boto_iam.role_exists'](name, region, key, keyid,
                                               profile)
     if exists:
         if __opts__['test']:
-            ret['result'] = None
             ret['comment'] = 'IAM role {0} is set to be removed.'.format(
                 name)
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_iam.delete_role'](name, region, key, keyid,
                                                    profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = {'role': name}
             ret['changes']['new'] = {'role': None}
             ret['comment'] = 'IAM role {0} removed.'.format(name)
@@ -405,21 +403,20 @@ def _instance_profile_absent(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
 
     exists = __salt__['boto_iam.instance_profile_exists'](name, region, key,
                                                           keyid, profile)
     if exists:
         if __opts__['test']:
-            ret['result'] = None
             msg = 'Instance profile {0} is set to be removed.'
             ret['comment'] = msg.format(name)
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_iam.delete_instance_profile'](name, region,
                                                                key, keyid,
                                                                profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = {'instance_profile': name}
             ret['changes']['new'] = {'instance_profile': None}
             ret['comment'] = 'Instance profile {0} removed.'.format(name)
@@ -438,20 +435,19 @@ def _policies_absent(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     _list = __salt__['boto_iam.list_role_policies'](name, region, key, keyid,
                                                     profile)
     if not _list:
         msg = 'No policies in role {0}.'.format(name)
         ret['comment'] = msg
         return ret
-    msg = '{0} policies to be removed from role {1}.'
-    ret['comment'] = msg.format(', '.join(_list), name)
     if __opts__['test']:
+        msg = '{0} policies to be removed from role {1}.'
+        ret['comment'] = msg.format(', '.join(_list), name)
         ret['result'] = None
         return ret
     ret['changes']['old'] = {'policies': _list}
-    ret['result'] = True
     for policy_name in _list:
         policy_unset = __salt__['boto_iam.delete_role_policy'](name,
                                                                policy_name,
@@ -481,14 +477,14 @@ def _instance_profile_disassociated(
         key=None,
         keyid=None,
         profile=None):
-    ret = {'result': None, 'comment': '', 'changes': {}}
+    ret = {'result': True, 'comment': '', 'changes': {}}
     is_associated = __salt__['boto_iam.profile_associated'](name, name, region,
                                                             key, keyid,
                                                             profile)
     if is_associated:
-        msg = 'Instance profile {0} is set to be disassociated.'
-        ret['comment'] = msg.format(name)
         if __opts__['test']:
+            msg = 'Instance profile {0} is set to be disassociated.'
+            ret['comment'] = msg.format(name)
             ret['result'] = None
             return ret
         associated = __salt__['boto_iam.disassociate_profile_from_role'](name, name, region, key, keyid, profile)

--- a/salt/states/boto_lc.py
+++ b/salt/states/boto_lc.py
@@ -213,7 +213,7 @@ def present(
     if user_data and cloud_init:
         raise SaltInvocationError('user_data and cloud_init are mutually'
                                   ' exclusive options.')
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     exists = __salt__['boto_asg.launch_configuration_exists'](name, region,
                                                               key, keyid,
                                                               profile)
@@ -221,6 +221,7 @@ def present(
         if __opts__['test']:
             msg = 'Launch configuration set to be created.'
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         if cloud_init:
             user_data = __salt__['boto_asg.get_cloud_init_mime'](cloud_init)
@@ -234,7 +235,6 @@ def present(
             delete_on_termination, iops, use_block_device_types, region, key,
             keyid, profile)
         if created:
-            ret['result'] = True
             ret['changes']['old'] = None
             ret['changes']['new'] = name
         else:
@@ -270,19 +270,18 @@ def absent(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
     exists = __salt__['boto_asg.launch_configuration_exists'](name, region,
                                                               key, keyid,
                                                               profile)
     if exists:
         if __opts__['test']:
-            ret['result'] = None
             ret['comment'] = 'Launch configuration set to be deleted.'
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_asg.delete_launch_configuration'](
             name, region, key, keyid, profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = name
             ret['changes']['new'] = None
             ret['comment'] = 'Deleted launch configuration.'

--- a/salt/states/boto_route53.py
+++ b/salt/states/boto_route53.py
@@ -125,7 +125,7 @@ def present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     record = __salt__['boto_route53.get_record'](name, zone, record_type,
                                                  False, region, key, keyid,
@@ -134,13 +134,13 @@ def present(
     if isinstance(record, dict) and not record:
         if __opts__['test']:
             ret['comment'] = 'Route53 record {0} set to be added.'.format(name)
+            ret['result'] = None
             return ret
         added = __salt__['boto_route53.add_record'](name, value, zone,
                                                     record_type, identifier,
                                                     ttl, region, key, keyid,
                                                     profile)
         if added:
-            ret['result'] = True
             ret['changes']['old'] = None
             ret['changes']['new'] = {'name': name,
                                      'value': value,
@@ -172,6 +172,7 @@ def present(
             if __opts__['test']:
                 msg = 'Route53 record {0} set to be updated.'.format(name)
                 ret['comment'] = msg
+                ret['result'] = None
                 return ret
             updated = __salt__['boto_route53.update_record'](name, value, zone,
                                                              record_type,
@@ -179,7 +180,6 @@ def present(
                                                              region, key,
                                                              keyid, profile)
             if updated:
-                ret['result'] = True
                 ret['changes']['old'] = record
                 ret['changes']['new'] = {'name': name,
                                          'value': value,
@@ -229,7 +229,7 @@ def absent(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     record = __salt__['boto_route53.get_record'](name, zone, record_type,
                                                  False, region, key, keyid,
@@ -238,6 +238,7 @@ def absent(
         if __opts__['test']:
             msg = 'Route53 record {0} set to be deleted.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_route53.delete_record'](name, zone,
                                                          record_type,
@@ -245,7 +246,6 @@ def absent(
                                                          region, key, keyid,
                                                          profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = record
             ret['changes']['new'] = None
             ret['comment'] = 'Deleted {0} Route53 record.'.format(name)

--- a/salt/states/boto_sqs.py
+++ b/salt/states/boto_sqs.py
@@ -96,7 +96,7 @@ def present(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     is_present = __salt__['boto_sqs.exists'](name, region, key, keyid, profile)
 
@@ -104,11 +104,11 @@ def present(
         if __opts__['test']:
             msg = 'AWS SQS queue {0} is set to be created.'.format(name)
             ret['comment'] = msg
+            ret['result'] = None
             return ret
         created = __salt__['boto_sqs.create'](name, region, key, keyid,
                                               profile)
         if created:
-            ret['result'] = True
             ret['changes']['old'] = None
             ret['changes']['new'] = {'queue': name}
         else:
@@ -128,13 +128,12 @@ def present(
     attr_names = ','.join(attrs_to_set.keys())
     if attrs_to_set:
         if __opts__['test']:
-            ret['result'] = None
             ret['comment'] = 'Attribute(s) {0} to be set on {1}.'.format(
                 attr_names, name)
+            ret['result'] = None
             return ret
         msg = (' Setting {0} attribute(s).'.format(attr_names))
         ret['comment'] = ret['comment'] + msg
-        ret['result'] = True
         if 'new' in ret['changes']:
             ret['changes']['new']['attributes_set'] = []
         else:
@@ -177,7 +176,7 @@ def absent(
         A dict with region, key and keyid, or a pillar key (string)
         that contains a dict with region, key and keyid.
     '''
-    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
 
     is_present = __salt__['boto_sqs.exists'](name, region, key, keyid, profile)
 
@@ -185,11 +184,11 @@ def absent(
         if __opts__['test']:
             ret['comment'] = 'AWS SQS queue {0} is set to be removed.'.format(
                 name)
+            ret['result'] = None
             return ret
         deleted = __salt__['boto_sqs.delete'](name, region, key, keyid,
                                               profile)
         if deleted:
-            ret['result'] = True
             ret['changes']['old'] = name
             ret['changes']['new'] = None
         else:


### PR DESCRIPTION
This change sets the default return value of the boto states to True,
rather than None as previously set. None is now used for test runs.
Failures still use False.
