### PR TITLE
salt.output.nested: rm unused import of sys module

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -26,7 +26,6 @@ Example output::
 # Import python libs
 from numbers import Number
 import re
-import sys
 
 # Import salt libs
 import salt.utils


### PR DESCRIPTION
```
************* Module salt.output.nested
salt/output/nested.py:29: [W0611(unused-import), ] Unused import sys
```
