### PR TITLE
If the minion keypair does not exist, generate it

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -305,6 +305,8 @@ class Auth(object):
             self.mpub = 'monitor_master.pub'
         else:
             self.mpub = 'minion_master.pub'
+        if not os.path.isfile(self.pub_path):
+            self.get_keys()
 
     def get_keys(self):
         '''


### PR DESCRIPTION
Catches a bug where salt-call doe snot gen the key
