### PR TITLE
fixed bug with outputting unicode text in state's result summary

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -18,6 +18,10 @@ import salt.utils
 from salt.utils import print_cli
 
 
+reload(sys)
+sys.setdefaultencoding('utf-8')
+
+
 log = logging.getLogger(__name__)
 
 STATIC = (


### PR DESCRIPTION
The problem is in salt/output/nested.py module in display method of NestDisplay class.

Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 122, in salt_call
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/**init**.py", line 419, in run
    caller.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 235, in run
    self.opts)
  File "/usr/lib/python2.7/dist-packages/salt/output/**init**.py", line 38, in display_output
    display_data = get_printout(out, opts)(data).rstrip()
  File "/usr/lib/python2.7/dist-packages/salt/output/highstate.py", line 74, in output
    return _format_host(host, hostdata)[0]
  File "/usr/lib/python2.7/dist-packages/salt/output/highstate.py", line 118, in _format_host
    schanged, ctext = _format_changes(ret['changes'])
  File "/usr/lib/python2.7/dist-packages/salt/output/highstate.py", line 340, in _format_changes
    __opts__)
  File "/usr/lib/python2.7/dist-packages/salt/output/**init**.py", line 106, in out_format
    return get_printout(out, opts)(data).rstrip()
  File "/usr/lib/python2.7/dist-packages/salt/output/nested.py", line 109, in output
    return nest.display(ret, **opts**.get('nested_indent', 0), '', '')
  File "/usr/lib/python2.7/dist-packages/salt/output/nested.py", line 100, in display
    out = self.display(val, indent + 4, '', out)
  File "/usr/lib/python2.7/dist-packages/salt/output/nested.py", line 73, in display
    self.colors['ENDC'])
UnicodeDecodeError: 'ascii' codec can't decode byte 0xd0 in position 0: ordinal not in range(128)

Variable 'line' (probably non-ascii) is decoded with default 'ascii' encoding.

Setting the default encoding to 'utf-8' in /salt/output/**init**.py module solves this problem.
