### PR TITLE
modules.sysrc: avoid shadowing built-in set type

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -8,6 +8,11 @@ import salt.utils
 from salt.exceptions import CommandExecutionError
 
 
+__func_alias__ = {
+    'set_': 'set'
+}
+
+
 def __virtual__():
     '''
     Only runs if sysrc exists
@@ -57,7 +62,7 @@ def get(**kwargs):
     return ret
 
 
-def set(name, value, **kwargs):
+def set_(name, value, **kwargs):
     '''
     Set system rc configuration variables
 


### PR DESCRIPTION
```
************* Module salt.modules.sysrc
salt/modules/sysrc.py:60: [W0622(redefined-builtin), set] Redefining built-in 'set'
```
