### PR TITLE
Match case for argument documentation

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -321,7 +321,7 @@ def delval(key, destructive=False):
 
     Delete a grain from the grains config file
 
-    :param Destructive: Delete the key, too. Defaults to False.
+    :param destructive: Delete the key, too. Defaults to False.
 
     CLI Example:
 


### PR DESCRIPTION
It's `destructive`, not `Destructive`
