### PR TITLE
salt-call must use the current master in Multimaster-PKI (and possibly Multimaster)

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -199,8 +199,7 @@ class ZeroMQCaller(object):
             oput = self.minion.functions[fun].__outputter__
             if isinstance(oput, string_types):
                 ret['out'] = oput
-        self.is_local = self.opts['local'] or self.opts.get(
-            'file_client', False) == 'local'
+
         returners = self.opts.get('return', '').split(',')
         if (not self.is_local) or returners:
             ret['id'] = self.opts['id']

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -86,7 +86,9 @@ class ZeroMQCaller(object):
         self.is_local = self.opts['local'] or self.opts.get(
             'file_client', False) == 'local'
 
-        if not self.is_local:
+        # we only query the minion if not running local only
+        # and more than 1 master is defined in config
+        if not self.is_local and len(opts['master']) > 1:
             self.fire_get_master()
 
         # Handle this here so other deeper code which might

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1605,6 +1605,9 @@ class Minion(MinionBase):
 
                 self.schedule.modify_job(name='__master_alive',
                                          schedule=schedule)
+        elif package.startswith('__salt_call_master'):
+            event = salt.utils.event.get_event('minion', opts=self.opts, listen=False)
+            event.fire_event({'cur_master': self.opts['master']}, '__current_master')
 
     # Main Minion Tune In
     def tune_in(self):


### PR DESCRIPTION
This is a fix/improvement for #15082 and not ready for merge yet.

When running in Multimaster-PKI (and possibly in Multimaster too), salt-call always uses the first master in the list from the minions config. In a failover scenario that might result in salt-call timing out because the master is down.

These additions enable salt-call to query a running minion for its current master over the minions eventbus. 

While this works well in my testing-env, im pretty sure that the for-loop in ZeroMQCaller.fire_get_master() might result in an infinite loop if the __current_master-event was fired before the for-loop has started. If you agree, what is a better to approach to do event-firing and -listening in the same place?

Does the approach in general seem reasonable?

salt-call --local is not affected by this.
