### PR TITLE
Set the route dst in the api maste_call interface

### DIFF
--- a/salt/runner.py
+++ b/salt/runner.py
@@ -131,6 +131,8 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         #         'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
         #        )
         sreq = salt.transport.Channel.factory(self.opts, crypt='clear')
+        if self.opts['transport'] == 'raet':
+            sreq.dst = (None, None, 'local_cmd')
         ret = sreq.send(load)
         if isinstance(ret, collections.Mapping):
             if 'error' in ret:


### PR DESCRIPTION
Fix a bug in the salt-raet api interface
