### PR TITLE
[DON'T MERGE] Add pkg runner, list available pkg upgrades and group by packages

### DIFF
--- a/salt/runners/pkg.py
+++ b/salt/runners/pkg.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+'''
+Package helper functions which provide other formatted output of
+salt.modules.pkg
+'''
+
+# Import python libs
+import os
+
+# Import salt libs
+import salt.output
+import salt.minion
+
+
+def _get_returner(returner_types):
+    '''
+    Helper to iterate over retuerner_types and pick the first one
+    '''
+    for returner in returner_types:
+        if returner:
+            return returner
+
+
+def group_upgrades(jid, outputter='nested', ext_source=None):
+    '''
+    List available pkg upgrades and group by packages
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run pkg.group_upgrades jid=20141120114114417719
+    '''
+    mminion = salt.minion.MasterMinion(__opts__)
+    returner = _get_returner((
+        __opts__['ext_job_cache'],
+        ext_source,
+        __opts__['master_job_cache']
+    ))
+
+    data = mminion.returners['{0}.get_jid'.format(returner)](jid)
+    pkgs = {}
+
+    for minion in data:
+        results = data[minion]['return']
+        for pkg, pkgver in results.items():
+            if pkg not in pkgs.keys():
+                pkgs.update({pkg: {pkgver: {'hosts': []}}})
+            pkgs[pkg][pkgver]['hosts'].append(minion)
+
+    if outputter:
+        salt.output.display_output(pkgs, outputter, opts=__opts__)
+    return pkgs

--- a/salt/runners/pkg.py
+++ b/salt/runners/pkg.py
@@ -4,9 +4,6 @@ Package helper functions which provide other formatted output of
 salt.modules.pkg
 '''
 
-# Import python libs
-import os
-
 # Import salt libs
 import salt.output
 import salt.minion
@@ -45,7 +42,11 @@ def group_upgrades(jid, outputter='nested', ext_source=None):
         results = data[minion]['return']
         for pkg, pkgver in results.items():
             if pkg not in pkgs.keys():
-                pkgs.update({pkg: {pkgver: {'hosts': []}}})
+                pkgs[pkg] = {pkgver: {'hosts': []}}
+
+            if pkgver not in pkgs[pkg].keys():
+                pkgs[pkg].update({pkgver: {'hosts': []}})
+
             pkgs[pkg][pkgver]['hosts'].append(minion)
 
     if outputter:


### PR DESCRIPTION
```
# salt-run pkg.list_upgrades jid=20150123193640519478
mysql-server-core-5.5:
    ----------
    5.5.41-0+wheezy1:
        ----------
        hosts:
            - ipm1013.domain.de
            - ypm1024.domain.de
            - ypm1007.domain.de
            - ypfo1030.domain.de
php54:
    ----------
    5.4.37~arbe-1-201501231844:
        ----------
        hosts:
            - wpm1003.domain.de
            - wpfo1031.domain.de
            - wpm1015.domain.de
php55:
    ----------
    5.5.21~arbe-1-201501231844:
        ----------
        hosts:
            - wpm1003.domain.de
            - wpfo1031.domain.de
            - wpm1015.domain.de
```
