### PR TITLE
sodium_grabber_installer: fix kwarg spacing

### DIFF
--- a/pkg/smartos/esky/sodium_grabber_installer.py
+++ b/pkg/smartos/esky/sodium_grabber_installer.py
@@ -13,8 +13,8 @@ HERE = path.dirname(__file__)
 
 SETUP_KWARGS = {}
 sodium_grabber = Extension('sodium_grabber',
-    sources = [path.join(HERE, 'sodium_grabber.c')],
-    libraries = ['sodium'],
+    sources=[path.join(HERE, 'sodium_grabber.c')],
+    libraries=['sodium'],
 )
 SETUP_KWARGS['ext_modules'] = [sodium_grabber]
 SETUP_KWARGS['name'] = "sodium_grabber"


### PR DESCRIPTION
```
************* Module sodium_grabber_installer
pkg/smartos/esky/sodium_grabber_installer.py:16: [C0326(bad-whitespace), ] No space allowed around keyword argument assignment
    sources = [path.join(HERE, 'sodium_grabber.c')],
            ^
pkg/smartos/esky/sodium_grabber_installer.py:17: [C0326(bad-whitespace), ] No space allowed around keyword argument assignment
    libraries = ['sodium'],
              ^
```
