### PR TITLE
Update timeout help to indicate it is in seconds

### DIFF
--- a/salt/utils/parsers.py
+++ b/salt/utils/parsers.py
@@ -962,7 +962,7 @@ class TimeoutMixIn(object):
             type=int,
             default=self.default_timeout,
             help=('Change the timeout, if applicable, for the running '
-                  'command; default=%default')
+                  'command (in seconds); default=%default')
         )
 
 


### PR DESCRIPTION
I always ask myself this question - having it in the help clears it up quick.
