### PR TITLE
Review and merge #15720

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -453,9 +453,15 @@ class SSH(object):
             host = ret.keys()[0]
             self.cache_job(jid, host, ret[host])
             ret = self.key_deploy(host, ret)
+
+            opt=[]
+            try:
+                opt=self.opts.get('output', 'nested')
+            except AttributeError:
+                raise salt.exceptions.SaltClientError('Permission denied.')
             salt.output.display_output(
                     ret,
-                    self.opts.get('output', 'nested'),
+                    opt,
                     self.opts)
             if self.event:
                 self.event.fire_event(


### PR DESCRIPTION
Thanks for bringing this in @ror6ax, this is a delicate area of the code, here are the changes I am proposing:
If we raise an exception here it will prevent any other returns from being processed correctly, so I am floating the error up that we got from key_deploy to the cli. This should make it clear to the user what has happened without killing the other connections, which would just result in the commands being fired on remote hosts but not displaying the outcomes.

Thanks @ror6ax! Keep em' coming!
