### PR TITLE
fix state.py requisite sls problem, fix #12480

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1653,15 +1653,15 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if chunk['__id__'] == req_val:
-                            if chunk['state'] == req_key:
-                                found = True
-                                reqs[r_state].append(chunk)
-                        elif req_key == 'sls':
+                        if (chunk['__id__'] == req_val
+                                and chunk['state'] == req_key):
+                            found = True
+                            reqs[r_state].append(chunk)
+                        elif (req_key == 'sls'
+                                and chunk['__sls__'] == req_val):
                             # Allow requisite tracking of entire sls files
-                            if chunk['__sls__'] == req_val:
-                                found = True
-                                reqs[r_state].append(chunk)
+                            found = True
+                            reqs[r_state].append(chunk)
                     if not found:
                         return 'unmet', ()
         fun_stats = set()
@@ -1760,21 +1760,21 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if chunk['__id__'] == req_val:
-                            if chunk['state'] == req_key:
-                                if requisite == 'prereq':
-                                    chunk['__prereq__'] = True
-                                elif requisite == 'prerequired':
-                                    chunk['__prerequired__'] = True
-                                reqs.append(chunk)
-                                found = True
-                        elif req_key == 'sls':
-                            # Allow requisite tracking of entire sls files
-                            if chunk['__sls__'] == req_val:
-                                if requisite == 'prereq':
-                                    chunk['__prereq__'] = True
-                                reqs.append(chunk)
-                                found = True
+                        if (chunk['__id__'] == req_val
+                                and chunk['state'] == req_key):
+                            if requisite == 'prereq':
+                                chunk['__prereq__'] = True
+                            elif requisite == 'prerequired':
+                                chunk['__prerequired__'] = True
+                            reqs.append(chunk)
+                            found = True
+                        # Allow requisite tracking of entire sls files
+                        elif (req_key == 'sls'
+                                and chunk['__sls__'] == req_val):
+                            if requisite == 'prereq':
+                                chunk['__prereq__'] = True
+                            reqs.append(chunk)
+                            found = True
                     if not found:
                         lost[requisite].append(req)
             if lost['require'] or lost['watch'] or lost['prereq'] or lost['onfail'] or lost['onchanges'] or lost.get('prerequired'):

--- a/salt/state.py
+++ b/salt/state.py
@@ -847,8 +847,7 @@ class State(object):
             for req in data[reqdec]:
                 reqfirst = next(iter(req))
                 if data['state'] == reqfirst:
-                    if (fnmatch.fnmatch(data['name'], req[reqfirst])
-                            or fnmatch.fnmatch(data['__id__'], req[reqfirst])):
+                    if fnmatch.fnmatch(data['__id__'], req[reqfirst]):
                         err = ('Recursive require detected in SLS {0} for'
                                ' require {1} in ID {2}').format(
                                    data['__sls__'],
@@ -1654,8 +1653,7 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if (fnmatch.fnmatch(chunk['name'], req_val) or
-                            fnmatch.fnmatch(chunk['__id__'], req_val)):
+                        if fnmatch.fnmatch(chunk['__id__'], req_val):
                             if chunk['state'] == req_key:
                                 found = True
                                 reqs[r_state].append(chunk)
@@ -1762,8 +1760,7 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if (fnmatch.fnmatch(chunk['name'], req_val) or
-                            fnmatch.fnmatch(chunk['__id__'], req_val)):
+                        if fnmatch.fnmatch(chunk['__id__'], req_val):
                             if chunk['state'] == req_key:
                                 if requisite == 'prereq':
                                     chunk['__prereq__'] = True

--- a/salt/state.py
+++ b/salt/state.py
@@ -1653,12 +1653,12 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if (chunk['__id__'] == req_val
-                                and chunk['state'] == req_key):
+                        if (req_key == chunk['state']
+                                and req_val == chunk['__id__']):
                             found = True
                             reqs[r_state].append(chunk)
                         elif (req_key == 'sls'
-                                and chunk['__sls__'] == req_val):
+                                and req_val == chunk['__sls__']):
                             # Allow requisite tracking of entire sls files
                             found = True
                             reqs[r_state].append(chunk)
@@ -1760,8 +1760,8 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if (chunk['__id__'] == req_val
-                                and chunk['state'] == req_key):
+                        if (req_key == chunk['state']
+                                and req_val == chunk['__id__']):
                             if requisite == 'prereq':
                                 chunk['__prereq__'] = True
                             elif requisite == 'prerequired':
@@ -1770,7 +1770,7 @@ class State(object):
                             found = True
                         # Allow requisite tracking of entire sls files
                         elif (req_key == 'sls'
-                                and chunk['__sls__'] == req_val):
+                                and req_val == chunk['__sls__']):
                             if requisite == 'prereq':
                                 chunk['__prereq__'] = True
                             reqs.append(chunk)

--- a/salt/state.py
+++ b/salt/state.py
@@ -1653,13 +1653,13 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if fnmatch.fnmatch(chunk['__id__'], req_val):
+                        if chunk['__id__'] == req_val:
                             if chunk['state'] == req_key:
                                 found = True
                                 reqs[r_state].append(chunk)
                         elif req_key == 'sls':
                             # Allow requisite tracking of entire sls files
-                            if fnmatch.fnmatch(chunk['__sls__'], req_val):
+                            if chunk['__sls__'] == req_val:
                                 found = True
                                 reqs[r_state].append(chunk)
                     if not found:
@@ -1760,7 +1760,7 @@ class State(object):
                         req_val = req[req_key]
                         if req_val is None:
                             continue
-                        if fnmatch.fnmatch(chunk['__id__'], req_val):
+                        if chunk['__id__'] == req_val:
                             if chunk['state'] == req_key:
                                 if requisite == 'prereq':
                                     chunk['__prereq__'] = True
@@ -1770,7 +1770,7 @@ class State(object):
                                 found = True
                         elif req_key == 'sls':
                             # Allow requisite tracking of entire sls files
-                            if fnmatch.fnmatch(chunk['__sls__'], req_val):
+                            if chunk['__sls__'] == req_val:
                                 if requisite == 'prereq':
                                     chunk['__prereq__'] = True
                                 reqs.append(chunk)


### PR DESCRIPTION
3 & 4 commits fix #12480 

The first and second commits fix things that I think they are bugs:
1. According to https://salt.readthedocs.org/en/latest/ref/states/highstate.html#requisite-reference , requisite must matching stateID, not state's name, because name is not unique. Counter example:

```
ls etc/passwd:
  cmd:
    - run

barid:
  cmd:
    - run
    - name: echo bar
    - require:
      - cmd: ls /etc/passwd

another_state:
  cmd:
    - run
    - name: ls /etc/passwd
    - require:
      - cmd: barid
============
local:
----------
          ID: ls etc/passwd
    Function: cmd.run
      Result: True
     Comment: Command "ls etc/passwd" run
     Changes:   
              ----------
              pid:
                  2255
              retcode:
                  0
              stderr:

              stdout:
                  etc/passwd
----------
          ID: another_state
    Function: cmd.run
        Name: ls /etc/passwd
      Result: False
     Comment: Recursive requisite found
     Changes:   
----------
          ID: barid
    Function: cmd.run
        Name: echo bar
      Result: False
     Comment: One or more requisite failed
     Changes:   
```
1. Only compare string, not matching shell pattern. I don't know why fnmatch is used in many place. Do salt want to support require multiple stateIDs by just `require: - file: /etc/*`  ? 
   Counter example:

```


test_ls:
  cmd:
    - run
    - name: ls /etc/passwd
    - require:
      - file: /tmp/test*

/tmp/test_zero:
  file:
    - managed

/tmp/test_one:
  file:
    - managed
    - require:
      - cmd: test_ls
====

local:
----------
          ID: /tmp/test_zero
    Function: file.managed
      Result: True
     Comment: File /tmp/test_zero is in the correct state
     Changes:   
----------
          ID: /tmp/test_one
    Function: file.managed
      Result: False
     Comment: Recursive requisite found
     Changes:   
----------
          ID: test_ls
    Function: cmd.run
        Name: ls /etc/passwd
      Result: False
     Comment: One or more requisite failed
     Changes:   

Summary
------------
Succeeded: 1
Failed:    2
------------
Total:     3

```
