### PR TITLE
Handle pkgrepo keyids that have been converted to int.  #19737

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1525,6 +1525,8 @@ def mod_repo(repo, saltenv='base', **kwargs):
         if not keyid or not keyserver:
             error_str = 'both keyserver and keyid options required.'
             raise NameError(error_str)
+        if isinstance(keyid, int):  # yaml can make this an int, we need the hex version
+            keyid = hex(keyid)
         cmd = 'apt-key export {0}'.format(_cmd_quote(keyid))
         output = __salt__['cmd.run_stdout'](cmd, **kwargs)
         imported = output.startswith('-----BEGIN PGP')


### PR DESCRIPTION
If an apt pkgrepo keyid is provided without quoting in the state/pillar, YAML can convert it to an INT.
This allows us to still use it anyway.
#19737
