### PR TITLE
fix broken refs to salt.client.ssh.client.SSHClient

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -644,7 +644,7 @@ def revoke_auth():
 
 def _get_ssh_or_api_client(cfgfile, ssh=False):
     if ssh:
-        client = salt.client.ssh.SSHClient(cfgfile)
+        client = salt.client.ssh.client.SSHClient(cfgfile)
     else:
         client = salt.client.get_local_client(cfgfile)
     return client
@@ -721,7 +721,7 @@ def cmd_iter(tgt,
         salt '*' saltutil.cmd_iter
     '''
     if ssh:
-        client = salt.client.ssh.SSHClient(__opts__['conf_file'])
+        client = salt.client.ssh.client.SSHClient(__opts__['conf_file'])
     else:
         client = salt.client.get_local_client(__opts__['conf_file'])
     for ret in client.cmd_iter(

--- a/salt/runners/manage.py
+++ b/salt/runners/manage.py
@@ -204,7 +204,7 @@ def safe_accept(target, expr_form='glob'):
         salt-run manage.safe_accept minion1,minion2 expr_form=list
     '''
     salt_key = salt.key.Key(__opts__)
-    ssh_client = salt.client.SSHClient()
+    ssh_client = salt.client.ssh.client.SSHClient()
 
     ret = ssh_client.cmd(target, 'key.finger', expr_form=expr_form)
 


### PR DESCRIPTION
```
************* Module salt.modules.saltutil
salt/modules/saltutil.py:647: [E1101(no-member), _get_ssh_or_api_client] Module 'salt.client.ssh' has no 'SSHClient' member
salt/modules/saltutil.py:724: [E1101(no-member), cmd_iter] Module 'salt.client.ssh' has no 'SSHClient' member
************* Module salt.runners.manage
salt/runners/manage.py:207: [E1101(no-member), safe_accept] Module 'salt.client' has no 'SSHClient' member
```
