### PR TITLE
Prevent 'DSID-0C0906E8' error when binding to ActiveDirectory.

### DIFF
--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -117,8 +117,10 @@ def _do_search(conf):
     '''
     # Build LDAP connection args
     connargs = {}
-    for name in ['server', 'port', 'tls', 'binddn', 'bindpw']:
+    for name in ['server', 'port', 'tls', 'binddn', 'bindpw', 'anonymous']:
         connargs[name] = _config(name, conf)
+    if connargs['binddn'] and connargs['bindpw']:
+        connargs['anonymous'] = False
     # Build search args
     try:
         _filter = conf['filter']


### PR DESCRIPTION
When binding (using `binddn` and `bindpw`) to an ActiveDirectory for LDAP lookups without explicitely setting `anonymous=False`, the LDAP search will fail with `DSID-0C0906E8`.

This fixes the issue for me and I can finally use LDAP pillars without looking at backtraces in my master log :)
