### PR TITLE
Update to dockerio.import_image()

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1486,7 +1486,8 @@ def _parse_image_multilogs_string(ret, repo):
                     buf = json.loads(buf)
                 except Exception:
                     pass
-                image_logs.append(buf)
+                else:
+                    image_logs.append(buf)
                 buf = ''
         image_logs.reverse()
         # search last layer grabbed


### PR DESCRIPTION
Import image was failing for me because the _parse_image_multilogs_string() function was returning a list containing:

[u'\n', u'\r', {'status', '....'}]

The import_image function then takes this returned list and attempts to access the dictionary containing the status by checking index 0 of the list.  Since the status is in index 2, this fails.

This change should prevent '\r' and '\n' from being added to the list.
