### PR TITLE
Fixed problem with tags occuring twice with docker.pulled

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -250,9 +250,6 @@ def pulled(name,
         Set to ``True`` to allow connections to non-HTTPS registries. Default ``False``.
     '''
 
-    if tag:
-        name = '{0}:{1}'.format(name, tag)
-
     inspect_image = __salt__['docker.inspect_image']
     image_infos = inspect_image('{0}:{1}'.format(name, tag))
     if image_infos['status'] and not force:


### PR DESCRIPTION
This patch fixes tags from being applied twice when running docker.pulled.

Example:
    ----------
          ID: test-image
    Function: docker.pulled
        Name: docker-registry.home.loc/user/test
      Result: True
     Comment: Image already pulled: docker-registry.home.loc/user/test:latest:latest
     Started: 13:47:52.958703
    Duration: 254.007 ms
     Changes:  
    ----------
