### PR TITLE
multiple source files in windows repo to fix saltstack/salt#9028

### DIFF
--- a/doc/topics/windows/windows-package-manager.rst
+++ b/doc/topics/windows/windows-package-manager.rst
@@ -165,8 +165,20 @@ project's wiki_:
         uninstaller: salt://win/repo/7zip/7z920-x64.msi
         uninstall_flags: ' /qn'
 
+Add ``cache_dir: True`` when the installer requires multiple source files. The
+directory containing the installer file will be recursively cached on the minion.
+Only applies to salt: installer URLs.
 
+.. code-block:: yaml
 
+    sqlexpress:
+      12.0.2000.8:
+        installer: 'salt://win/repo/sqlexpress/setup.exe'
+        full_name: Microsoft SQL Server 2014 Setup (English)
+        reboot: False
+        install_flags: ' /ACTION=install /IACCEPTSQLSERVERLICENSETERMS /Q'
+        cache_dir: True
+       
 Generate Repo Cache File
 ========================
 


### PR DESCRIPTION
Added a simple check to win_pkg for cache_dir: True in win repo package definition to support installers requiring multiple source files.

If True the entire directory containing the file specified by the installer key is downloaded using cp.cache_dir. This essentially does the same thing that @eliasp does with a state file. This is an old issue and this solution is really simple (code wise) so maybe this has some pretty big drawback?

The cmd.run is slightly modified to run in the cache directory in order to support references to files in the install_flags key, e.g. 'setup.exe /withconfigfile config.ini'.

Please be gentle, this is my first pull request.
