### PR TITLE
Fixes #14048 and also a bug in win_servermanager

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -203,12 +203,17 @@ class Client(object):
             saltenv = env
 
         ret = []
+
         path = self._check_proto(path)
-        # We want to make sure files start with this *directory*, use
-        # '/' explicitly because the master (that's generating the
-        # list of files) only runs on POSIX
-        if not path.endswith('/'):
-            path = path + '/'
+        # We want to make sure files start with this *directory*. Use the os
+        # path seperator only if the file_client is local since the master is
+        # running on a POSIX system.
+        if self.opts.get('file_client', 'remote') == 'local':
+            if not path.endswith(os.path.sep):
+                path = path + os.path.sep
+        else:
+            if not path.endswith('/'):
+                path = path + '/'
 
         log.info(
             'Caching directory {0!r} for environment {1!r}'.format(

--- a/salt/modules/win_servermanager.py
+++ b/salt/modules/win_servermanager.py
@@ -41,8 +41,11 @@ def _parse_powershell_list(lst):
     for line in lst.splitlines():
         if line:
             splt = line.split()
-            ret[splt[0]] = splt[2]
-
+            # Ensure it's not a malformed line, e.g.:
+            #   FeatureResult : {foo, bar,
+            #                    baz}
+            if len(splt) > 2:
+                ret[splt[0]] = splt[2]
     return ret
 
 
@@ -56,7 +59,7 @@ def list_available():
 
         salt '*' win_servermanager.list_available
     '''
-    return _srvmgr('Get-WindowsFeature -erroraction silentlycontinue')
+    return _srvmgr('Get-WindowsFeature -erroraction silentlycontinue -warningaction silentlycontinue')
 
 
 def list_installed():
@@ -102,7 +105,7 @@ def install(feature, recurse=False):
     sub = ''
     if recurse:
         sub = '-IncludeAllSubFeature'
-    out = _srvmgr('Add-WindowsFeature -Name {0} {1} -erroraction silentlycontinue | format-list'.format(
+    out = _srvmgr('Add-WindowsFeature -Name {0} {1} -erroraction silentlycontinue -warningaction silentlycontinue | format-list'.format(
                   _cmd_quote(feature), sub))
     return _parse_powershell_list(out)
 
@@ -124,6 +127,6 @@ def remove(feature):
 
         salt -t 600 '*' win_servermanager.remove Telnet-Client
     '''
-    out = _srvmgr('Remove-WindowsFeature -Name {0} -erroraction silentlycontinue | format-list'.format(
+    out = _srvmgr('Remove-WindowsFeature -Name {0} -erroraction silentlycontinue -warningaction silentlycontinue | format-list'.format(
                   _cmd_quote(feature)))
     return _parse_powershell_list(out)


### PR DESCRIPTION
1. # 14048 causes custom modules to not be loaded on a Masterless Windows
   
   minion. This commit adds code to use os.path.sep for the path ONLY if the
   fileclient is local. There should be no effect on any master-based
   minions, and no effect on Linux minions, only Masterless Windows.
2. If the add-windowsfeature output is very long, PowerShell will force a
   linebreak, causing an error. This discards lines that do not conform to
   the parsable format because they're not actually used anyway. Also 
   clears out any weird "warning" message lines that creep into stdout.
