### PR TITLE
Bugfix in hg.clone for superfluous quotes

### DIFF
--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -237,7 +237,7 @@ def clone(cwd, repository, opts=None, user=None):
         salt '*' hg.clone /path/to/repo https://bitbucket.org/birkenfeld/sphinx
     '''
     _check_hg()
-    cmd = ['hg', 'clone', '"{0}"'.format(repository), '"{0}"'.format(cwd)]
+    cmd = ['hg', 'clone', '{0}'.format(repository), '{0}'.format(cwd)]
     if opts:
         for opt in opts.split():
             cmd.append('{0}'.format(opt))


### PR DESCRIPTION
Removed extra quotes in hg.clone (not needed as command is already split as list so each item does not need escaping or quoting) which was causing hg to abort on non-local repos like "ssh://...." saying it could not find the repo.
