### PR TITLE
Fix for mysql pillar's ignore_null

### DIFF
--- a/salt/pillar/mysql.py
+++ b/salt/pillar/mysql.py
@@ -408,7 +408,7 @@ class Merger(object):
                         crd[ret[nk]] = []
                     crd[ret[nk]].append(ret[self.num_fields-1])
                 else:
-                    if not self.ignore_null or ret[self.num_fields-1]:
+                    if not self.ignore_null or ret[self.num_fields-1] is not None:
                         crd[ret[nk]] = ret[self.num_fields-1]
             else:
                 # Otherwise, the field name is the key but we have a spare.
@@ -442,7 +442,7 @@ class Merger(object):
                         else:
                             crd[nk] = [crd[nk], ret[i]]
                     else:
-                        if not self.ignore_null or ret[i]:
+                        if not self.ignore_null or ret[i] is not None:
                             crd[nk] = ret[i]
         # Get key list and work backwards.  This is inner-out processing
         ks = list(listify_dicts.keys())


### PR DESCRIPTION
PR #14924 from @jond64 introduced logic to ignore null values but it appears the logic is slightly off.
I'm changing the code to compare against None rather than basing off anything that evaluates true.  As was, fields set to false, 0 or an empty string would be ignored meaning you couldn't turn off any fields from an override.
