### PR TITLE
allow for git HTTP Basic Auth when using https://

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -11,6 +11,8 @@ import subprocess
 # Import salt libs
 from salt import utils
 from salt.exceptions import SaltInvocationError, CommandExecutionError
+from salt.ext.six.moves.urllib.parse import urlparse
+from salt.ext.six.moves.urllib.parse import urlunparse
 
 
 def __virtual__():
@@ -98,6 +100,19 @@ def _check_git():
     utils.check_or_die('git')
 
 
+def _add_http_basic_auth(repository, https_user=None, https_pass=None):
+    if not https_user is None and not https_pass is None:
+        urltuple = urlparse(repository)
+        if urltuple.scheme == 'https':
+            netloc = "{0}:{1}@{2}".format(https_user, https_pass,
+                                          urltuple.netloc)
+            urltuple = urltuple._replace(netloc=netloc)
+            return urlunparse(urltuple)
+        else:
+            raise ValueError('Basic Auth only supported for HTTPS scheme')
+    return repository
+
+
 def current_branch(cwd, user=None):
     '''
     Returns the current branch name, if on a branch.
@@ -141,7 +156,8 @@ def revision(cwd, rev='HEAD', short=False, user=None):
     return _git_run(cmd, cwd, runas=user)
 
 
-def clone(cwd, repository, opts=None, user=None, identity=None):
+def clone(cwd, repository, opts=None, user=None, identity=None,
+          https_user=None, https_pass=None):
     '''
     Clone a new repository
 
@@ -160,6 +176,12 @@ def clone(cwd, repository, opts=None, user=None, identity=None):
     identity : None
         A path to a private key to use over SSH
 
+    https_user : None
+        HTTP Basic Auth username for HTTPS (only) clones
+
+    https_pass : None
+        HTTP Basic Auth password for HTTPS (only) clones
+
     CLI Example:
 
     .. code-block:: bash
@@ -171,6 +193,8 @@ def clone(cwd, repository, opts=None, user=None, identity=None):
 
     '''
     _check_git()
+
+    repository = _add_http_basic_auth(repository, https_user, https_pass)
 
     if not opts:
         opts = ''
@@ -694,7 +718,8 @@ def remote_get(cwd, remote='origin', user=None):
         return None
 
 
-def remote_set(cwd, name='origin', url=None, user=None):
+def remote_set(cwd, name='origin', url=None, user=None, https_user=None,
+               https_pass=None):
     '''
     sets a remote with name and URL like git remote add <remote_name> <remote_url>
 
@@ -707,6 +732,12 @@ def remote_set(cwd, name='origin', url=None, user=None):
     user : None
         Run git as a user other than what the minion runs as
 
+    https_user : None
+        HTTP Basic Auth username for HTTPS (only) clones
+
+    https_pass : None
+        HTTP Basic Auth password for HTTPS (only) clones
+
     CLI Example:
 
     .. code-block:: bash
@@ -717,6 +748,7 @@ def remote_set(cwd, name='origin', url=None, user=None):
     if remote_get(cwd, name):
         cmd = 'git remote rm {0}'.format(name)
         _git_run(cmd, cwd=cwd, runas=user)
+    url = _add_http_basic_auth(url, https_user, https_pass)
     cmd = 'git remote add {0} {1}'.format(name, url)
     _git_run(cmd, cwd=cwd, runas=user)
     return remote_get(cwd=cwd, remote=name, user=None)
@@ -876,7 +908,8 @@ def config_get(cwd=None, setting_name=None, user=None):
     return _git_run('git config {0}'.format(setting_name), cwd=cwd, runas=user)
 
 
-def ls_remote(cwd, repository="origin", branch="master", user=None, identity=None):
+def ls_remote(cwd, repository="origin", branch="master", user=None,
+              identity=None, https_user=None, https_pass=None):
     '''
     Returns the upstream hash for any given URL and branch.
 
@@ -896,6 +929,12 @@ def ls_remote(cwd, repository="origin", branch="master", user=None, identity=Non
     identity : none
         a path to a private key to use over ssh
 
+    https_user : None
+        HTTP Basic Auth username for HTTPS (only) clones
+
+    https_pass : None
+        HTTP Basic Auth password for HTTPS (only) clones
+
     CLI Example:
 
     .. code-block:: bash
@@ -904,5 +943,6 @@ def ls_remote(cwd, repository="origin", branch="master", user=None, identity=Non
 
     '''
     _check_git()
+    repository = _add_http_basic_auth(repository, https_user, https_pass)
     cmd = "git ls-remote -h " + repository + " " + branch + " | cut -f 1"
     return _git_run(cmd, cwd=cwd, runas=user, identity=identity)

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -11,8 +11,8 @@ import subprocess
 # Import salt libs
 from salt import utils
 from salt.exceptions import SaltInvocationError, CommandExecutionError
-from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=no-name-in-module,import-error
-from salt.ext.six.moves.urllib.parse import urlunparse  # pylint: disable=no-name-in-module,import-error
+from salt.ext.six.moves.urllib.parse import urlparse as _urlparse  # pylint: disable=no-name-in-module,import-error
+from salt.ext.six.moves.urllib.parse import urlunparse as _urlunparse  # pylint: disable=no-name-in-module,import-error
 
 
 def __virtual__():
@@ -104,12 +104,12 @@ def _add_http_basic_auth(repository, https_user=None, https_pass=None):
     if https_user is None and https_pass is None:
         return repository
     else:
-        urltuple = urlparse(repository)
+        urltuple = _urlparse(repository)
         if urltuple.scheme == 'https':
             netloc = "{0}:{1}@{2}".format(https_user, https_pass,
                                           urltuple.netloc)
             urltuple = urltuple._replace(netloc=netloc)
-            return urlunparse(urltuple)
+            return _urlunparse(urltuple)
         else:
             raise ValueError('Basic Auth only supported for HTTPS scheme')
 

--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -11,8 +11,8 @@ import subprocess
 # Import salt libs
 from salt import utils
 from salt.exceptions import SaltInvocationError, CommandExecutionError
-from salt.ext.six.moves.urllib.parse import urlparse
-from salt.ext.six.moves.urllib.parse import urlunparse
+from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=no-name-in-module,import-error
+from salt.ext.six.moves.urllib.parse import urlunparse  # pylint: disable=no-name-in-module,import-error
 
 
 def __virtual__():
@@ -101,7 +101,9 @@ def _check_git():
 
 
 def _add_http_basic_auth(repository, https_user=None, https_pass=None):
-    if not https_user is None and not https_pass is None:
+    if https_user is None and https_pass is None:
+        return repository
+    else:
         urltuple = urlparse(repository)
         if urltuple.scheme == 'https':
             netloc = "{0}:{1}@{2}".format(https_user, https_pass,
@@ -110,7 +112,6 @@ def _add_http_basic_auth(repository, https_user=None, https_pass=None):
             return urlunparse(urltuple)
         else:
             raise ValueError('Basic Auth only supported for HTTPS scheme')
-    return repository
 
 
 def current_branch(cwd, user=None):

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -48,6 +48,8 @@ def latest(name,
            remote_name='origin',
            always_fetch=False,
            identity=None,
+           https_user=None,
+           https_pass=None,
            onlyif=False,
            unless=False):
     '''
@@ -102,6 +104,12 @@ def latest(name,
 
     identity
         A path to a private key to use over SSH
+
+    https_user
+        HTTP Basic Auth username for HTTPS (only) clones
+
+    https_pass
+        HTTP Basic Auth password for HTTPS (only) clones
 
     onlyif
         A command to run as a check, run the named command only if the command
@@ -192,7 +200,9 @@ def latest(name,
                                                        repository=name,
                                                        branch=branch,
                                                        user=user,
-                                                       identity=identity)
+                                                       identity=identity,
+                                                       https_user=https_user,
+                                                       https_pass=https_pass)
 
             # only do something, if the specified rev differs from the
             # current_rev and remote_rev
@@ -221,7 +231,9 @@ def latest(name,
                     __salt__['git.remote_set'](target,
                                                name=remote_name,
                                                url=name,
-                                               user=user)
+                                               user=user,
+                                               https_user=https_user,
+                                               https_pass=https_pass)
                     ret['changes']['remote/{0}'.format(remote_name)] = (
                         "{0} => {1}".format(str(remote), name)
                     )
@@ -352,7 +364,9 @@ def latest(name,
                                   name,
                                   user=user,
                                   opts=opts,
-                                  identity=identity)
+                                  identity=identity,
+                                  https_user=https_user,
+                                  https_pass=https_pass)
 
             if rev and not bare:
                 __salt__['git.checkout'](target, rev, user=user)


### PR DESCRIPTION
- Overview

This commit adds support for HTTP Basic Auth user and passwords when cloning a git repository. Restrictions are placed to ensure Basic Auth is only used when accessing remote repositories over HTTPS.

Support for updating remotes is included for user/password/uri changes.

Submodule support is not supported with HTTPS Basic Auth, as those are outside the scope of my initial need. 

This has a terrific tendency to leak credentials in the clear due to logging in the cmd.run set of tools.
- Motivation

Specifically, GitHub's HTTPS access layer has some niceties not available when using the SSH protocol. See https://help.github.com/articles/which-remote-url-should-i-use/#cloning-with-https-recommended

It is nice to enforce read-only access to repositories from remote hosts.

Also, it is a lot cleaner to drop Passwords/Security Tokens in configurations rather than PEM form private keys.
