### PR TITLE
Python 3 compatibility changes to make pylint happy

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -110,11 +110,10 @@ def minion_mods(opts, context=None, whitelist=None, include_errors=False, initia
     if not whitelist:
         whitelist = opts.get('whitelist_modules', None)
     ret = LazyLoader(_module_dirs(opts, 'modules', 'module'),
-                         opts,
-                         tag='modules',
-                         pack={'__context__': context},
-                         whitelist=whitelist,
-                         )
+                     opts,
+                     tag='modules',
+                     pack={'__context__': context},
+                     whitelist=whitelist)
     ret.pack['__salt__'] = ret
 
     return ret
@@ -135,11 +134,10 @@ def raw_mod(opts, _, functions, mod='modules'):
         testmod['test.ping']()
     '''
     return LazyLoader(_module_dirs(opts, mod, 'rawmodule'),
-                        opts,
-                        tag=mod,
-                        virtual_enable=False,
-                        pack={'__salt__': functions},
-                        )
+                      opts,
+                      tag=mod,
+                      virtual_enable=False,
+                      pack={'__salt__': functions})
 
 
 def proxy(opts, functions, whitelist=None):
@@ -147,11 +145,10 @@ def proxy(opts, functions, whitelist=None):
     Returns the proxy module for this salt-proxy-minion
     '''
     return LazyLoader(_module_dirs(opts, 'proxy', 'proxy'),
-                         opts,
-                         tag='proxy',
-                         whitelist=whitelist,
-                         pack={'__proxy__': functions},
-                         )
+                      opts,
+                      tag='proxy',
+                      whitelist=whitelist,
+                      pack={'__proxy__': functions})
 
 
 def returners(opts, functions, whitelist=None):
@@ -159,11 +156,10 @@ def returners(opts, functions, whitelist=None):
     Returns the returner modules
     '''
     return LazyLoader(_module_dirs(opts, 'returners', 'returner'),
-                         opts,
-                         tag='returners',
-                         whitelist=whitelist,
-                         pack={'__salt__': functions},
-                         )
+                      opts,
+                      tag='returners',
+                      whitelist=whitelist,
+                      pack={'__salt__': functions})
 
 
 def utils(opts, whitelist=None):
@@ -171,10 +167,9 @@ def utils(opts, whitelist=None):
     Returns the utility modules
     '''
     return LazyLoader(_module_dirs(opts, 'utils', 'utils', ext_type_dirs='utils_dirs'),
-                         opts,
-                         tag='utils',
-                         whitelist=whitelist,
-                         )
+                      opts,
+                      tag='utils',
+                      whitelist=whitelist)
 
 
 def pillars(opts, functions):
@@ -182,10 +177,9 @@ def pillars(opts, functions):
     Returns the pillars modules
     '''
     ret = LazyLoader(_module_dirs(opts, 'pillar', 'pillar'),
-                        opts,
-                        tag='pillar',
-                        pack={'__salt__': functions},
-                        )
+                     opts,
+                     tag='pillar',
+                     pack={'__salt__': functions})
     return FilterDictWrapper(ret, '.ext_pillar')
 
 
@@ -195,12 +189,11 @@ def tops(opts):
     '''
     if 'master_tops' not in opts:
         return {}
-    whitelist = opts['master_tops'].keys()
+    whitelist = list(opts['master_tops'].keys())
     ret = LazyLoader(_module_dirs(opts, 'tops', 'top'),
-                        opts,
-                        tag='tops',
-                        whitelist=whitelist,
-                        )
+                     opts,
+                     tag='tops',
+                     whitelist=whitelist)
     return FilterDictWrapper(ret, '.top')
 
 
@@ -209,10 +202,9 @@ def wheels(opts, whitelist=None):
     Returns the wheels modules
     '''
     return LazyLoader(_module_dirs(opts, 'wheel', 'wheel'),
-                         opts,
-                         tag='wheel',
-                         whitelist=whitelist,
-                         )
+                      opts,
+                      tag='wheel',
+                      whitelist=whitelist)
 
 
 def outputters(opts):
@@ -220,9 +212,8 @@ def outputters(opts):
     Returns the outputters modules
     '''
     ret = LazyLoader(_module_dirs(opts, 'output', 'output', ext_type_dirs='outputter_dirs'),
-                        opts,
-                        tag='output',
-                        )
+                     opts,
+                     tag='output')
     wrapped_ret = FilterDictWrapper(ret, '.output')
     # TODO: this name seems terrible... __salt__ should always be execution mods
     ret.pack['__salt__'] = wrapped_ret
@@ -234,11 +225,10 @@ def auth(opts, whitelist=None):
     Returns the auth modules
     '''
     return LazyLoader(_module_dirs(opts, 'auth', 'auth'),
-                         opts,
-                         tag='auth',
-                         whitelist=whitelist,
-                         pack={'__salt__': minion_mods(opts)},
-                         )
+                      opts,
+                      tag='auth',
+                      whitelist=whitelist,
+                      pack={'__salt__': minion_mods(opts)})
 
 
 def fileserver(opts, backends):
@@ -246,10 +236,9 @@ def fileserver(opts, backends):
     Returns the file server modules
     '''
     return LazyLoader(_module_dirs(opts, 'fileserver', 'fileserver'),
-                         opts,
-                         tag='fileserver',
-                         whitelist=backends,
-                         )
+                      opts,
+                      tag='fileserver',
+                      whitelist=backends)
 
 
 def roster(opts, whitelist=None):
@@ -257,10 +246,9 @@ def roster(opts, whitelist=None):
     Returns the roster modules
     '''
     return LazyLoader(_module_dirs(opts, 'roster', 'roster'),
-                         opts,
-                         tag='roster',
-                         whitelist=whitelist,
-                         )
+                      opts,
+                      tag='roster',
+                      whitelist=whitelist)
 
 
 def states(opts, functions, whitelist=None):
@@ -276,11 +264,10 @@ def states(opts, functions, whitelist=None):
         statemods = salt.loader.states(__opts__, None)
     '''
     return LazyLoader(_module_dirs(opts, 'states', 'states'),
-                         opts,
-                         tag='states',
-                         pack={'__salt__': functions},
-                         whitelist=whitelist,
-                         )
+                      opts,
+                      tag='states',
+                      pack={'__salt__': functions},
+                      whitelist=whitelist)
 
 
 def beacons(opts, context=None):
@@ -290,10 +277,9 @@ def beacons(opts, context=None):
     if context is None:
         context = {}
     return LazyLoader(_module_dirs(opts, 'beacons', 'beacons'),
-                         opts,
-                         tag='beacons',
-                         pack={'__context__': context},
-                         )
+                      opts,
+                      tag='beacons',
+                      pack={'__context__': context})
 
 
 def search(opts, returners, whitelist=None):
@@ -301,11 +287,10 @@ def search(opts, returners, whitelist=None):
     Returns the search modules
     '''
     return LazyLoader(_module_dirs(opts, 'search', 'search'),
-                         opts,
-                         tag='search',
-                         whitelist=whitelist,
-                         pack={'__ret__': returners},
-                         )
+                      opts,
+                      tag='search',
+                      whitelist=whitelist,
+                      pack={'__ret__': returners})
 
 
 def log_handlers(opts):
@@ -805,7 +790,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             self.pillar = {}
 
         mod_opts = {}
-        for key, val in opts.items():
+        for key, val in list(opts.items()):
             if key in ('logger', 'grains'):
                 continue
             mod_opts[key] = val

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -23,7 +23,6 @@ from random import randint, shuffle
 # Import third party libs
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
-from salt.ext.six.moves import range
 # pylint: enable=no-name-in-module,redefined-builtin
 try:
     import zmq
@@ -2446,7 +2445,7 @@ class Matcher(object):
         '''
         Returns true if the passed glob matches the id
         '''
-        if not isinstance(tgt, basestring):
+        if not isinstance(tgt, six.string_types):
             return False
 
         return fnmatch.fnmatch(self.opts['id'], tgt)

--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -258,17 +258,18 @@ TODO
 * Interface for working with reactor files
 '''
 
+# Import Python Libs
 from __future__ import absolute_import
-
 import logging
 import re
-from salt.ext.six import exec_
 
+# Import Salt Libs
+from salt.ext.six import exec_
 import salt.utils
 import salt.loader
-
 from salt.fileclient import get_file_client
 from salt.utils.pyobjects import Registry, StateFactory, SaltObject, Map
+import salt.ext.six as six
 
 # our import regexes
 FROM_RE = re.compile(r'^\s*from\s+(salt:\/\/.*)\s+import (.*)$')
@@ -304,7 +305,7 @@ def load_states():
     )
 
     # TODO: some way to lazily do this? This requires loading *all* state modules
-    for key, func in lazy_states.iteritems():
+    for key, func in six.iteritems(lazy_states):
         mod_name, func_name = key.split('.', 1)
         if mod_name not in states:
             states[mod_name] = {}

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+# Import Python Libs
+from __future__ import absolute_import
 import logging
 import collections
 

--- a/tests/integration/loader/globals.py
+++ b/tests/integration/loader/globals.py
@@ -11,7 +11,8 @@ from __future__ import absolute_import
 
 # Import Salt Testing libs
 from salttesting.helpers import ensure_in_syspath
-ensure_in_syspath('../')
+
+ensure_in_syspath('../../')
 
 # Import salt libs
 import integration
@@ -53,7 +54,7 @@ class LoaderGlobalsTest(integration.ModuleCase):
         # Now, test each module!
         for item in global_vars:
             for name in names:
-                self.assertIn(name, item.keys())
+                self.assertIn(name, list(item.keys()))
 
     def test_auth(self):
         '''

--- a/tests/integration/loader/loader.py
+++ b/tests/integration/loader/loader.py
@@ -11,7 +11,6 @@ from __future__ import absolute_import
 import inspect
 import tempfile
 import shutil
-import os.path
 import os
 
 # Import Salt Testing libs
@@ -20,9 +19,10 @@ from salttesting.helpers import ensure_in_syspath
 
 import integration
 
-ensure_in_syspath('../..')
+ensure_in_syspath('../../')
 
 # Import Salt libs
+import salt.ext.six as six
 from salt.config import minion_config
 
 from salt.loader import LazyLoader, _module_dirs
@@ -35,9 +35,8 @@ class LazyLoaderVirtualEnabledTest(TestCase):
     def setUp(self):
         self.opts = _config = minion_config(None)
         self.loader = LazyLoader(_module_dirs(self.opts, 'modules', 'module'),
-                         self.opts,
-                         tag='modules',
-                         )
+                                 self.opts,
+                                 tag='modules')
 
     def test_basic(self):
         '''
@@ -49,7 +48,7 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         self.assertTrue(inspect.isfunction(self.loader['test.ping']))
 
         # make sure we only loaded "test" functions
-        for key, val in self.loader._dict.iteritems():
+        for key, val in six.iteritems(self.loader._dict):
             self.assertEqual(key.split('.', 1)[0], 'test')
 
         # make sure the depends thing worked (double check of the depends testing,
@@ -72,7 +71,7 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         '''
         self.assertEqual(self.loader._dict, {})
         # force a load all
-        for key, func in self.loader.iteritems():
+        for key, func in six.iteritems(self.loader):
             break
         self.assertNotEqual(self.loader._dict, {})
 
@@ -93,7 +92,7 @@ class LazyLoaderVirtualEnabledTest(TestCase):
         self.assertEqual(func_globals['__grains__'], self.opts.get('grains', {}))
         self.assertEqual(func_globals['__pillar__'], self.opts.get('pillar', {}))
         # the opts passed into modules is at least a subset of the whole opts
-        for key, val in func_globals['__opts__'].iteritems():
+        for key, val in six.iteritems(func_globals['__opts__']):
             self.assertEqual(self.opts[key], val)
 
     def test_pack(self):
@@ -112,10 +111,9 @@ class LazyLoaderVirtualDisabledTest(TestCase):
     def setUp(self):
         self.opts = _config = minion_config(None)
         self.loader = LazyLoader(_module_dirs(self.opts, 'modules', 'module'),
-                         self.opts,
-                         tag='modules',
-                         virtual_enable=False,
-                         )
+                                 self.opts,
+                                 tag='modules',
+                                 virtual_enable=False)
 
     def test_virtual(self):
         self.assertTrue(inspect.isfunction(self.loader['test_virtual.ping']))
@@ -128,10 +126,9 @@ class LazyLoaderWhitelistTest(TestCase):
     def setUp(self):
         self.opts = _config = minion_config(None)
         self.loader = LazyLoader(_module_dirs(self.opts, 'modules', 'module'),
-                         self.opts,
-                         tag='modules',
-                         whitelist=['test', 'pillar']
-                         )
+                                 self.opts,
+                                 tag='modules',
+                                 whitelist=['test', 'pillar'])
 
     def test_whitelist(self):
         self.assertTrue(inspect.isfunction(self.loader['test.ping']))
@@ -180,9 +177,8 @@ class LazyLoaderReloadingTest(TestCase):
         dirs = _module_dirs(self.opts, 'modules', 'module')
         dirs.append(self.tmp_dir)
         self.loader = LazyLoader(dirs,
-                         self.opts,
-                         tag='modules',
-                         )
+                                 self.opts,
+                                 tag='modules')
 
     def tearDown(self):
         shutil.rmtree(self.tmp_dir)
@@ -232,7 +228,7 @@ class LazyLoaderReloadingTest(TestCase):
 
         # make sure we only loaded our custom module
         # which means that we did correctly refresh the file mapping
-        for k, v in self.loader._dict.iteritems():
+        for k, v in six.iteritems(self.loader._dict):
             self.assertTrue(k.startswith(self.module_name))
 
     def test_load(self):
@@ -265,7 +261,7 @@ class LazyLoaderReloadingTest(TestCase):
         self.assertNotIn(self.module_key, self.loader)
 
         # make sure it updates correctly
-        for x in xrange(1, 3):
+        for x in range(1, 3):
             self.update_module()
             self.loader.clear()
             self.assertEqual(self.loader[self.module_key](), self.count)

--- a/tests/unit/modules/mine_test.py
+++ b/tests/unit/modules/mine_test.py
@@ -3,6 +3,10 @@
     :codeauthor: :email:`Rupesh Tare <rupesht@saltstack.com>`
 '''
 
+# Import Python Libs
+from __future__ import absolute_import
+import copy
+
 # Import Salt Testing Libs
 from salttesting import TestCase, skipIf
 from salttesting.mock import (
@@ -11,11 +15,13 @@ from salttesting.mock import (
     NO_MOCK,
     NO_MOCK_REASON
 )
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
 
 # Import Salt Libs
 import salt.utils
 from salt.modules import mine
-import copy
 
 
 # Globals


### PR DESCRIPTION
Also moved one of the test files: unit/loader.py --> integration/loader/loader.py. These are integration tests, not unit tests, so they should be in the correct directory. Let's be sure we check that change to make sure those tests ran and passed before merging.
