### PR TITLE
Bug: syspaths all or nothing

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -952,6 +952,7 @@ ARGS = {9}\n'''.format(self.minion_config,
             # RSTR was found in stdout but not stderr - which means there
             # is a SHIM command for the master.
             shim_command = re.split(r'\r?\n', stdout, 1)[0].strip()
+            log.debug('SHIM retcode({0}) and command: {1}'.format(retcode, shim_command))
             if 'deploy' == shim_command and retcode == salt.defaults.exitcodes.EX_THIN_DEPLOY:
                 self.deploy()
                 stdout, stderr, retcode = self.shim_cmd(cmd_str)

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -27,14 +27,24 @@ EX_MOD_DEPLOY = 13
 
 
 class OBJ(object):
+    """An empty class for holding instance attribute values."""
     pass
+
 
 OPTIONS = None
 ARGS = None
+# The below line is where OPTIONS can be redefined with internal options
+# (rather than cli arguments) when the shim is bundled by
+# client.ssh.Single._cmd_str()
+# pylint: disable=block-comment-should-start-with-'# '
 #%%OPTS
 
 
 def need_deployment():
+    """
+    Salt thin needs to be deployed - prep the target directory and emit the
+    delimeter and exit code that signals a required deployment.
+    """
     if os.path.exists(OPTIONS.saltdir):
         shutil.rmtree(OPTIONS.saltdir)
     old_umask = os.umask(0o077)
@@ -53,8 +63,8 @@ def need_deployment():
     sudo_gid = os.environ.get('SUDO_GID')
     if sudo_gid:
         os.chown(OPTIONS.saltdir, -1, int(sudo_gid))
-        st = os.stat(OPTIONS.saltdir)
-        os.chmod(OPTIONS.saltdir, st.st_mode | stat.S_IWGRP | stat.S_IRGRP | stat.S_IXGRP)
+        stt = os.stat(OPTIONS.saltdir)
+        os.chmod(OPTIONS.saltdir, stt.st_mode | stat.S_IWGRP | stat.S_IRGRP | stat.S_IXGRP)
 
     # Delimiter emitted on stdout *only* to indicate shim message to master.
     sys.stdout.write("{0}\ndeploy\n".format(OPTIONS.delimiter))
@@ -63,6 +73,7 @@ def need_deployment():
 
 # Adapted from salt.utils.get_hash()
 def get_hash(path, form='sha1', chunk_size=4096):
+    """Generate a hash digest string for a file."""
     try:
         hash_type = getattr(hashlib, form)
     except AttributeError:
@@ -76,6 +87,7 @@ def get_hash(path, form='sha1', chunk_size=4096):
 
 
 def unpack_thin(thin_path):
+    """Unpack the Salt thin archive."""
     tfile = tarfile.TarFile.gzopen(thin_path)
     tfile.extractall(path=OPTIONS.saltdir)
     tfile.close()
@@ -83,11 +95,13 @@ def unpack_thin(thin_path):
 
 
 def need_ext():
+    """Signal that external modules need to be deployed."""
     sys.stdout.write("{0}\next_mods\n".format(OPTIONS.delimiter))
     sys.exit(EX_MOD_DEPLOY)
 
 
 def unpack_ext(ext_path):
+    """Unpack the external modules."""
     modcache = os.path.join(
             OPTIONS.saltdir,
             'running_data',
@@ -106,6 +120,7 @@ def unpack_ext(ext_path):
 
 
 def main(argv):  # pylint: disable=W0613
+    """Main program body"""
     thin_path = os.path.join(OPTIONS.saltdir, THIN_ARCHIVE)
     if os.path.isfile(thin_path):
         if OPTIONS.checksum != get_hash(thin_path, OPTIONS.hashfunc):
@@ -121,17 +136,28 @@ def main(argv):  # pylint: disable=W0613
             need_deployment()
 
         if not os.path.isdir(OPTIONS.saltdir):
-            sys.stderr.write('ERROR: salt path "{0}" exists but is not a directory\n'.format(OPTIONS.saltdir))
+            sys.stderr.write(
+                'ERROR: salt path "{0}" exists but is'
+                ' not a directory\n'.format(OPTIONS.saltdir)
+            )
             sys.exit(os.EX_CANTCREAT)
 
         version_path = os.path.join(OPTIONS.saltdir, 'version')
         if not os.path.exists(version_path) or not os.path.isfile(version_path):
-            sys.stderr.write('WARNING: Unable to locate current thin version.\n')
+            sys.stderr.write(
+                'WARNING: Unable to locate current thin '
+                ' version: {0}.\n'.format(version_path)
+            )
             need_deployment()
         with open(version_path, 'r') as vpo:
             cur_version = vpo.readline().strip()
         if cur_version != OPTIONS.version:
-            sys.stderr.write('WARNING: current thin version is not up-to-date.\n')
+            sys.stderr.write(
+                'WARNING: current thin version {0}'
+                ' is not up-to-date with {1}.\n'.format(
+                    cur_version, OPTIONS.version
+                )
+            )
             need_deployment()
         # Salt thin exists and is up-to-date - fall through and use it
 
@@ -154,7 +180,7 @@ def main(argv):  # pylint: disable=W0613
                 cur_version = vpo.readline().strip()
             if cur_version != OPTIONS.ext_mods:
                 need_ext()
-    #Fix parameter passing issue
+    # Fix parameter passing issue
     if len(ARGS) == 1:
         argv_prepared = ARGS[0].split()
     else:
@@ -181,7 +207,7 @@ def main(argv):  # pylint: disable=W0613
     sys.stderr.flush()
     if OPTIONS.tty:
         import subprocess
-        stdout, stderr = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
+        stdout, _ = subprocess.Popen(salt_argv, stdout=subprocess.PIPE, stderr=subprocess.PIPE).communicate()
         sys.stdout.write(stdout)
         sys.stdout.flush()
         if OPTIONS.wipe:

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -18,6 +18,8 @@
 '''
 
 # Import python libs
+
+from __future__ import absolute_import
 import sys
 import os.path
 
@@ -37,7 +39,7 @@ except ImportError:
     # pylint: disable=too-few-public-methods
     class Empty(object):
         """An empty class to substitute for _syspaths"""
-        pass
+        __slots__ = ()
 
     # pylint: disable=invalid-name
     _syspaths = Empty()

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -23,9 +23,9 @@ import os.path
 
 if 'SETUP_DIRNAME' in globals():
     # This is from the exec() call in Salt's setup.py
-    THIS_FILE = os.path.join(SETUP_DIRNAME, 'salt', 'syspaths.py')  # pylint: disable=E0602
+    _THIS_FILE = os.path.join(SETUP_DIRNAME, 'salt', 'syspaths.py')  # pylint: disable=E0602
 else:
-    THIS_FILE = __file__
+    _THIS_FILE = __file__
 
 try:
     # Let's try loading the system paths from the generated module at
@@ -34,7 +34,13 @@ try:
                                 # because pylint thinks that _syspaths is an
                                 # attribute of salt.__init__
 except ImportError:
-    pass
+    # pylint: disable=too-few-public-methods
+    class Empty(object):
+        """An empty class to substitute for _syspaths"""
+        pass
+
+    # pylint: disable=invalid-name
+    _syspaths = Empty()
 
 
 _PLATFORM = sys.platform.lower()
@@ -72,7 +78,7 @@ _SETTINGS = [
     ('BASE_MASTER_ROOTS_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'salt-master')),
     ('LOGS_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'var', 'log', 'salt')),
     ('PIDFILE_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'var', 'run')),
-    ('INSTALL_DIR', lambda: os.path.dirname(os.path.realpath(THIS_FILE))),
+    ('INSTALL_DIR', lambda: os.path.dirname(os.path.realpath(_THIS_FILE))),
     ('CLOUD_DIR', lambda: os.path.join(globals()['INSTALL_DIR'], 'cloud')),
     ('BOOTSTRAP', lambda: os.path.join(globals()['CLOUD_DIR'], 'deploy', 'bootstrap-salt.sh')),
 ]
@@ -80,5 +86,5 @@ _SETTINGS = [
 
 __all__ = []
 for key, val in _SETTINGS:
-    globals()[key] = _syspaths.__dict__.get(key, val())
+    globals()[key] = getattr(_syspaths, key, val()) or val()
     __all__.append(key)

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -18,111 +18,67 @@
 '''
 
 # Import python libs
-from __future__ import absolute_import
 import sys
 import os.path
 
-__PLATFORM = sys.platform.lower()
-
+if 'SETUP_DIRNAME' in globals():
+    # This is from the exec() call in Salt's setup.py
+    THIS_FILE = os.path.join(SETUP_DIRNAME, 'salt', 'syspaths.py')  # pylint: disable=E0602
+else:
+    THIS_FILE = __file__
 
 try:
     # Let's try loading the system paths from the generated module at
     # installation time.
-    import salt._syspaths as __generated_syspaths  # pylint: disable=no-name-in-module
-except ImportError:
-    class __generated_syspaths(object):
-        __slots__ = ('ROOT_DIR',
-                     'CONFIG_DIR',
-                     'CACHE_DIR',
-                     'SOCK_DIR',
-                     'SRV_ROOT_DIR',
-                     'BASE_FILE_ROOTS_DIR',
-                     'BASE_PILLAR_ROOTS_DIR',
-                     'BASE_MASTER_ROOTS_DIR',
-                     'LOGS_DIR',
-                     'PIDFILE_DIR')
-        ROOT_DIR = CONFIG_DIR = CACHE_DIR = SOCK_DIR = None
-        SRV_ROOT_DIR = BASE_FILE_ROOTS_DIR = BASE_PILLAR_ROOTS_DIR = None
-        BASE_MASTER_ROOTS_DIR = LOGS_DIR = PIDFILE_DIR = None
+    from salt import _syspaths # pylint: disable=W0611,E0611,import-error
+                               # because pylint thinks that _syspaths is an
+                               # attribute of salt.__init__
+except:
+    pass
 
 
-# Let's find out the path of this module
-if 'SETUP_DIRNAME' in globals():
-    # This is from the exec() call in Salt's setup.py
-    __THIS_FILE = os.path.join(SETUP_DIRNAME, 'salt', 'syspaths.py')  # pylint: disable=E0602
-else:
-    __THIS_FILE = __file__
+_PLATFORM = sys.platform.lower()
 
+# These are tuples of an install path settings and a function that
+# generates a default value.  Each is processed individually and added to
+# __all__ for export.  This makes it so that a all of the install options
+# or a sub-set of them can be written to salt/_syspaths.py.  Previously if
+# any one option was missing in salt/_syspaths.py then an exception was
+# raised and none of the existing settings were used - only defaults.
 
-# These values are always relative to salt's installation directory
-INSTALL_DIR = os.path.dirname(os.path.realpath(__THIS_FILE))
-CLOUD_DIR = os.path.join(INSTALL_DIR, 'cloud')
-BOOTSTRAP = os.path.join(CLOUD_DIR, 'deploy', 'bootstrap-salt.sh')
-
-ROOT_DIR = __generated_syspaths.ROOT_DIR
-if ROOT_DIR is None:
-    # The installation time value was not provided, let's define the default
-    if __PLATFORM.startswith('win'):
-        ROOT_DIR = r'c:\salt' or '/'
-    else:
-        ROOT_DIR = '/'
-
-CONFIG_DIR = __generated_syspaths.CONFIG_DIR
-if CONFIG_DIR is None:
-    if __PLATFORM.startswith('win'):
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'conf')
-    elif 'freebsd' in __PLATFORM:
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'local', 'etc', 'salt')
-    elif 'netbsd' in __PLATFORM:
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'usr', 'pkg', 'etc', 'salt')
-    else:
-        CONFIG_DIR = os.path.join(ROOT_DIR, 'etc', 'salt')
-
-CACHE_DIR = __generated_syspaths.CACHE_DIR
-if CACHE_DIR is None:
-    CACHE_DIR = os.path.join(ROOT_DIR, 'var', 'cache', 'salt')
-
-SOCK_DIR = __generated_syspaths.SOCK_DIR
-if SOCK_DIR is None:
-    SOCK_DIR = os.path.join(ROOT_DIR, 'var', 'run', 'salt')
-
-SRV_ROOT_DIR = __generated_syspaths.SRV_ROOT_DIR
-if SRV_ROOT_DIR is None:
-    SRV_ROOT_DIR = os.path.join(ROOT_DIR, 'srv')
-
-BASE_FILE_ROOTS_DIR = __generated_syspaths.BASE_FILE_ROOTS_DIR
-if BASE_FILE_ROOTS_DIR is None:
-    BASE_FILE_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'salt')
-
-BASE_PILLAR_ROOTS_DIR = __generated_syspaths.BASE_PILLAR_ROOTS_DIR
-if BASE_PILLAR_ROOTS_DIR is None:
-    BASE_PILLAR_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'pillar')
-
-BASE_MASTER_ROOTS_DIR = __generated_syspaths.BASE_MASTER_ROOTS_DIR
-if BASE_MASTER_ROOTS_DIR is None:
-    BASE_MASTER_ROOTS_DIR = os.path.join(SRV_ROOT_DIR, 'salt-master')
-
-LOGS_DIR = __generated_syspaths.LOGS_DIR
-if LOGS_DIR is None:
-    LOGS_DIR = os.path.join(ROOT_DIR, 'var', 'log', 'salt')
-
-PIDFILE_DIR = __generated_syspaths.PIDFILE_DIR
-if PIDFILE_DIR is None:
-    PIDFILE_DIR = os.path.join(ROOT_DIR, 'var', 'run')
-
-
-__all__ = [
-    'ROOT_DIR',
-    'CONFIG_DIR',
-    'CACHE_DIR',
-    'SOCK_DIR',
-    'SRV_ROOT_DIR',
-    'BASE_FILE_ROOTS_DIR',
-    'BASE_PILLAR_ROOTS_DIR',
-    'BASE_MASTER_ROOTS_DIR',
-    'LOGS_DIR',
-    'PIDFILE_DIR',
-    'INSTALL_DIR',
-    'CLOUD_DIR',
-    'BOOTSTRAP'
+# WARNING: These must be dependency-ordered!  Notice that ROOT_DIR comes
+# before all settings that use it and similarly INSTALL_DIR and CLOUD_DIR.
+_SETTINGS = [
+    ('ROOT_DIR', lambda: r'c:\salt' if _PLATFORM.startswith('win') else '/'),
+    ('CONFIG_DIR', lambda: (
+            os.path.join(globals()['ROOT_DIR'], 'conf')
+            if _PLATFORM.startswith('win')
+            else (
+                os.path.join(globals()['ROOT_DIR'], 'usr', 'local', 'etc', 'salt')
+                if 'freebsd' in _PLATFORM
+                else (
+                    os.path.join(globals()['ROOT_DIR'], 'usr', 'pkg', 'etc', 'salt')
+                    if 'netbsd' in _PLATFORM
+                    else os.path.join(globals()['ROOT_DIR'], 'etc', 'salt')
+                    )
+                )
+            )
+     ),
+    ('CACHE_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'var', 'cache', 'salt')),
+    ('SOCK_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'var', 'run', 'salt')),
+    ('SRV_ROOT_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'srv')),
+    ('BASE_FILE_ROOTS_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'salt')),
+    ('BASE_PILLAR_ROOTS_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'pillar')),
+    ('BASE_MASTER_ROOTS_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'salt-master')),
+    ('LOGS_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'var', 'log', 'salt')),
+    ('PIDFILE_DIR', lambda: os.path.join(globals()['ROOT_DIR'], 'var', 'run')),
+    ('INSTALL_DIR', lambda: os.path.dirname(os.path.realpath(THIS_FILE))),
+    ('CLOUD_DIR', lambda: os.path.join(globals()['INSTALL_DIR'], 'cloud')),
+    ('BOOTSTRAP', lambda: os.path.join(globals()['CLOUD_DIR'], 'deploy', 'bootstrap-salt.sh')),
 ]
+
+
+__all__ = []
+for key, val in _SETTINGS:
+    globals()[key] = _syspaths.__dict__.get(key, val())
+    __all__.append(key)

--- a/salt/syspaths.py
+++ b/salt/syspaths.py
@@ -30,10 +30,10 @@ else:
 try:
     # Let's try loading the system paths from the generated module at
     # installation time.
-    from salt import _syspaths # pylint: disable=W0611,E0611,import-error
-                               # because pylint thinks that _syspaths is an
-                               # attribute of salt.__init__
-except:
+    from salt import _syspaths  # pylint: disable=W0611,E0611,import-error
+                                # because pylint thinks that _syspaths is an
+                                # attribute of salt.__init__
+except ImportError:
     pass
 
 

--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -236,7 +236,7 @@ class SerializerExtension(Extension, object):
 
     .. code-block:: jinja
 
-        {{ data|yaml(False)}}
+        {{ data|yaml(False) }}
 
     will be rendered as:
 


### PR DESCRIPTION
Allow partial override of syspaths:

Previously if any one option was missing in salt/_syspaths.py then an
exception was raised and none of the existing settings were used - only
defaults.  BOOTSTRAP is not set in the setup.py template and causes
an exception thus preventing all of the _syspaths.py settings from being
utilized.  Maybe it should be added to the template in setup.py too.
