### PR TITLE
Also return the requisites from check_requisite; add mod_watch support to states.test

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1855,6 +1855,7 @@ class State(object):
                 low = low.copy()
                 low['sfun'] = low['fun']
                 low['fun'] = 'mod_watch'
+                low['__reqs__'] = reqs
                 ret = self.call(low, chunks, running)
             running[tag] = ret
         elif status == 'pre':

--- a/salt/states/test.py
+++ b/salt/states/test.py
@@ -36,6 +36,7 @@ Provide test case states that enable easy testing of things to do with
 # Import Python libs
 import logging
 import random
+from salt.state import _gen_tag
 from salt.exceptions import SaltInvocationError
 
 log = logging.getLogger(__name__)
@@ -223,4 +224,50 @@ def configurable_test_state(name, changes=True, result=True, comment=''):
         ret['result'] = None
         ret['comment'] = 'This is a test'
 
+    return ret
+
+
+def mod_watch(name, sfun=None, **kwargs):
+    ''''
+    Call this function via a watch statement
+
+    .. versionadded:: 2014.7.0
+
+    Any parameters in the state return dictionary can be customized by adding
+    the keywords ``result``, ``comment``, and ``changes``.
+
+    .. code-block:: yaml
+
+        this_state_will_return_changes:
+          test.succeed_with_changes
+
+        this_state_will_NOT_return_changes:
+          test.succeed_without_changes
+
+        this_state_is_watching_another_state:
+          test.succeed_without_changes:
+            - comment: 'This is a custom comment'
+            - watch:
+              - test: this_state_will_return_changes
+              - test: this_state_will_NOT_return_changes
+
+        this_state_is_also_watching_another_state:
+          test.succeed_without_changes:
+            - watch:
+              - test: this_state_will_NOT_return_changes
+    '''
+    has_changes = []
+    for req in __low__['__reqs__']['watch']:
+        tag = _gen_tag(req)
+        if __running__[tag]['changes']:
+            has_changes.append('{state}: {__id__}'.format(**req))
+
+    ret = {
+        'name': name,
+        'result': kwargs.get('result', True),
+        'comment': kwargs.get('comment', 'Watch statement fired.'),
+        'changes': kwargs.get('changes', {
+            'Requisites with changes': has_changes,
+        }),
+    }
     return ret


### PR DESCRIPTION
I'd like to be able to get at the actual returns for watched states from a `mod_watch` function but we don't have enough detail in `__low__` to look them up in `__running__` (i.e. not enough data to call `_gen_tag()`; at least not without repeating the `check_requisite()` work to get the full tag). Since we're already doing that work, how about we pass it through instead? The `reqs` dictionary that `check_requisite()` generates is crazy cool, I can see this being useful in other places as well.

@thatch45 thoughts?
