### PR TITLE
Added the default directory that gpg imports to

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -41,7 +41,7 @@ To generate a cipher from a secret:
 
 .. code-block:: bash
 
-   $ echo -n "supersecret" | gpg --homedir --armor --encrypt -r <KEY-name>
+   $ echo -n "supersecret" | gpg --homedir ~/.gnupg --armor --encrypt -r <KEY-name>
 
 Set up the renderer on your master by adding something like this line to your
 config:


### PR DESCRIPTION
gpg will use ~/.gnupg when you import the key. This needs to be set when encrypting or it throws a nasty error about trying to use --armor as the dir. 
