### PR TITLE
Fixed put method in swift module

### DIFF
--- a/salt/modules/swift.py
+++ b/salt/modules/swift.py
@@ -182,7 +182,7 @@ def put(cont, path=None, local_file=None, profile=None):
     '''
     swift_conn = _auth(profile)
 
-    if path is not None:
+    if path is None:
         return swift_conn.put_container(cont)
     elif local_file is not None:
         return swift_conn.put_object(cont, path, local_file)


### PR DESCRIPTION
A logic error in this module prevented salt from being able to use the swift module to put an object inside a swift container.

The comments for the put function suggest that this change is the intended behavior.
