### PR TITLE
Fix GET regression in s3.query

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -142,6 +142,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
         if querystring:
             requesturl += '?{0}'.format(querystring)
 
+    data = None
     if method == 'PUT':
         if local_file:
             with salt.utils.fopen(local_file, 'r') as ifile:


### PR DESCRIPTION
While #19079 fixed PUT requests, it broke GET... Thanks to @sebest, GET works again.

S3 integration still feels buggy. I should have written unit tests for S3, but sorry, not this time.

I've manually tested PUT, DELETE and GET. My test scenario:

``` sh
echo foo > ~/foo.txt
BUCKET=my-bucket-1
salt-call s3.put bucket=$BUCKET local_file=~/foo.txt path=foo.txt -l debug
salt-call s3.get bucket=$BUCKET local_file=~/foo.txt path=foo.txt -l debug
salt-call s3.delete bucket=$BUCKET path=foo.txt -l debug
```
