### PR TITLE
Fix jinja search path for local file_client

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -64,10 +64,7 @@ class SaltCacheLoader(BaseLoader):
         self.opts = opts
         self.saltenv = saltenv
         self.encoding = encoding
-        if opts.get('file_client', 'remote') == 'local':
-            self.searchpath = opts['file_roots'][saltenv]
-        else:
-            self.searchpath = [path.join(opts['cachedir'], 'files', saltenv)]
+        self.searchpath = [path.join(opts['cachedir'], 'files', saltenv)]
         log.debug('Jinja search path: {0!r}'.format(self.searchpath))
         self._file_client = None
         self.cached = []


### PR DESCRIPTION
Now that FS backends other than roots work with a local file_client, there is
no need to look only in the file_roots directories.

Fixes #17963.
