### PR TITLE
Fix traceback for non-string values in lxc config files

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1828,8 +1828,12 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset):
                 if not row:
                     continue
                 for conf in row:
-                    filtered_lxc_conf.append((conf.strip(),
-                                              row[conf].strip()))
+                    try:
+                        filtered_lxc_conf.append((conf.strip(),
+                                                  row[conf].strip()))
+                    except AttributeError:
+                        filtered_lxc_conf.append((conf.strip(),
+                                                  str(row[conf]).strip()))
             ret['comment'] = 'lxc.conf is up to date'
             lines = []
             orig_config = fic.read()


### PR DESCRIPTION
Resolves #19055.
