### PR TITLE
Fixes for develop

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -114,4 +114,5 @@ class AsyncClientMixin(object):
                 target=self._proc_function,
                 args=(fun, low, user, tag, jid))
         proc.start()
+        proc.join()  # MUST join, otherwise we leave zombies all over
         return {'tag': tag, 'jid': jid}

--- a/tests/integration/netapi/test_client.py
+++ b/tests/integration/netapi/test_client.py
@@ -104,7 +104,12 @@ class NetapiClientTest(TestCase):
         self.assertIn('tag', ret)
 
     def test_runner(self):
-        low = {'client': 'runner', 'fun': 'cache.grains'}
+        # TODO: fix race condition in init of event-- right now the event class
+        # will finish init even if the underlying zmq socket hasn't connected yet
+        # this is problematic for the runnerclient's master_call method if the
+        # runner is quick
+        #low = {'client': 'runner', 'fun': 'cache.grains'}
+        low = {'client': 'runner', 'fun': 'test.sleep', 'arg': [2]}
         low.update(self.eauth_creds)
 
         ret = self.netapi.run(low)


### PR DESCRIPTION
We've noticed a few weird failures on develop lately-- and I tracked down 2 of them.

One, since the switch on the master to use MWorkers in the RunnerClient, the call to async (the mixin) wasn't joining the pid, meaning we were leaving zombies all over creation. There is some magic down in the python stdlib to alleviate this problem, but we should just join-- esp. since it should be more or less instant (just joining waiting on another fork).

Also noticed that the runnerclient spins while waiting for returns, not a good plan. In addition there is a race condition between the client's event client connecting and the job completing on the master. As of right now I don't see an API in zmq to have connect() be synchronous, so I'm just working around it in the tests (instead of putting sleeps in there).

@cachedout I _think_ these cover the issues we were discussing in #19545, nothing to do with my previous PR :)
