### PR TITLE
Bug in file.symlink

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1989,9 +1989,9 @@ def symlink(src, path):
 
         salt '*' file.symlink /path/to/file /path/to/link
     '''
-    src = os.path.expanduser(src)
+    path = os.path.expanduser(path)
 
-    if not os.path.isabs(src):
+    if not os.path.isabs(path):
         raise SaltInvocationError('File path must be absolute.')
 
     try:


### PR DESCRIPTION
Fix the absolute directory check in `file.symlink` for the path of the symbolic link itself (not the target which doesn't have to be absolute nor actually point to a valid directory)
