### PR TITLE
State `debconf.set_file` now accepts a template as a file

### DIFF
--- a/salt/modules/debconfmod.py
+++ b/salt/modules/debconfmod.py
@@ -133,6 +133,42 @@ def set_(package, question, type, value, *extra):
     return True
 
 
+def set_template(path, template, context, defaults, saltenv='base', **kwargs):
+    '''
+    Set answers to debconf questions from a template.
+
+    path
+        location of the file containing the package selections
+
+    template
+        template format
+
+    context
+        variables to add to the template environment
+
+    default
+        default values for the template environment
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' debconf.set_template salt://pathto/pkg.selections.jinja jinja None None
+
+    '''
+
+    path = __salt__['cp.get_template'](
+        path=path,
+        dest=None,
+        template=template,
+        saltenv=saltenv,
+        context=context,
+        defaults=defaults,
+        **kwargs)
+
+    return set_file(path, saltenv, **kwargs)
+
+
 def set_file(path, saltenv='base', **kwargs):
     '''
     Set answers to debconf questions from a file.

--- a/salt/states/debconfmod.py
+++ b/salt/states/debconfmod.py
@@ -100,15 +100,16 @@ def set_file(name, source, template=None, context=None, defaults=None, **kwargs)
     if context is None:
         context = {}
     elif not isinstance(context, dict):
-        return _error(
-            ret, 'Context must be formed as a dict')
+        ret['result'] = False
+        ret['comment'] = 'Context must be formed as a dict'
+        return ret
 
     if defaults is None:
         defaults = {}
     elif not isinstance(defaults, dict):
-        return _error(
-            ret, 'Defaults must be formed as a dict')
-
+        ret['result'] = False
+        ret['comment'] = 'Defaults must be formed as a dict'
+        return ret
 
     if __opts__['test']:
         ret['result'] = None


### PR DESCRIPTION
It follows the same convention as `file.managed` for example.

This also introduces a new function in the `debconfmod` module to set the
Debconf selections from a template or, as before, from a simple file.

I would gladly had some tests for this, but I struggled to do what I wanted. If somebody could point me out a way _not to call_ `debconf-set-selections` (from `salt.modules.debconfmod._set_file`), that would be great.
I tried to mock this function in a integration test with `mock.patch()`, but the mock is never called, and I suspect this is due to the way the integration tests are working (the call to `_set_file` must be done **somewhere else**, like another process?). I also tried to do **unit** tests, but it looks like I have to mock the whole Salt universe to do something...

Fixes #7331
