### PR TITLE
Also catch TokenAuthenticationError tracebacks to properly raise a 401

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -345,7 +345,8 @@ def hypermedia_handler(*args, **kwargs):
     try:
         cherrypy.response.processors = dict(ct_out_map)
         ret = cherrypy.serving.request._hypermedia_inner_handler(*args, **kwargs)
-    except salt.exceptions.EauthAuthenticationError:
+    except (salt.exceptions.EauthAuthenticationError,
+            salt.exceptions.TokenAuthenticationError):
         raise cherrypy.HTTPError(401)
     except cherrypy.CherryPyException:
         raise


### PR DESCRIPTION
rest_cherrypy will incorrectly return a 500 response for some auth errors.
