### PR TITLE
Fix #15170 - keep comments within the hosts file

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -27,6 +27,7 @@ def _list_hosts():
     '''
     Return the hosts found in the hosts file in as an OrderedDict
     '''
+    count = 0
     hfn = __get_hosts_filename()
     ret = odict.OrderedDict()
     if not os.path.isfile(hfn):
@@ -37,6 +38,8 @@ def _list_hosts():
             if not line:
                 continue
             if line.startswith('#'):
+                ret.setdefault('comment-{0}'.format(count), []).extend(line)
+                count += 1
                 continue
             if '#' in line:
                 line = line[:line.index('#')].strip()
@@ -225,10 +228,14 @@ def add_host(ip, alias):
 def _write_hosts(hosts):
     lines = []
     for ip, aliases in hosts.iteritems():
-        line = '{0}\t\t{1}'.format(
-            ip,
-            '\t\t'.join(aliases)
-            )
+        if ip:
+            if ip.startswith('comment'):
+                line = ''.join(aliases)
+            else:
+                line = '{0}\t\t{1}'.format(
+                    ip,
+                    '\t\t'.join(aliases)
+                    )
         lines.append(line)
 
     hfn = __get_hosts_filename()


### PR DESCRIPTION
Ensure that comments remain in the /etc/hosts file 
