### PR TITLE
Handle OSErrorin processmanager

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -177,12 +177,15 @@ class ProcessManager(object):
         signal.signal(signal.SIGTERM, self.kill_children)
 
         while True:
-            pid, exit_status = os.wait()
-            if pid not in self._process_map:
-                log.debug(('Process of pid {0} died, not a known'
-                           ' process, will not restart').format(pid))
-                continue
-            self.restart_process(pid)
+            try:
+                pid, exit_status = os.wait()
+                if pid not in self._process_map:
+                    log.debug(('Process of pid {0} died, not a known'
+                               ' process, will not restart').format(pid))
+                    continue
+                self.restart_process(pid)
+            except OSError:
+                pass
 
             # in case someone died while we were waiting...
             self.check_children()

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -185,7 +185,7 @@ class ProcessManager(object):
                     continue
                 self.restart_process(pid)
             except OSError:
-                pass
+                break
 
             # in case someone died while we were waiting...
             self.check_children()

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -205,4 +205,8 @@ class ProcessManager(object):
         for pid, p_map in self._process_map.items():
             p_map['Process'].terminate()
             p_map['Process'].join()
-            del self._process_map[pid]
+            # This is a race condition if a signal was passed to all children
+            try:
+                del self._process_map[pid]
+            except KeyError:
+                pass

--- a/tests/integration/shell/arguments.py
+++ b/tests/integration/shell/arguments.py
@@ -18,7 +18,7 @@ class ArgumentTestCase(integration.ModuleCase):
         '''
         Test passing a non-supported keyword argument. The relevant code that
         checks for invalid kwargs is located in salt/minion.py, within the
-        'parse_args_and_kwargs' function.
+        'load_args_and_kwargs' function.
         '''
         self.assertIn(
             ("ERROR executing 'test.ping': The following keyword arguments"),


### PR DESCRIPTION
, you will get this because the signal handler interrupts the systemcall to avoid traces like:

```
Traceback (most recent call last):
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 232, in _bootstrap
    self.run()
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 88, in run
    self._target(*self._args, **self._kwargs)
  File "/home/thjackso/src/salt/salt/master.py", line 308, in run_reqserver
    reqserv.run()
  File "/home/thjackso/src/salt/salt/master.py", line 506, in run
    self.__bind()
  File "/home/thjackso/src/salt/salt/master.py", line 500, in __bind
    self.process_manager.run()
  File "/home/thjackso/src/salt/salt/utils/process.py", line 180, in run
    pid, exit_status = os.wait()
OSError: [Errno 4] Interrupted system call
```
