### PR TITLE
2014.7 file.replace integration test coverage

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1129,7 +1129,7 @@ def replace(path,
         # will be an empty file after iterating over it just for searching
         fi_file = fileinput.input(path,
                         inplace=False,
-                        backup=False if (dry_run or search_only) else backup,
+                        backup=False,
                         bufsize=bufsize,
                         mode='r')
 
@@ -1144,7 +1144,7 @@ def replace(path,
                     found = True
                     break
 
-            if ( prepend_if_not_found or append_if_not_found ) and not not_found_content:
+            else:
                 if line == repl:
                     if search_only:
                         return True
@@ -1157,9 +1157,9 @@ def replace(path,
     try:
         fi_file = fileinput.input(path,
                         inplace=not (dry_run or search_only),
-                        backup=False if (dry_run or search_only) else backup,
+                        backup=False if (dry_run or search_only or found) else backup,
                         bufsize=bufsize,
-                        mode='r' if (dry_run or search_only) else 'rb')
+                        mode='r' if (dry_run or search_only or found) else 'rb')
 
         if not found:
             for line in fi_file:

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1052,7 +1052,7 @@ def replace(path,
 
         .. versionadded:: 2014.7.0
     :param prepend_if_not_found: If pattern is not found and set to ``True``
-        then, the content will be appended to the file.
+        then, the content will be prepended to the file.
 
         .. versionadded:: 2014.7.0
     :param not_found_content: Content to use for append/prepend if not found. If
@@ -1086,8 +1086,8 @@ def replace(path,
 
     .. code-block:: bash
 
-        salt '*' file.replace /etc/httpd/httpd.conf 'LogLevel warn' 'LogLevel info'
-        salt '*' file.replace /some/file 'before' 'after' flags='[MULTILINE, IGNORECASE]'
+        salt '*' file.replace /etc/httpd/httpd.conf pattern='LogLevel warn' repl='LogLevel info'
+        salt '*' file.replace /some/file pattern='before' repl='after' flags='[MULTILINE, IGNORECASE]'
     '''
     if not os.path.exists(path):
         raise SaltInvocationError('File not found: {0}'.format(path))
@@ -1129,22 +1129,35 @@ def replace(path,
         # will be an empty file after iterating over it just for searching
         fi_file = fileinput.input(path,
                         inplace=False,
+                        backup=False if (dry_run or search_only) else backup,
                         bufsize=bufsize,
                         mode='r')
 
         for line in fi_file:
-            result = re.search(repl, line)
-            if result:
-                if search_only:
-                    return True
-                found = True
+
+            line = line.strip()
+
+            if ( prepend_if_not_found or append_if_not_found ) and not_found_content:
+                if line == not_found_content:
+                    if search_only:
+                        return True
+                    found = True
+                    break
+
+            if ( prepend_if_not_found or append_if_not_found ) and not not_found_content:
+                if line == repl:
+                    if search_only:
+                        return True
+                    found = True
+                    break
+
     finally:
         fi_file.close()
 
     try:
         fi_file = fileinput.input(path,
                         inplace=not (dry_run or search_only),
-                        backup=False if dry_run else backup,
+                        backup=False if (dry_run or search_only) else backup,
                         bufsize=bufsize,
                         mode='r' if (dry_run or search_only) else 'rb')
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1137,7 +1137,7 @@ def replace(path,
 
             line = line.strip()
 
-            if ( prepend_if_not_found or append_if_not_found ) and not_found_content:
+            if (prepend_if_not_found or append_if_not_found) and not_found_content:
                 if line == not_found_content:
                     if search_only:
                         return True

--- a/tests/integration/files/file.replace/test_replace_issue_18612_append.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_append.in
@@ -1,0 +1,5 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18612_append.out
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_append.out
@@ -1,0 +1,6 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing
+en_US.UTF-8

--- a/tests/integration/files/file.replace/test_replace_issue_18612_append_not_found_content.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_append_not_found_content.in
@@ -1,0 +1,5 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18612_append_not_found_content.out
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_append_not_found_content.out
@@ -1,0 +1,6 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing
+THIS LINE WASN'T FOUND! SO WE'RE APPENDING IT HERE!

--- a/tests/integration/files/file.replace/test_replace_issue_18612_change_mid_line_with_comment.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_change_mid_line_with_comment.in
@@ -1,0 +1,5 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18612_change_mid_line_with_comment.out
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_change_mid_line_with_comment.out
@@ -1,0 +1,5 @@
+#john=doe
+#foo = bar
+foo=salt
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18612_prepend.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_prepend.in
@@ -1,0 +1,5 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18612_prepend.out
+++ b/tests/integration/files/file.replace/test_replace_issue_18612_prepend.out
@@ -1,0 +1,6 @@
+en_US.UTF-8
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18841.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18841.in
@@ -1,0 +1,5 @@
+#john=doe
+#foo = bar
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18841_no_changes.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18841_no_changes.in
@@ -1,0 +1,6 @@
+#john=doe
+#foo = bar
+goodbye world
+#foo=bar
+#blah=blub
+#some=thing

--- a/tests/integration/files/file.replace/test_replace_issue_18841_omit_backup.in
+++ b/tests/integration/files/file.replace/test_replace_issue_18841_omit_backup.in
@@ -1,5 +1,6 @@
 #john=doe
 #foo = bar
+goodbye world
 #foo=bar
 #blah=blub
 #some=thing

--- a/tests/integration/states/file.py
+++ b/tests/integration/states/file.py
@@ -12,6 +12,7 @@ import pwd
 import shutil
 import stat
 import tempfile
+import filecmp
 
 # Import Salt Testing libs
 from salttesting import skipIf
@@ -517,6 +518,277 @@ class FileTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             self.assertSaltTrueReturn(ret)
         finally:
             os.remove(name)
+
+    def test_replace_issue_18612(self):
+        '''
+        Test the (mis-)behaviour of file.replace as described in #18612:
+
+        Using 'prepend_if_not_found' or 'append_if_not_found' resulted in
+        an infinitely growing file as 'file.replace' didn't check beforehand
+        whether the changes had already been done to the file
+
+        # Case description:
+
+        The tested file contains one commented line
+        The commented line should be uncommented in the end, nothing else should change
+        '''
+        test_name = 'test_replace_issue_18612'
+        path_test = os.path.join(integration.TMP, test_name)
+
+        with salt.utils.fopen(path_test, 'w+') as fp_test_:
+            fp_test_.write('# en_US.UTF-8')
+
+        ret = []
+        for x in range(0, 3):
+            ret.append(self.run_state('file.replace',
+                name=path_test, pattern='^# en_US.UTF-8$', repl='en_US.UTF-8', append_if_not_found=True))
+
+        try:
+            # ensure, the number of lines didn't change, even after invoking 'file.replace' 3 times
+            with salt.utils.fopen(path_test, 'r') as fp_test_:
+                self.assertTrue((sum(1 for _ in fp_test_) == 1))
+
+            # ensure, the replacement succeeded
+            with salt.utils.fopen(path_test, 'r') as fp_test_:
+                self.assertTrue(fp_test_.read().startswith('en_US.UTF-8'))
+
+            # ensure, all runs of 'file.replace' reported success
+            for item in ret:
+                self.assertSaltTrueReturn(item)
+        finally:
+            os.remove(path_test)
+
+    def test_replace_issue_18612_prepend(self):
+        '''
+        Test the (mis-)behaviour of file.replace as described in #18612:
+
+        Using 'prepend_if_not_found' or 'append_if_not_found' resulted in
+        an infinitely growing file as 'file.replace' didn't check beforehand
+        whether the changes had already been done to the file
+
+        # Case description:
+
+        The tested multfile contains multiple lines not matching the pattern or replacement in any way
+        The replacement pattern should be prepended to the file
+        '''
+        test_name = 'test_replace_issue_18612_prepend'
+        path_in = os.path.join(
+            integration.FILES, 'file.replace', '{0}.in'.format(test_name)
+        )
+        path_out = os.path.join(
+            integration.FILES, 'file.replace', '{0}.out'.format(test_name)
+        )
+        path_test = os.path.join(integration.TMP, test_name)
+
+        # create test file based on initial template
+        shutil.copyfile(path_in, path_test)
+
+        ret = []
+        for x in range(0, 3):
+            ret.append(self.run_state('file.replace',
+                name=path_test, pattern='^# en_US.UTF-8$', repl='en_US.UTF-8', prepend_if_not_found=True))
+
+        try:
+            # ensure, the resulting file contains the expected lines
+            self.assertTrue(filecmp.cmp(path_test, path_out))
+
+            # ensure the initial file was properly backed up
+            self.assertTrue(filecmp.cmp(path_test + '.bak', path_in))
+
+            # ensure, all runs of 'file.replace' reported success
+            for item in ret:
+                self.assertSaltTrueReturn(item)
+        finally:
+            os.remove(path_test)
+
+    def test_replace_issue_18612_append(self):
+        '''
+        Test the (mis-)behaviour of file.replace as described in #18612:
+
+        Using 'prepend_if_not_found' or 'append_if_not_found' resulted in
+        an infinitely growing file as 'file.replace' didn't check beforehand
+        whether the changes had already been done to the file
+
+        # Case description:
+
+        The tested multfile contains multiple lines not matching the pattern or replacement in any way
+        The replacement pattern should be appended to the file
+        '''
+        test_name = 'test_replace_issue_18612_append'
+        path_in = os.path.join(
+            integration.FILES, 'file.replace', '{0}.in'.format(test_name)
+        )
+        path_out = os.path.join(
+            integration.FILES, 'file.replace', '{0}.out'.format(test_name)
+        )
+        path_test = os.path.join(integration.TMP, test_name)
+
+        # create test file based on initial template
+        shutil.copyfile(path_in, path_test)
+
+        ret = []
+        for x in range(0, 3):
+            ret.append(self.run_state('file.replace',
+                name=path_test, pattern='^# en_US.UTF-8$', repl='en_US.UTF-8', append_if_not_found=True))
+
+        try:
+            # ensure, the resulting file contains the expected lines
+            self.assertTrue(filecmp.cmp(path_test, path_out))
+
+            # ensure the initial file was properly backed up
+            self.assertTrue(filecmp.cmp(path_test + '.bak', path_in))
+
+            # ensure, all runs of 'file.replace' reported success
+            for item in ret:
+                self.assertSaltTrueReturn(item)
+        finally:
+            os.remove(path_test)
+
+    def test_replace_issue_18612_append_not_found_content(self):
+        '''
+        Test the (mis-)behaviour of file.replace as described in #18612:
+
+        Using 'prepend_if_not_found' or 'append_if_not_found' resulted in
+        an infinitely growing file as 'file.replace' didn't check beforehand
+        whether the changes had already been done to the file
+
+        # Case description:
+
+        The tested multfile contains multiple lines not matching the pattern or replacement in any way
+        The 'not_found_content' value should be appended to the file
+        '''
+        test_name = 'test_replace_issue_18612_append_not_found_content'
+        path_in = os.path.join(
+            integration.FILES, 'file.replace', '{0}.in'.format(test_name)
+        )
+        path_out = os.path.join(
+            integration.FILES, 'file.replace', '{0}.out'.format(test_name)
+        )
+        path_test = os.path.join(integration.TMP, test_name)
+
+        # create test file based on initial template
+        shutil.copyfile(path_in, path_test)
+
+        ret = []
+        for x in range(0, 3):
+            ret.append(
+                self.run_state('file.replace',
+                    name=path_test,
+                    pattern='^# en_US.UTF-8$',
+                    repl='en_US.UTF-8',
+                    append_if_not_found=True,
+                    not_found_content='THIS LINE WASN\'T FOUND! SO WE\'RE APPENDING IT HERE!'
+            ))
+
+        try:
+            # ensure, the resulting file contains the expected lines
+            self.assertTrue(filecmp.cmp(path_test, path_out))
+
+            # ensure the initial file was properly backed up
+            self.assertTrue(filecmp.cmp(path_test + '.bak', path_in))
+
+            # ensure, all runs of 'file.replace' reported success
+            for item in ret:
+                self.assertSaltTrueReturn(item)
+        finally:
+            os.remove(path_test)
+
+    def test_replace_issue_18612_change_mid_line_with_comment(self):
+        '''
+        Test the (mis-)behaviour of file.replace as described in #18612:
+
+        Using 'prepend_if_not_found' or 'append_if_not_found' resulted in
+        an infinitely growing file as 'file.replace' didn't check beforehand
+        whether the changes had already been done to the file
+
+        # Case description:
+
+        The tested file contains 5 key=value pairs
+        The commented key=value pair #foo=bar should be changed to foo=salt
+        The comment char (#) in front of foo=bar should be removed
+        '''
+        test_name = 'test_replace_issue_18612_change_mid_line_with_comment'
+        path_in = os.path.join(
+            integration.FILES, 'file.replace', '{0}.in'.format(test_name)
+        )
+        path_out = os.path.join(
+            integration.FILES, 'file.replace', '{0}.out'.format(test_name)
+        )
+        path_test = os.path.join(integration.TMP, test_name)
+
+        # create test file based on initial template
+        shutil.copyfile(path_in, path_test)
+
+        ret = []
+        for x in range(0, 3):
+            ret.append(self.run_state('file.replace',
+                name=path_test, pattern='^#foo=bar$', repl='foo=salt', append_if_not_found=True))
+
+        try:
+            # ensure, the resulting file contains the expected lines
+            self.assertTrue(filecmp.cmp(path_test, path_out))
+
+            # ensure the initial file was properly backed up
+            self.assertTrue(filecmp.cmp(path_test + '.bak', path_in))
+
+            # ensure, all 'file.replace' runs reported success
+            for item in ret:
+                self.assertSaltTrueReturn(item)
+        finally:
+            os.remove(path_test)
+
+    def test_replace_issue_18841(self):
+        '''
+        Test the (mis-)behaviour of file.replace as described in #18841:
+
+        Using file.replace in a way which shouldn't modify the file at all
+        results in changed mtime of the original file and a backup file being created.
+
+        # Case description
+
+        The tested file contains some irrelevant lines
+        The tested file's content shouldn't change at all
+        The tested file's mtime shouldn't change at all
+        There should be no corresponding backup file created
+        '''
+        test_name = 'test_replace_issue_18841'
+        path_in = os.path.join(
+            integration.FILES, 'file.replace', '{0}.in'.format(test_name)
+        )
+        path_test = os.path.join(integration.TMP, test_name)
+
+        # create test file based on initial template
+        shutil.copyfile(path_in, path_test)
+
+        # get (m|a)time of file
+        fstats_orig = os.stat(path_test)
+
+        # define how far we predate the file
+        age = 5*24*60*60
+
+        # set (m|a)time of file 5 days into the past
+        os.utime(path_test, (fstats_orig.st_mtime-age, fstats_orig.st_atime-age))
+
+        ret = self.run_state('file.replace',
+            name=path_test, pattern='^hello world$', repl='goodbye world', search_only=True)
+
+        # get (m|a)time of file
+        fstats_post = os.stat(path_test)
+
+        try:
+            # ensure, the file content didn't change
+            self.assertTrue(filecmp.cmp(path_in, path_test))
+
+            # ensure no backup file was created
+            self.assertFalse(os.path.exists(path_test + '.bak'))
+
+            # ensure the file's mtime didn't change
+            self.assertTrue(fstats_post.st_mtime, fstats_orig.st_mtime-age)
+
+            # ensure, all 'file.replace' runs reported success
+            self.assertSaltTrueReturn(ret)
+        finally:
+            os.remove(path_test)
 
     def test_sed(self):
         '''


### PR DESCRIPTION
Based on the things reported in #18612, attempted to fix in #18615 and an additional case reported in #18841 I started to write some integration tests for `states.file.replace()`.
All new tests work fine after applying the changes to `modules/file.py` also provided by this PR.

Besides the tests which are provided with this PR, some more things should be tested regarding `replace()` such as:
- are the `flags` honored in all cases?
- can matching groups be used in `repl` in different scenarios?
- is `count` respected in different scenarios?
- handling of `bufsize`/`bufsize='file'`? Do multiline operations work properly?

Due to time limits someone else will have to take care of those.
