### PR TITLE
Properly discover directories in s3fs file server.  Fixes #16638.

### DIFF
--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -289,7 +289,7 @@ def _read_buckets_cache_file(cache_file):
     return data
 
 
-def _find_files(metadata, dirs_only=False):
+def _find_files(metadata):
     '''
     Looks for all the files in the S3 bucket cache metadata
     '''
@@ -302,8 +302,8 @@ def _find_files(metadata, dirs_only=False):
 
         # grab the paths from the metadata
         filePaths = map(lambda k: k['Key'], data)
-        # filter out the files or the dirs depending on flag
-        ret[bucket] += filter(lambda k: k.endswith('/') == dirs_only,
+        # filter out the dirs
+        ret[bucket] += filter(lambda k: not k.endswith('/'),
                               filePaths)
 
     return ret


### PR DESCRIPTION
Also, remove the dirs_only parameter to _find_files in pillar s3,
because it doesn't work in some cases and isn't used anyway.
