### PR TITLE
Remove XMPP from docs for salt.states.smtp

### DIFF
--- a/salt/states/smtp.py
+++ b/salt/states/smtp.py
@@ -5,7 +5,7 @@ Sending Messages via SMTP
 
 .. versionadded:: 2014.7.0
 
-This state is useful for firing messages during state runs, using the XMPP
+This state is useful for firing messages during state runs, using the SMTP
 protocol
 
 .. code-block:: yaml


### PR DESCRIPTION
Pretty sure this module doesn't use XMPP -- a typo from another module?
