### PR TITLE
Revert "Remove old-style event tags."

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -795,12 +795,11 @@ class LocalClient(object):
         '''
         if event is None:
             event = self.event
-        jid_tag = 'salt/job/{0}'.format(jid)
         while True:
             if HAS_ZMQ:
                 try:
                     raw = event.get_event_noblock()
-                    if raw and raw.get('tag', '').startswith(jid_tag):
+                    if raw and raw.get('tag', '').startswith(jid):
                         yield raw
                     else:
                         yield None
@@ -811,7 +810,7 @@ class LocalClient(object):
                         raise
             else:
                 raw = event.get_event_noblock()
-                if raw and raw.get('tag', '').startswith(jid_tag):
+                if raw and raw.get('tag', '').startswith(jid):
                     yield raw
                 else:
                     yield None

--- a/salt/master.py
+++ b/salt/master.py
@@ -1207,6 +1207,7 @@ class AESFuncs(object):
             saveload_fstr = '{0}.save_load'.format(self.opts['master_job_cache'])
             self.mminion.returners[saveload_fstr](load['jid'], load)
         log.info('Got return from {id} for job {jid}'.format(**load))
+        self.event.fire_event(load, load['jid'])  # old dup event
         self.event.fire_event(
             load, tagify([load['jid'], 'ret', load['id']], 'job'))
         self.event.fire_ret_load(load)
@@ -2309,6 +2310,7 @@ class ClearFuncs(object):
             }
 
         # Announce the job on the event bus
+        self.event.fire_event(new_job_load, 'new_job')  # old dup event
         self.event.fire_event(new_job_load, tagify([clear_load['jid'], 'new'], 'job'))
 
         if self.opts['ext_job_cache']:


### PR DESCRIPTION
Reverts saltstack/salt#17235

@cachedout @thatch45 This commit introduced some test failures, so I am reverting this for now until they can be cleaned up. The original PR test data isn't available any more, so if you're wondering, the relevant failures were:
- integration.client.kwarg.StdTest.test_full_returns
- integration.client.kwarg.StdTest.test_kwarg_type
- integration.client.standard.StdTest.test_full_returns
- integration.shell.matcher.MatchTest.test_static
