### PR TITLE
fixes to debian_ip.py

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1086,6 +1086,8 @@ def _parse_bridge_opts(opts, iface):
     config = {}
 
     if 'ports' in opts:
+        if isinstance(opts['ports'], list):
+            opts['ports'] = ','.join(opts['ports'])
         config.update({'ports': opts['ports']})
 
     for opt in ['ageing', 'fd', 'gcint', 'hello', 'maxage']:
@@ -1536,7 +1538,7 @@ def build_interface(iface, iface_type, enabled, **settings):
 
     elif iface_type == 'bridge':
         if 'ports' not in settings:
-            msg = 'ports is a required setting for bridge interfaces'
+            msg = 'ports is a required setting for bridge interfaces on Debian or Ubuntu based systems'
             log.error(msg)
             raise AttributeError(msg)
         __salt__['pkg.install']('bridge-utils')

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -148,11 +148,18 @@ all interfaces are ignored unless specified.
         - proto: dhcp
         - bridge: br0
         - delay: 0
+        - ports: eth4
         - bypassfirewall: True
         - use:
           - network: eth4
         - require:
           - network: eth4
+
+.. note::
+
+    When managing bridged interfaces on a Debian or Ubuntu based system, the
+    ports argument is required.  Red Hat systems will ignore the argument.
+
 '''
 
 # Import python libs


### PR DESCRIPTION
Cleaning up the documentation to make it clear that for setting up a network bridge on a Debian or Ubuntu system that the ports argument, specifying what interfaces are part of the bridge, is required.  #12178 
