### PR TITLE
Propose update to master config file

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -186,11 +186,11 @@
 # option, then the master will log a warning message.
 #
 # Include a config file from some other path:
-#include: /etc/salt/extra_config
+# include: /etc/salt/extra_config
 #
 # Include config from several files and directories:
-#include:
-#  - /etc/salt/extra_config
+# include:
+#   - /etc/salt/extra_config
 
 
 #####        Security settings       #####


### PR DESCRIPTION
Per the documentation: http://docs.saltstack.com/en/latest/ref/configuration/master.html#include-configuration  the include directive is unset by default.  As documented at the top of the master config file: "Values that are commented out but have no space after the comment are defaults that need not be set in the config. If there is a space after the comment that the value is presented as an example and is not the default."  Therefore, I propose adding a space after the comment to clarify that this is an example directive and not the default.
