### PR TITLE
mount: add support for OpenBSD

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -127,7 +127,7 @@ def _active_mounts_openbsd(ret):
         ret[comps[3]] = {'device': comps[0],
                          'fstype': comps[5],
                          'opts': parens[1].split(", "),
-                         'major': str(nod[4].replace(",", "")),
+                         'major': str(nod[4].strip(",")),
                          'minor': str(nod[5]),
                          'device_uuid': parens[0]}
     return ret

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -115,6 +115,24 @@ def _active_mounts_solaris(ret):
     return ret
 
 
+def _active_mounts_openbsd(ret):
+    '''
+    List active mounts on OpenBSD systems
+    '''
+    for line in __salt__['cmd.run_stdout']('mount -v').split('\n'):
+        comps = re.sub(r"\s+", " ", line).split()
+        nod = __salt__['cmd.run_stdout']('ls -l {0}'.format(comps[0]))
+        nod = ' '.join(nod.split()).split(" ")
+        parens = re.findall(r'\((.*?)\)', line, re.DOTALL)
+        ret[comps[3]] = {'device': comps[0],
+                         'fstype': comps[5],
+                         'opts': parens[1].split(", "),
+                         'major': str(nod[4].replace(",", "")),
+                         'minor': str(nod[5]),
+                         'device_uuid': parens[0]}
+    return ret
+
+
 def active():
     '''
     List the active mounts.
@@ -130,6 +148,8 @@ def active():
         _active_mounts_freebsd(ret)
     elif __grains__['os'] == 'Solaris':
         _active_mounts_solaris(ret)
+    if __grains__['os'] == 'OpenBSD':
+        _active_mounts_openbsd(ret)
     else:
         try:
             _active_mountinfo(ret)
@@ -384,13 +404,16 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults'):
     mnts = active()
     if name in mnts:
         # The mount point is mounted, attempt to remount it with the given data
-        if 'remount' not in opts:
+        if 'remount' not in opts and __grains__['os'] != 'OpenBSD':
             opts.append('remount')
         lopts = ','.join(opts)
         args = '-o {0}'.format(lopts)
         if fstype:
             args += ' -t {0}'.format(fstype)
-        cmd = 'mount {0} {1} {2} '.format(args, device, name)
+        if __grains__['os'] != 'OpenBSD':
+            cmd = 'mount {0} {1} {2} '.format(args, device, name)
+        else:
+            cmd = 'mount -u {0} {1} {2} '.format(args, device, name)
         out = __salt__['cmd.run_all'](cmd)
         if out['retcode']:
             return out['stderr']
@@ -453,15 +476,28 @@ def swaps():
         salt '*' mount.swaps
     '''
     ret = {}
-    with salt.utils.fopen('/proc/swaps') as fp_:
-        for line in fp_:
-            if line.startswith('Filename'):
+    if __grains__['os'] != 'OpenBSD':
+        with salt.utils.fopen('/proc/swaps') as fp_:
+            for line in fp_:
+               if line.startswith('Filename'):
+                  continue
+               comps = line.split()
+               ret[comps[0]] = {'type': comps[1],
+                                'size': comps[2],
+                                'used': comps[3],
+                                'priority': comps[4]}
+    else:
+        for line in __salt__['cmd.run_stdout']('swapctl -kl').splitlines():
+            type = "file"
+            if line.startswith(('Device', 'Total')):
                 continue
             comps = line.split()
-            ret[comps[0]] = {'type': comps[1],
-                             'size': comps[2],
-                             'used': comps[3],
-                             'priority': comps[4]}
+            if comps[0].startswith('/dev/'):
+                type = "partition"
+            ret[comps[0]] = {'type': type,
+                             'size': comps[1],
+                             'used': comps[2],
+                             'priority': comps[5]}
     return ret
 
 
@@ -505,7 +541,10 @@ def swapoff(name):
     '''
     on_ = swaps()
     if name in on_:
-        __salt__['cmd.run']('swapoff {0}'.format(name))
+        if __grains__['os'] != 'OpenBSD':
+            __salt__['cmd.run']('swapoff {0}'.format(name))
+        else:
+            __salt__['cmd.run']('swapctl -d {0}'.format(name))
         on_ = swaps()
         if name in on_:
             return False


### PR DESCRIPTION
Add support for missing functions that make sense on OpenBSD.

Here's an extract of mount.active after this change:
local:
    ----------
    /:
        ----------
        device:
            /dev/sd0a
        device_uuid:
            ec8ffaec819a9077.a
        fstype:
            ffs
        major:
            4
        minor:
            0
        opts:
            - rw
            - local
            - ctime=Mon Sep  1 13:51:24 2014
