### PR TITLE
Fix linode test failures and test all modules

### DIFF
--- a/tests/integration/loader/globals.py
+++ b/tests/integration/loader/globals.py
@@ -31,22 +31,23 @@ class LoaderGlobalsTest(integration.ModuleCase):
         Verify that the globals listed in the doc string (from the test) are in these modules
         '''
         # find the globals
-        global_vars = None
+        global_vars = []
         for val in mod_dict.itervalues():
-            if hasattr(val, '__globals__'):
-                global_vars = val.__globals__
-                break
-        # if we couldn't find any, then we have no modules-- so something is broken
-        if global_vars is None:
-            # TODO: log or something? Skip however we do that
-            return
+            # only find salty globals
+            if val.__module__.startswith('salt.loaded') and hasattr(val, '__globals__'):
+                global_vars.append(val.__globals__)
+
+        # if we couldn't find any, then we have no modules -- so something is broken
+        self.assertNotEqual(global_vars, [], msg='No modules were loaded.')
 
         # get the names of the globals you should have
         func_name = inspect.stack()[1][3]
         names = yaml.load(getattr(self, func_name).__doc__).values()[0]
 
-        for name in names:
-            assert name in global_vars
+        # Now, test each module!
+        for item in global_vars:
+            for name in names:
+                self.assertIn(name, item)
 
     def test_auth(self):
         '''
@@ -111,13 +112,6 @@ class LoaderGlobalsTest(integration.ModuleCase):
             - __grains__
         '''
         self._verify_globals(salt.loader.states(self.master_opts, {}))
-
-    def test_log_handlers(self):
-        '''
-        Test that log_handlers have:
-            - __path__
-        '''
-        self._verify_globals(salt.loader.log_handlers(self.master_opts))
 
     def test_renderers(self):
         '''


### PR DESCRIPTION
- Fixes test failure when running on Linode instances (was evaluating a module that contained a **global** not related to salt)
- Made tests use testcase assertions instead of using Python's `assert` value
- Previously these tests were only running on the _first_ module found with a **global**. Now it checks all of the salty ones.
- Removed the `test_log_handlers` because log handlers only load if it's configured on the master. This test has been silently failing.
