### PR TITLE
add sudo, sudo_password params to vsphere deploy to allow for non-root deploys

### DIFF
--- a/salt/cloud/clouds/vsphere.py
+++ b/salt/cloud/clouds/vsphere.py
@@ -359,7 +359,13 @@ def _deploy(vm_):
         'script_env': config.get_cloud_config_value(
             'script_env', vm_, __opts__
         ),
-        'minion_conf': salt.utils.cloud.minion_config(__opts__, vm_)
+        'minion_conf': salt.utils.cloud.minion_config(__opts__, vm_),
+        'sudo': config.get_cloud_config_value(
+            'sudo', vm_, __opts__, default=(template_user != 'root')
+        ),
+        'sudo_password': config.get_cloud_config_value(
+            'sudo_password', vm_, __opts__, default=None
+        )
     }
 
     # Store what was used to the deploy the VM


### PR DESCRIPTION
We are using vsphere at my company, and came across this overlooked param for deploys (easy to do, since everyone has full control over their own vsphere, so I'm sure everyone just uses root).  Our images don't have a root login, so we need to sudo the deploy bootstrap.  

(I think i stole this chain of config values from saltify)
