### PR TITLE
Changing default hash in file.py

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -457,7 +457,7 @@ def chgrp(path, group):
     return chown(path, user, group)
 
 
-def get_sum(path, form='md5'):
+def get_sum(path, form='sha256'):
     '''
     Return the sum for the given file, default is md5, sha1, sha224, sha256,
     sha384, sha512 are supported
@@ -479,7 +479,7 @@ def get_sum(path, form='md5'):
     return salt.utils.get_hash(path, form, 4096)
 
 
-def get_hash(path, form='md5', chunk_size=65536):
+def get_hash(path, form='sha256', chunk_size=65536):
     '''
     Get the hash sum of a file
 
@@ -2516,7 +2516,7 @@ def get_managed(
         if data['result']:
             sfn = data['data']
             hsum = get_hash(sfn)
-            source_sum = {'hash_type': 'md5',
+            source_sum = {'hash_type': 'sha256',
                           'hsum': hsum}
         else:
             __clean_tmp(sfn)
@@ -2558,7 +2558,7 @@ def get_managed(
     return sfn, source_sum, ''
 
 
-def extract_hash(hash_fn, hash_type='md5', file_name=''):
+def extract_hash(hash_fn, hash_type='sha256', file_name=''):
     '''
     This routine is called from the :mod:`file.managed
     <salt.states.file.managed>` state to pull a hash from a remote file.


### PR DESCRIPTION
Changed default hashtype in file.py to sha256.  This was not reading
the hash_type from the minion config.  FIPS doesnt allow md5 as a valid
hash type.

```
salt-call --versions
           Salt: 2014.1.7
         Python: 2.6.6 (r266:84292, Nov 21 2013, 10:50:32)
         Jinja2: 2.2.1
       M2Crypto: 0.20.2
 msgpack-python: 0.1.13
   msgpack-pure: Not Installed
       pycrypto: 2.0.1
         PyYAML: 3.10
          PyZMQ: 2.2.0.1
            ZMQ: 3.2.4
```

```
REDACTED ID :
----------
          ID: /etc/snmp/snmpd.conf
    Function: file.managed
      Result: False
     Comment: An exception occurred in this state: Traceback (most
recent call last):
                File "/usr/lib/python2.6/site-packages/salt/state.py",
line 1379, in call
                  **cdata['kwargs'])
                File
"/usr/lib/python2.6/site-packages/salt/states/file.py", line 1246, in
managed
                  **kwargs
                File
"/usr/lib/python2.6/site-packages/salt/modules/file.py", line 2363, in
check_managed
                  **kwargs)
                File
"/usr/lib/python2.6/site-packages/salt/modules/file.py", line 2106, in
get_managed
                  hsum = get_hash(sfn)
                File
"/usr/lib/python2.6/site-packages/salt/modules/file.py", line 424, in
get_hash
                  return salt.utils.get_hash(path, form, chunk_size)
                File
"/usr/lib/python2.6/site-packages/salt/utils/__init__.py", line 1468,
in get_hash
                  hash_obj = hash_type()
              ValueError: error:060800A3:digital envelope
routines:EVP_DigestInit_ex:disabled for fips

```

After the change:

```
REDACTED ID:
----------
          ID: /etc/snmp/snmpd.conf
    Function: file.managed
      Result: True
     Comment: File /etc/snmp/snmpd.conf updated
              diff: ---  
              +++  
              @@ -1,3 +1,3 @@
              REDACTED

```
