### PR TITLE
Test long jid passed on CLI

### DIFF
--- a/tests/unit/utils/args.py
+++ b/tests/unit/utils/args.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Import Salt Libs
+from salt.utils import args
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ArgsTestCase(TestCase):
+    '''
+    TestCase for salt.utils.args module
+    '''
+
+    def test_condition_input_string(self):
+        '''
+        Test passing a jid on the command line
+        '''
+        cmd = args.condition_input(['*', 'foo.bar', 20141020201325675584], None)
+        self.assertIsInstance(cmd[2], str)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ArgsTestCase, needs_daemon=False)


### PR DESCRIPTION
JIDs should be strings.

Refs #16762
