### PR TITLE
Fix salt-ssh with sudo and tty enabled

### DIFF
--- a/salt/client/ssh/shell.py
+++ b/salt/client/ssh/shell.py
@@ -197,6 +197,9 @@ class Shell(object):
         # TODO: if tty, then our SSH_SHIM cannot be supplied from STDIN Will
         # need to deliver the SHIM to the remote host and execute it there
 
+        tty = self.tty
+        if ssh != 'ssh':
+            tty = False
         if self.passwd:
             opts = self._passwd_opts()
         if self.priv:
@@ -204,7 +207,7 @@ class Shell(object):
         return "{0} {1} {2} {3} {4}".format(
                 ssh,
                 '' if ssh == 'scp' else self.host,
-                '-t -t' if self.tty else '',
+                '-t -t' if tty else '',
                 opts,
                 cmd)
 

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -177,7 +177,14 @@ def main(argv):
     sys.stdout.flush()
     sys.stderr.write(OPTIONS.delimiter + '\n')
     sys.stderr.flush()
-    if OPTIONS.wipe:
+    if OPTIONS.tty:
+        import subprocess
+        stdout, stderr = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+        sys.stdout.write(stdout)
+        sys.stdout.flush()
+        if OPTIONS.wipe:
+            shutil.rmtree(OPTIONS.saltdir)
+    elif OPTIONS.wipe:
         import subprocess
         subprocess.call(salt_argv)
         shutil.rmtree(OPTIONS.saltdir)


### PR DESCRIPTION
First problem: we were passing `-t -t` to scp commands, which isn't supported.

Second problem: Because we're using a tty, we only get a combined stdout and stderr. So we throw away the stderr from our salt command and we don't worry about the lack of an RSTR in the stderr on the master side

Fixes #16847
