### PR TITLE
[32702] Patch salt to allow scheduling to work properly on Windows

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -545,7 +545,7 @@ class Schedule(object):
                     _when = []
                     for i in data['when']:
                         try:
-                            tmp = int(dateutil_parser.parse(i).strftime('%s'))
+                            tmp = int(time.mktime(dateutil_parser.parse(i).timetuple()))
                         except ValueError:
                             log.error('Invalid date string {0}. Ignoring job {1}.'.format(i, job))
                             continue
@@ -585,7 +585,7 @@ class Schedule(object):
 
                 else:
                     try:
-                        when = int(dateutil_parser.parse(data['when']).strftime('%s'))
+                        when = int(time.mktime(dateutil_parser.parse(data['when']).timetuple()))
                     except ValueError:
                         log.error('Invalid date string. Ignoring')
                         continue
@@ -613,7 +613,7 @@ class Schedule(object):
                     log.error('Missing python-croniter. Ignoring job {0}'.format(job))
                     continue
 
-                now = int(datetime.datetime.now().strftime('%s'))
+                now = int(time.mktime(datetime.datetime.now().timetuple()))
                 try:
                     cron = int(croniter.croniter(data['cron'], now).get_next())
                 except (ValueError, KeyError):
@@ -678,12 +678,12 @@ class Schedule(object):
                     else:
                         if isinstance(data['range'], dict):
                             try:
-                                start = int(dateutil_parser.parse(data['range']['start']).strftime('%s'))
+                                start = int(time.mktime(dateutil_parser.parse(data['range']['start']).timetuple()))
                             except ValueError:
                                 log.error('Invalid date string for start. Ignoring job {0}.'.format(job))
                                 continue
                             try:
-                                end = int(dateutil_parser.parse(data['range']['end']).strftime('%s'))
+                                end = int(time.mktime(dateutil_parser.parse(data['range']['end']).timetuple()))
                             except ValueError:
                                 log.error('Invalid date string for end. Ignoring job {0}.'.format(job))
                                 continue


### PR DESCRIPTION
See bug: https://github.com/saltstack/salt/issues/19277

Replaced the existing strftime('%s') based conversion to epoch time with something more portable.
