### PR TITLE
READ BEFORE MERGE

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,10 +4,10 @@
 The setup script for salt
 '''
 
-# pylint: disable=C0111,E1101,E1103,F0401,W0611
+# pylint: disable=C0111,E1101,E1103,F0401,W0611,W0201,W0232,R0201,R0902,R0903
 
 # For Python 2.5.  A no-op on 2.6 and above.
-from __future__ import with_statement
+from __future__ import print_function, with_statement
 
 import os
 import sys
@@ -15,6 +15,7 @@ import glob
 import urllib2
 from datetime import datetime
 # pylint: disable=E0611
+import distutils.dist
 from distutils import log
 from distutils.cmd import Command
 from distutils.errors import DistutilsArgError
@@ -104,10 +105,8 @@ SALT_SYSPATHS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'salt', 'syspaths.p
 
 # Salt SSH Packaging Detection
 PACKAGED_FOR_SALT_SSH_FILE = os.path.join(os.path.abspath(SETUP_DIRNAME), '.salt-ssh-package')
-if '--ssh-packaging' in sys.argv:
-    with open(PACKAGED_FOR_SALT_SSH_FILE, 'w+') as fp_:
-        fp_.write(' ')
 PACKAGED_FOR_SALT_SSH = os.path.isfile(PACKAGED_FOR_SALT_SSH_FILE)
+
 
 # pylint: disable=W0122
 exec(compile(open(SALT_VERSION).read(), SALT_VERSION, 'exec'))
@@ -145,7 +144,7 @@ class WriteSaltVersion(Command):
         if not os.path.exists(SALT_VERSION_HARDCODED):
             # Write the version file
             if getattr(self.distribution, 'salt_version_hardcoded_path', None) is None:
-                print 'This command is not meant to be called on it\'s own'
+                print('This command is not meant to be called on it\'s own')
                 exit(1)
 
             # pylint: disable=E0602
@@ -172,7 +171,7 @@ class WriteSaltSshPackaingFile(Command):
         if not os.path.exists(PACKAGED_FOR_SALT_SSH_FILE):
             # Write the salt-ssh packaging file
             if getattr(self.distribution, 'salt_ssh_packaging_file', None) is None:
-                print 'This command is not meant to be called on it\'s own'
+                print('This command is not meant to be called on it\'s own')
                 exit(1)
 
             # pylint: disable=E0602
@@ -180,44 +179,13 @@ class WriteSaltSshPackaingFile(Command):
             # pylint: enable=E0602
 
 
-if WITH_SETUPTOOLS is True:
-    class EggInfo(egg_info):
-
-        def finalize_options(self):
-            if getattr(self.distribution, 'packaged_for_salt_ssh', PACKAGED_FOR_SALT_SSH):
-                self.distribution.metadata.name = 'salt-ssh'
-            egg_info.finalize_options(self)
-
-
 class Sdist(sdist):
-    user_options = sdist.user_options + [
-        ('ssh-packaging', None, 'Prepare the salt-ssh packaging')
-    ]
-    boolean_options = sdist.boolean_options + [
-        'ssh-packaging'
-    ]
-
-    def initialize_options(self):
-        sdist.initialize_options(self)
-        self.ssh_packaging = PACKAGED_FOR_SALT_SSH
-
-    def finalize_options(self):
-        sdist.finalize_options(self)
-        self.distribution.packaged_for_salt_ssh = self.ssh_packaging
 
     def make_release_tree(self, base_dir, files):
-        if self.ssh_packaging:
+        if self.distribution.ssh_packaging:
             self.distribution.salt_ssh_packaging_file = PACKAGED_FOR_SALT_SSH_FILE
             self.run_command('write-salt-ssh-packaging-file')
-            self.distribution.package_data.pop('salt.daemons.flo', None)
             self.filelist.files.append(os.path.basename(PACKAGED_FOR_SALT_SSH_FILE))
-            self.distribution.metadata.name = 'salt-ssh'
-            self.distribution.data_files = [('share/man/man1',
-                                             ['doc/man/salt-ssh.1',
-                                              'doc/man/salt-run.1',
-                                              'doc/man/salt-call.1',
-                                              'doc/man/salt-cloud.1']),
-                                            ('share/man/man7', ['doc/man/salt.7'])]
 
         sdist.make_release_tree(self, base_dir, files)
 
@@ -230,7 +198,7 @@ class Sdist(sdist):
 
     def make_distribution(self):
         sdist.make_distribution(self)
-        if self.ssh_packaging:
+        if self.distribution.ssh_packaging:
             os.unlink(PACKAGED_FOR_SALT_SSH_FILE)
 
 
@@ -325,33 +293,13 @@ class CloudSdist(Sdist):
         Sdist.run(self)
 
     def write_manifest(self):
-        if IS_WINDOWS_PLATFORM:
-            # Remove un-necessary scripts grabbed by MANIFEST.in
-            for filename in self.filelist.files[:]:
-                if filename in ('scripts/salt',
-                                'scripts/salt-api',
-                                'scripts/salt-cloud',
-                                'scripts/salt-api',
-                                'scripts/salt-key',
-                                'scripts/salt-master',
-                                'scripts/salt-run',
-                                'scripts/salt-ssh',
-                                'scripts/salt-syndic'):
-                    self.filelist.files.pop(
-                        self.filelist.files.index(filename)
-                    )
-        elif self.distribution.packaged_for_salt_ssh:
-            # Remove un-necessary script from Salt-SSH package
-            for filename in self.filelist.files[:]:
-                if not filename.startswith('scripts/'):
-                    continue
-                if filename not in ('scripts/salt-ssh',
-                                    'scripts/salt-run',
-                                    'scripts/salt-call',
-                                    'scripts/salt-cloud'):
-                    self.filelist.files.pop(
-                        self.filelist.files.index(filename)
-                    )
+        # We only need to ship the scripts which are supposed to be installed
+        dist_scripts = self.distribution.scripts
+        for script in self.filelist.files[:]:
+            if not script.startswith('scripts/'):
+                continue
+            if script not in dist_scripts:
+                self.filelist.files.remove(script)
         return Sdist.write_manifest(self)
 
 
@@ -392,7 +340,7 @@ class Clean(clean):
         # Let's clean compiled *.py[c,o]
         for subdir in ('salt', 'tests', 'doc'):
             root = os.path.join(os.path.dirname(__file__), subdir)
-            for dirname, dirnames, filenames in os.walk(root):
+            for dirname, _, _ in os.walk(root):
                 for to_remove_filename in glob.glob('{0}/*.py[oc]'.format(dirname)):
                     os.remove(to_remove_filename)
 
@@ -458,9 +406,6 @@ class Build(build):
 
 class Install(install):
     user_options = install.user_options + [
-        ('salt-transport=', None,
-         'The transport to prepare salt for. Choices are \'zeromq\' '
-         '\'raet\' or \'both\'. Defaults to \'zeromq\''),
         ('salt-root-dir=', None,
          'Salt\'s pre-configured root directory'),
         ('salt-config-dir=', None,
@@ -485,14 +430,7 @@ class Install(install):
 
     def initialize_options(self):
         install.initialize_options(self)
-        if not hasattr(self.distribution, 'install_requires'):
-            # Non setuptools installation
-            self.distribution.install_requires = _parse_requirements_file(SALT_REQS)
-        # pylint: disable=E0602
-        if PACKAGED_FOR_SALT_SSH:
-            self.salt_transport = 'ssh'
-        else:
-            self.salt_transport = 'zeromq'
+        # pylint: disable=undefined-variable
         self.salt_root_dir = ROOT_DIR
         self.salt_config_dir = CONFIG_DIR
         self.salt_cache_dir = CACHE_DIR
@@ -503,12 +441,10 @@ class Install(install):
         self.salt_base_master_roots_dir = BASE_MASTER_ROOTS_DIR
         self.salt_logs_dir = LOGS_DIR
         self.salt_pidfile_dir = PIDFILE_DIR
-        # pylint: enable=E0602
+        # pylint: enable=undefined-variable
 
     def finalize_options(self):
         install.finalize_options(self)
-        if PACKAGED_FOR_SALT_SSH and self.salt_transport != 'ssh':
-            raise DistutilsArgError('The only available transport for salt-ssh is \'ssh\'')
 
         for optname in ('root_dir', 'config_dir', 'cache_dir', 'sock_dir',
                         'srv_root_dir', 'base_file_roots_dir',
@@ -522,28 +458,6 @@ class Install(install):
                     )
                 )
             setattr(self.distribution, 'salt_{0}'.format(optname), optvalue)
-
-        if self.salt_transport not in ('zeromq', 'raet', 'both', 'ssh', 'none'):
-            raise DistutilsArgError(
-                'The value of --salt-transport needs be \'zeromq\', '
-                '\'raet\', \'both\' \'ssh\' or \'none\' not {0!r}'.format(
-                    self.salt_transport
-                )
-            )
-        elif self.salt_transport in ('ssh', 'none'):
-            for requirement in _parse_requirements_file(SALT_ZEROMQ_REQS):
-                if requirement not in self.distribution.install_requires:
-                    continue
-                self.distribution.install_requires.remove(requirement)
-        elif self.salt_transport in ('raet', 'both'):
-            self.distribution.install_requires.extend(
-                _parse_requirements_file(SALT_RAET_REQS)
-            )
-            if self.salt_transport == 'raet':
-                for requirement in _parse_requirements_file(SALT_ZEROMQ_REQS):
-                    if requirement not in self.distribution.install_requires:
-                        continue
-                    self.distribution.install_requires.remove(requirement)
 
     def run(self):
         # Let's set the running_salt_install attribute so we can add
@@ -578,325 +492,380 @@ class InstallLib(install_lib):
             os.chmod(filename, 0755)
 # <---- Custom Distutils/Setuptools Commands -------------------------------------------------------------------------
 
-if PACKAGED_FOR_SALT_SSH:
-    NAME = 'salt-ssh'
-else:
-    NAME = 'salt'
 
-VER = __version__  # pylint: disable=E0602
-DESC = 'Portable, distributed, remote execution and configuration management system'
-SETUP_KWARGS = {'name': NAME,
-                'version': VER,
-                'description': DESC,
-                'author': 'Thomas S Hatch',
-                'author_email': 'thatch45@gmail.com',
-                'url': 'http://saltstack.org',
-                'cmdclass': {
-                    'test': TestCommand,
-                    'clean': Clean,
-                    'build': Build,
-                    'sdist': Sdist,
-                    'install': Install,
-                    'write-salt-version': WriteSaltVersion,
-                    'write-salt-ssh-packaging-file': WriteSaltSshPackaingFile,
-                },
-                'classifiers': ['Programming Language :: Python',
-                                'Programming Language :: Cython',
-                                'Programming Language :: Python :: 2.6',
-                                'Programming Language :: Python :: 2.7',
-                                'Development Status :: 5 - Production/Stable',
-                                'Environment :: Console',
-                                'Intended Audience :: Developers',
-                                'Intended Audience :: Information Technology',
-                                'Intended Audience :: System Administrators',
-                                ('License :: OSI Approved ::'
-                                 ' Apache Software License'),
-                                'Operating System :: POSIX :: Linux',
-                                'Topic :: System :: Clustering',
-                                'Topic :: System :: Distributed Computing',
-                                ],
-                'packages': ['salt',
-                             'salt.auth',
-                             'salt.cli',
-                             'salt.client',
-                             'salt.client.raet',
-                             'salt.client.ssh',
-                             'salt.client.ssh.wrapper',
-                             'salt.cloud',
-                             'salt.cloud.clouds',
-                             'salt.daemons',
-                             'salt.daemons.flo',
-                             'salt.ext',
-                             'salt.fileserver',
-                             'salt.grains',
-                             'salt.log',
-                             'salt.log.handlers',
-                             'salt.modules',
-                             'salt.netapi',
-                             'salt.netapi.rest_cherrypy',
-                             'salt.netapi.rest_cherrypy.tools',
-                             'salt.netapi.rest_tornado',
-                             'salt.output',
-                             'salt.pillar',
-                             'salt.proxy',
-                             'salt.renderers',
-                             'salt.returners',
-                             'salt.roster',
-                             'salt.runners',
-                             'salt.search',
-                             'salt.states',
-                             'salt.tops',
-                             'salt.templates',
-                             'salt.transport',
-                             'salt.utils',
-                             'salt.utils.decorators',
-                             'salt.utils.openstack',
-                             'salt.utils.validate',
-                             'salt.utils.serializers',
-                             'salt.wheel',
-                             ],
-                'package_data': {'salt.templates': [
-                                    'rh_ip/*.jinja',
-                                    'debian_ip/*.jinja',
-                                    'virt/*.jinja',
-                                    'git/*',
-                                    'lxc/*',
-                                    ],
-                                 'salt.daemons.flo': [
-                                    '*.flo'
-                                    ]
-                                },
-                'data_files': [('share/man/man1',
-                                ['doc/man/salt-cp.1',
-                                 'doc/man/salt-call.1',
-                                 'doc/man/salt-minion.1',
-                                 'doc/man/salt-unity.1',
-                                 ]),
-                               ('share/man/man7',
-                                ['doc/man/salt.7',
-                                 ]),
-                               ],
-                # Required for esky builds, ZeroMQ or RAET deps will be added
-                # at install time
-                'install_requires':
-                    _parse_requirements_file(SALT_REQS) +
-                    _parse_requirements_file(SALT_ZEROMQ_REQS),
-                'extras_require': {
-                    'RAET': _parse_requirements_file(SALT_RAET_REQS),
-                    'Cloud': _parse_requirements_file(SALT_CLOUD_REQS)
-                },
-                # The dynamic module loading in salt.modules makes this
-                # package zip unsafe. Required for esky builds
-                'zip_safe': False
-                }
+# ----- Custom Distribution Class ----------------------------------------------------------------------------------->
+# We use this to override the package name in case --ssh-packaging is passed to
+# setup.py or the special .salt-ssh-package is found
+class SaltDistribution(distutils.dist.Distribution):
+    '''
+    Just so it's completely clear
 
-if PACKAGED_FOR_SALT_SSH:
-    SETUP_KWARGS['data_files'][0][1].extend([
-        'doc/man/salt-ssh.1',
-        'doc/man/salt-run.1',
-        'doc/man/salt-cloud.1',
-    ])
+    Under windows, the following scripts should be installed:
 
-if IS_WINDOWS_PLATFORM is False:
-    SETUP_KWARGS['cmdclass']['sdist'] = CloudSdist
-    SETUP_KWARGS['cmdclass']['install_lib'] = InstallLib
-    # SETUP_KWARGS['packages'].extend(['salt.cloud',
-    #                                  'salt.cloud.clouds'])
-    SETUP_KWARGS['package_data']['salt.cloud'] = ['deploy/*.sh']
+        * salt-call
+        * salt-cp
+        * salt-minion
+        * salt-unity
 
-    SETUP_KWARGS['data_files'][0][1].extend([
-        'doc/man/salt-master.1',
-        'doc/man/salt-key.1',
-        'doc/man/salt.1',
-        'doc/man/salt-api.1',
-        'doc/man/salt-syndic.1',
-        'doc/man/salt-unity.1',
-    ])
-    if PACKAGED_FOR_SALT_SSH is False:
-        SETUP_KWARGS['data_files'][0][1].extend([
-            'doc/man/salt-ssh.1',
-            'doc/man/salt-run.1',
-            'doc/man/salt-cloud.1',
-        ])
+    When packaged for salt-ssh, the following scripts should be installed:
+        * salt-call
+        * salt-run
+        * salt-ssh
+        * salt-cloud
 
+        Under windows, the following scripts should be omitted from the salt-ssh package:
+            * salt-cloud
+            * salt-run
 
-# bbfreeze explicit includes
-# Sometimes the auto module traversal doesn't find everything, so we
-# explicitly add it. The auto dependency tracking especially does not work for
-# imports occurring in salt.modules, as they are loaded at salt runtime.
-# Specifying includes that don't exist doesn't appear to cause a freezing
-# error.
-FREEZER_INCLUDES = [
-    'zmq.core.*',
-    'zmq.utils.*',
-    'ast',
-    'difflib',
-    'distutils',
-    'distutils.version',
-    'numbers',
-    'json',
-    'M2Crypto',
-    'Cookie',
-    'asyncore',
-    'fileinput',
-    'sqlite3',
-    'email',
-    'email.mime.*',
-    'requests',
-    'sqlite3',
-]
-
-if HAS_ZMQ and hasattr(zmq, 'pyzmq_version_info'):
-    if HAS_ZMQ and zmq.pyzmq_version_info() >= (0, 14):
-        # We're freezing, and when freezing ZMQ needs to be installed, so this
-        # works fine
-        if 'zmq.core.*' in FREEZER_INCLUDES:
-            # For PyZMQ >= 0.14, freezing does not need 'zmq.core.*'
-            FREEZER_INCLUDES.remove('zmq.core.*')
-
-if IS_WINDOWS_PLATFORM:
-    FREEZER_INCLUDES.extend([
-        'win32api',
-        'win32file',
-        'win32con',
-        'win32com',
-        'win32net',
-        'win32netcon',
-        'win32gui',
-        'win32security',
-        'ntsecuritycon',
-        'pywintypes',
-        'pythoncom',
-        '_winreg',
-        'wmi',
-        'site',
-        'psutil',
-    ])
-    SETUP_KWARGS['install_requires'].append('WMI')
-elif sys.platform.startswith('linux'):
-    FREEZER_INCLUDES.append('spwd')
-    try:
-        import yum
-        FREEZER_INCLUDES.append('yum')
-    except ImportError:
-        pass
-elif sys.platform.startswith('sunos'):
-    # (The sledgehammer approach)
-    # Just try to include everything
-    # (This may be a better way to generate FREEZER_INCLUDES generally)
-    try:
-        from bbfreeze.modulegraph.modulegraph import ModuleGraph
-        mf = ModuleGraph(sys.path[:])
-        for arg in glob.glob('salt/modules/*.py'):
-            mf.run_script(arg)
-        for mod in mf.flatten():
-            if type(mod).__name__ != 'Script' and mod.filename:
-                FREEZER_INCLUDES.append(str(os.path.basename(mod.identifier)))
-    except ImportError:
-        pass
-    # Include C extension that convinces esky to package up the libsodium C library
-    # This is needed for ctypes to find it in libnacl which is in turn needed for raet
-    # see pkg/smartos/esky/sodium_grabber{.c,_installer.py}
-    FREEZER_INCLUDES.extend([
-        'sodium_grabber',
-        'ioflo',
-        'raet',
-        'libnacl',
-    ])
-
-if HAS_ESKY:
-    # if the user has the esky / bbfreeze libraries installed, add the
-    # appropriate kwargs to setup
-    OPTIONS = SETUP_KWARGS.get('options', {})
-    OPTIONS['bdist_esky'] = {
-        'freezer_module': 'bbfreeze',
-        'freezer_options': {
-            'includes': FREEZER_INCLUDES
-        }
-    }
-    SETUP_KWARGS['options'] = OPTIONS
-
-if WITH_SETUPTOOLS:
-    SETUP_KWARGS['cmdclass']['egg_info'] = EggInfo
-    if PACKAGED_FOR_SALT_SSH is False:
-        SETUP_KWARGS['entry_points'] = {
-            'console_scripts': ['salt-call = salt.scripts:salt_call',
-                                'salt-cp = salt.scripts:salt_cp',
-                                'salt-minion = salt.scripts:salt_minion',
-                                ]
-        }
-    else:
-        SETUP_KWARGS['entry_points'] = {'console_scripts': [
-            'salt-ssh = salt.scripts:salt_ssh',
-            'salt-run = salt.scripts:salt_run',
-            'salt-call = salt.scripts:salt_call',
-            'salt-cloud = salt.scripts:salt_cloud',
-        ]}
-    if IS_WINDOWS_PLATFORM is False:
-        if PACKAGED_FOR_SALT_SSH:
-            SETUP_KWARGS['entry_points']['console_scripts'].extend([
-                'salt = salt.scripts:salt_main',
-                'salt-api = salt.scripts:salt_api',
-                'salt-key = salt.scripts:salt_key',
-                'salt-master = salt.scripts:salt_master',
-                'salt-syndic = salt.scripts:salt_syndic',
-            ])
-        else:
-            SETUP_KWARGS['entry_points']['console_scripts'].extend([
-                'salt = salt.scripts:salt_main',
-                'salt-api = salt.scripts:salt_api',
-                'salt-cloud = salt.scripts:salt_cloud',
-                'salt-key = salt.scripts:salt_key',
-                'salt-master = salt.scripts:salt_master',
-                'salt-run = salt.scripts:salt_run',
-                'salt-ssh = salt.scripts:salt_ssh',
-                'salt-syndic = salt.scripts:salt_syndic',
-            ])
-
-    # Required for running the tests suite
-    SETUP_KWARGS['dependency_links'] = [
-        'https://github.com/saltstack/salt-testing/tarball/develop#egg=SaltTesting'
+    Under *nix, all scripts should be installed
+    '''
+    global_options = distutils.dist.Distribution.global_options + [
+        ('ssh-packaging', None, 'Run in SSH packaging mode'),
+        ('salt-transport=', None, 'The transport to prepare salt for. Choices are \'zeromq\' '
+                                  '\'raet\' or \'both\'. Defaults to \'zeromq\'', 'zeromq')
     ]
-    SETUP_KWARGS['tests_require'] = ['SaltTesting']
 
-# When WITH_SETUPTOOLS is True, esky builds would fail to include the scripts,
-# and, if WITH_SETUPTOOLS is True, having scripts and console_scripts defined
-# does not, apparently, break the build, so, let's have both
-if PACKAGED_FOR_SALT_SSH is False:
-    SETUP_KWARGS['scripts'] = ['scripts/salt-call',
-                               'scripts/salt-cp',
-                               'scripts/salt-minion',
-                               'scripts/salt-unity',
-                               ]
+    def __init__(self, attrs=None):
+        distutils.dist.Distribution.__init__(self, attrs)
 
-if IS_WINDOWS_PLATFORM is False:
-    if PACKAGED_FOR_SALT_SSH:
-        SETUP_KWARGS['scripts'] = [
-            'scripts/salt-ssh',
-            'scripts/salt-run',
-            'scripts/salt-call',
-            'scripts/salt-cloud'
+        self.ssh_packaging = PACKAGED_FOR_SALT_SSH
+        self.salt_transport = None
+
+        self.name = 'salt-ssh' if PACKAGED_FOR_SALT_SSH else 'salt'
+        self.version = __version__  # pylint: disable=undefined-variable
+        self.description = 'Portable, distributed, remote execution and configuration management system'
+        self.author = 'Thomas S Hatch'
+        self.author_email = 'thatch45@gmail.com'
+        self.url = 'http://saltstack.org'
+        self.cmdclass.update({'test': TestCommand,
+                              'clean': Clean,
+                              'build': Build,
+                              'sdist': Sdist,
+                              'install': Install,
+                              'write-salt-version': WriteSaltVersion,
+                              'write-salt-ssh-packaging-file': WriteSaltSshPackaingFile})
+        if not IS_WINDOWS_PLATFORM:
+            self.cmdclass.update({'sdist': CloudSdist,
+                                  'install_lib': InstallLib})
+
+        self.license = 'Apache Software License 2.0'
+        self.packages = self.discover_packages()
+        self.zip_safe = False
+
+        if HAS_ESKY:
+            self.setup_esky()
+
+        self.update_metadata()
+
+    def update_metadata(self):
+        for attrname in dir(self):
+            attrvalue = getattr(self, attrname, None)
+            if attrvalue == 0:
+                continue
+            if hasattr(self.metadata, 'set_{0}'.format(attrname)):
+                getattr(self.metadata, 'set_{0}'.format(attrname))(attrvalue)
+            elif hasattr(self.metadata, attrname):
+                setattr(self.metadata, attrname, attrvalue)
+
+    def discover_packages(self):
+        modules = []
+        for root, _, files in os.walk(os.path.join(SETUP_DIRNAME, 'salt')):
+            if '__init__.py' not in files:
+                continue
+            modules.append(os.path.relpath(root, SETUP_DIRNAME).replace(os.sep, '.'))
+        return modules
+
+    # ----- Static Data ---------------------------------------------------------------------------------------------
+    @property
+    def _property_classifiers(self):
+        return ['Programming Language :: Python',
+                'Programming Language :: Cython',
+                'Programming Language :: Python :: 2.6',
+                'Programming Language :: Python :: 2.7',
+                'Development Status :: 5 - Production/Stable',
+                'Environment :: Console',
+                'Intended Audience :: Developers',
+                'Intended Audience :: Information Technology',
+                'Intended Audience :: System Administrators',
+                'License :: OSI Approved :: Apache Software License',
+                'Operating System :: POSIX :: Linux',
+                'Topic :: System :: Clustering',
+                'Topic :: System :: Distributed Computing']
+
+    @property
+    def _property_dependency_links(self):
+        return ['https://github.com/saltstack/salt-testing/tarball/develop#egg=SaltTesting']
+
+    @property
+    def _property_tests_require(self):
+        return ['SaltTesting']
+    # <---- Static Data ----------------------------------------------------------------------------------------------
+
+    # ----- Dynamic Data -------------------------------------------------------------------------------------------->
+    @property
+    def _property_package_data(self):
+        package_data = {'salt.templates': ['rh_ip/*.jinja',
+                                           'debian_ip/*.jinja',
+                                           'virt/*.jinja',
+                                           'git/*',
+                                           'lxc/*',
+                                          ]}
+        if not IS_WINDOWS_PLATFORM:
+            package_data['salt.cloud'] = ['deploy/*.sh']
+
+        if not self.ssh_packaging and not PACKAGED_FOR_SALT_SSH:
+            package_data['salt.daemons.flo'] = ['*.flo']
+        return package_data
+
+    @property
+    def _property_data_files(self):
+        # Data files common to all scenarios
+        data_files = [
+            ('share/man/man1', ['doc/man/salt-call.1']),
+            ('share/man/man7', ['doc/man/salt.7'])
         ]
-    else:
-        SETUP_KWARGS['scripts'].extend([
-            'scripts/salt',
-            'scripts/salt-api',
-            'scripts/salt-cloud',
-            'scripts/salt-key',
-            'scripts/salt-master',
-            'scripts/salt-run',
-            'scripts/salt-ssh',
-            'scripts/salt-syndic',
-        ])
+        if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
+            data_files[0][1].append('doc/man/salt-ssh.1')
+            if IS_WINDOWS_PLATFORM:
+                return data_files
+            data_files[0][1].extend(['doc/man/salt-run.1',
+                                     'doc/man/salt-cloud.1'])
+            return data_files
 
+        if IS_WINDOWS_PLATFORM:
+            data_files[0][1].extend(['doc/man/salt-cp.1',
+                                     'doc/man/salt-minion.1',
+                                     'doc/man/salt-unity.1'])
+            return data_files
 
-if PACKAGED_FOR_SALT_SSH:
-    SETUP_KWARGS.pop('extras_require')
-    for requirement in _parse_requirements_file(SALT_ZEROMQ_REQS):
-        if requirement not in SETUP_KWARGS['install_requires']:
-            continue
-        SETUP_KWARGS['install_requires'].remove(requirement)
+        # *nix, so, we need all man pages
+        data_files[0][1].extend(['doc/man/salt-api.1',
+                                 'doc/man/salt-cloud.1',
+                                 'doc/man/salt-cp.1',
+                                 'doc/man/salt-key.1',
+                                 'doc/man/salt-master.1',
+                                 'doc/man/salt-minion.1',
+                                 'doc/man/salt-run.1',
+                                 'doc/man/salt-ssh.1',
+                                 'doc/man/salt-syndic.1',
+                                 'doc/man/salt-unity.1'])
+        return data_files
+
+    @property
+    def _property_install_requires(self):
+        install_requires = _parse_requirements_file(SALT_REQS)
+
+        if IS_WINDOWS_PLATFORM:
+            install_requires.append('WMI')
+
+        if self.salt_transport == 'zeromq':
+            install_requires += _parse_requirements_file(SALT_ZEROMQ_REQS)
+        elif self.salt_transport == 'raet':
+            install_requires += _parse_requirements_file(SALT_RAET_REQS)
+        return install_requires
+
+    @property
+    def _property_extras_require(self):
+        if self.ssh_packaging:
+            return {}
+        return {'RAET': _parse_requirements_file(SALT_RAET_REQS),
+                'Cloud': _parse_requirements_file(SALT_CLOUD_REQS)}
+
+    @property
+    def _property_scripts(self):
+        # Scripts common to all scenarios
+        scripts = ['scripts/salt-call']
+        if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
+            scripts.append('scripts/salt-ssh')
+            if IS_WINDOWS_PLATFORM:
+                return scripts
+            scripts.extend(['scripts/salt-cloud', 'scripts/salt-run'])
+            return scripts
+
+        if IS_WINDOWS_PLATFORM:
+            scripts.extend(['scripts/salt-cp',
+                            'scripts/salt-minion',
+                            'scripts/salt-unity'])
+            return scripts
+
+        # *nix, so, we need all scripts
+        scripts.extend(['scripts/salt',
+                        'scripts/salt-api',
+                        'scripts/salt-cloud',
+                        'scripts/salt-cp',
+                        'scripts/salt-key',
+                        'scripts/salt-master',
+                        'scripts/salt-minion',
+                        'scripts/salt-run',
+                        'scripts/salt-ssh',
+                        'scripts/salt-syndic',
+                        'scripts/salt-unity'])
+        return scripts
+
+    # We don't actually need to set the console_scripts entry point since the
+    # packaged scripts with do the same work
+    #@property
+    #def _property_entry_points(self):
+    #    return {}
+    #    # console scripts common to all scenarios
+    #    scripts = ['salt-call = salt.scripts:salt_call']
+    #    if self.ssh_packaging or PACKAGED_FOR_SALT_SSH:
+    #        scripts.append('salt-ssh = salt.scripts:salt_ssh')
+    #        if IS_WINDOWS_PLATFORM:
+    #            return {'console_scripts': scripts}
+    #        scripts.extend(['salt-cloud = salt.scripts:salt_cloud',
+    #                        'salt-run = salt.scripts:salt_run'])
+    #        return {'console_scripts': scripts}
+    #
+    #    if IS_WINDOWS_PLATFORM:
+    #        scripts.extend(['salt-cp = salt.scripts:salt_cp'
+    #                        'salt-minion = salt.scripts:salt_minion',
+    #                        'salt-unity = salt.scripts:salt_unity'])
+    #        return {'console_scripts': scripts}
+    #
+    #    # *nix, so, we need all scripts
+    #    scripts.extend(['salt = salt.scripts:salt_main',
+    #                    'salt-api = salt.scripts:salt_api',
+    #                    'salt-cloud = salt.scripts:salt_cloud',
+    #                    'salt-cp = salt.scripts:salt_cp',
+    #                    'salt-key = salt.scripts:salt_key',
+    #                    'salt-master = salt.scripts:salt_master',
+    #                    'salt-minion = salt.scripts:salt_minion',
+    #                    'salt-run = salt.scripts:salt_run',
+    #                    'salt-ssh = salt.scripts:salt_ssh',
+    #                    'salt-syndic = salt.scripts:salt_syndic',
+    #                    'salt-unity = salt.scripts:salt_unity'])
+    #    return {'console_scripts': scripts}
+    # <---- Dynamic Data ---------------------------------------------------------------------------------------------
+
+    # ----- Esky Setup ---------------------------------------------------------------------------------------------->
+    def setup_esky(self):
+        opt_dict = self.get_option_dict('bdist_esky')
+        opt_dict['freezer_module'] = ('setup script', 'bbfreeze')
+        opt_dict['freezer_options'] = ('setup script', {'includes': self.get_esky_freezer_includes()})
+
+    @property
+    def _property_freezer_options(self):
+        return {'includes': self.get_esky_freezer_includes()}
+
+    def get_esky_freezer_includes(self):
+        # Sometimes the auto module traversal doesn't find everything, so we
+        # explicitly add it. The auto dependency tracking especially does not work for
+        # imports occurring in salt.modules, as they are loaded at salt runtime.
+        # Specifying includes that don't exist doesn't appear to cause a freezing
+        # error.
+        freezer_includes = [
+            'zmq.core.*',
+            'zmq.utils.*',
+            'ast',
+            'difflib',
+            'distutils',
+            'distutils.version',
+            'numbers',
+            'json',
+            'M2Crypto',
+            'Cookie',
+            'asyncore',
+            'fileinput',
+            'sqlite3',
+            'email',
+            'email.mime.*',
+            'requests',
+            'sqlite3',
+        ]
+        if HAS_ZMQ and hasattr(zmq, 'pyzmq_version_info'):
+            if HAS_ZMQ and zmq.pyzmq_version_info() >= (0, 14):
+                # We're freezing, and when freezing ZMQ needs to be installed, so this
+                # works fine
+                if 'zmq.core.*' in freezer_includes:
+                    # For PyZMQ >= 0.14, freezing does not need 'zmq.core.*'
+                    freezer_includes.remove('zmq.core.*')
+
+        if IS_WINDOWS_PLATFORM:
+            freezer_includes.extend([
+                'win32api',
+                'win32file',
+                'win32con',
+                'win32com',
+                'win32net',
+                'win32netcon',
+                'win32gui',
+                'win32security',
+                'ntsecuritycon',
+                'pywintypes',
+                'pythoncom',
+                '_winreg',
+                'wmi',
+                'site',
+                'psutil',
+            ])
+        elif sys.platform.startswith('linux'):
+            freezer_includes.append('spwd')
+            try:
+                import yum  # pylint: disable=unused-variable
+                freezer_includes.append('yum')
+            except ImportError:
+                pass
+        elif sys.platform.startswith('sunos'):
+            # (The sledgehammer approach)
+            # Just try to include everything
+            # (This may be a better way to generate freezer_includes generally)
+            try:
+                from bbfreeze.modulegraph.modulegraph import ModuleGraph
+                mgraph = ModuleGraph(sys.path[:])
+                for arg in glob.glob('salt/modules/*.py'):
+                    mgraph.run_script(arg)
+                for mod in mgraph.flatten():
+                    if type(mod).__name__ != 'Script' and mod.filename:
+                        freezer_includes.append(str(os.path.basename(mod.identifier)))
+            except ImportError:
+                pass
+            # Include C extension that convinces esky to package up the libsodium C library
+            # This is needed for ctypes to find it in libnacl which is in turn needed for raet
+            # see pkg/smartos/esky/sodium_grabber{.c,_installer.py}
+            freezer_includes.extend([
+                'sodium_grabber',
+                'ioflo',
+                'raet',
+                'libnacl',
+            ])
+        return freezer_includes
+    # <---- Esky Setup -----------------------------------------------------------------------------------------------
+
+    # ----- Overridden Methods -------------------------------------------------------------------------------------->
+    def parse_command_line(self):
+        args = distutils.dist.Distribution.parse_command_line(self)
+
+        # Setup our property functions after class initialization and
+        # after parsing the command line since most are set to None
+        for funcname in dir(self):
+            if not funcname.startswith('_property_'):
+                continue
+            property_name = funcname.split('_property_', 1)[-1]
+            setattr(self, property_name, getattr(self, funcname))
+
+        if not self.ssh_packaging and PACKAGED_FOR_SALT_SSH:
+            self.ssh_packaging = 1
+
+        if self.ssh_packaging:
+            self.metadata.name = 'salt-ssh'
+            self.salt_transport = 'ssh'
+        elif self.salt_transport is None:
+            self.salt_transport = 'zeromq'
+
+        if self.salt_transport not in ('zeromq', 'raet', 'both', 'ssh', 'none'):
+            raise DistutilsArgError(
+                'The value of --salt-transport needs be \'zeromq\', '
+                '\'raet\', \'both\', \'ssh\' or \'none\' not {0!r}'.format(
+                    self.salt_transport
+                )
+            )
+
+        return args
+    # <---- Overridden Methods ---------------------------------------------------------------------------------------
+
+# <---- Custom Distribution Class ------------------------------------------------------------------------------------
 
 
 if __name__ == '__main__':
-    setup(**SETUP_KWARGS)
+    setup(distclass=SaltDistribution)


### PR DESCRIPTION
This PR greatly simplifies Salt's setup.py script logic.

This PR is being made against `2014.7` because it started as the resolution for packaging salt-ssh. **However**, since the `2014.7.0` final release might be really close, and no RC is supposed to be released before it, this should probably be merged **AFTER** the `2014.7.0` final has been released.

I've tested this locally by packaging using distutils, esky freezing and setuptools, and installing using pip(with and without the setuptools env var) and easy_install'ing it. It worked.

The reason why I bring this to everyone's attention is because we don't want to make a bad release because of these changes to the setup script.

Consider all this wisely.
