### PR TITLE
Yaml dump a dict, rather than an odict for boto_asg cloud-config

### DIFF
--- a/salt/modules/boto_asg.py
+++ b/salt/modules/boto_asg.py
@@ -367,7 +367,7 @@ def get_cloud_init_mime(cloud_init):
             _cloud_init.attach(_script)
     if 'cloud-config' in cloud_init:
         cloud_config = cloud_init['cloud-config']
-        _cloud_config = email.mime.text.MIMEText(yaml.dump(cloud_config),
+        _cloud_config = email.mime.text.MIMEText(yaml.dump(dict(cloud_config)),
                                                  'cloud-config')
         _cloud_init.attach(_cloud_config)
     return _cloud_init.as_string()


### PR DESCRIPTION
yaml.dump doesn't handle ordered dicts properly. This change casts the odict passed in from states to boto_asg.get_cloud_init_mime into a dict, so that the resulting cloud-config is properly formatted.

Without this change it's impossible to use cloud-config inside of cloud-init in launch configurations.
