### PR TITLE
Bugfix git_pillar (__env__ related)

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -17,7 +17,8 @@ to look for Pillar files (such as ``top.sls``).
     The optional ``root`` parameter will be added.
 
 .. versionchanged:: @TBD
-    The special branch name '__env__' will be replace by the environment ({{env}})
+    The special branch name '__env__' will be replace by the
+    environment ({{env}})
 
 Note that this is not the same thing as configuring pillar data using the
 :conf_master:`pillar_roots` parameter. The branch referenced in the
@@ -167,9 +168,9 @@ class GitPillar(object):
     def map_branch(self, branch, opts=None):
         opts = __opts__ if opts is None else opts
         if branch == '__env__':
-            branch = opts['environment']
+            branch = opts.get('environment', 'base')
             if branch == 'base':
-                branch = opts['gitfs_base']
+                branch = opts.get('gitfs_base', 'master')
         return branch
 
     def update(self):


### PR DESCRIPTION
Fixes bug that shows up when caches are cleared.
Use dict.get in stead of **getitem** to catch missing values
in opts.
