### PR TITLE
Fixing docker.absent to match its documentation

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -498,12 +498,27 @@ def absent(name):
                     comment=('Container {0!r}'
                              ' could not be stopped'.format(cid)))
             else:
-                return _valid(comment=('Container {0!r}'
-                                       ' was stopped,'.format(cid)),
-                              changes={name: True})
+                __salt__['docker.remove_container'](cid)
+                is_gone = __salt__['docker.exists'](cid)
+                if is_gone:
+                    return _valid(comment=('Container {0!r}'
+                                           ' was stopped and destroyed, '.format(cid)),
+                                           changes={name: True})
+                else:
+                    return _valid(comment=('Container {0!r}'
+                                           ' was stopped but could not be destroyed,'.format(cid)),
+                                           changes={name: True})
         else:
-            return _valid(comment=('Container {0!r}'
-                                   ' is stopped,'.format(cid)))
+            __salt__['docker.remove_container'](cid)
+            is_gone = __salt__['docker.exists'](cid)
+            if is_gone:
+                return _valid(comment=('Container {0!r}'
+                                       ' is stopped and was destroyed, '.format(cid)),
+                                       changes={name: True})
+            else:
+                return _valid(comment=('Container {0!r}'
+                                       ' is stopped but could not be destroyed,'.format(cid)),
+                                       changes={name: True})
     else:
         return _valid(comment='Container {0!r} not found'.format(name))
 


### PR DESCRIPTION
The documentation states that the function will stop and destroy the container. Unfortunately the code only stops the container, does not destroy it.

This pull request makes it do what the documentation states it should do.
