### PR TITLE
Rbenv documentation fix

### DIFF
--- a/salt/states/rbenv.py
+++ b/salt/states/rbenv.py
@@ -35,7 +35,7 @@ and 2.x using rbenv on Ubuntu/Debian:
           - autoconf
           - bison
           - build-essential
-          - libssl-dev
+          - libffi-dev
           - libyaml-dev
           - libreadline6-dev
           - zlib1g-dev


### PR DESCRIPTION
Removed a duplicate dependecy and added libffi which is needed according to https://github.com/sstephenson/ruby-build/wiki#build-failure-of-fiddle-with-ruby-220
