### PR TITLE
Added ability to mount using mount.mounted on OSX

### DIFF
--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -98,8 +98,9 @@ def list_pkgs(versions_as_list=False, **kwargs):
         salt '*' pkg.list_pkgs
     '''
     versions_as_list = salt.utils.is_true(versions_as_list)
-    # 'removed' not yet implemented or not applicable
-    if salt.utils.is_true(kwargs.get('removed')):
+    # 'removed', 'purge_desired' not yet implemented or not applicable
+    if any([salt.utils.is_true(kwargs.get(x))
+            for x in ('removed', 'purge_desired')]):
         return {}
 
     if 'pkg.list_pkgs' in __context__:

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -137,6 +137,7 @@ def _active_mounts_openbsd(ret):
                          'device_uuid': parens[0]}
     return ret
 
+
 def _active_mounts_darwin(ret):
     '''
     List active mounts on Mac OS systems
@@ -148,6 +149,7 @@ def _active_mounts_darwin(ret):
                          'fstype': parens[0],
                          'opts': parens[1:]}
     return ret
+
 
 def active(extended=False):
     '''
@@ -477,7 +479,6 @@ def set_automaster(
     if not os.path.isfile(config):
         __salt__['file.touch'](config)
         __salt__['file.append'](automaster_file, "/-\t\t\t{0}".format(config))
-
 
     name = "/..{0}".format(name)
     device_fmt = "{0}:{1}".format(fstype, device)

--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -33,7 +33,12 @@ def __virtual__():
 
 def _list_mounts():
     ret = {}
-    for line in __salt__['cmd.run_stdout']('mount -l').split('\n'):
+    if __grains__['os'] in ['MacOS', 'Darwin']:
+        mounts = __salt__['cmd.run_stdout']('mount')
+    else:
+        mounts = __salt__['cmd.run_stdout']('mount -l')
+
+    for line in mounts.split('\n'):
         comps = re.sub(r"\s+", " ", line).split()
         ret[comps[2]] = comps[0]
     return ret
@@ -132,6 +137,17 @@ def _active_mounts_openbsd(ret):
                          'device_uuid': parens[0]}
     return ret
 
+def _active_mounts_darwin(ret):
+    '''
+    List active mounts on Mac OS systems
+    '''
+    for line in __salt__['cmd.run_stdout']('mount').split('\n'):
+        comps = re.sub(r"\s+", " ", line).split()
+        parens = re.findall(r'\((.*?)\)', line, re.DOTALL)[0].split(", ")
+        ret[comps[2]] = {'device': comps[0],
+                         'fstype': parens[0],
+                         'opts': parens[1:]}
+    return ret
 
 def active(extended=False):
     '''
@@ -148,8 +164,10 @@ def active(extended=False):
         _active_mounts_freebsd(ret)
     elif __grains__['os'] == 'Solaris':
         _active_mounts_solaris(ret)
-    if __grains__['os'] == 'OpenBSD':
+    elif __grains__['os'] == 'OpenBSD':
         _active_mounts_openbsd(ret)
+    elif __grains__['os'] in ['MacOS', 'Darwin']:
+        _active_mounts_darwin(ret)
     else:
         if extended:
             try:
@@ -370,7 +388,224 @@ def set_fstab(
     return 'new'
 
 
-def mount(name, device, mkmnt=False, fstype='', opts='defaults'):
+def rm_automaster(name, device, config='/etc/auto_salt'):
+    '''
+    Remove the mount point from the auto_master
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mount.rm_automaster /mnt/foo
+    '''
+    contents = automaster(config)
+    if name not in contents:
+        return True
+    # The entry is present, get rid of it
+    lines = []
+    try:
+        with salt.utils.fopen(config, 'r') as ifile:
+            for line in ifile:
+                if line.startswith('#'):
+                    # Commented
+                    lines.append(line)
+                    continue
+                if not line.strip():
+                    # Blank line
+                    lines.append(line)
+                    continue
+                comps = line.split()
+                if len(comps) != 3:
+                    # Invalid entry
+                    lines.append(line)
+                    continue
+
+                comps = line.split()
+                prefix = "/.."
+                name_chk = comps[0].replace(prefix, "")
+                device_fmt = comps[2].split(":")
+
+                if device:
+                    if name_chk == name and device_fmt[1] == device:
+                        continue
+                else:
+                    if name_chk == name:
+                        continue
+                lines.append(line)
+    except (IOError, OSError) as exc:
+        msg = "Couldn't read from {0}: {1}"
+        raise CommandExecutionError(msg.format(config, str(exc)))
+
+    try:
+        with salt.utils.fopen(config, 'w+') as ofile:
+            ofile.writelines(lines)
+    except (IOError, OSError) as exc:
+        msg = "Couldn't write to {0}: {1}"
+        raise CommandExecutionError(msg.format(config, str(exc)))
+
+    # Update automount
+    __salt__['cmd.run']('automount -cv')
+    return True
+
+
+def set_automaster(
+        name,
+        device,
+        fstype,
+        opts='',
+        config='/etc/auto_salt',
+        test=False,
+        **kwargs):
+    '''
+    Verify that this mount is represented in the auto_salt, change the mount
+    to match the data passed, or add the mount if it is not present.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mount.set_automaster /mnt/foo /dev/sdz1 ext4
+    '''
+    # Fix the opts type if it is a list
+    if isinstance(opts, list):
+        opts = ','.join(opts)
+    lines = []
+    change = False
+    present = False
+    automaster_file = "/etc/auto_master"
+
+    if not os.path.isfile(config):
+        __salt__['file.touch'](config)
+        __salt__['file.append'](automaster_file, "/-\t\t\t{0}".format(config))
+
+
+    name = "/..{0}".format(name)
+    device_fmt = "{0}:{1}".format(fstype, device)
+    type_opts = "-fstype={0},{1}".format(fstype, opts)
+
+    if fstype == 'smbfs':
+        device_fmt = device_fmt.replace(fstype, "")
+
+    try:
+        with salt.utils.fopen(config, 'r') as ifile:
+            for line in ifile:
+                if line.startswith('#'):
+                    # Commented
+                    lines.append(line)
+                    continue
+                if not line.strip():
+                    # Blank line
+                    lines.append(line)
+                    continue
+                comps = line.split()
+                if len(comps) != 3:
+                    # Invalid entry
+                    lines.append(line)
+                    continue
+                if comps[0] == name or comps[2] == device_fmt:
+                    # check to see if there are changes
+                    # and fix them if there are any
+                    present = True
+                    if comps[0] != name:
+                        change = True
+                        comps[0] = name
+                    if comps[1] != type_opts:
+                        change = True
+                        comps[1] = type_opts
+                    if comps[2] != device_fmt:
+                        change = True
+                        comps[2] = device_fmt
+                    if change:
+                        log.debug(
+                            'auto_master entry for mount point {0} needs to be '
+                            'updated'.format(name)
+                        )
+                        newline = (
+                            '{0}\t{1}\t{2}\n'.format(
+                                name, type_opts, device_fmt)
+                        )
+                        lines.append(newline)
+                else:
+                    lines.append(line)
+    except (IOError, OSError) as exc:
+        msg = 'Couldn\'t read from {0}: {1}'
+        raise CommandExecutionError(msg.format(config, str(exc)))
+
+    if change:
+        if not salt.utils.test_mode(test=test, **kwargs):
+            try:
+                with salt.utils.fopen(config, 'w+') as ofile:
+                    # The line was changed, commit it!
+                    ofile.writelines(lines)
+            except (IOError, OSError):
+                msg = 'File not writable {0}'
+                raise CommandExecutionError(msg.format(config))
+
+        return 'change'
+
+    if not change:
+        if present:
+            # The right entry is already here
+            return 'present'
+        else:
+            if not salt.utils.test_mode(test=test, **kwargs):
+                # The entry is new, add it to the end of the fstab
+                newline = (
+                    '{0}\t{1}\t{2}\n'.format(
+                        name, type_opts, device_fmt)
+                )
+                lines.append(newline)
+                try:
+                    with salt.utils.fopen(config, 'w+') as ofile:
+                        # The line was changed, commit it!
+                        ofile.writelines(lines)
+                except (IOError, OSError):
+                    raise CommandExecutionError(
+                        'File not writable {0}'.format(
+                            config
+                        )
+                    )
+    return 'new'
+
+
+def automaster(config='/etc/auto_salt'):
+    '''
+    List the contents of the fstab
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' mount.fstab
+    '''
+    ret = {}
+    if not os.path.isfile(config):
+        return ret
+    with salt.utils.fopen(config) as ifile:
+        for line in ifile:
+            if line.startswith('#'):
+                # Commented
+                continue
+            if not line.strip():
+                # Blank line
+                continue
+            comps = line.split()
+            if len(comps) != 3:
+                # Invalid entry
+                continue
+
+            prefix = "/.."
+            name = comps[0].replace(prefix, "")
+            device_fmt = comps[2].split(":")
+            opts = comps[1].split(',')
+
+            ret[name] = {'device': device_fmt[1],
+                         'fstype': opts[0],
+                         'opts': opts[1:]}
+    return ret
+
+
+def mount(name, device, mkmnt=False, fstype='', opts='defaults', user=None):
     '''
     Mount a device
 
@@ -380,22 +615,31 @@ def mount(name, device, mkmnt=False, fstype='', opts='defaults'):
 
         salt '*' mount.mount /mnt/foo /dev/sdz1 True
     '''
+
+    # Darwin doesn't expect defaults when mounting without other options
+    if 'defaults' in opts and __grains__['os'] in ['MacOS', 'Darwin']:
+        opts = None
+
     if isinstance(opts, string_types):
         opts = opts.split(',')
+
     if not os.path.exists(name) and mkmnt:
-        os.makedirs(name)
-    lopts = ','.join(opts)
-    args = '-o {0}'.format(lopts)
+        __salt__['file.mkdir'](name=name, user=user)
+
+    args = ''
+    if opts is not None:
+        lopts = ','.join(opts)
+        args = '-o {0}'.format(lopts)
     if fstype:
         args += ' -t {0}'.format(fstype)
     cmd = 'mount {0} {1} {2} '.format(args, device, name)
-    out = __salt__['cmd.run_all'](cmd)
+    out = __salt__['cmd.run_all'](cmd, runas=user)
     if out['retcode']:
         return out['stderr']
     return True
 
 
-def remount(name, device, mkmnt=False, fstype='', opts='defaults'):
+def remount(name, device, mkmnt=False, fstype='', opts='defaults', user=None):
     '''
     Attempt to remount a device, if the device is not already mounted, mount
     is called
@@ -406,30 +650,40 @@ def remount(name, device, mkmnt=False, fstype='', opts='defaults'):
 
         salt '*' mount.remount /mnt/foo /dev/sdz1 True
     '''
+    force_mount = False
+    if __grains__['os'] in ['MacOS', 'Darwin']:
+        if opts == 'defaults':
+            opts = 'noowners'
+        if fstype == 'smbfs':
+            force_mount = True
+
     if isinstance(opts, string_types):
         opts = opts.split(',')
     mnts = active()
     if name in mnts:
         # The mount point is mounted, attempt to remount it with the given data
-        if 'remount' not in opts and __grains__['os'] != 'OpenBSD':
+        if 'remount' not in opts and __grains__['os'] not in ['OpenBSD', 'MacOS', 'Darwin']:
             opts.append('remount')
+        if force_mount:
+            # We need to force the mount but first we should unmount
+            umount(name, device, user=user)
         lopts = ','.join(opts)
         args = '-o {0}'.format(lopts)
         if fstype:
             args += ' -t {0}'.format(fstype)
-        if __grains__['os'] != 'OpenBSD':
+        if __grains__['os'] not in ['OpenBSD', 'MacOS', 'Darwin'] or force_mount:
             cmd = 'mount {0} {1} {2} '.format(args, device, name)
         else:
             cmd = 'mount -u {0} {1} {2} '.format(args, device, name)
-        out = __salt__['cmd.run_all'](cmd)
+        out = __salt__['cmd.run_all'](cmd, runas=user)
         if out['retcode']:
             return out['stderr']
         return True
     # Mount a filesystem that isn't already
-    return mount(name, device, mkmnt, fstype, opts)
+    return mount(name, device, mkmnt, fstype, opts, user=user)
 
 
-def umount(name, device=None):
+def umount(name, device=None, user=None):
     '''
     Attempt to unmount a device by specifying the directory it is mounted on
 
@@ -451,7 +705,7 @@ def umount(name, device=None):
         cmd = 'umount {0}'.format(name)
     else:
         cmd = 'umount {0}'.format(device)
-    out = __salt__['cmd.run_all'](cmd)
+    out = __salt__['cmd.run_all'](cmd, runas=user)
     if out['retcode']:
         return out['stderr']
     return True

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -482,7 +482,7 @@ def unmounted(name,
     return ret
 
 
-def mod_watch(name, **kwargs):
+def mod_watch(name, user=None, **kwargs):
     '''
     The mounted watcher, called to invoke the watch command.
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -46,7 +46,8 @@ def mounted(name,
             pass_num=0,
             config='/etc/fstab',
             persist=True,
-            mount=True):
+            mount=True,
+            user=None):
     '''
     Verify that a device is mounted
 
@@ -82,11 +83,19 @@ def mounted(name,
 
     mount
         Set if the mount should be mounted immediately, Default is ``True``
+
+    user
+        The user to own the mount; this defaults to the user salt is
+        running as on the minion
     '''
     ret = {'name': name,
            'changes': {},
            'result': True,
            'comment': ''}
+
+    # Defaults is not a valid option on Mac OS
+    if __grains__['os'] in ['MacOS', 'Darwin'] and opts == 'defaults':
+        opts = 'noowners'
 
     # Make sure that opts is correct, it can be a list or a comma delimited
     # string
@@ -158,7 +167,7 @@ def mounted(name,
                         else:
                             ret['changes']['umount'] = "Forced remount because " \
                                                        + "options changed"
-                            remount_result = __salt__['mount.remount'](real_name, device, mkmnt=mkmnt, fstype=fstype, opts=opts)
+                            remount_result = __salt__['mount.remount'](real_name, device, mkmnt=mkmnt, fstype=fstype, opts=opts, user=user)
                             ret['result'] = remount_result
                             return ret
             if real_device not in device_list:
@@ -174,7 +183,7 @@ def mounted(name,
                     if real_device != device:
                         ret['changes']['umount'] += " (" + real_device + ")"
                     ret['changes']['umount'] += ", current: " + ', '.join(device_list)
-                    out = __salt__['mount.umount'](real_name)
+                    out = __salt__['mount.umount'](real_name, user=user)
                     active = __salt__['mount.active']()
                     if real_name in active:
                         ret['comment'] = "Unable to unmount"
@@ -196,13 +205,13 @@ def mounted(name,
 
             if not os.path.exists(name):
                 if mkmnt:
-                    __salt__['file.mkdir'](name)
+                    __salt__['file.mkdir'](name, user=user)
                 else:
                     ret['result'] = False
                     ret['comment'] = 'Mount directory is not present'
                     return ret
 
-            out = __salt__['mount.mount'](name, device, mkmnt, fstype, opts)
+            out = __salt__['mount.mount'](name, device, mkmnt, fstype, opts, user=user)
             active = __salt__['mount.active']()
             if isinstance(out, string_types):
                 # Failed to (re)mount, the state has failed!
@@ -217,15 +226,27 @@ def mounted(name,
             ret['comment'] = '{0} not mounted'.format(name)
 
     if persist:
+        # Override default for Mac OS
+        if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
+            config = "/etc/auto_salt"
+
         if __opts__['test']:
-            out = __salt__['mount.set_fstab'](name,
+            if __grains__['os'] in ['MacOS', 'Darwin']:
+                out = __salt__['mount.set_automaster'](name,
                                               device,
                                               fstype,
                                               opts,
-                                              dump,
-                                              pass_num,
                                               config,
                                               test=True)
+            else:
+                out = __salt__['mount.set_fstab'](name,
+                                                  device,
+                                                  fstype,
+                                                  opts,
+                                                  dump,
+                                                  pass_num,
+                                                  config,
+                                                  test=True)
             if out != 'present':
                 ret['result'] = None
                 if out == 'new':
@@ -254,13 +275,20 @@ def mounted(name,
                 return ret
 
         else:
-            out = __salt__['mount.set_fstab'](name,
+            if __grains__['os'] in ['MacOS', 'Darwin']:
+                out = __salt__['mount.set_automaster'](name,
                                               device,
                                               fstype,
                                               opts,
-                                              dump,
-                                              pass_num,
                                               config)
+            else:
+                out = __salt__['mount.set_fstab'](name,
+                                                  device,
+                                                  fstype,
+                                                  opts,
+                                                  dump,
+                                                  pass_num,
+                                                  config)
 
         if out == 'present':
             ret['comment'] += '. Entry already exists in the fstab.'
@@ -360,7 +388,8 @@ def swap(name, persist=True, config='/etc/fstab'):
 def unmounted(name,
               device,
               config='/etc/fstab',
-              persist=False):
+              persist=False,
+              user=None):
     '''
     .. versionadded:: 0.17.0
 
@@ -379,6 +408,10 @@ def unmounted(name,
 
     persist
         Set if the mount should be purged from the fstab, Default is ``False``
+
+    user
+        The user to own the mount; this defaults to the user salt is
+        running as on the minion
     '''
     ret = {'name': name,
            'changes': {},
@@ -398,9 +431,9 @@ def unmounted(name,
                               'be').format(name)
             return ret
         if device:
-            out = __salt__['mount.umount'](name, device)
+            out = __salt__['mount.umount'](name, device, user=user)
         else:
-            out = __salt__['mount.umount'](name)
+            out = __salt__['mount.umount'](name, user=user)
         if isinstance(out, string_types):
             # Failed to umount, the state has failed!
             ret['comment'] = out
@@ -414,7 +447,13 @@ def unmounted(name,
             ret['result'] = True
 
     if persist:
-        fstab_data = __salt__['mount.fstab'](config)
+        # Override default for Mac OS
+        if __grains__['os'] in ['MacOS', 'Darwin'] and config == '/etc/fstab':
+            config = "/etc/auto_salt"
+            fstab_data = __salt__['mount.automaster'](config)
+        else:
+            fstab_data = __salt__['mount.fstab'](config)
+
         if name not in fstab_data:
             ret['comment'] += '. fstab entry not found'
         else:
@@ -429,7 +468,10 @@ def unmounted(name,
                                   'persistent').format(name, config)
                 return ret
             else:
-                out = __salt__['mount.rm_fstab'](name, device, config)
+                if __grains__['os'] in ['MacOS', 'Darwin']:
+                    out = __salt__['mount.rm_automaster'](name, device, config)
+                else:
+                    out = __salt__['mount.rm_fstab'](name, device, config)
                 if out is not True:
                     ret['result'] = False
                     ret['comment'] += '. Failed to persist purge'
@@ -454,7 +496,7 @@ def mod_watch(name, **kwargs):
            'comment': ''}
 
     if kwargs['sfun'] == 'mounted':
-        out = __salt__['mount.remount'](name, kwargs['device'], False, kwargs['fstype'], kwargs['opts'])
+        out = __salt__['mount.remount'](name, kwargs['device'], False, kwargs['fstype'], kwargs['opts'], user=user)
         if out:
             ret['comment'] = '{0} remounted'.format(name)
         else:


### PR DESCRIPTION
This is to resolve the issue in #16925, it seems OS X automounting is a little messy and doesn't use /etc/fstab, hence the creation of a few extra functions
