### PR TITLE
Add example for iptables policy

### DIFF
--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -178,6 +178,11 @@ at some point be deprecated in favor of a more generic `firewall` state.
         - sport: 1025:65535
         - save: True
 
+    default to accept:
+      iptables.set_policy:
+        - chain: INPUT
+        - policy: ACCEPT
+
 .. note::
 
     Various functions of the ``iptables`` module use the ``--check`` option. If
@@ -539,6 +544,9 @@ def set_policy(name, family='ipv4', **kwargs):
 
     family
         Networking family, either ipv4 or ipv6
+
+    policy
+        The requested table policy
 
     '''
     ret = {'name': name,


### PR DESCRIPTION
Add a missing example of iptables.set_policy. Also mention the `policy`
parameter explicitly in the documentation since there is no long option
equivalent in the iptables man page.
