### PR TITLE
Add support for mine.get in salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -812,7 +812,10 @@ class Single(object):
                 self.kwargs = {}
 
         try:
-            result = self.wfuncs[self.fun](*self.args, **self.kwargs)
+            if self.mine:
+                result = wrapper[self.fun](*self.args, **self.kwargs)
+            else:
+                result = self.wfuncs[self.fun](*self.args, **self.kwargs)
         except TypeError as exc:
             result = 'TypeError encountered executing {0}: {1}'.format(self.fun, exc)
         except Exception as exc:

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -796,7 +796,7 @@ class Single(object):
         # roster, pillar, master config (in that order)
         if self.mine:
             mine_args = None
-            if self.mine_functions and self.fun in mine_functions:
+            if self.mine_functions and self.fun in self.mine_functions:
                 mine_args = self.mine_functions[self.fun]
             elif opts['pillar'] and self.fun in opts['pillar'].get('mine_functions', {}):
                 mine_args = opts['pillar']['mine_functions'][self.fun]

--- a/salt/client/ssh/wrapper/mine.py
+++ b/salt/client/ssh/wrapper/mine.py
@@ -8,8 +8,11 @@ def get(tgt, fun, expr_form='glob', roster='flat'):
     '''
     Get data from the mine based on the target, function and expr_form
 
-    This is basically a wrapper around publish.publish, as salt-ssh clients
-    can't update the mine themselves.
+    This will actually run the function on all targeted minions (like
+    publish.publish), as salt-ssh clients can't update the mine themselves.
+
+    We will look for mine_functions in the roster, pillar, and master config,
+    in that order, looking for a match for the defined function
 
     Targets can be matched based on any standard matching system that can be
     matched on the defined roster (in salt-ssh) via these keywords::

--- a/salt/client/ssh/wrapper/mine.py
+++ b/salt/client/ssh/wrapper/mine.py
@@ -1,0 +1,28 @@
+'''
+Wrapper function for mine operations for salt-ssh
+
+.. versionadded:: Lithium
+'''
+
+def get(tgt, fun, expr_form='glob', roster='flat'):
+    '''
+    Get data from the mine based on the target, function and expr_form
+
+    This is basically a wrapper around publish.publish, as salt-ssh clients
+    can't update the mine themselves.
+
+    Targets can be matched based on any standard matching system that can be
+    matched on the defined roster (in salt-ssh) via these keywords::
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-ssh '*' mine.get '*' network.interfaces
+        salt-ssh '*' mine.get 'myminion' network.interfaces roster=flat
+        salt-ssh '*' mine.get '192.168.5.0' network.ipaddrs roster=scan
+    '''
+    return __salt__['publish.publish'](tgt,
+                                       fun,
+                                       expr_form=expr_form,
+                                       roster=roster)

--- a/salt/client/ssh/wrapper/mine.py
+++ b/salt/client/ssh/wrapper/mine.py
@@ -4,6 +4,13 @@ Wrapper function for mine operations for salt-ssh
 .. versionadded:: Lithium
 '''
 
+# Import python libs
+import copy
+
+# Import salt libs
+import salt.client.ssh
+
+
 def get(tgt, fun, expr_form='glob', roster='flat'):
     '''
     Get data from the mine based on the target, function and expr_form


### PR DESCRIPTION
Fixes #7903 

Added support for `mine.get` as a wrapper function.

Similar to publish, `mine.get` will call to each target using args from `mine_functions` out of the roster, pillar, or master config (in that order).

This is very slow, as it is basically a nested wfunc call, so we will generate pillar and grains a second time for each minion. However, it also means salt-ssh is mostly feature complete.

Will be adding to the mine docs tomorrow.
