### PR TITLE
Backport #16877 to 2014.7

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -101,9 +101,9 @@ def avail_images(call=None):
     items = query(method='images')
     ret = {}
     for image in items['images']:
-        ret[image['name']] = {}
+        ret[image['id']] = {}
         for item in image.keys():
-            ret[image['name']][item] = str(image[item])
+            ret[image['id']][item] = str(image[item])
 
     return ret
 


### PR DESCRIPTION
Backport #16877 to 2014.7

Only the changes to `salt/cloud/clouds/digital_ocean.py` were backported as `digital_ocean_v2.py` does not exist on the 2014.7 branch.
