### PR TITLE
Add certifi to the deps in thin tarball

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -20,6 +20,11 @@ try:
 except ImportError:
     HAS_MSGPACK = False
 try:
+    import certifi
+    HAS_CERTIFI = True
+except ImportError:
+    HAS_CERTIFI = False
+try:
     import urllib3
     HAS_URLLIB3 = True
 except ImportError:
@@ -67,6 +72,13 @@ if __name__ == '__main__':
 '''
 
 
+def thin_path(cachedir):
+    '''
+    Return the path to the thin tarball
+    '''
+    return os.path.join(cachedir, 'thin', 'thin.tgz')
+
+
 def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
     '''
     Generate the salt-thin tarball and print the location of the tarball
@@ -92,7 +104,10 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
         fp_.write(SALTCALL)
     if os.path.isfile(thintar):
         if overwrite or not os.path.isfile(thinver):
-            os.remove(thintar)
+            try:
+                os.remove(thintar)
+            except OSError:
+                pass
         elif open(thinver).read() == salt.__version__:
             return thintar
     tops = [
@@ -112,6 +127,9 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
 
     if HAS_CHARDET:
         tops.append(os.path.dirname(chardet.__file__))
+
+    if HAS_CERTIFI:
+        tops.append(os.path.dirname(certifi.__file__))
 
     for mod in [m for m in extra_mods.split(',') if m]:
         if mod not in locals() and mod not in globals():


### PR DESCRIPTION
This solves the problem of debian not sending the right cert data down if certifi is installed
Fix #16773
