### PR TITLE
Send ext mods better

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -504,7 +504,7 @@ class Single(object):
         self.fun, self.args, self.kwargs = self.__arg_comps()
         self.id = id_
 
-        self.mods = mods
+        self.mods = mods if mods else {}
         args = {'host': host,
                 'user': user,
                 'port': port,

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -726,7 +726,7 @@ OPTIONS.saltdir = '{2}'
 OPTIONS.checksum = '{3}'
 OPTIONS.hashfunc = '{4}'
 OPTIONS.version = '{5}'
-OPTIONS.ext_mods = {6}
+OPTIONS.ext_mods = '{6}'
 ARGS = {7}\n'''.format(self.minion_config,
                          RSTR,
                          self.thin_dir,
@@ -825,6 +825,12 @@ ARGS = {7}\n'''.format(self.minion_config,
             elif 'ext_mods' == shim_command:
                 self.deploy_ext()
                 stdout, stderr, retcode = self.shell.exec_cmd(cmd_str)
+                if not re.search(RSTR_RE, stdout) or not re.search(RSTR_RE, stderr):
+                    # If RSTR is not seen in both stdout and stderr then there
+                    # was a thin deployment problem.
+                    return 'ERROR: Failure deploying thin: {0}'.format(stdout), stderr, retcode
+                stdout = re.split(RSTR_RE, stdout, 1)[1].strip()
+                stderr = re.split(RSTR_RE, stderr, 1)[1].strip()
 
         return stdout, stderr, retcode
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -986,12 +986,7 @@ def mod_data(fsclient):
                         if not os.path.isfile(mod_path):
                             continue
                         mod_data[os.path.basename(fn_)] = mod_path
-                        fns = os.stat(mod_path)
-                        chunk = '{0}{1}{2}{3}'.format(
-                                fns.st_size,
-                                fns.st_atime,
-                                fns.st_ctime,
-                                fns.st_mtime,)
+                        chunk = salt.utils.get_hash(mod_path)
                         ver_base += chunk
             if mod_data:
                 if ref in ret:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -568,6 +568,18 @@ class Single(object):
             thin,
             os.path.join(self.thin_dir, 'salt-thin.tgz'),
         )
+        self.deploy_ext()
+        return True
+
+    def deploy_ext(self):
+        '''
+        Deploy the ext_mods tarball
+        '''
+        if self.mods.get('file'):
+            self.shell.send(
+                self.mods['file'],
+                os.path.join(self.thin_dir, 'salt-ext_mods.tgz'),
+            )
         return True
 
     def run(self, deploy_attempted=False):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -1010,7 +1010,7 @@ def mod_data(fsclient):
     tfp.add(verfile, 'ext_version')
     for ref in ret:
         for fn_ in ret[ref]:
-            tfp.add(ret[ref][fn_], os.path.join('_{0}'.format(ref), fn_))
+            tfp.add(ret[ref][fn_], os.path.join(ref, fn_))
     tfp.close()
     return mods
 

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -734,7 +734,7 @@ ARGS = {8}\n'''.format(self.minion_config,
                          thin_sum,
                          'sha1',
                          salt.__version__,
-                         self.mods.get('version'),
+                         self.mods.get('version', ''),
                          'True' if self.opts.get('wipe_ssh') else 'False',
                          self.argv)
         py_code = SSH_PY_SHIM.replace('#%%OPTS', arg_str)

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -348,9 +348,6 @@ class Shell(object):
                                   'auto accept run salt-ssh with the -i '
                                   'flag:\n{0}').format(stdout)
                     return ret_stdout, '', 254
-            elif stdout and stdout.endswith('_||ext_mods||_'):
-                mods_raw = json.dumps(self.mods, separators=(',', ':')) + '|_E|0|'
-                term.sendline(mods_raw)
             if not term.isalive():
                 while True:
                     stdout, stderr = term.recv()

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -7,7 +7,6 @@ Manage transport commands via ssh
 import re
 import os
 import time
-import json
 import logging
 import subprocess
 

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -82,7 +82,7 @@ def unpack_thin(thin_path):
 
 
 def need_ext():
-    sys.stdout.write('ext_mods')
+    sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
     sys.exit(EX_MOD_DEPLOY)
 
 


### PR DESCRIPTION
This changes the way ext_mods are sent again, I tried to be clever in the last 2 iterations but that proved to be a problem. fortunately the last 2 iterations did simplify the code and opened up a lot of possibilities, they were still great additions tot he underlying flexibility of salt-ssh!
This PR makes the ext_mods get deployed in much the same way the thin tarball is, the ext_mods are also versioned so they only get deployed when they need to be.
