### PR TITLE
MySQL: Don't execute query if test mode is enabled.

### DIFF
--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -137,6 +137,7 @@ def run(name,
     elif __opts__['test']:
         ret['result'] = None
         ret['comment'] = 'Query would execute, not storing result'
+        return ret
 
     # The database is present, execute the query
     query_result = __salt__['mysql.query'](database, query, **connection_args)


### PR DESCRIPTION
MySQL was executing query in test mode when output is not defined. Fixes #16756
