### PR TITLE
Quote role name in postgres_user alter role

### DIFF
--- a/salt/modules/postgres.py
+++ b/salt/modules/postgres.py
@@ -707,7 +707,7 @@ def _role_cmd_args(name,
         sub_cmd = sub_cmd.replace(' WITH', '')
     if groups:
         for group in groups.split(','):
-            sub_cmd = '{0}; GRANT {1} TO {2}'.format(sub_cmd, group, name)
+            sub_cmd = '{0}; GRANT "{1}" TO "{2}"'.format(sub_cmd, group, name)
     return sub_cmd
 
 
@@ -851,7 +851,7 @@ def _role_update(name,
         log.info('{0} {1!r} could not be found'.format(typ_.capitalize(), name))
         return False
 
-    sub_cmd = 'ALTER ROLE {0} WITH'.format(name)
+    sub_cmd = 'ALTER ROLE "{0}" WITH'.format(name)
     sub_cmd = '{0} {1}'.format(sub_cmd, _role_cmd_args(
         name,
         encrypted=encrypted,


### PR DESCRIPTION
If you had a user www-data then this state would fail. The create works fine, 

Something like the below should illustrate this. I first found it by creating a user without a password and then setting a password on a subsequent run

``` yaml
# Create the user, this will work
postgresql_user_create:
  postgres_user.present:
    - name: www-data
    - password: old_password

# Change the password, this will fail
postgresql_user_change_password:
  postgres_user.present:
    - name: www-data
    - password: new_password
    - require:
      - postgres_user: postgresql_user_create

```
