### PR TITLE
Finish out the matcher_args for compound matcher, Fixes #20074

### DIFF
--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -380,16 +380,17 @@ class CkMinions(object):
                     matcher_args = ['@'.join(comps[1:])]
                     if comps[0] in ('G', 'P', 'I'):
                         matcher_args.append(delimiter)
+                    matcher_args.append(True)
 
                     if not matcher:
                         # If an unknown matcher is called at any time, fail out
                         return []
                     if unmatched and unmatched[-1] == '-':
-                        results.append(str(set(matcher('@'.join(comps[1:]), True))))
+                        results.append(str(set(matcher(*matcher_args))))
                         results.append(')')
                         unmatched.pop()
                     else:
-                        results.append(str(set(matcher('@'.join(comps[1:]), True))))
+                        results.append(str(set(matcher(*matcher_args))))
                 elif match in opers:
                     # We didn't match a target, so append a boolean operator or
                     # subexpression


### PR DESCRIPTION
Appears that someone started adding matcher_args to help with the
addition of the delimiter arg, but forgot to finish it.

Fixes #20074
