### PR TITLE
Win service stop reliably

### DIFF
--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -18,6 +18,7 @@ BUFFSIZE = 5000
 SERVICE_STOP_DELAY_SECONDS = 15
 SERVICE_STOP_POLL_MAX_ATTEMPTS = 5
 
+
 def __virtual__():
     '''
     Only works on Windows systems

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -7,6 +7,9 @@ Windows Service module.
 import salt.utils
 from subprocess import list2cmdline
 import time
+import logging
+
+log = logging.getLogger(__name__)
 
 # Define the module's virtual name
 __virtualname__ = 'service'
@@ -238,6 +241,7 @@ def stop(name):
         if not status(name):
             return True
 
+    log.warning('Giving up on waiting for service `%s` to stop', name)
     return False
 
 

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -238,9 +238,10 @@ def stop(name):
     # we requested a stop, but the service is still thinking about it.
     # poll for the real status
     for attempt in range(SERVICE_STOP_POLL_MAX_ATTEMPTS):
-        time.sleep(SERVICE_STOP_DELAY_SECONDS)
         if not status(name):
             return True
+        log.debug('Waiting for %s to stop', name)
+        time.sleep(SERVICE_STOP_DELAY_SECONDS)
 
     log.warning('Giving up on waiting for service `%s` to stop', name)
     return False

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -258,8 +258,7 @@ def restart(name):
     if has_powershell():
         cmd = 'Restart-Service {0}'.format(name)
         return not __salt__['cmd.retcode'](cmd, shell='powershell')
-    stop(name)
-    return start(name)
+    return stop(name) and start(name)
 
 
 def status(name, sig=None):

--- a/salt/modules/win_service.py
+++ b/salt/modules/win_service.py
@@ -224,11 +224,11 @@ def stop(name):
     '''
     # net stop issues a stop command and waits briefly (~30s), but will give
     # up if the service takes too long to stop with a misleading
-    # "service could not be stopped" message.
+    # "service could not be stopped" message and RC 0.
 
     cmd = list2cmdline(['net', 'stop', name])
-    rc = __salt__['cmd.retcode'](cmd)
-    if rc == 0:
+    res = __salt__['cmd.run'](cmd)
+    if 'service was stopped' in res:
         return True
 
     # we requested a stop, but the service is still thinking about it.


### PR DESCRIPTION
`net stop` is not a reliable means to stop a service. It issues a stop command, waits briefly, then exits with rc 0 regardless of whether the service is stopped or not.

These patches add a polling loop using `win_service.status` to wait until the service is actually stopped. This appears to be the common approach used by windows admins in batch/vbs scripts.

See commit messages for more details and links to relevant stackoverflow articles.
