### PR TITLE
bugfixes: netbsd_sysctl

### DIFF
--- a/salt/modules/netbsd_sysctl.py
+++ b/salt/modules/netbsd_sysctl.py
@@ -133,7 +133,7 @@ def persist(name, value):
                 edited = True
 
     if not edited:
-        newline = '{0}{1}{2}'.format(name, m.group(1), value)
+        newline = '{0}={1}'.format(name, value)
         nlines.append("{0}\n".format(newline))
 
     with salt.utils.fopen(config, 'w+') as ofile:

--- a/salt/modules/netbsd_sysctl.py
+++ b/salt/modules/netbsd_sysctl.py
@@ -3,6 +3,7 @@
 Module for viewing and modifying sysctl parameters
 '''
 from __future__ import absolute_import
+import os
 import re
 
 # Import salt libs
@@ -96,7 +97,7 @@ def assign(name, value):
     return ret
 
 
-def persist(name, value):
+def persist(name, value, config='/etc/sysctl.conf'):
     '''
     Assign and persist a simple sysctl parameter for this minion
 
@@ -109,7 +110,14 @@ def persist(name, value):
     nlines = []
     edited = False
     value = str(value)
-    config = '/etc/sysctl.conf'
+
+    # create /etc/sysctl.conf if not present
+    if not os.path.isfile(config):
+        try:
+            salt.utils.fopen(config, 'w+').close()
+        except (IOError, OSError):
+            msg = 'Could not create {0}'
+            raise CommandExecutionError(msg.format(config))
 
     with salt.utils.fopen(config, 'r') as ifile:
         for line in ifile:


### PR DESCRIPTION
(state) sysctl.present is broken on netbsd (module not behaving like on other OS)
state calls modules with 3 arguments, but netbsd only took 2 (now takes 3 like all others)

(module) sysctl.persist broken on new entries (traced)
