### PR TITLE
Fix exception, while tmp_dir not exists, just create it.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -999,7 +999,7 @@ def deploy_script(host,
                 log.debug('Using {0} as the password'.format(password))
                 ssh_kwargs['password'] = password
 
-            if root_cmd('test -e \\"{0}\\"'.format(tmp_dir), tty, sudo, **ssh_kwargs):
+            if root_cmd('test -e \\"{0}\\"'.format(tmp_dir), tty, sudo, True, **ssh_kwargs):
                 ret = root_cmd(('sh -c "( mkdir -p \\"{0}\\" &&'
                                 ' chmod 700 \\"{0}\\" )"').format(tmp_dir),
                                tty, sudo, **ssh_kwargs)


### PR DESCRIPTION
Pass argument that allow exception in root_cmd while checking if tmp_dir exists, because if NOT we should to create it...

[ERROR   ] Failed to deploy 'fredis1'. Error: Command 'ssh -t -t -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oControlPath=none -oPasswordAuthentication=no -oChallengeResponseAuthentication=no -oPubkeyAuthentication=yes -oKbdInteractiveAuthentication=no -i /etc/cloud/google_compute_engine -p 22 gceuser@107.178.219.237 \'sudo test -e \"/tmp/.saltcloud-e304a61e-a98b-4512-bb62-2c4d9f375bd0\"\'' failed. Exit code: 1
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/**init**.py", line 2118, in create_multiprocessing
    local_master=parallel_data['local_master']
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/**init**.py", line 1205, in create
    output = self.clouds[func](vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/gce.py", line 1982, in create
    deployed = salt.utils.cloud.deploy_script(*_deploy_kwargs)
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/cloud.py", line 996, in deploy_script
    if root_cmd('test -e \"{0}\"'.format(tmp_dir), tty, sudo, *_ssh_kwargs):
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/cloud.py", line 1619, in root_cmd
    retcode = _exec_ssh_cmd(cmd, allow_failure=allow_failure, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/cloud.py", line 1373, in _exec_ssh_cmd
    cmd, proc.exitstatus
SaltCloudSystemExit: Command 'ssh -t -t -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oControlPath=none -oPasswordAuthentication=no -oChallengeResponseAuthentication=no -oPubkeyAuthentication=yes -oKbdInteractiveAuthentication=no -i /etc/cloud/google_compute_engine -p 22 gceuser@107.178.219.237 \'sudo test -e \"/tmp/.saltcloud-e304a61e-a98b-4512-bb62-2c4d9f375bd0\"\'' failed. Exit code: 1
