### PR TITLE
openbsd_rcctl: improve performance of available() and missing()

### DIFF
--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -50,7 +50,10 @@ def available(name):
 
         salt '*' service.available sshd
     '''
-    return name in get_all()
+    cmd = '{0} status {1}'.format(_cmd(), name)
+    if __salt__['cmd.retcode'](cmd) == 2:
+        return False
+    return True
 
 
 def missing(name):
@@ -64,7 +67,7 @@ def missing(name):
 
         salt '*' service.missing sshd
     '''
-    return name not in get_all()
+    return not available(name)
 
 
 def get_all():


### PR DESCRIPTION
Previously, these 2 functions were very expensive because they needed to
parse the output of the full services status. I modified rcctl(8) in
OpenBSD to return ENOENT when a service does not exist which is
instantaneous.

`time salt-call service.available sshd`
before
    0m4.82s real     0m0.42s user     0m3.05s system
after
    0m1.38s real     0m0.40s user     0m0.78s system
