### PR TITLE
This patch fixes the 'test' mode of the 'network' state module.

### DIFF
--- a/salt/modules/rh_ip.py
+++ b/salt/modules/rh_ip.py
@@ -811,7 +811,7 @@ def _read_temp(data):
     tout = StringIO.StringIO()
     tout.write(data)
     tout.seek(0)
-    output = tout.readlines()
+    output = tout.read().splitlines()  # Discard newlines
     tout.close()
     return output
 

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -236,21 +236,21 @@ def managed(name, type, enabled=True, **kwargs):
                 ret['comment'] = 'Interface {0} is set to be ' \
                                  'added.'.format(name)
             elif old != new:
-                diff = difflib.unified_diff(old, new)
+                diff = difflib.unified_diff(old, new, lineterm='')
                 ret['result'] = None
                 ret['comment'] = 'Interface {0} is set to be ' \
                                  'updated.'.format(name)
-                ret['changes']['interface'] = ''.join(diff)
+                ret['changes']['interface'] = '\n'.join(diff)
         else:
             if not old and new:
                 ret['comment'] = 'Interface {0} ' \
                                  'added.'.format(name)
                 ret['changes']['interface'] = 'Added network interface.'
             elif old != new:
-                diff = difflib.unified_diff(old, new)
+                diff = difflib.unified_diff(old, new, lineterm='')
                 ret['comment'] = 'Interface {0} ' \
                                  'updated.'.format(name)
-                ret['changes']['interface'] = ''.join(diff)
+                ret['changes']['interface'] = '\n'.join(diff)
     except AttributeError as error:
         ret['result'] = False
         ret['comment'] = str(error)
@@ -269,21 +269,21 @@ def managed(name, type, enabled=True, **kwargs):
                     ret['comment'] = 'Bond interface {0} is set to be ' \
                                      'added.'.format(name)
                 elif old != new:
-                    diff = difflib.unified_diff(old, new)
+                    diff = difflib.unified_diff(old, new, lineterm='')
                     ret['result'] = None
                     ret['comment'] = 'Bond interface {0} is set to be ' \
                                      'updated.'.format(name)
-                    ret['changes']['bond'] = ''.join(diff)
+                    ret['changes']['bond'] = '\n'.join(diff)
             else:
                 if not old and new:
                     ret['comment'] = 'Bond interface {0} ' \
                                      'added.'.format(name)
                     ret['changes']['bond'] = 'Added bond {0}.'.format(name)
                 elif old != new:
-                    diff = difflib.unified_diff(old, new)
+                    diff = difflib.unified_diff(old, new, lineterm='')
                     ret['comment'] = 'Bond interface {0} ' \
                                      'updated.'.format(name)
-                    ret['changes']['bond'] = ''.join(diff)
+                    ret['changes']['bond'] = '\n'.join(diff)
         except AttributeError as error:
             #TODO Add a way of reversing the interface changes.
             ret['result'] = False
@@ -356,20 +356,20 @@ def routes(name, **kwargs):
                 ret['comment'] = 'Interface {0} routes are set to be added.'.format(name)
                 return ret
             elif old != new:
-                diff = difflib.unified_diff(old, new)
+                diff = difflib.unified_diff(old, new, lineterm='')
                 ret['result'] = None
                 ret['comment'] = 'Interface {0} routes are set to be updated.'.format(name)
-                ret['changes']['network_routes'] = ''.join(diff)
+                ret['changes']['network_routes'] = '\n'.join(diff)
                 return ret
         if not old and new:
             apply_routes = True
             ret['comment'] = 'Interface {0} routes added.'.format(name)
             ret['changes']['network_routes'] = 'Added interface {0} routes.'.format(name)
         elif old != new:
-            diff = difflib.unified_diff(old, new)
+            diff = difflib.unified_diff(old, new, lineterm='')
             apply_routes = True
             ret['comment'] = 'Interface {0} routes updated.'.format(name)
-            ret['changes']['network_routes'] = ''.join(diff)
+            ret['changes']['network_routes'] = '\n'.join(diff)
     except AttributeError as error:
         ret['result'] = False
         ret['comment'] = str(error)
@@ -418,18 +418,18 @@ def system(name, **kwargs):
                 ret['comment'] = 'Global network settings are set to be added.'
                 return ret
             elif old != new:
-                diff = difflib.unified_diff(old, new)
+                diff = difflib.unified_diff(old, new, lineterm='')
                 ret['result'] = None
                 ret['comment'] = 'Global network settings are set to be updated.'
-                ret['changes']['network_settings'] = ''.join(diff)
+                ret['changes']['network_settings'] = '\n'.join(diff)
                 return ret
         if not old and new:
             apply_net_settings = True
             ret['changes']['network_settings'] = 'Added global network settings.'
         elif old != new:
-            diff = difflib.unified_diff(old, new)
+            diff = difflib.unified_diff(old, new, lineterm='')
             apply_net_settings = True
-            ret['changes']['network_settings'] = ''.join(diff)
+            ret['changes']['network_settings'] = '\n'.join(diff)
     except AttributeError as error:
         ret['result'] = False
         ret['comment'] = str(error)


### PR DESCRIPTION
Before this patch, rh_ip.py returned newlines in some cases and no newlines in other cases, making the 'network' state think there were always differences that needed to be applied. This patch makes rh_ip.py never return newlines. This patch also fixes the formatting of the diff output.
