### PR TITLE
Only add mine.update to schedule if function is available

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -616,15 +616,17 @@ class Minion(MinionBase):
             self.returners)
 
         # add default scheduling jobs to the minions scheduler
-        self.schedule.add_job({
-            '__mine_interval':
-            {
-                'function': 'mine.update',
-                'minutes': opts['mine_interval'],
-                'jid_include': True,
-                'maxrunning': 2
-            }
-        })
+        if 'mine.update' in self.functions:
+            log.info('Added mine.update to schedular')
+            self.schedule.add_job({
+                '__mine_interval':
+                {
+                    'function': 'mine.update',
+                    'minutes': opts['mine_interval'],
+                    'jid_include': True,
+                    'maxrunning': 2
+                }
+            })
 
         # add master_alive job if enabled
         if self.opts['master_alive_interval'] > 0:


### PR DESCRIPTION
If a user disables the mine-module with 

``` yaml
disable_modules: [mine]
```

the scheduler complains about missing 'mine.update' in the log in 1-second intervals. To prevent this, only add the mine.update-job to schedule if the function is available.
