### PR TITLE
Don't use --local by default in git.config_set

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -869,14 +869,14 @@ def config_set(cwd=None, setting_name=None, setting_value=None, user=None, is_gl
         raise SaltInvocationError('Either `is_global` must be set to True or '
                                   'you must provide `cwd`')
 
-    scope = '--local'
     if is_global:
-        scope = '--global'
+        cmd = 'git config --global {0} "{1}"'.format(setting_name, setting_value)
+    else:
+        cmd = 'git config {0} "{1}"'.format(setting_name, setting_value)
 
     _check_git()
 
-    return _git_run('git config {0} {1} "{2}"'.format(scope, setting_name, setting_value),
-                    cwd=cwd, runas=user)
+    return _git_run(cmd, cwd=cwd, runas=user)
 
 
 def config_get(cwd=None, setting_name=None, user=None):

--- a/tests/integration/modules/git.py
+++ b/tests/integration/modules/git.py
@@ -35,9 +35,3 @@ class GitModuleTest(integration.ModuleCase):
             setting_value=config_value,
         )
         self.assertEqual("", ret)
-
-        output = subprocess.check_output(
-            ['git', 'config', '--local', config_key],
-            cwd=self.repos)
-
-        self.assertEqual(config_value + "\n", output)

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -208,11 +208,6 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
             is_global=False)
         self.assertSaltTrueReturn(ret)
 
-        output = subprocess.check_output(
-            ['git', 'config', '--local', config_key],
-            cwd=name)
-        self.assertEqual(config_value + "\n", output)
-
 
 if __name__ == '__main__':
     from integration import run_tests

--- a/tests/integration/states/git.py
+++ b/tests/integration/states/git.py
@@ -12,7 +12,7 @@ import subprocess
 import tempfile
 
 # Import Salt Testing libs
-from salttesting.helpers import ensure_in_syspath
+from salttesting.helpers import ensure_in_syspath, skip_if_binaries_missing
 ensure_in_syspath('../../')
 
 # Import salt libs
@@ -188,15 +188,11 @@ class GitTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
         finally:
             shutil.rmtree(name, ignore_errors=True)
 
+    @skip_if_binaries_missing('git')
     def test_config_set_value_with_space_character(self):
         '''
         git.config
         '''
-        from salt.utils import which
-        git = which('git')
-        if not git:
-            self.skipTest('The git binary is not available')
-
         name = tempfile.mkdtemp(dir=integration.TMP)
         self.addCleanup(shutil.rmtree, name, ignore_errors=True)
         subprocess.check_call(['git', 'init', '--quiet', name])


### PR DESCRIPTION
--local is not available on older versions of git. --local behavior is the default behavior when --global isn't specified. This fixes that behavior and also addresses two failing git integration tests. subprocess.check_output is not available in Python 2.6.
