### PR TITLE
Fixes to scheduler in 2014.7

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -495,8 +495,9 @@ class Schedule(object):
             when = 0
             seconds = 0
             cron = 0
-
+            now = int(time.time())
             time_conflict = False
+
             for item in ['seconds', 'minutes', 'hours', 'days']:
                 if item in data and 'when' in data:
                     time_conflict = True
@@ -526,7 +527,6 @@ class Schedule(object):
 
                 if isinstance(data['when'], list):
                     _when = []
-                    now = int(time.time())
                     for i in data['when']:
                         try:
                             tmp = int(dateutil_parser.parse(i).strftime('%s'))
@@ -546,7 +546,7 @@ class Schedule(object):
                         if '_when' in data and data['_when'] != when:
                             data['_when_run'] = True
                             data['_when'] = when
-                        seconds = when - int(time.time())
+                        seconds = when - now
 
                         # scheduled time is in the past
                         if seconds < 0:
@@ -574,7 +574,6 @@ class Schedule(object):
                         log.error('Invalid date string. Ignoring')
                         continue
 
-                    now = int(time.time())
                     seconds = when - now
 
                     # scheduled time is in the past
@@ -612,14 +611,16 @@ class Schedule(object):
             # loop interval needed. If it is lower then overwrite variable
             # external loops using can then check this variable for how often
             # they need to reschedule themselves
-            if seconds < self.loop_interval:
-                self.loop_interval = seconds
-            now = int(time.time())
+            # Not used with 'when' parameter, causes run away jobs and CPU
+            # spikes.
+            if 'when' not in data:
+                if seconds < self.loop_interval:
+                    self.loop_interval = seconds
             run = False
 
             if job in self.intervals:
                 if 'when' in data:
-                    if now - when >= seconds:
+                    if seconds == 0:
                         if data['_when_run']:
                             data['_when_run'] = False
                             run = True
@@ -643,7 +644,7 @@ class Schedule(object):
                             data['_seconds'] = 0
 
                 if 'when' in data:
-                    if now - when >= seconds:
+                    if seconds == 0:
                         if data['_when_run']:
                             data['_when_run'] = False
                             run = True
@@ -739,7 +740,7 @@ class Schedule(object):
                 if self.opts.get('multiprocessing', True):
                     proc.join()
             finally:
-                self.intervals[job] = int(time.time())
+                self.intervals[job] = now
 
 
 def clean_proc_dir(opts):


### PR DESCRIPTION
Fixing a bug in the scheduler that caused a runaway job and CPU spikes when using the 'when' parameter.  Also some cleanup of redundant calls to time.time and the comparison used to see when a job should run. #18534 
