### PR TITLE
salt.returners.get_returner_options attributes are always overwritten with a blank dictionary

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -64,7 +64,9 @@ def get_returner_options(virtualname=None,
 
     ret_config = _fetch_ret_config(ret)
 
-    attrs = attrs = {}
+    if attrs is None:
+        attrs = attrs = {}
+
     profile_attr = kwargs.get('profile_attr', None)
     profile_attrs = kwargs.get('profile_attrs', None)
     defaults = kwargs.get('defaults', None)


### PR DESCRIPTION
When attributes are passed over to the `salt.returners.get_returner_options` function, the attributes are overwritten with a blank dictionary.
