### PR TITLE
Filter out IPv6 localhost from FQDN on OS X

### DIFF
--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -94,6 +94,7 @@ def _filter_localhost_names(name_list):
         '::1.*',
         'fe00::.*',
         'fe02::.*',
+        '1.0.0*.ip6.arpa'
     ]
     for name in name_list:
         filtered = False


### PR DESCRIPTION
Don't return the hostname "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa" for  OS  X when no minion ID is found in the config
