### PR TITLE
Major problem with salt.output

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -58,7 +58,7 @@ def display_output(data, out=None, opts=None):
                 if isinstance(fdata, unicode):
                     try:
                         fdata = fdata.encode('utf-8')
-                    except:
+                    except (UnicodeDecodeError, UnicodeEncodeError):
                         # try to let the stream write
                         # even if we didnt encode it
                         pass

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -17,9 +17,12 @@ import salt.loader
 import salt.utils
 from salt.utils import print_cli
 
-
-reload(sys)
-sys.setdefaultencoding('utf-8')
+# Are you really sure !!!
+# dealing with unicode is not as simple as setting defaultencoding
+# which can break other python modules imported by salt in bad ways...
+# reloading sys is not either a good idea...
+# reload(sys)
+# sys.setdefaultencoding('utf-8')
 
 
 log = logging.getLogger(__name__)

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -49,7 +49,8 @@ def display_output(data, out=None, opts=None):
     output_filename = opts.get('output_file', None)
     log.trace('data = {0}'.format(data))
     try:
-        if output_filename is not None:
+        # output filename can be either '' or None
+        if output_filename:
             with salt.utils.fopen(output_filename, 'a') as ofh:
                 ofh.write(display_data)
                 ofh.write('\n')

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -39,6 +39,8 @@ def display_output(data, out=None, opts=None):
     '''
     Print the passed data using the desired output
     '''
+    if opts is None:
+        opts = {}
     try:
         display_data = get_printout(out, opts)(data).rstrip()
     except (KeyError, AttributeError):
@@ -52,7 +54,15 @@ def display_output(data, out=None, opts=None):
         # output filename can be either '' or None
         if output_filename:
             with salt.utils.fopen(output_filename, 'a') as ofh:
-                ofh.write(display_data)
+                fdata = display_data
+                if isinstance(fdata, unicode):
+                    try:
+                        fdata = fdata.encode('utf-8')
+                    except:
+                        # try to let the stream write
+                        # even if we didnt encode it
+                        pass
+                ofh.write(fdata)
                 ofh.write('\n')
             return
         if display_data:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1667,7 +1667,10 @@ def print_cli(msg):
     when salt output is piped to less and less is stopped prematurely).
     '''
     try:
-        print(msg)
+        try:
+            print(msg)
+        except UnicodeEncodeError:
+            print(msg.encode('utf-8'))
     except IOError as exc:
         if exc.errno != errno.EPIPE:
             raise

--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -5,6 +5,9 @@
 
 # Import Salt Libs
 import integration
+import os
+import copy
+from salt.output import display_output
 
 # Import Salt Testing Libs
 from salttesting.helpers import ensure_in_syspath
@@ -74,3 +77,25 @@ class OutputReturnTest(integration.ShellCase):
         expected = ['local: true']
         ret = self.run_call('test.ping --out=yaml')
         self.assertEqual(ret, expected)
+
+    def test_output_unicodebad(self):
+        '''
+        Tests outputter reliability with utf8
+        '''
+        opts = copy.deepcopy(self.minion_opts)
+        opts['output_file'] = os.path.join(
+            self.minion_opts['root_dir'], 'outputtest')
+        data = {'foo': {'result': False,
+                        'aaa': 'azerzaeréééé',
+                        'comment': u'ééééàààà'}}
+        try:
+            # this should not raises UnicodeEncodeError
+            display_output(data, opts=self.minion_opts)
+            self.assertTrue(True)
+        except:
+            self.assertTrue(False)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(OutputReturnTest)

--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -4,6 +4,7 @@
 '''
 
 # Import Salt Libs
+import traceback
 import integration
 import os
 import copy
@@ -93,7 +94,9 @@ class OutputReturnTest(integration.ShellCase):
             display_output(data, opts=self.minion_opts)
             self.assertTrue(True)
         except:
-            self.assertTrue(False)
+            # display trace in error message for debugging on jenkins
+            trace = traeback.format_exc()
+            self.assertEqual(trace, '')
 
 
 if __name__ == '__main__':

--- a/tests/integration/output/output.py
+++ b/tests/integration/output/output.py
@@ -93,9 +93,9 @@ class OutputReturnTest(integration.ShellCase):
             # this should not raises UnicodeEncodeError
             display_output(data, opts=self.minion_opts)
             self.assertTrue(True)
-        except:
+        except Exception:
             # display trace in error message for debugging on jenkins
-            trace = traeback.format_exc()
+            trace = traceback.format_exc()
             self.assertEqual(trace, '')
 
 


### PR DESCRIPTION
@basepi @thatch45 this is a very bad regression here:
- Reloading sys is not a very good idea... even more nested in an imported module....
- Setting default encoding in such way can cause bad collateral damages on install where we use custom python modules and deal with internationnlized data where setting encoding is important. Moreover in python2, it is better to keep encoded strings in serialisations (like we do in Zope world)...
-  Third is the file test which can be an empty string in several situations, the if test addresses that.
