### PR TITLE
Fix example command to one that exists

### DIFF
--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -272,7 +272,7 @@ targeted minions:
 
 .. code-block:: bash
 
-    salt '*' disk.percent
+    salt '*' disk.usage
 
 
 Getting to Know the Functions


### PR DESCRIPTION
Fix walkthrough to use disk.usage instead of disk.percent (which doesn't appear to exist any more).
