### PR TITLE
Reduce missing returns during reauth

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -353,7 +353,7 @@ DEFAULT_MINION_OPTS = {
     'recon_max': 10000,
     'recon_default': 1000,
     'recon_randomize': True,
-    'random_reauth_delay': 60,
+    'random_reauth_delay': 10,
     'win_repo_cachefile': 'salt://win/repo/winrepo.p',
     'pidfile': os.path.join(salt.syspaths.PIDFILE_DIR, 'salt-minion.pid'),
     'range_server': 'range:80',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -64,6 +64,7 @@ import salt.payload
 import salt.utils
 import salt.utils.args
 import salt.utils.event
+import salt.utils.minion
 import salt.utils.schedule
 import salt.exitcodes
 
@@ -865,9 +866,15 @@ class Minion(MinionBase):
             # decryption of the payload failed, try to re-auth but wait
             # random seconds if set in config with random_reauth_delay
             if 'random_reauth_delay' in self.opts:
-                reauth_delay = randint(0, int(self.opts['random_reauth_delay']))
-                log.debug('Waiting {0} seconds to re-authenticate'.format(reauth_delay))
-                time.sleep(reauth_delay)
+                reauth_delay = randint(0, float(self.opts['random_reauth_delay']))
+                # This mitigates the issue wherein a long-running job might not return
+                # on a master key rotation. However, new commands issued during the re-auth
+                # splay period will still fail to return.
+                if not salt.utils.minion.running(self.opts):
+                    log.debug('Waiting {0} seconds to re-authenticate'.format(reauth_delay))
+                    time.sleep(reauth_delay)
+                else:
+                    log.warning('Ignoring re-auth delay because jobs are running')
 
             self.authenticate()
             data = self.crypticle.loads(load)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -17,7 +17,6 @@ import fnmatch
 import time
 import sys
 import copy
-import threading
 from urllib2 import URLError
 
 # Import salt libs
@@ -27,6 +26,7 @@ import salt.state
 import salt.client
 import salt.utils
 import salt.utils.process
+import salt.utils.minion
 import salt.transport
 from salt.exceptions import (
     SaltReqTimeoutError, SaltRenderError, CommandExecutionError
@@ -462,63 +462,7 @@ def running():
 
         salt '*' saltutil.running
     '''
-    ret = []
-    serial = salt.payload.Serial(__opts__)
-    pid = os.getpid()
-    current_thread = threading.currentThread().name
-    proc_dir = os.path.join(__opts__['cachedir'], 'proc')
-    if not os.path.isdir(proc_dir):
-        return []
-
-    def _read_proc_file(path):
-        '''
-        Return a dict of JID metadata, or None
-        '''
-        with salt.utils.fopen(path, 'rb') as fp_:
-            buf = fp_.read()
-            fp_.close()
-            if buf:
-                data = serial.loads(buf)
-            else:
-                # Proc file is empty, remove
-                os.remove(path)
-                return None
-        if not isinstance(data, dict):
-            # Invalid serial object
-            return None
-        if not salt.utils.process.os_is_running(data['pid']):
-            # The process is no longer running, clear out the file and
-            # continue
-            os.remove(path)
-            return None
-        if __opts__['multiprocessing']:
-            if data.get('pid') == pid:
-                return None
-        else:
-            if data.get('pid') != pid:
-                os.remove(path)
-                return None
-            if data.get('jid') == current_thread:
-                return None
-            if not data.get('jid') in [x.name for x in threading.enumerate()]:
-                os.remove(path)
-                return None
-
-        return data
-
-    for fn_ in os.listdir(proc_dir):
-        path = os.path.join(proc_dir, fn_)
-        try:
-            data = _read_proc_file(path)
-            if data is not None:
-                ret.append(data)
-        except IOError:
-            # proc files may be removed at any time during this process by
-            # the minion process that is executing the JID in question, so
-            # we must ignore ENOENT during this process
-            pass
-
-    return ret
+    return salt.utils.minion.running(__opts__)
 
 
 def clear_cache():

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -1,0 +1,63 @@
+import os
+import threading
+
+import salt.utils
+import salt.payload
+
+def running(opts):
+    ret = []
+    current_thread = threading.currentThread().name
+    proc_dir = os.path.join(opts['cachedir'], 'proc')
+    if not os.path.isdir(proc_dir):
+        return []
+    for fn_ in os.listdir(proc_dir):
+        path = os.path.join(proc_dir, fn_)
+        try:
+            data = _read_proc_file(path, opts)
+            if data is not None:
+                ret.append(data)
+        except IOError:
+            # proc files may be removed at any time during this process by
+            # the minion process that is executing the JID in question, so
+            # we must ignore ENOENT during this process
+            pass
+
+    return ret
+
+def _read_proc_file(path, opts):
+    '''
+    Return a dict of JID metadata, or None
+    '''
+    serial = salt.payload.Serial(opts)
+    pid = os.getpid()
+    with salt.utils.fopen(path, 'rb') as fp_:
+        buf = fp_.read()
+        fp_.close()
+        if buf:
+            data = serial.loads(buf)
+        else:
+            # Proc file is empty, remove
+            os.remove(path)
+            return None
+    if not isinstance(data, dict):
+        # Invalid serial object
+        return None
+    if not salt.utils.process.os_is_running(data['pid']):
+        # The process is no longer running, clear out the file and
+        # continue
+        os.remove(path)
+        return None
+    if opts['multiprocessing']:
+        if data.get('pid') == pid:
+            return None
+    else:
+        if data.get('pid') != pid:
+            os.remove(path)
+            return None
+        if data.get('jid') == current_thread:
+            return None
+        if not data.get('jid') in [x.name for x in threading.enumerate()]:
+            os.remove(path)
+            return None
+
+    return data

--- a/salt/utils/minion.py
+++ b/salt/utils/minion.py
@@ -1,12 +1,19 @@
+# -*- coding: utf-8 -*-
+'''
+Utility functions for minions
+'''
 import os
 import threading
 
 import salt.utils
 import salt.payload
 
+
 def running(opts):
+    '''
+    Return the running jobs on this minion
+    '''
     ret = []
-    current_thread = threading.currentThread().name
     proc_dir = os.path.join(opts['cachedir'], 'proc')
     if not os.path.isdir(proc_dir):
         return []
@@ -21,14 +28,15 @@ def running(opts):
             # the minion process that is executing the JID in question, so
             # we must ignore ENOENT during this process
             pass
-
     return ret
+
 
 def _read_proc_file(path, opts):
     '''
     Return a dict of JID metadata, or None
     '''
     serial = salt.payload.Serial(opts)
+    current_thread = threading.currentThread().name
     pid = os.getpid()
     with salt.utils.fopen(path, 'rb') as fp_:
         buf = fp_.read()


### PR DESCRIPTION
When the master key rotates (on a schedule or via salt-key -d), minions
will not be able to decrypt messages from the master until reauth completes.

Therefore, new jobs will effectively be lost during the splay period if we hit the CLI timeout before the reauth timeout.

This turns the reauth splay down to 10s (from 60s) and makes it a float
for more granularity. 

Additinoally, this moves the 'running' function out of the saltutil exec
module and into salt.utils so it can be easily re-used. It's now wrapped
in the exec module.
