### PR TITLE
The `gpgkeys` path should use `salt.syspaths`

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -70,8 +70,10 @@ Now you can include your ciphers in your pillar data like so:
       -----END PGP MESSAGE-----
 '''
 
+import os
 import re
 import salt.utils
+import salt.syspaths
 try:
     import gnupg
     HAS_GPG = True
@@ -85,7 +87,7 @@ from salt.exceptions import SaltRenderError
 
 log = logging.getLogger(__name__)
 GPG_HEADER = re.compile(r'-----BEGIN PGP MESSAGE-----')
-DEFAULT_GPG_KEYDIR = '/etc/salt/gpgkeys'
+DEFAULT_GPG_KEYDIR = os.path.join(salt.syspaths.CONFIG_DIR, 'gpgkeys')
 
 
 def decrypt_ciphertext(c, gpg):


### PR DESCRIPTION
The `gpgkeys` path should use `salt.syspaths` for proper  multi-platform support.

Fixes #18877
