### PR TITLE
states.dockerio: Show the error instead of the container name again.

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -734,7 +734,7 @@ def running(name, container=None, port_bindings=None, binds=None,
             else:
                 return _invalid(
                     comment=(
-                        'Container {0!r} cannot be started\n{0!s}'
+                        'Container {0!r} cannot be started\n{1!s}'
                         .format(
                             container,
                             started['out'],


### PR DESCRIPTION
Before this fix, the error output (see `comment`) would just look like this, as `started['out']` was never used in `.format()`.

``` YAML
    docker_|-mysqld_|-mysqld_|-running:
        ----------
        __run_num__:
            3
        changes:
            ----------
        comment:
            Container 'mysqld' cannot be started
            mysqld            
        name:

        result:
            False
```

Now it shows the actual error:

``` YAML
    docker_|-mysqld_|-mysqld_|-running:
        ----------
        __run_num__:
            3
        changes:
            ----------
        comment:
            Container 'mysqld' cannot be started
            Traceback (most recent call last):
              File "/usr/lib/python2.7/dist-packages/salt/modules/dockerio.py", line 915, in start
                network_mode=network_mode)
              File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 886, in start
                self._raise_for_status(res)
              File "/usr/local/lib/python2.7/dist-packages/docker/client.py", line 88, in _raise_for_status
                raise errors.APIError(e, response, explanation=explanation)
            APIError: 500 Server Error: Internal Server Error ("Cannot start container cc5ef4d926868d6910dbbfd91e49bead667b1a67f8fc013a94ed157cfa0d9398: Err
or getting container cc5ef4d926868d6910dbbfd91e49bead667b1a67f8fc013a94ed157cfa0d9398 from driver devicemapper: Error mounting '/dev/mapper/docker-252:0-212
33665-cc5ef4d926868d6910dbbfd91e49bead667b1a67f8fc013a94ed157cfa0d9398' on '/var/lib/docker/devicemapper/mnt/cc5ef4d926868d6910dbbfd91e49bead667b1a67f8fc013
a94ed157cfa0d9398': device or resource busy")

        name:

        result:
            False
```
- Should be cherry-picked into `2014.1`
- Should be merged into `develop`
