### PR TITLE
Route minion module failures through the event system

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -167,6 +167,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             retcodes = []
             try:
                 # local will be None when there was an error
+                errors = []
                 if local:
                     if self.options.subset:
                         cmd_func = local.cmd_subset
@@ -192,16 +193,20 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                             kwargs['verbose'] = True
                         ret = {}
                         for full_ret in cmd_func(**kwargs):
-                            ret_, out, retcode = self._format_ret(full_ret)
-                            retcodes.append(retcode)
-                            self._output_ret(ret_, out)
-                            ret.update(ret_)
+                            try:
+                                ret_, out, retcode = self._format_ret(full_ret)
+                                retcodes.append(retcode)
+                                self._output_ret(ret_, out)
+                                ret.update(ret_)
+                            except KeyError:
+                                errors.append(full_ret)
 
                     # Returns summary
                     if self.config['cli_summary'] is True:
                         if self.config['fun'] != 'sys.doc':
                             if self.options.output is None:
                                 self._print_returns_summary(ret)
+                                self._print_errors_summary(errors)
 
                     # NOTE: Return code is set here based on if all minions
                     # returned 'ok' with a retcode of 0.
@@ -214,6 +219,15 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 ret = str(exc)
                 out = ''
                 self._output_ret(ret, out)
+
+    def _print_errors_summary(self, errors):
+        if errors:
+            print_cli('\n')
+            print_cli('---------------------------')
+            print_cli('Errors')
+            print_cli('---------------------------')
+            for minion in errors:
+                print_cli(self._format_error(minion))
 
     def _print_returns_summary(self, ret):
         '''
@@ -266,6 +280,12 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if 'retcode' in data:
                 retcode = data['retcode']
         return ret, out, retcode
+
+    def _format_error(self, minion_error):
+
+        for minion, error_doc in minion_error.items():
+            error = 'Minion [{0}] encountered exception \'{1}\''.format(minion, error_doc['exception']['message'])
+        return error
 
     def _print_docs(self, ret):
         '''

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -818,8 +818,6 @@ class LocalClient(object):
                             yield None
                         else:
                             raise
-
-
             else:
                 raw = event.get_event_noblock()
                 if raw and raw.get('tag', '').startswith(jid):

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -13,6 +13,13 @@ class SaltException(Exception):
     Base exception class; all Salt-specific exceptions should subclass this
     '''
 
+    def pack(self):
+        '''
+        Pack this exception into a serializable dictionary that is safe for
+        transport via msgpack
+        '''
+        return dict(message=self.__unicode__(), args=self.args)
+
 
 class SaltClientError(SaltException):
     '''

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -677,11 +677,6 @@ def __remove_temp_logging_handler():
         logging.captureWarnings(True)
 
 
-# Let's setup a global exception hook handler which will log all exceptions
-# Store a reference to the original handler
-__GLOBAL_EXCEPTION_HANDLER = sys.excepthook
-
-
 def __global_logging_exception_handler(exc_type, exc_value, exc_traceback):
     '''
     This function will log all python exceptions.
@@ -698,7 +693,7 @@ def __global_logging_exception_handler(exc_type, exc_value, exc_traceback):
         )
     )
     # Call the original sys.excepthook
-    __GLOBAL_EXCEPTION_HANDLER(exc_type, exc_value, exc_traceback)
+    sys.__excepthook__(exc_type, exc_value, exc_traceback)
 
 
 # Set our own exception handler as the one to use

--- a/salt/master.py
+++ b/salt/master.py
@@ -257,7 +257,7 @@ class Master(SMaster):
 
 
     def __handle_error_react(self, event):
-        log.error('Received minion error from [{minion}]: {data}'.format(minion=event['id'], data=event['data']))
+        log.error('Received minion error from [{minion}]: {data}'.format(minion=event['id'], data=event['data']['exception']))
 
     def __register_reactions(self):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -255,6 +255,18 @@ class Master(SMaster):
                     )
                 )
 
+
+    def __handle_error_react(self, event):
+        log.error('Received minion error from [{minion}]: {data}'.format(minion=event['id'], data=event['data']))
+
+    def __register_reactions(self):
+        '''
+        Register any reactions the master will need
+        '''
+        log.info('Registering master reactions')
+        log.info('Registering master error handling')
+        self.opts['reactor'].append({'_salt_error': self.__handle_error_react})
+
     def _pre_flight(self):
         '''
         Run pre flight checks. If anything in this method fails then the master
@@ -262,6 +274,7 @@ class Master(SMaster):
         '''
         errors = []
         fileserver = salt.fileserver.Fileserver(self.opts)
+        self.__register_reactions()
         if not fileserver.servers:
             errors.append(
                 'Failed to load fileserver backends, the configured backends '

--- a/salt/master.py
+++ b/salt/master.py
@@ -255,7 +255,6 @@ class Master(SMaster):
                     )
                 )
 
-
     def __handle_error_react(self, event):
         log.error('Received minion error from [{minion}]: {data}'.format(minion=event['id'], data=event['data']['exception']))
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -66,6 +66,7 @@ import salt.utils.args
 import salt.utils.event
 import salt.utils.minion
 import salt.utils.schedule
+import salt.utils.error
 import salt.exitcodes
 
 from salt.defaults import DEFAULT_TARGET_DELIM
@@ -1088,6 +1089,7 @@ class Minion(MinionBase):
             except Exception:
                 msg = 'The minion function caused an exception'
                 log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
+                salt.utils.error.fire_raw_exception(salt.exceptions.MinionError(msg), opts)
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'
         else:
@@ -1621,6 +1623,10 @@ class Minion(MinionBase):
 
                 self.schedule.modify_job(name='__master_alive',
                                          schedule=schedule)
+        elif package.startswith('_salt_error'):
+            tag, data = salt.utils.event.MinionEvent.unpack(package)
+            log.debug('Forwarding salt error event tag={tag}'.format(tag=tag))
+            self._fire_master(data, tag)
 
     # Main Minion Tune In
     def tune_in(self):

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1089,7 +1089,7 @@ class Minion(MinionBase):
             except Exception:
                 msg = 'The minion function caused an exception'
                 log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
-                salt.utils.error.fire_raw_exception(salt.exceptions.MinionError(msg), opts)
+                salt.utils.error.fire_exception(salt.exceptions.MinionError(msg), opts, job=data)
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'
         else:

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -447,3 +447,7 @@ def tty(*args, **kwargs):  # pylint: disable=W0613
         salt '*' test.tty pts3 'This is a test'
     '''
     return 'ERROR: This function has been moved to cmd.tty'
+
+
+def assertion(assertion):
+    assert assertion

--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -10,6 +10,7 @@ import exceptions
 
 # Import salt libs
 import salt.exceptions
+import salt.utils.event
 
 
 def raise_error(name=None, args=None, message=''):
@@ -30,3 +31,15 @@ def raise_error(name=None, args=None, message=''):
         raise ex(*args)
     else:
         raise ex(message)
+
+
+def fire_raw_exception(exc, opts, node='minion'):
+    '''
+    Fire raw exception across the event bus
+    '''
+    if hasattr(exc, 'pack'):
+        packed_exception = exc.pack()
+    else:
+        packed_exception = {'message': exc.__unicode__(), 'args': exc.args}
+    event = salt.utils.event.SaltEvent(node, opts=opts)
+    event.fire_event(packed_exception, '_salt_error')

--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -32,12 +32,14 @@ def raise_error(name=None, args=None, message=''):
     else:
         raise ex(message)
 
+
 def pack_exception(exc):
     if hasattr(exc, 'pack'):
         packed_exception = exc.pack()
     else:
         packed_exception = {'message': exc.__unicode__(), 'args': exc.args}
     return packed_exception
+
 
 def fire_exception(exc, opts, job={}, node='minion'):
     '''

--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -32,14 +32,17 @@ def raise_error(name=None, args=None, message=''):
     else:
         raise ex(message)
 
-
-def fire_raw_exception(exc, opts, node='minion'):
-    '''
-    Fire raw exception across the event bus
-    '''
+def pack_exception(exc):
     if hasattr(exc, 'pack'):
         packed_exception = exc.pack()
     else:
         packed_exception = {'message': exc.__unicode__(), 'args': exc.args}
+    return packed_exception
+
+def fire_exception(exc, opts, job={}, node='minion'):
+    '''
+    Fire raw exception across the event bus
+    '''
     event = salt.utils.event.SaltEvent(node, opts=opts)
-    event.fire_event(packed_exception, '_salt_error')
+    event.fire_event({'exception': pack_exception(exc),
+                      'job': job}, '_salt_error')

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -644,6 +644,8 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
             if fnmatch.fnmatch(tag, key):
                 if isinstance(val, string_types):
                     reactors.append(val)
+                elif hasattr(val, '__call__'):
+                    reactors.append(val)
                 elif isinstance(val, list):
                     reactors.extend(val)
         return reactors
@@ -656,6 +658,9 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         high = {}
         chunks = []
         for fn_ in reactors:
+            if hasattr(fn_, '__call__'):  # Is a func
+                fn_(data)
+                continue
             high.update(self.render_reaction(fn_, tag, data))
         if high:
             errors = self.verify_high(high)


### PR DESCRIPTION
A couple changes:
- Added test.assertion for easy testing of this sort of thing
- A small change to the logging system to use sys.**excepthook** instead of storing the var. (cc: @s0undt3ch )
- Routes module failures onto the minion event bus and then shot back upstream to the master. Routing through the minion should allow us to create a more pluggable system for error streaming, handle masterless, etc, etc.
- Register error handlers with reactor as callbacks I modified the reactor system to accept raw functions that act as callbacks...

..This means that we can get rid of loops that check for events and
instead just write functions that can register _theselves_ with the
reactor and then have events streamed back to them. This has a lot of
interesting applications, such as facilitating a GUI that, instead of
using an REST API, could simply have a lightweight event-driven API that
registers with the reactor and has updates streamed back to it.

This is a proof of concept of this idea which illustrates minion error
messages being tossed across the event bus and the master registering an
error handler with the reactor to process them.
- Includes job data
- Now routes error data to LocalClient, viewable via `--summary`
