### PR TITLE
Rename key_no_rotate to rotate_aes_key

### DIFF
--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -668,6 +668,23 @@ signature. The :conf_master:`master_pubkey_signature` must also be set for this.
     master_use_pubkey_signature: True
 
 
+.. conf_master:: rotate_aes_key
+
+``rotate_aes_key``
+------------------
+
+Default: ``True``
+
+Rotate the salt-masters AES-key when a minion-public is deleted with salt-key.
+This is a very important security-setting. Disabling it will enable deleted
+minions to still listen in on the messages published by the salt-master.
+Do not disable this unless it is absolutely clear what this does.
+
+.. code-block:: yaml
+
+    rotate_aes_key: True
+
+
 Master Module Management
 ========================
 

--- a/salt/config.py
+++ b/salt/config.py
@@ -252,6 +252,7 @@ VALID_OPTS = {
     'password': str,
     'zmq_filtering': bool,
     'con_cache': bool,
+    'rotate_aes_key': bool,
 }
 
 # default configurations
@@ -539,6 +540,7 @@ DEFAULT_MASTER_OPTS = {
     'master_use_pubkey_signature': False,
     'zmq_filtering': False,
     'con_cache': False,
+    'rotate_aes_key': True,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/key.py
+++ b/salt/key.py
@@ -690,7 +690,7 @@ class Key(object):
                 except (OSError, IOError):
                     pass
         self.check_minion_cache()
-        if self.opts.get('key_no_rotate'):
+        if self.opts.get('rotate_aes_key'):
             salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return (
             self.name_match(match) if match is not None
@@ -712,7 +712,7 @@ class Key(object):
                 except (OSError, IOError):
                     pass
         self.check_minion_cache()
-        if self.opts.get('key_no_rotate'):
+        if self.opts.get('rotate_aes_key'):
             salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
 
@@ -750,7 +750,7 @@ class Key(object):
                 except (IOError, OSError):
                     pass
         self.check_minion_cache()
-        if self.opts.get('key_no_rotate'):
+        if self.opts.get('rotate_aes_key'):
             salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return (
             self.name_match(match) if match is not None
@@ -781,7 +781,7 @@ class Key(object):
             except (IOError, OSError):
                 pass
         self.check_minion_cache()
-        if self.opts.get('key_no_rotate'):
+        if self.opts.get('rotate_aes_key'):
             salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
 

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1825,12 +1825,12 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         )
 
         self.add_option(
-            '--no-key-rotate',
-            default=False,
-            action='store_true',
-            help=('This option prevents the master from refreshing the key '
-                  'session when keys are deleted or rejected, this lowers '
-                  'the security of the key deletion/rejection operation.')
+            '--rotate-aes-key',
+            default=True,
+            help=('Setting this to False prevents the master from refreshing '
+                  'the key session when keys are deleted or rejected, this '
+                  'lowers the security of the key deletion/rejection operation. '
+                  'Default is True.')
         )
 
         key_options_group = optparse.OptionGroup(


### PR DESCRIPTION
A few additions and fixes for the key_no_rotate option.

Renames the option to 'rotate_aes_key'. Boolean-options should not have 
'true/false' or 'yes/no' in their name. It gets really confusing.

Currently 

``` yaml
'key_no_rotate': True
```

actually rotates they key when deleting a minion-key.

Renaming it also adds clarity on what key exactly is being rotated.

Also adds documentation to master configuration reference that was missing.
