### PR TITLE
adds __salt__ as a kwarg to Varstacks `evaluate()`

### DIFF
--- a/salt/pillar/varstack_pillar.py
+++ b/salt/pillar/varstack_pillar.py
@@ -34,4 +34,4 @@ def ext_pillar(minion_id,  # pylint: disable=W0613
     Parse varstack data and return the result
     '''
     vs = varstack.Varstack(config_filename=conf)
-    return vs.evaluate(__grains__)
+    return vs.evaluate(__grains__, salt=__salt__)


### PR DESCRIPTION
This adds a salt object for jinja processing in Varstack. Although
this is not as elegant as saltstacks own jinja renderer which has the
`salt.somethin` aliases for `salt['something']`, its a great addition
so one can use dynamic content (e.g. salt mine content) in pillar
with varstack.

See this PR https://github.com/conversis/varstack/pull/1 for the
Varstack side of this change.
