### PR TITLE
Ssh clean pillar

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -224,8 +224,12 @@ class ZeroMQCaller(object):
         '''
         try:
             ret = self.call()
+            if self.opts['metadata']:
+                print_ret = ret
+            else:
+                print_ret = ret.get('return', {})
             salt.output.display_output(
-                    {'local': ret.get('return', {})},
+                    {'local': print_ret},
                     ret.get('out', 'nested'),
                     self.opts)
             if self.opts.get('retcode_passthrough', False):
@@ -257,8 +261,12 @@ class RAETCaller(ZeroMQCaller):
             self.stack.server.close()
             salt.transport.jobber_stack = None
 
+            if self.opts['metadata']:
+                print_ret = ret
+            else:
+                print_ret = ret.get('return', {})
             salt.output.display_output(
-                    {'local': ret.get('return', {})},
+                    {'local': print_ret},
                     ret.get('out', 'nested'),
                     self.opts)
             if self.opts.get('retcode_passthrough', False):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -453,9 +453,10 @@ class SSH(object):
             host = ret.keys()[0]
             self.cache_job(jid, host, ret[host])
             ret = self.key_deploy(host, ret)
-            outputter = ret.get('out', self.opts.get('output', 'nested'))
+            outputter = ret[host].get('out', self.opts.get('output', 'nested'))
+            p_data = {host: ret[host].get('return', {})}
             salt.output.display_output(
-                    ret.get('return', {}),
+                    p_data,
                     outputter,
                     self.opts)
             if self.event:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -453,9 +453,10 @@ class SSH(object):
             host = ret.keys()[0]
             self.cache_job(jid, host, ret[host])
             ret = self.key_deploy(host, ret)
+            outputter = ret.get('out', self.opts.get('output', 'nested'))
             salt.output.display_output(
-                    ret,
-                    self.opts.get('output', 'nested'),
+                    ret.get('return', {}),
+                    outputter,
                     self.opts)
             if self.event:
                 self.event.fire_event(

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -661,9 +661,11 @@ class Single(object):
         # Mimic the json data-structure that "salt-call --local" will
         # emit (as seen in ssh_py_shim.py)
         if 'local' in result:
-            return json.dumps(result)
+            result['local']['return'] = result['local']
+            ret = json.dumps(result)
         else:
-            return json.dumps({'local': result})
+            ret = json.dumps({'local': {'return': result}})
+        return ret
 
     def _cmd_str(self):
         '''

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -164,6 +164,7 @@ def main(argv):
         sys.executable,
         salt_call_path,
         '--local',
+        '--metadata',
         '--out', 'json',
         '-l', 'quiet',
         '-c', OPTIONS.saltdir,

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -55,9 +55,10 @@ class FunctionWrapper(dict):
             stdout, _, _ = single.cmd_block()
             try:
                 ret = json.loads(stdout, object_hook=salt.utils.decode_dict)
+                if len(ret) < 2 and 'local' in ret:
+                    ret = ret['local']
+                ret = ret.get('return', {})
             except ValueError:
                 ret = {'_error': 'Failed to return clean data'}
-            if len(ret) < 2 and 'local' in ret:
-                ret = ret['local']
             return ret
         return caller

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1981,6 +1981,15 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'retcode')
         )
         self.add_option(
+            '--metadata',
+            default=False,
+            dest='metadata',
+            action='store_true',
+            help=('Print out the execution metadata as well as the return. '
+                  'This will print out the outputter data, the return code, '
+                  'etc.')
+        )
+        self.add_option(
             '--id',
             default='',
             dest='id',


### PR DESCRIPTION
This adds the ssh_minion_cache option, this option when turned to False disables the ssh minion cache which prevents the server from keeping a copy of the minion's pillar and opts. This will reduce performance if enabled
