### PR TITLE
Add documentation for renderes in pillar files

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -49,6 +49,14 @@ config:
 .. code-block:: yaml
 
     renderer: jinja | yaml | gpg
+    
+Setting a gpg renderer in the master currently requires minions to be 
+configured for gpg.  The workaround for this is to add a line to the top of
+any pillar with gpg data in it 
+
+.. code-block:: yaml
+
+    #!yaml|gpg
 
 Now you can include your ciphers in your pillar data like so:
 


### PR DESCRIPTION
Including renderer in master currently causes failures if minions do not have gpg configured.  Added in section showing an alternative to the /etc/salt/master  renderer line ... shebang line in pillar files containg gpg data.
