### PR TITLE
Use salt.utils.get_hash for hashing

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -840,9 +840,7 @@ class LocalClient(Client):
         if not path:
             return {}
         ret = {}
-        with salt.utils.fopen(path, 'rb') as ifile:
-            ret['hsum'] = getattr(hashlib, self.opts['hash_type'])(
-                ifile.read()).hexdigest()
+        ret['hsum'] = salt.utils.get_hash(path, self.opts['hash_type'])
         ret['hash_type'] = self.opts['hash_type']
         return ret
 
@@ -1008,15 +1006,11 @@ class RemoteClient(Client):
                     # Master has prompted a file verification, if the
                     # verification fails, re-download the file. Try 3 times
                     d_tries += 1
-                    with salt.utils.fopen(dest, 'rb') as fp_:
-                        hsum = getattr(
-                            hashlib,
-                            data.get('hash_type', 'md5')
-                        )(fp_.read()).hexdigest()
-                        if hsum != data['hsum']:
-                            log.warn('Bad download of file {0}, attempt {1} '
-                                     'of 3'.format(path, d_tries))
-                            continue
+                    hsum = salt.utils.get_hash(dest, data.get('hash_type', 'md5'))
+                    if hsum != data['hsum']:
+                        log.warn('Bad download of file {0}, attempt {1} '
+                                 'of 3'.format(path, d_tries))
+                        continue
                 break
             if not fn_:
                 with self._cache_loc(data['dest'], saltenv) as cache_dest:

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -1284,9 +1284,7 @@ def file_hash(load, fnd):
     if not os.path.isfile(hashdest):
         if not os.path.exists(os.path.dirname(hashdest)):
             os.makedirs(os.path.dirname(hashdest))
-        with salt.utils.fopen(path, 'rb') as fp_:
-            ret['hsum'] = getattr(hashlib, __opts__['hash_type'])(
-                fp_.read()).hexdigest()
+        ret['hsum'] = salt.utils.get_hash(path, __opts__['hash_type'])
         with salt.utils.fopen(hashdest, 'w+') as fp_:
             fp_.write(ret['hsum'])
         return ret

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -550,9 +550,7 @@ def file_hash(load, fnd):
                             '{0}.hash.{1}'.format(relpath,
                                                   __opts__['hash_type']))
     if not os.path.isfile(hashdest):
-        with salt.utils.fopen(path, 'rb') as fp_:
-            ret['hsum'] = getattr(hashlib, __opts__['hash_type'])(
-                fp_.read()).hexdigest()
+        ret['hsum'] = salt.utils.get_hash(path, __opts__['hash_type'])
         with salt.utils.fopen(hashdest, 'w+') as fp_:
             fp_.write(ret['hsum'])
         return ret

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -522,12 +522,10 @@ def _get_file_from_s3(metadata, saltenv, bucket_name, path, cached_file_path):
 
             if file_etag.find('-') == -1:
                 file_md5 = file_etag
-                cached_file_hash = hashlib.md5()
-                with salt.utils.fopen(cached_file_path, 'rb') as fp_:
-                    cached_file_hash.update(fp_.read())
+                cached_md5 = salt.utils.get_hash(cached_file_path, 'md5')
 
                 # hashes match we have a cache hit
-                if cached_file_hash.hexdigest() == file_md5:
+                if cached_md5 == file_md5:
                     return
             else:
                 cached_file_stat = os.stat(cached_file_path)

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -112,14 +112,10 @@ def _sync(form, saltenv=None):
             log.info('Copying {0!r} to {1!r}'.format(fn_, dest))
             if os.path.isfile(dest):
                 # The file is present, if the sum differs replace it
-                hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
-                srch = hash_type(
-                    salt.utils.fopen(fn_, 'r').read()
-                ).hexdigest()
-                dsth = hash_type(
-                    salt.utils.fopen(dest, 'r').read()
-                ).hexdigest()
-                if srch != dsth:
+                hash_type = __opts__.get('hash_type', 'md5')
+                src_digest = salt.utils.get_hash(fn_, hash_type)
+                dst_digest = salt.utils.get_hash(dest, hash_type)
+                if src_digest != dst_digest:
                     # The downloaded file differs, replace!
                     shutil.copyfile(fn_, dest)
                     ret.append('{0}.{1}'.format(form, relname))

--- a/salt/modules/timezone.py
+++ b/salt/modules/timezone.py
@@ -163,17 +163,15 @@ def zone_compare(timezone):
     if not os.path.exists(tzfile):
         return 'Error: {0} does not exist.'.format(tzfile)
 
-    hash_type = getattr(hashlib, __opts__.get('hash_type', 'md5'))
+    hash_type = __opts__.get('hash_type', 'md5')
 
     try:
-        with salt.utils.fopen(zonepath, 'r') as fp_:
-            usrzone = hash_type(fp_.read()).hexdigest()
+        usrzone = salt.utils.get_hash(zonepath, hash_type)
     except IOError as exc:
         raise SaltInvocationError('Invalid timezone {0!r}'.format(timezone))
 
     try:
-        with salt.utils.fopen(tzfile, 'r') as fp_:
-            etczone = hash_type(fp_.read()).hexdigest()
+        etczone = salt.utils.get_hash(tzfile, hash_type)
     except IOError as exc:
         raise CommandExecutionError(
             'Problem reading timezone file {0}: {1}'

--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -329,12 +329,10 @@ def _get_file_from_s3(creds, metadata, saltenv, bucket, path,
         file_md5 = filter(str.isalnum, file_meta['ETag']) \
             if file_meta else None
 
-        cached_file_hash = hashlib.md5()
-        with salt.utils.fopen(cached_file_path, 'rb') as fp_:
-            cached_file_hash.update(fp_.read())
+        cached_md5 = salt.utils.get_hash(cached_file_path, 'md5')
 
         # hashes match we have a cache hit
-        if cached_file_hash.hexdigest() == file_md5:
+        if cached_md5 == file_md5:
             return
 
     # ... or get the file from S3

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -501,13 +501,8 @@ class PrintOption(Option):
                     result.append(gid)
             elif arg == 'md5':
                 if stat.S_ISREG(fstat[stat.ST_MODE]):
-                    with salt.utils.fopen(fullpath, 'rb') as ifile:
-                        buf = ifile.read(8192)
-                        md5hash = hashlib.md5()
-                        while buf:
-                            md5hash.update(buf)
-                            buf = ifile.read(8192)
-                    result.append(md5hash.hexdigest())
+                    md5digest = salt.utils.get_hash(fullpath, 'md5')
+                    result.append(md5digest)
                 else:
                     result.append('')
 


### PR DESCRIPTION
Prevents memory errors for large files since get_hash uses chunked
hashing.

This is similar to https://github.com/saltstack/salt/issues/14784, but this is all the other places I found where custom hashing is used, didn't check for others at the time of the old issue.

One thing: We use comparing digests several places for detecting changes to files, which is quite inefficient for large files, since it requires reading the entirety of both files, hashing them both, and then compare, instead of simply iterating over both in chunks and stop on the first differing byte. This is the approach used by the [filecmp.cmp](https://docs.python.org/2/library/filecmp.html#filecmp.cmp) f. ex. Any thoughts on this?
