### PR TITLE
Remove *insane* 7200s timeout (2h).

### DIFF
--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -89,8 +89,6 @@ class RemotePillar(object):
             load['ext'] = self.ext
         ret_pillar = self.channel.crypted_transfer_decode_dictentry(load,
                                                                     dictkey='pillar',
-                                                                    tries=3,
-                                                                    timeout=7200,
                                                                     )
 
         if not isinstance(ret_pillar, dict):


### PR DESCRIPTION
If the pillar isn't back in the regular 1m its probably busted, if not we can set this timeout to something else, but 2h seems excessive.

I've found a few minions stuck in this code block, since the minion's main process can get stuck here waiting for 2 hours.
