### PR TITLE
Fix Git's config set with values containing white spaces.

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -840,7 +840,7 @@ def config_set(cwd=None, setting_name=None, setting_value=None, user=None, is_gl
 
     _check_git()
 
-    return _git_run('git config {0} {1} {2}'.format(scope, setting_name, setting_value),
+    return _git_run('git config {0} {1} "{2}"'.format(scope, setting_name, setting_value),
                     cwd=cwd, runas=user)
 
 

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+
+import shutil
+import subprocess
+import tempfile
+
+# Import Salt Testing libs
+from salttesting.helpers import ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+
+
+class GitModuleTest(integration.ModuleCase):
+    @classmethod
+    def setUpClass(self):
+        from salt.utils import which
+        git = which('git')
+        if not git:
+            self.skipTest('The git binary is not available')
+
+
+    def setUp(self):
+        self.repos = tempfile.mkdtemp(dir=integration.TMP)
+        self.addCleanup(shutil.rmtree, self.repos, ignore_errors=True)
+        subprocess.check_call(['git', 'init', '--quiet', self.repos])
+
+
+    def test_config_set_value_has_space_characters(self):
+        '''
+        git.config_set
+        '''
+        config_key = "user.name"
+        config_value = "foo bar"
+
+        ret = self.run_function(
+            'git.config_set',
+            cwd=self.repos,
+            setting_name=config_key,
+            setting_value=config_value,
+        )
+        self.assertEqual("", ret)
+
+        output = subprocess.check_output(
+            ['git', 'config', '--local', config_key],
+            cwd=self.repos)
+
+        self.assertEqual(config_value + "\n", output)

--- a/tests/integration/modules/pillar.py
+++ b/tests/integration/modules/pillar.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import absolute_import
+
 # Import Python Libs
 from distutils.version import LooseVersion
 


### PR DESCRIPTION
The Salt function `git.config_set` and the state `git.config` (which relies on the former) don't escape the value to be set in the configuration file passed by Salt. For example, this doesn't work:

```
  mylocalrepo:
    git.config:
      - name: user.name
      - value: "Jonathan Ballet"
      - repo: file://my/path/to/repo
```

This set the `user.name` configuration value to `Jonathan` only.
(Additionally, the state discovers that the value set is not the one specified, and keeps trying to set the right value, which ends up with lot of `name = Jonathan` into the`[user]` section of Git's config file.)

This commit fixes the problem and adds some unit tests to verify it's working properly. The fix is pretty simple yet too simple, and I wonder if there's not something bigger underlying. Since there's no shell quoting at all, it's very to bork anything from this state, this command, or a command written similarly. It looks so obvious that it might be just a design decision though.

I didn't fix the quoting for the name of the setting, since it's not supposed to have space inside. (Or is it?)
