### PR TITLE
Don't run weird pip install test on CentOS 5

### DIFF
--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -3,9 +3,9 @@
     - system_site_packages: False
     - distribute: True
 
-carbon-weird-setup:
+carbonite-weird-setup:
   pip.installed:
-    - name: carbon
+    - name: carbonite
     - no_deps: True
     - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
     - mirrors: http://testpypi.python.org/pypi

--- a/tests/integration/files/file/base/pip-installed-weird-install.sls
+++ b/tests/integration/files/file/base/pip-installed-weird-install.sls
@@ -3,9 +3,9 @@
     - system_site_packages: False
     - distribute: True
 
-carbonite-weird-setup:
+carbon-weird-setup:
   pip.installed:
-    - name: carbonite
+    - name: carbon
     - no_deps: True
     - bin_env: {{ salt['runtests_helpers.get_sys_temp_dir_for_path']('pip-installed-weird-install') }}
     - mirrors: http://testpypi.python.org/pypi

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -101,7 +101,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                     continue
                 self.assertEqual(
                     ret[key]['comment'],
-                    'There was no error installing package \'carbon\' '
+                    'There was no error installing package \'carbonite\' '
                     'although it does not show when calling \'pip.freeze\'.'
                 )
         finally:

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -64,6 +64,16 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                 shutil.rmtree(venv_dir)
 
     def test_pip_installed_weird_install(self):
+        # First, check to see if this is running on CentOS 5
+        os_grain = self.run_function('grains.item', ['os'])
+        os_version = self.run_function('grains.item', ['osmajorrelease'])
+
+        # Skip this test if running on CentOS 5
+        if os_grain['os'] == 'CentOS' and os_version['osmajorrelease'] == 5:
+            self.skipTest(
+                'This test does not run reliably on CentOS 5'
+            )
+
         ographite = '/opt/graphite'
         if os.path.isdir(ographite):
             self.skipTest(

--- a/tests/integration/states/pip.py
+++ b/tests/integration/states/pip.py
@@ -111,7 +111,7 @@ class PipStateTest(integration.ModuleCase, integration.SaltReturnAssertsMixIn):
                     continue
                 self.assertEqual(
                     ret[key]['comment'],
-                    'There was no error installing package \'carbonite\' '
+                    'There was no error installing package \'carbon\' '
                     'although it does not show when calling \'pip.freeze\'.'
                 )
         finally:


### PR DESCRIPTION
The egg needed to run more complex tests fails on CentOS 5 with an upstream bug. Let's skip it there.
