### PR TITLE
minion.py:Minion.__init__(): fix broken ref to ProxyMinion

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -678,7 +678,7 @@ class Minion(MinionBase):
                 if pid > 0:
                     continue
                 else:
-                    proxyminion = salt.ProxyMinion()
+                    proxyminion = ProxyMinion()
                     proxyminion.start(self.opts['pillar']['proxy'][p])
                     self.clean_die(signal.SIGTERM, None)
         else:


### PR DESCRIPTION
ಠ_ಠ

```
************* Module salt.minion
salt/minion.py:681: [E1101(no-member), Minion.__init__] Module 'salt' has no 'ProxyMinion' member
```
