### PR TITLE
Event _stamp should be UTC

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -404,7 +404,7 @@ class SaltEvent(object):
         if not self.cpush:
             self.connect_pull(timeout=timeout)
 
-        data['_stamp'] = datetime.datetime.now().isoformat()
+        data['_stamp'] = datetime.datetime.utcnow().isoformat()
 
         tagend = TAGEND
         serialized_data = salt.utils.dicttrim.trim_dict(self.serial.dumps(data),


### PR DESCRIPTION
The timestamp added to events should be formatted as UTC rather than localtime.
