### PR TITLE
Custom grain for detailed info. about display adapter

### DIFF
--- a/salt/grains/display_adapters.py
+++ b/salt/grains/display_adapters.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+
+import glob
+import re
+import salt.log
+import salt.utils
+
+# Solve the Chicken and egg problem where grains need to run before any
+# of the modules are loaded and are generally available for any usage.
+import salt.modules.cmdmod
+
+def _linux_display_adapters(path):
+    # Get pci bus, device and function
+    pci = re.split(':|\.', path.replace('/sys/bus/pci/devices/0000:', ''))
+    bus_num = pci[0]
+    device_num = pci[1]
+    device_func = '.' + pci[2]
+
+    # Get vendor id
+    f = open(path + '/vendor', 'r')
+    vendor_id = f.readline().rstrip().replace('0x', '')
+    f.close
+
+    # Get device id
+    f = open(path + '/device', 'r')
+    device_id = f.readline().rstrip().replace('0x', '')
+    f.close
+
+    # Get boot display adapter
+    f = open(path + '/boot_vga', 'r')
+    boot_device = bool(f.readline().rstrip())
+    f.close
+
+    # Get vendor and device name
+    vendor_name = ''
+    device_name = ''
+    no_cols = 1
+    with open('/usr/share/hwdata/pci.ids') as f:
+        for line in f:
+            col = re.split('\s+', line, no_cols)
+            if col[0] == vendor_id:
+                vendor_name = col[1].rstrip()
+                no_cols += 1
+                continue
+            if vendor_name != '' and col[1] == device_id:
+                device_name = col[2].rstrip()
+                break
+            if vendor_name != '' and col[0] != '':
+                break
+
+    display_adapter = {
+        'path': path,
+        'pci': {
+            'bus': bus_num,
+            'device': device_num,
+            'function': device_func
+        },
+        'vendor_id': vendor_id,
+        'vendor_name': vendor_name,
+        'device_id': device_id,
+        'device_name': device_name,
+        'boot_device': boot_device,
+    };
+    return display_adapter

--- a/salt/grains/display_adapters.py
+++ b/salt/grains/display_adapters.py
@@ -9,7 +9,7 @@ import salt.utils
 # of the modules are loaded and are generally available for any usage.
 import salt.modules.cmdmod
 
-def _linux_display_adapters(path):
+def _get_display_adapter(path):
     # Get pci bus, device and function
     pci = re.split(':|\.', path.replace('/sys/bus/pci/devices/0000:', ''))
     bus_num = pci[0]
@@ -62,3 +62,20 @@ def _linux_display_adapters(path):
         'boot_device': boot_device,
     };
     return display_adapter
+
+def display_adapters():
+    # Find display adapters
+    grains = {}
+    grains['display_adapters'] = []
+    files = glob.glob('/sys/bus/pci/devices/*/class')
+    for file in files:
+        f = open(file, 'r')
+
+        # Only consider devices with device class 0x030000
+        if f.readline().rstrip() == '0x030000':
+            grains['display_adapters'].append(_get_display_adapter(file.replace('/class', '')))
+        f.close()
+    return grains
+
+if __name__ == "__main__":
+    print display_adapters()


### PR DESCRIPTION
Parses /sys to get detailed information about display adapters, useful when determining which driver to install for Linux Desktops.

Might need refactoring for other Distributions then RedHat based one's since it assumes PCI list is in: /usr/share/hwdata/pci.ids.

Also I'm unaware if this follows req. guidelines for official grains.
