### PR TITLE
pub_sig to pubkey_sign so that the tutorial isnt broken in /doc/topics/t...

### DIFF
--- a/doc/topics/tutorials/multimaster_pki.rst
+++ b/doc/topics/tutorials/multimaster_pki.rst
@@ -109,7 +109,7 @@ When that is done, enable the signature checking in the minions configuration
 
 .. code-block:: yaml
 
-    verify_master_pub_sig: True
+    verify_master_pubkey_sign: True
 
 and restart the minion. For the first try, the minion should be run in manual
 debug mode.


### PR DESCRIPTION
...utorials/multimaster_pki.rst
Didn't create ticket since its just a doc bug...but its an annoying one that cost me an hour until i got off my can and looked in the source for the correct option to use.
