### PR TITLE
Expand documentation about Saltfile for salt-ssh

### DIFF
--- a/doc/topics/ssh/index.rst
+++ b/doc/topics/ssh/index.rst
@@ -144,16 +144,29 @@ If you are commonly passing in CLI options to ``salt-ssh``, you can create
 a ``Saltfile`` to automatically use these options. This is common if you're
 managing several different salt projects on the same server.
 
-So if you ``cd`` into a directory with a Saltfile with the following
-contents:
+So if you ``cd`` into a directory with a ``Saltfile`` with the following
+YAML contents:
 
 .. code-block:: yaml
 
     salt-ssh:
       config_dir: path/to/config/dir
       max_prox: 30
+      wipe_ssh: true
 
 Instead of having to call
-``salt-ssh --config-dir=path/to/config/dir --max-procs=30 \* test.ping`` you
+``salt-ssh --config-dir=path/to/config/dir --max-procs=30 --wipe \* test.ping`` you
 can call ``salt-ssh \* test.ping``.
+
+Boolean-style options should be specified in their YAML representation.
+
+.. note::
+
+   The option keys specified must match the destination attributes for the
+   options specified in the parser
+   :py:class:`salt.utils.parsers.SaltSSHOptionParser`.  For example, in the
+   case of the ``--wipe`` command line option, its ``dest`` is configured to
+   be ``wipe_ssh`` and thus this is what should be configured in the
+   ``Saltfile``.  Using the names of flags for this option, being ``wipe:
+   true`` or ``w: true``, will not work.
 


### PR DESCRIPTION
Explains how options from Saltfile are applied to salt-ssh, and clarifies about Boolean flags.
