### PR TITLE
set the osfinger grain for Debian

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1044,6 +1044,12 @@ def os_data():
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['osfullname'],
             ver=grains['osrelease'])
+    elif grains['osfullname'] == "Debian":
+        grains['osmajorrelease'] = grains['osrelease'].split('.', 1)[0]
+
+        grains['osfinger'] = '{os}-{ver}'.format(
+            os=grains['osfullname'],
+            ver=grains['osrelease'].partition('.')[0])
 
     if grains.get('osrelease', ''):
         osrelease_info = grains['osrelease'].split('.')


### PR DESCRIPTION
This change will make sure that the grain osfinger is set on Debian.

I noticed that it was missing so i thought i would add it.
