### PR TITLE
fix sysctl test state comparison

### DIFF
--- a/salt/states/sysctl.py
+++ b/salt/states/sysctl.py
@@ -79,7 +79,7 @@ def present(name, value, config=None):
                     'The value {0} is set to be changed to {1} '
             return ret
         elif name in configured and name in current:
-            if str(value) == __salt__['sysctl.get'](name):
+            if str(value).split() == __salt__['sysctl.get'](name).split():
                 ret['result'] = True
                 ret['comment'] = 'Sysctl value {0} = {1} is already set'.format(
                         name,


### PR DESCRIPTION
Fixes #20145; sysctl, at least on linux, pads the output of its values
with extra spaces,

Example:

```
centos-7-main salt fix_sysctl # sysctl net.ipv4.ip_local_port_range
net.ipv4.ip_local_port_range = 48000    58000
centos-7-main salt fix_sysctl # cat /etc/sysctl.d/99-salt.conf
net.ipv4.ip_local_port_range = 48000  58000
```

insomuch that a comparison of `'48000    58000'` and `'48000  58000'` will
result in a false changed state with test=True.
