### PR TITLE
gitfs: accept per-remote auth params (fixes #16698)

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -54,12 +54,12 @@ import subprocess
 from datetime import datetime
 
 VALID_PROVIDERS = ('gitpython', 'pygit2', 'dulwich')
-PER_REMOTE_PARAMS = ('base', 'mountpoint', 'root')
 
 # Auth support (auth params can be global or per-remote, too)
 AUTH_PROVIDERS = ('pygit2',)
 AUTH_PARAMS = ('user', 'password', 'pubkey', 'privkey', 'passphrase',
                'insecure_auth')
+PER_REMOTE_PARAMS = AUTH_PARAMS + ('base', 'mountpoint', 'root')
 
 _RECOMMEND_GITPYTHON = (
     'GitPython is installed, you may wish to set gitfs_provider to '


### PR DESCRIPTION
This fix should be low-risk and I tested that it addresses the issue - that per-remote auth params cause an error which is contrary to the current documentation.

However, I didn't test that per-remote auth params actually work because I'm using GitPython, which doesn't support per-remote auth params.  A more thorough fix would be to log an error when the config has per-remote settings that aren't supported by whatever git library is being used.

So, feel free to merge this or close it in favor of a better fix in the future - I don't need it for my setup.
