### PR TITLE
Fix influx API name warnings and user delete bug

### DIFF
--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -491,7 +491,7 @@ def login_test(name, password, database=None, host=None, port=None):
         client.get_list_database()
         return True
     except InfluxDBClientError as e:
-        if e.status_code == 401:
+        if e.code == 401:
             return False
         else:
             raise

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -455,8 +455,8 @@ def query(database, query, time_precision='s', chunked=False, user=None,
     client.switch_database(database)
     return client.query(query, time_precision=time_precision, chunked=chunked)
 
-def login_test(
-        name, password, database=None, host=None, port=None):
+
+def login_test(name, password, database=None, host=None, port=None):
     '''
     Checks if a credential pair can log in at all.
 
@@ -490,5 +490,8 @@ def login_test(
         client = _client(user=name, password=password, host=host, port=port)
         client.get_list_database()
         return True
-    except:
-        return False
+    except InfluxDBClientError as e:
+        if e.status_code == 401:
+            return False
+        else:
+            raise

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -490,7 +490,7 @@ def login_test(name, password, database=None, host=None, port=None):
         client = _client(user=name, password=password, host=host, port=port)
         client.get_list_database()
         return True
-    except InfluxDBClientError as e:
+    except influxdb.client.InfluxDBClientError as e:
         if e.code == 401:
             return False
         else:

--- a/salt/modules/influx.py
+++ b/salt/modules/influx.py
@@ -83,7 +83,7 @@ def db_list(user=None, password=None, host=None, port=None):
 
     """
     client = _client(user=user, password=password, host=host, port=port)
-    return client.get_database_list()
+    return client.get_list_database()
 
 
 def db_exists(name, user=None, password=None, host=None, port=None):
@@ -216,7 +216,7 @@ def user_list(database=None, user=None, password=None, host=None, port=None):
     """
     client = _client(user=user, password=password, host=host, port=port)
     if database:
-        client.switch_db(database)
+        client.switch_database(database)
         return client.get_database_users()
     return client.get_list_cluster_admins()
 
@@ -308,7 +308,7 @@ def user_create(name, passwd, database=None, user=None, password=None,
 
     client = _client(user=user, password=password, host=host, port=port)
     if database:
-        client.switch_db(database)
+        client.switch_database(database)
         return client.add_database_user(name, passwd)
     return client.add_cluster_admin(name, passwd)
 
@@ -359,7 +359,7 @@ def user_chpass(name, passwd, database=None, user=None, password=None,
         return False
     client = _client(user=user, password=password, host=host, port=port)
     if database:
-        client.switch_db(database)
+        client.switch_database(database)
         return client.update_database_user_password(name, passwd)
     return client.update_cluster_admin_password(name, passwd)
 
@@ -410,9 +410,9 @@ def user_remove(name, database=None, user=None, password=None, host=None,
         return False
     client = _client(user=user, password=password, host=host, port=port)
     if database:
-        client.switch_db(database)
-        return client.delete_database_user(user)
-    return client.delete_cluster_admin(user)
+        client.switch_database(database)
+        return client.delete_database_user(name)
+    return client.delete_cluster_admin(name)
 
 
 def query(database, query, time_precision='s', chunked=False, user=None,
@@ -452,5 +452,43 @@ def query(database, query, time_precision='s', chunked=False, user=None,
         salt '*' influxdb.query <database> <query> <time_precision> <chunked> <user> <password> <host> <port>
     """
     client = _client(user=user, password=password, host=host, port=port)
-    client.switch_db(database)
+    client.switch_database(database)
     return client.query(query, time_precision=time_precision, chunked=chunked)
+
+def login_test(
+        name, password, database=None, host=None, port=None):
+    '''
+    Checks if a credential pair can log in at all.
+
+    If a database is specified: it will check for database user existence.
+    If a database is not specified: it will check for cluster admin existence.
+
+    name
+        The user to connect as
+
+    password
+        The password of the user
+
+    database
+        The database to try to log in to
+
+    host
+        The host to connect to
+
+    port
+        The port to connect to
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' influxdb.login_test <name>
+        salt '*' influxdb.login_test <name> <database>
+        salt '*' influxdb.login_test <name> <database> <user> <password> <host> <port>
+    '''
+    try:
+        client = _client(user=name, password=password, host=host, port=port)
+        client.get_list_database()
+        return True
+    except:
+        return False


### PR DESCRIPTION
Some influxdb python API methods changed names and were generating
warnings every time this module was run.

The user_remove method had a bug that actually deleted the user you were
logged in as rather than the user you wanted to delete when run.

Added a method to test login for a user to see if they exist (mostly to
work around a use case described in #20496.) - for example to try logging
in as root:root to see if it's been deleted.
