### PR TITLE
add slscolonpath

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -65,6 +65,7 @@ def wrap_tmpl_func(render_str):
                 if not tmplpath.lower().replace('\\', '/').endswith('/init.sls'):
                     slspath = os.path.dirname(slspath)
             context['slsdotpath'] = slspath.replace('/', '.')
+            context['slscolonpath'] = slspath.replace('/', ':')
             if slspath:
                 slspath = slspath + '/'
             context['slspath'] = slspath


### PR DESCRIPTION
added slscolonpath because this is helpfull in formulas as a shortcut to:

```
{% set vars = salt['pillar.get'](slsdotpath.replace('.',':'), default=vars, merge=True) %}
```
