### PR TITLE
Remove obsolete unreferenced tuple of static outputters.

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -29,6 +29,7 @@ import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
+
 def get_progress(opts, out, progress):
     '''
     Get the progress bar from the given outputter

--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -29,14 +29,6 @@ import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
-STATIC = (
-    'yaml_out',
-    'text_out',
-    'raw_out',
-    'json_out',
-)
-
-
 def get_progress(opts, out, progress):
     '''
     Get the progress bar from the given outputter


### PR DESCRIPTION
Completes commit 9f758a8 / follow-up to PR #6608. (Deprecation of --out-*)
