### PR TITLE
Fix file.directory in test mode to show all the changes instead of just one

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -463,8 +463,8 @@ def _check_directory(name,
     if changes:
         comments = ['The following files will be changed:\n']
         for fn_ in changes:
-            key, val = changes[fn_].keys()[0], changes[fn_].values()[0]
-            comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))
+            for key, val in changes[fn_].items():
+                comments.append('{0}: {1} - {2}\n'.format(fn_, key, val))
         return None, ''.join(comments)
     return True, 'The directory {0} is in the correct state'.format(name)
 


### PR DESCRIPTION
Fix file.directory in test mode to show all the changes (user, group and/or mode) instead of just one
