### PR TITLE
url fix of dependency in installation guide

### DIFF
--- a/doc/topics/installation/index.rst
+++ b/doc/topics/installation/index.rst
@@ -96,7 +96,7 @@ Optional Dependencies
 .. _`Python 2.6`: http://python.org/download/
 .. _`ZeroMQ`: http://zeromq.org/
 .. _`pyzmq`: https://github.com/zeromq/pyzmq
-.. _`msgpack-python`:  https://pypi.python.org/pypi/msgpack-python/0.1.12
+.. _`msgpack-python`:  https://pypi.python.org/pypi/msgpack-python/
 .. _`PyCrypto`: https://www.dlitz.net/software/pycrypto/
 .. _`M2Crypto`: http://chandlerproject.org/Projects/MeTooCrypto
 .. _`YAML`: http://pyyaml.org/


### PR DESCRIPTION
http://docs.saltstack.com/en/latest/topics/installation/index.html linked to msgpack-python version 0.1.12. The fix links to the latest version (which is version 0.4.4 at the time of this commit), since not a specific version of msgpack-python was written down as a dependency.
