### PR TITLE
Fixing bug where _grant_to_tokens in the mysql module does not construct full db.table name

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -420,6 +420,9 @@ def _grant_to_tokens(grant):
             except IndexError:
                 break
 
+        elif phrase == 'tables':
+            database += token
+
         elif phrase == 'user':
             if dict_mode:
                 break


### PR DESCRIPTION
See https://github.com/saltstack/salt/issues/18260
