### PR TITLE
Added support for capabilities in docker state

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -25,12 +25,12 @@ Installation Prerequisites
   path that is running salt. Its version should support `Docker Remote API
   v1.12 <http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.12>`_.
 
-  Currently, ``docker-py 0.3.2`` is known to support `Docker Remote API v1.12
+  Currently, ``docker-py 0.5.0`` is known to support `Docker Remote API v1.12
   <http://docs.docker.io/en/latest/reference/api/docker_remote_api_v1.12>`_
 
   .. code-block:: bash
 
-      pip install docker-py==0.3.2
+      pip install docker-py==0.5.0
 
 Prerequisite Pillar Configuration for Authentication
 ----------------------------------------------------
@@ -833,7 +833,9 @@ def start(container,
           privileged=False,
           dns=None,
           volumes_from=None,
-          network_mode=None):
+          network_mode=None,
+          cap_add=None,
+          cap_drop=None):
     '''
     Start the specified container
 
@@ -877,7 +879,9 @@ def start(container,
                          privileged=privileged,
                          dns=dns,
                          volumes_from=volumes_from,
-                         network_mode=network_mode)
+                         network_mode=network_mode,
+                         cap_add=cap_add,
+                         cap_drop=cap_drop)
 
             if is_running(dcontainer):
                 _valid(status,

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -712,7 +712,8 @@ def script(*args, **kw):
 def running(name, container=None, port_bindings=None, binds=None,
             publish_all_ports=False, links=None, lxc_conf=None,
             privileged=False, dns=None, volumes_from=None,
-            network_mode=None, check_is_running=True):
+            network_mode=None, cap_add=None, cap_drop=None,
+            check_is_running=True):
     '''
     Ensure that a container is running. (`docker inspect`)
 
@@ -792,6 +793,12 @@ def running(name, container=None, port_bindings=None, binds=None,
 
             - network_mode: host
 
+    cap_add
+        List of capabilities to add in a container.
+
+    cap_drop
+        List of capabilities to drop in a container.
+
     check_is_running
         Enable checking if a container should run or not.
         Useful for data-only containers that must be linked to another one.
@@ -809,6 +816,7 @@ def running(name, container=None, port_bindings=None, binds=None,
             lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
             links=links, privileged=privileged,
             dns=dns, volumes_from=volumes_from, network_mode=network_mode,
+            cap_add=cap_add, cap_drop=cap_drop
         )
         if check_is_running:
             is_running = __salt__['docker.is_running'](container)


### PR DESCRIPTION
This pull request adds support for specifying `cap_add` and `cap_drop` in `docker.running` state as supported by latest Docker and docker-py.
