### PR TITLE
Revert "Remove redundant keys() since dict is an iterator of keys"

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -193,7 +193,7 @@ class SREQ(object):
         '''
         if hasattr(self, '_socket'):
             if isinstance(self.poller.sockets, dict):
-                for socket in self.poller.sockets:
+                for socket in self.poller.sockets.keys():
                     self.poller.unregister(socket)
             else:
                 for socket in self.poller.sockets:
@@ -235,7 +235,7 @@ class SREQ(object):
 
     def destroy(self):
         if isinstance(self.poller.sockets, dict):
-            for socket in self.poller.sockets:
+            for socket in self.poller.sockets.keys():
                 if socket.closed is False:
                     socket.setsockopt(zmq.LINGER, 1)
                     socket.close()


### PR DESCRIPTION
This reverts commit 1ef0b85ff5f81ce20dcfce3d1c810dae55aeb1f7.

This caused a bunch of RuntimeError exceptions like the following:

```
Exception RuntimeError: 'dictionary changed size during iteration' in
<bound method SREQ.__del__ of <salt.payload.SREQ object at 0x7fde1c240590>> ignored
```

@jacksontj FYI
