### PR TITLE
Use correct outputter in asynclient mixin

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -450,8 +450,7 @@ class AsyncClientMixin(object):
         # people use more events that don't quite fit into this mold
         if suffix == 'ret':  # for "ret" just print out return
             if isinstance(event['return'], dict):
-                outputter = event['return'].get('outputter', None)
-                event['return'].pop('outputter', None)
+                outputter = event['return'].pop('outputter', None)
             else:
                 outputter = None
             salt.output.display_output(event['return'], outputter, self.opts)

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -449,7 +449,12 @@ class AsyncClientMixin(object):
         # more general, since this will get *really* messy as
         # people use more events that don't quite fit into this mold
         if suffix == 'ret':  # for "ret" just print out return
-            salt.output.display_output(event['return'], None, self.opts)
+            if isinstance(event['return'], dict):
+                outputter = event['return'].get('outputter', None)
+                event['return'].pop('outputter', None)
+            else:
+                outputter = None
+            salt.output.display_output(event['return'], outputter, self.opts)
         elif isinstance(event, dict) and 'outputter' in event and event['outputter'] is not None:
             print(self.outputters[event['outputter']](event['data']))
         # otherwise fall back on basic printing


### PR DESCRIPTION
This is necessary for runners that specify an outputter in their allowed args
