### PR TITLE
Don't use funcs not present in 2014.1

### DIFF
--- a/salt/states/user.py
+++ b/salt/states/user.py
@@ -330,7 +330,7 @@ def present(name,
     if gid_from_name:
         gid = __salt__['file.group_to_gid'](name)
 
-    if empty_password:
+    if empty_password and 'shadow.del_password' in __salt__:
         __salt__['shadow.del_password'](name)
 
     changes = _changes(name,


### PR DESCRIPTION
This only applies to the 2014.1 branch and does not need to be merged forward.
