### PR TITLE
Fix for #16888

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -292,7 +292,7 @@ DEFAULT_MINION_OPTS = {
     'failhard': False,
     'autoload_dynamic_modules': True,
     'environment': None,
-    'extension_modules': os.path.join(salt.syspaths.CACHE_DIR, 'extmods'),
+    'extension_modules': '',
     'state_top': 'top.sls',
     'startup_states': '',
     'sls_list': [],


### PR DESCRIPTION
We can't set the default value to something if you want the config to be relative to cachedir.

Since there is already code in apply_minion_config to take care of this we remove this, meaning now that if you set cachedir it won't break these
