### PR TITLE
added note about Arch Linux's default transport

### DIFF
--- a/doc/topics/installation/arch.rst
+++ b/doc/topics/installation/arch.rst
@@ -18,6 +18,10 @@ Install Salt stable releases from the Arch Linux Official repositories as follow
 
     pacman -S salt
 
+.. note:: transports
+
+    Unlike other linux distributions, please be aware that Arch Linux's package manager pacman defaults to RAET as the Salt transport. If you want to use ZeroMQ instead, make sure to enter the associated number for the salt-zmq repository when prompted.
+
 Tracking develop
 ----------------
 


### PR DESCRIPTION
It's been written that Salt defaults to ZeroMQ as the transport (public source: http://docs.saltstack.com/en/latest/topics/installation/index.html). However, Arch Linux's package manager defaults to RAET. A note for the Arch Linux installation page has been added to highlight this difference to other linux distributions.
