### PR TITLE
Cloud: Check the exit status code of scp before assuming it has failed.

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1076,7 +1076,7 @@ def sftp_file(dest_path, contents, kwargs, allow_failure=False):
             if not proc.isalive():
                 break
             time.sleep(0.025)
-        if allow_failure is False:
+        if allow_failure is False and proc.exitstatus != 0:
             raise SaltCloudSystemExit(
                 'Failed to upload {0} to {1}. Exit code: {2}'.format(
                     tmppath, dest_path, proc.exitstatus


### PR DESCRIPTION
Latest 2014.1 broke salt-cloud due to this. With this small patch I can deploy instances again.
