### PR TITLE
Disable `test_issue_10404_ptys_not_released`

### DIFF
--- a/tests/unit/utils/vt_test.py
+++ b/tests/unit/utils/vt_test.py
@@ -47,6 +47,7 @@ class VTTestCase(TestCase):
         terminal.wait()
         terminal.close()
 
+    @skipIf(True, 'Disabled until we can find out why this kills the tests suite with an exit code of 134')
     def test_issue_10404_ptys_not_released(self):
         n_executions = 15
 


### PR DESCRIPTION
Disabled until we can find out why this kills the tests suite with an exit code of 134
