### PR TITLE
Fix valid ipv6 netmask values in debian_ip.py.

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -334,9 +334,9 @@ def __ipv4_netmask(value):
 
 def __ipv6_netmask(value):
     '''validate an IPv6 integer netmask'''
-    valid, errmsg = False, 'IPv6 netmask (0->127)'
+    valid, errmsg = False, 'IPv6 netmask (0->128)'
     valid, value, _ = __int(value)
-    valid = (valid and 0 <= value <= 127)
+    valid = (valid and 0 <= value <= 128)
     return (valid, value, errmsg)
 
 


### PR DESCRIPTION
Loopback addresses which typically have a /128 mask are currently not
allowed.
