### PR TITLE
Do not sync grains in grains.setval when using local mode

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -237,8 +237,9 @@ def setvals(grains, destructive=False):
     except (IOError, OSError):
         msg = 'Unable to write to cache file {0}. Check permissions.'
         log.error(msg.format(fn_))
-    # Sync the grains
-    __salt__['saltutil.sync_grains']()
+    if not __opts__.get('local', False):
+        # Sync the grains
+        __salt__['saltutil.sync_grains']()
     # Return the grains we just set to confirm everything was OK
     return new_grains
 


### PR DESCRIPTION
Backport fix for not calling sync_grains when --local is being used for grains.set_vals.
