### PR TITLE
Additions to pkg state module

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -801,6 +801,9 @@ def installed(
     if not isinstance(version, string_types) and version is not None:
         version = str(version)
 
+    if version is not None and version == 'latest':
+        version = __salt__['pkg.latest_version'](name)
+
     kwargs['allow_updates'] = allow_updates
     result = _find_install_targets(name, version, pkgs, sources,
                                    fromrepo=fromrepo,


### PR DESCRIPTION
Allow the version argument for the pkg state to accept the "latest" as a value.  If specified then the latest version available will be installed.  Per #19291
