### PR TITLE
Fix support for allow-hotplug in debian_ip network module

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1165,6 +1165,9 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     if enabled:
         adapters[iface]['enabled'] = True
 
+    if opts.get('hotplug', False):
+        adapters[iface]['hotplug'] = True
+
     iface_data['inet']['addrfam'] = 'inet'
 
     if iface_type not in ['bridge']:


### PR DESCRIPTION
This patch restores support for allow-hotplug directive which have been dropped
by commit b2fa638d6dc4e7b629b478a0dd2685acdc50d260

When setting "hotplug: True" in network.managed state, this was not taken into
account and the allow-hotplug setting would be removed from
/etc/network/interfaces.
