### PR TITLE
Change profile name for Digital Ocean cloud tests

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/digital_ocean.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/digital_ocean.conf
@@ -1,4 +1,4 @@
 digitalocean-test:
   provider: digitalocean-config
-  image: Ubuntu 14.04 x64
+  image: 14.04 x64
   size: 2GB


### PR DESCRIPTION
Digital Ocean changed their image-naming scheme. This should fix the failing tests.
