### PR TITLE
Always run download_packages() after executing buildpackage SLS

### DIFF
--- a/tests/jenkins.py
+++ b/tests/jenkins.py
@@ -766,9 +766,8 @@ def run(opts):
             print(stderr)
         sys.stderr.flush()
 
-        # Download packages only if the script ran and was successful
-        if 'Build complete' in stdout:
-            download_packages(opts)
+        # Grab packages and log file (or just log file if build failed)
+        download_packages(opts)
 
     if opts.download_remote_reports:
         # Download unittest reports


### PR DESCRIPTION
By restricting this function call to when the script is successful, we end up
losing the log file from buildpackage.py when it fails, making it next to impossible to
troubleshoot. This commit makes jenkins retrieve at least the log file, no
matter what happens.

ping @s0undt3ch @rallytime
