### PR TITLE
small doc fix

### DIFF
--- a/doc/topics/development/conventions/formulas.rst
+++ b/doc/topics/development/conventions/formulas.rst
@@ -315,7 +315,7 @@ different from the base must be specified of the alternates:
             'python': 'dev-python/mysql-python',
         },
     },
-    merge=salt['pillar.get']('mysql:lookup'), base=default) %}
+    merge=salt['pillar.get']('mysql:lookup'), base='default') %}
 
 
 Overriding values in the lookup table


### PR DESCRIPTION
On "Collecting common values" (in formulas) with grains.filter_by.  According to [docs](https://github.com/saltstack/salt/blob/1e7bc9cba14cbf08108c7b3223c2333cc413e50f/salt/modules/grains.py#L420-L424) `base` arg should be a key (string) of the given dict
