### PR TITLE
Added some more cmdmod unittests

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -322,11 +322,15 @@ def _run(cmd,
               'stderr': stderr,
               'with_communicate': with_communicate}
 
-    if umask:
+    if umask is not None:
+        _umask = str(umask).lstrip('0')
+
+        if _umask == '':
+            msg = 'Zero umask is not allowed.'
+            raise CommandExecutionError(msg)
+
         try:
-            _umask = int(str(umask).lstrip('0'), 8)
-            if not _umask:
-                raise ValueError('Zero umask not allowed.')
+            _umask = int(_umask, 8)
         except ValueError:
             msg = 'Invalid umask: \'{0}\''.format(umask)
             raise CommandExecutionError(msg)

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -100,7 +100,7 @@ def _render_cmd(cmd, cwd, template, saltenv='base'):
         if not data['result']:
             # Failed to render the template
             raise CommandExecutionError(
-                'Failed to cmd with error: {0}'.format(
+                'Failed to execute cmd with error: {0}'.format(
                     data['data']
                 )
             )

--- a/tests/unit/modules/cmdmod_test.py
+++ b/tests/unit/modules/cmdmod_test.py
@@ -5,6 +5,7 @@
 
 # Import Salt Libs
 from salt.modules import cmdmod
+from salt.exceptions import CommandExecutionError
 from salt.log import LOG_LEVELS
 
 # Import Salt Testing Libs
@@ -29,12 +30,21 @@ class CMDMODTestCase(TestCase):
                       'trace': 'bar', 'garbage': 'bar', 'error': 'bar',
                       'debug': 'bar', 'warning': 'bar', 'quiet': 'bar'}
 
-    def test_render_cmd(self):
+    def test_render_cmd_no_template(self):
         '''
         Tests return when template=None
         '''
         self.assertEqual(cmdmod._render_cmd('foo', 'bar', None),
                          ('foo', 'bar'))
+
+    def test_render_cmd_unavailable_engine(self):
+        '''
+        Tests CommandExecutionError raised when template isn't in the
+        template registry
+        '''
+        self.assertRaises(CommandExecutionError,
+                          cmdmod._render_cmd,
+                          'boo', 'bar', 'baz')
 
     def test_check_loglevel_bad_level(self):
         '''

--- a/tests/unit/modules/cmdmod_test.py
+++ b/tests/unit/modules/cmdmod_test.py
@@ -153,10 +153,7 @@ class CMDMODTestCase(TestCase):
         '''
         Tests error raised when umask is set to zero
         '''
-        with patch.dict(cmdmod.__grains__, {'os': 'fake_os'}):
-            self.assertRaises(CommandExecutionError,
-                              cmdmod._run,
-                              'foo', 'bar', runas='baz', umask=0)
+        self.assertRaises(CommandExecutionError, cmdmod._run, 'foo', 'bar', umask=0)
 
     @patch('salt.modules.cmdmod._is_valid_shell', MagicMock(return_value=True))
     @patch('salt.utils.is_windows', MagicMock(return_value=False))
@@ -167,10 +164,7 @@ class CMDMODTestCase(TestCase):
         '''
         Tests error raised when an invalid umask is given
         '''
-        with patch.dict(cmdmod.__grains__, {'os': 'fake_os'}):
-            self.assertRaises(CommandExecutionError,
-                              cmdmod._run,
-                              'foo', 'bar', umask='baz')
+        self.assertRaises(CommandExecutionError, cmdmod._run, 'foo', 'bar', umask='baz')
 
     @patch('salt.utils.is_windows', MagicMock(return_value=True))
     def test_is_valid_shell_windows(self):


### PR DESCRIPTION
Also changed a little bit of the umask logic: If `umask=0` kwarg was set, the `if umask` statement was never entered. Also, the first `ValueError` in the original "Zero umask is not allowed" was getting skipped over in favor of the `CommandExecutionError` in the `except` statement. This should be fixed now and has corresponding tests.
