### PR TITLE
Make the value extraction a little smarter.

### DIFF
--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -185,7 +185,12 @@ def get_var(var):
         conf_file = fn_.readlines()
     for line in conf_file:
         if line.startswith(var):
-            ret = line.split('=', 1)[1].replace('"', '')
+            ret = line.split('=', 1)[1]
+            if '"' in ret:
+                ret = ret.split('"')[1]
+            elif '#' in ret:
+                ret = ret.split('#')[0]
+            ret = ret.strip()
             return ret
     return None
 


### PR DESCRIPTION
The previous method of splitting on = then removing " had the problem of leaving a trailing new line, making the makeconf.present state always fail if given a valid comparison.  It would also fail to cope with inline comments and leading/trailing whitespace.

This code isn't foolproof but works as long as there's no quotes in the comment, or the string isn't quoted but the comment does have a quote in it.

This is primarily a bug fix so I've submitted it against the 2015.2 branch but it will want cherry picking over.
