### PR TITLE
disk.usage forces check for /etc/mtab

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -54,7 +54,7 @@ def usage(args=None):
         salt '*' disk.usage
     '''
     flags = _clean_flags(args, 'disk.usage')
-    if not os.path.isfile('/etc/mtab'):
+    if not os.path.isfile('/etc/mtab') and __grains__['kernel'] != 'Darwin':
         log.warn('df cannot run without /etc/mtab')
         if __grains__.get('virtual_subtype') == 'LXC':
             log.warn('df command failed and LXC detected. If you are running '


### PR DESCRIPTION
Darwin-based systems do not necessarily have to have an `/etc/mtab` present for mounted filesystems to be present or for `df` to execute correctly. This commit refines the enforcement on `/etc/mtab` to systems other than Darwin in the `disk.usage` function
