### PR TITLE
Unbreak salt-ssh highstate TypeError

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -195,7 +195,7 @@ def highstate(test=None, **kwargs):
     single = salt.client.ssh.Single(
             __opts__,
             cmd,
-            **kwargs)
+            **__salt__.kwargs)
     single.shell.send(
             trans_tar,
             '{0}/salt_state.tgz'.format(__opts__['_thin_dir']))


### PR DESCRIPTION
I believe that the fix from #15550 (fixes #12810) should be reverted -- commit 1a90b5f actually breaks `salt-ssh` as now the `kwargs` do not contain the necessary fields which results in a `TypeError`:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/multiprocessing/process.py", line 258, in _bootstrap
    self.run()
  File "/usr/lib/python2.7/multiprocessing/process.py", line 114, in run
    self._target(*self._args, **self._kwargs)
  File "/home/kostko/development/virtualenvs/salt/local/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 328, in handle_routine
    stdout, stderr, retcode = single.run()
  File "/home/kostko/development/virtualenvs/salt/local/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 609, in run
    stdout = self.run_wfunc()
  File "/home/kostko/development/virtualenvs/salt/local/lib/python2.7/site-packages/salt/client/ssh/__init__.py", line 703, in run_wfunc
    result = self.wfuncs[self.fun](*self.args, **self.kwargs)
  File "/home/kostko/development/virtualenvs/salt/local/lib/python2.7/site-packages/salt/client/ssh/wrapper/state.py", line 199, in highstate
    **kwargs)
TypeError: __init__() takes at least 5 arguments (3 given)
```

Reverting this commit (using `__salt__.kwargs` instead of `kwargs`) fixes the issue for me. From #12810 it looks like there are some cases when `__salt__.kwargs` is not available, so perhaps the code should be changed so that `kwargs` is only used when `__salt__.kwargs` is not available or it can be done so that `kwargs` override `__salt__.kwargs`. I am not sure which is the correct way as I am at the moment not that familiar with Salt internal semantics.
