### PR TITLE
Add a policies_from_pillars argument to boto_iam_role.present

### DIFF
--- a/salt/states/boto_iam_role.py
+++ b/salt/states/boto_iam_role.py
@@ -41,6 +41,8 @@ with the role. This is the default behavior of the AWS console.
             - region: us-east-1
             - key: GKTADJGHEIQSXMKKRBJ08H
             - keyid: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            - policies_from_pillars:
+                - shared_iam_bootstrap_policy
             - policies:
                 MySQSPolicy:
                     Statement:


### PR DESCRIPTION
This change makes it possible to include IAM policies from pillars, rather than needing to be hardcoded in the state. Since policies are dictionaries, this allows us to avoid using the indent filter in jinja.
