### PR TITLE
Add note for masterless tutorials about not running the salt-minion daemon

### DIFF
--- a/doc/topics/tutorials/quickstart.rst
+++ b/doc/topics/tutorials/quickstart.rst
@@ -51,6 +51,11 @@ minion is configured to not gather this data from the master.
 Now the salt minion will not look for a master and will assume that the local
 system has all of the file and pillar resources.
 
+.. note::
+
+    When running Salt in masterless mode, do not run the salt-minion daemon.
+    Otherwise, it will attempt to connect to a master and fail. The salt-call
+    command stands on its own and does not need the salt-minion daemon.
 
 Create State Tree
 =================

--- a/doc/topics/tutorials/standalone_minion.rst
+++ b/doc/topics/tutorials/standalone_minion.rst
@@ -9,6 +9,12 @@ things:
 - Use salt-call commands on a system without connectivity to a master
 - Masterless States, run states entirely from files local to the minion
 
+.. note::
+
+    When running Salt in masterless mode, do not run the salt-minion daemon.
+    Otherwise, it will attempt to connect to a master and fail. The salt-call
+    command stands on its own and does not need the salt-minion daemon.
+
 Telling Salt Call to Run Masterless
 ===================================
 


### PR DESCRIPTION
This fixes the documentation aspects of #16345.
