### PR TITLE
Fixes for Syndic

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -2236,9 +2236,11 @@ class ClearFuncs(object):
                     }
                 }
         # Retrieve the jid
-        if not clear_load['jid']:
-            fstr = '{0}.prep_jid'.format(self.opts['master_job_cache'])
-            clear_load['jid'] = self.mminion.returners[fstr](nocache=extra.get('nocache', False))
+        fstr = '{0}.prep_jid'.format(self.opts['master_job_cache'])
+        clear_load['jid'] = self.mminion.returners[fstr](nocache=extra.get('nocache', False),
+                                                         # the jid in clear_load can be None, '', or something else.
+                                                         # this is an attempt to clean up the value before passing to plugins
+                                                         passed_jid=clear_load['jid'] if clear_load.get('jid') else None)
         self.event.fire_event({'minions': minions}, clear_load['jid'])
 
         new_job_load = {

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1931,15 +1931,17 @@ class Syndic(Minion):
         '''
         Lock onto the publisher. This is the main event loop for the syndic
         '''
-        # Instantiate the local client
-        self.local = salt.client.get_local_client(self.opts['_minion_conf_file'])
-        self.local.event.subscribe('')
-        self.local.opts['interface'] = self._syndic_interface
-
         signal.signal(signal.SIGTERM, self.clean_die)
         log.debug('Syndic {0!r} trying to tune in'.format(self.opts['id']))
 
         self._init_context_and_poller()
+
+        # Instantiate the local client
+        self.local = salt.client.get_local_client(self.opts['_minion_conf_file'])
+        self.local.event.subscribe('')
+        self.local.opts['interface'] = self._syndic_interface
+        # register the event sub to the poller
+        self.poller.register(self.local.event.sub)
 
         # Start with the publish socket
         # Share the poller with the event object

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -208,8 +208,8 @@ def returner(ret):
             total_sent_bytes += sent_bytes
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
     Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/cassandra_return.py
+++ b/salt/returners/cassandra_return.py
@@ -74,9 +74,8 @@ def returner(ret):
     ccf.insert(ret['jid'], columns)
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any work necessary to prepare the jid for storage,
-    including returning a custom jid
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/couchbase_return.py
+++ b/salt/returners/couchbase_return.py
@@ -119,22 +119,28 @@ def _get_ttl():
 
 
 #TODO: add to returner docs-- this is a new one
-def prep_jid(nocache=False):
+def prep_jid(nocache=False, passed_jid=None):
     '''
     Return a job id and prepare the job id directory
     This is the function responsible for making sure jids don't collide (unless its passed a jid)
     So do what you have to do to make sure that stays the case
     '''
+    if passed_jid is None:
+        jid = salt.utils.gen_jid()
+    else:
+        jid = passed_jid
+
     cb_ = _get_connection()
 
-    jid = salt.utils.gen_jid()
     try:
         cb_.add(str(jid),
                {'nocache': nocache},
                ttl=_get_ttl(),
                )
     except couchbase.exceptions.KeyExistsError:
-        return prep_jid(nocache=nocache)
+        # TODO: some sort of sleep or something? Spinning is generally bad practice
+        if passed_jid is None:
+            return prep_jid(nocache=nocache)
 
     return jid
 

--- a/salt/returners/couchdb_return.py
+++ b/salt/returners/couchdb_return.py
@@ -312,8 +312,8 @@ def set_salt_view():
     return True
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any necessary pre-processing and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/elasticsearch_return.py
+++ b/salt/returners/elasticsearch_return.py
@@ -125,9 +125,8 @@ def returner(ret):
              )
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Prepare the jid, including doing any pre-processing and
-    returning the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -168,8 +168,8 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Pre-process the JID and return the JID to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -89,13 +89,16 @@ def _format_jid_instance(jid, job):
 
 
 #TODO: add to returner docs-- this is a new one
-def prep_jid(nocache=False):
+def prep_jid(nocache=False, passed_jid=None):
     '''
     Return a job id and prepare the job id directory
     This is the function responsible for making sure jids don't collide (unless its passed a jid)
     So do what you have to do to make sure that stays the case
     '''
-    jid = salt.utils.gen_jid()
+    if passed_jid is None:  # this can be a None of an empty string
+        jid = salt.utils.gen_jid()
+    else:
+        jid = passed_jid
 
     jid_dir_ = _jid_dir(jid)
 
@@ -105,7 +108,8 @@ def prep_jid(nocache=False):
         os.makedirs(jid_dir_)
     except OSError:
         # TODO: some sort of sleep or something? Spinning is generally bad practice
-        return prep_jid(nocache=nocache)
+        if passed_jid is None:
+            return prep_jid(nocache=nocache)
 
     with salt.utils.fopen(os.path.join(jid_dir_, 'jid'), 'w+') as fn_:
         fn_.write(jid)

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -62,11 +62,11 @@ def _get_serv():
     #    an integer weight value.
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Pre-process the jid and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()
 
 
 def returner(ret):

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -181,8 +181,8 @@ def get_jids():
     return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Pre-process the jid and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -126,8 +126,8 @@ def get_fun(fun):
     return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Pre-process the jid and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/multi_returner.py
+++ b/salt/returners/multi_returner.py
@@ -30,7 +30,7 @@ def _mminion():
     return MMINION
 
 
-def prep_jid(nocache=False):
+def prep_jid(nocache=False, passed_jid=None):
     '''
     Call both with prep_jid on all returners in multi_returner
 
@@ -41,7 +41,7 @@ def prep_jid(nocache=False):
     returners is non-trivial
     '''
 
-    jid = None
+    jid = passed_jid
     for returner in __opts__[CONFIG_KEY]:
         if jid is None:
             jid = _mminion().returners['{0}.prep_jid'.format(returner)](nocache=nocache)

--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -264,8 +264,8 @@ def get_minions():
         return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Generate a JID
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/odbc.py
+++ b/salt/returners/odbc.py
@@ -271,8 +271,8 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any jid pre-processing and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/postgres.py
+++ b/salt/returners/postgres.py
@@ -238,8 +238,8 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any pre-processing necessary and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/redis_return.py
+++ b/salt/returners/redis_return.py
@@ -133,8 +133,8 @@ def get_minions():
     return list(serv.smembers('minions'))
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any pre-processing necessary and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/sentry_return.py
+++ b/salt/returners/sentry_return.py
@@ -111,8 +111,8 @@ def returner(ret):
         )
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any necessary pre-processing and then return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -153,8 +153,8 @@ def returner(ret):
     server.quit()
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any necessary pre-processing and return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/sqlite3_return.py
+++ b/salt/returners/sqlite3_return.py
@@ -247,8 +247,8 @@ def get_minions():
     return ret
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any necessary pre-processing and then return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()

--- a/salt/returners/syslog_return.py
+++ b/salt/returners/syslog_return.py
@@ -41,8 +41,8 @@ def returner(ret):
     syslog.syslog(syslog.LOG_INFO, 'salt-minion: {0}'.format(json.dumps(ret)))
 
 
-def prep_jid(nocache):  # pylint: disable=unused-argument
+def prep_jid(nocache, passed_jid=None):  # pylint: disable=unused-argument
     '''
-    Do any necessary pre-preocessing and then return the jid to use
+    Do any work necessary to prepare a JID, including sending a custom id
     '''
-    return salt.utils.gen_jid()
+    return passed_jid if passed_jid is not None else salt.utils.gen_jid()


### PR DESCRIPTION
Event forwarding is busted in syndic (although would probably work in multisyndic), and there is a problem with the lower level masters saving the return data (#16825) which is fixed.
