### PR TITLE
Listing images by name results in naming conflicts

### DIFF
--- a/salt/cloud/clouds/digital_ocean.py
+++ b/salt/cloud/clouds/digital_ocean.py
@@ -101,9 +101,9 @@ def avail_images(call=None):
     items = query(method='images')
     ret = {}
     for image in items['images']:
-        ret[image['name']] = {}
+        ret[image['id']] = {}
         for item in image.keys():
-            ret[image['name']][item] = str(image[item])
+            ret[image['id']][item] = str(image[item])
 
     return ret
 


### PR DESCRIPTION
Recent changes at digital ocean has caused them to use duplicate image names for different images. For example: "image name "7.0 x64" now exists as both Debian and CentOS so the current code will only return the first image with that name. Referencing the image name during an image deployment will thus cause inconsistencies in the OS Image type that is deployed. Since images have unique IDs, listing images by ID and subsequently defining them by ID in salt cloud profiles is more reliable.
