### PR TITLE
Fix for salt-api runner access.

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1799,7 +1799,7 @@ class ClearFuncs(object):
                 fun = clear_load.pop('fun')
                 runner_client = salt.runner.RunnerClient(self.opts)
                 return runner_client.async(fun,
-                                           clear_load.get('kwarg', {}),
+                                           clear_load,
                                            clear_load.get('username', 'UNKNOWN'))
             except Exception as exc:
                 log.error('Exception occurred while '


### PR DESCRIPTION
Since upgrading from 2014.01 to 2014.07 we've broken the salt-api's /jobs endpoint. Since upgrading we now have to specify that the specific user is able to use runners (which is arguably a good thing). In addition it was switched to make the master process do the job run (going through the sreq system). The job is being passed in a low-state, but for some reason the master process is only passing a single dict of that downstream.
