### PR TITLE
Default to nested for outputter of ''

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -131,7 +131,7 @@ def get_printout(out, opts=None, **kwargs):
         if out == 'text':
             out = 'txt'
 
-    if out is None:
+    if out is None or out == '':
         out = 'nested'
     if opts.get('progress', False):
         out = 'progress'


### PR DESCRIPTION
Eliminates errors when no outputter specified

Fixes #20077 
