### PR TITLE
adding the salt-api binary to the list of dependency requirements

### DIFF
--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -7,7 +7,8 @@ A REST API for Salt
 
 .. py:currentmodule:: salt.netapi.rest_cherrypy.app
 
-:depends:   - CherryPy Python module, salt-api binary 
+:depends:   - CherryPy Python module
+            - salt-api binary
 :optdepends:    - ws4py Python module for websockets support.
 :configuration: All authentication is done through Salt's :ref:`external auth
     <acl-eauth>` system which requires additional configuration not described

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -7,7 +7,7 @@ A REST API for Salt
 
 .. py:currentmodule:: salt.netapi.rest_cherrypy.app
 
-:depends:   - CherryPy Python module
+:depends:   - CherryPy Python module, salt-api binary 
 :optdepends:    - ws4py Python module for websockets support.
 :configuration: All authentication is done through Salt's :ref:`external auth
     <acl-eauth>` system which requires additional configuration not described

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -8,7 +8,7 @@ A REST API for Salt
 .. py:currentmodule:: salt.netapi.rest_cherrypy.app
 
 :depends:   - CherryPy Python module
-            - salt-api binary
+            - salt-api package
 :optdepends:    - ws4py Python module for websockets support.
 :configuration: All authentication is done through Salt's :ref:`external auth
     <acl-eauth>` system which requires additional configuration not described


### PR DESCRIPTION
I spent quite a while trying to get this api working properly. The documentation was helpful in everything except for the fact that you need the salt-api binary installed on the salt-master to begin with. I believe this is relevant information that has been left out and should be included. 
