### PR TITLE
Fixes secgroup return for EC2-VPC

### DIFF
--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -139,6 +139,10 @@ def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None):  # pyl
             for group in filtered_groups:
                 # a group in EC2-Classic will have vpc_id set to None
                 if group.vpc_id is None:
+                    log.debug('Found EC2-Classic group: {0}'.format(group))
+                    return group
+                else:
+                    log.debug('Found EC2-VPC group: {0}'.format(group))
                     return group
             return None
         elif vpc_id:


### PR DESCRIPTION
boto_secgroup.present makes use of _get_group to return the security group after created.
If the AWS account uses EC2-VPC (which was the default for my case) the state always fails and it returns None since it never finds the security group. Although it is created without any rules even if you declare rules.

This is because _get_group is called with name as parameter and no vpc_id is provided.
This quick fix allows for the state to return the security group and apply the rules.
But I am not sure if you can have both classic and vpc in the same region. In that case the classic will take priority which I don't think is ok. There should be some sort of logic to this.

Maybe some one with more boto experience could shed some light.
