### PR TITLE
No need to check if process is alive. Fixes #16487. Refs #16317.

### DIFF
--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -647,7 +647,7 @@ class Terminal(object):
                     self.child_fde = None
                     stderr = None
                 finally:
-                    if self.isalive() and self.child_fde is not None:
+                    if self.child_fde is not None:
                         fcntl.fcntl(self.child_fde, fcntl.F_SETFL, fde_flags)
             # <---- Process STDERR -------------------------------------------
 
@@ -677,7 +677,7 @@ class Terminal(object):
                     self.child_fd = None
                     stdout = None
                 finally:
-                    if self.isalive() and self.child_fd is not None:
+                    if self.child_fd is not None:
                         fcntl.fcntl(self.child_fd, fcntl.F_SETFL, fd_flags)
             # <---- Process STDOUT -------------------------------------------
             return stdout, stderr


### PR DESCRIPTION
There's no need to check for a live process because since we're changing flags on the file descriptor, if it's not none, we
reset the flags.
