### PR TITLE
Allow pkg.install to install packages with an arch in the name

### DIFF
--- a/salt/modules/pkg_resource.py
+++ b/salt/modules/pkg_resource.py
@@ -70,6 +70,7 @@ def parse_targets(name=None,
                   pkgs=None,
                   sources=None,
                   saltenv='base',
+                  normalize=True,
                   **kwargs):
     '''
     Parses the input to pkg.install and returns back the package(s) to be
@@ -128,9 +129,12 @@ def parse_targets(name=None,
         return [x[2] for x in srcinfo], 'file'
 
     elif name:
-        _normalize_name = \
-            __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
-        packed = dict([(_normalize_name(x), None) for x in name.split(',')])
+        if normalize:
+            _normalize_name = \
+                __salt__.get('pkg.normalize_name', lambda pkgname: pkgname)
+            packed = dict([(_normalize_name(x), None) for x in name.split(',')])
+        else:
+            packed = dict([(x, None) for x in name.split(',')])
         return packed, 'repository'
 
     else:

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -495,6 +495,7 @@ def check_db(*names, **kwargs):
         salt '*' pkg.check_db <package1> <package2> <package3> fromrepo=epel-testing
         salt '*' pkg.check_db <package1> <package2> <package3> disableexcludes=main
     '''
+    normalize = kwargs.pop('normalize') if kwargs.get('normalize') else False
     repo_arg = _get_repo_options(**kwargs)
     exclude_arg = _get_excludes_option(**kwargs)
     repoquery_base = \
@@ -514,7 +515,10 @@ def check_db(*names, **kwargs):
                 name, arch = line.split('_|-')
             except ValueError:
                 continue
-            avail.append(normalize_name('.'.join((name, arch))))
+            if normalize:
+                avail.append(normalize_name('.'.join((name, arch))))
+            else:
+                avail.append('.'.join((name, arch)))
         __context__['pkg._avail'] = avail
 
     ret = {}
@@ -678,6 +682,7 @@ def install(name=None,
             pkgs=None,
             sources=None,
             reinstall=False,
+            normalize=True,
             **kwargs):
     '''
     Install the passed package(s), add refresh=True to clean the yum database
@@ -771,6 +776,20 @@ def install(name=None,
 
             salt '*' pkg.install sources='[{"foo": "salt://foo.rpm"}, {"bar": "salt://bar.rpm"}]'
 
+    normalize
+        Normalize the package name by removing the architecture.  Default is True.
+        This is useful for poorly created packages which might include the
+        architecture as an actual part of the name such as kernel modules
+        which match a specific kernel version.
+
+        .. versionadded:: 2014.7.0
+
+    Example:
+
+    .. code-block:: bash
+
+        salt -G role:nsd pkg.install gpfs.gplbin-2.6.32-279.31.1.el6.x86_64 normalize=False
+
 
     Returns a dict containing the new package names and versions::
 
@@ -783,7 +802,7 @@ def install(name=None,
 
     try:
         pkg_params, pkg_type = __salt__['pkg_resource.parse_targets'](
-            name, pkgs, sources, **kwargs
+            name, pkgs, sources, normalize=normalize, **kwargs
         )
     except MinionError as exc:
         raise CommandExecutionError(exc)


### PR DESCRIPTION
This is for (often) poorly created vendor packages such as kernel modules
where you can't easily re-spin a more correct rpm due to vendor support
issues.

Fixes #13924

Sorry this took so long gents, I've been i sick since last week (and even have taken 3 days off of work this week).

This PR supercedes #15343  
