### PR TITLE
Provide modules.pillar.obfuscate and modules.pillar.ls

### DIFF
--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -108,7 +108,7 @@ def items(*args):
 data = items
 
 
-def obfuscate_inner(var):
+def _obfuscate_inner(var):
     '''
     Recursive obfuscation of collection types.
 
@@ -117,10 +117,10 @@ def obfuscate_inner(var):
     In the special case of mapping types, keys are not obfuscated
     '''
     if isinstance(var, (dict, salt.utils.odict.OrderedDict)):
-        return var.__class__((k, obfuscate_inner(v))
+        return var.__class__((k, _obfuscate_inner(v))
                              for k, v in var.iteritems())
     elif isinstance(var, (list, set, tuple)):
-        return type(var)(obfuscate_inner(v) for v in var)
+        return type(var)(_obfuscate_inner(v) for v in var)
     else:
         return '<{0}>'.format(var.__class__.__name__)
 
@@ -152,7 +152,7 @@ def obfuscate(*args):
         salt '*' pillar.obfuscate
 
     '''
-    return obfuscate_inner(items(*args))
+    return _obfuscate_inner(items(*args))
 
 
 # naming chosen for consistency with grains.ls, although it breaks the short

--- a/salt/modules/pillar.py
+++ b/salt/modules/pillar.py
@@ -127,7 +127,7 @@ def obfuscate_inner(var):
 
 def obfuscate(*args):
     '''
-    .. versionadded:: develop
+    .. versionadded:: Beryllium
 
     Same as :py:func:`items`, but replace pillar values with a simple type indication.
 
@@ -159,7 +159,7 @@ def obfuscate(*args):
 # identifier rule.
 def ls(*args):
     '''
-    .. versionadded:: develop
+    .. versionadded:: Beryllium
 
     Calls the master for a fresh pillar, generates the pillar data on the
     fly (same as :py:func:`items`), but only shows the available main keys.

--- a/tests/unit/modules/pillar_test.py
+++ b/tests/unit/modules/pillar_test.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# Import Salt Testing libs
+from salttesting import skipIf, TestCase
+from salttesting.helpers import ensure_in_syspath
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+ensure_in_syspath('../../')
+
+# Import Salt libs
+from salt.utils.odict import OrderedDict
+from salt.modules import pillar as pillarmod
+
+
+pillar_value_1 = dict(a=1, b='very secret')
+
+
+class PillarModuleTestCase(TestCase):
+
+    def test_obfuscate_inner_recursion(self):
+        self.assertEqual(
+                pillarmod.obfuscate_inner(dict(a=[1, 2],
+                                               b=dict(pwd='secret', deeper=('a', 1)))),
+                dict(a=['<int>', '<int>'],
+                     b=dict(pwd='<str>', deeper=('<str>', '<int>')))
+        )
+
+    def test_obfuscate_inner_more_types(self):
+        self.assertEqual(pillarmod.obfuscate_inner(OrderedDict([('key', 'value')])),
+                         OrderedDict([('key', '<str>')]))
+
+        self.assertEqual(pillarmod.obfuscate_inner(set((1, 2))),
+                         set(['<int>']))
+
+        self.assertEqual(pillarmod.obfuscate_inner((1, 2)),
+                         ('<int>', '<int>'))
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    @patch('salt.modules.pillar.items', MagicMock(return_value=pillar_value_1))
+    def test_obfuscate(self):
+        self.assertEqual(pillarmod.obfuscate(),
+                         dict(a='<int>', b='<str>'))
+
+    @skipIf(NO_MOCK, NO_MOCK_REASON)
+    @patch('salt.modules.pillar.items', MagicMock(return_value=pillar_value_1))
+    def test_ls(self):
+        self.assertEqual(pillarmod.ls(), ['a', 'b'])
+
+
+# gracinet: not sure this is really useful, but other test modules have this as well
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(PillarModuleTestCase, needs_daemon=False)

--- a/tests/unit/modules/pillar_test.py
+++ b/tests/unit/modules/pillar_test.py
@@ -24,20 +24,20 @@ class PillarModuleTestCase(TestCase):
 
     def test_obfuscate_inner_recursion(self):
         self.assertEqual(
-                pillarmod.obfuscate_inner(dict(a=[1, 2],
-                                               b=dict(pwd='secret', deeper=('a', 1)))),
+                pillarmod._obfuscate_inner(dict(a=[1, 2],
+                                                b=dict(pwd='secret', deeper=('a', 1)))),
                 dict(a=['<int>', '<int>'],
                      b=dict(pwd='<str>', deeper=('<str>', '<int>')))
         )
 
     def test_obfuscate_inner_more_types(self):
-        self.assertEqual(pillarmod.obfuscate_inner(OrderedDict([('key', 'value')])),
+        self.assertEqual(pillarmod._obfuscate_inner(OrderedDict([('key', 'value')])),
                          OrderedDict([('key', '<str>')]))
 
-        self.assertEqual(pillarmod.obfuscate_inner(set((1, 2))),
+        self.assertEqual(pillarmod._obfuscate_inner(set((1, 2))),
                          set(['<int>']))
 
-        self.assertEqual(pillarmod.obfuscate_inner((1, 2)),
+        self.assertEqual(pillarmod._obfuscate_inner((1, 2)),
                          ('<int>', '<int>'))
 
     @skipIf(NO_MOCK, NO_MOCK_REASON)


### PR DESCRIPTION
This fulfills #19329. As explained there, 'ls' is not that useful, but still including it for completeness.
Also first attempt at writing a unit test within salt.
