### PR TITLE
Fix salt cloud volumes

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2313,9 +2313,8 @@ def create_attach_volumes(name, kwargs, call=None, wait_to_finish=True):
         if 'volume_id' not in volume_dict:
             created_volume = create_volume(volume_dict, call='function', wait_to_finish=wait_to_finish)
             created = True
-            for item in created_volume:
-                if 'volumeId' in item:
-                    volume_dict['volume_id'] = item['volumeId']
+            if 'volumeId' in created_volume:
+                volume_dict['volume_id'] = created_volume['volumeId']
 
         attach = attach_volume(
             name,

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2611,10 +2611,12 @@ def run_func_until_ret_arg(fun, kwargs, fun_call=None, argument_being_watched=No
         f_result = fun(kwargs, call=fun_call)
         r_set = {}
         for d in f_result:
-            for k, v in d.items():
-                r_set[k] = v
-        result = r_set.get('item')
-        status = _unwrap_dict(result, argument_being_watched)
+            if type(d) is list:
+                d0 = d[0]
+                if type(d0) is dict:
+                    for k, v in d0.items():
+                        r_set[k] = v
+        status = _unwrap_dict(r_set, argument_being_watched)
         log.debug('Function: {0}, Watched arg: {1}, Response: {2}'.format(str(fun).split(' ')[1],
                                                                           argument_being_watched,
                                                                           status))

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -2611,9 +2611,9 @@ def run_func_until_ret_arg(fun, kwargs, fun_call=None, argument_being_watched=No
         f_result = fun(kwargs, call=fun_call)
         r_set = {}
         for d in f_result:
-            if type(d) is list:
+            if isinstance(d, list):
                 d0 = d[0]
-                if type(d0) is dict:
+                if isinstance(d0, dict):
                     for k, v in d0.items():
                         r_set[k] = v
         status = _unwrap_dict(r_set, argument_being_watched)


### PR DESCRIPTION
I am encountering two ERROR messages when using salt-cloud to create the EC2 volumes that I am specifying in the following cloud.profiles

```
hadoop_node_profile_193:
  provider: ec2_us_east_1_vpc
  image: ami-76817c1e
  size: r3.xlarge
  ssh_username: ec2-user
  script: bootstrap-salt
  network_interfaces:
    - DeviceIndex: 0
      PrivateIpAddresses:
        - Primary: True
          PrivateIpAddress: 10.0.0.193
      #auto assign public ip (not EIP)
      AssociatePublicIpAddress: False
      SubnetId: subnet-12345678
      SecurityGroupId:
        - sg-87654321
  block_device_mappings:
    - DeviceName: /dev/xvda
      Ebs.VolumeSize: 100
    - DeviceName: /dev/sdb
      VirtualName: ephemeral0
  volumes:
    - { size: 200, device: /dev/sdf, type: gp2 }
    - { size: 200, device: /dev/sdg, type: gp2 }
    - { size: 200, device: /dev/sdh, type: gp2 }
    - { size: 200, device: /dev/sdi, type: gp2 }
    - { size: 200, device: /dev/sdj, type: gp2 }
    - { size: 200, device: /dev/sdk, type: gp2 }
  del_root_vol_on_destroy: True
  del_all_vols_on_destroy: True
  tag: {'Environment': 'development', 'Role': 'hadoop'}
  sync_after_install: grains
  startup_states: hadoop
```

The first error I encounter is AttributeError: 'list' object has no attribute 'items' which is being caused because the code was written expecting a dictionary to be returned but the code that is being called is returning a list.

```
[INFO    ] Create and attach volumes to node shad_hadoop_minion_193
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
[DEBUG   ] Setting read timeout to None
[DEBUG   ] "GET /?Action=DescribeVolumes&Version=2014-10-01&VolumeId.0=vol-d497d490 HTTP/1.1" 200 None
[DEBUG   ] AWS Response Status Code: 200
[ERROR   ] There was a profile error: 'list' object has no attribute 'items'
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/cli.py", line 254, in run
    self.config.get('names')
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1370, in run_profile
    ret[name] = self.create(vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1240, in create
    output = self.clouds[func](vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/ec2.py", line 2221, in create
    call='action'
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/ec2.py", line 2314, in create_attach_volumes
    created_volume = create_volume(volume_dict, call='function', wait_to_finish=wait_to_finish)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/ec2.py", line 3388, in create_volume
    required_argument_response='available')
  File "/usr/local/lib/python2.7/dist-packages/salt/utils/cloud.py", line 2614, in run_func_until_ret_arg
    for k, v in d.items():
AttributeError: 'list' object has no attribute 'items'
```

The next error I encounter is TypeError: string indices must be integers, not str which is being caused because the returned dictionary is not being processed correctly. The returned type is actually a tuple which contains a string and a list which contains a dictionary.

```
[INFO    ] Create and attach volumes to node shad_hadoop_minion_193
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
[INFO    ] Starting new HTTPS connection (1): ec2.us-east-1.amazonaws.com
[DEBUG   ] Setting read timeout to None
[DEBUG   ] "GET /?Action=DescribeVolumes&Version=2014-10-01&VolumeId.0=vol-1f91d25b HTTP/1.1" 200 None
[DEBUG   ] AWS Response Status Code: 200
[DEBUG   ] Function: describe_volumes, Watched arg: status, Response: available
[ERROR   ] There was a profile error: string indices must be integers, not str
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/cli.py", line 254, in run
    self.config.get('names')
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1370, in run_profile
    ret[name] = self.create(vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/__init__.py", line 1240, in create
    output = self.clouds[func](vm_)
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/ec2.py", line 2221, in create
    call='action'
  File "/usr/local/lib/python2.7/dist-packages/salt/cloud/clouds/ec2.py", line 2318, in create_attach_volumes
    volume_dict['volume_id'] = item['volumeId']
TypeError: string indices must be integers, not str
```

The following is my salt --versions-report

```
root@saltmaster:~# salt --versions-report
           Salt: 2014.7.0-2018-gddc7930
         Python: 2.7.6 (default, Mar 22 2014, 22:59:56)
         Jinja2: 2.7.2
       M2Crypto: 0.21.1
 msgpack-python: 0.3.0
   msgpack-pure: Not Installed
       pycrypto: 2.6.1
        libnacl: Not Installed
         PyYAML: 3.10
          ioflo: Not Installed
          PyZMQ: 14.0.1
           RAET: Not Installed
            ZMQ: 4.0.4
           Mako: 0.9.1
```
