### PR TITLE
Re-inject opts into modules under multi-master mode.

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -465,6 +465,7 @@ class MultiMinion(MinionBase):
         for master in set(self.opts['master']):
             s_opts = copy.copy(self.opts)
             s_opts['master'] = master
+            s_opts['multimaster'] = True
             try:
                 minions.append(Minion(s_opts, 5, False))
             except SaltClientError as exc:
@@ -960,6 +961,10 @@ class Minion(MinionBase):
         # python needs to be able to reconstruct the reference on the other
         # side.
         instance = self
+        # If we are running in multi-master mode, re-inject opts into module funcs
+        if instance.opts.get('multimaster', False):
+            for func in instance.functions:
+                sys.modules[instance.functions[func].__module__].__opts__ = self.opts
         if self.opts['multiprocessing']:
             if sys.platform.startswith('win'):
                 # let python reconstruct the minion on the other side if we're


### PR DESCRIPTION
I discovered a problem wherein opts were not correctly being set in `__opts__` in loaded modules when running under multi-master mode. Effectively, modules would use the `__opts__` dictionary last encountered during minion initialization. This creates subtle bugs, but most noticeable a case wherein a state run would send pubs and receive returns through one master but perform file transfers through another master!

This fix ensures that loaded modules will contain the correct copy of `__opts__` when running in multi-master mode. It also adds a new options flag called `multimaster` which is set to True when multiple masters are detected on start up.

I'm not sure if this particular bug affects any open issues, but it could potentially have an effect on issues such as #13944.
