### PR TITLE
Fix auto-order problem in state.template

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -187,7 +187,10 @@ def high(data, queue=False, **kwargs):
 
 def template(tem, queue=False, **kwargs):
     '''
-    Execute the information stored in a template file on the minion
+    Execute the information stored in a template file on the minion.
+
+    This function does not ask a master for a SLS file to render but
+    instead directly processes the file at the provided path on the minion.
 
     CLI Example:
 
@@ -198,8 +201,14 @@ def template(tem, queue=False, **kwargs):
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
-    st_ = salt.state.State(__opts__)
-    ret = st_.call_template(tem)
+    st_ = salt.state.HighState(__opts__)
+    if not tem.endswith('.sls'):
+        tem = '{sls}.sls'.format(sls=tem)
+    high, errors = st_.render_state(tem, None, '', None, local=True)
+    if errors:
+        __context__['retcode'] = 1
+        return errors
+    ret = st_.state.call_high(high)
     _set_retcode(ret)
     return ret
 

--- a/salt/state.py
+++ b/salt/state.py
@@ -2340,14 +2340,22 @@ class BaseHighState(object):
             self.state.opts['pillar'] = self.state._gather_pillar()
         self.state.module_refresh()
 
-    def render_state(self, sls, saltenv, mods, matches):
+    def render_state(self, sls, saltenv, mods, matches, local=False):
         '''
         Render a state file and retrieve all of the include states
         '''
         err = ''
         errors = []
-        state_data = self.client.get_state(sls, saltenv)
-        fn_ = state_data.get('dest', False)
+        if not local:
+            state_data = self.client.get_state(sls, saltenv)
+            fn_ = state_data.get('dest', False)
+        else:
+            fn_ = sls
+            if not os.path.isfile(fn_):
+                errors.append(
+                    'Specified SLS {0} on local filesystem cannot '
+                    'be found.'.format(sls)
+                )
         if not fn_:
             errors.append(
                 'Specified SLS {0} in saltenv {1} is not '
@@ -2375,7 +2383,10 @@ class BaseHighState(object):
                 exc_info_on_loglevel=logging.DEBUG
             )
             errors.append('{0}\n{1}'.format(msg, traceback.format_exc()))
-        mods.add('{0}:{1}'.format(saltenv, sls))
+        try:
+            mods.add('{0}:{1}'.format(saltenv, sls))
+        except AttributeError:
+            pass
         if state:
             if not isinstance(state, dict):
                 errors.append(


### PR DESCRIPTION
Use the highstate renderer so we can add correct ordering and state metadata prior to processing.

Refs #13146
