### PR TITLE
adding new argument dataset_pillar to salt.states.file.serialize()

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -3918,14 +3918,14 @@ def serialize(name,
 
     if len([_f for _f in [dataset, dataset_pillar] if _f]) > 1:
         return _error(
-            ret, 'Only one of dataset and dataset_pillar is permitted')
+            ret, 'Only one of \'dataset\' and \'dataset_pillar\' is permitted')
 
     if dataset_pillar:
         dataset = __salt__['pillar.get'](dataset_pillar)
 
     if dataset is None:
         return _error(
-            ret, 'Neither \'dataset\' nor \'dataset_pillar\' was defined.')
+            ret, 'Neither \'dataset\' nor \'dataset_pillar\' was defined')
 
     if merge_if_exists:
         if os.path.isfile(name):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1324,7 +1324,7 @@ def managed(name,
 
     if len([_f for _f in [contents, contents_pillar, contents_grains] if _f]) > 1:
         return _error(
-            ret, 'Only one of contents, contents_pillar, and contents_grains is permitted')
+            ret, 'Only one of contents, contents_pillar and contents_grains is permitted')
 
     # If contents_pillar was used, get the pillar data
     if contents_pillar:
@@ -3784,7 +3784,8 @@ def _merge_dict(obj, k, v):
 
 
 def serialize(name,
-              dataset,
+              dataset=None,
+              dataset_pillar=None,
               user=None,
               group=None,
               mode=None,
@@ -3803,7 +3804,17 @@ def serialize(name,
         The location of the file to create
 
     dataset
-        the dataset that will be serialized
+        The dataset that will be serialized
+
+    dataset_pillar
+        Operates like ``dataset``, but draws from a value stored in pillar,
+        using the pillar path syntax used in :mod:`pillar.get
+        <salt.modules.pillar.get>`. This is useful when the pillar value
+        contains newlines, as referencing a pillar variable using a jinja/mako
+        template can result in YAML formatting issues due to the newlines
+        causing indentation mismatches.
+
+        .. versionadded:: FIXME
 
     formatter
         Write the data as this format. Supported output formats:
@@ -3904,6 +3915,17 @@ def serialize(name,
             return ret
 
     formatter = kwargs.pop('formatter', 'yaml').lower()
+
+    if len([_f for _f in [dataset, dataset_pillar] if _f]) > 1:
+        return _error(
+            ret, 'Only one of dataset and dataset_pillar is permitted')
+
+    if dataset_pillar:
+        dataset = __salt__['pillar.get'](dataset_pillar)
+
+    if dataset is None:
+        return _error(
+            ret, 'Neither \'dataset\' nor \'dataset_pillar\' was defined.')
 
     if merge_if_exists:
         if os.path.isfile(name):

--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1324,7 +1324,7 @@ def managed(name,
 
     if len([_f for _f in [contents, contents_pillar, contents_grains] if _f]) > 1:
         return _error(
-            ret, 'Only one of contents, contents_pillar and contents_grains is permitted')
+            ret, 'Only one of contents, contents_pillar, and contents_grains is permitted')
 
     # If contents_pillar was used, get the pillar data
     if contents_pillar:


### PR DESCRIPTION
There are some existing tests in tests/unit/states/file_test.py which should be extended with dataset_pillar-based tests, but unfortunately I have no clue how to combine tests with working pillars.
