### PR TITLE
salt.states.cmd: fixed 'unless' behaviour in case of multiple commands are given

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -324,10 +324,11 @@ def mod_run_check(cmd_kwargs, onlyif, unless, group, creates):
                         'skip_watch': True,
                         'result': True}
         elif isinstance(unless, list):
+            cmd = []
             for entry in unless:
-                cmd = __salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs)
+                cmd.append(__salt__['cmd.retcode'](entry, ignore_retcode=True, python_shell=True, **cmd_kwargs))
                 log.debug('Last command return code: {0}'.format(cmd))
-                if cmd == 0:
+                if all([c == 0 for c in cmd]):
                     return {'comment': 'unless execution succeeded',
                             'skip_watch': True,
                             'result': True}


### PR DESCRIPTION
Before the pull request #11898 unless worked as described in the documentation:

> The unless requisite specifies that a state should only run when any of the specified commands return  False.
#11898 changed the behaviour. After that 'unless' means that a state is run if all of the commands return false. Which is basically NOR and the corresponding change was also added to the documentation (#16044):

> The unless requisite operates as NOR and is useful in giving more granular control over when a state should execute

But this functionality can already be achieved with 'onlyif' when inverting the 'onlyif' commands.
So I assume the change of behaviour was unwanted, hence this pull request.

test.sls

``` yaml
test-unless-all-true:
  cmd.run:
    - name: echo 'all true'
    - unless:
      - /bin/true
      - /bin/true

test-unless-one-false:
  cmd.run:
    - name: echo 'one false'
    - unless:
      - /bin/false
      - /bin/true

test-unless-all-false:
  cmd.run:
    - name: echo 'all false'
    - unless:
      - /bin/false
      - /bin/false
```

Current result:

```
----------
          ID: test-unless-all-true
    Function: cmd.run
        Name: echo 'all true'
      Result: True
     Comment: unless execution succeeded
     Started: 21:03:50.239047
    Duration: 7.938 ms
     Changes:   
----------
          ID: test-unless-one-false
    Function: cmd.run
        Name: echo 'one false'
      Result: True
     Comment: unless execution succeeded
     Started: 21:03:50.247571
    Duration: 14.274 ms
     Changes:   
----------
          ID: test-unless-all-false
    Function: cmd.run
        Name: echo 'all false'
      Result: True
     Comment: Command "echo 'all false'" run
     Started: 21:03:50.262392
    Duration: 25.381 ms
     Changes:   
              ----------
              pid:
                  4817
              retcode:
                  0
              stderr:

              stdout:
                  all false
```

Correct result:

```
----------
          ID: test-unless-all-true
    Function: cmd.run
        Name: echo 'all true'
      Result: True
     Comment: unless execution succeeded
     Started: 20:12:51.323207
    Duration: 8.214 ms
     Changes:   
----------
          ID: test-unless-one-false
    Function: cmd.run
        Name: echo 'one false'
      Result: True
     Comment: Command "echo 'one false'" run
     Started: 20:12:51.331956
    Duration: 20.512 ms
     Changes:   
              ----------
              pid:
                  9509
              retcode:
                  0
              stderr:

              stdout:
                  one false
----------
          ID: test-unless-all-false
    Function: cmd.run
        Name: echo 'all false'
      Result: True
     Comment: Command "echo 'all false'" run
     Started: 20:12:51.352963
    Duration: 21.019 ms
     Changes:   
              ----------
              pid:
                  9512
              retcode:
                  0
              stderr:

              stdout:
                  all false
```
