### PR TITLE
fixes a bug which broke eauth with group permissions

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -2263,7 +2263,7 @@ class ClearFuncs(object):
             if name in self.opts['external_auth'][extra['eauth']]:
                 auth_list = self.opts['external_auth'][extra['eauth']][name]
             if group_auth_match:
-                auth_list.append(self.ckminions.gather_groups(self.opts['external_auth'][extra['eauth']], groups, auth_list))
+                auth_list = self.ckminions.fill_auth_list_from_groups(self.opts['external_auth'][extra['eauth']], groups, auth_list)
 
             good = self.ckminions.auth_check(
                 auth_list,

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -653,23 +653,20 @@ class CkMinions(object):
             return False
         return False
 
-    def gather_groups(self, auth_provider, user_groups, auth_list):
+    def fill_auth_list_from_groups(self, auth_provider, user_groups, auth_list):
         '''
-        Returns the list of groups, if any, for a given authentication provider type
+        Returns the provided list auf permission matchers, plus any matchers
+        that are given to a group the user is in.
 
         Groups are defined as any dict in which a key has a trailing '%'
+        and the values are permission matchers.
         '''
-        group_perm_keys = [item for item in auth_provider if item.endswith('%')]
-        groups = {}
-        if group_perm_keys:
-            for group_perm in group_perm_keys:
-                for matcher in auth_provider[group_perm]:
-                    if group_perm[:-1] in user_groups:
-                        groups[group_perm] = matcher
-        else:
-            return None
-        for item in six.itervalues(groups):
-            auth_list.append(item)
+        group_names = [item for item in auth_provider if item.endswith('%')]
+        if group_names:
+            for group_name in group_names:
+                if group_name.rstrip("%") in user_groups:
+                    for matcher in auth_provider[group_name]:
+                        auth_list.append(matcher)
         return auth_list
 
     def wheel_check(self, auth_list, fun):

--- a/salt/utils/minions.py
+++ b/salt/utils/minions.py
@@ -655,11 +655,9 @@ class CkMinions(object):
 
     def fill_auth_list_from_groups(self, auth_provider, user_groups, auth_list):
         '''
-        Returns the provided list auf permission matchers, plus any matchers
-        that are given to a group the user is in.
-
-        Groups are defined as any dict in which a key has a trailing '%'
-        and the values are permission matchers.
+        Returns a list of authorisation matchers that a user is eligible for.
+        This list is a combination of the provided personal matchers plus the
+        matchers of any group the user is in.
         '''
         group_names = [item for item in auth_provider if item.endswith('%')]
         if group_names:


### PR DESCRIPTION
# What is wrong

Given the salt master is running a current develop branch (3462081) and is set up with pam as the external_auth provider:

```
external_auth: {'pam': {'sudo%': ['.*', '@wheel', '@runner']}}
```

Given there is a local user called _Alice_. She is in the local group called _sudo_:

```
[alice@master1-salt1 ~]$ id
uid=4075(alice) gid=4075(alice) groups=4075(alice),498(sudo) context=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023
```

However, whenever Alice tries to use `salt -a pam '*' test.ping`, she enters her name and her password but gets a green error message: `Failed to authenticate!  This is most likely because this user is not permitted to execute commands, but there is a small possibility that a disk error occurred (check disk/inode usage).`
She can run any command just fine when her user name is added explicitly like so:

```
external_auth: {'pam': {'sudo%': ['.*', '@wheel', '@runner'], 'alice':  ['.*', '@wheel', '@runner']}}
```

Lets have a look at the code that should merge personal permissions and group permission.

```
# salt/master.py - comments added
[...]
            auth_list = []
            if name in self.opts['external_auth'][extra['eauth']]:
                auth_list = self.opts['external_auth'][extra['eauth']][name]
# here auth_list is still empty as Alice does not have anything personally set (here name is not in self.opts['external_auth'][extra['eauth']]) 
            if group_auth_match:
# group_auth_match is true because there is a key ending with % in the pam object (see line #2215 to # 2223)
                auth_list.append(self.ckminions.gather_groups(self.opts['external_auth'][extra['eauth']], groups, auth_list))
# here we append to the empty list the element that is returned by CkMinions#gather_groups
```

The aforementioned method `gather_groups` is in `salt/utils/minions.py`:

```
# salt/utils/minions.py

   def gather_groups(self, auth_provider, user_groups, auth_list):
        '''
        Returns the list of groups, if any, for a given authentication provider type

        Groups are defined as any dict in which a key has a trailing '%'
        '''
        group_perm_keys = [item for item in auth_provider if item.endswith('%')]
        groups = {}
        if group_perm_keys:
            for group_perm in group_perm_keys:
                for matcher in auth_provider[group_perm]:
                    if group_perm[:-1] in user_groups:
                        groups[group_perm] = matcher
        else:
            return None
        for item in six.itervalues(groups):
            auth_list.append(item)
        return auth_list
```

IMHO there are multiple flaws in this method:
1. It does not actually do what its function name suggests
2. It does not actually do what the comments say it does
3. It is very hard to mentally unwrap the stacked for loops, given the name of the elements don't give much of a clue
4. It iterates over every 'matcher' it finds for every group (e.g. '@runners') despite the group isn't even in the users group.
5. Whenever a 'matcher' is found, it is collected in a hashmap at `group_perm`. This overwrites the previously found matcher.
6. It has an useless iterator that moves the previously collected matcher from `groups` to `auth_list.
7. Despite this method never being called when no group is defined in the eauth config (again, see see line #2215 to # 2223 in `salt/master.py`), it does care for that. This is okay IMO as this method could potentially be used from other places as well. However, returning `None` instead of `auth_list` is an error!

So what now gets returned to

```
# salt/master.py
[...]
                auth_list.append(self.ckminions.gather_groups(self.opts['external_auth'][extra['eauth']], groups, auth_list))
[...]
```

is actually a list of the last entry for any group that the user gets permissions from: `['@runner']`, in our example.
This enhanced list now gets appended to the empty list in 'auth_list' and we end a list of lists.
This list of lists is now used in `CkMinions#auth_check`, which does not expect it to contain lists:

```
# salt/utils/minions.py
for ind in auth_list:
                    if isinstance(ind, string_types):
                        [...]
                    elif isinstance(ind, dict):
                        [...]
```

and Alice ends up without any authorization / permission!
# What I did

This PR reworks the mentioned methods so that the list is actually filled with the permissions a user gets from here groups. Also I renamed the method to better describe what it does. The only place this was used got adjusted.
Running `salt -a pam ...` now works as expected.

However I am unsure if I am completely missing the point here, as this code was in place since May 2014 (403699697) and it seems no one besides me ran into this error...
