### PR TITLE
Fixes #20322, check for existing cert, return CN (not ca_name)

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -786,11 +786,11 @@ def create_ca_signed_cert(ca_name, CN, days=365, cacert_path=None, digest='sha25
         salt '*' tls.create_ca_signed_cert test localhost
     '''
     set_ca_path(cacert_path)
-    if os.path.exists(
-            '{0}/{1}/{2}.crt'.format(cert_base_path(),
-                                     ca_name, CN)
-    ):
-        return 'Certificate "{0}" already exists'.format(ca_name)
+
+    crt_f = '{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
+                                           ca_name, CN)
+    if os.path.exists(crt_f):
+        return 'Certificate "{0}" already exists'.format(CN)
 
     try:
         maybe_fix_ssl_version(ca_name)


### PR DESCRIPTION
This change fixes #20322:

```
[root@node1 ~]# salt-call tls.create_ca_signed_cert ca_name=foo CN=localhost
local:
    Created Certificate for "localhost": "/etc/pki/foo/certs/localhost.crt"
[root@node1 ~]# salt-call tls.create_ca_signed_cert ca_name=foo CN=localhost
local:
    Certificate "localhost" already exists
```

I also updated the function's `return` to reference the `CN` (rather than `ca_name`).
