### PR TITLE
Fix regression in __pillar__ dunder

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -281,7 +281,7 @@ class SMinion(object):
             self.opts,
             self.opts['grains'],
             self.opts['id'],
-            self.opts['environment'],
+            self.opts['environment']
         ).compile_pillar()
         self.functions = salt.loader.minion_mods(self.opts, include_errors=True)
         self.function_errors = self.functions['_errors']
@@ -619,14 +619,13 @@ class Minion(MinionBase):
                                           timeout,
                                           safe)
 
-        self.functions, self.returners, self.function_errors = self._load_modules()
         self.opts['pillar'] = salt.pillar.get_pillar(
             opts,
             opts['grains'],
             opts['id'],
-            opts['environment'],
-            funcs=self.functions
+            opts['environment']
         ).compile_pillar()
+        self.functions, self.returners, self.function_errors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)
@@ -2673,14 +2672,13 @@ class ProxyMinion(Minion):
         opts.update(resolve_dns(opts))
         self.opts = opts
         self.authenticate(timeout, safe)
-        self.functions, self.returners, self.function_errors = self._load_modules()
         self.opts['pillar'] = salt.pillar.get_pillar(
             opts,
             opts['grains'],
             opts['id'],
-            opts['environment'],
-            funcs=self.functions
+            opts['environment']
         ).compile_pillar()
+        self.functions, self.returners, self.function_errors = self._load_modules()
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)


### PR DESCRIPTION
In `salt.minion.Minion.__init__()`, `self._load_modules()` is invoked, which loads
the execution modules via `salt.loader.Loader.gen_modules()`. However, this
function also assigns the `__pillar__` dunder to each execution module, and the
necessary pillar data wasn't being compiled until the line _after_
`salt.minion.Minion._load_modules()` was invoked.

This looks to have been changed in 4be8ff95, in order to be able to pass the
minion's functions to `salt.pillar.get_pillar()`, avoiding another invocation of
the loader in `salt.pillar.Pillar.__init__()`, but this came at the expense of
breaking the `__pillar__` dunder.

Fixes #18867.

CC: @thatch45 @cachedout, please double-check this pull request, and let me
know if there is a better fix for this.
