### PR TITLE
Added some pylint disables to handle six imports

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -34,7 +34,7 @@ from functools import reduce
 from six import string_types
 from six.moves import range
 from six.moves import zip
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse  # pylint: disable=E0611
 
 try:
     import grp

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -24,7 +24,7 @@ import shutil
 import re
 import random
 import six
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse  # pylint: disable=E0611
 
 # Import salt libs
 import salt

--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -29,7 +29,8 @@ import sys  # do not remove, used in imported file.py functions
 import fileinput  # do not remove, used in imported file.py functions
 import fnmatch  # do not remove, used in imported file.py functions
 from six import string_types  # do not remove, used in imported file.py functions
-from six.moves.urllib.parse import urlparse  # do not remove, used in imported file.py functions
+# do not remove, used in imported file.py functions
+from six.moves.urllib.parse import urlparse  # pylint: disable=E0611
 import salt.utils.atomicfile  # do not remove, used in imported file.py functions
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 # pylint: enable=W0611

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -12,7 +12,7 @@ import logging
 import re
 import os
 import six
-import six.moves.configparser
+import six.moves.configparser  # pylint: disable=E0611
 import urlparse
 from xml.dom import minidom as dom
 

--- a/salt/pillar/cobbler.py
+++ b/salt/pillar/cobbler.py
@@ -28,7 +28,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
-import six.moves.xmlrpc_client
+import six.moves.xmlrpc_client  # pylint: disable=E0611
 
 
 __opts__ = {'cobbler.url': 'http://localhost/cobbler_api',

--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -50,7 +50,7 @@ from __future__ import absolute_import
 from contextlib import contextmanager
 import collections
 import logging
-import six.moves.cPickle as pickle
+import six.moves.cPickle as pickle  # pylint: disable=E0611
 import socket
 import struct
 import time

--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -50,7 +50,6 @@ from salt.exceptions import (
     CommandExecutionError, MinionError, SaltInvocationError
 )
 from salt.modules.pkg_resource import _repack_pkgs
-import six
 
 _repack_pkgs = _namespaced_function(_repack_pkgs, globals())
 

--- a/salt/tops/cobbler.py
+++ b/salt/tops/cobbler.py
@@ -23,7 +23,7 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
-import six.moves.xmlrpc_client
+import six.moves.xmlrpc_client  # pylint: disable=E0611
 
 
 # Set up logging

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -36,7 +36,7 @@ import yaml
 import string
 from calendar import month_abbr as months
 from six import string_types
-from six.moves.urllib.parse import urlparse
+from six.moves.urllib.parse import urlparse  # pylint: disable=E0611
 import six
 from six.moves import range
 from six.moves import zip

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -10,7 +10,7 @@ import pprint
 import os.path
 import json
 import logging
-import six.moves.http_cookiejar
+import six.moves.http_cookiejar  # pylint: disable=E0611
 from salt._compat import ElementTree as ET
 
 # Import salt libs

--- a/salt/utils/ipaddr.py
+++ b/salt/utils/ipaddr.py
@@ -29,7 +29,6 @@ from __future__ import absolute_import
 import struct
 
 # Import salt libs
-from six.moves import range as xrange
 from six.moves import range
 
 __version__ = 'trunk'


### PR DESCRIPTION
Some of the `import __future__ from absolute_import`'s were confusing
pylint on Jenkins. I checked that the version of six on Jenkins is
up-to-date-enough to actually import the modules that are now disabled,
and they all worked as of at least `six 1.5.2`.

This doesn't fix all of the pylint errors, but it's a good start.
