### PR TITLE
Ability to override default returner configuration options.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -137,6 +137,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if getattr(self.options, 'return'):
                 kwargs['ret'] = getattr(self.options, 'return')
 
+            if getattr(self.options, 'return_config'):
+                kwargs['ret_config'] = getattr(self.options, 'return_config')
+
             # If using eauth and a token hasn't already been loaded into
             # kwargs, prompt the user to enter auth credentials
             if 'token' not in kwargs and self.options.eauth:

--- a/salt/master.py
+++ b/salt/master.py
@@ -2251,8 +2251,9 @@ class ClearFuncs(object):
         if 'to' in clear_load:
             load['to'] = clear_load['to']
 
-        if 'ret_config' in clear_load['kwargs']:
-            load['ret_config'] = clear_load['kwargs'].get('ret_config')
+        if 'kwargs' in clear_load:
+            if 'ret_config' in clear_load['kwargs']:
+                load['ret_config'] = clear_load['kwargs'].get('ret_config')
 
         if 'user' in clear_load:
             log.info(

--- a/salt/master.py
+++ b/salt/master.py
@@ -2251,6 +2251,9 @@ class ClearFuncs(object):
         if 'to' in clear_load:
             load['to'] = clear_load['to']
 
+        if 'ret_config' in clear_load['kwargs']:
+            load['ret_config'] = clear_load['kwargs'].get('ret_config')
+
         if 'user' in clear_load:
             log.info(
                 'User {user} Published command {fun} with jid {jid}'.format(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1084,6 +1084,8 @@ class Minion(MinionBase):
             ret['master_id'] = data['master_id']
         minion_instance._return_pub(ret)
         if data['ret']:
+            if 'ret_config' in data:
+                ret['ret_config'] = data['ret_config']
             ret['id'] = opts['id']
             for returner in set(data['ret'].split(',')):
                 try:
@@ -1136,6 +1138,8 @@ class Minion(MinionBase):
             ret['fun_args'] = data['arg']
         minion_instance._return_pub(ret)
         if data['ret']:
+            if 'ret_config' in data:
+                ret['ret_config'] = data['ret_config']
             for returner in set(data['ret'].split(',')):
                 ret['id'] = opts['id']
                 try:

--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -249,7 +249,7 @@ def build_schedule_item(name, **kwargs):
         else:
             schedule[name]['splay'] = kwargs['splay']
 
-    for item in ['range', 'when', 'cron', 'returner']:
+    for item in ['range', 'when', 'cron', 'returner', 'return_config']:
         if item in kwargs:
             schedule[name][item] = kwargs[item]
 
@@ -270,7 +270,6 @@ def add(name, **kwargs):
     ret = {'comment': [],
            'result': True}
 
-    log.debug('kwargs {0}'.format(kwargs))
     current_schedule = __opts__['schedule'].copy()
     if 'schedule' in __pillar__:
         current_schedule.update(__pillar__['schedule'])

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -68,8 +68,10 @@ def _get_options(ret):
     '''
     Returns options used for the carbon returner.
     '''
-
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'host': 'host',
              'port': 'port',
@@ -208,7 +210,7 @@ def returner(ret):
         [module].[function].[minion_id].[metric path [...]].[metric name]
 
     '''
-    _options = _get_options()
+    _options = _get_options(ret)
 
     host = _options.get('host')
     port = _options.get('port')

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -25,9 +25,23 @@ Carbon settings may also be configured as::
         skip_on_error: True
         mode: (pickle|text)
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.carbon:
+        host: <server IP or hostname>
+        port: <carbon port>
+        skip_on_error: True
+        mode: (pickle|text)
+
   To use the carbon returner, append '--return carbon' to the salt command. ex:
 
     salt '*' test.ping --return carbon
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return carbon --return_config alternative
 '''
 
 
@@ -48,6 +62,49 @@ __virtualname__ = 'carbon'
 
 def __virtual__():
     return __virtualname__
+
+
+def _get_options(ret):
+    '''
+    Returns options used for the carbon returner.
+    '''
+
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'host': 'host',
+             'port': 'port',
+             'skip': 'skip_on_error',
+             'mode': 'mode'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
 
 
 @contextmanager
@@ -151,21 +208,13 @@ def returner(ret):
         [module].[function].[minion_id].[metric path [...]].[metric name]
 
     '''
+    _options = _get_options()
 
-    if 'config.option' in __salt__:
-        cfg = __salt__['config.option']
-        c_cfg = cfg('carbon', {})
-
-        host = c_cfg.get('host', cfg('carbon.host', None))
-        port = c_cfg.get('port', cfg('carbon.port', None))
-        skip = c_cfg.get('skip_on_error', cfg('carbon.skip_on_error', False))
-        mode = c_cfg.get('mode', cfg('carbon.mode', 'text')).lower()
-    else:
-        cfg = __opts__
-        host = cfg.get('cabon.host', None)
-        port = cfg.get('cabon.port', None)
-        skip = cfg.get('carbon.skip_on_error', False)
-        mode = cfg.get('carbon.mode', 'text').lower()
+    host = _options.get('host')
+    port = _options.get('port')
+    skip = _options.get('skip')
+    if 'mode' in _options:
+        mode = _options.get('mode').lower()
 
     log.debug('Carbon minion configured with host: {0}:{1}'.format(host, port))
     log.debug('Using carbon protocol: {0}'.format(mode))

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -36,7 +36,7 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the couchdb options from salt.
     '''

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -40,7 +40,10 @@ def _get_options(ret=None):
     '''
     Get the couchdb options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'url': 'server_url',
              'db': 'db_name'}
@@ -161,7 +164,7 @@ def get_jid(jid):
     '''
     Get the document with a given JID.
     '''
-    options = _get_options()
+    options = _get_options(ret=None)
     _response = _request("GET", options['url'] + options['db'] + '/' + jid)
     if 'error' in _response:
         log.error('Unable to get JID "{0}" : "{1}"'.format(jid, _response))
@@ -173,7 +176,7 @@ def get_jids():
     '''
     List all the jobs that we have..
     '''
-    options = _get_options()
+    options = _get_options(ret=None)
     _response = _request("GET", options['url'] + options['db'] + "/_all_docs")
 
     # Make sure the 'total_rows' is returned.. if not error out.
@@ -210,7 +213,7 @@ def get_fun(fun):
     '''
 
     # Get the options..
-    options = _get_options()
+    options = _get_options(ret=None)
 
     # Define a simple return object.
     _ret = {}
@@ -252,7 +255,7 @@ def get_minions():
     '''
     Return a list of minion identifiers from a request of the view.
     '''
-    options = _get_options()
+    options = _get_options(ret=None)
 
     # Make sure the views are valid, which includes the minions..
     if not ensure_views():
@@ -283,7 +286,7 @@ def ensure_views():
     '''
 
     # Get the options so we have the URL and DB..
-    options = _get_options()
+    options = _get_options(ret=None)
 
     # Make a request to check if the design document exists.
     _response = _request("GET",
@@ -329,7 +332,7 @@ def set_salt_view():
     document. Uses get_valid_salt_views and some hardcoded values.
     '''
 
-    options = _get_options()
+    options = _get_options(ret=None)
 
     # Create the new object that we will shove in as the design doc.
     new_doc = {}

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -6,9 +6,20 @@ settings are listed below, along with sane defaults.
 couchdb.db:     'salt'
 couchdb.url:        'http://salt:5984/'
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+alternative.couchdb.db:     'salt'
+alternative.couchdb.url:        'http://salt:5984/'
+
   To use the couchdb returner, append '--return couchdb' to the salt command. ex:
 
     salt '*' test.ping --return couchdb
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return couchdb --return_config alternative
 '''
 import logging
 import time
@@ -25,18 +36,46 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options():
+def _get_options(ret):
     '''
-    Get the couchdb options from salt. Apply defaults
-    if required.
+    Get the couchdb options from salt.
     '''
-    if 'config.option' in __salt__:
-        server_url = __salt__['config.option']('couchdb.url')
-        db_name = __salt__['config.option']('couchdb.db')
-    else:
-        cfg = __opts__
-        server_url = cfg.get('couchdb.url', None)
-        db_name = cfg.get('couchdb.db', None)
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'url': 'server_url',
+             'db': 'db_name'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+
+    server_url = _options.get('server_url')
+    db_name = _options.get('db_name')
 
     if not server_url:
         log.debug("Using default url.")
@@ -88,7 +127,7 @@ def returner(ret):
     Take in the return and shove it into the couchdb database.
     '''
 
-    options = _get_options()
+    options = _get_options(ret)
 
     # Check to see if the database exists.
     _response = _request("GET", options['url'] + "_all_dbs")

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -9,7 +9,22 @@ config, these are the defaults:
     memcache.host: 'localhost'
     memcache.port: '11211'
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.memcache.host: 'localhost'
+    alternative.memcache.port: '11211'
+
 python2-memcache uses 'localhost' and '11211' as syntax on connection.
+
+  To use the memcache returner, append '--return memcache' to the salt command. ex:
+
+    salt '*' test.ping --return memcache
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return memcache --return_config alternative
 '''
 
 # Import python libs
@@ -35,26 +50,64 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_serv():
+def _get_options(ret):
+    '''
+    Get the memcache options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'host': 'host',
+             'port': 'port'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
+def _get_serv(ret):
     '''
     Return a memcache server object
     '''
-    if 'config.option' in __salt__:
-        host = __salt__['config.option']('memcache.host')
-        port = __salt__['config.option']('memcache.port')
-    else:
-        cfg = __opts__
-        host = cfg.get('memcache.host', None)
-        port = cfg.get('memcache.port', None)
+
+    _options = _get_options()
+    host = _options.get('host')
+    port = _options.get('port')
+
     log.debug('memcache server: {0}:{1}'.format(host, port))
     if not host or not port:
         log.error('Host or port not defined in salt config')
         return
-    #Combine host and port to conform syntax of python memcache client
+    # Combine host and port to conform syntax of python memcache client
     memcacheoptions = (host, port)
 
     return memcache.Client([':'.join(memcacheoptions)], debug=0)
-    ## TODO: make memcacheoptions cluster aware
+    # # TODO: make memcacheoptions cluster aware
     # Servers can be passed in two forms:
     # 1. Strings of the form C{"host:port"}, which implies a default weight of 1
     # 2. Tuples of the form C{("host:port", weight)}, where C{weight} is
@@ -65,7 +118,7 @@ def returner(ret):
     '''
     Return data to a memcache data store
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret)
     serv.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
     serv.prepend('{0}:{1}'.format(ret['id'], ret['fun']), ret['jid'])
     serv.append('minions', ret['id'])

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -50,11 +50,14 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the memcache options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'host': 'host',
              'port': 'port'}
@@ -129,7 +132,7 @@ def save_load(jid, load):
     '''
     Save the load to the specified jid
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     serv.set(jid, json.dumps(load))
     serv.append('jids', jid)
 
@@ -138,7 +141,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     data = serv.get(jid)
     if data:
         return json.loads(data)
@@ -149,7 +152,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     ret = {}
     for minion in serv.smembers('minions'):
         data = serv.get('{0}:{1}'.format(minion, jid))
@@ -162,7 +165,7 @@ def get_fun(fun):
     '''
     Return a dict of the last function called for all minions
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     ret = {}
     for minion in serv.smembers('minions'):
         ind_str = '{0}:{1}'.format(minion, fun)
@@ -180,7 +183,7 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     return serv.get_multi('jids')
 
 
@@ -188,5 +191,5 @@ def get_minions():
     '''
     Return a list of minions
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     return serv.get_multi('minions')

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -95,7 +95,7 @@ def _get_serv(ret):
     Return a memcache server object
     '''
 
-    _options = _get_options()
+    _options = _get_options(ret)
     host = _options.get('host')
     port = _options.get('port')
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -15,12 +15,27 @@ to the minion config files::
     mongo.password: <MongoDB user password>
     mongo.port: 27017
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.mongo.db: <database name>
+    alternative.mongo.host: <server ip address>
+    alternative.mongo.user: <MongoDB username>
+    alternative.mongo.password: <MongoDB user password>
+    alternative.mongo.port: 27017
+
+
 This mongo returner is being developed to replace the default mongodb returner
 in the future and should not be considered API stable yet.
 
   To use the mongo returner, append '--return mongo' to the salt command. ex:
 
     salt '*' test.ping --return mongo
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return mongo --return_config alternative
 '''
 
 # Import python libs
@@ -54,23 +69,60 @@ def _remove_dots(src):
     return output
 
 
-def _get_conn():
+def _get_options(ret):
+    '''
+    Get the mongo options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'host': 'host',
+             'port': 'port',
+             'db': 'db',
+             'username': 'username',
+             'password': 'password'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
+def _get_conn(ret):
     '''
     Return a mongodb connection object
     '''
-    if 'config.option' in __salt__:
-        host = __salt__['config.option']('mongo.host')
-        port = __salt__['config.option']('mongo.port')
-        db = __salt__['config.option']('mongo.db')
-        user = __salt__['config.option']('mongo.user')
-        password = __salt__['config.option']('mongo.password')
-    else:
-        cfg = __opts__
-        host = cfg.get('mongo.host', None)
-        port = cfg.get('mongo.port', None)
-        db = cfg.get('mongo.db', None)
-        user = cfg.get('mongo.user', None)
-        password = cfg.get('mongo.password', None)
+    _options = _get_options()
+
+    host = _options.get('host')
+    port = _options.get('port')
+    db = _options.get('db')
+    user = _options.get('user')
+    password = _options.get('password')
 
     conn = pymongo.Connection(host, port)
     mdb = conn[db]
@@ -84,7 +136,7 @@ def returner(ret):
     '''
     Return data to a mongodb server
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret)
     col = mdb[ret['id']]
 
     if isinstance(ret['return'], dict):

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -69,11 +69,14 @@ def _remove_dots(src):
     return output
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the mongo options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'host': 'host',
              'port': 'port',
@@ -116,7 +119,7 @@ def _get_conn(ret):
     '''
     Return a mongodb connection object
     '''
-    _options = _get_options()
+    _options = _get_options(ret)
 
     host = _options.get('host')
     port = _options.get('port')
@@ -155,7 +158,7 @@ def save_load(jid, load):
     '''
     Save the load for a given job id
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     col = mdb[jid]
     col.insert(load)
 
@@ -164,7 +167,7 @@ def get_load(jid):
     '''
     Return the load associated with a given job id
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     return mdb[jid].find_one()
 
 
@@ -172,7 +175,7 @@ def get_jid(jid):
     '''
     Return the return information associated with a jid
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     ret = {}
     for collection in mdb.collection_names():
         rdata = mdb[collection].find_one({jid: {'$exists': 'true'}})
@@ -185,7 +188,7 @@ def get_fun(fun):
     '''
     Return the most recent jobs that have executed the named function
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     ret = {}
     for collection in mdb.collection_names():
         rdata = mdb[collection].find_one({'fun': fun})
@@ -198,7 +201,7 @@ def get_minions():
     '''
     Return a list of minions
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     ret = []
     for name in mdb.collection_names():
         if len(name) == 20:
@@ -215,7 +218,7 @@ def get_jids():
     '''
     Return a list of job ids
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     ret = []
     for name in mdb.collection_names():
         if len(name) == 20:

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -110,11 +110,11 @@ def _get_options(ret):
     return _options
 
 
-def _get_conn():
+def _get_conn(ret):
     '''
     Return a mongodb connection object
     '''
-    _options = _get_options()
+    _options = _get_options(ret)
 
     host = _options.get('host')
     port = _options.get('port')
@@ -134,7 +134,7 @@ def returner(ret):
     '''
     Return data to a mongodb server
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret)
     col = mdb[ret['id']]
 
     if isinstance(ret['return'], dict):

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -71,7 +71,10 @@ def _get_options(ret):
     '''
     Get the monogo_return options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'host': 'host',
              'port': 'port',
@@ -153,7 +156,7 @@ def get_jid(jid):
     '''
     Return the return information associated with a jid
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     ret = {}
     for collection in mdb.collection_names():
         rdata = mdb[collection].find_one({jid: {'$exists': 'true'}})
@@ -166,7 +169,7 @@ def get_fun(fun):
     '''
     Return the most recent jobs that have executed the named function
     '''
-    conn, mdb = _get_conn()
+    conn, mdb = _get_conn(ret=None)
     ret = {}
     for collection in mdb.collection_names():
         rdata = mdb[collection].find_one({'fun': fun})

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -15,9 +15,23 @@ to the minion config files::
     mongo.password: <MongoDB user password>
     mongo.port: 27017
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.mongo.db: <database name>
+    alternative.mongo.host: <server ip address>
+    alternative.mongo.user: <MongoDB username>
+    alternative.mongo.password: <MongoDB user password>
+    alternative.mongo.port: 27017
+
   To use the mongo returner, append '--return mongo' to the salt command. ex:
 
-    salt '*' test.ping --return mongo
+    salt '*' test.ping --return mongo_return
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return mongo_return --return_config alternative
 '''
 
 # Import python libs
@@ -32,6 +46,10 @@ except ImportError:
 
 
 log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+# currently only used iby _get_options
+__virtualname__ = 'mongo'
 
 
 def __virtual__():
@@ -49,23 +67,60 @@ def _remove_dots(src):
     return output
 
 
+def _get_options(ret):
+    '''
+    Get the monogo_return options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'host': 'host',
+             'port': 'port',
+             'db': 'db',
+             'username': 'username',
+             'password': 'password'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
 def _get_conn():
     '''
     Return a mongodb connection object
     '''
-    if 'config.option' in __salt__:
-        host = __salt__['config.option']('mongo.host')
-        port = __salt__['config.option']('mongo.port')
-        db = __salt__['config.option']('mongo.db')
-        user = __salt__['config.option']('mongo.user')
-        password = __salt__['config.option']('mongo.password')
-    else:
-        cfg = __opts__
-        host = cfg.get('mongo.host', None)
-        port = cfg.get('mongo.port', None)
-        db = cfg.get('mongo.db', None)
-        user = cfg.get('mongo.user', None)
-        password = cfg.get('mongo.password', None)
+    _options = _get_options()
+
+    host = _options.get('host')
+    port = _options.get('port')
+    db = _options.get('db')
+    user = _options.get('user')
+    password = _options.get('password')
 
     conn = pymongo.Connection(host, port)
     mdb = conn[db]

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -156,7 +156,7 @@ def _get_options(ret):
 
 
 @contextmanager
-def _get_serv(ret, commit=False):
+def _get_serv(ret=None, commit=False):
     '''
     Return a mysql cursor
     '''

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -102,11 +102,14 @@ def __virtual__():
     return True
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Returns options used for the MySQL connection.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     defaults = {'host': 'salt',
                 'user': 'salt',
@@ -210,7 +213,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    with _get_serv(commit=True) as cur:
+    with _get_serv(ret=None, commit=True) as cur:
 
         sql = '''SELECT load FROM `jids`
                 WHERE `jid` = '%s';'''
@@ -226,7 +229,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed
     '''
-    with _get_serv(commit=True) as cur:
+    with _get_serv(ret=None, commit=True) as cur:
 
         sql = '''SELECT id, full_ret FROM `salt_returns`
                 WHERE `jid` = %s'''
@@ -244,7 +247,7 @@ def get_fun(fun):
     '''
     Return a dict of the last function called for all minions
     '''
-    with _get_serv(commit=True) as cur:
+    with _get_serv(ret=None, commit=True) as cur:
 
         sql = '''SELECT s.id,s.jid, s.full_ret
                 FROM `salt_returns` s
@@ -268,7 +271,7 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    with _get_serv(commit=True) as cur:
+    with _get_serv(ret=None, commit=True) as cur:
 
         sql = '''SELECT DISTINCT jid
                 FROM `jids`'''
@@ -285,7 +288,7 @@ def get_minions():
     '''
     Return a list of minions
     '''
-    with _get_serv(commit=True) as cur:
+    with _get_serv(ret=None, commit=True) as cur:
 
         sql = '''SELECT DISTINCT id
                 FROM `salt_returns`'''

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -131,11 +131,14 @@ def __virtual__():
     return True
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the odbc options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'dsn': 'dsn',
              'user': 'user',
@@ -218,7 +221,7 @@ def save_load(jid, load):
     '''
     Save the load to the specified jid id
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''INSERT INTO jids (jid, load) VALUES (?, ?)'''
 
@@ -230,7 +233,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT load FROM jids WHERE jid = ?;'''
 
@@ -246,7 +249,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT id, full_ret FROM salt_returns WHERE jid = ?'''
 
@@ -264,7 +267,7 @@ def get_fun(fun):
     '''
     Return a dict of the last function called for all minions
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT s.id,s.jid, s.full_ret
             FROM salt_returns s
@@ -288,7 +291,7 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT distinct jid FROM jids'''
 
@@ -305,7 +308,7 @@ def get_minions():
     '''
     Return a list of minions
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT DISTINCT id FROM salt_returns'''
 

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -172,7 +172,7 @@ def _get_options(ret):
     return _options
 
 
-def _get_conn(ret):
+def _get_conn(ret=None):
     '''
     Return a MSSQL connection.
     '''

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -53,6 +53,14 @@ Configure as you see fit::
     returner.odbc.user: 'salt'
     returner.odbc.passwd: 'salt'
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.returner.odbc.dsn: 'TS'
+    alternative.returner.odbc.user: 'salt'
+    alternative.returner.odbc.passwd: 'salt'
+
 Running the following commands against Microsoft SQL Server in the desired
 database as the appropriate user should create the database tables
 correctly.  Replace with equivalent SQL for other ODBC-compliant servers::
@@ -94,6 +102,9 @@ correctly.  Replace with equivalent SQL for other ODBC-compliant servers::
 
     salt '*' status.diskusage --return odbc
 
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return odbc --return_config alternative
 '''
 # Let's not allow PyLint complain about string substitution
 # pylint: disable=W1321,E1321
@@ -110,6 +121,9 @@ try:
 except ImportError:
     HAS_ODBC = False
 
+# Define the module's virtual name
+__virtualname__ = 'odbc'
+
 
 def __virtual__():
     if not HAS_ODBC:
@@ -117,21 +131,60 @@ def __virtual__():
     return True
 
 
-def _get_conn():
+def _get_options(ret):
+    '''
+    Get the odbc options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'dsn': 'dsn',
+             'user': 'user',
+             'passwd': 'passwd'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('returner.{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.returner.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('returner.{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.returner.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
+def _get_conn(ret):
     '''
     Return a MSSQL connection.
     '''
-    if 'config.option' in __salt__:
-        return pyodbc.connect('DSN={0};UID={1};PWD={2}'.format(
-                __salt__['config.option']('returner.odbc.dsn'),
-                __salt__['config.option']('returner.odbc.user'),
-                __salt__['config.option']('returner.odbc.passwd')))
-    else:
-        cfg = __opts__
-        return pyodbc.connect('DSN={0};UID={1};PWD={2}'.format(
-                cfg.get('returner.odbc.dsn', None),
-                cfg.get('returner.odbc.user', None),
-                cfg.get('returner.odbc.passwd', None)))
+    _options = _get_options(ret)
+    dsn = _options.get('dsn')
+    user = _options.get('user')
+    passwd = _options.get('passwd')
+
+    return pyodbc.connect('DSN={0};UID={1};PWD={2}'.format(
+            dsn,
+            user,
+            passwd))
 
 
 def _close_conn(conn):
@@ -143,7 +196,7 @@ def returner(ret):
     '''
     Return data to an odbc server
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret)
     cur = conn.cursor()
     sql = '''INSERT INTO salt_returns
             (fun, jid, retval, id, success, full_ret)

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -144,7 +144,7 @@ def _get_conn(ret):
     '''
     Return a postgres connection.
     '''
-    _options = _get_options()
+    _options = _get_options(ret)
 
     host = _options.get('host')
     user = _options.get('user')

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -97,11 +97,14 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the odbc options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'host': 'host',
              'user': 'user',
@@ -140,7 +143,7 @@ def _get_options(ret):
     return _options
 
 
-def _get_conn(ret):
+def _get_conn(ret=None):
     '''
     Return a postgres connection.
     '''
@@ -190,7 +193,7 @@ def save_load(jid, load):
     '''
     Save the load to the specified jid id
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''INSERT INTO jids (jid, load) VALUES (%s, %s)'''
 
@@ -202,7 +205,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT load FROM jids WHERE jid = %s;'''
 
@@ -218,7 +221,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT id, full_ret FROM salt_returns WHERE jid = %s'''
 
@@ -236,7 +239,7 @@ def get_fun(fun):
     '''
     Return a dict of the last function called for all minions
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT s.id,s.jid, s.full_ret
             FROM salt_returns s
@@ -260,7 +263,7 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT jid FROM jids'''
 
@@ -277,7 +280,7 @@ def get_minions():
     '''
     Return a list of minions
     '''
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT DISTINCT id FROM salt_returns'''
 

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -49,11 +49,14 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the redis options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'host': 'host',
              'port': 'port',
@@ -120,7 +123,7 @@ def save_load(jid, load):
     '''
     Save the load to the specified jid
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     serv.set(jid, json.dumps(load))
     serv.sadd('jids', jid)
 
@@ -129,7 +132,7 @@ def get_load(jid):
     '''
     Return the load data that marks a specified jid
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     data = serv.get(jid)
     if data:
         return json.loads(data)
@@ -140,7 +143,7 @@ def get_jid(jid):
     '''
     Return the information returned when the specified job id was executed
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     ret = {}
     for minion in serv.smembers('minions'):
         data = serv.get('{0}:{1}'.format(minion, jid))
@@ -153,7 +156,7 @@ def get_fun(fun):
     '''
     Return a dict of the last function called for all minions
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     ret = {}
     for minion in serv.smembers('minions'):
         ind_str = '{0}:{1}'.format(minion, fun)
@@ -171,7 +174,7 @@ def get_jids():
     '''
     Return a list of all job ids
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     return list(serv.smembers('jids'))
 
 
@@ -179,5 +182,5 @@ def get_minions():
     '''
     Return a list of minions
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret=None)
     return list(serv.smembers('minions'))

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -90,7 +90,7 @@ def _get_options(ret):
     return _options
 
 
-def _get_serv(ret):
+def _get_serv(ret=None):
     '''
     Return a redis server object
     '''

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -12,9 +12,21 @@ config, these are the defaults:
     redis.host: 'salt'
     redis.port: 6379
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.redis.db: '0'
+    alternative.redis.host: 'salt'
+    alternative.redis.port: 6379
+
   To use the redis returner, append '--return redis' to the salt command. ex:
 
     salt '*' test.ping --return redis
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return redis --return_config alternative
 '''
 
 # Import python libs
@@ -37,28 +49,67 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_serv():
+def _get_options(ret):
+    '''
+    Get the redis options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'host': 'host',
+             'port': 'port',
+             'db': 'db'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
+def _get_serv(ret):
     '''
     Return a redis server object
     '''
-    if 'config.option' in __salt__:
-        return redis.Redis(
-                host=__salt__['config.option']('redis.host'),
-                port=__salt__['config.option']('redis.port'),
-                db=__salt__['config.option']('redis.db'))
-    else:
-        cfg = __opts__
-        return redis.Redis(
-                host=cfg.get('redis.host', None),
-                port=cfg.get('redis.port', None),
-                db=cfg.get('redis.db', None))
+    _options = _get_options(ret)
+    host = _options.get('host')
+    port = _options.get('port')
+    db = _options.get('db')
+
+    return redis.Redis(
+            host=host,
+            port=port,
+            db=db)
 
 
 def returner(ret):
     '''
     Return data to a redis data store
     '''
-    serv = _get_serv()
+    serv = _get_serv(ret)
     serv.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
     serv.lpush('{0}:{1}'.format(ret['id'], ret['fun']), ret['jid'])
     serv.sadd('minions', ret['id'])

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -15,6 +15,21 @@ The following fields can be set in the minion conf file::
     smtp.gpgowner (optional)
     smtp.fields (optional)
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.smtp.from
+    alternative.smtp.to
+    alternative.smtp.host
+    alternative.smtp.port
+    alternative.smtp.username
+    alternative.smtp.password
+    alternative.smtp.tls
+    alternative.smtp.subject
+    alternative.smtp.gpgowner
+    alternative.smtp.fields
+
 There are a few things to keep in mind:
 
 * If a username is used, a password is also required. It is recommended (but
@@ -42,6 +57,10 @@ There are a few things to keep in mind:
 
     salt '*' test.ping --return smtp
 
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return smtp --return_config alternative
+
 '''
 
 # Import python libs
@@ -67,34 +86,69 @@ def __virtual__():
     return __virtualname__
 
 
+def _get_options(ret):
+    '''
+    Get the redis options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'from': 'from',
+             'to': 'to',
+             'host': 'host',
+             'username': 'username',
+             'password': 'password',
+             'subject': 'subject',
+             'gpgowner': 'gpgowner',
+             'fields': 'fields',
+             'tls': 'tls'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
 def returner(ret):
     '''
     Send an email with the data
     '''
 
-    if 'config.option' in __salt__:
-        from_addr = __salt__['config.option']('smtp.from')
-        to_addrs = __salt__['config.option']('smtp.to')
-        host = __salt__['config.option']('smtp.host')
-        port = __salt__['config.option']('smtp.port')
-        user = __salt__['config.option']('smtp.username')
-        passwd = __salt__['config.option']('smtp.password')
-        subject = __salt__['config.option']('smtp.subject')
-        gpgowner = __salt__['config.option']('smtp.gpgowner')
-        fields = __salt__['config.option']('smtp.fields').split(',')
-        smtp_tls = __salt__['config.option']('smtp.tls')
-    else:
-        cfg = __opts__
-        from_addr = cfg.get('smtp.from', None)
-        to_addrs = cfg.get('smtp.to', None)
-        host = cfg.get('smtp.host', None)
-        port = cfg.get('smtp.port', None)
-        user = cfg.get('smtp.username', None)
-        passwd = cfg.get('smtp.password', None)
-        subject = cfg.get('smtp.subject', None)
-        gpgowner = cfg.get('smtp.gpgowner', None)
-        fields = cfg.get('smtp.fields', '').split(',')
-        smtp_tls = cfg('smtp.tls', False)
+    _options = _get_options(ret)
+    from_addr = _options.get('from')
+    to_addrs = _options.get('to')
+    host = _options.get('host')
+    port = _options.get('port')
+    user = _options.get('username')
+    passwd = _options.get('password')
+    subject = _options.get('subject')
+    gpgowner = _options.get('gpgowner')
+    fields = _options.get('fields').split(',') if 'fields' in _options else []
+    smtp_tls = _options.get('tls')
 
     if not port:
         port = 25
@@ -105,10 +159,10 @@ def returner(ret):
     log.debug("smtp_return: Subject is '{0}'".format(subject))
 
     content = ('id: {0}\r\n'
-            'function: {1}\r\n'
-            'function args: {2}\r\n'
-            'jid: {3}\r\n'
-            'return: {4}\r\n').format(
+               'function: {1}\r\n'
+               'function args: {2}\r\n'
+               'jid: {3}\r\n'
+               'return: {4}\r\n').format(
                     ret.get('id'),
                     ret.get('fun'),
                     ret.get('fun_args'),

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -86,11 +86,14 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the redis options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'from': 'from',
              'to': 'to',

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -131,7 +131,7 @@ def _get_conn(ret):
     '''
     # Possible todo: support detect_types, isolation_level, check_same_thread,
     # factory, cached_statements. Do we really need to though?
-    _options = _get_options()
+    _options = _get_options(ret)
     database = _options.get('database')
     timeout = _options.get('timeout')
 

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -17,6 +17,13 @@ minion config::
     returner.sqlite3.database: /usr/lib/salt/salt.db
     returner.sqlite3.timeout: 5.0
 
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    alternative.returner.sqlite3.database: /usr/lib/salt/salt.db
+    alternative.returner.sqlite3.timeout: 5.0
+
 Use the commands to create the sqlite3 database and tables::
 
     sqlite3 /usr/lib/salt/salt.db << EOF
@@ -47,6 +54,11 @@ Use the commands to create the sqlite3 database and tables::
   To use the sqlite returner, append '--return sqlite' to the salt command. ex:
 
     salt '*' test.ping --return sqlite
+
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return sqlite3 --return_config alternative
+
 '''
 
 # Import python libs
@@ -73,19 +85,55 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_conn():
+def _get_options(ret):
+    '''
+    Get the redis options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'database': 'database',
+             'timeout': 'timeout'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('returner.{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.returner.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('returner.{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.returner.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.returner.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('returner.{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+    return _options
+
+
+def _get_conn(ret):
     '''
     Return a sqlite3 database connection
     '''
     # Possible todo: support detect_types, isolation_level, check_same_thread,
     # factory, cached_statements. Do we really need to though?
-    if 'config.option' in __salt__:
-        database = __salt__['config.option']('returner.sqlite3.database')
-        timeout = __salt__['config.option']('returner.sqlite3.timeout')
-    else:
-        cfg = __opts__
-        database = cfg.get('returner.sqlite3.database', None)
-        timeout = cfg.get('returner.sqlite3.timeout', None)
+    _options = _get_options()
+    database = _options.get('database')
+    timeout = _options.get('timeout')
 
     if not database:
         raise Exception(
@@ -114,7 +162,7 @@ def returner(ret):
     Insert minion return data into the sqlite3 database
     '''
     log.debug('sqlite3 returner <returner> called with data: {0}'.format(ret))
-    conn = _get_conn()
+    conn = _get_conn(ret)
     cur = conn.cursor()
     sql = '''INSERT INTO salt_returns
              (fun, jid, id, fun_args, date, full_ret, success)

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -85,11 +85,14 @@ def __virtual__():
     return __virtualname__
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the redis options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'database': 'database',
              'timeout': 'timeout'}
@@ -125,7 +128,7 @@ def _get_options(ret):
     return _options
 
 
-def _get_conn(ret):
+def _get_conn(ret=None):
     '''
     Return a sqlite3 database connection
     '''
@@ -184,7 +187,7 @@ def save_load(jid, load):
     '''
     log.debug('sqlite3 returner <save_load> called jid:{0} load:{1}'
               .format(jid, load))
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''INSERT INTO jids (jid, load) VALUES (:jid, :load)'''
     cur.execute(sql,
@@ -198,7 +201,7 @@ def get_load(jid):
     Return the load from a specified jid
     '''
     log.debug('sqlite3 returner <get_load> called jid: {0}'.format(jid))
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT load FROM jids WHERE jid = :jid'''
     cur.execute(sql,
@@ -215,7 +218,7 @@ def get_jid(jid):
     Return the information returned from a specified jid
     '''
     log.debug('sqlite3 returner <get_jid> called jid: {0}'.format(jid))
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT id, full_ret FROM salt_returns WHERE jid = :jid'''
     cur.execute(sql,
@@ -235,7 +238,7 @@ def get_fun(fun):
     Return a dict of the last function called for all minions
     '''
     log.debug('sqlite3 returner <get_fun> called fun: {0}'.format(fun))
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT s.id, s.full_ret, s.jid
             FROM salt_returns s
@@ -263,7 +266,7 @@ def get_jids():
     Return a list of all job ids
     '''
     log.debug('sqlite3 returner <get_fun> called')
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT jid FROM jids'''
     cur.execute(sql)
@@ -280,7 +283,7 @@ def get_minions():
     Return a list of minions
     '''
     log.debug('sqlite3 returner <get_minions> called')
-    conn = _get_conn()
+    conn = _get_conn(ret=None)
     cur = conn.cursor()
     sql = '''SELECT DISTINCT id FROM salt_returns'''
     cur.execute(sql)

--- a/salt/returners/xmpp_return.py
+++ b/salt/returners/xmpp_return.py
@@ -74,11 +74,14 @@ except ImportError:
 __virtualname__ = 'xmpp'
 
 
-def _get_options(ret):
+def _get_options(ret=None):
     '''
     Get the redis options from salt.
     '''
-    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    if ret:
+        ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+    else:
+        ret_config = None
 
     attrs = {'xmpp_profile': 'profile',
              'from_jid': 'jid',

--- a/salt/returners/xmpp_return.py
+++ b/salt/returners/xmpp_return.py
@@ -7,6 +7,40 @@ The following fields can be set in the minion conf file::
     xmpp.jid (required)
     xmpp.password (required)
     xmpp.recipient (required)
+    xmpp.profile (optional)
+
+Alternative configuration values can be used by prefacing the configuration.
+Any values not found in the alternative configuration will be pulled from
+the default location::
+
+    xmpp.jid
+    xmpp.password
+    xmpp.recipient
+    xmpp.profile
+
+XMPP settings may also be configured as::
+
+    xmpp:
+        jid: user@xmpp.domain.com/resource
+        password: password
+        recipient: user@xmpp.example.com
+
+    alternative.xmpp:
+        jid: user@xmpp.domain.com/resource
+        password: password
+        recipient: someone@xmpp.example.com
+
+    xmpp_profile:
+        jid: user@xmpp.domain.com/resource
+        password: password
+
+    xmpp:
+        profile: xmpp_profile
+        recipient: user@xmpp.example.com
+
+    alternative.xmpp:
+        profile: xmpp_profile
+        recipient: someone-else@xmpp.example.com
 
   To use the XMPP returner, append '--return xmpp' to the salt command. ex:
 
@@ -14,6 +48,9 @@ The following fields can be set in the minion conf file::
 
     salt '*' test.ping --return xmpp
 
+  To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
+
+    salt '*' test.ping --return xmpp --return_config alternative
 '''
 
 # Import python libs
@@ -35,6 +72,62 @@ except ImportError:
 
 
 __virtualname__ = 'xmpp'
+
+
+def _get_options(ret):
+    '''
+    Get the redis options from salt.
+    '''
+    ret_config = '{0}'.format(ret['ret_config']) if 'ret_config' in ret else ''
+
+    attrs = {'xmpp_profile': 'profile',
+             'from_jid': 'jid',
+             'password': 'password',
+             'recipient_jid': 'recipient'}
+
+    _options = {}
+    for attr in attrs:
+        if 'config.option' in __salt__:
+            cfg = __salt__['config.option']
+            c_cfg = cfg('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                    log.debug('_attr {0}'.format(_attr))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        else:
+            cfg = __opts__
+            c_cfg = cfg.get('{0}'.format(__virtualname__), {})
+            if ret_config:
+                ret_cfg = cfg.get('{0}.{1}'.format(ret_config, __virtualname__), {})
+                if ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr]))):
+                    _attr = ret_cfg.get(attrs[attr], cfg.get('{0}.{1}.{2}'.format(ret_config, __virtualname__, attrs[attr])))
+                else:
+                    _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+            else:
+                _attr = c_cfg.get(attrs[attr], cfg.get('{0}.{1}'.format(__virtualname__, attrs[attr])))
+        if not _attr:
+            _options[attr] = None
+            continue
+        _options[attr] = _attr
+
+    # If we're using an xmpp_profile
+    # pull from_jid and password from there
+    if 'xmpp_profile' in _options:
+        log.info('Using xmpp.profile {0}'.format(_options['xmpp_profile']))
+        if 'config.option' in __salt__:
+            creds = cfg(_options['xmpp_profile'])
+        else:
+            creds = cfg.get(_options['xmpp_profile'])
+        if creds:
+            _options['from_jid'] = creds.get('xmpp.jid')
+            _options['password'] = creds.get('xmpp.password')
+
+    return _options
 
 
 def __virtual__():
@@ -78,29 +171,11 @@ def returner(ret):
     Send an xmpp message with the data
     '''
 
-    if 'config.option' in __salt__:
-        cfg = __salt__['config.option']
-        c_cfg = cfg('xmpp', {})
-        xmpp_profile = c_cfg.get('xmpp_profile', cfg('xmpp.profile', None))
-        if xmpp_profile:
-            creds = __salt__['config.option'](xmpp_profile)
-            from_jid = creds.get('xmpp.jid')
-            password = creds.get('xmpp.password')
-        else:
-            from_jid = c_cfg.get('from_jid', cfg('xmpp.jid', None))
-            password = c_cfg.get('password', cfg('xmpp.password', None))
-        recipient_jid = c_cfg.get('recipient_jid', cfg('xmpp.recipient', None))
-    else:
-        cfg = __opts__
-        xmpp_profile = cfg.get('xmpp.profile', None)
-        if xmpp_profile:
-            creds = cfg.get(xmpp_profile)
-            from_jid = creds.get('xmpp.jid', None)
-            password = creds.get('xmpp.password', None)
-        else:
-            from_jid = cfg.get('xmpp.jid', None)
-            password = cfg.get('xmpp.password', None)
-        recipient_jid = cfg.get('xmpp.recipient', None)
+    _options = _get_options(ret)
+
+    from_jid = _options.get('from_jid')
+    password = _options.get('password')
+    recipient_jid = _options.get('recipient_jid')
 
     if not from_jid:
         log.error('xmpp.jid not defined in salt config')

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -55,6 +55,26 @@ Management of the Salt scheduler
     schedule the command: state.sls httpd test=True to run every 5 minutes.  Requires
     that python-croniter is installed.
 
+    job1:
+      schedule.present:
+        - function: state.sls
+        - args:
+          - httpd
+        - kwargs:
+          test: True
+        - when:
+            - Monday 5:00pm
+            - Tuesday 3:00pm
+            - Wednesday 5:00pm
+            - Thursday 3:00pm
+            - Friday 5:00pm
+        - returner: xmpp
+        - return_config: xmpp_state_run
+
+    This will schedule the command: state.sls httpd test=True at 5pm on Monday,
+    Wednesday and Friday, and 3pm on Tuesday and Thursday.  Using the xmpp returner
+    to return the results of the scheduled job, with the alternative configuration
+    options found in the xmpp_state_run section.
 
 '''
 
@@ -116,6 +136,12 @@ def present(name,
         This will schedule the command within the range specified.
         The range parameter must be a dictionary with the date strings
         using the dateutil format.
+
+    returner
+        The returner to use to return the results of the scheduled job.
+
+    return_config
+        The alternative configuration to use for returner configuration options.
 
     '''
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1524,6 +1524,15 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'systems, databases or applications.')
         )
         self.add_option(
+            '--return_config',
+            default='',
+            metavar='RETURNER_CONF',
+            help=('Set an alternative return method. By default salt will '
+                  'send the return data from the command back to the master, '
+                  'but the return data can be redirected into any number of '
+                  'systems, databases or applications.')
+        )
+        self.add_option(
             '-d', '--doc', '--documentation',
             dest='doc',
             default=False,

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -422,6 +422,8 @@ class Schedule(object):
 
             data_returner = data.get('returner', None)
             if data_returner or self.schedule_returner:
+                if 'returner_config' in data:
+                    ret['ret_config'] = data['returner_config']
                 rets = []
                 for returner in [data_returner, self.schedule_returner]:
                     if isinstance(returner, str):


### PR DESCRIPTION
Adding an additional CLI argument, ret_config, which can be used to override configuration options passed to the returner.

Adding support for ret_config to all returners.

Adding _get_options to all returners that use configurable options.

Adding return_config support to the scheduler and scheduler related management module & state.
