### PR TITLE
fix returning docs when some minions did not return

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -308,6 +308,8 @@ class SaltCMD(parsers.SaltCMDOptionParser):
         if isinstance(ret, str):
             self.exit(2, '{0}\n'.format(ret))
         for host in ret:
+            if ret[host] == 'Minion did not return. [Not connected]':
+                continue
             for fun in ret[host]:
                 if fun not in docs:
                     if ret[host][fun]:


### PR DESCRIPTION
when using
`salt \* pkg -d`
some minions will likly not return and you get an ugly error:

```
[root@salt salt]# salt oat-app\* pkg -d
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
TypeError: string indices must be integers, not str
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 343, in salt_main
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 175, in run
    self._output_ret(ret, out)
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 262, in _output_ret
    self._print_docs(ret)
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 303, in _print_docs
    if ret[host][fun]:
TypeError: string indices must be integers, not str
Traceback (most recent call last):
  File "/usr/bin/salt", line 10, in <module>
    salt_main()
  File "/usr/lib/python2.6/site-packages/salt/scripts.py", line 343, in salt_main
    client.run()
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 175, in run
    self._output_ret(ret, out)
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 262, in _output_ret
    self._print_docs(ret)
  File "/usr/lib/python2.6/site-packages/salt/cli/salt.py", line 303, in _print_docs
    if ret[host][fun]:
TypeError: string indices must be integers, not str
```

the patch is is ugly!!! so please fix correctly.

```
            if ret[host] == 'Minion did not return. [Not connected]':
                continue
```

thanks
