### PR TITLE
Explicitly include stdlib csv module in esky build. Fixes missing csv mo...

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -765,6 +765,7 @@ class SaltDistribution(distutils.dist.Distribution):
             'zmq.core.*',
             'zmq.utils.*',
             'ast',
+            'csv',
             'difflib',
             'distutils',
             'distutils.version',


### PR DESCRIPTION
...dule in Windows builds.
