### PR TITLE
Fix for docker login saltstack/salt#18673

### DIFF
--- a/salt/modules/dockerio.py
+++ b/salt/modules/dockerio.py
@@ -1158,7 +1158,7 @@ def login(url=None, username=None, password=None, email=None):
         salt '*' docker.login <url> <username> <password> <email>
     '''
     client = _get_client()
-    return client.login(url, username, password, email)
+    return client.login(username, password, email, url)
 
 
 def search(term):


### PR DESCRIPTION
Arguments to docker.Client.login were the wrong way around.
