### PR TITLE
Tomcat module: Fixed deploy_war not working and added version retrieval

### DIFF
--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -526,7 +526,7 @@ def deploy_war(war,
     else:
         tfile = war
 
-    version_extract = re.findall("\d+.\d+.\d+?",os.path.basename(war).replace('.war', ''))
+    version_extract = re.findall("\d+.\d+.\d+?", os.path.basename(war).replace('.war', ''))
     if len(version_extract) == 1:
         version_string = version_extract[0]
     else:

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -80,6 +80,7 @@ def __catalina_home():
                     return catalina_home
     return False
 
+
 def _get_credentials():
     '''
     Get the username and password from opts, grains & pillar

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -48,6 +48,7 @@ import urllib
 import urllib2
 import tempfile
 import os
+import re
 
 # Import Salt libs
 import salt.utils
@@ -79,7 +80,6 @@ def __catalina_home():
                     return catalina_home
     return False
 
-
 def _get_credentials():
     '''
     Get the username and password from opts, grains & pillar
@@ -99,7 +99,6 @@ def _get_credentials():
             else:
                 break
     return ret['user'], ret['passwd']
-
 
 def _auth(uri):
     '''
@@ -523,12 +522,20 @@ def deploy_war(war,
             __salt__['file.set_mode'](cached, '0644')
         except KeyError:
             pass
+    else:
+        tfile = war
+
+    version_extract = re.findall("\d+.\d+.\d+?",os.path.basename(war).replace('.war', ''))
+    if len(version_extract) == 1:
+        version_string = version_extract[0]
+    else:
+        version_string = None
 
     # Prepare options
     opts = {
         'war': 'file:{0}'.format(tfile),
         'path': context,
-        'version': os.path.basename(war).replace('.war', ''),
+        'version': version_string,
     }
     if force == 'yes':
         opts['update'] = 'true'

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -101,6 +101,7 @@ def _get_credentials():
                 break
     return ret['user'], ret['passwd']
 
+
 def _auth(uri):
     '''
     returns a authentication handler.
@@ -526,7 +527,7 @@ def deploy_war(war,
     else:
         tfile = war
 
-    version_extract = re.findall("\d+.\d+.\d+?", os.path.basename(war).replace('.war', ''))
+    version_extract = re.findall("\\d+.\\d+.\\d+?", os.path.basename(war).replace('.war', ''))
     if len(version_extract) == 1:
         version_string = version_extract[0]
     else:


### PR DESCRIPTION
Because of wrong filenames for non salt:// files it could not deploy the war file properly.

Also, the logic to determine the version was a bit iffy so I have added a different approach of retrieving a version.
