### PR TITLE
13197 - pkg.install can use sources for yumpkg

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -991,17 +991,26 @@ def install(name=None,
 
     __context__.pop('pkg.list_pkgs', None)
     new = list_pkgs()
+
+    versionName = pkgname
     ret = salt.utils.compare_dicts(old, new)
+
+    if sources is not None:
+        versionName = pkgname + '-' + new.get(pkgname, '')
+        if pkgname in ret:
+            ret[versionName] = ret.pop(pkgname)
     for pkgname in to_reinstall:
-        if not pkgname not in old:
-            ret.update({pkgname: {'old': old.get(pkgname, ''),
+        if not versionName not in old:
+            ret.update({versionName: {'old': old.get(pkgname, ''),
                                   'new': new.get(pkgname, '')}})
         else:
-            if pkgname not in ret:
-                ret.update({pkgname: {'old': old.get(pkgname, ''),
+            if versionName not in ret:
+                ret.update({versionName: {'old': old.get(pkgname, ''),
                                       'new': new.get(pkgname, '')}})
     if ret:
         __context__.pop('pkg._avail', None)
+    elif sources is not None:
+        ret = {versionName: {}}
     return ret
 
 


### PR DESCRIPTION
This is a fix for:
https://github.com/saltstack/salt/issues/13197

Allows sources to be provided to yumpkg, if the version isn't given in the key then a cached file is used, and if it is used - then salt didn't see that the item had been updated, as the pkgname was returned, not including the version (as specified in the key)
