### PR TITLE
Issue #20235: blockdev.format fails when succeeding

### DIFF
--- a/salt/states/blockdev.py
+++ b/salt/states/blockdev.py
@@ -130,6 +130,7 @@ def formatted(name, fs_type='ext4', **kwargs):
             cmd += '-i size={0} '.format(kwargs['inode_size'])
     cmd += name
     __salt__['cmd.run'](cmd).splitlines()
+    __salt__['cmd.run']('sync').splitlines()
     blk = __salt__['cmd.run']('lsblk -o fstype {0}'.format(name)).splitlines()
 
     if len(blk) == 1:


### PR DESCRIPTION
After a mkfs is issued, an immediate lsblk will show the device as
unformatted. Issuing a sync before lsblk will allow the check to
succeed.
