### PR TITLE
fix memcache_return

### DIFF
--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -119,7 +119,6 @@ def returner(ret):
             serv.add('jids', ret['jid'] + ',')
 
 
-
 def save_load(jid, load):
     '''
     Save the load to the specified jid

--- a/salt/returners/memcache_return.py
+++ b/salt/returners/memcache_return.py
@@ -106,9 +106,18 @@ def returner(ret):
     '''
     serv = _get_serv(ret)
     serv.set('{0}:{1}'.format(ret['id'], ret['jid']), json.dumps(ret))
-    serv.prepend('{0}:{1}'.format(ret['id'], ret['fun']), ret['jid'])
-    serv.append('minions', ret['id'])
-    serv.append('jids', ret['jid'])
+
+    # The following operations are neither efficient nor atomic.
+    # If there is a way to make them so, this should be updated.
+    if ret['id'] not in get_minions():
+        r = serv.append('minions', ret['id'] + ',')
+        if not r:
+            serv.add('minions', ret['id'] + ',')
+    if ret['jid'] not in get_jids():
+        r = serv.append('jids', ret['jid'] + ',')
+        if not r:
+            serv.add('jids', ret['jid'] + ',')
+
 
 
 def save_load(jid, load):
@@ -137,7 +146,7 @@ def get_jid(jid):
     '''
     serv = _get_serv(ret=None)
     ret = {}
-    for minion in serv.smembers('minions'):
+    for minion in get_minions():
         data = serv.get('{0}:{1}'.format(minion, jid))
         if data:
             ret[minion] = json.loads(data)
@@ -167,7 +176,10 @@ def get_jids():
     Return a list of all job ids
     '''
     serv = _get_serv(ret=None)
-    return serv.get_multi('jids')
+    try:
+        return serv.get('jids').strip(',').split(',')
+    except AttributeError:
+        return []
 
 
 def get_minions():
@@ -175,4 +187,7 @@ def get_minions():
     Return a list of minions
     '''
     serv = _get_serv(ret=None)
-    return serv.get_multi('minions')
+    try:
+        return serv.get('minions').strip(',').split(',')
+    except AttributeError:
+        return []


### PR DESCRIPTION
This returner appears to have been based on the redis returner, but not quite completed. It references non existent functions (`smembers` is a redis function, not memcache) and uses `get_multi` incorrectly.

My update is not ideal (there's an issue with atomicity and efficiency with a large number of minions). It does, however, make the returner functional.
