### PR TITLE
Evented runners

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -211,6 +211,8 @@ def save_load(jid, clear_load):
 
     # Save the invocation information
     try:
+        if not os.path.exists(jid_dir):
+            os.mkdir(jid_dir)
         serial.dump(
             clear_load,
             salt.utils.fopen(os.path.join(jid_dir, LOAD_P), 'w+b')

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -313,11 +313,14 @@ class Runner(RunnerClient):
             if raw is None or (time.time() > timeout_at and time.time() - last_progress_timestamp > timeout):
                 # Timeout reached
                 break
-            if not raw['tag'].split('/')[1] == 'runner':
+            try:
+                if not raw['tag'].split('/')[1] == 'runner':
+                    continue
+                elif raw['tag'].split('/')[3] == 'progress':
+                    last_progress_timestamp = time.time()
+                    yield({'data': raw['data']['data'], 'outputter': raw['data']['outputter']})
+                elif raw['tag'].split('/')[3] == 'return':
+                    yield(raw['data']['return'])
+                    break
+            except IndexError:
                 continue
-            elif raw['tag'].split('/')[3] == 'progress':
-                last_progress_timestamp = time.time()
-                yield({'data': raw['data']['data'], 'outputter': raw['data']['outputter']})
-            elif raw['tag'].split('/')[3] == 'return':
-                yield(raw['data']['return'])
-                break

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -282,6 +282,11 @@ class Runner(RunnerClient):
                 # Run the runner!
                 jid = super(Runner, self).cmd(
                     self.opts['fun'], self.opts['arg'], self.opts)
+                if self.opts.get('async', False):
+                    log.info('Running in async mode. Results of this execution may '
+                             'be collected by attaching to the master event bus or '
+                             'by examing the master job cache, if configured.')
+                    sys.exit(0)
                 # Gather the returns
                 for ret in self.get_runner_returns(jid, timeout=60):  # 60 second timeout
                     if not self.opts.get('quiet', False):

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -284,10 +284,11 @@ class Runner(RunnerClient):
                     self.opts['fun'], self.opts['arg'], self.opts)
                 # Gather the returns
                 for ret in self.get_runner_returns(jid, timeout=60):  # 60 second timeout
-                    if isinstance(ret, dict) and 'outputter' in ret:
-                        print(self.outputters[ret['outputter']](ret['data']))
-                    else:
-                        print(ret)
+                    if not self.opts.get('quiet', False):
+                        if isinstance(ret, dict) and 'outputter' in ret:
+                            print(self.outputters[ret['outputter']](ret['data']))
+                        else:
+                            print(ret)
 
             except salt.exceptions.SaltException as exc:
                 ret = str(exc)
@@ -308,9 +309,13 @@ class Runner(RunnerClient):
 
         while True:
             raw = self.event.get_event(timeout, full=True)
-            # If we saw no events in the event bus timeout OR we have reached the total timeout AND
+            # If we saw no events in the event bus timeout
+            # OR
+            # we have reached the total timeout
+            # AND
             # have not seen any progress events for the length of the timeout.
-            if raw is None or (time.time() > timeout_at and time.time() - last_progress_timestamp > timeout):
+            if raw is None or (time.time() > timeout_at and \
+                    time.time() - last_progress_timestamp > timeout):
                 # Timeout reached
                 break
             try:

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -311,7 +311,6 @@ class Runner(RunnerClient):
         Gather the return data from the event system, break hard when timeout
         is reached.
         '''
-        print('TOP JID: {0}'.format(jid))
         if timeout is None:
             timeout = self.opts['timeout'] * 2
 
@@ -320,7 +319,6 @@ class Runner(RunnerClient):
 
         while True:
             raw = self.event.get_event(timeout, full=True)
-            print(raw['tag'])
             # If we saw no events in the event bus timeout
             # OR
             # we have reached the total timeout

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -284,10 +284,10 @@ class Runner(RunnerClient):
                     self.opts['fun'], self.opts['arg'], self.opts)
                 # Gather the returns
                 for ret in self.get_runner_returns(jid, timeout=60):  # 60 second timeout
-                    if 'outputter' in ret:
+                    if isinstance(ret, dict) and 'outputter' in ret:
                         print(self.outputters[ret['outputter']](ret['data']))
                     else:
-                        print(ret)
+                        print(self.outputters['nested'](ret))
 
             except salt.exceptions.SaltException as exc:
                 ret = str(exc)
@@ -319,5 +319,5 @@ class Runner(RunnerClient):
                 last_progress_timestamp = time.time()
                 yield({'data': raw['data']['data'], 'outputter': raw['data']['outputter']})
             elif raw['tag'].split('/')[3] == 'return':
-                yield('Return: {0}'.format(raw['data']['return']))
+                yield(raw['data']['return'])
                 break

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -305,6 +305,8 @@ class Runner(RunnerClient):
                 ret = str(exc)
                 print(ret)
                 return ret
+            log.debug('Runner return: {0}'.format(ret))
+            return ret
 
     def get_runner_returns(self, jid, timeout=None):
         '''
@@ -319,6 +321,7 @@ class Runner(RunnerClient):
 
         while True:
             raw = self.event.get_event(timeout, full=True)
+            time.sleep(0.1)
             # If we saw no events in the event bus timeout
             # OR
             # we have reached the total timeout
@@ -329,9 +332,6 @@ class Runner(RunnerClient):
                 # Timeout reached
                 break
             try:
-                # Handle a findjob that might have been kicked off under the covers
-                if raw['data']['fun'] == 'saltutil.findjob':
-                    timeout_at = timeout_at + 10
                 if not raw['tag'].split('/')[1] == 'runner' and raw['tag'].split('/')[2] == jid:
                     continue
                 elif raw['tag'].split('/')[3] == 'progress' and raw['tag'].split('/')[2] == jid:
@@ -340,5 +340,9 @@ class Runner(RunnerClient):
                 elif raw['tag'].split('/')[3] == 'return' and raw['tag'].split('/')[2] == jid:
                     yield raw['data']['return']
                     break
+                # Handle a findjob that might have been kicked off under the covers
+                elif raw['data']['fun'] == 'saltutil.findjob':
+                    timeout_at = timeout_at + 10
+                    continue
             except (IndexError, KeyError):
                 continue

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -287,7 +287,7 @@ class Runner(RunnerClient):
                     if isinstance(ret, dict) and 'outputter' in ret:
                         print(self.outputters[ret['outputter']](ret['data']))
                     else:
-                        print(self.outputters['nested'](ret))
+                        print(ret)
 
             except salt.exceptions.SaltException as exc:
                 ret = str(exc)

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -288,7 +288,7 @@ class Runner(RunnerClient):
                              'by examing the master job cache, if configured.')
                     sys.exit(0)
                 # Gather the returns
-                for ret in self.get_runner_returns(jid, timeout=60):  # 60 second timeout
+                for ret in self.get_runner_returns(jid):
                     if not self.opts.get('quiet', False):
                         if isinstance(ret, dict) and 'outputter' in ret:
                             print(self.outputters[ret['outputter']](ret['data']))
@@ -307,7 +307,6 @@ class Runner(RunnerClient):
         '''
         if timeout is None:
             timeout = self.opts['timeout']
-            timeout = 10
 
         timeout_at = time.time() + timeout
         last_progress_timestamp = time.time()

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -290,10 +290,10 @@ class Runner(RunnerClient):
                 # Gather the returns
                 for ret in self.get_runner_returns(jid):
                     if not self.opts.get('quiet', False):
-                        if isinstance(ret, dict) and 'outputter' in ret:
+                        if isinstance(ret, dict) and 'outputter' in ret and ret['outputter'] is not None:
                             print(self.outputters[ret['outputter']](ret['data']))
                         else:
-                            print(ret)
+                            salt.output.display_output(ret, '', self.opts)
 
             except salt.exceptions.SaltException as exc:
                 ret = str(exc)

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -78,6 +78,7 @@ def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
     else:
         return cached_pillar
 
+
 def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
     '''
     Return cached mine data of the targeted minions

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -42,8 +42,7 @@ def grains(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      grains_fallback=False,
                                                      opts=__opts__)
     cached_grains = pillar_util.get_minion_grains()
-    salt.output.display_output(cached_grains, outputter, __opts__)
-    return cached_grains
+    return salt.output.out_format(cached_grains, outputter, __opts__)
 
 
 def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
@@ -72,8 +71,7 @@ def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      pillar_fallback=False,
                                                      opts=__opts__)
     cached_pillar = pillar_util.get_minion_pillar()
-    salt.output.display_output(cached_pillar, outputter, __opts__)
-    return cached_pillar
+    return salt.output.out_format(cached_pillar, outputter, __opts__)
 
 
 def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
@@ -102,7 +100,7 @@ def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      pillar_fallback=False,
                                                      opts=__opts__)
     cached_mine = pillar_util.get_cached_mine_data()
-    salt.output.display_output(cached_mine, outputter, __opts__)
+    return salt.output.out_format(cached_mine, outputter, __opts__)
 
 
 def _clear_cache(tgt=None,

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -8,7 +8,6 @@ import logging
 # Import salt libs
 import salt.log
 import salt.utils.master
-import salt.output
 import salt.payload
 from salt._compat import string_types
 

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -42,7 +42,10 @@ def grains(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      grains_fallback=False,
                                                      opts=__opts__)
     cached_grains = pillar_util.get_minion_grains()
-    return salt.output.out_format(cached_grains, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': cached_grains}
+    else:
+        return cached_grains
 
 
 def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
@@ -71,8 +74,10 @@ def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      pillar_fallback=False,
                                                      opts=__opts__)
     cached_pillar = pillar_util.get_minion_pillar()
-    return salt.output.out_format(cached_pillar, outputter, __opts__)
-
+    if outputter:
+        return {'outputter': outputter, 'data': cached_pillar}
+    else:
+        return cached_pillar
 
 def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
     '''
@@ -100,7 +105,10 @@ def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      pillar_fallback=False,
                                                      opts=__opts__)
     cached_mine = pillar_util.get_cached_mine_data()
-    return salt.output.out_format(cached_mine, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': cached_mine}
+    else:
+        return cached_mine
 
 
 def _clear_cache(tgt=None,

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -12,6 +12,7 @@ import os
 
 # Import Salt libs
 import salt.cloud
+import salt.output
 
 
 def _get_client():

--- a/salt/runners/cloud.py
+++ b/salt/runners/cloud.py
@@ -12,7 +12,6 @@ import os
 
 # Import Salt libs
 import salt.cloud
-import salt.output
 
 
 def _get_client():

--- a/salt/runners/doc.py
+++ b/salt/runners/doc.py
@@ -9,7 +9,6 @@ import itertools
 # Import salt libs
 import salt.client
 import salt.runner
-import salt.output
 import salt.wheel
 
 
@@ -88,7 +87,7 @@ def __list_functions(user=None):
     for ret in gener:
         funcs.update(ret)
     if not user:
-        salt.output.display_output(funcs, '', __opts__)
+        progress(funcs)
         return funcs
     for _, val in __opts__['external_auth'].items():
         if user in val:

--- a/salt/runners/doc.py
+++ b/salt/runners/doc.py
@@ -32,8 +32,7 @@ def runner():
     '''
     client = salt.runner.RunnerClient(__opts__)
     ret = client.get_docs()
-    salt.output.display_output(ret, '', __opts__)
-    return ret
+    return salt.output.out_format(ret, '', __opts__)
 
 
 def wheel():
@@ -48,8 +47,7 @@ def wheel():
     '''
     client = salt.wheel.Wheel(__opts__)
     ret = client.get_docs()
-    salt.output.display_output(ret, '', __opts__)
-    return ret
+    return salt.output.out_format(ret, '', __opts__)
 
 
 def execution():
@@ -72,8 +70,7 @@ def execution():
     i = itertools.chain.from_iterable([i.items() for i in docs.itervalues()])
     ret = dict(list(i))
 
-    salt.output.display_output(ret, '', __opts__)
-    return ret
+    return salt.output.out_format(ret, '', __opts__)
 
 
 # Still need to modify some of the backend for auth checks to make this work

--- a/salt/runners/doc.py
+++ b/salt/runners/doc.py
@@ -32,7 +32,7 @@ def runner():
     '''
     client = salt.runner.RunnerClient(__opts__)
     ret = client.get_docs()
-    return salt.output.out_format(ret, '', __opts__)
+    return ret
 
 
 def wheel():
@@ -47,7 +47,7 @@ def wheel():
     '''
     client = salt.wheel.Wheel(__opts__)
     ret = client.get_docs()
-    return salt.output.out_format(ret, '', __opts__)
+    return ret
 
 
 def execution():
@@ -70,7 +70,7 @@ def execution():
     i = itertools.chain.from_iterable([i.items() for i in docs.itervalues()])
     ret = dict(list(i))
 
-    return salt.output.out_format(ret, '', __opts__)
+    return ret
 
 
 # Still need to modify some of the backend for auth checks to make this work

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -22,7 +22,10 @@ def dir_list(saltenv='base', outputter='nested'):
     load = {'saltenv': saltenv}
     output = fileserver.dir_list(load=load)
 
-    return salt.output.out_format(output, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
 def envs(backend=None, sources=False, outputter='nested'):
@@ -40,7 +43,10 @@ def envs(backend=None, sources=False, outputter='nested'):
     fileserver = salt.fileserver.Fileserver(__opts__)
     output = fileserver.envs(back=backend, sources=sources)
 
-    return salt.output.out_format(output, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
 def file_list(saltenv='base', outputter='nested'):
@@ -58,7 +64,10 @@ def file_list(saltenv='base', outputter='nested'):
     load = {'saltenv': saltenv}
     output = fileserver.file_list(load=load)
 
-    return salt.output.out_format(output, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
 def symlink_list(saltenv='base', outputter='nested'):
@@ -75,8 +84,11 @@ def symlink_list(saltenv='base', outputter='nested'):
     fileserver = salt.fileserver.Fileserver(__opts__)
     load = {'saltenv': saltenv}
     output = fileserver.symlink_list(load=load)
-
-    return salt.output.out_format(output, outputter, __opts__)
+    
+    if outputter:
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
 def update(backend=None):

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -22,9 +22,7 @@ def dir_list(saltenv='base', outputter='nested'):
     load = {'saltenv': saltenv}
     output = fileserver.dir_list(load=load)
 
-    if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+    return salt.output.out_format(output, outputter, __opts__)
 
 
 def envs(backend=None, sources=False, outputter='nested'):
@@ -42,9 +40,7 @@ def envs(backend=None, sources=False, outputter='nested'):
     fileserver = salt.fileserver.Fileserver(__opts__)
     output = fileserver.envs(back=backend, sources=sources)
 
-    if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+    return salt.output.out_format(output, outputter, __opts__)
 
 
 def file_list(saltenv='base', outputter='nested'):
@@ -62,9 +58,7 @@ def file_list(saltenv='base', outputter='nested'):
     load = {'saltenv': saltenv}
     output = fileserver.file_list(load=load)
 
-    if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+    return salt.output.out_format(output, outputter, __opts__)
 
 
 def symlink_list(saltenv='base', outputter='nested'):
@@ -82,9 +76,7 @@ def symlink_list(saltenv='base', outputter='nested'):
     load = {'saltenv': saltenv}
     output = fileserver.symlink_list(load=load)
 
-    if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+    return salt.output.out_format(output, outputter, __opts__)
 
 
 def update(backend=None):

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -3,11 +3,14 @@
 Module for making various web calls. Primarily designed for webhooks and the
 like, but also useful for basic http testing.
 '''
+# Import Python libs
+import logging
 
 # Import salt libs
 import salt.output
 import salt.utils.http
 
+log = logging.getLogger(__name__)
 
 def query(url, output=True, **kwargs):
     '''
@@ -23,6 +26,8 @@ def query(url, output=True, **kwargs):
         salt-run http.query http://somelink.com/ method=POST \
             data='<xml>somecontent</xml>'
     '''
+    if output is not True:
+        log.warn('Output option has been deprecated. Please use --quiet.')
     if 'node' not in kwargs:
         kwargs['node'] = 'master'
 

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -7,7 +7,6 @@ like, but also useful for basic http testing.
 import logging
 
 # Import salt libs
-import salt.output
 import salt.utils.http
 
 log = logging.getLogger(__name__)

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -27,7 +27,6 @@ def query(url, output=True, **kwargs):
         kwargs['node'] = 'master'
 
     ret = salt.utils.http.query(url=url, opts=__opts__, **kwargs)
-
     if output:
-        salt.output.display_output(ret, '', __opts__)
+        return salt.output.out_format(ret, '', __opts__)
     return ret

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -32,6 +32,4 @@ def query(url, output=True, **kwargs):
         kwargs['node'] = 'master'
 
     ret = salt.utils.http.query(url=url, opts=__opts__, **kwargs)
-    if output:
-        return salt.output.out_format(ret, '', __opts__)
     return ret

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -60,7 +60,10 @@ def active(outputter=None, display_progress=False):
             if minion not in ret[jid]['Returned']:
                 ret[jid]['Returned'].append(minion)
 
-    return salt.output.out_format(ret, outputter, opts=__opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': ret}
+    else:
+        return ret
 
 
 def lookup_jid(jid,
@@ -101,7 +104,10 @@ def lookup_jid(jid,
         for minion_id in exp:
             if minion_id not in data:
                 ret[minion_id] = 'Minion did not return'
-    return salt.output.out_format(ret, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': ret}
+    else:
+        return ret
 
 
 def list_job(jid, ext_source=None, outputter=None):
@@ -121,7 +127,10 @@ def list_job(jid, ext_source=None, outputter=None):
     job = mminion.returners['{0}.get_load'.format(returner)](jid)
     ret.update(_format_jid_instance(jid, job))
     ret['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
-    return salt.output.out_format(ret, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': ret}
+    else:
+        return ret
 
 
 def list_jobs(ext_source=None,
@@ -190,7 +199,10 @@ def list_jobs(ext_source=None,
                         _mret[item] = ret[item]
         mret = _mret.copy()
 
-    return salt.output.out_format(mret, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': mret}
+    else:
+        return mret
 
 
 def print_job(jid, ext_source=None, outputter=None):
@@ -216,7 +228,10 @@ def print_job(jid, ext_source=None, outputter=None):
             'Check master log for details.'.format(returner))
         return ret
     ret[jid]['Result'] = mminion.returners['{0}.get_jid'.format(returner)](jid)
-    return salt.output.out_format(ret, outputter, __opts__)
+    if outputter:
+        return {'outputter': outputter, 'data': ret}
+    else:
+        return ret
 
 
 def _get_returner(returner_types):

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -15,7 +15,6 @@ import os
 import salt.client
 import salt.payload
 import salt.utils
-import salt.output
 import salt.minion
 
 from salt._compat import string_types

--- a/salt/runners/launchd.py
+++ b/salt/runners/launchd.py
@@ -44,10 +44,8 @@ def write_launchd_plist(program):
         sys.stderr.write('Supported programs: {0!r}\n'.format(supported_programs))
         sys.exit(-1)
 
-    sys.stdout.write(
-        plist_sample_text.format(
+        return plist_sample_text.format(
             program=program,
             python=sys.executable,
             script=os.path.join(os.path.dirname(sys.executable), program)
         )
-    )

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -84,17 +84,15 @@ def find_guest(name, quiet=False):
 
         salt-run lxc.find_guest name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     for data in _list_iter():
         host, l = data.items()[0]
         for x in 'running', 'frozen', 'stopped':
             if name in l[x]:
-                progress(salt.output.display_output(
-                        host,
-                        'lxc_find_host',
-                        __opts__))
+                if not quiet:
+                    salt.output.display_output(
+                            host,
+                            'lxc_find_host',
+                            __opts__)
                 return host
     return None
 
@@ -183,9 +181,6 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         Optional config parameters. By default, the id is set to
         the name of the container.
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     ret = {'comment': '', 'result': True}
     if host is None:
         # TODO: Support selection of host based on available memory/cpu/etc.
@@ -198,12 +193,12 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         ret['comment'] = 'Container names are not formed as a list'
         ret['result'] = False
         return ret
-    progress('Searching for LXC Hosts')
+    log.info('Searching for LXC Hosts')
     data = __salt__['lxc.list'](host, quiet=True)
     for host, containers in data.items():
         for name in names:
             if name in sum(containers.values(), []):
-                progress('Container \'{0}\' already exists'
+                log.info('Container \'{0}\' already exists'
                          ' on host \'{1}\','
                          ' init can be a NO-OP'.format(
                              name, host))
@@ -333,7 +328,9 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     # we result to False
     if not done:
         ret['result'] = False
-    return salt.output.out_format(ret, '', __opts__)
+    if not quiet:
+        salt.output.display_output(ret, '', __opts__)
+    return ret
 
 
 def cloud_init(names, host=None, quiet=False, **kwargs):
@@ -388,14 +385,12 @@ def list_(host=None, quiet=False):
 
         salt-run lxc.list [host=minion_id]
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     it = _list_iter(host)
     ret = {}
     for chunk in it:
         ret.update(chunk)
-        progress(salt.output.out_format(chunk, 'lxc_list', __opts__))
+        if not quiet:
+            salt.output.display_output(chunk, 'lxc_list', __opts__)
     return ret
 
 
@@ -408,9 +403,6 @@ def purge(name, delete_key=True, quiet=False):
 
         salt-run lxc.purge name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     data = _do_names(name, 'destroy')
     if data is False:
         return data
@@ -422,7 +414,9 @@ def purge(name, delete_key=True, quiet=False):
     if data is None:
         return
 
-    return salt.output.out_format(data, 'lxc_purge', __opts__)
+    if not quiet:
+        salt.output.display_output(data, 'lxc_purge', __opts__)
+    return data
 
 
 def start(name, quiet=False):
@@ -433,12 +427,10 @@ def start(name, quiet=False):
 
         salt-run lxc.start name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     data = _do_names(name, 'start')
-    if data: 
-        return salt.output.out_format(data, 'lxc_start', __opts__)
+    if data and not quiet:
+        salt.output.display_output(data, 'lxc_start', __opts__)
+    return data
 
 
 def stop(name, quiet=False):
@@ -449,12 +441,10 @@ def stop(name, quiet=False):
 
         salt-run lxc.stop name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     data = _do_names(name, 'stop')
-    if data:
-        return salt.output.out_format(data, 'lxc_force_off', __opts__)
+    if data and not quiet:
+        salt.output.display_output(data, 'lxc_force_off', __opts__)
+    return data
 
 
 def freeze(name, quiet=False):
@@ -465,12 +455,10 @@ def freeze(name, quiet=False):
 
         salt-run lxc.freeze name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     data = _do_names(name, 'freeze')
-    if data:
-        return salt.output.out_format(data, 'lxc_pause', __opts__)
+    if data and not quiet:
+        salt.output.display_output(data, 'lxc_pause', __opts__)
+    return data
 
 
 def unfreeze(name, quiet=False):
@@ -481,12 +469,10 @@ def unfreeze(name, quiet=False):
 
         salt-run lxc.unfreeze name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     data = _do_names(name, 'unfreeze')
-    if data:
-        return salt.output.out_format(data, 'lxc_resume', __opts__)
+    if data and not quiet:
+        salt.output.display_output(data, 'lxc_resume', __opts__)
+    return data
 
 
 def info(name, quiet=False):
@@ -497,9 +483,7 @@ def info(name, quiet=False):
 
         salt-run lxc.info name
     '''
-    if quiet is not False:
-        log.warn('\'quiet\' function argument is no longer supported. '
-                 'Please use --quiet.')
     data = _do_names(name, 'info')
-    if data:
-        return salt.output.out_format(data, 'lxc_info', __opts__)
+    if data and not quiet:
+        salt.output.display_output(data, 'lxc_info', __opts__)
+    return data

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -84,15 +84,17 @@ def find_guest(name, quiet=False):
 
         salt-run lxc.find_guest name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     for data in _list_iter():
         host, l = data.items()[0]
         for x in 'running', 'frozen', 'stopped':
             if name in l[x]:
-                if not quiet:
-                    salt.output.display_output(
-                            host,
-                            'lxc_find_host',
-                            __opts__)
+                progress(salt.output.display_output(
+                        host,
+                        'lxc_find_host',
+                        __opts__))
                 return host
     return None
 
@@ -181,6 +183,9 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         Optional config parameters. By default, the id is set to
         the name of the container.
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     ret = {'comment': '', 'result': True}
     if host is None:
         # TODO: Support selection of host based on available memory/cpu/etc.
@@ -193,12 +198,12 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         ret['comment'] = 'Container names are not formed as a list'
         ret['result'] = False
         return ret
-    log.info('Searching for LXC Hosts')
+    progress('Searching for LXC Hosts')
     data = __salt__['lxc.list'](host, quiet=True)
     for host, containers in data.items():
         for name in names:
-            if name in sum(containers.itervalues(), []):
-                log.info('Container \'{0}\' already exists'
+            if name in sum(containers.values(), []):
+                progress('Container \'{0}\' already exists'
                          ' on host \'{1}\','
                          ' init can be a NO-OP'.format(
                              name, host))
@@ -328,9 +333,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     # we result to False
     if not done:
         ret['result'] = False
-    if not quiet:
-        salt.output.display_output(ret, '', __opts__)
-    return ret
+    return salt.output.out_format(ret, '', __opts__)
 
 
 def cloud_init(names, host=None, quiet=False, **kwargs):
@@ -385,12 +388,14 @@ def list_(host=None, quiet=False):
 
         salt-run lxc.list [host=minion_id]
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     it = _list_iter(host)
     ret = {}
     for chunk in it:
         ret.update(chunk)
-        if not quiet:
-            salt.output.display_output(chunk, 'lxc_list', __opts__)
+        progress(salt.output.out_format(chunk, 'lxc_list', __opts__))
     return ret
 
 
@@ -403,6 +408,9 @@ def purge(name, delete_key=True, quiet=False):
 
         salt-run lxc.purge name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     data = _do_names(name, 'destroy')
     if data is False:
         return data
@@ -414,9 +422,7 @@ def purge(name, delete_key=True, quiet=False):
     if data is None:
         return
 
-    if not quiet:
-        salt.output.display_output(data, 'lxc_purge', __opts__)
-    return data
+    return salt.output.out_format(data, 'lxc_purge', __opts__)
 
 
 def start(name, quiet=False):
@@ -427,10 +433,12 @@ def start(name, quiet=False):
 
         salt-run lxc.start name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     data = _do_names(name, 'start')
-    if data and not quiet:
-        salt.output.display_output(data, 'lxc_start', __opts__)
-    return data
+    if data: 
+        return salt.output.out_format(data, 'lxc_start', __opts__)
 
 
 def stop(name, quiet=False):
@@ -441,10 +449,12 @@ def stop(name, quiet=False):
 
         salt-run lxc.stop name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     data = _do_names(name, 'stop')
-    if data and not quiet:
-        salt.output.display_output(data, 'lxc_force_off', __opts__)
-    return data
+    if data:
+        return salt.output.out_format(data, 'lxc_force_off', __opts__)
 
 
 def freeze(name, quiet=False):
@@ -455,10 +465,12 @@ def freeze(name, quiet=False):
 
         salt-run lxc.freeze name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     data = _do_names(name, 'freeze')
-    if data and not quiet:
-        salt.output.display_output(data, 'lxc_pause', __opts__)
-    return data
+    if data:
+        return salt.output.out_format(data, 'lxc_pause', __opts__)
 
 
 def unfreeze(name, quiet=False):
@@ -469,10 +481,12 @@ def unfreeze(name, quiet=False):
 
         salt-run lxc.unfreeze name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     data = _do_names(name, 'unfreeze')
-    if data and not quiet:
-        salt.output.display_output(data, 'lxc_resume', __opts__)
-    return data
+    if data:
+        return salt.output.out_format(data, 'lxc_resume', __opts__)
 
 
 def info(name, quiet=False):
@@ -483,7 +497,9 @@ def info(name, quiet=False):
 
         salt-run lxc.info name
     '''
+    if quiet is not False:
+        log.warn('\'quiet\' function argument is no longer supported. '
+                 'Please use --quiet.')
     data = _do_names(name, 'info')
-    if data and not quiet:
-        salt.output.display_output(data, 'lxc_info', __opts__)
-    return data
+    if data:
+        return salt.output.out_format(data, 'lxc_info', __opts__)

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -84,15 +84,17 @@ def find_guest(name, quiet=False):
 
         salt-run lxc.find_guest name
     '''
+    if quiet:
+        log.warn('\'quiet\' argument is being deprecated. Please migrate to --quiet')
     for data in _list_iter():
         host, l = data.items()[0]
         for x in 'running', 'frozen', 'stopped':
             if name in l[x]:
                 if not quiet:
-                    return salt.output.out_format(
+                    progress(salt.output.out_format(
                             host,
                             'lxc_find_host',
-                            __opts__)
+                            __opts__))
                 return host
     return None
 
@@ -181,6 +183,8 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         Optional config parameters. By default, the id is set to
         the name of the container.
     '''
+    if quiet:
+        log.warn('\'quiet\' argument is being deprecated. Please migrate to --quiet')
     ret = {'comment': '', 'result': True}
     if host is None:
         # TODO: Support selection of host based on available memory/cpu/etc.
@@ -329,7 +333,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     if not done:
         ret['result'] = False
     if not quiet:
-        return salt.output.out_format(ret, '', __opts__)
+        progress(ret)
     return ret
 
 
@@ -347,6 +351,8 @@ def cloud_init(names, host=None, quiet=False, **kwargs):
     saltcloud_mode
         init the container with the saltcloud opts format instead
     '''
+    if quiet:
+        log.warn('\'quiet\' argument is being deprecated. Please migrate to --quiet')
     return __salt__['lxc.init'](names=names, host=host,
                                 saltcloud_mode=True, quiet=quiet, **kwargs)
 
@@ -390,7 +396,7 @@ def list_(host=None, quiet=False):
     for chunk in it:
         ret.update(chunk)
         if not quiet:
-            return salt.output.out_format(chunk, 'lxc_list', __opts__)
+            progress(salt.output.out_format(chunk, 'lxc_list', __opts__))
     return ret
 
 
@@ -415,7 +421,7 @@ def purge(name, delete_key=True, quiet=False):
         return
 
     if not quiet:
-        return salt.output.out_format(data, 'lxc_purge', __opts__)
+        progress(salt.output.out_format(data, 'lxc_purge', __opts__))
     return data
 
 
@@ -429,7 +435,7 @@ def start(name, quiet=False):
     '''
     data = _do_names(name, 'start')
     if data and not quiet:
-        return salt.output.out_format(data, 'lxc_start', __opts__)
+        progress(salt.output.out_format(data, 'lxc_start', __opts__))
     return data
 
 
@@ -443,7 +449,7 @@ def stop(name, quiet=False):
     '''
     data = _do_names(name, 'stop')
     if data and not quiet:
-        return salt.output.out_format(data, 'lxc_force_off', __opts__)
+        progress(salt.output.out_format(data, 'lxc_force_off', __opts__))
     return data
 
 
@@ -457,7 +463,7 @@ def freeze(name, quiet=False):
     '''
     data = _do_names(name, 'freeze')
     if data and not quiet:
-        return salt.output.out_format(data, 'lxc_pause', __opts__)
+        progress(salt.output.out_format(data, 'lxc_pause', __opts__))
     return data
 
 
@@ -471,7 +477,7 @@ def unfreeze(name, quiet=False):
     '''
     data = _do_names(name, 'unfreeze')
     if data and not quiet:
-        return salt.output.out_format(data, 'lxc_resume', __opts__)
+        salt.output.out_format(data, 'lxc_resume', __opts__)
     return data
 
 
@@ -485,5 +491,5 @@ def info(name, quiet=False):
     '''
     data = _do_names(name, 'info')
     if data and not quiet:
-        salt.output.out_format(data, 'lxc_info', __opts__)
+        progress(salt.output.out_format(data, 'lxc_info', __opts__))
     return data

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -15,7 +15,6 @@ import logging
 # Import Salt libs
 from salt.utils.odict import OrderedDict
 import salt.client
-import salt.output
 import salt.utils.virt
 import salt.utils.cloud
 import salt.key
@@ -91,10 +90,7 @@ def find_guest(name, quiet=False):
         for x in 'running', 'frozen', 'stopped':
             if name in l[x]:
                 if not quiet:
-                    progress(salt.output.out_format(
-                            host,
-                            'lxc_find_host',
-                            __opts__))
+                    progress(host, outputter='lxc_find_host')
                 return host
     return None
 
@@ -396,7 +392,7 @@ def list_(host=None, quiet=False):
     for chunk in it:
         ret.update(chunk)
         if not quiet:
-            progress(salt.output.out_format(chunk, 'lxc_list', __opts__))
+            progress(chunk, outputter='lxc_list')
     return ret
 
 
@@ -421,7 +417,7 @@ def purge(name, delete_key=True, quiet=False):
         return
 
     if not quiet:
-        progress(salt.output.out_format(data, 'lxc_purge', __opts__))
+        progress(data, outputter='lxc_purge')
     return data
 
 
@@ -435,7 +431,7 @@ def start(name, quiet=False):
     '''
     data = _do_names(name, 'start')
     if data and not quiet:
-        progress(salt.output.out_format(data, 'lxc_start', __opts__))
+        progress(data, outputter='lxc_start')
     return data
 
 
@@ -449,7 +445,7 @@ def stop(name, quiet=False):
     '''
     data = _do_names(name, 'stop')
     if data and not quiet:
-        progress(salt.output.out_format(data, 'lxc_force_off', __opts__))
+        progress(data, outputter='lxc_force_off')
     return data
 
 
@@ -463,7 +459,7 @@ def freeze(name, quiet=False):
     '''
     data = _do_names(name, 'freeze')
     if data and not quiet:
-        progress(salt.output.out_format(data, 'lxc_pause', __opts__))
+        progress(data, outputter='lxc_pause')
     return data
 
 
@@ -477,7 +473,7 @@ def unfreeze(name, quiet=False):
     '''
     data = _do_names(name, 'unfreeze')
     if data and not quiet:
-        salt.output.out_format(data, 'lxc_resume', __opts__)
+        progress(data, outputter='lxc_resume')
     return data
 
 
@@ -491,5 +487,5 @@ def info(name, quiet=False):
     '''
     data = _do_names(name, 'info')
     if data and not quiet:
-        progress(salt.output.out_format(data, 'lxc_info', __opts__))
+        progress(data, outputter='lxc_info')
     return data

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -89,7 +89,7 @@ def find_guest(name, quiet=False):
         for x in 'running', 'frozen', 'stopped':
             if name in l[x]:
                 if not quiet:
-                    salt.output.display_output(
+                    return salt.output.out_format(
                             host,
                             'lxc_find_host',
                             __opts__)
@@ -329,7 +329,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     if not done:
         ret['result'] = False
     if not quiet:
-        salt.output.display_output(ret, '', __opts__)
+        return salt.output.out_format(ret, '', __opts__)
     return ret
 
 
@@ -390,7 +390,7 @@ def list_(host=None, quiet=False):
     for chunk in it:
         ret.update(chunk)
         if not quiet:
-            salt.output.display_output(chunk, 'lxc_list', __opts__)
+            return salt.output.out_format(chunk, 'lxc_list', __opts__)
     return ret
 
 
@@ -415,7 +415,7 @@ def purge(name, delete_key=True, quiet=False):
         return
 
     if not quiet:
-        salt.output.display_output(data, 'lxc_purge', __opts__)
+        return salt.output.out_format(data, 'lxc_purge', __opts__)
     return data
 
 
@@ -429,7 +429,7 @@ def start(name, quiet=False):
     '''
     data = _do_names(name, 'start')
     if data and not quiet:
-        salt.output.display_output(data, 'lxc_start', __opts__)
+        return salt.output.out_format(data, 'lxc_start', __opts__)
     return data
 
 
@@ -443,7 +443,7 @@ def stop(name, quiet=False):
     '''
     data = _do_names(name, 'stop')
     if data and not quiet:
-        salt.output.display_output(data, 'lxc_force_off', __opts__)
+        return salt.output.out_format(data, 'lxc_force_off', __opts__)
     return data
 
 
@@ -457,7 +457,7 @@ def freeze(name, quiet=False):
     '''
     data = _do_names(name, 'freeze')
     if data and not quiet:
-        salt.output.display_output(data, 'lxc_pause', __opts__)
+        return salt.output.out_format(data, 'lxc_pause', __opts__)
     return data
 
 
@@ -471,7 +471,7 @@ def unfreeze(name, quiet=False):
     '''
     data = _do_names(name, 'unfreeze')
     if data and not quiet:
-        salt.output.display_output(data, 'lxc_resume', __opts__)
+        return salt.output.out_format(data, 'lxc_resume', __opts__)
     return data
 
 
@@ -485,5 +485,5 @@ def info(name, quiet=False):
     '''
     data = _do_names(name, 'info')
     if data and not quiet:
-        salt.output.display_output(data, 'lxc_info', __opts__)
+        salt.output.out_format(data, 'lxc_info', __opts__)
     return data

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -17,7 +17,6 @@ import urllib
 # Import salt libs
 import salt.key
 import salt.client
-import salt.output
 import salt.utils.minions
 import salt.wheel
 import salt.version
@@ -45,7 +44,7 @@ def status(output=True):
     ret['up'] = sorted(minions)
     ret['down'] = sorted(set(keys['minions']) - set(minions))
     if output:
-        progress(salt.output.out_format(ret, '', __opts__))
+        progress(ret)
     return ret
 
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -45,7 +45,7 @@ def status(output=True):
     ret['up'] = sorted(minions)
     ret['down'] = sorted(set(keys['minions']) - set(minions))
     if output:
-        return salt.output.out_format(ret, '', __opts__)
+        progress(salt.output.out_format(ret, '', __opts__))
     return ret
 
 
@@ -114,8 +114,6 @@ def down(removekeys=False):
         if removekeys:
             wheel = salt.wheel.Wheel(__opts__)
             wheel.call_func('key.delete', match=minion)
-        else:
-            progress(salt.output.out_format(minion, '', __opts__))
     return ret
 
 
@@ -130,8 +128,6 @@ def up():  # pylint: disable=C0103
         salt-run manage.up
     '''
     ret = status(output=False).get('up', [])
-    for minion in ret:
-        salt.output.display_output(minion, '', __opts__)
     return ret
 
 
@@ -157,7 +153,6 @@ def present(subset=None, show_ipv4=False):
     minions = ckminions.connected_ids(show_ipv4=show_ipv4, subset=subset)
     connected = dict(minions) if show_ipv4 else sorted(minions)
 
-    salt.output.display_output(connected, '', __opts__)
     return connected
 
 
@@ -191,7 +186,6 @@ def not_present(subset=None, show_ipv4=False):
         if minion not in connected:
             not_connected.append(minion)
 
-    salt.output.display_output(not_connected, '', __opts__)
     return connected
 
 
@@ -243,7 +237,7 @@ def safe_accept(target, expr_form='glob'):
             print(message)
             print('')
 
-    print('Accepted {0:d} keys'.format(len(ret)))
+    progress('Accepted {0:d} keys'.format(len(ret)))
     return ret, failures
 
 
@@ -289,7 +283,6 @@ def versions():
         else:
             for minion in sorted(version_status[key]):
                 ret.setdefault(labels[key], {})[minion] = version_status[key][minion]
-    salt.output.display_output(ret, '', __opts__)
     return ret
 
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -94,7 +94,7 @@ def key_regen():
            'will not be able to reconnect and may require manual\n'
            'regeneration via a local call to\n'
            '    salt-call saltutil.regen_keys')
-    print(msg)
+    return msg
 
 
 def down(removekeys=False):
@@ -115,7 +115,7 @@ def down(removekeys=False):
             wheel = salt.wheel.Wheel(__opts__)
             wheel.call_func('key.delete', match=minion)
         else:
-            salt.output.display_output(minion, '', __opts__)
+            progress(salt.output.out_format(minion, '', __opts__))
     return ret
 
 

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -13,6 +13,7 @@ import subprocess
 import tempfile
 import time
 import urllib
+import logging
 
 # Import salt libs
 import salt.key
@@ -24,6 +25,7 @@ import salt.version
 
 FINGERPRINT_REGEX = re.compile(r'^([a-f0-9]{2}:){15}([a-f0-9]{2})$')
 
+log = logging.getLogger(__name__)
 
 def status(output=True):
     '''
@@ -35,6 +37,9 @@ def status(output=True):
 
         salt-run manage.status
     '''
+    if output is not True:
+        log.warn('\'output\' function argument is no longer supported. '
+                 'Please use --quiet.')
     client = salt.client.get_local_client(__opts__['conf_file'])
     minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
 
@@ -44,9 +49,7 @@ def status(output=True):
     ret = {}
     ret['up'] = sorted(minions)
     ret['down'] = sorted(set(keys['minions']) - set(minions))
-    if output:
-        salt.output.display_output(ret, '', __opts__)
-    return ret
+    return salt.output.out_format(ret, '', __opts__)
 
 
 def key_regen():

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -13,7 +13,6 @@ import subprocess
 import tempfile
 import time
 import urllib
-import logging
 
 # Import salt libs
 import salt.key
@@ -25,7 +24,6 @@ import salt.version
 
 FINGERPRINT_REGEX = re.compile(r'^([a-f0-9]{2}:){15}([a-f0-9]{2})$')
 
-log = logging.getLogger(__name__)
 
 def status(output=True):
     '''
@@ -37,9 +35,6 @@ def status(output=True):
 
         salt-run manage.status
     '''
-    if output is not True:
-        log.warn('\'output\' function argument is no longer supported. '
-                 'Please use --quiet.')
     client = salt.client.get_local_client(__opts__['conf_file'])
     minions = client.cmd('*', 'test.ping', timeout=__opts__['timeout'])
 
@@ -49,7 +44,9 @@ def status(output=True):
     ret = {}
     ret['up'] = sorted(minions)
     ret['down'] = sorted(set(keys['minions']) - set(minions))
-    return salt.output.out_format(ret, '', __opts__)
+    if output:
+        return salt.output.out_format(ret, '', __opts__)
+    return ret
 
 
 def key_regen():

--- a/salt/runners/mine.py
+++ b/salt/runners/mine.py
@@ -5,7 +5,6 @@ A runner to access data from the salt mine
 
 # Import salt libs
 import salt.utils.minions
-import salt.output
 
 
 def get(tgt, fun, tgt_type='glob', output='yaml'):

--- a/salt/runners/mine.py
+++ b/salt/runners/mine.py
@@ -20,5 +20,4 @@ def get(tgt, fun, tgt_type='glob', output='yaml'):
         salt-run mine.get '*' network.interfaces
     '''
     ret = salt.utils.minions.mine_get(tgt, fun, tgt_type, __opts__)
-    salt.output.display_output(ret, output, __opts__)
     return ret

--- a/salt/runners/network.py
+++ b/salt/runners/network.py
@@ -32,7 +32,7 @@ def wollist(maclist, bcast='255.255.255.255', destport=9):
                 print('Waking up {0}'.format(mac.strip()))
                 ret.append(mac)
     except Exception as err:
-        print('Failed to open the MAC file. Error: {0}'.format(err))
+        progress('Failed to open the MAC file. Error: {0}'.format(err))
         return []
     return ret
 
@@ -65,5 +65,5 @@ def wol(mac, bcast='255.255.255.255', destport=9):
            ('\\x' + mac[8:10]).decode('string_escape') + \
            ('\\x' + mac[10:12]).decode('string_escape')
     sock.sendto('\xff' * 6 + dest * 16, (bcast, int(destport)))
-    print('Sent magic packet to minion.')
+    progress('Sent magic packet to minion.')
     return True

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -6,7 +6,6 @@ Functions to interact with the pillar compiler on the master
 # Import salt libs
 import salt.pillar
 import salt.utils.minions
-import salt.output
 
 
 def show_top(minion=None, saltenv='base'):
@@ -30,7 +29,7 @@ def show_top(minion=None, saltenv='base'):
     top, errors = pillar.get_top()
 
     if errors:
-        salt.output.display_output(errors, 'nested', __opts__)
+        progress(errors, outputter='nested')
         return errors
 
     return top

--- a/salt/runners/pillar.py
+++ b/salt/runners/pillar.py
@@ -33,7 +33,6 @@ def show_top(minion=None, saltenv='base'):
         salt.output.display_output(errors, 'nested', __opts__)
         return errors
 
-    salt.output.display_output(top, 'nested', __opts__)
     return top
 
 
@@ -93,5 +92,4 @@ def show_pillar(minion='*', **kwargs):
         saltenv)
 
     compiled_pillar = pillar.compile_pillar()
-    salt.output.display_output(compiled_pillar, 'nested', __opts__)
     return compiled_pillar

--- a/salt/runners/queue.py
+++ b/salt/runners/queue.py
@@ -56,7 +56,6 @@ def insert(queue, items, backend='sqlite'):
     if cmd not in queue_funcs:
         raise SaltInvocationError('Function "{0}" is not available'.format(cmd))
     ret = queue_funcs[cmd](items=items, queue=queue)
-    salt.output.display_output(ret, 'nested', __opts__)
     return ret
 
 
@@ -77,7 +76,6 @@ def delete(queue, items, backend='sqlite'):
     if cmd not in queue_funcs:
         raise SaltInvocationError('Function "{0}" is not available'.format(cmd))
     ret = queue_funcs[cmd](items=items, queue=queue)
-    salt.output.display_output(ret, 'nested', __opts__)
     return ret
 
 
@@ -97,7 +95,6 @@ def list_queues(backend='sqlite'):
     if cmd not in queue_funcs:
         raise SaltInvocationError('Function "{0}" is not available'.format(cmd))
     ret = queue_funcs[cmd]()
-    salt.output.display_output(ret, 'nested', __opts__)
     return ret
 
 
@@ -117,7 +114,6 @@ def list_length(queue, backend='sqlite'):
     if cmd not in queue_funcs:
         raise SaltInvocationError('Function "{0}" is not available'.format(cmd))
     ret = queue_funcs[cmd](queue=queue)
-    salt.output.display_output(ret, 'nested', __opts__)
     return ret
 
 
@@ -137,7 +133,6 @@ def list_items(queue, backend='sqlite'):
     if cmd not in queue_funcs:
         raise SaltInvocationError('Function "{0}" is not available'.format(cmd))
     ret = queue_funcs[cmd](queue=queue)
-    salt.output.display_output(ret, 'nested', __opts__)
     return ret
 
 
@@ -160,7 +155,6 @@ def pop(queue, quantity=1, backend='sqlite'):
     if cmd not in queue_funcs:
         raise SaltInvocationError('Function "{0}" is not available'.format(cmd))
     ret = queue_funcs[cmd](quantity=quantity, queue=queue)
-    salt.output.display_output(ret, 'nested', __opts__)
     return ret
 
 
@@ -188,7 +182,7 @@ def process_queue(queue, quantity=1, backend='sqlite'):
         items = pop(queue=queue, quantity=quantity, backend=backend)
     except SaltInvocationError as exc:
         error_txt = '{0}'.format(exc)
-        salt.output.display_output(error_txt, 'nested', __opts__)
+        progress(error_txt)
         return False
 
     data = {'items': items,

--- a/salt/runners/queue.py
+++ b/salt/runners/queue.py
@@ -32,7 +32,6 @@ from __future__ import print_function
 
 # Import salt libs
 import salt.loader
-import salt.output
 import salt.utils.event
 from salt.utils.event import tagify
 from salt.exceptions import SaltInvocationError

--- a/salt/runners/search.py
+++ b/salt/runners/search.py
@@ -5,7 +5,6 @@ Runner frontend to search system
 
 # Import salt libs
 import salt.search
-import salt.output
 
 
 def query(term):

--- a/salt/runners/search.py
+++ b/salt/runners/search.py
@@ -20,5 +20,4 @@ def query(term):
     '''
     search = salt.search.Search(__opts__)
     result = search.query(term)
-    salt.output.display_output(result, 'pprint', __opts__)
     return result

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -11,7 +11,6 @@ import logging
 import sys
 
 # Import salt libs
-import salt.output
 import salt.overstate
 import salt.syspaths
 import salt.utils.event
@@ -52,15 +51,9 @@ def over(saltenv='base', os_fn=None):
             print('Stage execution results:')
             for key, val in stage.items():
                 if '_|-' in key:
-                    salt.output.display_output(
-                            {'error': {key: val}},
-                            'highstate',
-                            opts=__opts__)
+                    progress({'error': {key: val}}, outputter='highstate')
                 else:
-                    salt.output.display_output(
-                            {key: val},
-                            'highstate',
-                            opts=__opts__)
+                    progress({key: val}, outputter='highstate')
         elif isinstance(stage, list):
             # This is a stage
             if stage_num == 0:

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -48,7 +48,7 @@ def over(saltenv='base', os_fn=None):
     for stage in overstate.stages_iter():
         if isinstance(stage, dict):
             # This is highstate data
-            print('Stage execution results:')
+            progress('Stage execution results:')
             for key, val in stage.items():
                 if '_|-' in key:
                     progress({'error': {key: val}}, outputter='highstate')

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -64,10 +64,10 @@ def over(saltenv='base', os_fn=None):
         elif isinstance(stage, list):
             # This is a stage
             if stage_num == 0:
-                print('Executing the following Over State:')
+                progress('Executing the following Over State:')
             else:
-                print('Executed Stage:')
-            salt.output.display_output(stage, 'overstatestage', opts=__opts__)
+                progress('Executed Stage:')
+            progress(stage, outputter='overstatestage')
             stage_num += 1
     return overstate.over_run
 
@@ -107,7 +107,7 @@ def orchestrate(mods, saltenv='base', test=None, exclude=None, pillar=None):
             exclude,
             pillar=pillar)
     ret = {minion.opts['id']: running}
-    salt.output.display_output(ret, 'highstate', opts=__opts__)
+    progress(ret, outputter='highstate')
     return ret
 
 # Aliases for orchestrate runner
@@ -129,10 +129,7 @@ def show_stages(saltenv='base', os_fn=None):
         salt-run state.show_stages saltenv=dev /root/overstate.sls
     '''
     overstate = salt.overstate.OverState(__opts__, saltenv, os_fn)
-    salt.output.display_output(
-            overstate.over,
-            'overstatestage',
-            opts=__opts__)
+    progress(overstate.over, 'outputter='overstatestage)
     return overstate.over
 
 

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -122,7 +122,7 @@ def show_stages(saltenv='base', os_fn=None):
         salt-run state.show_stages saltenv=dev /root/overstate.sls
     '''
     overstate = salt.overstate.OverState(__opts__, saltenv, os_fn)
-    progress(overstate.over, 'outputter='overstatestage)
+    progress(overstate.over, outputter='overstatestage')
     return overstate.over
 
 

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -33,3 +33,8 @@ def raw_arg(*args, **kwargs):
     }
     pprint.pprint(ret)
     return ret
+
+def ping():
+    ret = True
+    pprint.pprint(ret)
+    return ret

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -37,7 +37,7 @@ def raw_arg(*args, **kwargs):
     pprint.pprint(ret)
     return ret
 
-def stream(jid=None):
+def stream():
     '''
     Return True
     '''

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -4,6 +4,7 @@ This runner is used only for test purposes and servers no production purpose
 '''
 # Import python libs
 import pprint
+import time
 
 # Import salt requirements
 import salt.utils.event
@@ -36,10 +37,12 @@ def raw_arg(*args, **kwargs):
     pprint.pprint(ret)
     return ret
 
-def true(jid=None):
+def stream(jid=None):
     '''
     Return True
     '''
     ret = True
-    salt.utils.event.RunnerEvent(__opts__).fire_progress(jid, ret)
+    for i in range(1,100):
+        progress('Runner is {0}% done'.format(i), outputter='pprint')
+        time.sleep(0.1)
     return ret

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -5,6 +5,8 @@ This runner is used only for test purposes and servers no production purpose
 # Import python libs
 import pprint
 
+# Import salt requirements
+import salt.utils.event
 
 def arg(*args, **kwargs):
     '''
@@ -34,10 +36,10 @@ def raw_arg(*args, **kwargs):
     pprint.pprint(ret)
     return ret
 
-def true():
+def true(jid=None):
     '''
     Return True
     '''
     ret = True
-    pprint.pprint(ret)
+    salt.utils.event.RunnerEvent(__opts__).fire_progress(jid, ret)
     return ret

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -3,7 +3,6 @@
 This runner is used only for test purposes and servers no production purpose
 '''
 # Import python libs
-import pprint
 import time
 
 # Import salt requirements

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -34,7 +34,10 @@ def raw_arg(*args, **kwargs):
     pprint.pprint(ret)
     return ret
 
-def ping():
+def true():
+    '''
+    Return True
+    '''
     ret = True
     pprint.pprint(ret)
     return ret

--- a/salt/runners/test.py
+++ b/salt/runners/test.py
@@ -22,7 +22,6 @@ def arg(*args, **kwargs):
         'args': args,
         'kwargs': kwargs,
     }
-    pprint.pprint(ret)
     return ret
 
 
@@ -34,7 +33,6 @@ def raw_arg(*args, **kwargs):
         'args': args,
         'kwargs': kwargs,
     }
-    pprint.pprint(ret)
     return ret
 
 def stream():

--- a/salt/runners/thin.py
+++ b/salt/runners/thin.py
@@ -29,4 +29,4 @@ def generate(extra_mods='', overwrite=False, so_mods=''):
         salt-run thin.generate mako,wempy 1
         salt-run thin.generate overwrite=1
     '''
-    print(salt.utils.thin.gen_thin(__opts__['cachedir'], extra_mods, overwrite, so_mods))
+    progress(salt.utils.thin.gen_thin(__opts__['cachedir'], extra_mods, overwrite, so_mods))

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -5,6 +5,7 @@ Control virtual machines via Salt
 
 # Import python libs
 from __future__ import print_function
+import logger
 
 # Import Salt libs
 import salt.client
@@ -12,6 +13,7 @@ import salt.output
 import salt.utils.virt
 import salt.key
 
+log = logger.getLogger(__name__)
 
 def _determine_hyper(data, omit=''):
     '''
@@ -58,6 +60,8 @@ def query(hyper=None, quiet=False):
     are detected and a full query is returned. A single hypervisor can be
     passed in to specify an individual hypervisor to query.
     '''
+    if quiet:
+        log.warn('\'quiet\' is deprecated. Please migrate to --quiet')
     ret = {}
     client = salt.client.get_local_client(__opts__['conf_file'])
     for info in client.cmd_iter('virtual:physical',
@@ -80,7 +84,7 @@ def query(hyper=None, quiet=False):
         chunk[id_] = info[id_]['ret']
         ret.update(chunk)
         if not quiet:
-            salt.output.display_output(chunk, 'virt_query', __opts__)
+            progress(chunk, outputter='virt_query')
 
     return ret
 
@@ -92,6 +96,8 @@ def list(hyper=None, quiet=False):  # pylint: disable=redefined-builtin
     A single hypervisor can be passed in to specify an individual hypervisor
     to list.
     '''
+    if quiet:
+        log.warn('\'quiet\' is deprecated. Please migrate to --quiet')
     ret = {}
     client = salt.client.get_local_client(__opts__['conf_file'])
     for info in client.cmd_iter('virtual:physical',
@@ -120,7 +126,7 @@ def list(hyper=None, quiet=False):  # pylint: disable=redefined-builtin
         chunk[id_] = data
         ret.update(chunk)
         if not quiet:
-            salt.output.display_output(chunk, 'virt_list', __opts__)
+            progress(chunk, outputter='virt_list')
 
     return ret
 
@@ -193,30 +199,30 @@ def init(
         Set to False to prevent Salt from installing a minion on the new vm
         before it spins up.
     '''
-    print('Searching for Hypervisors')
+    progress('Searching for Hypervisors')
     data = query(hyper, quiet=True)
     # Check if the name is already deployed
     for hyper in data:
         if 'vm_info' in data[hyper]:
             if name in data[hyper]['vm_info']:
-                print('Virtual machine {0} is already deployed'.format(name))
+                progress('Virtual machine {0} is already deployed'.format(name))
                 return 'fail'
 
     if hyper is None:
         hyper = _determine_hyper(data)
 
     if hyper not in data or not hyper:
-        print('Hypervisor {0} was not found'.format(hyper))
+        progress('Hypervisor {0} was not found'.format(hyper))
         return 'fail'
 
     if seed:
-        print('Minion will be preseeded')
+        progress('Minion will be preseeded')
         kv_ = salt.utils.virt.VirtKey(hyper, name, __opts__)
         kv_.authorize()
 
     client = salt.client.get_local_client(__opts__['conf_file'])
 
-    print('Creating VM {0} on hypervisor {1}'.format(name, hyper))
+    progress('Creating VM {0} on hypervisor {1}'.format(name, hyper))
     cmd_ret = client.cmd_iter(
             hyper,
             'virt.init',
@@ -233,10 +239,10 @@ def init(
 
     ret = next(cmd_ret)
     if not ret:
-        print('VM {0} was not initialized.'.format(name))
+        progress('VM {0} was not initialized.'.format(name))
         return 'fail'
 
-    print('VM {0} initialized on hypervisor {1}'.format(name, hyper))
+    progress('VM {0} initialized on hypervisor {1}'.format(name, hyper))
     return 'good'
 
 
@@ -256,7 +262,7 @@ def reset(name):
     client = salt.client.get_local_client(__opts__['conf_file'])
     data = vm_info(name, quiet=True)
     if not data:
-        print('Failed to find vm {0} to reset'.format(name))
+        progress('Failed to find vm {0} to reset'.format(name))
         return 'fail'
     hyper = data.iterkeys().next()
     cmd_ret = client.cmd_iter(
@@ -266,7 +272,7 @@ def reset(name):
             timeout=600)
     for comp in cmd_ret:
         ret.update(comp)
-    print('Reset VM {0}'.format(name))
+    progress('Reset VM {0}'.format(name))
     return ret
 
 
@@ -278,7 +284,7 @@ def start(name):
     client = salt.client.get_local_client(__opts__['conf_file'])
     data = vm_info(name, quiet=True)
     if not data:
-        print('Failed to find vm {0} to start'.format(name))
+        progress('Failed to find vm {0} to start'.format(name))
         return 'fail'
     hyper = data.iterkeys().next()
     if data[hyper][name]['state'] == 'running':
@@ -291,7 +297,7 @@ def start(name):
             timeout=600)
     for comp in cmd_ret:
         ret.update(comp)
-    print('Started VM {0}'.format(name))
+    progress('Started VM {0}'.format(name))
     return 'good'
 
 
@@ -316,7 +322,7 @@ def force_off(name):
             timeout=600)
     for comp in cmd_ret:
         ret.update(comp)
-    print('Powered off VM {0}'.format(name))
+    progress('Powered off VM {0}'.format(name))
     return 'good'
 
 
@@ -328,7 +334,7 @@ def purge(name, delete_key=True):
     client = salt.client.get_local_client(__opts__['conf_file'])
     data = vm_info(name, quiet=True)
     if not data:
-        print('Failed to find vm {0} to purge'.format(name))
+        progress('Failed to find vm {0} to purge'.format(name))
         return 'fail'
     hyper = data.iterkeys().next()
     cmd_ret = client.cmd_iter(
@@ -342,7 +348,7 @@ def purge(name, delete_key=True):
     if delete_key:
         skey = salt.key.Key(__opts__)
         skey.delete_key(name)
-    print('Purged VM {0}'.format(name))
+    progress('Purged VM {0}'.format(name))
     return 'good'
 
 
@@ -355,11 +361,11 @@ def pause(name):
 
     data = vm_info(name, quiet=True)
     if not data:
-        print('Failed to find VM {0} to pause'.format(name))
+        progress('Failed to find VM {0} to pause'.format(name))
         return 'fail'
     hyper = data.iterkeys().next()
     if data[hyper][name]['state'] == 'paused':
-        print('VM {0} is already paused'.format(name))
+        progress('VM {0} is already paused'.format(name))
         return 'bad state'
     cmd_ret = client.cmd_iter(
             hyper,
@@ -368,7 +374,7 @@ def pause(name):
             timeout=600)
     for comp in cmd_ret:
         ret.update(comp)
-    print('Paused VM {0}'.format(name))
+    progress('Paused VM {0}'.format(name))
     return 'good'
 
 
@@ -380,11 +386,11 @@ def resume(name):
     client = salt.client.get_local_client(__opts__['conf_file'])
     data = vm_info(name, quiet=True)
     if not data:
-        print('Failed to find VM {0} to pause'.format(name))
+        progress('Failed to find VM {0} to pause'.format(name))
         return 'not found'
     hyper = data.iterkeys().next()
     if data[hyper][name]['state'] != 'paused':
-        print('VM {0} is not paused'.format(name))
+        progress('VM {0} is not paused'.format(name))
         return 'bad state'
     cmd_ret = client.cmd_iter(
             hyper,
@@ -393,7 +399,7 @@ def resume(name):
             timeout=600)
     for comp in cmd_ret:
         ret.update(comp)
-    print('Resumed VM {0}'.format(name))
+    progress('Resumed VM {0}'.format(name))
     return 'good'
 
 
@@ -406,18 +412,18 @@ def migrate(name, target=''):
     data = query(quiet=True)
     origin_data = _find_vm(name, data, quiet=True)
     try:
-        origin_hyper = origin_data.iterkeys().next()
-    except StopIteration:
-        print('Named vm {0} was not found to migrate'.format(name))
+        origin_hyper = origin_data.keys()[0]
+    except IndexError:
+        progress('Named vm {0} was not found to migrate'.format(name))
         return ''
     disks = origin_data[origin_hyper][name]['disks']
     if not origin_data:
-        print('Named vm {0} was not found to migrate'.format(name))
+        progress('Named vm {0} was not found to migrate'.format(name))
         return ''
     if not target:
         target = _determine_hyper(data, origin_hyper)
     if target not in data:
-        print('Target hypervisor {0} not found'.format(origin_data))
+        progress('Target hypervisor {0} not found'.format(origin_data))
         return ''
     client.cmd(target, 'virt.seed_non_shared_migrate', [disks, True])
     jid = client.cmd_async(origin_hyper,
@@ -428,4 +434,4 @@ def migrate(name, target=''):
            'and can be tracked via jid {2}. The ``salt-run virt.query`` '
            'runner can also be used, the target vm will be shown as paused '
            'until the migration is complete.').format(name, target, jid)
-    print(msg)
+    progress(msg)

--- a/salt/runners/virt.py
+++ b/salt/runners/virt.py
@@ -5,15 +5,14 @@ Control virtual machines via Salt
 
 # Import python libs
 from __future__ import print_function
-import logger
+import logging
 
 # Import Salt libs
 import salt.client
-import salt.output
 import salt.utils.virt
 import salt.key
 
-log = logger.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 def _determine_hyper(data, omit=''):
     '''
@@ -46,10 +45,7 @@ def _find_vm(name, data, quiet=False):
         if name in data[hv_].get('vm_info', {}):
             ret = {hv_: {name: data[hv_]['vm_info'][name]}}
             if not quiet:
-                salt.output.display_output(
-                        ret,
-                        'nested',
-                        __opts__)
+                progress(ret, outputter='nested')
             return ret
     return {}
 
@@ -150,7 +146,7 @@ def hyper_info(hyper=None):
     for id_ in data:
         if 'vm_info' in data[id_]:
             data[id_].pop('vm_info')
-    salt.output.display_output(data, 'nested', __opts__)
+    progress(data, outputter='nested')
     return data
 
 

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -54,7 +54,7 @@ def genrepo():
                         # when log.debug works
                         log.debug('Failed to compile'
                                   '{0}: {1}'.format(os.path.join(root, name), exc))
-                        print('Failed to compile {0}: {1}'.format(os.path.join(root, name), exc))
+                        progress('Failed to compile {0}: {1}'.format(os.path.join(root, name), exc))
                 if config:
                     revmap = {}
                     for pkgname, versions in config.items():
@@ -65,14 +65,13 @@ def genrepo():
                             if not isinstance(repodata, dict):
                                 log.debug('Failed to compile'
                                           '{0}.'.format(os.path.join(root, name)))
-                                print('Failed to compile {0}.'.format(os.path.join(root, name)))
+                                progress('Failed to compile {0}.'.format(os.path.join(root, name)))
                                 continue
                             revmap[repodata['full_name']] = pkgname
                     ret.setdefault('repo', {}).update(config)
                     ret.setdefault('name_map', {}).update(revmap)
     with salt.utils.fopen(os.path.join(repo, winrepo), 'w+b') as repo:
         repo.write(msgpack.dumps(ret))
-    salt.output.display_output(ret, 'pprint', __opts__)
     return ret
 
 
@@ -105,5 +104,4 @@ def update_git_repos():
                                               target=gittarget,
                                               force=True)
         ret[result['name']] = result['result']
-    salt.output.display_output(ret, 'pprint', __opts__)
     return ret

--- a/salt/runners/winrepo.py
+++ b/salt/runners/winrepo.py
@@ -18,7 +18,6 @@ except ImportError:
     import msgpack_pure as msgpack
 
 # Import salt libs
-import salt.output
 import salt.utils
 import logging
 import salt.minion

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -253,6 +253,8 @@ def salt_run():
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
             hardcrash, trace=trace)
+    except SystemExit:
+        os._exit(0)  # Kick it in the teeth
 
 
 def salt_ssh():

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -253,8 +253,6 @@ def salt_run():
             SystemExit('\nExiting gracefully on Ctrl-c'),
             err,
             hardcrash, trace=trace)
-    except SystemExit:
-        os._exit(0)  # Kick it in the teeth
 
 
 def salt_ssh():

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -501,6 +501,14 @@ class LocalClientEvent(MasterEvent):
     specially on logs, but it's the same as MasterEvent.
     '''
 
+class RunnerEvent(MasterEvent):
+    '''
+    This is used to send progress and return events from runners.
+    It extends MasterEvent to include information about how to
+    display events to the user as a runner progresses.
+    '''
+
+
 
 class MinionEvent(SaltEvent):
     '''

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -501,13 +501,20 @@ class LocalClientEvent(MasterEvent):
     specially on logs, but it's the same as MasterEvent.
     '''
 
+
 class RunnerEvent(MasterEvent):
     '''
     This is used to send progress and return events from runners.
     It extends MasterEvent to include information about how to
     display events to the user as a runner progresses.
     '''
+    def __init__(self, opts):
+        super(RunnerEvent, self).__init__(opts['sock_dir'])
 
+    def fire_progress(self, jid, data, outputter='pprint'):
+        progress_event = {'data': data,
+                          'outputter': outputter}
+        self.fire_event(progress_event, tagify([jid, 'progress'], 'runner'))
 
 
 class MinionEvent(SaltEvent):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -508,13 +508,14 @@ class RunnerEvent(MasterEvent):
     It extends MasterEvent to include information about how to
     display events to the user as a runner progresses.
     '''
-    def __init__(self, opts):
+    def __init__(self, opts, jid):
         super(RunnerEvent, self).__init__(opts['sock_dir'])
+        self.jid = jid
 
-    def fire_progress(self, jid, data, outputter='pprint'):
+    def fire_progress(self, data, outputter='pprint'):
         progress_event = {'data': data,
                           'outputter': outputter}
-        self.fire_event(progress_event, tagify([jid, 'progress'], 'runner'))
+        self.fire_event(progress_event, tagify([self.jid, 'progress'], 'runner'))
 
 
 class MinionEvent(SaltEvent):

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2163,6 +2163,12 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
             action='store_true',
             help='Force colored output'
         )
+        group.add_option(
+            '--quiet',
+            default=False,
+            action='store_true',
+            help='Do not display the results of the run'
+        )
 
     def _mixin_after_parsed(self):
         if self.options.doc and len(self.args) > 1:

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2146,6 +2146,12 @@ class SaltRunOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                   'runner.function to see documentation on only that runner '
                   'or function.')
         )
+        self.add_option(
+            '--async',
+            default=False,
+            action='store_true',
+            help=('Start the runner operation and immediately return control.')
+        )
         group = self.output_options_group = optparse.OptionGroup(
             self, 'Output Options', 'Configure your preferred output format'
         )

--- a/tests/integration/runners/fileserver.py
+++ b/tests/integration/runners/fileserver.py
@@ -21,24 +21,24 @@ class ManageTest(integration.ShellCase):
         fileserver.dir_list
         '''
         ret = self.run_run_plus(fun='fileserver.dir_list')
-        self.assertIsInstance(ret['fun'], list)
+        self.assertIsInstance(ret['fun'], dict)
 
     def test_envs(self):
         '''
         fileserver.envs
         '''
         ret = self.run_run_plus(fun='fileserver.envs')
-        self.assertIsInstance(ret['fun'], list)
+        self.assertIsInstance(ret['fun'], dict)
 
         ret = self.run_run_plus(fun='fileserver.envs', args=['backend="{0}"'.format(['root'])])
-        self.assertIsInstance(ret['fun'], list)
+        self.assertIsInstance(ret['fun'], dict)
 
     def test_file_list(self):
         '''
         fileserver.file_list
         '''
         ret = self.run_run_plus(fun='fileserver.file_list')
-        self.assertIsInstance(ret['fun'], list)
+        self.assertIsInstance(ret['fun'], dict)
 
     def test_symlink_list(self):
         '''

--- a/tests/integration/runners/manage.py
+++ b/tests/integration/runners/manage.py
@@ -21,8 +21,8 @@ class ManageTest(integration.ShellCase):
         ret = self.run_run_plus('manage.up')
         self.assertIn('minion', ret['fun'])
         self.assertIn('sub_minion', ret['fun'])
-        self.assertIn('minion', ret['out'])
-        self.assertIn('sub_minion', ret['out'])
+        self.assertIn('- minion', ret['out'])
+        self.assertIn('- sub_minion', ret['out'])
 
     def test_down(self):
         '''


### PR DESCRIPTION
Modified the runner system to be fully event based.
- Injects a special function at runtime called 'progress()' to stream runner progress events across the event bus
- Now uses a generator to collect and display events off the event bus
- All runners modified to direct output to the event bus instead of to stdout
- Runners can now dump to a master job cache if the returner supports it
- Output encoding now handled by the output system instead of the runner code
- New --quiet option to suppress all output in a run
- New --async option to allow runners to be fire-and-forget

Refs #15759 
