### PR TITLE
Call meta

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -224,8 +224,12 @@ class ZeroMQCaller(object):
         '''
         try:
             ret = self.call()
+            if self.opts['metadata']:
+                print_ret = ret
+            else:
+                print_ret = ret.get('return', {})
             salt.output.display_output(
-                    {'local': ret.get('return', {})},
+                    {'local': print_ret},
                     ret.get('out', 'nested'),
                     self.opts)
             if self.opts.get('retcode_passthrough', False):
@@ -257,8 +261,12 @@ class RAETCaller(ZeroMQCaller):
             self.stack.server.close()
             salt.transport.jobber_stack = None
 
+            if self.opts['metadata']:
+                print_ret = ret
+            else:
+                print_ret = ret.get('return', {})
             salt.output.display_output(
-                    {'local': ret.get('return', {})},
+                    {'local': print_ret},
                     ret.get('out', 'nested'),
                     self.opts)
             if self.opts.get('retcode_passthrough', False):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1981,6 +1981,15 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'retcode')
         )
         self.add_option(
+            '--metadata',
+            default=False,
+            dest='metadata',
+            action='store_true',
+            help=('Print out the execution metadata as well as the return. '
+                  'This will print out the outputter data, the return code, '
+                  'etc.')
+        )
+        self.add_option(
             '--id',
             default='',
             dest='id',


### PR DESCRIPTION
Add the ability for salt-call to display the metadata from the execution routine. this includes the outputter etc.
