### PR TITLE
Fix typo in 2014.7.0 release notes

### DIFF
--- a/doc/topics/releases/2014.7.0.rst
+++ b/doc/topics/releases/2014.7.0.rst
@@ -552,8 +552,8 @@ New Salt-Cloud Providers
 Deprecations
 ============
 
-:mod:`salt.modules.virturalenv_mod`
------------------------------------
+:mod:`salt.modules.virtualenv_mod`
+----------------------------------
 
 - Removed deprecated ``memoize`` function from ``salt/utils/__init__.py`` (deprecated)
 - Removed deprecated ``no_site_packages`` argument from ``create`` function (deprecated)


### PR DESCRIPTION
virturalenv → virtualenv
