### PR TITLE
fix str.format() call in modules.boto_elb.deregister_instances

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -583,7 +583,7 @@ def deregister_instances(name, instances, region=None, key=None, keyid=None,
     deregister_failures = set(instances).intersection(set(registered_instance_ids))
     if deregister_failures:
         log.warn('Instance(s): {0} not deregistered from ELB {1}.'
-                 .format(list(deregister_failures)), name)
+                 .format(list(deregister_failures), name))
         deregister_result = False
     else:
         deregister_result = True


### PR DESCRIPTION
```
************* Module salt.modules.boto_elb
salt/modules/boto_elb.py:585: [E1306(too-few-format-args), deregister_instances] Not enough arguments for format string
```
