### PR TITLE
Fix incorrect client ACL documentation

### DIFF
--- a/doc/ref/clientacl.rst
+++ b/doc/ref/clientacl.rst
@@ -29,7 +29,7 @@ users specified:
 
 .. code-block:: bash
 
-    chmod 755 /var/cache/salt /var/cache/salt/master/jobs /var/run/salt
+    chmod 755 /var/cache/salt /var/cache/salt/master/jobs /var/run/salt /var/run/salt/master
 
 .. note::
 


### PR DESCRIPTION
Tested this by setting up a local Vagrant instance using the following
procedure:
1. Made a fresh minion/master install (using salt-bootstrap) of version
   2014.1.10.
2. Adding a `test.ping` ACL rule for the `vagrant` user.
3. Asserting that I couldn't execute `salt '*' test.ping'` as `vagrant`
   user.
4. Applying `chmod 755 /var/cache/salt /var/cache/salt/master/jobs
   /var/run/salt /var/run/salt/master`.
5. Verifying that `salt '*' test.ping'` now works.

Fixes #16318.
