### PR TITLE
RVM user-only installation is broken

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -29,7 +29,7 @@ def _get_rvm_location(runas=None):
     if runas:
         runas_home = os.path.expanduser('~{0}'.format(runas))
         rvmpath = '{0}/.rvm/bin/rvm'.format(runas_home)
-        if os.path.isdir(rvmpath):
+        if os.path.exists(rvmpath):
             return rvmpath
     return '/usr/local/rvm/bin/rvm'
 


### PR DESCRIPTION
RVM module always try to use globally installed RVM even if user-only installation exists.
All RVM functions related to users-only installations are not working.

The bug is in:

```
def _get_rvm_location(runas=None):
    if runas:
        runas_home = os.path.expanduser('~{0}'.format(runas))
        rvmpath = '{0}/.rvm/bin/rvm'.format(runas_home)
        if os.path.isdir(rvmpath):
            return rvmpath
    return '/usr/local/rvm/bin/rvm'
```

`rvmpath` here pointing to file, not a dir. So `os.path.isdir(rvmpath)` will always return `False`.
`os.path.exists(rvmpath)` should be used.

Salt: 2014.7.1
         Python: 2.7.3 (default, Apr 20 2012, 22:39:59)
         Jinja2: 2.6
       M2Crypto: 0.21.1
 msgpack-python: 0.1.10
   msgpack-pure: Not Installed
       pycrypto: 2.4.1
        libnacl: Not Installed
         PyYAML: 3.10
          ioflo: Not Installed
          PyZMQ: 13.0.0
           RAET: Not Installed
            ZMQ: 3.2.2
           Mako: Not Installed
