### PR TITLE
Docker pulled - compare against images correctly

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -242,6 +242,10 @@ def pulled(name, tag=None, force=False, *args, **kwargs):
     force
         Pull even if the image is already pulled
     '''
+
+    if tag:
+        name = '{0}:{1}'.format(name, tag)
+
     inspect_image = __salt__['docker.inspect_image']
     image_infos = inspect_image(name)
     if image_infos['status'] and not force:


### PR DESCRIPTION
Hi Guys

When running a `docker.pulled` with force against an image tag the state can often return changes even though no changes occurred. 
### Example

``` yaml
foo:
  docker.pulled:
    - tag: bar
    - force: true
```

This will force salt to check for a new version of the `foo` image at tag `bar`. However because the `dockerio.pulled` method runs `__salt__['docker.inspect_image']('foo')` the comparison of image ID's would be `None` vs `3ac61da661ee...` which would result in the changes dict being populated which is not correct.

This pull request ensures that if a tag is provided the call to `inspect_image` would be `foo:bar` ensuring we compare the correct existing image with the remote image.

I think that explains it lol
