### PR TITLE
Fixes to cron.py state

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -424,7 +424,10 @@ def file(name,
 
     cron_path = salt.utils.mkstemp()
     with salt.utils.fopen(cron_path, 'w+') as fp_:
-        fp_.write(__salt__['cron.raw_cron'](user))
+        raw_cron = __salt__['cron.raw_cron'](user)
+        if not raw_cron.endswith('\n'):
+            raw_cron = '{0}'.format(raw_cron)
+        fp_.write(raw_cron)
 
     ret = {'changes': {},
            'comment': '',


### PR DESCRIPTION
cron.raw_cron does not return the cron tab with a newline at the end while file.manage_file does, if there is not a newline already in the raw_cron output add it in. #15699 
