### PR TITLE
DOC: add certifi to get proper https support.

### DIFF
--- a/doc/topics/installation/windows.rst
+++ b/doc/topics/installation/windows.rst
@@ -263,14 +263,20 @@ Setting up a Windows build environment
 
         pip install esky
 
-24. Install Salt
+24. Install certifi
+
+    .. code-block:: bash
+
+        pip install certifi
+
+25. Install Salt
 
     .. code-block:: bash
 
         cd salt
         python setup.py install
 
-25. Build a frozen binary distribution of Salt
+26. Build a frozen binary distribution of Salt
 
     .. code-block:: bash
 


### PR DESCRIPTION
The latest official windows installer (2014.7.1) does not support https, e.g.:

```
salt-call --local cp.get_url https://httpbin.org/gzip C:\hello.txt
```

will crash with a certificate error. I believe this is due to how requests is installed as an egg in the frozen binary. By installing certifi _from pip_ (i.e. not as an egg), the cert can be loaded correctly by the frozen binary, and it then works as expected. I only tested the above on top of the 2014.7.1 tag.
