### PR TITLE
Add darwin pkg support

### DIFF
--- a/salt/modules/darwin_pkgutil.py
+++ b/salt/modules/darwin_pkgutil.py
@@ -13,9 +13,6 @@ PKGUTIL = "/usr/sbin/pkgutil"
 
 
 def __virtual__():
-    '''
-    Set the virtual pkg module if the os is Solaris
-    '''
     if __grains__['os'] == 'MacOS':
         return 'darwin_pkgutil'
     return False
@@ -24,6 +21,12 @@ def __virtual__():
 def list():
     '''
     List the installed packages.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' darwin_pkgutil.list
     '''
     cmd = PKGUTIL + ' --pkgs'
     return __salt__['cmd.run_stdout'](cmd)
@@ -32,6 +35,12 @@ def list():
 def is_installed(package_id):
     '''
     Returns whether a given package id is installed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' darwin_pkgutil.is_installed com.apple.pkg.gcc4.2Leo
     '''
     def has_package_id(lines):
         for line in lines:
@@ -56,6 +65,13 @@ def _install_from_path(path):
 def install(source, package_id=None):
     '''
     Install a .pkg from an URI or an absolute path.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' darwin_pkgutil.install source=/vagrant/build_essentials.pkg \
+            package_id=com.apple.pkg.gcc4.2Leo
     '''
     if package_id is not None and is_installed(package_id):
         return ''

--- a/salt/modules/darwin_pkgutil.py
+++ b/salt/modules/darwin_pkgutil.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+'''
+Installer support for OS X.
+
+Installer is the native .pkg/.mpkg package manager for OS X.
+'''
+import os.path
+
+from salt.ext.six.moves import urllib
+
+
+PKGUTIL = "/usr/sbin/pkgutil"
+
+
+def __virtual__():
+    '''
+    Set the virtual pkg module if the os is Solaris
+    '''
+    if __grains__['os'] == 'MacOS':
+        return 'darwin_pkgutil'
+    return False
+
+
+def list():
+    '''
+    List the installed packages.
+    '''
+    cmd = PKGUTIL + ' --pkgs'
+    return __salt__['cmd.run_stdout'](cmd)
+
+
+def is_installed(package_id):
+    '''
+    Returns whether a given package id is installed.
+    '''
+    def has_package_id(lines):
+        for line in lines:
+            if line == package_id:
+                return True
+        return False
+
+    cmd = PKGUTIL + ' --pkgs'
+    out = __salt__['cmd.run_stdout'](cmd)
+    return has_package_id(out.splitlines())
+
+
+def _install_from_path(path):
+    if not os.path.exists(path):
+        msg = "Path {0!r} does not exist, cannot install".format(path)
+        raise ValueError(msg)
+    else:
+        cmd = 'installer -pkg "{0}" -target /'.format(path)
+        return __salt__['cmd.retcode'](cmd)
+
+
+def install(source, package_id=None):
+    '''
+    Install a .pkg from an URI or an absolute path.
+    '''
+    if package_id is not None and is_installed(package_id):
+        return ''
+
+    uri = urllib.parse.urlparse(source)
+    if uri.scheme == "":
+        return _install_from_path(source)
+    else:
+        msg = "Unsupported scheme for source uri: {0!r}".format(uri.scheme)
+        raise ValueError(msg)

--- a/tests/unit/modules/darwin_pkgutil_test.py
+++ b/tests/unit/modules/darwin_pkgutil_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from salt.modules import darwin_pkgutil
 
 from salttesting import TestCase, skipIf

--- a/tests/unit/modules/darwin_pkgutil_test.py
+++ b/tests/unit/modules/darwin_pkgutil_test.py
@@ -1,0 +1,85 @@
+from salt.modules import darwin_pkgutil
+
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+
+darwin_pkgutil.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class DarwingPkgutilTestCase(TestCase):
+    def test_list_installed_command(self):
+        # Given
+        r_output = "com.apple.pkg.iTunes"
+
+        # When
+        mock_cmd = MagicMock(return_value=r_output)
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            output = darwin_pkgutil.list()
+
+        # Then
+        mock_cmd.assert_called_with("/usr/sbin/pkgutil --pkgs")
+
+    def test_list_installed_output(self):
+        # Given
+        r_output = "com.apple.pkg.iTunes"
+
+        # When
+        mock_cmd = MagicMock(return_value=r_output)
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            output = darwin_pkgutil.list()
+
+        # Then
+        self.assertEqual(output, r_output)
+
+    def test_is_installed(self):
+        # Given
+        r_output = "com.apple.pkg.iTunes"
+
+        # When
+        mock_cmd = MagicMock(return_value=r_output)
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            ret = darwin_pkgutil.is_installed("com.apple.pkg.iTunes")
+
+        # Then
+        self.assertTrue(ret)
+
+        # When
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            ret = darwin_pkgutil.is_installed("com.apple.pkg.Safari")
+
+        # Then
+        self.assertFalse(ret)
+
+    def test_install(self):
+        # Given
+        source = "/foo/bar/fubar.pkg"
+        package_id = "com.foo.fubar.pkg"
+
+        # When
+        mock_cmd = MagicMock(return_value=True)
+        with patch("salt.modules.darwin_pkgutil.is_installed",
+                   return_value=False) as is_installed:
+            with patch("salt.modules.darwin_pkgutil._install_from_path",
+                   return_value=True) as _install_from_path:
+                ret = darwin_pkgutil.install(source, package_id)
+
+        # Then
+        _install_from_path.assert_called_with(source)
+
+    def test_install_already_there(self):
+        # Given
+        source = "/foo/bar/fubar.pkg"
+        package_id = "com.foo.fubar.pkg"
+
+        # When
+        mock_cmd = MagicMock(return_value=True)
+        with patch("salt.modules.darwin_pkgutil.is_installed",
+                   return_value=True) as is_installed:
+            with patch("salt.modules.darwin_pkgutil._install_from_path",
+                   return_value=True) as _install_from_path:
+                ret = darwin_pkgutil.install(source, package_id)
+
+        # Then
+        self.assertEqual(_install_from_path.called, 0)


### PR DESCRIPTION
This PR implements installation of `.pkg` on OS X. This is the modules level implementation, but if the proof of concept is accepted by the project, I'd like to implement the state-level as well.

Missing features:
- state support
- install from a .dmg
- install from uris (especially remote ones)
