### PR TITLE
Respect ruby when using gem with rbenv

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -22,7 +22,10 @@ def _gem(command, ruby=None, runas=None, gem_bin=None):
             return __salt__['rvm.do'](ruby, cmdline, runas=runas)
 
         if __salt__['rbenv.is_installed'](runas=runas):
-            return __salt__['rbenv.do'](cmdline, runas=runas)
+            if ruby is None:
+                return __salt__['rbenv.do'](cmdline, runas=runas)
+            else:
+                return __salt__['rbenv.do_with_ruby'](ruby, cmdline, runas=runas)
 
     ret = __salt__['cmd.run_all'](
         cmdline,


### PR DESCRIPTION
It fixes #7681. Without it you cannot install new gem when using rbenv without default.
