### PR TITLE
Layman improvements

### DIFF
--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -5,6 +5,7 @@ Support for Layman
 from __future__ import absolute_import
 
 import salt.utils
+import salt.exceptions
 
 
 def __virtual__():
@@ -46,7 +47,9 @@ def add(overlay):
     ret = list()
     old_overlays = list_local()
     cmd = 'layman --quietness=0 --add {0}'.format(overlay)
-    __salt__['cmd.retcode'](cmd, python_shell=False)
+    add_attempt = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if add_attempt['retcode'] != 0:
+        raise salt.exceptions.CommandExecutionError(add_attempt['stdout'])
     new_overlays = list_local()
 
     # If we did not have any overlays before and we successfully added
@@ -78,7 +81,9 @@ def delete(overlay):
     ret = list()
     old_overlays = list_local()
     cmd = 'layman --quietness=0 --delete {0}'.format(overlay)
-    __salt__['cmd.retcode'](cmd, python_shell=False)
+    delete_attempt = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if delete_attempt['retcode'] != 0:
+        raise salt.exceptions.CommandExecutionError(delete_attempt['stdout'])
     new_overlays = list_local()
 
     # If we now have no overlays added, We need to ensure that the make.conf

--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -127,3 +127,20 @@ def list_local():
     out = __salt__['cmd.run'](cmd, python_shell=False).split('\n')
     ret = [line.split()[1] for line in out if len(line.split()) > 2]
     return ret
+
+def list_all():
+    '''
+    List all overlays, including remote ones.
+
+    Return a list of available overlays:
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' layman.list_all
+    '''
+    cmd = 'layman --quietness=1 --list --nocolor'
+    out = __salt__['cmd.run'](cmd, python_shell=False).split('\n')
+    ret = [line.split()[1] for line in out if len(line.split()) > 2]
+    return ret

--- a/salt/modules/layman.py
+++ b/salt/modules/layman.py
@@ -133,6 +133,7 @@ def list_local():
     ret = [line.split()[1] for line in out if len(line.split()) > 2]
     return ret
 
+
 def list_all():
     '''
     List all overlays, including remote ones.

--- a/salt/states/layman.py
+++ b/salt/states/layman.py
@@ -39,17 +39,22 @@ def present(name):
         ret['result'] = None
         return ret
     else:
-        # Attempt to add the overlay
-        changes = __salt__['layman.add'](name)
-
-        # The overlay failed to add
-        if len(changes) < 1:
-            ret['comment'] = 'Overlay {0} failed to add'.format(name)
+        # Does the overlay exist?
+        if name not in __salt__['layman.list_all']():
+            ret['comment'] = 'Overlay {0} not found'.format(name)
             ret['result'] = False
-        # Success
         else:
-            ret['changes']['added'] = changes
-            ret['comment'] = 'Overlay {0} added.'.format(name)
+            # Attempt to add the overlay
+            changes = __salt__['layman.add'](name)
+
+            # The overlay failed to add
+            if len(changes) < 1:
+                ret['comment'] = 'Overlay {0} failed to add'.format(name)
+                ret['result'] = False
+            # Success
+            else:
+                ret['changes']['added'] = changes
+                ret['comment'] = 'Overlay {0} added.'.format(name)
 
     return ret
 


### PR DESCRIPTION
Relates to #20564 
I've included all 3 changes in a single PR to keep things simple.
- Add module function layman.list_all() to complement layman.list_local()
- Change state function layman.present() to check for the overlay in layman.list_all() and fail gracefully if not found.  This also triggers a sync, avoiding problems with stale overlay lists and uninitialized installs.
- Changed module function layman.add() and layman.delete() so that they raise an exception if the actual add/delete fails, thus exposing an problems that occur.

This change depends on #19238, due to the fix to `python_shell=False`, just in case it comes up.
