### PR TITLE
[2014.7] Hint PF type if bracket enclosed IPv6 address

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -175,9 +175,12 @@ class SREQ(object):
                     zmq.RECONNECT_IVL_MAX, 5000
                 )
 
-            if self.master.startswith('tcp://') and hasattr(zmq, 'IPV4ONLY'):
-                # IPv6 sockets work for both IPv6 and IPv4 addresses
-                self._socket.setsockopt(zmq.IPV4ONLY, 0)
+            if self.master.startswith('tcp://['):
+                # Hint PF type if bracket enclosed IPv6 address
+                if hasattr(zmq, 'IPV6'):
+                    self._socket.setsockopt(zmq.IPV6, 1)
+                elif hasattr(zmq, 'IPV4ONLY'):
+                    self._socket.setsockopt(zmq.IPV4ONLY, 0)
             self._socket.linger = self.linger
             if self.id_:
                 self._socket.setsockopt(zmq.IDENTITY, self.id_)


### PR DESCRIPTION
Develop: https://github.com/saltstack/salt/pull/16423
2014.7: https://github.com/saltstack/salt/pull/16422

I believe the comment here was misleading.  In 3bb602104c6d51159a17fb2a67c96f894921c966, the [ might have been intentional to only capture interface addresses.

If this is preventing further IPv6 work, may need to do DNS resolution before passing it into ZMQ?

Discussion:
- https://groups.google.com/forum/#!topic/salt-users/whOCEqQgcTM
- https://gist.github.com/kev009/7c7973aedbce08ef4c56
