### PR TITLE
Document the dependencies for the schedule options 'when' and 'range'

### DIFF
--- a/doc/topics/jobs/schedule.rst
+++ b/doc/topics/jobs/schedule.rst
@@ -1,9 +1,9 @@
 
 In Salt versions greater than 0.12.0, the scheduling system allows incremental
-executions on minions or the master. The schedule system exposes the execution 
+executions on minions or the master. The schedule system exposes the execution
 of any execution function on minions or any runner on the master.
 
-Scheduling is enabled via the ``schedule`` option on either the master or minion 
+Scheduling is enabled via the ``schedule`` option on either the master or minion
 config files, or via a minion's pillar data. Schedules that are impletemented via
 pillar data, only need to refresh the minion's pillar data, for example by using
 ``saltutil.refresh_pillar``. Schedules implemented in the master or minion config
@@ -20,7 +20,7 @@ or higher. Refer to :doc:`minion logging settings</ref/configuration/minion>`.
 
 Specify ``maxrunning`` to ensure that there are no more than N copies of
 a particular routine running.  Use this for jobs that may be long-running
-and could step on each other or otherwise double execute.  The default for 
+and could step on each other or otherwise double execute.  The default for
 ``maxrunning`` is 1.
 
 States are executed on the minion, as all states are. You can pass positional
@@ -39,7 +39,7 @@ arguments and provide a yaml dict of named arguments.
 
 This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour)
- 
+
 .. code-block:: yaml
 
     schedule:
@@ -75,7 +75,8 @@ This will schedule the command: state.sls httpd test=True every 3600 seconds
 .. versionadded:: 2014.7.0
 
 Frequency of jobs can also be specified using date strings supported by
-the python dateutil library.
+the python dateutil library. This requires python-dateutil to be installed on
+the minion.
 
 .. code-block:: yaml
 
@@ -126,7 +127,8 @@ and Friday, and 3pm on Tuesday and Thursday.
 
 This will schedule the command: state.sls httpd test=True every 3600 seconds
 (every hour) between the hours of 8am and 5pm.  The range parameter must be a
-dictionary with the date strings using the dateutil format.
+dictionary with the date strings using the dateutil format. This requires
+python-dateutil to be installed on the minion.
 
 .. versionadded:: 2014.7.0
 
@@ -171,12 +173,12 @@ minion config or pillar:
         function: state.highstate
         minutes: 60
 
-Time intervals can be specified as seconds, minutes, hours, or days. 
+Time intervals can be specified as seconds, minutes, hours, or days.
 
 Runners
 =======
 
-Runner executions can also be specified on the master within the master 
+Runner executions can also be specified on the master within the master
 configuration file:
 
 .. code-block:: yaml
@@ -209,7 +211,7 @@ returner database:
         function: status.meminfo
         minutes: 5
         returner: mysql
-      
+
 Since specifying the returner repeatedly can be tiresome, the
 ``schedule_returner`` option is available to specify one or a list of global
 returners to be used by the minions when scheduling.

--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -40,7 +40,8 @@ Management of the Salt scheduler
             - Friday 5:00pm
 
     This will schedule the command: state.sls httpd test=True at 5pm on Monday,
-    Wednesday and Friday, and 3pm on Tuesday and Thursday.
+    Wednesday and Friday, and 3pm on Tuesday and Thursday.  Requires that
+    python-dateutil is installed on the minion.
 
     job1:
       schedule.present:
@@ -53,7 +54,7 @@ Management of the Salt scheduler
 
     Scheduled jobs can also be specified using the format used by cron.  This will
     schedule the command: state.sls httpd test=True to run every 5 minutes.  Requires
-    that python-croniter is installed.
+    that python-croniter is installed on the minion.
 
     job1:
       schedule.present:
@@ -107,10 +108,12 @@ def present(name,
         This will schedule the job at the specified time(s).
         The when parameter must be a single value or a dictionary
         with the date string(s) using the dateutil format.
+        Requires python-dateutil.
 
     cron
         This will schedule the job at the specified time(s)
         using the crontab format.
+        Requires python-croniter.
 
     function
         The function that should be executed by the scheduled job.
@@ -135,7 +138,7 @@ def present(name,
     range
         This will schedule the command within the range specified.
         The range parameter must be a dictionary with the date strings
-        using the dateutil format.
+        using the dateutil format. Requires python-dateutil.
 
     returner
         The returner to use to return the results of the scheduled job.


### PR DESCRIPTION
As the subject says, plus some removed Whitespace at the line endings my editor took care of...

Thought the docs should mention it, especially since all minions depend on those libraries, which makes them quite a requirement. Right now, the only way to know of those dependencies is to try it (and read the error logs) or to read the code.
