### PR TITLE
Replace any spaces if separated by commas

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1595,7 +1595,7 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         if self.options.list:
             try:
                 if ',' in self.args[0]:
-                    self.config['tgt'] = self.args[0].split(',')
+                    self.config['tgt'] = self.args[0].replace(' ', '').split(',')
                 else:
                     self.config['tgt'] = self.args[0].split()
             except IndexError:


### PR DESCRIPTION
When specifying a list of hosts using commas the command execution will fail if spaces are present:-

``` bash
salt -L 'minion1, minion2' test.ping
```

The above will only cause minion1 to return since ' minion2' does not exist.
