### PR TITLE
Revert "Route minion module failures through the event system"

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -167,7 +167,6 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             retcodes = []
             try:
                 # local will be None when there was an error
-                errors = []
                 if local:
                     if self.options.subset:
                         cmd_func = local.cmd_subset
@@ -193,20 +192,16 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                             kwargs['verbose'] = True
                         ret = {}
                         for full_ret in cmd_func(**kwargs):
-                            try:
-                                ret_, out, retcode = self._format_ret(full_ret)
-                                retcodes.append(retcode)
-                                self._output_ret(ret_, out)
-                                ret.update(ret_)
-                            except KeyError:
-                                errors.append(full_ret)
+                            ret_, out, retcode = self._format_ret(full_ret)
+                            retcodes.append(retcode)
+                            self._output_ret(ret_, out)
+                            ret.update(ret_)
 
                     # Returns summary
                     if self.config['cli_summary'] is True:
                         if self.config['fun'] != 'sys.doc':
                             if self.options.output is None:
                                 self._print_returns_summary(ret)
-                                self._print_errors_summary(errors)
 
                     # NOTE: Return code is set here based on if all minions
                     # returned 'ok' with a retcode of 0.
@@ -219,15 +214,6 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 ret = str(exc)
                 out = ''
                 self._output_ret(ret, out)
-
-    def _print_errors_summary(self, errors):
-        if errors:
-            print_cli('\n')
-            print_cli('---------------------------')
-            print_cli('Errors')
-            print_cli('---------------------------')
-            for minion in errors:
-                print_cli(self._format_error(minion))
 
     def _print_returns_summary(self, ret):
         '''
@@ -280,12 +266,6 @@ class SaltCMD(parsers.SaltCMDOptionParser):
             if 'retcode' in data:
                 retcode = data['retcode']
         return ret, out, retcode
-
-    def _format_error(self, minion_error):
-
-        for minion, error_doc in minion_error.items():
-            error = 'Minion [{0}] encountered exception \'{1}\''.format(minion, error_doc['exception']['message'])
-        return error
 
     def _print_docs(self, ret):
         '''

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -787,8 +787,7 @@ class LocalClient(object):
     def get_returns_no_block(
             self,
             jid,
-            event=None,
-            gather_errors=False):
+            event=None):
         '''
         Raw function to just return events of jid excluding timeout logic
 
@@ -798,30 +797,17 @@ class LocalClient(object):
             event = self.event
         while True:
             if HAS_ZMQ:
-                if not gather_errors:
-                    try:
-                        raw = event.get_event_noblock()
-                        if raw and raw.get('tag', '').startswith(jid):
-                            yield raw
-                        else:
-                            yield None
-                    except zmq.ZMQError as ex:
-                        if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
-                            yield None
-                        else:
-                            raise
-                else:
-                    try:
-                        raw = event.get_event_noblock()
-                        if raw and (raw.get('tag', '').startswith(jid) or raw.get('tag', '').startswith('_salt_error')):
-                            yield raw
-                        else:
-                            yield None
-                    except zmq.ZMQError as ex:
-                        if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
-                            yield None
-                        else:
-                            raise
+                try:
+                    raw = event.get_event_noblock()
+                    if raw and raw.get('tag', '').startswith(jid):
+                        yield raw
+                    else:
+                        yield None
+                except zmq.ZMQError as ex:
+                    if ex.errno == errno.EAGAIN or ex.errno == errno.EINTR:
+                        yield None
+                    else:
+                        raise
             else:
                 raw = event.get_event_noblock()
                 if raw and raw.get('tag', '').startswith(jid):
@@ -837,7 +823,6 @@ class LocalClient(object):
             tgt='*',
             tgt_type='glob',
             expect_minions=False,
-            gather_errors=True,
             **kwargs):
         '''
         Watch the event system and return job data as it comes in
@@ -874,7 +859,7 @@ class LocalClient(object):
             )
         )
         # iterator for this job's return
-        ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors)
+        ret_iter = self.get_returns_no_block(jid)
         # iterator for the info of this job
         jinfo_iter = []
         jinfo_timeout = time.time() + timeout
@@ -887,10 +872,7 @@ class LocalClient(object):
                 # if we got None, then there were no events
                 if raw is None:
                     break
-                if gather_errors:
-                    if raw['tag'] == '_salt_error':
-                        ret = {raw['data']['id']: raw['data']['data']}
-                        yield ret
+
                 if 'minions' in raw.get('data', {}):
                     minions.update(raw['data']['minions'])
                     continue

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -13,13 +13,6 @@ class SaltException(Exception):
     Base exception class; all Salt-specific exceptions should subclass this
     '''
 
-    def pack(self):
-        '''
-        Pack this exception into a serializable dictionary that is safe for
-        transport via msgpack
-        '''
-        return dict(message=self.__unicode__(), args=self.args)
-
 
 class SaltClientError(SaltException):
     '''

--- a/salt/log/setup.py
+++ b/salt/log/setup.py
@@ -677,6 +677,11 @@ def __remove_temp_logging_handler():
         logging.captureWarnings(True)
 
 
+# Let's setup a global exception hook handler which will log all exceptions
+# Store a reference to the original handler
+__GLOBAL_EXCEPTION_HANDLER = sys.excepthook
+
+
 def __global_logging_exception_handler(exc_type, exc_value, exc_traceback):
     '''
     This function will log all python exceptions.
@@ -693,7 +698,7 @@ def __global_logging_exception_handler(exc_type, exc_value, exc_traceback):
         )
     )
     # Call the original sys.excepthook
-    sys.__excepthook__(exc_type, exc_value, exc_traceback)
+    __GLOBAL_EXCEPTION_HANDLER(exc_type, exc_value, exc_traceback)
 
 
 # Set our own exception handler as the one to use

--- a/salt/master.py
+++ b/salt/master.py
@@ -302,17 +302,6 @@ class Master(SMaster):
                     )
                 )
 
-    def __handle_error_react(self, event):
-        log.error('Received minion error from [{minion}]: {data}'.format(minion=event['id'], data=event['data']['exception']))
-
-    def __register_reactions(self):
-        '''
-        Register any reactions the master will need
-        '''
-        log.info('Registering master reactions')
-        log.info('Registering master error handling')
-        self.opts['reactor'].append({'_salt_error': self.__handle_error_react})
-
     def _pre_flight(self):
         '''
         Run pre flight checks. If anything in this method fails then the master
@@ -320,7 +309,6 @@ class Master(SMaster):
         '''
         errors = []
         fileserver = salt.fileserver.Fileserver(self.opts)
-        self.__register_reactions()
         if not fileserver.servers:
             errors.append(
                 'Failed to load fileserver backends, the configured backends '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -66,7 +66,6 @@ import salt.utils.args
 import salt.utils.event
 import salt.utils.minion
 import salt.utils.schedule
-import salt.utils.error
 import salt.exitcodes
 
 from salt.defaults import DEFAULT_TARGET_DELIM
@@ -1091,7 +1090,6 @@ class Minion(MinionBase):
             except Exception:
                 msg = 'The minion function caused an exception'
                 log.warning(msg, exc_info_on_loglevel=logging.DEBUG)
-                salt.utils.error.fire_exception(salt.exceptions.MinionError(msg), opts, job=data)
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'
         else:
@@ -1625,10 +1623,6 @@ class Minion(MinionBase):
 
                 self.schedule.modify_job(name='__master_alive',
                                          schedule=schedule)
-        elif package.startswith('_salt_error'):
-            tag, data = salt.utils.event.MinionEvent.unpack(package)
-            log.debug('Forwarding salt error event tag={tag}'.format(tag=tag))
-            self._fire_master(data, tag)
 
     # Main Minion Tune In
     def tune_in(self):

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -447,7 +447,3 @@ def tty(*args, **kwargs):  # pylint: disable=W0613
         salt '*' test.tty pts3 'This is a test'
     '''
     return 'ERROR: This function has been moved to cmd.tty'
-
-
-def assertion(assertion):
-    assert assertion

--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -10,7 +10,6 @@ import exceptions
 
 # Import salt libs
 import salt.exceptions
-import salt.utils.event
 
 
 def raise_error(name=None, args=None, message=''):
@@ -31,20 +30,3 @@ def raise_error(name=None, args=None, message=''):
         raise ex(*args)
     else:
         raise ex(message)
-
-
-def pack_exception(exc):
-    if hasattr(exc, 'pack'):
-        packed_exception = exc.pack()
-    else:
-        packed_exception = {'message': exc.__unicode__(), 'args': exc.args}
-    return packed_exception
-
-
-def fire_exception(exc, opts, job={}, node='minion'):
-    '''
-    Fire raw exception across the event bus
-    '''
-    event = salt.utils.event.SaltEvent(node, opts=opts)
-    event.fire_event({'exception': pack_exception(exc),
-                      'job': job}, '_salt_error')

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -644,8 +644,6 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
             if fnmatch.fnmatch(tag, key):
                 if isinstance(val, string_types):
                     reactors.append(val)
-                elif hasattr(val, '__call__'):
-                    reactors.append(val)
                 elif isinstance(val, list):
                     reactors.extend(val)
         return reactors
@@ -658,9 +656,6 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         high = {}
         chunks = []
         for fn_ in reactors:
-            if hasattr(fn_, '__call__'):  # Is a func
-                fn_(data)
-                continue
             high.update(self.render_reaction(fn_, tag, data))
         if high:
             errors = self.verify_high(high)


### PR DESCRIPTION
Reverts saltstack/salt#16861

@cachedout @thatch45 This PR was causing some pretty bad test breakage on develop. Usually I can figure out the fix quickly, but there are a lot of failures in a bunch of different places. I think this just needs to be resubmitted with some fixes for the test suite in mind before we should merge this change back in.
