### PR TITLE
Bugfix: crash on highstate population when empty path is passed

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -223,7 +223,9 @@ class Client(object):
             if fn_.strip() and fn_.startswith(path):
                 if salt.utils.check_include_exclude(
                         fn_, include_pat, exclude_pat):
-                    ret.append(self.cache_file('salt://' + fn_, saltenv))
+                    fn_ = self.cache_file('salt://' + fn_, saltenv)
+                    if fn_:
+                        ret.append(fn_)
 
         if include_empty:
             # Break up the path into a list containing the bottom-level


### PR DESCRIPTION
There are situations when minion does not likes module sync'ing and simply crashes the `highstate` procedure. Because of returned file list includes one empty element, this happens precisely in `saltutils.py`, here: https://github.com/saltstack/salt/blob/develop/salt/modules/saltutil.py#L109

The empty element is happening due to passed URL `salt://top.sls` during modules sync'ing here: https://github.com/saltstack/salt/blob/develop/salt/fileclient.py#L510 and this causes to return no path here: https://github.com/saltstack/salt/blob/develop/salt/fileclient.py#L518 which renders to one empty element for `saltutil.py` part.

Hope this helps.
