### PR TITLE
modules.hg clone operation on directories/repos with spaces in them

### DIFF
--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -203,5 +203,5 @@ def clone(cwd, repository, opts=None, user=None):
 
     if not opts:
         opts = ''
-    cmd = 'hg clone {0} {1} {2}'.format(repository, cwd, opts)
+    cmd = 'hg clone "{0}" "{1}" {2}'.format(repository, cwd, opts)
     return __salt__['cmd.run'](cmd, runas=user)


### PR DESCRIPTION
Encapsulte the repository and cwd arguments in quotes for hg clone command to allow for directories with spaces in them
