### PR TITLE
modules.linux_acl: add tests

### DIFF
--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -5,6 +5,7 @@ Support for Linux File Access Control Lists
 
 # Import salt libs
 import salt.utils
+from salt.exceptions import CommandExecutionError
 
 # Define the module's virtual name
 __virtualname__ = 'acl'
@@ -147,6 +148,11 @@ def _parse_acl(acl, user, group):
     return vals
 
 
+def _raise_on_no_files(*args):
+    if len(args) == 0:
+        raise CommandExecutionError('You need to specify at least one file or directory to work with!')
+
+
 def wipefacls(*args):
     '''
     Remove all FACLs from the specified file(s)
@@ -158,6 +164,7 @@ def wipefacls(*args):
         salt '*' acl.wipefacls /tmp/house/kitchen
         salt '*' acl.wipefacls /tmp/house/kitchen /tmp/house/livingroom
     '''
+    _raise_on_no_files(*args)
     cmd = 'setfacl -b'
     for dentry in args:
         cmd += ' {0}'.format(dentry)
@@ -178,6 +185,8 @@ def modfacl(acl_type, acl_name, perms, *args):
         salt '*' acl.modfacl d:u myuser 7 /tmp/house/kitchen
         salt '*' acl.modfacl g mygroup 0 /tmp/house/kitchen /tmp/house/livingroom
     '''
+    _raise_on_no_files(*args)
+
     cmd = 'setfacl -m'
 
     prefix = ''

--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -219,6 +219,8 @@ def delfacl(acl_type, acl_name, *args):
         salt '*' acl.delfacl d:u myuser /tmp/house/kitchen
         salt '*' acl.delfacl g myuser /tmp/house/kitchen /tmp/house/livingroom
     '''
+    _raise_on_no_files(*args)
+
     cmd = 'setfacl -x'
 
     prefix = ''

--- a/salt/modules/linux_acl.py
+++ b/salt/modules/linux_acl.py
@@ -36,6 +36,11 @@ def version():
     return ret[1].strip()
 
 
+def _raise_on_no_files(*args):
+    if len(args) == 0:
+        raise CommandExecutionError('You need to specify at least one file or directory to work with!')
+
+
 def getfacl(*args):
     '''
     Return (extremely verbose) map of FACLs on specified file(s)
@@ -47,6 +52,8 @@ def getfacl(*args):
         salt '*' acl.getfacl /tmp/house/kitchen
         salt '*' acl.getfacl /tmp/house/kitchen /tmp/house/livingroom
     '''
+    _raise_on_no_files(*args)
+
     ret = {}
     cmd = 'getfacl -p'
     for dentry in args:
@@ -146,11 +153,6 @@ def _parse_acl(acl, user, group):
     vals['octal'] = octal
 
     return vals
-
-
-def _raise_on_no_files(*args):
-    if len(args) == 0:
-        raise CommandExecutionError('You need to specify at least one file or directory to work with!')
 
 
 def wipefacls(*args):

--- a/tests/integration/modules/linux_acl.py
+++ b/tests/integration/modules/linux_acl.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Import python libs
+import os
+import shutil
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath, requires_salt_modules, skip_if_binaries_missing
+import salt.utils
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+# from salt.modules import linux_acl as acl
+
+
+# Acl package should be installed to test linux_acl module
+@skip_if_binaries_missing(['getfacl'])
+# Doesn't work. Why?
+# @requires_salt_modules('acl')
+# @requires_salt_modules('linux_acl')
+class LinuxAclModuleTest(integration.ModuleCase,
+                         integration.AdaptedConfigurationTestCaseMixIn):
+    '''
+    Validate the linux_acl module
+    '''
+    def setUp(self):
+        # Blindly copied from tests.integration.modules.file; Refactoring?
+        self.myfile = os.path.join(integration.TMP, 'myfile')
+        with salt.utils.fopen(self.myfile, 'w+') as fp:
+            fp.write('Hello\n')
+        self.mydir = os.path.join(integration.TMP, 'mydir/isawesome')
+        if not os.path.isdir(self.mydir):
+            # left behind... Don't fail because of this!
+            os.makedirs(self.mydir)
+        self.mysymlink = os.path.join(integration.TMP, 'mysymlink')
+        if os.path.islink(self.mysymlink):
+            os.remove(self.mysymlink)
+        os.symlink(self.myfile, self.mysymlink)
+        self.mybadsymlink = os.path.join(integration.TMP, 'mybadsymlink')
+        if os.path.islink(self.mybadsymlink):
+            os.remove(self.mybadsymlink)
+        os.symlink('/nonexistentpath', self.mybadsymlink)
+        super(LinuxAclModuleTest, self).setUp()
+
+    def tearDown(self):
+        if os.path.isfile(self.myfile):
+            os.remove(self.myfile)
+        if os.path.islink(self.mysymlink):
+            os.remove(self.mysymlink)
+        if os.path.islink(self.mybadsymlink):
+            os.remove(self.mybadsymlink)
+        shutil.rmtree(self.mydir, ignore_errors=True)
+        super(LinuxAclModuleTest, self).tearDown()
+    
+    def test_version(self):
+        self.assertRegexpMatches(self.run_function('acl.version'), r'\d+\.\d+\.\d+')
+
+    def test_getfacl_w_single_file_without_acl(self):
+        ret = self.run_function('acl.getfacl', arg=[self.myfile])
+        self.assertEqual(
+            ret,
+            {self.myfile: {'other': {'octal': 4, 'permissions': {'read': True, 'write': False, 'execute': False}}, 'users': [{'root': {'octal': 6, 'permissions': {'read': True, 'write': True, 'execute': False}}}], 'groups': [{'root': {'octal': 4, 'permissions': {'read': True, 'write': False, 'execute': False}}}], 'comments': {'owner': 'root', 'group': 'root', 'file': self.myfile}}}
+        )
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(TestModuleTest)

--- a/tests/integration/modules/linux_acl.py
+++ b/tests/integration/modules/linux_acl.py
@@ -5,7 +5,7 @@ import os
 import shutil
 
 # Import Salt Testing libs
-from salttesting.helpers import ensure_in_syspath, requires_salt_modules, skip_if_binaries_missing
+from salttesting.helpers import ensure_in_syspath, skip_if_binaries_missing
 import salt.utils
 ensure_in_syspath('../../')
 
@@ -53,7 +53,7 @@ class LinuxAclModuleTest(integration.ModuleCase,
             os.remove(self.mybadsymlink)
         shutil.rmtree(self.mydir, ignore_errors=True)
         super(LinuxAclModuleTest, self).tearDown()
-    
+
     def test_version(self):
         self.assertRegexpMatches(self.run_function('acl.version'), r'\d+\.\d+\.\d+')
 
@@ -67,4 +67,4 @@ class LinuxAclModuleTest(integration.ModuleCase,
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(TestModuleTest)
+    run_tests(LinuxAclModuleTest)

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -40,6 +40,17 @@ class LinuxAclTestCase(TestCase):
         # integration
         # self.assertRegexpMatches(linux_acl.version(), r'\d+\.\d+\.\d+')
 
+    def test_getfacl_wo_args(self):
+        self.assertRaises(CommandExecutionError, linux_acl.getfacl)
+
+    def test_getfacl_w_single_arg(self):
+        linux_acl.getfacl(self.file)
+        self.cmdrun.assert_called_once_with('getfacl -p {}'.format(self.file))
+
+    def test_getfacl_w_multiple_args(self):
+        linux_acl.getfacl(*self.files)
+        self.cmdrun.assert_called_once_with('getfacl -p {} {}'.format(*self.files))
+
     def test_wipefacls_wo_args(self):
         self.assertRaises(CommandExecutionError, linux_acl.wipefacls)
 

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+ensure_in_syspath('../../')
+
+# Import salt libs
+from salt.modules import linux_acl
+from salt.exceptions import CommandExecutionError
+
+# linux_acl.__salt__ = {'cmd.which_bin': lambda _: 'pip'}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class LinuxAclTestCase(TestCase):
+
+    def setUp(self):
+        linux_acl.__salt__ = {'cmd.run': MagicMock()}
+        self.cmdrun = linux_acl.__salt__['cmd.run']
+        self.file = '/tmp/file'
+        self.files = ['/tmp/file1', '/tmp/file2']
+        self.u_acl = ['u', 'myuser', 'rwx']
+        self.user_acl = ['user', 'myuser', 'rwx']
+        self.user_acl_cmd = 'u:myuser:rwx'
+        self.g_acl = ['g', 'mygroup', 'rwx']
+        self.group_acl = ['group', 'mygroup', 'rwx']
+        self.group_acl_cmd = 'g:mygroup:rwx'
+
+    # too easy to test
+    def test_version(self):
+        pass
+        # linux_acl.version()
+        # self.cmdrun.called_once_with('getfacl --version')
+        # integration
+        # self.assertRegexpMatches(linux_acl.version(), r'\d+\.\d+\.\d+')
+
+    def test_wipefacls_wo_args(self):
+        self.assertRaises(CommandExecutionError, linux_acl.wipefacls)
+
+    def test_wipefacls_w_single_arg(self):
+        linux_acl.wipefacls(self.file)
+        self.cmdrun.assert_called_once_with('setfacl -b {}'.format(self.file))
+
+    def test_wipefacls_w_multiple_args(self):
+        linux_acl.wipefacls(*self.files)
+        self.cmdrun.assert_called_once_with('setfacl -b {} {}'.format(*self.files))
+
+    def test_modfacl_wo_args(self):
+        for acl in [self.u_acl, self.user_acl, self.g_acl, self.group_acl]:
+            self.assertRaises(CommandExecutionError, linux_acl.modfacl, *acl)
+
+    def test_modfacl__u_w_single_arg(self):
+        linux_acl.modfacl(*(self.u_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.user_acl_cmd, self.file))
+
+    def test_modfacl__u_w_multiple_args(self):
+        linux_acl.modfacl(*(self.u_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.user_acl_cmd, *self.files))
+
+    def test_modfacl__user_w_single_arg(self):
+        linux_acl.modfacl(*(self.user_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.user_acl_cmd, self.file))
+
+    def test_modfacl__user_w_multiple_args(self):
+        linux_acl.modfacl(*(self.user_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.user_acl_cmd, *self.files))

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -3,14 +3,12 @@
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock
 ensure_in_syspath('../../')
 
 # Import salt libs
 from salt.modules import linux_acl
 from salt.exceptions import CommandExecutionError
-
-# linux_acl.__salt__ = {'cmd.which_bin': lambda _: 'pip'}
 
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
@@ -32,13 +30,9 @@ class LinuxAclTestCase(TestCase):
         self.default_user_acl = ['d:user', 'myuser', 'rwx']
         self.default_user_acl_cmd = 'd:u:myuser:rwx'
 
-    # too easy to test
+    # too easy to test (DRY)
     def test_version(self):
         pass
-        # linux_acl.version()
-        # self.cmdrun.called_once_with('getfacl --version')
-        # integration
-        # self.assertRegexpMatches(linux_acl.version(), r'\d+\.\d+\.\d+')
 
     def test_getfacl_wo_args(self):
         self.assertRaises(CommandExecutionError, linux_acl.getfacl)

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -39,22 +39,22 @@ class LinuxAclTestCase(TestCase):
 
     def test_getfacl_w_single_arg(self):
         linux_acl.getfacl(self.file)
-        self.cmdrun.assert_called_once_with('getfacl -p {}'.format(self.file))
+        self.cmdrun.assert_called_once_with('getfacl -p ' + self.file)
 
     def test_getfacl_w_multiple_args(self):
         linux_acl.getfacl(*self.files)
-        self.cmdrun.assert_called_once_with('getfacl -p {} {}'.format(*self.files))
+        self.cmdrun.assert_called_once_with('getfacl -p ' + ' '.join(self.files))
 
     def test_wipefacls_wo_args(self):
         self.assertRaises(CommandExecutionError, linux_acl.wipefacls)
 
     def test_wipefacls_w_single_arg(self):
         linux_acl.wipefacls(self.file)
-        self.cmdrun.assert_called_once_with('setfacl -b {}'.format(self.file))
+        self.cmdrun.assert_called_once_with('setfacl -b ' + self.file)
 
     def test_wipefacls_w_multiple_args(self):
         linux_acl.wipefacls(*self.files)
-        self.cmdrun.assert_called_once_with('setfacl -b {} {}'.format(*self.files))
+        self.cmdrun.assert_called_once_with('setfacl -b ' + ' '.join(self.files))
 
     def test_modfacl_wo_args(self):
         for acl in [self.u_acl, self.user_acl, self.g_acl, self.group_acl]:
@@ -62,59 +62,59 @@ class LinuxAclTestCase(TestCase):
 
     def test_modfacl__u_w_single_arg(self):
         linux_acl.modfacl(*(self.u_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.user_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd, self.file]))
 
     def test_modfacl__u_w_multiple_args(self):
         linux_acl.modfacl(*(self.u_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.user_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd] + self.files))
 
     def test_modfacl__user_w_single_arg(self):
         linux_acl.modfacl(*(self.user_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.user_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd, self.file]))
 
     def test_modfacl__user_w_multiple_args(self):
         linux_acl.modfacl(*(self.user_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.user_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.user_acl_cmd] + self.files))
 
     def test_modfacl__g_w_single_arg(self):
         linux_acl.modfacl(*(self.g_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.group_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd, self.file]))
 
     def test_modfacl__g_w_multiple_args(self):
         linux_acl.modfacl(*(self.g_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.group_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd] + self.files))
 
     def test_modfacl__group_w_single_arg(self):
         linux_acl.modfacl(*(self.group_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.group_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd, self.file]))
 
     def test_modfacl__group_w_multiple_args(self):
         linux_acl.modfacl(*(self.group_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.group_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.group_acl_cmd] + self.files))
 
     def test_modfacl__d_u_w_single_arg(self):
         linux_acl.modfacl(*(self.d_u_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.default_user_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.file]))
 
     def test_modfacl__d_u_w_multiple_args(self):
         linux_acl.modfacl(*(self.d_u_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.default_user_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.files))
 
     def test_modfacl__d_user_w_single_arg(self):
         linux_acl.modfacl(*(self.d_user_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.default_user_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.file]))
 
     def test_modfacl__d_user_w_multiple_args(self):
         linux_acl.modfacl(*(self.d_user_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.default_user_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.files))
 
     def test_modfacl__default_user_w_single_arg(self):
         linux_acl.modfacl(*(self.default_user_acl + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.default_user_acl_cmd, self.file))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd, self.file]))
 
     def test_modfacl__default_user_w_multiple_args(self):
         linux_acl.modfacl(*(self.default_user_acl + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.default_user_acl_cmd, *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m ' + ' '.join([self.default_user_acl_cmd] + self.files))
 
     def test_delfacl_wo_args(self):
         for acl in [self.u_acl, self.user_acl, self.g_acl, self.group_acl]:
@@ -122,56 +122,56 @@ class LinuxAclTestCase(TestCase):
 
     def test_delfacl__u_w_single_arg(self):
         linux_acl.delfacl(*(self.u_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.user_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__u_w_multiple_args(self):
         linux_acl.delfacl(*(self.u_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.user_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0]] + self.files))
 
     def test_delfacl__user_w_single_arg(self):
         linux_acl.delfacl(*(self.user_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.user_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__user_w_multiple_args(self):
         linux_acl.delfacl(*(self.user_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.user_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.user_acl_cmd.rpartition(':')[0]] + self.files))
 
     def test_delfacl__g_w_single_arg(self):
         linux_acl.delfacl(*(self.g_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.group_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__g_w_multiple_args(self):
         linux_acl.delfacl(*(self.g_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.group_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0]] + self.files))
 
     def test_delfacl__group_w_single_arg(self):
         linux_acl.delfacl(*(self.group_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.group_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__group_w_multiple_args(self):
         linux_acl.delfacl(*(self.group_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.group_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.group_acl_cmd.rpartition(':')[0]] + self.files))
 
     def test_delfacl__d_u_w_single_arg(self):
         linux_acl.delfacl(*(self.d_u_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__d_u_w_multiple_args(self):
         linux_acl.delfacl(*(self.d_u_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files))
 
     def test_delfacl__d_user_w_single_arg(self):
         linux_acl.delfacl(*(self.d_user_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__d_user_w_multiple_args(self):
         linux_acl.delfacl(*(self.d_user_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files))
 
     def test_delfacl__default_user_w_single_arg(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + [self.file]))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], self.file))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0], self.file]))
 
     def test_delfacl__default_user_w_multiple_args(self):
         linux_acl.delfacl(*(self.default_user_acl[:-1] + self.files))
-        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], *self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x ' + ' '.join([self.default_user_acl_cmd.rpartition(':')[0]] + self.files))

--- a/tests/unit/modules/linux_acl_test.py
+++ b/tests/unit/modules/linux_acl_test.py
@@ -27,6 +27,10 @@ class LinuxAclTestCase(TestCase):
         self.g_acl = ['g', 'mygroup', 'rwx']
         self.group_acl = ['group', 'mygroup', 'rwx']
         self.group_acl_cmd = 'g:mygroup:rwx'
+        self.d_u_acl = ['d:u', 'myuser', 'rwx']
+        self.d_user_acl = ['d:user', 'myuser', 'rwx']
+        self.default_user_acl = ['d:user', 'myuser', 'rwx']
+        self.default_user_acl_cmd = 'd:u:myuser:rwx'
 
     # too easy to test
     def test_version(self):
@@ -66,3 +70,103 @@ class LinuxAclTestCase(TestCase):
     def test_modfacl__user_w_multiple_args(self):
         linux_acl.modfacl(*(self.user_acl + self.files))
         self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.user_acl_cmd, *self.files))
+
+    def test_modfacl__g_w_single_arg(self):
+        linux_acl.modfacl(*(self.g_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.group_acl_cmd, self.file))
+
+    def test_modfacl__g_w_multiple_args(self):
+        linux_acl.modfacl(*(self.g_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.group_acl_cmd, *self.files))
+
+    def test_modfacl__group_w_single_arg(self):
+        linux_acl.modfacl(*(self.group_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.group_acl_cmd, self.file))
+
+    def test_modfacl__group_w_multiple_args(self):
+        linux_acl.modfacl(*(self.group_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.group_acl_cmd, *self.files))
+
+    def test_modfacl__d_u_w_single_arg(self):
+        linux_acl.modfacl(*(self.d_u_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.default_user_acl_cmd, self.file))
+
+    def test_modfacl__d_u_w_multiple_args(self):
+        linux_acl.modfacl(*(self.d_u_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.default_user_acl_cmd, *self.files))
+
+    def test_modfacl__d_user_w_single_arg(self):
+        linux_acl.modfacl(*(self.d_user_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.default_user_acl_cmd, self.file))
+
+    def test_modfacl__d_user_w_multiple_args(self):
+        linux_acl.modfacl(*(self.d_user_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.default_user_acl_cmd, *self.files))
+
+    def test_modfacl__default_user_w_single_arg(self):
+        linux_acl.modfacl(*(self.default_user_acl + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {}'.format(self.default_user_acl_cmd, self.file))
+
+    def test_modfacl__default_user_w_multiple_args(self):
+        linux_acl.modfacl(*(self.default_user_acl + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -m {} {} {}'.format(self.default_user_acl_cmd, *self.files))
+
+    def test_delfacl_wo_args(self):
+        for acl in [self.u_acl, self.user_acl, self.g_acl, self.group_acl]:
+            self.assertRaises(CommandExecutionError, linux_acl.delfacl, *acl[:-1])
+
+    def test_delfacl__u_w_single_arg(self):
+        linux_acl.delfacl(*(self.u_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.user_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__u_w_multiple_args(self):
+        linux_acl.delfacl(*(self.u_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.user_acl_cmd.rpartition(':')[0], *self.files))
+
+    def test_delfacl__user_w_single_arg(self):
+        linux_acl.delfacl(*(self.user_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.user_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__user_w_multiple_args(self):
+        linux_acl.delfacl(*(self.user_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.user_acl_cmd.rpartition(':')[0], *self.files))
+
+    def test_delfacl__g_w_single_arg(self):
+        linux_acl.delfacl(*(self.g_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.group_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__g_w_multiple_args(self):
+        linux_acl.delfacl(*(self.g_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.group_acl_cmd.rpartition(':')[0], *self.files))
+
+    def test_delfacl__group_w_single_arg(self):
+        linux_acl.delfacl(*(self.group_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.group_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__group_w_multiple_args(self):
+        linux_acl.delfacl(*(self.group_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.group_acl_cmd.rpartition(':')[0], *self.files))
+
+    def test_delfacl__d_u_w_single_arg(self):
+        linux_acl.delfacl(*(self.d_u_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__d_u_w_multiple_args(self):
+        linux_acl.delfacl(*(self.d_u_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], *self.files))
+
+    def test_delfacl__d_user_w_single_arg(self):
+        linux_acl.delfacl(*(self.d_user_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__d_user_w_multiple_args(self):
+        linux_acl.delfacl(*(self.d_user_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], *self.files))
+
+    def test_delfacl__default_user_w_single_arg(self):
+        linux_acl.delfacl(*(self.default_user_acl[:-1] + [self.file]))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], self.file))
+
+    def test_delfacl__default_user_w_multiple_args(self):
+        linux_acl.delfacl(*(self.default_user_acl[:-1] + self.files))
+        self.cmdrun.assert_called_once_with('setfacl -x {} {} {}'.format(self.default_user_acl_cmd.rpartition(':')[0], *self.files))


### PR DESCRIPTION
I had some problems with Docker containers: https://github.com/saltstack/docker-containers/issues/10

Look at the unit tests. They are damn boring. And unmaintainable. I propose a better approach: #17140 

Also I gave up with `getfacl` integration testing. See #17141 for more information.
