### PR TITLE
Bug in grains.core

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1095,7 +1095,7 @@ def os_data():
         grains['osfinger'] = '{os}-{ver}'.format(
             os=grains['osfullname'],
             ver=grains['osrelease'])
-    elif grains['osfullname'] == "Debian":
+    elif grains.get('osfullname') == "Debian":
         grains['osmajorrelease'] = grains['osrelease'].split('.', 1)[0]
 
         grains['osfinger'] = '{os}-{ver}'.format(


### PR DESCRIPTION
 Use `grains.get` for `osfullname` since the key may not exist on some platforms
