### PR TITLE
Don't let exit()'s within modules stop the daemons.

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -652,10 +652,18 @@ class Loader(object):
                 exc_info=True
             )
             return mod
-        except (Exception, SystemExit) as error:
+        except Exception as error:
             log.error(
                 'Failed to import {0} {1}, this is due most likely to a '
                 'syntax error:\n'.format(
+                    self.tag, name
+                ),
+                exc_info=True
+            )
+            return mod
+        except SystemExit as error:
+            log.error(
+                'Failed to import {0} {1} as the module called exit()\n'.format(
                     self.tag, name
                 ),
                 exc_info=True
@@ -1005,11 +1013,18 @@ class Loader(object):
                             self.tag, name, error))
                         failed_loads[name] = path
                     continue
-                except (Exception, SystemExit) as error:
+                except Exception as error:
                     log.warning(
                         'Failed to import {0} {1}, this is due most likely to a '
                         'syntax error. The exception is {2}. Traceback raised:\n'.format(
                             self.tag, name, error
+                        ),
+                        exc_info=True
+                    )
+                except SystemExit as error:
+                    log.warning(
+                        'Failed to import {0} {1} as the module called exit()\n'.format(
+                            self.tag, name
                         ),
                         exc_info=True
                     )

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -652,7 +652,7 @@ class Loader(object):
                 exc_info=True
             )
             return mod
-        except Exception:
+        except (Exception, SystemExit) as error:
             log.error(
                 'Failed to import {0} {1}, this is due most likely to a '
                 'syntax error:\n'.format(
@@ -1005,7 +1005,7 @@ class Loader(object):
                             self.tag, name, error))
                         failed_loads[name] = path
                     continue
-                except Exception as error:
+                except (Exception, SystemExit) as error:
                     log.warning(
                         'Failed to import {0} {1}, this is due most likely to a '
                         'syntax error. The exception is {2}. Traceback raised:\n'.format(

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -20,6 +20,7 @@ import salt.ext.six as six
 
 __proxyenabled__ = ['*']
 
+
 def echo(text):
     '''
     Return a string - used for testing the connection

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -20,7 +20,7 @@ import salt.ext.six as six
 
 __proxyenabled__ = ['*']
 
-
+exit(1)
 def echo(text):
     '''
     Return a string - used for testing the connection

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -20,7 +20,6 @@ import salt.ext.six as six
 
 __proxyenabled__ = ['*']
 
-exit(1)
 def echo(text):
     '''
     Return a string - used for testing the connection


### PR DESCRIPTION
This change catches those and just logs the error instead of exiting.
