### PR TITLE
SmartOS esky packaging of 2014.7

### DIFF
--- a/pkg/smartos/esky/sodium_grabber.c
+++ b/pkg/smartos/esky/sodium_grabber.c
@@ -1,0 +1,16 @@
+#include <Python.h>
+#include <sodium.h>
+
+static PyObject* grabber_init(PyObject* self, PyObject* args)                                                                                                                                                                                {
+  return Py_BuildValue("i", sodium_init());
+}
+
+PyMethodDef methods[] = {
+  {"init", grabber_init, METH_VARARGS},
+  {NULL, NULL},
+};
+
+void initsodium_grabber()
+{
+  (void)Py_InitModule("sodium_grabber", methods);
+}

--- a/pkg/smartos/esky/sodium_grabber_installer.py
+++ b/pkg/smartos/esky/sodium_grabber_installer.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+'''
+The setup script for sodium_grabber
+'''
+
+# pylint: disable=C0111,E1101,E1103,F0401,W0611
+
+from distutils.core import setup, Extension
+from os import path
+
+HERE = path.dirname(__file__)
+
+SETUP_KWARGS = {}
+sodium_grabber = Extension('sodium_grabber',
+    sources = [path.join(HERE, 'sodium_grabber.c')],
+    libraries = ['sodium'],
+)
+SETUP_KWARGS['ext_modules'] = [sodium_grabber]
+SETUP_KWARGS['name'] = "sodium_grabber"
+
+if __name__ == '__main__':
+    setup(**SETUP_KWARGS)

--- a/pkg/smartos/esky/zeromq_requirements.txt
+++ b/pkg/smartos/esky/zeromq_requirements.txt
@@ -1,2 +1,7 @@
--r ../../../zeromq-requirements.txt
+# Need to set a specific version of pyzmq, so can't use the main project's requirements file... have to copy it in and modify...
+#-r ../../../zeromq-requirements.txt
+-r ../../../_requirements.txt
+M2Crypto
+pycrypto
+pyzmq == 13.1.0
 -r requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -683,12 +683,21 @@ elif sys.platform.startswith('sunos'):
         from bbfreeze.modulegraph.modulegraph import ModuleGraph
         mf = ModuleGraph(sys.path[:])
         for arg in glob.glob('salt/modules/*.py'):
-                mf.run_script(arg)
+            mf.run_script(arg)
         for mod in mf.flatten():
             if type(mod).__name__ != 'Script' and mod.filename:
                 FREEZER_INCLUDES.append(str(os.path.basename(mod.identifier)))
     except ImportError:
         pass
+    # Include C extension that convinces esky to package up the libsodium C library
+    # This is needed for ctypes to find it in libnacl which is in turn needed for raet
+    # see pkg/smartos/esky/sodium_grabber{.c,_installer.py}
+    FREEZER_INCLUDES.extend([
+        'sodium_grabber',
+        'ioflo',
+        'raet',
+        'libnacl',
+    ])
 
 if HAS_ESKY:
     # if the user has the esky / bbfreeze libraries installed, add the


### PR DESCRIPTION
Resulting builds can be used either with zeromq or with raet
