### PR TITLE
Detect chroot virtualization subtype

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -583,6 +583,11 @@ def _virtual(osdata):
     isdir = os.path.isdir
     sysctl = salt.utils.which('sysctl')
     if osdata['kernel'] in choices:
+        if os.path.isdir('/proc'):
+            self_root = os.stat('/')
+            init_root = os.stat('/proc/1/root/.')
+            if self_root != init_root:
+                grains['virtual_subtype'] = 'chroot'
         if os.path.isfile('/proc/1/cgroup'):
             try:
                 if ':/lxc/' in salt.utils.fopen(


### PR DESCRIPTION
Add a check against PID 1 root and current root for chrooted environment.
