### PR TITLE
Homebrew explicitly discourages the use of sudo

### DIFF
--- a/doc/topics/installation/osx.rst
+++ b/doc/topics/installation/osx.rst
@@ -5,18 +5,26 @@ OS X
 Dependency Installation
 -----------------------
 
-When using Homebrew, install this way:
+It should be noted that Homebrew explicitly discourages the `use of sudo`_:
+
+    Homebrew is designed to work without using sudo. You can decide to use it but we strongly recommend not to do so. If you have used sudo and run into a bug then it is likely to be the cause. Please don’t file a bug report unless you can reproduce it after reinstalling Homebrew from scratch without using sudo
+
+So when using Homebrew, if you want support from the Homebrew community, install this way:
 
 .. code-block:: bash
 
     brew install saltstack
+
+.. _use of sudo: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md#sudo
+
+
 
 When using MacPorts, install this way:
 
 .. code-block:: bash
 
     sudo port install salt
-    
+
 When only using the OS X system's pip, install this way:
 
 .. code-block:: bash

--- a/doc/topics/installation/osx.rst
+++ b/doc/topics/installation/osx.rst
@@ -9,7 +9,7 @@ When using Homebrew, install this way:
 
 .. code-block:: bash
 
-    sudo brew install saltstack
+    brew install saltstack
 
 When using MacPorts, install this way:
 


### PR DESCRIPTION
Homebrew [explicitly discourages the use of sudo](https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/FAQ.md#sudo) (emphasis mine):

> Homebrew is designed to work without using sudo. You can decide to use it but we strongly recommend not to do so. If you have used sudo and run into a bug then it is likely to be the cause. Please **don’t file a bug report unless you can reproduce it after reinstalling Homebrew from scratch without using sudo**.

With the current instructions a Homebrew saltstack install will not be supported by the Homebrew community.
