### PR TITLE
Skip test_max_open_files test until we can find the real problem

### DIFF
--- a/tests/unit/utils/verify_test.py
+++ b/tests/unit/utils/verify_test.py
@@ -109,8 +109,7 @@ class TestVerify(TestCase):
                 # not support IPv6.
                 pass
 
-    @skipIf(os.environ.get('TRAVIS_PYTHON_VERSION', None) is not None,
-            'Travis environment does not like too many open files')
+    @skipIf(True, 'Skipping until we can find why Jenkins is bailing out')
     def test_max_open_files(self):
 
         with TestsLoggingHandler() as handler:


### PR DESCRIPTION
Jenkins is bailing out around 512 on both the 2014.7 and the develop branches, which has been narrowed down to this test. The quick fix here is to skip this test for now until we can find the real problem and get Jenkins back on its feet as much as possible.

@cachedout recommended that the test be disabled outright on both branches since it's failing in both places (and not just ssh runs) to see what happens.

@s0undt3ch ping.
