### PR TITLE
Forcefully reset the highstate stack on each pydsl test

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -3012,6 +3012,15 @@ class HighState(BaseHighState):
         self.stack.append(self)
 
     @classmethod
+    def clear_active(cls):
+        # Nuclear option
+        #
+        # Blow away the entire stack. Used primarily by the test runner but also
+        # useful in custom wrappers of the HighState class, to reset the stack
+        # to a fresh state.
+        cls.stack = []
+
+    @classmethod
     def pop_active(cls):
         cls.stack.pop()
 

--- a/tests/unit/pydsl_test.py
+++ b/tests/unit/pydsl_test.py
@@ -46,7 +46,10 @@ class PyDSLRendererTestCase(TestCase):
         self.HIGHSTATE.push_active()
 
     def tearDown(self):
-        self.HIGHSTATE.pop_active()
+        try:
+            self.HIGHSTATE.pop_active()
+        except IndexError:
+            pass
 
     def render_sls(self, content, sls='', env='base', **kws):
         return self.HIGHSTATE.state.rend['pydsl'](
@@ -509,6 +512,7 @@ def write_to(fpath, content):
 def state_highstate(state, dirpath):
     OPTS['file_roots'] = dict(base=[dirpath])
     HIGHSTATE = HighState(OPTS)
+    HIGHSTATE.clear_active()
     HIGHSTATE.push_active()
     try:
         high, errors = HIGHSTATE.render_highstate(state)


### PR DESCRIPTION
I cannot reproduce the pydsl test failures locally except in rare instances, so this _should_ prevent collisions from happening inside the highstate stack during test runs.
