### PR TITLE
[2014.7] Prevent all `publish.` calls from publish calls

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -51,8 +51,8 @@ def _publish(
 
         salt system.example.com publish.publish '*' cmd.run 'ls -la /tmp'
     '''
-    if fun == 'publish.publish':
-        log.info('Function name is \'publish.publish\'. Returning {}')
+    if fun.startswith('publish.'):
+        log.info('Cannot publish publish calls. Returning {}')
         return {}
 
     arg = [salt.utils.args.yamlify_arg(arg)]


### PR DESCRIPTION
The old if statement only stopped `publish.publish` calls. Should not allow any calls to the `publish` module.
