### PR TITLE
Tweak releasenotes for 2014.7.0

### DIFF
--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -219,7 +219,7 @@ New Salt-Cloud Providers
 
 - :mod:`Aliyun ECS Cloud <salt.cloud.clouds.aliyun>`
 - :mod:`LXC Containers <salt.cloud.clouds.lxc>`
-- :mod:`Proxmox KVM Containers <salt.cloud.clouds.proxmox>`
+- :mod:`Proxmox (OpenVZ containers & KVM) <salt.cloud.clouds.proxmox>`
 
 
 Deprecations


### PR DESCRIPTION
Just a minor tweak here since there is no such thing as "KVM containers" :-)
Proxmox does provide OpenVZ containers and KVM virtualization, so lets call it that instead.
