### PR TITLE
Suppress echoing of line in deprecation warnings

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1857,6 +1857,19 @@ def warn_until(version,
         )
 
     if _dont_call_warnings is False:
+        def _formatwarning(message,
+                           category,
+                           filename,
+                           lineno,
+                           line=None):  # pylint: disable=W0613
+            '''
+            Replacement for warnings.formatwarning that disables the echoing of
+            the 'line' parameter.
+            '''
+            return '{0}:{1}: {2}: {3}'.format(
+                filename, lineno, category.__name__, message
+            )
+        warnings.formatwarning = _formatwarning
         warnings.warn(
             message.format(version=version.formatted_version),
             category,


### PR DESCRIPTION
This is done by replacing warnings.formatwarning with a replacement function
that ignores the "line" parameter.

This is an ugly hack, and I'm open to better suggestions.

@s0undt3ch thoughts?
