### PR TITLE
Remove Mako from mocked deps for docs build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,8 +91,6 @@ MOCK_MODULES = [
     # modules, renderers, states, returners, et al
     'django',
     'libvirt',
-    'mako',
-    'mako.template',
     'MySQLdb',
     'MySQLdb.cursors',
     'psutil',


### PR DESCRIPTION
If Mako was mocked for a reason originally, it doesn't seem to be needed
anymore. The docs build just fine with and without Mako installed.

Closes #9571 (at long last).
