### PR TITLE
The aptpkg uninstall operation needs to inherit DPKG_ENV_VARS set above as install and upgrade currently do.

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -544,9 +544,11 @@ def _uninstall(action='remove', name=None, pkgs=None, **kwargs):
         return {}
     cmd = ['apt-get', '-q', '-y', action]
     cmd.extend(targets)
+    env = _parse_env(kwargs.get('env'))
+    env.update(DPKG_ENV_VARS.copy())
     __salt__['cmd.run'](
         cmd,
-        env=kwargs.get('env'),
+        env=env,
         python_shell=False,
         output_loglevel='trace'
     )


### PR DESCRIPTION
Without this packages that prompt on removal cause that state to hang. resolvconf in particular prompts you with a warning about rebooting your system after removal.
