### PR TITLE
Reorganize orchestration docs for state.over deprecation

### DIFF
--- a/doc/topics/tutorials/states_pt5.rst
+++ b/doc/topics/tutorials/states_pt5.rst
@@ -9,140 +9,12 @@ States Tutorial, Part 5 - Orchestration with Salt
   :doc:`Part 1 <states_pt1>` if you are not familiar with how to use states.
 
 
-Orchestration can be accomplished in two distinct ways:
-
-1. The :ref:`OverState System <states-overstate>`. Added in version 0.11.0,
-   this Salt :doc:`Runner </ref/runners/index>` allows for SLS files to be
-   organized into stages, and to require that one or more stages successfully
-   execute before another stage will run.
-
-2. The :ref:`Orchestrate Runner <orchestrate-runner>`. Added in version 0.17.0,
-   this Salt :doc:`Runner </ref/runners/index>` can use the full suite of
-   :doc:`requisites </ref/states/requisites>` available in states, and can also
-   execute states/functions using salt-ssh. This runner was designed with the
-   eventual goal of replacing the :ref:`OverState <states-overstate>`. 
-
-
-.. _states-overstate:
-
-The OverState System
---------------------
-
-Often, servers need to be set up and configured in a specific order, and systems
-should only be set up if systems earlier in the sequence have been set up
-without any issues.
-
-The OverState system can be used to orchestrate deployment in a smooth and
-reliable way across multiple systems in small to large environments.
-
-The OverState SLS
-~~~~~~~~~~~~~~~~~
-
-The OverState system is managed by an SLS file named ``overstate.sls``, located
-in the root of a Salt fileserver environment.
-
-The overstate.sls configures an unordered list of stages, each stage defines
-the minions on which to execute the state, and can define what sls files to
-run, execute a :mod:`state.highstate <salt.modules.state.highstate>`, or
-execute a function. Here's a sample ``overstate.sls``:
-
-.. code-block:: yaml
-
-    mysql:
-      match: 'db*'
-      sls:
-        - mysql.server
-        - drbd
-    webservers:
-      match: 'web*'
-      require:
-        - mysql
-    all:
-      match: '*'
-      require:
-        - mysql
-        - webservers
-
-.. note::
-   The ``match`` argument uses :ref:`compound matching <targeting-compound>`
-
-Given the above setup, the OverState will be carried out as follows:
-
-1. The ``mysql`` stage will be executed first because it is required by the
-   ``webservers`` and ``all`` stages.  It will execute :mod:`state.sls
-   <salt.modules.state.sls>` once for each of the two listed SLS targets
-   (``mysql.server`` and ``drbd``).  These states will be executed on all
-   minions whose minion ID starts with "db".
-   
-2. The ``webservers`` stage will then be executed, but only if the ``mysql``
-   stage executes without any failures. The ``webservers`` stage will execute a
-   :mod:`state.highstate <salt.modules.state.highstate>` on all minions whose
-   minion IDs start with "web".
-
-3. Finally, the ``all`` stage will execute, running :mod:`state.highstate
-   <salt.modules.state.highstate>` on all systems, if and only if the ``mysql``
-   and ``webservers`` stages completed without any failures.
-
-Any failure in the above steps would cause the requires to fail, preventing the
-dependent stages from executing.
-
-
-Using Functions with OverState
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In the above example, you'll notice that the stages lacking an ``sls`` entry
-run a :mod:`state.highstate <salt.modules.state.highstate>`. As mentioned
-earlier, it is also possible to execute other functions in a stage. This
-functionality was added in version 0.15.0.
-
-Running a function is easy:
-
-.. code-block:: yaml
-
-    http:
-      function:
-        pkg.install:
-          - httpd
-
-
-The list of function arguments are defined after the declared function. So, the
-above stage would run ``pkg.install http``. Requisites only function properly
-if the given function supports returning a custom return code.
-
-Executing an OverState
-~~~~~~~~~~~~~~~~~~~~~~
-
-Since the OverState is a :doc:`Runner </ref/runners/index>`, it is executed
-using the ``salt-run`` command. The runner function for the OverState is
-``state.over``.
-
-.. code-block:: bash
-
-    salt-run state.over
-
-The function will by default look in the root of the ``base`` environment (as
-defined in :conf_master:`file_roots`) for a file called ``overstate.sls``, and
-then execute the stages defined within that file.
-
-Different environments and paths can be used as well, by adding them as
-positional arguments:
-
-.. code-block:: bash
-
-    salt-run state.over dev /root/other-overstate.sls
-
-The above would run an OverState using the ``dev`` fileserver environment, with
-the stages defined in ``/root/other-overstate.sls``.
-
-.. warning::
-
-    Since these are positional arguments, when defining the path to the
-    overstate file the environment must also be specified, even if it is the
-    ``base`` environment.
-
-.. note::
-
-    Remember, salt-run is always executed on the master.
+Orchestration is accomplished in salt primarily through the :ref:`Orchestrate
+Runner <orchestrate-runner>`. Added in version 0.17.0, this Salt :doc:`Runner
+</ref/runners/index>` can use the full suite of :doc:`requisites
+</ref/states/requisites>` available in states, and can also execute
+states/functions using salt-ssh. This runner replaces the :ref:`OverState
+<states-overstate>`.
 
 
 .. _orchestrate-runner:
@@ -274,3 +146,136 @@ Given the above setup, the orchestration will be carried out as follows:
 
 3. Finally, the ``ceph`` SLS target will be executed on all minions which have
    a grain called ``role`` with a value of ``storage``.
+
+
+
+
+
+.. _states-overstate:
+
+The OverState System
+--------------------
+
+.. warning::
+
+    The OverState runner is deprecated, and will be removed in the feature
+    release of Salt codenamed Beryllium. (Two feature releases after 2014.7.0,
+    which is codenamed Helium)
+
+Often, servers need to be set up and configured in a specific order, and systems
+should only be set up if systems earlier in the sequence have been set up
+without any issues.
+
+The OverState system can be used to orchestrate deployment in a smooth and
+reliable way across multiple systems in small to large environments.
+
+The OverState SLS
+~~~~~~~~~~~~~~~~~
+
+The OverState system is managed by an SLS file named ``overstate.sls``, located
+in the root of a Salt fileserver environment.
+
+The overstate.sls configures an unordered list of stages, each stage defines
+the minions on which to execute the state, and can define what sls files to
+run, execute a :mod:`state.highstate <salt.modules.state.highstate>`, or
+execute a function. Here's a sample ``overstate.sls``:
+
+.. code-block:: yaml
+
+    mysql:
+      match: 'db*'
+      sls:
+        - mysql.server
+        - drbd
+    webservers:
+      match: 'web*'
+      require:
+        - mysql
+    all:
+      match: '*'
+      require:
+        - mysql
+        - webservers
+
+.. note::
+   The ``match`` argument uses :ref:`compound matching <targeting-compound>`
+
+Given the above setup, the OverState will be carried out as follows:
+
+1. The ``mysql`` stage will be executed first because it is required by the
+   ``webservers`` and ``all`` stages.  It will execute :mod:`state.sls
+   <salt.modules.state.sls>` once for each of the two listed SLS targets
+   (``mysql.server`` and ``drbd``).  These states will be executed on all
+   minions whose minion ID starts with "db".
+   
+2. The ``webservers`` stage will then be executed, but only if the ``mysql``
+   stage executes without any failures. The ``webservers`` stage will execute a
+   :mod:`state.highstate <salt.modules.state.highstate>` on all minions whose
+   minion IDs start with "web".
+
+3. Finally, the ``all`` stage will execute, running :mod:`state.highstate
+   <salt.modules.state.highstate>` on all systems, if and only if the ``mysql``
+   and ``webservers`` stages completed without any failures.
+
+Any failure in the above steps would cause the requires to fail, preventing the
+dependent stages from executing.
+
+
+Using Functions with OverState
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the above example, you'll notice that the stages lacking an ``sls`` entry
+run a :mod:`state.highstate <salt.modules.state.highstate>`. As mentioned
+earlier, it is also possible to execute other functions in a stage. This
+functionality was added in version 0.15.0.
+
+Running a function is easy:
+
+.. code-block:: yaml
+
+    http:
+      function:
+        pkg.install:
+          - httpd
+
+
+The list of function arguments are defined after the declared function. So, the
+above stage would run ``pkg.install http``. Requisites only function properly
+if the given function supports returning a custom return code.
+
+Executing an OverState
+~~~~~~~~~~~~~~~~~~~~~~
+
+Since the OverState is a :doc:`Runner </ref/runners/index>`, it is executed
+using the ``salt-run`` command. The runner function for the OverState is
+``state.over``.
+
+.. code-block:: bash
+
+    salt-run state.over
+
+The function will by default look in the root of the ``base`` environment (as
+defined in :conf_master:`file_roots`) for a file called ``overstate.sls``, and
+then execute the stages defined within that file.
+
+Different environments and paths can be used as well, by adding them as
+positional arguments:
+
+.. code-block:: bash
+
+    salt-run state.over dev /root/other-overstate.sls
+
+The above would run an OverState using the ``dev`` fileserver environment, with
+the stages defined in ``/root/other-overstate.sls``.
+
+.. warning::
+
+    Since these are positional arguments, when defining the path to the
+    overstate file the environment must also be specified, even if it is the
+    ``base`` environment.
+
+.. note::
+
+    Remember, salt-run is always executed on the master.
+
+

--- a/doc/topics/tutorials/states_pt5.rst
+++ b/doc/topics/tutorials/states_pt5.rst
@@ -159,7 +159,7 @@ The OverState System
 .. warning::
 
     The OverState runner is deprecated, and will be removed in the feature
-    release of Salt codenamed Beryllium. (Two feature releases after 2014.7.0,
+    release of Salt codenamed Boron. (Three feature releases after 2014.7.0,
     which is codenamed Helium)
 
 Often, servers need to be set up and configured in a specific order, and systems

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -46,9 +46,6 @@ def over(saltenv='base', os_fn=None):
             'removed in Salt Boron. Please migrate to state.orchestrate.'
             )
 
-    print('The state.over runner is on a deprecation path and will be '
-          'removed in Salt Boron. Please migrate to state.orchestrate.')
-
     stage_num = 0
     try:
         overstate = salt.overstate.OverState(__opts__, saltenv, os_fn)

--- a/salt/runners/state.py
+++ b/salt/runners/state.py
@@ -24,6 +24,13 @@ def over(saltenv='base', os_fn=None):
     '''
     .. versionadded:: 0.11.0
 
+    .. warning::
+
+        ``state.over`` is deprecated in favor of ``state.orchestrate``, and
+        will be removed in the Salt feature release codenamed Boron.
+        (Three feature releases after the 2014.7.0 release, which is codenamed
+        Helium)
+
     Execute an overstate sequence to orchestrate the executing of states
     over a group of systems
 
@@ -38,6 +45,9 @@ def over(saltenv='base', os_fn=None):
             'The state.over runner is on a deprecation path and will be '
             'removed in Salt Boron. Please migrate to state.orchestrate.'
             )
+
+    print('The state.over runner is on a deprecation path and will be '
+          'removed in Salt Boron. Please migrate to state.orchestrate.')
 
     stage_num = 0
     try:


### PR DESCRIPTION
The overstate docs were still first on the page, which was silly, since overstate is on a deprecation path for Boron.

Also added a warning in the overstate docstring itself.
