### PR TITLE
salt/utils/process.py: fix order of args to os.kill()

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -89,7 +89,7 @@ def clean_proc(proc, wait_for_kill=10):
                         proc.pid
                     )
                 )
-                os.kill(signal.SIGKILL, proc.pid)
+                os.kill(proc.pid, signal.SIGKILL)
     except (AssertionError, AttributeError):
         # Catch AssertionError when the proc is evaluated inside the child
         # Catch AttributeError when the process dies between proc.is_alive()


### PR DESCRIPTION
Fixes: #15269
Signed-off-by: Dan Mick dan.mick@inktank.com
