### PR TITLE
modules.mount.swaps: avoid shadowing `type` built-in

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -488,13 +488,13 @@ def swaps():
                                  'priority': comps[4]}
     else:
         for line in __salt__['cmd.run_stdout']('swapctl -kl').splitlines():
-            type = "file"
             if line.startswith(('Device', 'Total')):
                 continue
+            swap_type = "file"
             comps = line.split()
             if comps[0].startswith('/dev/'):
-                type = "partition"
-            ret[comps[0]] = {'type': type,
+                swap_type = "partition"
+            ret[comps[0]] = {'type': swap_type,
                              'size': comps[1],
                              'used': comps[2],
                              'priority': comps[5]}


### PR DESCRIPTION
```
************* Module salt.modules.mount
salt/modules/mount.py:491: [W0622(redefined-builtin), swaps] Redefining built-in 'type'
```
