### PR TITLE
grains.ssds: rm redundant import

### DIFF
--- a/salt/grains/ssds.py
+++ b/salt/grains/ssds.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import
 
 # Import python libs
 import glob
-import salt.utils
 import logging
 
 # Import salt libs


### PR DESCRIPTION
```
************* Module salt.grains.ssds
salt/grains/ssds.py:13: [W0404(reimported), ] Reimport 'salt.utils' (imported line 9)
```
