### PR TITLE
Fix salt-ssh return value handling

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -459,7 +459,7 @@ class SSH(object):
             ret = self.key_deploy(host, ret)
             if not isinstance(ret[host], dict):
                 p_data = {host: ret[host]}
-            if 'return' not in ret[host]:
+            elif 'return' not in ret[host]:
                 p_data = ret
             else:
                 outputter = ret[host].get('out', self.opts.get('output', 'nested'))


### PR DESCRIPTION
Without this trivial fix, the statement on line 465 fails due to `ret[host]` not being a dictionary when the operation result `ret[host]` is a string called `"Failed to return clean data"`. Note that since the string contains a `return` substring, the `'return' not in ret[host]` check is not triggered.
