### PR TITLE
removed end slash on slspath

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -66,8 +66,7 @@ def wrap_tmpl_func(render_str):
                     slspath = os.path.dirname(slspath)
             context['slsdotpath'] = slspath.replace('/', '.')
             context['slscolonpath'] = slspath.replace('/', ':')
-            if slspath:
-                slspath = slspath + '/'
+            context['sls_path'] = slspath.replace('/', '_')
             context['slspath'] = slspath
 
         if isinstance(tmplsrc, string_types):

--- a/tests/unit/stateconf_test.py
+++ b/tests/unit/stateconf_test.py
@@ -277,7 +277,7 @@ formula/woot.sls:
 ''', sls='formula.woot', argline='yaml . jinja')
 
         r = result['formula/woot.sls']['cmd.run'][0]['name']
-        self.assertEqual(r, 'echo formula/woot/')
+        self.assertEqual(r, 'echo formula/woot')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
removed end slash on slspath.
First i added slspath, then added the slash.. now im removing it...
long story short, it's better this way and I want this resolved in the next salt release.

I also added sls_path because some people might want underscores.
