### PR TITLE
Add a projectid configuration for cloudstack provider.

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -194,6 +194,22 @@ def get_networkid(vm_):
     else:
         return False
 
+def get_project(conn, vm_):
+    '''
+    Return the project to use.
+    '''
+    projects = conn.ex_list_projects()
+    projid = config.get_cloud_config_value('projectid', vm_, __opts__)
+
+    if not projid:
+        return False
+
+    for project in projects:
+        if str(projid) in (str(project.id), str(project.name)):
+            return project
+
+    log.warning("Couldn't find project {0} in projects".format(projid))
+    return False
 
 def create(vm_):
     '''
@@ -230,6 +246,9 @@ def create(vm_):
                                                    kwargs['networkids'],
                                                    None, None),
                              )
+
+    if get_project(conn, vm_) is not False:
+        kwargs['project'] = get_project(conn, vm_)
 
     salt.utils.cloud.fire_event(
         'event',

--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -194,6 +194,7 @@ def get_networkid(vm_):
     else:
         return False
 
+
 def get_project(conn, vm_):
     '''
     Return the project to use.
@@ -210,6 +211,7 @@ def get_project(conn, vm_):
 
     log.warning("Couldn't find project {0} in projects".format(projid))
     return False
+
 
 def create(vm_):
     '''


### PR DESCRIPTION
This adds a projectid configuration option to the cloudstack provider, allowing the user to specify the project in which he wishes to create the VM.
