### PR TITLE
Fixes an error where a prereq of a file.recurse fails on Windows

### DIFF
--- a/salt/modules/win_file.py
+++ b/salt/modules/win_file.py
@@ -46,7 +46,7 @@ except ImportError:
 import salt.utils
 from salt.modules.file import (check_hash,  # pylint: disable=W0611
         directory_exists, get_managed, mkdir, makedirs_, makedirs_perms,
-        check_managed, check_perms, remove, source_list,
+        check_managed, check_managed_changes, check_perms, remove, source_list,
         touch, append, contains, contains_regex, contains_regex_multiline,
         contains_glob, find, psed, get_sum, _get_bkroot,
         get_hash, manage_file, file_exists, get_diff, list_backups,
@@ -72,8 +72,8 @@ def __virtual__():
         if HAS_WINDOWS_MODULES:
             global check_perms, get_managed, makedirs_perms, manage_file
             global source_list, mkdir, __clean_tmp, makedirs_, file_exists
-            global check_managed, check_file_meta, remove, append, _error
-            global directory_exists, touch, contains
+            global check_managed, check_managed_changes, check_file_meta
+            global remove, append, _error, directory_exists, touch, contains
             global contains_regex, contains_regex_multiline, contains_glob
             global find, psed, get_sum, check_hash, get_hash, delete_backup
             global get_diff, _get_flags, extract_hash
@@ -97,6 +97,7 @@ def __virtual__():
             check_perms = _namespaced_function(check_perms, globals())
             get_managed = _namespaced_function(get_managed, globals())
             check_managed = _namespaced_function(check_managed, globals())
+            check_managed_changes = _namespaced_function(check_managed_changes, globals())
             check_file_meta = _namespaced_function(check_file_meta, globals())
             makedirs_perms = _namespaced_function(makedirs_perms, globals())
             makedirs_ = _namespaced_function(makedirs_, globals())


### PR DESCRIPTION
Any state with a file.recurse prerequisite fails on Windows because file.py's function
check_managed_changes function is not imported into win_file.py.
