### PR TITLE
fix syndic getting user from kwarg

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -1345,7 +1345,7 @@ class LocalClient(object):
             payload_kwargs['kwargs'] = kwargs
 
         # If we have a salt user, add it to the payload
-        if self.opts['order_masters'] and 'user' in kwargs:
+        if self.opts['syndic_master'] and 'user' in kwargs:
             payload_kwargs['user'] = kwargs['user']
         elif self.salt_user:
             payload_kwargs['user'] = self.salt_user


### PR DESCRIPTION
This fixes https://github.com/saltstack/salt/issues/15608

salt-syndic currently does not send the correct user with its job data to the syndic master.  Instead, the fallback calling salt.utils.get_user() is shown as the originator of the job in the syndic master's log output.

It appears to me that this code path is intended for salt-syndic to hit when sending a job to a syndic master to inject the publishing user into the payload.  It doesn't work currently because 'order_masters' is set on the top level master, not the syndic master.  Instead, we should be checking that 'syndic_master' is so that we do this injection on the actual syndic.
