### PR TITLE
Use Salt defined exit codes.

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -16,6 +16,7 @@ import salt.cli.batch
 import salt.client
 import salt.client.ssh
 import salt.client.netapi
+import salt.exitcodes
 import salt.output
 import salt.runner
 import salt.auth

--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -410,11 +410,11 @@ class SaltCall(parsers.SaltCallOptionParser):
 
         if self.options.doc:
             caller.print_docs()
-            self.exit(os.EX_OK)
+            self.exit(salt.exitcodes.EX_OK)
 
         if self.options.grains_run:
             caller.print_grains()
-            self.exit(os.EX_OK)
+            self.exit(salt.exitcodes.EX_OK)
 
         caller.run()
 
@@ -453,7 +453,7 @@ class SaltRun(parsers.SaltRunOptionParser):
         runner = salt.runner.Runner(self.config)
         if self.options.doc:
             runner._print_docs()
-            self.exit(os.EX_OK)
+            self.exit(salt.exitcodes.EX_OK)
 
         # Run this here so SystemExit isn't raised anywhere else when
         # someone tries to use the runners via the python API

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -298,7 +298,7 @@ class SSH(object):
                 if stderr:
                     return {host: stderr}
                 return {host: 'Bad Return'}
-        if os.EX_OK != retcode:
+        if salt.exitcodes.EX_OK != retcode:
             return {host: stderr}
         return {host: stdout}
 
@@ -911,7 +911,7 @@ ARGS = {8}\n'''.format(self.minion_config,
                 'The salt thin transfer was corrupted'
             ),
             (
-                (os.EX_CANTCREAT,),
+                (salt.exitcodes.EX_CANTCREAT,),
                 'salt path .* exists but is not a directory',
                 'A necessary path for salt thin unexpectedly exists:\n ' + stderr,
             ),
@@ -936,7 +936,7 @@ ARGS = {8}\n'''.format(self.minion_config,
                 perm_error_fmt.format(stderr)
             ),
             (
-                (os.EX_SOFTWARE,),
+                (salt.exitcodes.EX_SOFTWARE,),
                 'exists but is not',
                 'An internal error occurred with the shim, please investigate:\n ' + stderr,
             ),

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -11,6 +11,7 @@ import logging
 import subprocess
 
 # Import salt libs
+import salt.exitcodes
 import salt.utils
 import salt.utils.nb_popen
 import salt.utils.vt

--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -184,7 +184,7 @@ class Shell(object):
         Execute ssh-copy-id to plant the id file on the target
         '''
         stdout, stderr, retcode = self._run_cmd(self._copy_id_str_old())
-        if os.EX_OK != retcode and stderr.startswith('Usage'):
+        if salt.exitcodes.EX_OK != retcode and stderr.startswith('Usage'):
             stdout, stderr, retcode = self._run_cmd(self._copy_id_str_new())
         return stdout, stderr, retcode
 

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -14,15 +14,10 @@ import shutil
 import sys
 import os
 import stat
+import salt.exitcodes
 
 THIN_ARCHIVE = 'salt-thin.tgz'
 EXT_ARCHIVE = 'salt-ext_mods.tgz'
-
-# FIXME - it would be ideal if these could be obtained directly from
-#         salt.exitcodes rather than duplicated.
-EX_THIN_DEPLOY = 11
-EX_THIN_CHECKSUM = 12
-EX_MOD_DEPLOY = 13
 
 
 class OBJ(object):
@@ -57,7 +52,7 @@ def need_deployment():
 
     # Delimeter emitted on stdout *only* to indicate shim message to master.
     sys.stdout.write("{0}\ndeploy\n".format(OPTIONS.delimiter))
-    sys.exit(EX_THIN_DEPLOY)
+    sys.exit(salt.exitcodes.EX_THIN_DEPLOY)
 
 
 # Adapted from salt.utils.get_hash()
@@ -83,7 +78,7 @@ def unpack_thin(thin_path):
 
 def need_ext():
     sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
-    sys.exit(EX_MOD_DEPLOY)
+    sys.exit(salt.exitcodes.EX_MOD_DEPLOY)
 
 
 def unpack_ext(ext_path):
@@ -112,7 +107,7 @@ def main(argv):
             sys.stderr.write('{0}\n'.format(get_hash(thin_path, OPTIONS.hashfunc)))
             os.unlink(thin_path)
             sys.stderr.write('WARNING: checksum mismatch for "{0}"\n'.format(thin_path))
-            sys.exit(EX_THIN_CHECKSUM)
+            sys.exit(salt.exitcodes.EX_THIN_CHECKSUM)
         unpack_thin(thin_path)
         # Salt thin now is available to use
     else:

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -121,7 +121,7 @@ def main(argv):
 
         if not os.path.isdir(OPTIONS.saltdir):
             sys.stderr.write('ERROR: salt path "{0}" exists but is not a directory\n'.format(OPTIONS.saltdir))
-            sys.exit(os.EX_CANTCREAT)
+            sys.exit(salt.exitcodes.EX_CANTCREAT)
 
         version_path = os.path.join(OPTIONS.saltdir, 'version')
         if not os.path.exists(version_path) or not os.path.isfile(version_path):

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -18,8 +18,7 @@ import stat
 THIN_ARCHIVE = 'salt-thin.tgz'
 EXT_ARCHIVE = 'salt-ext_mods.tgz'
 
-# FIXME - it would be ideal if these could be obtained directly from
-#         salt.exitcodes rather than duplicated.
+# Keep these in sync with salt/exitcodes.py
 EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
 EX_MOD_DEPLOY = 13

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -14,10 +14,15 @@ import shutil
 import sys
 import os
 import stat
-import salt.exitcodes
 
 THIN_ARCHIVE = 'salt-thin.tgz'
 EXT_ARCHIVE = 'salt-ext_mods.tgz'
+
+# FIXME - it would be ideal if these could be obtained directly from
+#         salt.exitcodes rather than duplicated.
+EX_THIN_DEPLOY = 11
+EX_THIN_CHECKSUM = 12
+EX_MOD_DEPLOY = 13
 
 
 class OBJ(object):
@@ -52,7 +57,7 @@ def need_deployment():
 
     # Delimeter emitted on stdout *only* to indicate shim message to master.
     sys.stdout.write("{0}\ndeploy\n".format(OPTIONS.delimiter))
-    sys.exit(salt.exitcodes.EX_THIN_DEPLOY)
+    sys.exit(EX_THIN_DEPLOY)
 
 
 # Adapted from salt.utils.get_hash()
@@ -78,7 +83,7 @@ def unpack_thin(thin_path):
 
 def need_ext():
     sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
-    sys.exit(salt.exitcodes.EX_MOD_DEPLOY)
+    sys.exit(EX_MOD_DEPLOY)
 
 
 def unpack_ext(ext_path):
@@ -107,7 +112,7 @@ def main(argv):
             sys.stderr.write('{0}\n'.format(get_hash(thin_path, OPTIONS.hashfunc)))
             os.unlink(thin_path)
             sys.stderr.write('WARNING: checksum mismatch for "{0}"\n'.format(thin_path))
-            sys.exit(salt.exitcodes.EX_THIN_CHECKSUM)
+            sys.exit(EX_THIN_CHECKSUM)
         unpack_thin(thin_path)
         # Salt thin now is available to use
     else:
@@ -116,7 +121,7 @@ def main(argv):
 
         if not os.path.isdir(OPTIONS.saltdir):
             sys.stderr.write('ERROR: salt path "{0}" exists but is not a directory\n'.format(OPTIONS.saltdir))
-            sys.exit(salt.exitcodes.EX_CANTCREAT)
+            sys.exit(os.EX_CANTCREAT)
 
         version_path = os.path.join(OPTIONS.saltdir, 'version')
         if not os.path.exists(version_path) or not os.path.isfile(version_path):

--- a/salt/cloud/cli.py
+++ b/salt/cloud/cli.py
@@ -77,7 +77,7 @@ class SaltCloud(parsers.SaltCloudParser):
                 self.options.output, self.config
             )
             print(display_output(ret))
-            self.exit(os.EX_OK)
+            self.exit(salt.exitcodes.EX_OK)
 
         log.info('salt-cloud starting')
         mapper = salt.cloud.Map(self.config)
@@ -150,7 +150,7 @@ class SaltCloud(parsers.SaltCloudParser):
 
             if not matching:
                 print('No machines were found to be destroyed')
-                self.exit(os.EX_OK)
+                self.exit(salt.exitcodes.EX_OK)
 
             msg = 'The following virtual machines are set to be destroyed:\n'
             names = set()
@@ -311,7 +311,7 @@ class SaltCloud(parsers.SaltCloudParser):
         )
         # display output using salt's outputter system
         print(display_output(ret))
-        self.exit(os.EX_OK)
+        self.exit(salt.exitcodes.EX_OK)
 
     def print_confirm(self, msg):
         if self.options.assume_yes:

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -666,7 +666,7 @@ class Auth(object):
                             'minion.\nOr restart the Salt Master in open mode to '
                             'clean out the keys. The Salt Minion will now exit.'
                         )
-                        sys.exit(os.EX_OK)
+                        sys.exit(salt.exitcodes.EX_OK)
                 # has the master returned that its maxed out with minions?
                 elif payload['load']['ret'] == 'full':
                     return 'full'

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -25,6 +25,7 @@ except ImportError:
     pass
 
 # Import salt libs
+import salt.exitcodes
 import salt.utils
 import salt.payload
 import salt.utils.verify

--- a/salt/exitcodes.py
+++ b/salt/exitcodes.py
@@ -13,6 +13,7 @@ EX_GENERIC = 1
 EX_THIN_PYTHON_OLD = 10
 EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
+EX_MOD_DEPLOY = 13
 
 # The os.EX_* exit codes are Unix only so in the interest of cross-platform
 # compatiblility define them explicitly here.

--- a/salt/exitcodes.py
+++ b/salt/exitcodes.py
@@ -13,3 +13,16 @@ EX_GENERIC = 1
 EX_THIN_PYTHON_OLD = 10
 EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
+
+# The os.EX_* exit codes are Unix only so in the interest of cross-platform
+# compatiblility define them explicitly here.
+#
+# These constants are documented here:
+# https://docs.python.org/2/library/os.html#os.EX_OK
+
+EX_OK = 0
+EX_NOUSER = 67
+EX_UNAVAILABLE = 69
+EX_CANTCREAT = 73
+EX_SOFTWARE = 70
+EX_USAGE = 64

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -13,6 +13,7 @@ import logging
 # Import salt libs
 import salt
 import salt.exceptions
+import salt.exitcodes
 import salt.cli
 
 

--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -201,7 +201,7 @@ def salt_cloud():
 
     if not HAS_SALTCLOUD:
         print('salt-cloud is not available in this system')
-        sys.exit(os.EX_UNAVAILABLE)
+        sys.exit(salt.exitcodes.EX_UNAVAILABLE)
 
     client = None
     try:

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -274,7 +274,7 @@ def daemonize(redirect_out=True):
         pid = os.fork()
         if pid > 0:
             # exit first parent
-            sys.exit(os.EX_OK)
+            sys.exit(salt.exitcodes.EX_OK)
     except OSError as exc:
         log.error(
             'fork #1 failed: {0} ({1})'.format(exc.errno, exc.strerror)
@@ -291,7 +291,7 @@ def daemonize(redirect_out=True):
     try:
         pid = os.fork()
         if pid > 0:
-            sys.exit(os.EX_OK)
+            sys.exit(salt.exitcodes.EX_OK)
     except OSError as exc:
         log.error(
             'fork #2 failed: {0} ({1})'.format(

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -98,6 +98,7 @@ except ImportError:
 
 # Import salt libs
 import salt._compat
+import salt.exitcodes
 import salt.log
 import salt.payload
 import salt.version

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -100,6 +100,7 @@ except ImportError:
     pass
 
 # Import salt libs
+import salt.exitcodes
 import salt.utils
 from salt._compat import MAX_SIZE
 from salt.utils.filebuffer import BufferedReader

--- a/salt/utils/find.py
+++ b/salt/utils/find.py
@@ -649,7 +649,7 @@ def find(path, options):
 def _main():
     if len(sys.argv) < 2:
         sys.stderr.write('usage: {0} path [options]\n'.format(sys.argv[0]))
-        sys.exit(os.EX_USAGE)
+        sys.exit(salt.exitcodes.EX_USAGE)
 
     path = sys.argv[1]
     criteria = {}

--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -191,7 +191,7 @@ class OptionParser(optparse.OptionParser):
 
     def print_versions_report(self, file=sys.stdout):
         print('\n'.join(version.versions_report()), file=file)
-        self.exit(os.EX_OK)
+        self.exit(salt.exitcodes.EX_OK)
 
 
 class MergeConfigMixIn(object):
@@ -1633,7 +1633,7 @@ class SaltCPOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         # salt-cp needs arguments
         if len(self.args) <= 1:
             self.print_help()
-            self.exit(os.EX_USAGE)
+            self.exit(salt.exitcodes.EX_USAGE)
 
         if self.options.list:
             if ',' in self.args[0]:
@@ -2024,7 +2024,7 @@ class SaltCallOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
     def _mixin_after_parsed(self):
         if not self.args and not self.options.grains_run and not self.options.doc:
             self.print_help()
-            self.exit(os.EX_USAGE)
+            self.exit(salt.exitcodes.EX_USAGE)
 
         elif len(self.args) >= 1:
             if self.options.grains_run:
@@ -2254,7 +2254,7 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
     def _mixin_after_parsed(self):
         if not self.args:
             self.print_help()
-            self.exit(os.EX_USAGE)
+            self.exit(salt.exitcodes.EX_USAGE)
 
         if self.options.list:
             if ',' in self.args[0]:
@@ -2267,7 +2267,7 @@ class SaltSSHOptionParser(OptionParser, ConfigDirMixIn, MergeConfigMixIn,
         self.config['argv'] = self.args[1:]
         if not self.config['argv'] or not self.config['tgt']:
             self.print_help()
-            self.exit(os.EX_USAGE)
+            self.exit(salt.exitcodes.EX_USAGE)
 
         if self.options.ssh_askpass:
             self.options.ssh_passwd = getpass.getpass('Password: ')
@@ -2301,7 +2301,7 @@ class SaltCloudParser(OptionParser,
     def print_versions_report(self, file=sys.stdout):
         print('\n'.join(version.versions_report(include_salt_cloud=True)),
               file=file)
-        self.exit(os.EX_OK)
+        self.exit(salt.exitcodes.EX_OK)
 
     def parse_args(self, args=None, values=None):
         try:
@@ -2318,7 +2318,7 @@ class SaltCloudParser(OptionParser,
 
             print('Salt cloud configuration dump(INCLUDES SENSIBLE DATA):')
             pprint.pprint(self.config)
-            self.exit(os.EX_OK)
+            self.exit(salt.exitcodes.EX_OK)
 
         if self.args:
             self.config['names'] = self.args

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -58,7 +58,7 @@ def set_pidfile(pidfile, user):
                 user
             )
         )
-        sys.exit(os.EX_NOUSER)
+        sys.exit(salt.exitcodes.EX_NOUSER)
 
     if os.getuid() == uid:
         # The current user already owns the pidfile. Return!

--- a/salt/utils/process.py
+++ b/salt/utils/process.py
@@ -9,6 +9,7 @@ import multiprocessing
 import signal
 
 # Import salt libs
+import salt.exitcodes
 import salt.utils
 
 log = logging.getLogger(__name__)

--- a/salt/utils/saltminionservice.py
+++ b/salt/utils/saltminionservice.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import os
 
 # Import salt libs
 from salt.utils.winservice import Service, instart
 import salt
+import salt.exitcodes
 
 # Import third party libs
 import win32serviceutil

--- a/salt/utils/saltminionservice.py
+++ b/salt/utils/saltminionservice.py
@@ -38,7 +38,7 @@ def _main():
     except win32service.error as details:
         if details[0] == winerror.ERROR_SERVICE_DOES_NOT_EXIST:
             instart(MinionService, servicename, 'Salt Minion')
-            sys.exit(os.EX_OK)
+            sys.exit(salt.exitcodes.EX_OK)
     if status[1] == win32service.SERVICE_RUNNING:
         win32serviceutil.StopServiceWithDeps(servicename)
         win32serviceutil.StartService(servicename)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -22,6 +22,7 @@ else:
 # Import salt libs
 from salt.log import is_console_configured
 from salt.exceptions import SaltClientError
+import salt.exitcodes
 import salt.utils
 
 log = logging.getLogger(__name__)

--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -156,7 +156,7 @@ def verify_files(files, user):
         err = ('Failed to prepare the Salt environment for user '
                '{0}. The user is not available.\n').format(user)
         sys.stderr.write(err)
-        sys.exit(os.EX_NOUSER)
+        sys.exit(salt.exitcodes.EX_NOUSER)
     for fn_ in files:
         dirname = os.path.dirname(fn_)
         try:
@@ -197,7 +197,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
         err = ('Failed to prepare the Salt environment for user '
                '{0}. The user is not available.\n').format(user)
         sys.stderr.write(err)
-        sys.exit(os.EX_NOUSER)
+        sys.exit(salt.exitcodes.EX_NOUSER)
     for dir_ in dirs:
         if not dir_:
             continue


### PR DESCRIPTION
Fixes #18244 

Use Salt defined exit codes.   os.EX_OK and other os.EX_\* exit codes are unix only in python.
