### PR TITLE
Copy perms of destination file when backing up

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -606,6 +606,7 @@ def backup_minion(path, bkroot):
     shutil.copyfile(path, bkpath)
     if not salt.utils.is_windows():
         os.chown(bkpath, fstat.st_uid, fstat.st_gid)
+        os.chmod(bkpath, fstat.st_mode)
 
 
 def path_join(*parts):


### PR DESCRIPTION
Fixes #19643
