### PR TITLE
Enable pillar/compound matching in mine/publish, with no pillar globbing support

### DIFF
--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -488,9 +488,6 @@ class RemoteFuncs(object):
         '''
         Gathers the data from the specified minions' mine
         '''
-        # Don't allow matching by pillar or compound
-        if load.get('expr_form', 'glob').lower() in ('pillar', 'compound'):
-            return {}
         if not skip_verify:
             if any(key not in load for key in ('id', 'tgt', 'fun')):
                 return {}
@@ -508,10 +505,15 @@ class RemoteFuncs(object):
         ret = {}
         if not salt.utils.verify.valid_id(self.opts, load['id']):
             return ret
+        match_type = load.get('expr_form', 'glob')
+        if match_type.lower() == 'pillar':
+            match_type = 'pillar_exact'
+        if match_type.lower() == 'compound':
+            match_type = 'compound_pillar_exact'
         checker = salt.utils.minions.CkMinions(self.opts)
         minions = checker.check_minions(
                 load['tgt'],
-                load.get('expr_form', 'glob'),
+                match_type,
                 greedy=False
                 )
         for minion in minions:

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -415,7 +415,7 @@ class RemoteFuncs(object):
         tgt_type = load.get('tgt_type', 'glob')
         if tgt_type.lower() == 'pillar':
             tgt_type = 'pillar_exact'
-        elif tgt_typ.lower() == 'compound':
+        elif tgt_type.lower() == 'compound':
             tgt_type = 'compound_pillar_exact'
         good = self.ckminions.auth_check(
                 perms,

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -412,16 +412,12 @@ class RemoteFuncs(object):
             for arg in load['arg']:
                 arg_.append(arg.split())
             load['arg'] = arg_
-        tgt_type = load.get('tgt_type', 'glob')
-        if tgt_type.lower() == 'pillar':
-            tgt_type = 'pillar_exact'
-        elif tgt_type.lower() == 'compound':
-            tgt_type = 'compound_pillar_exact'
         good = self.ckminions.auth_check(
                 perms,
                 load['fun'],
                 load['tgt'],
-                tgt_type)
+                load.get('tgt_type', 'glob'),
+                publish_validate=True)
         if not good:
             return False
         return True

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -398,9 +398,6 @@ class RemoteFuncs(object):
         # If the command will make a recursive publish don't run
         if re.match('publish.*', load['fun']):
             return False
-        # Don't allow pillar or compound matching
-        if load.get('tgt_type', 'glob').lower() in ('pillar', 'compound'):
-            return False
         # Check the permissions for this minion
         perms = []
         for match in self.opts['peer']:
@@ -415,11 +412,16 @@ class RemoteFuncs(object):
             for arg in load['arg']:
                 arg_.append(arg.split())
             load['arg'] = arg_
+        tgt_type = load.get('tgt_type', 'glob')
+        if tgt_type.lower() == 'pillar':
+            tgt_type = 'pillar_exact'
+        elif tgt_typ.lower() == 'compound':
+            tgt_type = 'compound_pillar_exact'
         good = self.ckminions.auth_check(
                 perms,
                 load['fun'],
                 load['tgt'],
-                load.get('tgt_type', 'glob'))
+                tgt_type)
         if not good:
             return False
         return True

--- a/salt/master.py
+++ b/salt/master.py
@@ -854,7 +854,8 @@ class AESFuncs(object):
             perms,
             clear_load['fun'],
             clear_load['tgt'],
-            clear_load.get('tgt_type', 'glob'))
+            clear_load.get('tgt_type', 'glob'),
+            publish_validate=True)
 
     def __verify_load(self, load, verify_keys):
         '''

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2428,6 +2428,20 @@ class Matcher(object):
             return False
         return salt.utils.subdict_match(self.opts['pillar'], tgt, delim=delim)
 
+    def pillar_exact_match(self, tgt, delim=':'):
+        '''
+        Reads in the pillar match, no globbing
+        '''
+        log.debug('pillar target: {0}'.format(tgt))
+        if delim not in tgt:
+            log.error('Got insufficient arguments for pillar match '
+                      'statement from master')
+            return False
+        return salt.utils.subdict_match(self.opts['pillar'],
+                                        tgt,
+                                        delim=delim,
+                                        exact_match=True)
+
     def ipcidr_match(self, tgt):
         '''
         Matches based on ip address or CIDR notation

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -173,6 +173,11 @@ def get(tgt, fun, expr_form='glob'):
         pcre
         grain
         grain_pcre
+        compound
+        pillar
+
+    Note that all pillar matches, whether using the compound matching system or
+    the pillar matching system, will be exact matches, with globbing disabled.
 
     CLI Example:
 
@@ -182,9 +187,6 @@ def get(tgt, fun, expr_form='glob'):
         salt '*' mine.get 'os:Fedora' network.interfaces grain
         salt '*' mine.get 'os:Fedora and S@192.168.5.0/24' network.ipaddrs compound
     '''
-    if expr_form.lower() in ('pillar', 'compound'):
-        log.error('Pillar/compound matching not supported on mine.get')
-        return ''
     if __opts__['file_client'] == 'local':
         ret = {}
         is_target = {'glob': __salt__['match.glob'],
@@ -193,6 +195,8 @@ def get(tgt, fun, expr_form='glob'):
                      'grain': __salt__['match.grain'],
                      'grain_pcre': __salt__['match.grain_pcre'],
                      'ipcidr': __salt__['match.ipcidr'],
+                     'compound': __salt__['match.compound'],
+                     'pillar': __salt__['match.pillar'],
                      }[expr_form](tgt)
         if is_target:
             data = __salt__['data.getval']('mine_cache')

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -143,6 +143,9 @@ def publish(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
     - range
     - compound
 
+    Note that for pillar matches must be exact, both in the pillar matcher
+    and the compound matcher. No globbing is supported.
+
     The arguments sent to the minion publish function are separated with
     commas. This means that for a minion executing a command with multiple
     args it will look like this:

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -54,9 +54,6 @@ def _publish(
     if fun == 'publish.publish':
         log.info('Function name is \'publish.publish\'. Returning {}')
         return {}
-    if expr_form.lower() in ('pillar', 'compound'):
-        log.error('Pillar/compound matching disabled for published commands.')
-        return {}
 
     arg = [salt.utils.args.yamlify_arg(arg)]
     if len(arg) == 1 and arg[0] is None:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1153,7 +1153,7 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     return ret
 
 
-def subdict_match(data, expr, delim=':', regex_match=False):
+def subdict_match(data, expr, delim=':', regex_match=False, exact_match=False):
     '''
     Check for a match in a dictionary using a delimiter character to denote
     levels of subdicts, and also allowing the delimiter character to be
@@ -1161,13 +1161,15 @@ def subdict_match(data, expr, delim=':', regex_match=False):
     data['foo']['bar'] == 'baz'. The former would take priority over the
     latter.
     '''
-    def _match(target, pattern, regex_match=False):
+    def _match(target, pattern, regex_match=False, exact_match=False):
         if regex_match:
             try:
                 return re.match(pattern.lower(), str(target).lower())
             except Exception:
                 log.error('Invalid regex {0!r} in match'.format(pattern))
                 return False
+        elif exact_match:
+            return str(target).lower() == pattern.lower()
         else:
             return fnmatch.fnmatch(str(target).lower(), pattern.lower())
 
@@ -1191,12 +1193,21 @@ def subdict_match(data, expr, delim=':', regex_match=False):
                 if isinstance(member, dict):
                     if matchstr.startswith('*:'):
                         matchstr = matchstr[2:]
-                    if subdict_match(member, matchstr, regex_match=regex_match):
+                    if subdict_match(member,
+                                     matchstr,
+                                     regex_match=regex_match,
+                                     exact_match=exact_match):
                         return True
-                if _match(member, matchstr, regex_match=regex_match):
+                if _match(member,
+                          matchstr,
+                          regex_match=regex_match,
+                          exact_match=exact_match):
                     return True
             continue
-        if _match(match, matchstr, regex_match=regex_match):
+        if _match(match,
+                  matchstr,
+                  regex_match=regex_match,
+                  exact_match=exact_match):
             return True
     return False
 

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -327,7 +327,7 @@ class CkMinions(object):
 
         Disable pillar glob matching
         '''
-        return _check_compound_minions(self, expr, greedy, pillar_exact=True)
+        return self._check_compound_minions(self, expr, greedy, pillar_exact=True)
 
     def _check_compound_minions(self, expr, greedy, pillar_exact=False):  # pylint: disable=unused-argument
         '''

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -327,7 +327,7 @@ class CkMinions(object):
 
         Disable pillar glob matching
         '''
-        return self._check_compound_minions(self, expr, greedy, pillar_exact=True)
+        return self._check_compound_minions(expr, greedy, pillar_exact=True)
 
     def _check_compound_minions(self, expr, greedy, pillar_exact=False):  # pylint: disable=unused-argument
         '''


### PR DESCRIPTION
STATUS: Merge away! (Assuming tests pass, of course)

I have manually tested both mine and publish for compound/pillar matching and it's working now, and successfully preventing pillar globbing.

This should be reviewed carefully. With this patch, pillar and compound matching will work for both mine and publish functions. However, pillar matches will use exact matching, globbing is disabled. This is primarily accomplished with the changes to `subdict_match` in `salt.utils.minions.CkMinions`. I also added two new match types, `pillar_exact` and `compound_pillar_exact`, and ensure that those matches are used instead of `pillar` and `compound` respectively for all publish and mine queries.
