### PR TITLE
Send cloud maps through salt renderer system

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -1562,7 +1562,6 @@ class Map(Cloud):
             )
             return {}
 
-
         if 'include' in map_:
             map_ = salt.config.include_config(
                 map_, self.opts['map'], verbose=False

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -32,20 +32,13 @@ import salt.utils
 import salt.utils.cloud
 from salt.utils import context
 from salt._compat import string_types
+from salt.template import compile_template
 
 # Import third party libs
 import yaml
 
 # Get logging started
 log = logging.getLogger(__name__)
-
-try:
-    from mako.template import Template
-    from mako.exceptions import MakoException
-    MAKO_AVAILABLE = True
-except ImportError:
-    log.debug('Mako not available')
-    MAKO_AVAILABLE = False
 
 
 def communicator(func):
@@ -1541,17 +1534,6 @@ class Map(Cloud):
                         vm_names.append(vm_name)
         return vm_names
 
-    def _mako_read(self, fp):
-        try:
-            # open mako file
-            temp_ = Template(fp.read())
-            # render as yaml
-            yaml_str_ = temp_.render()
-            map_ = yaml.safe_load(yaml_str_)
-        except MakoException:
-            map_ = yaml.safe_load(fp.read())
-        return map_
-
     def read(self):
         '''
         Read in the specified map file and return the map structure
@@ -1566,11 +1548,11 @@ class Map(Cloud):
                 )
             )
         try:
-            with open(self.opts['map'], 'rb') as fp_:
-                if MAKO_AVAILABLE:
-                    map_ = self._mako_read(fp_)
-                else:
-                    map_ = yaml.safe_load(fp_.read())
+            renderer = self.opts.get('renderer', 'yaml_jinja')
+            rend = salt.loader.render(self.opts, {})
+            map_ = compile_template(
+                self.opts['map'], rend, renderer
+            )
         except Exception as exc:
             log.error(
                 'Rendering map {0} failed, render error:\n{1}'.format(
@@ -1579,6 +1561,7 @@ class Map(Cloud):
                 exc_info_on_loglevel=logging.DEBUG
             )
             return {}
+
 
         if 'include' in map_:
             map_ = salt.config.include_config(


### PR DESCRIPTION
Fixes #8403.

Also, this changes some (undocumented) usage; previously, if mako was detected, it would always be used as the rendering engine. If mako is already defined as the default renderer, this change will not break anything. However, if mako was previously used for cloud maps, and no render pipes are set inside the map (because, why would they be?), and the default renderer is not set to mako, there will be breakage.

Do NOT backport this fix; let's leave it in develop until the Lithium release, so that affected people have time to get used to it.

Ping @inthecloud247.
