### PR TITLE
fix systemd stacktrace on debian

### DIFF
--- a/salt/modules/debian_service.py
+++ b/salt/modules/debian_service.py
@@ -32,7 +32,7 @@ def __virtual__():
     '''
     Only work on Debian and when systemd isn't running
     '''
-    if __grains__['os'] in ('Debian', 'Raspbian') and not _sd_booted():
+    if __grains__['os'] in ('Debian', 'Raspbian') and not _sd_booted(__context__):
         return __virtualname__
     return False
 

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -58,7 +58,7 @@ def default_config():
 
         salt -G 'kernel:Linux' sysctl.default_config
     '''
-    if _sd_booted():
+    if _sd_booted(__context__):
         for line in __salt__['cmd.run_stdout'](
             'systemctl --version'
         ).splitlines():

--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -25,26 +25,26 @@ def __virtual__():
     '''
     Only work on systems that have been booted with systemd
     '''
-    if __grains__['kernel'] == 'Linux' and _sd_booted():
+    if __grains__['kernel'] == 'Linux' and _sd_booted(__context__):
         return __virtualname__
     return False
 
 
-def _sd_booted():
+def _sd_booted(context):
     '''
     Return True if the system was booted with systemd, False otherwise.
     '''
     # We can cache this for as long as the minion runs.
-    if "systemd.sd_booted" not in __context__:
+    if "systemd.sd_booted" not in context:
         try:
             # This check does the same as sd_booted() from libsystemd-daemon:
             # http://www.freedesktop.org/software/systemd/man/sd_booted.html
             if os.stat('/run/systemd/system'):
-                __context__['systemd.sd_booted'] = True
+                context['systemd.sd_booted'] = True
         except OSError:
-            __context__['systemd.sd_booted'] = False
+            context['systemd.sd_booted'] = False
 
-    return __context__['systemd.sd_booted']
+    return context['systemd.sd_booted']
 
 
 def _canonical_unit_name(name):


### PR DESCRIPTION
`__context__` is not loaded for hidden module functions (functions
beginning with '_')
