### PR TITLE
Add list_users() to pw_user (FreeBSD)

### DIFF
--- a/salt/modules/pw_user.py
+++ b/salt/modules/pw_user.py
@@ -413,3 +413,16 @@ def list_groups(name):
         salt '*' user.list_groups foo
     '''
     return salt.utils.get_group_list(name)
+
+
+def list_users():
+    '''
+    Return a list of all users
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' user.list_users
+    '''
+    return sorted([user.pw_name for user in pwd.getpwall()])


### PR DESCRIPTION
Synced list_users() from useradd.py to pw_user.py.
This is required so that ssh.user_keys works on FreeBSD.
