### PR TITLE
Move from __future__ import to beginning of module

### DIFF
--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -29,12 +29,12 @@ In other words `salt mac-machine pkg.refresh_db` is more like
 `apt-get update; apt-get upgrade dpkg apt-get` than simply `apt-get update`.
 
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import copy
 import logging
 import re
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/mine.py
+++ b/salt/modules/mine.py
@@ -2,11 +2,11 @@
 '''
 The function cache system allows for data to be stored on the master so it can be easily read by other minions
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import copy
 import logging
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.crypt

--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -33,6 +33,7 @@ Module to provide MySQL compatibility to salt.
     </ref/states/all/salt.states.mysql_user>`. Additionally, it is now possible
     to setup a user with no password.
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import time
@@ -40,7 +41,6 @@ import logging
 import re
 import sys
 import shlex
-from __future__ import absolute_import
 from six.moves import zip
 from six.moves import range
 

--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -6,11 +6,11 @@ See http://code.google.com/p/psutil.
 :depends:   - psutil Python module, version 0.3.0 or later
             - python-utmp package (optional)
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import time
 import datetime
-from __future__ import absolute_import
 
 # Import salt libs
 from salt.exceptions import SaltInvocationError, CommandExecutionError

--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -2,13 +2,13 @@
 '''
 Execute puppet routines
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import logging
 import os
 import yaml
 import datetime
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/qemu_nbd.py
+++ b/salt/modules/qemu_nbd.py
@@ -6,6 +6,7 @@ Qemu Command Wrapper
 The qemu system comes with powerful tools, such as qemu-img and qemu-nbd which
 are used here to build up kvm images.
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import os
@@ -13,7 +14,6 @@ import glob
 import tempfile
 import time
 import logging
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/selinux.py
+++ b/salt/modules/selinux.py
@@ -10,10 +10,10 @@ Execute calls on selinux
     documentation for your distro to ensure that the proper packages are
     installed.
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import os
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.utils

--- a/salt/modules/serverdensity_device.py
+++ b/salt/modules/serverdensity_device.py
@@ -5,10 +5,12 @@ Wrapper around Server Density API
 
 .. versionadded:: 2014.7.0
 '''
+from __future__ import absolute_import
+
 import requests
 import json
 import logging
-from __future__ import absolute_import
+
 from six.moves import map
 
 from salt.exceptions import CommandExecutionError

--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -2,6 +2,7 @@
 '''
 Control the state system on the minion
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import os
@@ -13,7 +14,6 @@ import logging
 import tarfile
 import datetime
 import tempfile
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.config

--- a/salt/modules/sysmod.py
+++ b/salt/modules/sysmod.py
@@ -2,11 +2,11 @@
 '''
 The sys module provides information about the available functions on the minion
 '''
+from __future__ import absolute_import
 
 # Import python libs
 import fnmatch
 import logging
-from __future__ import absolute_import
 
 # Import salt libs
 import salt.loader


### PR DESCRIPTION
PEP 0236 [0] demands that "all future_statements must appear near the top of the
module." and that the only lines that can appear before a future_statment are
the module docstring, comments, blank lines or other future_statements

This commit fixes the following modules:
- salt.modules.macports
- salt.modules.mine
- salt.modules.mysql
- salt.modules.ps
- salt.modules.qemu_nbd
- salt.modules.selinux
- salt.modules.serverdensity_device
- salt.modules.state
- salt.modules.sysmod
- salt.modules.puppet

This commit fixes #17684

[0] http://legacy.python.org/dev/peps/pep-0236/
