### PR TITLE
Fixes to scheduler in 2014.7

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -636,7 +636,11 @@ class Schedule(object):
                     elif 'cron' in data:
                         log.error('Unable to use "splay" with "cron" option at this time. Ignoring.')
                     else:
-                        data['_seconds'] = data['seconds']
+                        if 'seconds' in data:
+                            log.debug('breakage here')
+                            data['_seconds'] = data['seconds']
+                        else:
+                            data['_seconds'] = 0
 
                 if 'when' in data:
                     if now - when >= seconds:
@@ -694,7 +698,7 @@ class Schedule(object):
                         log.error('Unable to use "splay" with "when" option at this time. Ignoring.')
                     else:
                         if isinstance(data['splay'], dict):
-                            if data['splay']['end'] > data['splay']['start']:
+                            if data['splay']['end'] >= data['splay']['start']:
                                 splay = random.randint(data['splay']['start'], data['splay']['end'])
                             else:
                                 log.error('schedule.handle_func: Invalid Splay, end must be larger than start. \
@@ -706,7 +710,10 @@ class Schedule(object):
                         if splay:
                             log.debug('schedule.handle_func: Adding splay of '
                                       '{0} seconds to next run.'.format(splay))
-                            data['seconds'] = data['_seconds'] + splay
+                            if 'seconds' in data:
+                                data['seconds'] = data['_seconds'] + splay
+                            else:
+                                data['seconds'] = 0 + splay
 
                 log.info('Running scheduled job: {0}'.format(job))
 


### PR DESCRIPTION
Adding some fixes to the schedule when splay is specified but the seconds option is not.  Also allowing splay start and end flags to be equal to lock down splay to a specific number of seconds.
