### PR TITLE
Update multimaster tutorial

### DIFF
--- a/doc/topics/tutorials/multimaster.rst
+++ b/doc/topics/tutorials/multimaster.rst
@@ -31,14 +31,16 @@ Summary of Steps
 Prepping a Redundant Master
 ---------------------------
 
-The first task is to prepare the redundant master. There is only one
-requirement when preparing a redundant master, which is that masters share the
-same private key. When the first master was created, the master's identifying
-key was generated and placed in the master's ``pki_dir``. The default location
-of the key is ``/etc/salt/pki/master/master.pem``. Take this key and copy it to
-the same location on the redundant master. Assuming that no minions have yet
-been connected to the new redundant master, it is safe to delete any existing
-key in this location and replace it.
+The first task is to prepare the redundant master. If the redundant master is
+already running, stop it. There is only one requirement when preparing a
+redundant master, which is that masters share the same private key. When the
+first master was created, the master's identifying key pair was generated and
+placed in the master's ``pki_dir``. The default location of the master's key
+pair is ``/etc/salt/pki/master/``. Take the private key, ``master.pem`` and
+copy it to the same location on the redundant master. Do the same for the
+master's public key, ``master.pub``. Assuming that no minions have yet been
+connected to the new redundant master, it is safe to delete any existing key
+in this location and replace it.
 
 .. note::
     There is no logical limit to the number of redundant masters that can be


### PR DESCRIPTION
When preparing the redundant master, both the `master.pem` and the `master.pub` keys must be copied from the original master to the new redundant master.
