### PR TITLE
fix docs for filter_by arguments

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -414,13 +414,16 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
     :param default: default lookup_dict's key used if the grain does not exists
         or if the grain value has no match on lookup_dict.  If unspecified
         the value is "default".
+
+        .. versionadded:: 2014.1.0
+
     :param base: A lookup_dict key to use for a base dictionary.  The
         grain-selected ``lookup_dict`` is merged over this and then finally
         the ``merge`` dictionary is merged.  This allows common values for
         each case to be collected in the base and overridden by the grain
         selection dictionary and the merge dictionary.  Default is unset.
 
-         .. versionadded:: 2014.1.0
+        .. versionadded:: Lithium
 
     CLI Example:
 


### PR DESCRIPTION
It seems that `base` arg (introduced by Thayne Harbaugh) is only on Lithium (develop branch)
and the `default` arg was actually added on 2014.1.0.
This is particularly confusing because usage of `base` arg is shown on formulas docs
as a best practice

http://docs.saltstack.com/en/latest/topics/development/conventions/formulas.html#collecting-common-values

As I side note I'm really sad that `base` arg didn't make it to Helium release :/
