### PR TITLE
Don't change a file again if it's already been done.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1150,30 +1150,22 @@ def replace(path,
 
         if not found:
             for line in fi_file:
+                result, nrepl = re.subn(cpattern, repl, line, count)
 
-                if search_only:
-                    # Just search; bail as early as a match is found
-                    result = re.search(cpattern, line)
+                # found anything? (even if no change)
+                if nrepl > 0:
+                    found = True
 
-                    if result:
-                        return True  # `finally` block handles file closure
-                else:
-                    result, nrepl = re.subn(cpattern, repl, line, count)
+                # Identity check each potential change until one change is made
+                if has_changes is False and result != line:
+                    has_changes = True
 
-                    # found anything? (even if no change)
-                    if nrepl > 0:
-                        found = True
+                if show_changes:
+                    orig_file.append(line)
+                    new_file.append(result)
 
-                    # Identity check each potential change until one change is made
-                    if has_changes is False and result != line:
-                        has_changes = True
-
-                    if show_changes:
-                        orig_file.append(line)
-                        new_file.append(result)
-
-                    if not dry_run:
-                        print(result, end='', file=sys.stdout)
+                if not dry_run:
+                    print(result, end='', file=sys.stdout)
     finally:
         fi_file.close()
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1127,31 +1127,40 @@ def replace(path,
                         bufsize=bufsize,
                         mode='r' if (dry_run or search_only) else 'rb')
         found = False
+        # First check the whole file, whether the replacement has already been made
         for line in fi_file:
+            result = re.search(repl, line)
+            if result:
+                if search_only:
+                    return True
+                found = True
 
-            if search_only:
-                # Just search; bail as early as a match is found
-                result = re.search(cpattern, line)
+        if not found:
+            for line in fi_file:
 
-                if result:
-                    return True  # `finally` block handles file closure
-            else:
-                result, nrepl = re.subn(cpattern, repl, line, count)
+                if search_only:
+                    # Just search; bail as early as a match is found
+                    result = re.search(cpattern, line)
 
-                # found anything? (even if no change)
-                if nrepl > 0:
-                    found = True
+                    if result:
+                        return True  # `finally` block handles file closure
+                else:
+                    result, nrepl = re.subn(cpattern, repl, line, count)
 
-                # Identity check each potential change until one change is made
-                if has_changes is False and result != line:
-                    has_changes = True
+                    # found anything? (even if no change)
+                    if nrepl > 0:
+                        found = True
 
-                if show_changes:
-                    orig_file.append(line)
-                    new_file.append(result)
+                    # Identity check each potential change until one change is made
+                    if has_changes is False and result != line:
+                        has_changes = True
 
-                if not dry_run:
-                    print(result, end='', file=sys.stdout)
+                    if show_changes:
+                        orig_file.append(line)
+                        new_file.append(result)
+
+                    if not dry_run:
+                        print(result, end='', file=sys.stdout)
     finally:
         fi_file.close()
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1120,20 +1120,33 @@ def replace(path,
 
     # Avoid TypeErrors by forcing repl to be a string
     repl = str(repl)
+
+    found = False
+
+    # First check the whole file, whether the replacement has already been made
     try:
+        # open the file read-only and inplace=False, otherwise the result
+        # will be an empty file after iterating over it just for searching
         fi_file = fileinput.input(path,
-                        inplace=not (dry_run or search_only),
-                        backup=False if dry_run else backup,
+                        inplace=False,
                         bufsize=bufsize,
-                        mode='r' if (dry_run or search_only) else 'rb')
-        found = False
-        # First check the whole file, whether the replacement has already been made
+                        mode='r')
+
         for line in fi_file:
             result = re.search(repl, line)
             if result:
                 if search_only:
                     return True
                 found = True
+    finally:
+        fi_file.close()
+
+    try:
+        fi_file = fileinput.input(path,
+                        inplace=not (dry_run or search_only),
+                        backup=False if dry_run else backup,
+                        bufsize=bufsize,
+                        mode='r' if (dry_run or search_only) else 'rb')
 
         if not found:
             for line in fi_file:


### PR DESCRIPTION
When using `append_if_not_found=True` or `prepend_if_not_found=True`
the file will grow infinitely as replace() didn't check until now
whether the change has already been made.

This fixes this behavior (#18612).
