### PR TITLE
Update formatting for manage.bootstrap runner

### DIFF
--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -293,19 +293,22 @@ def versions():
     return ret
 
 
-def bootstrap(version="develop",
+def bootstrap(version='develop',
               script=None,
-              hosts="",
+              hosts='',
               root_user=True):
     '''
     Bootstrap minions with salt-bootstrap
 
     version : develop
         Git tag of version to install
+
     script : https://bootstrap.saltstack.com
         Script to execute
+
     hosts
-        Comma separated hosts [example: hosts="host1.local,host2.local"]
+        Comma-separated hosts [example: hosts='host1.local,host2.local']
+
     root_user : True
         Prepend ``root@`` to each host.
 
@@ -313,24 +316,25 @@ def bootstrap(version="develop",
 
     .. code-block:: bash
 
-        salt-run manage.bootstrap hosts="host1,host2"
-        salt-run manage.bootstrap hosts="host1,host2" version="v0.17"
-        salt-run manage.bootstrap hosts="host1,host2" version="v0.17" script="https://bootstrap.saltstack.com/develop"
-        salt-run manage.bootstrap hosts="ec2-user@host1,ec2-user@host2" root_user=False
+        salt-run manage.bootstrap hosts='host1,host2'
+        salt-run manage.bootstrap hosts='host1,host2' version='v0.17'
+        salt-run manage.bootstrap hosts='host1,host2' version='v0.17' script='https://bootstrap.saltstack.com/develop'
+        salt-run manage.bootstrap hosts='ec2-user@host1,ec2-user@host2' root_user=False
 
     '''
     if script is None:
         script = 'https://bootstrap.saltstack.com'
-    for host in hosts.split(","):
+
+    for host in hosts.split(','):
         # Could potentially lean on salt-ssh utils to make
-        # deployment easier on existing hosts (i.e. use sshpass,
-        # or expect, pass better options to ssh etc)
-        subprocess.call(["ssh",
-                        "root@" if root_user else "" + host,
-                        "python -c 'import urllib; "
-                        "print urllib.urlopen("
-                        "\"" + script + "\""
-                        ").read()' | sh -s -- git " + version])
+        # deployment easier on existing hosts (i.e. use salt.utils.vt,
+        # pass better options to ssh, etc)
+        subprocess.call(['ssh',
+                        'root@' if root_user else '' + host,
+                        'python -c 'import urllib; '
+                        'print urllib.urlopen('
+                        '\'' + script + '\''
+                        ').read()' | sh -s -- git ' + version])
 
 
 def bootstrap_psexec(hosts='', master=None, version=None, arch='win32',


### PR DESCRIPTION
The biggest thing was double-quotes, which we avoid in Salt.
