### PR TITLE
Fix for pyobjects __salt__ wrapper (SaltObject)

### DIFF
--- a/salt/utils/pyobjects.py
+++ b/salt/utils/pyobjects.py
@@ -272,27 +272,16 @@ class SaltObject(object):
         Salt.cmd.run(bar)
     '''
     def __init__(self, salt):
-        _mods = {}
-        for full_func in salt:
-            mod, func = full_func.split('.')
-
-            if mod not in _mods:
-                _mods[mod] = {}
-            _mods[mod][func] = salt[full_func]
-
-        # now transform using namedtuples
-        self.mods = {}
-        for mod in _mods:
-            mod_name = '{0}Module'.format(str(mod).capitalize())
-            mod_object = namedtuple(mod_name, _mods[mod])
-
-            self.mods[mod] = mod_object(**_mods[mod])
+        self._salt = salt
 
     def __getattr__(self, mod):
-        if mod not in self.mods:
-            raise AttributeError
-
-        return self.mods[mod]
+        class __wrapper__(object):
+            def __getattr__(wself, func):
+                try:
+                    return self._salt["%s.%s" % (mod, func)]
+                except KeyError:
+                    raise AttributeError
+        return __wrapper__()
 
 
 class MapMeta(type):


### PR DESCRIPTION
This is a proposed fix for #18088 where the `__salt__` object cannot simply be iterated over when used via `salt-ssh`. The existing implementation of `SaltObject` (the pyobjects renderer wrapper for more object-oriented access to functions registered in the `__salt__` dictionary) requires iteration to resolve all modules in advance.

The new implementation changes this so it does not need to prepare the list of modules in advance but it just wraps anything passed and forwards it to the underlying dictionary.
