### PR TITLE
Fix bad auth param handling in gitfs

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -540,7 +540,8 @@ GitPython
 ---------
 
 With GitPython_, only passphrase-less SSH public key authentication is
-supported.
+supported. **The auth parameters (pubkey, privkey, etc.) shown in the pygit2
+authentication examples above do not work with GitPython.**
 
 .. code-block:: yaml
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -599,11 +599,13 @@ def init():
         override_params += AUTH_PARAMS
     elif global_auth_params:
         log.critical(
-            'GitFS authentication was configured, but the {0} gitfs_provider '
-            'does not support authentication. The providers for which '
-            'authentication is supported in gitfs are: {1}'
-            .format(provider, ', '.join(AUTH_PROVIDERS))
+            'GitFS authentication was configured, but the {0!r} '
+            'gitfs_provider does not support authentication. The providers '
+            'for which authentication is supported in gitfs are: {1}. See the '
+            'GitFS Walkthrough in the Salt documentation for further '
+            'information.'.format(provider, ', '.join(AUTH_PROVIDERS))
         )
+        return []
 
     # ignore git ssl verification if requested
     ssl_verify = 'true' if __opts__.get('gitfs_ssl_verify', True) else 'false'
@@ -616,6 +618,7 @@ def init():
 
     for remote in __opts__['gitfs_remotes']:
         repo_conf = copy.deepcopy(per_remote_defaults)
+        bad_per_remote_conf = False
         if isinstance(remote, dict):
             repo_url = next(iter(remote))
             per_remote_conf = salt.utils.repack_dictlist(remote[repo_url])
@@ -628,14 +631,34 @@ def init():
                 )
             for param in (x for x in per_remote_conf
                           if x not in override_params):
-                log.error(
-                    'Invalid configuration parameter {0!r} in remote {1}. '
-                    'Valid parameters are: {2}. See the documentation for '
-                    'further information.'.format(
-                        param, repo_url, ', '.join(PER_REMOTE_PARAMS)
+                bad_per_remote_conf = True
+                if param in AUTH_PARAMS and provider not in AUTH_PROVIDERS:
+                    log.critical(
+                        'GitFS authentication parameter {0!r} (from remote '
+                        '{1}) is only supported by the following provider(s): '
+                        '{2}. Current gitfs_provider is {3!r}. See the '
+                        'GitFS Walkthrough in the Salt documentation for '
+                        'further information.'.format(
+                            param,
+                            repo_url,
+                            ', '.join(AUTH_PROVIDERS),
+                            provider
+                        )
                     )
-                )
-                per_remote_conf.pop(param)
+                else:
+                    log.critical(
+                        'Invalid configuration parameter {0!r} in remote {1}. '
+                        'Valid parameters are: {2}. See the GitFS Walkthrough '
+                        'in the Salt documentation for further '
+                        'information.'.format(
+                            param,
+                            repo_url,
+                            ', '.join(PER_REMOTE_PARAMS)
+                        )
+                    )
+            if bad_per_remote_conf:
+                # Don't let Salt try to use a badly-configured remote
+                continue
             repo_conf.update(per_remote_conf)
         else:
             repo_url = remote

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -54,12 +54,12 @@ import subprocess
 from datetime import datetime
 
 VALID_PROVIDERS = ('gitpython', 'pygit2', 'dulwich')
+PER_REMOTE_PARAMS = ('base', 'mountpoint', 'root')
 
 # Auth support (auth params can be global or per-remote, too)
 AUTH_PROVIDERS = ('pygit2',)
 AUTH_PARAMS = ('user', 'password', 'pubkey', 'privkey', 'passphrase',
                'insecure_auth')
-PER_REMOTE_PARAMS = AUTH_PARAMS + ('base', 'mountpoint', 'root')
 
 _RECOMMEND_GITPYTHON = (
     'GitPython is installed, you may wish to set gitfs_provider to '


### PR DESCRIPTION
Pull #16724 broke how Salt handles invalid auth params. This pull request
reverts #16724 and makes the logging more explicit.
