### PR TITLE
Revert ec2 changes

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1541,7 +1541,7 @@ def create_attach_volumes(name, kwargs, call=None):
         )
 
     if 'instance_id' not in kwargs:
-        kwargs['instance_id'] = _get_node(name)[name]['instanceId']
+        kwargs['instance_id'] = _get_node(name)['instanceId']
 
     if type(kwargs['volumes']) is str:
         volumes = yaml.safe_load(kwargs['volumes'])
@@ -1616,7 +1616,7 @@ def stop(name, call=None):
 
     log.info('Stopping node {0}'.format(name))
 
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
 
     params = {'Action': 'StopInstances',
               'InstanceId.1': instance_id}
@@ -1659,7 +1659,7 @@ def set_tags(name, tags, call=None, location=None, instance_id=None):
         )
 
     if instance_id is None:
-        instance_id = _get_node(name, location)[name]['instanceId']
+        instance_id = _get_node(name, location)['instanceId']
 
     params = {'Action': 'CreateTags',
               'ResourceId.1': instance_id}
@@ -1748,7 +1748,7 @@ def del_tags(name, kwargs, call=None):
             'A tag or tags must be specified using tags=list,of,tags'
         )
 
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
     params = {'Action': 'DeleteTags',
               'ResourceId.1': instance_id}
 
@@ -1869,7 +1869,7 @@ def reboot(name, call=None):
 
         salt-cloud -a reboot mymachine
     '''
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
     params = {'Action': 'RebootInstances',
               'InstanceId.1': instance_id}
     result = query(params)

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1636,7 +1636,7 @@ def start(name, call=None):
 
     log.info('Starting node {0}'.format(name))
 
-    instance_id = _get_node(name)[name]['instanceId']
+    instance_id = _get_node(name)['instanceId']
 
     params = {'Action': 'StartInstances',
               'InstanceId.1': instance_id}


### PR DESCRIPTION
The changes introduced by #15901 broke all of the functions that are referenced in the pervious fix. Creating a VM in EC2 would work, but not creating volumes, setting or deleting tags, start/stop/reboot of the VM, or destroying the instance. Those changes were causing stack traces. By reverting this fix, I am able to perform all of those functions again.

ping @techhat and @UtahDave 
