### PR TITLE
Remove self-referencial cross-calls from lxc module

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1459,14 +1459,14 @@ def stop(name, kill=True):
            'result': True,
            'comment': 'Stopped'}
     try:
-        does_exist = __salt__['lxc.exists'](name)
+        does_exist = exists(name)
         if not does_exist:
             return {'name': name,
                     'result': False,
                     'changes': {},
                     'comment': 'Container does not exist'}
         ret.update(_change_state('lxc-stop', name, 'stopped'))
-        infos = __salt__['lxc.info'](name)
+        infos = info(name)
         ret['result'] = infos['state'] == 'stopped'
         if ret['change']:
             ret['changes']['stopped'] = 'stopped'

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -903,7 +903,7 @@ def init(name,
                      cpuset=cpuset, cpushare=cpushare, memory=memory)
     old_chunks = []
     if os.path.exists(cfg.path):
-        old_chunks = lxc.read_conf(cfg.path)
+        old_chunks = read_conf(cfg.path)
     cfg.write()
     chunks = read_conf(cfg.path)
     if old_chunks != chunks:
@@ -982,7 +982,7 @@ def init(name,
                     name, 'test -e {0}'.format(ogid),
                     stdout=False, stderr=False)))
         if True not in lxcrets:
-            cret = lxc.set_dns(name, dnsservers=dnsservers)
+            cret = set_dns(name, dnsservers=dnsservers)
             changes['350_dns'] = 'DNS updated\n'
             if not cret['result']:
                 ret['result'] = False

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -37,7 +37,8 @@ log = logging.getLogger(__name__)
 
 # Don't shadow built-in's.
 __func_alias__ = {
-    'list_': 'list'
+    'list_': 'list',
+    'ls_': 'ls'
 }
 
 
@@ -1268,7 +1269,7 @@ def clone(name,
         ).format(cmd, ret['stderr'])}
 
 
-def ls():
+def ls_():
     '''
     Return just a list of the containers available
 


### PR DESCRIPTION
Updating to Salt standards. I can't think of any good reason to cross-call a function from inside itself; it's only causing a lot of extra work for Salt. More cleanup to come.

Ping @kiorky and @mgwilliams.
