### PR TITLE
Fix archive.zip, archive.unzip

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -190,7 +190,7 @@ def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
 
         .. code-block:: bash
 
-            salt '*' archive.zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1,/tmp/{{grains.id}}.txt
+            salt '*' archive.cmd_zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1,/tmp/{{grains.id}}.txt
 
     cwd : None
         Use this argument along with relative paths in ``sources`` to create
@@ -202,7 +202,7 @@ def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
 
         .. code-block:: bash
 
-            salt '*' archive.zip /tmp/baz.zip baz.txt cwd=/foo/bar
+            salt '*' archive.cmd_zip /tmp/baz.zip baz.txt cwd=/foo/bar
 
         .. versionadded:: 2014.7.1
 
@@ -398,7 +398,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
         .. code-block:: bash
 
-            salt '*' archive.unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
+            salt '*' archive.cmd_unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
 
     options : None
         Additional command-line options to pass to the ``unzip`` binary.
@@ -413,7 +413,7 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
     .. code-block:: bash
 
-        salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
+        salt '*' archive.cmd_unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
     '''
     if isinstance(excludes, string_types):
         excludes = [x.strip() for x in excludes.split(',')]

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -169,8 +169,8 @@ def gunzip(gzipfile, template=None, runas=None):
 
 
 @decorators.which('zip')
-def cmd_zip_(zip_file, sources, template=None,
-             cwd=None, recurse=False, runas=None):
+def cmd_zip(zip_file, sources, template=None,
+            cwd=None, recurse=False, runas=None):
     '''
     Uses the zip command to create zip files
 
@@ -225,8 +225,8 @@ def cmd_zip_(zip_file, sources, template=None,
                                python_shell=False).splitlines()
 
 
-@decorators.depends('zipfile', fallback_function=cmd_zip_)
-def zip_(archive, sources, template=None, runas=None):
+@decorators.depends('zipfile', fallback_function=cmd_zip)
+def zip_(archive, sources, template=None):
     '''
     Uses the zipfile module to create zip files
 
@@ -271,7 +271,8 @@ def zip_(archive, sources, template=None, runas=None):
 
 
 @decorators.which('unzip')
-def cmd_unzip_(zip_file, dest, excludes=None, template=None, options=None, runas=None):
+def cmd_unzip(zip_file, dest, excludes=None,
+              template=None, options=None, runas=None):
     '''
     Uses the unzip command to unpack zip files
 
@@ -321,8 +322,8 @@ def cmd_unzip_(zip_file, dest, excludes=None, template=None, options=None, runas
                                python_shell=False).splitlines()
 
 
-@decorators.depends('zipfile', fallback_function=cmd_unzip_)
-def unzip(archive, dest, excludes=None, template=None, options=None, runas=None):
+@decorators.depends('zipfile', fallback_function=cmd_unzip)
+def unzip(archive, dest, excludes=None, template=None, options=None):
     '''
     Uses the zipfile module to unpack zip files
 

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -10,7 +10,7 @@ import os
 
 # Import salt libs
 from salt.exceptions import SaltInvocationError, CommandExecutionError
-from salt.ext.six import string_types
+from salt.ext.six import string_types, integer_types
 from salt.utils import \
     which as _which, which_bin as _which_bin, is_windows as _is_windows
 import salt.utils.decorators as decorators
@@ -64,7 +64,7 @@ def tar(options, tarfile, sources=None, dest=None, cwd=None, template=None, runa
 
     sources
         Comma delimited list of files to **pack** into the tarfile. Can also be
-        passed as a python list.
+        passed as a Python list.
 
     dest
         The destination directory into which to **unpack** the tarfile
@@ -172,15 +172,20 @@ def gunzip(gzipfile, template=None, runas=None):
 def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
     '''
     .. versionadded:: 2015.2.0
+        In versions 2014.7.x and earlier, this function was known as
+        ``archive.zip``.
 
-    Uses the zip command to create zip files
+    Uses the ``zip`` command to create zip files. This command is part of the
+    `Info-ZIP`_ suite of tools, and is typically packaged as simply ``zip``.
+
+    .. _`Info-ZIP`: http://www.info-zip.org/
 
     zip_file
         Path of zip file to be created
 
     sources
         Comma-separated list of sources to include in the zip file. Sources can
-        also be passed in a python list.
+        also be passed in a Python list.
 
     template : None
         Can be set to 'jinja' or another supported template engine to render
@@ -191,26 +196,31 @@ def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
             salt '*' archive.zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1,/tmp/{{grains.id}}.txt
 
     cwd : None
-        Run the zip command from the specified directory. Use this argument
-        along with relative file paths to create zip files which do not
-        contain the leading directories. If not specified, this will default
-        to the home directory of the user under which the salt minion process
-        is running.
+        Use this argument along with relative paths in ``sources`` to create
+        zip files which do not contain the leading directories. If not
+        specified, the zip file will be created as if the cwd was ``/``, and
+        creating a zip file of ``/foo/bar/baz.txt`` will contain the parent
+        directories ``foo`` and ``bar``. To create a zip file containing just
+        ``baz.txt``, the following command would be used:
+
+        .. code-block:: bash
+
+            salt '*' archive.zip /tmp/baz.zip baz.txt cwd=/foo/bar
 
         .. versionadded:: 2014.7.1
 
-    recurse : False
-        Recursively include contents of sources which are directories. Combine
-        this with the ``cwd`` argument and use relative paths for the sources
-        to create a zip file which does not contain the leading directories.
+    runas : None
+        Create the zip file as the specified user. Defaults to the user under
+        which the minion is running.
 
-        .. versionadded:: 2014.7.1
+        .. versionadded:: 2015.2.0
+
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' archive.zip /tmp/zipfile.zip /tmp/sourcefile1,/tmp/sourcefile2
+        salt '*' archive.cmd_zip /tmp/zipfile.zip /tmp/sourcefile1,/tmp/sourcefile2
     '''
     if isinstance(sources, string_types):
         sources = [s.strip() for s in sources.split(',')]
@@ -227,36 +237,62 @@ def cmd_zip(zip_file, sources, template=None, cwd=None, runas=None):
 @decorators.depends('zipfile', fallback_function=cmd_zip)
 def zip_(zip_file, sources, template=None, cwd=None, runas=None):
     '''
-    Uses the ``zipfile`` python module to create zip files
+    Uses the ``zipfile`` Python module to create zip files
 
     .. versionchanged:: 2015.2.0
         This function was rewritten to use Python's native zip file support.
         The old functionality has been preserved in the new function
-        :mod:`archive.zip <salt.modules.archive.cmd_zip`.
+        :mod:`archive.cmd_zip <salt.modules.archive.cmd_zip>`. For versions
+        2014.7.x and earlier, see the :mod:`archive.cmd_zip
+        <salt.modules.archive.cmd_zip>` documentation.
 
-    .. note::
+    zip_file
+        Path of zip file to be created
 
-        If creating a zip file using the ``runas`` parameter,
-        :mod:`archive.cmd_zip <salt.modules.archive.cmd_zip>` will be used
-        instead.
+    sources
+        Comma-separated list of sources to include in the zip file. Sources can
+        also be passed in a Python list.
+
+    template : None
+        Can be set to 'jinja' or another supported template engine to render
+        the command arguments before execution:
+
+        .. code-block:: bash
+
+            salt '*' archive.zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1,/tmp/{{grains.id}}.txt
+
+    cwd : None
+        Use this argument along with relative paths in ``sources`` to create
+        zip files which do not contain the leading directories. If not
+        specified, the zip file will be created as if the cwd was ``/``, and
+        creating a zip file of ``/foo/bar/baz.txt`` will contain the parent
+        directories ``foo`` and ``bar``. To create a zip file containing just
+        ``baz.txt``, the following command would be used:
+
+        .. code-block:: bash
+
+            salt '*' archive.zip /tmp/baz.zip baz.txt cwd=/foo/bar
+
+    runas : None
+        Create the zip file as the specified user. Defaults to the user under
+        which the minion is running.
+
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' archive.zip /tmp/zipfile.zip /tmp/sourcefile1,/tmp/sourcefile2
-
-    The template arg can be set to 'jinja' or another supported template
-    engine to render the command arguments before execution.
-
-    For example:
-
-    .. code-block:: bash
-
-        salt '*' archive.zip template=jinja /tmp/zipfile.zip /tmp/sourcefile1,/tmp/{{grains.id}}.txt
     '''
     if runas:
-        return cmd_zip(zip_file, sources, template, cwd, runas)
+        euid = os.geteuid()
+        egid = os.getegid()
+        uinfo = __salt__['user.info'](runas)
+        if not uinfo:
+            raise SaltInvocationError(
+                'User \'{0}\' does not exist'.format(runas)
+            )
+
     zip_file, sources = _render_filenames(zip_file, sources, None, template)
 
     if isinstance(sources, string_types):
@@ -279,37 +315,58 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
         except AttributeError:
             _bad_cwd()
 
-    archived_files = []
-    with zipfile.ZipFile(zip_file, "w", zipfile.ZIP_DEFLATED) as zfile:
-        for src in sources:
-            if cwd:
-                src = os.path.join(cwd, src)
-            if os.path.exists(src):
-                if os.path.isabs(src):
-                    rel_root = '/'
-                else:
-                    rel_root = cwd if cwd is not None else '/'
-                if os.path.isdir(src):
-                    for dir_name, sub_dirs, files in os.walk(src):
-                        if cwd and dir_name.startswith(cwd):
-                            arc_dir = os.path.relpath(dir_name, cwd)
-                        else:
-                            arc_dir = os.path.relpath(dir_name, rel_root)
-                        if arc_dir:
-                            archived_files.append(arc_dir + '/')
-                            zfile.write(dir_name, arc_dir)
-                        for filename in files:
-                            abs_name = os.path.join(dir_name, filename)
-                            arc_name = os.path.join(arc_dir, filename)
-                            archived_files.append(arc_name)
-                            zfile.write(abs_name, arc_name)
-                else:
-                    if cwd and src.startswith(cwd):
-                        arc_name = os.path.relpath(src, cwd)
+    if runas and (euid != uinfo['uid'] or guid != uinfo['gid']):
+        # Change the egid first, as changing it after the euid will likely fail
+        # if the runas user is non-privileged.
+        os.setegid(uinfo['gid'])
+        os.seteuid(uinfo['uid'])
+
+    try:
+        exc = None
+        archived_files = []
+        with zipfile.ZipFile(zip_file, "w", zipfile.ZIP_DEFLATED) as zfile:
+            for src in sources:
+                if cwd:
+                    src = os.path.join(cwd, src)
+                if os.path.exists(src):
+                    if os.path.isabs(src):
+                        rel_root = '/'
                     else:
-                        arc_name = os.path.relpath(src, rel_root)
-                    archived_files.append(arc_name)
-                    zfile.write(src, arc_name)
+                        rel_root = cwd if cwd is not None else '/'
+                    if os.path.isdir(src):
+                        for dir_name, sub_dirs, files in os.walk(src):
+                            if cwd and dir_name.startswith(cwd):
+                                arc_dir = os.path.relpath(dir_name, cwd)
+                            else:
+                                arc_dir = os.path.relpath(dir_name, rel_root)
+                            if arc_dir:
+                                archived_files.append(arc_dir + '/')
+                                zfile.write(dir_name, arc_dir)
+                            for filename in files:
+                                abs_name = os.path.join(dir_name, filename)
+                                arc_name = os.path.join(arc_dir, filename)
+                                archived_files.append(arc_name)
+                                zfile.write(abs_name, arc_name)
+                    else:
+                        if cwd and src.startswith(cwd):
+                            arc_name = os.path.relpath(src, cwd)
+                        else:
+                            arc_name = os.path.relpath(src, rel_root)
+                        archived_files.append(arc_name)
+                        zfile.write(src, arc_name)
+    except Exception as exc:
+        pass
+    finally:
+        # Restore the euid/egid
+        if runas:
+            os.seteuid(euid)
+            os.setegid(egid)
+        if exc is not None:
+            # Wait to raise the exception until euid/egid are restored to avoid
+            # permission errors in writing to minion log.
+            raise CommandExecutionError(
+                'Exception encountered creating zipfile: {0}'.format(exc)
+            )
 
     return archived_files
 
@@ -318,7 +375,14 @@ def zip_(zip_file, sources, template=None, cwd=None, runas=None):
 def cmd_unzip(zip_file, dest, excludes=None,
               template=None, options=None, runas=None):
     '''
-    Uses the unzip command to unpack zip files
+    .. versionadded:: 2015.2.0
+        In versions 2014.7.x and earlier, this function was known as
+        ``archive.unzip``.
+
+    Uses the ``unzip`` command to unpack zip files. This command is part of the
+    `Info-ZIP`_ suite of tools, and is typically packaged as simply ``unzip``.
+
+    .. _`Info-ZIP`: http://www.info-zip.org/
 
     zip_file
         Path of zip file to be unpacked
@@ -326,8 +390,9 @@ def cmd_unzip(zip_file, dest, excludes=None,
     dest
         The destination directory into which the file should be unpacked
 
-    options : None
-        Options to pass to the ``unzip`` binary
+    excludes : None
+        Comma-separated list of files not to unpack. Can also be passed in a
+        Python list.
 
     template : None
         Can be set to 'jinja' or another supported template engine to render
@@ -337,6 +402,15 @@ def cmd_unzip(zip_file, dest, excludes=None,
 
             salt '*' archive.unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
 
+    options : None
+        Additional command-line options to pass to the ``unzip`` binary.
+
+    runas : None
+        Unpack the zip file as the specified user. Defaults to the user under
+        which the minion is running.
+
+        .. versionadded:: 2015.2.0
+
     CLI Example:
 
     .. code-block:: bash
@@ -344,7 +418,9 @@ def cmd_unzip(zip_file, dest, excludes=None,
         salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
     '''
     if isinstance(excludes, string_types):
-        excludes = [entry.strip() for entry in excludes.split(',')]
+        excludes = [x.strip() for x in excludes.split(',')]
+    elif isinstance(excludes, (float, integer_types)):
+        excludes = [str(excludes)]
 
     cmd = ['unzip']
     if options:
@@ -363,47 +439,108 @@ def cmd_unzip(zip_file, dest, excludes=None,
         cmd.extend(excludes)
     return __salt__['cmd.run'](cmd,
                                template=template,
+                               runas=runas,
                                python_shell=False).splitlines()
 
 
 @decorators.depends('zipfile', fallback_function=cmd_unzip)
-def unzip(archive, dest, excludes=None, template=None, options=None):
+def unzip(zip_file, dest, excludes=None, template=None, runas=None):
     '''
-    Uses the zipfile module to unpack zip files
+    Uses the ``zipfile`` Python module to unpack zip files
 
-    options:
-        Options to pass to the ``unzip`` binary.
+    .. versionchanged:: 2015.2.0
+        This function was rewritten to use Python's native zip file support.
+        The old functionality has been preserved in the new function
+        :mod:`archive.cmd_unzip <salt.modules.archive.cmd_unzip>`. For versions
+        2014.7.x and earlier, see the :mod:`archive.cmd_zip
+        <salt.modules.archive.cmd_zip>` documentation.
+
+    zip_file
+        Path of zip file to be unpacked
+
+    dest
+        The destination directory into which the file should be unpacked
+
+    excludes : None
+        Comma-separated list of files not to unpack. Can also be passed in a
+        Python list.
+
+    template : None
+        Can be set to 'jinja' or another supported template engine to render
+        the command arguments before execution:
+
+        .. code-block:: bash
+
+            salt '*' archive.unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
+
+    runas : None
+        Unpack the zip file as the specified user. Defaults to the user under
+        which the minion is running.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt '*' archive.unzip /tmp/zipfile.zip /home/strongbad/ excludes=file_1,file_2
-
-    The template arg can be set to 'jinja' or another supported template
-    engine to render the command arguments before execution.
-
-    For example:
-
-    .. code-block:: bash
-
-        salt '*' archive.unzip template=jinja /tmp/zipfile.zip /tmp/{{grains.id}}/ excludes=file_1,file_2
-
     '''
-    (archive, dest) = _render_filenames(archive, dest, None, template)
-    with zipfile.ZipFile(archive) as zf:
-        files = zf.namelist()
-        if excludes is None:
-            zf.extractall(dest)
-            return files
+    if runas:
+        euid = os.geteuid()
+        egid = os.getegid()
+        uinfo = __salt__['user.info'](runas)
+        if not uinfo:
+            raise SaltInvocationError(
+                'User \'{0}\' does not exist'.format(runas)
+            )
 
-        if not isinstance(excludes, list):
-            excludes = excludes.split(",")
-        cleaned_files = [x for x in files if x not in excludes]
-        for f in cleaned_files:
-            if f not in excludes:
-                zf.extract(f, dest)
-        return cleaned_files
+    zip_file, dest = _render_filenames(zip_file, dest, None, template)
+
+    if not os.path.isdir(dest):
+        raise SaltInvocationError(
+            'Destination directory {0} does not exist'.format(dest)
+        )
+
+    if runas and (euid != uinfo['uid'] or guid != uinfo['gid']):
+        # Change the egid first, as changing it after the euid will likely fail
+        # if the runas user is non-privileged.
+        os.setegid(uinfo['gid'])
+        os.seteuid(uinfo['uid'])
+
+    try:
+        exc = None
+        # Define cleaned_files here so that an exception will not prevent this
+        # variable from being defined and cause a NameError in the return
+        # statement at the end of the function.
+        cleaned_files = []
+        with zipfile.ZipFile(zip_file) as zfile:
+            files = zfile.namelist()
+            if excludes is None:
+                zfile.extractall(dest)
+                return files
+
+            if isinstance(excludes, string_types):
+                excludes = [x.strip() for x in excludes.split(',')]
+            elif isinstance(excludes, (float, integer_types)):
+                excludes = [str(excludes)]
+
+            cleaned_files.extend([x for x in files if x not in excludes])
+            for target in cleaned_files:
+                if target not in excludes:
+                    zfile.extract(target, dest)
+    except Exception as exc:
+        pass
+    finally:
+        # Restore the euid/egid
+        if runas:
+            os.seteuid(euid)
+            os.setegid(egid)
+        if exc is not None:
+            # Wait to raise the exception until euid/egid are restored to avoid
+            # permission errors in writing to minion log.
+            raise CommandExecutionError(
+                'Exception encountered unpacking zipfile: {0}'.format(exc)
+            )
+
+    return cleaned_files
 
 
 @decorators.which('rar')
@@ -418,7 +555,7 @@ def rar(rarfile, sources, template=None, cwd=None, runas=None):
 
     sources
         Comma-separated list of sources to include in the rar file. Sources can
-        also be passed in a python list.
+        also be passed in a Python list.
 
     cwd : None
         Run the rar command from the specified directory. Use this argument

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -2286,3 +2286,32 @@ def sdecode(string_):
         except UnicodeDecodeError:
             continue
     return string_
+
+
+def relpath(path, start='.'):
+    '''
+    Work around Python bug #5117, which is not (and will not be) patched in
+    Python 2.6 (http://bugs.python.org/issue5117)
+    '''
+    if sys.version_info < (2, 7) and 'posix' in sys.builtin_module_names:
+        # The below code block is based on posixpath.relpath from Python 2.7,
+        # which has the fix for this bug.
+        if not path:
+            raise ValueError('no path specified')
+
+        start_list = [
+            x for x in os.path.abspath(start).split(os.path.sep) if x
+        ]
+        path_list = [
+            x for x in os.path.abspath(path).split(os.path.sep) if x
+        ]
+
+        # work out how much of the filepath is shared by start and path.
+        i = len(os.path.commonprefix([start_list, path_list]))
+
+        rel_list = [os.path.pardir] * (len(start_list)-i) + path_list[i:]
+        if not rel_list:
+            return os.path.curdir
+        return os.path.join(*rel_list)
+
+    return os.path.relpath(path, start=start)

--- a/tests/unit/modules/archive_test.py
+++ b/tests/unit/modules/archive_test.py
@@ -16,6 +16,7 @@ ensure_in_syspath('../../')
 # Import salt libs
 from salt.modules import archive
 from salt.exceptions import CommandNotFoundError
+from salt.utils import which_bin
 
 
 class ZipFileMock(MagicMock):
@@ -129,28 +130,28 @@ class ArchiveTestCase(TestCase):
     def test_cmd_zip(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
-            ret = archive.cmd_zip_(
+            ret = archive.cmd_zip(
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
                 template='jinja'
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(
-                ['zip', '/tmp/salt.{{grains.id}}.zip',
+                ['zip', '-r', '/tmp/salt.{{grains.id}}.zip',
                  '/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
                  runas=None, python_shell=False, template='jinja', cwd=None
             )
 
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
-            ret = archive.cmd_zip_(
+            ret = archive.cmd_zip(
                 '/tmp/salt.{{grains.id}}.zip',
                 ['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
                 template='jinja'
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(
-                ['zip', '/tmp/salt.{{grains.id}}.zip',
+                ['zip', '-r', '/tmp/salt.{{grains.id}}.zip',
                  '/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
                 runas=None, python_shell=False, template='jinja', cwd=None
             )
@@ -164,7 +165,7 @@ class ArchiveTestCase(TestCase):
             '/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
             template='jinja'
         )
-        self.assertEqual(['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'], ret)
+        self.assertEqual(['tmp/tmpePe8yO', 'tmp/tmpLeSw1A'], ret)
 
     @patch('salt.utils.which', lambda exe: None)
     def test_zip_raises_exception_if_not_found(self):
@@ -172,7 +173,7 @@ class ArchiveTestCase(TestCase):
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
             self.assertRaises(
                 CommandNotFoundError,
-                archive.cmd_zip_,
+                archive.cmd_zip,
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
                 template='jinja',
@@ -183,22 +184,22 @@ class ArchiveTestCase(TestCase):
     def test_cmd_unzip(self):
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
-            ret = archive.cmd_unzip_(
+            ret = archive.cmd_unzip(
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/dest',
                 excludes='/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
-                runas=None, template='jinja'
+                template='jinja'
             )
             self.assertEqual(['salt'], ret)
             mock.assert_called_once_with(
                 ['unzip', '/tmp/salt.{{grains.id}}.zip', '-d', '/tmp/dest',
                  '-x', '/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
-                python_shell=False, template='jinja'
+                runas=None, python_shell=False, template='jinja'
             )
 
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
-            ret = archive.cmd_unzip_(
+            ret = archive.cmd_unzip(
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/dest',
                 excludes=['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
@@ -208,12 +209,12 @@ class ArchiveTestCase(TestCase):
             mock.assert_called_once_with(
                 ['unzip', '/tmp/salt.{{grains.id}}.zip', '-d', '/tmp/dest',
                  '-x', '/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
-                python_shell=False, template='jinja'
+                runas=None, python_shell=False, template='jinja'
             )
 
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
-            ret = archive.cmd_unzip_(
+            ret = archive.cmd_unzip(
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/dest',
                 excludes='/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
@@ -224,12 +225,12 @@ class ArchiveTestCase(TestCase):
             mock.assert_called_once_with(
                 ['unzip', '-fo', '/tmp/salt.{{grains.id}}.zip', '-d',
                  '/tmp/dest', '-x', '/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
-                python_shell=False, template='jinja'
+                runas=None, python_shell=False, template='jinja'
             )
 
         mock = MagicMock(return_value='salt')
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
-            ret = archive.cmd_unzip_(
+            ret = archive.cmd_unzip(
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/dest',
                 excludes=['/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
@@ -240,7 +241,7 @@ class ArchiveTestCase(TestCase):
             mock.assert_called_once_with(
                 ['unzip', '-fo', '/tmp/salt.{{grains.id}}.zip', '-d',
                  '/tmp/dest', '-x', '/tmp/tmpePe8yO', '/tmp/tmpLeSw1A'],
-                python_shell=False, template='jinja'
+                runas=None, python_shell=False, template='jinja'
             )
 
     def test_unzip(self):
@@ -260,7 +261,7 @@ class ArchiveTestCase(TestCase):
         with patch.dict(archive.__salt__, {'cmd.run': mock}):
             self.assertRaises(
                 CommandNotFoundError,
-                archive.cmd_unzip_,
+                archive.cmd_unzip,
                 '/tmp/salt.{{grains.id}}.zip',
                 '/tmp/dest',
                 excludes='/tmp/tmpePe8yO,/tmp/tmpLeSw1A',
@@ -308,6 +309,7 @@ class ArchiveTestCase(TestCase):
             )
             self.assertFalse(mock.called)
 
+    @skipIf(which_bin(('unrar', 'rar')) is None, 'unrar not installed')
     @patch('salt.utils.which', lambda exe: exe)
     @patch('salt.utils.which_bin', lambda exe: exe)
     def test_unrar(self):


### PR DESCRIPTION
Recently, `archive.zip` and `archive.unzip` were rewritten to use Python's
native `zipfile` module, however there were a couple things wrong with how this
was done:
1. The new functions did not produce the same result as the legacy functions
   when run with the same arguments.
2. The legacy functions were, for some reason, named `archive.cmd_zip_` and
   `archive.cmd_unzip_`. The trailing underscore means that the functions
   would need to be invoked with that trailing underscore (since they were not
   being modified using a func_alias). This was likely done mistakenly because
   zip_ had the trailing underscore to avoid shadowing the Python builtin
   `zip()` function.

In addition to the above, some additional functionality was added in the 2014.7
branch which, after merging forward, needed to be replicated in the new
versions of `archive.zip` and `archive.unzip`.

This pull request makes those necessary changes.
