### PR TITLE
add pkgrepo.managed clean_file option

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -195,6 +195,10 @@ def managed(name, **kwargs):
        file.  The consolidate will run every time the state is processed. The
        option only needs to be set on one repo managed by salt to take effect.
 
+    clean_file
+       If set to true, empty file before config repo, dangerous if use
+       multiple sources in one file.
+
     refresh_db
        If set to false this will skip refreshing the apt package database on
        debian based systems.
@@ -281,6 +285,10 @@ def managed(name, **kwargs):
             ret['comment'] = ('Package repo {0!r} already configured'
                               .format(name))
             return ret
+
+    if kwargs.get('clean_file', False):
+        open(kwargs['file'], 'w').close()
+
     if __opts__['test']:
         ret['comment'] = ('Package repo {0!r} will be configured. This may '
                           'cause pkg states to behave differently than stated '


### PR DESCRIPTION
I'm using `pkgrepo.managed` to manage our softwares repositories. The idea is: if `private_mirror` pillar key is undefined, switch to use a public mirror instead.

``` sls
private_software:
  pkgrepo:
    - managed
    - name: deb {{ salt['pillar.get']('private_mirror', 'http://my-company.com') {{ grains['lsb_distrib_codename'] }} main
    - key_url: https://my-company-key
    - file: /etc/apt/sources.list.d/company.list
```

But when try to change `private_mirror` pillar key, salt will end up with both old and new mirror in `/etc/apt/sources.list.d/company.list`. I solve it by adding option `clean_file` to `pkgrepo.managed` that will erase file contents before config new repo. If repo is already configured, it does nothing.
