### PR TITLE
Fix #18689 by handling psutil exceptions.

### DIFF
--- a/salt/modules/ps.py
+++ b/salt/modules/ps.py
@@ -64,7 +64,12 @@ def _get_proc_name(proc):
 
     It's backward compatible with < 2.0 versions of psutil.
     '''
-    return proc.name() if PSUTIL2 else proc.name
+    ret = []
+    try:
+        ret = proc.name() if PSUTIL2 else proc.name
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+    return ret
 
 
 def _get_proc_status(proc):


### PR DESCRIPTION
The information of some processes can't be accessed on Windows when
they're run under the 'LOCAL SERVICE' account.
This caused exceptions which bubbled up into `ps.pgrep` and caused
there backtraces as described in #18689.
