### PR TITLE
UTF8 fix in highstate output

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -197,6 +197,13 @@ def _format_host(host, data):
             if comps[1] != comps[2]:
                 state_lines.insert(
                     3, u'    {tcolor}    Name: {comps[2]}{colors[ENDC]}')
+            # be sure that ret['comment'] is utf-8 friendly
+            try:
+                if not isinstance(ret['comment'], unicode):
+                    ret['comment'] = ret['comment'].decode('utf-8')
+            except UnicodeDecodeError:
+                # but try to continue on errors
+                pass
             try:
                 comment = ret['comment'].strip().replace(
                     u'\n',


### PR DESCRIPTION
If some states have bad comments, this can lead without the fix to : 

```
        Traceback (most recent call last):
          File "/srv/salt/makina-states/mc_states/modules/mc_project_2.py", line 1520, in guarded_step
            step, cfg['api_version'])](name, *args, **kwargs)
          File "/srv/salt/makina-states/mc_states/modules/mc_project_2.py", line 1781, in install
            cret = _step_exec(cfg, sls)
          File "/srv/salt/makina-states/mc_states/modules/mc_project_2.py", line 319, in _step_exec
            cret = _sls_exec(name, cfg, sls)
          File "/srv/salt/makina-states/mc_states/modules/mc_project_2.py", line 246, in _sls_exec
            ret['raw_comment'] += indent(_raw_hs(copy.deepcopy(cret)))
          File "/srv/salt/makina-states/mc_states/modules/mc_project_2.py", line 167, in _raw_hs
            return _hs(mapping, raw=True)
          File "/srv/salt/makina-states/mc_states/modules/mc_project_2.py", line 161, in _hs
            ret = _outputters('highstate')({'local': mapping})
          File "/srv/salt/makina-states/src/salt/salt/output/highstate.py", line 74, in output
            return _format_host(host, hostdata)[0]
          File "/srv/salt/makina-states/src/salt/salt/output/highstate.py", line 203, in _format_host
            u'\n' + u' ' * 14)
        UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 139621: ordinal not in range(128)

```
