### PR TITLE
Provides support for RAET Salt so master name tis not hard coded to 'master' in routes

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -191,7 +191,7 @@ class ZeroMQCaller(object):
         '''
         Return the data up to the master
         '''
-        channel = salt.transport.Channel.factory(self.opts, usage='call_cmd')
+        channel = salt.transport.Channel.factory(self.opts, usage='salt_call')
         load = {'cmd': '_return', 'id': self.opts['id']}
         for key, value in ret.items():
             load[key] = value

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -191,7 +191,7 @@ class ZeroMQCaller(object):
         '''
         Return the data up to the master
         '''
-        channel = salt.transport.Channel.factory(self.opts)
+        channel = salt.transport.Channel.factory(self.opts, usage='call_cmd')
         load = {'cmd': '_return', 'id': self.opts['id']}
         for key, value in ret.items():
             load[key] = value

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -964,8 +964,8 @@ class NixExecutor(ioflo.base.deeding.Deed):
 
     def _setup_jobber_stack(self):
         '''
-        Setup and return the LaneStack and Yard used by the jobber to communicate to-from
-        the minion
+        Setup and return the LaneStack and Yard used by the jobber yard
+        to communicate with the minion manor yard
 
         '''
         mid = self.opts['id']
@@ -977,6 +977,7 @@ class NixExecutor(ioflo.base.deeding.Deed):
                 sockdirpath=self.opts['sock_dir'])
 
         stack.Pk = raeting.packKinds.pack
+        # add remote for the manor yard
         stack.addRemote(RemoteYard(stack=stack,
                                    name='manor',
                                    lanename=mid,
@@ -1008,6 +1009,11 @@ class NixExecutor(ioflo.base.deeding.Deed):
         '''
         Pull the queue for functions to execute
         '''
+        if self.udp_stack.value.remotes:
+            # assigne master_name opt so any RAETChannel clients can correctly
+            # assign dst estate in return route
+            self.opts['master_name'] = self.udp_stack.value.remotes.values()[0].name
+
         while self.fun.value:
             exchange = self.fun.value.popleft()
             data = exchange.get('pub')
@@ -1028,6 +1034,7 @@ class NixExecutor(ioflo.base.deeding.Deed):
                         'Executing command {0[fun]} with jid {0[jid]}'.format(data)
                         )
             log.debug('Command details {0}'.format(data))
+
             process = multiprocessing.Process(
                     target=self.proc_run,
                     kwargs={'exchange': exchange}

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -127,13 +127,9 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         '''
         load = kwargs
         load['cmd'] = 'runner'
-        # sreq = salt.payload.SREQ(
-        #         'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
-        #        )
-        sreq = salt.transport.Channel.factory(self.opts, crypt='clear', usage='local_cmd')
-        #if self.opts['transport'] == 'raet':
-            # in this case sreq is the raet route dict
-            # sreq.dst = (None, None, 'local_cmd') # override destination
+        sreq = salt.transport.Channel.factory(self.opts,
+                                              crypt='clear',
+                                              usage='master_call')
         ret = sreq.send(load)
         if isinstance(ret, collections.Mapping):
             if 'error' in ret:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -130,10 +130,10 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         # sreq = salt.payload.SREQ(
         #         'tcp://{0[interface]}:{0[ret_port]}'.format(self.opts),
         #        )
-        sreq = salt.transport.Channel.factory(self.opts, crypt='clear')
-        if self.opts['transport'] == 'raet':
+        sreq = salt.transport.Channel.factory(self.opts, crypt='clear', usage='local_cmd')
+        #if self.opts['transport'] == 'raet':
             # in this case sreq is the raet route dict
-            sreq.dst = (None, None, 'local_cmd') # override destination
+            # sreq.dst = (None, None, 'local_cmd') # override destination
         ret = sreq.send(load)
         if isinstance(ret, collections.Mapping):
             if 'error' in ret:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -132,7 +132,8 @@ class RunnerClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
         #        )
         sreq = salt.transport.Channel.factory(self.opts, crypt='clear')
         if self.opts['transport'] == 'raet':
-            sreq.dst = (None, None, 'local_cmd')
+            # in this case sreq is the raet route dict
+            sreq.dst = (None, None, 'local_cmd') # override destination
         ret = sreq.send(load)
         if isinstance(ret, collections.Mapping):
             if 'error' in ret:

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -33,7 +33,7 @@ class Channel(object):
     Factory class to create communication-channels for different transport
     '''
     @staticmethod
-    def factory(opts, **kwargs):
+    def factory(opts, usage=None, **kwargs):
         # Default to ZeroMQ for now
         ttype = 'zeromq'
 
@@ -47,7 +47,7 @@ class Channel(object):
         if ttype == 'zeromq':
             return ZeroMQChannel(opts, **kwargs)
         elif ttype == 'raet':
-            return RAETChannel(opts, **kwargs)
+            return RAETChannel(opts, usage=usage, **kwargs)
         else:
             raise Exception('Channels are only defined for ZeroMQ and raet')
             # return NewKindOfChannel(opts, **kwargs)
@@ -71,11 +71,18 @@ class RAETChannel(Channel):
         The difference between the two is how the destination route
         is assigned.
     '''
-    def __init__(self, opts, **kwargs):
+    def __init__(self, opts, usage=None, **kwargs):
         self.opts = opts
         self.ttype = 'raet'
+        if usage == 'master_call':
+            self.dst = (None, None, 'local_cmd') # runner.py master_call
+        elif usage == 'salt_call':
+            self.dst = (None, None, 'call_cmd') # salt_call caller
+        else:
+            self.dst = (None, None, 'remote_cmd') # normal use case mintion to master
+
         # assign dst estate in return route for minion to master comms
-        self.dst = (self.opts.get('master_name', None), None, 'remote_cmd')
+        #self.dst = (self.opts.get('master_name', None), None, 'remote_cmd')
         self.stack = None
 
     def _setup_stack(self):

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -74,8 +74,8 @@ class RAETChannel(Channel):
     def __init__(self, opts, **kwargs):
         self.opts = opts
         self.ttype = 'raet'
-        self.dst = ('master', None, 'remote_cmd') # minion to master comms
-        #self.dst = (None, None, 'remote_cmd')
+        # assign dst estate in return route for minion to master comms
+        self.dst = (self.opts.get('master_name', None), None, 'remote_cmd')
         self.stack = None
 
     def _setup_stack(self):

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -77,9 +77,9 @@ class RAETChannel(Channel):
         if usage == 'master_call':
             self.dst = (None, None, 'local_cmd') # runner.py master_call
         elif usage == 'salt_call':
-            self.dst = (None, None, 'call_cmd') # salt_call caller
-        else:
-            self.dst = (None, None, 'remote_cmd') # normal use case mintion to master
+            self.dst = (None, None, 'remote_cmd') # salt_call caller
+        else: # everything else
+            self.dst = (None, None, 'remote_cmd') # normal use case minion to master
         self.stack = None
 
     def _setup_stack(self):

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -33,7 +33,7 @@ class Channel(object):
     Factory class to create communication-channels for different transport
     '''
     @staticmethod
-    def factory(opts, usage=None, **kwargs):
+    def factory(opts, **kwargs):
         # Default to ZeroMQ for now
         ttype = 'zeromq'
 
@@ -47,7 +47,7 @@ class Channel(object):
         if ttype == 'zeromq':
             return ZeroMQChannel(opts, **kwargs)
         elif ttype == 'raet':
-            return RAETChannel(opts, usage=usage, **kwargs)
+            return RAETChannel(opts, **kwargs)
         else:
             raise Exception('Channels are only defined for ZeroMQ and raet')
             # return NewKindOfChannel(opts, **kwargs)


### PR DESCRIPTION
Channel factory now has usage argument this is used by RAETChannel to determine routing destination addressing

Fixed three usages of RAETChannel

usage == 'local_cmd'  # Used by master_call for master to master communications
usage == 'call_cmd'   # Used by salt-call for cli to master communications through minion
otherwise default usage == None  # Used by minion to master communications

The destination estate is now None for all three usages.

These usages get translated into share destinations in the route dict for raet messages

usage 'local_cmd'  -> destination share 'local_cmd'
usage 'call_cmd'   -> destination share 'call_cmd'
usage None         -> destination share 'remote_cmd'

Fixed core.py Lane Router _process_uxd_rxmsg to recognize the share destinations and
do the apppropriate routing

Mainly this allows the destination estate to be none when a RAETCHannel is created and then
the router can substitute the approapriate destination estate for the master
