### PR TITLE
Remove expect fork from master upstart script

### DIFF
--- a/debian/salt-master.upstart
+++ b/debian/salt-master.upstart
@@ -6,7 +6,6 @@ start on (net-device-up
 stop on runlevel [!2345]
 limit nofile 100000 100000
 
-expect fork
 script
   # Read configuration variable file if it is present
   [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB


### PR DESCRIPTION
This could be related to the new process manager, but I haven't
investigated fully. At any rate, this allows Upstart to function
correctly when starting and stopping the salt master.

This may need some thorough regression testing on other Ubuntu versions.

cc: @rallytime 

Closes #15133 
