### PR TITLE
Add an example of keyword argument passing to module state

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -51,6 +51,17 @@ argument, to avoid a collision with the ``name`` argument. For example:
       module.run:
         - name: service.disable
         - m_name: nfs
+
+Note that some modules read all or some of the arguments from a list of keyword
+arguments. For example:
+
+.. code-block:: yaml
+
+    mine.send:
+      module.run:
+        - func: network.ip_addrs
+        - kwargs:
+            interface: eth0
 '''
 # Import python libs
 import datetime


### PR DESCRIPTION
I spent some time to figure out how does this work, and I thought that it would be a good idea to add a small example to the module description.

I see that there is a need to document this better or change the module https://github.com/saltstack/salt/issues/8392
