### PR TITLE
Add compatibility to mount by label

### DIFF
--- a/salt/modules/mount.py
+++ b/salt/modules/mount.py
@@ -66,9 +66,11 @@ def _active_mountinfo(ret):
             _sep = comps.index('-')
             device_name = comps[_sep + 2]
             device_uuid = None
+            device_label = None
             if device_name:
                 device_uuid = blkid_info.get(device_name, {}).get('UUID')
                 device_uuid = device_uuid and device_uuid.lower()
+                device_label = blkid_info.get(device_name, {}).get('LABEL')
             ret[comps[4]] = {'mountid': comps[0],
                              'parentid': comps[1],
                              'major': device[0],
@@ -79,7 +81,8 @@ def _active_mountinfo(ret):
                              'device': device_name,
                              'alt_device': _list.get(comps[4], None),
                              'superopts': comps[_sep + 3].split(','),
-                             'device_uuid': device_uuid}
+                             'device_uuid': device_uuid,
+                             'device_label': device_label}
     return ret
 
 

--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -60,7 +60,7 @@ def mounted(name,
 
     device
         The device name, typically the device node, such as ``/dev/sdb1``
-        or ``UUID=066e0200-2867-4ebe-b9e6-f30026ca2314``
+        or ``UUID=066e0200-2867-4ebe-b9e6-f30026ca2314`` or ``LABEL=DATA``
 
     fstype
         The filesystem type, this will be ``xfs``, ``ext2/3/4`` in the case of classic
@@ -177,10 +177,13 @@ def mounted(name,
             device_list.append(os.path.realpath(device_list[0]))
             alt_device = active[real_name]['alt_device'] if 'alt_device' in active[real_name] else None
             uuid_device = active[real_name]['device_uuid'] if 'device_uuid' in active[real_name] else None
+            label_device = active[real_name]['device_label'] if 'device_label' in active[real_name] else None
             if alt_device and alt_device not in device_list:
                 device_list.append(alt_device)
             if uuid_device and uuid_device not in device_list:
                 device_list.append(uuid_device)
+            if label_device and label_device not in device_list:
+                device_list.append(label_device)
             if opts:
                 mount_invisible_options = [
                     '_netdev',
@@ -204,6 +207,7 @@ def mounted(name,
                     'password',
                     'retry',
                 ]
+
                 for opt in opts:
                     keyval_option = opt.split('=')[0]
                     if keyval_option in mount_invisible_keys:


### PR DESCRIPTION
Previously this would always force a remount as label was missing from the extended mount.active function.

Tested in 2014.7.
