### PR TITLE
State Module, not State Declaration

### DIFF
--- a/doc/ref/states/highstate.rst
+++ b/doc/ref/states/highstate.rst
@@ -359,7 +359,7 @@ components.
     # standard declaration
 
     <ID Declaration>:
-      <State Declaration>:
+      <State Module>:
         - <Function>
         - <Function Arg>
         - <Function Arg>
@@ -373,7 +373,7 @@ components.
     # inline function and names
 
     <ID Declaration>:
-      <State Declaration>.<Function>:
+      <State Module>.<Function>:
         - <Function Arg>
         - <Function Arg>
         - <Function Arg>
@@ -385,17 +385,17 @@ components.
           - <Requisite Reference>
           - <Requisite Reference>
 
- 
+
     # multiple states for single id
 
     <ID Declaration>:
-      <State Declaration>:
-        - <Function> 
+      <State Module>:
+        - <Function>
         - <Function Arg>
         - <Name>: <name>
         - <Requisite Declaration>:
           - <Requisite Reference>
-      <State Declaration>:
+      <State Module>:
         - <Function>
         - <Function Arg>
         - <Names>:


### PR DESCRIPTION
In practice, and in many places in the docs, we use the phrase `state declaration` to mean a few different things. Sometimes we call the `file.managed` piece a state declaration. Sometimes we call the entire state stanza a state declaration. But in my experience, nobody calls the `file` piece of `file.managed` the state declaration -- rather, we call that the state module.

@thatch45 should OK this fix, but I think it fits much better.
