### PR TITLE
Change ext_module passing and make shim interactive to caller

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -827,6 +827,8 @@ class Single(object):
                     return 'ERROR: Failure deploying thin: {0}'.format(stdout), stderr, retcode
                 stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
                 stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
+            if 'ext_mods' == shim_command:
+                pass
 
         return stdout, stderr, retcode
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -651,7 +651,6 @@ class Single(object):
             pre_wrapper = salt.client.ssh.wrapper.FunctionWrapper(
                 self.opts,
                 self.id,
-                mods=self.mods,
                 **self.target)
             opts_pkg = pre_wrapper['test.opts_pkg']()
             opts_pkg['file_roots'] = self.opts['file_roots']
@@ -700,7 +699,6 @@ class Single(object):
         wrapper = salt.client.ssh.wrapper.FunctionWrapper(
             opts,
             self.id,
-            mods=self.mods,
             **self.target)
         self.wfuncs = salt.loader.ssh_wrapper(opts, wrapper, self.context)
         wrapper.wfuncs = self.wfuncs

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -348,8 +348,8 @@ class Shell(object):
                                   'auto accept run salt-ssh with the -i '
                                   'flag:\n{0}').format(stdout)
                     return ret_stdout, '', 254
-            elif stdout and stdout == 'ext_mod':
-                mods_raw = json.dumps(self.mods, separators=(',',':')) + 'EOF_||'
+            elif stdout and stdout == 'ext_mods':
+                mods_raw = json.dumps(self.mods, separators=(',',':')) + '|_E|0|'
                 term.sendline(mods_raw)
             if not term.isalive():
                 while True:

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -7,6 +7,7 @@ Manage transport commands via ssh
 import re
 import os
 import time
+import json
 import logging
 import subprocess
 
@@ -53,7 +54,8 @@ class Shell(object):
             priv=None,
             timeout=None,
             sudo=False,
-            tty=False):
+            tty=False,
+            mods=None):
         self.opts = opts
         self.host = host
         self.user = user
@@ -63,6 +65,7 @@ class Shell(object):
         self.timeout = timeout
         self.sudo = sudo
         self.tty = tty
+        self.mods = mods
 
     def get_error(self, errstr):
         '''
@@ -346,7 +349,8 @@ class Shell(object):
                                   'flag:\n{0}').format(stdout)
                     return ret_stdout, '', 254
             elif stdout and stdout == 'ext_mod':
-                pass
+                mods_raw = json.dumps(self.mods, separators=(',',':')) + 'EOF_||'
+                term.sendline(mods_raw)
             if not term.isalive():
                 while True:
                     stdout, stderr = term.recv()

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -345,6 +345,8 @@ class Shell(object):
                                   'auto accept run salt-ssh with the -i '
                                   'flag:\n{0}').format(stdout)
                     return ret_stdout, '', 254
+            elif stdout and stdout == 'ext_mod':
+                pass
             if not term.isalive():
                 while True:
                     stdout, stderr = term.recv()

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -349,7 +349,7 @@ class Shell(object):
                                   'flag:\n{0}').format(stdout)
                     return ret_stdout, '', 254
             elif stdout and stdout.endswith('_||ext_mods||_'):
-                mods_raw = json.dumps(self.mods, separators=(',',':')) + '|_E|0|'
+                mods_raw = json.dumps(self.mods, separators=(',', ':')) + '|_E|0|'
                 term.sendline(mods_raw)
             if not term.isalive():
                 while True:

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -348,7 +348,7 @@ class Shell(object):
                                   'auto accept run salt-ssh with the -i '
                                   'flag:\n{0}').format(stdout)
                     return ret_stdout, '', 254
-            elif stdout and stdout == 'ext_mods':
+            elif stdout and stdout.endswith('_||ext_mods||_'):
                 mods_raw = json.dumps(self.mods, separators=(',',':')) + '|_E|0|'
                 term.sendline(mods_raw)
             if not term.isalive():

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -23,12 +23,14 @@ THIN_ARCHIVE = 'salt-thin.tgz'
 EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
 
+
 class OBJ(object):
     pass
 
 OPTIONS = None
 ARGS = None
 #%%OPTS
+
 
 def need_deployment():
     if os.path.exists(OPTIONS.saltdir):
@@ -77,6 +79,7 @@ def unpack_thin(thin_path):
     tfile.close()
     os.unlink(thin_path)
 
+
 def get_modules():
     glob = ''
     while True:
@@ -87,6 +90,7 @@ def get_modules():
             break
     ext_mods = json.loads(glob[:-6])
     write_modules(ext_mods)
+
 
 def write_modules(ext_mods):
     modcache = os.path.join(

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -80,8 +80,9 @@ def unpack_thin(thin_path):
 def get_modules():
     glob = ''
     while True:
-        sys.stdout.write('ext_mods')
-        glob += sys.stdin.readline()
+        sys.stdout.write('_||ext_mods||_')
+        sys.stdout.flush()
+        glob += raw_input()
         if glob.endswith('|_E|0|'):
             break
     ext_mods = json.loads(glob[:-6])
@@ -102,11 +103,10 @@ def write_modules(ext_mods):
         chunks = ext_mods.get(mtype)
         if not chunks:
             continue
-        for chunk in chunks.split(','):
-            name, raw = chunk.split('|')
+        for name in chunks:
             dest = os.path.join(dest_dir, name)
             with open(dest, 'w+') as fp_:
-                fp_.write(raw.decode('base64'))
+                fp_.write(chunks[name].decode('base64'))
 
 
 def main(argv):

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -8,7 +8,6 @@ helper script used by salt.client.ssh.Single.  It is here, in a
 seperate file, for convenience of development.
 '''
 
-import optparse
 import hashlib
 import tarfile
 import shutil
@@ -24,65 +23,12 @@ THIN_ARCHIVE = 'salt-thin.tgz'
 EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
 
+class OBJ(object):
+    pass
 
 OPTIONS = None
 ARGS = None
-
-
-def parse_argv(argv):
-    global OPTIONS
-    global ARGS
-
-    oparser = optparse.OptionParser(usage='%prog -- [SHIM_OPTIONS] -- [SALT_OPTIONS]')
-    oparser.add_option(
-        '-c', '--config',
-        default='',
-        help='YAML configuration for salt thin',
-    )
-    oparser.add_option(
-        '-d', '--delimiter',
-        help='Delimeter string (viz. magic string) to indicate beginning of salt output',
-    )
-    oparser.add_option(
-        '-s', '--saltdir',
-        help='Directory where salt thin is or will be installed.',
-    )
-    oparser.add_option(
-        '--sum', '--checksum',
-        dest='checksum',
-        help='Salt thin checksum',
-    )
-    oparser.add_option(
-        '--hashfunc',
-        default='sha1',
-        help='Hash function for computing checksum',
-    )
-    oparser.add_option(
-        '--get-modules',
-        dest='get_modules',
-        default=False,
-        help='Call the routine to bring down ext_mods',
-        )
-    oparser.add_option(
-        '-v', '--version',
-        help='Salt thin version to be deployed/verified',
-    )
-
-    if argv and '--' not in argv:
-        oparser.error('A "--" argument must be the initial argument indicating the start of options to this script')
-
-    (OPTIONS, ARGS) = oparser.parse_args(argv[argv.index('--')+1:])
-
-    for option in (
-            'delimiter',
-            'saltdir',
-            'checksum',
-            'version',
-    ):
-        if getattr(OPTIONS, option, None):
-            continue
-        oparser.error('Option "--{0}" is required.'.format(option))
-
+#%%OPTS
 
 def need_deployment():
     if os.path.exists(OPTIONS.saltdir):
@@ -164,8 +110,6 @@ def write_modules(ext_mods):
 
 
 def main(argv):
-    parse_argv(argv)
-
     thin_path = os.path.join(OPTIONS.saltdir, THIN_ARCHIVE)
     if os.path.exists(thin_path):
         if OPTIONS.checksum != get_hash(thin_path, OPTIONS.hashfunc):

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -58,29 +58,10 @@ def parse_argv(argv):
         help='Hash function for computing checksum',
     )
     oparser.add_option(
-        '--modules',
-        dest='modules',
-        help='base64 modules, comma delim'
-        )
-    oparser.add_option(
-        '--states',
-        dest='states',
-        help='base64 states, comma delim'
-        )
-    oparser.add_option(
-        '--grains',
-        dest='grains',
-        help='base64 grains, comma delim'
-        )
-    oparser.add_option(
-        '--returners',
-        dest='returners',
-        help='base64 returners, comma delim'
-        )
-    oparser.add_option(
-        '--renderers',
-        dest='renderers',
-        help='base64 renderers, comma delim'
+        '--get-modules',
+        dest='get_modules',
+        default=False,
+        help='Call the routine to bring down ext_mods',
         )
     oparser.add_option(
         '-v', '--version',
@@ -219,7 +200,8 @@ def main(argv):
 
     with open(os.path.join(OPTIONS.saltdir, 'minion'), 'w') as config:
         config.write(OPTIONS.config + '\n')
-    get_modules()
+    if OPTIONS.get_modules:
+        get_modules()
     #Fix parameter passing issue
     if len(ARGS) == 1:
         argv_prepared = ARGS[0].split()

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -134,9 +134,9 @@ def unpack_thin(thin_path):
 def get_modules():
     glob = ''
     while True:
-        sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
-        glob += raw_input()
-        if glob.endswith('EOF_||'):
+        sys.stdout.write('ext_mods')
+        glob += sys.stdin.readline()
+        if glob.endswith('|_E|0|'):
             break
     ext_mods = json.loads(glob[:-6])
     write_modules(ext_mods)

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -151,9 +151,9 @@ def unpack_thin(thin_path):
     os.unlink(thin_path)
 
 def get_modules():
-    sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
     glob = ''
     while True:
+        sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
         glob += raw_input()
         if glob.endswith('EOF_||'):
             break

--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -30,10 +30,7 @@ class FunctionWrapper(dict):
         super(FunctionWrapper, self).__init__()
         self.wfuncs = wfuncs if isinstance(wfuncs, dict) else {}
         self.opts = opts
-        if isinstance(mods, dict):
-            self.mods = mods
-        else:
-            self.mods = {}
+        self.mods = mods
         self.kwargs = {'id_': id_,
                        'host': host}
         self.kwargs.update(kwargs)


### PR DESCRIPTION
Fix #16456

This is very cool, it allows us to stream data on a per request basis down to the running process on the other side of ssh. It allows us to cleanly send the ext_mods with each call without overloading the arguments (still needs some testing on super large ext_modules)
This also shrinks the shim a little, smaller shims are better :)

@s0undt3ch please take a look, this is a radical simplification vs what you were doing and you would know best if I am overlooking anything
