### PR TITLE
Svn export fix issue 19343

### DIFF
--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -213,14 +213,14 @@ def export(name,
                     ret,
                     ('{0} doesn\'t exist and is set to be checked out.').format(target))
         svn_cmd = 'svn.list'
-	rev = 'HEAD'
+        rev = 'HEAD'
         out = __salt__[svn_cmd](cwd, target, user, username, password, *opts)
         return _neutral_test(
                 ret,
                 ('{0}').format(out))
 
     if not rev:
-	rev = 'HEAD'
+        rev = 'HEAD'
 
     if force:
         opts += ('--force',)

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -219,7 +219,7 @@ def export(name,
                 ret,
                 ('{0}').format(out))
 
-    if rev:
+    if not rev:
 	rev = 'HEAD'
 
     if force:

--- a/salt/states/svn.py
+++ b/salt/states/svn.py
@@ -213,14 +213,14 @@ def export(name,
                     ret,
                     ('{0} doesn\'t exist and is set to be checked out.').format(target))
         svn_cmd = 'svn.list'
-        opts += ('-r', 'HEAD')
+	rev = 'HEAD'
         out = __salt__[svn_cmd](cwd, target, user, username, password, *opts)
         return _neutral_test(
                 ret,
                 ('{0}').format(out))
 
     if rev:
-        opts += ('-r', str(rev))
+	rev = 'HEAD'
 
     if force:
         opts += ('--force',)
@@ -231,7 +231,7 @@ def export(name,
     if trust:
         opts += ('--trust-server-cert',)
 
-    out = __salt__[svn_cmd](cwd, name, basename, user, username, password, *opts)
+    out = __salt__[svn_cmd](cwd, name, basename, user, username, password, rev, *opts)
     ret['changes'] = name + ' was Exported to ' + target
 
     return ret


### PR DESCRIPTION
This fixes issue #19343 by just removing the rev argument from the opts argument list and passing the revision argument directly like the other parameters (cwd, target, user, username, password). This way, we match the function header in modules/svn.py svn.export...
