### PR TITLE
dont merge, example of issue.

### DIFF
--- a/salt/modules/cloud.py
+++ b/salt/modules/cloud.py
@@ -278,7 +278,7 @@ def volume_detach(provider, names, **kwargs):
 
     .. code-block:: bash
 
-        salt minionname cloud.volume_detach my-nova myblock \
+        salt minionname cloud.volume_detach my-nova myblock \\
                 server_name=myserver
 
     '''


### PR DESCRIPTION
currently in my shell

```
salt salt\* cloud -d
...
cloud.volume_detach:

    Detach volume from a server

    CLI Example:

        salt minionname cloud.volume_detach my-nova myblock                 server_name=myserver
```

notice the ugly space...

if i change the code doc to:

```
    Detach volume from a server

    CLI Example:

    .. code-block:: bash

        salt minionname cloud.volume_detach my-nova myblock \\
                server_name=myserver

```

the doc looks correct when rendered in the shell.

```
cloud.volume_detach:

    Detach volume from a server

    CLI Example:

        salt minionname cloud.volume_detach my-nova myblock \
                server_name=myserver
```
