### PR TITLE
fixes to schedule module in 2014.7

### DIFF
--- a/salt/modules/schedule.py
+++ b/salt/modules/schedule.py
@@ -39,7 +39,7 @@ SCHEDULE_CONF = [
         'days',
         'enabled',
         'cron'
-        ]
+]
 
 
 def list_(show_all=False, return_yaml=True):
@@ -72,7 +72,6 @@ def list_(show_all=False, return_yaml=True):
         for item in schedule[job]:
             if item not in SCHEDULE_CONF:
                 del schedule[job][item]
-                continue
             if schedule[job][item] == 'true':
                 schedule[job][item] = True
             if schedule[job][item] == 'false':


### PR DESCRIPTION
fixing a bug where schedule.list would error out if it encountered a configuration item that wasn't in the list of supported items.
