### PR TITLE
Fix for #8670

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -301,7 +301,8 @@ class SaltEvent(object):
             if not ret['tag'].startswith(tag):  # tag not match
                 if any(ret['tag'].startswith(ptag) for ptag in pending_tags):
                     self.pending_events.append(ret)
-                wait = timeout_at - time.time()
+                if wait:  # only update the wait timeout if we had one
+                    wait = timeout_at - time.time()
                 continue
 
             log.trace('get_event() received = {0}'.format(ret))

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -170,6 +170,16 @@ class TestSaltEvent(TestCase):
             evt2 = me.get_event(tag='evt1')
             self.assertIsNone(evt2)
 
+    def test_event_no_timeout(self):
+        '''Test no wait timeout, we should block forever, until we get one '''
+        with eventpublisher_process():
+            me = event.MasterEvent(SOCK_DIR)
+            me.subscribe()
+            me.fire_event({'data': 'foo1'}, 'evt1')
+            me.fire_event({'data': 'foo2'}, 'evt2')
+            evt = me.get_event(tag='evt2', wait=0)
+            self.assertGotEvent(evt, {'data': 'foo2'})
+
     def test_event_subscription_matching(self):
         '''Test a subscription startswith matching'''
         with eventpublisher_process():


### PR DESCRIPTION
We should only update the wait timeout on mis-matched event if we had a timeout to begin with
