### PR TITLE
lxc runner: delete mistakenly committed merge conflict

### DIFF
--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -13,10 +13,6 @@ import copy
 import logging
 
 # Import Salt libs
-<<<<<<< HEAD
-=======
-from salt.utils.odict import OrderedDict as _OrderedDict
->>>>>>> 7f92f2a92b9f9010adc44d1241a93c8cfd28afee
 import salt.client
 import salt.utils
 import salt.utils.virt


### PR DESCRIPTION
Was introduced by 200a6ae8100fa063d55aabdab0930ebb0e39b550
