### PR TITLE
Fix delimiter on _check_compound_minions

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -303,7 +303,7 @@ class CkMinions(object):
                     minions.remove(id_)
         return list(minions)
 
-    def _check_compound_minions(self, expr):
+    def _check_compound_minions(self, expr, delimiter):
         '''
         Return the minions found by looking via compound matcher
         '''
@@ -328,15 +328,20 @@ class CkMinions(object):
                 if '@' in match and match[1] == '@':
                     comps = match.split('@')
                     matcher = ref.get(comps[0])
+
+                    matcher_args = ['@'.join(comps[1:])]
+                    if comps[0] in ('G', 'P', 'I'):
+                        matcher_args.append(delimiter)
+
                     if not matcher:
                         # If an unknown matcher is called at any time, fail out
                         return []
                     if unmatched and unmatched[-1] == '-':
-                        results.append(str(set(matcher('@'.join(comps[1:])))))
+                        results.append(str(set(matcher(*matcher_args))))
                         results.append(')')
                         unmatched.pop()
                     else:
-                        results.append(str(set(matcher('@'.join(comps[1:])))))
+                        results.append(str(set(matcher(*matcher_args))))
                 elif match in opers:
                     # We didn't match a target, so append a boolean operator or
                     # subexpression
@@ -457,7 +462,7 @@ class CkMinions(object):
         try:
             check_func = getattr(self, '_check_{0}_minions'.format(expr_form),
                                  None)
-            if expr_form in ('grain', 'grain_pcre', 'pillar'):
+            if expr_form in ('grain', 'grain_pcre', 'pillar', 'compound'):
                 minions = check_func(expr, delimiter)
             else:
                 minions = check_func(expr)


### PR DESCRIPTION
Refs commits from #13716

Using compound matchers doesn't work since the addition of the custom delimiter with 9695c6e212d9873da33e7afa81a54fba3460f74e

Hopefully I'll have a setup of the test suite working with Docker, in order to add the compound matchers unit test.
Meanwhile, it can be tested with

```
[vagrant@salt ~]$ sudo salt -C 'G@foo:bar' test.ping
No minions matched the target. No command was sent, no jid was assigned.

[vagrant@salt ~]$ sudo tail /var/log/salt/master
  File "/usr/lib/python2.6/site-packages/salt/utils/minions.py", line 339, in _check_compound_minions
    results.append(str(set(matcher('@'.join(comps[1:])))))
TypeError: _check_grain_minions() takes exactly 3 arguments (2 given)
2014-09-18 02:49:38,032 [salt.utils.minions                         ][ERROR   ] Failed matching available minions with compound pattern: G@foo:bar
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/utils/minions.py", line 463, in check_minions
    minions = check_func(expr)
  File "/usr/lib/python2.6/site-packages/salt/utils/minions.py", line 339, in _check_compound_minions
    results.append(str(set(matcher('@'.join(comps[1:])))))
TypeError: _check_grain_minions() takes exactly 3 arguments (2 given)
```
