### PR TITLE
[2014.7] Iterate over the shortopts if there are more than one for archive.extracted

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -194,8 +194,9 @@ def extracted(name,
 
             for opt in tar_opts:
                 if not opt.startswith('-'):
-                    if opt not in ['x', 'f']:
-                        tar_shortopts = tar_shortopts + opt
+                    for shortopt in opt:
+                        if shortopt not in ['x', 'f']:
+                            tar_shortopts = tar_shortopts + shortopt
                 else:
                     tar_longopts.append(opt)
 


### PR DESCRIPTION
Fixes #20195
