### PR TITLE
#18320 fixing the blocker for salt.cloud.client

### DIFF
--- a/salt/cloud/__init__.py
+++ b/salt/cloud/__init__.py
@@ -631,9 +631,9 @@ class Cloud(object):
                 # If driver has function list_nodes_min, just replace it
                 # with query param to check existing vms on this driver
                 # for minimum information, Otherwise still use query param.
-                if 'selected_query_option' not in opts:
-                    if '{0}.list_nodes_min'.format(driver) in self.clouds:
-                        this_query = 'list_nodes_min'
+                # if 'selected_query_option' not in opts:
+                #     if '{0}.list_nodes_min'.format(driver) in self.clouds:
+                #         this_query = 'list_nodes_min'
                 fun = '{0}.{1}'.format(driver, this_query)
                 if fun not in self.clouds:
                     log.error(


### PR DESCRIPTION
proposed patch for bug #18320
This is a problematic code that I had to remove. 
It blocks the detailed query of aws and defaults to list_nodes_min.
I dont see the point of a global 'selected_query_option' being check because I am not using this from the cli.
