### PR TITLE
Adds minions_denied directory to test-env

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1723,6 +1723,7 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'unaccepted/unsigned keys. '
                   '"acc" or "accepted" will list accepted/signed keys. '
                   '"rej" or "rejected" will list rejected keys. '
+                  '"den" or "denied" will list denied keys. '
                   'Finally, "all" will list all keys.')
         )
 
@@ -1929,7 +1930,7 @@ class SaltKeyOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         # Filter accepted list arguments as soon as possible
         if not self.options.list:
             return
-        if not self.options.list.startswith(('acc', 'pre', 'un', 'rej', 'all')):
+        if not self.options.list.startswith(('acc', 'pre', 'un', 'rej', 'den', 'all')):
             self.error(
                 '{0!r} is not a valid argument to \'--list\''.format(
                     self.options.list

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -547,6 +547,7 @@ class TestDaemon(object):
         verify_env([os.path.join(master_opts['pki_dir'], 'minions'),
                     os.path.join(master_opts['pki_dir'], 'minions_pre'),
                     os.path.join(master_opts['pki_dir'], 'minions_rejected'),
+                    os.path.join(master_opts['pki_dir'], 'minions_denied'),
                     os.path.join(master_opts['cachedir'], 'jobs'),
                     os.path.join(master_opts['cachedir'], 'raet'),
                     os.path.join(syndic_master_opts['pki_dir'], 'minions'),

--- a/tests/integration/wheel/key.py
+++ b/tests/integration/wheel/key.py
@@ -24,6 +24,7 @@ class KeyWheelModuleTest(integration.ClientCase):
             ],
             'minions_rejected': [],
             'minions_pre': [],
+            'minions_denied': [],
             'minions': ['minion', 'sub_minion'],
         })
 


### PR DESCRIPTION
The master-pki directory in the test-environment is missing 'minions_denied'.

This also updates 'tests/integration/wheel/key.py' to additionaly expect 'minions_denied'.

This is a required change for PR #15933 to pass the tests.
