### PR TITLE
extfs: skip 'Group descriptor size'

### DIFF
--- a/salt/modules/extfs.py
+++ b/salt/modules/extfs.py
@@ -242,7 +242,7 @@ def dump(device, args=None):
             comps = line.split(': ')
             if line.startswith('Filesystem features'):
                 ret['attributes'][comps[0]] = comps[1].split()
-            elif line.startswith('Group'):
+            elif line.startswith('Group') and not line.startswith('Group descriptor size'):
                 mode = 'blocks'
             else:
                 ret['attributes'][comps[0]] = comps[1].strip()


### PR DESCRIPTION
skip attribute 'Group descriptor size' for mode 'blocks'.
dumpe2fs 1.42.9 (e.g, on CentOS 7) show this attribute.
