### PR TITLE
Fixing issue with ps.top and ps.pgrep

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -91,7 +91,7 @@ def _get_proc_pid(proc):
 
     It's backward compatible with < 2.0 versions of psutil.
     '''
-    return proc.pid() if PSUTIL2 else proc.pid
+    return proc.pid
 
 
 def top(num_processes=5, interval=3):

--- a/tests/unit/modules/ps_test.py
+++ b/tests/unit/modules/ps_test.py
@@ -66,7 +66,7 @@ def _get_proc_name(proc):
 
 
 def _get_proc_pid(proc):
-    return proc.pid() if PSUTIL2 else proc.pid
+    return proc.pid
 
 
 @skipIf(not HAS_PSUTIL, "psutils are required for this test case")


### PR DESCRIPTION
Fixing issue with ps.top and ps.pgrep.  I checked all versions of psutil and couldn't find any reference to using a pid() function to return the PID from a process object. #16445 #16444
