### PR TITLE
Added salt-ssh integration test for custom module within SLS

### DIFF
--- a/tests/integration/cli/custom_module.py
+++ b/tests/integration/cli/custom_module.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Daniel Mizyrycki (mzdaniel@glidelink.net)`
+
+
+    tests.integration.cli.custom_module
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    Test salt-ssh sls with a custom module work.
+
+    $ cat srv/custom_module.sls
+    custom-module:
+      module.run:
+        - name: test.recho
+        - text: hello
+
+
+    $ cat srv/_modules/override_test.py
+    __virtualname__ = 'test'
+
+    def __virtual__():
+        return __virtualname__
+
+    def recho(text):
+        return text[::-1]
+
+
+    $ salt-ssh localhost state.sls custom_module
+    localhost:
+        olleh
+
+'''
+
+# Import Salt Libs
+import integration
+
+
+class SSHCustomModuleTest(integration.SSHCase):
+    '''
+    Test sls with custom module functionality using ssh
+    '''
+
+    def test_ssh_regular_module(self):
+        '''
+        Test regular module work using SSHCase environment
+        '''
+        expected = 'hello'
+        cmd = self.run_function('test.echo', arg=['hello'])
+        self.assertEqual(expected, cmd)
+
+
+    def test_ssh_custom_module(self):
+        '''
+        Test custom module work using SSHCase environment
+        '''
+        expected = 'hello'[::-1]
+        cmd = self.run_function('test.recho', arg=['hello'])
+        self.assertEqual(expected, cmd)
+
+
+    def test_ssh_sls_with_custom_module(self):
+        '''
+        Test sls with custom module work using SSHCase environment
+        '''
+        expected = {
+            "module_|-regular-module_|-test.echo_|-run": 'hello',
+            "module_|-custom-module_|-test.recho_|-run": 'olleh'}
+        cmd = self.run_function('state.sls', arg=['custom_module'])
+        for key in cmd:
+            if not cmd[key]['result']:
+                raise AssertionError(cmd[key]['comment'])
+            cmd_ret = cmd[key]['changes'].get('ret', None)
+            self.assertEqual(cmd_ret, expected[key])
+
+
+if __name__ == '__main__':
+    '''
+    This test can be run in a small test suite with:
+
+    python tests/runtests.py -C --ssh
+    '''
+    from integration import run_tests
+    run_tests(SSHCustomModuleTest)

--- a/tests/integration/cli/custom_module.py
+++ b/tests/integration/cli/custom_module.py
@@ -29,6 +29,10 @@
     localhost:
         olleh
 
+
+    This test can be run in a small test suite with:
+
+    $ python tests/runtests.py -C --ssh
 '''
 
 # Import Salt Libs
@@ -48,7 +52,6 @@ class SSHCustomModuleTest(integration.SSHCase):
         cmd = self.run_function('test.echo', arg=['hello'])
         self.assertEqual(expected, cmd)
 
-
     def test_ssh_custom_module(self):
         '''
         Test custom module work using SSHCase environment
@@ -56,7 +59,6 @@ class SSHCustomModuleTest(integration.SSHCase):
         expected = 'hello'[::-1]
         cmd = self.run_function('test.recho', arg=['hello'])
         self.assertEqual(expected, cmd)
-
 
     def test_ssh_sls_with_custom_module(self):
         '''
@@ -74,10 +76,5 @@ class SSHCustomModuleTest(integration.SSHCase):
 
 
 if __name__ == '__main__':
-    '''
-    This test can be run in a small test suite with:
-
-    python tests/runtests.py -C --ssh
-    '''
     from integration import run_tests
     run_tests(SSHCustomModuleTest)

--- a/tests/integration/files/file/base/custom_module.sls
+++ b/tests/integration/files/file/base/custom_module.sls
@@ -1,0 +1,9 @@
+regular-module:
+  module.run:
+    - name: test.echo
+    - text: hello
+
+custom-module:
+  module.run:
+    - name: test.recho
+    - text: hello


### PR DESCRIPTION
This PR reproduce the issue mention in #16271

As of aa6f87e62, this integration test is giving the following output

```
$ python2 tests/runtests.py -C --ssh
. ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~  
 * Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
 * Current Directory: /tmp/salt2
 * Test suite is running under PID 1750
 * Logging tests on /tmp/salt-runtests.log
. ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ * Setting up Salt daemons to execute tests
.  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 * Waiting at most 0:02:00 for minions(minion, sub_minion) to connect back
   * minion connected.                                                                                                                                   
   * sub_minion connected.                                                                                                                               
 * Syncing minion's modules (saltutil.sync_modules)
   * Synced minion modules: modules.override_test, modules.runtests_decorators, modules.runtests_helpers, modules.salttest                               
   * Synced sub_minion modules: modules.override_test, modules.runtests_decorators, modules.runtests_helpers, modules.salttest
 * Syncing minion's states (saltutil.sync_states)
   * Synced minion states: states.salttest                                                                                                               
   * Synced sub_minion states: states.salttest
 * Initializing SSH subsystem
.  ===============================================================================
.  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
Starting CLI Tests
.  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
....[ERROR   ] Git-based ext_pillar is enabled in configuration but could not be loaded, is GitPython installed?
[CRITICAL] Specified ext_pillar interface git is unavailable
[CRITICAL] Specified ext_pillar interface git is unavailable
[CRITICAL] Specified ext_pillar interface test_ext_pillar_opts is unavailable
F
.  =====================================================================
FAIL: test_ssh_sls_with_custom_module (integration.cli.custom_module.SSHCustomModuleTest)
.  ----------------------------------------------------------------------
Traceback (most recent call last):
  File "/tmp/salt2/tests/integration/cli/custom_module.py", line 71, in test_ssh_sls_with_custom_module
    raise AssertionError(cmd[key]['comment'])
AssertionError: Module function test.recho is not available

.  ----------------------------------------------------------------------
Ran 5 tests in 38.387s

FAILED (failures=1)

.  ==============================  Overall Tests Report  ================================
*** CLI Tests      *****************************************************************************************************
. --------  Failed Tests   --------------------------------------------------------------------------------------------------
   -> integration.cli.custom_module.SSHCustomModuleTest.test_ssh_sls_with_custom_module    ................
       Traceback (most recent call last):
         File "/tmp/salt2/tests/integration/cli/custom_module.py", line 71, in test_ssh_sls_with_custom_module
           raise AssertionError(cmd[key]['comment'])
       AssertionError: Module function test.recho is not available
.   ......................................................................................................................................................
.  ----------------------------------------------------------------------------------------------------------------------------
.  ==============================================================================
FAILED (total=5, skipped=0, passed=4, failures=1, errors=0) 
.  ================================  Overall Tests Report  ==============================
```
