### PR TITLE
Correct documentation for sqlite returner

### DIFF
--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -51,9 +51,9 @@ Use the commands to create the sqlite3 database and tables::
       );
     EOF
 
-  To use the sqlite returner, append '--return sqlite' to the salt command. ex:
+  To use the sqlite returner, append '--return sqlite3' to the salt command. ex:
 
-    salt '*' test.ping --return sqlite
+    salt '*' test.ping --return sqlite3
 
   To use the alternative configuration, append '--return_config alternative' to the salt command. ex:
 


### PR DESCRIPTION
The `__virtualname__` is `sqlite3`, not `sqlite`.
