### PR TITLE
Revert "Add six to list of mocked modules"

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -47,7 +47,6 @@ MOCK_MODULES = [
     'Crypto.PublicKey',
     'Crypto.Random',
     'M2Crypto',
-    'six',
     'msgpack',
     'yaml',
     'yaml.constructor',


### PR DESCRIPTION
This reverts commit 6ebf0fd3aa3c2b17a2ae324196f59c9e0e4614ab.

We need six installed in order for the docs to build. Six is too magical
to be mocked, at last, for now.
