### PR TITLE
Resolve issue #15532 set metadata to mdadm

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -146,6 +146,7 @@ def destroy(device):
 def create(name,
            level,
            devices,
+           metadata="default",
            test_mode=False,
            **kwargs):
     '''
@@ -177,6 +178,9 @@ def create(name,
     devices
         A list of devices used to build the array.
 
+    metadata
+        Version of metadata to use when creating the array.
+
     kwargs
         Optional arguments to be passed to mdadm.
 
@@ -206,9 +210,10 @@ def create(name,
             else:
                 opts += '--{0}={1} '.format(key, kwargs[key])
 
-    cmd = "mdadm -C {0} -v {1}-l {2} -n {3} {4}".format(name,
+    cmd = "mdadm -C {0} -v {1}-l {2} -e {3} -n {4} {5}".format(name,
             opts,
             level,
+            metadata,
             len(devices),
             ' '.join(devices))
 

--- a/tests/unit/modules/mdadm_test.py
+++ b/tests/unit/modules/mdadm_test.py
@@ -37,7 +37,7 @@ class MdadmTestCase(TestCase):
             )
             self.assertEqual('salt', ret)
             mock.assert_called_once_with(
-                    'mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -n 3 '
+                    'mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -e default -n 3 '
                     '/dev/sdb1 /dev/sdc1 /dev/sdd1'
             )
 
@@ -53,7 +53,7 @@ class MdadmTestCase(TestCase):
                     chunk=256,
                     test_mode=True
             )
-            self.assertEqual('mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -n 3 '
+            self.assertEqual('mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -e default -n 3 '
                     '/dev/sdb1 /dev/sdc1 /dev/sdd1', ret)
             assert not mock.called, 'test mode failed, cmd.run called'
 


### PR DESCRIPTION
Sets a default value to the metadata flag when calling `mdadm`. This resolves issue #15532 
