### PR TITLE
Remove doubled up code for adding slspath variants to template context

### DIFF
--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -69,17 +69,6 @@ def wrap_tmpl_func(render_str):
             context['sls_path'] = slspath.replace('/', '_')
             context['slspath'] = slspath
 
-        if 'sls' in context:
-            slspath = context['sls'].replace('.', '/')
-            if tmplpath is not None:
-                context['tplpath'] = tmplpath
-                if not tmplpath.lower().replace('\\', '/').endswith('/init.sls'):
-                    slspath = os.path.dirname(slspath)
-            context['slsdotpath'] = slspath.replace('/', '.')
-            context['slscolonpath'] = slspath.replace('/', ':')
-            context['sls_path'] = slspath.replace('/', '_')
-            context['slspath'] = slspath
-
         if isinstance(tmplsrc, string_types):
             if from_str:
                 tmplstr = tmplsrc


### PR DESCRIPTION
Looks like a simple git merge fart that resulted in the same code block
being pulled in twice.
