### PR TITLE
fixes GPG renderer when working with states in salt-ssh

### DIFF
--- a/salt/client/ssh/wrapper/__init__.py
+++ b/salt/client/ssh/wrapper/__init__.py
@@ -16,7 +16,7 @@ import salt.utils
 import salt.client.ssh
 
 
-class FunctionWrapper(object):
+class FunctionWrapper(dict):
     '''
     Create an object that acts like the salt function dict and makes function
     calls remotely via the SSH shell system


### PR DESCRIPTION
this is a quick fix for working with states in salt-ssh while using GPG
renderer. The issue is that gpg renderer (`salt.renderers.gpg`)
checks if `__salt__` is an instance of `dict` and since in
`salt-ssh` `__salt__` is a `salt.client.ssh.wrapper.FunctionWrapper`
we make it inherit from dict (this is inconsistent with other modules
BTW see #19114 for details)
