### PR TITLE
Cast ssh_port as an integer to stop stacktrace when provising azure instances

### DIFF
--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -611,7 +611,7 @@ def create(vm_):
         deploy_kwargs = {
             'opts': __opts__,
             'host': hostname,
-            'port': ssh_port,
+            'port': int(ssh_port),
             'username': ssh_username,
             'password': ssh_password,
             'script': deploy_script,


### PR DESCRIPTION
This will solve the stacktracing problem reported in #20385, but doesn't fix the bug completely.

@techhat ping
