### PR TITLE
modules.genesis._bootstrap_yum: rm unused string format args

### DIFF
--- a/salt/modules/genesis.py
+++ b/salt/modules/genesis.py
@@ -129,8 +129,8 @@ def _bootstrap_yum(root, pkg_confs='/etc/yum*'):
         which are required for the install to work.
     '''
     _make_nodes(root)
-    __salt__['cmd.run']('cp /etc/resolv/conf /etc/*release {root}/etc'.format(root=root, confs=pkg_confs))
-    __salt__['cmd.run']('cp -r /etc/*release {root}/etc'.format(root=root, confs=pkg_confs))
+    __salt__['cmd.run']('cp /etc/resolv/conf /etc/*release {root}/etc'.format(root=root))
+    __salt__['cmd.run']('cp -r /etc/*release {root}/etc'.format(root=root))
     __salt__['cmd.run']('cp -r {confs} {root}/etc'.format(root=root, confs=pkg_confs))
     __salt__['cmd.run']('yum install --installroot={0} -y yum centos-release iputils'.format(root))
     __salt__['cmd.run']('rpm --root={0} -Uvh http://download.fedoraproject.org/pub/epel/6/i386/epel-release-6-8.noarch.rpm'.format(root))


### PR DESCRIPTION
```
************* Module salt.modules.genesis
salt/modules/genesis.py:131: [W1304(unused-format-string-argument), _bootstrap_yum] Unused format argument 'confs'
salt/modules/genesis.py:132: [W1304(unused-format-string-argument), _bootstrap_yum] Unused format argument 'confs'
```
