### PR TITLE
fileserver.s3fs: avoid shadowing dir() built-in

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -500,9 +500,9 @@ def _find_dirs(metadata):
         for path in [k['Key'] for k in data]:
             prefix = ''
             for part in path.split('/')[:-1]:
-                dir = prefix + part + '/'
-                ret[bucket_name].add(dir)
-                prefix = dir
+                directory = prefix + part + '/'
+                ret[bucket_name].add(directory)
+                prefix = directory
 
     return ret
 


### PR DESCRIPTION
```
************* Module salt.fileserver.s3fs
salt/fileserver/s3fs.py:503: [W0622(redefined-builtin), _find_dirs] Redefining built-in 'dir'
```
