### PR TITLE
Make log file group readable

### DIFF
--- a/salt/cli/daemons.py
+++ b/salt/cli/daemons.py
@@ -209,7 +209,7 @@ class Minion(parsers.MinionOptionParser):
                                                                 'udp://',
                                                                 'file://')):
                     # Logfile is not using Syslog, verify
-                    current_umask = os.umask(0o077)
+                    current_umask = os.umask(0o027)
                     verify_files([logfile], self.config['user'])
                     os.umask(current_umask)
         except OSError as err:


### PR DESCRIPTION
The log file can only read and written by root. Making the log file group readable allows users belonging to this group to read the salt log without becoming root first.

This is a follow-up merge request after #20469. For root:root owned log files, this commit should have no effect, but for root:adm owned log files (which I want to do for the Debian package) it has an effect.
