### PR TITLE
states.git.latest - Don't report changes on test=True when there aren't any.

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -212,7 +212,7 @@ def latest(name,
             branch = __salt__['git.current_branch'](target, user=user)
             # We're only interested in the remote branch if a branch
             # (instead of a hash, for example) was provided for rev.
-            if branch != 'HEAD' and branch == rev:
+            if (branch != 'HEAD' and branch == rev) or rev == None:
                 remote_rev = __salt__['git.ls_remote'](target,
                                                        repository=name,
                                                        branch=branch, user=user,


### PR DESCRIPTION
`states.git.latest` with `test=True` always reports changes for existing clones of a repo:

**SLS:**

``` YAML
https://github.com/saltstack/raet.git:
    git.latest:
        target: /tmp/raet
```

**with test=True (after initial clone was done):**

``` ----------
          ID: https://github.com/saltstack/raet.git
    Function: git.latest
      Result: None
     Comment: Repository /tmp/raet update is probably required (current revision is 7a2456b395e81f7288c9992901f908db901873e9)
     Started: 20:26:53.577614
    Duration: 21.434 ms
     Changes:   
              ----------
              new:
                  None
              old:
                  7a2456b395e81f7288c9992901f908db901873e9
```

This PR fixes that.
