### PR TITLE
Backport #18274 to 2014.1

### DIFF
--- a/salt/modules/freebsdpkg.py
+++ b/salt/modules/freebsdpkg.py
@@ -461,7 +461,7 @@ def rehash():
 
         salt '*' pkg.rehash
     '''
-    shell = __salt__['cmd.run']('echo $SHELL', output_loglevel='debug')
+    shell = __salt__['environ.get']('SHELL', output_loglevel='debug')
     if shell.split('/')[-1] in ('csh', 'tcsh'):
         __salt__['cmd.run']('rehash', output_loglevel='debug')
 


### PR DESCRIPTION
Backport #18274 to 2014.1

Conflicts:
    salt/modules/freebsdpkg.py
