### PR TITLE
Get non standard saltfile opts into opts

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -2175,6 +2175,12 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
                  'faster communication should be, default is %default'
         )
         self.add_option(
+            '--extra-filerefs',
+            dest='extra_filerefs',
+            default=None,
+            help='Pass in extra files to include in the state tarball'
+        )
+        self.add_option(
             '-v', '--verbose',
             default=False,
             action='store_true',

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -293,6 +293,8 @@ class SaltfileMixIn(object):
             saltfile = os.path.join(os.getcwd(), 'Saltfile')
             if os.path.isfile(saltfile):
                 self.options.saltfile = saltfile
+        else:
+            saltfile = self.options.saltfile
 
         if not self.options.saltfile:
             # There's still no valid Saltfile? No need to continue...

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -374,6 +374,10 @@ class SaltfileMixIn(object):
                             option.dest,
                             cli_config[option.dest])
 
+        # Any left over value in the saltfile can now be safely added
+        for key in cli_config:
+            setattr(self.options, key, cli_config[key])
+
 
 class HardCrashMixin(object):
     __metaclass__ = MixInMeta


### PR DESCRIPTION
@s0undt3ch for some reason the non-standard opts I added are still not making it into the opts dict
