### PR TITLE
Fix modules/iptables match-set parsing

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -1080,7 +1080,7 @@ def _parser():
     ## sctp
     add_arg('--chunk-types', dest='chunk-types', action='append')
     ## set
-    add_arg('--match-set', dest='match-set', action='append')
+    add_arg('--match-set', dest='match-set', action='append', nargs=2)
     add_arg('--return-nomatch', dest='return-nomatch', action='append')
     add_arg('--update-counters', dest='update-counters', action='append')
     add_arg('--update-subcounters', dest='update-subcounters', action='append')


### PR DESCRIPTION
As for man iptables-extensions

```
       [!] --match-set setname flag[,flag]...
```

match-set must have two arguments.
