### PR TITLE
fix returner config bug

### DIFF
--- a/salt/returners/__init__.py
+++ b/salt/returners/__init__.py
@@ -64,7 +64,7 @@ def get_returner_options(virtualname=None,
 
     ret_config = _fetch_ret_config(ret)
 
-    attrs = attrs = {}
+    attrs = attrs or {}
     profile_attr = kwargs.get('profile_attr', None)
     profile_attrs = kwargs.get('profile_attrs', None)
     defaults = kwargs.get('defaults', None)


### PR DESCRIPTION
@feth Did you mean this?

`attrs = attrs = {}` wipes out the arg by that name.
