### PR TITLE
Influxdb admin user

### DIFF
--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -184,9 +184,12 @@ def db_remove(name, user=None, password=None, host=None, port=None):
     return client.delete_database(name)
 
 
-def user_list(database, user=None, password=None, host=None, port=None):
+def user_list(database=None, user=None, password=None, host=None, port=None):
     """
-    List users of a InfluxDB database
+    List cluster admins or database users.
+
+    If a database is specified: it will return database users list.
+    If a database is not specified: it will return cluster admins list.
 
     database
         The database to list the users from
@@ -207,12 +210,15 @@ def user_list(database, user=None, password=None, host=None, port=None):
 
     .. code-block:: bash
 
+        salt '*' influxdb.user_list
         salt '*' influxdb.user_list <database>
         salt '*' influxdb.user_list <database> <user> <password> <host> <port>
     """
     client = _client(user=user, password=password, host=host, port=port)
-    client.switch_db(database)
-    return client.get_database_users()
+    if database:
+        client.switch_db(database)
+        return client.get_database_users()
+    return client.get_list_cluster_admins()
 
 
 def user_exists(

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -144,7 +144,7 @@ def db_create(name, user=None, password=None, host=None, port=None):
         salt '*' influxdb.db_create <name>
         salt '*' influxdb.db_create <name> <user> <password> <host> <port>
     """
-    if db_exists(name):
+    if db_exists(name, user, password, host, port):
         log.info('DB {0!r} already exists'.format(name))
         return False
     client = _client(user=user, password=password, host=host, port=port)
@@ -177,7 +177,7 @@ def db_remove(name, user=None, password=None, host=None, port=None):
         salt '*' influxdb.db_remove <name>
         salt '*' influxdb.db_remove <name> <user> <password> <host> <port>
     """
-    if not db_exists(name):
+    if not db_exists(name, user, password, host, port):
         log.info('DB {0!r} does not exist'.format(name))
         return False
     client = _client(user=user, password=password, host=host, port=port)

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -298,7 +298,7 @@ def user_create(name, passwd, database=None, user=None, password=None,
         salt '*' influxdb.user_create <name> <passwd> <database>
         salt '*' influxdb.user_create <name> <passwd> <database> <user> <password> <host> <port>
     """
-    if user_exists(name, database):
+    if user_exists(name, database, user, password, host, port):
         if database:
             log.info('User {0!r} already exists for DB {0!r}'.format(
                 name, database))
@@ -349,7 +349,7 @@ def user_chpass(name, passwd, database=None, user=None, password=None,
         salt '*' influxdb.user_chpass <name> <passwd> <database>
         salt '*' influxdb.user_chpass <name> <passwd> <database> <user> <password> <host> <port>
     """
-    if not user_exists(name, database):
+    if not user_exists(name, database, user, password, host, port):
         if database:
             log.info('User {0!r} does not exist for DB {0!r}'.format(
                 name, database))
@@ -400,7 +400,7 @@ def user_remove(name, database=None, user=None, password=None, host=None,
         salt '*' influxdb.user_remove <name> <database>
         salt '*' influxdb.user_remove <name> <database> <user> <password> <host> <port>
     """
-    if not user_exists(name, database):
+    if not user_exists(name, database, user, password, host, port):
         if database:
             log.info('User {0!r} does not exist for DB {0!r}'.format(
                 name, database))

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -222,9 +222,12 @@ def user_list(database=None, user=None, password=None, host=None, port=None):
 
 
 def user_exists(
-        name, database, user=None, password=None, host=None, port=None):
+        name, database=None, user=None, password=None, host=None, port=None):
     '''
-    Checks if a user exists for a InfluxDB database
+    Checks if a cluster admin or database user exists.
+
+    If a database is specified: it will check for database user existence.
+    If a database is not specified: it will check for cluster admin existence.
 
     name
         User name
@@ -248,6 +251,7 @@ def user_exists(
 
     .. code-block:: bash
 
+        salt '*' influxdb.user_exists <name>
         salt '*' influxdb.user_exists <name> <database>
         salt '*' influxdb.user_exists <name> <database> <user> <password> <host> <port>
     '''

--- a/salt/states/influxdb_user.py
+++ b/salt/states/influxdb_user.py
@@ -73,9 +73,10 @@ def present(name, passwd, database=None, user=None, password=None, host=None,
     return ret
 
 
-def absent(name, database, user=None, password=None, host=None, port=None):
+def absent(name, database=None, user=None, password=None, host=None,
+           port=None):
     '''
-    Ensure that the named user is absent
+    Ensure that the named cluster admin or database user is absent.
 
     name
         The name of the user to remove

--- a/salt/states/influxdb_user.py
+++ b/salt/states/influxdb_user.py
@@ -10,10 +10,10 @@ Management of InfluxDB users
 '''
 
 
-def present(name, passwd, database, user=None, password=None, host=None,
+def present(name, passwd, database=None, user=None, password=None, host=None,
             port=None):
     '''
-    Ensure that the user is present
+    Ensure that the cluster admin or database user is present.
 
     name
         The name of the user to manage
@@ -43,7 +43,7 @@ def present(name, passwd, database, user=None, password=None, host=None,
            'comment': ''}
 
     # check if db does not exist
-    if not __salt__['influxdb.db_exists'](
+    if database and not __salt__['influxdb.db_exists'](
             database, user, password, host, port):
         ret['result'] = False
         ret['comment'] = 'Database {0} does not exist'.format(database)


### PR DESCRIPTION
This pull request adds support for cluster admin users (see: http://influxdb.com/docs/v0.8/api/administration.html#cluster-admin).

It also fixes a bug in influxdb salt module: we need to forward auth credentials and hostname/port parameters when internally calling `db_exists` and `user_exists` function.
