### PR TITLE
Added preliminary support for multiple master in Raet

### DIFF
--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -214,21 +214,25 @@ class SaltRaetRoadStackJoiner(ioflo.base.deeding.Deed):
                     opts='.salt.opts')
 
     def postinitio(self):
-        self.mha = (self.opts.value['master'], int(self.opts.value['master_port']))
+        self.masters = daemons.extractMasters(self.opts.value)
+        # self.mha = (self.opts.value['master'], int(self.opts.value['master_port']))
 
     def action(self, **kwa):
         '''
-        Receive any udp packets on server socket and put in rxes
-        Send any packets in txes
+        Join with all masters
         '''
         stack = self.stack.value
         if stack and isinstance(stack, RoadStack):
             if not stack.remotes:
-                stack.addRemote(RemoteEstate(stack=stack,
-                                             fuid=0,  # vacuous join
-                                             sid=0,  # always 0 for join
-                                             ha=self.mha))
-            stack.join(uid=stack.remotes.values()[0].uid, timeout=0.0)
+                for master in self.masters:
+                    mha = master['external']
+                    stack.addRemote(RemoteEstate(stack=stack,
+                                                 fuid=0,  # vacuous join
+                                                 sid=0,  # always 0 for join
+                                                 ha=mha))
+            # stack.join(uid=stack.remotes.values()[0].uid, timeout=0.0)
+            for remote in stack.remotes.values():
+                stack.join(uid=remote.uid, timeout=0.0)
 
 
 class SaltRaetRoadStackJoined(ioflo.base.deeding.Deed):

--- a/salt/daemons/test/test_multimaster.py
+++ b/salt/daemons/test/test_multimaster.py
@@ -149,11 +149,11 @@ class BasicTestCase(unittest.TestCase):
                                                        ('localhost::4510', 4506))
 
 
-    def testExtractMasters(self):
+    def testExtractMastersSingle(self):
         '''
         Test extracting from master provided according to syntax for opts['master']
         '''
-        console.terse("{0}\n".format(self.testExtractMasters.__doc__))
+        console.terse("{0}\n".format(self.testExtractMastersSingle.__doc__))
 
         master = 'localhost'
         self.opts.update(master=master)
@@ -241,8 +241,85 @@ class BasicTestCase(unittest.TestCase):
         self.assertEquals(extractMasters(self.opts),[])
 
 
+    def testExtractMastersMultiple(self):
+        '''
+        Test extracting from master provided according to syntax for opts['master']
+        '''
+        console.terse("{0}\n".format(self.testExtractMastersMultiple.__doc__))
 
+        master = [
+                    'localhost',
+                    '10.0.2.23',
+                    'me.example.com'
+                 ]
+        self.opts.update(master=master)
+        self.assertEquals(extractMasters(self.opts),
+                          [
+                            {
+                                'external': ('localhost', 4506),
+                                'internal': None
+                            },
+                            {
+                                'external': ('10.0.2.23', 4506),
+                                'internal': None
+                            },
+                            {
+                                'external': ('me.example.com', 4506),
+                                'internal': None
+                            },
+                          ])
 
+        master = [
+                    'localhost 4510',
+                    '10.0.2.23 4510',
+                    'me.example.com 4510'
+                 ]
+        self.opts.update(master=master)
+        self.assertEquals(extractMasters(self.opts),
+                          [
+                            {
+                                'external': ('localhost', 4510),
+                                'internal': None
+                            },
+                            {
+                                'external': ('10.0.2.23', 4510),
+                                'internal': None
+                            },
+                            {
+                                'external': ('me.example.com', 4510),
+                                'internal': None
+                            },
+                          ])
+
+        master = [
+                    {
+                        'external': 'localhost 4510',
+                        'internal': '',
+                    },
+                    {
+                        'external': 'me.example.com 4510',
+                        'internal': '10.0.2.23 4510',
+                    },
+                    {
+                        'external': 'you.example.com 4509',
+                    }
+                 ]
+        self.opts.update(master=master)
+        self.assertEquals(extractMasters(self.opts),
+                          [
+                            {
+                                'external': ('localhost', 4510),
+                                'internal': None
+                            },
+                            {
+                                'external': ('me.example.com', 4510),
+                                'internal': ('10.0.2.23', 4510)
+                            },
+                            {
+                                'external': ('you.example.com', 4509),
+                                'internal': None
+                            },
+                          ])
 
 
 def runOne(test):
@@ -260,7 +337,8 @@ def runSome():
     tests =  []
     names = [
                 'testParseHostname',
-                'testExtractMasters',
+                'testExtractMastersSingle',
+                'testExtractMastersMultiple',
             ]
 
     tests.extend(map(BasicTestCase, names))


### PR DESCRIPTION
If 'master' opt has multiple entries will attempt to join to all entries.
