### PR TITLE
fix for ping_on_rotate not in config

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -159,7 +159,7 @@ class Master(SMaster):
                         self.opts['user'],
                         self.opts['sock_dir'])
                     rotate = now
-                    if self.opts['ping_on_rotate']:
+                    if self.opts.get('ping_on_rotate'):
                         # Ping all minions to get them to pick up the new key
                         log.debug('Pinging all connected minions due to AES key rotation')
                         salt.utils.master.ping_all_connected_minions(self.opts)


### PR DESCRIPTION
Since this isn't a default (in config.py), if you didn't set it you get backtraces from _clear_old_jobs:

```
Process Process-1:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 232, in _bootstrap
    self.run()
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 88, in run
    self._target(*self._args, **self._kwargs)
  File "/home/thjackso/src/salt-github/salt/master.py", line 162, in _clear_old_jobs
    if self.opts['ping_on_rotate']:
KeyError: 'ping_on_rotate'
```
