### PR TITLE
Add Returner Setting section for returner's config

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -654,3 +654,8 @@
 # List of git repositories to include with the local repo:
 #win_gitrepos:
 #  - 'https://github.com/saltstack/salt-winrepo.git'
+
+#####      Returner settings          ######
+############################################
+# Which returner(s) will be used for minion's result:
+#return: mysql

--- a/conf/minion
+++ b/conf/minion
@@ -575,3 +575,9 @@
 ############################################
 # Location of the repository cache file on the master:
 #win_repo_cachefile: 'salt://win/repo/winrepo.p'
+
+
+######      Returner  settings        ######
+############################################
+# Which returner(s) will be used for minion's result:
+#return: mysql


### PR DESCRIPTION
We have a publish system use saltstack for configuration & package management with thousands minions. We use a mysql returner to collect minion result, and we also want to put all saltstack configurations into master or minion's configuration file. At first we found that there is no config item in master or minion's configuration file for returner, so we use command like "salt '*' test.ping --return mysql" to collect minion result. After reading the sourcecode we found that we can add 'return' in master or minion's configuration file to use the returner we want. So I add the 'Returner Section' into these configuration file.  We can put some other things related to returner like 'mysql.host' into this section too.
