### PR TITLE
Ssh user iso

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2153,6 +2153,15 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'reached.')
         )
         self.add_option(
+            '--no_minion_cache',
+            dest='ssh_minion_cache',
+            default=True,
+            action='store_false',
+            help=('Set this flag to disable the ssh minion cache, this will '
+                  'prevent information about the target systems from being '
+                  'stored on the originating system.')
+        )
+        self.add_option(
             '--max-procs',
             dest='ssh_max_procs',
             default=25,

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2153,7 +2153,7 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'reached.')
         )
         self.add_option(
-            '--no_minion_cache',
+            '--no-minion-cache',
             dest='ssh_minion_cache',
             default=True,
             action='store_false',


### PR DESCRIPTION
This change makes salt-ssh isolate the user directories it creates on target systems. This allows for multiple users to access target systems via separate user accounts in an isolated fashon
