### PR TITLE
Extended mysql_user and mysql_grants documentation

### DIFF
--- a/salt/states/mysql_grants.py
+++ b/salt/states/mysql_grants.py
@@ -20,6 +20,10 @@ specification as defined in the MySQL documentation:
 * db_name.tbl_name
 * etc...
 
+This state is not able to set password for the permission from the
+specified host. See :py:mod:`salt.states.mysql_user` for further
+instructions.
+
 .. code-block:: yaml
 
    frank_exampledb:

--- a/salt/states/mysql_user.py
+++ b/salt/states/mysql_user.py
@@ -34,6 +34,11 @@ overridden in states using the following arguments: ``connection_host``,
         - connection_charset: utf8
         - saltenv:
           - LC_ALL: "en_US.utf8"
+
+
+This state is not able to grant permissions for the user. See
+:py:mod:`salt.states.mysql_grants` for further instructions.
+
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
It was hard to figure out, how to set the password for a new
permission allowing the user to log in from another host. mysql_user is
the right state for this. I crosslinked the documentations of both
states. So the information will be found easier by others.
