### PR TITLE
Better fail message.

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -639,7 +639,7 @@ class Auth(object):
             if safe:
                 log.warning('SaltReqTimeoutError: {0}'.format(e))
                 return 'retry'
-            raise SaltClientError('Failed sign in')
+            raise SaltClientError('Attempt to authenticate with the salt master failed')
 
         if 'load' in payload:
             if 'ret' in payload['load']:


### PR DESCRIPTION
If you're using salt-call for the first time and don't pass --local, the message 'Failed to sign in' is kind of confusing. 

This makes it a little more clear about what the problem really is.
