### PR TITLE
Fixed bug and reverted some unnecessary changes where .six.itervalues was applied 

### DIFF
--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -698,7 +698,7 @@ class SaltLoadPillar(ioflo.base.deeding.Deed):
         self.master_estate_name.value = master.name
 
         route = {'src': (self.road_stack.value.local.name, None, None),
-                 'dst': (next(self.road_stack.value.remotes.values()).name, None, 'remote_cmd')}
+                 'dst': (master.name, None, 'remote_cmd')}
         load = {'id': self.opts.value['id'],
                 'grains': self.grains.value,
                 'saltenv': self.opts.value['environment'],

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -1338,20 +1338,6 @@ class SaltRaetRouterMinion(SaltRaetRouter):
         return list(set(minions) &
                     set((name.rstrip(suffix) for name in self.availables.value)))
 
-    def action(self):
-        '''
-        Process the messages!
-        '''
-        while self.road_stack.value.rxMsgs:
-            msg, sender = self.road_stack.value.rxMsgs.popleft()
-            self._process_udp_rxmsg(msg=msg, sender=sender)
-        while self.laters.value:  # process requeued LaneMsgs
-            msg, sender = self.laters.value.popleft()
-            self.lane_stack.value.rxMsgs.append((msg, sender))
-        while self.lane_stack.value.rxMsgs:
-            msg, sender = self.lane_stack.value.rxMsgs.popleft()
-            self._process_uxd_rxmsg(msg=msg, sender=sender)
-
 
 class SaltRaetEventer(ioflo.base.deeding.Deed):
     '''

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -205,7 +205,7 @@ class SaltRaetRoadClusterLoadSetup(ioflo.base.deeding.Deed):
         Populate loads from masters in stack.remotes
         '''
         if self.opts.value.get('cluster_mode'):
-            for remote in six.itervalues(self.stack.value.remotes):
+            for remote in self.stack.value.remotes.values():
                 if remote.kind == kinds.applKinds.master:
                     self.masters.value[remote.name] = odict(load=0.0, expire=self.store.stamp)
 
@@ -303,7 +303,7 @@ class SaltRaetRoadStackSetup(ioflo.base.deeding.Deed):
                                      offset=0.5)
 
         if self.opts.value.get('raet_clear_remotes'):
-            for remote in six.itervalues(self.stack.value.remotes):
+            for remote in self.stack.value.remotes.values():
                 self.stack.value.removeRemote(remote, clear=True)
             self.stack.puid = self.stack.value.Uid  # reset puid
 
@@ -359,12 +359,12 @@ class SaltRaetRoadStackJoiner(ioflo.base.deeding.Deed):
                        not stack.remotes)
 
             if refresh_masters:  # clear all remote masters
-                for remote in six.itervalues(stack.remotes):
+                for remote in stack.remotes.values():
                     if remote.kind == kinds.applKinds.master:
                         stack.removeRemote(remote, clear=True)
 
             if refresh_all:  # clear all remotes
-                for remote in six.itervalues(stack.remotes):
+                for remote in stack.remotes.values():
                     stack.removeRemote(remote, clear=True)
 
             if refresh_all or refresh_masters:
@@ -378,7 +378,7 @@ class SaltRaetRoadStackJoiner(ioflo.base.deeding.Deed):
                                                  ha=mha,
                                                  kind=kinds.applKinds.master))
 
-            for remote in six.itervalues(stack.remotes):
+            for remote in stack.remotes.values():
                 if remote.kind == kinds.applKinds.master:
                     stack.join(uid=remote.uid, timeout=0.0)
 
@@ -409,7 +409,7 @@ class SaltRaetRoadStackJoined(ioflo.base.deeding.Deed):
         joined = False
         if stack and isinstance(stack, RoadStack):
             if stack.remotes:
-                joined = any([remote.joined for remote in six.itervalues(stack.remotes)
+                joined = any([remote.joined for remote in stack.remotes.values()
                               if remote.kind == kinds.applKinds.master])
         self.status.update(joined=joined)
 
@@ -441,7 +441,7 @@ class SaltRaetRoadStackRejected(ioflo.base.deeding.Deed):
         if stack and isinstance(stack, RoadStack):
             if stack.remotes:
                 rejected = all([remote.acceptance == raeting.acceptances.rejected
-                                for remote in six.itervalues(stack.remotes)
+                                for remote in stack.remotes.values()
                                 if remote.kind == kinds.applKinds.master])
             else:  # no remotes so assume rejected
                 rejected = True
@@ -467,7 +467,7 @@ class SaltRaetRoadStackAllower(ioflo.base.deeding.Deed):
         '''
         stack = self.stack.value
         if stack and isinstance(stack, RoadStack):
-            for remote in six.itervalues(stack.remotes):
+            for remote in stack.remotes.values():
                 if remote.kind == kinds.applKinds.master:
                     stack.allow(uid=remote.uid, timeout=0.0)
 
@@ -498,7 +498,7 @@ class SaltRaetRoadStackAllowed(ioflo.base.deeding.Deed):
         allowed = False
         if stack and isinstance(stack, RoadStack):
             if stack.remotes:
-                allowed = any([remote.allowed for remote in six.itervalues(stack.remotes)
+                allowed = any([remote.allowed for remote in stack.remotes.values()
                                if remote.kind == kinds.applKinds.master])
         self.status.update(allowed=allowed)
 
@@ -682,10 +682,10 @@ class SaltLoadPillar(ioflo.base.deeding.Deed):
         Initial pillar
         '''
         # default master is the first remote that is allowed
-        available_masters = [remote for remote in six.itervalues(self.road_stack.value.remotes)
+        available_masters = [remote for remote in self.road_stack.value.remotes.values()
                                                if remote.allowed]
         while not available_masters:
-            available_masters = [remote for remote in six.itervalues(self.road_stack.value.remotes)
+            available_masters = [remote for remote in self.road_stack.value.remotes.values()
                                                            if remote.allowed]
             time.sleep(0.1)
 
@@ -698,7 +698,7 @@ class SaltLoadPillar(ioflo.base.deeding.Deed):
         self.master_estate_name.value = master.name
 
         route = {'src': (self.road_stack.value.local.name, None, None),
-                 'dst': (next(six.itervalues(self.road_stack.value.remotes)).name, None, 'remote_cmd')}
+                 'dst': (next(self.road_stack.value.remotes.values()).name, None, 'remote_cmd')}
         load = {'id': self.opts.value['id'],
                 'grains': self.grains.value,
                 'saltenv': self.opts.value['environment'],
@@ -1314,7 +1314,7 @@ class SaltRaetRouterMinion(SaltRaetRouter):
         master = self.road_stack.value.nameRemotes.get(self.master_estate_name.value)
         if not master or not master.alived:  # select a different master
             available_masters = [remote for remote in
-                                 six.itervalues(self.road_stack.value.remotes)
+                                 self.road_stack.value.remotes.values()
                                                        if remote.alived]
             if available_masters:
                 random_master = opts.get('random_master')
@@ -1417,7 +1417,7 @@ class SaltRaetEventerMaster(SaltRaetEventer):
         if self.opts.value.get('cluster_mode'):
             if msg.get('origin') is None:
                 masters = (self.availables.value &
-                           set((remote.name for remote in six.itervalues(self.road_stack.value.remotes)
+                           set((remote.name for remote in self.road_stack.value.remotes.values()
                                 if remote.kind == kinds.applKinds.master)))
                 for name in masters:
                     remote = self.road_stack.value.nameRemotes[name]
@@ -1526,7 +1526,7 @@ class SaltRaetPublisher(ioflo.base.deeding.Deed):
         # only publish to available minions by intersecting sets
 
         minions = (self.availables.value &
-                   set((remote.name for remote in six.itervalues(stack.remotes)
+                   set((remote.name for remote in stack.remotes.values()
                             if remote.kind in [kinds.applKinds.minion,
                                                kinds.applKinds.syndic])))
         for minion in minions:
@@ -1606,7 +1606,7 @@ class SaltRaetMasterEvents(ioflo.base.deeding.Deed):
         while self.master_events.value:
             events.append(self.master_events.value.popleft())
         route = {'src': (self.road_stack.value.local.name, None, None),
-                 'dst': (next(six.itervalues(self.road_stack.value.remotes)).name, None, 'remote_cmd')}
+                 'dst': (next(self.road_stack.value.remotes.values()).name, None, 'remote_cmd')}
         load = {'id': self.opts.value['id'],
                 'events': events,
                 'cmd': '_minion_event'}


### PR DESCRIPTION
The core.py SaltLoadPillar behavior was selecting a master via an iterator with next(). This was wrong as the iterator was
being recreated each time the behavior ran so it would always select the first one. The behavior  already had code to
select a master either randomly if opt random_master or to select the first one if not. So removed the next (iterator).

Also throughout the code many for loops the had .values() were replaced with six.itervalues().  This is a questionable choice because the need for six only arises iff the python2 code is using .itervalues() not .values().   .values() in a for expressing is already python2 and python3 compliant. So at the risk of making the code much less readable, six.itervalues() was used but not needed.

One could argue that the original python2 code that used .values() could be refactored to use .itervalues() which would then require six.itervalues() for python 2 and 3 compliance. But there is no statistically significant advantage in performance to using itervalues over values on a dict when iterated in a for loop. Python already optimizes the code under the hood.

timeit runs in python 2.7 of

for v in x.values():
   pass

vs

or v in x.itervalues():
   pass

are statistically the same (sometime one if faster than the other)

So refactoring to use itervalues actually makes the code much less readable and requires using six to get python2to3
compatibility. 

It should be the case in general to use .values() as this already works performantly in both python2 and 3 

 (at least in python2.7, I didn't test python2.6)
