### PR TITLE
Fixes to mount module

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -52,7 +52,13 @@ def _active_mountinfo(ret):
         for line in ifile:
             comps = line.split()
             device = comps[2].split(':')
-            device_name = comps[8]
+            # each line can have any number of
+            # optional parameters, we use the
+            # location of the seperator field to
+            # determine the location of the elements
+            # after it.
+            _sep = comps.index('-')
+            device_name = comps[_sep + 2]
             device_uuid = None
             if device_name:
                 device_uuid = blkid_info.get(device_name, {}).get('UUID')
@@ -63,10 +69,10 @@ def _active_mountinfo(ret):
                              'minor': device[1],
                              'root': comps[3],
                              'opts': comps[5].split(','),
-                             'fstype': comps[7],
+                             'fstype': comps[_sep + 1],
                              'device': device_name,
                              'alt_device': _list.get(comps[4], None),
-                             'superopts': comps[9].split(','),
+                             'superopts': comps[_sep + 3].split(','),
                              'device_uuid': device_uuid}
     return ret
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -149,7 +149,7 @@ def mounted(name,
                     comment_option = opt.split('=')[0]
                     if comment_option == 'comment':
                         opt = comment_option
-                    if opt not in active[real_name]['opts'] and opt not in mount_invisible_options:
+                    if opt not in active[real_name]['opts'] and opt not in active[real_name]['superopts'] and opt not in mount_invisible_options:
                         if __opts__['test']:
                             ret['result'] = None
                             ret['comment'] = "Remount would be forced because options changed"
@@ -159,6 +159,10 @@ def mounted(name,
                                                         + "options changed"
                             remount_result = __salt__['mount.remount'](real_name, device, mkmnt=mkmnt, fstype=fstype, opts=opts)
                             ret['result'] = remount_result
+                            # Cleanup after the remount, so we
+                            # don't write remount into fstab
+                            if 'remount' in opts:
+                                opts.remove('remount')
             if real_device not in device_list:
                 # name matches but device doesn't - need to umount
                 if __opts__['test']:


### PR DESCRIPTION
Each line can have any number of optional parameters, we use the location of the seperator field to determine the location of the elements after it.
On remount, the remount option was ending up in the /etc/fstab.
Ensuring that it is removed from the options.
Some mount options end up in the superopts so we should look for them there too.
#18874
