### PR TITLE
add systemd info in grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -960,7 +960,7 @@ def os_data():
         # Add systemd grain, if you have it
         if _linux_bin_exists('systemctl') and _linux_bin_exists('localectl'):
             grains['systemd'] = {}
-            systemd_info =  __salt__['cmd.run'](
+            systemd_info = __salt__['cmd.run'](
                 'systemctl --version'
             ).splitlines()
             grains['systemd']['version'] = systemd_info[0].split()[1]

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -957,6 +957,15 @@ def os_data():
                     'getenforce'
                 ).strip()
 
+        # Add systemd grain, if you have it
+        if _linux_bin_exists('systemctl') and _linux_bin_exists('localectl'):
+            grains['systemd'] = {}
+            systemd_info =  __salt__['cmd.run'](
+                'systemctl --version'
+            ).splitlines()
+            grains['systemd']['version'] = systemd_info[0].split()[1]
+            grains['systemd']['features'] = systemd_info[1]
+
         # Add lsb grains on any distro with lsb-release
         try:
             import lsb_release


### PR DESCRIPTION
There are several cases in which it's useful to know if a machine has systemd installed or not.

Not only when configuring a machine (i.e. running commands in sls files) but this could also be useful in salt itself.

Cheers
