### PR TITLE
Add minimum version requirement for six

### DIFF
--- a/_requirements.txt
+++ b/_requirements.txt
@@ -3,4 +3,4 @@ msgpack-python > 0.3
 PyYAML
 MarkupSafe
 requests >= 1.0.0
-six
+six >= 1.4.0


### PR DESCRIPTION
Salt uses the function add_metaclass function which had a different name
prior to six version 1.4.0.

See issue #19100
