### PR TITLE
Don't allow args to be longs, msgpack does not like this and jids

### DIFF
--- a/salt/utils/args.py
+++ b/salt/utils/args.py
@@ -17,12 +17,18 @@ def condition_input(args, kwargs):
     '''
     Return a single arg structure for the publisher to safely use
     '''
+    ret = []
+    for arg in args:
+        if isinstance(arg, long):
+            ret.append(str(arg))
+        else:
+            ret.append(arg)
     if isinstance(kwargs, dict) and kwargs:
         kw_ = {'__kwarg__': True}
         for key, val in kwargs.iteritems():
             kw_[key] = val
-        return list(args) + [kw_]
-    return args
+        return ret + [kw_]
+    return ret
 
 
 def parse_input(args, condition=True):


### PR DESCRIPTION
should always be strings
Fix #16762
