### PR TITLE
Remove verify_* from all the non-daemon CLI scripts

### DIFF
--- a/salt/cli/api.py
+++ b/salt/cli/api.py
@@ -9,7 +9,6 @@
 
 # Import Python libs
 from __future__ import absolute_import, print_function
-import sys
 import os.path
 import logging
 
@@ -48,20 +47,6 @@ class SaltAPI(six.with_metaclass(parsers.OptionParserMeta,  # pylint: disable=W0
         '''
         import salt.client.netapi
         self.parse_args()
-        try:
-            if self.config['verify_env']:
-                logfile = self.config['log_file']
-                if logfile is not None and not logfile.startswith('tcp://') \
-                        and not logfile.startswith('udp://') \
-                        and not logfile.startswith('file://'):
-                    # Logfile is not using Syslog, verify
-                    salt.utils.verify.verify_files(
-                        [logfile], self.config['user']
-                    )
-        except OSError as err:
-            log.error(err)
-            sys.exit(err.errno)
-
         self.setup_logfile_logger()
         client = salt.client.netapi.NetapiClient(self.config)
         self.daemonize_if_required()

--- a/salt/cli/call.py
+++ b/salt/cli/call.py
@@ -4,7 +4,6 @@ from __future__ import absolute_import
 import os
 
 from salt.utils import parsers
-from salt.utils.verify import verify_env, verify_files
 from salt.config import _expand_glob_path
 import salt.cli.caller
 
@@ -19,24 +18,6 @@ class SaltCall(parsers.SaltCallOptionParser):
         Execute the salt call!
         '''
         self.parse_args()
-
-        if self.config['verify_env']:
-            verify_env([
-                    self.config['pki_dir'],
-                    self.config['cachedir'],
-                ],
-                self.config['user'],
-                permissive=self.config['permissive_pki_access'],
-                pki_dir=self.config['pki_dir'],
-            )
-            if not self.config['log_file'].startswith(('tcp://',
-                                                       'udp://',
-                                                       'file://')):
-                # Logfile is not using Syslog, verify
-                verify_files(
-                    [self.config['log_file']],
-                    self.config['user']
-                )
 
         if self.options.file_root:
             # check if the argument is pointing to a file on disk

--- a/salt/cli/cp.py
+++ b/salt/cli/cp.py
@@ -16,7 +16,6 @@ import pprint
 # Import salt libs
 import salt.client
 from salt.utils import parsers, print_cli
-from salt.utils.verify import verify_files
 
 
 class SaltCPCli(parsers.SaltCPOptionParser):
@@ -29,16 +28,6 @@ class SaltCPCli(parsers.SaltCPOptionParser):
         Execute salt-cp
         '''
         self.parse_args()
-
-        if self.config['verify_env']:
-            if not self.config['log_file'].startswith(('tcp://',
-                                                       'udp://',
-                                                       'file://')):
-                # Logfile is not using Syslog, verify
-                verify_files(
-                    [self.config['log_file']],
-                    self.config['user']
-                )
 
         # Setup file logging!
         self.setup_logfile_logger()

--- a/salt/cli/key.py
+++ b/salt/cli/key.py
@@ -2,10 +2,8 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import os
-
 from salt.utils import parsers
-from salt.utils.verify import check_user, verify_env, verify_files
+from salt.utils.verify import check_user
 
 
 class SaltKey(parsers.SaltKeyOptionParser):
@@ -22,39 +20,6 @@ class SaltKey(parsers.SaltKeyOptionParser):
         multi = False
         if self.config.get('zmq_behavior') and self.config.get('transport') == 'raet':
             multi = True
-
-        if self.config['verify_env']:
-            verify_env_dirs = []
-            if not self.config['gen_keys']:
-                if self.config['transport'] == 'raet' or multi:
-                    verify_env_dirs.extend([
-                        self.config['pki_dir'],
-                        os.path.join(self.config['pki_dir'], 'accepted'),
-                        os.path.join(self.config['pki_dir'], 'pending'),
-                        os.path.join(self.config['pki_dir'], 'rejected'),
-                    ])
-                if self.config['transport'] == 'zeromq' or multi:
-                    verify_env_dirs.extend([
-                        self.config['pki_dir'],
-                        os.path.join(self.config['pki_dir'], 'minions'),
-                        os.path.join(self.config['pki_dir'], 'minions_pre'),
-                        os.path.join(self.config['pki_dir'], 'minions_rejected'),
-                    ])
-
-            verify_env(
-                verify_env_dirs,
-                self.config['user'],
-                permissive=self.config['permissive_pki_access'],
-                pki_dir=self.config['pki_dir'],
-            )
-            if not self.config['log_file'].startswith(('tcp://',
-                                                       'udp://',
-                                                       'file://')):
-                # Logfile is not using Syslog, verify
-                verify_files(
-                    [self.config['key_logfile']],
-                    self.config['user']
-                )
 
         self.setup_logfile_logger()
 

--- a/salt/cli/run.py
+++ b/salt/cli/run.py
@@ -5,7 +5,7 @@ from __future__ import absolute_import
 import os
 
 from salt.utils import parsers
-from salt.utils.verify import check_user, verify_env, verify_files
+from salt.utils.verify import check_user
 from salt.exceptions import SaltClientError
 
 
@@ -20,24 +20,6 @@ class SaltRun(parsers.SaltRunOptionParser):
         '''
         import salt.runner
         self.parse_args()
-
-        if self.config['verify_env']:
-            verify_env([
-                    self.config['pki_dir'],
-                    self.config['cachedir'],
-                ],
-                self.config['user'],
-                permissive=self.config['permissive_pki_access'],
-                pki_dir=self.config['pki_dir'],
-            )
-            if not self.config['log_file'].startswith(('tcp://',
-                                                       'udp://',
-                                                       'file://')):
-                # Logfile is not using Syslog, verify
-                verify_files(
-                    [self.config['log_file']],
-                    self.config['user']
-                )
 
         # Setup file logging!
         self.setup_logfile_logger()

--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -6,7 +6,6 @@ import os
 import sys
 
 from salt.utils import parsers, print_cli
-from salt.utils.verify import verify_files
 from salt.exceptions import (
         SaltClientError,
         SaltInvocationError,
@@ -26,16 +25,6 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         import salt.auth
         import salt.client
         self.parse_args()
-
-        if self.config['verify_env']:
-            if not self.config['log_file'].startswith(('tcp://',
-                                                       'udp://',
-                                                       'file://')):
-                # Logfile is not using Syslog, verify
-                verify_files(
-                    [self.config['log_file']],
-                    self.config['user']
-                )
 
         # Setup file logging!
         self.setup_logfile_logger()


### PR DESCRIPTION
In the current implementation any call to these would cause the script to traverse _every_ salt file on the box. Primarily problematic for salt-run on a master with a large number of minions as part of verify_env touched _each_ minion's key.

This should be fine since the config option specifically says "Verify and set permissions on configuration directories at startup"
