### PR TITLE
Add SSL/TLS option to profile

### DIFF
--- a/salt/modules/smtp.py
+++ b/salt/modules/smtp.py
@@ -15,6 +15,7 @@ Module for Sending Messages via SMTP
 
         my-smtp-login:
             smtp.server: smtp.domain.com
+            smtp.tls: True
             smtp.sender: admin@domain.com
             smtp.username: myuser
             smtp.password: verybadpass
@@ -26,12 +27,14 @@ Module for Sending Messages via SMTP
 
         my-smtp-login:
             smtp.server: smtp.domain.com
+            smtp.tls: True
             smtp.sender: admin@domain.com
             smtp.username: myuser
             smtp.password: verybadpass
 
         another-smtp-login:
             smtp.server: smtp.domain.com
+            smtp.tls: True
             smtp.sender: admin@domain.com
             smtp.username: myuser
             smtp.password: verybadpass
@@ -88,6 +91,7 @@ def send_msg(recipient,
     if profile:
         creds = __salt__['config.option'](profile)
         server = creds.get('smtp.server')
+        use_ssl = creds.get('smtp.tls')
         sender = creds.get('smtp.sender')
         username = creds.get('smtp.username')
         password = creds.get('smtp.password')


### PR DESCRIPTION
This simple change adds in an option to set the use_ssl parameter in the profile by specifying smtp.tls.  The reason for the discrepancy is that the ec2-autoscale-reactor stack formula, at https://github.com/saltstack-formulas/ec2-autoscale-reactor, uses smtp.tls in the documentation.  TLS is the more generic term, so I stuck with that.
