### PR TITLE
Fixed namespace issue in cloud/clouds/cloudstack.py which was breaking i...

### DIFF
--- a/salt/cloud/clouds/cloudstack.py
+++ b/salt/cloud/clouds/cloudstack.py
@@ -45,6 +45,7 @@ except ImportError:
 log = logging.getLogger(__name__)
 
 # Redirect CloudStack functions to this module namespace
+get_node = namespaced_function(get_node, globals())
 get_size = namespaced_function(get_size, globals())
 get_image = namespaced_function(get_image, globals())
 avail_locations = namespaced_function(avail_locations, globals())


### PR DESCRIPTION
Fixed namespace issue in cloud/clouds/cloudstack.py which was breaking its destroy method.

This is the traceback, before the patch:

```
[ERROR   ] There was an error destroying machines: global name '__active_provider_name__' is not defined
Traceback (most recent call last):
  File "/usr/lib/python2.6/site-packages/salt/cloud/cli.py", line 166, in run
    ret = mapper.destroy(names, cached=True)
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 957, in destroy
    ret = self.clouds[fun](name)
  File "/usr/lib64/python2.6/contextlib.py", line 34, in __exit__
    self.gen.throw(type, value, traceback)
  File "/usr/lib/python2.6/site-packages/salt/utils/context.py", line 41, in func_globals_inject
    yield
  File "/usr/lib/python2.6/site-packages/salt/cloud/__init__.py", line 957, in destroy
    ret = self.clouds[fun](name)
  File "/usr/lib/python2.6/site-packages/salt/cloud/clouds/cloudstack.py", line 455, in destroy
    node = get_node(conn, name)
  File "/usr/lib/python2.6/site-packages/salt/cloud/libcloudfuncs.py", line 105, in get_node
    salt.utils.cloud.cache_node(salt.utils.cloud.simple_types_filter(node.__dict__), __active_provider_name__, __opts__)
NameError: global name '__active_provider_name__' is not defined
```
