### PR TITLE
Install repoquery if not present on yum-based distro

### DIFF
--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -108,6 +108,18 @@ If this repo is added *before* Salt is installed, then installing either
 additional states to upgrade ZeroMQ and pyzmq are unnecessary.
 
 
+Package Management
+==================
+
+Salt's interface to :mod:`yum <salt.modules.yumpkg>` makes heavy use of the
+**repoquery** utility, from the yum-utils_ package. This package will be
+installed as a dependency if salt is installed via EPEL. However, if salt has
+been installed using pip, or a host is being managed using salt-ssh, then as of
+version 2014.7.0 yum-utils_ will be installed automatically to satisfy this
+dependency.
+
+.. _yum-utils: http://yum.baseurl.org/wiki/YumUtils
+
 Post-installation tasks
 =======================
 

--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -496,8 +496,3 @@ Deprecations
   - ``vm_config_path`` (deprecated)
 - Removed deprecated ``libcloud_version`` function from ``salt/cloud/libcloudfuncs.py`` (deprecated)
 - Removed deprecated ``CloudConfigMixIn`` class from ``salt/utils/parsers.py`` (deprecated)
-
-Known Issues
-============
-
-- Salt-SSH: pkg module on RedHat-based systems is dependent on yum-utils.

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1,6 +1,16 @@
 # -*- coding: utf-8 -*-
 '''
 Support for YUM
+
+.. note::
+    This module makes heavy use of the **repoquery** utility, from the
+    yum-utils_ package. This package will be installed as a dependency if salt
+    is installed via EPEL. However, if salt has been installed using pip, or a
+    host is being managed using salt-ssh, then as of version 2014.7.0
+    yum-utils_ will be installed automatically to satisfy this dependency.
+
+    .. _yum-utils: http://yum.baseurl.org/wiki/YumUtils
+
 '''
 
 # Import python libs

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -102,10 +102,27 @@ def _repoquery_pkginfo(repoquery_args):
     return ret
 
 
+def _check_repoquery():
+    '''
+    Check for existence of repoquery and install yum-utils if it is not
+    present.
+    '''
+    if not salt.utils.which('repoquery'):
+        __salt__['cmd.run'](
+            ['yum', '-y', 'install', 'yum-utils'],
+            python_shell=False,
+            output_loglevel='trace'
+        )
+        # Check again now that we've installed yum-utils
+        if not salt.utils.which('repoquery'):
+            raise CommandExecutionError('Unable to install yum-utils')
+
+
 def _repoquery(repoquery_args, query_format=__QUERYFORMAT):
     '''
     Runs a repoquery command and returns a list of namedtuples
     '''
+    _check_repoquery()
     cmd = 'repoquery --plugins --queryformat="{0}" {1}'.format(
         query_format, repoquery_args
     )


### PR DESCRIPTION
Resolves #16874.

Also added comments explaining this behavior to RHEL install docs, and to the
yumpkg docstring, and removed the "known issue" that this fixes from the
release notes.
