### PR TITLE
also deny minion if limit is reached, not just below

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1437,7 +1437,7 @@ class ClearFuncs(object):
                              'to enable the ConCache with \'con_cache: True\' '
                              'in the masters configuration file.')
 
-            if not len(minions) < self.opts['max_minions']:
+            if not len(minions) <= self.opts['max_minions']:
                 # we reject new minions, minions that are already
                 # connected must be allowed for the mine, highstate, etc.
                 if load['id'] not in minions:


### PR DESCRIPTION
Currently the master only rejects minions as long as the number of minions is _below_ max_minions. It obviously also has to reject them, if the limit _is_ max_minions.
