### PR TITLE
Provide nbopen poller default and increase interval in jenkins

### DIFF
--- a/salt/utils/nb_popen.py
+++ b/salt/utils/nb_popen.py
@@ -206,7 +206,7 @@ class NonBlockingPopen(subprocess.Popen):
                 if not conn.closed:
                     fcntl.fcntl(conn, fcntl.F_SETFL, flags)
 
-    def poll_and_read_until_finish(self):
+    def poll_and_read_until_finish(self, interval=0.01):
         silent_iterations = 0
         while self.poll() is None:
             if self.stdout is not None:
@@ -226,7 +226,7 @@ class NonBlockingPopen(subprocess.Popen):
                     log.debug(stdoutdata)
                 if stderrdata:
                     log.error(stderrdata)
-            time.sleep(0.01)
+            time.sleep(interval)
 
     def communicate(self, input=None):
         super(NonBlockingPopen, self).communicate(input)

--- a/tests/jenkins-ng.py
+++ b/tests/jenkins-ng.py
@@ -244,7 +244,7 @@ def sync_minion(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
 
         if proc.returncode != 0:
@@ -320,7 +320,7 @@ def delete_vm(options):
         stderr=subprocess.PIPE,
         stream_stds=True
     )
-    proc.poll_and_read_until_finish()
+    proc.poll_and_read_until_finish(interval=0.5)
     proc.communicate()
 
 
@@ -371,7 +371,7 @@ def download_unittest_reports(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -425,7 +425,7 @@ def download_coverage_report(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -504,7 +504,7 @@ def download_remote_logs(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -572,7 +572,7 @@ def prepare_ssh_access(options):
         stderr=subprocess.PIPE,
         stream_stds=True
     )
-    proc.poll_and_read_until_finish()
+    proc.poll_and_read_until_finish(interval=0.5)
     proc.communicate()
     if proc.returncode != 0:
         print(
@@ -894,7 +894,7 @@ def main():
         stderr=subprocess.PIPE,
         stream_stds=True
     )
-    proc.poll_and_read_until_finish()
+    proc.poll_and_read_until_finish(interval=0.5)
     proc.communicate()
 
     retcode = proc.returncode
@@ -1017,7 +1017,7 @@ def main():
         stderr=subprocess.PIPE,
         stream_stds=True
     )
-    proc.poll_and_read_until_finish()
+    proc.poll_and_read_until_finish(interval=0.5)
     proc.communicate()
     if proc.returncode != 0:
         print('Failed to execute the preparation SLS file. Exit code: {0}'.format(proc.returncode))
@@ -1060,7 +1060,7 @@ def main():
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print('Failed to execute the 2nd preparation SLS file. Exit code: {0}'.format(proc.returncode))

--- a/tests/jenkins.py
+++ b/tests/jenkins.py
@@ -113,7 +113,7 @@ def delete_vm(options):
         stderr=subprocess.PIPE,
         stream_stds=True
     )
-    proc.poll_and_read_until_finish()
+    proc.poll_and_read_until_finish(interval=0.5)
     proc.communicate()
 
 
@@ -207,7 +207,7 @@ def download_unittest_reports(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -247,7 +247,7 @@ def download_coverage_report(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -303,7 +303,7 @@ def download_remote_logs(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -349,7 +349,7 @@ def download_packages(options):
             stderr=subprocess.PIPE,
             stream_stds=True
         )
-        proc.poll_and_read_until_finish()
+        proc.poll_and_read_until_finish(interval=0.5)
         proc.communicate()
         if proc.returncode != 0:
             print(
@@ -411,7 +411,7 @@ def run(opts):
         stderr=subprocess.PIPE,
         stream_stds=True
     )
-    proc.poll_and_read_until_finish()
+    proc.poll_and_read_until_finish(interval=0.5)
     proc.communicate()
 
     retcode = proc.returncode


### PR DESCRIPTION
After poking at Jenkins for a few minutes, I discovered that nearly all of the CPU time was being taken just looping thousands of times/sec waiting for long-running procs to finish.

This PR provides a default for the poller but pulls the test suite back to 0.5s intervals, which will hopefully lower the load.

cc: @s0undt3ch 
