### PR TITLE
runners.lxc: basestring => six.string_types

### DIFF
--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -11,6 +11,7 @@ import time
 import os
 import copy
 import logging
+from six import string_types
 
 # Import Salt libs
 from salt.utils.odict import OrderedDict
@@ -187,7 +188,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         ret['comment'] = 'A host must be provided'
         ret['result'] = False
         return ret
-    if isinstance(names, basestring):
+    if isinstance(names, string_types):
         names = names.split(',')
     if not isinstance(names, list):
         ret['comment'] = 'Container names are not formed as a list'


### PR DESCRIPTION
```
************* Module salt.runners.lxc
salt/runners/lxc.py:190: [W1602(basestring-builtin), init] basestring built-in referenced
```
