### PR TITLE
schedule.list should return an empty dictionary, not None

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -90,7 +90,7 @@ def list_(show_all=False, return_yaml=True):
         else:
             return schedule
     else:
-        return None
+        return {'schedule': {}}
 
 
 def purge(**kwargs):


### PR DESCRIPTION
schedule.list should return an empty dictionary, not None #18969 
