### PR TITLE
Populate the 'virtual' grain on OpenStack FreeBSD systems

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -606,6 +606,8 @@ def _virtual(osdata):
                 grains['virtual'] = 'xen'
             if maker.startswith('Microsoft') and product.startswith('Virtual'):
                 grains['virtual'] = 'VirtualPC'
+            if maker.startswith('OpenStack'):
+                grains['virtual'] = 'OpenStack'
         if sysctl:
             model = __salt__['cmd.run']('{0} hw.model'.format(sysctl))
             jail = __salt__['cmd.run'](


### PR DESCRIPTION
Detect a FreeBSD virtual machine running on OpenStack and set the 'virtual' grain.
