### PR TITLE
Make lscsi more verbose, and cut down on typing

### DIFF
--- a/salt/modules/scsi.py
+++ b/salt/modules/scsi.py
@@ -34,12 +34,14 @@ def ls_():
             majmin = comps.pop()
             major, minor = majmin.replace('[', '').replace(']', '').split(':')
             device = comps.pop()
+            model = ' '.join(comps[3:])
             ret[key] = {
                 'lun': key.replace('[', '').replace(']', ''),
                 'size': size,
                 'major': major,
                 'minor': minor,
                 'device': device,
+                'model': model,
             }
         elif line.startswith(' '):
             if line.strip().startswith('dir'):

--- a/salt/modules/scsi.py
+++ b/salt/modules/scsi.py
@@ -8,19 +8,50 @@ import logging
 
 log = logging.getLogger(__name__)
 
+__func_alias__ = {
+    'ls_': 'ls'
+}
 
-def lsscsi():
+
+def ls_():
     '''
-    List SCSI devices
+    List SCSI devices, with details
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' scsi.lsscsi
+        salt '*' scsi.ls
     '''
-    cmd = 'lsscsi'
-    return __salt__['cmd.run'](cmd).splitlines()
+    cmd = 'lsscsi -dLsv'
+    ret = {}
+    for line in __salt__['cmd.run'](cmd).splitlines():
+        if line.startswith('['):
+            mode = 'start'
+            comps = line.strip().split()
+            key = comps[0]
+            size = comps.pop()
+            majmin = comps.pop()
+            major, minor = majmin.replace('[', '').replace(']', '').split(':')
+            device = comps.pop()
+            ret[key] = {
+                'lun': key.replace('[', '').replace(']', ''),
+                'size': size,
+                'major': major,
+                'minor': minor,
+                'device': device,
+            }
+        elif line.startswith(' '):
+            if line.strip().startswith('dir'):
+                comps = line.strip().split()
+                ret[key]['dir'] = [
+                    comps[1],
+                    comps[2].replace('[', '').replace(']', '')
+                ]
+            else:
+                comps = line.strip().split('=')
+                ret[key][comps[0]] = comps[1]
+    return ret
 
 
 def rescan_all(host):


### PR DESCRIPTION
This makes the new functionality added by @ror6ax in #16323 more verbose. Previously the output looked like:

```
[0:0:0:0]    disk    ATA      HGST HTS725050A7 GH2Z  /dev/sda 
[1:0:0:0]    disk    ATA      WDC WD5000BPVT-2 01.0  /dev/sdb 
```

Now the output looks like:

```
{'local': {'[0:0:0:0]': {'device': '/dev/sda',
                         'device_blocked': '0',
                         'dir': ['/sys/bus/scsi/devices/0:0:0:0',
                                 '/sys/devices/pci0000:00/0000:00:1f.2/ata1/host0/target0:0:0/0:0:0:0'],
                         'iocounterbits': '32',
                         'iodone_cnt': '0x1c1bbee',
                         'ioerr_cnt': '0x5d7b',
                         'iorequest_cnt': '0x1c6753a',
                         'lun': '0:0:0:0',
                         'major': '8',
                         'minor': '0',
                         'model': 'HGST HTS725050A7 GH2Z',
                         'queue_depth': '31',
                         'queue_type': 'simple',
                         'scsi_level': '6',
                         'size': '500GB',
                         'state': 'running',
                         'timeout': '30',
                         'type': '0'},
           '[1:0:0:0]': {'device': '/dev/sdb',
                         'device_blocked': '0',
                         'dir': ['/sys/bus/scsi/devices/1:0:0:0',
                                 '/sys/devices/pci0000:00/0000:00:1f.2/ata2/host1/target1:0:0/1:0:0:0'],
                         'iocounterbits': '32',
                         'iodone_cnt': '0x303f0f',
                         'ioerr_cnt': '0x4eef',
                         'iorequest_cnt': '0x311e12',
                         'lun': '1:0:0:0',
                         'major': '8',
                         'minor': '16',
                         'model': 'WDC WD5000BPVT-2 01.0',
                         'queue_depth': '31',
                         'queue_type': 'simple',
                         'scsi_level': '6',
                         'size': '500GB',
                         'state': 'running',
                         'timeout': '30',
                         'type': '0'}}}
```

I also changed the function name from `scsi.lsscsi` to `scsi.ls`, which cuts down on typing.
