### PR TITLE
Fix for passing pillar to state runs in salt-ssh

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,23 +561,7 @@ class Single(object):
         Return the function name and the arg list
         '''
         fun = self.argv[0] if self.argv else ''
-        args = []
-        kws = {}
-        for arg in self.argv[1:]:
-            # FIXME - there is a bug here that will steal a non-keyword argument.
-            # example:
-            #
-            # .. code-block:: bash
-            #
-            #     salt-ssh '*' cmd.run_all 'n=$((RANDOM%8)); exit $n'
-            #
-            # The 'n=' appears to be a keyword argument, but it is
-            # simply the argument!
-            if re.match(r'\w+=', arg):
-                (key, val) = arg.split('=', 1)
-                kws[key] = val
-            else:
-                args.append(arg)
+        args, kws = salt.utils.args.parse_input(args)
         return fun, args, kws
 
     def _escape_arg(self, arg):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,7 +561,7 @@ class Single(object):
         Return the function name and the arg list
         '''
         fun = self.argv[0] if self.argv else ''
-        args, kws = salt.utils.args.parse_input(self.argv[1:])
+        args, kws = salt.utils.args.parse_input(self.argv[1:], condition=False)
         return fun, args, kws
 
     def _escape_arg(self, arg):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,7 +561,7 @@ class Single(object):
         Return the function name and the arg list
         '''
         fun = self.argv[0] if self.argv else ''
-        args, kws = salt.utils.args.parse_input(args)
+        args, kws = salt.utils.args.parse_input(self.argv[1:])
         return fun, args, kws
 
     def _escape_arg(self, arg):

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -793,23 +793,6 @@ ARGS = {9}\n'''.format(self.minion_config,
 
         return cmd
 
-    def cmd(self):
-        '''
-        Prepare the pre-check command to send to the subsystem
-        '''
-        if self.fun.startswith('state.highstate'):
-            self.highstate_seed()
-        elif self.fun.startswith('state.sls'):
-            args, kwargs = salt.minion.load_args_and_kwargs(
-                self.sls_seed,
-                salt.utils.args.parse_input(self.args)
-            )
-            self.sls_seed(*args, **kwargs)
-        cmd_str = self._cmd_str()
-
-        for stdout, stderr, retcode in self.shell.exec_nb_cmd(cmd_str):
-            yield stdout, stderr, retcode
-
     def shim_cmd(self, cmd_str):
         '''
         Run a shim command.

--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -561,7 +561,9 @@ class Single(object):
         Return the function name and the arg list
         '''
         fun = self.argv[0] if self.argv else ''
-        args, kws = salt.utils.args.parse_input(self.argv[1:], condition=False)
+        parsed = salt.utils.args.parse_input(self.argv[1:], condition=False)
+        args = parsed[0]
+        kws = parsed[1]
         return fun, args, kws
 
     def _escape_arg(self, arg):

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -409,7 +409,6 @@ def show_highstate():
 
         salt '*' state.show_highstate
     '''
-    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,
@@ -429,7 +428,6 @@ def show_lowstate():
 
         salt '*' state.show_lowstate
     '''
-    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,
@@ -498,7 +496,6 @@ def show_top():
 
         salt '*' state.show_top
     '''
-    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,

--- a/salt/client/ssh/wrapper/state.py
+++ b/salt/client/ssh/wrapper/state.py
@@ -204,6 +204,7 @@ def high(data, **kwargs):
 
         salt '*' state.high '{"vim": {"pkg": ["installed"]}}'
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     st_kwargs = __salt__.kwargs
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
@@ -269,6 +270,7 @@ def highstate(test=None, **kwargs):
         salt '*' state.highstate exclude=sls_to_exclude
         salt '*' state.highstate exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     st_kwargs = __salt__.kwargs
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
@@ -338,6 +340,7 @@ def top(topfn, test=None, **kwargs):
         salt '*' state.top reverse_top.sls exclude=sls_to_exclude
         salt '*' state.top reverse_top.sls exclude="[{'id': 'id_to_exclude'}, {'sls': 'sls_to_exclude'}]"
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     st_kwargs = __salt__.kwargs
     __opts__['grains'] = __grains__
     if salt.utils.test_mode(test=test, **kwargs):
@@ -406,6 +409,7 @@ def show_highstate():
 
         salt '*' state.show_highstate
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,
@@ -425,6 +429,7 @@ def show_lowstate():
 
         salt '*' state.show_lowstate
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,
@@ -445,6 +450,7 @@ def show_sls(mods, saltenv='base', test=None, env=None, **kwargs):
 
         salt '*' state.show_sls core,edit.vim dev
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     if env is not None:
         salt.utils.warn_until(
@@ -492,6 +498,7 @@ def show_top():
 
         salt '*' state.show_top
     '''
+    __pillar__.update(kwargs.get('pillar', {}))
     __opts__['grains'] = __grains__
     st_ = salt.client.ssh.state.SSHHighState(
             __opts__,


### PR DESCRIPTION
Fixes #19773 

Also cleaned up a few other things:
1. All args for salt-ssh are now parsed using the salt.utils.args functionality, to match normal salt
2. Removed unused cmd function in Single objects
