### PR TITLE
2014.7 eselect improvements

### DIFF
--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -52,7 +52,10 @@ def get_modules():
 
         salt '*' eselect.get_modules
     '''
-    return exec_action('modules', 'list')
+    try:
+        return exec_action('modules', 'list')
+    except:
+        return None
 
 
 def get_target_list(module):
@@ -65,7 +68,10 @@ def get_target_list(module):
 
         salt '*' eselect.get_target_list <module name>
     '''
-    return exec_action(module, 'list')
+    try:
+        return exec_action(module, 'list')
+    except:
+        return None
 
 
 def get_current_target(module):
@@ -78,7 +84,10 @@ def get_current_target(module):
 
         salt '*' eselect.get_current_target <module name>
     '''
-    return exec_action(module, 'show')[0]
+    try:
+        return exec_action(module, 'show')[0]
+    except:
+        return None
 
 
 def set_target(module, target):
@@ -92,4 +101,7 @@ def set_target(module, target):
 
         salt '*' eselect.set_target <module name> <target>
     '''
-    return exec_action(module, 'set', target, state_only=True)
+    try:
+        return exec_action(module, 'set', target, state_only=True)
+    except:
+        return False

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -89,9 +89,8 @@ def get_modules():
         salt '*' eselect.get_modules
     '''
     modules = []
-    try:
-        module_list = exec_action('modules', 'list', action_parameter='--only-names')
-    except:
+    module_list = exec_action('modules', 'list', action_parameter='--only-names')
+    if not module_list:
         return None
 
     for module in module_list:
@@ -112,9 +111,8 @@ def get_target_list(module):
 
         salt '*' eselect.get_target_list kernel
     '''
-    try:
-        exec_output = exec_action(module, 'list')
-    except:
+    exec_output = exec_action(module, 'list')
+    if not exec_output:
         return None
 
     target_list = []
@@ -151,9 +149,8 @@ def get_current_target(module, module_parameter=None, action_parameter=None):
 
         salt '*' eselect.get_current_target kernel
     '''
-    try:
-        result = exec_action(module, 'show', module_parameter=module_parameter, action_parameter=action_parameter)[0]
-    except:
+    result = exec_action(module, 'show', module_parameter=module_parameter, action_parameter=action_parameter)[0]
+    if not result:
         return None
 
     if result == '(unset)':
@@ -201,7 +198,7 @@ def set_target(module, target, module_parameter=None, action_parameter=None):
         log.error('Module {0} not available'.format(module))
         return False
 
-    try:
-        return exec_action(module, 'set', module_parameter=module_parameter, action_parameter=action_parameter, state_only=True)
-    except:
-        return False
+    exec_result = exec_action(module, 'set', module_parameter=module_parameter, action_parameter=action_parameter, state_only=True)
+    if exec_result:
+        return exec_result
+    return False

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -93,7 +93,7 @@ def get_current_target(module, parameter=None):
 
     .. code-block:: bash
 
-        salt '*' eselect.get_current_target <module name>
+        salt '*' eselect.get_current_target <module name> parameter='optional module params'
     '''
     try:
         return exec_action(module, 'show', parameter=parameter)[0]
@@ -110,7 +110,7 @@ def set_target(module, target, parameter=None):
 
     .. code-block:: bash
 
-        salt '*' eselect.set_target <module name> <target>
+        salt '*' eselect.set_target <module name> <target> parameter='optional module params'
     '''
     try:
         return exec_action(module, 'set', target, state_only=True, parameter=parameter)

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -73,10 +73,16 @@ def get_target_list(module):
 
         salt '*' eselect.get_target_list <module name>
     '''
+    target_list = []
     try:
-        return exec_action(module, 'list')
+        exec_output = exec_action(module, 'list')
     except:
         return None
+
+    for item in exec_output:
+        target_list.append(item.split(None, 1)[0])
+
+    return target_list
 
 
 def get_current_target(module, parameter=None):

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -145,11 +145,29 @@ def set_target(module, target, module_parameter=None, action_parameter=None):
     Set the target for the given module.
     Target can be specified by index or name.
 
-    CLI Example:
+    module
+        name of the module for which a target should be set
+
+    target
+        name of the target to be set for this module
+
+    module_parameter
+        additional params passed to the defined module
+
+    action_parameter
+        additional params passed to the defined action
+
+    CLI Example (setting target of system-wide ``java-vm``):
 
     .. code-block:: bash
 
-        salt '*' eselect.set_target <module name> <target> module_parameter='optional module params' action_parameter='optional action params'
+        salt '*' eselect.set_target java-vm icedtea-bin-7 action_parameter='system'
+
+    CLI Example (setting target of ``kernel`` symlink):
+
+    .. code-block:: bash
+
+        salt '*' eselect.set_target kernel linux-3.17.5-gentoo
     '''
     if action_parameter:
         action_parameter = '{0} {1}'.format(action_parameter, target)

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -52,7 +52,7 @@ def exec_action(module, action, module_parameter=None, action_parameter=None, pa
 
 def get_modules():
     '''
-    Get available modules list.
+    List available ``eselect`` modules.
 
     CLI Example:
 
@@ -73,13 +73,16 @@ def get_modules():
 
 def get_target_list(module):
     '''
-    Get available target for the given module.
+    List available targets for the given module.
+
+    module
+        name of the module to be queried for its targets
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' eselect.get_target_list <module name>
+        salt '*' eselect.get_target_list kernel
     '''
     target_list = []
     try:

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -3,9 +3,12 @@
 Support for eselect, Gentoo's configuration and management tool.
 '''
 
+import logging
+
 # Import salt libs
 import salt.utils
 
+log = logging.getLogger(__name__)
 
 def __virtual__():
     '''
@@ -192,6 +195,12 @@ def set_target(module, target, module_parameter=None, action_parameter=None):
         action_parameter = '{0} {1}'.format(action_parameter, target)
     else:
         action_parameter = target
+
+    # get list of available modules
+    if module not in get_modules():
+        log.error('Module {0} not available'.format(module))
+        return False
+
     try:
         return exec_action(module, 'set', module_parameter=module_parameter, action_parameter=action_parameter, state_only=True)
     except:

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -16,7 +16,7 @@ def __virtual__():
     return False
 
 
-def exec_action(module, action, parameter='', state_only=False):
+def exec_action(module, action, module_parameter=None, action_parameter=None, parameter=None, state_only=False):
     '''
     Execute an arbitrary action on a module.
 
@@ -24,11 +24,19 @@ def exec_action(module, action, parameter='', state_only=False):
 
     .. code-block:: bash
 
-        salt '*' eselect.exec_action <module name> <action> [parameter]
+        salt '*' eselect.exec_action <module name> [module_parameter] <action> [action_parameter]
     '''
+    if parameter:
+        salt.utils.warn_until(
+            'Lithium',
+            'The \'parameter\' option is deprecated and will be removed in the '
+            '\'Lithium\' Salt release. Please use either \'module_parameter\' or '
+            '\'action_parameter\' instead.'
+        )
+        action_parameter=parameter
     out = __salt__['cmd.run'](
-        'eselect --brief --colour=no {0} {1} {2}'.format(
-            module, action, parameter
+        'eselect --brief --colour=no {0} {1} {2} {3}'.format(
+            module, module_parameter or '', action, action_parameter or ''
         )
     )
     out = out.strip().split('\n')
@@ -54,7 +62,7 @@ def get_modules():
     '''
     modules = []
     try:
-        module_list = exec_action('modules', 'list', parameter='--only-names')
+        module_list = exec_action('modules', 'list', action_parameter='--only-names')
     except:
         return None
 
@@ -85,7 +93,7 @@ def get_target_list(module):
     return target_list
 
 
-def get_current_target(module, parameter=None):
+def get_current_target(module, module_parameter=None, action_parameter=None):
     '''
     Get the currently selected target for the given module.
 
@@ -93,15 +101,15 @@ def get_current_target(module, parameter=None):
 
     .. code-block:: bash
 
-        salt '*' eselect.get_current_target <module name> parameter='optional module params'
+        salt '*' eselect.get_current_target <module name> module_parameter='optional module params' action_parameter='optional action params'
     '''
     try:
-        return exec_action(module, 'show', parameter=parameter)[0]
+        return exec_action(module, 'show', module_parameter=module_parameter, action_parameter=action_parameter)[0]
     except:
         return None
 
 
-def set_target(module, target, parameter=None):
+def set_target(module, target, module_parameter=None, action_parameter=None):
     '''
     Set the target for the given module.
     Target can be specified by index or name.
@@ -110,9 +118,9 @@ def set_target(module, target, parameter=None):
 
     .. code-block:: bash
 
-        salt '*' eselect.set_target <module name> <target> parameter='optional module params'
+        salt '*' eselect.set_target <module name> <target> module_parameter='optional module params' action_parameter='optional action params'
     '''
     try:
-        return exec_action(module, 'set', target, state_only=True, parameter=parameter)
+        return exec_action(module, 'set', target, module_parameter=module_parameter, action_parameter=action_parameter)
     except:
         return False

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -52,11 +52,16 @@ def get_modules():
 
         salt '*' eselect.get_modules
     '''
+    modules = []
     try:
-        return exec_action('modules', 'list')
+        module_list = exec_action('modules', 'list', parameter='--only-names')
     except:
         return None
 
+    for module in module_list:
+        if module not in ['help', 'usage', 'version']:
+            modules.append(module)
+    return modules
 
 def get_target_list(module):
     '''

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -74,7 +74,7 @@ def get_target_list(module):
         return None
 
 
-def get_current_target(module):
+def get_current_target(module, parameter=None):
     '''
     Get the currently selected target for the given module.
 
@@ -85,12 +85,12 @@ def get_current_target(module):
         salt '*' eselect.get_current_target <module name>
     '''
     try:
-        return exec_action(module, 'show')[0]
+        return exec_action(module, 'show', parameter=parameter)[0]
     except:
         return None
 
 
-def set_target(module, target):
+def set_target(module, target, parameter=None):
     '''
     Set the target for the given module.
     Target can be specified by index or name.
@@ -102,6 +102,6 @@ def set_target(module, target):
         salt '*' eselect.set_target <module name> <target>
     '''
     try:
-        return exec_action(module, 'set', target, state_only=True)
+        return exec_action(module, 'set', target, state_only=True, parameter=parameter)
     except:
         return False

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -20,11 +20,30 @@ def exec_action(module, action, module_parameter=None, action_parameter=None, pa
     '''
     Execute an arbitrary action on a module.
 
-    CLI Example:
+    module
+        name of the module to be executed
+
+    action
+        name of the module's action to be run
+
+    module_parameter
+        additional params passed to the defined module
+
+    action_parameter
+        additional params passed to the defined action
+
+    parameter
+        additional params passed to the defined action
+        .. deprecated:: Lithium
+
+    state_only
+        don't return any output but only the success/failure of the operation
+
+    CLI Example (updating the ``php`` implementation used for ``apache2``):
 
     .. code-block:: bash
 
-        salt '*' eselect.exec_action <module name> [module_parameter] <action> [action_parameter]
+        salt '*' eselect.exec_action php update action_parameter='apache2'
     '''
     if parameter:
         salt.utils.warn_until(

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -130,9 +130,14 @@ def get_current_target(module, module_parameter=None, action_parameter=None):
         salt '*' eselect.get_current_target kernel
     '''
     try:
-        return exec_action(module, 'show', module_parameter=module_parameter, action_parameter=action_parameter)[0]
+        result = exec_action(module, 'show', module_parameter=module_parameter, action_parameter=action_parameter)[0]
     except:
         return None
+
+    if result == '(unset)':
+        return None
+
+    return result
 
 
 def set_target(module, target, module_parameter=None, action_parameter=None):

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -10,6 +10,7 @@ import salt.utils
 
 log = logging.getLogger(__name__)
 
+
 def __virtual__():
     '''
     Only work on Gentoo systems with eselect installed
@@ -55,7 +56,7 @@ def exec_action(module, action, module_parameter=None, action_parameter=None, pa
             '\'Lithium\' Salt release. Please use either \'module_parameter\' or '
             '\'action_parameter\' instead.'
         )
-        action_parameter=parameter
+        action_parameter = parameter
     out = __salt__['cmd.run'](
         'eselect --brief --colour=no {0} {1} {2} {3}'.format(
             module, module_parameter or '', action, action_parameter or ''
@@ -97,6 +98,7 @@ def get_modules():
         if module not in ['help', 'usage', 'version']:
             modules.append(module)
     return modules
+
 
 def get_target_list(module):
     '''

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -47,6 +47,12 @@ def exec_action(module, action, module_parameter=None, action_parameter=None, pa
     if state_only:
         return True
 
+    if len(out) < 1:
+        return False
+
+    if len(out) == 1 and not out[0].strip():
+        return False
+
     return out
 
 
@@ -84,16 +90,18 @@ def get_target_list(module):
 
         salt '*' eselect.get_target_list kernel
     '''
-    target_list = []
     try:
         exec_output = exec_action(module, 'list')
     except:
         return None
 
-    for item in exec_output:
-        target_list.append(item.split(None, 1)[0])
+    target_list = []
+    if isinstance(exec_output, list):
+        for item in exec_output:
+            target_list.append(item.split(None, 1)[0])
+        return target_list
 
-    return target_list
+    return None
 
 
 def get_current_target(module, module_parameter=None, action_parameter=None):

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -120,7 +120,11 @@ def set_target(module, target, module_parameter=None, action_parameter=None):
 
         salt '*' eselect.set_target <module name> <target> module_parameter='optional module params' action_parameter='optional action params'
     '''
+    if action_parameter:
+        action_parameter = '{0} {1}'.format(action_parameter, target)
+    else:
+        action_parameter = target
     try:
-        return exec_action(module, 'set', target, module_parameter=module_parameter, action_parameter=action_parameter)
+        return exec_action(module, 'set', module_parameter=module_parameter, action_parameter=action_parameter, state_only=True)
     except:
         return False

--- a/salt/modules/eselect.py
+++ b/salt/modules/eselect.py
@@ -108,11 +108,26 @@ def get_current_target(module, module_parameter=None, action_parameter=None):
     '''
     Get the currently selected target for the given module.
 
-    CLI Example:
+    module
+        name of the module to be queried for its current target
+
+    module_parameter
+        additional params passed to the defined module
+
+    action_parameter
+        additional params passed to the 'show' action
+
+    CLI Example (current target of system-wide ``java-vm``):
 
     .. code-block:: bash
 
-        salt '*' eselect.get_current_target <module name> module_parameter='optional module params' action_parameter='optional action params'
+        salt '*' eselect.get_current_target java-vm action_parameter='system'
+
+    CLI Example (current target of ``kernel`` symlink):
+
+    .. code-block:: bash
+
+        salt '*' eselect.get_current_target kernel
     '''
     try:
         return exec_action(module, 'show', module_parameter=module_parameter, action_parameter=action_parameter)[0]

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -58,7 +58,7 @@ def set_(name, target, parameter=None, module_parameter=None, action_parameter=N
             '\'Lithium\' Salt release. Please use either \'module_parameter\' or '
             '\'action_parameter\' instead.'
         )
-        action_parameter=parameter
+        action_parameter = parameter
 
     old_target = __salt__['eselect.get_current_target'](name, module_parameter=module_parameter, action_parameter=action_parameter)
 

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -12,6 +12,8 @@ A state module to manage Gentoo configuration via eselect
             target: hardened/linux/amd64
 '''
 
+import salt.utils
+
 # Define a function alias in order not to shadow built-in's
 __func_alias__ = {
     'set_': 'set'

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -31,6 +31,20 @@ def set_(name, target, parameter=None, module_parameter=None, action_parameter=N
 
     name
         The name of the module
+
+    target
+        The target to be set for this module
+
+    module_parameter
+        additional params passed to the defined module
+
+    action_parameter
+        additional params passed to the defined action
+
+    parameter
+        additional params passed to the defined action
+        .. deprecated:: Lithium
+
     '''
     ret = {'changes': {},
            'comment': '',

--- a/salt/states/eselect.py
+++ b/salt/states/eselect.py
@@ -25,7 +25,7 @@ def __virtual__():
     return 'eselect' if 'eselect.exec_action' in __salt__ else False
 
 
-def set_(name, target):
+def set_(name, target, parameter=None, module_parameter=None, action_parameter=None):
     '''
     Verify that the given module is set to the given target
 
@@ -37,7 +37,16 @@ def set_(name, target):
            'name': name,
            'result': True}
 
-    old_target = __salt__['eselect.get_current_target'](name)
+    if parameter:
+        salt.utils.warn_until(
+            'Lithium',
+            'The \'parameter\' option is deprecated and will be removed in the '
+            '\'Lithium\' Salt release. Please use either \'module_parameter\' or '
+            '\'action_parameter\' instead.'
+        )
+        action_parameter=parameter
+
+    old_target = __salt__['eselect.get_current_target'](name, module_parameter=module_parameter, action_parameter=action_parameter)
 
     if target == old_target:
         ret['comment'] = 'Target {0!r} is already set on {1!r} module.'.format(
@@ -56,7 +65,7 @@ def set_(name, target):
         )
         ret['result'] = None
     else:
-        result = __salt__['eselect.set_target'](name, target)
+        result = __salt__['eselect.set_target'](name, target, module_parameter=module_parameter, action_parameter=action_parameter)
         if result:
             ret['changes'][name] = {'old': old_target, 'new': target}
             ret['comment'] = 'Target {0!r} set on {1!r} module.'.format(


### PR DESCRIPTION
This PR introduces quite a few improvements to the `eselect` module and state.
Most of the changes are improvements to the documentation and some safe-guards to deal better with some specific scenarios, but also introduces new features.

Until now, the `parameter` param was used throughout the state and module, but this was limiting the use-cases of `eselect` in Salt quite a bit as outlined by @podshumok in #18783.
This PR deprecates (but still supports) the usage of `parameter` and introduces `module_parameter` and `function_parameter`. This allows a more fine-grained control over what the module and state can do and also fixes the issue described in #18783.
