### PR TITLE
Resolves #15537 malformed mdadm.conf lines

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -258,7 +258,7 @@ def save_config():
         cfg_file = '/etc/mdadm.conf'
 
     try:
-        vol_d = {line.split()[1]: line for line in scan}
+        vol_d = dict([(line.split()[1], line) for line in scan])
         for vol in vol_d:
             pattern = r'^ARRAY\s+{0}'.format(re.escape(vol))
             __salt__['file.replace'](cfg_file, pattern, vol_d[vol], append_if_not_found=True)


### PR DESCRIPTION
This resolves a few different issues with the save_config method of salt.modules.mdadm:
- If multiple mdadm raid volumes are present they are properly recorded on seperate lines in the mdadm.conf
- if a given volume was already represented in mdadm.conf it's ARRAY line is updated instead of having a duplicate blindly appended
- The logic for the ubuntu bugfix workaround was also modified to use a case insensitive regex replace
