### PR TITLE
Bug fix for #15349: node_data is an object of type Node, not a dictionar...

### DIFF
--- a/salt/cloud/clouds/gce.py
+++ b/salt/cloud/clouds/gce.py
@@ -1928,7 +1928,7 @@ def create(vm_=None, call=None):
         return False
 
     try:
-        node_dict = show_instance(node_data['name'], 'action')
+        node_dict = show_instance(node_data.name, 'action')
     except TypeError:
         # node_data is a libcloud Node which is unsubscriptable
         node_dict = show_instance(node_data.name, 'action')


### PR DESCRIPTION
It looks to me like the conn.create_node returns an object of type Node, but it is treated as a dictionary on line 1931. Hopefully this is a fix for https://github.com/saltstack/salt/issues/15349
