### PR TITLE
Issue #16424: List all providers when creating salt-cloud instance without profile

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -365,7 +365,7 @@ class CloudClient(object):
                         'delvol_on_destroy': True})
         '''
         mapper = salt.cloud.Map(self._opts_defaults())
-        providers = mapper.map_providers_parallel()
+        providers = self.opts['providers']
         if provider in providers:
             provider += ':{0}'.format(providers[provider].keys()[0])
         else:


### PR DESCRIPTION
 `mapper.map_providers_parallel()` filters out providers that return empty data, saltify always return empty dictionaries, so it's never included into the output, therefore `cloud.CloudClient.create()` never works for saltify.

This PR replaces `mapper.map_providers_parallel()` call with just `self.opts['providers']` that is just as good for the purpose.
