### PR TITLE
utils.verify.verify_env(): fix "defulats" typo

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -199,7 +199,7 @@ def verify_env(dirs, user, permissive=False, pki_dir=''):
         err = ('Failed to prepare the Salt environment for user '
                '{0}. The user is not available.\n').format(user)
         sys.stderr.write(err)
-        sys.exit(salt.defulats.exitcodes.EX_NOUSER)
+        sys.exit(salt.defaults.exitcodes.EX_NOUSER)
     for dir_ in dirs:
         if not dir_:
             continue


### PR DESCRIPTION
```
************* Module salt.utils.verify
salt/utils/verify.py:202: [E1101(no-member), verify_env] Module 'salt' has no 'defulats' member
```
