### PR TITLE
Fixed installation of packages via macports on OS X

### DIFF
--- a/salt/modules/macports.py
+++ b/salt/modules/macports.py
@@ -206,11 +206,12 @@ def remove(name=None, pkgs=None, **kwargs):
     targets = [x for x in pkg_params if x in old]
     if not targets:
         return {}
-    cmd = ['port', 'uninstall'].append(targets)
+    cmd = ['port', 'uninstall']
+    cmd.extend(targets)
     __salt__['cmd.run_all'](cmd, output_loglevel='trace', python_shell=False)
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
-    return __salt__['saltutil.compare_dicts'](old, new)
+    return salt.utils.compare_dicts(old, new)
 
 
 def install(name=None, refresh=False, pkgs=None, **kwargs):
@@ -302,7 +303,8 @@ def install(name=None, refresh=False, pkgs=None, **kwargs):
         formulas_array.append(pname + (pparams or ''))
 
     old = list_pkgs()
-    cmd = ['port', 'install'].append(formulas_array)
+    cmd = ['port', 'install']
+    cmd.extend(formulas_array)
 
     __salt__['cmd.run'](cmd, output_loglevel='trace', python_shell=False)
     __context__.pop('pkg.list_pkgs', None)


### PR DESCRIPTION
- append/extend on arrays return None and therefore None was being passed to run_all
- compare_dicts function was called incorrectly
