### PR TITLE
Don't let YAML have a newline party

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -540,7 +540,7 @@ class Single(object):
                     'root_dir': os.path.join(self.thin_dir, 'running_data'),
                     'id': self.id,
                     'sock_dir': '/',
-                }).strip()
+                }, width=1000).strip()
         self.target = kwargs
         self.target.update(args)
         self.serial = salt.payload.Serial(opts)


### PR DESCRIPTION
YAML thought it would be super-helpful to break up a long string into
newlines. It was not that helpful.

Fixes #16413
