### PR TITLE
Ssh fsclient mods

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -975,12 +975,13 @@ def mod_data(fsclient):
             for fn_ in files:
                 if fn_.startswith(pref):
                     if fn_.endswith(('.py', '.so', '.pyx')):
-                        mod_path = fsclient.cache_file(fn_, env)
+                        full = 'salt://{0}'.format(fn_)
+                        mod_path = fsclient.cache_file(full, env)
                         if not os.path.isfile(mod_path):
                             continue
                         with open(mod_path) as fp_:
                             code_str = fp_.read().encode('base64')
-                        mod_str += '{0}|{1},'.format(fn_, code_str)
+                        mod_str += '{0}|{1},'.format(os.path.basename(fn_), code_str)
             if mod_str:
                 if ref in ret:
                     ret[ref] += mod_str

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -223,7 +223,7 @@ class SSH(object):
         self.serial = salt.payload.Serial(opts)
         self.returners = salt.loader.returners(self.opts, {})
         self.fsclient = salt.fileclient.FSClient(self.opts)
-        self.mods = mod_data(self.opts)
+        self.mods = mod_data(self.fsclient)
 
     def get_pubkey(self):
         '''
@@ -953,7 +953,7 @@ def salt_refs(data):
     return ret
 
 
-def mod_data(opts):
+def mod_data(fsclient):
     '''
     Generate the module arguments for the shim data
     '''
@@ -966,21 +966,28 @@ def mod_data(opts):
             'returners',
             ]
     ret = {}
-    for env in opts['file_roots']:
-        for path in opts['file_roots'][env]:
-            for ref in sync_refs:
-                mod_str = ''
-                pl_dir = os.path.join(path, '_{0}'.format(ref))
-                if os.path.isdir(pl_dir):
-                    for fn_ in os.listdir(pl_dir):
-                        mod_path = os.path.join(pl_dir, fn_)
+    envs = fsclient.envs()
+    for env in envs:
+        files = fsclient.file_list(env)
+        for ref in sync_refs:
+            mod_str = ''
+            pref = '_{0}'.format(ref)
+            for fn_ in files:
+                if fn_.startswith(pref):
+                    if fn_.endswith(('.py', '.so', '.pyx')):
+                        mod_path = fsclient.cache_file(fn_, env)
                         if not os.path.isfile(mod_path):
                             continue
                         with open(mod_path) as fp_:
                             code_str = fp_.read().encode('base64')
                         mod_str += '{0}|{1},'.format(fn_, code_str)
-                mod_str = mod_str.rstrip(',')
-                ret[ref] = mod_str
+            if mod_str:
+                if ref in ret:
+                    ret[ref] += mod_str
+                else:
+                    ret[ref] = mod_str
+    for ref in ret:
+        ret[ref] = ret[ref].rstrip(',')
     return ret
 
 

--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -57,10 +57,8 @@ class SSHHighState(salt.state.BaseHighState):
     '''
     stack = []
 
-    def __init__(self, opts, pillar=None, wrapper=None, mopts=None):
-        if mopts is None:
-            mopts = {}
-        self.client = salt.fileclient.FSClient(mopts)
+    def __init__(self, opts, pillar=None, wrapper=None, fsclient=None):
+        self.client = fsclient
         salt.state.BaseHighState.__init__(self, opts)
         self.state = SSHState(opts, pillar, wrapper)
         self.matcher = salt.minion.Matcher(self.opts)
@@ -119,14 +117,13 @@ def salt_refs(data):
     return ret
 
 
-def prep_trans_tar(opts, chunks, file_refs, pillar=None):
+def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
     '''
     Generate the execution package from the saltenv file refs and a low state
     data structure
     '''
     gendir = tempfile.mkdtemp()
     trans_tar = salt.utils.mkstemp()
-    file_client = salt.fileclient.FSClient(opts)
     lowfn = os.path.join(gendir, 'lowstate.json')
     pillarfn = os.path.join(gendir, 'pillar.json')
     sync_refs = [

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -41,7 +41,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     if isinstance(mods, str):
         mods = mods.split(',')
     high_data, errors = st_.render_highstate({saltenv: mods})
@@ -67,7 +67,7 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
     chunks = st_.state.compile_high_data(high_data)
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __master_opts__,
+            __context__['fileclient'],
             chunks,
             file_refs,
             __pillar__)
@@ -114,13 +114,13 @@ def low(data, **kwargs):
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     err = st_.verify_data(data)
     if err:
         return err
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __master_opts__,
+            __context__['fileclient'],
             chunks,
             file_refs,
             __pillar__)
@@ -160,11 +160,11 @@ def high(data, **kwargs):
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     chunks = st_.state.compile_high_data(high)
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __master_opts__,
+            __context__['fileclient'],
             chunks,
             file_refs,
             __pillar__)
@@ -206,11 +206,11 @@ def highstate(test=None, **kwargs):
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     chunks = st_.compile_low_chunks()
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __master_opts__,
+            __context__['fileclient'],
             chunks,
             file_refs,
             __pillar__)
@@ -261,12 +261,12 @@ def top(topfn, test=None, **kwargs):
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     st_.opts['state_top'] = os.path.join('salt://', topfn)
     chunks = st_.compile_low_chunks()
     file_refs = salt.client.ssh.state.lowstate_file_refs(chunks, kwargs.get('extra_filerefs', ''))
     trans_tar = salt.client.ssh.state.prep_trans_tar(
-            __master_opts__,
+            __context__['fileclient'],
             chunks,
             file_refs,
             __pillar__)
@@ -306,7 +306,7 @@ def show_highstate():
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     return st_.compile_highstate()
 
 
@@ -325,7 +325,7 @@ def show_lowstate():
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     return st_.compile_low_chunks()
 
 
@@ -359,7 +359,7 @@ def show_sls(mods, saltenv='base', test=None, env=None, **kwargs):
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors
@@ -390,7 +390,7 @@ def show_top():
             __opts__,
             __pillar__,
             __salt__,
-            __master_opts__)
+            __context__['fileclient'])
     top_data = st_.get_top()
     errors = []
     errors += st_.verify_tops(top_data)

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -868,6 +868,15 @@ class LocalClient(Client):
         '''
         return self.opts
 
+    def envs(self):
+        '''
+        Return the available environments
+        '''
+        ret = []
+        for saltenv in self.opts['file_roots']:
+            ret.append(saltenv)
+        return ret
+
     def ext_nodes(self):
         '''
         Originally returned information via the external_nodes subsystem.
@@ -1168,6 +1177,17 @@ class RemoteClient(Client):
 
         load = {'saltenv': saltenv,
                 'cmd': '_file_list'}
+        try:
+            channel = self._get_channel()
+            return channel.send(load)
+        except SaltReqTimeoutError:
+            return ''
+
+    def envs(self):
+        '''
+        Return a list of available environments
+        '''
+        load = {'cmd': '_file_envs'}
         try:
             channel = self._get_channel()
             return channel.send(load)

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -564,7 +564,7 @@ class FSChan(object):
         if cmd in self.cmd_stub:
             return self.cmd_stub[cmd]
         if cmd == 'file_envs':
-            cmd = 'envs'
+            return self.fs.envs()
         if not hasattr(self.fs, cmd):
             log.error('Malformed request, invalid cmd: {0}'.format(load))
             return {}

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -551,6 +551,7 @@ class FSChan(object):
         self.fs = Fileserver(self.opts)
         self.fs.init()
         self.fs.update()
+        self.cmd_stub = {'ext_nodes': {}}
 
     def send(self, load, tries=None, timeout=None):
         '''
@@ -560,6 +561,8 @@ class FSChan(object):
             log.error('Malformed request, no cmd: {0}'.format(load))
             return {}
         cmd = load['cmd'].lstrip('_')
+        if cmd in self.cmd_stub:
+            return self.cmd_stub[cmd]
         if not hasattr(self.fs, cmd):
             log.error('Malformed request, invalid cmd: {0}'.format(load))
             return {}

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -563,6 +563,8 @@ class FSChan(object):
         cmd = load['cmd'].lstrip('_')
         if cmd in self.cmd_stub:
             return self.cmd_stub[cmd]
+        if cmd == 'file_envs':
+            cmd = 'envs'
         if not hasattr(self.fs, cmd):
             log.error('Malformed request, invalid cmd: {0}'.format(load))
             return {}

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -291,12 +291,12 @@ def log_handlers(opts):
     return load.filter_func('setup_handlers')
 
 
-def ssh_wrapper(opts, functions=None, mopts=None):
+def ssh_wrapper(opts, functions=None, context=None):
     '''
     Returns the custom logging handler modules
     '''
-    if mopts is None:
-        mopts = {}
+    if context is None:
+        context = {}
     if functions is None:
         functions = {}
     load = _create_loader(
@@ -307,12 +307,10 @@ def ssh_wrapper(opts, functions=None, mopts=None):
             'client',
             'ssh'))
     )
-    pack = {'name': '__salt__',
-            'value': functions}
     pack = [{'name': '__salt__',
              'value': functions},
-            {'name': '__master_opts__',
-             'value': mopts}]
+            {'name': '__context__',
+             'value': context}]
     return load.gen_functions(pack)
 
 


### PR DESCRIPTION
Enables the salt-ssh module delivery system to use fileserver backends
