### PR TITLE
bugfix: module function cmd.which would be wrong if arg is a dirname

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -353,8 +353,14 @@ def which(exe=None):
     '''
     Python clone of /usr/bin/which
     '''
+    def _is_executable_file_or_link(exe):
+        # check for os.X_OK doesn't suffice because directory may executable
+        return (os.access(exe, os.X_OK) and
+                (os.path.isfile(exe) or os.path.islink(exe)))
+
     if exe:
-        if os.access(exe, os.X_OK):
+        if _is_executable_file_or_link(exe):
+            # executable in cwd or fullpath
             return exe
 
         # default path based on busybox's default
@@ -394,7 +400,7 @@ def which(exe=None):
             )
         for path in search_path:
             full_path = os.path.join(path, exe)
-            if os.access(full_path, os.X_OK):
+            if _is_executable_file_or_link(full_path):
                 return full_path
             elif is_windows() and not _exe_has_ext():
                 # On Windows, check for any extensions in PATHEXT.
@@ -402,7 +408,7 @@ def which(exe=None):
                 for ext in ext_list:
                     # Windows filesystem is case insensitive so we
                     # safely rely on that behavior
-                    if os.access(full_path + ext, os.X_OK):
+                    if _is_executable_file_or_link(full_path + ext):
                         return full_path + ext
         log.trace(
             '{0!r} could not be found in the following search '

--- a/tests/unit/utils/which_test.py
+++ b/tests/unit/utils/which_test.py
@@ -55,7 +55,8 @@ class TestWhich(integration.TestCase):
         # Let's patch os.environ to provide a custom PATH variable
         with patch.dict(os.environ, {'PATH': '/bin'}):
             # Let's also patch is_windows to return True
-            with patch('salt.utils.is_windows', lambda: True):
+            with patch('salt.utils.is_windows', lambda: True), \
+                    patch('os.path.isfile', lambda x: True):
                 self.assertEqual(
                     salt.utils.which('this-binary-exists-under-windows'),
                     # The returned path should return the .exe suffix
@@ -109,7 +110,8 @@ class TestWhich(integration.TestCase):
                                      'PATHEXT': '.COM;.EXE;.BAT;.CMD;.VBS;'
                                      '.VBE;.JS;.JSE;.WSF;.WSH;.MSC;.PY'}):
             # Let's also patch is_windows to return True
-            with patch('salt.utils.is_windows', lambda: True):
+            with patch('salt.utils.is_windows', lambda: True), \
+                    patch('os.path.isfile', lambda x: True):
                 self.assertEqual(
                     salt.utils.which('this-binary-exists-under-windows'),
                     # The returned path should return the .exe suffix


### PR DESCRIPTION
because a directory can have -x permission but not a runnable file
