### PR TITLE
Improve error reporting for failing git module commands

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -74,7 +74,9 @@ def _git_run(cmd, cwd=None, runas=None, identity=None, **kwargs):
         if retcode == 0:
             return result['stdout']
         else:
-            raise CommandExecutionError(result['stderr'])
+            raise CommandExecutionError(
+                'Command {0!r} failed. Stderr: {1!r}'.format(cmd,
+                                                             result['stderr']))
 
 
 def _git_getdir(cwd, user=None):


### PR DESCRIPTION
This ensures git command execution failures describe the command that failed, not just returning the `stderr`.  In some cases, `stderr` can be empty, such as the case of running `git.config_get`, which is calling `git config [key]` under the hood.  When `git config [key]` is called for a non-existent key, the return code is `1` (eg non-zero) and the `stderr` is empty.  

In my case, this module method was being called by the `git.latest` Salt state.  Compare before this PR, noting the `Comment` field is empty because `stderr` was an empty string:

```
target:
----------
          ID: Software installation
    Function: git.latest
        Name: https://github.com/davidjb/example.git
      Result: False
     Comment: 
     Started: 15:25:05.246615
    Duration: 5315.367 ms
     Changes:
```

to after:

```
target:
----------
          ID: Software installation
    Function: git.latest
        Name: https://github.com/davidjb/example.git
      Result: False
     Comment: Command 'git config branch.my-branch.remote' failed. Stderr: ''
     Started: 15:41:05.125871
    Duration: 5315.367 ms
     Changes:
```

Now I can tell which git command is failing, debug it manually, and find a solution.

Feel free to suggest a different way of formatting the output string; this is just a starting point.
