### PR TITLE
Revert "Fixes secgroup return for EC2-VPC"

### DIFF
--- a/salt/modules/boto_secgroup.py
+++ b/salt/modules/boto_secgroup.py
@@ -139,10 +139,6 @@ def _get_group(conn, name=None, vpc_id=None, group_id=None, region=None):  # pyl
             for group in filtered_groups:
                 # a group in EC2-Classic will have vpc_id set to None
                 if group.vpc_id is None:
-                    log.debug('Found EC2-Classic group: {0}'.format(group))
-                    return group
-                else:
-                    log.debug('Found EC2-VPC group: {0}'.format(group))
                     return group
             return None
         elif vpc_id:


### PR DESCRIPTION
As described in https://github.com/saltstack/salt/pull/19782, this change is dangerous and should be reverted.
