### PR TITLE
Do not use 'is' for string comparison

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1532,7 +1532,7 @@ def build_interface(iface, iface_type, enabled, **settings):
         if not __salt__['pkg.version']('ppp'):
             inst = __salt__['pkg.install']('ppp')
 
-    elif iface_type is 'bond':
+    elif iface_type == 'bond':
         if 'slaves' not in settings:
             msg = 'slaves is a required setting for bond interfaces'
             log.error(msg)


### PR DESCRIPTION
Ref #19528 
