### PR TITLE
Fix ssh_auth.present test when enc != ssh-rsa

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -160,25 +160,7 @@ def present(
            'result': True,
            'comment': ''}
 
-    if __opts__['test']:
-        ret['result'], ret['comment'] = _present_test(
-                user,
-                name,
-                enc,
-                comment,
-                options or [],
-                source,
-                config,
-                )
-        return ret
-
-    if source != '':
-        data = __salt__['ssh.set_auth_key_from_file'](
-                user,
-                source,
-                config,
-                saltenv=__env__)
-    else:
+    if source == '':
         # check if this is of form {options} {enc} {key} {comment}
         sshre = re.compile(r'^(.*?)\s?((?:ssh\-|ecds)[\w-]+\s.+)$')
         fullkey = sshre.search(name)
@@ -199,6 +181,25 @@ def present(
             if len(comps) == 3:
                 comment = comps[2]
 
+    if __opts__['test']:
+        ret['result'], ret['comment'] = _present_test(
+                user,
+                name,
+                enc,
+                comment,
+                options or [],
+                source,
+                config,
+                )
+        return ret
+
+    if source != '':
+        data = __salt__['ssh.set_auth_key_from_file'](
+                user,
+                source,
+                config,
+                saltenv=__env__)
+    else:
         data = __salt__['ssh.set_auth_key'](
                 user,
                 name,


### PR DESCRIPTION
When using fullkeys, test=True will fail if the key encryption is not ssh-rsa.

For the following example (in salt documentation):

sshkeys:
  ssh_auth:
    - present
    - user: root
    - enc: ssh-rsa
    - options:
      - option1="value1"
      - option2="value2 flag2"
    - comment: myuser
    - names:
      - AAAAB3NzaC1kc3MAAACBAL0sQ9fJ5bYTEyY==
      - ssh-dss AAAAB3NzaCL0sQ9fJ5bYTEyY== user@domain
      - option3="value3" ssh-dss AAAAB3NzaC1kcQ9J5bYTEyY== other@testdomain
      - AAAAB3NzaC1kcQ9fJFF435bYTEyY== newcomment

ssh-dss AAAAB3NzaCL0sQ9fJ5bYTEyY== user@domain will be tested against ssh-rsa and not ssh-dss.

This commit fixes the problem.
