### PR TITLE
Add "wipesignatures" to lvcreate allowed kwargs

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -273,7 +273,7 @@ def lvcreate(lvname, vgname, size=None, extents=None, snapshot=None, pv=None, **
              'stripesize', 'minor', 'persistent', 'mirrors', 'noudevsync',
              'monitor', 'ignoremonitoring', 'permission', 'poolmetadatasize',
              'readahead', 'regionsize', 'thin', 'thinpool', 'type', 'virtualsize',
-             'zero',)
+             'wipesignatures', 'zero',)
     no_parameter = ('noudevsync', 'ignoremonitoring', )
 
     extra_arguments = []


### PR DESCRIPTION
If a logical volume is removed and recreated, it can have a filesystem
signature for which lvcreate errantly asks a non-tty if we want to
remove it:

```
WARNING: xfs signature detected on /dev/data/ceph at offset 0. Wipe it? [y/n]:
```

Allowing wipesignatures in the kwargs allows that behavior to be
overriden.
