### PR TITLE
Revert "Only softfail with a state kwarg mismatch"

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -805,7 +805,7 @@ def format_call(fun,
                     '{0}.{1}'.format(fun.__module__, fun.__name__)
                 )
             )
-        log.critical(
+        raise SaltInvocationError(
             '{0}. If you were trying to pass additional data to be used '
             'in a template context, please populate \'context\' with '
             '\'key: value\' pairs.{1}'.format(


### PR DESCRIPTION
Reverts saltstack/salt#20257

The failure was intentional.

We've been warning users since [2014.1.x](https://github.com/saltstack/salt/blob/2014.1/salt/utils/__init__.py#L921-L958)

I'll be providing a fix to the traceback shown on the CLI next.
