### PR TITLE
Use salt.ext.six instead of "import six"

### DIFF
--- a/salt/cli/api.py
+++ b/salt/cli/api.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import salt.ext.six
+import salt.ext.six as six
 import sys
 import logging
 

--- a/salt/cli/api.py
+++ b/salt/cli/api.py
@@ -2,7 +2,7 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import six
+import salt.ext.six
 import sys
 import logging
 

--- a/salt/utils/yamlencoding.py
+++ b/salt/utils/yamlencoding.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import io
 import yaml
-import six
+import salt.ext.six
 
 
 def yaml_dquote(text):

--- a/salt/utils/yamlencoding.py
+++ b/salt/utils/yamlencoding.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import io
 import yaml
-import salt.ext.six
+import salt.ext.six as six
 
 
 def yaml_dquote(text):


### PR DESCRIPTION
Prevent hard-dep on external six install.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/saltstack/salt/19330)

<!-- Reviewable:end -->
