### PR TITLE
Make the error on passwords float up to the key_deploy catch

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -320,7 +320,7 @@ class Shell(object):
                         term.close(terminate=True, kill=True)
                     except salt.utils.vt.TerminalException:
                         pass
-                    return '', 'No authentication information available', 254
+                    return '', 'Permission denied, no authentication information', 254
                 if sent_passwd < passwd_retries:
                     term.sendline(self.passwd)
                     sent_passwd += 1


### PR DESCRIPTION
This fixes a number of issues, including the password prompt being clobbered #10613

Or rather this finishes fixing them
