### PR TITLE
Update documentation on salt-ssh

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -55,6 +55,11 @@ address. A more elaborate roster can be created:
       sudo: True         # Whether to sudo to root, not enabled by default
     web2:
       host: 192.168.42.2
+      
+.. note::
+
+    sudo works only if NOPASSWD is set for user in /etc/sudoers:
+    ``fred ALL=(ALL) NOPASSWD: ALL`` 
 
 Calling Salt SSH
 ================


### PR DESCRIPTION
User must set NOPASSWD option for a non-root user to use sudo. 
Solves #12808.
