### PR TITLE
Add missing docstring for templates directory

### DIFF
--- a/salt/templates/__init__.py
+++ b/salt/templates/__init__.py
@@ -1,1 +1,4 @@
 # -*- coding: utf-8 -*-
+'''
+Templates Directory
+'''


### PR DESCRIPTION
This fixes the following build error message:

```
package init file 'salt/templates/__init__.py' not found (or not a regular file)
```
