### PR TITLE
removed debug line

### DIFF
--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -921,8 +921,6 @@ class SaltRaetRouter(ioflo.base.deeding.Deed):
         msg is message body dict
         sender is unique name  of remote that sent the message
         '''
-        import wingdbstub
-
         try:
             s_estate, s_yard, s_share = msg['route']['src']
             d_estate, d_yard, d_share = msg['route']['dst']


### PR DESCRIPTION
List of minion roles in

msg['return']['ret']['minions'] is intersected with available minions

So only expected returners are avalable

Also cleaned up joint definitions for salt.presence.event_req and salt.presence.availables so that the init value is only given once.
