### PR TITLE
Add master opts to the loader

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -186,7 +186,7 @@ dummy-variables-rgx=_|dummy
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__,__low__,__states__,__lowstate__,__running__,__active_provider_name__
+additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__,__low__,__states__,__lowstate__,__running__,__active_provider_name__,__master_opts__
 
 
 [SIMILARITIES]

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -150,7 +150,7 @@ indent-string='    '
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__,__low__,__states__,__lowstate__,__running__,__active_provider_name__
+additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__,__low__,__states__,__lowstate__,__running__,__active_provider_name__,__master_opts__
 
 
 [IMPORTS]

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -12,9 +12,6 @@ import multiprocessing
 import subprocess
 import os
 import re
-import shutil
-import tarfile
-import tempfile
 import time
 import yaml
 
@@ -532,7 +529,7 @@ class Single(object):
         self.target = kwargs
         self.target.update(args)
         self.serial = salt.payload.Serial(opts)
-        self.wfuncs = salt.loader.ssh_wrapper(opts)
+        self.wfuncs = salt.loader.ssh_wrapper(opts, None, self.opts)
         self.mods = mods if mods else {}
 
     def __arg_comps(self):
@@ -691,7 +688,7 @@ class Single(object):
             opts,
             self.id,
             **self.target)
-        self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper)
+        self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.opts)
         wrapper.wfuncs = self.wfuncs
         result = self.wfuncs[self.fun](*self.args, **self.kwargs)
         # Mimic the json data-structure that "salt-call --local" will

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -57,8 +57,10 @@ class SSHHighState(salt.state.BaseHighState):
     '''
     stack = []
 
-    def __init__(self, opts, pillar=None, wrapper=None):
-        self.client = salt.fileclient.FSClient(opts)
+    def __init__(self, opts, pillar=None, wrapper=None, mopts=None):
+        if mopts is None:
+            mopts = {}
+        self.client = salt.fileclient.FSClient(mopts)
         salt.state.BaseHighState.__init__(self, opts)
         self.state = SSHState(opts, pillar, wrapper)
         self.matcher = salt.minion.Matcher(self.opts)

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -37,7 +37,11 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
         saltenv = env
 
     __pillar__.update(kwargs.get('pillar', {}))
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     if isinstance(mods, str):
         mods = mods.split(',')
     high_data, errors = st_.render_highstate({saltenv: mods})
@@ -63,7 +67,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
     chunks = st_.state.compile_high_data(high_data)
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __opts__,
+            __master_opts__,
             chunks,
             file_refs,
             __pillar__)
@@ -106,13 +110,17 @@ def low(data, **kwargs):
     '''
     __opts__['grains'] = __grains__
     chunks = [data]
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     err = st_.verify_data(data)
     if err:
         return err
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __opts__,
+            __master_opts__,
             chunks,
             file_refs,
             __pillar__)
@@ -148,11 +156,15 @@ def high(data, **kwargs):
         salt '*' state.high '{"vim": {"pkg": ["installed"]}}'
     '''
     __opts__['grains'] = __grains__
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     chunks = st_.state.compile_high_data(high)
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __opts__,
+            __master_opts__,
             chunks,
             file_refs,
             __pillar__)
@@ -190,11 +202,15 @@ def highstate(test=None, **kwargs):
         salt '*' state.highstate exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"
     '''
     __opts__['grains'] = __grains__
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     chunks = st_.compile_low_chunks()
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __opts__,
+            __master_opts__,
             chunks,
             file_refs,
             __pillar__)
@@ -241,12 +257,16 @@ def top(topfn, test=None, **kwargs):
         __opts__['test'] = True
     else:
         __opts__['test'] = __opts__.get('test', None)
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     st_.opts['state_top'] = os.path.join('salt://', topfn)
     chunks = st_.compile_low_chunks()
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __opts__,
+            __master_opts__,
             chunks,
             file_refs,
             __pillar__)
@@ -282,7 +302,11 @@ def show_highstate():
         salt '*' state.show_highstate
     '''
     __opts__['grains'] = __grains__
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     return st_.compile_highstate()
 
 
@@ -297,7 +321,11 @@ def show_lowstate():
         salt '*' state.show_lowstate
     '''
     __opts__['grains'] = __grains__
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     return st_.compile_low_chunks()
 
 
@@ -327,7 +355,11 @@ def show_sls(mods, saltenv='base', test=None, env=None, **kwargs):
         opts['test'] = True
     else:
         opts['test'] = __opts__.get('test', None)
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors
@@ -354,7 +386,11 @@ def show_top():
         salt '*' state.show_top
     '''
     __opts__['grains'] = __grains__
-    st_ = salt.client.ssh.state.SSHHighState(__opts__, __pillar__, __salt__)
+    st_ = salt.client.ssh.state.SSHHighState(
+            __opts__,
+            __pillar__,
+            __salt__,
+            __master_opts__)
     top_data = st_.get_top()
     errors = []
     errors += st_.verify_tops(top_data)

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -291,10 +291,12 @@ def log_handlers(opts):
     return load.filter_func('setup_handlers')
 
 
-def ssh_wrapper(opts, functions=None):
+def ssh_wrapper(opts, functions=None, mopts=None):
     '''
     Returns the custom logging handler modules
     '''
+    if mopts is None:
+        mopts = {}
     if functions is None:
         functions = {}
     load = _create_loader(
@@ -307,6 +309,10 @@ def ssh_wrapper(opts, functions=None):
     )
     pack = {'name': '__salt__',
             'value': functions}
+    pack = [{'name': '__salt__',
+             'value': functions},
+            {'name': '__master_opts__',
+             'value': mopts}]
     return load.gen_functions(pack)
 
 


### PR DESCRIPTION
This allows us to create objects in the wrapper classes that are run
purely on the master opts, Fix #16061
