### PR TITLE
Adds fire_master to the Salt Event library, for use in 3rd-party code.

### DIFF
--- a/doc/topics/event/index.rst
+++ b/doc/topics/event/index.rst
@@ -151,11 +151,14 @@ dictionary should be sent instead.
 
     # Import the proper library
     import salt.utils.event
+    # bring in the system configuration
+    import salt.config
+    cfg = salt.config.minion_config("/etc/salt/minion")
     # Fire deploy action
     sock_dir = '/var/run/salt/minion'
     payload = {'sample-msg': 'this is a test',
                'example': 'this is the same test'}
-    event = salt.utils.event.SaltEvent('master', sock_dir)
+    event = salt.utils.event.SaltEvent('master', sock_dir, opts=cfg)
     event.fire_event(payload, 'tag')
 
 It should be noted that this code can be used in 3rd party applications as well.
@@ -177,3 +180,19 @@ programmatically, without having to make other calls to Salt.
 A 3rd party process can listen to the event bus on the master and another 3rd party
 process can fire events to the process on the master, which Salt will happily
 pass along.
+
+To fire an event to be sent to the master, from the minion, from code:
+
+.. code-block:: python
+    
+    import salt.utils.event
+    import salt.config
+    cfg = salt.config.minion_config("/etc/salt/minion")
+    sock_dir = '/var/run/salt/minion'
+    tag = "tag"
+    payload = {'sample-msg": "this is a test'}
+    # The message wrapper
+    # Create an event interface
+    event = salt.utils.event.SaltEvent("minion", sock_dir, opts=cfg)
+    # Fire the event across
+    event.fire_master(payload, tag)

--- a/salt/modules/darwin_pkgutil.py
+++ b/salt/modules/darwin_pkgutil.py
@@ -13,9 +13,6 @@ PKGUTIL = "/usr/sbin/pkgutil"
 
 
 def __virtual__():
-    '''
-    Set the virtual pkg module if the os is Solaris
-    '''
     if __grains__['os'] == 'MacOS':
         return 'darwin_pkgutil'
     return False
@@ -24,6 +21,12 @@ def __virtual__():
 def list():
     '''
     List the installed packages.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' darwin_pkgutil.list
     '''
     cmd = PKGUTIL + ' --pkgs'
     return __salt__['cmd.run_stdout'](cmd)
@@ -32,6 +35,12 @@ def list():
 def is_installed(package_id):
     '''
     Returns whether a given package id is installed.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' darwin_pkgutil.is_installed com.apple.pkg.gcc4.2Leo
     '''
     def has_package_id(lines):
         for line in lines:
@@ -56,6 +65,13 @@ def _install_from_path(path):
 def install(source, package_id=None):
     '''
     Install a .pkg from an URI or an absolute path.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' darwin_pkgutil.install source=/vagrant/build_essentials.pkg \
+            package_id=com.apple.pkg.gcc4.2Leo
     '''
     if package_id is not None and is_installed(package_id):
         return ''

--- a/salt/modules/darwin_pkgutil.py
+++ b/salt/modules/darwin_pkgutil.py
@@ -1,0 +1,68 @@
+# -*- coding: utf-8 -*-
+'''
+Installer support for OS X.
+
+Installer is the native .pkg/.mpkg package manager for OS X.
+'''
+import os.path
+
+from salt.ext.six.moves import urllib
+
+
+PKGUTIL = "/usr/sbin/pkgutil"
+
+
+def __virtual__():
+    '''
+    Set the virtual pkg module if the os is Solaris
+    '''
+    if __grains__['os'] == 'MacOS':
+        return 'darwin_pkgutil'
+    return False
+
+
+def list():
+    '''
+    List the installed packages.
+    '''
+    cmd = PKGUTIL + ' --pkgs'
+    return __salt__['cmd.run_stdout'](cmd)
+
+
+def is_installed(package_id):
+    '''
+    Returns whether a given package id is installed.
+    '''
+    def has_package_id(lines):
+        for line in lines:
+            if line == package_id:
+                return True
+        return False
+
+    cmd = PKGUTIL + ' --pkgs'
+    out = __salt__['cmd.run_stdout'](cmd)
+    return has_package_id(out.splitlines())
+
+
+def _install_from_path(path):
+    if not os.path.exists(path):
+        msg = "Path {0!r} does not exist, cannot install".format(path)
+        raise ValueError(msg)
+    else:
+        cmd = 'installer -pkg "{0}" -target /'.format(path)
+        return __salt__['cmd.retcode'](cmd)
+
+
+def install(source, package_id=None):
+    '''
+    Install a .pkg from an URI or an absolute path.
+    '''
+    if package_id is not None and is_installed(package_id):
+        return ''
+
+    uri = urllib.parse.urlparse(source)
+    if uri.scheme == "":
+        return _install_from_path(source)
+    else:
+        msg = "Unsupported scheme for source uri: {0!r}".format(uri.scheme)
+        raise ValueError(msg)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2666,7 +2666,7 @@ def get_managed(
                 if not source_sum:
                     return '', {}, 'Source file {0} not found'.format(source)
             elif source_hash:
-                protos = ['salt', 'http', 'https', 'ftp', 'swift']
+                protos = ['salt', 'http', 'https', 'ftp', 'swift', 's3']
                 if _urlparse(source_hash).scheme in protos:
                     # The source_hash is a file on a server
                     hash_fn = __salt__['cp.cache_file'](source_hash, saltenv)

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2138,7 +2138,7 @@ def run_cmd(name, cmd, no_start=False, preserve_state=True,
         if not use_vt:
             res = __salt__['cmd.run_all'](cmd)
         else:
-            stdout, stderr = '', ''
+            stdout_buffer, stderr_buffer = '', ''
             try:
                 proc = vt.Terminal(cmd,
                                    shell=True,
@@ -2158,26 +2158,26 @@ def run_cmd(name, cmd, no_start=False, preserve_state=True,
                         except IOError:
                             cstdout, cstderr = '', ''
                         if cstdout:
-                            stdout += cstdout
+                            stdout_buffer += cstdout
                         else:
                             cstdout = ''
                         if cstderr:
-                            stderr += cstderr
+                            stderr_buffer += cstderr
                         else:
                             cstderr = ''
                     except KeyboardInterrupt:
                         break
                 res = {'retcode': proc.exitstatus,
                        'pid': 2,
-                       'stdout': stdout,
-                       'stderr': stderr}
+                       'stdout': stdout_buffer,
+                       'stderr': stderr_buffer}
             except vt.TerminalException:
                 trace = traceback.format_exc()
                 log.error(trace)
                 res = {'retcode': 127,
                        'pid': '2',
-                       'stdout': stdout,
-                       'stderr': stderr}
+                       'stdout': stdout_buffer,
+                       'stderr': stderr_buffer}
             finally:
                 proc.close(terminate=True, kill=True)
     else:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -420,6 +420,22 @@ class SaltEvent(object):
             raise
         return True
 
+    def fire_master(self, data, tag, timeout=1000):
+        ''''
+        Send a single event to the master, with the payload "data" and the
+        event identifier "tag".
+
+        Default timeout is 1000ms
+        '''
+        msg = {
+            'tag': tag,
+            'data': data,
+            'events': None,
+            'pretag': None
+        }
+        return self.fire_event(msg, "fire_master", timeout)
+
+
     def destroy(self, linger=5000):
         if self.cpub is True and self.sub.closed is False:
             # Wait at most 2.5 secs to send any remaining messages in the

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -495,6 +495,22 @@ class SaltEvent(object):
             raise
         return True
 
+    def fire_master(self, data, tag, timeout=1000):
+        ''''
+        Send a single event to the master, with the payload "data" and the
+        event identifier "tag".
+
+        Default timeout is 1000ms
+        '''
+        msg = {
+            'tag': tag,
+            'data': data,
+            'events': None,
+            'pretag': None
+        }
+        return self.fire_event(msg, "fire_master", timeout)
+
+
     def destroy(self, linger=5000):
         if self.cpub is True and self.sub.closed is False:
             # Wait at most 2.5 secs to send any remaining messages in the

--- a/tests/unit/modules/darwin_pkgutil_test.py
+++ b/tests/unit/modules/darwin_pkgutil_test.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from salt.modules import darwin_pkgutil
 
 from salttesting import TestCase, skipIf

--- a/tests/unit/modules/darwin_pkgutil_test.py
+++ b/tests/unit/modules/darwin_pkgutil_test.py
@@ -1,0 +1,85 @@
+from salt.modules import darwin_pkgutil
+
+from salttesting import TestCase, skipIf
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+
+
+darwin_pkgutil.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class DarwingPkgutilTestCase(TestCase):
+    def test_list_installed_command(self):
+        # Given
+        r_output = "com.apple.pkg.iTunes"
+
+        # When
+        mock_cmd = MagicMock(return_value=r_output)
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            output = darwin_pkgutil.list()
+
+        # Then
+        mock_cmd.assert_called_with("/usr/sbin/pkgutil --pkgs")
+
+    def test_list_installed_output(self):
+        # Given
+        r_output = "com.apple.pkg.iTunes"
+
+        # When
+        mock_cmd = MagicMock(return_value=r_output)
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            output = darwin_pkgutil.list()
+
+        # Then
+        self.assertEqual(output, r_output)
+
+    def test_is_installed(self):
+        # Given
+        r_output = "com.apple.pkg.iTunes"
+
+        # When
+        mock_cmd = MagicMock(return_value=r_output)
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            ret = darwin_pkgutil.is_installed("com.apple.pkg.iTunes")
+
+        # Then
+        self.assertTrue(ret)
+
+        # When
+        with patch.dict(darwin_pkgutil.__salt__, {'cmd.run_stdout': mock_cmd}):
+            ret = darwin_pkgutil.is_installed("com.apple.pkg.Safari")
+
+        # Then
+        self.assertFalse(ret)
+
+    def test_install(self):
+        # Given
+        source = "/foo/bar/fubar.pkg"
+        package_id = "com.foo.fubar.pkg"
+
+        # When
+        mock_cmd = MagicMock(return_value=True)
+        with patch("salt.modules.darwin_pkgutil.is_installed",
+                   return_value=False) as is_installed:
+            with patch("salt.modules.darwin_pkgutil._install_from_path",
+                   return_value=True) as _install_from_path:
+                ret = darwin_pkgutil.install(source, package_id)
+
+        # Then
+        _install_from_path.assert_called_with(source)
+
+    def test_install_already_there(self):
+        # Given
+        source = "/foo/bar/fubar.pkg"
+        package_id = "com.foo.fubar.pkg"
+
+        # When
+        mock_cmd = MagicMock(return_value=True)
+        with patch("salt.modules.darwin_pkgutil.is_installed",
+                   return_value=True) as is_installed:
+            with patch("salt.modules.darwin_pkgutil._install_from_path",
+                   return_value=True) as _install_from_path:
+                ret = darwin_pkgutil.install(source, package_id)
+
+        # Then
+        self.assertEqual(_install_from_path.called, 0)

--- a/tests/unit/utils/event_test.py
+++ b/tests/unit/utils/event_test.py
@@ -294,6 +294,19 @@ class TestSaltEvent(TestCase):
                 evt = me.get_event(tag='testevents')
                 self.assertGotEvent(evt, {'data': '{0}'.format(i)}, 'Event {0}'.format(i))
 
+    # Test the fire_master function. As it wraps the underlying fire_event,
+    # we don't need to perform extensive testing.
+    def test_send_master_event(self):
+        """"Tests that sending an event through fire_master generates expected event"""
+        with eventpublisher_process():
+            me = event.SaltEvent("minion", SOCK_DIR)
+            data = {"data": "foo1"}
+            me.fire_master(data, "test_master")
+
+            evt = me.get_event(tag="fire_master")
+            self.assertGotEvent(evt, {"data": data, "tag": "test_master", "events": None, "pretag": None})
+
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
In the main Salt event documentation, there is a commandline interface for firing an event, via `salt-call event.fire_master`.

This patch adds an internal method to `salt.utils.event:SaltEvent` which provides this functionality directly to 3rd-party code interacting with the salt event library.
