### PR TITLE
Raise exception if python-apt not installed

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -695,8 +695,7 @@ def list_pkgs(versions_as_list=False,
 
     if not apt_cache_support:
         msg = 'Error: apt.cache python module not found'
-        log.error(msg)
-        return msg
+        raise CommandExecutionError(msg)
 
     # Check for virtual packages. We need dctrl-tools for this.
     if not removed:


### PR DESCRIPTION
I found myself on a system without python-apt installed and I was getting the following error:

```
$ salt-call pkg.install python-pip -l debug
...
The minion function caused an exception: Traceback (most recent call last):
      File "/usr/lib/python2.7/dist-packages/salt/minion.py", line 809, in _thread_return
        return_data = func(*args, **kwargs)
      File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 468, in install
        return salt.utils.compare_dicts(old, new)
      File "/usr/lib/python2.7/dist-packages/salt/utils/__init__.py", line 1788, in compare_dicts
        for key in set((new or {}).keys()).union((old or {}).keys()):
    AttributeError: 'str' object has no attribute 'keys'
```

Have modified `aptpkg` module to throw an exception in `list_pkgs` if python-apt is not installed instead of returning an error string.  Now gives

```
$ salt-call pkg.install python-pip -l debug
...
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 81, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 420, in install
    old = list_pkgs()
  File "/usr/lib/python2.7/dist-packages/salt/modules/aptpkg.py", line 698, in list_pkgs
    raise CommandExecutionError(msg)
CommandExecutionError: Error: apt.cache python module not found
Error running 'pkg.install': Error: apt.cache python module not found
``
```
