### PR TITLE
Adds a function to store/update dns serial numbers

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -26,7 +26,6 @@ Example output::
 # Import python libs
 from numbers import Number
 import re
-import sys
 
 # Import salt libs
 import salt.utils


### PR DESCRIPTION
The point is to avoid the need to manually update the serial number of a
zone file each time the zone file changes.

Example use:

``` yaml
/etc/bind/example.com.zone.include:
  file.managed:
    - source: salt://dns/example.com.zone.include
    - template: jinja
    - user: root
    - group: root
    - mode: 644
    - require:
      - pkg: bind9
    - watch_in:
      - service: bind9

/etc/bind/example.com.zone:
  module.wait:
    - name: dnsutils.serial
    - update: True
    - zone: examplecom
    - watch:
      - file: /etc/bind/example.com.zone.include
  file.managed:
    - source: salt://dns/example.com.zone
    - template: jinja
    - require:
      - module: /etc/bind/example.com.zone
```

The include file contains all the dynamically generated zone data, the
example.com zone files is mostly static and has a serial number like:

``` yaml
{{ salt['dnsutils.serial']('examplecom') }}      ; serial number YYMMDDNN
```
