### PR TITLE
Updated aptpkg.mod_repo() module to properly add new PPAs

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1314,10 +1314,10 @@ def mod_repo(repo, saltenv='base', **kwargs):
             # implementation via apt-add-repository.  The code path for
             # secure PPAs should be the same as urllib method
             if HAS_SOFTWAREPROPERTIES and 'ppa_auth' not in kwargs:
-                try:
-                    get_repo(repo)
-                    return {repo: ''}
-                except Exception:
+                repo_info = get_repo(repo)
+                if repo_info:
+                    return {repo: repo_info}
+                else:
                     if float(__grains__['osrelease']) < 12.04:
                         cmd = 'apt-add-repository {0}'.format(repo)
                     else:


### PR DESCRIPTION
This is one potential fix for issue #17709.

In addition to parsing the return of `get_repo()` rather than catching its exceptions, this also fixes the return value for `mod_repo()` if the PPA is already installed by returning the repo info rather than an empty string.
