### PR TITLE
utils/__init__.py: rm redundant import of six.string_types

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -106,7 +106,6 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 import salt.log
 import salt.payload
 import salt.version
-from six import string_types
 from salt.utils.decorators import memoize as real_memoize
 from salt.exceptions import (
     CommandExecutionError, SaltClientError,


### PR DESCRIPTION
```
salt/utils/__init__.py:109: [W0404(reimported), ] Reimport 'string_types' (imported line 38)
```
