### PR TITLE
Fix for:  TypeError: pub() got multiple values for keyword argument 'user' 

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1939,7 +1939,6 @@ class Syndic(Minion):
                        data['ret'],
                        data['jid'],
                        data['to'],
-                       user=data.get('user', ''),
                        **kwargs)
 
     def _setsockopts(self):


### PR DESCRIPTION
Since we already add "user" above, this just causes it to be sent twice. Looks like there was a merge conflict :)
