### PR TITLE
Added special branch '_' in git_pillar to match saltenv

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -17,7 +17,7 @@ to look for Pillar files (such as ``top.sls``).
     The optional ``root`` parameter will be added.
 
 .. versionchanged:: @TBD
-    The special branch name '_' will be replace by the environment ({{env}})
+    The special branch name '__env__' will be replace by the environment ({{env}})
 
 Note that this is not the same thing as configuring pillar data using the
 :conf_master:`pillar_roots` parameter. The branch referenced in the
@@ -166,7 +166,7 @@ class GitPillar(object):
 
     def map_branch(self, branch, opts=None):
         opts = __opts__ if opts is None else opts
-        if branch == '_':
+        if branch == '__env__':
             branch = opts['environment']
             if branch == 'base':
                 branch = opts['gitfs_base']


### PR DESCRIPTION
I prefer a setup where states/pillar come from a remote git repository. Something like:

```
## srv/salt/top.sls:
{{env}}:
  - bar

## srv/pillar/top.sls:
{{env}}:
  - bar
```

Such that I can do:
`salt '*' state.highstate test=True saltenv=my_test_branch`

This will effectively translated to:

```
## srv/salt/top.sls:
my_test_branch:
  - bar

## srv/pillar/top.sls:
my_test_branch:
  - bar
```

Corresponding master config:

```
fileserver_backend:
  - git

gitfs_remotes:
    - file:///var/tmp/saltmaster:
        - root: salt

ext_pillar:
  - git: _ file:///var/tmp/saltmaster root=pillar
```
