### PR TITLE
fire an event on reactor startup

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -677,7 +677,9 @@ class Reactor(multiprocessing.Process, salt.state.Compiler):
         '''
         salt.utils.appendproctitle(self.__class__.__name__)
         self.event = SaltEvent('master', self.opts['sock_dir'])
-        for data in self.event.iter_events(full=True):
+        events = self.event.iter_events(full=True)
+        self.event.fire_event({}, 'salt/reactor/start')
+        for data in events:
             reactors = self.list_reactors(data['tag'])
             if not reactors:
                 continue


### PR DESCRIPTION
This pull request makes it possible to spin off a (potentially long running) runner at master startup. Essentially, a pluggable way to create custom processes.
