### PR TITLE
modules.mac_user: xrange() => six.moves.range()

### DIFF
--- a/salt/modules/mac_user.py
+++ b/salt/modules/mac_user.py
@@ -12,6 +12,7 @@ import logging
 import random
 import string
 import time
+from six.moves import range
 
 # Import salt libs
 import salt.utils
@@ -55,7 +56,7 @@ def _dscl(cmd, ctype='create'):
 
 def _first_avail_uid():
     uids = set(x.pw_uid for x in pwd.getpwall())
-    for idx in xrange(501, 2 ** 32):
+    for idx in range(501, 2 ** 32):
         if idx not in uids:
             return idx
 
@@ -110,7 +111,7 @@ def add(name,
     # Set random password, since without a password the account will not be
     # available. TODO: add shadow module
     randpass = ''.join(
-        random.SystemRandom().choice(string.letters + string.digits) for x in xrange(20)
+        random.SystemRandom().choice(string.letters + string.digits) for x in range(20)
     )
     _dscl('/Users/{0} {1!r}'.format(name, randpass), ctype='passwd')
 


### PR DESCRIPTION
```
************* Module salt.modules.mac_user
salt/modules/mac_user.py:58: [W1613(xrange-builtin), _first_avail_uid] xrange built-in referenced
salt/modules/mac_user.py:113: [W1613(xrange-builtin), add] xrange built-in referenced
```
