### PR TITLE
ignore null string from blkid output

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -216,6 +216,8 @@ def blkid(device=None):
 
     ret = {}
     for line in __salt__['cmd.run_stdout']('blkid' + args, python_shell=False).split('\n'):
+        if not line:
+            continue
         comps = line.split()
         device = comps[0][:-1]
         info = {}


### PR DESCRIPTION
currently salt disk module is broken on diskless node because it doesn't do any sanity check for blkid results before processing it:

```
0 [stg][root@minion01:~]# salt-call disk.blkid
[INFO    ] Executing command 'blkid' in directory '/root'
[ERROR   ] Command 'blkid' failed with return code: 2
[ERROR   ] retcode: 2
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
IndexError: list index out of range
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 123, in salt_call
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/__init__.py", line 420, in run
    caller.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 225, in run
    ret = self.call()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 129, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/disk.py", line 215, in blkid
    device = comps[0][:-1]
IndexError: list index out of range
Traceback (most recent call last):
  File "/usr/bin/salt-call", line 11, in <module>
    salt_call()
  File "/usr/lib/python2.7/dist-packages/salt/scripts.py", line 123, in salt_call
    client.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/__init__.py", line 420, in run
    caller.run()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 225, in run
    ret = self.call()
  File "/usr/lib/python2.7/dist-packages/salt/cli/caller.py", line 129, in call
    ret['return'] = func(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/salt/modules/disk.py", line 215, in blkid
    device = comps[0][:-1]
IndexError: list index out of range
1 [stg][root@minion01:~]# which blkid
/sbin/blkid
0 [stg][root@minion01:~]# blkid
2 [stg][root@minion01:~]# echo $?
2
```

This PR just adds a simple check to ignore null string of blkid output.
This issue also breaks all the mount state which is using disk module, like mount tmpfs on those diskless node.
