### PR TITLE
[DON'T MERGE] Backwards compatibility for Tomcat module Pillar configuration

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -339,7 +339,7 @@ def highstate(test=None,
     try:
         if salt.utils.is_windows():
             # Make sure cache file isn't read-only
-            __salt__['cmd.run']('attrib -R "{0}"'.format(cache_file))
+            __salt__['cmd.run'](['attrib', '-R', cache_file], python_shell=False)
         with salt.utils.fopen(cache_file, 'w+b') as fp_:
             serial.dump(ret, fp_)
     except (IOError, OSError):
@@ -481,7 +481,7 @@ def sls(mods,
     try:
         if salt.utils.is_windows():
             # Make sure cache file isn't read-only
-            __salt__['cmd.run']('attrib -R "{0}"'.format(cache_file))
+            __salt__['cmd.run'](['attrib', '-R', cache_file], python_shell=False)
         with salt.utils.fopen(cache_file, 'w+b') as fp_:
             serial.dump(ret, fp_)
     except (IOError, OSError):

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -2,15 +2,32 @@
 '''
 Support for Tomcat
 
-This module uses the manager webapp to manage Apache tomcat webapps
-If the manager webapp is not configured some of the functions won't work
+This module uses the manager webapp to manage Apache tomcat webapps.
+If the manager webapp is not configured some of the functions won't work.
 
-The following grains/pillar should be set::
+.. note::
 
-    tomcat-manager:user: admin user name
-    tomcat-manager:passwd: password
+    The config format was changed in 2014.7.0, but backwards compatibility for
+    the old-style config will be in the 2014.7.1 release.
 
-and also configure a user in the conf/tomcat-users.xml file::
+The following grains/pillar should be set:
+
+.. code-block:: yaml
+
+    tomcat-manager:
+      user: <username>
+      password: <passwd>
+
+or the old format:
+
+.. code-block:: yaml
+
+    tomcat-manager.user: <username>
+    tomcat-manager.password: <passwd>
+
+Also configure a user in the conf/tomcat-users.xml file:
+
+.. code-block:: xml
 
     <?xml version='1.0' encoding='utf-8'?>
     <tomcat-users>
@@ -18,27 +35,27 @@ and also configure a user in the conf/tomcat-users.xml file::
         <user username="tomcat" password="tomcat" roles="manager-script"/>
     </tomcat-users>
 
-Notes:
+.. note::
 
-- More information about tomcat manager:
-  http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html
-- if you use only this module for deployments you've might want to strict
-  access to the manager only from localhost for more info:
-  http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html#Configuring_Manager_Application_Access
-- Tested on:
-
-  JVM Vendor:
-      Sun Microsystems Inc.
-  JVM Version:
-      1.6.0_43-b01
-  OS Architecture:
-      amd64
-  OS Name:
-      Linux
-  OS Version:
-      2.6.32-358.el6.x86_64
-  Tomcat Version:
-      Apache Tomcat/7.0.37
+   - More information about tomcat manager:
+     http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html
+   - if you use only this module for deployments you've might want to strict
+     access to the manager only from localhost for more info:
+     http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html#Configuring_Manager_Application_Access
+   - Tested on:
+ 
+     JVM Vendor:
+         Sun Microsystems Inc.
+     JVM Version:
+         1.6.0_43-b01
+     OS Architecture:
+         amd64
+     OS Name:
+         Linux
+     OS Version:
+         2.6.32-358.el6.x86_64
+     Tomcat Version:
+         Apache Tomcat/7.0.37
 '''
 
 # Import python libs
@@ -56,6 +73,18 @@ __func_alias__ = {
     'reload_': 'reload'
 }
 
+# Support old-style grains/pillar
+# config as well as new.
+__valid_configs = {
+    'user': [
+        'tomcat-manager.user',
+        'tomcat-manager:user'
+    ],
+    'passwd': [
+        'tomcat-manager.passwd',
+        'tomcat-manager:passwd'
+    ]
+}
 
 def __virtual__():
     '''
@@ -82,22 +111,31 @@ def __catalina_home():
 
 def _get_credentials():
     '''
-    Get the username and password from opts, grains & pillar
+    Get the username and password from opts, grains, or pillar
     '''
-
     ret = {
         'user': False,
         'passwd': False
     }
 
+    # Loop through opts, grains, and pillar
+    # Return the first acceptable configuration found
     for item in ret:
-        entry = 'tomcat-manager:{0}'.format(item)
         for struct in [__opts__, __grains__, __pillar__]:
-            ret[item] = salt.utils.traverse_dict_and_list(struct, entry, '_|-')
-            if ret[item] == '_|-':
-                ret[item] = False
+            # Look for the config key
+            # Support old-style config format and new
+            for config_key in __valid_configs[item]:
+                value = salt.utils.traverse_dict_and_list(struct,
+                                                          config_key,
+                                                          None)
+                if value:
+                    ret[item] = value
+                    break
             else:
-                break
+                continue
+        else:
+            continue
+        break
     return ret['user'], ret['passwd']
 
 
@@ -645,3 +683,31 @@ def signal(signal=None):
         __catalina_home(), valid_signals[signal]
     )
     __salt__['cmd.run'](cmd)
+
+
+if __name__ == '__main__':
+    '''
+    Allow testing from the CLI
+    '''
+    __opts__ = {}
+    __grains__ = {}
+    __pillar__ = {
+        'tomcat-manager.user': 'foobar',
+        'tomcat-manager.passwd': 'barfoo1!',
+    }
+
+    old_format_creds = _get_credentials()
+
+    __pillar__ = {
+        'tomcat-manager': {
+            'user': 'foobar',
+            'passwd': 'barfoo1!'
+        }
+    }
+
+    new_format_creds = _get_credentials()
+
+    if old_format_creds == new_format_creds:
+        print 'Config backwards compatible'
+    else:
+        print 'Config not backwards compatible'

--- a/salt/modules/tomcat.py
+++ b/salt/modules/tomcat.py
@@ -43,7 +43,7 @@ Also configure a user in the conf/tomcat-users.xml file:
      access to the manager only from localhost for more info:
      http://tomcat.apache.org/tomcat-7.0-doc/manager-howto.html#Configuring_Manager_Application_Access
    - Tested on:
- 
+
      JVM Vendor:
          Sun Microsystems Inc.
      JVM Version:
@@ -85,6 +85,7 @@ __valid_configs = {
         'tomcat-manager:passwd'
     ]
 }
+
 
 def __virtual__():
     '''
@@ -131,11 +132,6 @@ def _get_credentials():
                 if value:
                     ret[item] = value
                     break
-            else:
-                continue
-        else:
-            continue
-        break
     return ret['user'], ret['passwd']
 
 
@@ -688,7 +684,7 @@ def signal(signal=None):
 if __name__ == '__main__':
     '''
     Allow testing from the CLI
-    '''
+    '''  # pylint: disable=W0105
     __opts__ = {}
     __grains__ = {}
     __pillar__ = {


### PR DESCRIPTION
Updated the Tomcat module and docs so 2014.7 supports the previous configuration format for pillar.
## New Format

```
tomcat-manager:
  user: <username>
  password: <passwd>
```
## Old Format

```
tomcat-manager.user: <username>
tomcat-manager.password: <passwd>
```

I've added a simple test for this when running the module from the CLI, but a unit test would be more appropriate.
