### PR TITLE
Fix saltstack/salt#19415 pkgrepo.managed not enabling disabled ppas

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -250,10 +250,10 @@ def managed(name, **kwargs):
 
     # aptpkg supports "disabled", yumpkg supports "enabled"
     # lets just provide both to everyone.
-    if 'enabled' in kwargs and not 'disabled' in kwargs:
+    if 'enabled' in kwargs and 'disabled' not in kwargs:
         kw_enabled = kwargs['enabled'] in (['true', 'True', 'TRUE', True, 1])
         kwargs['disabled'] = not kw_enabled
-    if 'disabled' in kwargs and not 'enabled' in kwargs:
+    if 'disabled' in kwargs and 'enabled' not in kwargs:
         kw_disabled = kwargs['disabled'] in (['true', 'True', 'TRUE', True, 1])
         kwargs['enabled'] = not kw_disabled
 

--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -248,6 +248,15 @@ def managed(name, **kwargs):
             'Failed to configure repo {0!r}: {1}'.format(name, exc)
         return ret
 
+    # aptpkg supports "disabled", yumpkg supports "enabled"
+    # lets just provide both to everyone.
+    if 'enabled' in kwargs and not 'disabled' in kwargs:
+        kw_enabled = kwargs['enabled'] in (['true', 'True', 'TRUE', True, 1])
+        kwargs['disabled'] = not kw_enabled
+    if 'disabled' in kwargs and not 'enabled' in kwargs:
+        kw_disabled = kwargs['disabled'] in (['true', 'True', 'TRUE', True, 1])
+        kwargs['enabled'] = not kw_disabled
+
     # this is because of how apt-sources works.  This pushes distro logic
     # out of the state itself and into a module that it makes more sense
     # to use.  Most package providers will simply return the data provided


### PR DESCRIPTION
I'm a little less confident of this one, and have only tested it with apt repos on Ubuntu. Some might need to check that
I didn't break Yum or others. It _should_ be fairly safe, but I'm not all that familiar with Salt yet.
