### PR TITLE
Add --list-profiles to salt-cloud query options

### DIFF
--- a/doc/ref/cli/salt-cloud.rst
+++ b/doc/ref/cli/salt-cloud.rst
@@ -84,6 +84,16 @@ Options
     Can be used in conjunction with -m to display only information about the
     specified map.
 
+.. option:: --list-providers
+
+    Display a list of configured providers.
+
+.. option:: --list-profiles
+
+    .. versionadded:: 2014.7.0
+
+    Display a list of configured profiles.
+
 .. option:: --list-images
 
     Display a list of images available in configured cloud providers.

--- a/doc/ref/cli/salt-cloud.rst
+++ b/doc/ref/cli/salt-cloud.rst
@@ -92,7 +92,9 @@ Options
 
     .. versionadded:: 2014.7.0
 
-    Display a list of configured profiles.
+    Display a list of configured profiles. Pass in a cloud provider to view
+    the provider's associated profiles, such as ``digital_ocean``, or pass in
+    ``all`` to list all the configured profiles.
 
 .. option:: --list-images
 

--- a/doc/topics/cloud/cloud.rst
+++ b/doc/topics/cloud/cloud.rst
@@ -187,7 +187,7 @@ This function is only necessary for libcloud-based modules, and does not need
 to exist otherwise.
 
 The get_image() Function
--------------------------
+------------------------
 This function is only necessary for libcloud-based modules, and does not need
 to exist otherwise.
 

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -457,19 +457,6 @@ class Cloud(object):
             providers.add(alias)
         return providers
 
-    def get_configured_profiles(self):
-        '''
-        Return the configured profiles
-        '''
-        profiles = set()
-        for alias, drivers in self.opts['profiles'].iteritems():
-            if len(drivers) > 1:
-                for driver in drivers:
-                    profiles.add('{0}:{1}'.format(alias, driver))
-                continue
-            profiles.add(alias)
-        return profiles
-
     def lookup_providers(self, lookup):
         '''
         Get a dict describing the configured providers

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -503,25 +503,35 @@ class Cloud(object):
             )
         return providers
 
-    def lookup_profiles(self, lookup):
+    def lookup_profiles(self, provider, lookup):
         '''
         Return a dictionary describing the configured profiles
         '''
+        if provider is None:
+            provider = 'all'
         if lookup is None:
             lookup = 'all'
 
         if lookup == 'all':
             profiles = set()
+            provider_profiles = set()
             for alias, info in self.opts['profiles'].iteritems():
                 providers = info.get('provider')
+
                 if providers:
-                    provider = providers.split(':')[1]
-                    profiles.add((alias, provider))
+                    prov_name = providers.split(':')[1]
+                    profiles.add((alias, prov_name))
+
+                    if prov_name == provider:
+                        provider_profiles.add((alias, prov_name))
 
             if not profiles:
                 raise SaltCloudSystemExit(
                     'There are no cloud profiles configured.'
                 )
+
+            if provider != 'all':
+                return provider_profiles
 
             return profiles
 
@@ -862,12 +872,12 @@ class Cloud(object):
                 data[alias][driver] = {}
         return data
 
-    def profile_list(self, lookup='all'):
+    def profile_list(self, provider, lookup='all'):
         '''
         Return a mapping of all configured profiles
         '''
         data = {}
-        lookups = self.lookup_profiles(lookup)
+        lookups = self.lookup_profiles(provider, lookup)
 
         if not lookups:
             return data

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -538,33 +538,6 @@ class Cloud(object):
 
             return profiles
 
-        if ':' in lookup:
-            alias, driver = lookup.split(':')
-            if alias not in self.opts['profiles'] or \
-                    driver not in self.opts['profiles'][alias]:
-                raise SaltCloudSystemExit(
-                    'No cloud profiles matched {0!r}. Available: {1}'.format(
-                        lookup, ', '.join(self.get_configured_profiles())
-                    )
-                )
-
-            return set((alias, driver))
-
-        profiles = set()
-        for alias, drivers in self.opts['profiles'].iteritems():
-            for driver in drivers:
-                if lookup in (alias, driver):
-                    profiles.add((alias, driver))
-
-        if not profiles:
-            raise SaltCloudSystemExit(
-                'No cloud profiles matched {0!r}. '
-                'Available selections: {1}'.format(
-                    lookup, ', '.join(self.get_configured_profiles())
-                )
-            )
-        return profiles
-
     def map_providers(self, query='list_nodes', cached=False):
         '''
         Return a mapping of what named VMs are running on what VM providers

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -93,8 +93,9 @@ class SaltCloud(parsers.SaltCloudParser):
                     self.handle_exception(msg, exc)
 
             elif self.selected_query_option == 'list_profiles':
+                provider = self.options.list_profiles
                 try:
-                    ret = mapper.profile_list()
+                    ret = mapper.profile_list(provider)
                 except(SaltCloudException, Exception) as exc:
                     msg = 'There was an error listing profiles: {0}'
                     self.handle_exception(msg, exc)

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -92,6 +92,13 @@ class SaltCloud(parsers.SaltCloudParser):
                     msg = 'There was an error listing providers: {0}'
                     self.handle_exception(msg, exc)
 
+            elif self.selected_query_option == 'list_profiles':
+                try:
+                    ret = mapper.profile_list()
+                except(SaltCloudException, Exception) as exc:
+                    msg = 'There was an error listing profiles: {0}'
+                    self.handle_exception(msg, exc)
+
             elif self.config.get('map', None):
                 log.info('Applying map from {0!r}.'.format(self.config['map']))
                 try:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1239,6 +1239,12 @@ class CloudQueriesMixIn(object):
                             )
                     elif opt.dest == 'list_profiles':
                         query = 'list_profiles'
+                        option_dict = vars(self.options)
+                        if option_dict.get('list_profiles') == '--list-providers':
+                            self.error(
+                                '\'--list-profiles\' does not accept '
+                                '\'--list-providers\' as an argument'
+                            )
                     self.selected_query_option = query
 
             funcname = 'process_{0}'.format(option.dest)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1207,7 +1207,13 @@ class CloudQueriesMixIn(object):
             '--list-providers',
             default=False,
             action='store_true',
-            help=('Display a list of configured providers.')
+            help='Display a list of configured providers.'
+        )
+        group.add_option(
+            '--list-profiles',
+            default=False,
+            action='store_true',
+            help='Display a list of configured profiles.'
         )
         self.add_option_group(group)
         self._create_process_functions()
@@ -1226,6 +1232,13 @@ class CloudQueriesMixIn(object):
                         if self.args:
                             self.error(
                                 '\'--list-providers\' does not accept any '
+                                'arguments'
+                            )
+                    elif opt.dest == 'list_profiles':
+                        query = 'list_profiles'
+                        if self.args:
+                            self.error(
+                                '\'--list-profiles\' does not accept any '
                                 'arguments'
                             )
                     self.selected_query_option = query

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1211,9 +1211,12 @@ class CloudQueriesMixIn(object):
         )
         group.add_option(
             '--list-profiles',
-            default=False,
-            action='store_true',
-            help='Display a list of configured profiles.'
+            default=None,
+            action='store',
+            help='Display a list of configured profiles. Pass in a cloud '
+                 'provider to view the provider\'s associated profiles, '
+                 'such as digital_ocean, or pass in "all" to list all the '
+                 'configured profiles.'
         )
         self.add_option_group(group)
         self._create_process_functions()
@@ -1236,11 +1239,6 @@ class CloudQueriesMixIn(object):
                             )
                     elif opt.dest == 'list_profiles':
                         query = 'list_profiles'
-                        if self.args:
-                            self.error(
-                                '\'--list-profiles\' does not accept any '
-                                'arguments'
-                            )
                     self.selected_query_option = query
 
             funcname = 'process_{0}'.format(option.dest)
@@ -1249,7 +1247,8 @@ class CloudQueriesMixIn(object):
 
     def _mixin_after_parsed(self):
         group_options_selected = filter(
-            lambda option: getattr(self.options, option.dest) is not False,
+            lambda option: getattr(self.options, option.dest) is not False
+            and getattr(self.options, option.dest) is not None,
             self.cloud_queries_group.option_list
         )
         if len(group_options_selected) > 1:


### PR DESCRIPTION
References #15063

Because we're using `optparse` instead of `argparse` in `salt/utils/parsers.py`, we can only choose to use an argument, or no arguments at all. Therefore, the feature request to have a default behavior to list all profiles and then add a provider name agrument to list only the provider's associated profiles isn't possible in `salt-cloud` until `parsers.py` is refactored.

From Python's `optparse` docs:

```
Typically, a given option either takes an argument or it doesn’t. Lots of people want an “optional option arguments” feature, meaning that some options will take an argument if they see it, and won’t if they don’t. This is somewhat controversial, because it makes parsing ambiguous: if -a takes an optional argument and -b is another option entirely, how do we interpret -ab? Because of this ambiguity, optparse does not support this feature.
```

I've opted for the "default" behavior, where passing --list-profiles will list ALL configured profiles. It's easy to change to only list profiles from a named provider, if that would be preferred.
