### PR TITLE
Fix zypper

### DIFF
--- a/_requirements.txt
+++ b/_requirements.txt
@@ -3,3 +3,4 @@ msgpack-python > 0.3
 PyYAML
 MarkupSafe
 requests >= 1.0.0
+six

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -255,7 +255,7 @@ def _get_repo_info(alias, repos_cfg=None):
         return {}
 
 
-def get_repo(repo):
+def get_repo(repo, **dummy_kwargs):
     '''
     Display a repo.
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -255,7 +255,7 @@ def _get_repo_info(alias, repos_cfg=None):
         return {}
 
 
-def get_repo(repo, **dummy_kwargs):
+def get_repo(repo, **kwargs):
     '''
     Display a repo.
 


### PR DESCRIPTION
`states/pkgrepo.py` always sets 'ppa_auth' when calling `get_repo()`. For `modules/zypper.py` this results in an error. The pull request fixes this problem on the `modules/zypper.py` side by ignoring the extra argument.

sample SLS:

``` yaml
jenkins:
    pkgrepo.managed: 
        - url: http://download.opensuse.org/repositories/devel:/tools:/building/openSUSE_13.1/
        - name: devel:tools:building.repo
        - gpgcheck: 0
        - require_in:
            - pkg: jenkins
    pkg.installed:
        - name: jenkins
```

Second change is the specification of 'six' as a requirement (introduced through `modules/zypper.py`).
