### PR TITLE
Don't empty the file when it is supposed to be only read.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1122,10 +1122,10 @@ def replace(path,
     repl = str(repl)
     try:
         fi_file = fileinput.input(path,
-                        inplace=not dry_run,
+                        inplace=not (dry_run or search_only),
                         backup=False if dry_run else backup,
                         bufsize=bufsize,
-                        mode='rb')
+                        mode='r' if (dry_run or search_only) else 'rb')
         found = False
         for line in fi_file:
 


### PR DESCRIPTION
Iterating over an `fileinput.input()` object with `inplace=True`
and not returning any results per iteration leaves an empty
input file.

Solves #18680 
