### PR TITLE
Fix broken test on 2014.7

### DIFF
--- a/tests/integration/shell/call.py
+++ b/tests/integration/shell/call.py
@@ -297,7 +297,7 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
 
             self.run_script(
                 'salt-call',
-                '-c {0} --output-file={1} --output-file-append -g'.format(
+                '-c {0} --output-file={1} -g'.format(
                     self.get_config_dir(),
                     output_file
                 ),
@@ -306,27 +306,7 @@ class CallTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             )
             stat2 = os.stat(output_file)
             self.assertEqual(stat1.st_mode, stat2.st_mode)
-            # Data was appeneded to file
-            self.assertTrue(stat1.st_size < stat2.st_size)
-
-            # Let's remove the output file
-            os.unlink(output_file)
-
-            # Not appending data
-            self.run_script(
-                'salt-call',
-                '-c {0} --output-file={1} -g'.format(
-                    self.get_config_dir(),
-                    output_file
-                ),
-                catch_stderr=True,
-                with_retcode=True
-            )
-            stat3 = os.stat(output_file)
-            # Mode must have changed since we're creating a new log file
-            self.assertNotEqual(stat1.st_mode, stat3.st_mode)
-            # Data was appended to file
-            self.assertEqual(stat1.st_size, stat3.st_size)
+            # self.assertEqual(stat1.st_ctime, stat2.st_ctime)
         finally:
             if os.path.exists(output_file):
                 os.unlink(output_file)


### PR DESCRIPTION
I backported #15877 when I should not have, as the feature only existed in develop. Commenting out the `st_ctime` comparison test isn't the best approach, but was the original hotfix on develop when #15826 broke the tests. We'll need to look at a better way to test this on 2014.7 like we are on develop, but this should work for now.

@s0undt3ch ping
