### PR TITLE
Fix mdadm tests

### DIFF
--- a/tests/unit/modules/mdadm_test.py
+++ b/tests/unit/modules/mdadm_test.py
@@ -37,9 +37,9 @@ class MdadmTestCase(TestCase):
             )
             self.assertEqual('salt', ret)
             mock.assert_called_once_with(
-                    'mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -e default -n 3 '
-                    '/dev/sdb1 /dev/sdc1 /dev/sdd1'
-            )
+                ['mdadm', '-C', '/dev/md0', '-v', '--chunk', 256, '--force',
+                 '-l', 5, '-e', 'default', '-n', 3, '/dev/sdb1', '/dev/sdc1',
+                 '/dev/sdd1'], python_shell=False)
 
     def test_create_test_mode(self):
         mock = MagicMock()
@@ -53,8 +53,9 @@ class MdadmTestCase(TestCase):
                     chunk=256,
                     test_mode=True
             )
-            self.assertEqual('mdadm -C /dev/md0 -v --chunk=256 --force -l 5 -e default -n 3 '
-                    '/dev/sdb1 /dev/sdc1 /dev/sdd1', ret)
+            self.assertEqual(['mdadm', '-C', '/dev/md0', '-v', '--chunk', 256,
+                              '--force', '-l', 5, '-e', 'default', '-n', 3,
+                              '/dev/sdb1', '/dev/sdc1', '/dev/sdd1'], ret)
             assert not mock.called, 'test mode failed, cmd.run called'
 
 if __name__ == '__main__':


### PR DESCRIPTION
The changes to the `mdadm` module in #15600 altered the return mdadm calls, breaking the tests. This fixes them.
