### PR TITLE
Prevent stacktrace if wrong type in outputter with state_verbose False

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -349,6 +349,8 @@ def _strip_clean(returns):
     '''
     rm_tags = []
     for tag in returns:
+        if not isinstance(tag, dict):
+            continue
         if returns[tag]['result'] and not returns[tag]['changes']:
             rm_tags.append(tag)
     for tag in rm_tags:


### PR DESCRIPTION
Closes #16488
