### PR TITLE
adds shell glob support to file_root and pillar_root

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -8,6 +8,7 @@ from __future__ import print_function
 import logging
 import os
 import sys
+from glob import glob
 
 # Import salt libs
 import salt.cli.caller
@@ -20,6 +21,7 @@ import salt.output
 import salt.runner
 import salt.auth
 import salt.key
+from salt.config import _expand_glob_path
 
 from salt.utils import parsers, print_cli
 from salt.utils.verify import check_user, verify_env, verify_files
@@ -398,12 +400,12 @@ class SaltCall(parsers.SaltCallOptionParser):
         if self.options.file_root:
             # check if the argument is pointing to a file on disk
             file_root = os.path.abspath(self.options.file_root)
-            self.config['file_roots'] = {'base': [file_root]}
+            self.config['file_roots'] = {'base': _expand_glob_path([file_root])}
 
         if self.options.pillar_root:
             # check if the argument is pointing to a file on disk
             pillar_root = os.path.abspath(self.options.pillar_root)
-            self.config['pillar_roots'] = {'base': [pillar_root]}
+            self.config['pillar_roots'] = {'base': _expand_glob_path([pillar_root])}
 
         if self.options.local:
             self.config['file_client'] = 'local'

--- a/salt/config.py
+++ b/salt/config.py
@@ -639,11 +639,23 @@ def _validate_file_roots(opts):
     if not isinstance(opts['file_roots'], dict):
         log.warning('The file_roots parameter is not properly formatted,'
                     ' using defaults')
-        return {'base': [salt.syspaths.BASE_FILE_ROOTS_DIR]}
+        return {'base': _expand_glob_path([salt.syspaths.BASE_FILE_ROOTS_DIR])}
     for saltenv, dirs in list(opts['file_roots'].items()):
         if not isinstance(dirs, list) and not isinstance(dirs, tuple):
             opts['file_roots'][saltenv] = []
+        opts['file_roots'][saltenv] = _expand_glob_path(opts['file_roots'][saltenv])
     return opts['file_roots']
+
+
+def _expand_glob_path(file_roots):
+    '''
+    Applies shell globbing to a set of directories and returns
+    the expanded paths
+    '''
+    unglobbed_path = []
+    for path in file_roots:
+        unglobbed_path.extend(glob.glob(path))
+    return unglobbed_path
 
 
 def _validate_opts(opts):


### PR DESCRIPTION
In salts master config, I found it uncomfortable to write each included formula in file_roots one by one like so:

```
file_roots:
  base:
    - /vagrant/formulas/formula-foo/
    - /vagrant/formulas/formula-bar/
    - /vagrant/formulas/formula-baz/
    - /vagrant/formulas/formula-moare/
```

To use the `formulas` top level dir wasn sufficient, as that results in "double" namespaces depending on the formulas directory structure e.g. `formula-baz.baz.function` instead of `baz.function`.

Now one can instead simple use a shell glob:

```
file_roots:
  base:
    - /vagrant/formulas/**/
```

Also works with `pillar_roots` and the corresponding singular cli parameters of `salt-call`.

Unfortunately I wasn't able to locate a proper test case example in the current repo, if you know of a good way to test this behavior, please let me know!
