### PR TITLE
Update cloud driver docs with/without libcloud deps

### DIFF
--- a/doc/topics/cloud/digitalocean.rst
+++ b/doc/topics/cloud/digitalocean.rst
@@ -5,11 +5,6 @@ Getting Started With DigitalOcean
 DigitalOcean is a public cloud provider that specializes in Linux instances.
 
 
-Dependencies
-============
-This driver requires the Python ``requests`` library to be installed.
-
-
 Configuration
 =============
 Using Salt for DigitalOcean requires a client_key, an api_key, an ssh_key_file,

--- a/doc/topics/cloud/gogrid.rst
+++ b/doc/topics/cloud/gogrid.rst
@@ -7,8 +7,7 @@ GoGrid is a public cloud provider supporting Linux and Windows.
 
 Dependencies
 ============
-The GoGrid driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
-installed.
+* Libcloud >= 0.13.2
 
 
 Configuration

--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -6,9 +6,7 @@ Linode is a public cloud provider with a focus on Linux instances.
 
 Dependencies
 ============
-The Linode driver for Salt Cloud requires Libcloud 0.13.2 or higher to be
-installed.
-
+* Libcloud >= 0.13.2
 
 Configuration
 =============

--- a/doc/topics/cloud/openstack.rst
+++ b/doc/topics/cloud/openstack.rst
@@ -6,6 +6,14 @@ OpenStack is one the most popular cloud projects. It's an open source project
 to build public and/or private clouds. You can use Salt Cloud to launch
 OpenStack instances.
 
+
+Dependencies
+============
+* Libcloud >= 0.13.2
+
+
+Configuration
+=============
 * Using the new format, set up the cloud configuration at
   ``/etc/salt/cloud.providers`` or
   ``/etc/salt/cloud.providers.d/openstack.conf``:
@@ -37,7 +45,6 @@ OpenStack instances.
 
       # skip SSL certificate validation (default false)
       insecure: false
-
 
 
 Using nova client to get information from OpenStack

--- a/doc/topics/cloud/rackspace.rst
+++ b/doc/topics/cloud/rackspace.rst
@@ -11,6 +11,14 @@ will *not* work with OpenStack-based instances. Unless you explicitly have a
 reason to use it, it is highly recommended that you use the `openstack` driver
 instead.
 
+
+Dependencies
+============
+* Libcloud >= 0.13.2
+
+
+Configuration
+=============
 To use the `openstack` driver (recommended), set up the cloud configuration at 
   ``/etc/salt/cloud.providers`` or 
   ``/etc/salt/cloud.providers.d/rackspace.conf``:

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -6,6 +6,8 @@ CloudStack Cloud Module
 The CloudStack cloud module is used to control access to a CloudStack based
 Public Cloud.
 
+:depends: libcloud
+
 Use of this module requires the ``apikey``, ``secretkey``, ``host`` and
 ``path`` parameters.
 

--- a/salt/cloud/clouds/gogrid.py
+++ b/salt/cloud/clouds/gogrid.py
@@ -8,6 +8,8 @@ service. To use Salt Cloud with GoGrid log into the GoGrid web interface and
 create an api key. Do this by clicking on "My Account" and then going to the
 API Keys tab.
 
+:depends: libcloud >= 0.13.2
+
 Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/gogrid.conf``:
 

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -7,6 +7,8 @@ The Linode cloud module is used to control access to the Linode VPS system
 
 Use of this module only requires the ``apikey`` parameter.
 
+:depends: libcloud >= 0.13.2
+
 Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/linode.conf``:
 

--- a/salt/cloud/clouds/openstack.py
+++ b/salt/cloud/clouds/openstack.py
@@ -6,6 +6,8 @@ OpenStack Cloud Module
 OpenStack is an open source project that is in use by a number a cloud
 providers, each of which have their own ways of using it.
 
+:depends: libcloud >- 0.13.2
+
 OpenStack provides a number of ways to authenticate. This module uses password-
 based authentication, using auth v2.0. It is likely to start supporting other
 methods of authentication provided by OpenStack in the future.

--- a/salt/cloud/clouds/rackspace.py
+++ b/salt/cloud/clouds/rackspace.py
@@ -7,6 +7,8 @@ The Rackspace cloud module. This module uses the preferred means to set up a
 libcloud based cloud module and should be used as the general template for
 setting up additional libcloud based modules.
 
+:depends: libcloud >= 0.13.2
+
 Please note that the `rackspace` driver is only intended for 1st gen instances,
 aka, "the old cloud" at Rackspace. It is required for 1st gen instances, but
 will *not* work with OpenStack-based instances. Unless you explicitly have a

--- a/tests/integration/cloud/providers/digital_ocean.py
+++ b/tests/integration/cloud/providers/digital_ocean.py
@@ -7,7 +7,6 @@
 import os
 
 # Import Salt Testing Libs
-from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -15,22 +14,7 @@ ensure_in_syspath('../../../')
 import integration
 from salt.config import cloud_providers_config
 
-# Import Third-Party Libs
-try:
-    import libcloud  # pylint: disable=W0611
-    HAS_LIBCLOUD = True
-except ImportError:
-    HAS_LIBCLOUD = False
 
-try:
-    import requests  # pylint: disable=W0611
-    HAS_REQUESTS = True
-except ImportError:
-    HAS_REQUESTS = False
-
-
-@skipIf(HAS_LIBCLOUD is False, 'salt-cloud requires >= libcloud 0.13.2')
-@skipIf(HAS_REQUESTS is False, 'salt-cloud requires python requests library')
 class DigitalOceanTest(integration.ShellCase):
     '''
     Integration tests for the DigitalOcean cloud provider in Salt-Cloud

--- a/tests/integration/cloud/providers/gogrid.py
+++ b/tests/integration/cloud/providers/gogrid.py
@@ -16,16 +16,8 @@ ensure_in_syspath('../../../')
 import integration
 from salt.config import cloud_providers_config
 
-# Import Third-Party Libs
-try:
-    import libcloud  # pylint: disable=W0611
-    HAS_LIBCLOUD = True
-except ImportError:
-    HAS_LIBCLOUD = False
-
 
 @skipIf(True, 'waiting on bug report fixes from #13365')
-@skipIf(HAS_LIBCLOUD is False, 'salt-cloud requires >= libcloud 0.13.2')
 class GoGridTest(integration.ShellCase):
     '''
     Integration tests for the GoGrid cloud provider in Salt-Cloud


### PR DESCRIPTION
- Since libcloud is no longer a hard dependency for salt-cloud, the drivers that still depend on libcloud should say so.
- Changed the cloud integration tests accordingly (some don't require the `skipIf` because they don't need libcloud).
- Requests dependency notices were removed since salt deps on requests now and not just certain salt-cloud drivers.
