### PR TITLE
Fix some performance regressions

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -105,8 +105,6 @@ from salt.exceptions import (
     SaltInvocationError
 )
 
-# Import third party libs
-import yaml
 
 log = logging.getLogger(__name__)
 _empty = object()
@@ -137,6 +135,8 @@ def get_color_theme(theme):
     '''
     Return the color theme to use
     '''
+    # Keep the heavy lifting out of the module space
+    import yaml
     if not os.path.isfile(theme):
         log.warning('The named theme {0} if not available'.format(theme))
     try:

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -175,10 +175,6 @@ class SaltEvent(object):
         self.pending_events = []
         self.__load_cache_regex()
 
-        # since ZMQ connect()  has no guarantees about the socket actually being
-        # connected this is a hack to attempt to do so.
-        self.get_event(wait=1)
-
     @classmethod
     def __load_cache_regex(cls):
         '''


### PR DESCRIPTION
Move YAML load down into function and keep it out of module space

The get_event() call incurs a 1s penelty on all LocalClient
initalizations. Removed.
