### PR TITLE
modules.boto_elb: avoid shadowing imported `elb`

### DIFF
--- a/salt/modules/boto_elb.py
+++ b/salt/modules/boto_elb.py
@@ -77,8 +77,8 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
     if not conn:
         return False
     try:
-        elb = conn.get_all_load_balancers(load_balancer_names=[name])
-        if elb:
+        lb = conn.get_all_load_balancers(load_balancer_names=[name])
+        if lb:
             return True
         else:
             msg = 'The load balancer does not exist in region {0}'.format(region)


### PR DESCRIPTION
```
************* Module salt.modules.boto_elb
salt/modules/boto_elb.py:80: [W0621(redefined-outer-name), exists] Redefining name 'elb' from outer scope (line 49)
```
