### PR TITLE
Add varstack ext_pillar

### DIFF
--- a/salt/pillar/varstack_pillar.py
+++ b/salt/pillar/varstack_pillar.py
@@ -6,13 +6,6 @@ Use varstack data as a Pillar source
 # Import python libs
 import logging
 
-# Import salt libs
-import salt.utils
-from salt._compat import string_types
-
-# Import third party libs
-import yaml
-
 HAS_VARSTACK = False
 try:
     import varstack
@@ -26,12 +19,14 @@ log = logging.getLogger(__name__)
 # Define the module's virtual name
 __virtualname__ = 'varstack'
 
+
 def __virtual__():
     if not HAS_VARSTACK:
         log.error('Varstack ext_pillar is enabled in configuration but '
                   'could not be loaded because Varstack is not installed.')
         return False
     return __virtualname__
+
 
 def ext_pillar(minion_id,  # pylint: disable=W0613
                pillar,  # pylint: disable=W0613

--- a/salt/pillar/varstack_pillar.py
+++ b/salt/pillar/varstack_pillar.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+'''
+Use varstack data as a Pillar source
+'''
+
+# Import python libs
+import logging
+
+# Import salt libs
+import salt.utils
+from salt._compat import string_types
+
+# Import third party libs
+import yaml
+
+HAS_VARSTACK = False
+try:
+    import varstack
+    HAS_VARSTACK = True
+except ImportError:
+    pass
+
+# Set up logging
+log = logging.getLogger(__name__)
+
+# Define the module's virtual name
+__virtualname__ = 'varstack'
+
+def __virtual__():
+    if not HAS_VARSTACK:
+        log.error('Varstack ext_pillar is enabled in configuration but '
+                  'could not be loaded because Varstack is not installed.')
+        return False
+    return __virtualname__
+
+def ext_pillar(minion_id,  # pylint: disable=W0613
+               pillar,  # pylint: disable=W0613
+               conf):
+    '''
+    Parse varstack data and return the result
+    '''
+    vs = varstack.Varstack(config_filename=conf)
+    return vs.evaluate(__grains__)


### PR DESCRIPTION
This PR adds an external pillar using the Varstack system. Varstack ist very similar to the puppet related hiera project and allow to merge multiple sets of data into a single combined set of variables.

In order to use this ext_pillar module Varstack has to be installed from this location:
https://github.com/conversis/varstack

To activate the pillar the ext_pillar section in the saltstack master configuration has to look like this:

```
...
ext_pillar:
  - varstack: /etc/varstack.yaml
...
```

More information about Varstack itself can be found here:
https://github.com/conversis/varstack/blob/master/README.md
