### PR TITLE
[DO NOT MERGE] Remove msgpack from thin generation for salt-ssh

### DIFF
--- a/salt/utils/thin.py
+++ b/salt/utils/thin.py
@@ -15,11 +15,6 @@ import jinja2
 import yaml
 import requests
 try:
-    import msgpack
-    HAS_MSGPACK = True
-except ImportError:
-    HAS_MSGPACK = False
-try:
     import certifi
     HAS_CERTIFI = True
 except ImportError:
@@ -128,9 +123,6 @@ def gen_thin(cachedir, extra_mods='', overwrite=False, so_mods=''):
             os.path.dirname(yaml.__file__),
             os.path.dirname(requests.__file__)
             ]
-    if HAS_MSGPACK:
-        tops.append(os.path.dirname(msgpack.__file__))
-
     if HAS_URLLIB3:
         tops.append(os.path.dirname(urllib3.__file__))
 


### PR DESCRIPTION
This is a test pull request. I want to have a few people test this to see if we can track down any ungated imports of msgpack in salt-ssh.

I have done a variety of basic commands, including a simple highstate, and have had no errors with this change.

Refs #7913 
