### PR TITLE
Adds param to def create_attach_volume (wait_to_finish), default to true...

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2093,7 +2093,7 @@ def queue_instances(instances):
         salt.utils.cloud.cache_node(node, __active_provider_name__, __opts__)
 
 
-def create_attach_volumes(name, kwargs, call=None):
+def create_attach_volumes(name, kwargs, call=None, wait_to_finish=True):
     '''
     Create and attach volumes to created node
     '''
@@ -2133,7 +2133,7 @@ def create_attach_volumes(name, kwargs, call=None):
                 volume_dict['iops'] = volume['iops']
 
         if 'volume_id' not in volume_dict:
-            created_volume = create_volume(volume_dict, call='function')
+            created_volume = create_volume(volume_dict, call='function', wait_to_finish=wait_to_finish)
             created = True
             for item in created_volume:
                 if 'volumeId' in item:


### PR DESCRIPTION
Issue: #18118 
In a nutshell, as far as I know you cannot attach a newly created volume to an instance until it's 'available'. Therefore, when _creating and attaching volumes_ we always need to _wait for the volume to finish_.

I've added an additional param to def _create_attach_volume_ defaulted to True (in case for some reason you want to tell this to be False as well). This will obviously hand itself to _create_volume_, which now behaves as expected.
