### PR TITLE
Fix error message for missing include

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2407,9 +2407,13 @@ class BaseHighState(object):
                         self.merge_included_states(highstate, state, errors)
                     for i, error in enumerate(errors[:]):
                         if 'is not available on the salt master' in error:
-                            errors[i] = (
-                                'No matching sls found for {0!r} '
-                                'in env {1!r}'.format(sls_match, saltenv))
+                            # match SLS foobar in environment
+                            this_sls = 'SLS {0} in environment'.format(
+                                sls_match)
+                            if this_sls in error:
+                                errors[i] = (
+                                    'No matching sls found for {0!r} '
+                                    'in env {1!r}'.format(sls_match, saltenv))
                     all_errors.extend(errors)
 
         self.clean_duplicate_extends(highstate)


### PR DESCRIPTION
This fixes an error where the wrong SLS target would be reported as missing,
when a missing include was encountered.

This is fixed upstream already, this commit just brings the relevant part of
the fix to the 2014.1 branch.
