### PR TITLE
fixes to iptables module

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -745,6 +745,7 @@ def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
 
     ret = {}
     table = ''
+    parser = _parser()
     for line in rules.splitlines():
         if line.startswith('*'):
             table = line.replace('*', '')
@@ -780,7 +781,6 @@ def _parse_conf(conf_file=None, in_mem=False, family='ipv4'):
                 index += 1
             if args[-1].startswith('-'):
                 args.append('')
-            parser = _parser()
             parsed_args = []
             if sys.version.startswith('2.6'):
                 (opts, leftover_args) = parser.parse_args(args)


### PR DESCRIPTION
Moving the call to the parser out of the for loop loop so that it's not re-created for each iptables rule. #17185 
