### PR TITLE
Add minute granular start time

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -430,7 +430,7 @@ class Schedule(object):
                 ret['metadata'] = data['metadata']
                 ret['metadata']['_TOS'] = self.time_offset
                 ret['metadata']['_TS'] = time.ctime()
-                ret['metadata']['_TT'] = time.strftime('%Y %B %d %a %H %m')
+                ret['metadata']['_TT'] = time.strftime('%Y %B %d %a %H %m', time.gmtime())
             else:
                 log.warning('schedule: The metadata parameter must be '
                             'specified as a dictionary.  Ignoring.')

--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -430,6 +430,7 @@ class Schedule(object):
                 ret['metadata'] = data['metadata']
                 ret['metadata']['_TOS'] = self.time_offset
                 ret['metadata']['_TS'] = time.ctime()
+                ret['metadata']['_TT'] = time.strftime('%Y %B %d %a %H %m')
             else:
                 log.warning('schedule: The metadata parameter must be '
                             'specified as a dictionary.  Ignoring.')


### PR DESCRIPTION
Allows for easy tracking of lateral schedule runs
