### PR TITLE
update ret of check_managed_changes

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2982,7 +2982,7 @@ def check_managed_changes(
     changes = check_file_meta(name, sfn, source, source_sum, user,
                               group, mode, saltenv, template, contents)
     __clean_tmp(sfn)
-    return changes
+    return None if changes else True, changes
 
 
 def check_file_meta(

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1355,8 +1355,7 @@ def managed(name,
 
     try:
         if __opts__['test']:
-            ret['result'] = None
-            ret['changes'] = __salt__['file.check_managed_changes'](
+            ret['result'], ret['changes'] = __salt__['file.check_managed_changes'](
                 name,
                 source,
                 source_hash,


### PR DESCRIPTION
1. In test=True mode, if ret['result'] is always None, then file.managed will always show changes.
2. It's better to always return "[True|False|None], changes" for check_managed_changes as line 2981 already "return False, Comments".
