### PR TITLE
Support multiple roots per environment for external pillars S3 and Git

### DIFF
--- a/salt/pillar/git_pillar.py
+++ b/salt/pillar/git_pillar.py
@@ -294,14 +294,13 @@ def ext_pillar(minion_id,
 
     # Don't recurse forever-- the Pillar object will re-call the ext_pillar
     # function
-    if __opts__['pillar_roots'].get(branch, []) == [pillar_dir]:
+    if pillar_dir in __opts__['pillar_roots'].get(branch, []):
         return {}
 
     gitpil.update()
 
     opts = deepcopy(__opts__)
-
-    opts['pillar_roots'][branch] = [pillar_dir]
+    opts['pillar_roots'].setdefault(branch, []).append(pillar_dir)
 
     pil = Pillar(opts, __grains__, minion_id, branch)
 

--- a/salt/pillar/s3.py
+++ b/salt/pillar/s3.py
@@ -112,7 +112,7 @@ def ext_pillar(minion_id,
     pillar_dir = os.path.normpath(os.path.join(_get_cache_dir(), environment,
                                                bucket))
 
-    if __opts__['pillar_roots'].get(environment, []) == [pillar_dir]:
+    if pillar_dir in __opts__['pillar_roots'].get(environment, []):
         return {}
 
     metadata = _init(s3_creds, multiple_env, environment)
@@ -134,7 +134,7 @@ def ext_pillar(minion_id,
         log.info('Sync local pillar cache from S3 completed.')
 
     opts = deepcopy(__opts__)
-    opts['pillar_roots'][environment] = [pillar_dir]
+    opts['pillar_roots'].setdefault(environment, []).append(pillar_dir)
 
     pil = Pillar(opts, __grains__, minion_id, environment)
 


### PR DESCRIPTION
Issue #18355

In our Salt 2014.7 Master we encountered the issue that the pillar for each environment could only come from one root directory in the cache. To support a mix of S3 and Git external pillars, I had to put in the following with regards to how the `__opts__['pillar_roots'][environment]` lists were being populated.

I'm not comfortable modifying the other pillar modules since I'm not familiar with those systems, but maybe someone on the Saltstack project could apply a similar fix (if this change is acceptable).
