### PR TITLE
Specify the version that interface properties were added in doc/topics/cloud/aws.rst

### DIFF
--- a/doc/topics/cloud/aws.rst
+++ b/doc/topics/cloud/aws.rst
@@ -887,6 +887,8 @@ image should be created. Then, edit your cloud.profiles file like so:-
 Specifying interface properties
 -------------------------------
 
+.. versionadded:: 2014.7.0
+
 Launching into a VPC allows you to specify more complex configurations for
 the network interfaces of your virtual machines, for example:-
 


### PR DESCRIPTION
Interface properties features such as 'allocation_new_eip: True' and 'allocate_new_eips: True' did not exist in 2014.1.XXX so added a versionadded of 2014.7.0.
