### PR TITLE
fix ec2 cloud provider for endpoint URLs with paths

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -314,8 +314,11 @@ def query(params=None, setname=None, requesturl=None, location=None,
             )
 
             requesturl = 'https://{0}/'.format(endpoint)
+            endpoint = urlparse.urlparse(requesturl).netloc
+            endpoint_path = urlparse.urlparse(requesturl).path
         else:
             endpoint = _urlparse(requesturl).netloc
+            endpoint_path = urlparse.urlparse(requesturl).path
             if endpoint == '':
                 endpoint_err = (
                         'Could not find a valid endpoint in the '
@@ -347,9 +350,10 @@ def query(params=None, setname=None, requesturl=None, location=None,
         # %20, however urlencode uses '+'. So replace pluses with %20.
         querystring = querystring.replace('+', '%20')
 
-        uri = '{0}\n{1}\n/\n{2}'.format(method.encode('utf-8'),
-                                        endpoint.encode('utf-8'),
-                                        querystring.encode('utf-8'))
+        uri = '{0}\n{1}\n{2}\n{3}'.format(method.encode('utf-8'),
+                                          endpoint.encode('utf-8'),
+                                          endpoint_path.encode('utf-8'),
+                                          querystring.encode('utf-8'))
 
         hashed = hmac.new(provider['key'], uri, hashlib.sha256)
         sig = binascii.b2a_base64(hashed.digest())

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2880,7 +2880,7 @@ def _vm_provider_driver(vm_):
 
 
 def _extract_name_tag(item):
-    if 'tagSet' in item:
+    if 'tagSet' in item and item['tagSet'] is not None:
         tagset = item['tagSet']
         if isinstance(tagset['item'], list):
             for tag in tagset['item']:


### PR DESCRIPTION
The EC2 endpoint for the NeCTAR OpenStack cloud has a path end.
The logic in the `ec2.py` cloud module did not handle that properly, leading to failed authentication.
This small patch fixed it for me. I don't, however, have extensive EC2 experience or experience with other EC2 compatible endpoints.
Happy to iterate on this/test further until everyone is happy.
