### PR TITLE
Don't return multiple elements for grain 'osmajorrelease'.

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1035,7 +1035,7 @@ def os_data():
 
     # Load additional OS family grains
     if grains['os_family'] == "RedHat":
-        grains['osmajorrelease'] = grains['osrelease'].split('.', 1)
+        grains['osmajorrelease'] = grains['osrelease'].split('.', 1)[0]
 
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['osfullname'],


### PR DESCRIPTION
Before this fix, the output of the `osmajorrelease` grain looked like
this:

```
osmajorrelease:
    7
    0.1406
```

Now it'll only return the actual major release number:

```
osmajorrelease: 7
```

This fix needs to be merged into `develop` and cherry-picked into `2014.1`.
