### PR TITLE
default run as root user because ``erlexec`` need HOME env to be set

### DIFF
--- a/salt/states/rabbitmq_cluster.py
+++ b/salt/states/rabbitmq_cluster.py
@@ -29,7 +29,7 @@ def __virtual__():
     return salt.utils.which('rabbitmqctl') is not None
 
 
-def join(name, host, user='rabbit', runas=None):
+def join(name, host, user='rabbit', runas='root'):
     '''
     Ensure the RabbitMQ plugin is enabled.
 

--- a/salt/states/rabbitmq_plugin.py
+++ b/salt/states/rabbitmq_plugin.py
@@ -29,7 +29,7 @@ def __virtual__():
     return False
 
 
-def enabled(name, runas=None):
+def enabled(name, runas='root'):
     '''
     Ensure the RabbitMQ plugin is enabled.
 
@@ -62,7 +62,7 @@ def enabled(name, runas=None):
     return ret
 
 
-def disabled(name, runas=None):
+def disabled(name, runas='root'):
     '''
     Ensure the RabbitMQ plugin is enabled.
 

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -37,7 +37,7 @@ def present(name,
             definition,
             priority=0,
             vhost='/',
-            runas=None):
+            runas='root'):
     '''
     Ensure the RabbitMQ policy exists.
 
@@ -108,7 +108,7 @@ def present(name,
 
 def absent(name,
            vhost='/',
-           runas=None):
+           runas='root'):
     '''
     Ensure the named policy is absent
 

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -41,7 +41,7 @@ def present(name,
             force=False,
             tags=None,
             perms=(),
-            runas=None):
+            runas='root'):
     '''
     Ensure the RabbitMQ user exists.
 
@@ -140,7 +140,7 @@ def present(name,
 
 
 def absent(name,
-           runas=None):
+           runas='root'):
     '''
     Ensure the named user is absent
 

--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -33,11 +33,11 @@ def __virtual__():
 
 def present(name,
             user=None,
-            owner=None,
+            owner='root',
             conf=None,
             write=None,
             read=None,
-            runas=None):
+            runas='root'):
     '''
     Ensure the RabbitMQ VHost exists.
 
@@ -146,7 +146,7 @@ def present(name,
 
 
 def absent(name,
-           runas=None):
+           runas='root'):
     '''
     Ensure the RabbitMQ Virtual Host is absent
 


### PR DESCRIPTION
with salt2014.1.10, we got this problem:

```
Nov  3 07:16:06 rmq-1 salt-minion[9209] salt.loaded.int.module.cmdmod: Command '/usr/sbin/rabbitmq-plugins list -m -e' failed with return code: 1
Nov  3 07:16:06 rmq-1 salt-minion[9209] salt.loaded.int.module.cmdmod: output: erlexec: HOME must be set
Nov  3 07:16:06 rmq-1 salt-minion[9209] salt.loaded.int.module.cmdmod: Command '/usr/sbin/rabbitmq-plugins enable rabbitmq_management' failed with return code: 1
Nov  3 07:16:06 rmq-1 salt-minion[9209] salt.loaded.int.module.cmdmod: stderr: erlexec: HOME must be set
Nov  3 07:16:06 rmq-1 salt-minion[9209] salt.state: {'pid': 13533, 'retcode': 1, 'stderr': 'erlexec: HOME must be set', 'stdout': ''}

```

It caused by when call /usr/sbin/rabbitmq-plugins, salt module run it with user `root` but not set ENV - which will be set it user specify `runas`, so the state will fail if user does not set runas to an user.

This only happen when call the minion from master , because if run with salt-call (--local) on minion, salt will get env from running bash session.
