### PR TITLE
Return pillar data if not external pillar data

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -480,18 +480,18 @@ class Pillar(object):
 
     def ext_pillar(self, pillar, pillar_dirs):
         '''
-        Render the external pillar data
+        Render the external pillar data, and merge with pillar data
         '''
         if 'ext_pillar' not in self.opts:
-            return {}
+            return pillar
         if not isinstance(self.opts['ext_pillar'], list):
             log.critical('The "ext_pillar" option is malformed')
-            return {}
+            return pillar
         ext = None
         for run in self.opts['ext_pillar']:
             if not isinstance(run, dict):
                 log.critical('The "ext_pillar" option is malformed')
-                return {}
+                return pillar
             for key, val in run.items():
                 if key not in self.ext_pillars:
                     err = ('Specified ext_pillar interface {0} is '


### PR DESCRIPTION
Pillar data should be returned if there is no external pillar data.

The ext_pillar function merge pillar and external-pillar data if any.
So, if there is no external-pillar data (or errors), the function should return pillar.

Fixes #16210.
