### PR TITLE
Bugfix setting sysctl keys with '/' in it

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -13,6 +13,7 @@ import salt.utils
 from salt._compat import string_types
 from salt.exceptions import CommandExecutionError
 from salt.modules.systemd import _sd_booted
+from string import maketrans
 
 log = logging.getLogger(__name__)
 
@@ -132,7 +133,7 @@ def assign(name, value):
         salt '*' sysctl.assign net.ipv4.ip_forward 1
     '''
     value = str(value)
-    sysctl_file = '/proc/sys/{0}'.format(name.replace('.', '/'))
+    sysctl_file = '/proc/sys/{0}'.format(name.translate(maketrans('./', '/.')))
     if not os.path.exists(sysctl_file):
         raise CommandExecutionError('sysctl {0} does not exist'.format(name))
 


### PR DESCRIPTION
When a sysctl key contains a /, in /proc this key can only be found by replacing that / with a ..
sysctl.present fails on these values because that translation isn't done.

(for example VLAN interfaces; net.ipv6.conf.bond0/560.use_tempaddr = 0)
