### PR TITLE
Force roots fileclient on Masterless Windows to return fake POSIX/"url"

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -205,15 +205,11 @@ class Client(object):
         ret = []
 
         path = self._check_proto(path)
-        # We want to make sure files start with this *directory*. Use the os
-        # path seperator only if the file_client is local since the master is
-        # running on a POSIX system.
-        if self.opts.get('file_client', 'remote') == 'local':
-            if not path.endswith(os.path.sep):
-                path = path + os.path.sep
-        else:
-            if not path.endswith('/'):
-                path = path + '/'
+        # We want to make sure files start with this *directory*, use
+        # '/' explicitly because the master (that's generating the
+        # list of files) only runs on POSIX
+        if not path.endswith('/'):
+            path = path + '/'
 
         log.info(
             'Caching directory {0!r} for environment {1!r}'.format(

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -31,6 +31,7 @@ def find_file(path, saltenv='base', env=None, **kwargs):
         # Backwards compatibility
         saltenv = env
 
+    path = os.path.normpath(path)
     fnd = {'path': '',
            'rel': ''}
     if os.path.isabs(path):
@@ -87,8 +88,7 @@ def serve_file(load, fnd):
         return ret
     ret['dest'] = fnd['rel']
     gzip = load.get('gzip', None)
-
-    with salt.utils.fopen(fnd['path'], 'rb') as fp_:
+    with salt.utils.fopen(os.path.normpath(fnd['path']), 'rb') as fp_:
         fp_.seek(load['loc'])
         data = fp_.read(__opts__['file_buffer_size'])
         if gzip and data:
@@ -267,6 +267,8 @@ def _file_lists(load, form):
                     path,
                     followlinks=__opts__['fileserver_followsymlinks']):
                 dir_rel_fn = os.path.relpath(root, path)
+                if __opts__.get('file_client', 'remote') == 'local' and os.path.sep == "\\":
+                    dir_rel_fn = dir_rel_fn.replace('\\','/')
                 ret['dirs'].append(dir_rel_fn)
                 if len(dirs) == 0 and len(files) == 0:
                     if not salt.fileserver.is_file_ignored(__opts__, dir_rel_fn):
@@ -282,6 +284,8 @@ def _file_lists(load, form):
                                 path
                             )
                     if not salt.fileserver.is_file_ignored(__opts__, rel_fn):
+                        if __opts__.get('file_client', 'remote') == 'local' and os.path.sep == "\\":
+                            rel_fn = rel_fn.replace('\\','/')
                         ret['files'].append(rel_fn)
         if save_cache:
             salt.fileserver.write_file_list_cache(


### PR DESCRIPTION
Fixes #19815, reverts the part of #19805 that fixes #14048 but fixes it in a
different manner.

This is somewhat of an experimental pull request since I'm not quite sure
how to test this due to how differently the Windows client is packaged vs
the Linux one.

I'm mostly sure it won't break anything - the various file operations
(managed, recurse, etc.) still SEEM to work - but I would like another
pair of eyes/test passes on this for sure.

What this does is forces all paths returned by the "roots" fileserver into
the POSIX form (/x/y/z) rather than the Windows form (\x\y\z) despite
being on Windows. It also then uses os.path.normpath to convert the
filepaths back into the Windows versions before using them in find_file
and serve_file. In theory this should mean that everything works just
fine, but it certainly is possible that if paths are being checked in some
other place, it might break them because it thinks it's a POSIX path.

Examples:

Before:

```
C:\salt>c:\salt\salt-call cp.list_master
local:
    - _modules\win_pkg.py
    - _modules\win_servermanager.py
    - _states\win_archive.py
    - base\heka\agent.sls
    - base\heka\aggregator.sls
```

```
C:\salt>c:\salt\salt-call cp.list_master
local:
    - _modules/win_pkg.py
    - _modules/win_servermanager.py
    - _states/win_archive.py
    - base/heka/agent.sls
    - base/heka/aggregator.sls
```
