### PR TITLE
Don't use hardcoded timeout value in batch mode.

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -33,7 +33,7 @@ class Batch(object):
         args = [self.opts['tgt'],
                 'test.ping',
                 [],
-                5,
+                self.opts['timeout'],
                 ]
 
         selected_target_option = self.opts.get('selected_target_option', None)

--- a/tests/unit/cli/batch_test.py
+++ b/tests/unit/cli/batch_test.py
@@ -21,7 +21,7 @@ class BatchTestCase(TestCase):
     '''
 
     def setUp(self):
-        opts = {'batch': '', 'conf_file': {}, 'tgt': ''}
+        opts = {'batch': '', 'conf_file': {}, 'tgt': '', 'timeout': ''}
         mock_client = MagicMock()
         with patch('salt.client.get_local_client', MagicMock(return_value=mock_client)):
             with patch('salt.client.LocalClient.cmd_iter', MagicMock(return_value=[])):


### PR DESCRIPTION
Hello,

I'm not sure if this was intended, but batch mode uses hardcoded 5 seconds to get a list of minions. I've modified batch mode code to get timeout value from configuration/commandline.
