### PR TITLE
fix error log when using service.dead

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -211,7 +211,8 @@ def status(name, sig=None):
     if sig:
         return bool(__salt__['status.pid'](sig))
     cmd = 'service {0} status'.format(name)
-    return not __salt__['cmd.retcode'](cmd, python_shell=False)
+    return not __salt__['cmd.retcode'](cmd, ignore_retcode=True,
+                                       python_shell=False)
 
 
 def enable(name, **kwargs):

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -406,8 +406,10 @@ def status(name, sig=None):
         return bool(__salt__['status.pid'](sig))
     cmd = 'service {0} status'.format(name)
     if _service_is_upstart(name):
-        return 'start/running' in __salt__['cmd.run'](cmd, python_shell=False)
-    return not bool(__salt__['cmd.retcode'](cmd, python_shell=False))
+        return 'start/running' in __salt__['cmd.run'](cmd, ignore_retcode=True,
+                                                      python_shell=False)
+    return not bool(__salt__['cmd.retcode'](cmd, ignore_retcode=True,
+                                            python_shell=False))
 
 
 def _get_service_exec():


### PR DESCRIPTION
return False is enough, no need to log output as error

when using service.status module function in service.dead state
it outputed error log when it is expected behavior when using
service.dead.

```
...
[ERROR ] Command 'service rsync status' failed with return code: 3
[ERROR ] output: * rsync is not running

```

After

```
[INFO ] Executing command 'service rsync status' in directory '/root'
[INFO ] output: * rsync is not running
```

It may need to change other service module back-end for different platforms but I only familiar with ubuntu/debian.
