### PR TITLE
Allow archive.extracted to be used during highstate run

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -145,9 +145,15 @@ def extracted(name,
             file_result = file_result[file_result.keys()[0]]
         except AttributeError:
             pass
-        if not file_result['result']:
-            log.debug('failed to download {0}'.format(source))
-            return file_result
+
+        try:
+            if not file_result['result']:
+                log.debug('failed to download {0}'.format(source))
+                return file_result
+        except AttributeError:
+            if not file_result:
+                log.debug('failed to download {0}'.format(source))
+                return file_result
     else:
         log.debug('Archive file {0} is already in cache'.format(name))
 

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -109,6 +109,8 @@ def extracted(name,
 
     log.debug('Input seem valid so far')
     filename = os.path.join(__opts__['cachedir'],
+                            'files',
+                            __env__,
                             '{0}.{1}'.format(if_missing.replace('/', '_'),
                                              archive_format))
     if not os.path.exists(filename):
@@ -131,7 +133,12 @@ def extracted(name,
                 ]
             }
         }
-        file_result = __salt__['state.high'](data)
+        file_result = __salt__['state.single']('file.managed',
+                                               filename,
+                                               source=source,
+                                               source_hash=source_hash,
+                                               makedirs=True,
+                                               saltenv=__env__)
         log.debug('file.managed: {0}'.format(file_result))
         # get value of first key
         file_result = file_result[file_result.keys()[0]]

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -150,7 +150,7 @@ def extracted(name,
             if not file_result['result']:
                 log.debug('failed to download {0}'.format(source))
                 return file_result
-        except AttributeError:
+        except TypeError:
             if not file_result:
                 log.debug('failed to download {0}'.format(source))
                 return file_result

--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -141,7 +141,10 @@ def extracted(name,
                                                saltenv=__env__)
         log.debug('file.managed: {0}'.format(file_result))
         # get value of first key
-        file_result = file_result[file_result.keys()[0]]
+        try:
+            file_result = file_result[file_result.keys()[0]]
+        except AttributeError:
+            pass
         if not file_result['result']:
             log.debug('failed to download {0}'.format(source))
             return file_result


### PR DESCRIPTION
Use state.single instead.
Use better target cache dir. (Note that this may cause previously cached
files to be re-cached!)

Fixes #16658 
