### PR TITLE
Fix error in lvcreate (pv=None)

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -254,7 +254,7 @@ def vgcreate(vgname, devices, **kwargs):
     return vgdata
 
 
-def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv='', **kwargs):
+def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv=None, **kwargs):
     '''
     Create a new logical volume, with option for which physical volume to be used
 


### PR DESCRIPTION
Hello.I have state:

<pre>
 /dev/sda5_zabbix01:
   lvm.pv_present:
     - name: /dev/sda5
 
 head-vg_zabbix01:
   lvm.vg_present:
     - name: head-vg
     - devices:
       - /dev/sda5

 zabbix01_root: 
   lvm.lv_present:
     - vgname: head-vg
     - size: 32G 
     - require:
       - lvm: head-vg
</pre>

This is not work in 2014.7, because

<pre>
[INFO    ] Executing command ['lvcreate', '-n', 'zabbix01_root', 'head-vg', '-L', '32G', ''] in directory '/root'
[ERROR   ] Command ['lvcreate', '-n', 'zabbix01_root', 'head-vg', '-L', '32G', ''] failed with return code: 5
[ERROR   ] output:   Physical Volume "" not found in Volume Group "head-vg"
</pre>

Me ubuntu execute "lvcreate -n zabbix01_root head-vg -L 32G ''  and return "Physical Volume "" not found in Volume Group "head-vg"", because pv=''. I think this is error. You can fix this?
