### PR TITLE
Allow to add extensions to a certificate

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -727,7 +727,7 @@ def create_self_signed_cert(tls_dir='tls',
     return ret
 
 
-def create_ca_signed_cert(ca_name, CN, days=365, cacert_path=None, digest='sha256'):
+def create_ca_signed_cert(ca_name, CN, days=365, cacert_path=None, digest='sha256', **extensions):
     '''
     Create a Certificate (CERT) signed by a named Certificate Authority (CA)
 
@@ -754,6 +754,9 @@ def create_ca_signed_cert(ca_name, CN, days=365, cacert_path=None, digest='sha25
         The message digest algorithm. Must be a string describing a digest
         algorithm supported by OpenSSL (by EVP_get_digestbyname, specifically).
         For example, "md5" or "sha1". Default: 'sha256'
+
+    **extensions
+        X509 V3 certificate extension
 
     Writes out a Certificate (CERT). If the file already
     exists, the function just returns assuming the CERT already exists.
@@ -842,6 +845,15 @@ def create_ca_signed_cert(ca_name, CN, days=365, cacert_path=None, digest='sha25
     cert.set_serial_number(_new_serial(ca_name, CN))
     cert.set_issuer(ca_cert.get_subject())
     cert.set_pubkey(req.get_pubkey())
+    extensions_list = []
+    for name in extensions:
+        log.debug("name: {0}, critical: {1}, options: {2}".format(
+            name, extensions[name]['critical'], extensions[name]['options']))
+        extensions_list.append(OpenSSL.crypto.X509Extension(
+            name,
+            extensions[name]['critical'],
+            extensions[name]['options']))
+    cert.add_extensions(extensions_list)
     cert.sign(ca_key, digest)
 
     with salt.utils.fopen('{0}/{1}/certs/{2}.crt'.format(cert_base_path(),


### PR DESCRIPTION
In case of OpenVPN, the certificate must have key usage extensions, if not we will got something like this:

```
Fri Jan 23 02:14:10 2015 us=94192 Certificate does not have key usage extension
Fri Jan 23 02:14:10 2015 us=94203 VERIFY KU ERROR
Fri Jan 23 02:14:10 2015 us=94289 TLS_ERROR: BIO read tls_read_plaintext error: error:14090086:SSL routines:SSL3_GET_SERVER_CERTIFICATE:certificate verify failed
Fri Jan 23 02:14:10 2015 us=94312 TLS Error: TLS object -> incoming plaintext read error
Fri Jan 23 02:14:10 2015 us=94319 TLS Error: TLS handshake failed
```

So, I created this PR to allow to specify X509 extensions.
Example:

``` yaml
openvpn_server_cert_{{ instance }}:
  module:
    - wait
    - name: tls.create_ca_signed_cert
    - ca_name: {{ ca_name }}
    - CN: server_{{ instance }}
    - extensions:
        basicConstraints:
          critical: False
          options: 'CA:FALSE'
        keyUsage:
          critical: False
          options: 'Digital Signature, Key Encipherment'
        extendedKeyUsage:
          critical: False
          options: 'serverAuth'
    - watch:
      - module: openvpn_server_csr_{{ instance }}
```
