### PR TITLE
lxc module: kwarg shadowing in run_cmd provokes unexpected return value

### DIFF
--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2138,7 +2138,7 @@ def run_cmd(name, cmd, no_start=False, preserve_state=True,
         if not use_vt:
             res = __salt__['cmd.run_all'](cmd)
         else:
-            stdout, stderr = '', ''
+            stdout_buffer, stderr_buffer = '', ''
             try:
                 proc = vt.Terminal(cmd,
                                    shell=True,
@@ -2158,26 +2158,26 @@ def run_cmd(name, cmd, no_start=False, preserve_state=True,
                         except IOError:
                             cstdout, cstderr = '', ''
                         if cstdout:
-                            stdout += cstdout
+                            stdout_buffer += cstdout
                         else:
                             cstdout = ''
                         if cstderr:
-                            stderr += cstderr
+                            stderr_buffer += cstderr
                         else:
                             cstderr = ''
                     except KeyboardInterrupt:
                         break
                 res = {'retcode': proc.exitstatus,
                        'pid': 2,
-                       'stdout': stdout,
-                       'stderr': stderr}
+                       'stdout': stdout_buffer,
+                       'stderr': stderr_buffer}
             except vt.TerminalException:
                 trace = traceback.format_exc()
                 log.error(trace)
                 res = {'retcode': 127,
                        'pid': '2',
-                       'stdout': stdout,
-                       'stderr': stderr}
+                       'stdout': stdout_buffer,
+                       'stderr': stderr_buffer}
             finally:
                 proc.close(terminate=True, kill=True)
     else:


### PR DESCRIPTION
Hi, while testing out the lxc module I encountered an unexpected return value of _lxc.run_cmd_: the function should return a dict with _pid_, _retcode_, _stdout_ and _stderr_ if the **stdout** and **stderr** kwargs are both set to _True_: http://docs.saltstack.com/en/latest/ref/modules/all/salt.modules.lxc.html#salt.modules.lxc.run_cmd.

However, if the **use_vt** kwarg is also set to _True_, **stdout** and **stderr** kwargs are re-used as temporary variables to bufferize the program's output.

At the end of the function, **stdout** and **stderr** kwargs are used to test whether or not the function should return the _pid_, _retcode_, _stdout_ and _stderr_ dict.

In this patch, I simply changed the shadowing **stdout** and **stderr** variables in the **use_vt** condition to **stdout_buffer** and **stderr_buffer**. 

Some output example below to show the unexpected behavior.

A dict with _pid_, _retcode_, _stdout_ and _stderr_ should be returned but since there is only the **stdout** variable that evaluates to _True_, a string is returned (since there is some output on _stdout_, if there was no output, only the _retcode_ will be returned):

```
# salt-call -l quiet lxc.run_cmd lxc-jessie-test 'ls -l /' stdout=True stderr=True use_vt=True 
total 64
drwxr-xr-x   2 root root 4096 Jan  4 10:12 bin
drwxr-xr-x   2 root root 4096 Nov 30 13:37 boot
drwxr-xr-x   6 root root  500 Jan 11 14:25 dev
drwxr-xr-x  46 root root 4096 Jan 11 14:25 etc
drwxr-xr-x   2 root root 4096 Nov 30 13:37 home
drwxr-xr-x  10 root root 4096 Jan  4 10:12 lib
drwxr-xr-x   2 root root 4096 Jan  4 10:12 lib64
drwxr-xr-x   2 root root 4096 Jan  4 10:12 media
drwxr-xr-x   2 root root 4096 Jan  4 10:12 mnt
drwxr-xr-x   2 root root 4096 Jan  4 10:12 opt
dr-xr-xr-x 134 root root    0 Jan 11 14:25 proc
drwx------   2 root root 4096 Jan  4 10:12 root
drwxr-xr-x   9 root root  260 Jan 11 14:25 run
drwxr-xr-x   2 root root 4096 Jan  4 10:12 sbin
drwxr-xr-x   2 root root 4096 Jan 11 14:25 selinux
drwxr-xr-x   2 root root 4096 Jan  4 10:12 srv
dr-xr-xr-x  13 root root    0 Jan 11 14:26 sys
drwxrwxrwt   7 root root 4096 Jan 11 14:25 tmp
drwxr-xr-x  10 root root 4096 Jan  4 10:12 usr
drwxr-xr-x  11 root root 4096 Jan  4 10:12 var
local:
    total 64
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 bin
    drwxr-xr-x   2 root root 4096 Nov 30 13:37 boot
    drwxr-xr-x   6 root root  500 Jan 11 14:25 dev
    drwxr-xr-x  46 root root 4096 Jan 11 14:25 etc
    drwxr-xr-x   2 root root 4096 Nov 30 13:37 home
    drwxr-xr-x  10 root root 4096 Jan  4 10:12 lib
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 lib64
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 media
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 mnt
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 opt
    dr-xr-xr-x 134 root root    0 Jan 11 14:25 proc
    drwx------   2 root root 4096 Jan  4 10:12 root
    drwxr-xr-x   9 root root  260 Jan 11 14:25 run
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 sbin
    drwxr-xr-x   2 root root 4096 Jan 11 14:25 selinux
    drwxr-xr-x   2 root root 4096 Jan  4 10:12 srv
    dr-xr-xr-x  13 root root    0 Jan 11 14:26 sys
    drwxrwxrwt   7 root root 4096 Jan 11 14:25 tmp
    drwxr-xr-x  10 root root 4096 Jan  4 10:12 usr
    drwxr-xr-x  11 root root 4096 Jan  4 10:12 var
```

If I force _ls_ to output on _stderr_ and so filling the **stderr** kwarg, I got the expected result since **stderr** and **stdout** both evaluate to _True_:

```
# salt-call -l quiet lxc.run_cmd lxc-jessie-test 'ls -l / /none' stdout=True stderr=True use_vt=True 
ls: cannot access /none: No such file or directory
/:
total 64
drwxr-xr-x   2 root root 4096 Jan  4 10:12 bin
drwxr-xr-x   2 root root 4096 Nov 30 13:37 boot
drwxr-xr-x   6 root root  500 Jan 11 14:25 dev
drwxr-xr-x  46 root root 4096 Jan 11 14:25 etc
drwxr-xr-x   2 root root 4096 Nov 30 13:37 home
drwxr-xr-x  10 root root 4096 Jan  4 10:12 lib
drwxr-xr-x   2 root root 4096 Jan  4 10:12 lib64
drwxr-xr-x   2 root root 4096 Jan  4 10:12 media
drwxr-xr-x   2 root root 4096 Jan  4 10:12 mnt
drwxr-xr-x   2 root root 4096 Jan  4 10:12 opt
dr-xr-xr-x 134 root root    0 Jan 11 14:25 proc
drwx------   2 root root 4096 Jan  4 10:12 root
drwxr-xr-x   9 root root  260 Jan 11 14:25 run
drwxr-xr-x   2 root root 4096 Jan  4 10:12 sbin
drwxr-xr-x   2 root root 4096 Jan 11 14:25 selinux
drwxr-xr-x   2 root root 4096 Jan  4 10:12 srv
dr-xr-xr-x  13 root root    0 Jan 11 14:26 sys
drwxrwxrwt   7 root root 4096 Jan 11 14:25 tmp
drwxr-xr-x  10 root root 4096 Jan  4 10:12 usr
drwxr-xr-x  11 root root 4096 Jan  4 10:12 var
local:
    ----------
    pid:
        2
    retcode:
        2
    stderr:
        ls: cannot access /none: No such file or directory

    stdout:
        /:
        total 64
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 bin
        drwxr-xr-x   2 root root 4096 Nov 30 13:37 boot
        drwxr-xr-x   6 root root  500 Jan 11 14:25 dev
        drwxr-xr-x  46 root root 4096 Jan 11 14:25 etc
        drwxr-xr-x   2 root root 4096 Nov 30 13:37 home
        drwxr-xr-x  10 root root 4096 Jan  4 10:12 lib
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 lib64
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 media
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 mnt
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 opt
        dr-xr-xr-x 134 root root    0 Jan 11 14:25 proc
        drwx------   2 root root 4096 Jan  4 10:12 root
        drwxr-xr-x   9 root root  260 Jan 11 14:25 run
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 sbin
        drwxr-xr-x   2 root root 4096 Jan 11 14:25 selinux
        drwxr-xr-x   2 root root 4096 Jan  4 10:12 srv
        dr-xr-xr-x  13 root root    0 Jan 11 14:26 sys
        drwxrwxrwt   7 root root 4096 Jan 11 14:25 tmp
        drwxr-xr-x  10 root root 4096 Jan  4 10:12 usr
        drwxr-xr-x  11 root root 4096 Jan  4 10:12 var
```
