### PR TITLE
Fix scheduler on 2015.2

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -69,7 +69,7 @@ class ClientFuncsDict(collections.MutableMapping):
                 if k.startswith('__pub_'):
                     pub_data[k] = kwargs.pop(k)
 
-            async_pub = self.client._gen_async_pub(pub_data.get('jid'))
+            async_pub = self.client._gen_async_pub(pub_data.get('__pub_jid'))
 
             user = salt.utils.get_specific_user()
             return self.client._proc_function(key,

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -360,6 +360,10 @@ class AsyncClientMixin(object):
         '''
         Print all of the events with the prefix 'tag'
         '''
+        # if we are "quiet", don't print
+        if self.opts.get('quiet', False):
+            return
+
         # some suffixes we don't want to print
         if suffix in ('new', ):
             return

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -37,11 +37,70 @@ CLIENT_INTERNAL_KEYWORDS = frozenset([
 ])
 
 
+class ClientFuncsDict(collections.MutableMapping):
+    '''
+    Class to make a read-only dict for accessing runner funcs "directly"
+    '''
+    def __init__(self, client):
+        self.client = client
+
+    def __setitem__(self, key, val):
+        raise NotImplementedError()
+
+    def __delitem__(self, key):
+        raise NotImplementedError()
+
+    def __getitem__(self, key):
+        '''
+        Return a function that you can call with regular func params, but
+        will do all the _proc_function magic
+        '''
+        if key not in self.client.functions:
+            raise KeyError
+
+        def wrapper(*args, **kwargs):
+            low = {'fun': key,
+                   'args': args,
+                   'kwargs': kwargs,
+                   }
+            pub_data = {}
+            # pull out pub_data if you have it
+            for k, v in kwargs.items():
+                if k.startswith('__pub_'):
+                    pub_data[k] = kwargs.pop(k)
+
+            async_pub = self.client._gen_async_pub(pub_data.get('jid'))
+
+            user = salt.utils.get_specific_user()
+            return self.client._proc_function(key,
+                   low,
+                   user,
+                   async_pub['tag'],  # TODO: fix
+                   async_pub['jid'],  # TODO: fix
+                   False,  # Don't daemonize
+                   )
+        return wrapper
+
+    def __len__(self):
+        return len(self.client.functions)
+
+    def __iter__(self):
+        return iter(self.client.functions)
+
+
 class SyncClientMixin(object):
     '''
     A mixin for *Client interfaces to abstract common function execution
     '''
     functions = ()
+
+    def functions_dict(self):
+        '''
+        Return a dict that will mimic the "functions" dict used all over salt.
+        It creates a wrapper around the function allowing **kwargs, and if pub_data
+        is passed in as kwargs, will re-use the JID passed in
+        '''
+        return ClientFuncsDict(self)
 
     def _verify_fun(self, fun):
         '''
@@ -337,8 +396,9 @@ class AsyncClientMixin(object):
         '''
         return self.master_call(**low)
 
-    def _gen_async_pub(self):
-        jid = salt.utils.jid.gen_jid()
+    def _gen_async_pub(self, jid=None):
+        if jid is None:
+            jid = salt.utils.jid.gen_jid()
         tag = tagify(jid, prefix=self.tag_prefix)
         return {'tag': tag, 'jid': jid}
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -101,44 +101,6 @@ class SMaster(object):
         return salt.daemons.masterapi.access_keys(self.opts)
 
 
-class Scheduler(multiprocessing.Process):
-    '''
-    The master scheduler process.
-
-    This runs in its own process so that it can have a fully
-    independent loop from the Maintenance process.
-    '''
-    def __init__(self, opts):
-        super(Scheduler, self).__init__()
-        self.opts = opts
-        # Init Scheduler
-        self.schedule = salt.utils.schedule.Schedule(self.opts,
-                                                    salt.loader.runner(self.opts),
-                                                    returners=salt.loader.returners(self.opts, {}))
-
-    def run(self):
-        salt.utils.appendproctitle('Scheduler')
-        while True:
-            self.handle_schedule()
-            try:
-                time.sleep(self.schedule.loop_interval)
-            except KeyboardInterrupt:
-                break
-            except IOError:
-                time.sleep(self.opts['loop_interval'])
-
-    def handle_schedule(self):
-        '''
-        Evaluate the scheduler
-        '''
-        try:
-            self.schedule.eval()
-        except Exception as exc:
-            log.error(
-                'Exception {0} occurred in scheduled job'.format(exc)
-            )
-
-
 class Maintenance(multiprocessing.Process):
     '''
     A generalized maintenance process which performances maintenance

--- a/salt/master.py
+++ b/salt/master.py
@@ -74,6 +74,7 @@ class SMaster(object):
     Create a simple salt-master, this will generate the top-level master
     '''
     aes = None
+
     def __init__(self, opts):
         '''
         Create a salt master server instance

--- a/salt/master.py
+++ b/salt/master.py
@@ -167,12 +167,15 @@ class Maintenance(multiprocessing.Process):
         # Init fileserver manager
         self.fileserver = salt.fileserver.Fileserver(self.opts)
         # Load Runners
-        self.runners = salt.loader.runner(self.opts)
+        ropts = dict(self.opts)
+        ropts['quiet'] = True
+        runner_client = salt.runner.RunnerClient(ropts)
         # Load Returners
         self.returners = salt.loader.returners(self.opts, {})
+
         # Init Scheduler
         self.schedule = salt.utils.schedule.Schedule(self.opts,
-                                                     self.runners,
+                                                     runner_client.functions_dict(),
                                                      returners=self.returners)
         self.ckminions = salt.utils.minions.CkMinions(self.opts)
         # Make Event bus for firing

--- a/salt/pillar/__init__.py
+++ b/salt/pillar/__init__.py
@@ -129,9 +129,6 @@ class Pillar(object):
         # location of file_roots. Issue 5951
         ext_pillar_opts = dict(self.opts)
         ext_pillar_opts['file_roots'] = self.actual_file_roots
-        # TODO: consolidate into "sanitize opts"
-        if 'aes' in ext_pillar_opts:
-            ext_pillar_opts.pop('aes')
         self.merge_strategy = 'smart'
         if opts.get('pillar_source_merging_strategy'):
             self.merge_strategy = opts['pillar_source_merging_strategy']
@@ -590,11 +587,8 @@ class Pillar(object):
         errors.extend(terrors)
         if self.opts.get('pillar_opts', True):
             mopts = dict(self.opts)
-            # TODO: consolidate into sanitize function
             if 'grains' in mopts:
                 mopts.pop('grains')
-            if 'aes' in mopts:
-                mopts.pop('aes')
             # Restore the actual file_roots path. Issue 5449
             mopts['file_roots'] = self.actual_file_roots
             mopts['saltversion'] = __version__

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -220,6 +220,7 @@ import yaml
 # Import Salt libs
 import salt.utils
 import salt.utils.process
+import salt.utils.args
 from salt.utils.odict import OrderedDict
 from salt.utils.process import os_is_running
 import salt.payload
@@ -493,6 +494,13 @@ class Schedule(object):
         kwargs = {}
         if 'kwargs' in data:
             kwargs = data['kwargs']
+        # if the func support **kwargs, lets pack in the pub data we have
+        # TODO: pack the *same* pub data as a minion?
+        argspec = salt.utils.args.get_function_argspec(self.functions[func])
+        if argspec.keywords:
+            # this function accepts **kwargs, pack in the publish data
+            for key, val in ret.iteritems():
+                kwargs['__pub_{0}'.format(key)] = val
 
         try:
             ret['return'] = self.functions[func](*args, **kwargs)

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -486,26 +486,16 @@ class Schedule(object):
             with salt.utils.fopen(proc_fn, 'w+') as fp_:
                 fp_.write(salt.payload.Serial(self.opts).dumps(ret))
 
-        args = None
+        args = tuple()
         if 'args' in data:
             args = data['args']
 
-        kwargs = None
+        kwargs = {}
         if 'kwargs' in data:
             kwargs = data['kwargs']
 
         try:
-            if args and kwargs:
-                ret['return'] = self.functions[func](*args, **kwargs)
-
-            if args and not kwargs:
-                ret['return'] = self.functions[func](*args)
-
-            if kwargs and not args:
-                ret['return'] = self.functions[func](**kwargs)
-
-            if not kwargs and not args:
-                ret['return'] = self.functions[func]()
+            ret['return'] = self.functions[func](*args, **kwargs)
 
             data_returner = data.get('returner', None)
             if data_returner or self.schedule_returner:


### PR DESCRIPTION
Couple fixes for 2015.2 after the major refactor of runners:
- move "aes" out of opts
- silence runner event printing in scheduler
- add "functions" interface to client mixin
- remove unused scheduler daemon class

I'm doing something similar in my transport overhaul, so this will match more with that.

Fix for #20065
