### PR TITLE
Fix timeout issue with syndic

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -888,6 +888,9 @@ class LocalClient(object):
                     log.debug('jid {0} return from {1}'.format(jid, raw['data']['id']))
                     yield ret
 
+            if timeout_at >= int(time.time()):
+                continue
+
             # if we have all of the returns, no need for anything fancy
             if len(found.intersection(minions)) >= len(minions):
                 # All minions have returned, break out of the loop


### PR DESCRIPTION
@jacksontj This bug was a result of your changes to the timeout code, figured you might be interested to see this fix. Basically we aren't using `timeout_at` anymore in your code, which meant if you targeted minions below a syndic it would timeout immediately.
