### PR TITLE
Fix spurious log message

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -97,8 +97,12 @@ def compile_template(template,
                     template,
                     ret.read()))
                 ret.seek(0)
-            except Exception as exp:
-                log.error('error: {0}'.format(exp))
+            except Exception:
+                # ret is not a StringIO, which means it was rendered using
+                # yaml, mako, or another engine which renders to a data
+                # structure. We don't want to log this, so ignore this
+                # exception.
+                pass
     return ret
 
 


### PR DESCRIPTION
c65af6a8 introduced a spurious log message in template.py. When a rendering
engine such as yaml, ~~mako~~ json, etc. which renders to an OrderedDict is run, the
rendered data will not be a StringIO and thus does not need to be logged. This
was the reason for ignoring the exception.

This commit reverts that change from c65af6a8, and also adds comments 
explaining the reasoning for why the exception is being ignored.
