### PR TITLE
Attempt to resolve relative requisites on minion start

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -889,7 +889,6 @@ class Loader(object):
         failed_loads = {}
 
         def load_names(names, failhard=False):
-            log.info('Loading names')
             for name in names:
                 try:
                     if names[name].endswith('.pyx'):


### PR DESCRIPTION
As outlined in #16722, the minion will fail to load modules with
cross-imports at start because they can't be resolved.

This stores those failures and re-tries them because the requisites may
be loaded later on in the loop.

This does incur a performance penalty but allows a minion to correctly start with the following in `_modules`:

```
a.py
-----

def ping():
    return Tru

b.py
------

import a
def ping():
    return True

def ping_a():
    return True
```

Without this change, this is possible on a running minion, because we _already_ have the necessary imports loaded. However, it will break on minion restart.

To improve this, we could add a `cold_start` flag to the loader, I suppose...
