### PR TITLE
Improved fix for the newline at the end of crontabs

### DIFF
--- a/salt/states/cron.py
+++ b/salt/states/cron.py
@@ -426,7 +426,7 @@ def file(name,
     with salt.utils.fopen(cron_path, 'w+') as fp_:
         raw_cron = __salt__['cron.raw_cron'](user)
         if not raw_cron.endswith('\n'):
-            raw_cron = '{0}'.format(raw_cron)
+            raw_cron = "{0}\n".format(raw_cron)
         fp_.write(raw_cron)
 
     ret = {'changes': {},


### PR DESCRIPTION
Fixes issue #15699 and improves PR #15771 

To be merged into develop and 2014.7
