### PR TITLE
Provide the ability to pass environment variables into pip build process

### DIFF
--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -197,6 +197,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
             process_dependency_links=False,
             __env__=None,
             saltenv='base',
+            env_vars=None,
             use_vt=False):
     '''
     Install packages with pip
@@ -311,6 +312,11 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         Enable the processing of dependency links
     use_vt
         Use VT terminal emulation (see ouptut while installing)
+    env_vars
+        Set environment variables that some builds will depend on. For example,
+        a Python C-module may have a Makefile that needs INCLUDE_PATH set to
+        pick up a header file while compiling.
+
 
     CLI Example:
 
@@ -575,6 +581,9 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
 
     if process_dependency_links:
         cmd.append('--process-dependency-links')
+
+    if env_vars:
+        os.environ.update(env_vars)
 
     try:
         cmd_kwargs = dict(runas=user, cwd=cwd, saltenv=saltenv, use_vt=use_vt)

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -130,6 +130,7 @@ def installed(name,
               allow_external=None,
               allow_unverified=None,
               process_dependency_links=False,
+              env_vars=None,
               use_vt=False):
     '''
     Make sure the package is installed
@@ -266,6 +267,11 @@ def installed(name,
         Absolute path to a virtual environment directory or absolute path to
         a pip executable. The example below assumes a virtual environment
         has been created at ``/foo/.virtualenvs/bar``.
+
+    env_vars
+        Add or modify environment variables. Useful for tweaking build steps,
+        such as specifying INCLUDE or LIBRARY paths in Makefiles, build scripts or
+        compiler calls.
 
     use_vt
         Use VT terminal emulation (see ouptut while installing)
@@ -554,6 +560,7 @@ def installed(name,
         allow_unverified=allow_unverified,
         process_dependency_links=process_dependency_links,
         saltenv=__env__,
+        env_vars=env_vars,
         use_vt=use_vt
     )
 


### PR DESCRIPTION
While attempting to pip install a scientific data handling package, pyhdf, it became apparent that a mechanism is required to pass environment variables into the child processes of pip in order to tweak the Makefile-based build process. For this specific package, it is the equivalent of:

```
export INCLUDE_DIRS=/usr/local/hdf-4.2r3/include
export LIBRARY_DIRS=/usr/local/hdf-4.2r3/lib
make
make install
```

where the environment variables are used inside the Makefile in this case, but could also affect a configure script or other build tools used in the creation of a Python C module.

The accompanying commit, implements this feature in a simple and straight-forward way that immediately resolved my own build problem. In fact, at the risk of bringing the wrath of the coding gods down on my head, I might dare to say that it is "obviously correct". :-/

The specific state file fragment with which I have used this patch and obtained a successful build is:

```
py27_sci_pkg_pyhdf-tweaked:
  pip.installed:
    - name: pyhdf
    - no_index: True
    - find_links: /var/lib/pip_cache/pyhdf-0.8.3.zip
    - bin_env: {{venv_dir}}
    - user: py27_sci
    - env_vars:
        INCLUDE_DIRS: /usr/include/hdf
        LIBRARY_DIRS: '/usr/lib64/hdf:/usr/local/package/util/szip/2.1/lib'
```
