### PR TITLE
Note about a oneliner check on pysphere python module

### DIFF
--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -9,6 +9,12 @@ The vSphere cloud module is used to control access to VMWare vSphere.
 
 :depends:   - PySphere Python module
 
+Note: Ensure python pysphere module is installed by running following onliner check, 0 should be the output.
+
+.. code-block:: bash
+
+   python -c "import pysphere" ; echo $?
+
 Use of this module only requires a URL, username and password. Set up the cloud
 configuration at:
 
@@ -32,6 +38,7 @@ your VMWare installation is configured:
     https://10.1.1.1:443
     https://10.1.1.1:443/sdk
     10.1.1.1:443/sdk
+
 
 folder: Name of the folder that will contain the new VM. If not set, the VM will
         be added to the folder the original VM belongs to.


### PR DESCRIPTION
Just a note.  The real fix is to have salt-cloud break out if pysphere is not installed.
