### PR TITLE
Fix salt-cloud regression

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1519,7 +1519,7 @@ def win_cmd(command, **kwargs):
     return 1
 
 
-def root_cmd(command, tty, sudo, allow_failure=False, **kwargs):
+def root_cmd(command, tty, sudo, allow_failure=True, **kwargs):
     '''
     Wrapper for commands to be run as root
     '''


### PR DESCRIPTION
A regression was introduced into salt-cloud with #15158 causing the errors in #15290. 

Changing `False` to `True` for `allow_failure` in the `cmd_root` function fixes the regression. @s0undt3ch will that change still work with the changes you made in #15158?
