### PR TITLE
Checking if exceptions module can be imported as it's removed from Python3

### DIFF
--- a/salt/utils/error.py
+++ b/salt/utils/error.py
@@ -6,8 +6,10 @@ Utilities to enable exception reraising across the master commands
 from __future__ import absolute_import
 
 # Import python libs
-import exceptions
-
+try:
+    import exceptions
+except ImportError:
+    pass
 
 # Import salt libs
 import salt.exceptions


### PR DESCRIPTION
Fixes #18068
