### PR TITLE
Add boto AWS tagging module

### DIFF
--- a/salt/modules/boto_tag.py
+++ b/salt/modules/boto_tag.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+'''
+Tagging module for Amazon AWS Resources
+
+.. versionadded:: Lithium
+
+:configuration: This module accepts explicit AWS credentials but can also
+    utilize IAM roles assigned to the instance trough Instance Profiles.
+    Dynamic credentials are then automatically obtained from AWS API and no
+    further configuration is necessary. More Information available at::
+
+       http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html
+
+    If IAM roles are not used you need to specify them either in a pillar or
+    in the minion's config file:
+
+        vpc.keyid: GKTADJGHEIQSXMKKRBJ08H
+        vpc.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    Or using spefic credentials for the AWS endpoint that is being tagged::
+
+        ec2.keyid: GKTADJGHEIQSXMKKRBJ08H
+        ec2.key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+
+    A region may also be specified in the configuration::
+
+        vpc.region: us-east-1
+
+    If a region is not specified, the default is us-east-1.
+
+    It's also possible to specify key, keyid and region via a profile, either
+    as a passed in dict, or as a string to pull from pillars or minion config:
+
+        myprofile:
+            keyid: GKTADJGHEIQSXMKKRBJ08H
+            key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
+            region: us-east-1
+
+    Currently supported resources are:
+
+        security-groups, prefix: 'sg'
+        instances, prefix: 'i'
+        vpcs, prefix: 'vpc'
+
+    Appropriate AWS Endpoint is automatically detected based on the resource id.
+
+:depends: boto
+
+'''
+from __future__ import absolute_import
+
+# Import Python libs
+import logging
+import json
+
+# Import third party libs
+from salt.exceptions import CommandExecutionError
+
+log = logging.getLogger(__name__)
+
+try:
+    import boto
+    import boto.regioninfo
+    logging.getLogger('boto').setLevel(logging.CRITICAL)
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+from salt.ext.six import string_types
+
+def __virtual__():
+    '''
+    Only load if boto libraries exist.
+    '''
+    if not HAS_BOTO:
+        return False
+    return True
+
+def _get_conn(resource_endpoint, region, key, keyid, profile):
+    '''
+    Get a boto connection to vpc.
+    '''
+    if profile:
+        if isinstance(profile, string_types):
+            _profile = __salt__['config.option'](profile)
+        elif isinstance(profile, dict):
+            _profile = profile
+        key = _profile.get('key', None)
+        keyid = _profile.get('keyid', None)
+        region = _profile.get('region', None)
+
+    if not region and __salt__['config.option']("{0}.region".format(resource_endpoint)):
+        region = __salt__['config.option']("{0}.region".format(resource_endpoint))
+
+    if not region:
+        region = 'us-east-1'
+
+    if not key and __salt__['config.option']("{0}.key".format(resource_endpoint)):
+        key = __salt__['config.option']("{0}.key".format(resource_endpoint))
+    if not keyid and __salt__['config.option']("{0}.keyid".format(resource_endpoint)):
+        keyid = __salt__['config.option']("{0}.keyid".format(resource_endpoint))
+
+    try:
+        # Can't use connect_to_region here without importing modules eg. ec2, vpc
+        # inside this function. This trick allows to avoid those imports
+        # region_endpoint is a hack, ec2 allows to query the regions for all
+        # connections (vpc, sns, etc.)
+        try:
+            region = [ri for ri in \
+            boto.regioninfo.get_regions(resource_endpoint) if ri.name == region][0]
+        except boto.exception.BotoClientError:
+            region = [ri for ri in \
+            boto.regioninfo.get_regions('ec2') if ri.name == region][0]
+
+        log.debug("Connecting to region: {0}".format(region))
+        conn = getattr(boto, "connect_{0}".format(resource_endpoint))(aws_access_key_id=keyid,
+                                                                      aws_secret_access_key=key,
+                                                                      region=region)
+
+    except boto.exception.NoAuthHandlerFound:
+        log.error('No authentication credentials found when attempting to'
+                  "make boto {0} connection.".format(resource_endpoint))
+        return None
+    return conn
+
+def _get_resource(resource_id, region, key, keyid, profile):
+    '''
+    Get resource for tagging based on the collected attribtues
+    '''
+    resource_attr = _recognize_resource(resource_id)
+    if resource_attr:
+        conn = _get_conn(resource_endpoint=resource_attr['endpoint'],
+                         region=region,
+                         key=key,
+                         keyid=keyid,
+                         profile=profile)
+        if conn:
+            try:
+                filters = {resource_attr['filter']:[resource_id]}
+                resource = getattr(conn, resource_attr['accessor'])(**filters)
+                if resource:
+                    return resource.pop()
+            except boto.exception.BotoServerError as exc:
+                log.error(exc)
+    else:
+        raise CommandExecutionError("Resource id: {0} could not be recognized.".format(resource_id))
+    return None
+
+def _recognize_resource(resource_id=None):
+    '''
+    Get metadata about the resource for tagging
+    '''
+    resource_prefix = resource_id.split('-')[0]
+    log.debug("Detected resource prefix: {0}".format(resource_prefix))
+    resource_map = dict(sg=dict(endpoint='ec2',
+                                family='instances',
+                                filter='group_ids',
+                                accessor='get_all_security_groups'),
+                        vpc=dict(endpoint='vpc',
+                                 family='vpcs',
+                                 filter='vpc_ids',
+                                 accessor='get_all_vpcs'),
+                        i=dict(endpoint='ec2',
+                               family='instances',
+                               filter='instance_ids',
+                               accessor='get_only_instances'))
+    resource_attr = resource_map.get(resource_prefix, None)
+    log.debug("Recognized resource details: {0}".format(resource_attr))
+    return resource_attr
+
+
+def _parse_arg_tags(tags=None):
+    '''
+    Convert passed string representing dict into dict obj
+    '''
+    ret = False
+    log.debug("Parsing tags: {0}".format(tags))
+    try:
+        ret = json.loads(tags)
+    except TypeError:
+        log.warning('Could not decode passed tags as dict')
+    return ret
+
+
+def _is_subset(superset=None, subset=None):
+    '''
+    Compares dictionaries against inclusion
+    '''
+    return set(subset.items()).issubset(set(superset.items()))
+
+
+def add(resource_id, tags=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Adds tags to the resource_id of type resource
+
+    CLI Example::
+
+    .. code-block:: bash
+
+        salt myminion boto_tag.add 'vpc-6b1fe401' tags='{"environment":"development"}'
+
+    .. code-block:: bash
+
+        salt myminion boto_tag.add 'sg-1b1f1112' tags='{"environment":"development"}'
+
+    .. code-block:: bash
+
+        salt myminion boto_tag.add 'i-7b1fe401' tags='{"environment":"development"}'
+
+    '''
+    ret = False
+    resource = _get_resource(resource_id=resource_id,
+                             region=region,
+                             key=key,
+                             keyid=keyid,
+                             profile=profile)
+    try:
+        if resource:
+            log.debug("Adding tags: {1} to {0}".format(resource.id, tags))
+            resource.add_tags(tags)
+            log.debug("Current Resource tags: {0}".format(resource.tags))
+            ret = _is_subset(superset=resource.tags, subset=tags)
+        else:
+            log.warning("Failed to add tags: {1} to {0}".format(resource_id, tags))
+    except boto.exception.BotoServerError as exc:
+        log.error(exc)
+    return ret
+
+
+def remove(resource_id, tags=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Adds tags to the resource_id of type resource
+
+    CLI Example::
+
+    .. code-block:: bash
+
+        salt myminion boto_tag.remove 'vpc-6b1fe401' tags='{"environment":"development"}'
+
+    .. code-block:: bash
+
+        salt myminion boto_tag.remove 'sg-1b1f1112' tags='{"environment":"development"}'
+
+    .. code-block:: bash
+
+        salt myminion boto_tag.remove 'i-7b1fe401' tags='{"environment":"development"}'
+
+    '''
+    ret = False
+    resource = _get_resource(resource_id=resource_id,
+                             region=region,
+                             key=key,
+                             keyid=keyid,
+                             profile=profile)
+    try:
+        if resource:
+            log.debug("Removing tags: {1} to {0}".format(resource.id, tags))
+            resource.remove_tags(tags)
+            log.debug("Current resource tags: {0}".format(resource.tags))
+            ret = not _is_subset(superset=resource.tags, subset=tags)
+        else:
+            log.warning("Failed to remove tags: {1} to {0}".format(resource_id, tags))
+    except boto.exception.BotoServerError as exc:
+        log.error(exc)
+    return ret
+
+
+

--- a/tests/unit/modules/boto_tag_test.py
+++ b/tests/unit/modules/boto_tag_test.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+
+# import Python Third Party Libs
+
+from mock import patch
+
+from salt.exceptions import CommandExecutionError
+from salt.modules.boto_tag import _get_conn
+
+
+try:
+    import boto
+    from boto.exception import BotoServerError
+
+    HAS_BOTO = True
+except ImportError:
+    HAS_BOTO = False
+
+try:
+    from moto import mock_ec2
+
+    HAS_MOTO = True
+except ImportError:
+    HAS_MOTO = False
+
+# Import Python libs
+from distutils.version import LooseVersion
+
+# Import Salt Libs
+from salt.modules import boto_tag
+
+# Import Salt Testing Libs
+from salttesting import skipIf, TestCase
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+required_boto_version = '2.8.0'
+required_moto_version = '0.3.7'
+region = 'us-east-1'
+access_key = 'GKTADJGHEIQSXMKKRBJ08H'
+secret_key = 'askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs'
+conn_parameters = {'region': region, 'key': access_key, 'keyid': secret_key, 'profile': {}}
+cidr_block = '10.0.0.0/24'
+dhcp_options_parameters = {'domain_name': 'example.com', 'domain_name_servers': ['1.2.3.4'], 'ntp_servers': ['5.6.7.8'],
+                           'netbios_name_servers': ['10.0.0.1'], 'netbios_node_type': 2}
+network_acl_entry_parameters = ('fake', 100, -1, 'allow', cidr_block)
+dhcp_options_parameters.update(conn_parameters)
+
+
+def _has_required_boto():
+    '''
+    Returns True/False boolean depending on if Boto is installed and correct
+    version.
+    '''
+    if not HAS_BOTO:
+        return False
+    elif LooseVersion(boto.__version__) < LooseVersion(required_boto_version):
+        return False
+    else:
+        return True
+
+
+def _has_required_moto():
+    '''
+    Returns True/False boolean depending on if Moto is installed and correct
+    version.
+    '''
+    if not HAS_MOTO:
+        return False
+    else:
+        import pkg_resources
+
+        if LooseVersion(pkg_resources.get_distribution('moto').version) < LooseVersion(required_moto_version):
+            return False
+        return True
+
+
+class BotoTagTestCaseBase(TestCase):
+    conn = None
+
+    def _create_vpc(self, name=None, tags=None):
+        '''
+        Helper function to create a test vpc
+        '''
+        if not self.conn:
+            self.conn = _get_conn('vpc', **conn_parameters)
+
+        vpc = self.conn.create_vpc(cidr_block)
+        return vpc
+
+    def _create_security_group(self, name=None, description=None):
+        '''
+        Helper function to create a test subnet
+        '''
+        if not self.conn:
+            self.conn = _get_conn('ec2', **conn_parameters)
+
+        security_group = self.conn.create_security_group(name, description)
+        return security_group
+
+
+    def _create_instance(self, ami_id='ami-08389d60'):
+        '''
+        Helper function to create a test instance
+        '''
+        if not self.conn:
+            self.conn = _get_conn('ec2', **conn_parameters)
+
+        reservations = self.conn.run_instances(ami_id)
+        return reservations.instances[0]
+
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+@skipIf(HAS_BOTO is False, 'The boto module must be installed.')
+@skipIf(HAS_MOTO is False, 'The moto module must be installed.')
+@skipIf(_has_required_boto() is False,
+        'The boto module must be greater than'
+        ' or equal to version {0}'.format(required_boto_version))
+class BotoTagTestCase(BotoTagTestCaseBase):
+    '''
+    TestCase for salt.modules.boto_tags module
+    '''
+    # vpc
+    @mock_ec2
+    def test_that_when_adding_tags_to_vpc_method_returns_true(self):
+        vpc = self._create_vpc()
+        ret = boto_tag.add(resource_id=vpc.id, tags={"environment":"development"}, **conn_parameters)
+        self.assertTrue(ret) and self.assertEqual(vpc.tags, {"environment":"development"})
+
+    @mock_ec2
+    def test_that_when_adding_tags_to_non_existing_vpc_method_returns_false(self):
+        ret = boto_tag.add(resource_id='vpc-123456', tags='{"environment":"development"}', **conn_parameters)
+        self.assertFalse(ret)
+    
+    @mock_ec2
+    def test_that_when_removing_tags_from_vpc_method_returns_true(self):
+        vpc = self._create_vpc(tags={"environment":"development", "cluster":"compute1"})
+        ret = boto_tag.remove(resource_id=vpc.id, tags={"cluster":"compute1"}, **conn_parameters)
+        self.assertTrue(ret) and self.assertEqual(vpc.tags, {"environment":"development"})
+
+    @mock_ec2
+    def test_that_when_removing_tags_from_non_existing_vpc_method_returns_false(self):
+        ret = boto_tag.remove(resource_id='vpc-123456', tags={"cluster":"compute1"}, **conn_parameters)
+        self.assertFalse(ret)
+    
+    # sg
+    @mock_ec2
+    def test_that_when_adding_tags_to_sg_method_returns_true(self):
+        sg = self._create_security_group()
+        ret = boto_tag.add(resource_id=sg.id, tags={"environment":"development"}, **conn_parameters)
+        self.assertTrue(ret) and self.assertEqual(sg.tags, {"environment":"development"})
+
+    @mock_ec2
+    def test_that_when_adding_tags_to_non_existing_sg_method_returns_false(self):
+        ret = boto_tag.add(resource_id='sg-123456', tags={"environment":"development"}, **conn_parameters)
+        self.assertFalse(ret)
+    
+    @mock_ec2
+    def test_that_when_removing_tags_from_sg_method_returns_true(self):
+        sg = self._create_security_group()
+        boto_tag.add(resource_id=sg.id, tags={"environment":"development", "cluster":"compute1"}, **conn_parameters)
+        ret = boto_tag.remove(resource_id=sg.id, tags={"cluster":"compute1"}, **conn_parameters)
+        self.assertTrue(ret) and self.assertEqual(sg.tags, {"environment":"development"})
+
+    @mock_ec2
+    def test_that_when_removing_tags_from_non_existing_sg_method_returns_false(self):
+        ret = boto_tag.remove(resource_id='sg-123456', tags={"cluster":"compute1"}, **conn_parameters)
+        self.assertFalse(ret)
+
+    # instance
+    @mock_ec2
+    def test_that_when_adding_tags_to_instance_method_returns_true(self):
+        instance = self._create_instance()
+        ret = boto_tag.add(resource_id=instance.id, tags={"environment":"development"}, **conn_parameters)
+        self.assertTrue(ret) and self.assertEqual(sg.tags, {"environment":"development"})
+
+    @mock_ec2
+    def test_that_when_adding_tags_to_non_existing_instance_method_returns_false(self):
+        ret = boto_tag.add(resource_id='i-123456', tags={"environment":"development"}, **conn_parameters)
+        self.assertFalse(ret)
+    
+    @mock_ec2
+    def test_that_when_removing_tags_from_instance_method_returns_true(self):
+        instance = self._create_instance()
+        boto_tag.add(resource_id=instance.id, tags={"environment":"development", "cluster":"compute1"}, **conn_parameters)
+        ret = boto_tag.remove(resource_id=instance.id, tags={"cluster":"compute1"}, **conn_parameters)
+        self.assertTrue(ret) and self.assertEqual(instance.tags, {"environment":"development"})
+
+    @mock_ec2
+    def test_that_when_removing_tags_from_non_existing_instance_method_returns_false(self):
+        ret = boto_tag.remove(resource_id='i-123456', tags={"cluster":"compute1"}, **conn_parameters)
+        self.assertFalse(ret)
+    
+    # unknown    
+    @mock_ec2
+    def test_that_when_adding_tags_to_unknown_resource_method_returns_false(self):
+        with self.assertRaisesRegexp(CommandExecutionError, 'Resource id: unknown-123456 could not be recognized.'):
+            ret = boto_tag.add(resource_id='unknown-123456', tags={"cluster":"compute1"}, **conn_parameters)
+
+    @mock_ec2        
+    def test_that_when_removing_tags_from_unknown_resource_method_returns_false(self):
+        with self.assertRaisesRegexp(CommandExecutionError, 'Resource id: unknown-123456 could not be recognized.'):
+            ret = boto_tag.remove(resource_id='unknown-123456', tags={"cluster":"compute1"}, **conn_parameters)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+
+    run_tests(BotoTagTestCase, needs_daemon=False)


### PR DESCRIPTION
This is a first stab at tagging in AWS.
The module allows to tag instances, vpcs and security groups.

If you think this is the right direction, next iteration would include support for more VPC resources.
