### PR TITLE
Cleanup pip state when requirements file is used

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -558,16 +558,16 @@ def installed(name,
         if requirements or editable:
             comments = []
             if requirements:
-                for eachline in pip_install_call.get('stdout', '').split('\n'):
-                    if not eachline.startswith('Requirement already satisfied') and eachline != 'Cleaning up...':
+                for line in pip_install_call.get('stdout', '').split('\n'):
+                    if not line.startswith('Requirement already satisfied') \
+                            and line != 'Cleaning up...':
                         ret['changes']['requirements'] = True
                 if ret['changes'].get('requirements'):
                     comments.append('Successfully processed requirements file '
                                     '{0}.'.format(requirements))
                 else:
-                    comments.append('Requirements was successfully installed')
-                comments.append('Successfully processed requirements file '
-                                '{0}.'.format(requirements))
+                    comments.append('Requirements were already installed.')
+
             if editable:
                 comments.append('Package successfully installed from VCS '
                                 'checkout {0}.'.format(editable))


### PR DESCRIPTION
This cleans up the comments for the pip.installed state, removing an 
extraneous comment and making a minor grammar fix.
