### PR TITLE
Service enabled kwargs

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -274,7 +274,7 @@ def disable(name, **kwargs):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Return True if the named service is enabled, false otherwise
 

--- a/salt/modules/freebsdservice.py
+++ b/salt/modules/freebsdservice.py
@@ -209,7 +209,7 @@ def disable(name, **kwargs):
     return _switch(name, False, **kwargs)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Return True if the named service is enabled, false otherwise
 

--- a/salt/modules/gentoo_service.py
+++ b/salt/modules/gentoo_service.py
@@ -188,7 +188,7 @@ def disable(name, **kwargs):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Return True if the named service is enabled, false otherwise
 

--- a/salt/modules/netbsdservice.py
+++ b/salt/modules/netbsdservice.py
@@ -258,7 +258,7 @@ def disable(name, **kwargs):
     return _rcconf_status(name, 'NO')
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Return True if the named service is enabled, false otherwise
 

--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -40,6 +40,16 @@ def _cmd():
     return rcctl
 
 
+def _get_flags(**kwargs):
+    '''
+    Return the configured service flags.
+    '''
+    flags = kwargs.get('flags', \
+                       __salt__['config.option']('service.flags', \
+                       default=''))
+    return flags
+
+
 def available(name):
     '''
     Return True if the named service is available.
@@ -216,15 +226,8 @@ def enable(name, **kwargs):
         salt '*' service.enable <service name>
         salt '*' service.enable <service name> flags=<flags>
     '''
-    flags = kwargs.get('flags',
-                       __salt__['config.option']('service.flags',
-                       default=''))
-
-    if not flags:
-        cmd = '{0} enable {1}'.format(_cmd(), name)
-    else:
-        cmd = '{0} enable {1} flags {2}'.format(_cmd(), name, flags)
-
+    flags = _get_flags(**kwargs)
+    cmd = '{0} enable {1} flags {2}'.format(_cmd(), name, flags)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -258,7 +261,8 @@ def disabled(name):
 
 def enabled(name, **kwargs):
     '''
-    Return True if the named service is enabled at boot, False otherwise.
+    Return True if the named service is enabled at boot and the provided
+    flags match the configured ones (if any). Return False otherwise.
 
     name
         Service name
@@ -268,6 +272,15 @@ def enabled(name, **kwargs):
     .. code-block:: bash
 
         salt '*' service.enabled <service name>
+        salt '*' service.enabled <service name> flags=<flags>
     '''
     cmd = '{0} status {1}'.format(_cmd(), name)
-    return not __salt__['cmd.retcode'](cmd)
+    if not __salt__['cmd.retcode'](cmd):
+        # also consider a service disabled if the current flags are different
+        # than the configured ones so we have a chance to update them
+        flags = _get_flags(**kwargs)
+        cur_flags = __salt__['cmd.run_stdout']('{0} status {1}'.format(_cmd(), name))
+        if format(flags) == format(cur_flags):
+            return True
+
+    return False

--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -256,7 +256,7 @@ def disabled(name):
     return not __salt__['cmd.retcode'](cmd) == 0
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Return True if the named service is enabled at boot, False otherwise.
 

--- a/salt/modules/openbsdservice.py
+++ b/salt/modules/openbsdservice.py
@@ -243,7 +243,7 @@ def get_enabled():
     return sorted(set(get_all()) & set(services))
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     .. versionadded:: 2014.7.0
 

--- a/salt/modules/rh_service.py
+++ b/salt/modules/rh_service.py
@@ -465,7 +465,7 @@ def disable(name, **kwargs):
         return _sysv_disable(name)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Check to see if the named service is enabled to start on boot
 

--- a/salt/modules/smf.py
+++ b/salt/modules/smf.py
@@ -262,7 +262,7 @@ def disable(name, **kwargs):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Check to see if the named service is enabled to start on boot
 

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -380,7 +380,7 @@ def _enabled(name):
     return is_enabled or _templated_instance_enabled(name)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Return if the named service is enabled to start on boot
 

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -474,7 +474,7 @@ def disable(name, **kwargs):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Check to see if the named service is enabled to start on boot
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -312,7 +312,7 @@ def disable(name, **kwargs):
     return not __salt__['cmd.retcode'](cmd)
 
 
-def enabled(name):
+def enabled(name, **kwargs):
     '''
     Check to see if the named service is enabled to start on boot
 

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -93,7 +93,7 @@ def _enable(name, started, result=True, **kwargs):
             return ret
 
     # Service can be enabled
-    if __salt__['service.enabled'](name):
+    if __salt__['service.enabled'](name, **kwargs):
         # Service is enabled
         if started is True:
             ret['changes'][name] = True


### PR DESCRIPTION
Allow passing kwargs to service.enabled()

On OpenBSD, it's possible to define particular flags a daemon should be
enabled with (ala /etc/sysconfig/... in RedHat). To make sure the flags
are properly updated when changed (in pillars or states), we return a
service as "disabled" if the currently configured flags do not match the
provided ones; this ensures /etc/rc.conf.local is always in sync.

See https://github.com/saltstack/salt/issues/15275 for details.
