### PR TITLE
Fix mount module and state on linux to stop remounting every time state is executed.

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -133,7 +133,7 @@ def _active_mounts_openbsd(ret):
     return ret
 
 
-def active():
+def active(extended=False):
     '''
     List the active mounts.
 
@@ -151,9 +151,12 @@ def active():
     if __grains__['os'] == 'OpenBSD':
         _active_mounts_openbsd(ret)
     else:
-        try:
-            _active_mountinfo(ret)
-        except CommandExecutionError:
+        if extended:
+            try:
+                _active_mountinfo(ret)
+            except CommandExecutionError:
+                _active_mounts(ret)
+        else:
             _active_mounts(ret)
     return ret
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -130,8 +130,12 @@ def mounted(name,
             if uuid_device and uuid_device not in device_list:
                 device_list.append(uuid_device)
             if opts:
+                mount_invisible_options = ['defaults', 'comment', 'nobootwait']
                 for opt in opts:
-                    if opt not in active[real_name]['opts'] and opt != 'defaults':
+                    comment_option = opt.split('=')[0]
+                    if comment_option == 'comment':
+                        opt = comment_option
+                    if opt not in active[real_name]['opts'] and opt not in mount_invisible_options:
                         if __opts__['test']:
                             ret['result'] = None
                             ret['comment'] = "Remount would be forced because options changed"


### PR DESCRIPTION
Fix salt.modules.mount.active to use /proc/self/mounts, unless user explicitly enabled use of /proc/self/mountinfo via extended=True option. 

Fix remount on every state application, when options that don't appear in /proc/self/mounts are used.

Fixes #14533
