### PR TITLE
require DNS for win network.managed state

### DIFF
--- a/salt/states/win_network.py
+++ b/salt/states/win_network.py
@@ -93,9 +93,7 @@ def _validate(dns_proto, dns_servers, ip_proto, ip_addrs, gateway):
     '''
     errors = []
     # Validate DNS configuration
-    if not dns_proto:
-        pass  # user does not want dns
-    elif dns_proto == 'dhcp':
+    if dns_proto == 'dhcp':
         if dns_servers is not None:
             errors.append(
                 'The dns_servers param cannot be set if unless dns_proto is '
@@ -214,7 +212,7 @@ def managed(name,
     dns_proto : None
         Set to ``static`` and use the ``dns_servers`` parameter to provide a
         list of DNS nameservers. set to ``dhcp`` to use DHCP to get the DNS
-        servers, or set to ``None`` to disable DNS configuration.
+        servers.
 
     dns_servers : None
         A list of static DNS servers.


### PR DESCRIPTION
Unfixes #18513.  The original fix (#19968) I submitted was incomplete,
and I've found that I'll have to do more work than I originally though
to make it happen, so here's a manual revert for now so that the code
isn't broken.
