### PR TITLE
dockerio.get_containers optional call to dockerio._get_container_infos

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -355,7 +355,8 @@ def get_containers(all=True,
                    since=None,
                    before=None,
                    limit=-1,
-                   host=False):
+                   host=False,
+                   inspect=False):
     '''
     Get a list of mappings representing all containers
 
@@ -368,27 +369,49 @@ def get_containers(all=True,
     host
         include the Docker host's ipv4 and ipv6 address in return, Default is ``False``
 
+    inspect
+        Get more granular information about each container by running a docker inspect
+
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' docker.get_containers
         salt '*' docker.get_containers host=True
+        salt '*' docker.get_containers host=True inspect=True
     '''
+
     client = _get_client()
     status = base_status.copy()
+
     if host:
         status['host'] = {}
         status['host']['interfaces'] = __salt__['network.interfaces']()
-    ret = client.containers(all=all,
-                            trunc=trunc,
-                            since=since,
-                            before=before,
-                            limit=limit)
+
+    containers = ret = client.containers(all=all,
+                                         trunc=trunc,
+                                         since=since,
+                                         before=before,
+                                         limit=limit)
+
+    # Optionally for each container get more granular information from them
+    # by inspecting the container
+    if inspect:
+        ret = []
+        for container in containers:
+            container_id = container.get('Id')
+            if container_id:
+                inspect = _get_container_infos(container_id)
+                container['detail'] = {}
+                for key, value in inspect.iteritems():
+                    container['detail'][key] = value
+            ret.append(container)
+
     if ret:
         _valid(status, comment='All containers in out', out=ret)
     else:
         _invalid(status)
+
     return status
 
 


### PR DESCRIPTION
Hi Guys

I've been thinking about how Salt could better utilise docker. One of dockers strengths is you can run as many containers of the same image as you require. However Salt has very limited capability when it comes to getting information about running containers.

One limitation I've found is mining information about containers that do not have published ports: https://github.com/saltstack/salt/blob/develop/salt/modules/mine.py#L350 will raise a KeyError in the event you haven't run your container with `-p 0.0.0.0:5000:5000` for example.

Another limitation is the amount of information `modules.dockerio.get_containers` returns, its basically the information gathered from `docker ps` which is great but what if I want to mine more information about my containers? The volumes shared, the ports exposed, the private IP of the container itself, you can't which I think would be extremely useful.

To that end a propose adding an `inspect` option to the `dockerio.modules.get_containers` method (`False` by default) which for each container will call `_get_container_infos` which basically runs a `docker inspect <container_id>`. This would give us the option of mining much more granular and useful data about our running containers.

I have a working prototype and If you guys think this is worth while I'll get a PR in on this issue :smile: 

Thanks,

Chris
