### PR TITLE
[don't merge!!] Add six dependency notice to building docs intructions

### DIFF
--- a/doc/topics/development/conventions/documentation.rst
+++ b/doc/topics/development/conventions/documentation.rst
@@ -290,8 +290,15 @@ cross-referenced using two custom roles, ``conf_master`` and ``conf_minion``.
 Building the documentation
 ==========================
 
-1.  Install Sphinx using a system package manager or pip. The package name is
-    often of the form ``python-sphinx``. There are no other dependencies.
+1.  Install Sphinx using a system package manager. The other dependency
+    needed to build the docs is ``six``. The package names are often of the
+    form ``python-sphinx`` and ``python-six``. Both packages can also be
+    installed in a virtualenv with pip:
+
+    .. code-block:: bash
+
+        pip install Sphinx
+        pip install six
 
 2.  Build the documentation using the provided Makefile or ``.bat`` file on
     Windows.

--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -226,12 +226,14 @@ Editing and previewing the documentation
 ----------------------------------------
 
 You need ``sphinx-build`` command to build the docs. In Debian/Ubuntu this is
-provided in the ``python-sphinx`` package. Sphinx can also be installed
-to a virtualenv using pip:
+provided in the ``python-sphinx`` package. ``six`` is also needed to build the
+docs and is available on Debian/Ubuntu systems as ``python-six``. Sphinx and
+six can also be installed to a virtualenv using pip:
 
 .. code-block:: bash
 
     pip install Sphinx
+    pip install six
 
 Change to salt documentation directory, then:
 


### PR DESCRIPTION
Don't merge this yet! Refs: #18113

ping @s0undt3ch @whiteinge 

This adds the dependency information about six if it is indeed needed to build the docs. I know @whiteinge is still investigating the errors. If the dep on six is needed, here's the doc change. If there is a better work-around discovered, feel free to just close this PR.
