### PR TITLE
Docker insecure registry

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1577,7 +1577,7 @@ def _pull_assemble_error_status(status, ret, logs):
     return status
 
 
-def pull(repo, tag=None):
+def pull(repo, tag=None, insecure_registry=False):
     '''
     Pulls an image from any registry. See documentation at top of this page to
     configure authenticated access
@@ -1588,6 +1588,10 @@ def pull(repo, tag=None):
     tag
         specific tag to pull (Optional)
 
+    insecure_registry
+        set as ``True`` to use insecure (non HTTPS) registry. Default is ``False``
+        (only available if using docker-py >= 0.5.0)
+
     CLI Example:
 
     .. code-block:: bash
@@ -1597,7 +1601,14 @@ def pull(repo, tag=None):
     client = _get_client()
     status = base_status.copy()
     try:
-        ret = client.pull(repo, tag=tag)
+        kwargs = {'tag' : tag}
+        # if docker-py version is greater than 0.5.0 use the
+        # insecure_registry parameter
+        if salt.utils.compare_versions(ver1=docker.__version__,
+                                       oper='>=',
+                                       ver2='0.5.0'):
+            kwargs['insecure_registry'] = insecure_registry
+        ret = client.pull(repo, **kwargs)
         if ret:
             image_logs, infos = _parse_image_multilogs_string(ret, repo)
             if infos and infos.get('Id', None):
@@ -1661,7 +1672,7 @@ def _push_assemble_error_status(status, ret, logs):
     return status
 
 
-def push(repo, tag=None, quiet=False):
+def push(repo, tag=None, quiet=False, insecure_registry=False):
     '''
     Pushes an image to any registry. See documentation at top of this page to
     configure authenticated access
@@ -1675,6 +1686,10 @@ def push(repo, tag=None, quiet=False):
     quiet
         set as ``True`` to quiet output, Default is ``False``
 
+    insecure_registry
+        set as ``True`` to use insecure (non HTTPS) registry. Default is ``False``
+        (only available if using docker-py >= 0.5.0)
+
     CLI Example:
 
     .. code-block:: bash
@@ -1685,7 +1700,14 @@ def push(repo, tag=None, quiet=False):
     status = base_status.copy()
     registry, repo_name = docker.auth.resolve_repository_name(repo)
     try:
-        ret = client.push(repo, tag=tag)
+        kwargs = {'tag' : tag}
+        # if docker-py version is greater than 0.5.0 use the
+        # insecure_registry parameter
+        if salt.utils.compare_versions(ver1=docker.__version__,
+                                       oper='>=',
+                                       ver2='0.5.0'):
+            kwargs['insecure_registry'] = insecure_registry
+        ret = client.pull(repo, **kwargs)
         if ret:
             image_logs, infos = _parse_image_multilogs_string(ret, repo_name)
             if image_logs:

--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -221,7 +221,12 @@ def mod_watch(name, sfun=None, *args, **kw):
                         ' implemented for {0}'.format(sfun))}
 
 
-def pulled(name, tag=None, force=False, *args, **kwargs):
+def pulled(name,
+           tag=None,
+           force=False,
+           insecure_registry=False,
+           *args,
+           **kwargs):
     '''
     Pull an image from a docker registry. (`docker pull`)
 
@@ -245,6 +250,9 @@ def pulled(name, tag=None, force=False, *args, **kwargs):
 
     force
         Pull even if the image is already pulled
+
+    insecure_registry
+        Set to ``True``to allow connections to non-HTTPS registries. Default ``False``.
     '''
     inspect_image = __salt__['docker.inspect_image']
     image_infos = inspect_image(name)
@@ -262,7 +270,7 @@ def pulled(name, tag=None, force=False, *args, **kwargs):
 
     previous_id = image_infos['out']['Id'] if image_infos['status'] else None
     pull = __salt__['docker.pull']
-    returned = pull(name, tag=tag)
+    returned = pull(name, tag=tag, insecure_registry=insecure_registry)
     if previous_id != returned['id']:
         changes = {name: {'old': previous_id,
                           'new': returned['id']}}
@@ -271,7 +279,7 @@ def pulled(name, tag=None, force=False, *args, **kwargs):
     return _ret_status(returned, name, changes=changes)
 
 
-def pushed(name, tag=None):
+def pushed(name, tag=None, insecure_registry=False):
     '''
     Push an image from a docker registry. (`docker push`)
 
@@ -293,6 +301,8 @@ def pushed(name, tag=None):
     tag
         Tag of the image [Optional]
 
+    insecure_registry
+        Set to ``True``to allow connections to non-HTTPS registries. Default ``False``.
     '''
 
     if __opts__['test']:
@@ -303,7 +313,7 @@ def pushed(name, tag=None):
                 'comment': comment}
 
     push = __salt__['docker.push']
-    returned = push(name, tag=tag)
+    returned = push(name, tag=tag, insecure_registry=insecure_registry)
     log.debug("Returned: "+str(returned))
     if returned['status']:
         changes = {name: {'Rev': returned['id']}}


### PR DESCRIPTION
Since `docker-py 0.5.0` registries (private or not) must be configured with HTTPS.
This merge request allows non-HTTPS registries by using the `insecure_registry` argument.
