### PR TITLE
Fix missing text

### DIFF
--- a/doc/topics/tutorials/walkthrough.rst
+++ b/doc/topics/tutorials/walkthrough.rst
@@ -200,7 +200,7 @@ The easiest way to accept the minion key is to accept all pending keys:
 
     On the master:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         # salt-key -f foo.domain.com
         Unaccepted Keys:
@@ -208,7 +208,7 @@ The easiest way to accept the minion key is to accept all pending keys:
 
     On the minion:
 
-    .. code-block: bash
+    .. code-block:: bash
 
         # salt-call key.finger --local
         local:


### PR DESCRIPTION
Found missing colon, causing code blocks not to display.  This fixes issue #18879
