### PR TITLE
Add a default value for saltenv arg in state.sls_id module

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -617,7 +617,7 @@ def show_lowstate(queue=False, **kwargs):
 def sls_id(
         id_,
         mods,
-        saltenv,
+        saltenv='base',
         test=None,
         queue=False,
         **kwargs):


### PR DESCRIPTION
Module fails if the saltenv argument isn't passed. Default to 'base' to be more in line with other state functions.
