### PR TITLE
Create parent directories

### DIFF
--- a/salt/returners/local_cache.py
+++ b/salt/returners/local_cache.py
@@ -137,7 +137,7 @@ def returner(load):
     hn_dir = os.path.join(jid_dir, load['id'])
 
     try:
-        os.mkdir(hn_dir)
+        os.makedirs(hn_dir)
     except OSError as err:
         if err.errno == errno.EEXIST:
             # Minion has already returned this jid and it should be dropped


### PR DESCRIPTION
While running the tests suite, we see a lot of:

```
17:12:11,005 [salt.master                                :1480][ERROR   ] Error in function _syndic_return:
Traceback (most recent call last):
  File "/home/vampas/projects/salt/salt/salt/master.py", line 1470, in run_func
    ret = getattr(self, func)(load)
  File "/home/vampas/projects/salt/salt/salt/master.py", line 1316, in _syndic_return
    self.mminion.returners[fstr](load['jid'], load)
  File "/home/vampas/projects/salt/salt/salt/returners/local_cache.py", line 217, in save_load
    os.mkdir(jid_dir)
OSError: [Errno 2] No such file or directory: '/tmp/vampas/salt-tests-tmpdir/syndic-master-root/cache/jobs/d1/cee8dbdc07bb12e7440e0ac84cba6f'
```

Making sure that the parent directories are created with `os.makedirs` solves this.
