### PR TITLE
Wrap map function in a list so file.append will work

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -616,7 +616,7 @@ def _unify_sources_and_hashes(source=None, source_hash=None,
         return (True, '', [(source, source_hash)])
 
     # Make a nice neat list of tuples exactly len(sources) long..
-    return (True, '', map(None, sources, source_hashes[:len(sources)]))
+    return True, '', list(map(None, sources, source_hashes[:len(sources)]))
 
 
 def _get_template_texts(source_list=None,


### PR DESCRIPTION
`file.append` broke with the `six` changes. This change will fix it by returning a list instead of an iterator from `_unify_sources_and_hashes`.
