### PR TITLE
dulwich.__version__ returns a tuple of ints instead of a string

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -238,7 +238,14 @@ def _verify_dulwich(quiet=False):
             log.error(_RECOMMEND_PYGIT2)
         return False
 
-    dulwich_ver = distutils.version.LooseVersion(dulwich.__version__)
+    # Get version of dulwich and convert it from a tuple of ints to a string
+    version = []
+    dulwich_version = dulwich.__version__
+    for ver_num in dulwich_version:
+        version.append(str(ver_num))
+    version_str = '.'.join(version)
+
+    dulwich_ver = distutils.version.LooseVersion(version_str)
     dulwich_minver_str = '0.9.4'
     dulwich_minver = distutils.version.LooseVersion(dulwich_minver_str)
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -238,24 +238,16 @@ def _verify_dulwich(quiet=False):
             log.error(_RECOMMEND_PYGIT2)
         return False
 
-    # Get version of dulwich and convert it from a tuple of ints to a string
-    version = []
     dulwich_version = dulwich.__version__
-    for ver_num in dulwich_version:
-        version.append(str(ver_num))
-    version_str = '.'.join(version)
-
-    dulwich_ver = distutils.version.LooseVersion(version_str)
-    dulwich_minver_str = '0.9.4'
-    dulwich_minver = distutils.version.LooseVersion(dulwich_minver_str)
+    dulwich_min_version = (0, 9, 4)
 
     errors = []
 
-    if dulwich_ver < dulwich_minver:
+    if dulwich_version < dulwich_min_version:
         errors.append(
             'Git fileserver backend is enabled in the master config file, but '
             'the installed version of Dulwich is earlier than {0}. Version {1} '
-            'detected.'.format(dulwich_minver_str, dulwich.__version__)
+            'detected.'.format(dulwich_min_version, dulwich_version)
         )
 
         if HAS_PYGIT2 and not quiet:

--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -212,7 +212,7 @@ def latest(name,
             branch = __salt__['git.current_branch'](target, user=user)
             # We're only interested in the remote branch if a branch
             # (instead of a hash, for example) was provided for rev.
-            if (branch != 'HEAD' and branch == rev) or rev == None:
+            if (branch != 'HEAD' and branch == rev) or rev is None:
                 remote_rev = __salt__['git.ls_remote'](target,
                                                        repository=name,
                                                        branch=branch, user=user,


### PR DESCRIPTION
LooseVersion expects a string, so it was stacktracing. This should fix that right up.
