### PR TITLE
Fixes related to to sys.argspec.

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2057,12 +2057,11 @@ def argspec_report(functions, module=''):
     if module:
         # allow both "sys" and "sys." to match sys, without also matching
         # sysctl
-        comps = module.split('.')
-        comps = filter(None, comps)
-        if len(comps) < 2:
-            module = module + '.' if not module.endswith('.') else module
+        target_module = module + '.' if not module.endswith('.') else module
+    else:
+        target_module = ''
     for fun in functions:
-        if fun.startswith(module):
+        if fun == module or fun.startswith(target_module):
             try:
                 aspec = get_function_argspec(functions[fun])
             except TypeError:


### PR DESCRIPTION
Fixing #15774, argspec was showing additional functions based on the module that was passed.  eg. showing cmd.which and cmd.which_bin when the module cmd.which was passed.  This borrows functionality from the sys.doc function for handling this situation.
