### PR TITLE
Follow on patch for https://github.com/saltstack/salt/pull/18536

### DIFF
--- a/doc/contents-1.rst
+++ b/doc/contents-1.rst
@@ -15,9 +15,4 @@ Salt Table of Contents
     topics/reactor/index
     topics/mine/index
     topics/eauth/index
-    topics/jobs/index
-    topics/event/index
-    topics/topology/index
-    topics/windows/index
-    topics/cloud/index
     glossary

--- a/doc/contents-1.rst
+++ b/doc/contents-1.rst
@@ -3,7 +3,7 @@ Salt Table of Contents
 ======================
 
 .. toctree::
-    :maxdepth: 2
+    :maxdepth: 3
     :glob:
     :numbered:
 
@@ -20,17 +20,4 @@ Salt Table of Contents
     topics/topology/index
     topics/windows/index
     topics/cloud/index
-    topics/netapi/index
-    topics/virt/index
-    topics/yaml/index
-    topics/master_tops/index
-    topics/ssh/*
-    ref/index
-    topics/best_practices
-    topics/troubleshooting/index
-    topics/development/index
-    topics/releases/index
-    topics/projects/index
-    security/index
-    faq
     glossary

--- a/doc/contents-2.rst
+++ b/doc/contents-2.rst
@@ -7,15 +7,12 @@ Salt Table of Contents
     :glob:
     :numbered:
 
+    topics/jobs/index
+    topics/event/index
     topics/topology/index
     topics/windows/index
     topics/cloud/index
-    topics/releases/index
-    topics/projects/index
-    faq
     topics/netapi/index
     topics/virt/index
     topics/yaml/index
-    topics/master_tops/index
-    topics/ssh/*
     glossary

--- a/doc/contents-2.rst
+++ b/doc/contents-2.rst
@@ -7,6 +7,12 @@ Salt Table of Contents
     :glob:
     :numbered:
 
+    topics/topology/index
+    topics/windows/index
+    topics/cloud/index
+    topics/releases/index
+    topics/projects/index
+    faq
     topics/netapi/index
     topics/virt/index
     topics/yaml/index

--- a/doc/contents-3.rst
+++ b/doc/contents-3.rst
@@ -6,6 +6,7 @@ Salt Table of Contents
     :maxdepth: 3
     :glob:
     :numbered:
+
     topics/best_practices
     topics/troubleshooting/index
     topics/development/index

--- a/doc/contents-3.rst
+++ b/doc/contents-3.rst
@@ -7,10 +7,13 @@ Salt Table of Contents
     :glob:
     :numbered:
 
+    topics/master_tops/index
+    topics/ssh/*
     topics/best_practices
     topics/troubleshooting/index
     topics/development/index
     topics/releases/index
     topics/projects/index
     security/index
+    faq
     glossary


### PR DESCRIPTION
Hi
With this patch, now Salt-{1-3}.pdf have intended chapters in each pdf. Previously Salt-2.pdf and Slat-3.pdf have no TOC or chapters' content.

The know issue of this separation is that some of reference(in Slat-1.pdf) will not able to click and jump to destination(Salt-2.pdf). 
