### PR TITLE
etcd_return.get_load(): fix str.join() call

### DIFF
--- a/salt/returners/etcd_return.py
+++ b/salt/returners/etcd_return.py
@@ -118,7 +118,7 @@ def get_load(jid):
     Return the load data that marks a specified jid
     '''
     client, path = _get_conn(__opts__)
-    return json.loads(client.get('/'.join(path, 'jobs', jid, '.load.p')))
+    return json.loads(client.get('/'.join((path, 'jobs', jid, '.load.p'))))
 
 
 def get_jid(jid):


### PR DESCRIPTION
```
************* Module salt.returners.etcd_return
salt/returners/etcd_return.py:121: [E1121(too-many-function-args), get_load] Too many positional arguments for method call
```

`str.join()` takes 1 argument, namely an iterable of strings to join, NOT an arbitrary number of string arguments.
