### PR TITLE
Allow pkg.install to install packages with an arch in the name

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -70,6 +70,7 @@ def parse_targets(name=None,
                   pkgs=None,
                   sources=None,
                   saltenv='base',
+                  normalize=True,
                   **kwargs):
     '''
     Parses the input to pkg.install and returns back the package(s) to be
@@ -128,9 +129,12 @@ def parse_targets(name=None,
         return [x[2] for x in srcinfo], 'file'
 
     elif name:
-        _normalize_name = \
-            __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
-        packed = dict([(_normalize_name(x), None) for x in name.split(',')])
+        if normalize:
+            _normalize_name = \
+                __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+            packed = dict([(_normalize_name(x), None) for x in name.split(',')])
+        else:
+            packed = dict([(x, None) for x in name.split(',')])
         return packed, 'repository'
 
     else:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -506,6 +506,7 @@ def check_db(*names, **kwargs):
         salt '*' pkg.check_db <package1> <package2> <package3> fromrepo=epel-testing
         salt '*' pkg.check_db <package1> <package2> <package3> disableexcludes=main
     '''
+    normalize = kwargs.pop('normalize') if kwargs.get('normalize') else False
     repo_arg = _get_repo_options(**kwargs)
     exclude_arg = _get_excludes_option(**kwargs)
     repoquery_base = \
@@ -525,7 +526,10 @@ def check_db(*names, **kwargs):
                 name, arch = line.split('_|-')
             except ValueError:
                 continue
-            avail.append(normalize_name('.'.join((name, arch))))
+            if normalize:
+                avail.append(normalize_name('.'.join((name, arch))))
+            else:
+                avail.append('.'.join((name, arch)))
         __context__['pkg._avail'] = avail
 
     ret = {}
@@ -689,6 +693,7 @@ def install(name=None,
             pkgs=None,
             sources=None,
             reinstall=False,
+            normalize=True,
             **kwargs):
     '''
     Install the passed package(s), add refresh=True to clean the yum database
@@ -782,6 +787,20 @@ def install(name=None,
 
             salt '*' pkg.install sources='[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
 
+    normalize
+        Normalize the package name by removing the architecture.  Default is True.
+        This is useful for poorly created packages which might include the
+        architecture as an actual part of the name such as kernel modules
+        which match a specific kernel version.
+
+        .. versionadded:: 2014.7.0
+
+    Example:
+
+    .. code-block:: bash
+
+        salt -G role:nsd pkg.install gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 normalize=False
+
 
     Returns a dict containing the new package names and versions::
 
@@ -794,7 +813,7 @@ def install(name=None,
 
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name, pkgs, sources, **kwargs
+            name, pkgs, sources, normalize=normalize, **kwargs
         )
     except MinionError as exc:
         raise CommandExecutionError(exc)

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -123,6 +123,7 @@ def _find_install_targets(name=None,
                           sources=None,
                           skip_suggestions=False,
                           pkg_verify=False,
+                          normalize=True,
                           **kwargs):
     '''
     Inspect the arguments to pkg.installed and discover what packages need to
@@ -174,8 +175,13 @@ def _find_install_targets(name=None,
                                    'repository.'.format(name)}
             if version is None:
                 version = _get_latest_pkg_version(pkginfo)
-        _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
-        desired = {_normalize_name(name): version}
+
+        if normalize:
+            _normalize_name = __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+            desired = {_normalize_name(name): version}
+        else:
+            desired = {name: version}
+
         to_unpurge = _find_unpurge_targets(desired)
 
         cver = cur_pkgs.get(name, [])
@@ -393,6 +399,7 @@ def installed(
         sources=None,
         allow_updates=False,
         pkg_verify=False,
+        normalize=True,
         **kwargs):
     '''
     Ensure that the package is installed, and that it is the correct version
@@ -678,6 +685,21 @@ def installed(
             - install_recommends: False
 
 
+    normalize
+        Normalize the package name by removing the architecture.  Default is True.
+        This is useful for poorly created packages which might include the
+        architecture as an actual part of the name such as kernel modules
+        which match a specific kernel version.
+
+        .. versionadded:: 2014.7.0
+
+    Example:
+
+    .. code-block:: yaml
+
+        gpfs.gplbin-2.6.32-279.31.1.el6.x86_64:
+          pkg.installed:
+            - normalize: False
     '''
     kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
@@ -701,6 +723,7 @@ def installed(
                                    fromrepo=fromrepo,
                                    skip_suggestions=skip_suggestions,
                                    pkg_verify=pkg_verify,
+                                   normalize=normalize,
                                    **kwargs)
 
     try:
@@ -820,6 +843,7 @@ def installed(
                                             pkgs=pkgs,
                                             sources=sources,
                                             reinstall=reinstall,
+                                            normalize=normalize,
                                             **kwargs)
 
             if os.path.isfile(rtag) and refresh:


### PR DESCRIPTION
Before:

``` bash
(ve)[root@omniscience salt]# scripts/salt-call --local state.single pkg.installed name=gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 
[INFO    ] Executing state pkg.installed for gpfs.gplbin-2.6.32-279.31.1.el6.x86_64
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}" --all --pkgnarrow=installed' in directory '/root' 
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{ARCH}"  --pkgnarrow=all --all' in directory '/root'
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}"   --all --quiet --whatprovides gpfs.gplbin-2.6.32-279.31.1.el6' in directory '/root' 
[ERROR   ] The following package(s) were not found, and no possible matches were found in the package db: gpfs.gplbin-2.6.32-279.31.1.el6
[INFO    ] Completed state [gpfs.gplbin-2.6.32-279.31.1.el6.x86_64] at time 22:42:33.946103
    local:
    ----------
              ID: gpfs.gplbin-2.6.32-279.31.1.el6.x86_64
        Function: pkg.installed
          Result: False
         Comment: The following package(s) were not found, and no possible matches were found in the package db: gpfs.gplbin-2.6.32-279.31.1.el6
... snip ...
```

After this patch on Fedora 20 and RHEL7:

``` bash
(ve)[root@omniscience salt]# scripts/salt-call --local state.single pkg.installed name=gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 normalize=False
[INFO    ] Executing state pkg.installed for gpfs.gplbin-2.6.32-279.31.1.el6.x86_64
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}" --all --pkgnarrow=installed' in directory '/root' 
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{ARCH}"  --pkgnarrow=all --all' in directory '/root'
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}"   --all --quiet --whatprovides gpfs.gplbin-2.6.32-279.31.1.el6.x86_64' in directory '/root' 
[INFO    ] Executing command 'yum -q clean expire-cache && yum -q check-update ' in directory '/root'
[INFO    ] Executing command 'yum -y     install gpfs.gplbin-2.6.32-279.31.1.el6.x86_64' in directory '/root'
[INFO    ] Executing command 'repoquery --plugins --queryformat="%{NAME}_|-%{VERSION}_|-%{RELEASE}_|-%{ARCH}_|-%{REPOID}" --all --pkgnarrow=installed' in directory '/root' 
[INFO    ] Installed Packages:
gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 changed from absent to 0.7.1-1.fc20
... snip ...
```

I also ran `make html` in the doc directory to ensure the documentation for these bits rendered properly. Let me know if this is acceptable. I would really like to see this make it into helium as it affects our ability to roll out bits for our hpc environment using salt.
