### PR TITLE
Add support ppp in debian_ip.py

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -397,7 +397,7 @@ DEBIAN_ATTR_TO_SALT_ATTR_MAP = dict(
 DEBIAN_ATTR_TO_SALT_ATTR_MAP['address'] = 'address'
 DEBIAN_ATTR_TO_SALT_ATTR_MAP['hwaddress'] = 'hwaddress'
 
-IPV4_VALID_PROTO = ['bootp', 'dhcp', 'static', 'manual', 'loopback']
+IPV4_VALID_PROTO = ['bootp', 'dhcp', 'static', 'manual', 'loopback', 'ppp']
 
 IPV4_ATTR_MAP = {
     'proto': __within(IPV4_VALID_PROTO, dtype=str),


### PR DESCRIPTION
Hello! You lost support ppp in debian_ip.py. I added this. If i start "salt-call (v 2014.7)", i see error:
## local: 

```
      ID: network-dsl-provider
Function: network.managed
    Name: dsl-provider
  Result: False
 Comment: 'dsl-provider'
 Started: 16:49:14.396052
Duration: 2823.714 ms
 Changes:   
```
## Summary

Succeeded: 1
Failed:    1

I see all code and not can find error. You can help for me with this error?
