### PR TITLE
Documentation fix for Issue 19513.

### DIFF
--- a/doc/_incl/_incl/sls_filename_cant_contain_period.rst
+++ b/doc/_incl/_incl/sls_filename_cant_contain_period.rst
@@ -1,0 +1,9 @@
+.. admonition:: Do not use dots in SLS file names
+
+    The initial implementation of :conf_master:`top.sls <state_top>` and
+    :ref:`include-declaration` followed the python import model where a slash
+    is represented as a period.  This means that a SLS file with a period in
+    the name ( besides the suffix period) can not be referenced.  For example,
+    webserver_1.0.sls is not referenceable because webserver_1.0 would refer
+    to the directory/file webserver_1/0.sls
+  

--- a/doc/ref/states/include.rst
+++ b/doc/ref/states/include.rst
@@ -30,6 +30,8 @@ the following syntax is used:
     include:
       - dev: http
 
+.. include:: /_incl/sls_filename_cant_contain_period.rst
+
 Relative Include
 ================
 

--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -173,6 +173,8 @@ this:
 So the httpd.conf is just a file in the apache directory, and is referenced
 directly.
 
+.. include:: /_incl/sls_filename_cant_contain_period.rst
+
 But when using more than one single SLS file, more components can be added to
 the toolkit. Consider this SSH example:
 

--- a/doc/topics/tutorials/states_pt1.rst
+++ b/doc/topics/tutorials/states_pt1.rst
@@ -150,13 +150,20 @@ and all changes made.
 
     Note that in the :ref:`example <targeting-minions>` above, the SLS file
     ``webserver.sls`` was referred to simply as ``webserver``. The namespace
-    for SLS files follows a few simple rules:
+    for SLS files when referenced in :conf_master:`top.sls <state_top>` or an :ref:`include-declaration` 
+    follows a few simple rules:
 
     1. The ``.sls`` is discarded (i.e. ``webserver.sls`` becomes
        ``webserver``).
     2. Subdirectories can be used for better organization.
-        a. Each subdirectory is represented by a dot.
-        b. ``webserver/dev.sls`` is referred to as ``webserver.dev``.
+        a. Each subdirectory can be represented with a dot (following the python 
+           import model) or a slash.  ``webserver/dev.sls`` can also be referred to 
+           as ``webserver.dev``
+        b. Because slashes can be represented as dots, SLS files can not contain
+           dots in the name besides the dot for the SLS suffix.  The SLS file 
+           webserver_1.0.sls can not be matched, and webserver_1.0 would match 
+           the directory/file webserver_1/0.sls
+        
     3. A file called ``init.sls`` in a subdirectory is referred to by the path
        of the directory. So, ``webserver/init.sls`` is referred to as
        ``webserver``.


### PR DESCRIPTION
Documentation fix for Issue 19513.  Periods in SLS file names can not be referenced from top.sls or includes.
