### PR TITLE
Adding 4 smallerpdf files beside one giant 1600+ pages Salt-all.pdf

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -14,11 +14,6 @@ ifeq ($(shell which $(SPHINXBUILD) >/dev/null 2>&1; echo $$?), 1)
 $(error The '$(SPHINXBUILD)' command was not found. Make sure you have Sphinx installed, then set the SPHINXBUILD environment variable to point to the full path of the '$(SPHINXBUILD)' executable. Alternatively you can add the directory with the executable to your PATH. If you don't have Sphinx installed, grab it from http://sphinx-doc.org/)
 endif
 
-# User-friendly check for xelatex
-ifeq ($(shell which $(XELATEX) >/dev/null 2>&1; echo $$?), 1)
-$(error The '$(XELATEX)' command was not found.)
-endif
-
 # ----- Translations Support ------------------------------------------------>
 #  If language is set, also set translation options
 ifeq ($(shell [ "x$(SPHINXLANG)" != "x" ] && echo 0 || echo 1), 0)
@@ -55,7 +50,7 @@ help:
 	@echo "  devhelp    to make HTML files and a Devhelp project"
 	@echo "  epub       to make an epub"
 	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  xetexpdf   to make LaTeX files and run them through xelatex"
+	@echo "  pdf        to make Salt-all.pdf and splitted pdf using xelatex"
 	@echo "  cheatsheet to create salt-cheatsheet.pdf"
 	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
 	@echo "  latexpdfja to make LaTeX files and run them through platex/dvipdfmx"
@@ -147,7 +142,10 @@ latexpdfja: translations
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
-xetexpdf: translations
+pdf: translations
+	@if [ "$(XELATEX)"  = "xelatex" ] || [ "x$(XELATEX)" = "x" ]; then \
+		echo "The '$(XELATEX)' command was not found."; \
+	fi
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
 	@echo "Running LaTeX files through xelatex..."
 	perl -pi -e 's!pdflatex!xelatex!' $(BUILDDIR)/latex/Makefile

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -272,8 +272,13 @@ html_show_sphinx = True
 html_show_copyright = True
 
 ### Latex options
+
 latex_documents = [
-  ('contents', 'Salt.tex', 'Salt Documentation', 'SaltStack, Inc.', 'manual'),
+  ('contents','Salt-All.tex','Salt All-In-One Documentation','SaltStack, Inc.','manual'),
+  ('contents-1','Salt-1.tex','Salt 1/4 Documentation','SaltStack, Inc.','manual'),
+  ('contents-2','Salt-2.tex','Salt 2/4 Documentation', 'SaltStack, Inc.','manual'),
+  ('contents-3','Salt-3.tex','Salt 3/4 Documentation','SaltStack, Inc.','manual'),
+  ('contents-4','Salt-4.tex','Salt 4/4 Documentation','SaltStack, Inc.','manual'),
 ]
 
 latex_logo = '_static/salt-logo.pdf'

--- a/doc/contents-1.rst
+++ b/doc/contents-1.rst
@@ -1,0 +1,36 @@
+======================
+Salt Table of Contents
+======================
+
+.. toctree::
+    :maxdepth: 2
+    :glob:
+    :numbered:
+
+    topics/index
+    topics/installation/index
+    topics/tutorials/index
+    topics/targeting/index
+    topics/pillar/index
+    topics/reactor/index
+    topics/mine/index
+    topics/eauth/index
+    topics/jobs/index
+    topics/event/index
+    topics/topology/index
+    topics/windows/index
+    topics/cloud/index
+    topics/netapi/index
+    topics/virt/index
+    topics/yaml/index
+    topics/master_tops/index
+    topics/ssh/*
+    ref/index
+    topics/best_practices
+    topics/troubleshooting/index
+    topics/development/index
+    topics/releases/index
+    topics/projects/index
+    security/index
+    faq
+    glossary

--- a/doc/contents-2.rst
+++ b/doc/contents-2.rst
@@ -1,0 +1,15 @@
+======================
+Salt Table of Contents
+======================
+
+.. toctree::
+    :maxdepth: 3
+    :glob:
+    :numbered:
+
+    topics/netapi/index
+    topics/virt/index
+    topics/yaml/index
+    topics/master_tops/index
+    topics/ssh/*
+    glossary

--- a/doc/contents-3.rst
+++ b/doc/contents-3.rst
@@ -1,0 +1,15 @@
+======================
+Salt Table of Contents
+======================
+
+.. toctree::
+    :maxdepth: 3
+    :glob:
+    :numbered:
+    topics/best_practices
+    topics/troubleshooting/index
+    topics/development/index
+    topics/releases/index
+    topics/projects/index
+    security/index
+    glossary

--- a/doc/contents-4.rst
+++ b/doc/contents-4.rst
@@ -1,0 +1,11 @@
+======================
+Salt Table of Contents
+======================
+
+.. toctree::
+    :maxdepth: 3
+    :glob:
+    :numbered:
+
+    ref/index
+    glossary

--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -179,7 +179,9 @@ Once the minion starts, you may see an error like the following:
 
 .. code-block:: bash
 
-    zmq.core.error.ZMQError: ipc path "/path/to/your/virtualenv/var/run/salt/minion/minion_event_7824dcbcfd7a8f6755939af70b96249f_pub.ipc" is longer than 107 characters (sizeof(sockaddr_un.sun_path)).
+    zmq.core.error.ZMQError: ipc path "/path/to/your/virtualenv/
+var/run/salt/minion/minion_event_7824dcbcfd7a8f6755939af70b96249f_pub.ipc" 
+is longer than 107 characters (sizeof(sockaddr_un.sun_path)).
 
 This means that the path to the socket the minion is using is too long. This is
 a system limitation, so the only workaround is to reduce the length of this


### PR DESCRIPTION
The All-in-on Salt-all.pdf is about 1600 pages.  Goal is to let people have option to print out salt doc in 3 smaller books, the 4th book(Reference section) along is around 1000 pages. Please review this pull, it was a quick cut and chop. 
Also move xelatex checking inside "make pdf" target,so "make html" won't break.
