### PR TITLE
Bug fix. _grant_to_tokens not constructing full table name.

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -417,6 +417,9 @@ def _grant_to_tokens(grant):
             except IndexError:
                 break
 
+        elif phrase == 'tables':
+            database += token
+
         elif phrase == 'user':
             if dict_mode:
                 break


### PR DESCRIPTION
See https://github.com/saltstack/salt/issues/18260
