### PR TITLE
Ensure that the extract destination ends with a slash

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -96,6 +96,9 @@ def extracted(name,
             name, ','.join(valid_archives))
         return ret
 
+    if not name.endswith('/'):
+        name += '/'
+
     if if_missing is None:
         if_missing = name
     if (


### PR DESCRIPTION
When using the archive state, if a user does not specify the absolute path with the trailing slash it can cause the state to stack trace.

``` yaml
install:
  archive.extracted:
    - name: /tmp/server
    - source: http://example.com/test.tgz
    - source_hash: md5=d892d0c495fd884f1650276f40de9925
    - tar_options: XF
    - archive_format: tar
    - keep: True
```

The above state will fail to create the `/tmp/server` directory due to the slash missing off the end of the path.

``` python
local:
----------
          ID: install_server
    Function: archive.extracted
        Name: /tmp/server
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/state.py", line 1517, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.6/site-packages/salt/states/archive.py", line 164, in extracted
                  tar_options, filename), cwd=name)
                File "/usr/lib/python2.6/site-packages/salt/modules/cmdmod.py", line 857, in run_all
                  use_vt=use_vt)
                File "/usr/lib/python2.6/site-packages/salt/modules/cmdmod.py", line 341, in _run
                  .format(cwd)
              CommandExecutionError: Specified cwd '/tmp/server' either not absolute or does not exist
     Started: 21:40:44.689929
     Duration: 966.887 ms
     Changes:   

Summary
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
```
