### PR TITLE
Make AES key never hit disk on the master

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -2056,8 +2056,6 @@ def apply_master_config(overrides=None, defaults=None):
     if len(opts['sock_dir']) > len(opts['cachedir']) + 10:
         opts['sock_dir'] = os.path.join(opts['cachedir'], '.salt-unix')
 
-    opts['aes'] = salt.crypt.Crypticle.generate_key_string()
-
     opts['extension_modules'] = (
         opts.get('extension_modules') or
         os.path.join(opts['cachedir'], 'extmods')

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -42,59 +42,28 @@ log = logging.getLogger(__name__)
 
 def dropfile(cachedir, user=None, sock_dir=None):
     '''
-    Set an AES dropfile to update the publish session key
-
-    A dropfile is checked periodically by master workers to determine
-    if AES key rotation has occurred.
+    Set an AES dropfile to request the master update the publish session key
     '''
-    dfnt = os.path.join(cachedir, '.dfnt')
     dfn = os.path.join(cachedir, '.dfn')
-
-    def ready():
-        '''
-        Because MWorker._update_aes uses second-precision mtime
-        to detect changes to the file, we must avoid writing two
-        versions with the same mtime.
-
-        Note that this only makes rapid updates in serial safe: concurrent
-        updates could still both pass this check and then write two different
-        keys with the same mtime.
-        '''
-        try:
-            stats = os.stat(dfn)
-        except os.error:
-            # Not there, go ahead and write it
-            return True
-        else:
-            if stats.st_mtime == time.time():
-                # The mtime is the current time, we must
-                # wait until time has moved on.
-                return False
-            else:
-                return True
-
-    while not ready():
-        log.warning('Waiting before writing {0}'.format(dfn))
-        time.sleep(1)
-
-    log.info('Rotating AES key')
-    aes = Crypticle.generate_key_string()
+    # set a mask (to avoid a race condition on file creation) and store original.
     mask = os.umask(191)
-    with salt.utils.fopen(dfnt, 'w+') as fp_:
-        fp_.write(aes)
-    if user:
-        try:
-            import pwd
-            uid = pwd.getpwnam(user).pw_uid
-            os.chown(dfnt, uid, -1)
-        except (KeyError, ImportError, OSError, IOError):
-            pass
+    try:
+        log.info('Rotating AES key')
 
-    shutil.move(dfnt, dfn)
-    os.umask(mask)
+        with salt.utils.fopen(dfn, 'w+') as fp_:
+            fp_.write('')
+        if user:
+            try:
+                import pwd
+                uid = pwd.getpwnam(user).pw_uid
+                os.chown(dfn, uid, -1)
+            except (KeyError, ImportError, OSError, IOError):
+                pass
+    finally:
+        os.umask(mask)  # restore original umask
     if sock_dir:
-        event = salt.utils.event.SaltEvent('master', sock_dir)
-        event.fire_event({'rotate_aes_key': True}, tag='key')
+        # TODO: deprecation warning
+        pass
 
 
 def gen_keys(keydir, keyname, keysize, user=None):
@@ -745,7 +714,8 @@ class Crypticle(object):
     SIG_SIZE = hashlib.sha256().digest_size
 
     def __init__(self, opts, key_string, key_size=192):
-        self.keys = self.extract_keys(key_string, key_size)
+        self.key_string = key_string
+        self.keys = self.extract_keys(self.key_string, key_size)
         self.key_size = key_size
         self.serial = salt.payload.Serial(opts)
 

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -12,7 +12,6 @@ import os
 import sys
 import time
 import hmac
-import shutil
 import hashlib
 import logging
 import traceback

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -40,7 +40,7 @@ from salt.exceptions import (
 log = logging.getLogger(__name__)
 
 
-def dropfile(cachedir, user=None, sock_dir=None):
+def dropfile(cachedir, user=None):
     '''
     Set an AES dropfile to request the master update the publish session key
     '''
@@ -61,9 +61,6 @@ def dropfile(cachedir, user=None, sock_dir=None):
                 pass
     finally:
         os.umask(mask)  # restore original umask
-    if sock_dir:
-        # TODO: deprecation warning
-        pass
 
 
 def gen_keys(keydir, keyname, keysize, user=None):

--- a/salt/key.py
+++ b/salt/key.py
@@ -752,7 +752,7 @@ class Key(object):
                     pass
         self.check_minion_cache(preserve_minions=matches.get('minions', []))
         if self.opts.get('rotate_aes_key'):
-            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'], self.opts['sock_dir'])
+            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return (
             self.name_match(match) if match is not None
             else self.dict_match(matches)
@@ -774,7 +774,7 @@ class Key(object):
                     pass
         self.check_minion_cache()
         if self.opts.get('rotate_aes_key'):
-            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'], self.opts['sock_dir'])
+            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
 
     def reject(self, match=None, match_dict=None, include_accepted=False):
@@ -812,7 +812,7 @@ class Key(object):
                     pass
         self.check_minion_cache()
         if self.opts.get('rotate_aes_key'):
-            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'], self.opts['sock_dir'])
+            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return (
             self.name_match(match) if match is not None
             else self.dict_match(matches)
@@ -843,7 +843,7 @@ class Key(object):
                 pass
         self.check_minion_cache()
         if self.opts.get('rotate_aes_key'):
-            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'], self.opts['sock_dir'])
+            salt.crypt.dropfile(self.opts['cachedir'], self.opts['user'])
         return self.list_keys()
 
     def finger(self, match):

--- a/salt/master.py
+++ b/salt/master.py
@@ -241,7 +241,6 @@ class Maintenance(multiprocessing.Process):
         except os.error:
             pass
 
-
         if self.opts.get('publish_session'):
             if now - self.rotate >= self.opts['publish_session']:
                 to_rotate = True

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -134,6 +134,9 @@ class Pillar(object):
         # location of file_roots. Issue 5951
         ext_pillar_opts = dict(self.opts)
         ext_pillar_opts['file_roots'] = self.actual_file_roots
+        # TODO: consolidate into "sanitize opts"
+        if 'aes' in ext_pillar_opts:
+            ext_pillar_opts.pop('aes')
         self.merge_strategy = 'smart'
         if opts.get('pillar_source_merging_strategy'):
             self.merge_strategy = opts['pillar_source_merging_strategy']
@@ -591,6 +594,7 @@ class Pillar(object):
         errors.extend(terrors)
         if self.opts.get('pillar_opts', True):
             mopts = dict(self.opts)
+            # TODO: consolidate into sanitize function
             if 'grains' in mopts:
                 mopts.pop('grains')
             if 'aes' in mopts:


### PR DESCRIPTION
In the past we've been doing coordination of the aes key using dropfiles etc. Not only is this significantly more costly (at least 1 stat per reqserver request) it also means that the symmetric key we use to pub/req messages has been on disk. This re-works the aes key to be a multiprocessing.Array() (char array) which is shared amongst the processes. Now the dropfile is just a request for the master to rotate the key, and this means that _all_ key rotation on the master will generate the appropriate event (instead of just ones who passed in sock_dir to dropfile())
