### PR TITLE
Update hosts file creation for consistency and improved readability

### DIFF
--- a/salt/modules/hosts.py
+++ b/salt/modules/hosts.py
@@ -181,11 +181,11 @@ def rm_host(ip, alias):
             continue
         comps = tmpline.split()
         if comps[0] == ip:
-            newline = '{0}\t'.format(comps[0])
+            newline = '{0}\t\t'.format(comps[0])
             for existing in comps[1:]:
                 if existing == alias:
                     continue
-                newline += '\t{0}'.format(existing)
+                newline += ' {0}'.format(existing)
             if newline.strip() == ip:
                 # No aliases exist for the line, make it empty
                 lines[ind] = ''
@@ -237,7 +237,7 @@ def _write_hosts(hosts):
             else:
                 line = '{0}\t\t{1}'.format(
                     ip,
-                    '\t\t'.join(aliases)
+                    ' '.join(aliases)
                     )
         lines.append(line)
 


### PR DESCRIPTION
Update hosts file format to consistent format, including when adding and removing multiple aliases for a single ip

eg:
127.0.0.1   alias1 alias2, which is comprised of...
IP Address + TAB TAB + alias1 + space + alias2 + (space + aliasx)...

Current behaviour is to use double tab spacing between all elements, but rm_hosts process results in a single tab being used.
