### PR TITLE
Fix for #16455

### DIFF
--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -231,11 +231,16 @@ def _split_module_dicts():
 
         {{ salt.cmd.run('uptime') }}
     '''
+
+    class Container():
+        ''' This object allows us to set arbitrary attributes'''
+        pass
     mod_dict = dict(__salt__)
     for module_func_name, mod_fun in mod_dict.items():
         mod, fun = module_func_name.split('.', 1)
-        mod_dict.setdefault(mod,
-                {})[fun] = mod_fun
+        if mod not in mod_dict:
+            mod_dict[mod] = Container()
+        setattr(mod_dict[mod], fun, mod_fun)
     return mod_dict
 
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -232,14 +232,12 @@ def _split_module_dicts():
         {{ salt.cmd.run('uptime') }}
     '''
 
-    class Container():
-        ''' This object allows us to set arbitrary attributes'''
-        pass
     mod_dict = dict(__salt__)
     for module_func_name, mod_fun in mod_dict.items():
         mod, fun = module_func_name.split('.', 1)
         if mod not in mod_dict:
-            mod_dict[mod] = Container()
+            # create an empty object that we can add attributes to
+            mod_dict[mod] = lambda: None
         setattr(mod_dict[mod], fun, mod_fun)
     return mod_dict
 

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -221,15 +221,9 @@ import salt.utils.templates
 log = logging.getLogger(__name__)
 
 
-class SaltDotLookup(dict):
-    def __init__(self, *args, **kwargs):
-        dict.__init__(self, *args, **kwargs)
-        self.__dict__ = self
-
-
-def _split_module_dicts(__salt__):
+def _split_module_dicts():
     '''
-    Create a dictionary from module.function as module[function]
+    Create a copy of __salt__ dictionary with module.function and module[function]
 
     Takes advantage of Jinja's syntactic sugar lookup:
 
@@ -237,11 +231,11 @@ def _split_module_dicts(__salt__):
 
         {{ salt.cmd.run('uptime') }}
     '''
-    mod_dict = SaltDotLookup()
-    for module_func_name in __salt__.keys():
-        mod, _, fun = module_func_name.partition('.')
+    mod_dict = dict(__salt__)
+    for module_func_name, mod_fun in mod_dict.items():
+        mod, fun = module_func_name.split('.', 1)
         mod_dict.setdefault(mod,
-                SaltDotLookup())[fun] = __salt__[module_func_name]
+                {})[fun] = mod_fun
     return mod_dict
 
 
@@ -259,12 +253,9 @@ def render(template_file, saltenv='base', sls='', argline='',
                 'Unknown renderer option: {opt}'.format(opt=argline)
         )
 
-    salt_dict = SaltDotLookup(**__salt__)
-    salt_dict.__dict__.update(_split_module_dicts(__salt__))
-
     tmp_data = salt.utils.templates.JINJA(template_file,
                                           to_str=True,
-                                          salt=salt_dict,
+                                          salt=_split_module_dicts(),
                                           grains=__grains__,
                                           opts=__opts__,
                                           pillar=__pillar__,


### PR DESCRIPTION
This reverts saltstack/salt@5fdd866d12451eb765f808d7e0cdfbd2f5bdd210, which introduced a self-referential dictionary-- which mean that it could never be garbage collected.
