### PR TITLE
Remove references to masterless salt from gitfs docs

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -653,25 +653,6 @@ directed to look on the minion by setting this parameter to ``local``.
 
     file_client: remote
 
-.. conf_minion:: fileserver_backend
-
-``fileserver_backend``
-----------------------
-
-Default: ``['roots']``
-
-When using a local :conf_minion:`file_client`, this parameter is used to
-specify what fileserver backends to use. It operates identically to the
-:conf_master:`master config parameter<file_roots>` of the same name.
-
-Example:
-
-.. code-block:: yaml
-
-    fileserver_backend:
-      - roots
-      - git
-
 .. conf_minion:: file_roots
 
 ``file_roots``

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -119,7 +119,7 @@ To use the gitfs backend, only two configuration changes are required on the
 master:
 
 1. Include ``git`` in the :conf_master:`fileserver_backend` list in the master
-   config file (or minion config file, if running a standalone minion):
+   config file:
 
    .. code-block:: yaml
 
@@ -146,16 +146,13 @@ master:
    Information on how to authenticate to SSH remotes can be found :ref:`here
    <gitfs-authentication>`.
 
-3. Restart the master (or minion, if running a standalone minion) to load the
-   new configuration.
+3. Restart the master to load the new configuration.
    
 
 .. note::
 
-    In a master/minion setup, files from a gitfs remote are cached once by
-    the master; so minions do not need direct access 
-    to the git repository. In a standalone minion configuration, files from
-    each gitfs remote are cached by the minion.
+    In a master/minion setup, files from a gitfs remote are cached once by the
+    master, so minions do not need direct access to the git repository.
 
 
 Multiple Remotes
@@ -602,12 +599,6 @@ this can be done using the :mod:`ssh.set_known_host
             None
         status:
             updated
-
-.. note::
-
-    For a masterless minion, the same could be accomplished using ``salt-call
-    --local ssh.set_known_host user=root hostname=github.com``.
-
 
 If not, then the easiest way to add the key is to su to the user (usually
 ``root``) under which the salt-master runs and attempt to login to the


### PR DESCRIPTION
Alternate backends do not yet work with the local fileclient.
