### PR TITLE
Make /etc/salt-master usefull

### DIFF
--- a/debian/salt-master.upstart
+++ b/debian/salt-master.upstart
@@ -6,6 +6,8 @@ start on (net-device-up
 stop on runlevel [!2345]
 limit nofile 100000 100000
 
+env CONFIG_DIR=/etc/salt
+
 script
   # Read configuration variable file if it is present
   [ -f /etc/default/$UPSTART_JOB ] && . /etc/default/$UPSTART_JOB
@@ -13,5 +15,5 @@ script
   # Activate the virtualenv if defined
   [ -f $SALT_USE_VIRTUALENV/bin/activate ] && . $SALT_USE_VIRTUALENV/bin/activate
 
-  exec salt-master
+  exec salt-master -c $CONFIG_DIR
 end script


### PR DESCRIPTION
Our organization use a different path to store the salt configuration. It would be nice to have the option to change it easily. /etc/default/salt-master is made for that
