### PR TITLE
fix ddns tests

### DIFF
--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -29,7 +29,7 @@ ddns.__grains__ = {}
 ddns.__salt__ = {}
 
 
-@skipif(True, 'mocking dnspython without depending on it being installed'
+@skipIf(True, 'mocking dnspython without depending on it being installed'
         'requires more effort than unit testing the ddns module may be worth'
         'at this point.  An integration test would be easy though.')
 @skipIf(NO_MOCK, NO_MOCK_REASON)

--- a/tests/unit/modules/ddns_test.py
+++ b/tests/unit/modules/ddns_test.py
@@ -29,6 +29,9 @@ ddns.__grains__ = {}
 ddns.__salt__ = {}
 
 
+@skipif(True, 'mocking dnspython without depending on it being installed'
+        'requires more effort than unit testing the ddns module may be worth'
+        'at this point.  An integration test would be easy though.')
 @skipIf(NO_MOCK, NO_MOCK_REASON)
 class DDNSTestCase(TestCase):
     '''


### PR DESCRIPTION
These tests will only work if dnspython is installed.  Mocking away
dnspython is a great amount of work, so we'll just disable these tests
for now.
