### PR TITLE
Read Pillar files into OrderedDict to preserve source order

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -13,6 +13,7 @@ import logging
 import salt.log
 import salt.crypt
 from salt.exceptions import SaltReqTimeoutError
+from salt.utils.odict import OrderedDict
 import six
 
 # Import third party libs
@@ -92,7 +93,11 @@ class Serial(object):
         Run the correct loads serialization format
         '''
         try:
-            return msgpack.loads(msg, use_list=True)
+            # msgpack >= 0.2.0 supports object_pairs_hook parameter to return an OrderedDict
+            if msgpack.version >= (0, 2, 0):
+                return msgpack.loads(msg, use_list=True, object_pairs_hook=OrderedDict)
+            else:
+                return msgpack.loads(msg, use_list=True)
         except Exception as exc:
             log.critical('Could not deserialize msgpack message: {0}'
                          'This often happens when trying to read a file not in binary mode.'

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -441,7 +441,7 @@ class Pillar(object):
         Extract the sls pillar files from the matches and render them into the
         pillar
         '''
-        pillar = {}
+        pillar = OrderedDict()
         errors = []
         for saltenv, pstates in matches.items():
             mods = set()
@@ -578,7 +578,7 @@ class Pillar(object):
         top, terrors = self.get_top()
         if ext:
             if self.opts.get('ext_pillar_first', False):
-                self.opts['pillar'] = self.ext_pillar({}, pillar_dirs)
+                self.opts['pillar'] = self.ext_pillar(OrderedDict(), pillar_dirs)
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches)
                 pillar = self.merge_sources(pillar, self.opts['pillar'])

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -9,11 +9,13 @@ from __future__ import absolute_import
 import collections
 import six
 
+# Import salt libs
+from salt.utils.odict import OrderedDict
 
 def update(dest, upd):
     for key, val in six.iteritems(upd):
         if isinstance(val, collections.Mapping):
-            ret = update(dest.get(key, {}), val)
+            ret = update(dest.get(key, OrderedDict()), val)
             dest[key] = ret
         else:
             dest[key] = upd[key]


### PR DESCRIPTION
This pull request attempts to solve Enhancement #12161.

I'm very new to Salt, but It's something i'd like for my own states so I thought working on a patch was a good way to get familiar with the internals of SaltStack.

I've tested the functionality in both master-minion and masterless setup and it keeps the pillars in an OrdererdDict. 

It does not attempt to change the 'master' values, as I don't see the need and that would mean touching the code in many places.
