### PR TITLE
Fix salt-cloud list-images for DigitalOcean images

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -101,9 +101,9 @@ def avail_images(call=None):
     items = query(method='images')
     ret = {}
     for image in items['images']:
-        ret[image['name']] = {}
+        ret[image['id']] = {}
         for item in image.keys():
-            ret[image['name']][item] = str(image[item])
+            ret[image['id']][item] = str(image[item])
 
     return ret
 

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -111,7 +111,7 @@ def avail_images(call=None):
                 ret[image['id']][item] = str(image[item])
 
         page += 1
-        fetch = next in items['links']['pages']
+        fetch = 'next' in items['links']['pages']
 
     return ret
 

--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -106,9 +106,9 @@ def avail_images(call=None):
         items = query(method='images', command='?page=' + str(page))
 
         for image in items['images']:
-            ret[image['name']] = {}
+            ret[image['id']] = {}
             for item in image.keys():
-                ret[image['name']][item] = str(image[item])
+                ret[image['id']][item] = str(image[item])
 
         page += 1
         fetch = next in items['links']['pages']


### PR DESCRIPTION
This should fix listing images (and vm creation) on DigitalOcean via v1 and v2 API .

Both versions were using the name property from DigitalOcean when it should have been using id. It's not possible to use slug as that can be Null.

Also, v2 was failing to detect additional pages due to a simple existence-check error.

Thanks to @xpender for realizing there was a uniqueness issue.

Fixes #16866
