### PR TITLE
Remove unused restart_on_error config

### DIFF
--- a/conf/minion
+++ b/conf/minion
@@ -151,7 +151,6 @@
 #    auth_tries: 10
 #    auth_safemode: False
 #    ping_interval: 90
-#    restart_on_error: True
 #
 # Minions won't know master is missing until a ping fails. After the ping fail,
 # the minion will attempt authentication and likely fails out and cause a restart.

--- a/salt/config.py
+++ b/salt/config.py
@@ -422,7 +422,6 @@ DEFAULT_MINION_OPTS = {
     'raet_mutable': False,
     'raet_main': False,
     'raet_clear_remotes': True,
-    'restart_on_error': False,
     'ping_interval': 0,
     'username': None,
     'password': None,


### PR DESCRIPTION
This appears to have gone away in 2015.2
