### PR TITLE
Revert "Backport #19790 to 2014.7"

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -557,20 +557,6 @@ class MultiMinion(MinionBase):
                     minion['minion'].pillar_refresh()
                 minion['generator'].next()
 
-                # If a minion instance receives event, handle the event on all
-                # instances
-                if package:
-                    try:
-                        for master in masters:
-                            minions[master].handle_event(package)
-                    except Exception:
-                        pass
-                    finally:
-                        package = None
-
-                # have the Minion class run anything it has to run
-                next(minion['generator'])
-
 
 class Minion(MinionBase):
     '''


### PR DESCRIPTION
Reverts saltstack/salt#19960

The original backport was a fix for code that has been refactored in 2015.2, so the backport doesn't apply to 2014.7 very well. We'll have to try a different fix for the bug this was addressing in the 2014.7 branch.
