### PR TITLE
FreeBSD kmod bugfixes

### DIFF
--- a/salt/modules/freebsdkmod.py
+++ b/salt/modules/freebsdkmod.py
@@ -44,6 +44,7 @@ def _rm_mods(pre_mods, post_mods):
         post.add(mod['module'])
     return list(pre - post)
 
+
 def _get_persistent_modules():
     mods = set()
     for mod in __salt__['cmd.run']('sysrc -ni kld_list').split():
@@ -55,7 +56,8 @@ def _set_persistent_module(mod):
     '''
     Add a module to sysrc to make it persistent.
     '''
-    if not mod_name or mod_name in mod_list(True) or mod_name not in available():
+    if not mod_name or mod_name in mod_list(True) or mod_name not in \
+            available():
         return set()
     mods = _get_persistent_modules().add(mod)
     __salt__['cmd.run']('sysrc kld_list="{0}"'.format(mods))
@@ -131,6 +133,7 @@ def lsmod():
         mdat['depcount'] = comps[1]
         ret.append(mdat)
     return ret
+
 
 def mod_list(only_persist=False):
     '''

--- a/salt/modules/freebsdkmod.py
+++ b/salt/modules/freebsdkmod.py
@@ -121,16 +121,14 @@ def lsmod():
         comps = line.split()
         if not len(comps) > 2:
             continue
-        if comps[0] == 'Module':
+        if comps[0] == 'Id':
+            continue
+        if comps[4] == 'kernel':
             continue
         mdat = {}
-        mdat['module'] = comps[0]
-        mdat['size'] = comps[1]
-        mdat['depcount'] = comps[2]
-        if len(comps) > 3:
-            mdat['deps'] = comps[3].split(',')
-        else:
-            mdat['deps'] = []
+        mdat['module'] = comps[4][:-3]
+        mdat['size'] = comps[3]
+        mdat['depcount'] = comps[1]
         ret.append(mdat)
     return ret
 

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -84,10 +84,11 @@ def _set_persistent_module(mod):
     if not os.path.exists(conf):
         __salt__['file.touch'](conf)
     mod_name = _strip_module_name(mod)
-    if not mod_name or mod_name in mod_list(True) or mod_name not in available():
+    if not mod_name or mod_name in mod_list(True) or mod_name \
+            not in available():
         return set()
     escape_mod = re.escape(mod)
-    ## If module is commented only uncomment it
+    # If module is commented only uncomment it
     if __salt__['file.contains_regex_multiline'](conf,
                                                  '^#[\t ]*{0}[\t ]*$'.format(
                                                      escape_mod)):
@@ -219,7 +220,8 @@ def load(mod, persist=False):
         salt '*' kmod.load kvm
     '''
     pre_mods = lsmod()
-    response = __salt__['cmd.run_all']('modprobe {0}'.format(mod), python_shell=False)
+    response = __salt__['cmd.run_all']('modprobe {0}'.format(mod),
+                                       python_shell=False)
     if response['retcode'] == 0:
         post_mods = lsmod()
         mods = _new_mods(pre_mods, post_mods)

--- a/salt/modules/kmod.py
+++ b/salt/modules/kmod.py
@@ -46,13 +46,6 @@ def _rm_mods(pre_mods, post_mods):
     return pre - post
 
 
-def _union_module(a, b):
-    '''
-    Return union of two list where duplicated items are only once
-    '''
-    return list(set(a) | set(b))
-
-
 def _get_modules_conf():
     '''
     Return location of modules config file.

--- a/salt/states/kmod.py
+++ b/salt/states/kmod.py
@@ -46,7 +46,7 @@ def present(name, persist=False):
         mods_set = mods
     if name in mods_set:
         ret['comment'] = ('Kernel module {0} is already present'
-                              .format(name))
+                          .format(name))
         return ret
     # Module is not loaded, verify availability
     if __opts__['test']:
@@ -58,7 +58,12 @@ def present(name, persist=False):
         ret['result'] = False
         return ret
     for mod in __salt__['kmod.load'](name, persist):
-        ret['changes'][mod] = 'loaded'
+        if not mod:
+            # It's compiled into the kernel
+            ret['comment'] = 'Kernel module {0} is compiled in'.format(name)
+            return ret
+        else:
+            ret['changes'][mod] = 'loaded'
     if not ret['changes']:
         ret['result'] = False
         ret['comment'] = 'Failed to load kernel module {0}'.format(name)


### PR DESCRIPTION
The implementation of the FreeBSD kmod state module is completely broken in 2014.7.  The lsmod function in the freebsdkmod execution module is also broken.

Contains bugfixes and catches the freebsdkmod execution module up to the Linux kmod execution module API.

This uses sysrc to set kld_list in rc.conf to load modules at boot time .  It ignores the fact that modules can also be listed in /boot/loader.conf; this should be non-fatal (i.e. trying to loading already loaded modules) but finding some way to deal with those would be a nice future improvement.

Also some generic garbage collection and PEP8 fixes.
