### PR TITLE
SmartOS Esky: Fix minion SMF manifest

### DIFF
--- a/pkg/smartos/esky/salt-minion.xml
+++ b/pkg/smartos/esky/salt-minion.xml
@@ -28,7 +28,7 @@
 
       <exec_method type="method"
                    name="start"
-                   exec="auditconfig -setaudit 0 lo 0,0,localhost 5417 SALT_PREFIX/bin/salt-minion"
+                   exec="/usr/sbin/auditconfig -setaudit 0 lo 0,0,localhost 5417 SALT_PREFIX/bin/salt-minion"
                    timeout_seconds="60">
         <method_context>
           <method_environment>


### PR DESCRIPTION
Some users reported an errror that SMF couldn't find auditconfig despite
the fact that the PATH is set correctly. Invoking with the full path
seems to fix the issue.
