### PR TITLE
fix refactoring error in client.ssh.Single.sls_seed

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -926,7 +926,7 @@ class Single(object):
             trans_tar,
             os.path.join(self.thin_dir, 'salt_state.tgz'),
         )
-        self.argv = ['state.pkg', '{0}/salt_state.tgz', 'test={1}'.format(self.thin_dir, test)]
+        self.argv = ['state.pkg', '{0}/salt_state.tgz'.format(self.thin_dir), 'test={0}'.format(test)]
 
 
 class SSHState(salt.state.State):


### PR DESCRIPTION
```
salt/client/ssh/__init__.py:929: [E1305(too-many-format-args), Single.sls_seed] Too many arguments for format string
```
