### PR TITLE
2014.7 fix opts loading in unittests

### DIFF
--- a/tests/unit/highstateconf_test.py
+++ b/tests/unit/highstateconf_test.py
@@ -18,6 +18,7 @@ OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/tmp'])
 OPTS['test'] = False
 OPTS['grains'] = salt.loader.grains(OPTS)
+OPTS['cachedir'] = 'cachedir'
 
 
 class HighStateTestCase(TestCase):

--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -28,6 +28,7 @@ OPTS['state_events'] = False
 OPTS['id'] = 'whatever'
 OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/tmp'])
+OPTS['cachedir'] = 'cachedir'
 OPTS['test'] = False
 OPTS['grains'] = salt.loader.grains(OPTS)
 

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -198,7 +198,8 @@ class RendererMixin(object):
             'file_client': 'local',
             'file_roots': {
                 'base': [self.root_dir]
-            }
+            },
+            'cachedir': 'cachedir'
         })
 
     def tearDown(self, *args, **kwargs):

--- a/tests/unit/renderers/gpg_test.py
+++ b/tests/unit/renderers/gpg_test.py
@@ -39,6 +39,7 @@ OPTS['state_events'] = False
 OPTS['id'] = 'whatever'
 OPTS['file_client'] = 'local'
 OPTS['file_roots'] = dict(base=['/tmp'])
+OPTS['cachedir'] = 'cachedir'
 OPTS['test'] = False
 OPTS['grains'] = salt.loader.grains(OPTS)
 OPTS['gpg_keydir'] = GPG_KEYDIR

--- a/tests/unit/renderers/yamlex_test.py
+++ b/tests/unit/renderers/yamlex_test.py
@@ -3,7 +3,7 @@
 from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
 
-ensure_in_syspath('../')
+ensure_in_syspath('../..')
 
 import salt.state
 from salt.config import minion_config


### PR DESCRIPTION
These are required when running the tests suite as non-root.
