### PR TITLE
fix syntax error in writing grains code snippet

### DIFF
--- a/doc/topics/targeting/grains.rst
+++ b/doc/topics/targeting/grains.rst
@@ -178,7 +178,7 @@ approach would be code something similar to the following:
 .. code-block:: python
 
    #!/usr/bin/env python
-   def yourfunction()
+   def yourfunction():
         # initialize a grains dictionary
         grains = {}
         # Some code for logic that sets grains like


### PR DESCRIPTION
A small fix in the python code snippet. For me that isn't deeply familiar with Python it was a pitfall.
