### PR TITLE
Fix setup salt paths

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -22,52 +22,106 @@ from __future__ import absolute_import
 import sys
 import os.path
 
-if 'SETUP_DIRNAME' in globals():
-    # This is from the exec() call in Salt's setup.py
-    THIS_FILE = os.path.join(SETUP_DIRNAME, 'salt', 'syspaths.py')  # pylint: disable=E0602
-else:
-    THIS_FILE = __file__
+__PLATFORM = sys.platform.lower()
 
 try:
     # Let's try loading the system paths from the generated module at
     # installation time.
-    from salt._syspaths import (  # pylint: disable=W0611,E0611,import-error
-        ROOT_DIR,                 # because pylint thinks that _syspaths is an
-        CONFIG_DIR,               # attribute of salt.__init__
-        CACHE_DIR,
-        SOCK_DIR,
-        SRV_ROOT_DIR,
-        BASE_FILE_ROOTS_DIR,
-        BASE_PILLAR_ROOTS_DIR,
-        BASE_MASTER_ROOTS_DIR,
-        LOGS_DIR,
-        PIDFILE_DIR,
-        CLOUD_DIR,
-        INSTALL_DIR,
-        BOOTSTRAP,
-    )
+    import salt._syspaths as __generated_syspaths  # pylint: disable=no-name-in-module
 except ImportError:
-    # The installation time was not generated, let's define the default values
-    __platform = sys.platform.lower()
-    if __platform.startswith('win'):
+    class __generated_syspaths(object):
+        __slots__ = ('ROOT_DIR',
+                     'CONFIG_DIR',
+                     'CACHE_DIR',
+                     'SOCK_DIR',
+                     'SRV_ROOT_DIR',
+                     'BASE_FILE_ROOTS_DIR',
+                     'BASE_PILLAR_ROOTS_DIR',
+                     'BASE_MASTER_ROOTS_DIR',
+                     'LOGS_DIR',
+                     'PIDFILE_DIR')
+        ROOT_DIR = CONFIG_DIR = CACHE_DIR = SOCK_DIR = None
+        SRV_ROOT_DIR = BASE_FILE_ROOTS_DIR = BASE_PILLAR_ROOTS_DIR = None
+        BASE_MASTER_ROOTS_DIR = LOGS_DIR = PIDFILE_DIR = None
+
+
+# Let's find out the path of this module
+if 'SETUP_DIRNAME' in globals():
+    # This is from the exec() call in Salt's setup.py
+    __THIS_FILE = os.path.join(SETUP_DIRNAME, 'salt', 'syspaths.py')  # pylint: disable=E0602
+else:
+    __THIS_FILE = __file__
+
+
+# These values are always relative to salt's installation directory
+INSTALL_DIR = os.path.dirname(os.path.realpath(__THIS_FILE))
+CLOUD_DIR = os.path.join(INSTALL_DIR, 'cloud')
+BOOTSTRAP = os.path.join(CLOUD_DIR, 'deploy', 'bootstrap-salt.sh')
+
+ROOT_DIR = __generated_syspaths.ROOT_DIR
+if ROOT_DIR is None:
+    # The installation time value was not provided, let's define the default
+    if __PLATFORM.startswith('win'):
         ROOT_DIR = r'c:\salt' or '/'
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
     else:
         ROOT_DIR = '/'
-        if 'freebsd' in __platform:
-            CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
-        elif 'netbsd' in __platform:
-            CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'pkg', 'etc', 'salt')
-        else:
-            CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
+
+CONFIG_DIR = __generated_syspaths.CONFIG_DIR
+if CONFIG_DIR is None:
+    if __PLATFORM.startswith('win'):
+        CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
+    elif 'freebsd' in __PLATFORM:
+        CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
+    elif 'netbsd' in __PLATFORM:
+        CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'pkg', 'etc', 'salt')
+    else:
+        CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
+
+CACHE_DIR = __generated_syspaths.CACHE_DIR
+if CACHE_DIR is None:
     CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')
+
+SOCK_DIR = __generated_syspaths.SOCK_DIR
+if SOCK_DIR is None:
     SOCK_DIR = os.path.join(ROOT_DIR, 'var', 'run', 'salt')
+
+SRV_ROOT_DIR = __generated_syspaths.SRV_ROOT_DIR
+if SRV_ROOT_DIR is None:
     SRV_ROOT_DIR = os.path.join(ROOT_DIR, 'srv')
+
+BASE_FILE_ROOTS_DIR = __generated_syspaths.BASE_FILE_ROOTS_DIR
+if BASE_FILE_ROOTS_DIR is None:
     BASE_FILE_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'salt')
+
+BASE_PILLAR_ROOTS_DIR = __generated_syspaths.BASE_PILLAR_ROOTS_DIR
+if BASE_FILE_ROOTS_DIR is None:
     BASE_PILLAR_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'pillar')
+
+BASE_MASTER_ROOTS_DIR = __generated_syspaths.BASE_MASTER_ROOTS_DIR
+if BASE_MASTER_ROOTS_DIR is None:
     BASE_MASTER_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'salt-master')
+
+LOGS_DIR = __generated_syspaths.LOGS_DIR
+if LOGS_DIR is None:
     LOGS_DIR = os.path.join(ROOT_DIR, 'var', 'log', 'salt')
+
+PIDFILE_DIR = __generated_syspaths.PIDFILE_DIR
+if PIDFILE_DIR is None:
     PIDFILE_DIR = os.path.join(ROOT_DIR, 'var', 'run')
-    INSTALL_DIR = os.path.dirname(os.path.realpath(THIS_FILE))
-    CLOUD_DIR = os.path.join(INSTALL_DIR, 'cloud')
-    BOOTSTRAP = os.path.join(CLOUD_DIR, 'deploy', 'bootstrap-salt.sh')
+
+
+__all__ = [
+    'ROOT_DIR',
+    'CONFIG_DIR',
+    'CACHE_DIR',
+    'SOCK_DIR',
+    'SRV_ROOT_DIR',
+    'BASE_FILE_ROOTS_DIR',
+    'BASE_PILLAR_ROOTS_DIR',
+    'BASE_MASTER_ROOTS_DIR',
+    'LOGS_DIR',
+    'PIDFILE_DIR',
+    'INSTALL_DIR',
+    'CLOUD_DIR',
+    'BOOTSTRAP'
+]

--- a/setup.py
+++ b/setup.py
@@ -435,7 +435,7 @@ class Install(install):
     def initialize_options(self):
         install.initialize_options(self)
         # pylint: disable=undefined-variable
-        if __saltstack_version__.info >= (2015, 3):
+        if __saltstack_version__.info >= SaltStackVersion.from_name('Boron'):
             # XXX: Remove the Salt Specific Options In Salt Boron. They are now global options
             raise DistutilsArgError(
                 'Developers, please remove the salt paths configuration '

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,6 @@ SALT_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), '_requirements.txt')
 SALT_ZEROMQ_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'zeromq-requirements.txt')
 SALT_CLOUD_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'cloud-requirements.txt')
 SALT_RAET_REQS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'raet-requirements.txt')
-SALT_SYSPATHS = os.path.join(os.path.abspath(SETUP_DIRNAME), 'salt', 'syspaths.py')
 
 # Salt SSH Packaging Detection
 PACKAGED_FOR_SALT_SSH_FILE = os.path.join(os.path.abspath(SETUP_DIRNAME), '.salt-ssh-package')
@@ -116,7 +115,6 @@ PACKAGED_FOR_SALT_SSH = os.path.isfile(PACKAGED_FOR_SALT_SSH_FILE)
 
 # pylint: disable=W0122
 exec(compile(open(SALT_VERSION).read(), SALT_VERSION, 'exec'))
-exec(compile(open(SALT_SYSPATHS).read(), SALT_SYSPATHS, 'exec'))
 # pylint: enable=W0122
 
 

--- a/setup.py
+++ b/setup.py
@@ -409,7 +409,6 @@ class Build(build):
 
 
 class Install(install):
-    # XXX: Remove the Salt Specific Options In Salt Boron. They are now global options
     user_options = install.user_options + [
         ('salt-root-dir=', None,
          'Salt\'s pre-configured root directory'),
@@ -435,6 +434,14 @@ class Install(install):
 
     def initialize_options(self):
         install.initialize_options(self)
+        # pylint: disable=undefined-variable
+        if __saltstack_version__.info >= (2015, 3):
+            # XXX: Remove the Salt Specific Options In Salt Boron. They are now global options
+            raise DistutilsArgError(
+                'Developers, please remove the salt paths configuration '
+                'setting from the setup\'s install command'
+            )
+        # pylint: enable=undefined-variable
         self.salt_root_dir = None
         self.salt_config_dir = None
         self.salt_cache_dir = None


### PR DESCRIPTION
- Evaluate paths one by one since some depend on others
- Salt path options are now global and default to None. Since we now evaluate each `salt.syspath` entry one by one, we only set the passed settings in the generated `_syspaths` module. The default values will mandate unless explicitly overridden in the setup stage.
