### PR TITLE
Remove old-style event tags.

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -795,11 +795,12 @@ class LocalClient(object):
         '''
         if event is None:
             event = self.event
+        jid_tag = 'salt/job/{0}'.format(jid)
         while True:
             if HAS_ZMQ:
                 try:
                     raw = event.get_event_noblock()
-                    if raw and raw.get('tag', '').startswith(jid):
+                    if raw and raw.get('tag', '').startswith(jid_tag):
                         yield raw
                     else:
                         yield None
@@ -810,7 +811,7 @@ class LocalClient(object):
                         raise
             else:
                 raw = event.get_event_noblock()
-                if raw and raw.get('tag', '').startswith(jid):
+                if raw and raw.get('tag', '').startswith(jid_tag):
                     yield raw
                 else:
                     yield None

--- a/salt/master.py
+++ b/salt/master.py
@@ -1194,7 +1194,6 @@ class AESFuncs(object):
             saveload_fstr = '{0}.save_load'.format(self.opts['master_job_cache'])
             self.mminion.returners[saveload_fstr](load['jid'], load)
         log.info('Got return from {id} for job {jid}'.format(**load))
-        self.event.fire_event(load, load['jid'])  # old dup event
         self.event.fire_event(
             load, tagify([load['jid'], 'ret', load['id']], 'job'))
         self.event.fire_ret_load(load)
@@ -2297,7 +2296,6 @@ class ClearFuncs(object):
             }
 
         # Announce the job on the event bus
-        self.event.fire_event(new_job_load, 'new_job')  # old dup event
         self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new'], 'job'))
 
         if self.opts['ext_job_cache']:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -10,25 +10,15 @@ All of the formatting is self contained in the event module, so
 we should be able to modify the structure in the future since the same module
 used to read events is the same module used to fire off events.
 
-Old style event messages were comprised of two parts delimited
-at the 20 char point. The first 20 characters are used for the zeromq
-subscriber to match publications and 20 characters was chosen because it was at
-the time a few more characters than the length of a jid (Job ID).
-Any tags of length less than 20 characters were padded with "|" chars out to 20 characters.
-Although not explicit, the data for an event comprised a python dict that was serialized by
-msgpack.
-
-New style event messages support event tags longer than 20 characters while still
-being backwards compatible with old style tags.
+Event messages support event tags longer than 20 characters.
 The longer tags better enable name spaced event tags which tend to be longer.
-Moreover, the constraint that the event data be a python dict is now an explicit
+Moreover, the constraint that the event data be a python dict is an explicit
 constraint and fire-event will now raise a ValueError if not. Tags must be
-ascii safe strings, that is, have values less than 0x80
+ascii safe strings, that is, have values less than 0x80.
 
 Since the msgpack dict (map) indicators have values greater than or equal to 0x80
 it can be unambiguously determined if the start of data is at char 21 or not.
 
-In the new style:
 When the tag is longer than 20 characters, an end of tag string
 is appended to the tag given by the string constant TAGEND, that is, two line feeds '\n\n'.
 When the tag is less than 20 characters then the tag is padded with pipes
@@ -36,7 +26,6 @@ When the tag is less than 20 characters then the tag is padded with pipes
 When the tag is exactly 20 characters no padded is done.
 
 The get_event method intelligently figures out if the tag is longer than 20 characters.
-
 
 The convention for namespacing is to use dot characters "." as the name space delimiter.
 The name space "salt" is reserved by SaltStack for internal events.
@@ -250,11 +239,7 @@ class SaltEvent(object):
         if serial is None:
             serial = salt.payload.Serial({'serial': 'msgpack'})
 
-        if ord(raw[20]) >= 0x80:  # old style
-            mtag = raw[0:20].rstrip('|')
-            mdata = raw[20:]
-        else:  # new style
-            mtag, sep, mdata = raw.partition(TAGEND)  # split tag from data
+        mtag, sep, mdata = raw.partition(TAGEND)  # split tag from data
 
         data = serial.loads(mdata)
         return mtag, data
@@ -379,8 +364,6 @@ class SaltEvent(object):
         Send a single event into the publisher with payload dict "data" and event
         identifier "tag"
 
-        Supports new style long tags.
-        The 0MQ push timeout on the send is set to timeout in milliseconds
         The default is 1000 ms
         Note the linger timeout must be at least as long as this timeout
         '''
@@ -395,11 +378,7 @@ class SaltEvent(object):
 
         data['_stamp'] = datetime.datetime.now().isoformat()
 
-        tagend = ''
-        if len(tag) <= 20:  # old style compatible tag
-            tag = '{0:|<20}'.format(tag)  # pad with pipes '|' to 20 character length
-        else:  # new style longer than 20 chars
-            tagend = TAGEND
+        tagend = TAGEND
         serialized_data = salt.utils.trim_dict(self.serial.dumps(data),
                 self.opts.get('max_event_size', 1048576),
                 is_msgpacked=True


### PR DESCRIPTION
This will drop the load on the event bus by ~40% or so.

Approved by @thatch45 for the Lithium release.

Closes #13368
