### PR TITLE
Updated win_ntp.py to catch the ValueError that would occur when

### DIFF
--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -62,7 +62,10 @@ def get_servers():
     cmd = 'w32tm /query /configuration'
     lines = __salt__['cmd.run'](cmd).splitlines()
     for line in lines:
-        if 'NtpServer' in line:
-            _, ntpsvrs = line.rstrip(' (Local)').split(':', 1)
-            return sorted(ntpsvrs.split())
+        try:
+            if 'NtpServer' in line:
+                _, ntpsvrs = line.rstrip(' (Local)').split(':', 1)
+                return sorted(ntpsvrs.split())
+        except ValueError as e:
+            return False
     return False


### PR DESCRIPTION
Found that windows machines that are a part of a domain received an error when attempting to get their NTP time source
