### PR TITLE
Fix YAML syntax in mine_functions example.

### DIFF
--- a/doc/topics/mine/index.rst
+++ b/doc/topics/mine/index.rst
@@ -48,9 +48,8 @@ calls of the same function with different arguments.
         mine_function: network.ip_addrs
         cidr: 192.168.0.0/16
       loopback_ip_addrs:
-        - mine_function: network.ip_addrs
-        - lo
-        - True
+        mine_function: network.ip_addrs
+        lo: True
 
 Mine Interval
 =============


### PR DESCRIPTION
The elements provided for a mine_functions definition need to be
either a list or a dict, but not a mix of both.

This example was added in `2014.7`, but might also need some cherry-picking towards `develop` once it's merged.
