### PR TITLE
Add the ifcfg-* template for 'network.managed' to work on RHEL7

### DIFF
--- a/salt/templates/rh_ip/rh7_eth.jinja
+++ b/salt/templates/rh_ip/rh7_eth.jinja
@@ -1,0 +1,30 @@
+DEVICE="{{name}}"
+{% if addr %}HWADDR="{{addr}}"
+{%endif%}{% if userctl %}USERCTL="{{userctl}}"
+{%endif%}{% if master %}MASTER="{{master}}"
+{%endif%}{% if slave %}SLAVE="{{slave}}"
+{%endif%}{% if vlan %}VLAN="{{vlan}}"
+{%endif%}{% if devtype %}TYPE="{{devtype}}"
+{%endif%}{% if proto %}BOOTPROTO="{{proto}}"
+{%endif%}{% if onboot %}ONBOOT="{{onboot}}"
+{%endif%}{% if onparent %}ONPARENT={{onparent}}
+{%endif%}{% if ipaddr %}IPADDR="{{ipaddr}}"
+{%endif%}{% if netmask %}NETMASK="{{netmask}}"
+{%endif%}{% if gateway %}GATEWAY="{{gateway}}"
+{%endif%}{% if enable_ipv6 %}IPV6INIT="yes"
+{% if ipv6_autoconf %}IPV6_AUTOCONF="{{ipv6_autoconf}}"
+{%endif%}{% if ipv6addr %}IPV6ADDR="{{ipv6addr}}"
+{%endif%}{% if ipv6gateway %}IPV6_DEFAULTGW="{{ipv6gateway}}"
+{%endif%}{%endif%}{% if srcaddr %}SRCADDR="{{srcaddr}}"
+{%endif%}{% if peerdns %}PEERDNS="{{peerdns}}"
+{%endif%}{% if defroute %}DEFROUTE="{{defroute}}"
+{%endif%}{% if bridge %}BRIDGE="{{bridge}}"
+{%endif%}{% if delay %}DELAY="{{delay}}"
+{%endif%}{% if my_inner_ipaddr %}MY_INNER_IPADDR={{my_inner_ipaddr}}
+{%endif%}{% if my_outer_ipaddr %}MY_OUTER_IPADDR={{my_outer_ipaddr}}
+{%endif%}{%if bonding %}BONDING_OPTS="{%for item in bonding %}{{item}}={{bonding[item]}} {%endfor%}"
+{%endif%}{% if ethtool %}ETHTOOL_OPTS="{%for item in ethtool %}{{item}} {{ethtool[item]}} {%endfor%}"
+{%endif%}{% if domain %}DOMAIN="{{ domain|join(' ') }}"
+{% endif %}{% for server in dns -%}
+DNS{{loop.index}}="{{server}}"
+{% endfor -%}


### PR DESCRIPTION
Exact same as RHEL6 configuration, but the [official docs](https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Networking_Guide/sec-Using_the_Command_Line_Interface.html#sec-Configuring_a_Network_Interface_Using_ifcg_Files) show no changes. For my production environment, I've got a state which literally copies this file out so that `network.managed` works
