### PR TITLE
accept installing no packages

### DIFF
--- a/salt/states/pkg.py
+++ b/salt/states/pkg.py
@@ -784,6 +784,12 @@ def installed(
 
 
     '''
+    if isinstance(pkgs, list) and len(pkgs) == 0:
+        return {'name': name,
+                'changes': {},
+                'result': True,
+                'comment': 'No packages to install provided'}
+
     kwargs['saltenv'] = __env__
     rtag = __gen_rtag()
     refresh = bool(


### PR DESCRIPTION
accept installing no packages.. This helps make salt formulas require less jinja logic to workaround edge cases.

offen times no packages are needed pending different operation systems... like in FreeBSD no ntp package is needed however most distros have a package..

```
{%- if len(vars.pkgs) > 0 %}
{{ sls }} packages:
    pkg.installed:
        - pkgs: {{ vars.pkgs }}
{%- endif %}
```

this small patch allows

```
{{ sls }} packages:
    pkg.installed:
        - pkgs: []
```

I have many formulas that will benefit from this.

Thanks.
