### PR TITLE
set the keyboard using systemd when available (fixes bug in CentOS7)

### DIFF
--- a/salt/modules/keyboard.py
+++ b/salt/modules/keyboard.py
@@ -1,20 +1,24 @@
 # -*- coding: utf-8 -*-
 '''
-Module for managing keyboards on supported POSIX-like systems such as
-Arch, Redhat, Debian, and Gentoo systems.
+Module for managing keyboards on supported POSIX-like systems using
+systemd, or such as Redhat, Debian and Gentoo.
 '''
 
 # Import python libs
 import logging
+
+# Import salt libs
+import salt.utils
 
 log = logging.getLogger(__name__)
 
 
 def __virtual__():
     '''
-    Only work on supported POSIX-like systems
+    Only works with systemd or on supported POSIX-like systems
     '''
-    if __grains__['os_family'] in ('Arch', 'Redhat', 'Debian', 'Gentoo'):
+    if salt.utils.which('localectl') \
+            or __grains__['os_family'] in ('Redhat', 'Debian', 'Gentoo'):
         return True
     return False
 
@@ -30,7 +34,7 @@ def get_sys():
         salt '*' keyboard.get_sys
     '''
     cmd = ''
-    if 'Arch' in __grains__['os_family']:
+    if salt.utils.which('localectl'):
         cmd = 'localectl | grep Keymap | sed -e"s/: /=/" -e"s/^[ \t]*//"'
     elif 'RedHat' in __grains__['os_family']:
         cmd = 'grep LAYOUT /etc/sysconfig/keyboard | grep -vE "^#"'
@@ -53,7 +57,7 @@ def set_sys(layout):
 
         salt '*' keyboard.set_sys dvorak
     '''
-    if 'Arch' in __grains__['os_family']:
+    if salt.utils.which('localectl'):
         __salt__['cmd.run']('localectl set-keymap {0}'.format(layout))
     elif 'RedHat' in __grains__['os_family']:
         __salt__['file.sed']('/etc/sysconfig/keyboard',


### PR DESCRIPTION
CentOS 7 uses systemd and setting the keyboard throws an error (the sysconfig file doesn't exist).

Fix should be portable to `develop` also.

Cheers
