### PR TITLE
Remove finish [DO NOT MERGE]

### DIFF
--- a/salt/netapi/rest_tornado/saltnado.py
+++ b/salt/netapi/rest_tornado/saltnado.py
@@ -1370,7 +1370,7 @@ class EventsSaltAPIHandler(SaltAPIHandler):
             except TimeoutException:
                 break
 
-        self.finish()
+#        self.finish()
 
 
 class WebhookSaltAPIHandler(SaltAPIHandler):


### PR DESCRIPTION
The tornado tests cause the following exception to occur:

```
15:10:38,847 [salttesting.unit                                    :189 ][DEBUG   ] >>>>> START >>>>> integration.netapi.rest_tornado.test_app
.TestWebhookSaltAPIHandler.test_post
15:10:38,847 [tornado.general                                     :117 ][WARNING ] tornado.autoreload started more than once in the same proc
ess
15:10:38,847 [salt.config                                         :753 ][DEBUG   ] Reading configuration from /tmp/salt-tests-tmpdir/config/m
aster
15:10:38,853 [salt.config                                         :1934][DEBUG   ] Guessing ID. The id can be explicitly in set /etc/salt/min
ion
15:10:38,856 [salt.config                                         :1934][DEBUG   ] Guessing ID. The id can be explicitly in set /etc/salt/min
ion
15:10:38,865 [salt.config                                         :1937][INFO    ] Found minion id from generate_minion_id(): silver
15:10:38,866 [salt.config                                         :753 ][DEBUG   ] Reading configuration from /tmp/salt-tests-tmpdir/config/m
aster
15:10:38,868 [salt.config                                         :1937][INFO    ] Found minion id from generate_minion_id(): silver
15:10:38,891 [salt.config                                         :753 ][DEBUG   ] Reading configuration from /tmp/salt-tests-tmpdir/config/m
aster
15:10:38,899 [salt.config                                         :1934][DEBUG   ] Guessing ID. The id can be explicitly in set /etc/salt/min
ion
15:10:38,912 [salt.config                                         :1937][INFO    ] Found minion id from generate_minion_id(): silver
15:10:38,912 [salt.config                                         :753 ][DEBUG   ] Reading configuration from /tmp/salt-tests-tmpdir/config/m
aster
15:10:38,918 [salt.crypt                                          :273 ][DEBUG   ] Re-using SAuth for ('/tmp/salt-tests-tmpdir/master-minion-
root/pki', 'minion', 'tcp://127.0.0.1:54506')
15:10:38,919 [salt.master                                :823 ][INFO    ] AES payload received with command _minion_event
15:10:38,920 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.919487', 'ta
g': '20150129151038416727', 'data': {'_stamp': '2015-01-29T15:10:38.416900', 'minions': ['minion', 'sub_minion']}}
15:10:38,920 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.919715', 'ta
g': '20150129151038416727', 'data': {'_stamp': '2015-01-29T15:10:38.416900', 'minions': ['minion', 'sub_minion']}}
15:10:38,920 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.919897', 'ta
g': 'salt/job/20150129151038416727/new', 'data': {'tgt_type': 'glob', 'jid': '20150129151038416727', 'tgt': '*', '_stamp': '2015-01-29T15:10:
38.417059', 'user': 'sudo_mp', 'arg': [], 'fun': 'test.ping', 'minions': ['minion', 'sub_minion']}}
15:10:38,920 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.920085', 'ta
g': 'salt/job/20150129151038416727/new', 'data': {'tgt_type': 'glob', 'jid': '20150129151038416727', 'tgt': '*', '_stamp': '2015-01-29T15:10:
38.417059', 'user': 'sudo_mp', 'arg': [], 'fun': 'test.ping', 'minions': ['minion', 'sub_minion']}}
15:10:38,920 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.920265', 'ta
g': '20150129151038421570', 'data': {'_stamp': '2015-01-29T15:10:38.422012', 'minions': ['minion', 'sub_minion']}}
15:10:38,920 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.920442', 'ta
g': '20150129151038421570', 'data': {'_stamp': '2015-01-29T15:10:38.422012', 'minions': ['minion', 'sub_minion']}}
15:10:38,921 [salt.utils.event                           :485 ][DEBUG   ] Sending event - data = {'_stamp': '2015-01-29T15:10:38.920674', 'ta
15:10:35,245 [tornado.application                                 :1407][ERROR   ] Uncaught exception GET /events (127.0.0.1)                                                                                                                                                                                                                                                                                                             
HTTPServerRequest(protocol='http', host='localhost:34973', method='GET', uri='/events', version='HTTP/1.1', remote_ip='127.0.0.1', headers={'Connection': 'close', 'Host': 'localhost:34973', 'Accept-Encoding': 'gzip', 'X-Auth-Token': '749b00965833afb363b5db5bc26471a2'})
Traceback (most recent call last):                                                                                                                                                                                                                                                                                                                                                                                                        
  File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 1334, in _execute                                                                                                                                                                                                                                                                                                                                                    
    result = yield result                                                                                                                                                                                                                                                                                                                                                                                                                 
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 628, in run                                                                                                                                                                                                                                                                                                                                                          
    value = future.result()                                                                                                                                                                                                                                                                                                                                                                                                               
  File "/usr/local/lib/python2.7/dist-packages/tornado/concurrent.py", line 109, in result                                                                                                                                                                                                                                                                                                                                                
    raise_exc_info(self._exc_info)                                                                                                                                                                                                                                                                                                                                                                                                        
  File "/usr/local/lib/python2.7/dist-packages/tornado/gen.py", line 631, in run                                                                                                                                                                                                                                                                                                                                                          
    yielded = self.gen.throw(*sys.exc_info())                                                                                                                                                                                                                                                                                                                                                                                             
  File "/home/mp/Devel/salt/salt/netapi/rest_tornado/saltnado.py", line 1373, in get                                                                                                                                                                                                                                                                                                                                                      
    self.finish()                                                                                                                                                                                                                                                                                                                                                                                                                         
  File "/usr/local/lib/python2.7/dist-packages/tornado/web.py", line 864, in finish                                                                                                                                                                                                                                                                                                                                                       
    raise RuntimeError("finish() called twice.  May be caused "                                                                                                                                                                                                                                                                                                                                                                           
RuntimeError: finish() called twice.  May be caused by using async operations without the @asynchronous decorator.                                                                                                                                                                                                                                                                                                                        
15:10:35,246 [salttesting.unit                                    :195 ][DEBUG   ] <<<<< END <<<<<<< integration.netapi.rest_tornado.test_app.TestEventsSaltAPIHandler.test_get           
```

I have _no_ experience with Tornado, so I am hoping that @jacksontj might have a moment to investigate this. Removing the `self.finsh()` does seem to resolve the problem, but I really have no idea what negative affect this might have on Tornado. :]

When this failure occurs under machines with ZeroMQ 3.x, it seems to be related to MWorker procs actually aborting and then the test suite failing to continue. I am still investigating the root cause there but would like to get this fixed along the way.

@jacksontj Any thoughts that you might have here would be much appreciated!
