### PR TITLE
webutil.useradd throws exception KeyError: 'out'

### DIFF
--- a/salt/modules/htpasswd.py
+++ b/salt/modules/htpasswd.py
@@ -73,7 +73,7 @@ def useradd(pwfile, user, password, opts=''):
         salt '*' webutil.useradd /etc/httpd/htpasswd larry badpassword
         salt '*' webutil.useradd /etc/httpd/htpasswd larry badpass opts=ns
     '''
-    return useradd_all(pwfile, user, password, opts=opts)['out'].splitlines()
+    return useradd_all(pwfile, user, password, opts=opts)
 
 
 def userdel(pwfile, user):


### PR DESCRIPTION
return dictionary from cmd.run_all directly.
