### PR TITLE
improved running and present commands for dockerio

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -68,7 +68,8 @@ Available Functions
           - source: salt://_files/tmp/docker_image.tar
 
 - running
-
+  can be used only for starting, or for both creating and starting a container. 
+  See method documentation for details
   .. code-block:: yaml
 
       my_service:
@@ -595,13 +596,19 @@ def absent(name):
         return _valid(comment="Container {0!r} not found".format(name))
 
 
-def present(name):
+def present(name,image=None,is_latest=False):
     '''
     If a container with the given name is not present, this state will fail.
+    Supports optionally checking for specific image/version
     (`docker inspect`)
 
     name:
         container id
+    image:
+        image the container should be running (defaults to any)
+    is_latest:
+        also check if the container runs the latest version of the image (
+        latest defined as the latest pulled onto the local machine)
     '''
     ins_container = __salt__['docker.inspect_container']
     cinfos = ins_container(name)
@@ -609,10 +616,18 @@ def present(name):
         cid = cinfos['id']
     else:
         cid = name
-    if cinfos['status']:
-        return _valid(comment='Container {0} exists'.format(cid))
-    else:
-        return _invalid(comment='Container {0} not found'.format(cid or name))
+    if not cinfos['status']:
+      return _invalid(comment='Container {0} not found'.format(cid or name))
+    if cinfos['status'] and image is None:
+      return _valid(comment='Container {0} exists'.format(cid))
+    if cinfos['status'] and cinfos['out']['Config']["Image"]==image and not is_latest:
+      return _valid(comment='Container {0} exists and has image {1}'.format(cid,image))
+    ins_image = __salt__['docker.inspect_image']
+    iinfos = ins_image(image)
+    if cinfos['status'] and cinfos['out']['Image']==iinfos['out']['Id']:
+      return _valid(comment='Container {0} exists and has latest version of image {1}'.format(cid,image))
+    return _invalid(comment='Container {0} found with wrong image'.format(cid or name))
+
 
 
 def run(name,
@@ -709,79 +724,98 @@ def script(*args, **kw):
     raise NotImplementedError
 
 
-def running(name, container=None, port_bindings=None, binds=None,
-            publish_all_ports=False, links=None, lxc_conf=None,
-            privileged=False, dns=None, volumes_from=None,
-            network_mode=None, check_is_running=True):
-    '''
-    Ensure that a container is running. (`docker inspect`)
+def running(name,
+              image,
+              container=None,
+              command=None,
+              hostname=None,
+              user=None,
+              detach=True,
+              stdin_open=False,
+              tty=False,
+              mem_limit=0,
+              ports=[],
+              environment=None,
+              dns=None,
+              volumes=[],
+              volumes_from=[],
+              start=True,
+              cap_add=None,
+              cap_drop=None,
+              privileged=None,
+              lxc_conf=None,
+              network_mode=None,
+              check_is_running=True,
+              publish_all_ports=False,
+              links=None,
+              *args, **kwargs):
+    '''       
+    Ensure that a container with the given name exists;
+    if not, build a new container from the specified image.
+    (`docker run`)
 
-    name
-        name of the service
+    name / container
+        Name for the container
 
-    container
-        name of the container to start
+    image
+        Image from which to build this container
 
-    publish_all_ports
-
-    links
-        Link several container together
-
+    environment
+        Environment variables for the container, either
+            - a mapping of key, values
+            - a list of mappings of key, values
+    ports
+        List of ports definitions, either:
+            - a port to map
+            - a mapping of mapping portInHost : PortInContainer
         .. code-block:: yaml
-
-            - links:
-                name_other_container: alias_for_other_container
-
-    port_bindings
-        List of ports to expose on host system
-            - a mapping port's guest, hostname's host and port's host.
-
-        .. code-block:: yaml
-
-            - port_bindings:
-                "5000/tcp":
+            - ports:
+              - "5000/tcp":
                     HostIp: ""
                     HostPort: "5000"
-
-    binds
-        List of volumes to mount (like ``-v`` of ``docker run`` command),
+    publish_all_ports
+        Publish all ports from the port list (default is false,
+        only meaningfull if port does not contain portinhost:portincontainer mapping )
+    volumes
+        List of volumes to mount or create in the container (like ``-v`` of ``docker run`` command),
         mapping host directory to container directory.
-
-        For read-write mounting, use the short form:
-
+        For create in the host, just put a strin
         .. code-block:: yaml
-
-            - binds:
-                /var/log/service: /var/log/service
-
+          - volumes:
+            - "/var/log/service"
+        For read-write mounting, use the short form (note that the notion of
+        source:target from docker is preserved):
+        .. code-block:: yaml
+          - volumes:
+            - /var/log/service: /var/log/service
         Or, to specify read-only mounting, use the extended form:
-
         .. code-block:: yaml
+          - volumes:
+            - /home/user1:
+              bind: /mnt/vol2
+              ro: true
+            - /var/www:
+              bind: /mnt/vol1
+              ro: false
+        or (mostly for backwards compatibility) a dict style
+        .. code-block:: yaml
+          - volumes:
+            /home/user1:
+              bind: /mnt/vol2
+              ro: true
+            /var/www:
+              bind: /mnt/vol1
+              ro: false
 
-            - binds:
-                /home/user1:
-                    bind: /mnt/vol2
-                    ro: true
-                /var/www:
-                    bind: /mnt/vol1
-                    ro: false
-
+    volumes_from
+        List of containers to share volumes with
     dns
         List of DNS servers.
 
         .. code-block:: yaml
 
             - dns:
-                - 127.0.0.1
-
-    volumes_from
-        List of container names to get volumes definition from
-
-        .. code-block:: yaml
-
-            - volumes_from:
-                - name_other_container
-
+                - 127.0.0.1    
     network_mode
         - 'bridge': creates a new network stack for the container on the docker bridge
         - 'none': no networking for this container
@@ -792,43 +826,152 @@ def running(name, container=None, port_bindings=None, binds=None,
 
             - network_mode: host
 
+    cap_add
+        List of capabilities to add in a container.
+
+    cap_drop
+        List of capabilities to drop in a container.
+
     check_is_running
         Enable checking if a container should run or not.
         Useful for data-only containers that must be linked to another one.
         e.g. nginx <- static-files
+    For other parameters, see absolutely first the salt.modules.dockerio
+    execution module and the docker-py python bindings for docker
+    documentation
+    <https://github.com/dotcloud/docker-py#api>`_ for
+    `docker.create_container`.
+
+    .. note::
+        This command does not verify that the named container
+        is running the specified image.
     '''
-    if not container and name:
-        container = name
-    is_running = __salt__['docker.is_running'](container)
-    if is_running:
-        return _valid(
-            comment='Container {0!r} is started'.format(container))
-    else:
-        started = __salt__['docker.start'](
-            container, binds=binds, port_bindings=port_bindings,
-            lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
-            links=links, privileged=privileged,
-            dns=dns, volumes_from=volumes_from, network_mode=network_mode,
-        )
-        if check_is_running:
-            is_running = __salt__['docker.is_running'](container)
-            log.debug("Docker-io running:" + str(started))
-            log.debug("Docker-io running:" + str(is_running))
-            if is_running:
-                return _valid(
-                    comment='Container {0!r} started.\n'.format(container),
-                    changes={name: True})
-            else:
-                return _invalid(
-                    comment=(
-                        'Container {0!r} cannot be started\n{1!s}'
-                        .format(
-                            container,
-                            started['out'],
-                        )
-                    )
-                )
+    
+    if container is not None:
+      name = container
+    ins_image = __salt__['docker.inspect_image']
+    ins_container = __salt__['docker.inspect_container']
+    create = __salt__['docker.create_container']
+    iinfos = ins_image(image)
+    cinfos = ins_container(name)
+    already_exists = cinfos['status']
+    is_running = False
+    if already_exists:
+      is_running = __salt__['docker.is_running'](container)
+    # if container exists but is not started, try to start it
+    if already_exists and (is_running or start==False):
+        return _valid(comment='container {0!r} already exists'.format(name))
+    if not iinfos['status']:
+        return _invalid(comment='image "{0}" does not exist'.format(image))
+    # parse input data
+    exposeports, bindports, contvolumes, bindvolumes, denvironment, changes = [], {},[], {}, {}, []
+    if not ports:
+        ports = {}
+    if not volumes:
+        volumes = {}
+    if not volumes_from:
+        volumes_from = []
+    if isinstance(environment, dict):
+        for k in environment:
+            denvironment[unicode(k)] = unicode(environment[k])
+    if isinstance(environment, list):
+        for p in environment:
+            if isinstance(p, dict):
+                for k in p:
+                    denvironment[unicode(k)] = unicode(p[k])
+    if isinstance(volumes,dict):
+      bindvolumes = volumes
+      for p in volumes.keys():
+        if not volumes[p].get('isfile',False):
+          contvolumes.append(str(volumes[p]['bind']))
+    if isinstance(volumes,list):
+      for p in volumes:
+        if isinstance(p,dict):
+          # get source as the dict key
+          source = p.keys()[0]
+          # then find target
+          if isinstance(p[source],dict):
+            target = p[source]['bind']
+            ro = p[source].get('ro',False)
+          else:
+            target = str(p[source])
+            ro = False
+          bindvolumes[source] = {
+                'bind': target,
+                'ro': ro
+          }
+          contvolumes.append(str(p))
         else:
-            return _valid(
-                comment='Container {0!r} started.\n'.format(container),
-                changes={name: True})
+          # assume just an own volumes
+          contvolumes.append(str(p))
+    if isinstance(ports,dict):
+      bindports = ports
+      # in dict form all ports bind, so no need for exposeports
+    if isinstance(ports,list):
+      for p in volumes:
+        if isinstance(p,dict):
+          container_port = p.keys()[0]
+          #find target
+          if isinstance(p[container_port],dict):
+            host_port = p[container_port]['HostPort']
+            host_ip = p[container_port].get('HostIp','0.0.0.0')
+          else:
+            host_port = str(p[container_port])
+          bindports[container_port] = {
+            'HostPort': host_port,
+            'HostIp': host_ip
+          }
+        else:
+          #assume just a port to expose
+          exposeports.append(str(p))
+    if not already_exists:
+      a, kw = [image], dict(
+          command=command,
+          hostname=hostname,
+          user=user,
+          detach=detach,
+          stdin_open=stdin_open,
+          tty=tty,
+          mem_limit=mem_limit,
+          ports=exposeports,
+          environment=denvironment,
+          dns=dns,
+          volumes=contvolumes,
+          name=name)
+      out = create(*a, **kw)
+      # if container has been created, even if not started, we mark
+      # it as installed
+      try:
+        cid = out['out']['info']['id']
+        log.debug(str(cid))
+      except Exception, e:
+        changes.append('Container created')
+        log.debug(str(e))
+      else:
+        changes.append('Container {0} created'.format(cid))
+    if start:
+      started = __salt__['docker.start'](
+          name, binds=bindvolumes, port_bindings=bindports,
+          lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
+          links=links, privileged=privileged,
+          dns=dns, volumes_from=volumes_from, network_mode=network_mode
+      )# cap_add,cap_drop removed as not valid in 2014.1
+      if check_is_running:
+          is_running = __salt__['docker.is_running'](name)
+          log.debug("Docker-io running:" + str(started))
+          log.debug("Docker-io running:" + str(is_running))
+          if is_running:
+              changes.append('Container {0!r} started.\n'.format(name))
+          else:
+              return _invalid(
+                  comment=(
+                      'Container {0!r} cannot be started\n{1!s}'
+                      .format(
+                          name,
+                          started['out'],
+                      )
+                  )
+              )
+      else:
+          changes.append('Container {0!r} started.\n'.format(name))
+    return _valid(comment=','.join(changes),changes={name: True})

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -68,7 +68,7 @@ Available Functions
           - source: salt://_files/tmp/docker_image.tar
 
 - running
-  can be used only for starting, or for both creating and starting a container. 
+  can be used only for starting, or for both creating and starting a container.
   See method documentation for details
   .. code-block:: yaml
 
@@ -232,9 +232,9 @@ def pulled(name, tag=None, force=False, *args, **kwargs):
         (`docker import
         <http://docs.docker.io/en/latest/reference/commandline/cli/#import>`_).
         NOTE that we added in SaltStack a way to authenticate yourself with the
-        Docker Hub Registry by supplying your credentials (username, email & password)
-        using pillars. For more information, see salt.modules.dockerio execution
-        module.
+        Docker Hub Registry by supplying your credentials (username, email &
+        password) using pillars. For more information, see salt.modules.dockerio
+        execution module.
 
     name
         Name of the image
@@ -282,9 +282,9 @@ def pushed(name, tag=None):
         (`docker import
         <http://docs.docker.io/en/latest/reference/commandline/cli/#import>`_).
         NOTE that we added in SaltStack a way to authenticate yourself with the
-        Docker Hub Registry by supplying your credentials (username, email & password)
-        using pillars. For more information, see salt.modules.dockerio execution
-        module.
+        Docker Hub Registry by supplying your credentials (username, email
+        & password) using pillars. For more information, see
+        salt.modules.dockerio execution module.
 
     name
         Name of the image
@@ -355,7 +355,10 @@ def loaded(name, source=None, source_hash='', force=False):
             comment='Image already loaded: {0}'.format(name))
 
     tmp_filename = salt.utils.mkstemp()
-    __salt__['state.single']('file.managed', name=tmp_filename, source=source, source_hash=source_hash)
+    __salt__['state.single']('file.managed',
+                            name=tmp_filename,
+                            source=source,
+                            source_hash=source_hash)
     changes = {}
 
     if image_infos['status']:
@@ -364,7 +367,7 @@ def loaded(name, source=None, source_hash='', force=False):
         remove_info = remove_image(name)
         if not remove_info['status']:
             return _invalid(name=name,
-                            comment='Image could not be removed: {0}'.format(name))
+                    comment='Image could not be removed: {0}'.format(name))
 
     load = __salt__['docker.load']
     returned = load(tmp_filename)
@@ -596,7 +599,7 @@ def absent(name):
         return _valid(comment="Container {0!r} not found".format(name))
 
 
-def present(name,image=None,is_latest=False):
+def present(name, image=None, is_latest=False):
     '''
     If a container with the given name is not present, this state will fail.
     Supports optionally checking for specific image/version
@@ -617,15 +620,15 @@ def present(name,image=None,is_latest=False):
     else:
         cid = name
     if not cinfos['status']:
-      return _invalid(comment='Container {0} not found'.format(cid or name))
+        return _invalid(comment='Container {0} not found'.format(cid or name))
     if cinfos['status'] and image is None:
-      return _valid(comment='Container {0} exists'.format(cid))
-    if cinfos['status'] and cinfos['out']['Config']["Image"]==image and not is_latest:
-      return _valid(comment='Container {0} exists and has image {1}'.format(cid,image))
+        return _valid(comment='Container {0} exists'.format(cid))
+    if cinfos['status'] and cinfos['out']['Config']["Image"] == image and not is_latest:
+        return _valid(comment='Container {0} exists and has image {1}'.format(cid, image))
     ins_image = __salt__['docker.inspect_image']
     iinfos = ins_image(image)
-    if cinfos['status'] and cinfos['out']['Image']==iinfos['out']['Id']:
-      return _valid(comment='Container {0} exists and has latest version of image {1}'.format(cid,image))
+    if cinfos['status'] and cinfos['out']['Image'] == iinfos['out']['Id']:
+        return _valid(comment='Container {0} exists and has latest version of image {1}'.format(cid, image))
     return _invalid(comment='Container {0} found with wrong image'.format(cid or name))
 
 
@@ -734,11 +737,11 @@ def running(name,
               stdin_open=False,
               tty=False,
               mem_limit=0,
-              ports=[],
+              ports=None,
               environment=None,
               dns=None,
-              volumes=[],
-              volumes_from=[],
+              volumes=None,
+              volumes_from=None,
               start=True,
               cap_add=None,
               cap_drop=None,
@@ -749,7 +752,7 @@ def running(name,
               publish_all_ports=False,
               links=None,
               *args, **kwargs):
-    '''       
+    '''
     Ensure that a container with the given name exists;
     if not, build a new container from the specified image.
     (`docker run`)
@@ -815,7 +818,7 @@ def running(name,
         .. code-block:: yaml
 
             - dns:
-                - 127.0.0.1    
+                - 127.0.0.1
     network_mode
         - 'bridge': creates a new network stack for the container on the docker bridge
         - 'none': no networking for this container
@@ -846,9 +849,8 @@ def running(name,
         This command does not verify that the named container
         is running the specified image.
     '''
-    
     if container is not None:
-      name = container
+        name = container
     ins_image = __salt__['docker.inspect_image']
     ins_container = __salt__['docker.inspect_container']
     create = __salt__['docker.create_container']
@@ -857,14 +859,14 @@ def running(name,
     already_exists = cinfos['status']
     is_running = False
     if already_exists:
-      is_running = __salt__['docker.is_running'](container)
+        is_running = __salt__['docker.is_running'](container)
     # if container exists but is not started, try to start it
-    if already_exists and (is_running or start==False):
+    if already_exists and (is_running or start == False):
         return _valid(comment='container {0!r} already exists'.format(name))
     if not iinfos['status']:
         return _invalid(comment='image "{0}" does not exist'.format(image))
     # parse input data
-    exposeports, bindports, contvolumes, bindvolumes, denvironment, changes = [], {},[], {}, {}, []
+    exposeports, bindports, contvolumes, bindvolumes, denvironment, changes = [], {}, [], {}, {}, []
     if not ports:
         ports = {}
     if not volumes:
@@ -872,107 +874,99 @@ def running(name,
     if not volumes_from:
         volumes_from = []
     if isinstance(environment, dict):
-        for k in environment:
-            denvironment[unicode(k)] = unicode(environment[k])
+        for key in environment:
+            denvironment[unicode(key)] = unicode(environment[key])
     if isinstance(environment, list):
-        for p in environment:
-            if isinstance(p, dict):
-                for k in p:
-                    denvironment[unicode(k)] = unicode(p[k])
-    if isinstance(volumes,dict):
-      bindvolumes = volumes
-      for p in volumes.keys():
-        if not volumes[p].get('isfile',False):
-          contvolumes.append(str(volumes[p]['bind']))
-    if isinstance(volumes,list):
-      for p in volumes:
-        if isinstance(p,dict):
-          # get source as the dict key
-          source = p.keys()[0]
-          # then find target
-          if isinstance(p[source],dict):
-            target = p[source]['bind']
-            ro = p[source].get('ro',False)
-          else:
-            target = str(p[source])
-            ro = False
-          bindvolumes[source] = {
+        for var in environment:
+            if isinstance(var, dict):
+                for key in var:
+                    denvironment[unicode(key)] = unicode(var[key])
+    if isinstance(volumes, dict):
+        bindvolumes = volumes
+    if isinstance(volumes, list):
+        for vol in volumes:
+            if isinstance(vol, dict):
+                # get source as the dict key
+                source = vol.keys()[0]
+                # then find target
+                if isinstance(vol[source], dict):
+                    target = vol[source]['bind']
+                    read_only = vol[source].get('ro', False)
+                else:
+                    target = str(vol[source])
+                    read_only = False
+                bindvolumes[source] = {
                 'bind': target,
-                'ro': ro
-          }
-          contvolumes.append(str(p))
-        else:
-          # assume just an own volumes
-          contvolumes.append(str(p))
-    if isinstance(ports,dict):
-      bindports = ports
-      # in dict form all ports bind, so no need for exposeports
-    if isinstance(ports,list):
-      for p in volumes:
-        if isinstance(p,dict):
-          container_port = p.keys()[0]
-          #find target
-          if isinstance(p[container_port],dict):
-            host_port = p[container_port]['HostPort']
-            host_ip = p[container_port].get('HostIp','0.0.0.0')
-          else:
-            host_port = str(p[container_port])
-          bindports[container_port] = {
-            'HostPort': host_port,
-            'HostIp': host_ip
-          }
-        else:
-          #assume just a port to expose
-          exposeports.append(str(p))
+                'ro': read_only
+                }
+            else:
+                # assume just an own volumes
+                contvolumes.append(str(vol))
+    if isinstance(ports, dict):
+        bindports = ports
+        # in dict form all ports bind, so no need for exposeports
+    if isinstance(ports, list):
+        for port in ports:
+            if isinstance(port, dict):
+                container_port = port.keys()[0]
+                #find target
+                if isinstance(port[container_port], dict):
+                    host_port = port[container_port]['HostPort']
+                    host_ip = port[container_port].get('HostIp', '0.0.0.0')
+                else:
+                    host_port = str(port[container_port])
+                    host_ip = '0.0.0.0'
+                bindports[container_port] = {
+                    'HostPort': host_port,
+                    'HostIp': host_ip
+                }
+            else:
+                #assume just a port to expose
+                exposeports.append(str(port))
     if not already_exists:
-      a, kw = [image], dict(
-          command=command,
-          hostname=hostname,
-          user=user,
-          detach=detach,
-          stdin_open=stdin_open,
-          tty=tty,
-          mem_limit=mem_limit,
-          ports=exposeports,
-          environment=denvironment,
-          dns=dns,
-          volumes=contvolumes,
-          name=name)
-      out = create(*a, **kw)
-      # if container has been created, even if not started, we mark
-      # it as installed
-      try:
-        cid = out['out']['info']['id']
-        log.debug(str(cid))
-      except Exception, e:
-        changes.append('Container created')
-        log.debug(str(e))
-      else:
-        changes.append('Container {0} created'.format(cid))
+        args, kwargs = [image], dict(
+                        command=command,
+                        hostname=hostname,
+                        user=user,
+                        detach=detach,
+                        stdin_open=stdin_open,
+                        tty=tty,
+                        mem_limit=mem_limit,
+                        ports=exposeports,
+                        environment=denvironment,
+                        dns=dns,
+                        volumes=contvolumes,
+                        name=name)
+        out = create(*args, **kwargs)
+        # if container has been created, even if not started, we mark
+        # it as installed
+        try:
+            cid = out['out']['info']['id']
+            log.debug(str(cid))
+        except Exception, e:
+            changes.append('Container created')
+            log.debug(str(e))
+        else:
+            changes.append('Container {0} created'.format(cid))
     if start:
-      started = __salt__['docker.start'](
-          name, binds=bindvolumes, port_bindings=bindports,
-          lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
-          links=links, privileged=privileged,
-          dns=dns, volumes_from=volumes_from, network_mode=network_mode,
-          cap_add=cap_add,cap_drop=cap_drop
-      )
-      if check_is_running:
-          is_running = __salt__['docker.is_running'](name)
-          log.debug("Docker-io running:" + str(started))
-          log.debug("Docker-io running:" + str(is_running))
-          if is_running:
-              changes.append('Container {0!r} started.\n'.format(name))
-          else:
-              return _invalid(
-                  comment=(
-                      'Container {0!r} cannot be started\n{1!s}'
-                      .format(
-                          name,
-                          started['out'],
-                      )
-                  )
-              )
-      else:
-          changes.append('Container {0!r} started.\n'.format(name))
-    return _valid(comment=','.join(changes),changes={name: True})
+        started = __salt__['docker.start'](
+                name, binds=bindvolumes, port_bindings=bindports,
+                lxc_conf=lxc_conf, publish_all_ports=publish_all_ports,
+                links=links, privileged=privileged,
+                dns=dns, volumes_from=volumes_from, network_mode=network_mode,
+                cap_add=cap_add, cap_drop=cap_drop
+                )
+        if check_is_running:
+            is_running = __salt__['docker.is_running'](name)
+            log.debug("Docker-io running:" + str(started))
+            log.debug("Docker-io running:" + str(is_running))
+            if is_running:
+                changes.append('Container {0!r} started.\n'.format(name))
+            else:
+                return _invalid(
+                        comment=(
+                        'Container {0!r} cannot be started\n{1!s}'
+                        .format(name, started['out'],)))
+        else:
+            changes.append('Container {0!r} started.\n'.format(name))
+    return _valid(comment=','.join(changes), changes={name: True})

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -631,6 +631,7 @@ def present(name, image=None, is_latest=False):
         return _valid(comment='Container {0} exists and has latest version of image {1}'.format(cid, image))
     return _invalid(comment='Container {0} found with wrong image'.format(cid or name))
 
+
 def run(name,
         cid=None,
         hostname=None,
@@ -855,13 +856,14 @@ def running(name,
     iinfos = ins_image(image)
     cinfos = ins_container(name)
     already_exists = cinfos['status']
+    image_exists = iinfos['status']
     is_running = False
     if already_exists:
         is_running = __salt__['docker.is_running'](container)
     # if container exists but is not started, try to start it
     if already_exists and (is_running or not start):
         return _valid(comment='container {0!r} already exists'.format(name))
-    if (not iinfos['status']):
+    if not image_exists:
         return _invalid(comment='image "{0}" does not exist'.format(image))
     # parse input data
     exposeports, bindports, contvolumes, bindvolumes, denvironment, changes = [], {}, [], {}, {}, []

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -631,8 +631,6 @@ def present(name, image=None, is_latest=False):
         return _valid(comment='Container {0} exists and has latest version of image {1}'.format(cid, image))
     return _invalid(comment='Container {0} found with wrong image'.format(cid or name))
 
-
-
 def run(name,
         cid=None,
         hostname=None,
@@ -861,9 +859,9 @@ def running(name,
     if already_exists:
         is_running = __salt__['docker.is_running'](container)
     # if container exists but is not started, try to start it
-    if already_exists and (is_running or start == False):
+    if already_exists and (is_running or not start):
         return _valid(comment='container {0!r} already exists'.format(name))
-    if not iinfos['status']:
+    if (not iinfos['status']):
         return _invalid(comment='image "{0}" does not exist'.format(image))
     # parse input data
     exposeports, bindports, contvolumes, bindvolumes, denvironment, changes = [], {}, [], {}, {}, []


### PR DESCRIPTION
The current dockerio state module functionality closely reassembles the docker remote API, which actually makes common docker workflows relatively cumbersome. 

Especially one need to use two commands (with somewhat overlapping data) in order to create and run a container. 

Additionally raw shell commands is needed to test a containers image version even though that is a quite typical deployment workflow (pull latest image, test container for running latest image, delete+recreate if not latest). 

This PR addresses both by:
    Extending the running command to have the combined functionality of installed and running. yaml syntax is made to be backwards compatible with current version, but also supports the syntax of installed.
    Extending the present command to support check for specific image and latest version. yaml input is also backwards compatible here 
