### PR TITLE
Avoid trying to deserialize empty files

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -109,7 +109,8 @@ class Serial(object):
         '''
         data = fn_.read()
         fn_.close()
-        return self.loads(data)
+        if data:
+            return self.loads(data)
 
     def dumps(self, msg):
         '''


### PR DESCRIPTION
This fixes errors encountered by the minion where an attempt to read an empty file from the cache will produce msgpack exceptions in the log.
