### PR TITLE
Add function to update CA cert bundle

### DIFF
--- a/doc/topics/tutorials/http.rst
+++ b/doc/topics/tutorials/http.rst
@@ -275,9 +275,25 @@ as required. However, each must individually be turned on.
 The return from these will be found in the return dict as ``status``,
 ``headers`` and ``text``, respectively.
 
+Writing Return Data to Files
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is possible to write either the return data or headers to files, as soon as
+the response is received from the server, but specifying file locations via the
+``text_out`` or ``headers_out`` arguments. ``text`` and ``headers`` do not need
+to be returned to the user in order to do this.
+
+.. code-block:: python
+
+    salt.utils.http.query(
+        'http://example.com',
+        text=False,
+        headers=False,
+        text_out='/path/to/url_download.txt',
+        headers_out='/path/to/headers_download.txt',
+    )
+
 SSL Verification
 ~~~~~~~~~~~~~~~~
-
 By default, this function will verify SSL certificates. However, for testing or
 debugging purposes, SSL verification can be turned off.
 

--- a/doc/topics/tutorials/http.rst
+++ b/doc/topics/tutorials/http.rst
@@ -275,6 +275,19 @@ as required. However, each must individually be turned on.
 The return from these will be found in the return dict as ``status``,
 ``headers`` and ``text``, respectively.
 
+SSL Verification
+~~~~~~~~~~~~~~~~
+
+By default, this function will verify SSL certificates. However, for testing or
+debugging purposes, SSL verification can be turned off.
+
+.. code-block:: python
+
+    salt.utils.http.query(
+        'https://example.com',
+        ssl_verify=False,
+    )
+
 CA Bundles
 ~~~~~~~~~~
 The ``requests`` library has its own method of detecting which CA (certficate
@@ -292,18 +305,66 @@ using the ``ca_bundle`` variable.
         ca_bundle='/path/to/ca_bundle.pem',
     )
 
-SSL Verification
-~~~~~~~~~~~~~~~~
+Updating CA Bundles
++++++++++++++++++++
+The ``update_ca_bundle()`` function can be used to update the bundle file at a
+specified location. If the target location is not specified, then it will
+attempt to auto-detect the location of the bundle file. If the URL to download
+the bundle from does not exist, a bundle will be downloaded from the cURL
+website.
 
-By default, this function will verify SSL certificates. However, for testing or
-debugging purposes, SSL verification can be turned off.
+CAUTION: The ``target`` and the ``source`` should always be specified! Failure
+to specify the ``target`` may result in the file being written to the wrong
+location on the local system. Failure to specify the ``source`` may cause the
+upstream URL to receive excess unnecessary traffic, and may cause a file to be
+download which is hazardous or does not meet the needs of the user.
 
 .. code-block:: python
 
-    salt.utils.http.query(
-        'https://example.com',
-        ssl_verify=False,
+    salt.utils.http.update_ca_bundle(
+        target='/path/to/ca-bundle.crt',
+        source='https://example.com/path/to/ca-bundle.crt',
+        opts=__opts__,
     )
+
+The ``opts`` parameter should also always be specified. If it is, then the
+``target`` and the ``source`` may be specified in the relevant configuration
+file (master or minion) as ``ca_bundle`` and ``ca_bundle_url``, respectively.
+
+.. code-block:: yaml
+
+    ca_bundle: /path/to/ca-bundle.crt
+    ca_bundle_url: https://example.com/path/to/ca-bundle.crt
+
+If Salt is unable to auto-detect the location of the CA bundle, it will default
+to a file inside of ``file_roots`` (usually ``/srv/salt/``) called
+``cacert.pem``. If the update is performed on the master (such as with the
+runner module), then this file will automatically be made available to minions
+as ``salt://cacert.pem``. To update from the runner, with the ``ca_bundle`` and
+``ca_bundle_url`` configured on the master (``opts`` is already available to
+runners):
+
+.. code-block:: bash
+
+    salt-run http.update_ca_bundle
+
+The ``update_ca_bundle()`` function can also be passed a string or a list of
+strings which represent files on the local system, which should be appended (in
+the specified order) to the end of the CA bundle file. This is useful in
+environments where private certs need to be made available, and are not
+otherwise reasonable to add to the bundle file.
+
+.. code-block:: python
+
+    salt.utils.http.update_ca_bundle(
+        opts=__opts__,
+        merge_files=[
+            '/etc/ssl/private_cert_1.pem',
+            '/etc/ssl/private_cert_2.pem',
+            '/etc/ssl/private_cert_3.pem',
+        ]
+    )
+
 
 Test Mode
 ~~~~~~~~~

--- a/salt/modules/http.py
+++ b/salt/modules/http.py
@@ -24,3 +24,45 @@ def query(url, **kwargs):
             data='<xml>somecontent</xml>'
     '''
     return salt.utils.http.query(url=url, opts=__opts__, **kwargs)
+
+
+def update_ca_bundle(target=None, source=None, merge_files=None):
+    '''
+    Update the local CA bundle file from a URL
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' http.update_ca_bundle
+        salt '*' http.update_ca_bundle target=/path/to/cacerts.pem
+        salt '*' http.update_ca_bundle source=https://example.com/cacerts.pem
+
+    If the ``target`` is not specified, it will be pulled from the ``ca_cert``
+    configuration variable available to the minion. If it cannot be found there,
+    it will be placed at ``<<FILE_ROOTS>>/cacerts.pem``.
+
+    If the ``source`` is not specified, it will be pulled from the
+    ``ca_cert_url`` configuration variable available to the minion. If it cannot
+    be found, it will be downloaded from the cURL website, using an http (not
+    https) URL. USING THE DEFAULT URL SHOULD BE AVOIDED!
+
+    ``merge_files`` may also be specified, which includes a string or list of
+    strings representing a file or files to be appended to the end of the CA
+    bundle, once it is downloaded.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' http.update_ca_bundle merge_files=/path/to/mycert.pem
+    '''
+    if target is None:
+        target = __salt__['config.get']('ca_bundle', None)
+
+    if source is None:
+        source = __salt__['config.get']('ca_bundle_url', None)
+
+    return salt.utils.http.update_ca_bundle(
+        target, source, __opts__, merge_files
+    )

--- a/salt/runners/http.py
+++ b/salt/runners/http.py
@@ -34,3 +34,39 @@ def query(url, output=True, **kwargs):
 
     ret = salt.utils.http.query(url=url, opts=__opts__, **kwargs)
     return ret
+
+
+def update_ca_bundle(target=None, source=None, merge_files=None):
+    '''
+    Update the local CA bundle file from a URL
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run http.update_ca_bundle
+        salt-run http.update_ca_bundle target=/path/to/cacerts.pem
+        salt-run http.update_ca_bundle source=https://example.com/cacerts.pem
+
+    If the ``target`` is not specified, it will be pulled from the ``ca_cert``
+    configuration variable available to the master. If it cannot be found there,
+    it will be placed at ``<<FILE_ROOTS>>/cacerts.pem``.
+
+    If the ``source`` is not specified, it will be pulled from the
+    ``ca_cert_url`` configuration variable available to the master. If it cannot
+    be found, it will be downloaded from the cURL website, using an http (not
+    https) URL. USING THE DEFAULT URL SHOULD BE AVOIDED!
+
+    ``merge_files`` may also be specified, which includes a string or list of
+    strings representing a file or files to be appended to the end of the CA
+    bundle, once it is downloaded.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run http.update_ca_bundle merge_files=/path/to/mycert.pem
+    '''
+    return salt.utils.http.update_ca_bundle(
+        target, source, __opts__, merge_files
+    )

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -11,6 +11,7 @@ import os.path
 import json
 import logging
 import salt.ext.six.moves.http_cookiejar  # pylint: disable=E0611
+from salt.ext.six import string_types
 from salt._compat import ElementTree as ET
 
 import ssl
@@ -362,7 +363,8 @@ def get_ca_bundle(opts=None):
 def update_ca_bundle(
         target=None,
         source=None,
-        opts=None
+        opts=None,
+        merge_files=None,
     ):
     '''
     Attempt to update the CA bundle file from a URL
@@ -378,6 +380,9 @@ def update_ca_bundle(
     This is based on the information at:
 
         http://curl.haxx.se/docs/caextract.html
+
+    A string or list of strings representing files to be appended to the end of
+    the CA bundle file may also be passed through as ``merge_files``.
     '''
     if opts is None:
         opts = {}
@@ -393,6 +398,7 @@ def update_ca_bundle(
     if source is None:
         source = opts.get('ca_bundle_url', 'http://curl.haxx.se/ca/cacert.pem')
 
+    log.debug('Attempting to download {0} to {1}'.format(source, target))
     query(
         source,
         text=True,
@@ -401,6 +407,47 @@ def update_ca_bundle(
         status=False,
         text_out=target
     )
+
+    if merge_files is not None:
+        if isinstance(merge_files, string_types):
+            merge_files = [merge_files]
+
+        if not isinstance(merge_files, list):
+            log.error('A value was passed as merge_files which was not either '
+                      'a string or a list')
+            return
+
+        merge_content = ''
+
+        for cert_file in merge_files:
+            if os.path.exists(cert_file):
+                log.debug(
+                    'Queueing up {0} to be appended to {1}'.format(
+                        cert_file, target
+                    )
+                )
+                try:
+                    with salt.utils.fopen(cert_file, 'r') as fcf:
+                        merge_content = '\n'.join((merge_content, fcf.read()))
+                except IOError as exc:
+                    log.error(
+                        'Reading from {0} caused the following error: {1}'.format(
+                            cert_file, exc
+                        )
+                    )
+
+        if merge_content:
+            log.debug('Appending merge_files to {0}'.format(target))
+            try:
+                with salt.utils.fopen(target, 'a') as tfp:
+                    tfp.write('\n')
+                    tfp.write(merge_content)
+            except IOError as exc:
+                log.error(
+                    'Writing to {0} caused the following error: {1}'.format(
+                        target, exc
+                    )
+                )
 
 
 def _render(template, render, renderer, template_dict, opts):

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -336,11 +336,13 @@ def get_ca_bundle(opts=None):
     if opts_bundle is not None and os.path.exists(opts_bundle):
         return opts_bundle
 
+    file_roots = opts.get('file_roots', '/srv/salt')
+
     # Please do not change the order without good reason
     for path in (
         # Check Salt first
-        '/srv/salt/cacert.pem',
-        '/srv/salt/ca-bundle.crt',
+        os.path.join(file_roots, 'cacert.pem'),
+        os.path.join(file_roots, 'ca-bundle.crt'),
         # Debian has paths that often exist on other distros
         '/etc/ssl/certs/ca-certificates.crt',
         # RedHat is also very common
@@ -380,11 +382,13 @@ def update_ca_bundle(
     if opts is None:
         opts = {}
 
+    file_roots = opts.get('file_roots', '/srv/salt')
+
     if target is None:
         target = get_ca_bundle(opts)
 
     if target is None:
-        target = '/srv/salt/cacert.pem'
+        target = os.path.join(file_roots, 'cacert.pem')
 
     if source is None:
         source = opts.get('ca_bundle_url', 'http://curl.haxx.se/ca/cacert.pem')


### PR DESCRIPTION
I think this still needs some Windows and Mac love. The big problem with those two platforms is that, as near as I can tell, there is no standard location for CA bundles. But if somebody on those platforms has some ideas on a reliable way to handle bundles there, I'm sure they'll let us know.

Ping @UtahDave, @rallytime.
