### PR TITLE
Add IP reversal to network module

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -930,6 +930,19 @@ def is_loopback(ip_addr):
     return salt.utils.network.IPv4Address(ip_addr).is_loopback
 
 
+def reverse_ip(cidr):
+    '''
+    Returns the reversed IP address
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.reverse_ip 172.17.0.4
+    '''
+    return salt.utils.network.IPv4Address(ip_addr).reverse_pointer
+
+
 def _get_bufsize_linux(iface):
     '''
     Return network interface buffer information using ethtool

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -930,7 +930,7 @@ def is_loopback(ip_addr):
     return salt.utils.network.IPv4Address(ip_addr).is_loopback
 
 
-def reverse_ip(cidr):
+def reverse_ip(ip_addr):
     '''
     Returns the reversed IP address
 

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -1183,3 +1183,10 @@ class IPv4Address(object):
         :return: True if the address is a loopback address. Otherwise False.
         '''
         return 127 == self.dotted_quad[0]
+
+    @property
+    def reverse_pointer(self):
+        '''
+        :return: Reversed IP address
+        '''
+        return '.'.join(reversed(self.dotted_quad)) + '.in-addr.arpa.'


### PR DESCRIPTION
For a state I'm working on I needed a way to obtain the reversed IP address. 
Salt does have some nice tools to grab information (resolving hosts, arp etc) but was missing a feature to return a reversed IP.
