### PR TITLE
Bugfix in logging to users directory

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -664,7 +664,8 @@ class LogLevelMixIn(object):
                     # Yep, the user is in ACL!
                     # Let's write the logfile to its home directory instead.
                     xdg_dir = salt.utils.xdg.xdg_config_dir()
-                    user_salt_dir = xdg_dir if os.path.isdir(xdg_dir) else '~/.salt'
+                    user_salt_dir = (xdg_dir if os.path.isdir(xdg_dir) else
+                                     os.path.expanduser('~/.salt'))
 
                     if not os.path.isdir(user_salt_dir):
                         os.makedirs(user_salt_dir, 0750)


### PR DESCRIPTION
Fixes a bug where the logger creates a "~/.salt" directory instead of expanding the path to the actual user directory to create a .salt directory under the users home directory.
