### PR TITLE
dockerio.pull broken on verified images since docker 1.3

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1501,7 +1501,6 @@ def _parse_image_multilogs_string(ret, repo):
         valid_states = [
             'Download complete',
             'Already exists',
-            'Image is up to date',
         ]
 
         # search last layer grabbed

--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1496,12 +1496,21 @@ def _parse_image_multilogs_string(ret, repo):
                     image_logs.append(buf)
                 buf = ''
         image_logs.reverse()
+
+        # Valid statest when pulling an image from the docker registry
+        valid_states = [
+            'Download complete',
+            'Already exists',
+            'Image is up to date',
+        ]
+
         # search last layer grabbed
         for l in image_logs:
             if isinstance(l, dict):
-                if l.get('status') == 'Download complete' and l.get('id'):
+                if l.get('status') in valid_states and l.get('id'):
                     infos = _get_image_infos(l['id'])
                     break
+
     return image_logs, infos
 
 


### PR DESCRIPTION
Hey Guys

Pulling docker verified images (which is new in docker 1.3) is broken if the image already exists locally, for example (using the pydsl):

``` python
state('.nginx-image').docker \
    .pulled(
        name='nginx',
        tag='latest',
        user='root') \
    .require(stateconf='docker::goal')
```

Returns this error (when the image exists)

```
----------
          ID: nginx::nginx-image
    Function: docker.pulled
        Name: nginx
      Result: False
     Comment: An error occurred pulling your image

              {"status":"The image you are pulling has been verified","id":"nginx:1.7.6"}
              {"status":"Already exists","progressDetail":{},"id":"511136ea3c5a"}{"status":"Already exists","progressDetail":{},"id":"5a7d9470be44"}{"status":"Already exists","progressDetail":{},"id":"feb755848a9a"}{"status":"Already exists","progressDetail":{},"id":"7caab58ebef6"}{"status":"Already exists","progressDetail":{},"id":"847cf46d3d69"}{"status":"Already exists","progressDetail":{},"id":"ddd54642be42"}{"status":"Already exists","progressDetail":{},"id":"ad5b7af53616"}{"status":"Already exists","progressDetail":{},"id":"44a3dbb90234"}{"status":"Already exists","progressDetail":{},"id":"ed12dc3482fc"}{"status":"Already exists","progressDetail":{},"id":"7f9cd959dc81"}{"status":"Already exists","progressDetail":{},"id":"cf2c83853506"}{"status":"Already exists","progressDetail":{},"id":"2e980420641d"}{"status":"Already exists","progressDetail":{},"id":"b8c5a6ffc2bd"}{"status":"Already exists","progressDetail":{},"id":"f3f21bfe3d94"}{"status":"Status: Image is up to date for nginx:1.7.6"}
     Started: 10:09:53.022459
    Duration: 291965.096 ms
     Changes:
```

Digging around the code I think its an issue with this line: https://github.com/saltstack/salt/blob/2014.7/salt/modules/dockerio.py#L1499 which explicitly checks for the string to contain `Download complete`, for verified images docker will now return `Already exists` where as none verified images will still return `Download complete` even though they already exist.

This results in `infos` returning `None` which results in the pull method returning an error even though no error occurred.

I might try and get a PR in for this if I get some time over the weekend.
