### PR TITLE
Strip off tabs for tomcat version calls

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -597,7 +597,7 @@ def version():
         if not line:
             continue
         if 'Server version' in line:
-            comps = line.split(': ').lstrip()
+            comps = line.split(': ')
             return comps[1]
 
 

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -597,7 +597,7 @@ def version():
         if not line:
             continue
         if 'Server version' in line:
-            comps = line.split(': ')
+            comps = line.split(': ').lstrip()
             return comps[1]
 
 
@@ -619,7 +619,7 @@ def fullversion():
             continue
         if ': ' in line:
             comps = line.split(': ')
-            ret[comps[0]] = comps[1]
+            ret[comps[0]] = comps[1].lstrip()
     return ret
 
 


### PR DESCRIPTION
The script executed by `tomcat.fullstatus` has tabs to present its data but this module did not deal with them resulting in a "messy" output with several different tabs. 

This commit strips those off, on the left side and provides a clean(er) output.
