### PR TITLE
minion.Matcher.pillar_exact_match: fix utils.subdict_match() call

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2489,7 +2489,7 @@ class Matcher(object):
             return False
         return salt.utils.subdict_match(self.opts['pillar'],
                                         tgt,
-                                        delim=delim,
+                                        delimiter=delim,
                                         exact_match=True)
 
     def ipcidr_match(self, tgt):


### PR DESCRIPTION
```
************* Module salt.minion
salt/minion.py:2492: [E1123(unexpected-keyword-arg), Matcher.pillar_exact_match] Unexpected keyword argument 'delim' in function call
```
