### PR TITLE
Fix ec2 cloud test

### DIFF
--- a/tests/integration/files/conf/cloud.profiles.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/ec2.conf
@@ -1,5 +1,5 @@
 ec2-test:
   provider: ec2-config
-  image: ami-9eaa1cf6
+  image: ami-98aa1cf0
   size: t1.micro
   sh_username: ec2-user

--- a/tests/integration/files/conf/cloud.profiles.d/ec2.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/ec2.conf
@@ -1,5 +1,5 @@
 ec2-test:
   provider: ec2-config
-  image: ami-b06a98d8
+  image: ami-9eaa1cf6
   size: t1.micro
   sh_username: ec2-user


### PR DESCRIPTION
Use Ubuntu 14 image for ec2 cloud tests instead of RHEL 6
