### PR TITLE
Ext processes

### DIFF
--- a/doc/topics/ext_processes/index.rst
+++ b/doc/topics/ext_processes/index.rst
@@ -1,0 +1,59 @@
+.. _ext_processes:
+
+===============================
+Running Custom Master Processes
+===============================
+
+In addition to the processes that the Salt Master automatically spawns,
+it is possible to configure it to start additional custom processes.
+
+This is useful if a dedicated process is needed that should run throughout
+the life of the Salt Master. For periodic independent tasks, a
+:doc:`scheduled runner <../jobs/schedule.rst>` may be more appropriate.
+
+Processes started in this way will be restarted if they die and will be
+killed when the Salt Master is shut down.
+
+
+Example Configureation
+======================
+
+Processes are declared in the master config file with the `ext_processes`
+option. Processes will be started in the order they are declared.
+
+.. code-block:: yaml
+
+    ext_processes:
+      - mymodule.TestProcess
+      - mymodule.AnotherProcess
+
+
+Example Process Class
+=====================
+
+.. code-block:: python
+
+    # Import python libs
+    import time
+    import logging
+    from multiprocessing import Process
+    
+    # Import Salt libs
+    from salt.utils.event import SaltEvent
+    
+    
+    log = logging.getLogger(__name__)
+    
+    
+    class TestProcess(Process):
+        def __init__(self, opts):
+            Process.__init__(self)
+            self.opts = opts
+    
+        def run(self):
+            self.event = SaltEvent('master', self.opts['sock_dir'])
+            i = 0
+
+            while True:
+                self.event.fire_event({'iteration': i}, 'ext_processes/test{0}')
+                time.sleep(60)

--- a/salt/master.py
+++ b/salt/master.py
@@ -48,7 +48,6 @@ from salt.utils.event import tagify
 import binascii
 from salt.utils.master import ConnectedCache
 from salt.utils.cache import CacheCli
-import salt.monitoring
 
 # Import halite libs
 try:


### PR DESCRIPTION
This pull request allows the addition of custom processes to the master's process manager. The `ext_processes` master config option takes a list of subclasses of multiprocess.Process. The Process subclasses must accept one arg in `__init__` (opts).

``` yaml
ext_processes:
  - mymodule.submodule.SomeProcess
```
