### PR TITLE
salt/salt/modules/network.py documentation. Added versionadded to functions new in 2014.7

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -454,6 +454,8 @@ def interface(iface):
     '''
     Return the inet address for a given interface
 
+    .. versionadded:: 2014.7
+
     CLI Example:
 
     .. code-block:: bash
@@ -466,6 +468,8 @@ def interface(iface):
 def interface_ip(iface):
     '''
     Return the inet address for a given interface
+
+    .. versionadded:: 2014.7
 
     CLI Example:
 
@@ -618,6 +622,8 @@ def connect(host, port=None, **kwargs):
     '''
     Test connectivity to a host using a particular
     port from the minion.
+
+    .. versionadded:: 2014.7
 
     CLI Example:
 


### PR DESCRIPTION
Saw someone using 2014.1.10 asking about a couple of these on IRC and figured this would help clear confusion.
