### PR TITLE
Add list_upgrades method to salt.modules.gem

### DIFF
--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -6,6 +6,12 @@ from __future__ import absolute_import
 
 # Import python libs
 import re
+import logging
+
+# Import salt libs
+from salt.exceptions import CommandExecutionError
+
+logger = logging.getLogger(__name__)  # pylint: disable=C0103
 
 __func_alias__ = {
     'list_': 'list'

--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -42,7 +42,8 @@ def _gem(command, ruby=None, runas=None, gem_bin=None):
     if ret['retcode'] == 0:
         return ret['stdout']
     else:
-        return False
+        logger.error(ret['stderr'])
+        raise CommandExecutionError(ret['stderr'])
 
 
 def install(gems,           # pylint: disable=C0103
@@ -210,9 +211,7 @@ def list_(prefix='', ruby=None, runas=None, gem_bin=None):
                   ruby,
                   gem_bin=gem_bin,
                   runas=runas)
-    lines = []
-    if isinstance(stdout, str):
-        lines = stdout.splitlines()
+    lines = stdout.splitlines()
     for line in lines:
         match = re.match(r'^([^ ]+) \((.+)\)', line)
         if match:

--- a/salt/modules/gem.py
+++ b/salt/modules/gem.py
@@ -221,6 +221,44 @@ def list_(prefix='', ruby=None, runas=None, gem_bin=None):
     return gems
 
 
+def list_upgrades(ruby=None,
+                  runas=None,
+                  gem_bin=None):
+    '''
+    .. versionadded:: Beryllium
+
+    Check if an upgrade is available for installed gems
+
+    gem_bin : None
+        Full path to ``gem`` binary to use.
+    ruby : None
+        If RVM or rbenv are installed, the ruby version and gemset to use.
+        Ignored if ``gem_bin`` is specified.
+    runas : None
+        The user to run gem as.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' gem.list_upgrades
+    '''
+    result = _gem('outdated',
+                  ruby,
+                  gem_bin=gem_bin,
+                  runas=runas)
+    outdated = {}
+    for line in result.splitlines():
+        match = re.search(r'(\S+) \(\S+ < (\S+)\)', line)
+        if match:
+            name, version = match.groups()
+        else:
+            logger.error('Can\'t parse line {0!r}'.format(line))
+            continue
+        outdated[name] = version
+    return outdated
+
+
 def sources_add(source_uri, ruby=None, runas=None, gem_bin=None):
     '''
     Add a gem source.

--- a/tests/unit/modules/gem_test.py
+++ b/tests/unit/modules/gem_test.py
@@ -92,6 +92,20 @@ sass (3.1.15, 3.1.7)
                  'sass': ['3.1.15', '3.1.7']},
                 gem.list_())
 
+    def test_list_upgrades(self):
+        output = '''
+arel (5.0.1.20140414130214 < 6.0.0)
+rails (4.1.9 < 4.2.0)
+rake (10.3.2 < 10.4.2)
+'''
+        mock = MagicMock(return_value=output)
+        with patch.object(gem, '_gem', new=mock):
+            self.assertEqual(
+                {'arel': '6.0.0',
+                 'rails': '4.2.0',
+                 'rake': '10.4.2'}, gem.list_upgrades()
+            )
+
     def test_sources_list(self):
         output = '''*** CURRENT SOURCES ***
 


### PR DESCRIPTION
Adding a salt.modules.gem.list_upgrades method that is modeled (read: blatantly stolen from) on the same method from salt.modules.pip. Uses "gem outdated" to get a list of packages that have available updates.

I also made a change to raise a CommandExecutionError in the case that the gem command fails. This makes the behavior of the module more closely mimic the pip module. I can separate this out into another pull request if preferred.
