### PR TITLE
Pull grains into __opts__ before loading the execution modules

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -125,6 +125,8 @@ def minion_mods(opts, context=None, whitelist=None):
         import salt.loader
 
         __opts__ = salt.config.minion_config('/etc/salt/minion')
+        __grains__ = salt.loader.grains(__opts__)
+        __opts__['grains'] = __grains__
         __salt__ = salt.loader.minion_mods(__opts__)
         __salt__['test.ping']()
     '''


### PR DESCRIPTION
Otherwise the platform specific modules won't be loaded since the grains
aren't available.
