### PR TITLE
Add support for sockstat on FreeBSD as an alternative to lsof

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1359,6 +1359,14 @@ def is_sunos():
     return sys.platform.startswith('sunos')
 
 
+@real_memoize
+def is_freebsd():
+    '''
+    Simple function to return if host is FreeBSD or not
+    '''
+    return sys.platform.startswith('freebsd')
+
+
 def is_fcntl_available(check_sunos=False):
     '''
     Simple function to check if the `fcntl` module is available or not.

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -973,12 +973,69 @@ def _sunos_remotes_on(port, which_end):
     return remotes
 
 
+def _freebsd_remotes_on(port, which_end):
+    '''
+    Returns set of ipv4 host addresses of remote established connections
+    on local tcp port port.
+
+    Parses output of shell 'sockstat' (FreeBSD) 
+    to get connections
+
+    $ sudo sockstat -4
+    USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
+    root    python2.7   1456    29  tcp4   *:4505           *:*
+    root    python2.7   1445    17  tcp4   *:4506           *:*
+    root    python2.7   1294    14  tcp4   127.0.0.1:11813  127.0.0.1:4505
+    root    python2.7   1294    41  tcp4   127.0.0.1:61115  127.0.0.1:4506
+
+    $ sudo sockstat -4 -c -p 4506
+    USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
+    root    python2.7   1294    41  tcp4   127.0.0.1:61115  127.0.0.1:4506
+    '''
+
+    port = int(port)
+    remotes = set()
+
+    try:
+        data = subprocess.check_output(['sockstat', '-4', '-c', '-p {0}'.format(port)])
+    except subprocess.CalledProcessError as ex:
+        log.error('Failed "sockstat" with returncode = {0}'.format(ex.returncode))
+        raise
+
+    lines = data.split('\n')
+
+    for line in lines:
+        chunks = line.split()
+        if not chunks:
+            continue
+        # ['root', 'python2.7', '1456', '37', 'tcp4', 
+        #  '127.0.0.1:4505-', '127.0.0.1:55703']
+        #print chunks
+        if 'COMMAND' in chunks[1]:
+            continue  # ignore header
+        if len(chunks) < 2:
+            continue
+        local = chunks[5]
+        remote = chunks[6]
+        lhost, lport = local.split(':')
+        rhost, rport = remote.split(':')
+        if which_end == 'local' and int(lport) != port:  # ignore if local port not port
+            continue
+        if which_end == 'remote' and int(rport) != port:  # ignore if remote port not port
+            continue
+
+        remotes.add(rhost)
+
+    return remotes
+
+
 def remotes_on_local_tcp_port(port):
     '''
     Returns set of ipv4 host addresses of remote established connections
     on local tcp port port.
 
-    Parses output of shell 'lsof' to get connections
+    Parses output of shell 'lsof'
+    to get connections
 
     $ sudo lsof -i4TCP:4505 -n
     COMMAND   PID USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME
@@ -992,6 +1049,8 @@ def remotes_on_local_tcp_port(port):
 
     if salt.utils.is_sunos():
         return _sunos_remotes_on(port, 'local_port')
+    if salt.utils.is_freebsd():
+        return _freebsd_remotes_on(port, 'local_port')
 
     try:
         data = subprocess.check_output(['lsof', '-i4TCP:{0:d}'.format(port), '-n'])
@@ -1041,6 +1100,8 @@ def remotes_on_remote_tcp_port(port):
 
     if salt.utils.is_sunos():
         return _sunos_remotes_on(port, 'remote_port')
+    if salt.utils.is_freebsd():
+        return _freebsd_remotes_on(port, 'remote_port')
 
     try:
         data = subprocess.check_output(['lsof', '-i4TCP:{0:d}'.format(port), '-n'])

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -978,7 +978,7 @@ def _freebsd_remotes_on(port, which_end):
     Returns set of ipv4 host addresses of remote established connections
     on local tcp port port.
 
-    Parses output of shell 'sockstat' (FreeBSD) 
+    Parses output of shell 'sockstat' (FreeBSD)
     to get connections
 
     $ sudo sockstat -4
@@ -1008,7 +1008,7 @@ def _freebsd_remotes_on(port, which_end):
         chunks = line.split()
         if not chunks:
             continue
-        # ['root', 'python2.7', '1456', '37', 'tcp4', 
+        # ['root', 'python2.7', '1456', '37', 'tcp4',
         #  '127.0.0.1:4505-', '127.0.0.1:55703']
         #print chunks
         if 'COMMAND' in chunks[1]:

--- a/tests/unit/utils/network.py
+++ b/tests/unit/utils/network.py
@@ -84,6 +84,11 @@ vpn0: flags=120002200850<POINTOPOINT,RUNNING,MULTICAST,NONUD,IPv6,PHYSRUNNING> m
         inet6 ::/0 --> fe80::b2d6:7c10
 '''
 
+FREEBSD_SOCKSTAT = '''\
+USER    COMMAND     PID     FD  PROTO  LOCAL ADDRESS    FOREIGN ADDRESS
+root    python2.7   1294    41  tcp4   127.0.0.1:61115  127.0.0.1:4506
+'''
+
 
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class NetworkTestCase(TestCase):
@@ -166,6 +171,14 @@ class NetworkTestCase(TestCase):
                                                   'prefixlen': '0'}],
                                        'up': True}}
             )
+
+    def test_freebsd_remotes_on(self):
+        with patch('salt.utils.is_sunos', lambda: False):
+            with patch('salt.utils.is_freebsd', lambda: True):
+                with patch('subprocess.check_output', 
+                           return_value=FREEBSD_SOCKSTAT):
+                    remotes = network._freebsd_remotes_on('4506', 'remote')
+                    self.assertEqual(remotes, set(['127.0.0.1']))
 
 
 if __name__ == '__main__':

--- a/tests/unit/utils/network.py
+++ b/tests/unit/utils/network.py
@@ -175,7 +175,7 @@ class NetworkTestCase(TestCase):
     def test_freebsd_remotes_on(self):
         with patch('salt.utils.is_sunos', lambda: False):
             with patch('salt.utils.is_freebsd', lambda: True):
-                with patch('subprocess.check_output', 
+                with patch('subprocess.check_output',
                            return_value=FREEBSD_SOCKSTAT):
                     remotes = network._freebsd_remotes_on('4506', 'remote')
                     self.assertEqual(remotes, set(['127.0.0.1']))


### PR DESCRIPTION
This fixes #18584.
