### PR TITLE
Add WheelClient integration tests for cmd_sync and cmd_async

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1913,7 +1913,7 @@ class ClearFuncs(object):
             good = self.ckminions.wheel_check(
                 self.opts['external_auth'][clear_load['eauth']][name]
                 if name in self.opts['external_auth'][clear_load['eauth']]
-                else self.opts['external_auth'][token['eauth']]['*'],
+                else self.opts['external_auth'][clear_load['eauth']]['*'],
                 clear_load['fun'])
             if not good:
                 msg = ('Authentication failure of type "eauth" occurred for '

--- a/salt/netapi/__init__.py
+++ b/salt/netapi/__init__.py
@@ -117,7 +117,7 @@ class NetapiClient(object):
         '''
         kwargs['fun'] = fun
         wheel = salt.wheel.WheelClient(self.opts)
-        return wheel.master_call(**kwargs)
+        return wheel.cmd_sync(kwargs)
 
     def wheel_async(self, fun, **kwargs):
         '''

--- a/salt/wheel/__init__.py
+++ b/salt/wheel/__init__.py
@@ -98,26 +98,7 @@ class WheelClient(mixins.SyncClientMixin, mixins.AsyncClientMixin, object):
             })
             {'minions': {'jerry': '5d:f6:79:43:5e:d4:42:3f:57:b8:45:a8:7e:a4:6e:ca'}}
         '''
-        sevent = salt.utils.event.get_event('master',
-                                            self.opts['sock_dir'],
-                                            self.opts['transport'],
-                                            opts=self.opts)
-        job = self.master_call(**low)
-        ret_tag = tagify('ret', base=job['tag'])
-
-        timelimit = time.time() + (timeout or 300)
-        while True:
-            ret = sevent.get_event(full=True)
-            if ret is None:
-                continue
-
-            if ret['tag'] == ret_tag:
-                return ret['data']['return']
-
-            if time.time() > timelimit:
-                raise salt.exceptions.SaltClientTimeout(
-                    "WheelClient job '%s' timed out", job['jid'],
-                    jid=job['jid'])
+        return self.master_call(**low)
 
     def cmd_async(self, low):
         '''

--- a/tests/integration/wheel/__init__.py
+++ b/tests/integration/wheel/__init__.py
@@ -11,6 +11,12 @@ import salt.wheel
 
 
 class WheelModuleTest(integration.ClientCase):
+    eauth_creds = {
+        'username': 'saltdev_auto',
+        'password': 'saltdev',
+        'eauth': 'auto',
+    }
+
     def setUp(self):
         '''
         Configure an eauth user to test with
@@ -24,13 +30,13 @@ class WheelModuleTest(integration.ClientCase):
         The choice of using key.list_all for this is arbitrary and should be
         changed to some mocked function that is more testing friendly.
         '''
-        self.wheel.master_call(**{
+        low = {
             'client': 'wheel',
             'fun': 'key.list_all',
-            'eauth': 'auto',
-            'username': 'saltdev_auto',
-            'password': 'saltdev',
-        })
+        }
+        low.update(self.eauth_creds)
+
+        self.wheel.master_call(**low)
 
     def test_token(self):
         '''
@@ -45,17 +51,41 @@ class WheelModuleTest(integration.ClientCase):
         self.mkdir_p(os.path.join(opts['root_dir'], 'cache', 'tokens'))
 
         auth = salt.auth.LoadAuth(opts)
-        token = auth.mk_token({
-            'username': 'saltdev_auto',
-            'password': 'saltdev',
-            'eauth': 'auto',
-        })
+        token = auth.mk_token(self.eauth_creds)
 
         self.wheel.master_call(**{
             'client': 'wheel',
             'fun': 'key.list_all',
             'token': token['token'],
         })
+
+    def test_cmd_sync(self):
+        low = {
+            'client': 'wheel',
+            'fun': 'key.list_keys',
+        }
+        low.update(self.eauth_creds)
+
+        self.wheel.cmd_sync(low)
+
+    def test_cmd_async(self):
+        low = {
+            'client': 'wheel_async',
+            'fun': 'key.list_keys',
+        }
+        low.update(self.eauth_creds)
+
+        self.wheel.cmd_async(low)
+
+    def test_cmd_sync_w_arg(self):
+        low = {
+            'fun': 'key.finger',
+            'match': '*',
+        }
+        low.update(self.eauth_creds)
+
+        ret = self.wheel.cmd_sync(low)
+        self.assertIn('return', ret.get('data', {}))
 
     def test_wildcard_auth(self):
         low = {


### PR DESCRIPTION
This contains the same 'token' fix that (will be) in #16407. They should not conflict.
