### PR TITLE
Consistent logging for pcre match in flat roster

### DIFF
--- a/salt/roster/flat.py
+++ b/salt/roster/flat.py
@@ -73,6 +73,7 @@ class RosterMatcher(object):
                 data = self.get_data(minion)
                 if data:
                     minions[minion] = data
+        log.info('minions list: {0}'.format(minions))
         return minions
 
     def get_data(self, minion):


### PR DESCRIPTION
Version: salt-ssh 2015.2.0-3142-g9f34874 (Lithium)

Logging was missing for pcre matching on the `flat.py` roster.
