### PR TITLE
salt/daemons/__init__.py: less janky Python 3 support

### DIFF
--- a/salt/daemons/__init__.py
+++ b/salt/daemons/__init__.py
@@ -8,17 +8,14 @@ import sys
 from collections import namedtuple, Iterable, Sequence, Mapping
 import logging
 
-# Python2to3 support
-if sys.version > '3':
-    long = int
-    basestring = (str, bytes)
-    unicode = str
-    xrange = range
-
 # Import Salt Libs
 from salt.utils.odict import OrderedDict
+from salt._compat import text_type, binary_type
 
 log = logging.getLogger(__name__)
+
+if sys.version_info[0] == 3:
+    basestring = (text_type, binary_type)
 
 # Python equivalent of an enum
 APPL_KINDS = OrderedDict([('master', 0), ('minion', 1), ('syndic', 2), ('call', 3)])


### PR DESCRIPTION
Among other things:

> [`sys.version`](https://docs.python.org/2/library/sys.html#sys.version)
> [...] **Do not extract version information out of it**, rather, use `version_info` [...]
