### PR TITLE
Fix broken ipv6 address verification in salt.utils.validate.net

### DIFF
--- a/salt/utils/validate/net.py
+++ b/salt/utils/validate/net.py
@@ -24,38 +24,47 @@ def mac(addr):
     return valid.match(addr) is not None
 
 
-def ipv4_addr(addr):
+def __ip_addr(addr, address_family=socket.AF_INET):
     '''
     Returns True if the IP address (and optional subnet) are valid, otherwise
     returns False.
     '''
+    mask_max = '32'
+    if address_family == socket.AF_INET6:
+        mask_max = '128'
+
     try:
         if '/' not in addr:
-            addr += '/32'
+            addr = '{addr}/{mask_max}'.format(addr=addr, mask_max=mask_max)
     except TypeError:
         return False
 
-    ip, subnet_len = addr.rsplit('/', 1)
+    ip, mask = addr.rsplit('/', 1)
 
     # Verify that IP address is valid
     try:
-        socket.inet_aton(ip)
+        socket.inet_pton(address_family, ip)
     except socket.error:
         return False
-    else:
-        if len(ip.split('.')) != 4:
-            return False
 
-    # Verify that subnet length is valid
+    # Verify that mask is valid
     try:
-        subnet_len = int(subnet_len)
+        mask = int(mask)
     except ValueError:
         return False
     else:
-        if not 1 <= subnet_len <= 32:
+        if not 1 <= mask <= int(mask_max):
             return False
 
     return True
+
+
+def ipv4_addr(addr):
+    '''
+    Returns True if the IPv4 address (and optional subnet) are valid, otherwise
+    returns False.
+    '''
+    return __ip_addr(addr, socket.AF_INET)
 
 
 def ipv6_addr(addr):
@@ -63,33 +72,7 @@ def ipv6_addr(addr):
     Returns True if the IPv6 address (and optional subnet) are valid, otherwise
     returns False.
     '''
-    # From http://stackoverflow.com/questions/6276115/ipv6-regexp-python
-    ip6_regex = (r'(\A([0-9a-f]{1,4}:){1,1}(:[0-9a-f]{1,4}){1,6}\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){1,2}(:[0-9a-f]{1,4}){1,5}\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){1,3}(:[0-9a-f]{1,4}){1,4}\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){1,4}(:[0-9a-f]{1,4}){1,3}\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){1,5}(:[0-9a-f]{1,4}){1,2}\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){1,6}(:[0-9a-f]{1,4}){1,1}\Z)|'
-                 r'(\A(([0-9a-f]{1,4}:){1,7}|:):\Z)|(\A:(:[0-9a-f]{1,4})'
-                 r'{1,7}\Z)|(\A((([0-9a-f]{1,4}:){6})(25[0-5]|2[0-4]\d|[0-1]'
-                 r'?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3})\Z)|'
-                 r'(\A(([0-9a-f]{1,4}:){5}[0-9a-f]{1,4}:(25[0-5]|2[0-4]\d|'
-                 r'[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3})\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){5}:[0-9a-f]{1,4}:(25[0-5]|2[0-4]\d|'
-                 r'[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\Z)|'
-                 r'(\A([0-9a-f]{1,4}:){1,1}(:[0-9a-f]{1,4}){1,4}:(25[0-5]|'
-                 r'2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d))'
-                 r'{3}\Z)|(\A([0-9a-f]{1,4}:){1,2}(:[0-9a-f]{1,4}){1,3}:'
-                 r'(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?'
-                 r'\d?\d)){3}\Z)|(\A([0-9a-f]{1,4}:){1,3}(:[0-9a-f]{1,4})'
-                 r'{1,2}:(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|'
-                 r'[0-1]?\d?\d)){3}\Z)|(\A([0-9a-f]{1,4}:){1,4}(:[0-9a-f]'
-                 r'{1,4}){1,1}:(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|'
-                 r'2[0-4]\d|[0-1]?\d?\d)){3}\Z)|(\A(([0-9a-f]{1,4}:){1,5}|:):'
-                 r'(25[0-5]|2[0-4]\d|[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?'
-                 r'\d?\d)){3}\Z)|(\A:(:[0-9a-f]{1,4}){1,5}:(25[0-5]|2[0-4]\d|'
-                 r'[0-1]?\d?\d)(\.(25[0-5]|2[0-4]\d|[0-1]?\d?\d)){3}\Z)')
-    return bool(re.match(ip6_regex, addr))
+    return __ip_addr(addr, socket.AF_INET6)
 
 
 def netmask(mask):

--- a/tests/unit/utils/validate_net_test.py
+++ b/tests/unit/utils/validate_net_test.py
@@ -39,7 +39,11 @@ class ValidateNetTestCase(TestCase):
             '::1/28',
         ]
 
-        __ip_addr(true_addrs, false_addrs)
+        for addr in true_addrs:
+            self.assertTrue(net.ipv4_addr(addr))
+
+        for addr in false_addrs:
+            self.assertFalse(net.ipv4_addr(addr))
 
 
     def test_ipv6_addr(self):
@@ -61,15 +65,12 @@ class ValidateNetTestCase(TestCase):
             '::1/129',
         ]
 
-        __ip_addr(true_addrs, false_addrs)
-
-
-    def __ip_addr(self, true_addrs=[], false_addrs=[]):
         for addr in true_addrs:
-            self.assertTrue(net.ipv4_addr(addr))
+            self.assertTrue(net.ipv6_addr(addr))
 
         for addr in false_addrs:
-            self.assertFalse(net.ipv4_addr(addr))
+            self.assertFalse(net.ipv6_addr(addr))
+
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/unit/utils/validate_net_test.py
+++ b/tests/unit/utils/validate_net_test.py
@@ -1,0 +1,76 @@
+# -*- coding: utf-8 -*-
+
+# Import Salt Libs
+from salt.utils.validate import net
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class ValidateNetTestCase(TestCase):
+    '''
+    TestCase for salt.utils.validate.net module
+    '''
+
+    def test_ipv4_addr(self):
+        '''
+        Test IPv4 address validation
+        '''
+        true_addrs = [
+            '127.0.0.1',
+            '127.0.0.1',
+            '127.0.0.19',
+            '1.1.1.1/28',
+            '127.0.0.11/32',
+        ]
+
+        false_addrs = [
+            '127.0.0.911',
+            '127.0.0911',
+            '127.0.011',
+            '127.0.011/32',
+            '::1',
+            '::1/128',
+            '::1/28',
+        ]
+
+        __ip_addr(true_addrs, false_addrs)
+
+
+    def test_ipv6_addr(self):
+        '''
+        Test IPv6 address validation
+        '''
+        true_addrs = [
+            '::1',
+            '::1/32',
+            '::1/32',
+            '::1/128',
+            '2a03:4000:c:10aa:1017:f00d:aaaa:a',
+        ]
+
+        false_addrs = [
+            '1.1.1.1',
+            '::1/0',
+            '::1/32d',
+            '::1/129',
+        ]
+
+        __ip_addr(true_addrs, false_addrs)
+
+
+    def __ip_addr(self, true_addrs=[], false_addrs=[]):
+        for addr in true_addrs:
+            self.assertTrue(net.ipv4_addr(addr))
+
+        for addr in false_addrs:
+            self.assertFalse(net.ipv4_addr(addr))
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(ValidateNetTestCase, needs_daemon=False)


### PR DESCRIPTION
Because of https://github.com/saltstack/salt/commit/37af3acfe8ea3178b8fc660076c723ad5694bedc some tiny sweet cats must cry because in their opinion
1. It's absolutely nonsense to have regular expressions that nobody can understand and maintain
2. It's wrong to reinvent the wheel, so using the socket package would have been sufficient
3. It's wrong to change this validation process without knowing whether it will work or not due to not adding any tests

See here for sad cats: http://lmgtfy.com/?q=sad+cat

Also the current implementation of the ipv6_addr tells us that `2a03:4000:c:10aa:1017:f00d:aaaa:a` is not a valid IPv6 address. This is not true and breaks (in my case) salt.states.network.managed().

To make both functions less error-prone and less annoying I propose the following patch. 

See here for happy cats: http://lmgtfy.com/?q=happy+cat
