### PR TITLE
this supports complex grain types for map.jinja lookups

### DIFF
--- a/salt/modules/grains.py
+++ b/salt/modules/grains.py
@@ -437,8 +437,7 @@ def filter_by(lookup_dict, grain='os_family', merge=None, default='default', bas
     '''
 
     ret = lookup_dict.get(
-            __grains__.get(
-                grain, default),
+            salt.utils.traverse_dict_and_list(__grains__, grain, None),
             lookup_dict.get(
                 default, None)
             )


### PR DESCRIPTION
This is the only way I figured out how to support something like this

```
{% set mysql = salt['grains.filter_by']({
   'galera-cluster': {
        'cluster_name': 'galera-cluster',
        'members': [
            'galera-cluster01-dev.domain.com',
            'galera-cluster02-dev.domain.com',
            'galera-cluster03-dev.domain.com',
        ]
    },
   'default': {
        'cluster_name': 'galera-test',
        'members': [
        ]
    },
 },
grain = 'manage:type',
merge = salt['pillar.get']('mysql')) %}
```

If my grains for manage look something like

```
# salt-call grains.get manage
local:
    ----------
    ip:
        ----------
        private:
            10.102.74.107
        public:
            50.22.1.2
    pod:
        dev
    type:
        galera-cluster
```
