### PR TITLE
remove runas in rabbitmq

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -49,8 +49,8 @@ def _get_rabbitmq_plugin():
     if rabbitmq is None:
         version = __salt__['pkg.version']('rabbitmq-server').split('-')[0]
 
-        path = '/usr/lib/rabbitmq/lib/rabbitmq_server-{0}/sbin/rabbitmq-plugins'
-        rabbitmq = path.format(version)
+        rabbitmq = ('/usr/lib/rabbitmq/lib/rabbitmq_server-{0}'
+                    '/sbin/rabbitmq-plugins').format(version)
 
     return rabbitmq
 
@@ -268,8 +268,7 @@ def delete_vhost(vhost, runas=None):
     return _format_response(res, msg)
 
 
-def set_permissions(vhost, user, conf='.*', write='.*', read='.*',
-        runas=None):
+def set_permissions(vhost, user, conf='.*', write='.*', read='.*', runas=None):
     '''
     Sets permissions for vhost via rabbitmqctl set_permissions
 
@@ -513,7 +512,10 @@ def list_queues_vhost(vhost, runas=None, *kwargs):
     if runas is None:
         runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
-        'rabbitmqctl list_queues -p {0} {1}'.format(vhost, ' '.join(list(kwargs))),
+        'rabbitmqctl list_queues -p {0} {1}'.format(
+            vhost,
+            ' '.join(list(kwargs))
+            ),
         runas=runas,
         )
     return res

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -66,6 +66,8 @@ def list_users(runas=None):
         salt '*' rabbitmq.list_users
     '''
     ret = {}
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl list_users',
                               runas=runas)
     for line in res.splitlines():
@@ -88,6 +90,8 @@ def list_vhosts(runas=None):
 
         salt '*' rabbitmq.list_vhosts
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl list_vhosts',
                               runas=runas)
     lines = res.splitlines()
@@ -105,6 +109,8 @@ def user_exists(name, runas=None):
 
         salt '*' rabbitmq.user_exists rabbit_user
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     user_list = list_users(runas=runas)
     log.debug(user_list)
 
@@ -121,6 +127,8 @@ def vhost_exists(name, runas=None):
 
         salt '*' rabbitmq.vhost_exists rabbit_host
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     return name in list_vhosts(runas=runas)
 
 
@@ -142,6 +150,8 @@ def add_user(name, password=None, runas=None):
         password = ''.join(random.SystemRandom().choice(
             string.ascii_uppercase + string.digits) for x in range(15))
 
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl add_user {0} {1!r}'.format(name, password),
         output_loglevel='quiet',
@@ -172,6 +182,8 @@ def delete_user(name, runas=None):
 
         salt '*' rabbitmq.delete_user rabbit_user
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl delete_user {0}'.format(name),
                               runas=runas)
     msg = 'Deleted'
@@ -189,6 +201,8 @@ def change_password(name, password, runas=None):
 
         salt '*' rabbitmq.change_password rabbit_user password
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl change_password {0} {1!r}'.format(name, password),
         output_loglevel='quiet',
@@ -208,6 +222,8 @@ def clear_password(name, runas=None):
 
         salt '*' rabbitmq.clear_password rabbit_user
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl clear_password {0}'.format(name),
                               runas=runas)
     msg = 'Password Cleared'
@@ -225,6 +241,8 @@ def add_vhost(vhost, runas=None):
 
         salt '*' rabbitmq add_vhost '<vhost_name>'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl add_vhost {0}'.format(vhost),
                               runas=runas)
 
@@ -242,6 +260,8 @@ def delete_vhost(vhost, runas=None):
 
         salt '*' rabbitmq.delete_vhost '<vhost_name>'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl delete_vhost {0}'.format(vhost),
                               runas=runas)
     msg = 'Deleted'
@@ -259,6 +279,8 @@ def set_permissions(vhost, user, conf='.*', write='.*', read='.*',
 
         salt '*' rabbitmq.set_permissions 'myvhost' 'myuser'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl set_permissions -p {0} {1} "{2}" "{3}" "{4}"'.format(
             vhost, user, conf, write, read),
@@ -277,6 +299,8 @@ def list_permissions(vhost, runas=None):
 
         salt '*' rabbitmq.list_permissions '/myvhost'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl list_permissions -p {0}'.format(vhost),
         runas=runas)
@@ -293,6 +317,8 @@ def list_user_permissions(name, user=None):
 
         salt '*' rabbitmq.list_user_permissions 'user'.
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl list_user_permissions {0}'.format(name),
         runas=user)
@@ -308,6 +334,8 @@ def set_user_tags(name, tags, runas=None):
 
         salt '*' rabbitmq.set_user_tags 'myadmin' 'administrator'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl set_user_tags {0} {1}'.format(name, tags),
         runas=runas)
@@ -315,7 +343,7 @@ def set_user_tags(name, tags, runas=None):
     return _format_response(res, msg)
 
 
-def status(user=None):
+def status(runas=None):
     '''
     return rabbitmq status
 
@@ -325,9 +353,11 @@ def status(user=None):
 
         salt '*' rabbitmq.status
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl status',
-        runas=user
+        runas=runas
     )
     return res
 
@@ -342,9 +372,11 @@ def cluster_status(user=None):
 
         salt '*' rabbitmq.cluster_status
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl cluster_status',
-        runas=user)
+        runas=runas)
 
     return res
 
@@ -359,7 +391,8 @@ def join_cluster(host, user='rabbit', runas=None):
 
         salt '*' rabbitmq.join_cluster 'rabbit' 'rabbit.example.com'
     '''
-
+    if runas is None:
+        runas = salt.utils.get_user()
     stop_app(runas)
     res = __salt__['cmd.run'](
         'rabbitmqctl join_cluster {0}@{1}'.format(user, host),
@@ -379,6 +412,8 @@ def stop_app(runas=None):
 
         salt '*' rabbitmq.stop_app
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl stop_app',
         runas=runas)
@@ -396,6 +431,8 @@ def start_app(runas=None):
 
         salt '*' rabbitmq.start_app
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl start_app',
         runas=runas)
@@ -413,6 +450,8 @@ def reset(runas=None):
 
         salt '*' rabbitmq.reset
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl reset',
         runas=runas)
@@ -430,6 +469,8 @@ def force_reset(runas=None):
 
         salt '*' rabbitmq.force_reset
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl force_reset',
         runas=runas)
@@ -484,6 +525,8 @@ def list_policies(runas=None):
         salt '*' rabbitmq.list_policies'
     '''
     ret = {}
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run']('rabbitmqctl list_policies',
                               runas=runas)
     for line in res.splitlines():
@@ -516,6 +559,8 @@ def set_policy(vhost, name, pattern, definition, priority=None, runas=None):
 
         salt '*' rabbitmq.set_policy / HA '.*' '{"ha-mode": "all"}'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         "rabbitmqctl set_policy -p {0}{1}{2} {3} '{4}' '{5}'".format(
             vhost,
@@ -541,6 +586,8 @@ def delete_policy(vhost, name, runas=None):
 
         salt '*' rabbitmq.delete_policy / HA'
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl clear_policy -p {0} {1}'.format(
             vhost, name),
@@ -561,6 +608,8 @@ def policy_exists(vhost, name, runas=None):
 
         salt '*' rabbitmq.policy_exists / HA
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     policies = list_policies(runas=runas)
     return bool(vhost in policies and name in policies[vhost])
 
@@ -577,6 +626,8 @@ def plugin_is_enabled(name, runas=None):
     '''
     rabbitmq = _get_rabbitmq_plugin()
     cmd = '{0} list -m -e'.format(rabbitmq)
+    if runas is None:
+        runas = salt.utils.get_user()
     ret = __salt__['cmd.run'](cmd, runas=runas)
     return bool(name in ret)
 
@@ -594,6 +645,8 @@ def enable_plugin(name, runas=None):
     rabbitmq = _get_rabbitmq_plugin()
     cmd = '{0} enable {1}'.format(rabbitmq, name)
 
+    if runas is None:
+        runas = salt.utils.get_user()
     ret = __salt__['cmd.run_all'](cmd, runas=runas)
 
     return _format_response(ret, 'Enabled')
@@ -613,6 +666,8 @@ def disable_plugin(name, runas=None):
     rabbitmq = _get_rabbitmq_plugin()
     cmd = '{0} disable {1}'.format(rabbitmq, name)
 
+    if runas is None:
+        runas = salt.utils.get_user()
     ret = __salt__['cmd.run_all'](cmd, runas=runas)
 
     return _format_response(ret, 'Disabled')

--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -307,7 +307,7 @@ def list_permissions(vhost, runas=None):
     return [r.split('\t') for r in res.splitlines()]
 
 
-def list_user_permissions(name, user=None):
+def list_user_permissions(name, runas=None):
     '''
     List permissions for a user via rabbitmqctl list_user_permissions
 
@@ -321,7 +321,7 @@ def list_user_permissions(name, user=None):
         runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
         'rabbitmqctl list_user_permissions {0}'.format(name),
-        runas=user)
+        runas=runas)
     return [r.split('\t') for r in res.splitlines()]
 
 
@@ -362,7 +362,7 @@ def status(runas=None):
     return res
 
 
-def cluster_status(user=None):
+def cluster_status(runas=None):
     '''
     return rabbitmq cluster_status
 
@@ -478,7 +478,7 @@ def force_reset(runas=None):
     return res
 
 
-def list_queues(*kwargs):
+def list_queues(runas=None, *kwargs):
     '''
     Returns queue details of the / virtual host
 
@@ -488,12 +488,16 @@ def list_queues(*kwargs):
 
         salt '*' rabbitmq.list_queues messages consumers
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
-        'rabbitmqctl list_queues {0}'.format(' '.join(list(kwargs))))
+        'rabbitmqctl list_queues {0}'.format(' '.join(list(kwargs))),
+        runas=runas,
+        )
     return res
 
 
-def list_queues_vhost(vhost, *kwargs):
+def list_queues_vhost(vhost, runas=None, *kwargs):
     '''
     Returns queue details of specified virtual host. This command will consider
     first parameter as the vhost name and rest will be treated as
@@ -506,8 +510,12 @@ def list_queues_vhost(vhost, *kwargs):
 
         salt '*' rabbitmq.list_queues messages consumers
     '''
+    if runas is None:
+        runas = salt.utils.get_user()
     res = __salt__['cmd.run'](
-        'rabbitmqctl list_queues -p {0} {1}'.format(vhost, ' '.join(list(kwargs))))
+        'rabbitmqctl list_queues -p {0} {1}'.format(vhost, ' '.join(list(kwargs))),
+        runas=runas,
+        )
     return res
 
 

--- a/salt/states/rabbitmq_cluster.py
+++ b/salt/states/rabbitmq_cluster.py
@@ -29,7 +29,7 @@ def __virtual__():
     return salt.utils.which('rabbitmqctl') is not None
 
 
-def join(name, host, user='rabbit', runas='root'):
+def join(name, host, user='rabbit', runas=None):
     '''
     Ensure the RabbitMQ plugin is enabled.
 

--- a/salt/states/rabbitmq_plugin.py
+++ b/salt/states/rabbitmq_plugin.py
@@ -29,7 +29,7 @@ def __virtual__():
     return False
 
 
-def enabled(name, runas='root'):
+def enabled(name, runas=None):
     '''
     Ensure the RabbitMQ plugin is enabled.
 
@@ -62,7 +62,7 @@ def enabled(name, runas='root'):
     return ret
 
 
-def disabled(name, runas='root'):
+def disabled(name, runas=None):
     '''
     Ensure the RabbitMQ plugin is enabled.
 

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -37,7 +37,7 @@ def present(name,
             definition,
             priority=0,
             vhost='/',
-            runas='root'):
+            runas=None):
     '''
     Ensure the RabbitMQ policy exists.
 
@@ -108,7 +108,7 @@ def present(name,
 
 def absent(name,
            vhost='/',
-           runas='root'):
+           runas=None):
     '''
     Ensure the named policy is absent
 

--- a/salt/states/rabbitmq_user.py
+++ b/salt/states/rabbitmq_user.py
@@ -41,7 +41,7 @@ def present(name,
             force=False,
             tags=None,
             perms=(),
-            runas='root'):
+            runas=None):
     '''
     Ensure the RabbitMQ user exists.
 
@@ -140,7 +140,7 @@ def present(name,
 
 
 def absent(name,
-           runas='root'):
+           runas=None):
     '''
     Ensure the named user is absent
 

--- a/salt/states/rabbitmq_vhost.py
+++ b/salt/states/rabbitmq_vhost.py
@@ -33,11 +33,11 @@ def __virtual__():
 
 def present(name,
             user=None,
-            owner='root',
+            owner=None,
             conf=None,
             write=None,
             read=None,
-            runas='root'):
+            runas=None):
     '''
     Ensure the RabbitMQ VHost exists.
 
@@ -146,7 +146,7 @@ def present(name,
 
 
 def absent(name,
-           runas='root'):
+           runas=None):
     '''
     Ensure the RabbitMQ Virtual Host is absent
 


### PR DESCRIPTION
for https://github.com/saltstack/salt/pull/17226

this does not remove runas parameter to be backward compatible and allow user to specify who to run rabbitmq cmd (in case he has a complex setup to allow doing that with another user than root/rabbitmq).
Just set the default user to a sane value as @thatch45 suggested.
