### PR TITLE
Add localconfig to highstate

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -15,6 +15,7 @@ import datetime
 import tempfile
 
 # Import salt libs
+import salt.config
 import salt.utils
 import salt.state
 import salt.payload
@@ -224,7 +225,10 @@ def template_str(tem, queue=False, **kwargs):
     return ret
 
 
-def highstate(test=None, queue=False, **kwargs):
+def highstate(test=None,
+              queue=False,
+              localconfig=None,
+              **kwargs):
     '''
     Retrieve the state data from the salt master for this minion and execute it
 
@@ -242,6 +246,11 @@ def highstate(test=None, queue=False, **kwargs):
 
         This option starts a new thread for each queued state run so use this
         option sparingly.
+    localconfig: ``None``
+        Instead of using running minion opts, load ``localconfig`` and merge that
+        with the running minion opts. This allows you to create "roots" of
+        salt directories (with their own minion config, pillars, file_roots) to
+        run highstate out of.
 
     CLI Example:
 
@@ -260,6 +269,9 @@ def highstate(test=None, queue=False, **kwargs):
         return conflict
     orig_test = __opts__.get('test', None)
     opts = copy.deepcopy(__opts__)
+
+    if localconfig:
+        opts = salt.config.minion_config(localconfig, defaults=opts)
 
     if test is None:
         if salt.utils.test_mode(test=test, **kwargs):


### PR DESCRIPTION
This allows you to run highstate from a "root"ed directory of salt on the minion, which can include its own pillars, file_roots, modules, etc
