### PR TITLE
Fixed bug in client. Needs parens on if logic (and not on both or clause...

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -808,7 +808,9 @@ class LocalClient(object):
                 try:
                     raw = event.get_event_noblock()
                     if gather_errors:
-                        if raw and raw.get('tag', '').startswith('_salt_error') or raw.get('tag', '').startswith(jid_tag):
+                        if (raw and
+                               (raw.get('tag', '').startswith('_salt_error') or
+                                raw.get('tag', '').startswith(jid_tag))):
                             yield raw
                     else:
                         if raw and raw.get('tag', '').startswith(jid_tag):


### PR DESCRIPTION
``` python
if (raw and
        (raw.get('tag', '').startswith('_salt_error') or
         raw.get('tag', '').startswith(jid_tag))):
     yield raw
```
