### PR TITLE
Use the first parent on git describe when available.

### DIFF
--- a/salt/version.py
+++ b/salt/version.py
@@ -453,8 +453,8 @@ def __get_version(saltstack_version):
             kwargs['close_fds'] = True
 
         process = subprocess.Popen(
-            'git describe --tags --first-parent --match \'v[0-9]*\' --always 2>/dev/null || '
-            'git describe --tags --match \'v[0-9]*\' --always',
+            'git describe --tags --first-parent --match \'v[0-9]*\' --always 2>{0} || '
+            'git describe --tags --match \'v[0-9]*\' --always'.format(os.devnull),
             **kwargs
         )
         out, err = process.communicate()

--- a/salt/version.py
+++ b/salt/version.py
@@ -444,8 +444,7 @@ def __get_version(saltstack_version):
         kwargs = dict(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=cwd,
-            shell=True
+            cwd=cwd
         )
 
         if not sys.platform.startswith('win'):
@@ -453,11 +452,16 @@ def __get_version(saltstack_version):
             kwargs['close_fds'] = True
 
         process = subprocess.Popen(
-            'git describe --tags --first-parent --match \'v[0-9]*\' --always 2>{0} || '
-            'git describe --tags --match \'v[0-9]*\' --always'.format(os.devnull),
-            **kwargs
-        )
+            ['git', 'describe', '--tags', '--first-parent', '--match', 'v[0-9]*', '--always'], **kwargs)
+
         out, err = process.communicate()
+
+        if process.returncode != 0:
+            # The git version running this might not support --first-parent
+            # Revert to old command
+            process = subprocess.Popen(
+                ['git', 'describe', '--tags', '--match', 'v[0-9]*', '--always'], **kwargs)
+            out, err = process.communicate()
         out = out.strip()
         err = err.strip()
 

--- a/salt/version.py
+++ b/salt/version.py
@@ -444,7 +444,8 @@ def __get_version(saltstack_version):
         kwargs = dict(
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            cwd=cwd
+            cwd=cwd,
+            shell=True
         )
 
         if not sys.platform.startswith('win'):
@@ -452,7 +453,10 @@ def __get_version(saltstack_version):
             kwargs['close_fds'] = True
 
         process = subprocess.Popen(
-                ['git', 'describe', '--tags', '--match', 'v[0-9]*', '--always'], **kwargs)
+            'git describe --tags --first-parent --match \'v[0-9]*\' --always 2>/dev/null || '
+            'git describe --tags --match \'v[0-9]*\' --always',
+            **kwargs
+        )
         out, err = process.communicate()
         out = out.strip()
         err = err.strip()

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1168,13 +1168,22 @@ class ShellCaseCommonTestsMixIn(CheckShellBinaryNameAndVersionMixIn):
 
         # Let's get the output of git describe
         process = subprocess.Popen(
-            [git, 'describe', '--tags', '--match', 'v[0-9]*'],
+            [git, 'describe', '--tags', '--first-parent', '--match', 'v[0-9]*'],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             close_fds=True,
             cwd=CODE_DIR
         )
         out, err = process.communicate()
+        if process.returncode != 0:
+            process = subprocess.Popen(
+                [git, 'describe', '--tags', '--match', 'v[0-9]*'],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                close_fds=True,
+                cwd=CODE_DIR
+            )
+            out, err = process.communicate()
         if not out:
             self.skipTest(
                 'Failed to get the output of \'git describe\'. '


### PR DESCRIPTION
This is necessary since we now merge forward and git describe thinks the
HEAD with the less commits is the HEAD to use.

A little more information about this behaviour can be found here:

  http://www.xerxesb.com/2010/git-describe-and-the-tale-of-the-wrong-commits/
