### PR TITLE
Added hg identity argument to state and module

### DIFF
--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -247,7 +247,7 @@ def clone(cwd, repository, opts=None, user=None, identity=None):
         salt '*' hg.clone /path/to/repo https://bitbucket.org/birkenfeld/sphinx
     '''
     _check_hg()
-    cmd = ['hg', 'clone', '"{0}"'.format(repository), '"{0}"'.format(cwd)]
+    cmd = ['hg', 'clone', '{0}'.format(repository), '{0}'.format(cwd)]
     if opts:
         for opt in opts.split():
             cmd.append('{0}'.format(opt))

--- a/salt/modules/hg.py
+++ b/salt/modules/hg.py
@@ -188,7 +188,7 @@ def pull(cwd, opts=None, user=None, identity=None, repository=None):
             cmd.append(opt)
     if repository is not None:
         cmd.append(repository)
-    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user, python_shell=False)
+    return __salt__['cmd.run'](cmd, cwd=cwd, runas=user, python_shell=False, use_vt=True)
 
 
 def update(cwd, rev, force=False, user=None):

--- a/salt/states/hg.py
+++ b/salt/states/hg.py
@@ -44,6 +44,7 @@ def latest(name,
            target=None,
            clean=False,
            user=None,
+           identity=None,
            force=False,
            opts=False):
     '''
@@ -56,13 +57,16 @@ def latest(name,
         The remote branch, tag, or revision hash to clone/pull
 
     target
-        Name of the target directory where repository is about to be cloned
+        Target destination directory path on minion to clone into
 
     clean
         Force a clean update with -C (Default: False)
 
     user
         Name of the user performing repository management operations
+
+    identity
+        Private SSH key on the minion server for authentication (ssh://)
 
         .. versionadded: 0.17.0
 
@@ -82,7 +86,7 @@ def latest(name,
             os.path.isdir('{0}/.hg'.format(target)))
 
     if is_repository:
-        ret = _update_repo(ret, name, target, clean, user, rev, opts)
+        ret = _update_repo(ret, name, target, clean, user, identity, rev, opts)
     else:
         if os.path.isdir(target):
             fail = _handle_existing(ret, target, force)
@@ -97,11 +101,11 @@ def latest(name,
                     ret,
                     'Repository {0} is about to be cloned to {1}'.format(
                         name, target))
-        _clone_repo(ret, target, name, user, rev, opts)
+        _clone_repo(ret, target, name, user, identity, rev, opts)
     return ret
 
 
-def _update_repo(ret, name, target, clean, user, rev, opts):
+def _update_repo(ret, name, target, clean, user, identity, rev, opts):
     '''
     Update the repo to a given revision. Using clean passes -C to the hg up
     '''
@@ -124,7 +128,7 @@ def _update_repo(ret, name, target, clean, user, rev, opts):
                 ret,
                 test_result)
 
-    pull_out = __salt__['hg.pull'](target, user=user, opts=opts, repository=name)
+    pull_out = __salt__['hg.pull'](target, user=user, identity=identity, opts=opts, repository=name)
 
     if rev:
         __salt__['hg.update'](target, rev, force=clean, user=user)
@@ -165,8 +169,8 @@ def _handle_existing(ret, target, force):
         return _fail(ret, 'Directory exists, and is not empty')
 
 
-def _clone_repo(ret, target, name, user, rev, opts):
-    result = __salt__['hg.clone'](target, name, user=user, opts=opts)
+def _clone_repo(ret, target, name, user, identity, rev, opts):
+    result = __salt__['hg.clone'](target, name, user=user, identity=identity, opts=opts)
 
     if not os.path.isdir(target):
         return _fail(ret, result)


### PR DESCRIPTION
We now support supplying a private SSH key path for authentication.

Note: For whatever reason I needed to fall back to using vt instead of the salt.utils.timed_subprocess.TimedProc which was giving me errors...

```
  modified:   salt/modules/hg.py
  modified:   salt/states/hg.py
```
