### PR TITLE
set runas shell to True

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -323,7 +323,7 @@ def _run(cmd,
                            ).format(shell, runas, sys.executable)
             env_json = subprocess.Popen(
                 env_cmd,
-                shell=python_shell,
+                shell=True,
                 stdin=subprocess.PIPE,
                 stdout=subprocess.PIPE
             ).communicate(py_code)[0]


### PR DESCRIPTION
This was causing errors with pip and virtualenv state tests.  Those tests are still failing but for other reasons that @rallytime is tracking down.
