### PR TITLE
Split out tar options into long and short array-based arguments

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -186,7 +186,23 @@ def extracted(name,
         else:
             log.debug('Untar {0} in {1}'.format(filename, name))
 
-            tar_cmd = ['tar', 'x{0}'.format(tar_options), '-f', repr(filename)]
+            tar_opts = tar_options.split(' ')
+
+            tar_cmd = ['tar']
+            tar_shortopts = 'x'
+            tar_longopts = []
+
+            for opt in tar_opts:
+                if not opt.startswith('-'):
+                    if opt not in ['x', 'f']:
+                        tar_shortopts = tar_shortopts + opt
+                else:
+                    tar_longopts.append(opt)
+
+            tar_cmd.append(tar_shortopts)
+            tar_cmd.extend(tar_longopts)
+            tar_cmd.extend(['-f', filename])
+
             results = __salt__['cmd.run_all'](tar_cmd, cwd=name, python_shell=False)
             if results['retcode'] != 0:
                 ret['result'] = False


### PR DESCRIPTION
Fixes #19928. This commit changes the behavior of tar_options so that anything
without a - to start gets appended to the "x" for extraction (e.g. "z" or "J")
but anything that starts with a - properly gets appended as an explicit
argument. In addition, filename no longer needs quoting since it's an
array-based argument now.
