### PR TITLE
Add a use_master_when_local option to allow remote execution while using...

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -638,6 +638,20 @@ directed to look on the minion by setting this parameter to ``local``.
 
     file_client: remote
 
+.. conf_minion:: use_master_when_local
+
+``use_master_when_local``
+---------------
+
+Default: ``False``
+
+When using a local :conf_minion:`file_client`, this parameter is used to allow
+the client to connect to a master for remote execution.
+
+.. code-block:: yaml
+
+    use_master_when_local: False
+
 .. conf_minion:: file_roots
 
 ``file_roots``

--- a/salt/config.py
+++ b/salt/config.py
@@ -78,6 +78,7 @@ VALID_OPTS = {
     'sls_list': list,
     'top_file': str,
     'file_client': str,
+    'use_master_when_local': bool,
     'file_roots': dict,
     'pillar_roots': dict,
     'hash_type': str,
@@ -296,6 +297,7 @@ DEFAULT_MINION_OPTS = {
     'sls_list': [],
     'top_file': '',
     'file_client': 'remote',
+    'use_master_when_local': False,
     'file_roots': {
         'base': [salt.syspaths.BASE_FILE_ROOTS_DIR],
     },

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -91,7 +91,8 @@ def resolve_dns(opts):
     '''
     ret = {}
     check_dns = True
-    if opts.get('file_client', 'remote') == 'local' and check_dns:
+    if (opts.get('file_client', 'remote') == 'local' and
+            not opts.get('use_master_when_local', False)):
         check_dns = False
 
     if check_dns is True:
@@ -243,7 +244,8 @@ class SMinion(object):
         self.opts = opts
 
         # Clean out the proc directory (default /var/cache/salt/minion/proc)
-        if self.opts.get('file_client', 'remote') == 'remote':
+        if (self.opts.get('file_client', 'remote') == 'remote'
+                or self.opts.get('use_master_when_local', False)):
             if isinstance(self.opts['master'], list):
                 masters = self.opts['master']
                 if self.opts['random_master'] is True:


### PR DESCRIPTION
... a local file_client

This PR allows for remote execution while using a salt master for remote execution. This option will obviously have some side effects. For instance, the cp module will be slightly confusing, as it will trigger a cp to/from the minion to/from the master, which in this case would also be the minion.

However, this option makes it possible to do salt runs from the master successfully.
