### PR TITLE
utils.error.fire_exception: fix unsafe mutable default argument value

### DIFF
--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -41,10 +41,12 @@ def pack_exception(exc):
     return packed_exception
 
 
-def fire_exception(exc, opts, job={}, node='minion'):
+def fire_exception(exc, opts, job=None, node='minion'):
     '''
     Fire raw exception across the event bus
     '''
+    if job is None:
+        job = {}
     event = salt.utils.event.SaltEvent(node, opts=opts)
     event.fire_event({'exception': pack_exception(exc),
                       'job': job}, '_salt_error')


### PR DESCRIPTION
```
************* Module salt.utils.error
salt/utils/error.py:44: [W0102(dangerous-default-value), fire_exception] Dangerous default value {} as argument
```
