### PR TITLE
get_var in makeconf returns value with '\n' suffix

### DIFF
--- a/salt/modules/makeconf.py
+++ b/salt/modules/makeconf.py
@@ -179,7 +179,7 @@ def get_var(var):
     makeconf = _get_makeconf()
     # Open makeconf
     with salt.utils.fopen(makeconf) as fn_:
-        conf_file = fn_.readlines()
+        conf_file = fn_.read().splitlines()
     for line in conf_file:
         if line.startswith(var):
             ret = line.split('=', 1)[1].replace('"', '')


### PR DESCRIPTION
Since commit 89734a5ba195dd934b18214add0ffcb020d018d9, makeconf.present state raises an error when trying to set a variable with a specified value, because get_var in makeconf module returns value with '\n' suffix and comparaison between old value and new one is always false
