### PR TITLE
Make auth_keys to list keys from all users

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -261,25 +261,45 @@ def host_keys(keydir=None):
     return keys
 
 
-def auth_keys(user, config='.ssh/authorized_keys'):
+def auth_keys(user=None, config='.ssh/authorized_keys'):
     '''
-    Return the authorized keys for the specified user
+    Return the authorized keys for users
 
     CLI Example:
 
     .. code-block:: bash
 
+        salt '*' ssh.auth_keys
         salt '*' ssh.auth_keys root
+        salt '*' ssh.auth_keys user=root
+        salt '*' ssh.auth_keys user="[user1, user2]"
     '''
-    full = None
-    try:
-        full = _get_config_file(user, config)
-    except CommandExecutionError:
-        pass
+    if not user:
+        user = __salt__['user.list_users']()
 
-    if not full or not os.path.isfile(full):
-        return {}
-    return _validate_keys(full)
+    old_output_when_one_user = False
+    if not isinstance(user, list):
+        user = [user]
+        old_output_when_one_user = True
+
+    keys = {}
+    for u in user:
+        full = None
+        try:
+            full = _get_config_file(u, config)
+        except CommandExecutionError:
+            pass
+
+        if full and os.path.isfile(full):
+            keys[u] = _validate_keys(full)
+
+    if old_output_when_one_user:
+        if user[0] in keys:
+            return keys[user[0]]
+        else:
+            return {}
+
+    return keys
 
 
 def check_key_file(user,


### PR DESCRIPTION
Changed ssh.auth_keys to list keys from all users when user is not
defined. Change is backward compatible. When user is provided the
function returns keys from the user only (however not inside user as
user_keys).

Motivation was to use this in mining. I thought that it is a good idea to make auth_keys work in similar way as the new user_keys. However this changes existing functionality and I understand if this raises a discussion.
