### PR TITLE
Better output on requisite failure

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1855,9 +1855,21 @@ class State(object):
                 running[tag]['__sls__'] = low['__sls__']
             # otherwise the failure was due to a requisite down the chain
             else:
+                # determine what the requisite failures where, and return
+                # a nice error message
+                comment_dict = {}
+                for req_type, req_lows in reqs.iteritems():
+                    for req_low in req_lows:
+                        req_tag = _gen_tag(req_low)
+                        req_ret = self.pre.get(req_tag, running.get(req_tag))
+                        if req_ret is None:
+                            continue
+                        if req_ret['result'] is False:
+                            comment_dict[req_low['__id__']] = req_ret['comment']
+
                 running[tag] = {'changes': {},
                                 'result': False,
-                                'comment': 'One or more requisite failed',
+                                'comment': 'One or more requisite failed: {0}'.format(comment_dict),
                                 '__run_num__': self.__run_num,
                                 '__sls__': low['__sls__']}
             self.__run_num += 1

--- a/salt/state.py
+++ b/salt/state.py
@@ -1858,14 +1858,21 @@ class State(object):
                 # determine what the requisite failures where, and return
                 # a nice error message
                 comment_dict = {}
+                # look at all requisite types for a failure
                 for req_type, req_lows in reqs.iteritems():
                     for req_low in req_lows:
                         req_tag = _gen_tag(req_low)
                         req_ret = self.pre.get(req_tag, running.get(req_tag))
+                        # if there is no run output for the requisite it
+                        # can't be the failure
                         if req_ret is None:
                             continue
+                        # If the result was False (not None) it was a failure
                         if req_ret['result'] is False:
-                            comment_dict[req_low['__id__']] = req_ret['comment']
+                            # use SLS.ID for the key-- so its easier to find
+                            key = '{sls}.{_id}'.format(sls=req_low['__sls__'],
+                                                       _id=req_low['__id__'])
+                            comment_dict[key] = req_ret['comment']
 
                 running[tag] = {'changes': {},
                                 'result': False,


### PR DESCRIPTION
Got the idea from #15663

Basically, on the failure we know what ran, and what our requisites are. So if we look for all of our requisites in the "things that ran" and look for failures, we'll find ours.

This means that for an SLS like:

```
foo:
  cmd.run:
    - name: 'date'
    - prereq:
      - foo: fail_one
      - cmd: work

fail_one:
  foo.run:
    - name: 'exit 1'

work:
  cmd.run:
    - name: 'date'
```

The output goes from:

```
local:
----------
          ID: foo
    Function: cmd.run
        Name: date
      Result: False
     Comment: One or more requisite failed
     Started: 
    Duration: 
     Changes:   
----------
          ID: work
    Function: cmd.run
        Name: date
      Result: None
     Comment: Command "date" would have been executed
     Started: 
    Duration: 
     Changes:   
```

to:

```
local:
----------
          ID: foo
    Function: cmd.run
        Name: date
      Result: False
     Comment: One or more requisite failed: {'test.fail_one': "State 'foo.run' found in SLS 'test' is unavailable\n"}
     Started: 
    Duration: 
     Changes:   
----------
          ID: work
    Function: cmd.run
        Name: date
      Result: None
     Comment: Command "date" would have been executed
     Started: 
    Duration: 
     Changes:   
```

This implementation should work for all requisite types, not just prereq
