### PR TITLE
Suppress irrelevant log msg in virtual hardware detection

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -414,9 +414,16 @@ def _virtual(osdata):
     #   virtual_subtype
     grains = {'virtual': 'physical'}
 
+    # Skip the below loop on platforms which have none of the desired cmds
+    # This is a temporary measure until we can write proper virtual hardware
+    # detection.
+    skip_cmds = ('AIX',)
+
     # Check if enable_lspci is True or False
     if __opts__.get('enable_lspci', True) is False:
         _cmds = ('dmidecode', 'dmesg')
+    elif osdata['kernel'] in skip_cmds:
+        _cmds = ()
     else:
         # /proc/bus/pci does not exists, lspci will fail
         if not os.path.exists('/proc/bus/pci'):
@@ -507,12 +514,14 @@ def _virtual(osdata):
             # Break out of the loop so the next log message is not issued
             break
     else:
-        log.warn(
-            'The tools \'dmidecode\', \'lspci\' and \'dmesg\' failed to '
-            'execute because they do not exist on the system of the user '
-            'running this instance or the user does not have the necessary '
-            'permissions to execute them. Grains output might not be accurate.'
-        )
+        if osdata['kernel'] in skip_cmds:
+            log.warn(
+                'The tools \'dmidecode\', \'lspci\' and \'dmesg\' failed to '
+                'execute because they do not exist on the system of the user '
+                'running this instance or the user does not have the '
+                'necessary permissions to execute them. Grains output might '
+                'not be accurate.'
+            )
 
     choices = ('Linux', 'OpenBSD', 'HP-UX')
     isdir = os.path.isdir


### PR DESCRIPTION
This commit suppresses a log warning when the minion is AIX, and none of 
lspci, dmidecode, or dmesg are available.

This log message is just noise, especially in salt-call.
