### PR TITLE
Change getBareMetalInstances call to getHardware

### DIFF
--- a/salt/cloud/clouds/softlayer_hw.py
+++ b/salt/cloud/clouds/softlayer_hw.py
@@ -696,7 +696,7 @@ def list_nodes_full(mask='mask[id, hostname, primaryIpAddress, \
 
     ret = {}
     conn = get_conn(service='Account')
-    response = conn.getBareMetalInstances(mask=mask)
+    response = conn.getHardware(mask=mask)
 
     for node in response:
         ret[node['hostname']] = node


### PR DESCRIPTION
Per a ticket with softlayer because their API was returning an empty array to calls to getBareMetalInstances:

You do not have any machines flagged as a Bare Metal Instance. We used to refer to physical machines as Bare Metal Dedicated (monthly) and Bare Metal Instance (hourly). Now we refer to them as Bare Metal (monthly) and Bare Metal hourly (hourly). The getBareMetalInstances function will still return the hourly.

getHardware gets both according to Softlayer.
