### PR TITLE
Switch from smbclient to impacket

### DIFF
--- a/doc/topics/cloud/windows.rst
+++ b/doc/topics/cloud/windows.rst
@@ -9,11 +9,20 @@ Windows images.
 
 Requirements
 ============
-Salt Cloud makes use of `smbclient` and `winexe` to set up the Windows Salt
-Minion installer. `smbclient` may be part of either the `samba` package, or its
-own `smbclient` package, depending on the distribution. `winexe` is less
-commonly available in distribution-specific repositories. However, it is
-currently being built for various distributions in 3rd party channels:
+Salt Cloud makes use of `impacket` and `winexe` to set up the Windows Salt
+Minion installer.
+
+`impacket` is usually available as either the `impacket` or the
+`python-impacket` package, depending on the distribution. More information on
+`impacket` can be found at the project home:
+
+* `impacket project home`__
+
+.. __: https://code.google.com/p/impacket/
+
+`winexe` is less commonly available in distribution-specific repositories.
+However, it is currently being built for various distributions in 3rd party
+channels:
 
 * `RPMs at pbone.net`__
 

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1922,6 +1922,7 @@ def wait_for_instance(
                     # be generated for at least 4 minutes
                     time.sleep(60)
                 else:
+                    vm_['win_password'] = win_passwd
                     break
 
         if not salt.utils.cloud.wait_for_port(ip_address,


### PR DESCRIPTION
This replaces our samba dependency with a dependency on impacket. Because we are no longer shelling out to perform SMB commands, this should speed up things a bit. Also, impacket has been a really nice library to use, and I feel like the Salt Cloud code has been simplified greatly here.
