### PR TITLE
Fixes related to disabling state functionality

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -617,34 +617,6 @@ def show_lowstate(queue=False, **kwargs):
     return ret
 
 
-def show_state(mods, saltenv='base', queue=False, **kwargs):
-    '''
-    List out the low data that will be applied to this minion
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt '*' state.show_lowstate
-    '''
-    conflict = _check_queue(queue, kwargs)
-    if conflict is not None:
-        assert False
-        return conflict
-    st_ = salt.state.HighState(__opts__)
-    st_.push_active()
-
-    if isinstance(mods, string_types):
-        mods = mods.split(',')
-
-    try:
-        high_, errors = st_.render_highstate({saltenv: mods})
-        ret = st_.state.compile_high_data(high_)
-    finally:
-        st_.pop_active()
-    return ret
-
-
 def sls_id(
         id_,
         mods,

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -1074,13 +1074,27 @@ def _disabled(funs):
     _disabled = __salt__['grains.get']('state_runs_disabled')
     for state in funs:
         for _state in _disabled:
-            if _state == state:
-                err = (
-                    'The state or state function "{0}" is currently disabled, '
-                    'to re-enable, run state.enable {0}.'
-                ).format(
-                    _state,
-                )
-                ret.append(err)
-                continue
+            if '.*' in _state:
+                target_state = _state.split('.')[0]
+                target_state = target_state + '.' if not target_state.endswith('.') else target_state
+                if state.startswith(target_state):
+                    err = (
+                        'The state file "{0}" is currently disabled by "{1}", '
+                        'to re-enable, run state.enable {1}.'
+                    ).format(
+                        state,
+                        _state,
+                    )
+                    ret.append(err)
+                    continue
+            else:
+                if _state == state:
+                    err = (
+                        'The state file "{0}" is currently disabled, '
+                        'to re-enable, run state.enable {0}.'
+                    ).format(
+                        _state,
+                    )
+                    ret.append(err)
+                    continue
     return ret

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -636,6 +636,34 @@ def show_lowstate(queue=False, **kwargs):
     return ret
 
 
+def show_state(mods, saltenv='base', queue=False, **kwargs):
+    '''
+    List out the low data that will be applied to this minion
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' state.show_lowstate
+    '''
+    conflict = _check_queue(queue, kwargs)
+    if conflict is not None:
+        assert False
+        return conflict
+    st_ = salt.state.HighState(__opts__)
+    st_.push_active()
+
+    if isinstance(mods, string_types):
+        mods = mods.split(',')
+
+    try:
+        high_, errors = st_.render_highstate({saltenv: mods})
+        ret = st_.state.compile_high_data(high_)
+    finally:
+        st_.pop_active()
+    return ret
+
+
 def sls_id(
         id_,
         mods,

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -290,6 +290,16 @@ def highstate(test=None,
         }
         return ret
 
+    low_data_ = show_lowstate()
+    lows_ = []
+    for item in low_data_:
+        lows_.append('{0}.{1}'.format(item['state'], item['fun']))
+
+    disabled = _disabled(lows_)
+    if disabled:
+        __context__['retcode'] = 1
+        return disabled
+
     conflict = _check_queue(queue, kwargs)
     if conflict is not None:
         return conflict
@@ -461,12 +471,12 @@ def sls(mods,
     st_.push_active()
     try:
         high_, errors = st_.render_highstate({saltenv: mods})
-        lowstate_ = show_lowstate()
-        lows_ = []
-        for item in lowstate_:
-            lows_.append('{0}.{1}'.format(item['state'], item['fun']))
+        high_data_ = st_.state.compile_high_data(high_)
+        highs_ = []
+        for item in high_data_:
+            highs_.append('{0}.{1}'.format(item['state'], item['fun']))
 
-        disabled = _disabled(lows_)
+        disabled = _disabled(highs_)
         if disabled:
             __context__['retcode'] = 1
             return disabled

--- a/salt/state.py
+++ b/salt/state.py
@@ -1958,7 +1958,6 @@ class State(object):
         disabled = {}
         if 'state_runs_disabled' in self.opts['grains']:
             _chunks = copy.deepcopy(chunks)
-            __run_num = 0
             for low in _chunks:
                 state_ = '{0}.{1}'.format(low['state'], low['fun'])
                 for pat in self.opts['grains']['state_runs_disabled']:
@@ -1974,18 +1973,17 @@ class State(object):
                         disabled[_tag] = {'changes': {},
                                           'result': False,
                                           'comment': comment,
-                                          '__run_num__': __run_num,
+                                          '__run_num__': self.__run_num,
                                           '__sls__': low['__sls__']}
-                        __run_num += 1
+                        self.__run_num += 1
+                        chunks.remove(low)
                         break
-            if disabled:
-                return disabled
 
         # If there are extensions in the highstate, process them and update
         # the low data chunks
         if errors:
             return errors
-        ret = self.call_chunks(chunks)
+        ret = dict(disabled.items() + self.call_chunks(chunks).items())
         ret = self.call_listen(chunks, ret)
         return ret
 


### PR DESCRIPTION
Found an issue in the sls function when disabling states.  Originally Ihad used the show_lowstate to get what would be applied to the minion, to check for disabled states.  Turns out this shows what would be applied during a high state and not from an SLS file.  Switching to using st_.state.compile_high_data inside the SLS and moving the show_lowstate call into the highstate function where it's correct.
