### PR TITLE
Fixes to archive state

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -186,7 +186,7 @@ def extracted(name,
         else:
             log.debug('Untar {0} in {1}'.format(filename, name))
 
-            tar_cmd = ['tar', 'x{0}'.format(tar_options), '-f', repr(filename)]
+            tar_cmd = ['tar', 'x{0}'.format(tar_options), '-f', str(filename)]
             results = __salt__['cmd.run_all'](tar_cmd, cwd=name, python_shell=False)
             if results['retcode'] != 0:
                 ret['result'] = False


### PR DESCRIPTION
Changing repr to str for the filename which is untarred.  Using repr caused the string used as file to not be representative of the actual filename.
