### PR TITLE
Change Adjective in Starting States Tutorial

### DIFF
--- a/doc/topics/tutorials/starting_states.rst
+++ b/doc/topics/tutorials/starting_states.rst
@@ -519,7 +519,7 @@ The above example could be written as:
     Pkg.installed("django")
 
 
-This Python examples would look like this if they were written in YAML:
+These Python examples would look like this if they were written in YAML:
 
 .. code-block:: yaml
 


### PR DESCRIPTION
The line which compares the previous two examples to the following YAML
example should use a demonstrative adjective like 'these'.
