### PR TITLE
Lookup VPC security groups anywhere VPC resources are used

### DIFF
--- a/salt/states/boto_elasticache.py
+++ b/salt/states/boto_elasticache.py
@@ -156,7 +156,7 @@ def present(
         to the cache cluster during the maintenance window. A value of True
         allows these upgrades to occur; False disables automatic upgrades.
 
-    security_groups_ids
+    security_group_ids
         One or more VPC security groups associated with the cache cluster. Use
         this parameter only when you are creating a cluster in a VPC.
 
@@ -194,6 +194,18 @@ def present(
         that contains a dict with region, key and keyid.
     '''
     ret = {'name': name, 'result': True, 'comment': '', 'changes': {}}
+    if cache_security_group_names and cache_subnet_group_name:
+        _subnet_group = __salt__['boto_elasticache.get_cache_subnet_group'](
+            cache_subnet_group_name, region, key, keyid, profile
+        )
+        vpc_id = _subnet_group['vpc_id']
+        if not security_group_ids:
+            security_group_ids = []
+        _security_group_ids = __salt__['boto_secgroup.convert_to_group_ids'](
+            cache_security_group_names, vpc_id, region, key, keyid, profile
+        )
+        security_group_ids.extend(_security_group_ids)
+        cache_security_group_names = None
     config = __salt__['boto_elasticache.get_config'](name, region, key, keyid,
                                                      profile)
     if config is None:

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -237,6 +237,20 @@ def _elb_present(
         if 'certificate' in listener:
             _listener.append(listener['certificate'])
         _listeners.append(_listener)
+    if subnets:
+        vpc_id = __salt__['boto_vpc.get_subnet_association'](
+            subnets, region, key, keyid, profile
+        )
+        if not vpc_id:
+            msg = 'Subnets {0} do not map to a valid vpc id.'.format(subnets)
+            raise SaltInvocationError(msg)
+        security_groups = __salt__['boto_secgroup.convert_to_group_ids'](
+            security_groups, vpc_id, region, key, keyid, profile
+        )
+        if not security_groups:
+            msg = 'Security groups {0} do not map to valid security group ids.'
+            msg = msg.format(security_groups)
+            raise SaltInvocationError(msg)
     exists = __salt__['boto_elb.exists'](name, region, key, keyid, profile)
     if not exists:
         if __opts__['test']:

--- a/salt/states/boto_secgroup.py
+++ b/salt/states/boto_secgroup.py
@@ -290,6 +290,19 @@ def _rules_present(
         ret['comment'] = msg.format(name)
         ret['result'] = False
         return ret
+    if vpc_id:
+        for rule in rules:
+            _source_group_name = rule.get('source_group_name', None)
+            if _source_group_name:
+                _group_id = __salt__['boto_secgroup.get_group_id'](
+                    _source_group_name, vpc_id, region, key, keyid, profile
+                )
+                if not _group_id:
+                    msg = ('source_group_name {0} does not map to a valid'
+                           ' source group id.')
+                    raise SaltInvocationError(msg.format(_source_group_name))
+                rule['source_group_name'] = None
+                rule['source_group_group_id'] = _group_id
     # rules = rules that exist in salt state
     # sg['rules'] = that exist in present group
     to_delete, to_create = _get_rule_changes(rules, sg['rules'])


### PR DESCRIPTION
VPC fixes for most of the boto_\* modules. This change will translate security group names to security group IDs for VPC resources, since AWS requires group IDs when using VPC.
