### PR TITLE
Fix module.run state for non-dict return data

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -200,8 +200,12 @@ def run(name, **kwargs):
             returners[kwargs['returner']](ret_ret)
     ret['comment'] = 'Module function {0} executed'.format(name)
     ret['result'] = True
-    if ret['changes'].get('ret', {}).get('retcode', 0) != 0:
+    if ret['changes'].get('retcode', 0) != 0:
         ret['result'] = False
+    else:
+        changes_ret = ret['changes'].get('ret', {})
+        if isinstance(changes_ret, dict) and changes_ret.get('retcode', 0) != 0:
+            ret['result'] = False
     return ret
 
 mod_watch = run  # pylint: disable=C0103


### PR DESCRIPTION
This backports part of a fix for this that is already in the 2014.7 branch,
properly handling execution module functions which return non-dict data.
