### PR TITLE
Detect QEMU system from System manufacturer

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -526,6 +526,8 @@ def _virtual(osdata):
             if 'Vendor: QEMU' in output:
                 # FIXME: Make this detect between kvm or qemu
                 grains['virtual'] = 'kvm'
+            if 'Manufacturer: QEMU' in output:
+                grains['virtual'] = 'kvm'
             if 'Vendor: Bochs' in output:
                 grains['virtual'] = 'kvm'
             if 'BHYVE  BVXSDT' in output:


### PR DESCRIPTION
When system use SeaBIOS, the Vender: QEMU is not found in dmidecode. We must then
rely on System Manufacturer to check for QEMU.
