### PR TITLE
GCE Cloud: nicer error when private key does not exist

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -242,6 +242,9 @@ def get_conn():
             provider, __opts__)
     private_key = config.get_cloud_config_value('service_account_private_key',
             provider, __opts__)
+    if not os.path.exists(private_key):
+        raise SaltCloudException('Private key at %r not found / not available'
+                                 % private_key)
     gce = driver(email, private_key, project=project)
     gce.connection.user_agent_append('{0}/{1}'.format(_UA_PRODUCT,
                                                       _UA_VERSION))


### PR DESCRIPTION
Right now, you get a misleading error message when you try to use salt-cloud on
GCE with a missing RSA key (see the traceback below). This is particularly
pernicious because you have to convert the SSH key to a different format for
GCE (and install a bunch of deps) so it becomes a little unclear what's going
on (esp because you get the same error if you use a too-old version of
PyCrypto).  (and, I admit, this happened to me twice while trying to set up a
salt-master :))

Please tell me if there's anything I should do with this PR to make it better.
I'm not really sure how I'd set up a test case for this (I test it locally by
just temporarily removing the key from the given path.

``` python
[ERROR   ] Failed to get the output of 'gce.avail_locations()': RSA key format is not supported
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 453, in location_list
    data[alias][driver] = self.clouds[fun]()
  File "/usr/lib/python2.7/dist-packages/salt/cloud/libcloudfuncs.py", line 132, in avail_locations
    conn = get_conn()   # pylint: disable=E0602
  File "/usr/lib/python2.7/dist-packages/salt/cloud/clouds/gce.py", line 175, in get_conn
    gce = driver(email, private_key, project=project)
  File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 578, in __init__
    self.zone_list = self.ex_list_zones()
  File "/usr/local/lib/python2.7/dist-packages/libcloud/compute/drivers/gce.py", line 909, in ex_list_zones
    response = self.connection.request(request, method='GET').object
  File "/usr/local/lib/python2.7/dist-packages/libcloud/common/google.py", line 593, in request
    *args, **kwargs)
  File "/usr/local/lib/python2.7/dist-packages/libcloud/common/base.py", line 643, in request
    params, headers = self.pre_connect_hook(params, headers)
  File "/usr/local/lib/python2.7/dist-packages/libcloud/common/google.py", line 569, in pre_connect_hook
    self.token_info = self.auth_conn.refresh_token(self.token_info)
  File "/usr/local/lib/python2.7/dist-packages/libcloud/common/google.py", line 465, in refresh_token
    return self.get_new_token()
  File "/usr/local/lib/python2.7/dist-packages/libcloud/common/google.py", line 439, in get_new_token
    key = RSA.importKey(self.key)
  File "/usr/local/lib/python2.7/dist-packages/Crypto/PublicKey/RSA.py", line 682, in importKey
    raise ValueError("RSA key format is not supported")
```
