### PR TITLE
[DONT MERGE] Enable file permissions lint checker.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -27,7 +27,10 @@ persistent=yes
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=salttesting.pylintplugins.pep8,salttesting.pylintplugins.pep263,salttesting.pylintplugins.strings
+load-plugins=salttesting.pylintplugins.pep8,
+  salttesting.pylintplugins.pep263,
+  salttesting.pylintplugins.strings,
+  salttesting.pylintplugins.fileperms
 
 
 [MESSAGES CONTROL]

--- a/.pylintrc
+++ b/.pylintrc
@@ -33,6 +33,10 @@ load-plugins=salttesting.pylintplugins.pep8,
   salttesting.pylintplugins.fileperms
 
 
+# Fileperms Lint Plugin Settings
+fileperms-default=0644
+fileperms-ignore-paths=tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
+
 [MESSAGES CONTROL]
 
 # Enable the message, report, category or checker with the given id(s). You can

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -14,7 +14,10 @@ init-hook="
 # Pickle collected data for later comparisons.
 persistent=no
 
-load-plugins=salttesting.pylintplugins.pep8,salttesting.pylintplugins.pep263,salttesting.pylintplugins.strings
+load-plugins=salttesting.pylintplugins.pep8,
+  salttesting.pylintplugins.pep263,
+  salttesting.pylintplugins.strings,
+  salttesting.pylintplugins.fileperms
 
 [MESSAGES CONTROL]
 

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -19,6 +19,10 @@ load-plugins=salttesting.pylintplugins.pep8,
   salttesting.pylintplugins.strings,
   salttesting.pylintplugins.fileperms
 
+# Fileperms Lint Plugin Settings
+fileperms-default=0644
+fileperms-ignore-paths=tests/runtests.py,tests/jenkins*.py,tests/saltsh.py,tests/buildpackage.py
+
 [MESSAGES CONTROL]
 
 # Enable the message, report, category or checker with the given id(s). You can


### PR DESCRIPTION
This will allow us to confirm that no modules are added to salt with the wrong file permissions. Default file permissions is 0644.
