### PR TITLE
Add 'lib64' to .gitignore which might be created by 'virtualenv'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ MANIFEST
 bin/
 include/
 lib/
+lib64
 pip/
 share/
 tests/integration/tmp/


### PR DESCRIPTION
`virtualenv` might create `lib64` in 64bit environments as symlink pointing to `./lib/` - adding it to `.gitignore` helps keeping the development environment clean.
