### PR TITLE
Fixed file path check for sysctl settings with names containing slashes

### DIFF
--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -34,6 +34,12 @@ def __virtual__():
     return __virtualname__
 
 
+def _name_to_path(name):
+    return '/proc/sys/{0}'.format(
+        '/'.join([part.replace('/', '.') for part in name.split('.')])
+    )
+
+
 def default_config():
     '''
     Linux hosts using systemd 207 or later ignore ``/etc/sysctl.conf`` and only
@@ -113,7 +119,7 @@ def assign(name, value):
         salt '*' sysctl.assign net.ipv4.ip_forward 1
     '''
     value = str(value)
-    sysctl_file = '/proc/sys/{0}'.format(name.replace('.', '/'))
+    sysctl_file = _name_to_path(name)
     if not os.path.exists(sysctl_file):
         raise CommandExecutionError('sysctl {0} does not exist'.format(name))
 


### PR DESCRIPTION
There is a rare case where the sysctl module fails recognizing a valid sysctl setting name that contains a `/` which is a valid character on some machines.

Take this example: you have a network interface named `eno1.1` (ethernet interface eno1 on vlan1)
Such an interface is listed under `net.ipv4.conf` as `eno1/1` so if you want to configure `arp_announce` you write this state:

```
net.ipv4.conf.eno1/1.arp_announce:
  sysctl.present:
    - value: 1
```

Which results in this error:

```
      ID: net.ipv4.conf.eno1/1.arp_ignore
Function: sysctl.present
  Result: False
 Comment: An exception occurred in this state: Traceback (most recent call last):
            File "/usr/lib/python2.7/site-packages/salt/state.py", line 1533, in call                                                 
              **cdata['kwargs'])                                                                                                      
            File "/usr/lib/python2.7/site-packages/salt/states/sysctl.py", line 88, in present                                        
              update = __salt__['sysctl.persist'](name, value, config)                                                                
            File "/usr/lib/python2.7/site-packages/salt/modules/linux_sysctl.py", line 247, in persist                                
              assign(name, value)                                                                                                     
            File "/usr/lib/python2.7/site-packages/salt/modules/linux_sysctl.py", line 138, in assign                                 
              raise CommandExecutionError('sysctl {0} does not exist'.format(name))                                                   
          CommandExecutionError: sysctl net.ipv4.conf.eno1/1.arp_ignore does not exist                                                
 Started: 17:31:12.655409
Duration: 30.913 ms
 Changes:
```

This is caused by the over-simplistic check for the existence of the file with path `/proc/sys/net/ipv4/conf/eno1/1/arp_announce` while the proper path would be `/proc/sys/net/ipv4/conf/eno1.1/arp_announce`

Please consider backporting this in v2014.7.1

Thanks!
