### PR TITLE
fix the salt.utils.expr_match

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1089,7 +1089,7 @@ def flopen(*args, **kwargs):
                 fcntl.flock(fp_.fileno(), fcntl.LOCK_UN)
 
 
-def expr_match(expr, line):
+def expr_match(line, expr):
     '''
     Evaluate a line of text against an expression. First try a full-string
     match, next try globbing, and then try to match assuming expr is a regular


### PR DESCRIPTION
here is a new method in version `2014.7.0`, and only one caller `salt.utils.expr_match(keyid, line)` in 'salt.master.check_signing_file`. 
the caller pass keyid(the minion_id) and line(read from the autosign.conf) as sequence, but the method expr_match handles them as wrong seq.
fix it, and test it in my local env
