### PR TITLE
Fix missing args issue in mine.send

### DIFF
--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -128,6 +128,9 @@ def send(func, *args, **kwargs):
             # Safe error, arg may be in kwargs
             pass
     f_call = salt.utils.format_call(__salt__[func], func_data)
+    for arg in args:
+        if arg not in f_call['args']:
+            f_call['args'].append(arg)
     try:
         if 'kwargs' in f_call:
             data[func] = __salt__[func](*f_call['args'], **f_call['kwargs'])


### PR DESCRIPTION
Resolves #15309

mine.send was not functional for any function which didn't contain
defined arguments.

This forcibly packs those into the function call if they aren't
detected. 

I'm not totally convinced this is the best way to do this, so
other approaches are welcome.
