### PR TITLE
Added missing docs for the /key rest_cherrypy entry point

### DIFF
--- a/doc/ref/netapi/all/salt.netapi.rest_cherrypy.rst
+++ b/doc/ref/netapi/all/salt.netapi.rest_cherrypy.rst
@@ -56,17 +56,23 @@ REST URI Reference
 .. autoclass:: Events
     :members: GET
 
-``/ws``
--------
-
-.. autoclass:: WebsocketEndpoint
-    :members: GET
-
 ``/hook``
 ---------
 
 .. autoclass:: Webhook
     :members: POST
+
+``/key``
+---------
+
+.. autoclass:: Keys
+    :members: GET, POST
+
+``/ws``
+-------
+
+.. autoclass:: WebsocketEndpoint
+    :members: GET
 
 ``/stats``
 ----------

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -1083,7 +1083,7 @@ class Keys(LowDataAdapter):
                     -d username=kickstart \
                     -d password=kickstart \
                     -d eauth=pam \
-                | tar xf -
+                    -o jerry-salt-keys.tar
 
         .. code-block:: http
 


### PR DESCRIPTION
Should have been part of #16706.
