### PR TITLE
doc(dev-bootstrap): Sphinx 1.3b2

### DIFF
--- a/doc/topics/development/hacking.rst
+++ b/doc/topics/development/hacking.rst
@@ -233,7 +233,7 @@ to a virtualenv using pip:
 
 .. code-block:: bash
 
-    pip install Sphinx
+    pip install Sphinx==1.3b2
 
 Change to salt documentation directory, then:
 


### PR DESCRIPTION
I was getting an error that the current stable version of Sphinx wasn't
new enough. Installing Sphinx 1.3b2 did the trick.
