### PR TITLE
couchdb returner: Document a likely configuration.

### DIFF
--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -28,6 +28,18 @@ To use the alternative configuration, append ``--return_config alternative`` to 
 .. code-block:: bash
 
     salt '*' test.ping --return couchdb --return_config alternative
+
+On concurrent database access
+==============================
+
+As this returner creates a couchdb document whith the salt job id as document id
+and as only one document with a given id can exist in a given couchdb database,
+it is advised for most setups that every minion be configured to write to it own
+database (the value of ``couchdb.db`` may be suffixed with the minion id),
+otherwise multi-minion targetting can lead to losing output:
+
+* the first returning minion is able to create a document in the database
+* other minions fail with ``{'error': 'HTTP Error 409: Conflict'}``
 '''
 import logging
 import time


### PR DESCRIPTION
It is surprising to the newbie that only the first minion gets to write its data
in the couchdb database.

This documents a workaround that I hope is as clean as possible: create one db
per minion (for instance with the minion id in it).

Ref issue: #16265
