### PR TITLE
Fixed race conditions with salt-call using Raet when no local minion

### DIFF
--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -268,9 +268,12 @@ class Minion(parsers.MinionOptionParser):
         finally:
             self.shutdown()
 
-    def call(self):
+    def call(self, cleanup_protecteds):
         '''
         Start the actual minion as a caller minion.
+
+        cleanup_protecteds is list of yard host addresses that should not be
+        cleaned up this is to fix race condition when salt-caller minion starts up
 
         If sub-classed, don't **ever** forget to run:
 
@@ -282,6 +285,7 @@ class Minion(parsers.MinionOptionParser):
             self.prepare()
             if check_user(self.config['user']):
                 self.minion.opts['__role'] = kinds.APPL_KIND_NAMES[kinds.applKinds.caller]
+                self.minion.opts['raet_cleanup_protecteds'] = cleanup_protecteds
                 self.minion.call_in()
         except (KeyboardInterrupt, SaltSystemExit) as exc:
             logger.warn('Stopping the Salt Minion')

--- a/salt/daemons/flo/caller.flo
+++ b/salt/daemons/flo/caller.flo
@@ -32,10 +32,11 @@ framer callerroadstack be active first setup
             do salt raet road stack closer per inode ".salt.road.manor."
             do salt raet lane stack closer per inode ".salt.lane.manor."
 
-# Framer for handling inbound traffic
+
 framer inbound be inactive first start
     frame start
         do salt raet road stack service rx
+        do salt raet lane stack service rx
 
 framer bootstrap be inactive first join
     frame join
@@ -68,11 +69,10 @@ framer bootstrap be inactive first join
         print Allowed
         go next if elapsed >= 0.5
 
-    #frame pillar
-        #print Pillaring
-        #enter
-            #do salt load pillar
-        #go loading
+    frame manager
+        # start the manager framer
+        bid start manager #start alive presence from minion side
+        go next if elapsed >= 3.0
 
     frame loading
         print Loading
@@ -81,11 +81,8 @@ framer bootstrap be inactive first join
         go router
 
     frame router
-        # start the manager framer
-        bid start manager #start alive presence from minion side
         do salt raet router
-        #go pillar if .salt.var.pillar_refresh
-        #go loading if .salt.var.module_refresh
+
 
     frame abort
         bid stop all
@@ -98,8 +95,8 @@ framer manager be inactive first start at 10.0
     frame start
          do salt raet road stack manager per inode ".salt.road.manor"
 
-# Framer for handling outbound traffic
 framer outbound be inactive first start
     frame start
+        do salt raet lane stack service tx
         do salt raet road stack service tx
 

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -919,22 +919,6 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
                     "Using default route={0}.".format(msg['route']['dst']))
             self.road_stack.value.message(msg,
                     self.road_stack.value.nameRemotes[d_estate].uid)
-        elif d_share == 'call_cmd':  # salt call return pub to master
-            if not self.road_stack.value.remotes:
-                log.error("Missing joined master. Unable to route "
-                          "call_cmd.".format())
-                return
-            d_estate = self._get_master_estate_name()
-            if not d_estate:
-                log.error("**** No available destination estate for 'call_cmd'."
-                          "Unable to route.".format())
-                return
-            d_share = 'remote_cmd'
-            msg['route']['dst'] = (d_estate, d_yard, d_share)
-            log.debug("**** Missing destination estate for 'call_cmd'. "
-                        "Using default route={0}.".format(msg['route']['dst']))
-            self.road_stack.value.message(msg,
-                    self.road_stack.value.nameRemotes[d_estate].uid)
 
     def _get_master_estate_name(self):
         '''

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -77,6 +77,7 @@ class SaltRaetCleanup(ioflo.base.deeding.Deed):
         if self.opts.value.get('sock_dir'):
             sockdirpath = os.path.abspath(self.opts.value['sock_dir'])
             console.concise("Cleaning up uxd files in {0}\n".format(sockdirpath))
+            protecteds = self.opts.value.get('raet_cleanup_protecteds', [])
             for name in os.listdir(sockdirpath):
                 path = os.path.join(sockdirpath, name)
                 if os.path.isdir(path):
@@ -85,6 +86,8 @@ class SaltRaetCleanup(ioflo.base.deeding.Deed):
                 if ext != '.uxd':
                     continue
                 if not all(root.partition('.')):
+                    continue
+                if path in protecteds:
                     continue
                 try:
                     os.unlink(path)
@@ -719,14 +722,13 @@ class SaltRaetRoadStackService(ioflo.base.deeding.Deed):
 
 class SaltRaetRoadStackServiceRx(ioflo.base.deeding.Deed):
     '''
-    Process the inbound udp traffic
+    Process the inbound Road traffic
     FloScript:
 
-    do rx
+    do salt raet road stack service rx
 
     '''
     Ioinits = {
-               'lane_stack': '.salt.lane.manor.stack',
                'road_stack': '.salt.road.manor.stack',
                }
 
@@ -735,21 +737,18 @@ class SaltRaetRoadStackServiceRx(ioflo.base.deeding.Deed):
         Process inboud queues
         '''
         self.road_stack.value.serviceAllRx()
-        self.lane_stack.value.serviceAllRx()
-
 
 class SaltRaetRoadStackServiceTx(ioflo.base.deeding.Deed):
     '''
-    Process the inbound udp traffic
+    Process the outbound Road traffic
     FloScript:
 
-    do tx
+    do salt raet road stack service tx
 
     '''
     # Yes, this class is identical to RX, this is because we still need to
     # separate out rx and tx in raet itself
     Ioinits = {
-               'lane_stack': '.salt.lane.manor.stack',
                'road_stack': '.salt.road.manor.stack',
                }
 
@@ -757,13 +756,49 @@ class SaltRaetRoadStackServiceTx(ioflo.base.deeding.Deed):
         '''
         Process inbound queues
         '''
-        self.lane_stack.value.serviceAllTx()
         self.road_stack.value.serviceAllTx()
 
+class SaltRaetLaneStackServiceRx(ioflo.base.deeding.Deed):
+    '''
+    Process the inbound Lane traffic
+    FloScript:
+
+    do salt raet lane stack service rx
+
+    '''
+    Ioinits = {
+               'lane_stack': '.salt.lane.manor.stack',
+               }
+
+    def action(self):
+        '''
+        Process inboud queues
+        '''
+        self.lane_stack.value.serviceAllRx()
+
+class SaltRaetLaneStackServiceTx(ioflo.base.deeding.Deed):
+    '''
+    Process the outbound Lane traffic
+    FloScript:
+
+    do salt raet lane stack service tx
+
+    '''
+    # Yes, this class is identical to RX, this is because we still need to
+    # separate out rx and tx in raet itself
+    Ioinits = {
+               'lane_stack': '.salt.lane.manor.stack',
+               }
+
+    def action(self):
+        '''
+        Process outbound queues
+        '''
+        self.lane_stack.value.serviceAllTx()
 
 class SaltRaetRouter(ioflo.base.deeding.Deed):
     '''
-    Routes the communication in and out of uxd connections
+    Routes the communication in and out of Road and Lane connections
 
     This is the initial static salt router, we want to create a dynamic
     router that takes a map that defines where packets are send
@@ -783,7 +818,9 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
                'worker_verify': '.salt.var.worker_verify',
                'lane_stack': '.salt.lane.manor.stack',
                'road_stack': '.salt.road.manor.stack',
-               'master_estate_name': '.salt.track.master_estate_name', }
+               'master_estate_name': '.salt.track.master_estate_name',
+               'laters': {'ipath': '.salt.lane.manor.laters', #requeuing when not yet routable
+                          'ival': deque()},               }
 
     def _process_udp_rxmsg(self, msg, sender):
         '''
@@ -812,7 +849,7 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
             pass
         elif d_estate != self.road_stack.value.local.name:
             log.error(
-                    'Received message for wrong estate: {0}'.format(d_estate))
+                    'Road Router Received message for wrong estate: {0}'.format(d_estate))
             return
 
         if d_yard is not None:
@@ -852,7 +889,7 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
             s_estate, s_yard, s_share = msg['route']['src']
             d_estate, d_yard, d_share = msg['route']['dst']
         except (ValueError, IndexError):
-            log.error('Received invalid message: {0}'.format(msg))
+            log.error('Lane Router Received invalid message: {0}'.format(msg))
             return
 
         if s_yard is None:
@@ -893,7 +930,7 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
             return
         if d_share is None:
             # No queue destination!
-            log.error('Received message without share: {0}'.format(msg))
+            log.error('Lane Router Received message without share: {0}'.format(msg))
             return
         elif d_share == 'local_cmd':
             self.lane_stack.value.transmit(msg,
@@ -904,18 +941,20 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
         elif d_share == 'event_fire':
             self.event.value.append(msg)
             #log.debug("\n**** Event Fire \n {0}\n".format(msg))
-        elif d_share == 'remote_cmd':  # assume must be minion to master
+        elif d_share == 'remote_cmd':  # assume  minion to master or salt-call
             if not self.road_stack.value.remotes:
-                log.error("Missing joined master. Unable to route "
-                          "remote_cmd.".format())
+                log.error("**** Lane Router: Missing joined master. Unable to route "
+                          "remote_cmd. Requeuing".format())
+                self.laters.value.append((msg, sender))
                 return
             d_estate = self._get_master_estate_name()
             if not d_estate:
-                log.error("**** No available destination estate for 'remote_cmd'."
-                          "Unable to route.".format())
+                log.error("**** Lane Router: No available destination estate for 'remote_cmd'."
+                          "Unable to route. Requeuing".format())
+                self.laters.value.append((msg, sender))
                 return
             msg['route']['dst'] = (d_estate, d_yard, d_share)
-            log.debug("**** Missing destination estate for 'remote_cmd'. "
+            log.debug("**** Lane Router: Missing destination estate for 'remote_cmd'. "
                     "Using default route={0}.".format(msg['route']['dst']))
             self.road_stack.value.message(msg,
                     self.road_stack.value.nameRemotes[d_estate].uid)
@@ -952,6 +991,9 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
         while self.road_stack.value.rxMsgs:
             msg, sender = self.road_stack.value.rxMsgs.popleft()
             self._process_udp_rxmsg(msg=msg, sender=sender)
+        while self.laters.value:  # process requeued LaneMsgs
+            msg, sender = self.laters.value.popleft()
+            self.lane_stack.value.rxMsgs.append((msg, sender))
         while self.lane_stack.value.rxMsgs:
             msg, sender = self.lane_stack.value.rxMsgs.popleft()
             self._process_uxd_rxmsg(msg=msg, sender=sender)

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -738,6 +738,7 @@ class SaltRaetRoadStackServiceRx(ioflo.base.deeding.Deed):
         '''
         self.road_stack.value.serviceAllRx()
 
+
 class SaltRaetRoadStackServiceTx(ioflo.base.deeding.Deed):
     '''
     Process the outbound Road traffic
@@ -758,6 +759,7 @@ class SaltRaetRoadStackServiceTx(ioflo.base.deeding.Deed):
         '''
         self.road_stack.value.serviceAllTx()
 
+
 class SaltRaetLaneStackServiceRx(ioflo.base.deeding.Deed):
     '''
     Process the inbound Lane traffic
@@ -775,6 +777,7 @@ class SaltRaetLaneStackServiceRx(ioflo.base.deeding.Deed):
         Process inboud queues
         '''
         self.lane_stack.value.serviceAllRx()
+
 
 class SaltRaetLaneStackServiceTx(ioflo.base.deeding.Deed):
     '''
@@ -795,6 +798,7 @@ class SaltRaetLaneStackServiceTx(ioflo.base.deeding.Deed):
         Process outbound queues
         '''
         self.lane_stack.value.serviceAllTx()
+
 
 class SaltRaetRouter(ioflo.base.deeding.Deed):
     '''
@@ -819,8 +823,8 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
                'lane_stack': '.salt.lane.manor.stack',
                'road_stack': '.salt.road.manor.stack',
                'master_estate_name': '.salt.track.master_estate_name',
-               'laters': {'ipath': '.salt.lane.manor.laters', #requeuing when not yet routable
-                          'ival': deque()},               }
+               'laters': {'ipath': '.salt.lane.manor.laters',  # requeuing when not yet routable
+                          'ival': deque()}, }
 
     def _process_udp_rxmsg(self, msg, sender):
         '''

--- a/salt/daemons/flo/master.flo
+++ b/salt/daemons/flo/master.flo
@@ -44,6 +44,7 @@ framer masterudpstack be active first setup
 framer inbound be inactive first start
     frame start
         do salt raet road stack service rx
+        do salt raet lane stack service rx
 
 # Router framer
 framer uxdrouter be inactive first start
@@ -68,4 +69,5 @@ framer manager be inactive first start at 10.0
 # Outbound framer
 framer outbound be inactive first start
     frame start
+        do salt raet lane stack service tx
         do salt raet road stack service tx

--- a/salt/daemons/flo/minion.flo
+++ b/salt/daemons/flo/minion.flo
@@ -39,6 +39,7 @@ framer minionudpstack be active first setup
 framer inbound be inactive first start
     frame start
         do salt raet road stack service rx
+        do salt raet lane stack service rx
 
 framer bootstrap be inactive first join
     frame join
@@ -108,7 +109,9 @@ framer manager be inactive first start at 10.0
 # Framer for handling outbound traffic
 framer outbound be inactive first start
     frame start
+        do salt raet lane stack service tx
         do salt raet road stack service tx
+
 
 framer scheduler be inactive first start
     frame start

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -281,6 +281,7 @@ class Runner(RunnerClient):
         '''
         Execute the runner sequence
         '''
+        ret = {}
         if self.opts.get('doc', False):
             self.print_docs()
         else:

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -88,12 +88,7 @@ class RAETChannel(Channel):
         self.ttype = 'raet'
         if usage == 'master_call':  # runner.py master_call
             self.dst = (None, None, 'local_cmd')
-        elif usage == 'salt_call':  # salt_call caller
-            #self.dst = (None, None, 'remote_cmd')
-            self.dst = (jobber_estate_name or None,
-                        jobber_yard_name or None,
-                        'call_cmd')
-        else:  # everything else minion to master
+        else:  # everything else minion to master including salt-call
             self.dst = (jobber_estate_name or None,
                         jobber_yard_name or None,
                         'remote_cmd')


### PR DESCRIPTION
The minion cleans up stale uxd files. It would sometimes clean up the salt-caller fixed
The salt-caller would send msg to minoon before minion's master was available. Now requeues messages until avaiable
