### PR TITLE
Fix to allow for module.run to fail state execution

### DIFF
--- a/salt/states/module.py
+++ b/salt/states/module.py
@@ -211,8 +211,12 @@ def run(name, **kwargs):
     ret['comment'] = 'Module function {0} executed'.format(name)
 
     ret['result'] = True
-    if ret['changes'].get('retcode', 0) != 0:
+    # if mret is a dict and there is retcode and its non-zero
+    if isinstance(mret, dict) and mret.get('retcode', 0) != 0:
         ret['result'] = False
+    # if its a boolean, return that as the result
+    elif isinstance(mret, bool):
+        ret['result'] = mret
     else:
         changes_ret = ret['changes'].get('ret', {})
         if isinstance(changes_ret, dict) and changes_ret.get('retcode', 0) != 0:


### PR DESCRIPTION
There was code to check retcode-- but it was done improperly so it would never cause a failure. Also, it seems reasonable that if the return is a boolean we should use that as the result
