### PR TITLE
fix the mount.mounted opts default value behavior

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -38,7 +38,7 @@ def mounted(name,
             device,
             fstype,
             mkmnt=False,
-            opts=None,
+            opts='defaults',
             dump=0,
             pass_num=0,
             config='/etc/fstab',
@@ -89,8 +89,6 @@ def mounted(name,
     # string
     if isinstance(opts, string_types):
         opts = opts.split(',')
-    elif opts is None:
-        opts = ['defaults']
 
     # remove possible trailing slash
     if not name == '/':
@@ -133,7 +131,7 @@ def mounted(name,
                 device_list.append(uuid_device)
             if opts:
                 for opt in opts:
-                    if opt not in active[real_name]['opts']:
+                    if opt not in active[real_name]['opts'] and opt != 'defaults':
                         if __opts__['test']:
                             ret['result'] = None
                             ret['comment'] = "Remount would be forced because options changed"


### PR DESCRIPTION
the string "defaults" is useful when mounting a volume but doesn't show
up in the options of already-mounted volumes, so filter it out when
determining whether options have changed and we should therefore
remount.

my volume was remounting every time until I made this fix, simply because I wasn't specifying any options myself.
