### PR TITLE
Fix missing argument in file.replace

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1162,7 +1162,7 @@ def replace(path,
         if None == not_found_content:
             not_found_content = repl
         if prepend_if_not_found:
-            new_file.insert(not_found_content + '\n')
+            new_file.insert(0, not_found_content + '\n')
         else:
             # append_if_not_found
             # Make sure we have a newline at the end of the file


### PR DESCRIPTION
I was trying to use `file.replace` with `prepend_if_not_found` and it was throwing this exception:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 130, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 1165, in replace
    new_file.insert(not_found_content + '\n')
TypeError: insert() takes exactly 2 arguments (1 given)
```

Reproducable with `touch /tmp/b; salt-call file.replace /tmp/b pattern=a repl=b prepend_if_not_found=True`
