### PR TITLE
Fix to minion.py

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -822,8 +822,10 @@ class Minion(MinionBase):
         else:
             functions = salt.loader.minion_mods(self.opts)
         returners = salt.loader.returners(self.opts, functions)
-        errors = functions['_errors']
-        functions.pop('_errors')
+        errors = {}
+        if '_errors' in functions:
+            errors = functions['_errors']
+            functions.pop('_errors')
 
         # we're done, reset the limits!
         if modules_max_memory is True:


### PR DESCRIPTION
Fix for an exception that was causing the salt minion not to start up properly.
