### PR TITLE
utils/__init__.py: rm redundant import

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -97,7 +97,6 @@ from salt.defaults import DEFAULT_TARGET_DELIM
 import salt.defaults.exitcodes
 import salt.log
 import salt.version
-import salt.defaults.exitcodes
 from salt.utils.decorators import memoize as real_memoize
 from salt.exceptions import (
     CommandExecutionError, SaltClientError,


### PR DESCRIPTION
```
************* Module salt.utils
salt/utils/__init__.py:100: [W0404(reimported), ] Reimport 'salt.defaults.exitcodes' (imported line 97)
```
