### PR TITLE
add function to loader for loading utility modules (_utils)

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -187,6 +187,15 @@ def returners(opts, functions, whitelist=None):
                       )
 
 
+def utils(opts, whitelist=None):
+    '''
+    Returns the utility modules
+    '''
+    load = _create_loader(opts, 'utils', 'utils',
+                          ext_type_dirs='utils_dirs')
+    return LazyLoader(load, whitelist=whitelist)
+
+
 def pillars(opts, functions):
     '''
     Returns the pillars modules


### PR DESCRIPTION
This allows for generic shared code to be loaded on both master and minion. Like salt.utils, but third party. It also makes it possible to access util functions by key.

Example usage in a runner:

``` python
# Import salt libs
import salt.loader


# cache the utility modules
UTILS = None


def _utils():
    '''
    Load the utility modules exactly once.
    '''
    global UTILS

    if UTILS is None:
        UTILS = salt.loader.utils(__opts__)

    return UTILS


def page(*args, pager='pagerduty'):
    utils = _utils()
    utils['{0}.page'.format(pager)](*args)
```
