### PR TITLE
Point to the correct latest 2014.1.13 release

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -152,7 +152,7 @@ copyright = '2014 SaltStack, Inc.'
 
 version = salt.version.__version__
 #release = '.'.join(map(str, salt.version.__version_info__))
-release = '2014.1.11'
+release = '2014.1.13'
 
 spelling_lang = 'en_US'
 language = 'en'

--- a/doc/topics/releases/2014.1.13.rst
+++ b/doc/topics/releases/2014.1.13.rst
@@ -1,0 +1,10 @@
+============================
+Salt 2014.1.13 Release Notes
+============================
+
+:release: 2014-10-14
+
+Version 2014.1.13 is another bugfix release for :doc:`2014.1.0
+</topics/releases/2014.1.0>`.  Changes include:
+
+- Fix ``sftp_file`` by checking the exit status code of scp (which broke salt-cloud) (:issue:`16599`)

--- a/doc/topics/releases/index.rst
+++ b/doc/topics/releases/index.rst
@@ -11,7 +11,7 @@ Latest Stable Release
 .. releasestree::
     :maxdepth: 1
 
-    2014.1.12
+    2014.1.13
 
 Previous Releases
 =================


### PR DESCRIPTION
In order to update what is shown on http://docs.saltstack.com/en/latest/topics/releases/index.html as the latest version, I added the release notes from v2014.1.13 tag to the the develop branch and updated the documentation to point to it as the latest release.
