### PR TITLE
Allow relative paths for --config-dir with daemonized minions

### DIFF
--- a/salt/scripts.py
+++ b/salt/scripts.py
@@ -115,15 +115,6 @@ def salt_minion():
         minion.start()
         return
 
-    if '-d' in sys.argv or '--daemon' in sys.argv:
-        # disable daemonize on sub processes
-        if '-d' in sys.argv:
-            sys.argv.remove('-d')
-        if '--daemon' in sys.argv:
-            sys.argv.remove('--daemon')
-        # daemonize current process
-        salt.utils.daemonize()
-
     # keep one minion subprocess running
     while True:
         try:


### PR DESCRIPTION
Running salt-minion with the daemonize option and --config-dir specified as a relative path does not behave as expected. Specifically, the relative path will be interpreted as an absolute path.

The issue is caused by [this line](https://github.com/saltstack/salt/commit/bf8f936fa46cc42a28b8f20b4429ba067ec5c17f#diff-23c89aeeb9c98ac3a93b510a137923f4R78), that daemonizes the process [(which changes the cwd to '/')](https://github.com/saltstack/salt/blob/develop/salt/utils/__init__.py#L273) before minion.parse_args() is run.  As such, os.path.abspath() on the relative path provided just interprets the relative path as an absolute path.

Note that providing a relative path for --config-dir _does_ work with salt-master -d because the master runs daemonize_if_required() [at the end of its prepare() method](https://github.com/saltstack/salt/blob/develop/salt/cli/daemons.py#L131), after parse_args() has already executed.  The minion [actually does this too](https://github.com/saltstack/salt/blob/develop/salt/cli/daemons.py#L244), but the aforementioned commit short circuits this.

I'm not very familiar with the multiprocessing lib, so I can't say whether or not there was a legitimate need to move the daemonize earlier.  However, in my testing, I did not see any issues with removing this and allowing the minion to daemonize at the end of parse_args()
