### PR TITLE
Fix test failures on develop

### DIFF
--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -340,7 +340,7 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             )
             stat2 = os.stat(output_file)
             self.assertEqual(stat1.st_mode, stat2.st_mode)
-            self.assertEqual(stat1.st_ctime, stat2.st_ctime)
+            # self.assertEqual(stat1.st_ctime, stat2.st_ctime)
         finally:
             if os.path.exists(output_file):
                 os.unlink(output_file)


### PR DESCRIPTION
The changes in #15098 introduced an issue addressed in #15826, which then caused a test failure with `integration.shell.call.CallTest.test_issue_14979_output_file_permissions` on the develop branch.

@thatch45 said to comment out that test line for now. @s0undt3ch the test was your code - can you take a look at how to properly address this issue?
