### PR TITLE
Ensure that mount.mounted modifies entries in fstab on changes

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -288,7 +288,7 @@ def set_fstab(
                     # Invalid entry
                     lines.append(line)
                     continue
-                if comps[0] == device:
+                if comps[1] == name or comps[0] == device:
                     # check to see if there are changes
                     # and fix them if there are any
                     present = True


### PR DESCRIPTION
mount.mounted compared entries in fstab only by their fs_spec to determine if an
entry that is about to be added was already present and that the original one
should therefore be modified. It is, however, necessary to compare both fs_spec
and fs_file fields to allow users to mount new filesystems or block devices to
the same mountpoint.

This fixes #15968 which had already been fixed in #9573 but was re-introduced in
c8c6112 due to, what I believe, not rebasing that PR against develop.

Please double-check that this PR does not re-introduce #9520 and consider backporting
this fix of the regression caused in  #9666 to both 2014.1 and 2014.7.
