### PR TITLE
- the file.extract_hash function does not support Windows path format

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2587,7 +2587,7 @@ def extract_hash(hash_fn, hash_type='sha256', file_name=''):
     '''
     source_sum = None
     partial_id = False
-    name_sought = re.findall(r'^(.+)/([^/]+)$', '/x' + file_name)[0][1]
+    name_sought = os.path.basename(file_name)
     log.debug('modules.file.py - extract_hash(): Extracting hash for file '
               'named: {0}'.format(name_sought))
     hash_fn_fopen = salt.utils.fopen(hash_fn, 'r')


### PR DESCRIPTION
I use 'file.managed' state on Windows with 'source' parameter set to external HTTP URL and I need to pass 'source_hash' parameter to verify it. The current code of the module does not seem to support Windows path format. I simply replaced 'file_name' extraction by 're.findall' function with more multi-platform 'os.path.basename' function.
