### PR TITLE
Enabled debian services on ubuntu are always enabled

### DIFF
--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -455,7 +455,7 @@ def enable(name, **kwargs):
     if _service_is_upstart(name):
         return _upstart_enable(name)
     executable = _get_service_exec()
-    cmd = '{0} -f {1} defaults'.format(executable, name)
+    cmd = '{0} -f {1} enable'.format(executable, name)
     return not __salt__['cmd.retcode'](cmd)
 
 


### PR DESCRIPTION
Right now, 'service: enabled' on ubuntu will call 'update-rc.d defaults' which
will not enable the service if rc.d symlinks already exist. debian services on
debian will call 'update-rc.d enable', this change makes ubuntu consistent with
debian
