### PR TITLE
Refactor iptables

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -292,6 +292,11 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         'reject-with',
         'set-mark',
         'set-xmark',
+        'log-level',
+        'log-ip-options',
+        'log-prefix',
+        'log-tcp-options',
+        'log-tcp-sequence',
     )
     for after_jump_argument in after_jump_arguments:
         if after_jump_argument in kwargs:

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -282,42 +282,25 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
     # Jumps should appear last, except for any arguments that are passed to
     # jumps, which of course need to follow.
     after_jump = []
-
-    if 'jump' in kwargs:
-        after_jump.append('--jump {0} '.format(kwargs['jump']))
-        del kwargs['jump']
-
-    if 'j' in kwargs:
-        after_jump.append('-j {0} '.format(kwargs['j']))
-        del kwargs['j']
-
-    if 'to-port' in kwargs:
-        after_jump.append('--to-port {0} '.format(kwargs['to-port']))
-        del kwargs['to-port']
-
-    if 'to-ports' in kwargs:
-        after_jump.append('--to-ports {0} '.format(kwargs['to-ports']))
-        del kwargs['to-ports']
-
-    if 'to-destination' in kwargs:
-        after_jump.append('--to-destination {0} '.format(kwargs['to-destination']))
-        del kwargs['to-destination']
-
-    if 'to-source' in kwargs:
-        after_jump.append('--to-source {0} '.format(kwargs['to-source']))
-        del kwargs['to-source']
-
-    if 'reject-with' in kwargs:
-        after_jump.append('--reject-with {0} '.format(kwargs['reject-with']))
-        del kwargs['reject-with']
-
-    if 'set-mark' in kwargs:
-        after_jump.append('--set-mark {0} '.format(kwargs['set-mark']))
-        del kwargs['set-mark']
-
-    if 'set-xmark' in kwargs:
-        after_jump.append('--set-xmark {0} '.format(kwargs['set-xmark']))
-        del kwargs['set-xmark']
+    after_jump_arguments = (
+        'jump',
+        'j',
+        'to-port',
+        'to-ports',
+        'to-destination',
+        'to-source',
+        'reject-with',
+        'set-mark',
+        'set-xmark',
+    )
+    for after_jump_argument in after_jump_arguments:
+        if after_jump_argument in kwargs:
+            value = kwargs[after_jump_argument]
+            if len(str(value).split()) > 1:
+                after_jump.append('--{0} "{1}"'.format(after_jump_argument, value))
+            else:
+                after_jump.append('--{0} {1}'.format(after_jump_argument, value))
+            del kwargs[after_jump_argument]
 
     for item in kwargs:
         if str(kwargs[item]).startswith('!') or str(kwargs[item]).startswith('not'):
@@ -329,8 +312,7 @@ def build_rule(table=None, chain=None, command=None, position='', full=None, fam
         else:
             rule += '--{0} {1} '.format(item, kwargs[item])
 
-    for item in after_jump:
-        rule += item
+    rule += ' '.join(after_jump)
 
     if full in ['True', 'true']:
         if not table:

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -10,6 +10,7 @@ import re
 import sys
 import uuid
 import shlex
+import string
 
 # Import salt libs
 import salt.utils
@@ -265,7 +266,7 @@ def build_rule(table='filter', chain=None, command=None, position='', full=None,
     for after_jump_argument in after_jump_arguments:
         if after_jump_argument in kwargs:
             value = kwargs[after_jump_argument]
-            if len(str(value).split()) > 1:
+            if any(ws_char in str(value) for ws_char in string.whitespace):
                 after_jump.append('--{0} "{1}"'.format(after_jump_argument, value))
             else:
                 after_jump.append('--{0} {1}'.format(after_jump_argument, value))

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -98,7 +98,7 @@ def version(family='ipv4'):
     return out[1]
 
 
-def build_rule(table=None, chain=None, command=None, position='', full=None, family='ipv4',
+def build_rule(table='filter', chain=None, command=None, position='', full=None, family='ipv4',
                **kwargs):
     '''
     Build a well-formatted iptables rule based on kwargs. Long options must be

--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -522,7 +522,7 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
         return False
     else:
         cmd = '{0} -t {1} -C {2} {3}'.format(ipt_cmd, table, chain, rule)
-        out = __salt__['cmd.run'](cmd)
+        out = __salt__['cmd.run'](cmd, output_loglevel='quiet')
 
     if not out:
         return True

--- a/salt/states/iptables.py
+++ b/salt/states/iptables.py
@@ -263,6 +263,9 @@ def chain_absent(name, table='filter', family='ipv4'):
 
     Verify the chain is absent.
 
+    table
+        The table to remove the chain from
+
     family
         Networking family, either ipv4 or ipv6
     '''
@@ -307,7 +310,7 @@ def chain_absent(name, table='filter', family='ipv4'):
     return ret
 
 
-def append(name, family='ipv4', **kwargs):
+def append(name, table='filter', family='ipv4', **kwargs):
     '''
     .. versionadded:: 0.17.0
 
@@ -316,6 +319,9 @@ def append(name, family='ipv4', **kwargs):
     name
         A user-defined name to call this rule by in another part of a state or
         formula. This should not be an actual rule.
+
+    table
+        The table that owns the chain which should be modified
 
     family
         Network family, ipv4 or ipv6.
@@ -365,7 +371,7 @@ def append(name, family='ipv4', **kwargs):
     kwargs['name'] = name
     rule = __salt__['iptables.build_rule'](family=family, **kwargs)
     command = __salt__['iptables.build_rule'](full='True', family=family, command='A', **kwargs)
-    if __salt__['iptables.check'](kwargs['table'],
+    if __salt__['iptables.check'](table,
                                   kwargs['chain'],
                                   rule,
                                   family) is True:
@@ -401,7 +407,7 @@ def append(name, family='ipv4', **kwargs):
             command.strip(),
             family)
         return ret
-    if __salt__['iptables.append'](kwargs['table'], kwargs['chain'], rule, family):
+    if __salt__['iptables.append'](table, kwargs['chain'], rule, family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
         ret['comment'] = 'Set iptables rule for {0} to: {1} for {2}'.format(
@@ -427,7 +433,7 @@ def append(name, family='ipv4', **kwargs):
         return ret
 
 
-def insert(name, family='ipv4', **kwargs):
+def insert(name, table='filter', family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
@@ -436,6 +442,9 @@ def insert(name, family='ipv4', **kwargs):
     name
         A user-defined name to call this rule by in another part of a state or
         formula. This should not be an actual rule.
+
+    table
+        The table that owns the chain that should be modified
 
     family
         Networking family, either ipv4 or ipv6
@@ -485,7 +494,7 @@ def insert(name, family='ipv4', **kwargs):
     kwargs['name'] = name
     rule = __salt__['iptables.build_rule'](family=family, **kwargs)
     command = __salt__['iptables.build_rule'](full=True, family=family, command='I', **kwargs)
-    if __salt__['iptables.check'](kwargs['table'],
+    if __salt__['iptables.check'](table,
                                   kwargs['chain'],
                                   rule,
                                   family) is True:
@@ -521,7 +530,7 @@ def insert(name, family='ipv4', **kwargs):
             family,
             command.strip())
         return ret
-    if not __salt__['iptables.insert'](kwargs['table'], kwargs['chain'], kwargs['position'], rule, family):
+    if not __salt__['iptables.insert'](table, kwargs['chain'], kwargs['position'], rule, family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
         ret['comment'] = 'Set iptables rule for {0} to: {1} for {2}'.format(
@@ -543,7 +552,7 @@ def insert(name, family='ipv4', **kwargs):
         return ret
 
 
-def delete(name, family='ipv4', **kwargs):
+def delete(name, table='filter', family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
@@ -552,6 +561,9 @@ def delete(name, family='ipv4', **kwargs):
     name
         A user-defined name to call this rule by in another part of a state or
         formula. This should not be an actual rule.
+
+    table
+        The table that owns the chain that should be modified
 
     family
         Networking family, either ipv4 or ipv6
@@ -601,7 +613,7 @@ def delete(name, family='ipv4', **kwargs):
     kwargs['name'] = name
     rule = __salt__['iptables.build_rule'](family=family, **kwargs)
     command = __salt__['iptables.build_rule'](full=True, family=family, command='D', **kwargs)
-    if not __salt__['iptables.check'](kwargs['table'],
+    if not __salt__['iptables.check'](table,
                                       kwargs['chain'],
                                       rule,
                                       family) is True:
@@ -620,13 +632,13 @@ def delete(name, family='ipv4', **kwargs):
 
     if 'position' in kwargs:
         result = __salt__['iptables.delete'](
-                kwargs['table'],
+                table,
                 kwargs['chain'],
                 family=family,
                 position=kwargs['position'])
     else:
         result = __salt__['iptables.delete'](
-                kwargs['table'],
+                table,
                 kwargs['chain'],
                 family=family,
                 rule=rule)
@@ -652,11 +664,14 @@ def delete(name, family='ipv4', **kwargs):
         return ret
 
 
-def set_policy(name, family='ipv4', **kwargs):
+def set_policy(name, table='filter', family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
     Sets the default policy for iptables firewall tables
+
+    table
+        The table that owns the chain that should be modified
 
     family
         Networking family, either ipv4 or ipv6
@@ -675,23 +690,23 @@ def set_policy(name, family='ipv4', **kwargs):
             del kwargs[ignore]
 
     if __salt__['iptables.get_policy'](
-            kwargs['table'],
+            table,
             kwargs['chain'],
             family) == kwargs['policy']:
         ret['result'] = True
         ret['comment'] = ('iptables default policy for chain {0} on table {1} for {2} already set to {3}'
-                          .format(kwargs['chain'], kwargs['table'], family, kwargs['policy']))
+                          .format(kwargs['chain'], table, family, kwargs['policy']))
         return ret
     if __opts__['test']:
         ret['comment'] = 'iptables default policy for chain {0} on table {1} for {2} needs to be set to {3}'.format(
             kwargs['chain'],
-            kwargs['table'],
+            table,
             family,
             kwargs['policy']
         )
         return ret
     if not __salt__['iptables.set_policy'](
-            kwargs['table'],
+            table,
             kwargs['chain'],
             kwargs['policy'],
             family):
@@ -717,11 +732,14 @@ def set_policy(name, family='ipv4', **kwargs):
         return ret
 
 
-def flush(name, family='ipv4', **kwargs):
+def flush(name, table='filter', family='ipv4', **kwargs):
     '''
     .. versionadded:: 2014.1.0
 
     Flush current iptables state
+
+    table
+        The table that owns the chain that should be modified
 
     family
         Networking family, either ipv4 or ipv6
@@ -737,21 +755,21 @@ def flush(name, family='ipv4', **kwargs):
             del kwargs[ignore]
 
     if 'table' not in kwargs:
-        kwargs['table'] = 'filter'
+        table = 'filter'
 
     if 'chain' not in kwargs:
         kwargs['chain'] = ''
     if __opts__['test']:
         ret['comment'] = 'iptables rules in {0} table {1} chain {2} family needs to be flushed'.format(
             name,
-            kwargs['table'],
+            table,
             family)
         return ret
-    if not __salt__['iptables.flush'](kwargs['table'], kwargs['chain'], family):
+    if not __salt__['iptables.flush'](table, kwargs['chain'], family):
         ret['changes'] = {'locale': name}
         ret['result'] = True
         ret['comment'] = 'Flush iptables rules in {0} table {1} chain {2} family'.format(
-            kwargs['table'],
+            table,
             kwargs['chain'],
             family
         )

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -54,6 +54,38 @@ class IptablesTestCase(TestCase):
         '''
         self.assertEqual(iptables.build_rule(), '')
 
+        self.assertEqual(iptables.build_rule(name='ignored', state='ignored'),
+                         '',
+                         'build_rule should ignore name and state')
+
+        # Should properly negate bang-prefixed values
+        self.assertEqual(iptables.build_rule(**{'if': '!eth0'}),
+                         '! -i eth0 ')
+
+        # Should properly negate "not"-prefixed values
+        self.assertEqual(iptables.build_rule(**{'if': 'not eth0'}),
+                         '! -i eth0 ')
+
+        self.assertEqual(iptables.build_rule(dports=[80, 443], proto='tcp'),
+                         '-p tcp -m multiport --dports 80,443 ')
+
+        self.assertEqual(iptables.build_rule(dports='80,443', proto='tcp'),
+                         '-p tcp -m multiport --dports 80,443 ')
+
+        # Should it really behave this way?
+        self.assertEqual(iptables.build_rule(dports=['!80', 443],
+                                             proto='tcp'),
+                         '-p tcp -m multiport ! --dports 80,443 ')
+
+        self.assertEqual(iptables.build_rule(dports='!80,443', proto='tcp'),
+                         '-p tcp -m multiport ! --dports 80,443 ')
+
+        self.assertEqual(iptables.build_rule(sports=[80, 443], proto='tcp'),
+                         '-p tcp -m multiport --sports 80,443 ')
+
+        self.assertEqual(iptables.build_rule(sports='80,443', proto='tcp'),
+                         '-p tcp -m multiport --sports 80,443 ')
+
         self.assertEqual(iptables.build_rule('filter', 'INPUT', command='I',
                                              position='3', full=True,
                                              dports='proto', jump='ACCEPT'),

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -84,6 +84,11 @@ class IptablesTestCase(TestCase):
                                              **{'to-port': 8080}),
                          '--jump REDIRECT --to-port 8080')
 
+        # Should handle arguments with spaces to f. ex log-prefix
+        self.assertEqual(iptables.build_rule(jump='LOG',
+                                             **{'log-prefix': 'long prefix'}),
+                         '--jump LOG --log-prefix "long prefix"')
+
         ret = '/sbin/iptables --wait -t salt -I INPUT 3 -m state --jump ACCEPT '
         with patch.object(iptables, '_iptables_cmd',
                           MagicMock(return_value='/sbin/iptables')):

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -116,10 +116,15 @@ class IptablesTestCase(TestCase):
                                              **{'to-port': 8080}),
                          '--jump REDIRECT --to-port 8080')
 
-        # Should handle arguments with spaces to f. ex log-prefix
+        # Should quote arguments with spaces, like log-prefix often has
         self.assertEqual(iptables.build_rule(jump='LOG',
                                              **{'log-prefix': 'long prefix'}),
                          '--jump LOG --log-prefix "long prefix"')
+
+        # Should quote arguments with leading or trailing spaces
+        self.assertEqual(iptables.build_rule(jump='LOG',
+                                             **{'log-prefix': 'spam: '}),
+                         '--jump LOG --log-prefix "spam: "')
 
         ret = '/sbin/iptables --wait -t salt -I INPUT 3 -m state --jump ACCEPT'
         with patch.object(iptables, '_iptables_cmd',

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -79,6 +79,11 @@ class IptablesTestCase(TestCase):
                                              match='state', jump='ACCEPT'),
                          'Error: Command needs to be specified')
 
+        # Test arguments that should appear after the --jump
+        self.assertEqual(iptables.build_rule(jump='REDIRECT',
+                                             **{'to-port': 8080}),
+                         '--jump REDIRECT --to-port 8080')
+
         ret = '/sbin/iptables --wait -t salt -I INPUT 3 -m state --jump ACCEPT '
         with patch.object(iptables, '_iptables_cmd',
                           MagicMock(return_value='/sbin/iptables')):

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -60,31 +60,31 @@ class IptablesTestCase(TestCase):
 
         # Should properly negate bang-prefixed values
         self.assertEqual(iptables.build_rule(**{'if': '!eth0'}),
-                         '! -i eth0 ')
+                         '! -i eth0')
 
         # Should properly negate "not"-prefixed values
         self.assertEqual(iptables.build_rule(**{'if': 'not eth0'}),
-                         '! -i eth0 ')
+                         '! -i eth0')
 
         self.assertEqual(iptables.build_rule(dports=[80, 443], proto='tcp'),
-                         '-p tcp -m multiport --dports 80,443 ')
+                         '-p tcp -m multiport --dports 80,443')
 
         self.assertEqual(iptables.build_rule(dports='80,443', proto='tcp'),
-                         '-p tcp -m multiport --dports 80,443 ')
+                         '-p tcp -m multiport --dports 80,443')
 
         # Should it really behave this way?
         self.assertEqual(iptables.build_rule(dports=['!80', 443],
                                              proto='tcp'),
-                         '-p tcp -m multiport ! --dports 80,443 ')
+                         '-p tcp -m multiport ! --dports 80,443')
 
         self.assertEqual(iptables.build_rule(dports='!80,443', proto='tcp'),
-                         '-p tcp -m multiport ! --dports 80,443 ')
+                         '-p tcp -m multiport ! --dports 80,443')
 
         self.assertEqual(iptables.build_rule(sports=[80, 443], proto='tcp'),
-                         '-p tcp -m multiport --sports 80,443 ')
+                         '-p tcp -m multiport --sports 80,443')
 
         self.assertEqual(iptables.build_rule(sports='80,443', proto='tcp'),
-                         '-p tcp -m multiport --sports 80,443 ')
+                         '-p tcp -m multiport --sports 80,443')
 
         self.assertEqual(iptables.build_rule('filter', 'INPUT', command='I',
                                              position='3', full=True,
@@ -121,7 +121,7 @@ class IptablesTestCase(TestCase):
                                              **{'log-prefix': 'long prefix'}),
                          '--jump LOG --log-prefix "long prefix"')
 
-        ret = '/sbin/iptables --wait -t salt -I INPUT 3 -m state --jump ACCEPT '
+        ret = '/sbin/iptables --wait -t salt -I INPUT 3 -m state --jump ACCEPT'
         with patch.object(iptables, '_iptables_cmd',
                           MagicMock(return_value='/sbin/iptables')):
             self.assertEqual(iptables.build_rule('salt', 'INPUT', command='I',


### PR DESCRIPTION
Adds some tests and support for --log-\* arguments.

Also stops writing to error log for the checks (`iptables -C`), since it's not really a failure.

And most importantly, makes the module much more readable.

Some questions:
- The `build_rule` function returns strings on errors ("Error: Table needs to be specified"), is is better if this raises an exception instead?
- The `table` argument to `build_rule` defaults to `None`, wouldn't it be simpler for this to default to `'filter'`, and thus not require that to be specified everywhere? (That would also close #18745)
- The iptables state isn't able to track changes to a state, and will duplicate the entry if anything is changed (such as a comment, a source IP, etc). Is it possible to maybe add a comment or something to to track where each line comes from, to be able to update the entry in case of modifications? Like SALT_ID: sha1(<state-identifier>)[:10]? Sort of like how the cron state does it. The workaround I've come up with involves flushing the rules on every state run, but that leaves a small window of opporunity between rules being flushed and applied again, so it's not ideal.
