### PR TITLE
 Adding metadata to jobs, search jobs in runner.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -140,6 +140,9 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if getattr(self.options, 'return_config'):
                 kwargs['ret_config'] = getattr(self.options, 'return_config')
 
+            if getattr(self.options, 'metadata'):
+                kwargs['metadata'] = getattr(self.options, 'metadata')
+
             # If using eauth and a token hasn't already been loaded into
             # kwargs, prompt the user to enter auth credentials
             if 'token' not in kwargs and self.options.eauth:

--- a/salt/master.py
+++ b/salt/master.py
@@ -2332,6 +2332,9 @@ class ClearFuncs(object):
             if 'ret_config' in clear_load['kwargs']:
                 load['ret_config'] = clear_load['kwargs'].get('ret_config')
 
+            if 'metadata' in clear_load['kwargs']:
+                load['metadata'] = clear_load['kwargs'].get('metadata')
+
         if 'user' in clear_load:
             log.info(
                 'User {user} Published command {fun} with jid {jid}'.format(

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1095,6 +1095,11 @@ class Minion(MinionBase):
         ret['fun_args'] = data['arg']
         if 'master_id' in data:
             ret['master_id'] = data['master_id']
+        if 'metadata' in data:
+            if isinstance(data['metadata'], dict):
+                ret['metadata'] = data['metadata']
+            else:
+                log.warning('The metadata parameter must be a dictionary.  Ignoring.')
         minion_instance._return_pub(ret)
         if data['ret']:
             if 'ret_config' in data:
@@ -1150,6 +1155,8 @@ class Minion(MinionBase):
             ret['jid'] = data['jid']
             ret['fun'] = data['fun']
             ret['fun_args'] = data['arg']
+        if 'metadata' in data:
+            ret['metadata'] = data['metadata']
         minion_instance._return_pub(ret)
         if data['ret']:
             if 'ret_config' in data:

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -256,12 +256,20 @@ def get_jids():
 
 
 def _format_job_instance(job):
-    return {'Function': job.get('fun', 'unknown-function'),
-            'Arguments': list(job.get('arg', [])),
-            # unlikely but safeguard from invalid returns
-            'Target': job.get('tgt', 'unknown-target'),
-            'Target-type': job.get('tgt_type', []),
-            'User': job.get('user', 'root')}
+    ret = {'Function': job.get('fun', 'unknown-function'),
+           'Arguments': list(job.get('arg', [])),
+           # unlikely but safeguard from invalid returns
+           'Target': job.get('tgt', 'unknown-target'),
+           'Target-type': job.get('tgt_type', []),
+           'User': job.get('user', 'root')}
+
+    if 'metadata' in job:
+        ret['Metadata'] = job.get('metadata', {})
+    else:
+        if 'kwargs' in job:
+            if 'metadata' in job['kwargs']:
+                ret['Metadata'] = job['kwargs'].get('metadata', {})
+    return ret
 
 
 def _format_jid_instance(jid, job):

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -65,12 +65,20 @@ def _walk_through(job_dir):
 
 
 def _format_job_instance(job):
-    return {'Function': job.get('fun', 'unknown-function'),
-            'Arguments': list(job.get('arg', [])),
-            # unlikely but safeguard from invalid returns
-            'Target': job.get('tgt', 'unknown-target'),
-            'Target-type': job.get('tgt_type', []),
-            'User': job.get('user', 'root')}
+    ret = {'Function': job.get('fun', 'unknown-function'),
+           'Arguments': list(job.get('arg', [])),
+           # unlikely but safeguard from invalid returns
+           'Target': job.get('tgt', 'unknown-target'),
+           'Target-type': job.get('tgt_type', []),
+           'User': job.get('user', 'root')}
+
+    if 'metadata' in job:
+        ret['Metadata'] = job.get('metadata', {})
+    else:
+        if 'kwargs' in job:
+            if 'metadata' in job['kwargs']:
+                ret['Metadata'] = job['kwargs'].get('metadata', {})
+    return ret
 
 
 def _format_jid_instance(jid, job):

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -4,6 +4,7 @@ A convenience system to manage jobs, both active and already run
 '''
 
 # Import python libs
+import fnmatch
 import os
 
 # Import salt libs
@@ -12,6 +13,11 @@ import salt.payload
 import salt.utils
 import salt.output
 import salt.minion
+
+from salt._compat import string_types
+
+import logging
+log = logging.getLogger(__name__)
 
 
 def active(outputter=None):
@@ -104,7 +110,11 @@ def list_job(jid, ext_source=None, outputter=None):
     return ret
 
 
-def list_jobs(ext_source=None, outputter=None):
+def list_jobs(ext_source=None,
+              outputter=None,
+              search_metadata=None,
+              search_function=None,
+              search_target=None):
     '''
     List all detectable jobs and associated functions
 
@@ -118,9 +128,51 @@ def list_jobs(ext_source=None, outputter=None):
     mminion = salt.minion.MasterMinion(__opts__)
 
     ret = mminion.returners['{0}.get_jids'.format(returner)]()
-    salt.output.display_output(ret, outputter, opts=__opts__)
 
-    return ret
+    if search_metadata:
+        mret = {}
+        for item in ret:
+            if 'Metadata' in ret[item]:
+                if isinstance(search_metadata, dict):
+                    for key in search_metadata:
+                        if key in ret[item]['Metadata']:
+                            if ret[item]['Metadata'][key] == search_metadata[key]:
+                                mret[item] = ret[item]
+                else:
+                    log.info('The search_metadata parameter must be specified'
+                             ' as a dictionary.  Ignoring.')
+    else:
+        mret = ret.copy()
+
+    if search_target:
+        _mret = {}
+        for item in mret:
+            if 'Target' in ret[item]:
+                if isinstance(search_target, list):
+                    for key in search_target:
+                        if fnmatch.fnmatch(ret[item]['Target'], key):
+                            _mret[item] = ret[item]
+                elif isinstance(search_target, string_types):
+                    if fnmatch.fnmatch(ret[item]['Target'], search_target):
+                        _mret[item] = ret[item]
+        mret = _mret.copy()
+
+    if search_function:
+        _mret = {}
+        for item in mret:
+            if 'Function' in ret[item]:
+                if isinstance(search_function, list):
+                    for key in search_function:
+                        if fnmatch.fnmatch(ret[item]['Function'], key):
+                            _mret[item] = ret[item]
+                elif isinstance(search_function, string_types):
+                    if fnmatch.fnmatch(ret[item]['Function'], search_function):
+                        _mret[item] = ret[item]
+        mret = _mret.copy()
+
+    salt.output.display_output(mret, outputter, opts=__opts__)
+
+    return mret
 
 
 def print_job(jid, ext_source=None, outputter=None):
@@ -162,6 +214,13 @@ def _format_job_instance(job):
            'Target': job.get('tgt', 'unknown-target'),
            'Target-type': job.get('tgt_type', []),
            'User': job.get('user', 'root')}
+
+    if 'metadata' in job:
+        ret['Metadata'] = job.get('metadata', {})
+    else:
+        if 'kwargs' in job:
+            if 'metadata' in job['kwargs']:
+                ret['Metadata'] = job['kwargs'].get('metadata', {})
 
     if 'Minions' in job:
         ret['Minions'] = job['Minions']

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -1567,6 +1567,12 @@ class SaltCMDOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             nargs=1,
             help=('Password for external authentication')
         )
+        self.add_option(
+            '--metadata',
+            default='',
+            metavar='METADATA',
+            help=('Pass metadata into Salt, used to search jobs.')
+        )
 
     def _mixin_after_parsed(self):
         if len(self.args) <= 1 and not self.options.doc:


### PR DESCRIPTION
Adding the ability to include metadata in scheduled jobs as well as the ability to specify metadata from the command line using the command line.  Also including the ability to allow scheduled jobs to return data to the master, which can be used to list the scheduled jobs in the jobs runner.  Also including the ability to provided search criteria when listing jobs, eg. search by target, search by function and search by metadata.
