### PR TITLE
Fix for an issue where re-started sub-processes would inherit

### DIFF
--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -210,7 +210,6 @@ class ProcessManager(object):
             except OSError:
                 break
 
-
     def check_children(self):
         '''
         Check the children once
@@ -232,7 +231,6 @@ class ProcessManager(object):
                 return signal.default_int_handler(signal.SIGTERM)(*args)
             else:
                 return
-
 
         for pid, p_map in self._process_map.items():
             p_map['Process'].terminate()

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -133,6 +133,10 @@ class ProcessManager(object):
 
         self.wait_for_kill = wait_for_kill
 
+        # store some pointers for the SIGTERM handler
+        self._pid = os.getpid()
+        self._sigterm_handler = signal.getsignal(signal.SIGTERM)
+
     def add_process(self, tgt, args=None, kwargs=None):
         '''
         Create a processes and args + kwargs
@@ -181,6 +185,7 @@ class ProcessManager(object):
         Load and start all available api modules
         '''
         salt.utils.appendproctitle(self.name)
+
         # make sure to kill the subprocesses if the parent is killed
         signal.signal(signal.SIGTERM, self.kill_children)
 
@@ -193,6 +198,9 @@ class ProcessManager(object):
 
         while True:
             try:
+                # in case someone died while we were waiting...
+                self.check_children()
+
                 pid, exit_status = os.wait()
                 if pid not in self._process_map:
                     log.debug(('Process of pid {0} died, not a known'
@@ -202,8 +210,6 @@ class ProcessManager(object):
             except OSError:
                 break
 
-            # in case someone died while we were waiting...
-            self.check_children()
 
     def check_children(self):
         '''
@@ -217,10 +223,20 @@ class ProcessManager(object):
         '''
         Kill all of the children
         '''
+        # check that this is the correct process, children inherit this
+        # handler, if we are in a child lets just run the original handler
+        if os.getpid() != self._pid:
+            if callable(self._sigterm_handler):
+                return self._sigterm_handler(*args)
+            elif self._sigterm_handler is not None:
+                return signal.default_int_handler(signal.SIGTERM)(*args)
+            else:
+                return
+
+
         for pid, p_map in self._process_map.items():
             p_map['Process'].terminate()
 
-        #
         end_time = time.time() + self.wait_for_kill  # when to die
 
         while self._process_map and time.time() < end_time:


### PR DESCRIPTION
signal handlers from the process manager. Then you would end up with stack traces like:

```
Process Publisher-6:
Traceback (most recent call last):
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 232, in _bootstrap
    self.run()
  File "/home/thjackso/src/salt-github/salt/master.py", line 403, in run
    package = pull_sock.recv()
  File "socket.pyx", line 628, in zmq.backend.cython.socket.Socket.recv (zmq/backend/cython/socket.c:5616)
  File "socket.pyx", line 662, in zmq.backend.cython.socket.Socket.recv (zmq/backend/cython/socket.c:5436)
  File "socket.pyx", line 139, in zmq.backend.cython.socket._recv_copy (zmq/backend/cython/socket.c:1771)
  File "checkrc.pxd", line 11, in zmq.backend.cython.checkrc._check_rc (zmq/backend/cython/socket.c:5863)
  File "/home/thjackso/src/salt-github/salt/utils/process.py", line 242, in kill_children
    p_map['Process'].join(0)
  File "/usr/lib64/python2.6/multiprocessing/process.py", line 117, in join
    assert self._parent_pid == os.getpid(), 'can only join a child process'
AssertionError: can only join a child process
```
