### PR TITLE
Change misleading error message

### DIFF
--- a/salt/template.py
+++ b/salt/template.py
@@ -60,7 +60,7 @@ def compile_template(template,
         return ret
     # Template is an empty file
     if salt.utils.is_empty(template):
-        log.error('Template is an empty file: {0}'.format(template))
+        log.warn('Template is an empty file: {0}'.format(template))
         return ret
 
     # Get the list of render funcs in the render pipe line.


### PR DESCRIPTION
An empty SLS file is still a valid SLS file. 

It is misleading to throw an error message when it will compile and run without a problem. It's perfectly reasonable to have, for example, an empty pillar file which may (or may not) contain data to be applied.
