### PR TITLE
Update mysql_query.py

### DIFF
--- a/salt/states/mysql_query.py
+++ b/salt/states/mysql_query.py
@@ -176,7 +176,7 @@ def run(name,
         with salt.utils.fopen(output, 'w') as output_file:
             if 'results' in query_result:
                 for res in query_result['results']:
-                    for col, val in res:
+                    for col, val in res.iteritems():
                         output_file.write(col + ':' + val + '\n')
             else:
                 output_file.write(str(query_result))


### PR DESCRIPTION
mysql_query.py doesn't correctly iterate through dict res variable. 

Before, if you specifying the following query:
"SELECT name FROM table LIMIT 1;"
it throws the following error: ValueError: too many values to unpack

However selected a 2 char column name such as:
SELECT ab FROM table LIMIT 1;
produces the following in the output: "a:b"
