### PR TITLE
Add sysrc modules

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -75,7 +75,7 @@ def set(name, value, **kwargs):
     if 'jail' in kwargs:
         cmd += ' -j '+kwargs['jail']
 
-    cmd += ' '+name+"="+value
+    cmd += ' '+name+"=\""+value+"\"
 
     sysrcs = __salt__['cmd.run'](cmd, python_shell=False)
 

--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -4,17 +4,16 @@ sysrc module for FreeBSD
 '''
 from __future__ import absolute_import
 
-import salt
 import salt.utils
-
-from salt.utils.decorators import depends
 from salt.exceptions import CommandExecutionError
+
 
 def __virtual__():
     '''
     Only runs if sysrc exists
     '''
     return __salt__['cmd.has_exec']('sysrc')
+
 
 def get(**kwargs):
     '''
@@ -42,9 +41,8 @@ def get(**kwargs):
     if 'jail' in kwargs:
         cmd += ' -j '+kwargs['jail']
 
-    sysrcs = __salt__['cmd.run'](cmd)
+    sysrcs = __salt__['cmd.run'](cmd, python_shell=False)
     if "sysrc: unknown variable" in sysrcs:
-        # raise CommandExecutionError(sysrcs)
         return None
 
     ret = {}
@@ -52,10 +50,11 @@ def get(**kwargs):
         rcfile = sysrc.split(': ')[0]
         var = sysrc.split(': ')[1]
         val = sysrc.split(': ')[2]
-        if not rcfile in ret:
+        if rcfile not in ret:
             ret[rcfile] = {}
         ret[rcfile][var] = val
     return ret
+
 
 def set(name, value, **kwargs):
     '''
@@ -78,21 +77,18 @@ def set(name, value, **kwargs):
 
     cmd += ' '+name+"="+value
 
-    sysrcs = __salt__['cmd.run'](cmd)
+    sysrcs = __salt__['cmd.run'](cmd, python_shell=False)
 
     ret = {}
     for sysrc in sysrcs.split("\n"):
         rcfile = sysrc.split(': ')[0]
         var = sysrc.split(': ')[1]
-        oldval = sysrc.split(': ')[2].split(" -> ")[0]
         newval = sysrc.split(': ')[2].split(" -> ")[1]
-        if not rcfile in ret:
+        if rcfile not in ret:
             ret[rcfile] = {}
-        #ret[rcfile][var] = {}
-        #ret[rcfile][var]['old'] = oldval
-        #ret[rcfile][var]['new'] = newval
         ret[rcfile][var] = newval
     return ret
+
 
 def remove(name, **kwargs):
     '''
@@ -115,7 +111,7 @@ def remove(name, **kwargs):
 
     cmd += ' -x '+name
 
-    sysrcs = __salt__['cmd.run'](cmd)
+    sysrcs = __salt__['cmd.run'](cmd, python_shell=False)
     if "sysrc: unknown variable" in sysrcs:
         raise CommandExecutionError(sysrcs)
     else:

--- a/salt/states/sysrc.py
+++ b/salt/states/sysrc.py
@@ -1,12 +1,18 @@
-import salt.exceptions
+# -*- coding: utf-8 -*-
+'''
+Sysrc value states
 
-# define the module's virtual name
+Manage sysrc values.
+
+'''
+
 
 def __virtual__():
     '''
     Only load if sysrc executable exists
     '''
     return __salt__['cmd.has_exec']('sysrc')
+
 
 def managed(name, value, **kwargs):
     '''
@@ -26,14 +32,14 @@ def managed(name, value, **kwargs):
 
     # Check the current state
     current_state = __salt__['sysrc.get'](name=name, **kwargs)
-    if current_state != None:
+    if current_state is not None:
         for rcname, rcdict in current_state.iteritems():
             if rcdict[name] == value:
                 ret['result'] = True
                 ret['comment'] = '{0} is already set to the desired value.'.format(name)
                 return ret
 
-    if __opts__['test'] == True:
+    if __opts__['test'] is True:
         ret['comment'] = 'The value of "{0}" will be changed!'.format(name)
         ret['changes'] = {
             'old': current_state,
@@ -58,6 +64,7 @@ def managed(name, value, **kwargs):
 
     return ret
 
+
 def absent(name, **kwargs):
     '''
     Ensure a sysrc variable is absent.
@@ -74,12 +81,12 @@ def absent(name, **kwargs):
 
     # Check the current state
     current_state = __salt__['sysrc.get'](name=name, **kwargs)
-    if current_state == None:
+    if current_state is None:
         ret['result'] = True
         ret['comment'] = '"{0}" is already absent.'.format(name)
         return ret
 
-    if __opts__['test'] == True:
+    if __opts__['test'] is True:
         ret['comment'] = '"{0}" will be removed!'.format(name)
         ret['changes'] = {
             'old': current_state,


### PR DESCRIPTION
These are state and execution modules for managing rc.conf variables in FreeBSD that take advantage of the [sysrc](https://www.freebsd.org/cgi/man.cgi?query=sysrc) utility.
