### PR TITLE
Cleanup and performance tweaks (redo #19318 )

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -610,6 +610,8 @@ class Auth(object):
 
         m_pub_fn = os.path.join(self.opts['pki_dir'], self.mpub)
 
+        auth['master_uri'] = self.opts['master_uri']
+
         sreq = salt.payload.SREQ(
             self.opts['master_uri'],
         )
@@ -818,4 +820,5 @@ class SAuth(Auth):
                     log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))
                 continue
             break
+        self.creds = creds
         return Crypticle(self.opts, creds['aes'])

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -253,12 +253,42 @@ class MasterKeys(dict):
         return self.pub_signature
 
 
-class Auth(object):
+class SAuth(object):
     '''
-    The Auth class provides the sequence for setting up communication with
-    the master server from a minion.
+    Set up an object to maintain authentication with the salt master
     '''
+    # This class is only a singleton per minion/master pair
+    instances = {}
+
+    def __new__(cls, opts):
+        '''
+        Only create one instance of SAuth per __key()
+        '''
+        key = cls.__key(opts)
+        if key not in SAuth.instances:
+            SAuth.instances[key] = object.__new__(cls)
+            SAuth.instances[key].__singleton_init__(opts)
+        return SAuth.instances[key]
+
+    @classmethod
+    def __key(cls, opts):
+        return (opts['pki_dir'],     # where the keys are stored
+                opts['id'],          # minion ID
+                opts['master_uri'],  # master ID
+                )
+
+    def clear(self):
+        '''
+        Clear an instance from the instance cache, to use when auth rotates
+        '''
+        del self.instances[self.__key(opts)]
+
+    # has to remain empty for singletons, since __init__ will *always* be called
     def __init__(self, opts):
+        pass
+
+    # an init for the singleton instance to call
+    def __singleton_init__(self, opts):
         '''
         Init an Auth instance
 
@@ -279,6 +309,41 @@ class Auth(object):
             self.mpub = 'minion_master.pub'
         if not os.path.isfile(self.pub_path):
             self.get_keys()
+
+        self.crypticle = self.__authenticate()
+
+    def __authenticate(self):
+        '''
+        Authenticate with the master, this method breaks the functional
+        paradigm, it will update the master information from a fresh sign
+        in, signing in can occur as often as needed to keep up with the
+        revolving master AES key.
+
+        :rtype: Crypticle
+        :returns: A crypticle used for encryption operations
+        '''
+        acceptance_wait_time = self.opts['acceptance_wait_time']
+        acceptance_wait_time_max = self.opts['acceptance_wait_time_max']
+        if not acceptance_wait_time_max:
+            acceptance_wait_time_max = acceptance_wait_time
+
+        while True:
+            creds = self.sign_in()
+            if creds == 'retry':
+                if self.opts.get('caller'):
+                    print('Minion failed to authenticate with the master, '
+                          'has the minion key been accepted?')
+                    sys.exit(2)
+                if acceptance_wait_time:
+                    log.info('Waiting {0} seconds before retry.'.format(acceptance_wait_time))
+                    time.sleep(acceptance_wait_time)
+                if acceptance_wait_time < acceptance_wait_time_max:
+                    acceptance_wait_time += acceptance_wait_time
+                    log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))
+                continue
+            break
+        self.creds = creds
+        return Crypticle(self.opts, creds['aes'])
 
     def get_keys(self):
         '''
@@ -779,46 +844,3 @@ class Crypticle(object):
         if not data.startswith(self.PICKLE_PAD):
             return {}
         return self.serial.loads(data[len(self.PICKLE_PAD):])
-
-
-class SAuth(Auth):
-    '''
-    Set up an object to maintain the standalone authentication session
-    with the salt master
-    '''
-    def __init__(self, opts):
-        super(SAuth, self).__init__(opts)
-        self.crypticle = self.__authenticate()
-
-    def __authenticate(self):
-        '''
-        Authenticate with the master, this method breaks the functional
-        paradigm, it will update the master information from a fresh sign
-        in, signing in can occur as often as needed to keep up with the
-        revolving master AES key.
-
-        :rtype: Crypticle
-        :returns: A crypticle used for encryption operations
-        '''
-        acceptance_wait_time = self.opts['acceptance_wait_time']
-        acceptance_wait_time_max = self.opts['acceptance_wait_time_max']
-        if not acceptance_wait_time_max:
-            acceptance_wait_time_max = acceptance_wait_time
-
-        while True:
-            creds = self.sign_in()
-            if creds == 'retry':
-                if self.opts.get('caller'):
-                    print('Minion failed to authenticate with the master, '
-                          'has the minion key been accepted?')
-                    sys.exit(2)
-                if acceptance_wait_time:
-                    log.info('Waiting {0} seconds before retry.'.format(acceptance_wait_time))
-                    time.sleep(acceptance_wait_time)
-                if acceptance_wait_time < acceptance_wait_time_max:
-                    acceptance_wait_time += acceptance_wait_time
-                    log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))
-                continue
-            break
-        self.creds = creds
-        return Crypticle(self.opts, creds['aes'])

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -266,8 +266,11 @@ class SAuth(object):
         '''
         key = cls.__key(opts)
         if key not in SAuth.instances:
+            log.debug('Initializing new SAuth for {0}'.format(key))
             SAuth.instances[key] = object.__new__(cls)
             SAuth.instances[key].__singleton_init__(opts)
+        else:
+            log.debug('Re-using SAuth for {0}'.format(key))
         return SAuth.instances[key]
 
     @classmethod
@@ -310,9 +313,9 @@ class SAuth(object):
         if not os.path.isfile(self.pub_path):
             self.get_keys()
 
-        self.crypticle = self.__authenticate()
+        self.authenticate()
 
-    def __authenticate(self):
+    def authenticate(self):
         '''
         Authenticate with the master, this method breaks the functional
         paradigm, it will update the master information from a fresh sign
@@ -343,7 +346,7 @@ class SAuth(object):
                 continue
             break
         self.creds = creds
-        return Crypticle(self.opts, creds['aes'])
+        self.crypticle = Crypticle(self.opts, creds['aes'])
 
     def get_keys(self):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -812,7 +812,9 @@ class MWorker(multiprocessing.Process):
         try:
             data = self.crypticle.loads(load)
         except Exception:
-            return ''
+            # return something not encrypted so the minions know that they aren't
+            # encrypting correctly.
+            return 'bad load'
         if 'cmd' not in data:
             log.error('Received malformed command {0}'.format(data))
             return {}

--- a/salt/master.py
+++ b/salt/master.py
@@ -247,6 +247,7 @@ class Maintenance(multiprocessing.Process):
                 to_rotate = True
 
         if to_rotate:
+            log.info('Rotating master AES key')
             # should be unecessary-- since no one else should be modifying
             with self.opts['aes'].get_lock():
                 self.opts['aes'].value = salt.crypt.Crypticle.generate_key_string()

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -284,8 +284,7 @@ class SMinion(object):
             self.opts['environment']
         ).compile_pillar()
         self.functions = salt.loader.minion_mods(self.opts, include_errors=True)
-        self.function_errors = self.functions['_errors']
-        self.functions.pop('_errors')  # Keep the funcs clean
+        self.function_errors = self.functions.pop('_errors')  # Keep the funcs clean
         self.returners = salt.loader.returners(self.opts, self.functions)
         self.states = salt.loader.states(self.opts, self.functions)
         self.rend = salt.loader.render(self.opts, self.functions)
@@ -1414,34 +1413,13 @@ class Minion(MinionBase):
                 self.opts['master_ip']
             )
         )
-        auth = salt.crypt.Auth(self.opts)
+        auth = salt.crypt.SAuth(self.opts)
         self.tok = auth.gen_token('salt')
-        acceptance_wait_time = self.opts['acceptance_wait_time']
-        acceptance_wait_time_max = self.opts['acceptance_wait_time_max']
-        if not acceptance_wait_time_max:
-            acceptance_wait_time_max = acceptance_wait_time
-
-        while True:
-            creds = auth.sign_in(timeout, safe)
-            if creds == 'full':
-                return creds
-            elif creds != 'retry':
-                log.info('Authentication with master at {0} successful!'.format(self.opts['master_ip']))
-                break
-            log.info('Waiting for minion key to be accepted by the master.')
-            if acceptance_wait_time:
-                log.info('Waiting {0} seconds before retry.'.format(acceptance_wait_time))
-                time.sleep(acceptance_wait_time)
-            if acceptance_wait_time < acceptance_wait_time_max:
-                acceptance_wait_time += acceptance_wait_time
-                log.debug('Authentication wait time is {0}'.format(acceptance_wait_time))
-
-        self.aes = creds['aes']
+        self.crypticle = auth.crypticle
         if self.opts.get('syndic_master_publish_port'):
             self.publish_port = self.opts.get('syndic_master_publish_port')
         else:
-            self.publish_port = creds['publish_port']
-        self.crypticle = salt.crypt.Crypticle(self.opts, self.aes)
+            self.publish_port = auth.creds['publish_port']
 
     def module_refresh(self, force_refresh=False):
         '''
@@ -2134,7 +2112,10 @@ class Syndic(Minion):
                 self.event_forward_timeout = (
                         time.time() + self.opts['syndic_event_forward_timeout']
                         )
-            if salt.utils.jid.is_jid(event['tag']) and 'return' in event['data']:
+            tag_parts = event['tag'].split('/')
+            if len(tag_parts) >= 4 and tag_parts[1] == 'job' and \
+                salt.utils.jid.is_jid(tag_parts[2]) and tag_parts[3] == 'ret' and \
+                'return' in event['data']:
                 if 'jid' not in event['data']:
                     # Not a job return
                     continue
@@ -2148,7 +2129,8 @@ class Syndic(Minion):
                         self.mminion.returners[fstr](event['data']['jid'])
                         )
                 if 'master_id' in event['data']:
-                    jdict['master_id'] = event['data']['master_id']
+                    # __'s to make sure it doesn't print out on the master cli
+                    jdict['__master_id__'] = event['data']['master_id']
                 jdict[event['data']['id']] = event['data']['return']
             else:
                 # Add generic event aggregation here
@@ -2366,12 +2348,16 @@ class MultiSyndic(MinionBase):
                 if e.errno == errno.EAGAIN or e.errno == errno.EINTR:
                     break
                 raise
+
             log.trace('Got event {0}'.format(event['tag']))
             if self.event_forward_timeout is None:
                 self.event_forward_timeout = (
                         time.time() + self.opts['syndic_event_forward_timeout']
                         )
-            if salt.utils.jid.is_jid(event['tag']) and 'return' in event['data']:
+            tag_parts = event['tag'].split('/')
+            if len(tag_parts) >= 4 and tag_parts[1] == 'job' and \
+                salt.utils.jid.is_jid(tag_parts[2]) and tag_parts[3] == 'ret' and \
+                'return' in event['data']:
                 if 'jid' not in event['data']:
                     # Not a job return
                     continue

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -74,9 +74,7 @@ class RemotePillar(object):
         self.ext = ext
         self.grains = grains
         self.id_ = id_
-        self.serial = salt.payload.Serial(self.opts)
         self.channel = salt.transport.Channel.factory(opts)
-        # self.auth = salt.crypt.SAuth(opts)
 
     def compile_pillar(self):
         '''
@@ -89,12 +87,11 @@ class RemotePillar(object):
                 'cmd': '_pillar'}
         if self.ext:
             load['ext'] = self.ext
-        ret_pillar = self.channel.crypted_transfer_decode_dictentry(load, dictkey='pillar', tries=3, timeout=7200)
-
-        # key = self.auth.get_keys()
-        # aes = key.private_decrypt(ret['key'], 4)
-        # pcrypt = salt.crypt.Crypticle(self.opts, aes)
-        # ret_pillar = pcrypt.loads(ret['pillar'])
+        ret_pillar = self.channel.crypted_transfer_decode_dictentry(load,
+                                                                    dictkey='pillar',
+                                                                    tries=3,
+                                                                    timeout=7200,
+                                                                    )
 
         if not isinstance(ret_pillar, dict):
             log.error(

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -213,6 +213,7 @@ class ZeroMQChannel(Channel):
     # the sreq is the zmq connection, since those are relatively expensive to
     # set up, we are going to reuse them as much as possible.
     sreq_cache = defaultdict(dict)
+    auth_cache = defaultdict(dict)
 
     @property
     def sreq_key(self):
@@ -223,6 +224,19 @@ class ZeroMQChannel(Channel):
                 os.getpid(),                      # per process
                 threading.current_thread().name,  # per per-thread
                 )
+
+    # TODO: change SAuth to return a singleton, so we don't have to do this
+    @property
+    def auth(self):
+        '''
+        Return the appropriate "auth" for this channel
+
+        Note: auth is only cached keyed by master_uri, this means we assume that
+              a given master_uri has ONE auth mechanism (which seems reasonable enough)
+        '''
+        if self.master_uri not in ZeroMQChannel.auth_cache:
+            ZeroMQChannel.auth_cache[self.master_uri] = salt.crypt.SAuth(self.opts)
+        return ZeroMQChannel.auth_cache[self.master_uri]
 
     @property
     def sreq(self):
@@ -258,15 +272,14 @@ class ZeroMQChannel(Channel):
         # crypt defaults to 'aes'
         self.crypt = kwargs.get('crypt', 'aes')
 
-        if self.crypt != 'clear':
-            if 'auth' in kwargs:
-                self.auth = kwargs['auth']
-            else:
-                self.auth = salt.crypt.SAuth(opts)
         if 'master_uri' in kwargs:
             self.master_uri = kwargs['master_uri']
         else:
             self.master_uri = opts['master_uri']
+
+        if self.crypt != 'clear':
+            if 'auth' in kwargs and self.master_uri not in self.auth_cache:
+                self.auth_cache[self.master_uri] = kwargs['auth']
 
     def crypted_transfer_decode_dictentry(self, load, dictkey=None, tries=3, timeout=60):
         ret = self.sreq.send('aes', self.auth.crypticle.dumps(load), tries, timeout)
@@ -298,7 +311,7 @@ class ZeroMQChannel(Channel):
         try:
             return _do_transfer()
         except salt.crypt.AuthenticationError:
-            self.auth = salt.crypt.SAuth(self.opts)
+            del ZeroMQChannel.auth_cache[self.master_uri]
             return _do_transfer()
 
     def _uncrypted_transfer(self, load, tries=3, timeout=60):

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -263,8 +263,9 @@ class ZeroMQChannel(Channel):
         else:
             self.master_uri = opts['master_uri']
 
-        # we don't need to worry about auth as a kwarg, since its a singleton
-        self.auth = salt.crypt.SAuth(self.opts)
+        if self.crypt != 'clear':
+            # we don't need to worry about auth as a kwarg, since its a singleton
+            self.auth = salt.crypt.SAuth(self.opts)
 
     def crypted_transfer_decode_dictentry(self, load, dictkey=None, tries=3, timeout=60):
         ret = self.sreq.send('aes', self.auth.crypticle.dumps(load), tries, timeout)
@@ -296,8 +297,7 @@ class ZeroMQChannel(Channel):
         try:
             return _do_transfer()
         except salt.crypt.AuthenticationError:
-            self.auth.clear()
-            self.auth = salt.crypt.SAuth(self.opts)
+            self.auth.authenticate()
             return _do_transfer()
 
     def _uncrypted_transfer(self, load, tries=3, timeout=60):

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -213,7 +213,6 @@ class ZeroMQChannel(Channel):
     # the sreq is the zmq connection, since those are relatively expensive to
     # set up, we are going to reuse them as much as possible.
     sreq_cache = defaultdict(dict)
-    auth_cache = defaultdict(dict)
 
     @property
     def sreq_key(self):
@@ -224,25 +223,6 @@ class ZeroMQChannel(Channel):
                 os.getpid(),                      # per process
                 threading.current_thread().name,  # per per-thread
                 )
-
-    # TODO: change SAuth to return a singleton, so we don't have to do this
-    @property
-    def auth_key(self):
-        return (self.master_uri,  # which master you want to talk to
-                self.opts['id'],  # which minion you are
-                )
-
-    @property
-    def auth(self):
-        '''
-        Return the appropriate "auth" for this channel
-
-        Note: auth is only cached keyed by master_uri, this means we assume that
-              a given master_uri has ONE auth mechanism (which seems reasonable enough)
-        '''
-        if self.auth_key not in ZeroMQChannel.auth_cache:
-            ZeroMQChannel.auth_cache[self.auth_key] = salt.crypt.SAuth(self.opts)
-        return ZeroMQChannel.auth_cache[self.auth_key]
 
     @property
     def sreq(self):
@@ -283,9 +263,8 @@ class ZeroMQChannel(Channel):
         else:
             self.master_uri = opts['master_uri']
 
-        if self.crypt != 'clear':
-            if 'auth' in kwargs and self.master_uri not in self.auth_cache:
-                self.auth_cache[self.master_uri] = kwargs['auth']
+        # we don't need to worry about auth as a kwarg, since its a singleton
+        self.auth = salt.crypt.SAuth(self.opts)
 
     def crypted_transfer_decode_dictentry(self, load, dictkey=None, tries=3, timeout=60):
         ret = self.sreq.send('aes', self.auth.crypticle.dumps(load), tries, timeout)
@@ -317,7 +296,8 @@ class ZeroMQChannel(Channel):
         try:
             return _do_transfer()
         except salt.crypt.AuthenticationError:
-            del ZeroMQChannel.auth_cache[self.auth_key]
+            self.auth.clear()
+            self.auth = salt.crypt.SAuth(self.opts)
             return _do_transfer()
 
     def _uncrypted_transfer(self, load, tries=3, timeout=60):


### PR DESCRIPTION
The bug we were seeing is actually quite interesting. So in the integration testing code we init a bunch of minions within a single process- which means that the auth cache was confused because you had already init'd one of them. Now I do the caching based off of the minion_id (to make it work for the test), but I think its safe to say that it isn't "best practice" to have multiple separate minions init in the same process like that :) Especially since init-int a minion causes some requests to go off (specifically pillar)

Redo of #19318 
