### PR TITLE
caches.fs{cache,worker}: put main code into funcs to avoid shadowing

### DIFF
--- a/salt/caches/fscache.py
+++ b/salt/caches/fscache.py
@@ -272,22 +272,24 @@ class FSCache(multiprocessing.Process):
         log.debug('Shutting down')\
 
 if __name__ == '__main__':
+    def run_test():
+        opts = salt.config.master_config('./master')
 
-    opts = salt.config.master_config('./master')
+        wlk = FSCache(opts)
+        # add two jobs for jobs and cache-files
+        wlk.add_job(**{
+                        'name': 'grains',
+                        'path': '/var/cache/salt/master/minions',
+                        'ival': [2, 12, 22],
+                        'patt': '^.*$'
+                      })
 
-    wlk = FSCache(opts)
-    # add two jobs for jobs and cache-files
-    wlk.add_job(**{
-                    'name': 'grains',
-                    'path': '/var/cache/salt/master/minions',
-                    'ival': [2, 12, 22],
-                    'patt': '^.*$'
-                  })
+        wlk.add_job(**{
+                        'name': 'mine',
+                        'path': '/var/cache/salt/master/jobs/',
+                        'ival': [4, 14, 24, 34, 44, 54],
+                        'patt': '^.*$'
+                    })
+        wlk.start()
 
-    wlk.add_job(**{
-                    'name': 'mine',
-                    'path': '/var/cache/salt/master/jobs/',
-                    'ival': [4, 14, 24, 34, 44, 54],
-                    'patt': '^.*$'
-                })
-    wlk.start()
+    run_test()

--- a/salt/caches/fsworker.py
+++ b/salt/caches/fsworker.py
@@ -142,25 +142,28 @@ class FSWorker(multiprocessing.Process):
 
 # test code for the FSWalker class
 if __name__ == '__main__':
-    context = zmq.Context()
-    cupd_in = context.socket(zmq.REP)
-    cupd_in.setsockopt(zmq.LINGER, 100)
-    cupd_in.bind("ipc:///tmp/fsc_upd")
+    def run_test():
+        context = zmq.Context()
+        cupd_in = context.socket(zmq.REP)
+        cupd_in.setsockopt(zmq.LINGER, 100)
+        cupd_in.bind("ipc:///tmp/fsc_upd")
 
-    poller = zmq.Poller()
-    poller.register(cupd_in, zmq.POLLIN)
-    serial = salt.payload.Serial('msgpack')
-    fsw = FSWorker({'serial': 'msgpack'},
-                    'test',
-                    **{'path': '/tmp', 'patt': '.*'})
-    fsw.start()
+        poller = zmq.Poller()
+        poller.register(cupd_in, zmq.POLLIN)
+        serial = salt.payload.Serial('msgpack')
+        fsw = FSWorker({'serial': 'msgpack'},
+                        'test',
+                        **{'path': '/tmp', 'patt': '.*'})
+        fsw.start()
 
-    while 1:
-        socks = dict(poller.poll())
-        if socks.get(cupd_in) == zmq.POLLIN:
-            reply = serial.loads(cupd_in.recv())
-            print reply
-            cupd_in.send(serial.dumps('OK'))
-        break
-    fsw.join()
-    sys.exit(0)
+        while 1:
+            socks = dict(poller.poll())
+            if socks.get(cupd_in) == zmq.POLLIN:
+                reply = serial.loads(cupd_in.recv())
+                print reply
+                cupd_in.send(serial.dumps('OK'))
+            break
+        fsw.join()
+        sys.exit(0)
+
+    run_test()


### PR DESCRIPTION
```
************* Module salt.caches.fscache
salt/caches/fscache.py:24: [W0621(redefined-outer-name), FSTimer.__init__] Redefining name 'opts' from outer scope (line 276)
salt/caches/fscache.py:61: [W0621(redefined-outer-name), FSCache.__init__] Redefining name 'opts' from outer scope (line 276)
************* Module salt.caches.fsworker
salt/caches/fsworker.py:111: [W0621(redefined-outer-name), FSWorker.run] Redefining name 'context' from outer scope (line 145)
```
