### PR TITLE
Fix states.schedule examples

### DIFF
--- a/salt/states/schedule.py
+++ b/salt/states/schedule.py
@@ -28,10 +28,10 @@ Management of the Salt scheduler
     job1:
       schedule.present:
         - function: state.sls
-        - args:
+        - job_args:
           - httpd
-        - kwargs:
-          test: True
+        - job_kwargs:
+            test: True
         - when:
             - Monday 5:00pm
             - Tuesday 3:00pm
@@ -45,10 +45,10 @@ Management of the Salt scheduler
     job1:
       schedule.present:
         - function: state.sls
-        - args:
+        - job_args:
           - httpd
-        - kwargs:
-          test: True
+        - job_kwargs:
+            test: True
         - cron: '*/5 * * * *'
 
     Scheduled jobs can also be specified using the format used by cron.  This will


### PR DESCRIPTION
Salt Schedule system is awesome, but examples were broken.

**Note:** this PR is against **2014.7** as I was told on IRC :+1: 
