### PR TITLE
if con_cache is inactive, dont create con_cache-client

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1406,7 +1406,13 @@ class ClearFuncs(object):
         self.wheel_ = salt.wheel.Wheel(opts)
         self.masterapi = salt.daemons.masterapi.LocalFuncs(opts, key)
         self.auto_key = salt.daemons.masterapi.AutoKey(opts)
-        self.cache_cli = CacheCli(self.opts)
+
+        # only create a con_cache-client if the con_cache is active
+        if self.opts['con_cache']:
+            self.cache_cli = CacheCli(self.opts)
+        else:
+            self.cache_cli = False
+
 
     def _auth(self, load):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -1413,7 +1413,6 @@ class ClearFuncs(object):
         else:
             self.cache_cli = False
 
-
     def _auth(self, load):
         '''
         Authenticate the client, use the sent public key to encrypt the AES key

--- a/tests/unit/auth_test.py
+++ b/tests/unit/auth_test.py
@@ -79,6 +79,7 @@ class MasterACLTestCase(integration.ModuleCase):
         opts['client_acl_blacklist'] = {}
         opts['master_job_cache'] = ''
         opts['sign_pub_messages'] = False
+        opts['con_cache'] = ''
         opts['external_auth'] = {'pam': {'test_user': [{'*': ['test.ping']},
                                                        {'minion_glob*': ['foo.bar']},
                                                        {'minion_func_test': ['func_test.*']}],


### PR DESCRIPTION
If max_minions is used with an inactive con_cache-setting, the MWorkers will block in Clearfuncs._auth() while trying to connect to the con_cache which was not started.

This change checks for an active con_cache-setting, then creates the con_cache-client. 

Else set cache_cli=False to have the MWorkers use CkMinions.connected_ids() instead of the con_cache.
