### PR TITLE
Forced clean up of runtime config dictionary which includes a local client

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -144,6 +144,10 @@ def run_tests(*test_cases, **kwargs):
                     return SaltTestcaseParser.run_testcase(self, testcase)
             return SaltTestcaseParser.run_testcase(self, testcase)
 
+        def exit(self, status=0, msg=None):
+            TestDaemon.cleanup_runtime_config_instane()
+            TestcaseParser.exit(self, status, msg)
+
     parser = TestcaseParser()
     parser.parse_args()
     for case in test_cases:
@@ -612,6 +616,14 @@ class TestDaemon(object):
         cls.syndic_opts = syndic_opts
         cls.syndic_master_opts = syndic_master_opts
         # <---- Verify Environment -----------------------------------------------------------------------------------
+
+    @classmethod
+    def cleanup_runtime_config_instane(cls):
+        # Explicit and forced cleanup
+        for key in RUNTIME_CONFIGS.keys():
+            instance = RUNTIME_CONFIGS.pop(key)
+            del instance
+        del RUNTIME_CONFIGS
 
     def __exit__(self, type, value, traceback):
         '''

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -377,6 +377,10 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             status.append(results)
         return status
 
+    def exit(self, status=0, msg=None):
+        TestDaemon.cleanup_runtime_config_instane()
+        SaltTestsuiteParser.exit(self, status, msg)
+
 
 def main():
     '''


### PR DESCRIPTION
/cc @cachedout, @rallytime 

Let's see if this solves our tests issues....
