### PR TITLE
fix pip venv regression, deprecate activate param

### DIFF
--- a/doc/topics/releases/2014.7.2.rst
+++ b/doc/topics/releases/2014.7.2.rst
@@ -15,3 +15,7 @@ Version 2014.7.2 is a bugfix release for :doc:`2014.7.0
   to lowercase their npm package names for them.  The :py:mod:`npm module
   <salt.modules.npm>` was never affected by mandatory lowercasing.
   (:issue:`20329`)
+- Deprecate the `activate` parameter for pip.install for both the
+  :py:mod:`module <salt.modules.pip>` and the :py:mod:`state <salt.state.pip>`.
+  If `bin_env` is given and points to a virtualenv, there is no need to
+  activate that virtualenv in a shell for pip to install to the virtualenv.

--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -243,6 +243,10 @@ def installed(name,
         Activates the virtual environment, if given via bin_env,
         before running install.
 
+        .. deprecated:: 2014.7.2
+            If `bin_env` is given, pip will already be sourced from that
+            virualenv, making `activate` effectively a noop.
+
     pre_releases
         Include pre-releases in the available versions
 

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -298,7 +298,7 @@ class PipTestCase(TestCase):
             )
 
     @patch('os.path')
-    def test_install_fix_activate_env(self, mock_path):
+    def test_install_venv(self, mock_path):
         mock_path.is_file.return_value = True
         mock_path.isdir.return_value = True
 
@@ -307,9 +307,9 @@ class PipTestCase(TestCase):
         mock_path.join = join
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
-            pip.install('mock', bin_env='/test_env', activate=True)
+            pip.install('mock', bin_env='/test_env')
             mock.assert_called_once_with(
-                '. /test_env/bin/activate && /test_env/bin/pip install '
+                '/test_env/bin/pip install '
                 '\'mock\'',
                 env={'VIRTUAL_ENV': '/test_env'},
                 saltenv='base',


### PR DESCRIPTION
Fixes #20191.  If `bin_env` points to a virtualenv, there is no need to
activate that virtualenv for pip to install into the virtualenv.
