### PR TITLE
Add **kwargs to service.mod_watch

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -416,7 +416,12 @@ def disabled(name, **kwargs):
     return _disable(name, None, **kwargs)
 
 
-def mod_watch(name, sfun=None, sig=None, reload=False, full_restart=False):
+def mod_watch(name,
+              sfun=None,
+              sig=None,
+              reload=False,
+              full_restart=False,
+              **kwargs):
     '''
     The service watcher, called to invoke the watch command.
 


### PR DESCRIPTION
Gets rid of warnings about `enable` and `__reqs__` not being supported
by the function
