### PR TITLE
modules.service.__virtual__: use raw string for regex

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -54,7 +54,7 @@ def __virtual__():
             # non-digit characters, and the zeroth element is the major
             # number (it'd be so much simpler if it was always "X.Y"...)
             import re
-            if int(re.split('\D+', __grains__.get('osrelease', ''))[0]) >= 12:
+            if int(re.split(r'\D+', __grains__.get('osrelease', ''))[0]) >= 12:
                 return False
         except ValueError:
             return False


### PR DESCRIPTION
```
************* Module salt.modules.service
salt/modules/service.py:57: [W1401(anomalous-backslash-in-string), ] Anomalous backslash in string: '\D'. String constant might be missing an r prefix.
```
