### PR TITLE
Add s3 to protocols for remote source_hash

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2666,7 +2666,7 @@ def get_managed(
                 if not source_sum:
                     return '', {}, 'Source file {0} not found'.format(source)
             elif source_hash:
-                protos = ['salt', 'http', 'https', 'ftp', 'swift']
+                protos = ['salt', 'http', 'https', 'ftp', 'swift', 's3']
                 if _urlparse(source_hash).scheme in protos:
                     # The source_hash is a file on a server
                     hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)


### PR DESCRIPTION
Believe this fixes #15209. I've tested it on my ec2 node and things seem to function correctly. Let me know if I need to add test cases, etc.
