### PR TITLE
Hide `concurrent` arg for state.sls

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -329,7 +329,6 @@ def sls(mods,
         exclude=None,
         queue=False,
         env=None,
-        concurrent=False,
         **kwargs):
     '''
     Execute a set list of state modules from an environment.
@@ -367,6 +366,7 @@ def sls(mods,
 
         salt '*' state.sls myslsfile pillar="{foo: 'Foo!', bar: 'Bar!'}"
     '''
+    concurrent = kwargs.get('concurrent', False)
     if env is not None:
         salt.utils.warn_until(
             'Boron',


### PR DESCRIPTION
This arg should almost never be used, so I don't think it should be
featured in the function signature.  It remains documented in the
docstring, but with a giant warning below it.
