### PR TITLE
Per Python docs, favor open() over file() except for typechecking

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -426,7 +426,7 @@ def _upstart_disable(name):
     Disable an Upstart service.
     '''
     override = '/etc/init/{0}.override'.format(name)
-    with file(override, 'w') as ofile:
+    with open(override, 'w') as ofile:
         ofile.write('manual')
     return _upstart_is_disabled(name)
 

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3803,9 +3803,9 @@ def serialize(name,
     if merge_if_exists:
         if os.path.isfile(name):
             if formatter == 'yaml':
-                existing_data = yaml.safe_load(file(name, 'r'))
+                existing_data = yaml.safe_load(open(name, 'r'))
             elif formatter == 'json':
-                existing_data = json.load(file(name, 'r'))
+                existing_data = json.load(open(name, 'r'))
             else:
                 return {'changes': {},
                         'comment': ('{0} format is not supported for merging'


### PR DESCRIPTION
See note in https://docs.python.org/2/library/functions.html#file
