### PR TITLE
Nagios module pillar docs ex update

### DIFF
--- a/salt/modules/nagios.py
+++ b/salt/modules/nagios.py
@@ -46,10 +46,10 @@ def _execute_pillar(pillar_name, run_type):
     ------
     webserver:
         Ping_google:
-            - check_icmp:8.8.8.8
-            - check_icmp:google.com
+            - check_icmp: 8.8.8.8
+            - check_icmp: google.com
         Load:
-            - check_load:-w 0.8 -c 1
+            - check_load: -w 0.8 -c 1
         APT:
             - check_apt
     -------
@@ -135,10 +135,10 @@ def retcode_pillar(pillar_name):
         ------
         webserver:
             Ping_google:
-                - check_icmp:8.8.8.8
-                - check_icmp:google.com
+                - check_icmp: 8.8.8.8
+                - check_icmp: google.com
             Load:
-                - check_load:-w 0.8 -c 1
+                - check_load: -w 0.8 -c 1
             APT:
                 - check_apt
         -------
@@ -196,10 +196,10 @@ def run_pillar(pillar_name):
         ------
         webserver:
             Ping_google:
-                - check_icmp:8.8.8.8
-                - check_icmp:google.com
+                - check_icmp: 8.8.8.8
+                - check_icmp: google.com
             Load:
-                - check_load:-w 0.8 -c 1
+                - check_load: -w 0.8 -c 1
             APT:
                 - check_apt
         -------
@@ -228,10 +228,10 @@ def run_all_pillar(pillar_name):
         ------
         webserver:
             Ping_google:
-                - check_icmp:8.8.8.8
-                - check_icmp:google.com
+                - check_icmp: 8.8.8.8
+                - check_icmp: google.com
             Load:
-                - check_load:-w 0.8 -c 1
+                - check_load: -w 0.8 -c 1
             APT:
                 - check_apt
         -------


### PR DESCRIPTION
When copy/pasting the example nagios check Pillar shown in the
[online](http://docs.saltstack.com/en/latest/ref/modules/all/salt.module
s.nagios.html) and sys.doc documentation the load check doesn't run. By
adding the spaces the check is then run. It seems like there should
always be a space to avoid this from happening.
