### PR TITLE
openbsdrcctl: fix code to match new rcctl(8) syntax.

### DIFF
--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -61,7 +61,7 @@ def available(name):
 
         salt '*' service.available sshd
     '''
-    cmd = '{0} status {1}'.format(_cmd(), name)
+    cmd = '{0} get {1}'.format(_cmd(), name)
     if __salt__['cmd.retcode'](cmd) == 2:
         return False
     return True
@@ -91,11 +91,13 @@ def get_all():
 
         salt '*' service.get_all
     '''
+    badvar = [ "_timeout", "_user" ]
     ret = []
     service = _cmd()
-    for svc in __salt__['cmd.run']('{0} status'.format(service)).splitlines():
+    for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
         svc = re.sub('(_flags|)=.*$', '', svc)
-        ret.append(svc)
+        if not svc.endswith(tuple(badvar)):
+            ret.append(svc)
     return sorted(ret)
 
 
@@ -109,12 +111,14 @@ def get_disabled():
 
         salt '*' service.get_disabled
     '''
+    badvar = [ "_timeout", "_user" ]
     ret = []
     service = _cmd()
-    for svc in __salt__['cmd.run']('{0} status'.format(service)).splitlines():
+    for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
         if svc.endswith("=NO"):
             svc = re.sub('(_flags|)=.*$', '', svc)
-            ret.append(svc)
+            if not svc.endswith(tuple(badvar)):
+                ret.append(svc)
     return sorted(ret)
 
 
@@ -128,12 +132,14 @@ def get_enabled():
 
         salt '*' service.get_enabled
     '''
+    badvar = [ "_timeout", "_user" ]
     ret = []
     service = _cmd()
-    for svc in __salt__['cmd.run']('{0} status'.format(service)).splitlines():
+    for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
         if not svc.endswith("=NO"):
             svc = re.sub('(_flags|)=.*$', '', svc)
-            ret.append(svc)
+            if not svc.endswith(tuple(badvar)):
+                ret.append(svc)
     return sorted(ret)
 
 
@@ -227,8 +233,12 @@ def enable(name, **kwargs):
         salt '*' service.enable <service name>
         salt '*' service.enable <service name> flags=<flags>
     '''
-    flags = _get_flags(**kwargs)
-    cmd = '{0} enable {1} flags {2}'.format(_cmd(), name, flags)
+    cmd = '{0} set {1} status on'.format(_cmd(), name)
+    # only (re)set flags for services that have an rc.d(8) script
+    if os.path.exists('/etc/rc.d/{0}'.format(name)):
+        flags = _get_flags(**kwargs)
+        cmd = cmd + ' && {0} set {1} flags {2}'.format(_cmd(), name, flags)
+
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -242,7 +252,7 @@ def disable(name, **kwargs):
 
         salt '*' service.disable <service name>
     '''
-    cmd = '{0} disable {1}'.format(_cmd(), name)
+    cmd = '{0} set {1} status off'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd)
 
 
@@ -256,7 +266,7 @@ def disabled(name):
 
         salt '*' service.disabled <service name>
     '''
-    cmd = '{0} status {1}'.format(_cmd(), name)
+    cmd = '{0} get {1} status'.format(_cmd(), name)
     return not __salt__['cmd.retcode'](cmd) == 0
 
 
@@ -275,16 +285,16 @@ def enabled(name, **kwargs):
         salt '*' service.enabled <service name>
         salt '*' service.enabled <service name> flags=<flags>
     '''
-    cmd = '{0} status {1}'.format(_cmd(), name)
+    cmd = '{0} get {1} status'.format(_cmd(), name)
     if not __salt__['cmd.retcode'](cmd):
         # also consider a service disabled if the current flags are different
         # than the configured ones so we have a chance to update them
         flags = _get_flags(**kwargs)
-        cur_flags = __salt__['cmd.run_stdout']('{0} status {1}'.format(_cmd(), name))
+        cur_flags = __salt__['cmd.run_stdout']('{0} get {1} flags'.format(_cmd(), name))
         if format(flags) == format(cur_flags):
             return True
         if not flags:
-            def_flags = __salt__['cmd.run_stdout']('{0} default {1}'.format(_cmd(), name))
+            def_flags = __salt__['cmd.run_stdout']('{0} getdef {1} flags'.format(_cmd(), name))
             if format(cur_flags) == format(def_flags):
                 return True
 

--- a/salt/modules/openbsdrcctl.py
+++ b/salt/modules/openbsdrcctl.py
@@ -91,12 +91,12 @@ def get_all():
 
         salt '*' service.get_all
     '''
-    badvar = [ "_timeout", "_user" ]
+    badvar = ("_timeout", "_user")
     ret = []
     service = _cmd()
     for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
         svc = re.sub('(_flags|)=.*$', '', svc)
-        if not svc.endswith(tuple(badvar)):
+        if not svc.endswith(badvar):
             ret.append(svc)
     return sorted(ret)
 
@@ -111,13 +111,13 @@ def get_disabled():
 
         salt '*' service.get_disabled
     '''
-    badvar = [ "_timeout", "_user" ]
+    badvar = ("_timeout", "_user")
     ret = []
     service = _cmd()
     for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
         if svc.endswith("=NO"):
             svc = re.sub('(_flags|)=.*$', '', svc)
-            if not svc.endswith(tuple(badvar)):
+            if not svc.endswith(badvar):
                 ret.append(svc)
     return sorted(ret)
 
@@ -132,13 +132,13 @@ def get_enabled():
 
         salt '*' service.get_enabled
     '''
-    badvar = [ "_timeout", "_user" ]
+    badvar = ("_timeout", "_user")
     ret = []
     service = _cmd()
     for svc in __salt__['cmd.run']('{0} getall'.format(service)).splitlines():
         if not svc.endswith("=NO"):
             svc = re.sub('(_flags|)=.*$', '', svc)
-            if not svc.endswith(tuple(badvar)):
+            if not svc.endswith(badvar):
                 ret.append(svc)
     return sorted(ret)
 


### PR DESCRIPTION
I just recently rewrote some part of rcctl(8) on OpenBSD to make it much more useful.
In the process, the syntax has been modified.
http://marc.info/?l=openbsd-cvs&m=142054488027109&w=2
