### PR TITLE
fix typo in utils.parsers.OptionParser.parse_args

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -154,7 +154,7 @@ class OptionParser(optparse.OptionParser):
             try:
                 process_option_func()
             except Exception as err:
-                logging.getlogger(__name__).exception(err)
+                logging.getLogger(__name__).exception(err)
                 self.error(
                     'Error while processing {0}: {1}'.format(
                         process_option_func, traceback.format_exc(err)


### PR DESCRIPTION
```
************* Module salt.utils.parsers
salt/utils/parsers.py:157: [E1101(no-member), OptionParser.parse_args] Module 'logging' has no 'getlogger' member
```
