### PR TITLE
Add yaml_dquote() and yaml_squote() utilites; load them as Jinja filters...

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -315,8 +315,7 @@ different from the base must be specified of the alternates:
             'python': 'dev-python/mysql-python',
         },
     },
-    merge=salt['pillar.get']('mysql:lookup'),
-    base=default) %}
+    merge=salt['pillar.get']('mysql:lookup'), base=default) %}
 
 
 Overriding values in the lookup table
@@ -337,6 +336,26 @@ Pillar would replace the ``config`` value from the call above.
     mysql:
       lookup:
         config: /usr/local/etc/mysql/my.cnf
+
+.. note:: Protecting Expansion of Content with Special Characters
+
+  When templating keep in mind that YAML does have special characters
+  for quoting, flows and other special structure and content.  When a
+  Jinja substitution may have special characters that will be
+  incorrectly parsed by YAML the expansion must be protected by quoting.
+  It is a good policy to quote all Jinja expansions especially when
+  values may originate from Pillar.  Salt provides a Jinja filter for
+  doing just this: ``yaml_dquote``
+
+  .. code-block:: jinja
+
+      {%- set baz = '"The quick brown fox . . ."' %}
+      {%- set zap = 'The word of the day is "salty".' %}
+
+      {%- load_yaml as foo %}
+      bar: {{ baz|yaml_dquote }}
+      zip: {{ zap|yaml_dquote }}
+      {%- endload %}
 
 Single-purpose SLS files
 ------------------------

--- a/salt/renderers/jinja.py
+++ b/salt/renderers/jinja.py
@@ -124,7 +124,7 @@ starts at the root of the state tree or pillar.
 Filters
 =======
 
-Saltstack extends `builtin filters`_ with his custom filters:
+Saltstack extends `builtin filters`_ with these custom filters:
 
 strftime
   Converts any time related object into a time based string. It requires a
@@ -139,6 +139,32 @@ strftime
       {{ "1040814000"|strftime("%Y-%m-%d") }}
       {{ datetime|strftime("%u") }}
       {{ "now"|strftime }}
+
+sequence
+  Ensure that parsed data is a sequence.
+
+yaml_dquote
+  Serializes a string into a properly-escaped YAML double-quoted
+  string.  This is useful when the contents of a string are unknown
+  and may contain quotes or unicode that needs to be preserved.  The
+  resulting string will be emitted with opening and closing double
+  quotes.
+
+  .. code-block:: yaml
+
+      {%- set baz = '"The quick brown fox . . ."' %}
+      {%- set zap = 'The word of the day is "salty".' %}
+
+      {%- load_yaml as foo %}
+      bar: {{ baz|yaml_dquote }}
+      zip: {{ zap|yaml_dquote }}
+      {%- endload %}
+
+yaml_squote
+   Similar to the ``yaml_dquote`` filter but with single quotes.  Note
+   that YAML only allows special escapes inside double quotes so
+   ``yaml_squote`` is not nearly as useful (viz. you likely want to
+   use ``yaml_dquote``).
 
 .. _`builtin filters`: http://jinja.pocoo.org/docs/templates/#builtin-filters
 .. _`timelib`: https://github.com/pediapress/timelib/

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -15,6 +15,7 @@ import errno
 import fnmatch
 import hashlib
 import imp
+import io
 import inspect
 import json
 import logging
@@ -1788,6 +1789,28 @@ def date_format(date=None, format="%Y-%m-%d"):
     '2002-12-25'
     '''
     return date_cast(date).strftime(format)
+
+
+def yaml_dquote(text):
+    """Make text into a double-quoted YAML string with correct escaping
+    for special characters.  Includes the opening and closing double
+    quote characters.
+    """
+    with io.StringIO() as ostream:
+        yemitter = yaml.emitter.Emitter(ostream)
+        yemitter.write_double_quoted(unicode(text))
+        return ostream.getvalue()
+
+
+def yaml_squote(text):
+    """Make text into a single-quoted YAML string with correct escaping
+    for special characters.  Includes the opening and closing single
+    quote characters.
+    """
+    with io.StringIO() as ostream:
+        yemitter = yaml.emitter.Emitter(ostream)
+        yemitter.write_single_quoted(unicode(text))
+        return ostream.getvalue()
 
 
 def warn_until(version,

--- a/salt/utils/templates.py
+++ b/salt/utils/templates.py
@@ -274,6 +274,8 @@ def render_jinja_tmpl(tmplstr, context, tmplpath=None):
 
     jinja_env.filters['strftime'] = salt.utils.date_format
     jinja_env.filters['sequence'] = ensure_sequence_filter
+    jinja_env.filters['yaml_dquote'] = salt.utils.yaml_dquote
+    jinja_env.filters['yaml_squote'] = salt.utils.yaml_squote
 
     jinja_env.globals['odict'] = OrderedDict
     jinja_env.globals['show_full_context'] = show_full_context

--- a/tests/unit/utils/utils_test.py
+++ b/tests/unit/utils/utils_test.py
@@ -520,6 +520,14 @@ class UtilsTestCase(TestCase):
         ret = utils.date_format(src)
         self.assertEqual(ret, expected_ret)
 
+    def test_yaml_dquote(self):
+        ret = utils.yaml_dquote(r'"\ "')
+        self.assertEqual(ret, r'"\"\\ \""')
+
+    def test_yaml_squote(self):
+        ret = utils.yaml_squote(r'"')
+        self.assertEqual(ret, r"""'"'""")
+
     def test_compare_dicts(self):
         ret = utils.compare_dicts(old={'foo': 'bar'}, new={'foo': 'bar'})
         self.assertEqual(ret, {})


### PR DESCRIPTION
....

When templating state files the variable contents may contain
characters that YAML will interpret specially.  Rather than try to
escape the special characters so that they are safe use a filter that
protects special characters in YAML values.
