### PR TITLE
add 'state_output_profile' option for profile output

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -460,6 +460,10 @@
 # states is cluttering the logs. Set it to True to ignore them.
 #state_output_diff: False
 
+# The state_output_profile setting changes whether profile information
+# will be shown for each statei run.
+#state_output_profile: False
+
 # Fingerprint of the master public key to double verify the master is valid,
 # the master fingerprint can be found by running "salt-key -F master" on the
 # salt master.

--- a/conf/minion
+++ b/conf/minion
@@ -462,7 +462,7 @@
 
 # The state_output_profile setting changes whether profile information
 # will be shown for each state run.
-#state_output_profile: False
+#state_output_profile: True
 
 # Fingerprint of the master public key to double verify the master is valid,
 # the master fingerprint can be found by running "salt-key -F master" on the

--- a/conf/minion
+++ b/conf/minion
@@ -461,7 +461,7 @@
 #state_output_diff: False
 
 # The state_output_profile setting changes whether profile information
-# will be shown for each statei run.
+# will be shown for each state run.
 #state_output_profile: False
 
 # Fingerprint of the master public key to double verify the master is valid,

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -205,7 +205,7 @@ def _format_host(host, data):
                 u'    {tcolor}  Result: {ret[result]!s}{colors[ENDC]}',
                 u'    {tcolor} Comment: {comment}{colors[ENDC]}',
             ]
-            if __opts__.get('state_output_profile', False):
+            if __opts__.get('state_output_profile', True):
                 state_lines.extend([
                     u'    {tcolor} Started: {ret[start_time]!s}{colors[ENDC]}',
                     u'    {tcolor}Duration: {ret[duration]!s}{colors[ENDC]}',

--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -204,9 +204,12 @@ def _format_host(host, data):
                 u'    {tcolor}Function: {comps[0]}.{comps[3]}{colors[ENDC]}',
                 u'    {tcolor}  Result: {ret[result]!s}{colors[ENDC]}',
                 u'    {tcolor} Comment: {comment}{colors[ENDC]}',
-                u'    {tcolor} Started: {ret[start_time]!s}{colors[ENDC]}',
-                u'    {tcolor}Duration: {ret[duration]!s}{colors[ENDC]}'
             ]
+            if __opts__.get('state_output_profile', False):
+                state_lines.extend([
+                    u'    {tcolor} Started: {ret[start_time]!s}{colors[ENDC]}',
+                    u'    {tcolor}Duration: {ret[duration]!s}{colors[ENDC]}',
+                ])
             # This isn't the prettiest way of doing this, but it's readable.
             if comps[1] != comps[2]:
                 state_lines.insert(


### PR DESCRIPTION
We use "pdsh -l root -g group salt-call state.sls service.xxxx test=True| dshbak -c" to check whether the change is expected and identical for many hosts before actually apply them. With the profile information is shown, the diff infomation from different hosts can't be merged (by dshbak -c) because of the start time and duration. This patch add an option 'state_output_profile', so we can turn off the started and duration info.
