### PR TITLE
Fix chown in salt cloud provisioning

### DIFF
--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -1119,7 +1119,7 @@ def deploy_script(host,
 
                 if ssh_kwargs['username'] != 'root':
                     root_cmd(
-                        'chown -R root \\"{0}\\"'.format(
+                        'chown -R root "{0}"'.format(
                             preseed_minion_keys_tempdir
                         ),
                         tty, sudo, **ssh_kwargs


### PR DESCRIPTION
Provisioning with salt-cloud is broken for me on develop (and in 2014.7.0rc3):

```
chown: cannot access ‘"/tmp/.saltcloud-00b092ea-e2cc-488c-a63d-758d8b71fef0/preseed-minion-keys"’: No such file or directory
debug1: channel 0: free: client-session, nchannels 1
Connection to 54.77.89.172 closed.
Transferred: sent 4228, received 3408 bytes, in 0.5 seconds
Bytes per second: sent 8426.8, received 6792.5
debug1: Exit status 1
Error: There was a query error: Command 'ssh -v -t -t -oStrictHostKeyChecking=no -oUserKnownHostsFile=/dev/null -oControlPath=none -oPasswordAuthentication=no -oChallengeResponseAuthentication=no -oPubkeyAuthentication=yes -oKbdInteractiveAuthentication=no -i ./config/default.pem -p 22 ubuntu@54.77.89.172 \'sudo chown -R root \\"/tmp/.saltcloud-00b092ea-e2cc-488c-a63d-758d8b71fef0/preseed-minion-keys\\"\'' failed. Exit code: 1
```

This PR should fix it.
