### PR TITLE
Fixed tomcat.fullversion on Ubuntu in salt/modules/tomcat.py, issue 13456

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -72,9 +72,11 @@ def __catalina_home():
     '''
     locations = ['/usr/share/tomcat*', '/opt/tomcat']
     for location in locations:
-        catalina_home = glob.glob(location)
-        if catalina_home:
-            return catalina_home[-1]
+        folders = glob.glob(location)
+        if folders:
+            for catalina_home in folders:
+                if os.path.isdir(catalina_home + "/bin"):
+                    return catalina_home
     return False
 
 


### PR DESCRIPTION
Somebody else already fixed the password/username not being picked up from grains/pillars in this issue: https://github.com/saltstack/salt/issues/13456 once this has been merged the issue should be resolved.

Taking the last entry from glob.glob('/usr/share/tomcat*') will fail if a user has installed the tomcat-manager which is needed for the salt tomcat module.

> > > glob.glob('/usr/share/tomcat*')
> > > ['/usr/share/tomcat7-admin', '/usr/share/tomcat7', '/usr/share/tomcat7-root']
