### PR TITLE
fix ec2 instance creation with delete volume enabled (issue #18315)

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3015,7 +3015,10 @@ def _toggle_delvol(name=None, instance_id=None, device=None, volume_id=None,
 
     query(params, return_root=True)
 
-    return query(requesturl=requesturl)
+    kwargs = {'instance_id': instance_id,
+              'device': device,
+              'volume_id': volume_id}
+    return show_delvol_on_destroy(name, kwargs, call='action')
 
 
 def create_volume(kwargs=None, call=None, wait_to_finish=False):


### PR DESCRIPTION
- `ec2.query()` requires non-empty `param` argument
- replace `param`-less call to `ec2.query()` with `show_delvol_on_destroy()`
- TODO: remove `requesturl` as none of the callers of `_toggle_delvol()`
  make use of it
