### PR TITLE
Fix some pylint errors on develop

### DIFF
--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -27,7 +27,7 @@ import ioflo.base.deeding
 log = logging.getLogger(__name__)
 
 # convert to set once list is larger than about 3 because set hashes
-INHIBIT_RETURN = [] # ['_return']  # cmd for which we should not send return
+INHIBIT_RETURN = []  # ['_return']  # cmd for which we should not send return
 
 
 class SaltRaetWorkerFork(ioflo.base.deeding.Deed):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -15,7 +15,6 @@ import six
 import six.moves.configparser  # pylint: disable=E0611
 import urlparse
 from xml.dom import minidom as dom
-from contextlib import contextmanager as _contextmanager
 try:
     from shlex import quote as _cmd_quote
 except ImportError:

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -10,7 +10,6 @@ import collections
 import six
 
 
-
 def update(dest, upd):
     for key, val in six.iteritems(upd):
         if isinstance(val, collections.Mapping):


### PR DESCRIPTION
There are some more pylint errors left-over from a merge-forward.
However, those will be cleaned up on the next merge-forward.
