### PR TITLE
Change log message from #e6e7ab6c from error to debug

### DIFF
--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -50,7 +50,7 @@ try:
         PIDFILE_DIR,
     )
 except ImportError as error:
-    log.error('Error importing salt._syspaths with exception {0}'.format(error))
+    log.debug('Error importing salt._syspaths with exception {0}'.format(error))
     # The installation time was not generated, let's define the default values
     __platform = sys.platform.lower()
     if __platform.startswith('win'):


### PR DESCRIPTION
Change in #e6e7ab6c is _very_ chatty for local develop installs-- since the salt._syspaths module wasn't generated.
