### PR TITLE
[READ CAREFULLY] User switching and umask setting does not belong in VT

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -401,8 +401,7 @@ def _run(cmd,
                                log_stdout=True,
                                log_stderr=True,
                                cwd=cwd,
-                               user=runas,
-                               umask=umask,
+                               preexec_fn=kwargs.get('preexec_fn', None),
                                env=env,
                                log_stdin_level=output_loglevel,
                                log_stdout_level=output_loglevel,
@@ -446,7 +445,7 @@ def _run(cmd,
                         exc_info_on_loglevel=logging.DEBUG)
                     ret = {'retcode': 1, 'pid': '2'}
                     break
-                # only set stdout on sucess as we already mangled in other
+                # only set stdout on success as we already mangled in other
                 # cases
                 ret['stdout'] = stdout
                 if finished:

--- a/salt/utils/vt.py
+++ b/salt/utils/vt.py
@@ -47,7 +47,6 @@ else:
 # Import salt libs
 from salt._compat import string_types
 from salt.log.setup import LOG_LEVELS
-import salt.utils
 
 log = logging.getLogger(__name__)
 
@@ -93,10 +92,7 @@ class Terminal(object):
                  shell=False,
                  cwd=None,
                  env=None,
-
-                 # user setup
-                 user=None,
-                 umask=None,
+                 preexec_fn=None,
 
                  # Terminal Size
                  rows=None,
@@ -129,6 +125,7 @@ class Terminal(object):
         self.shell = shell
         self.cwd = cwd
         self.env = env
+        self.preexec_fn = preexec_fn
 
         # ----- Set the desired terminal size ------------------------------->
         if rows is None and cols is None:
@@ -145,8 +142,6 @@ class Terminal(object):
         self.pid = None
         self.stdin = None
         self.stdout = None
-        self.user = user
-        self.umask = umask
         self.stderr = None
 
         self.child_fd = None
@@ -445,9 +440,8 @@ class Terminal(object):
                 if self.cwd is not None:
                     os.chdir(self.cwd)
 
-                if self.user or self.umask:
-                    salt.utils.chugid_and_umask(
-                        self.user, self.umask)
+                if self.preexec_fn:
+                    self.preexec_fn()
 
                 if self.env is None:
                     os.execvp(self.executable, self.args)


### PR DESCRIPTION
This should have been done quite a while ago, but I could only get to this now.

I'm submitting this against 2014.7 so that we don't have to deprecate this previous and undesirable behavior.
The reason why I ask you to read carefully is because this won't be tested in another RC since the .7 final might be close, however, this change should not break anything as it simply switches the previous behavior to the right place, out of VT.

The VT "behaviour" should be as close to subprocess as possible and this commit reverts the "behavior" breakage introduced.
