### PR TITLE
Bug in os relase version comparison for OSX user and group modules

### DIFF
--- a/salt/modules/mac_group.py
+++ b/salt/modules/mac_group.py
@@ -11,16 +11,16 @@ except ImportError:
 
 import salt.utils
 from salt.exceptions import CommandExecutionError, SaltInvocationError
-from salt.modules.mac_user import _osmajor, _dscl, _flush_dscl_cache
+from salt.modules.mac_user import _dscl, _flush_dscl_cache
 
 # Define the module's virtual name
 __virtualname__ = 'group'
 
 
 def __virtual__():
-    global _osmajor, _dscl, _flush_dscl_cache
-    _osmajor = salt.utils.namespaced_function(_osmajor, globals())
-    if __grains__.get('kernel') != 'Darwin' or _osmajor() < 10.7:
+    global _dscl, _flush_dscl_cache
+    if (__grains__.get('kernel') != 'Darwin' or
+            __grains__['osrelease_info'] < (10, 7)):
         return False
     _dscl = salt.utils.namespaced_function(_dscl, globals())
     _flush_dscl_cache = salt.utils.namespaced_function(

--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -25,17 +25,11 @@ __virtualname__ = 'user'
 
 
 def __virtual__():
-    if __grains__.get('kernel') != 'Darwin':
+    if (__grains__.get('kernel') != 'Darwin' or
+            __grains__['osrelease_info'] < (10, 7)):
         return False
-    return __virtualname__ if _osmajor() >= 10.7 else False
-
-
-def _osmajor():
-    if '_osmajor' not in __context__:
-        __context__['_osmajor'] = float(
-            '.'.join(str(__grains__['osrelease']).split('.')[0:2])
-        )
-    return __context__['_osmajor']
+    else:
+        return __virtualname__
 
 
 def _flush_dscl_cache():
@@ -49,7 +43,7 @@ def _dscl(cmd, ctype='create'):
     '''
     Run a dscl -create command
     '''
-    if _osmajor() < 10.8:
+    if __grains__['osrelease_info'] < (10, 8):
         source, noderoot = '.', ''
     else:
         source, noderoot = 'localhost', '/Local/Default'

--- a/tests/unit/modules/mac_user_test.py
+++ b/tests/unit/modules/mac_user_test.py
@@ -46,14 +46,6 @@ class MacUserTestCase(TestCase):
                      'groups': ['TEST_GROUP'], 'home': '/Users/foo',
                      'fullname': 'TEST USER', 'uid': 4376}
 
-    def test_osmajor(self):
-        '''
-        Tests version of OS X
-        '''
-        with patch.dict(mac_user.__grains__, {'kernel': 'Darwin',
-                                              'osrelease': '10.9.1'}):
-            self.assertEqual(mac_user._osmajor(), 10.9)
-
     @skipIf(True, 'Waiting on some clarifications from bug report #10594')
     def test_flush_dscl_cache(self):
         # TODO: Implement tests after clarifications come in
@@ -68,8 +60,9 @@ class MacUserTestCase(TestCase):
                                            'stderr': '',
                                            'stdout': ''})
         with patch.dict(mac_user.__salt__, {'cmd.run_all': mac_mock}):
-            with patch.dict(mac_user.__grains__, {'kernel': 'Darwin',
-                                                  'osrelease': '10.9.1'}):
+            with patch.dict(mac_user.__grains__,
+                            {'kernel': 'Darwin', 'osrelease': '10.9.1',
+                             'osrelease_info': (10, 9, 1)}):
                 self.assertEqual(mac_user._dscl('username'), {'pid': 4948,
                                                               'retcode': 0,
                                                               'stderr': '',


### PR DESCRIPTION
This fixes a bug in the OSX user/group modules where it uses a helper function `_osmajor` to get a floating representation of the OS release version. The problem with `_osmajor` is that it parses the release version as a float which does not correctly handle versions `a.b` where `b>=10` so version 10.10 will then look like 10.1.

In fact, this bug is now evident with the release of OSX Yosemite which is version 10.10.

A better approach is to use the already defined grain `osrelease_info` which provides a tuple and then compare to a tuple of the version to test. The tuple comparison does the right thing - comparing the first number, then the seconds, etc. (https://docs.python.org/2/tutorial/datastructures.html#comparing-sequences-and-other-types)
