### PR TITLE
Fix regression in lxc.update_lxc_conf

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1885,7 +1885,7 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset):
             if conf_changed:
                 with salt.utils.fopen('{0}.{1}'.format(lxc_conf_p, chrono), 'w') as wfic:
                     wfic.write(conf)
-                with salt.utils.fopen(lxc_conf_p, 'w') as wific:
+                with salt.utils.fopen(lxc_conf_p, 'w') as wfic:
                     wfic.write(conf)
                 ret['comment'] = 'Updated'
                 ret['result'] = True


### PR DESCRIPTION
This regression snuck in after the 2014.7.0 release, in d447cead. Fixing this
ahead of the 2014.7.1 release.
