### PR TITLE
Fix usage of state.show_sls for salt-ssh

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -18,6 +18,7 @@ import salt.state
 import salt.loader
 import salt.minion
 import salt.log
+from salt._compat import string_types
 
 log = logging.getLogger(__name__)
 
@@ -360,6 +361,8 @@ def show_sls(mods, saltenv='base', test=None, env=None, **kwargs):
             __pillar__,
             __salt__,
             __context__['fileclient'])
+    if isinstance(mods, string_types):
+        mods = mods.split(',')
     high_data, errors = st_.render_highstate({saltenv: mods})
     high_data, ext_errors = st_.state.reconcile_extend(high_data)
     errors += ext_errors


### PR DESCRIPTION
Previously, this failed:

```
$ salt-ssh '*' state.show_sls test
example:
    - No matching sls found for 't' in env 'base'
    - No matching sls found for 'e' in env 'base'
    - No matching sls found for 's' in env 'base'
```

Now, it works!  The `mods` argument needed to be split for `salt-ssh`, as it was in the`salt.modules.state.show_sls`` function.  Previously, it was iterating through all chars in the string being inputted.
