### PR TITLE
Fix some mistakes from the merge forward

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -494,19 +494,6 @@ def highstate(test=None,
     serial = salt.payload.Serial(__opts__)
     cache_file = os.path.join(__opts__['cachedir'], 'highstate.p')
 
-    # Not 100% if this should be fatal or not,
-    # but I'm guessing it likely should not be.
-    cumask = os.umask(077)
-    try:
-        if salt.utils.is_windows():
-            # Make sure cache file isn't read-only
-            __salt__['cmd.run'](['attrib', '-R', cache_file], python_shell=False)
-        with salt.utils.fopen(cache_file, 'w+b') as fp_:
-            serial.dump(ret, fp_)
-    except (IOError, OSError):
-        msg = 'Unable to write to "state.highstate" cache file {0}'
-        log.error(msg.format(cache_file))
-    os.umask(cumask)
     _set_retcode(ret)
     # Work around Windows multiprocessing bug, set __opts__['test'] back to
     # value from before this function was run.

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -74,7 +74,6 @@ import salt.utils.cache
 import salt.utils.dicttrim
 import salt.utils.process
 import salt.utils.zeromq
-from salt._compat import string_types
 log = logging.getLogger(__name__)
 
 # The SUB_EVENT set is for functions that require events fired based on
@@ -625,7 +624,6 @@ class EventReturn(multiprocessing.Process):
         Return an EventReturn instance
         '''
         multiprocessing.Process.__init__(self)
-        salt.state.Compiler.__init__(self, opts)
 
         self.opts = opts
         self.event_return_queue = self.opts['event_return_queue']
@@ -633,107 +631,25 @@ class EventReturn(multiprocessing.Process):
         local_minion_opts['file_client'] = 'local'
         self.minion = salt.minion.MasterMinion(local_minion_opts)
 
-    def render_reaction(self, glob_ref, tag, data):
-        '''
-        Execute the render system against a single reaction file and return
-        the data structure
-        '''
-        react = {}
-
-        if glob_ref.startswith('salt://'):
-            glob_ref = self.minion.functions['cp.cache_file'](glob_ref)
-
-        for fn_ in glob.glob(glob_ref):
-            try:
-                react.update(self.render_template(
-                    fn_,
-                    tag=tag,
-                    data=data))
-            except Exception:
-                log.error('Failed to render "{0}"'.format(fn_))
-        return react
-
-    def list_reactors(self, tag):
-        '''
-        Take in the tag from an event and return a list of the reactors to
-        process
-        '''
-        log.debug('Gathering reactors for tag {0}'.format(tag))
-        reactors = []
-        if isinstance(self.opts['reactor'], string_types):
-            try:
-                with salt.utils.fopen(self.opts['reactor']) as fp_:
-                    react_map = yaml.safe_load(fp_.read())
-            except (OSError, IOError):
-                log.error(
-                    'Failed to read reactor map: "{0}"'.format(
-                        self.opts['reactor']
-                        )
-                    )
-            except Exception:
-                log.error(
-                    'Failed to parse YAML in reactor map: "{0}"'.format(
-                        self.opts['reactor']
-                        )
-                    )
-        else:
-            react_map = self.opts['reactor']
-        for ropt in react_map:
-            if not isinstance(ropt, dict):
-                continue
-            if len(ropt) != 1:
-                continue
-            key = ropt.iterkeys().next()
-            val = ropt[key]
-            if fnmatch.fnmatch(tag, key):
-                if isinstance(val, string_types):
-                    reactors.append(val)
-                elif isinstance(val, list):
-                    reactors.extend(val)
-        return reactors
-
-    def reactions(self, tag, data, reactors):
-        '''
-        Render a list of reactor files and returns a reaction struct
-        '''
-        log.debug('Compiling reactions for tag {0}'.format(tag))
-        high = {}
-        chunks = []
-        for fn_ in reactors:
-            high.update(self.render_reaction(fn_, tag, data))
-        if high:
-            errors = self.verify_high(high)
-            if errors:
-                log.error(('Unable to render reactions for event {0} due to '
-                           'errors ({1}) in one or more of the sls files ({2})').format(tag, errors, reactors))
-                return []  # We'll return nothing since there was an error
-            chunks = self.order_chunks(self.compile_high_data(high))
-        return chunks
-
-    def call_reactions(self, chunks):
-        '''
-        Execute the reaction state
-        '''
-        for chunk in chunks:
-            self.wrap.run(chunk)
-
     def run(self):
         '''
         Spin up the multiprocess event returner
         '''
         salt.utils.appendproctitle(self.__class__.__name__)
-
-        # instantiate some classes inside our new process
-        self.event = SaltEvent('master', self.opts['sock_dir'])
-        self.wrap = ReactWrap(self.opts)
-
-        for data in self.event.iter_events(full=True):
-            reactors = self.list_reactors(data['tag'])
-            if not reactors:
-                continue
-            chunks = self.reactions(data['tag'], data['data'], reactors)
-            if chunks:
-                self.call_reactions(chunks)
+        self.event = get_event('master', opts=self.opts)
+        events = self.event.iter_events(full=True)
+        self.event.fire_event({}, 'salt/event_listen/start')
+        event_queue = []
+        try:
+            for event in events:
+                if self._filter(event):
+                    event_queue.append(event)
+                if len(event_queue) >= self.event_return_queue:
+                    self.minion.returners['{0}.event_return'.format(self.opts['event_return'])](event_queue)
+                    event_queue = []
+        except KeyError:
+            log.error('Could not store return for events {0}. Returner {1} '
+                      'not found.'.format(events, self.opts.get('event_return', None)))
 
     def _filter(self, event):
         '''
@@ -750,65 +666,6 @@ class EventReturn(multiprocessing.Process):
         elif tag in self.opts['event_return_blacklist']:
             return False
         return True
-
-
-class ReactWrap(object):
-    '''
-    Create a wrapper that executes low data for the reaction system
-    '''
-    # class-wide cache of clients
-    client_cache = None
-
-    def __init__(self, opts):
-        self.opts = opts
-        if ReactWrap.client_cache is None:
-            ReactWrap.client_cache = salt.utils.cache.CacheDict(opts['reactor_refresh_interval'])
-
-        self.pool = salt.utils.process.ThreadPool(
-            self.opts['reactor_worker_threads'],  # number of workers for runner/wheel
-            queue_size=self.opts['reactor_worker_hwm']  # queue size for those workers
-        )
-
-    def run(self, low):
-        '''
-        Execute the specified function in the specified state by passing the
-        LowData
-        '''
-        l_fun = getattr(self, low['state'])
-        try:
-            f_call = salt.utils.format_call(l_fun, low)
-            l_fun(*f_call.get('args', ()), **f_call.get('kwargs', {}))
-        except Exception:
-            log.error(
-                    'Failed to execute {0}: {1}\n'.format(low['state'], l_fun),
-                    exc_info=True
-                    )
-
-    def local(self, *args, **kwargs):
-        '''
-        Wrap LocalClient for running :ref:`execution modules <all-salt.modules>`
-        '''
-        if 'local' not in self.client_cache:
-            self.client_cache['local'] = salt.client.LocalClient(self.opts['conf_file'])
-        self.client_cache['local'].cmd_async(*args, **kwargs)
-
-    cmd = local
-
-    def runner(self, fun, **kwargs):
-        '''
-        Wrap RunnerClient for executing :ref:`runner modules <all-salt.runners>`
-        '''
-        if 'runner' not in self.client_cache:
-            self.client_cache['runner'] = salt.runner.RunnerClient(self.opts)
-        self.pool.fire_async(self.client_cache['runner'].low, args=(fun, kwargs))
-
-    def wheel(self, fun, **kwargs):
-        '''
-        Wrap Wheel to enable executing :ref:`wheel modules <all-salt.wheel>`
-        '''
-        if 'wheel' not in self.client_cache:
-            self.client_cache['wheel'] = salt.wheel.Wheel(self.opts)
-        self.pool.fire_async(self.client_cache['wheel'].low, args=(fun, kwargs))
 
 
 class StateFire(object):


### PR DESCRIPTION
@jacksontj FYI this means that 06e9b02ac94274e2fc631e52094235c9ac8f8d4c and 036462592ad596458dbe54f11caf7a797ad98fb2 are not in develop. You should coordinate with @cachedout, who recently rewrote most of salt/utils/event.py, and see if those apply anymore.
