### PR TITLE
Make OrderedDict private (_OrderedDict) in pkg state

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -42,7 +42,7 @@ import re
 import salt.utils
 from salt.output import nested
 from salt.utils import namespaced_function as _namespaced_function
-from salt.utils.odict import OrderedDict
+from salt.utils.odict import OrderedDict as _OrderedDict
 from salt._compat import string_types
 from salt.exceptions import (
     CommandExecutionError, MinionError, SaltInvocationError
@@ -140,7 +140,7 @@ def _find_install_targets(name=None,
     # Get the ignore_types list if any from the pkg_verify argument
     if type(pkg_verify) is list and any(x.get('ignore_types') is not None
                                         for x in pkg_verify
-                                        if type(x) is OrderedDict
+                                        if type(x) is _OrderedDict
                                         and 'ignore_types' in x):
         ignore_types = next(x.get('ignore_types')
                             for x in pkg_verify
@@ -974,7 +974,7 @@ def installed(
     # Get the ignore_types list if any from the pkg_verify argument
     if type(pkg_verify) is list and any(x.get('ignore_types') is not None
                                         for x in pkg_verify
-                                        if type(x) is OrderedDict
+                                        if type(x) is _OrderedDict
                                         and 'ignore_types' in x):
         ignore_types = next(x.get('ignore_types')
                             for x in pkg_verify


### PR DESCRIPTION
As it is, OrderedDict shows up in things like sys.list_state_functions:

```
root@localhost:~# salt '*' sys.list_state_functions pkg
myminion:
    - pkg.OrderedDict
    - pkg.installed
    - pkg.latest
    - pkg.mod_aggregate
    - pkg.mod_init
    - pkg.purged
    - pkg.removed
    - pkg.uptodate
```
