### PR TITLE
fix error where file.recurse would mess up names on salt-ssh

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -96,7 +96,6 @@ def lowstate_file_refs(chunks, extras=''):
             for env in refs:
                 for x in extra_refs:
                     refs[env].append([x])
-
     return refs
 
 
@@ -159,10 +158,13 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
                 files = file_client.cache_dir(name, saltenv)
                 if files:
                     for filename in files:
+                        fn = filename[filename.find(short) + len(short):]
+                        if fn.startswith('/'):
+                            fn.strip('/')
                         tgt = os.path.join(
                                 env_root,
                                 short,
-                                filename[filename.find(short) + len(short) + 1:],
+                                fn,
                                 )
                         tgt_dir = os.path.dirname(tgt)
                         if not os.path.isdir(tgt_dir):


### PR DESCRIPTION
Fix #17266
