### PR TITLE
This is not caught in the event system, so this causes major issues

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -791,11 +791,17 @@ class LocalClient(object):
         if event is None:
             event = self.event
         while True:
-            raw = event.get_event_noblock()
-            if raw and raw.get('tag', '').startswith(jid):
-                yield raw
-            else:
-                yield None
+            try:
+                raw = event.get_event_noblock()
+                if raw and raw.get('tag', '').startswith(jid):
+                    yield raw
+                else:
+                    yield None
+            except zmq.ZMQError as ex:
+                if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
+                    yield None
+                else:
+                    raise
 
     def get_iter_returns(
             self,


### PR DESCRIPTION
Revert "The exception is properly caught inthe event system now"

This reverts commit 4502019340a602c90b7b3790c0a1f33f6e0d15a1.

Longer comment:
https://github.com/saltstack/salt/commit/4502019340a602c90b7b3790c0a1f33f6e0d15a1
