### PR TITLE
Add NoneType check for opts in modules.git.init

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -443,7 +443,9 @@ def init(cwd, opts=None, user=None):
         salt '*' git.init /path/to/repo.git opts='--bare'
     '''
     _check_git()
-
+    
+    if not opts:
+        opts = ''
     cmd = 'git init {0} {1}'.format(cwd, opts)
     return _git_run(cmd, runas=user)
 


### PR DESCRIPTION
`opts` should default to '' in `git.init`, as is the case with all other functions in `modules.git`
