### PR TITLE
Pass timeout for pub() down to channel

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1381,7 +1381,7 @@ class LocalClient(object):
                                               master_uri=master_uri)
 
         try:
-            payload = sreq.send(payload_kwargs)
+            payload = sreq.send(payload_kwargs, timeout=timeout)
         except SaltReqTimeoutError:
             log.error(
                 'Salt request timed out. If this error persists, '

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -884,7 +884,7 @@ class TestDaemon(object):
         jid_info = self.client.run_job(
             list(targets), 'saltutil.sync_{0}'.format(modules_kind),
             expr_form='list',
-            timeout=9999999999999999,
+            timeout=999999999999999,
         )
 
         if self.wait_for_jid(targets, jid_info['jid'], timeout) is False:


### PR DESCRIPTION
Previously regardless of timeout a pub job would take 60s (default for channel) to timeout.

I noticed this because after an Mworker dying its possible to stall the reactor for 60s (if the job went to that MWorker)
