### PR TITLE
fix for #18778 (salt-ssh tries to copy file to the filesystem root)

### DIFF
--- a/salt/client/ssh/state.py
+++ b/salt/client/ssh/state.py
@@ -161,7 +161,7 @@ def prep_trans_tar(file_client, chunks, file_refs, pillar=None):
                     for filename in files:
                         fn = filename[filename.find(short) + len(short):]
                         if fn.startswith('/'):
-                            fn.strip('/')
+                            fn = fn.strip('/')
                         tgt = os.path.join(
                                 env_root,
                                 short,


### PR DESCRIPTION
Hi folks,

this is fix for #18778 (salt-ssh tries to copy file to the filesystem root). Please have a look.

Thanks,
Kirill.
