### PR TITLE
Fix gitfs serving symlinks

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -1546,11 +1546,9 @@ def _file_list_pygit2(repo, tgt_env):
     relpath = lambda path: os.path.relpath(path, repo['root'])
     add_mountpoint = lambda path: os.path.join(repo['mountpoint'], path)
     for repo_path in blobs.get('files', []):
-        repo_path = relpath(repo_path)
-        files.add(add_mountpoint(repo_path))
+        files.add(add_mountpoint(relpath(repo_path)))
     for repo_path, link_tgt in blobs.get('symlinks', {}).iteritems():
-        repo_path = relpath(repo_path)
-        symlinks[add_mountpoint(repo_path)] = link_tgt
+        symlinks[add_mountpoint(relpath(repo_path))] = link_tgt
     return files, symlinks
 
 
@@ -1591,11 +1589,9 @@ def _file_list_dulwich(repo, tgt_env):
     relpath = lambda path: os.path.relpath(path, repo['root'])
     add_mountpoint = lambda path: os.path.join(repo['mountpoint'], path)
     for repo_path in blobs.get('files', []):
-        repo_path = relpath(repo_path)
-        files.add(add_mountpoint(repo_path))
+        files.add(add_mountpoint(relpath(repo_path)))
     for repo_path, link_tgt in blobs.get('symlinks', {}).iteritems():
-        repo_path = relpath(repo_path)
-        symlinks[add_mountpoint(repo_path)] = link_tgt
+        symlinks[add_mountpoint(relpath(repo_path))] = link_tgt
     return files, symlinks
 
 


### PR DESCRIPTION
**THIS NEEDS ANOTHER LOOK BEFORE MERGING, HOLD OFF FOR NOW**

This fixes #17700 by detecting when a blob refers to a symlink, and following
the symlink. I set a max recursion depth of 100, to prevent symlinks which
point to each other from causing an infinite loop.

Info for QA testing:

**Set the following in the master config file:**

```
fileserver_backend:
  - git

gitfs_provider: gitpython

gitfs_remotes:
  - https://github.com/terminalmage/salt-bootstrap.git:
    - base: symlink-test
```

**Run the following states:**

```
salt myminion state.single file.managed /tmp/mybootstrap.sh source=salt://subdir/mybootstrap.sh
salt myminion state.single file.managed /tmp/mybootstrap.sh source=salt://salt-bootstrap.sh
salt myminion state.single file.managed /tmp/mybootstrap.sh source=salt://bootstrap-salt.sh
salt myminion state.single file.managed /tmp/mybootstrap.sh source=salt://thisfiledoesnotexist
```
- The source URL in the first state is a 2-level symlink, pointing up a directory to salt-bootstrap.sh, which is itself a symlink of bootstrap-salt.sh.
- The source URL in the second state is symlinked to bootstrap-salt.sh in the same directory.
- The source URL in the third state points to an actual file.
- The source URL in the fourth state points to a nonexistant file.

The first three should work (with the second and third just saying that the file is in the correct state), while the fourth one should fail.

This test should be repeated with `gitfs_provider` set to `pygit2` and `dulwich`. See the [GitFS Walkthrough](http://docs.saltstack.com/en/latest/topics/tutorials/gitfs.html#installing-dependencies) for information on installing the dependencies.
