### PR TITLE
Fix pylint and matcher problems from merge forward

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2483,7 +2483,7 @@ class Matcher(object):
         Reads in the pillar match, no globbing
         '''
         log.debug('pillar target: {0}'.format(tgt))
-        if delim not in tgt:
+        if delimiter not in tgt:
             log.error('Got insufficient arguments for pillar match '
                       'statement from master')
             return False

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2478,7 +2478,7 @@ class Matcher(object):
             self.opts['pillar'], tgt, delimiter=delimiter
         )
 
-    def pillar_exact_match(self, tgt, delim=':'):
+    def pillar_exact_match(self, tgt, delimiter=':'):
         '''
         Reads in the pillar match, no globbing
         '''
@@ -2489,7 +2489,7 @@ class Matcher(object):
             return False
         return salt.utils.subdict_match(self.opts['pillar'],
                                         tgt,
-                                        delimiter=delim,
+                                        delimiter=delimiter,
                                         exact_match=True)
 
     def ipcidr_match(self, tgt):

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -218,12 +218,13 @@ class CkMinions(object):
         '''
         return self._check_cache_minions(expr, delimiter, greedy, 'pillar')
 
-    def _check_pillar_exact_minions(self, expr, greedy):
+    def _check_pillar_exact_minions(self, expr, delimiter, greedy):
         '''
         Return the minions found by looking via pillar
         '''
         return self._check_cache_minions(expr,
                                          greedy,
+                                         delimiter,
                                          'pillar',
                                          exact_match=True)
 
@@ -332,13 +333,16 @@ class CkMinions(object):
                         pass
         return list(minions)
 
-    def _check_compound_pillar_exact_minions(self, expr, greedy):
+    def _check_compound_pillar_exact_minions(self, expr, delimiter, greedy):
         '''
         Return the minions found by looking via compound matcher
 
         Disable pillar glob matching
         '''
-        return self._check_compound_minions(expr, greedy, pillar_exact=True)
+        return self._check_compound_minions(expr,
+                                            delimiter,
+                                            greedy,
+                                            pillar_exact=True)
 
     def _check_compound_minions(self,
                                 expr,
@@ -502,7 +506,12 @@ class CkMinions(object):
         '''
         try:
             check_func = getattr(self, '_check_{0}_minions'.format(expr_form), None)
-            if expr_form in ('grain', 'grain_pcre', 'pillar', 'compound'):
+            if expr_form in ('grain',
+                             'grain_pcre',
+                             'pillar',
+                             'pillar_exact',
+                             'compound',
+                             'compound_pillar_exact'):
                 minions = check_func(expr, delimiter, greedy)
             else:
                 minions = check_func(expr, greedy)


### PR DESCRIPTION
The matcher had been changed a bit in `develop` so the merge forward broke my pillar/compound fixes. This should put them back in working order, and fix the pylint in the process.
