### PR TITLE
modules.syslog_ng: avoid shadowing reload() built-in

### DIFF
--- a/salt/modules/syslog_ng.py
+++ b/salt/modules/syslog_ng.py
@@ -49,6 +49,11 @@ class SyslogNgError(Exception):
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 
+# Don't shadow built-in's.
+__func_alias__ = {
+    'reload_': 'reload'
+}
+
 _INDENT = ""
 _INDENT_STEP = "    "
 
@@ -1064,7 +1069,7 @@ def start(name=None,
     )
 
 
-def reload(name):
+def reload_(name):
     '''
     Reloads syslog-ng. This function is intended to be used from states.
 


### PR DESCRIPTION
```
************* Module salt.modules.syslog_ng
salt/modules/syslog_ng.py:1067: [W0622(redefined-builtin), reload] Redefining built-in 'reload'
```
