### PR TITLE
salt minion multi-master exception bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ htmlcov/
 /.project
 /.pydevproject
 /.idea
-/.ropeproject
+.ropeproject
 
 # ignore ctags file
 tags

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -370,6 +370,10 @@ class MultiMinion(object):
                 minions.append(Minion(s_opts, 5, False))
             except SaltClientError as exc:
                 log.error('Error while bringing up minion for multi-master. Is master at {0} responding?'.format(master))
+        if len(minions) == 0:
+            err = 'Error while bringing up minion for multi-master. All configured masters [{0}] are not responding!!!'.format(", ".join(map(str, set(self.opts['master']))))
+            log.error(err)
+            raise SaltClientError(err)
         return minions
 
     def minions(self):


### PR DESCRIPTION
- raise SaltClientError exception when a minion can't connect to any of the
  configured masters
