### PR TITLE
Fix salt-cloud ec2 requests containing spaces.

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -333,6 +333,10 @@ def query(params=None, setname=None, requesturl=None, location=None,
         values = map(params_with_headers.get, keys)
         querystring = urllib.urlencode(list(zip(keys, values)))
 
+        # AWS signature version 2 requires that spaces be encoded as
+        # %20, however urlencode uses '+'. So replace pluses with %20.
+        querystring = querystring.replace('+', '%20')
+
         uri = '{0}\n{1}\n/\n{2}'.format(method.encode('utf-8'),
                                         endpoint.encode('utf-8'),
                                         querystring.encode('utf-8'))


### PR DESCRIPTION
salt-cloud receives an error when trying to create an EC2 instance when
any number of argument values contain a space. This happens because
salt-cloud is incorrectly building the url string when calculating the
signature. AWS signature algorithm #2 requires that spaces be encoded
using %20, however python's urlencode method replaces them with a +.
The easy fix is to just search and replace in the encoded string.

I encountered this myself with a security group with a space in it.
This was reported in issue #10181
https://github.com/saltstack/salt/issues/10181

The error looks like this:
someinstancename:
    ----------
    Errors:
        ----------
        Error:
            ----------
            Code:
                SignatureDoesNotMatch
            Message:
                The request signature we calculated does not match the signature you provided. Check your AWS Secret Access Key and signing method. Consult the service documentation for details.
    RequestID:
        12345678-9abc-def0-1234-56789abcdef0
