### PR TITLE
sysctl: use user provided config if any

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -82,7 +82,10 @@ def show(config_file=False):
     '''
     ret = {}
     if config_file:
-        config_file_path = default_config()
+        if config_file is True:
+            config_file_path = default_config()
+        else:
+            config_file_path = config_file
         try:
             for line in salt.utils.fopen(config_file_path):
                 if not line.startswith('#') and '=' in line:

--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -54,7 +54,7 @@ def present(name, value, config=None):
             config = '/etc/sysctl.conf'
 
     current = __salt__['sysctl.show']()
-    configured = __salt__['sysctl.show'](config_file=True)
+    configured = __salt__['sysctl.show'](config_file=config)
     if __opts__['test']:
         if name in current and name not in configured:
             if re.sub(' +|\t+', ' ', current[name]) != re.sub(' +|\t+', ' ', str(value)):


### PR DESCRIPTION
After upgrade to 2014.7.0, sysctl states will show a message like this :
"Sysctl value is currently set on the running system but not in a config file."

But we have provide a config file when define state for salt.states.sysctl.present. After check the code, we found current module will always use the default config to check present. This pull request is intend to fix the bug, please review, thanks.
