### PR TITLE
[2014.7] Normalize cleanup and return routines for state wrappers in salt-ssh

### DIFF
--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -109,15 +109,21 @@ def sls(mods, saltenv='base', test=None, exclude=None, env=None, **kwargs):
             trans_tar,
             '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
-    try:
-        return json.loads(stdout, object_hook=salt.utils.decode_dict)
-    except Exception, e:
-        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
-        log.error(str(e))
+
+    # Clean up our tar
     try:
         os.remove(trans_tar)
     except (OSError, IOError):
         pass
+
+    # Read in the JSON data and return the data structure
+    try:
+        return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception as e:
+        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
+        log.error(str(e))
+
+    # If for some reason the json load fails, return the stdout
     return stdout
 
 
@@ -169,11 +175,22 @@ def low(data, **kwargs):
             trans_tar,
             '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
+
+    # Clean up our tar
     try:
         os.remove(trans_tar)
     except (OSError, IOError):
         pass
-    return json.loads(stdout, object_hook=salt.utils.decode_dict)
+
+    # Read in the JSON data and return the data structure
+    try:
+        return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception as e:
+        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
+        log.error(str(e))
+
+    # If for some reason the json load fails, return the stdout
+    return stdout
 
 
 def high(data, **kwargs):
@@ -221,11 +238,22 @@ def high(data, **kwargs):
             trans_tar,
             '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
+
+    # Clean up our tar
     try:
         os.remove(trans_tar)
     except (OSError, IOError):
         pass
-    return json.loads(stdout, object_hook=salt.utils.decode_dict)
+
+    # Read in the JSON data and return the data structure
+    try:
+        return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception as e:
+        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
+        log.error(str(e))
+
+    # If for some reason the json load fails, return the stdout
+    return stdout
 
 
 def highstate(test=None, **kwargs):
@@ -280,15 +308,21 @@ def highstate(test=None, **kwargs):
             trans_tar,
             '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
-    try:
-        stdout = json.loads(stdout, object_hook=salt.utils.decode_dict)
-    except Exception, e:
-        log.error('JSON Render failed for: {0}\n{1}'.format(stdout, stderr))
-        log.error(str(e))
+
+    # Clean up our tar
     try:
         os.remove(trans_tar)
     except (OSError, IOError):
         pass
+
+    # Read in the JSON data and return the data structure
+    try:
+        return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception as e:
+        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
+        log.error(str(e))
+
+    # If for some reason the json load fails, return the stdout
     return stdout
 
 
@@ -344,11 +378,22 @@ def top(topfn, test=None, **kwargs):
             trans_tar,
             '{0}/salt_state.tgz'.format(__opts__['thin_dir']))
     stdout, stderr, _ = single.cmd_block()
+
+    # Clean up our tar
     try:
         os.remove(trans_tar)
     except (OSError, IOError):
         pass
-    return json.loads(stdout, object_hook=salt.utils.decode_dict)
+
+    # Read in the JSON data and return the data structure
+    try:
+        return json.loads(stdout, object_hook=salt.utils.decode_dict)
+    except Exception as e:
+        log.error("JSON Render failed for: {0}\n{1}".format(stdout, stderr))
+        log.error(str(e))
+
+    # If for some reason the json load fails, return the stdout
+    return stdout
 
 
 def show_highstate():


### PR DESCRIPTION
In at least one case, we had the cleanup of the trans_tar after the return of the json data, which was a problem. I normalized all of the routines while I was in there.
