### PR TITLE
Set changes in return dict

### DIFF
--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -176,7 +176,7 @@ def install(name, clean=True):
         # Assume that the installation was a recompile with new options, and
         # set return dict so that changes are detected by the ports.installed
         # state.
-        ret = {name: {'old': old.get(name, '')
+        ret = {name: {'old': old.get(name, ''),
                       'new': new.get(name, '')}}
     return ret
 

--- a/salt/modules/freebsdports.py
+++ b/salt/modules/freebsdports.py
@@ -170,7 +170,15 @@ def install(name, clean=True):
         __context__['ports.install_error'] = result['stderr']
     __context__.pop('pkg.list_pkgs', None)
     new = __salt__['pkg.list_pkgs']()
-    return salt.utils.compare_dicts(old, new)
+    ret = salt.utils.compare_dicts(old, new)
+    if not ret and result['retcode'] == 0:
+        # No change in package list, but the make install was successful.
+        # Assume that the installation was a recompile with new options, and
+        # set return dict so that changes are detected by the ports.installed
+        # state.
+        ret = {name: {'old': old.get(name, '')
+                      'new': new.get(name, '')}}
+    return ret
 
 
 def deinstall(name):


### PR DESCRIPTION
This resolves a case in which an installed package is rebuilt but the version
does not change. Since the package db doesn't appear to have changed, the
ports.install function returns an empty dict, leading the ports.installed
state to believe there are no changes, thus setting the color of the highstate
output to green instead of cyan.

This changes the behavior of the ports.install function so that it sets the
return dict when the `make install` command succeeds, in cases where no changes
to the pkgdb are detected.

Fixes #9962.
