### PR TITLE
Fix for permission errors in cachedir and pkidir when running minion as non-root

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -469,7 +469,8 @@ class Auth(object):
                 log.info('Received signed and verified master pubkey '
                          'from master {0}'.format(self.opts['master']))
                 m_pub_fn = os.path.join(self.opts['pki_dir'], self.mpub)
-                salt.utils.fopen(m_pub_fn, 'w+').write(payload['pub_key'])
+                uid = salt.utils.get_uid(self.opts.get('user', None))
+                salt.utils.fopen(m_pub_fn, 'w+', uid=uid).write(payload['pub_key'])
                 return True
             else:
                 log.error('Received signed public-key from master {0} '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -137,15 +137,60 @@ def resolve_dns(opts):
     return ret
 
 
-def get_proc_dir(cachedir):
+def get_proc_dir(cachedir, **kwargs):
     '''
     Given the cache directory, return the directory that process data is
     stored in, creating it if it doesn't exist.
+
+    The following optional Keyword Arguments are handled:
+
+      mode: which is anything os.makedirs would accept as mode.
+
+      uid: the uid to set, if not set, or it is None or -1 no changes are
+           made. Same applies if the directory is already owned by this
+           uid. Must be int. Works only on unix/unix like systems.
+
+      gid: the gid to set, if not set, or it is None or -1 no changes are
+           made. Same applies if the directory is already owned by this
+           gid. Must be int. Works only on unix/unix like systems.
     '''
+
     fn_ = os.path.join(cachedir, 'proc')
+    mode = kwargs.pop('mode', None)
+    if mode is None:
+        mode = {}
+    else:
+        mode = {'mode': mode}
+
     if not os.path.isdir(fn_):
-        # proc_dir is not present, create it
-        os.makedirs(fn_)
+        # proc_dir is not present, create it with mode settings
+        os.makedirs(fn_, **mode)
+        d_stat = os.stat(fn_)
+    else:
+        d_stat = os.stat(fn_)
+        # if mode is not an empty dict then we have an explicit
+        # dir mode. So lets check if mode needs to be changed.
+        if mode:
+            if d_stat.st_mode | mode['mode'] != d_stat.st_mode:
+                os.chmod(fn_, d_stat.st_mode | mode['mode'])
+
+    if hasattr(os, 'chmod'):
+        uid = kwargs.pop('uid', None)
+        gid = kwargs.pop('gid', None)
+
+        if uid is None:
+            # -1 means no change to current uid
+            uid = -1
+        if gid is None:
+            # -1 means no change to current gid
+            gid = -1
+
+        # if uid and gid are both -1 then go ahead with
+        # no changes at all
+        if (d_stat.st_uid != uid or d_stat.st_gid != gid) and \
+                [i for i in (uid, gid) if i != -1]:
+            os.chown(fn_, uid, gid)
+
     return fn_
 
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -174,7 +174,7 @@ def get_proc_dir(cachedir, **kwargs):
             if d_stat.st_mode | mode['mode'] != d_stat.st_mode:
                 os.chmod(fn_, d_stat.st_mode | mode['mode'])
 
-    if hasattr(os, 'chmod'):
+    if hasattr(os, 'chown'):
         uid = kwargs.pop('uid', None)
         gid = kwargs.pop('gid', None)
 

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -652,7 +652,10 @@ class Minion(MinionBase):
         self.mod_opts = self._prep_mod_opts()
         self.functions, self.returners = self._load_modules()
         self.matcher = Matcher(self.opts, self.functions)
-        self.proc_dir = get_proc_dir(opts['cachedir'])
+
+        uid = salt.utils.get_uid(opts.get('user', None))
+
+        self.proc_dir = get_proc_dir(opts['cachedir'], uid=uid)
         self.schedule = salt.utils.schedule.Schedule(
             self.opts,
             self.functions,

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2671,7 +2671,10 @@ class ProxyMinion(Minion):
         self.mod_opts = self._prep_mod_opts()
         self.functions, self.returners = self._load_modules()
         self.matcher = Matcher(self.opts, self.functions)
-        self.proc_dir = get_proc_dir(opts['cachedir'])
+
+        uid = salt.utils.get_uid(opts.get('user', None))
+
+        self.proc_dir = get_proc_dir(opts['cachedir'], uid=uid)
         self.schedule = salt.utils.schedule.Schedule(
             self.opts,
             self.functions,

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -266,6 +266,55 @@ def get_user():
     else:
         return getpass.getuser()
 
+def get_uid(user=None):
+    """
+    Get the uid for a given user name. If no user given,
+    the current euid will be returned. If the user
+    does not exist, then None will be returned. On
+    systems which do not support pwd, grp or os.geteuid
+    it will return None.
+    """
+    if pwd is None:
+        result =  None
+    elif user is None:
+        try:
+            result = os.geteuid()
+        except:
+            result = None
+    else:
+        try:
+            u_struct = pwd.getpwnam(user)
+        except KeyError:
+            result = None
+        else:
+            result = u_struct.pw_uid
+    return result
+
+def get_gid(group=None):
+    """
+    Get the gid for a given group name. If no group given,
+    the current egid will be returned. If the group
+    does not exist, then None will be returned. On
+    systems which do not support pwd, grp or os.getegid
+    it will return None.
+    """
+    if grp is None:
+        result =  None
+    elif group is None:
+        try:
+            result = os.getegid()
+        except:
+            result = None
+    else:
+        try:
+            g_struct = grp.getgrnam(group)
+        except KeyError:
+            result = None
+        else:
+            result = g_struct.gr_gid
+    return result
+
+
 
 def daemonize(redirect_out=True):
     '''


### PR DESCRIPTION
Greetings,

i've run into this when trying to run salt-minion (v2014.7.1) as a non-root.
Problem was that get_proc_dir creates cachedir/proc as user root and after
changing the user (after the double fork etc. pp)  this user can not read cachedir/proc.

I made this non-intrusive (hopefully ... haha), that means you can call get_proc_dir with
no change of the previous default behavior at all.

I also extended salt.utils with get_uid and get_gid convinient functions
and use salt.utils.get_uid in the Minion and ProxyMinion Classes (when they
call get_proc_dir in **init**).

I do not know if i should open a issue for this, for me it was more important to fix this.
There is another minion permission issue in combination with those options:

verify_master_pubkey_sign: True
always_verify_signature: True

The minion_master.pub in the minion pki dir gets created as root and then, again after the fork and user setting, the minion is no longer able to read/write to minion_master.pub. I will also have a fix for it, but i
just wanne know, if i can go ahead with the style and so on, or do i need something to change?
