### PR TITLE
Use a minions saltenv if none is specified

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -346,7 +346,7 @@ def highstate(test=None,
 
 
 def sls(mods,
-        saltenv='base',
+        saltenv=None,
         test=None,
         exclude=None,
         queue=False,
@@ -369,11 +369,15 @@ def sls(mods,
 
         This option starts a new thread for each queued state run so use this
         option sparingly.
-    saltenv : base
+    saltenv : None
         Specify a ``file_roots`` environment.
 
         .. versionchanged:: 0.17.0
             Argument name changed from ``env`` to ``saltenv``.
+        .. versionchanged:: 2014.7
+            Defaults to None. If no saltenv is specified, the minion config will
+            be checked for a saltenv and if found, it will be used. If none is found,
+            base will be used.
     concurrent:
         WARNING: This flag is potentially dangerous. It is designed
         for use when multiple state runs can safely be run at the same
@@ -402,6 +406,11 @@ def sls(mods,
         )
         # Backwards compatibility
         saltenv = env
+    if not saltenv:
+        if __opts__.get('saltenv', None):
+            saltenv = __opts__['saltenv']
+        else:
+            saltenv = 'base'
 
     if queue:
         _wait(kwargs.get('__pub_jid'))


### PR DESCRIPTION
Fixes #16784
(Updated against develop instead of 2014.7)
