### PR TITLE
Fix saltutil.refresh_pillar reference in Pillar tutorial

### DIFF
--- a/doc/topics/tutorials/pillar.rst
+++ b/doc/topics/tutorials/pillar.rst
@@ -101,7 +101,7 @@ to them asking that they fetch their pillars from the master:
 
 .. code-block:: bash
     
-    salt '*' saltutil.pillar_refresh
+    salt '*' saltutil.refresh_pillar
 
 Now that the minions have the new pillar, it can be retreived:
 


### PR DESCRIPTION
It used to reference `saltutil.pillar_refresh` which gives the error:

```
'saltutil.pillar_refresh' is not available.
```
