### PR TITLE
Don't use salt.utils.cloud.bootstrap to set defaults

### DIFF
--- a/salt/cloud/clouds/msazure.py
+++ b/salt/cloud/clouds/msazure.py
@@ -787,9 +787,6 @@ def create(vm_):
         )
         ret['Attached Volumes'] = created
 
-    for key, value in salt.utils.cloud.bootstrap(vm_, __opts__).items():
-        ret.setdefault(key, value)
-
     data = show_instance(vm_['name'], call='action')
     log.info('Created Cloud VM {0[name]!r}'.format(vm_))
     log.debug(


### PR DESCRIPTION
Calling bootstrap here is unnecessary. The azure driver is bootstrapping
the minion before we even make it to this point in the code.

Fixes #20362
