### PR TITLE
Make s3fs work better.

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -64,6 +64,7 @@ structure::
 '''
 
 # Import python libs
+import datetime
 import os
 import hashlib
 import time
@@ -511,22 +512,64 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
     Checks the local cache for the file, if it's old or missing go grab the
     file from S3 and update the cache
     '''
+    key, keyid, service_url, verify_ssl = _get_s3_key()
 
     # check the local cache...
     if os.path.isfile(cached_file_path):
         file_meta = _find_file_meta(metadata, bucket_name, saltenv, path)
-        file_md5 = filter(str.isalnum, file_meta['ETag']) if file_meta else None
+        if file_meta:
+            file_etag = file_meta['ETag']
 
-        cached_file_hash = hashlib.md5()
-        with salt.utils.fopen(cached_file_path, 'rb') as fp_:
-            cached_file_hash.update(fp_.read())
+            if file_etag.find('-') == -1:
+                file_md5 = file_etag
+                cached_file_hash = hashlib.md5()
+                with salt.utils.fopen(cached_file_path, 'rb') as fp_:
+                    cached_file_hash.update(fp_.read())
 
-        # hashes match we have a cache hit
-        if cached_file_hash.hexdigest() == file_md5:
-            return
+                # hashes match we have a cache hit
+                if cached_file_hash.hexdigest() == file_md5:
+                    return
+            else:
+                cached_file_stat = os.stat(cached_file_path)
+                cached_file_size = cached_file_stat.st_size
+                cached_file_mtime = datetime.datetime.fromtimestamp(
+                    cached_file_stat.st_mtime)
+
+                cached_file_lastmod = datetime.datetime.strptime(
+                    file_meta['LastModified'], '%Y-%m-%dT%H:%M:%S.%fZ')
+                if (cached_file_size == int(file_meta['Size']) and
+                        cached_file_mtime > cached_file_lastmod):
+                    log.debug('cached file size equal to metadata size and '
+                              'cached file mtime later than metadata last '
+                              'modification time.')
+                    ret = s3.query(
+                        key=key,
+                        keyid=keyid,
+                        method='HEAD',
+                        bucket=bucket_name,
+                        service_url=service_url,
+                        verify_ssl=verify_ssl,
+                        path=urllib.quote(path),
+                        local_file=cached_file_path
+                    )
+                    for header in ret['headers']:
+                        name, value = header.split(':', 1)
+                        name = name.strip()
+                        value = value.strip()
+                        if name == 'Last-Modified':
+                            s3_file_mtime = datetime.datetime.strptime(
+                                value, '%a, %d %b %Y %H:%M:%S %Z')
+                        elif name == 'Content-Length':
+                            s3_file_size = int(value)
+                    if (cached_file_size == s3_file_size and
+                            cached_file_mtime > s3_file_mtime):
+                        log.info(
+                            '{0} - {1} : {2} skipped download since cached file size '
+                            'equal to and mtime after s3 values'.format(
+                                bucket_name, saltenv, path))
+                        return
 
     # ... or get the file from S3
-    key, keyid, service_url, verify_ssl = _get_s3_key()
     s3.query(
         key=key,
         keyid=keyid,


### PR DESCRIPTION
S3 uses https ETag headers. In some cases (non-multipart uploaded
files), the ETag header is the md5sum of the file. In other cases
(multipart uploaded files) the Etag does not correspond to anything
calculable locally. In that case, files used for the salt filesystem
backend would be downloaded every time the s3 cache timeout expires (a
static 30 seconds). Fortunately, non-md5sum ETags have a hyphen in them.
This patch applies the following logic to such files. If the cached
file is the same size in bytes and has a later last modification time,
it will be considered up to date and will not be downloaded. Otherwise,
it will be updated.

(cherry picked from commit 858e5f9c1d6fd41a8916e8127a2c92ce729ae9aa)
Signed-off-by: Warren Turkal wt@signalfuse.com

Conflicts:
    salt/fileserver/s3fs.py
