### PR TITLE
correct the TOC missing issue

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -151,7 +151,7 @@ xetexpdf: translations
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through xelatex..."
 	perl -pi -e 's!pdflatex!xelatex!' $(BUILDDIR)/latex/Makefile
-	$(MAKE) -C $(BUILDDIR)/latex LATEXOPTS="-interaction=nonstopmode"
+	$(MAKE) -C $(BUILDDIR)/latex -i LATEXOPTS="-interaction=nonstopmode"
 	@echo "xelatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 cheatsheet: translations


### PR DESCRIPTION
without "-i" option the tex run will only be ran once. Now we can do "make xetexpdf" without hit enter key 57 times ;) and still get a good Salt.pdf. Those latex warning will need to be addressed by other issue report.
