### PR TITLE
Fix salt.utils.fire_exception() ?

### DIFF
--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -47,4 +47,4 @@ def fire_exception(exc, opts, job=None, node='minion'):
     if job is None:
         job = {}
     event = salt.utils.event.SaltEvent(node, opts=opts)
-    event.fire_event(pack_exception, '_salt_error')
+    event.fire_event(pack_exception(exc), '_salt_error')


### PR DESCRIPTION
Ignoring the `exc` argument here seems very weird; presumably is a bug.

```
************* Module salt.utils.error
salt/utils/error.py:43: [W0613(unused-argument), fire_exception] Unused argument 'exc'
```
