### PR TITLE
file.replace issue when show_changes is False. Fixes #14978 (2014.1 branch)

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1019,7 +1019,7 @@ def replace(path,
             result = re.sub(cpattern, repl, line, count)
 
             # Identity check each potential change until one change is made
-            if has_changes is False and result is not line:
+            if has_changes is False and result != line:
                 has_changes = True
 
             if show_changes:


### PR DESCRIPTION
Here's the same fix for the 2014.1 branch, as #15372 (the fix for develop) doesn't apply cleanly here.
