### PR TITLE
[2014.7] Make publish.full_data wait for returns as well

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -212,7 +212,8 @@ def full_data(tgt, fun, arg=None, expr_form='glob', returner='', timeout=5):
                     expr_form=expr_form,
                     returner=returner,
                     timeout=timeout,
-                    form='full')
+                    form='full',
+                    wait=True)
 
 
 def runner(fun, arg=None, timeout=5):


### PR DESCRIPTION
I think this was just left off when wait was added to publish. As far as I can tell, `publish.full_data` is supposed to be the same as publish, just with more data.
