### PR TITLE
Remove duplicate lines in HACKING.rst

### DIFF
--- a/HACKING.rst
+++ b/HACKING.rst
@@ -172,9 +172,6 @@ ZeroMQ Transport:
     pip install psutil
     pip install -e .
 
-
-.. note:: Installing M2Crypto
-
 .. note:: Installing M2Crypto
 
     You may need ``swig`` and ``libssl-dev`` to build M2Crypto. If you


### PR DESCRIPTION
[.. note:: Installing M2Crypto](https://github.com/saltstack/salt/blame/develop/HACKING.rst#L176) was duplicated. This patch removes the duplicate text and surrounding whitespace.
