### PR TITLE
Make salt cli return a non-zero error code if an error occurred

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -895,6 +895,8 @@ class LocalClient(object):
                     ret = {raw['data']['id']: {'ret': raw['data']['return']}}
                     if 'out' in raw['data']:
                         ret[raw['data']['id']]['out'] = raw['data']['out']
+                    if 'retcode' in raw['data']:
+                        ret[raw['data']['id']]['retcode'] = raw['data']['retcode']
                     if kwargs.get('_cmd_meta', False):
                         ret[raw['data']['id']].update(raw['data'])
                     log.debug('jid {0} return from {1}'.format(jid, raw['data']['id']))

--- a/tests/integration/cli/batch.py
+++ b/tests/integration/cli/batch.py
@@ -27,11 +27,15 @@ class BatchTest(integration.ShellCase):
                "Executing run on ['sub_minion']",
                '',
                'sub_minion:',
+               'retcode:',
+               '    0',
                '    batch testing',
                '',
                "Executing run on ['minion']",
                '',
                'minion:',
+               'retcode:',
+               '    0',
                '    batch testing']
         ret = sorted(ret)
         cmd = sorted(self.run_salt('\'*\' test.echo \'batch testing\' -b 50%'))


### PR DESCRIPTION
We have all the logic in the CLI to do this, but we never actually passed a retcode in. (This is likely a regression.)

Fixes #18627
