### PR TITLE
LXC Refactor

### DIFF
--- a/doc/ref/modules/all/salt.modules.lxc.rst
+++ b/doc/ref/modules/all/salt.modules.lxc.rst
@@ -4,3 +4,4 @@ salt.modules.lxc
 
 .. automodule:: salt.modules.lxc
     :members:
+    :exclude-members: set_pass

--- a/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
+++ b/doc/topics/troubleshooting/yaml_idiosyncrasies.rst
@@ -33,8 +33,8 @@ fact that the data is uniform and not deeply nested.
 
 .. _nested-dict-indentation:
 
-Nested Dicts (key=value)
-------------------------
+Nested Dictionaries
+-------------------
 
 When :ref:`dicts <python2:typesmapping>` are nested within other data
 structures (particularly lists), the indentation logic sometimes changes.
@@ -61,8 +61,8 @@ Notice that while the indentation is two spaces per level, for the values under
 the ``context`` and ``defaults`` options there is a four-space indent. If only
 two spaces are used to indent, then those keys will be considered part of the
 same dictionary that contains the ``context`` key, and so the data will not be
-loaded correctly.  If using a double indent is not desirable, then a deeply-nested dict
-can be declared with curly braces:
+loaded correctly. If using a double indent is not desirable, then a
+deeply-nested dict can be declared with curly braces:
 
 .. code-block:: yaml
 

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -1,0 +1,29 @@
+.. _tutorial-lxc:
+
+========================
+LXC Management with Salt
+========================
+
+.. note::
+
+    This walkthrough assumes basic knowledge of Salt. To get up to speed, check
+    out the :doc:`Salt Walkthrough </topics/tutorials/walkthrough>`.
+
+.. warning::
+
+    Some of the features described here are only currently available in the
+    ``2014.7`` and ``develop`` branches, and will not be available in an
+    official Salt release until version 2014.7.1. These features will be
+    clearly labeled as such below.
+
+Put an opening paragraph here. Level headings are: = - ~ in that order.
+
+
+Dependencies
+============
+
+.. _tutorial-lxc-profiles:
+
+Profiles
+========
+

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -222,8 +222,8 @@ container, with three values:
 The :mod:`lxc.images <salt.modules.lxc.images>` function (new in version
 2015.2.0) can be used to list the available images. Alternatively, the releases
 can be viewed on http://images.linuxcontainers.org/images/. The images are
-organized in such a way that the dist, release, and arch can be determined
-using the following URL format:
+organized in such a way that the **dist**, **release**, and **arch** can be
+determined using the following URL format:
 ``http://images.linuxcontainers.org/images/dist/release/arch``. For example,
 ``http://images.linuxcontainers.org/images/centos/6/amd64`` would correspond to
 a **dist** of ``centos``, a **release** of ``6``, and an **arch** of ``amd64``.

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -26,7 +26,7 @@ packaged:
 
 - RHEL/CentOS 6 and later (via EPEL_)
 - Fedora (All non-EOL releases)
-- Debian 8.0 (Jessie) (not yet released)
+- Debian 8.0 (Jessie)
 - Ubuntu 14.04 LTS and later (LXC templates are packaged separately as
   **lxc-templates**, it is recommended to also install this package)
 - openSUSE 13.2 and later

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -27,9 +27,8 @@ packaged:
 - RHEL/CentOS 6 and later (via EPEL_)
 - Fedora (All non-EOL releases)
 - Debian 8.0 (Jessie) (not yet released)
-- Ubuntu 14.04 LTS and later
-  - LXC templates packaged separately (as **lxc-templates**), it is recommended
-    to also install this package.
+- Ubuntu 14.04 LTS and later (LXC templates are packaged separately as
+  **lxc-templates**, it is recommended to also install this package)
 - openSUSE 13.2 and later
 
 .. _EPEL: https://fedoraproject.org/wiki/EPEL
@@ -200,9 +199,10 @@ instance, the ``ubuntu`` template uses deb_bootstrap, the ``centos`` template
 uses yum, etc., making these templates impractical when a container from a
 different OS is desired.
 
-To create a CentOS container named ``container1`` on a CentOS minion named
-``mycentosminion``, using the ``centos`` LXC template, one can simply run the
-following command:
+The :mod:`lxc.create <salt.modules.lxc.create>` function is used to create
+containers using a template script. To create a CentOS container named
+``container1`` on a CentOS minion named ``mycentosminion``, using the
+``centos`` LXC template, one can simply run the following command:
 
 .. code-block:: bash
 
@@ -241,7 +241,7 @@ container, the following command can be used:
 
     .. code-block:: yaml
 
-        lxc.container_profile.centos:
+        lxc.container_profile.cent6:
           template: download
           options:
             dist: centos
@@ -251,3 +251,47 @@ container, the following command can be used:
     The ``options`` parameter is not supported in profiles for the 2014.7.x
     release cycle and earlier, so it would still need to be provided on the
     command-line.
+
+
+Cloning an Existing Container
+-----------------------------
+
+To clone a container, use the :mod:`lxc.clone <salt.modules.lxc.clone>`
+function:
+
+.. code-block:: bash
+
+    salt myminion lxc.clone container2 orig=container1
+
+
+Using a Container Image
+-----------------------
+
+While cloning is a good way to create new containers from a common base
+container, the source container that is being cloned needs to already exist on
+the minion. This makes deploying a common container across minions difficult.
+For this reason, Salt's :mod:`lxc.create <salt.modules.lxc.create>` is capable
+of installing a container from a tar archive of another container's rootfs. To
+create an image of a container named ``cent6``, run the following command as
+root:
+
+.. code-block:: bash
+
+    tar czf cent6.tar.gz -C /var/lib/lxc/cent6 rootfs
+
+The resulting tarball can then be placed alongside the files in the salt
+fileserver and referenced using a ``salt://`` URL. To create a container using
+an image, use the ``image`` parameter with :mod:`lxc.create
+<salt.modules.lxc.create>`:
+
+.. code-block:: bash
+
+    salt myminion lxc.create new-cent6 image=salt://path/to/cent6.tar.gz
+
+
+Container Management Using States
+=================================
+
+Several states are being renamed for the next feature release. The information
+in this tutorial refers to the new states. For 2014.7.x and earlier, please
+refer to the :mod:`documentation for the LXC states <salt.states.lxc>`.

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -12,8 +12,8 @@ LXC Management with Salt
 .. warning::
 
     Some features are only currently available in the ``develop`` branch, and
-    will not be available in an official Salt release until the next feature
-    release (codenamed "Lithium"). These new features will be clearly labeled.
+    are new in the upcoming 2015.2.0 release. These new features will be
+    clearly labeled.
     
 
 Dependencies
@@ -78,8 +78,8 @@ defined underneath the ``lxc.profile`` config option:
 However, due to the way that :mod:`config.get <salt.modules.config.get>` works,
 this means that if a ``lxc.profile`` key is defined in both the master config
 file and in a specific minion's config file, that will cause all profiles to be
-overwritten for that minion. For greater flexibility, in the next feature
-release each container profile should be configured in its own key, in the
+overwritten for that minion. For greater flexibility, starting in version
+2015.2.0 each container profile should be configured in its own key, in the
 format ``lxc.container_profile.profile_name``. For example:
 
 .. code-block:: yaml
@@ -102,22 +102,23 @@ without also removing the ``centos`` profile. The legacy usage will still be
 supported for a couple release cycles, to allow for some time to update
 configurations.
 
-Additionally, in the next feature release, container profiles have been
-expanded to support passing template-specific CLI options. Below is a table
-describing the parameters which can be configured in container profiles:
+Additionally, in version 2015.2.0 container profiles have been expanded to
+support passing template-specific CLI options to :mod:`lxc.create
+<salt.modules.lxc.create>`. Below is a table describing the parameters which
+can be configured in container profiles:
 
-================== ===================================== ====================
-Parameter          Develop Branch (Next Feature Release) 2014.7.x and Earlier
-================== ===================================== ====================
-*template*:sup:`1` Yes                                   Yes
-*options*:sup:`1`  Yes                                   No
-*image*:sup:`1`    Yes                                   Yes
-*backing*          Yes                                   Yes
-*snapshot*:sup:`2` Yes                                   Yes
-*lvname*:sup:`1`   Yes                                   Yes
-*fstype*:sup:`1`   Yes                                   Yes
-*size*             Yes                                   Yes
-================== ===================================== ====================
+================== ================== ====================
+Parameter          2015.2.0 and Newer 2014.7.x and Earlier
+================== ================== ====================
+*template*:sup:`1` Yes                Yes
+*options*:sup:`1`  Yes                No
+*image*:sup:`1`    Yes                Yes
+*backing*          Yes                Yes
+*snapshot*:sup:`2` Yes                Yes
+*lvname*:sup:`1`   Yes                Yes
+*fstype*:sup:`1`   Yes                Yes
+*size*             Yes                Yes
+================== ================== ====================
 
 1. Parameter is only supported for container creation, and will be ignored if
    the profile is used when cloning a container.
@@ -149,8 +150,8 @@ defined underneath the ``lxc.nic`` config option:
 However, due to the way that :mod:`config.get <salt.modules.config.get>` works,
 this means that if a ``lxc.nic`` key is defined in both the master config file
 and in a specific minion's config file, that will cause all network profiles to
-be overwritten for that minion. For greater flexibility, in the next feature
-release each container profile should be configured in its own key, in the
+be overwritten for that minion. For greater flexibility, starting with version
+2015.2.0 each network profile should be configured in its own key, in the
 format ``lxc.network_profile.profile_name``. For example:
 
 .. code-block:: yaml
@@ -218,10 +219,10 @@ container, with three values:
 2. **release** - the release name/version (i.e. ``trusty`` or ``6``)
 3. **arch** - CPU architecture (i.e. ``amd64`` or ``i386``)
 
-The :mod:`lxc.images <salt.modules.lxc.images>` function (new in the next
-feature release) can be used to list the available images. Alternatively, the
-releases can be viewed on http://images.linuxcontainers.org/images/. The images
-are organized in such a way that the dist, release, and arch can be determined
+The :mod:`lxc.images <salt.modules.lxc.images>` function (new in version
+2015.2.0) can be used to list the available images. Alternatively, the releases
+can be viewed on http://images.linuxcontainers.org/images/. The images are
+organized in such a way that the dist, release, and arch can be determined
 using the following URL format:
 ``http://images.linuxcontainers.org/images/dist/release/arch``. For example,
 ``http://images.linuxcontainers.org/images/centos/6/amd64`` would correspond to
@@ -352,12 +353,12 @@ Running Commands Within a Container
 For containers which are not running their own Minion, commands can be run
 within the container in a manner similar to using (:mod:`cmd.run
 <salt.modules.cmdmod.run`). The means of doing this have been changed
-significantly in the new feature release (though the deprecated behavior will
-still be supported for a couple releases). Both the old and new usage are
-documented below.
+significantly in version 2015.2.0 (though the deprecated behavior will still be
+supported for a few releases). Both the old and new usage are documented
+below.
 
-Develop Branch (Next Feature Release)
--------------------------------------
+2015.2.0 and Newer
+------------------
 
 New functions have been added to mimic the behavior of the functions in the
 :mod:`cmd <salt.modules.cmdmod>` module. Below is a table with the :mod:`cmd
@@ -412,8 +413,8 @@ To run a command and return all information:
 Container Management Using States
 =================================
 
-Several states are being renamed or otherwise modified for the next feature
-release. The information in this tutorial refers to the new states. For
+Several states are being renamed or otherwise modified in version 2015.2.0. The
+information in this tutorial refers to the new states. For
 2014.7.x and earlier, please refer to the :mod:`documentation for the LXC
 states <salt.states.lxc>`.
 

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -11,19 +11,243 @@ LXC Management with Salt
 
 .. warning::
 
-    Some of the features described here are only currently available in the
-    ``2014.7`` and ``develop`` branches, and will not be available in an
-    official Salt release until version 2014.7.1. These features will be
-    clearly labeled as such below.
-
-Put an opening paragraph here. Level headings are: = - ~ in that order.
-
+    Some features are only currently available in the ``develop`` branch, and
+    will not be available in an official Salt release until the next feature
+    release (codenamed "Lithium"). These new features will be clearly labeled.
+    
 
 Dependencies
 ============
+
+Manipulation of LXC containers in Salt requires the minion to have an LXC
+version of at least 1.0 (an alpha or beta release of LXC 1.0 is acceptable).
+The following distributions are known to have new enough versions of LXC
+packaged:
+
+- RHEL/CentOS 6 and later (via EPEL_)
+- Fedora (All non-EOL releases)
+- Debian 8.0 (Jessie) (not yet released)
+- Ubuntu 14.04 LTS and later
+  - LXC templates packaged separately (as **lxc-templates**), it is recommended
+    to also install this package.
+- openSUSE 13.2 and later
+
+.. _EPEL: https://fedoraproject.org/wiki/EPEL
+
 
 .. _tutorial-lxc-profiles:
 
 Profiles
 ========
 
+Profiles allow for a sort of shorthand for commonly-used
+configurations to be defined in the minion config file, :ref:`grains
+<targeting-grains>`, :ref:`pillar <pillar>`, or the master config file. The
+profile is retrieved by Salt using the :mod:`config.get
+<salt.modules.config.get>` function, which looks in those locations, in that
+order. This allows for profiles to be defined centrally in the master config
+file, with several options for overriding them (if necessary) on groups of
+minions or individual minions.
+
+There are two types of profiles, one for defining the parameters used in
+container creation, and one for defining the container's network interface(s).
+
+.. _tutorial-lxc-profiles-container:
+
+Container Profiles
+------------------
+
+In the 2014.7 release cycle and earlier, LXC container profiles were all
+defined underneath the ``lxc.profile`` config option:
+
+.. code-block:: yaml
+
+    lxc.profile:
+      centos:
+        template: centos
+        backing: lvm
+        vgname: vg1
+        lvname: lxclv
+        size: 10G
+      centos_big:
+        template: centos
+        backing: lvm
+        vgname: vg1
+        lvname: lxclv
+        size: 20G
+
+However, due to the way that :mod:`config.get <salt.modules.config.get>` works,
+this means that if a ``lxc.profile`` key is defined in both the master config
+file and in a specific minion's config file, that will cause all profiles to be
+overwritten for that minion. For greater flexibility, in the next feature
+release each container profile should be configured in its own key, in the
+format ``lxc.container_profile.profile_name``. For example:
+
+.. code-block:: yaml
+
+    lxc.container_profile.centos:
+      template: centos
+      backing: lvm
+      vgname: vg1
+      lvname: lxclv
+      size: 10G
+    lxc.container_profile.centos_big:
+      template: centos
+      backing: lvm
+      vgname: vg1
+      lvname: lxclv
+      size: 20G
+
+This way, the ``centos_big`` profile can be redefined for a single minion
+without also removing the ``centos`` profile. The legacy usage will still be
+supported for a couple release cycles, to allow for some time to update
+configurations.
+
+Additionally, in the next feature release, container profiles have been
+expanded to support passing template-specific CLI options. Below is a table
+describing the parameters which can be configured in container profiles:
+
+================== ===================================== ====================
+Parameter          Develop Branch (Next Feature Release) 2014.7.x and Earlier
+================== ===================================== ====================
+*template*:sup:`1` Yes                                   Yes
+*options*:sup:`1`  Yes                                   No
+*image*:sup:`1`    Yes                                   Yes
+*backing*          Yes                                   Yes
+*snapshot*:sup:`2` Yes                                   Yes
+*lvname*:sup:`1`   Yes                                   Yes
+*fstype*:sup:`1`   Yes                                   Yes
+*size*             Yes                                   Yes
+================== ===================================== ====================
+
+1. Parameter is only supported for container creation, and will be ignored if
+   the profile is used when cloning a container.
+2. Parameter is only supported for container cloning, and will be ignored if
+   the profile is used when not cloning a container.
+
+.. _tutorial-lxc-profiles-network:
+
+Network Profiles
+----------------
+
+In the 2014.7 release cycle and earlier, LXC network profiles were all
+defined underneath the ``lxc.nic`` config option:
+
+.. code-block:: yaml
+
+    lxc.nic:
+      centos:
+        eth0:
+          link: br0
+          type: veth
+          flags: up
+      ubuntu:
+        eth0:
+          link: lxcbr0
+          type: veth
+          flags: up
+
+However, due to the way that :mod:`config.get <salt.modules.config.get>` works,
+this means that if a ``lxc.nic`` key is defined in both the master config file
+and in a specific minion's config file, that will cause all network profiles to
+be overwritten for that minion. For greater flexibility, in the next feature
+release each container profile should be configured in its own key, in the
+format ``lxc.network_profile.profile_name``. For example:
+
+.. code-block:: yaml
+
+    lxc.network_profile.centos:
+      eth0:
+        link: br0
+        type: veth
+        flags: up
+    lxc.network_profile.ubuntu:
+      eth0:
+        link: lxcbr0
+        type: veth
+        flags: up
+
+This way, the ``ubuntu`` profile can be redefined for a single minion
+without also removing the ``centos`` profile. The legacy usage will still be
+supported for a couple release cycles, to allow for some time to update
+configurations.
+
+The following are parameters which can be configured in network profiles. These
+will directly correspond to a parameter in an LXC configuration file (see ``man
+5 lxc.container.conf``).
+
+- **type** - Corresponds to **lxc.network.type**
+- **link** - Corresponds to **lxc.network.link**
+- **flags** - Corresponds to **lxc.network.flags**
+
+Interface-specific options (MAC address, IPv4/IPv6, etc.) can be passed on a
+container-by-container basis.
+
+
+Creating a Container on the CLI
+===============================
+
+From a Template
+---------------
+
+LXC is commonly distributed with several template scripts in
+/usr/share/lxc/templates. Some distros may package these separately in an
+**lxc-templates** package, so make sure to check if this is the case.
+
+There are LXC template scripts for several different operating systems, but
+some of them are designed to use tools specific to a given distribution. For
+instance, the ``ubuntu`` template uses deb_bootstrap, the ``centos`` template
+uses yum, etc., making these templates impractical when a container from a
+different OS is desired.
+
+To create a CentOS container named ``container1`` on a CentOS minion named
+``mycentosminion``, using the ``centos`` LXC template, one can simply run the
+following command:
+
+.. code-block:: bash
+
+    salt mycentosminion lxc.create container1 template=centos
+
+
+For these instances, there is a ``download`` template which retrieves minimal
+container images for several different operating systems. To use this template,
+it is necessary to provide an ``options`` parameter when creating the
+container, with three values:
+
+1. **dist** - the Linux distribution (i.e. ``ubuntu`` or ``centos``)
+2. **release** - the release name/version (i.e. ``trusty`` or ``6``)
+3. **arch** - CPU architecture (i.e. ``amd64`` or ``i386``)
+
+The :mod:`lxc.images <salt.modules.lxc.images>` function (new in the next
+feature release) can be used to list the available images. Alternatively, the
+releases can be viewed on http://images.linuxcontainers.org/images/. The images
+are organized in such a way that the dist, release, and arch can be determined
+using the following URL format:
+``http://images.linuxcontainers.org/images/dist/release/arch``. For example,
+``http://images.linuxcontainers.org/images/centos/6/amd64`` would correspond to
+a **dist** of ``centos``, a **release** of ``6``, and an **arch** of ``amd64``.
+
+Therefore, to use the ``download`` template to create a new 64-bit CentOS 6
+container, the following command can be used:
+
+.. code-block:: bash
+
+    salt myminion lxc.create container1 template=download options='{dist: centos, release: 6, arch: amd64}'
+
+.. note::
+
+    These command-line options can be placed into a :ref:`container profile
+    <tutorial-lxc-profiles-container>`, like so:
+
+    .. code-block:: yaml
+
+        lxc.container_profile.centos:
+          template: download
+          options:
+            dist: centos
+            release: 6
+            arch: amd64
+
+    The ``options`` parameter is not supported in profiles for the 2014.7.x
+    release cycle and earlier, so it would still need to be provided on the
+    command-line.

--- a/doc/topics/tutorials/lxc.rst
+++ b/doc/topics/tutorials/lxc.rst
@@ -312,6 +312,17 @@ an image, use the ``image`` parameter with :mod:`lxc.create
         tar czf cent6.tar.gz -C /var/lib/lxc/cent6 rootfs
         umount /var/lib/lxc/cent6/rootfs
 
+.. warning::
+
+    One caveat of using this method of container creation is that
+    ``/etc/hosts`` is left unmodified.  This could cause confusion for some
+    distros if salt-minion is later installed on the container, as the
+    functions that determine the hostname take ``/etc/hosts`` into account.
+
+    Additionally, when creating an rootfs image, be sure to remove
+    ``/etc/salt/minion_id`` and make sure that ``id`` is not defined in
+    ``/etc/salt/minion``, as this will cause similar issues.
+
 
 Initializing a New Container as a Salt Minion
 =============================================

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -209,7 +209,9 @@ class Authorize(object):
 
         if 'django' in auth_data and '^model' in auth_data['django']:
             auth_from_django = salt.auth.django.retrieve_auth_entries()
-            auth_data = salt.utils.dictupdate.merge(auth_data, auth_from_django)
+            auth_data = salt.utils.dictupdate.merge(auth_data,
+                                                    auth_from_django,
+                                                    strategy='list')
 
         #for auth_back in self.opts.get('external_auth_sources', []):
         #    fstr = '{0}.perms'.format(auth_back)

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -13,7 +13,7 @@ class SaltException(Exception):
     '''
     Base exception class; all Salt-specific exceptions should subclass this
     '''
-    def __init__(self, message):
+    def __init__(self, message=''):
         super(SaltException, self).__init__(message)
         self.strerror = message
 

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -13,6 +13,9 @@ class SaltException(Exception):
     '''
     Base exception class; all Salt-specific exceptions should subclass this
     '''
+    def __init__(self, message):
+        super(SaltException, self).__init__(message)
+        self.strerror = message
 
     def pack(self):
         '''
@@ -98,13 +101,13 @@ class SaltRenderError(SaltException):
     of the error.
     '''
     def __init__(self,
-                 error,
+                 message,
                  line_num=None,
                  buf='',
                  marker='    <======================',
                  trace=None):
-        self.error = error
-        exc_str = copy.deepcopy(error)
+        self.error = message
+        exc_str = copy.deepcopy(message)
         self.line_num = line_num
         self.buffer = buf
         self.context = ''

--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -1408,12 +1408,26 @@ def tty(device, echo=None):
         }
 
 
-def run_chroot(root, cmd):
+def run_chroot(root,
+               cmd,
+               stdin=None,
+               output_loglevel='debug'):
     '''
     .. versionadded:: 2014.7.0
 
     This function runs :mod:`cmd.run_all <salt.modules.cmdmod.run_all>` wrapped
     within a chroot, with dev and proc mounted in the chroot
+
+    stdin : None
+        Standard input to be used for the command
+
+        .. versionadded:: 2014.7.1
+
+    output_loglevel : debug
+        Level at which to log the output from the command. Set to ``quiet`` to
+        suppress logging.
+
+        .. versionadded:: 2014.7.1
 
     CLI Example:
 
@@ -1439,7 +1453,8 @@ def run_chroot(root, cmd):
         root,
         sh_,
         cmd)
-    res = run_all(cmd, output_loglevel='quiet')
+    run_func = __context__.pop('cmd.run_chroot.func', run_all)
+    ret = run_func(cmd, stdin=stdin, output_loglevel=output_loglevel)
 
     # Kill processes running in the chroot
     for i in range(6):
@@ -1457,8 +1472,7 @@ def run_chroot(root, cmd):
 
     __salt__['mount.umount'](os.path.join(root, 'proc'))
     __salt__['mount.umount'](os.path.join(root, 'dev'))
-    log.info(res)
-    return res
+    return ret
 
 
 def _is_valid_shell(shell):

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -271,8 +271,7 @@ def dot_vals(value):
 
 def gather_bootstrap_script(bootstrap=None):
     '''
-    Download the salt-bootstrap script, and return the first location
-    downloaded to.
+    Download the salt-bootstrap script, and return its location
 
     CLI Example:
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -5,6 +5,7 @@ Return config information
 from __future__ import absolute_import
 
 # Import python libs
+import copy
 import re
 import os
 from salt.ext.six import string_types
@@ -198,52 +199,157 @@ def merge(value,
     return ret or default
 
 
-def get(key, default=''):
+def get(key, default='', delimiter=':', merge=None):
     '''
     .. versionadded: 0.14.0
 
     Attempt to retrieve the named value from the minion config file, pillar,
     grains or the master config. If the named value is not available, return the
-    value specified by ``default``. The default return value is an empty string.
+    value specified by ``default``. If not specified, the default is an empty
+    string.
 
-    The value can also represent a value in a nested dict using a ":" delimiter
-    for the dict. This means that if a dict looks like this::
+    Values can also be retrieved from nested dictionaries. Assume the below
+    data structure:
+
+    .. code-block:: python
 
         {'pkg': {'apache': 'httpd'}}
 
-    To retrieve the value associated with the apache key in the pkg dict this
-    key can be passed::
+    To retrieve the value associated with the ``apache`` key, in the
+    sub-dictionary corresponding to the ``pkg`` key, the following command can
+    be used:
 
-        pkg:apache
+    .. code-block:: bash
+
+        salt myminion config.get pkg:apache
+
+    The ``:`` (colon) is used to represent a nested dictionary level.
+
+    .. versionchanged:: 2015.2.0
+        The ``delimiter`` argument was added, to allow delimiters other than
+        ``:`` to be used.
 
     This function traverses these data stores in this order:
 
     - Minion config file
     - Minion's grains
-    - Minion's pillar
+    - Minion's pillar data
     - Master config file
+
+    delimiter
+        .. versionadded:: 2015.2.0
+
+        Override the delimiter used to separate nested levels of a data
+        structure.
+
+    merge
+        .. versionadded:: 2015.2.0
+
+        If passed, this parameter will change the behavior of the function so
+        that, instead of traversing each data store above in order and
+        returning the first match, the data stores are first merged together
+        and then searched. The pillar data is merged into the master config
+        data, then the grains are merged, followed by the Minion config data.
+        The resulting data structure is then searched for a match. This allows
+        for configurations to be more flexible.
+
+        .. note::
+
+            The merging described above does not mean that grain data will end
+            up in the Minion's pillar data, or pillar data will end up in the
+            master config data, etc. The data is just combined for the purposes
+            of searching an amalgam of the different data stores.
+
+        The supported merge strategies are as follows:
+
+        - **recurse** - If a key exists in both dictionaries, and the new value
+          is not a dictionary, it is replaced. Otherwise, the sub-dictionaries
+          are merged together into a single dictionary, recursively on down,
+          following the same criteria. For example:
+
+          .. code-block:: python
+
+              >>> dict1 = {'foo': {'bar': 1, 'qux': True},
+                           'hosts': ['a', 'b', 'c'],
+                           'only_x': None}
+              >>> dict2 = {'foo': {'baz': 2, 'qux': False},
+                           'hosts': ['d', 'e', 'f'],
+                           'only_y': None}
+              >>> merged
+              {'foo': {'bar': 1, 'baz': 2, 'qux': False},
+               'hosts': ['d', 'e', 'f'],
+               'only_dict1': None,
+               'only_dict2': None}
+
+        - **overwrite** - If a key exists in the top level of both
+          dictionaries, the new value completely overwrites the old. For
+          example:
+
+          .. code-block:: python
+
+              >>> dict1 = {'foo': {'bar': 1, 'qux': True},
+                           'hosts': ['a', 'b', 'c'],
+                           'only_x': None}
+              >>> dict2 = {'foo': {'baz': 2, 'qux': False},
+                           'hosts': ['d', 'e', 'f'],
+                           'only_y': None}
+              >>> merged
+              {'foo': {'baz': 2, 'qux': False},
+               'hosts': ['d', 'e', 'f'],
+               'only_dict1': None,
+               'only_dict2': None}
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' config.get pkg:apache
+        salt '*' config.get lxc.container_profile:centos merge=recurse
     '''
-    ret = salt.utils.traverse_dict_and_list(__opts__, key, '_|-')
-    if ret != '_|-':
-        return sdb.sdb_get(ret, __opts__)
+    if merge is None:
+        ret = salt.utils.traverse_dict_and_list(__opts__,
+                                                key,
+                                                '_|-',
+                                                delimiter=delimiter)
+        if ret != '_|-':
+            return sdb.sdb_get(ret, __opts__)
 
-    ret = salt.utils.traverse_dict_and_list(__grains__, key, '_|-')
-    if ret != '_|-':
-        return sdb.sdb_get(ret, __opts__)
+        ret = salt.utils.traverse_dict_and_list(__grains__,
+                                                key,
+                                                '_|-',
+                                                delimiter)
+        if ret != '_|-':
+            return sdb.sdb_get(ret, __opts__)
 
-    ret = salt.utils.traverse_dict_and_list(__pillar__, key, '_|-')
-    if ret != '_|-':
-        return sdb.sdb_get(ret, __opts__)
+        ret = salt.utils.traverse_dict_and_list(__pillar__,
+                                                key,
+                                                '_|-',
+                                                delimiter=delimiter)
+        if ret != '_|-':
+            return sdb.sdb_get(ret, __opts__)
 
-    ret = salt.utils.traverse_dict_and_list(__pillar__.get('master', {}), key, '_|-')
-    if ret != '_|-':
-        return sdb.sdb_get(ret, __opts__)
+        ret = salt.utils.traverse_dict_and_list(__pillar__.get('master', {}),
+                                                key,
+                                                '_|-',
+                                                delimiter=delimiter)
+        if ret != '_|-':
+            return sdb.sdb_get(ret, __opts__)
+    else:
+        if merge not in ('recurse', 'overwrite'):
+            log.warning('Unsupported merge strategy \'{0}\'. Falling back '
+                        'to \'recurse\'.'.format(merge))
+            merge = 'recurse'
+
+        data = copy.copy(__pillar__.get('master', {}))
+        data = salt.utils.dictupdate.merge(data, __pillar__, strategy=merge)
+        data = salt.utils.dictupdate.merge(data, __grains__, strategy=merge)
+        data = salt.utils.dictupdate.merge(data, __opts__, strategy=merge)
+        ret = salt.utils.traverse_dict_and_list(data,
+                                                key,
+                                                '_|-',
+                                                delimiter=delimiter)
+        if ret != '_|-':
+            return sdb.sdb_get(ret, __opts__)
 
     return default
 

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -202,9 +202,9 @@ def get(key, default=''):
     '''
     .. versionadded: 0.14.0
 
-    Attempt to retrieve the named value from opts, pillar, grains or the master
-    config, if the named value is not available return the passed default.
-    The default return is an empty string.
+    Attempt to retrieve the named value from the minion config file, pillar,
+    grains or the master config. If the named value is not available, return the
+    value specified by ``default``. The default return value is an empty string.
 
     The value can also represent a value in a nested dict using a ":" delimiter
     for the dict. This means that if a dict looks like this::
@@ -216,12 +216,12 @@ def get(key, default=''):
 
         pkg:apache
 
-    This routine traverses these data stores in this order:
+    This function traverses these data stores in this order:
 
-    - Local minion config (opts)
+    - Minion config file
     - Minion's grains
     - Minion's pillar
-    - Master config
+    - Master config file
 
     CLI Example:
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -474,8 +474,15 @@ def chgrp(path, group):
 
 def get_sum(path, form='sha256'):
     '''
-    Return the sum for the given file, default is md5, sha1, sha224, sha256,
-    sha384, sha512 are supported
+    Return the checksum for the given file. The following checksum algorithms
+    are supported:
+
+    * md5
+    * sha1
+    * sha224
+    * sha256 **(default)**
+    * sha384
+    * sha512
 
     path
         path to the file or directory

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -992,8 +992,6 @@ def init(name,
     if users is None:
         users = []
     dusers = ['root']
-    if __grains__['os'] in ['Ubuntu'] and 'ubuntu' not in users:
-        dusers.append('ubuntu')
     for user in dusers:
         if user not in users:
             users.append(user)

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1450,6 +1450,11 @@ def create(name,
         raise SaltInvocationError(
             'Only one of \'template\' and \'image\' is permitted'
         )
+    elif not any((template, image, profile)):
+        raise SaltInvocationError(
+            'At least one of \'template\', \'image\', and \'profile\' is '
+            'required'
+        )
 
     options = select('options') or {}
     backing = select('backing')

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2734,6 +2734,8 @@ def run_cmd(name,
             no_start=False,
             preserve_state=True,
             stdin=None,
+            stdout=True,
+            stderr=False,
             python_shell=True,
             output_loglevel='debug',
             use_vt=False,
@@ -2745,11 +2747,20 @@ def run_cmd(name,
     '''
     salt.utils.warn_until(
         'Boron',
-        'lxc.run_cmd has been renamed to lxc.cmd_run, please use lxc.cmd_run'
+        'lxc.run_cmd has been deprecated, please use one of the lxc.cmd_run* '
+        'functions. See the documentation for more information.'
     )
+    if stdout and stderr:
+        output = 'all'
+    elif stdout:
+        output = 'stdout'
+    elif stderr:
+        output = 'stderr'
+    else:
+        output = 'retcode'
     return _run(name,
                 cmd,
-                output=None,
+                output=output,
                 no_start=no_start,
                 preserve_state=preserve_state,
                 stdin=stdin,

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2131,9 +2131,9 @@ def info(name):
             free = limit - usage
             ret['memory_limit'] = limit
             ret['memory_free'] = free
-            ret['size'] = cmd_run_stdout(name,
-                                        'df /|tail -n1|awk \'{{print $2}}\'',
-                                         python_shell=False)
+            size = cmd_run_stdout(name, 'df /', python_shell=False)
+            # The size is the 2nd column of the last line
+            ret['size'] = size.splitlines()[-1].split()[1]
 
             # First try iproute2
             ip_cmd = cmd_run_all(name, 'ip link show', python_shell=False)

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -826,22 +826,6 @@ def init(name,
     will reset a bit the lxc configuration file but much of the hard work will
     be escaped as markers will prevent re-execution of harmful tasks.
 
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt 'minion' lxc.init name [cpuset=cgroups_cpuset] \\
-                [cpushare=cgroups_cpushare] [memory=cgroups_memory] \\
-                [profile=lxc_profile] [network_proflile=network_profile] \\
-                [nic_opts=nic_opts] [start=(True|False)] [seed=(True|False)] \\
-                [install=(True|False)] [config=minion_config] \\
-                [approve_key=(True|False) [clone_from=original] \\
-                [autostart=True] [priv_key=/path_or_content] \\
-                [pub_key=/path_or_content] [bridge=lxcbr0] \\
-                [gateway=10.0.3.1] [dnsservers[dns1,dns2]] \\
-                [users=[foo]] [password='secret'] \\
-                [password_encrypted=(True|False)]
-
     name
         Name of the container
 
@@ -967,7 +951,7 @@ def init(name,
                 [nic_opts=nic_opts] [start=(True|False)] \\
                 [seed=(True|False)] [install=(True|False)] \\
                 [config=minion_config] [approve_key=(True|False) \\
-                [clone=original] [autostart=True] \\
+                [clone_from=original] [autostart=True] \\
                 [priv_key=/path_or_content] [pub_key=/path_or_content] \\
                 [bridge=lxcbr0] [gateway=10.0.3.1] \\
                 [dnsservers[dns1,dns2]] \\
@@ -1555,7 +1539,6 @@ def create(name,
 
 def clone(name,
           orig,
-          clone_from=None,
           profile=None,
           **kwargs):
     '''
@@ -1566,12 +1549,6 @@ def clone(name,
 
     orig
         Name of the original container to be cloned
-
-    clone_from
-        Name of the original container to be cloned (added for consistency,
-        does the same thing as ``orig``)
-
-        .. versionadded:: 2015.2.0
 
     profile
         Profile to use in container cloning (see
@@ -1604,16 +1581,10 @@ def clone(name,
             'Container \'{0}\' already exists'.format(name)
         )
 
-    if clone_from and orig:
-        log.warning('Both \'clone_from\' and \'orig\' were passed, ignoring '
-                    '\'orig\'')
-    elif orig and not clone_from:
-        clone_from = orig
-
-    _ensure_exists(clone_from)
-    if state(clone_from) != 'stopped':
+    _ensure_exists(orig)
+    if state(orig) != 'stopped':
         raise CommandExecutionError(
-            'Container \'{0}\' must be stopped to be cloned'.format(clone_from)
+            'Container \'{0}\' must be stopped to be cloned'.format(orig)
         )
 
     profile = get_container_profile(copy.deepcopy(profile))
@@ -1640,7 +1611,7 @@ def clone(name,
     if backing in ('dir', 'overlayfs', 'btrfs'):
         size = None
 
-    cmd = 'lxc-clone {0} -o {1} -n {2}'.format(snapshot, clone_from, name)
+    cmd = 'lxc-clone {0} -o {1} -n {2}'.format(snapshot, orig, name)
     if backing:
         backing = backing.lower()
         cmd += ' -B {0}'.format(backing)

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2007,23 +2007,22 @@ def state(name):
 
 def get_parameter(name, parameter):
     '''
-    Returns the value of a cgroup parameter for a container.
+    Returns the value of a cgroup parameter for a container
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' lxc.get_parameter name parameter
+        salt '*' lxc.get_parameter container_name memory.limit_in_bytes
     '''
-    if not exists(name):
-        return None
-
+    _ensure_exists(name)
     cmd = 'lxc-cgroup -n {0} {1}'.format(name, parameter)
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
-        return False
-    else:
-        return {parameter: ret['stdout'].strip()}
+        raise CommandExecutionError(
+            'Unable to retrieve value for \'{0}\''.format(parameter)
+        )
+    return ret['stdout'].strip()
 
 
 def set_parameter(name, parameter, value):
@@ -2113,14 +2112,12 @@ def info(name):
 
         if ret['state'] == 'running':
             try:
-                limit = int(get_parameter(name, 'memory.limit_in_bytes').get(
-                    'memory.limit_in_bytes'))
-            except (TypeError, ValueError):
+                limit = int(get_parameter(name, 'memory.limit_in_bytes'))
+            except (CommandExecutionError, TypeError, ValueError):
                 limit = 0
             try:
-                usage = int(get_parameter(name, 'memory.usage_in_bytes').get(
-                    'memory.usage_in_bytes'))
-            except (TypeError, ValueError):
+                usage = int(get_parameter(name, 'memory.usage_in_bytes'))
+            except (CommandExecutionError, TypeError, ValueError):
                 usage = 0
             free = limit - usage
             ret['memory_limit'] = limit

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2343,24 +2343,24 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset):
                             dest_lxc_conf.append(line)
                         else:
                             changes['removed'].append(opt)
-        else:
-            dest_lxc_conf = lines
-        conf = ''
-        for key, val in dest_lxc_conf:
-            if not val:
-                conf += '{0}\n'.format(key)
             else:
-                conf += '{0} = {1}\n'.format(key.strip(), val.strip())
-        conf_changed = conf != orig_config
-        chrono = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-        if conf_changed:
-            path = '.'.join((lxc_conf_p, chrono))
-            with salt.utils.fopen(path, 'w') as wfic:
-                wfic.write(conf)
-            with salt.utils.fopen(lxc_conf_p, 'w') as wfic:
-                wfic.write(conf)
-            ret['comment'] = 'Updated'
-            ret['result'] = True
+                dest_lxc_conf = lines
+            conf = ''
+            for key, val in dest_lxc_conf:
+                if not val:
+                    conf += '{0}\n'.format(key)
+                else:
+                    conf += '{0} = {1}\n'.format(key.strip(), val.strip())
+            conf_changed = conf != orig_config
+            chrono = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
+            if conf_changed:
+                path = '.'.join((lxc_conf_p, chrono))
+                with salt.utils.fopen(path, 'w') as wfic:
+                    wfic.write(conf)
+                with salt.utils.fopen(lxc_conf_p, 'w') as wfic:
+                    wfic.write(conf)
+                ret['comment'] = 'Updated'
+                ret['result'] = True
 
     if not any(changes[x] for x in changes):
         # Ensure an empty changes dict if nothing was modified

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1630,22 +1630,37 @@ def clone(name,
         )
 
 
-def ls_():
+def ls_(active=None):
     '''
     Return a list of the containers available on the minion
+
+    active
+        If ``True``, return only active (i.e. running) containers
+
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' lxc.ls
+        salt '*' lxc.ls active=True
     '''
-    try:
-        return __context__['lxc.ls']
-    except KeyError:
-        output = __salt__['cmd.run']('lxc-ls | sort -u', python_shell=True)
-        __context__['lxc.ls'] = output.splitlines()
-    return __context__['lxc.ls']
+    contextvar = 'lxc.ls'
+    if active:
+        contextvar += '.active'
+    if contextvar in __context__:
+        return __context__[contextvar]
+    else:
+        ret = []
+        cmd = 'lxc-ls'
+        if active:
+            cmd += ' --active'
+        output = __salt__['cmd.run_stdout'](cmd, python_shell=False)
+        for line in output.splitlines():
+            ret.extend(line.split())
+        __context__[contextvar] = ret
+        return ret
 
 
 def list_(extra=False, limit=None):

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2741,7 +2741,7 @@ def run_cmd(name,
             keep_env='http_proxy,https_proxy,no_proxy'):
     '''
     .. deprecated:: Lithium
-        Use :mod:`lxc.cmd_run <salt.module.lxc.cmd_run>` instead
+        Use :mod:`lxc.cmd_run <salt.modules.lxc.cmd_run>` instead
     '''
     salt.utils.warn_until(
         'Boron',

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1548,7 +1548,7 @@ def clone(name,
         Profile to use in container cloning (see
         :mod:`lxc.get_container_profile
         <salt.modules.lxc.get_container_profile>`). Values in a profile will be
-        overridden by the **Container Creation Arguments** listed below.
+        overridden by the **Container Cloning Arguments** listed below.
 
     **Container Cloning Arguments**
 
@@ -1956,6 +1956,9 @@ def destroy(name, stop=True):
     .. warning::
 
         Destroys all data associated with the container.
+
+    stop : True
+        If ``False``, do not destroy the container if it is running/frozen.
 
     CLI Examples:
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1099,7 +1099,7 @@ def init(name,
             to_reboot = True
     if remove_seed_marker:
         cmd_run(name,
-                ['rm', '-f', SEED_MARKER],
+                'rm -f \'{0}\''.format(SEED_MARKER),
                 python_shell=False)
 
     # last time to be sure any of our property is correctly applied

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2270,7 +2270,7 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset):
 
     .. code-block:: bash
 
-        salt-call -lall lxc.update_lxc_conf ubuntu \\
+        salt myminion lxc.update_lxc_conf ubuntu \\
                 lxc_conf="[{'network.ipv4.ip':'10.0.3.5'}]" \\
                 lxc_conf_unset="['lxc.utsname']"
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1432,7 +1432,6 @@ def create(name,
 
 def clone(name,
           orig,
-          snapshot=False,
           profile=None,
           **kwargs):
     '''

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1339,10 +1339,11 @@ def create(name,
     kw_overrides = copy.deepcopy(kwargs)
 
     def select(key, default=None):
-        kw_overrides_match = kw_overrides.pop(key, _marker)
+        kw_overrides_match = kw_overrides.pop(key, None)
         profile_match = profile.pop(key, default)
-        # let kwarg overrides be the preferred choice
-        if kw_overrides_match is _marker:
+        # Return the profile match if the the kwarg match was None, as the
+        # lxc.present state will pass these kwargs set to None by default.
+        if kw_overrides_match is None:
             return profile_match
         return kw_overrides_match
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1308,6 +1308,26 @@ def images(dist=None):
     return ret
 
 
+def templates():
+    '''
+    .. versionadded:: Lithium
+
+    List the available LXC template scripts installed on the minion
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion lxc.templates
+    '''
+    try:
+        template_scripts = os.listdir('/usr/share/lxc/templates')
+    except OSError:
+        return []
+    else:
+        return [x[4:] for x in template_scripts if x.startswith('lxc-')]
+
+
 def create(name,
            config=None,
            profile=None,

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1511,7 +1511,8 @@ def clone(name,
         Name of the original container to be cloned
 
     clone_from
-        Name of the original container to be cloned
+        Name of the original container to be cloned (added for consistency,
+        does the same thing as ``orig``)
 
         .. versionadded:: Lithium
 
@@ -1538,8 +1539,8 @@ def clone(name,
 
     .. code-block:: bash
 
-        salt '*' lxc.clone myclone clone_from=orig_container
-        salt '*' lxc.clone myclone clone_from=orig_container snapshot=True
+        salt '*' lxc.clone myclone orig=orig_container
+        salt '*' lxc.clone myclone orig=orig_container snapshot=True
     '''
     if exists(name):
         raise CommandExecutionError(
@@ -1547,8 +1548,8 @@ def clone(name,
         )
 
     if clone_from and orig:
-        log.warning('Both \'clone_from\' and \'orig\' were passed, using '
-                    'ignoring \'orig\'')
+        log.warning('Both \'clone_from\' and \'orig\' were passed, ignoring '
+                    '\'orig\'')
     elif orig and not clone_from:
         clone_from = orig
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -728,7 +728,7 @@ def _get_base(**kwargs):
             return profile_match
         return kw_overrides_match
 
-    cntrs = ls()
+    cntrs = ls_()
     image = select('image')
     vgname = select('vgname')
     template = select('template')
@@ -1576,7 +1576,7 @@ def clone(name,
 
 def ls_():
     '''
-    Return just a list of the containers available
+    Return a list of the containers available on the minion
 
     CLI Example:
 
@@ -1616,7 +1616,7 @@ def list_(extra=False, limit=None):
         salt '*' lxc.list extra=True
         salt '*' lxc.list limit=running
     '''
-    ctnrs = ls()
+    ctnrs = ls_()
 
     if extra:
         stopped = {}
@@ -1911,7 +1911,7 @@ def exists(name):
 
         salt '*' lxc.exists name
     '''
-    return name in ls()
+    return name in ls_()
 
 
 def state(name):
@@ -2482,7 +2482,7 @@ def bootstrap(name,
                     'mkdir -p {0}'.format(dest_dir),
                     'chmod 700 {0}'.format(dest_dir),
                 ]:
-                    if run_cmd(name, cmd, stdout=True):
+                    if cmd_run_stdout(name, cmd):
                         log.error(
                             ('tmpdir {0} creation'
                              ' failed ({1}').format(dest_dir, cmd))

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -1357,7 +1357,7 @@ def create(name,
             'Only one of \'template\' and \'image\' is permitted'
         )
 
-    options = select('options')
+    options = select('options') or {}
     backing = select('backing')
     if vgname and not backing:
         backing = 'lvm'
@@ -1378,7 +1378,7 @@ def create(name,
                 'templates',
                 'lxc',
                 'salt_tarball')
-        profile['imgtar'] = img_tar
+        options['imgtar'] = img_tar
     if config:
         cmd += ' -f {0}'.format(config)
     if template:
@@ -1415,7 +1415,10 @@ def create(name,
                                   output_loglevel='trace')
     _clear_context()
     if ret['retcode'] == 0 and exists(name):
-        return True
+        c_state = state(name)
+        return {'result': True,
+                'changes': {'old': None, 'new': c_state},
+                'state': c_state}
     else:
         if exists(name):
             # destroy the container if it was partially created

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -859,12 +859,20 @@ def init(name,
         ``{"eth0": {"hwaddr": "aa:bb:cc:dd:ee:ff", "ipv4": "10.1.1.1/24", "ipv6": "2001:db8::ff00:42:8329"}}``
 
     users
-        Sysadmins users to set the administrative password to
-        e.g. [root, ubuntu, sysadmin], default [root] and [root, ubuntu]
-        on ubuntu
+        Users for which the password defined in the ``password`` param should
+        be set. Can be passed as a comma separated list or a python list.
+        Defaults to just the ``root`` user.
+
     password
-        Set the initial password for default sysadmin users, at least root
-        but also can be used for sudoers, e.g. [root, ubuntu, sysadmin]
+        Set the initial password for the users defined in the ``users``
+        parameter
+
+    password_encrypted : False
+        Set to ``True`` to denote a password hash instead of a plaintext
+        password
+
+        .. versionadded:: 2015.2.0
+
     profile
         A LXC profile (defined in config or pillar).
         This can be either a real profile mapping or a string

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -327,7 +327,7 @@ def cloud_init_interface(name, vm_=None, **kwargs):
 
 def get_container_profile(name=None, **kwargs):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Gather a pre-configured set of container configuration parameters. If no
     arguments are passed, an empty profile is returned.
@@ -391,7 +391,7 @@ def get_container_profile(name=None, **kwargs):
 
 def get_network_profile(name=None):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Gather a pre-configured set of network configuration parameters. If no
     arguments are passed, the following default profile is returned:
@@ -836,10 +836,10 @@ def init(name,
     network_profile
         Network profile to use for the container
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     nic
-        .. deprecated:: Lithium
+        .. deprecated:: 2015.2.0
             Use ``network_profile`` instead
 
     nic_opts
@@ -892,7 +892,7 @@ def init(name,
         Attempt to request key approval from the master. Default: ``True``
 
     clone
-        .. deprecated:: Lithium
+        .. deprecated:: 2015.2.0
             Use ``clone_from`` instead
 
     clone_from
@@ -903,7 +903,7 @@ def init(name,
         Delay in seconds between end of container creation and bootstrapping.
         Useful when waiting for container to obtain a DHCP lease.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     bootstrap_url
         See lxc.bootstrap
@@ -1259,7 +1259,7 @@ def cloud_init(name, vm_=None, **kwargs):
 
 def images(dist=None):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     List the available images for LXC's ``download`` template.
 
@@ -1310,7 +1310,7 @@ def images(dist=None):
 
 def templates():
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     List the available LXC template scripts installed on the minion
 
@@ -1352,7 +1352,7 @@ def create(name,
     network_profile
         Network profile to use for container
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     **Container Creation Arguments**
 
@@ -1534,7 +1534,7 @@ def clone(name,
         Name of the original container to be cloned (added for consistency,
         does the same thing as ``orig``)
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     profile
         Profile to use in container cloning (see
@@ -1660,7 +1660,7 @@ def list_(extra=False, limit=None):
         Return output matching a specific state (**frozen**, **running**, or
         **stopped**).
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     CLI Examples:
 
@@ -1788,7 +1788,7 @@ def _ensure_running(name, no_start=False):
 
 def restart(name, force=False):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Restart the named container. If the container was not running, the
     container will merely be started.
@@ -1822,7 +1822,7 @@ def start(name, **kwargs):
     Start the named container
 
     restart : False
-        .. deprecated:: Lithium
+        .. deprecated:: 2015.2.0
             Use :mod:`lxc.restart <salt.modules.lxc.restart>`
 
         Restart the container if it is already running
@@ -1857,7 +1857,7 @@ def stop(name, kill=False):
         Older LXC versions will stop containers like this irrespective of this
         argument.
 
-        .. versionchanged:: Lithium
+        .. versionchanged:: 2015.2.0
             Default value changed to ``False``
 
     CLI Example:
@@ -1889,7 +1889,7 @@ def freeze(name, **kwargs):
         If ``True`` and the container is stopped, the container will be started
         before attempting to freeze.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
@@ -2204,7 +2204,7 @@ def info(name):
 
 def set_password(name, users, password, encrypted=True):
     '''
-    .. versionchanged:: Lithium
+    .. versionchanged:: 2015.2.0
         Function renamed from ``set_pass`` to ``set_password``. Additionally,
         this function now supports (and defaults to using) a password hash
         instead of a plaintext password.
@@ -2222,7 +2222,7 @@ def set_password(name, users, password, encrypted=True):
         If true, ``password`` must be a password hash. Set to ``False`` to set
         a plaintext password (not recommended).
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
@@ -2370,7 +2370,7 @@ def update_lxc_conf(name, lxc_conf, lxc_conf_unset):
 
 def set_dns(name, dnsservers=None, searchdomains=None):
     '''
-    .. versionchanged:: Lithium
+    .. versionchanged:: 2015.2.0
         The ``dnsservers`` and ``searchdomains`` parameters can now be passed
         as a comma-separated list.
 
@@ -2453,7 +2453,7 @@ def bootstrap(name,
         Delay in seconds between end of container creation and bootstrapping.
         Useful when waiting for container to obtain a DHCP lease.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     bootstrap_url
         url, content or filepath to the salt bootstrap script
@@ -2740,7 +2740,7 @@ def run_cmd(name,
             ignore_retcode=False,
             keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. deprecated:: Lithium
+    .. deprecated:: 2015.2.0
         Use :mod:`lxc.cmd_run <salt.modules.lxc.cmd_run>` instead
     '''
     salt.utils.warn_until(
@@ -2771,7 +2771,7 @@ def cmd_run(name,
             ignore_retcode=False,
             keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Run :mod:`cmd.run <salt.modules.cmdmod.run>` within a container
 
@@ -2846,7 +2846,7 @@ def cmd_run_stdout(name,
                    ignore_retcode=False,
                    keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Run :mod:`cmd.run_stdout <salt.modules.cmdmod.run_stdout>` within a container
 
@@ -2921,7 +2921,7 @@ def cmd_run_stderr(name,
                    ignore_retcode=False,
                    keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Run :mod:`cmd.run_stderr <salt.modules.cmdmod.run_stderr>` within a container
 
@@ -2994,7 +2994,7 @@ def cmd_retcode(name,
                 ignore_retcode=False,
                 keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Run :mod:`cmd.retcode <salt.modules.cmdmod.retcode>` within a container
 
@@ -3069,7 +3069,7 @@ def cmd_run_all(name,
                 ignore_retcode=False,
                 keep_env='http_proxy,https_proxy,no_proxy'):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Run :mod:`cmd.run_all <salt.modules.cmdmod.run_all>` within a container
 
@@ -3158,7 +3158,7 @@ def cp(name, source, dest, makedirs=False):
     dest
         Destination on the container. Must be an absolute path.
 
-        .. versionchanged:: Lithium
+        .. versionchanged:: 2015.2.0
             If the destination is a directory, the file will be copied into
             that directory.
 
@@ -3167,7 +3167,7 @@ def cp(name, source, dest, makedirs=False):
         Create the parent directory on the container if it does not already
         exist.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
@@ -3395,7 +3395,7 @@ def edit_conf(conf_file, out_format='simple', **kwargs):
 
 def apply_network_profile(name, network_profile):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Apply a network profile to a container
 

--- a/salt/modules/seed.py
+++ b/salt/modules/seed.py
@@ -169,8 +169,12 @@ def apply_(path, id_=None, config=None, approve_key=True, install=True,
     return res
 
 
-def mkconfig(config=None, tmp=None, id_=None, approve_key=True,
-            pub_key=None, priv_key=None):
+def mkconfig(config=None,
+             tmp=None,
+             id_=None,
+             approve_key=True,
+             pub_key=None,
+             priv_key=None):
     '''
     Generate keys and config and put them in a tmp directory.
 

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -423,8 +423,11 @@ class Pillar(object):
                                         key: nstate
                                     }
 
-                                state = merge(state, nstate,
-                                              self.merge_strategy)
+                                state = merge(
+                                    state,
+                                    nstate,
+                                    self.merge_strategy,
+                                    self.opts.get('renderer', 'yaml'))
 
                             if err:
                                 errors += err
@@ -457,7 +460,11 @@ class Pillar(object):
                             )
                         )
                         continue
-                    pillar = merge(pillar, pstate, self.merge_strategy)
+                    pillar = merge(
+                        pillar,
+                        pstate,
+                        self.merge_strategy,
+                        self.opts.get('renderer', 'yaml'))
 
         return pillar, errors
 
@@ -539,7 +546,11 @@ class Pillar(object):
                                 )
                             )
             if ext:
-                pillar = merge(pillar, ext, self.merge_strategy)
+                pillar = merge(
+                    pillar,
+                    ext,
+                    self.merge_strategy,
+                    self.opts.get('renderer', 'yaml'))
                 ext = None
         return pillar
 
@@ -553,8 +564,10 @@ class Pillar(object):
                 self.opts['pillar'] = self.ext_pillar({}, pillar_dirs)
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches)
-                pillar = merge(pillar, self.opts['pillar'],
-                               self.merge_strategy)
+                pillar = merge(pillar,
+                               self.opts['pillar'],
+                               self.merge_strategy,
+                               self.opts.get('renderer', 'yaml'))
             else:
                 matches = self.top_matches(top)
                 pillar, errors = self.render_pillar(matches)

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -11,6 +11,7 @@ import time
 import os
 import copy
 import logging
+import pprint
 
 # Import Salt libs
 import salt.client
@@ -125,18 +126,19 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
 
         salt-run lxc.init name host=minion_id [cpuset=cgroups_cpuset] \\
                 [cpushare=cgroups_cpushare] [memory=cgroups_memory] \\
-                [template=lxc template name] [clone=original name] \\
-                [nic=nic_profile] [profile=lxc_profile] \\
-                [nic_opts=nic_opts] [start=(true|false)] \\
-                [seed=(true|false)] [install=(true|false)] \\
-                [config=minion_config] [snapshot=(true|false)]
+                [template=lxc_template_name] [clone=original name] \\
+                [profile=lxc_profile] [network_proflile=network_profile] \\
+                [nic=network_profile] [nic_opts=nic_opts] \\
+                [start=(true|false)] [seed=(true|false)] \\
+                [install=(true|false)] [config=minion_config] \\
+                [snapshot=(true|false)]
 
     names
         Name of the containers, supports a single name or a comma delimited
         list of names.
 
     host
-        Minion to start the container on. Required.
+        Minion on which to initialize the container **(required)**
 
     saltcloud_mode
         init the container with the saltcloud opts format instead
@@ -157,11 +159,17 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
     clone
         Clone this container from an existing container
 
-    nic
-        Network interfaces profile (defined in config or pillar).
-
     profile
         A LXC profile (defined in config or pillar).
+
+    network_profile
+        Network profile to use for the container
+
+        .. versionadded:: Lithium
+
+    nic
+        .. deprecated:: Lithium
+            Use ``network_profile`` instead
 
     nic_opts
         Extra options for network interfaces. E.g.:
@@ -327,7 +335,7 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
             ret['ping_status'] = False
             ret['result'] = False
 
-    # if no lxc detected as touched (either inited or verified
+    # if no lxc detected as touched (either inited or verified)
     # we result to False
     if not done:
         ret['result'] = False

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -11,7 +11,6 @@ import time
 import os
 import copy
 import logging
-import pprint
 
 # Import Salt libs
 import salt.client

--- a/salt/runners/lxc.py
+++ b/salt/runners/lxc.py
@@ -150,7 +150,12 @@ def init(names, host=None, saltcloud_mode=False, quiet=False, **kwargs):
         cgroups cpu shares.
 
     memory
-        cgroups memory limit, in MB.
+        cgroups memory limit, in MB
+
+        .. versionchanged:: 2015.2.0
+            If no value is passed, no limit is set. In earlier Salt versions,
+            not passing this value causes a 1024MB memory limit to be set, and
+            it was necessary to pass ``memory=0`` to set no limit.
 
     template
         Name of LXC template on which to base this container

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -649,3 +649,49 @@ def set_pass(name, **kwargs):  # pylint: disable=W0613
                        'information.',
             'result': False,
             'changes': {}}
+
+
+def edited_conf(name, lxc_conf=None, lxc_conf_unset=None):
+    '''
+    .. warning::
+
+        This state is unsuitable for setting parameters that appear more than
+        once in an LXC config file, or parameters which must appear in a
+        certain order (such as when configuring more than one network
+        interface). It is slated to be replaced, and as of version 2015.2.0 it
+        is deprecated.
+
+    Edit LXC configuration options
+
+    .. code-block:: bash
+
+        setconf:
+          lxc.edited_conf:
+            - name: ubuntu
+            - lxc_conf:
+                - network.ipv4.ip: 10.0.3.6
+            - lxc_conf_unset:
+                - lxc.utsname
+    '''
+    salt.utils.warn_until(
+        'Boron',
+        'This state is unsuitable for setting parameters that appear more '
+        'than once in an LXC config file, or parameters which must appear in '
+        'a certain order (such as when configuring more than one network '
+        'interface). It is slated to be replaced, and as of version 2015.2.0 '
+        'it is deprecated.'
+    )
+    if __opts__['test']:
+        return {'name': name,
+                'comment': '{0} lxc.conf will be edited'.format(name),
+                'result': True,
+                'changes': {}}
+    if not lxc_conf_unset:
+        lxc_conf_unset = {}
+    if not lxc_conf:
+        lxc_conf = {}
+    cret = __salt__['lxc.update_lxc_conf'](name,
+                                           lxc_conf=lxc_conf,
+                                           lxc_conf_unset=lxc_conf_unset)
+    cret['name'] = name
+    return cret

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 '''
-lxc / Spin up and control LXC containers
-=========================================
+Manage Linux Containers
+=======================
 '''
 
 from __future__ import absolute_import
 __docformat__ = 'restructuredtext en'
-import traceback
 
 # Import salt libs
 from salt.exceptions import CommandExecutionError, SaltInvocationError
@@ -623,3 +622,29 @@ def cloned(name,
                    size=size,
                    vgname=vgname,
                    profile=profile)
+
+
+def set_pass(name, **kwargs):  # pylint: disable=W0613
+    '''
+    .. deprecated:: 2015.2.0
+
+    This state function has been disabled, as it did not conform to design
+    guidelines. Specifically, due to the fact that :mod:`lxc.set_password
+    <salt.modules.lxc.set_password>` uses ``chpasswd(8)`` to set the password,
+    there was no method to make this action idempotent (in other words, the
+    password would be changed every time). This makes this state redundant,
+    since the following state will do the same thing:
+
+    .. code-block:: yaml
+
+        setpass:
+          module.run:
+            - name: set_pass
+            - m_name: root
+            - password: secret
+    '''
+    return {'name': name,
+            'comment': 'The lxc.set_pass state is no longer supported. Please '
+                       'see the documentation for further information.'
+            'result': False,
+            'changes': {}}

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -645,6 +645,7 @@ def set_pass(name, **kwargs):  # pylint: disable=W0613
     '''
     return {'name': name,
             'comment': 'The lxc.set_pass state is no longer supported. Please '
-                       'see the documentation for further information.'
+                       'see the LXC states documentation for further '
+                       'information.'
             'result': False,
             'changes': {}}

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -8,6 +8,7 @@ from __future__ import absolute_import
 __docformat__ = 'restructuredtext en'
 
 # Import salt libs
+import salt.utils
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -28,7 +28,7 @@ def present(name,
             vgname=None,
             lvname=None):
     '''
-    .. versionchanged:: Lithium
+    .. versionchanged:: 2015.2.0
         The :mod:`lxc.created <salt.states.lxc.created>` state has been renamed
         to ``lxc.present``, and the :mod:`lxc.cloned <salt.states.lxc.cloned>`
         state has been merged into this state.
@@ -44,7 +44,7 @@ def present(name,
         * If ``None``, do nothing with regards to the running state of the
           container
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     clone_from
         Create named container as a clone of the specified container
@@ -76,7 +76,7 @@ def present(name,
             <salt.modules.lxc.images>` function.
 
     options
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
         Template-specific options to pass to the lxc-create command. These
         correspond to the long options (ones beginning with two dashes) that
@@ -329,7 +329,7 @@ def absent(name):
 # Container state (running/frozen/stopped)
 def running(name, restart=False):
     '''
-    .. versionchanged:: Lithium
+    .. versionchanged:: 2015.2.0
         The :mod:`lxc.started <salt.states.lxc.started>` state has been renamed
         to ``lxc.running``
 
@@ -423,7 +423,7 @@ def running(name, restart=False):
 
 def frozen(name, start=True):
     '''
-    .. versionadded:: Lithium
+    .. versionadded:: 2015.2.0
 
     Ensure that a container is frozen
 
@@ -522,7 +522,7 @@ def stopped(name, kill=False):
         Older LXC versions will stop containers like this irrespective of this
         argument.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     .. code-block:: yaml
 
@@ -577,7 +577,7 @@ def stopped(name, kill=False):
 # Deprecated states
 def created(name, **kwargs):
     '''
-    .. deprecated:: Lithium
+    .. deprecated:: 2015.2.0
         Use :mod:`lxc.present <salt.states.lxc.present>`
     '''
     salt.utils.warn_until(
@@ -590,7 +590,7 @@ def created(name, **kwargs):
 
 def started(name, restart=False):
     '''
-    .. deprecated:: Lithium
+    .. deprecated:: 2015.2.0
         Use :mod:`lxc.running <salt.states.lxc.running>`
     '''
     salt.utils.warn_until(
@@ -608,7 +608,7 @@ def cloned(name,
            vgname=None,
            profile=None):
     '''
-    .. deprecated:: Lithium
+    .. deprecated:: 2015.2.0
         Use :mod:`lxc.present <salt.states.lxc.present>`
     '''
     salt.utils.warn_until(

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -12,6 +12,7 @@ import traceback
 from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 
+# Container existence/non-existence
 def present(name,
             running=None,
             clone_from=None,
@@ -53,8 +54,8 @@ def present(name,
 
     profile
         Profile to use in container creation (see the :ref:`LXC Tutorial
-        <lxc-tutorial-profiles>` for more information). Values in a profile
-        will be overridden by the parameters listed below.
+        <tutorial-lxc-profiles-container>` for more information). Values in a
+        profile will be overridden by the parameters listed below.
 
     **Container Creation Arguments**
 
@@ -325,6 +326,7 @@ def absent(name):
     return ret
 
 
+# Container state (running/frozen/stopped)
 def running(name, restart=False):
     '''
     .. versionchanged:: Lithium
@@ -599,9 +601,15 @@ def started(name, restart=False):
     return running(name, restart=restart)
 
 
-def cloned(name, orig, **kwargs):
+def cloned(name,
+           orig,
+           snapshot=True,
+           size=None,
+           vgname=None,
+           profile=None):
     '''
-    State has been renamed, show deprecation notice
+    .. deprecated:: Lithium
+        Use :mod:`lxc.present <salt.states.lxc.present>`
     '''
     salt.utils.warn_until(
         'Boron',
@@ -609,4 +617,9 @@ def cloned(name, orig, **kwargs):
         'Please update your states to use lxc.present, with the '
         '\'clone_from\' argument set to the name of the clone source.'
     )
-    return present(name, clone_from=orig, **kwargs)
+    return present(name,
+                   clone_from=orig,
+                   snapshot=snapshot,
+                   size=size,
+                   vgname=vgname,
+                   profile=profile)

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -201,8 +201,7 @@ def present(name,
                                                profile=profile,
                                                snapshot=snapshot,
                                                size=size,
-                                               backing=backing,
-                                               vgname=vgname)
+                                               backing=backing)
             else:
                 result = __salt__['lxc.create'](name,
                                                 profile=profile,

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -27,9 +27,10 @@ def present(name,
             vgname=None,
             lvname=None):
     '''
-    .. versionchanged:: 2014.7.1
-        The ``lxc.created`` state has been renamed to ``lxc.present``, and the
-        ``lxc.cloned`` state has been merged into this state.
+    .. versionchanged:: Lithium
+        The :mod:`lxc.created <salt.states.lxc.created>` state has been renamed
+        to ``lxc.present``, and the :mod:`lxc.cloned <salt.states.lxc.cloned>`
+        state has been merged into this state.
 
     Create the named container if it does not exist
 
@@ -42,7 +43,7 @@ def present(name,
         * If ``None``, do nothing with regards to the running state of the
           container
 
-        .. versionadded:: 2014.7.1
+        .. versionadded:: Lithium
 
     clone_from
         Create named container as a clone of the specified container
@@ -74,7 +75,7 @@ def present(name,
             <salt.modules.lxc.images>` function.
 
     options
-        .. versionadded:: 2014.7.1
+        .. versionadded:: Lithium
 
         Template-specific options to pass to the lxc-create command. These
         correspond to the long options (ones beginning with two dashes) that
@@ -326,8 +327,9 @@ def absent(name):
 
 def running(name, restart=False):
     '''
-    .. versionchanged:: 2014.7.1
-        The ``lxc.started`` state has been renamed to ``lxc.running``
+    .. versionchanged:: Lithium
+        The :mod:`lxc.started <salt.states.lxc.started>` state has been renamed
+        to ``lxc.running``
 
     Ensure that a container is running
 
@@ -419,7 +421,7 @@ def running(name, restart=False):
 
 def frozen(name, start=True):
     '''
-    .. versionadded:: 2014.7.1
+    .. versionadded:: Lithium
 
     Ensure that a container is frozen
 
@@ -499,7 +501,7 @@ def frozen(name, start=True):
 
 def stopped(name, kill=False):
     '''
-    Ensure that a container is running
+    Ensure that a container is stopped
 
     .. note::
 
@@ -518,7 +520,7 @@ def stopped(name, kill=False):
         Older LXC versions will stop containers like this irrespective of this
         argument.
 
-        .. versionadded:: 2014.7.1
+        .. versionadded:: Lithium
 
     .. code-block:: yaml
 
@@ -573,7 +575,8 @@ def stopped(name, kill=False):
 # Deprecated states
 def created(name, **kwargs):
     '''
-    State has been renamed, show deprecation notice
+    .. deprecated:: Lithium
+        Use :mod:`lxc.present <salt.states.lxc.present>`
     '''
     salt.utils.warn_until(
         'Boron',
@@ -581,6 +584,19 @@ def created(name, **kwargs):
         'lxc.present'
     )
     return present(name, **kwargs)
+
+
+def started(name, restart=False):
+    '''
+    .. deprecated:: Lithium
+        Use :mod:`lxc.running <salt.states.lxc.running>`
+    '''
+    salt.utils.warn_until(
+        'Boron',
+        'The lxc.started state has been renamed to lxc.running, please use '
+        'lxc.running'
+    )
+    return running(name, restart=restart)
 
 
 def cloned(name, orig, **kwargs):

--- a/salt/states/lxc.py
+++ b/salt/states/lxc.py
@@ -646,6 +646,6 @@ def set_pass(name, **kwargs):  # pylint: disable=W0613
     return {'name': name,
             'comment': 'The lxc.set_pass state is no longer supported. Please '
                        'see the LXC states documentation for further '
-                       'information.'
+                       'information.',
             'result': False,
             'changes': {}}

--- a/salt/templates/lxc/salt_tarball
+++ b/salt/templates/lxc/salt_tarball
@@ -23,13 +23,25 @@ lxc_network_link="br0"
 default_path="/var/lib/lxc"
 
 deploy_tar() {
-    if [ -f ${path}/config ]
+    if [ -f "${path}/config" ]
     then
-        cp ${path}/config ${path}/_orig_config
+        cp "${path}/config" "${path}/_orig_config"
     fi
-    tar xvf ${imgtar} -C ${path}
-    sed -i '/lxc.rootfs/d' ${path}/config
-    echo "lxc.rootfs = ${path}/rootfs" >> ${path}/config
+    tar xvf ${imgtar} -C "${path}"
+
+    # Set utsname
+    sed -i '/lxc.utsname/d' "${path}/config"
+    echo "lxc.utsname = ${name}" >> "${path}/config"
+
+    # Set rootfs
+    sed -i '/lxc.rootfs/d' "${path}/config"
+    echo "lxc.rootfs = ${path}/rootfs" >> "${path}/config"
+
+    # Set proper hostname in /etc/hostname if present
+    if [ -f "${path}/rootfs/etc/hostname" ]
+    then
+        echo ${name} >"${path}/rootfs/etc/hostname"
+    fi
 }
 
 usage() {

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -831,7 +831,7 @@ def deploy_windows(host,
 
         salt.utils.smb.mkdirs('salttemp', conn=smb_conn)
         salt.utils.smb.mkdirs('salt/conf/pki/minion', conn=smb_conn)
-        ## minion_pub, minion_pem
+        # minion_pub, minion_pem
         kwargs = {'hostname': host,
                   'creds': creds}
 
@@ -842,17 +842,17 @@ def deploy_windows(host,
             salt.utils.smb.put_str(minion_pem, 'salt\\conf\\pki\\minion\\minion.pem', conn=smb_conn)
 
         # Copy over win_installer
-        ## win_installer refers to a file such as:
-        ## /root/Salt-Minion-0.17.0-win32-Setup.exe
-        ## ..which exists on the same machine as salt-cloud
+        # win_installer refers to a file such as:
+        # /root/Salt-Minion-0.17.0-win32-Setup.exe
+        # ..which exists on the same machine as salt-cloud
         comps = win_installer.split('/')
         local_path = '/'.join(comps[:-1])
         installer = comps[-1]
         with salt.utils.fopen(win_installer, 'rb') as inst_fh:
             smb_conn.putFile('C$', 'salttemp/{0}'.format(installer), inst_fh.read)
         # Shell out to winexe to execute win_installer
-        ## We don't actually need to set the master and the minion here since
-        ## the minion config file will be set next via impacket
+        # We don't actually need to set the master and the minion here since
+        # the minion config file will be set next via impacket
         win_cmd('winexe {0} "c:\\salttemp\\{1} /S /master={2} /minion-name={3}"'.format(
             creds, installer, master, name
         ))
@@ -2209,7 +2209,7 @@ def update_bootstrap(config, url=None):
 
 
     '''
-    default_url = config.get('bootstrap_script__url',
+    default_url = config.get('bootstrap_script_url',
                              'https://bootstrap.saltstack.com')
     if not url:
         url = default_url

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -7,7 +7,10 @@ from __future__ import absolute_import
 
 # Import python libs
 import collections
+import copy
 import salt.ext.six as six
+from salt.utils.serializers.yamlex \
+    import merge_recursive as _yamlex_merge_recursive
 
 
 def update(dest, upd):
@@ -20,11 +23,51 @@ def update(dest, upd):
     return dest
 
 
-def merge(d1, d2):
-    md = {}
-    for k, v in d1.iteritems():
-        if k in d2:
-            md[k] = [v, d2[k]]
+def merge_list(obj_a, obj_b):
+    ret = {}
+    for key, val in six.iteritems(obj_a):
+        if key in obj_b:
+            ret[key] = [val, obj_b[key]]
         else:
-            md[k] = v
-    return md
+            ret[key] = val
+    return ret
+
+
+def merge_recurse(obj_a, obj_b):
+    copied = copy.copy(obj_a)
+    return update(copied, obj_b)
+
+
+def merge_aggregate(obj_a, obj_b):
+    return _yamlex_merge_recursive(obj_a, obj_b, level=1)
+
+
+def merge_overwrite(obj_a, obj_b):
+    for obj in obj_b:
+        if obj in obj_a:
+            obj_a[obj] = obj_b[obj]
+    return merge_recurse(obj_a, obj_b)
+
+
+def merge(obj_a, obj_b, strategy='smart', renderer='yaml'):
+    if strategy == 'smart':
+        if renderer == 'yamlex' or renderer.startswith('yamlex_'):
+            strategy = 'aggregate'
+        else:
+            strategy = 'recurse'
+
+    if strategy == 'list':
+        merged = merge_list(obj_a, obj_b)
+    elif strategy == 'recurse':
+        merged = merge_recurse(obj_a, obj_b)
+    elif strategy == 'aggregate':
+        #: level = 1 merge at least root data
+        merged = merge_aggregate(obj_a, obj_b)
+    elif strategy == 'overwrite':
+        merged = merge_overwrite(obj_a, obj_b)
+    else:
+        log.warning('Unknown merging strategy \'{0}\', '
+                    'fallback to recurse'.format(strategy))
+        merged = merge_recurse(obj_a, obj_b)
+
+    return merged

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -18,7 +18,10 @@ log = logging.getLogger(__name__)
 
 def update(dest, upd):
     for key, val in six.iteritems(upd):
-        dest_subkey = dest.get(key, {})
+        try:
+            dest_subkey = dest.get(key, {})
+        except AttributeError:
+            dest_subkey = None
         if isinstance(dest_subkey, collections.Mapping) \
                 and isinstance(val, collections.Mapping):
             ret = update(dest_subkey, val)

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -8,9 +8,12 @@ from __future__ import absolute_import
 # Import python libs
 import collections
 import copy
+import logging
 import salt.ext.six as six
 from salt.utils.serializers.yamlex \
     import merge_recursive as _yamlex_merge_recursive
+
+log = logging.getLogger(__name__)
 
 
 def update(dest, upd):

--- a/salt/utils/dictupdate.py
+++ b/salt/utils/dictupdate.py
@@ -18,8 +18,10 @@ log = logging.getLogger(__name__)
 
 def update(dest, upd):
     for key, val in six.iteritems(upd):
-        if isinstance(val, collections.Mapping):
-            ret = update(dest.get(key, {}), val)
+        dest_subkey = dest.get(key, {})
+        if isinstance(dest_subkey, collections.Mapping) \
+                and isinstance(val, collections.Mapping):
+            ret = update(dest_subkey, val)
             dest[key] = ret
         else:
             dest[key] = upd[key]

--- a/salt/utils/network.py
+++ b/salt/utils/network.py
@@ -803,14 +803,16 @@ def ip_in_subnet(ip_addr, cidr):
     return (ipaddr & mask) == (netaddr & mask)
 
 
-def ip_addrs(interface=None, include_loopback=False):
+def ip_addrs(interface=None, include_loopback=False, interface_data=None):
     '''
     Returns a list of IPv4 addresses assigned to the host. 127.0.0.1 is
     ignored, unless 'include_loopback=True' is indicated. If 'interface' is
     provided, then only IP addresses from that interface will be returned.
     '''
     ret = set()
-    ifaces = interfaces()
+    ifaces = interface_data \
+        if isinstance(interface_data, dict) \
+        else interfaces()
     if interface is None:
         target_ifaces = ifaces
     else:
@@ -831,14 +833,16 @@ def ip_addrs(interface=None, include_loopback=False):
     return sorted(list(ret))
 
 
-def ip_addrs6(interface=None, include_loopback=False):
+def ip_addrs6(interface=None, include_loopback=False, interface_data=None):
     '''
     Returns a list of IPv6 addresses assigned to the host. ::1 is ignored,
     unless 'include_loopback=True' is indicated. If 'interface' is provided,
     then only IP addresses from that interface will be returned.
     '''
     ret = set()
-    ifaces = interfaces()
+    ifaces = interface_data \
+        if isinstance(interface_data, dict) \
+        else interfaces()
     if interface is None:
         target_ifaces = ifaces
     else:

--- a/tests/integration/modules/lxc.py
+++ b/tests/integration/modules/lxc.py
@@ -5,20 +5,27 @@ Test the lxc module
 '''
 
 # Import Salt Testing libs
-from salttesting.helpers import ensure_in_syspath, skip_if_not_root, skip_if_binaries_missing
+from salttesting.helpers import (
+    ensure_in_syspath,
+    skip_if_not_root,
+    skip_if_binaries_missing
+)
+from salttesting import skipIf
 ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
 
 
+@skipIf(True,
+        'Needs rewrite to be more distro agnostic. Also, the tearDown '
+        'function destroys ALL containers on the box, which is BAD.')
 @skip_if_not_root
 @skip_if_binaries_missing('lxc-start', message='LXC is not installed or minimal version not met')
 class LXCModuleTest(integration.ModuleCase):
     '''
     Test the lxc module
     '''
-
     prefix = '_salttesting'
 
     def setUp(self):
@@ -50,7 +57,8 @@ class LXCModuleTest(integration.ModuleCase):
 
         r = self.run_function('lxc.create', [self.prefix],
                               template='sshd')
-        self.assertEqual(r, {'created': True})
+        self.assertEqual(r, {'state': {'new': 'stopped', 'old': None},
+                             'result': True})
         self.assertTrue(self.run_function('lxc.exists', [self.prefix]))
         r = self.run_function('lxc.destroy', [self.prefix])
         self.assertEqual(r, {'state': None, 'change': True})

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -56,6 +56,7 @@ class SysModuleTest(integration.ModuleCase):
         noexample = set()
         allow_failure = (
                 'cp.recv',
+                'lxc.run_cmd',
                 'pkg.expand_repo_def',
                 'runtests_decorators.depends',
                 'runtests_decorators.depends_will_fallback',


### PR DESCRIPTION
**This will need further work before it is ready to be merged. See below.**

This pull request refactors LXC support, bringing it up-to-date with Salt's
coding style guidelines, as well as adding several features/functions. It also
adds an initial draft of a tutorial to the docs.

There is one major change that I made which may be modified before this is
merged. I modified the way that profiles work (while leaving legacy behavior
backwards-compatible) so that they weren't all configured under a single key.
This allows a single profile to be overridden without requiring all profiles to
be re-defined. During a conversation with @thatch45 we discussed adding an
option to the config.get remote execution function that merges dictionaries, a
feature which would make it unnecessary to configure profiles under individual
top-level keys. We need to further discuss this before we move forward with
merging.

**To install this pull request for testing:**
1. Check out the pull request locally (see [steps 1-5 here](https://help.github.com/articles/checking-out-pull-requests-locally/) for instructions). Where the instructions reference `origin`, replace that with the name of the git remote you have created for upstream. If you don't have such a remote, run `git remote add upstream https://github.com/saltstack/salt.git`, and use `upstream` instead of `origin` when fetching in step 4.
2. Install using `setup.py install` or `pip install --editable=/path/to/git/checkout`.
