### PR TITLE
Quotations are not necessary when passing cmd arguments in as an array

### DIFF
--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -237,7 +237,7 @@ def clone(cwd, repository, opts=None, user=None):
         salt '*' hg.clone /path/to/repo https://bitbucket.org/birkenfeld/sphinx
     '''
     _check_hg()
-    cmd = ['hg', 'clone', '"{0}"'.format(repository), '"{0}"'.format(cwd)]
+    cmd = ['hg', 'clone', repository, cwd]
     if opts:
         for opt in opts.split():
             cmd.append('{0}'.format(opt))


### PR DESCRIPTION
- This also fixes the inability to clone mercurial repos on Ubuntu 12.04
