### PR TITLE
Improvements to releases page

### DIFF
--- a/doc/topics/releases/index.rst
+++ b/doc/topics/releases/index.rst
@@ -5,19 +5,23 @@ Release notes
 See the :doc:`version numbers</topics/releases/version_numbers>` page for more
 information about the version numbering scheme.
 
+Latest Stable Release
+=====================
+
 .. releasestree::
     :maxdepth: 1
 
-    2014.1.7
+    2014.1.11
 
-Archive
-=======
+Previous Releases
+=================
 
 .. releasestree::
     :maxdepth: 1
     :glob:
 
-    [0-9]*
+    2014.1.*
+    0.*
 
 .. seealso:: :doc:`Legacy salt-cloud release docs <../cloud/releases/index>`
 


### PR DESCRIPTION
This clarifies what the current stable release is. It also hides the 2014.7.0
release notes until we actually release that version.
