### PR TITLE
Fix ini_manage state - equality detection for non-string values

### DIFF
--- a/salt/states/ini_manage.py
+++ b/salt/states/ini_manage.py
@@ -58,8 +58,10 @@ def options_present(name, sections=None):
             current_value = __salt__['ini.get_option'](name,
                                                        section,
                                                        key)
-            if current_value == sections[section][key]:
+            # Test if the change is necessary
+            if current_value == str(sections[section][key]):
                 continue
+
             ret['changes'] = __salt__['ini.set_option'](name,
                                                         sections)
             if 'error' in ret['changes']:


### PR DESCRIPTION
The verification if the change is needed in ini_manage fails with non-string values. This will trigger change every time the state is called.

This example will trigger state change for every call:

``` yaml
/some/ini/file:
  ini.options_present:
    - sections:
      DEFAULT_IMPLICIT:
          string_value_is_fine: abcd
          number_is_not_good: 9091
```

The workaround is to make all values string in the yaml. For the above example it would be:

``` yaml
/some/ini/file:
  ini.options_present:
    - sections:
      DEFAULT_IMPLICIT:
          string_value_is_fine: abcd
          number_is_not_good: '9091'
```
