### PR TITLE
#14951 Provide salt-call timeout parameter

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2006,7 +2006,15 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             default=False,
             action='store_true',
             help=('Force a refresh of the grains cache')
-    )
+        )
+        self.add_option(
+            '-t', '--timeout',
+            default=60,
+            dest='auth_timeout',
+            type=int,
+            help=('Change the timeout, if applicable, for the running '
+                  'command; default=60')
+        )
 
     def _mixin_after_parsed(self):
         if not self.args and not self.options.grains_run and not self.options.doc:


### PR DESCRIPTION
This feature will set the timeout value for authentication, so if a mater is down we can timeout.

``` bash
$ salt-call --timeout=3 '*' test.ping
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 1 of 7)
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 2 of 7)
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 3 of 7)
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 4 of 7)
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 5 of 7)
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 6 of 7)
[INFO    ] SaltReqTimeoutError: after 3 seconds. (Try 7 of 7)
Failed sign in
```
