### PR TITLE
module/dockerio: Separate nsenter argument and command

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1751,7 +1751,7 @@ def _run_wrapper(status, container, func, cmd, *args, **kwargs):
             _invalid(status, id_=container, comment='Container is not running')
             return status
         full_cmd = ('nsenter --target {pid} --mount --uts --ipc --net --pid'
-                    ' {cmd}'.format(pid=container_pid, cmd=cmd))
+                    ' -- {cmd}'.format(pid=container_pid, cmd=cmd))
     else:
         raise NotImplementedError(
             'Unknown docker ExecutionDriver {0!r}. Or didn\'t find command'


### PR DESCRIPTION
This PR enables an execution of any arbitary command in docker container.

With a following state:

``` yaml
sudo -u postgres createuser admin:
  docker.run:
    - cid: containerid
```

I got the following error:

```
2014-11-01 06:26:41,280 [salt.loaded.int.module.cmdmod][ERROR   ] Command 'nsenter --target 15621 --mount --uts --ipc --net --pid sudo -u postgres createuser admin' failed with return code: 1
2014-11-01 06:26:41,281 [salt.loaded.int.module.cmdmod][ERROR   ] stderr: sudo: postgres: command not found
```

This is because nsenter takes `-u` as `--uts`, rendering `sudo postgres createuser admin`.
Non-existent command `postgres` was executed instead of the desired command `createuser`.

The temporary workaround should be modifying the state as follows:

``` yaml
-- sudo -u postgres createuser admin:
  docker.run:
    - cid: containerid
```

The solution is prepending `--` to the command string.

This fix works based on the feature of getopt_long, see http://www.gnu.org/software/libc/manual/html_node/Using-Getopt.html#Using-Getopt.
