### PR TITLE
Updates documentation with thin_dir and lack of persistence of SaltSSH environment

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -40,6 +40,8 @@ standard ``salt`` commands.
     copies those files down in the same tarball as the state run. 
     However, needed fileserver wrappers are still under development.
 
+    By default, Salt SSH 
+
 Salt SSH Roster
 ===============
 
@@ -117,6 +119,13 @@ Targeting with Salt SSH
 Due to the fact that the targeting approach differs in salt-ssh, only glob
 and regex targets are supported as of this writing, the remaining target
 systems still need to be implemented.
+
+.. note::
+    By default, Grains are settable through ``salt-ssh``. By
+    default, these grains will *not* be persisted across reboots. 
+
+    See the "thin_dir" setting in :doc:`Roster documentation </topics/ssh/roster>`
+    for more details.
 
 Configuring Salt SSH
 ====================

--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -40,8 +40,6 @@ standard ``salt`` commands.
     copies those files down in the same tarball as the state run. 
     However, needed fileserver wrappers are still under development.
 
-    By default, Salt SSH 
-
 Salt SSH Roster
 ===============
 

--- a/doc/topics/ssh/roster.rst
+++ b/doc/topics/ssh/roster.rst
@@ -34,14 +34,26 @@ The information which can be stored in a roster `target` is the following:
 
 .. code-block:: yaml
 
-    <Salt ID>:   # The id to reference the target system with
-        host:    # The IP address or DNS name of the remote host
-        user:    # The user to log in as
-        passwd:  # The password to log in with
+    <Salt ID>:    # The id to reference the target system with
+        host:     # The IP address or DNS name of the remote host
+        user:     # The user to log in as
+        passwd:   # The password to log in with
 
         # Optional parameters
-        port:    # The target system's ssh port number
-        sudo:    # Boolean to run command via sudo
-        priv:    # File path to ssh private key, defaults to salt-ssh.rsa
-        timeout: # Number of seconds to wait for response when establishing a
-                   SSH connection
+        port:     # The target system's ssh port number
+        sudo:     # Boolean to run command via sudo
+        priv:     # File path to ssh private key, defaults to salt-ssh.rsa
+        timeout:  # Number of seconds to wait for response when establishing a
+                    SSH connection
+        thin_dir: # The target system's storage directory for Salt components.
+                    Defaults to /tmp/salt-<hash>.
+
+thin_dir
+--------
+
+Salt needs to upload a standalone environment to the target system, and this
+defaults to /tmp/salt-<hash>. This directory will be cleaned up per normal 
+systems operation.
+
+If you need a persistent Salt environment, for instance to set persistent grains,
+this value will need to be changed.


### PR DESCRIPTION
Per #19638, grains set via salt-ssh don't persist across reboots. 

This updates the documentation to note this fact, and the reason why, and how to avoid this behaviour.
