### PR TITLE
Fix #16085 pam auth module was not closeing PamHandle hence there was memory leak.

### DIFF
--- a/salt/auth/pam.py
+++ b/salt/auth/pam.py
@@ -107,6 +107,10 @@ try:
     PAM_AUTHENTICATE = LIBPAM.pam_authenticate
     PAM_AUTHENTICATE.restype = c_int
     PAM_AUTHENTICATE.argtypes = [PamHandle, c_int]
+
+    PAM_END = LIBPAM.pam_end
+    PAM_END.restype = c_int
+    PAM_END.argtypes = [PamHandle, c_int]
 except Exception:
     HAS_PAM = False
 else:
@@ -155,9 +159,11 @@ def authenticate(username, password, service='login'):
     if retval != 0:
         # TODO: This is not an authentication error, something
         # has gone wrong starting up PAM
+        PAM_END(handle, retval)
         return False
 
     retval = PAM_AUTHENTICATE(handle, 0)
+    PAM_END(handle, 0)
     return retval == 0
 
 


### PR DESCRIPTION
Fix #16085 pam auth module was not closeing PamHandle hense there was memory leak.
pam_end doc: http://pubs.opengroup.org/onlinepubs/8329799/pam_end.htm
