### PR TITLE
Adds docker.latest_running state

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -113,12 +113,16 @@ Available Functions
 
 from __future__ import absolute_import
 import functools
+import inspect
 import logging
 
 # Import salt libs
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 from salt.ext.six import string_types
 import salt.utils
 import salt.ext.six as six
+
+import docker
 
 # Enable proper logging
 log = logging.getLogger(__name__)
@@ -182,6 +186,151 @@ def _invalid(exec_status=None, name='', comment='', changes=None):
                        name=name,
                        changes=changes,
                        result=False)
+
+
+def _host_config_changed(container, **kwargs):
+    """
+    Check for changes in running config vs. requested config
+    """
+    config_defaults = {
+        'Privileged': False,
+        'PublishAllPorts': False,
+        'DnsSearch': None,
+        'NetworkMode': '',
+        'RestartPolicy': {'MaximumRetryCount': 0, 'Name': ''},
+        'CapAdd': None,
+        'CapDrop': None,
+        'Devices': None,
+        'Dns': None,
+        'VolumesFrom': None,
+        'Binds': None,
+        'PortBindings': None,
+        'ExtraHosts': None,
+        'Links': None,
+        'LxcConf': None
+    }
+    current_config = container['HostConfig']
+    new_config = docker.utils.create_host_config(**kwargs)
+    # links go from "container:alias" to "/container:/name/alias"
+    if 'Links' in new_config:
+        patched_links = []
+        for link in new_config['Links']:
+            name, alias = link.split(':')
+            patched = '/{0}:{1}/{2}'.format(name, container['Name'], alias)
+            patched_links.append(patched)
+        new_config['Links'] = patched_links
+
+    changed = {}
+    # Compare keys and see what changed
+    for key, default in config_defaults.items():
+        new_val = new_config.get(key, default)
+        current_val = current_config.get(key, default)
+        if current_val != new_val:
+            changed[key] = {
+                'new': new_val,
+                'old': current_val,
+            }
+    return changed
+
+
+def _parse_args(**kwargs):
+    """
+    Split the incoming arguments into two dictionaries
+    matching what the docker library accepts
+    for `create_container` and `start`
+    """
+    # get all kwarg names except 'self'
+    start_kwarg_keys = inspect.getargspec(docker.Client.start)[0][1:]
+    create_container_kwarg_keys = inspect.getargspec(
+        docker.Client.create_container)[0][1:]
+    create_container_kwargs = {}
+    start_kwargs = {}
+    for key, value in kwargs.items():
+        if key in start_kwarg_keys:
+            start_kwargs[key] = value
+        if key in create_container_kwarg_keys:
+            create_container_kwargs[key] = value
+    # Tweaks to make CLI-style args work with Salt's modules
+    # which match the Python module except for `port_bindings`
+    if 'volumes' in kwargs:
+        volumes, binds = _parse_volumes_kwarg(kwargs['volumes'])
+        create_container_kwargs['volumes'] = volumes
+        start_kwargs['binds'] = binds
+    if 'ports' in kwargs:
+        ports, port_bindings = _parse_ports_kwarg(kwargs['ports'])
+        create_container_kwargs['ports'] = ports
+        start_kwargs['port_bindings'] = port_bindings
+    return create_container_kwargs, start_kwargs
+
+
+def _parse_volumes_kwarg(cli_style_volumes):
+    """
+    The Python API for mounting volumes is tedious.
+    https://github.com/docker/docker-py/blob/master/docs/volumes.md
+    This makes it work like the CLI
+    """
+    binds = {}
+    volumes = []
+    for volume in cli_style_volumes:
+        split = volume.split(':')
+        if len(split) == 1:
+            volume.append(split[0])
+            continue
+
+        host_path = split[0]
+        mountpoint = split[1]
+        if len(split) == 3:
+            read_only = split[2] == 'ro'
+        else:
+            read_only = False
+        volumes.append(mountpoint)
+        binds[host_path] = {'bind': mountpoint, 'ro': read_only}
+    return volumes, binds
+
+
+def _parse_ports_kwarg(cli_style_ports):
+    """
+    The Python API for port binding is tedious.
+    https://github.com/docker/docker-py/blob/master/docs/port-bindings.md
+    https://github.com/saltstack/salt/blob/2014.7/salt/modules/dockerio.py#L881-L891
+    This makes it work like the CLI which uses one of the following formats:
+
+    * ip:hostPort:containerPort
+    * ip::containerPort
+    * hostPort:containerPort
+    * containerPort
+    """
+    ports = []
+    port_bindings = {}
+    for port_defn in cli_style_ports:
+        split = port_defn.split(':')
+        container_port = split[-1]
+        if len(split) > 3:
+            raise SaltInvocationError('Port mapping has too many ":" in it.')
+
+        host_ip = len(split) == 3 and split[0] or ''
+        port_bindings[container_port] = {
+            'HostPort': split[-2],
+            'HostIp': host_ip,
+        }
+
+        # check for tcp/udp declaration
+        if '/' in container_port:
+            ports.append(tuple(container_port.split('/')))
+        else:
+            ports.append(container_port)
+    return ports, port_bindings
+
+
+def _run_and_check_salt_mod(mod, *args, **kwargs):
+    """
+    Execute a salt module and raise an exception if it failed
+    """
+    status = __salt__[mod](*args, **kwargs)
+    if not status['status']:
+        err = 'Call to {0} failed.\n{1}'.format(mod, status)
+        raise CommandExecutionError(err)
+    return status
 
 
 def mod_watch(name, sfun=None, *args, **kw):
@@ -1034,3 +1183,104 @@ def running(name,
         else:
             changes.append('Container {0!r} started.\n'.format(name))
     return _valid(comment=','.join(changes), changes={name: True})
+
+
+def latest_running(name, image, **kwargs):
+    """
+    Ensures the latest version of the container is running in the correct
+    configuration. New images will be pulled from the repo and running
+    containers will be restarted if necessary (new image or changed config.
+    """
+    create_container_kwargs, start_kwargs = _parse_args(**kwargs)
+    create_container_kwargs.update({
+        'name': name,
+        'image': image,
+    })
+    if ':' in image:
+        image_no_tag, tag = image.split(':')
+    else:
+        image_no_tag = image
+        tag = None
+    inspect_status = __salt__['docker.inspect_container'](name)
+    if not inspect_status['status']:
+        log.info('Container %s does not exist', name)
+        container = {}
+        is_running = False
+        current_image = None
+    else:
+        container = inspect_status['out']
+        current_image = container['Image']
+        is_running = container['State']['Running']
+    new_image = None
+    log.debug('Pulling latest image for %s (tag: %s)', image_no_tag, tag)
+    pull_status = _run_and_check_salt_mod('docker.pull', image_no_tag, tag)
+    new_image = pull_status['id']
+
+    # Container exists and new image is available
+    # Build a new one and start it
+    if new_image != current_image and container:
+        log.debug('new image: %s', new_image)
+        log.debug('current image: %s', current_image)
+        comment = ("The running container was out-of-date. "
+                  "It was replaced and restarted.")
+        log.info(comment)
+        if is_running:
+            _run_and_check_salt_mod('docker.stop', container['Id'])
+        _run_and_check_salt_mod('docker.remove_container', container['Id'])
+        _run_and_check_salt_mod('docker.remove_image', container['Image'])
+        cc_status = _run_and_check_salt_mod('docker.create_container',
+                                            **create_container_kwargs)
+        new_container = cc_status['out']['info']
+        ret = _valid(name=name,
+                     comment=comment,
+                     changes={'image': {'old': current_image,
+                                        'new': new_image},
+                              'container': {'old': container['Id'],
+                                            'new': new_container['Id']}})
+
+    # A container for this image does not exist
+    # Build a new one
+    elif not container:
+        comment = "The container did not exist. A new one was created."
+        log.info(comment)
+        cc_status = _run_and_check_salt_mod('docker.create_container',
+                                            **create_container_kwargs)
+        new_container = cc_status['out']['info']
+        ret = _valid(name=name,
+                     comment=comment,
+                     changes={'container': {'old': 'absent',
+                                            'new': new_container['Id']}})
+
+    # The container exists and its image is current, but it's not running
+    # Start it
+    elif not is_running:
+        comment = "The container was current, but stopped."
+        log.info(comment)
+        new_container = container
+        ret = _valid(name=name,
+                     comment=comment,
+                     changes={'state': {'old': 'stopped', 'new': 'starting'}})
+
+    # Container is running and current, but the config changed
+    # Restart with new config
+    else:
+        changes = _host_config_changed(container, **start_kwargs)
+        if changes:
+            comment = ("The container was current, but its configuration "
+                       "changed. It was restarted.")
+            log.info(comment)
+            _run_and_check_salt_mod('docker.stop', container['Id'])
+            new_container = container
+            ret = _valid(name=name,
+                     comment=comment,
+                     changes={'configuration': changes})
+
+        # If you get here, everything's in good shape already.
+        else:
+            comment = 'The container is current and in the correct state.'
+            log.info(comment)
+            return _valid(name=name, comment=comment)
+    # There's a new container that needs to be started
+    start_kwargs['container'] = new_container['Id']
+    _run_and_check_salt_mod('docker.start', **start_kwargs)
+    return ret


### PR DESCRIPTION
Submitting this for discussion. It's like `docker.running` but it also checks that the config matches and that the image is the latest one available in the repo. A few notes/thoughts:
- Should this functionality be merged into `running` with something like a `is_latest` flag?
- I deviated from the existing style by passing `kwargs` around instead of naming them. I thought this might future-proof it a bit more against Docker's fast-moving API.
- I added helper functions that will allow users to use the simpler CLI-style arguments for `volumes` and `ports`. This makes writing states easier and it would be nice to use them throughout this state.
- This is the first state I've written, am I doing it right? :wink: 
