### PR TITLE
Change expected return for deleting digital ocean instance

### DIFF
--- a/tests/integration/cloud/providers/digital_ocean.py
+++ b/tests/integration/cloud/providers/digital_ocean.py
@@ -91,7 +91,7 @@ class DigitalOceanTest(integration.ShellCase):
 
         # delete the instance
         delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
-        ret_str = '            OK'
+        ret_str = '                OK'
         try:
             self.assertIn(ret_str, delete)
         except AssertionError:


### PR DESCRIPTION
Digital Ocean tests were failing because the expected return was formatted slightly differently than the actual return. The cloud tests should pass now.
