### PR TITLE
Move the log message in case no results were returned into the right block

### DIFF
--- a/salt/pillar/pillar_ldap.py
+++ b/salt/pillar/pillar_ldap.py
@@ -135,12 +135,12 @@ def _do_search(conf):
     try:
         result = __salt__['ldap.search'](_filter, _dn, scope, attrs,
                                          **connargs)['results'][0][1]
+    except IndexError:  # we got no results for this search
         log.debug(
             'LDAP search returned no results for filter {0}'.format(
                 _filter
             )
         )
-    except IndexError:  # we got no results for this search
         result = {}
     except Exception:
         log.critical(


### PR DESCRIPTION
… without this, the message `LDAP search returned no results for filter {0}` will be logged even when the search returned results.

Now only log it, in case there are actually no results by moving it from `try` into `except`.
