### PR TITLE
Remove heading from top-level docstrings

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
-Management of Dockers
-=====================
+Management of Docker Containers
 
 .. versionadded:: 2014.1.0
 

--- a/salt/modules/memcached.py
+++ b/salt/modules/memcached.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 Module for Management of Memcached Keys
-=======================================
 
 .. versionadded:: 2014.1.0
 '''

--- a/salt/modules/qemu_nbd.py
+++ b/salt/modules/qemu_nbd.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 Qemu Command Wrapper
-====================
 
 The qemu system comes with powerful tools, such as qemu-img and qemu-nbd which
 are used here to build up kvm images.

--- a/salt/modules/solr.py
+++ b/salt/modules/solr.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 Apache Solr Salt Module
-=======================
 
 Author: Jed Glazner
 Version: 0.2.1

--- a/salt/modules/syslog_ng.py
+++ b/salt/modules/syslog_ng.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 Module for getting information about syslog-ng
-===============================================
 
 :maintainer:    Tibor Benke <btibi@sch.bme.hu>
 :maturity:      new

--- a/salt/modules/zcbuildout.py
+++ b/salt/modules/zcbuildout.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 '''
 Management of zc.buildout
-=========================
 
 .. versionadded:: 2014.1.0
 


### PR DESCRIPTION
It makes sphinx's autosummary look off by showing up in the summary text. For
example:

http://docs.saltstack.com/en/latest/ref/modules/all/index.html
