### PR TITLE
Migrate salt.cloud.exceptions to salt.exceptions

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -17,7 +17,7 @@ import multiprocessing
 from itertools import groupby
 
 # Import salt.cloud libs
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudException,
     SaltCloudSystemExit,

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -27,7 +27,7 @@ from salt.utils.verify import check_user, verify_env, verify_files
 
 # Import salt.cloud libs
 import salt.cloud
-from salt.cloud.exceptions import SaltCloudException, SaltCloudSystemExit
+from salt.exceptions import SaltCloudException, SaltCloudSystemExit
 
 log = logging.getLogger(__name__)
 

--- a/salt/cloud/clouds/aliyun.py
+++ b/salt/cloud/clouds/aliyun.py
@@ -41,7 +41,7 @@ from hashlib import sha1
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudSystemExit,
     SaltCloudExecutionFailure,

--- a/salt/cloud/clouds/botocore_aws.py
+++ b/salt/cloud/clouds/botocore_aws.py
@@ -38,7 +38,7 @@ import logging
 # Import salt.cloud libs
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.cloud.exceptions import SaltCloudException, SaltCloudSystemExit
+from salt.exceptions import SaltCloudException, SaltCloudSystemExit
 
 # Import libcloudfuncs and libcloud_aws, required to latter patch __opts__
 try:

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -30,7 +30,7 @@ import logging
 import salt.config as config
 from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
 from salt.utils import namespaced_function
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 
 # CloudStackNetwork will be needed during creation of a new node
 try:

--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -33,7 +33,7 @@ import logging
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudConfigError,
     SaltCloudNotFound,
     SaltCloudSystemExit,

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -89,7 +89,7 @@ from salt._compat import ElementTree as ET
 # Import salt.cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudException,
     SaltCloudSystemExit,
     SaltCloudConfigError,

--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -150,7 +150,7 @@ from salt.utils import namespaced_function
 import salt.utils.cloud
 import salt.config as config
 from salt.cloud.libcloudfuncs import *  # pylint: disable=W0401,W0614
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudException,
     SaltCloudSystemExit,
 )

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -36,7 +36,7 @@ from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
 # Import salt cloud libs
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)

--- a/salt/cloud/clouds/joyent.py
+++ b/salt/cloud/clouds/joyent.py
@@ -57,7 +57,7 @@ import salt.utils.cloud
 import salt.config as config
 from salt.utils import namespaced_function
 from salt.utils.cloud import is_public_ip
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudSystemExit,
     SaltCloudExecutionFailure,
     SaltCloudExecutionTimeout

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -43,7 +43,7 @@ import salt.utils.cloud
 import salt.config as config
 from salt.utils import namespaced_function
 
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudException,
     SaltCloudSystemExit,
     SaltCloudConfigError,

--- a/salt/cloud/clouds/lxc.py
+++ b/salt/cloud/clouds/lxc.py
@@ -22,7 +22,7 @@ import salt.utils
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 
 import salt.client
 import salt.runner

--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -33,7 +33,7 @@ import logging
 # Import salt cloud libs
 import salt.config as config
 import salt.utils.cloud
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 
 # Import azure libs
 HAS_LIBS = False

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -118,7 +118,7 @@ import salt.client
 import salt.utils.pycrypto as sup
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudConfigError,
     SaltCloudNotFound,
     SaltCloudSystemExit,

--- a/salt/cloud/clouds/opennebula.py
+++ b/salt/cloud/clouds/opennebula.py
@@ -31,7 +31,7 @@ import logging
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudConfigError,
     SaltCloudNotFound,
     SaltCloudSystemExit,

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -150,7 +150,7 @@ import salt.utils.cloud
 import salt.utils.pycrypto as sup
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudConfigError,
     SaltCloudNotFound,
     SaltCloudSystemExit,

--- a/salt/cloud/clouds/parallels.py
+++ b/salt/cloud/clouds/parallels.py
@@ -35,7 +35,7 @@ from salt._compat import ElementTree as ET
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudNotFound,
     SaltCloudSystemExit,
     SaltCloudExecutionFailure,

--- a/salt/cloud/clouds/proxmox.py
+++ b/salt/cloud/clouds/proxmox.py
@@ -38,7 +38,7 @@ import salt.utils
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudSystemExit,
     SaltCloudExecutionFailure,
     SaltCloudExecutionTimeout

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -55,7 +55,7 @@ import salt.utils
 import salt.utils.cloud
 import salt.config as config
 from salt.utils import namespaced_function
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudSystemExit,
     SaltCloudExecutionFailure,
     SaltCloudExecutionTimeout

--- a/salt/cloud/clouds/saltify.py
+++ b/salt/cloud/clouds/saltify.py
@@ -22,7 +22,7 @@ import salt.utils
 # Import salt cloud libs
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import SaltCloudConfigError, SaltCloudSystemExit
+from salt.exceptions import SaltCloudConfigError, SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)

--- a/salt/cloud/clouds/softlayer.py
+++ b/salt/cloud/clouds/softlayer.py
@@ -34,7 +34,7 @@ import time
 
 # Import salt cloud libs
 import salt.config as config
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
 from salt.utils import namespaced_function
 

--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -34,7 +34,7 @@ import time
 
 # Import salt cloud libs
 import salt.config as config
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 from salt.cloud.libcloudfuncs import *   # pylint: disable=W0614,W0401
 from salt.utils import namespaced_function
 

--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -53,7 +53,7 @@ import time
 # Import salt libs
 import salt.utils.cloud
 import salt.utils.xmlutil
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 
 # Import salt cloud libs
 import salt.config as config

--- a/salt/cloud/exceptions.py
+++ b/salt/cloud/exceptions.py
@@ -57,4 +57,3 @@ class SaltCloudPasswordError(SaltCloudException):
     '''
     Raise when virtual terminal password input failed
     '''
-

--- a/salt/cloud/exceptions.py
+++ b/salt/cloud/exceptions.py
@@ -25,7 +25,7 @@ class SaltCloudSystemExit(SaltCloudException):
     '''
     def __init__(self, message, exit_code=salt.exitcodes.EX_GENERIC):
         SaltCloudException.__init__(self, message)
-        self.message = message
+        self.message = '{0} [WARNING: salt.cloud.exceptions is deprecated. Please migrate to salt.exceptions!]'.format(message)
         self.exit_code = exit_code
 
 
@@ -57,3 +57,4 @@ class SaltCloudPasswordError(SaltCloudException):
     '''
     Raise when virtual terminal password input failed
     '''
+

--- a/salt/cloud/libcloudfuncs.py
+++ b/salt/cloud/libcloudfuncs.py
@@ -34,7 +34,7 @@ import salt.client
 import salt.utils
 import salt.utils.cloud
 import salt.config as config
-from salt.cloud.exceptions import SaltCloudNotFound, SaltCloudSystemExit
+from salt.exceptions import SaltCloudNotFound, SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)

--- a/salt/config.py
+++ b/salt/config.py
@@ -23,10 +23,8 @@ except Exception:
 
 # Import salt libs
 import salt.crypt
-import salt.loader
 import salt.utils
 import salt.utils.network
-import salt.pillar
 import salt.syspaths
 import salt.utils.validate.path
 import salt.utils.xdg

--- a/salt/config.py
+++ b/salt/config.py
@@ -13,7 +13,6 @@ import urlparse
 from copy import deepcopy
 import time
 import codecs
-
 # import third party libs
 import yaml
 try:
@@ -31,12 +30,10 @@ import salt.pillar
 import salt.syspaths
 import salt.utils.validate.path
 import salt.utils.xdg
+import salt.exceptions
 from salt._compat import string_types
 
 import sys
-# can't use salt.utils.is_windows, because config.py is included from salt.utils
-if not sys.platform.lower().startswith('win'):
-    import salt.cloud.exceptions
 
 log = logging.getLogger(__name__)
 
@@ -1078,7 +1075,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     # Grab data from the 4 sources
     # 1st - Master config
     if master_config_path is not None and master_config is not None:
-        raise salt.cloud.exceptions.SaltCloudConfigError(
+        raise salt.exceptions.SaltCloudConfigError(
             'Only pass `master_config` or `master_config_path`, not both.'
         )
     elif master_config_path is None and master_config is None:
@@ -1102,7 +1099,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     overrides = master_config
 
     if providers_config_path is not None and providers_config is not None:
-        raise salt.cloud.exceptions.SaltCloudConfigError(
+        raise salt.exceptions.SaltCloudConfigError(
             'Only pass `providers_config` or `providers_config_path`, '
             'not both.'
         )
@@ -1115,7 +1112,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
         )
 
     if profiles_config_path is not None and profiles_config is not None:
-        raise salt.cloud.exceptions.SaltCloudConfigError(
+        raise salt.exceptions.SaltCloudConfigError(
             'Only pass `profiles_config` or `profiles_config_path`, not both.'
         )
     elif profiles_config_path is None and profiles_config is None:
@@ -1132,7 +1129,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
     # 3rd - Include Cloud Providers
     if 'providers' in opts:
         if providers_config is not None:
-            raise salt.cloud.exceptions.SaltCloudConfigError(
+            raise salt.exceptions.SaltCloudConfigError(
                 'Do not mix the old cloud providers configuration with '
                 'the passing a pre-configured providers configuration '
                 'dictionary.'
@@ -1146,7 +1143,7 @@ def cloud_config(path, env_var='SALT_CLOUD_CONFIG', defaults=None,
 
             if (os.path.isfile(providers_config_path) or
                     glob.glob(providers_confd)):
-                raise salt.cloud.exceptions.SaltCloudConfigError(
+                raise salt.exceptions.SaltCloudConfigError(
                     'Do not mix the old cloud providers configuration with '
                     'the new one. The providers configuration should now go '
                     'in the file `{0}` or a separate `*.conf` file within '
@@ -1199,7 +1196,7 @@ def apply_cloud_config(overrides, defaults=None):
             if isinstance(details, list):
                 for detail in details:
                     if 'provider' not in detail:
-                        raise salt.cloud.exceptions.SaltCloudConfigError(
+                        raise salt.exceptions.SaltCloudConfigError(
                             'The cloud provider alias {0!r} has an entry '
                             'missing the required setting \'provider\''.format(
                                 alias
@@ -1218,7 +1215,7 @@ def apply_cloud_config(overrides, defaults=None):
                     config['providers'][alias][driver] = detail
             elif isinstance(details, dict):
                 if 'provider' not in details:
-                    raise salt.cloud.exceptions.SaltCloudConfigError(
+                    raise salt.exceptions.SaltCloudConfigError(
                         'The cloud provider alias {0!r} has an entry '
                         'missing the required setting \'provider\''.format(
                             alias
@@ -1319,7 +1316,7 @@ def apply_vm_profiles_config(providers, overrides, defaults=None):
         if key in ('conf_file', 'include', 'default_include', 'user'):
             continue
         if not isinstance(val, dict):
-            raise salt.cloud.exceptions.SaltCloudConfigError(
+            raise salt.exceptions.SaltCloudConfigError(
                 'The VM profiles configuration found in {0[conf_file]!r} is '
                 'not in the proper format'.format(config)
             )
@@ -1500,7 +1497,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                         'single entry for EC2, Joyent, Openstack, and so '
                         'forth.'
                     )
-                    raise salt.cloud.exceptions.SaltCloudConfigError(
+                    raise salt.exceptions.SaltCloudConfigError(
                         'The cloud provider alias {0!r} has multiple entries '
                         'for the {1[provider]!r} driver.'.format(key, details)
                     )
@@ -1535,7 +1532,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                 if ':' in extends:
                     alias, provider = extends.split(':')
                     if alias not in providers:
-                        raise salt.cloud.exceptions.SaltCloudConfigError(
+                        raise salt.exceptions.SaltCloudConfigError(
                             'The {0!r} cloud provider entry in {1!r} is '
                             'trying to extend data from {2!r} though {2!r} '
                             'is not defined in the salt cloud providers '
@@ -1547,7 +1544,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                         )
 
                     if provider not in providers.get(alias):
-                        raise salt.cloud.exceptions.SaltCloudConfigError(
+                        raise salt.exceptions.SaltCloudConfigError(
                             'The {0!r} cloud provider entry in {1!r} is '
                             'trying to extend data from \'{2}:{3}\' though '
                             '{3!r} is not defined in {1!r}'.format(
@@ -1561,7 +1558,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                     # change provider details '-only-extendable-' to extended provider name
                     details['provider'] = provider
                 elif providers.get(extends):
-                    raise salt.cloud.exceptions.SaltCloudConfigError(
+                    raise salt.exceptions.SaltCloudConfigError(
                         'The {0!r} cloud provider entry in {1!r} is trying '
                         'to extend from {2!r} and no provider was specified. '
                         'Not extending!'.format(
@@ -1569,7 +1566,7 @@ def apply_cloud_providers_config(overrides, defaults=None):
                         )
                     )
                 elif extends not in providers:
-                    raise salt.cloud.exceptions.SaltCloudConfigError(
+                    raise salt.exceptions.SaltCloudConfigError(
                         'The {0!r} cloud provider entry in {1!r} is trying '
                         'to extend data from {2!r} though {2!r} is not '
                         'defined in the salt cloud providers loaded '

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -172,14 +172,14 @@ class SaltWheelError(SaltException):
 
 
 class SaltSystemExit(SystemExit):
-   '''
-   This exception is raised when an unsolvable problem is found. There's
-   nothing else to do, salt should just exit.
-   '''
-   def __init__(self, code=0, msg=None):
-       SystemExit.__init__(self, code)
-       if msg:
-           self.message = msg
+    '''
+    This exception is raised when an unsolvable problem is found. There's
+    nothing else to do, salt should just exit.
+    '''
+    def __init__(self, code=0, msg=None):
+        SystemExit.__init__(self, code)
+        if msg:
+            self.message = msg
 
 
 class SaltCloudException(SaltException):

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -5,6 +5,7 @@ This module is a central location for all salt exceptions
 
 # Import python libs
 import copy
+import salt.exitcodes
 
 
 class SaltException(Exception):
@@ -171,11 +172,57 @@ class SaltWheelError(SaltException):
 
 
 class SaltSystemExit(SystemExit):
+   '''
+   This exception is raised when an unsolvable problem is found. There's
+   nothing else to do, salt should just exit.
+   '''
+   def __init__(self, code=0, msg=None):
+       SystemExit.__init__(self, code)
+       if msg:
+           self.message = msg
+
+
+class SaltCloudException(SaltException):
     '''
-    This exception is raised when an unsolvable problem is found. There's
-    nothing else to do, salt should just exit.
+    Generic Salt Cloud Exception
     '''
-    def __init__(self, code=0, msg=None):
-        SystemExit.__init__(self, code)
-        if msg:
-            self.message = msg
+
+
+class SaltCloudSystemExit(SaltCloudException):
+    '''
+    This exception is raised when the execution should be stopped.
+    '''
+    def __init__(self, message, exit_code=salt.exitcodes.EX_GENERIC):
+        SaltCloudException.__init__(self, message)
+        self.message = message
+        self.exit_code = exit_code
+
+
+class SaltCloudConfigError(SaltCloudException):
+    '''
+    Raised when a configuration setting is not found and should exist.
+    '''
+
+
+class SaltCloudNotFound(SaltCloudException):
+    '''
+    Raised when some cloud provider function cannot find what's being searched.
+    '''
+
+
+class SaltCloudExecutionTimeout(SaltCloudException):
+    '''
+    Raised when too much time has passed while querying/waiting for data.
+    '''
+
+
+class SaltCloudExecutionFailure(SaltCloudException):
+    '''
+    Raised when too much failures have occurred while querying/waiting for data.
+    '''
+
+
+class SaltCloudPasswordError(SaltCloudException):
+    '''
+    Raise when virtual terminal password input failed
+    '''

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -14,12 +14,6 @@ import logging
 import salt
 import salt.exceptions
 import salt.cli
-try:
-    import salt.cloud.cli
-    HAS_SALTCLOUD = True
-except ImportError:
-    # No salt cloud on Windows
-    HAS_SALTCLOUD = False
 
 
 log = logging.getLogger(__name__)
@@ -196,6 +190,12 @@ def salt_cloud():
     '''
     The main function for salt-cloud
     '''
+    try:
+        import salt.cloud.cli
+        HAS_SALTCLOUD = True
+    except ImportError:
+        # No salt cloud on Windows
+        HAS_SALTCLOUD = False
     if '' in sys.path:
         sys.path.remove('')
 

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -99,7 +99,6 @@ except ImportError:
 # Import salt libs
 import salt._compat
 import salt.log
-import salt.minion
 import salt.payload
 import salt.version
 from salt._compat import string_types

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -47,7 +47,7 @@ from salt.utils.validate.path import is_writeable
 
 # Import salt cloud libs
 import salt.cloud
-from salt.cloud.exceptions import (
+from salt.exceptions import (
     SaltCloudConfigError,
     SaltCloudException,
     SaltCloudSystemExit,

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -25,7 +25,7 @@ import logging
 
 # Import salt libs
 import salt.utils
-from salt.cloud.exceptions import SaltCloudSystemExit
+from salt.exceptions import SaltCloudSystemExit
 
 # Get logging started
 log = logging.getLogger(__name__)

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -31,9 +31,6 @@ import salt.utils.args
 import salt.utils.xdg
 from salt.utils.validate.path import is_writeable
 
-if not utils.is_windows():
-    import salt.cloud.exceptions
-
 
 def _sorted(mixins_or_funcs):
     return sorted(
@@ -2285,5 +2282,5 @@ class SaltCloudParser(OptionParser,
     def setup_config(self):
         try:
             return config.cloud_config(self.get_config_file_path())
-        except salt.cloud.exceptions.SaltCloudConfigError as exc:
+        except salt.exceptions.SaltCloudConfigError as exc:
             self.error(exc)

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -28,7 +28,7 @@ import salt.utils
 import salt.utils.network
 import integration
 from salt import config as sconfig
-from salt.cloud.exceptions import SaltCloudConfigError
+from salt.exceptions import SaltCloudConfigError
 
 # Import Third-Party Libs
 import yaml


### PR DESCRIPTION
This means that we no longer have to load salt.cloud when calling the
salt cli and paves the way for additional sandboxing of salt-cloud to avoid
unecessary imports.

Also moves the attempted import of salt.cloud inside the salt-cloud() function in the cli. 

Also removes some imports that appear to be unused. Saves a few ticks in my profiling tests.
