### PR TITLE
BTRFS module

### DIFF
--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -168,7 +168,7 @@ def defragment(path):
     return result
 
 
-def mkfs_features():
+def features():
     '''
     List currently available BTRFS features.
 

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -30,6 +30,7 @@ import fsutils
 
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     '''
     Only work on POSIX-like systems
@@ -206,7 +207,7 @@ def _usage_specific(raw):
     '''
     Parse usage/specific.
     '''
-    get_key = lambda val: dict([tuple(val.split(":")),])
+    get_key = lambda val: dict([tuple(val.split(":")), ])
     raw = raw.split("\n")
     section, size, used = raw[0].split(" ")
     section = section.replace(",", "_").replace(":", "").lower()

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -463,7 +463,7 @@ documentation regarding this topic.
     devices = fsutils._blkid_output(out['stdout'])
 
     ret['after'] = {
-        'fsck_status': "N/A", # ToDO
+        'fsck_status': "N/A",  # ToDO
         'mount_point': mountpoint,
         'type': devices[device]["type"],
     }

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -92,3 +92,19 @@ def info(device):
         raise CommandExecutionError(out['stderr'].replace("xfs_info:", "").strip())
     return _parse_btrfs_info(out['stdout'])
 
+
+def devices():
+    '''
+    Get known BTRFS formatted devices on the system.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' btrfs.devices
+    '''
+    out = __salt__['cmd.run_all']("blkid -o export")
+    fsutils._verify_run(out)
+
+    return fsutils._blkid_output(out['stdout'], fs_type='btrfs')
+

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -1,25 +1,18 @@
 # -*- coding: utf-8 -*-
 #
-# The MIT License (MIT)
-# Copyright (C) 2014 SUSE LLC
+# Copyright 2014 SUSE LLC
 #
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to
-# deal in the Software without restriction, including without limitation the
-# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-# sell copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# The above copyright notice and this permission notice shall be included in
-# all copies or substantial portions of the Software.
+# http://www.apache.org/licenses/LICENSE-2.0
 #
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
-# IN THE SOFTWARE.
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 '''
 Module for managing BTRFS file systems.

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -166,3 +166,25 @@ def defragment(path):
         result.append(d_res)
 
     return result
+
+
+def mkfs_features():
+    '''
+    List currently available BTRFS features.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' btrfs.mkfs_features    
+    '''
+    out = __salt__['cmd.run_all']("mkfs.btrfs -O list-all")
+    fsutils._verify_run(out)
+
+    ret = {}
+    for line in [re.sub(r"\s+", " ", line) for line in out['stderr'].split("\n") if " - " in line]:
+        option, description = line.split(" - ", 1)
+        ret[option] = description
+
+    return ret
+

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -90,8 +90,8 @@ def info(device):
         salt '*' btrfs.info /dev/sda1
     '''
     out = __salt__['cmd.run_all']("btrfs filesystem show {0}".format(device))
-    if out.get('stderr'):
-        raise CommandExecutionError(out['stderr'].replace("xfs_info:", "").strip())
+    fsutils._verify_run(out)
+
     return _parse_btrfs_info(out['stdout'])
 
 

--- a/salt/modules/btrfs.py
+++ b/salt/modules/btrfs.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+#
+# The MIT License (MIT)
+# Copyright (C) 2014 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+'''
+Module for managing BTRFS file systems.
+'''
+
+import os
+import re
+import time
+import logging
+
+import salt.utils
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+def __virtual__():
+    '''
+    Only work on POSIX-like systems
+    '''
+    return not salt.utils.is_windows() and __grains__.get('kernel') == 'Linux'
+
+
+def version():
+    '''
+    Return BTRFS version.
+    '''
+    out = __salt__['cmd.run_all']("btrfs --version")
+    if out.get('stderr'):
+        raise CommandExecutionError(out['stderr'])
+    return {'version': out['stdout'].split(" ", 1)[-1]}
+
+
+def _parse_btrfs_info(data):
+    '''
+    Parse BTRFS device info data.
+    '''
+    info = {}
+    for line in [line for line in data.split("\n") if line][:-1]:
+        if line.startswith("Label:"):
+            line = re.sub(r"Label:\s+", "", line)
+            label, uuid = [tkn.strip() for tkn in line.split("uuid:")]
+            info['label'] = label != 'none' and label or None
+            info['uuid'] = uuid
+            continue
+
+        if line.startswith("\tdevid"):
+            dev_data = re.split(r"\s+", line.strip())
+            dev_id = dev_data[-1]
+            info[dev_id] = {
+                'device_id': dev_data[1],
+                'size': dev_data[3],
+                'used': dev_data[5],
+                }
+
+    return info
+
+
+def info(device):
+    '''
+    Get BTRFS filesystem information.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' btrfs.info /dev/sda1
+    '''
+    out = __salt__['cmd.run_all']("btrfs filesystem show {0}".format(device))
+    if out.get('stderr'):
+        raise CommandExecutionError(out['stderr'].replace("xfs_info:", "").strip())
+    return _parse_btrfs_info(out['stdout'])
+

--- a/salt/modules/fsutils.py
+++ b/salt/modules/fsutils.py
@@ -35,6 +35,7 @@ from salt.exceptions import CommandExecutionError
 
 log = logging.getLogger(__name__)
 
+
 def _verify_run(out, cmd=None):
     '''
     Crash to the log if command execution was not successful.
@@ -62,7 +63,7 @@ def _get_mounts(fs_type):
             mounts[device] = []
 
         mounts[device].append({
-            'mount_point': mntpnt, 
+            'mount_point': mntpnt,
             'options': options.split(",")
         })
 

--- a/salt/modules/fsutils.py
+++ b/salt/modules/fsutils.py
@@ -80,7 +80,9 @@ def _blkid_output(out, fs_type=None):
         for items in flt(dev_meta.strip().split("\n")):
             key, val = items.split("=", 1)
             dev[key.lower()] = val
-        if fs_type and dev.pop("type") == fs_type or not fs_type:
+        if fs_type and dev.get("type", '') == fs_type or not fs_type:
+            if dev.has_key("type"):
+                dev.pop("type")
             dev['label'] = dev.get('label')
             data[dev.pop("devname")] = dev
 

--- a/salt/modules/fsutils.py
+++ b/salt/modules/fsutils.py
@@ -1,0 +1,104 @@
+# -*- coding: utf-8 -*-
+#
+# The MIT License (MIT)
+# Copyright (C) 2014 SUSE LLC
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+'''
+Run-time utilities
+'''
+
+import os
+import re
+import time
+import logging
+
+import salt.utils
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+def _verify_run(out, cmd=None):
+    '''
+    Crash to the log if command execution was not successful.
+    '''
+    if out.get("retcode", 0) and out['stderr']:
+        if cmd:
+            log.debug('Command: "{0}"'.format(cmd))
+
+        log.debug('Return code: {0}'.format(out.get('retcode')))
+        log.debug('Error output:\n{0}'.format(out.get('stderr', "N/A")))
+
+        raise CommandExecutionError(out['stderr'])
+
+
+def _get_mounts(fs_type):
+    '''
+    List mounted filesystems.
+    '''
+    mounts = {}
+    for line in open("/proc/mounts").readlines():
+        device, mntpnt, fstype, options, fs_freq, fs_passno = line.strip().split(" ")
+        if fstype != fs_type:
+            continue
+        if mounts.get(device) is None:
+            mounts[device] = []
+
+        mounts[device].append({
+            'mount_point': mntpnt, 
+            'options': options.split(",")
+        })
+
+    return mounts
+
+
+def _blkid_output(out, fs_type=None):
+    '''
+    Parse blkid output.
+    '''
+    flt = lambda data: [el for el in data if el.strip()]
+    data = {}
+    for dev_meta in flt(out.split("\n\n")):
+        dev = {}
+        for items in flt(dev_meta.strip().split("\n")):
+            key, val = items.split("=", 1)
+            dev[key.lower()] = val
+        if fs_type and dev.pop("type") == fs_type or not fs_type:
+            dev['label'] = dev.get('label')
+            data[dev.pop("devname")] = dev
+
+    if fs_type:
+        mounts = _get_mounts(fs_type)
+        for device in mounts.keys():
+            if data.get(device):
+                data[device]['mounts'] = mounts[device]
+
+    return data
+
+
+def _is_device(path):
+    '''
+    Return True if path is a physical device.
+    '''
+    out = __salt__['cmd.run_all']("file -i {0}".format(path))
+    _verify_run(out)
+
+    # Always [device, mime, charset]. See (file --help)
+    return re.split(r"\s+", out['stdout'])[1][:-1] == "inode/blockdevice"


### PR DESCRIPTION
Hi!
Since BTRFS is a flagship filesystem in **SUSE Linux Enterprise 12** and is offered by default (along with XFS for `/home`, module of which already merged), I would like to introduce BTRFS management module.

_NOTE: The module has some obvious duplication with XFS module, but this is intentionally: once current version of BTRFS module is merged, they will be brought to the common procedures, since they differ and need an additional polishing._

This module allows you to make filesystems, manage RAID arrays, scan, resize, get all required information and even reliably migrate from Ext2/Ext3/Ext4. Some additional features are still coming, but it already does initial not so very bad job and therefore I would like to just "release it early". :-)

Some examples:

```
e212:~ # salt '*' btrfs.info /foo
d122.suse.de:
    ----------
    /dev/sdb1:
        ----------
        device_id:
            1
        size:
            5.00GiB
        used:
            0.00B
    /dev/sdb2:
        ----------
        device_id:
            2
        size:
            4.99GiB
        used:
            1.28GiB
    label:
        None
    uuid:
        2bf3713d-603e-4fc3-a671-ce6b55517642
e212:~ # salt '*' btrfs.delete /foo /dev/sdb2 force=True
d122.suse.de:
    ----------
    /dev/sdb1:
        ----------
        device_id:
            1
        size:
            5.00GiB
        used:
            800.00MiB
    label:
        None
    uuid:
        2bf3713d-603e-4fc3-a671-ce6b55517642
e212:~ # salt '*' btrfs.mkfs /dev/sdb2 label='My Great Storage'
d122.suse.de:
    ----------
    /dev/sdb2:
        ----------
        device_id:
            1
        size:
            4.99GiB
        used:
            546.62MiB
    label:
        'My Great Storage'
    log:
        Btrfs v3.16+20140829
        See http://btrfs.wiki.kernel.org for more information.

        Turning ON incompat feature 'extref': increased hardlink limit per file to 65536
        Turning ON incompat feature 'skinny-metadata': reduced-size metadata extent refs
        fs created label bubamara on /dev/sdb2
           nodesize 16384 leafsize 16384 sectorsize 4096 size 4.99GiB
    uuid:
        067275df-7265-46a6-aed1-2aee720d979f

e212:~ # salt '*' btrfs.add /foo /dev/sdb2 force=True
d122.suse.de:
    ----------
    /dev/sdb1:
        ----------
        device_id:
            1
        size:
            5.00GiB
        used:
            0.00B
    /dev/sdb2:
        ----------
        device_id:
            2
        size:
            4.99GiB
        used:
            1.28GiB
    label:
        None
    log:
        Done, had to relocate 3 out of 3 chunks
    uuid:
        2bf3713d-603e-4fc3-a671-ce6b55517642

e212:~ # salt '*' btrfs.properties /foo set="label='My great storage'"
d122.suse.de:
    None
e212:~ # salt '*' btrfs.properties /foo
d122.suse.de:
    ----------
    compression:
        ----------
        description:
            Set/get compression for a file or directory
        value:
            N/A
    label:
        ----------
        description:
            Set/get label of device.
        value:
            My great storage
    ro:
        ----------
        description:
            Set/get read-only flag of subvolume.
        value:
            false
```
