### PR TITLE
Show all but list of unreturned minions with --summary

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -224,11 +224,10 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         print_cli('-------------------------------------------')
         print_cli('Summary')
         print_cli('-------------------------------------------')
-        if self.options.verbose:
-            print_cli('# of Minions Targeted: {0}'.format(return_counter + not_return_counter))
+        print_cli('# of Minions Targeted: {0}'.format(return_counter + not_return_counter))
         print_cli('# of Minions Returned: {0}'.format(return_counter))
+        print_cli('# of Minions Did Not Return: {0}'.format(not_return_counter))
         if self.options.verbose:
-            print_cli('# of Minions Did Not Return: {0}'.format(not_return_counter))
             print_cli('Minions Which Did Not Return: {0}'.format(" ".join(not_return_minions)))
         print_cli('-------------------------------------------')
 


### PR DESCRIPTION
I was playing around with the new `cli_summary` setting in the master config (also available via `--summary` on the CLI), and decided that if I'm asking for a summary, just the number of minions which returned is not very helpful.  I can't imagine a time when I would want that number, but not also want the number of minions which did _not_ return.

Now, when you pass in `--summary`, it will show everything except the line which enumerates exactly which minions didn't return.  That data will be added if the `-v` flag is included.
