### PR TITLE
Make --list-profiles argument more inclusive

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -519,7 +519,7 @@ class Cloud(object):
                 providers = info.get('provider')
 
                 if providers:
-                    prov_name = providers.split(':')[1]
+                    prov_name = providers.split(':')[0]
                     profiles.add((alias, prov_name))
 
                     if prov_name == provider:

--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -519,11 +519,13 @@ class Cloud(object):
                 providers = info.get('provider')
 
                 if providers:
-                    prov_name = providers.split(':')[0]
-                    profiles.add((alias, prov_name))
-
-                    if prov_name == provider:
-                        provider_profiles.add((alias, prov_name))
+                    given_prov_name = providers.split(':')[0]
+                    salt_prov_name = providers.split(':')[1]
+                    if given_prov_name == provider:
+                        provider_profiles.add((alias, given_prov_name))
+                    elif salt_prov_name == provider:
+                        provider_profiles.add((alias, salt_prov_name))
+                    profiles.add((alias, given_prov_name))
 
             if not profiles:
                 raise SaltCloudSystemExit(


### PR DESCRIPTION
Change the `provider` argument to search for the user-named providers or salt-cloud named providers. Returns providers names as given in the argument. 

For example:

```
$ salt-cloud --list-profiles my_linode_config
linode-profile-1:
    ----------
    my_linode_config:
        ----------
linode-profile-2:
    ----------
    my_linode_config:
        ----------
```

or

```
$ salt-cloud --list-profiles linode
linode-profile-1:
    ----------
    linode:
        ----------
linode-profile-2:
    ----------
    linode:
        ----------
```
