### PR TITLE
Add username/password to expected args

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -33,7 +33,9 @@ CLIENT_INTERNAL_KEYWORDS = frozenset([
     'token',
     '__jid__',
     '__tag__',
-    '__user__'
+    '__user__',
+    'username',
+    'password'
 ])
 
 


### PR DESCRIPTION
Fixes many broken netapi functions, such as wheel.key.list_all
