### PR TITLE
Fix state.sls_id

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -27,6 +27,7 @@ __proxyenabled__ = ['*']
 
 __outputter__ = {
     'sls': 'highstate',
+    'sls_id': 'highstate',
     'pkg': 'highstate',
     'top': 'highstate',
     'single': 'highstate',
@@ -643,10 +644,10 @@ def sls_id(
         opts['test'] = __opts__.get('test', None)
     st_ = salt.state.HighState(opts)
     if isinstance(mods, string_types):
-        mods = mods.split(',')
+        split_mods = mods.split(',')
     st_.push_active()
     try:
-        high_, errors = st_.render_highstate({saltenv: mods})
+        high_, errors = st_.render_highstate({saltenv: split_mods})
     finally:
         st_.pop_active()
     errors += st_.state.verify_high(high_)
@@ -654,12 +655,18 @@ def sls_id(
         __context__['retcode'] = 1
         return errors
     chunks = st_.state.compile_high_data(high_)
+    ret = {}
     for chunk in chunks:
         if chunk.get('__id__', '') == id_:
-            ret = st_.state.call_chunk(chunk, {}, chunks)
+            ret.update(st_.state.call_chunk(chunk, {}, chunks))
     # Work around Windows multiprocessing bug, set __opts__['test'] back to
     # value from before this function was run.
     __opts__['test'] = orig_test
+    if not ret:
+        raise SaltInvocationError(
+            'No matches for ID \'{0}\' found in SLS \'{1}\' within saltenv '
+            '\'{2}\''.format(id_, mods, saltenv)
+        )
     return ret
 
 


### PR DESCRIPTION
This resolves three issues:
1. outputter not properly specified for this function
2. multiple state declarations under the same ID declaration are not
   reflected in the output
3. traceback occurs when ID is not found in the specified mods

Fixes #17017
