### PR TITLE
[S3] Fixes a error where a variable is not initialised

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -77,6 +77,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
 
     # Try grabbing the credentials from the EC2 instance IAM metadata if available
     token = None
+    data = None
     if not key or not keyid:
         iam_creds = iam.get_iam_metadata()
         key = iam_creds['secret_key']


### PR DESCRIPTION
`data` may not be defined if the request is something else than PUT creating an exception when fetching files from s3 (eu-west-1 endpoint for example).
