### PR TITLE
Avoid double-quoting of group names for yum

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1429,7 +1429,7 @@ def group_info(name):
         'default packages': [],
         'description': ''
     }
-    cmd_template = 'repoquery --plugins --group --grouppkgs={0} --list {1!r}'
+    cmd_template = 'repoquery --plugins --group --grouppkgs={0} --list {1}'
 
     cmd = cmd_template.format('all', _cmd_quote(name))
     out = __salt__['cmd.run_stdout'](cmd, output_loglevel='trace')
@@ -1453,7 +1453,7 @@ def group_info(name):
     # considered to be conditional packages.
     ret['conditional packages'] = sorted(all_pkgs)
 
-    cmd = 'repoquery --plugins --group --info {0!r}'.format(_cmd_quote(name))
+    cmd = 'repoquery --plugins --group --info {0}'.format(_cmd_quote(name))
     out = __salt__['cmd.run_stdout'](
             cmd, output_loglevel='trace'
             )


### PR DESCRIPTION
This PR fixes usage of trying to use the module `pkg.group_install` with quoted group names on RPM-based distros.  Trying to install `Development tools`, for instance, results in commands being issued like this:

```
[INFO    ] Executing command 'repoquery --plugins --group --info "\'Development tools\'"' in directory '/root'
```

which fails, because `'Development tools'` doesn't exist (the single quotes are taken into account as they're within the double quotes).

The command templates are adjusted in this PR to avoid double-quoting.  The incoming group `name` is already quoted by `_cmd_quote` in both of this situations, so using repr string formatting isn't necessary.  
