### PR TITLE
Clean up doc build so it doesn't stacktrace

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -53,6 +53,7 @@ MOCK_MODULES = [
     'yaml.nodes',
     'yaml.scanner',
     'zmq',
+    'zmq.eventloop',
 
     # third-party libs for cloud modules
     'libcloud',

--- a/doc/ref/netapi/all/salt.netapi.rest_tornado.rst
+++ b/doc/ref/netapi/all/salt.netapi.rest_tornado.rst
@@ -1,6 +1,6 @@
-=============
+============
 rest_tornado
-=============
+============
 
 .. automodule:: salt.netapi.rest_tornado.saltnado
 
@@ -18,58 +18,40 @@ REST URI Reference
 -----
 
 .. autoclass:: SaltAPIHandler
-    :members: GET, POST
+    :members: get, post, disbatch
 
 ``/login``
 ----------
 
-.. autoclass:: Login
-    :members: GET, POST
-
-``/logout``
------------
-
-.. autoclass:: Logout
-    :members: POST
+.. autoclass:: SaltAuthHandler
+    :members: get, post
 
 ``/minions``
 ------------
 
-.. autoclass:: Minions
-    :members: GET, POST
+.. autoclass:: MinionSaltAPIHandler
+    :members: get, post
 
 ``/jobs``
 ---------
 
-.. autoclass:: Jobs
-    :members: GET
+.. autoclass:: JobsSaltAPIHandler
+    :members: get
 
 ``/run``
 --------
 
-.. autoclass:: Run
-    :members: POST
+.. autoclass:: RunSaltAPIHandler
+    :members: post
 
 ``/events``
 -----------
 
-.. autoclass:: Events
-    :members: GET
-
-``/ws``
--------
-
-.. autoclass:: WebsocketEndpoint
-    :members: GET
+.. autoclass:: EventsSaltAPIHandler
+    :members: get
 
 ``/hook``
 ---------
 
-.. autoclass:: Webhook
-    :members: POST
-
-``/stats``
-----------
-
-.. autoclass:: Stats
-    :members: GET
+.. autoclass:: WebhookSaltAPIHandler
+    :members: post

--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 '''
 A non-blocking REST API for Salt
-===================
+================================
 
 .. py:currentmodule:: salt.netapi.rest_tornado.saltnado
 


### PR DESCRIPTION
Fixes #18471
- Add zmq.eventloop to mocked modules in doc/conf.py
- Cleaned up rst references in rest_tornado.rst

ping @whiteinge
