### PR TITLE
Fix checking of active mounts on OS X

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -222,7 +222,8 @@ def mounted(name,
                             converted_size = int(size_match.group('size_value')) * 1024 * 1024
                         opt = "size={0}k".format(converted_size)
 
-                    if opt not in active[real_name]['opts'] and opt not in active[real_name]['superopts'] and opt not in mount_invisible_options:
+                    if opt not in active[real_name]['opts'] and opt not in mount_invisible_options and \
+                        ('superopts' in active[real_name] and opt not in active[real_name]['superopts']):
                         if __opts__['test']:
                             ret['result'] = None
                             ret['comment'] = "Remount would be forced because options ({0}) changed".format(opt)


### PR DESCRIPTION
- The extended version of mount is not used on OS X and therefore the superopts key doesn't exist
