### PR TITLE
fixing whitespacing bug in a debian_ip template

### DIFF
--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -59,7 +59,7 @@
 {%endfor-%}
 {%endif%}{% if interface.post_down_cmds %}{% for cmd in interface.post_down_cmds %}    post-down {{ cmd }}
 {%endfor-%}{%endif%}
-{%endif%}
+{%- endif%}
 {%- if data.data['inet6'] -%}
 {%- set interface = data.data['inet6'] -%}
 iface {{name}} {{interface.addrfam}} {{interface.proto}}


### PR DESCRIPTION
Salt adds a newline above "iface..." but removes it afterwards. This newline did already exist.

Tested with an ipv6 only interface:

```
    network:
    - managed
    - name: eth2
    - enabled: true
    - type: eth
    - enable_ipv6: true
    - ipv6proto: static
    - ipv6ipaddr: <addr>
    - ipv6netmask: 64
    - ipv6gateway: fe80::1
```

```
----------
          ID: network_eth2
    Function: network.managed
        Name: eth2
      Result: True
     Comment: Interface eth2 updated.
     Started: 01:08:17.682618
    Duration: 203.513 ms
     Changes:
              ----------
              interface:
                  ---
                  +++
                  @@ -1,4 +1,5 @@
                   auto eth2
                  +
                   iface eth2 inet6 static
                       address <addr>
                       netmask 64

              status:
                  Interface eth2 restart to validate
```
