### PR TITLE
Default http.query() to urllib2, still allow requests

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -80,12 +80,15 @@ def query(url,
           node='minion',
           port=80,
           opts=None,
-          requests_lib=False,
+          requests_lib=None,
           **kwargs):
     '''
     Query a resource, and decode the return data
     '''
     ret = {}
+
+    if requests_lib is None:
+        requests_lib = opts.get('requests_lib', False)
 
     if requests_lib is True:
         if  HAS_REQUESTS is False:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -13,6 +13,13 @@ import logging
 import salt.ext.six.moves.http_cookiejar  # pylint: disable=E0611
 from salt._compat import ElementTree as ET
 
+import ssl
+from ssl import CertificateError
+import socket
+import urllib
+import urllib2
+import httplib
+
 # Import salt libs
 import salt.utils
 import salt.utils.xmlutil as xml
@@ -22,7 +29,11 @@ from salt.template import compile_template
 from salt import syspaths
 
 # Import 3rd party libs
-import requests
+try:
+    import requests
+    HAS_REQUESTS = True
+except ImportError:
+    HAS_REQUESTS = False
 import msgpack
 
 log = logging.getLogger(__name__)
@@ -58,15 +69,24 @@ def query(url,
           test=False,
           test_url=None,
           node='minion',
+          port=80,
           opts=None,
+          requests_lib=False,
           **kwargs):
     '''
     Query a resource, and decode the return data
     '''
     ret = {}
 
-    requests_log = logging.getLogger('requests')
-    requests_log.setLevel(logging.WARNING)
+    if requests_lib is True:
+        if  HAS_REQUESTS is False:
+            ret['error'] = ('http.query has been set to use requests, but the '
+                            'requests library does not seem to be installed')
+            log.error(ret['error'])
+            return ret
+    else:
+        requests_log = logging.getLogger('requests')
+        requests_log.setLevel(logging.WARNING)
 
     if opts is None:
         if node == 'master':
@@ -122,20 +142,24 @@ def query(url,
     else:
         auth = None
 
-    sess = requests.Session()
-    sess.auth = auth
-    sess.headers.update(header_dict)
-    log.trace('Request Headers: {0}'.format(sess.headers))
+    if requests_lib is True:
+        sess = requests.Session()
+        sess.auth = auth
+        sess.headers.update(header_dict)
+        log.trace('Request Headers: {0}'.format(sess.headers))
+        sess_cookies = sess.cookies
+    else:
+        sess_cookies = None
 
     if cookies is not None:
         if cookie_format == 'mozilla':
-            sess.cookies = salt.ext.six.moves.http_cookiejar.MozillaCookieJar(cookie_jar)
+            sess_cookies = salt.ext.six.moves.http_cookiejar.MozillaCookieJar(cookie_jar)
         else:
-            sess.cookies = salt.ext.six.moves.http_cookiejar.LWPCookieJar(cookie_jar)
+            sess_cookies = salt.ext.six.moves.http_cookiejar.LWPCookieJar(cookie_jar)
         if not os.path.isfile(cookie_jar):
-            sess.cookies.save()
+            sess_cookies.save()
         else:
-            sess.cookies.load()
+            sess_cookies.load()
 
     if test is True:
         if test_url is None:
@@ -144,36 +168,77 @@ def query(url,
             url = test_url
             ret['test'] = True
 
-    result = sess.request(
-        method, url, params=params, data=data
-    )
-    log.debug('Response Status Code: {0}'.format(result.status_code))
-    log.trace('Response Headers: {0}'.format(result.headers))
-    log.trace('Response Text: {0}'.format(result.text))
-    log.trace('Response Cookies: {0}'.format(result.cookies.get_dict()))
+    if requests_lib is True:
+        result = sess.request(
+            method, url, params=params, data=data
+        )
+        result_status_code = result.status_code
+        result_headers = result.headers
+        result_text = result.text
+        result_cookies = result.cookies
+    else:
+        request = urllib2.Request(url)
+
+        if url.startswith('https') or port == 443:
+            hostname = request.get_host()
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            sock.connect((hostname, 443))
+            sockwrap = ssl.wrap_socket(sock, ca_certs='/etc/ssl/certs/ca-certificates.crt', cert_reqs=ssl.CERT_REQUIRED)
+            try:
+                ssl.match_hostname(sockwrap.getpeercert(), 'github.com')
+            except CertificateError as exc:
+                ret['error'] = (
+                    'The certificate was invalid. '
+                    'Error returned was: {0}'.format(
+                        pprint.pformat(exc)
+                    )
+                )
+                return ret
+
+        opener = urllib2.build_opener(
+            urllib2.HTTPHandler,
+            urllib2.HTTPCookieProcessor(sess_cookies)
+        )
+        for header in header_dict:
+            reques.add_header(header, header_dict[header])
+        request.get_method = lambda: method
+        result = opener.open(request)
+
+        result_status_code = result.code
+        result_headers = result.headers.headers
+        result_text = result.read()
+
+    log.debug('Response Status Code: {0}'.format(result_status_code))
+    log.trace('Response Headers: {0}'.format(result_headers))
+    log.trace('Response Cookies: {0}'.format(sess_cookies))
+    try:
+        log.trace('Response Text: {0}'.format(result_text))
+    except UnicodeEncodeError as exc:
+        log.trace(('Cannot Trace Log Response Text: {0}. This may be due to '
+                  'incompatibilities between requests and logging.').format(exc))
 
     if cookies is not None:
-        sess.cookies.save()
+        sess_cookies.save()
 
     if persist_session is True:
         # TODO: See persist_session above
-        if 'set-cookie' in result.headers:
+        if 'set-cookie' in result_headers:
             with salt.utils.fopen(session_cookie_jar, 'w') as fh_:
-                session_cookies = result.headers.get('set-cookie', None)
+                session_cookies = result_headers.get('set-cookie', None)
                 if session_cookies is not None:
                     msgpack.dump({'Cookie': session_cookies}, fh_)
                 else:
                     msgpack.dump('', fh_)
 
     if status is True:
-        ret['status'] = result.status_code
+        ret['status'] = result_status_code
 
     if headers is True:
-        ret['headers'] = result.headers
+        ret['headers'] = result_headers
 
     if decode is True:
         if decode_type == 'auto':
-            content_type = result.headers.get(
+            content_type = result_headers.get(
                 'content-type', 'application/json'
             )
             if 'xml' in content_type:
@@ -195,17 +260,17 @@ def query(url,
             return ret
 
         if decode_type == 'json':
-            ret['dict'] = json.loads(result.text)
+            ret['dict'] = json.loads(result_text)
         elif decode_type == 'xml':
             ret['dict'] = []
-            items = ET.fromstring(result.text)
+            items = ET.fromstring(result_text)
             for item in items:
                 ret['dict'].append(xml.to_dict(item))
         else:
             text = True
 
     if text is True:
-        ret['text'] = result.text
+        ret['text'] = result_text
 
     return ret
 


### PR DESCRIPTION
This switches `salt.utils.http.query()` to use `urllib2`, with host name checking for SSL, but still allows `requests` to be used if desired.
