### PR TITLE
make sreq-caching optional to lower connections on master

### DIFF
--- a/doc/ref/configuration/minion.rst
+++ b/doc/ref/configuration/minion.rst
@@ -415,6 +415,21 @@ environment, set this value to ``False``.
 
     dns_check: True
 
+.. conf_minion:: cache_sreqs
+
+``cache_sreqs``
+---------------
+
+Default: ``True``
+
+The connection to the master ret_port is kept open. When set to False, the minion
+creates a new connection for every return to the master.
+environment, set this value to ``False``.
+
+.. code-block:: yaml
+
+    cache_sreqs: True
+
 .. conf_minion:: ipc_mode
 
 ``ipc_mode``

--- a/salt/config.py
+++ b/salt/config.py
@@ -262,6 +262,7 @@ VALID_OPTS = {
     'zmq_filtering': bool,
     'con_cache': bool,
     'rotate_aes_key': bool,
+    'cache_sreqs': bool,
 }
 
 # default configurations
@@ -409,6 +410,7 @@ DEFAULT_MINION_OPTS = {
     'username': None,
     'password': None,
     'zmq_filtering': False,
+    'cache_sreqs': True,
 }
 
 DEFAULT_MASTER_OPTS = {

--- a/salt/config.py
+++ b/salt/config.py
@@ -583,6 +583,7 @@ DEFAULT_MASTER_OPTS = {
     'zmq_filtering': False,
     'con_cache': False,
     'rotate_aes_key': True,
+    'cache_sreqs': True,
 }
 
 # ----- Salt Cloud Configuration Defaults ----------------------------------->

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -197,20 +197,23 @@ class ZeroMQChannel(Channel):
     def sreq(self):
         key = self.sreq_key
 
-        if key not in ZeroMQChannel.sreq_cache:
-            master_type = self.opts.get('master_type', None)
-            if master_type == 'failover':
-                # remove all cached sreqs to the old master to prevent
-                # zeromq from reconnecting to old masters automagically
-                for check_key in self.sreq_cache.keys():
-                    if self.opts['master_uri'] != check_key[0]:
-                        del self.sreq_cache[check_key]
-                        log.debug('Removed obsolete sreq-object from '
-                                  'sreq_cache for master {0}'.format(check_key[0]))
+        if not self.opts['cache_sreqs']:
+            return salt.payload.SREQ(self.master_uri)
+        else:
+            if key not in ZeroMQChannel.sreq_cache:
+                master_type = self.opts.get('master_type', None)
+                if master_type == 'failover':
+                    # remove all cached sreqs to the old master to prevent
+                    # zeromq from reconnecting to old masters automagically
+                    for check_key in self.sreq_cache.keys():
+                        if self.opts['master_uri'] != check_key[0]:
+                            del self.sreq_cache[check_key]
+                            log.debug('Removed obsolete sreq-object from '
+                                      'sreq_cache for master {0}'.format(check_key[0]))
 
-            ZeroMQChannel.sreq_cache[key] = salt.payload.SREQ(self.master_uri)
+                ZeroMQChannel.sreq_cache[key] = salt.payload.SREQ(self.master_uri)
 
-        return ZeroMQChannel.sreq_cache[key]
+            return ZeroMQChannel.sreq_cache[key]
 
     def __init__(self, opts, **kwargs):
         self.opts = opts


### PR DESCRIPTION
With SREQ-Caching enabled the minions always keep the connection to 4506 open. Making it optional seems reasonabe for larger installations to lower connection count on master.
