### PR TITLE
Allow Linux Mint to use upstart

### DIFF
--- a/salt/modules/service.py
+++ b/salt/modules/service.py
@@ -40,7 +40,8 @@ def __virtual__():
         'OEL',
         'Linaro',
         'elementary OS',
-        'McAfee  OS Server'
+        'McAfee  OS Server',
+        'Mint'
     ))
     if __grains__.get('os', '') in disable:
         return False

--- a/salt/modules/upstart.py
+++ b/salt/modules/upstart.py
@@ -61,7 +61,7 @@ def __virtual__():
     Only work on Ubuntu
     '''
     # Disable on these platforms, specific service modules exist:
-    if __grains__['os'] in ('Ubuntu', 'Linaro', 'elementary OS'):
+    if __grains__['os'] in ('Ubuntu', 'Linaro', 'elementary OS', 'Mint'):
         return __virtualname__
     elif __grains__['os'] in ('Debian', 'Raspbian'):
         debian_initctl = '/sbin/initctl'


### PR DESCRIPTION
Version: salt-call 2015.2.0-395-gc75ec86 (Lithium)

Salt was only looking at the sysv scripts but Linux Mint uses upstart as well:

Attempting to run the state:

``` bash
ufw:
  pkg.installed: []
  service.running:
    - watch:
      - pkg: ufw
```

I would get the following error:

``` bash
----------
          ID: ufw
    Function: pkg.installed
      Result: True
     Comment: Package ufw is already installed.
     Started: 16:04:32.153946
    Duration: 1.302 ms
     Changes:   
----------
          ID: ufw
    Function: service.running
      Result: False
     Comment: The named service ufw is not available
     Started: 16:04:32.155598
    Duration: 0.645 ms
     Changes:   
```

After the patch:

``` bash
----------
          ID: ufw
    Function: pkg.installed
      Result: True
     Comment: Package ufw is already installed.
     Started: 16:09:36.739530
    Duration: 3.448 ms
     Changes:   
----------
          ID: ufw
    Function: service.running
      Result: True
     Comment: The service ufw is already running
     Started: 16:09:36.744060
    Duration: 22.155 ms
     Changes:   
```
