### PR TITLE
include rackconnectv3 variable

### DIFF
--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -610,13 +610,26 @@ def create(vm_):
             # Still not running, trigger another iteration
             return
 
+        rackconnectv3 = config.get_cloud_config_value(
+            'rackconnectv3', vm_, __opts__, default='False',
+            search_global=False
+        )
+
+        if rackconnectv3:
+            networkname = rackconnectv3
+            for network in node['addresses'].get(networkname, []):
+                if network['version'] is 4:
+                    node['extra']['access_ip'] = network['addr']
+                    break
+            vm_['rackconnect'] = True
+
         if rackconnect(vm_) is True:
             extra = node.get('extra', {})
             rc_status = extra.get('metadata', {}).get(
                 'rackconnect_automation_status', '')
             access_ip = extra.get('access_ip', '')
 
-            if rc_status != 'DEPLOYED':
+            if rc_status != 'DEPLOYED' and not rackconnectv3:
                 log.debug('Waiting for Rackconnect automation to complete')
                 return
 
@@ -663,7 +676,7 @@ def create(vm_):
                         result.append(private_ip)
 
         if rackconnect(vm_) is True:
-            if ssh_interface(vm_) != 'private_ips':
+            if ssh_interface(vm_) != 'private_ips' or rackconnectv3:
                 data.public_ips = access_ip
                 return data
 

--- a/salt/cloud/clouds/nova.py
+++ b/salt/cloud/clouds/nova.py
@@ -89,6 +89,9 @@ accept them
 
 Note: You must include the default net-ids when setting networks or the server
 will be created without the rest of the interfaces
+
+Note: For rackconnect v3, rackconnectv3 needs to be specified with the
+rackconnect v3 cloud network as it's variable
 '''
 from __future__ import absolute_import
 # pylint: disable=E0102

--- a/salt/utils/openstack/nova.py
+++ b/salt/utils/openstack/nova.py
@@ -60,13 +60,22 @@ class NovaServer(object):
             'access_ip': server['accessIPv4']
         }
 
-        if 'addresses' in server and 'public' in server['addresses']:
-            self.public_ips = [
-                ip['addr'] for ip in server['addresses']['public']
-            ]
-            self.private_ips = [
-                ip['addr'] for ip in server['addresses']['private']
-            ]
+        if 'addresses' in server:
+            if 'public' in server['addresses']:
+                self.public_ips = [
+                    ip['addr'] for ip in server['addresses']['public']
+                ]
+            else:
+                self.public_ips = []
+
+            if 'private' in server['addresses']:
+                self.private_ips = [
+                    ip['addr'] for ip in server['addresses']['private']
+                ]
+            else:
+                self.private_ips = []
+
+            self.addresses = server['addresses']
 
         if password:
             self.extra['password'] = password


### PR DESCRIPTION
While doing my rackconnect v3 stuff for saltconf, I realized that the ip for the rackconnectv3 network is not placed in the access_ipv4 slot in the metadata for the server.

This includes a rackconnectv3 variable in the config which allows you to set the variable name of the server to login to for ssh_interface, so that you can bootstrap through the rackconnectv3 cloud network, since a public ip address is not automatically provisioned on these servers.

Thanks
Daniel
