### PR TITLE
Fix linode stacktrace when ssh_agent isn't present

### DIFF
--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -290,7 +290,8 @@ def create(vm_):
                 'script_args', vm_, __opts__
             ),
             'script_env': config.get_cloud_config_value('script_env', vm_, __opts__),
-            'minion_conf': salt.utils.cloud.minion_config(__opts__, vm_)
+            'minion_conf': salt.utils.cloud.minion_config(__opts__, vm_),
+            'has_ssh_agent': False
         }
 
         if get_ssh_key_filename(vm_) is not None and get_pubkey(vm_) is not None:


### PR DESCRIPTION
Closes #16067
