### PR TITLE
Fixed saltutil.cmd_iter doc for automodule

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -728,7 +728,7 @@ def cmd_iter(tgt,
 
     .. code-block:: bash
 
-        salt '*' saltutil.cmd
+        salt '*' saltutil.cmd_iter
     '''
     if ssh:
         client = salt.client.SSHClient(__opts__['conf_file'])


### PR DESCRIPTION
Fixed documentation of `saltutil.cmd_iter` for automodule.
