### PR TITLE
Key name was changed in version 2 of the digital ocean API

### DIFF
--- a/salt/cloud/clouds/digital_ocean_v2.py
+++ b/salt/cloud/clouds/digital_ocean_v2.py
@@ -154,7 +154,7 @@ def list_nodes(call=None):
             'id': node['id'],
             'image': node['image']['name'],
             'networks': str(node['networks']),
-            'size': node['size']['slug'],
+            'size': node['size_slug'],
             'state': str(node['status']),
         }
     return ret


### PR DESCRIPTION
Keyname has changed in version 2 of digital oceans API

```
[DEBUG   ] Failed to execute 'digital_ocean.list_nodes()' while querying for running nodes: 'size'
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/salt/cloud/__init__.py", line 2195, in run_parallel_map_providers_query
    cloud.clouds[data['fun']]()
  File "/usr/lib/python2.7/site-packages/salt/cloud/clouds/digital_ocean_v2.py", line 158, in list_nodes
    'size': node['size']['slug'],
KeyError: 'size'
```
