### PR TITLE
Log 'zfs help' output at loglevel trace

### DIFF
--- a/salt/modules/zfs.py
+++ b/salt/modules/zfs.py
@@ -42,7 +42,7 @@ def _available_commands():
     ret = {}
     # Note that we append '|| :' as a unix hack to force return code to be 0.
     res = salt_cmd.run_stderr(
-        '{0} help || :'.format(zfs_path), output_loglevel='debug'
+        '{0} help || :'.format(zfs_path), output_loglevel='trace'
     )
 
     # This bit is dependent on specific output from `zfs help` - any major changes


### PR DESCRIPTION
This change was made in the past on 2014.7 and develop but never in 2014.1.
Adding it here in the event that we end up releasing a 2014.1.12.
