### PR TITLE
2014.7 modules.locale gentoo fixes

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -145,6 +145,11 @@ def set_locale(locale):
 
 
 def _normalize_locale(locale):
+    # depending on the environment, the provided locale will also contain a charmap
+    # (e.g. 'en_US.UTF-8 UTF-8' instead of only the locale 'en_US.UTF-8')
+    # drop the charmap
+    locale = locale.split()[0]
+
     lang_encoding = locale.split('.')
     lang_split = lang_encoding[0].split('_')
     if len(lang_split) > 1:


### PR DESCRIPTION
From the commits:

**efeed3e:**

> Improve locale._normalize_locale() by dropping the charmap.

**ea65712:**

> Improve/fix locale.gen_locale() on Debian and Gentoo.
> - Validate the locale first instead of trying to generate it blindly
> - Gentoo (just as Debian already did) requires the locale to be listed
>   in /etc/locale.gen before being able to generate it
> - 'locale-gen' needs the '--generate' param on Gentoo
> - Quote the locale supplied to 'locale-gen' as it might contain a
>   whitespace

This PR will only have full effect once #18612 is merged.
