### PR TITLE
don't use empty string as command parameter

### DIFF
--- a/salt/modules/linux_lvm.py
+++ b/salt/modules/linux_lvm.py
@@ -71,7 +71,9 @@ def pvdisplay(pvname=''):
         salt '*' lvm.pvdisplay /dev/md0
     '''
     ret = {}
-    cmd = ['pvdisplay', '-c', pvname]
+    cmd = ['pvdisplay', '-c']
+    if pvname:
+        cmd.append(pvname)
     cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if cmd_ret['retcode'] != 0:
@@ -109,7 +111,9 @@ def vgdisplay(vgname=''):
         salt '*' lvm.vgdisplay nova-volumes
     '''
     ret = {}
-    cmd = ['vgdisplay', '-c', vgname]
+    cmd = ['vgdisplay', '-c']
+    if vgname:
+        cmd.append(vgname)
     cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if cmd_ret['retcode'] != 0:
@@ -152,7 +156,9 @@ def lvdisplay(lvname=''):
         salt '*' lvm.lvdisplay /dev/vg_myserver/root
     '''
     ret = {}
-    cmd = ['lvdisplay', '-c', lvname]
+    cmd = ['lvdisplay', '-c']
+    if lvname:
+        cmd.append(lvname)
     cmd_ret = __salt__['cmd.run_all'](cmd, python_shell=False)
 
     if cmd_ret['retcode'] != 0:


### PR DESCRIPTION
This should fix the various display commands for the linux_lvm module.
