### PR TITLE
Adjust for a possible subtle bug in zeromq

### DIFF
--- a/tests/unit/payload_test.py
+++ b/tests/unit/payload_test.py
@@ -124,8 +124,13 @@ class SREQTestCase(TestCase):
         sreq = self.get_sreq()
         # client-side timeout
         start = time.time()
-        with self.assertRaises(salt.exceptions.SaltReqTimeoutError):
+        # This is a try/except instead of an assertRaises because of a possible
+        # subtle bug in zmq wherein a timeout=0 actually exceutes a single poll
+        # before the timeout is reached.
+        try:
             sreq.send('clear', 'foo', tries=0, timeout=0)
+        except salt.exceptions.SaltReqTimeoutError:
+            pass
         assert time.time() - start < 1  # ensure we didn't wait
 
         # server-side timeout


### PR DESCRIPTION
cc: @jacksontj

I'm not positive, but it appears that what may be happening here is that a timeout of `0` actually executes a single poll loop, which is occasionally fast enough to catch the response, thus triggering the `assertRaises``. Since the original intention here was to check that the timeout was indeed honoured, I've changed this slightly but this may be something to keep in mind for the future.
