### PR TITLE
change incorrect 'text' outputter to 'txt'

### DIFF
--- a/salt/output/__init__.py
+++ b/salt/output/__init__.py
@@ -82,10 +82,10 @@ def get_printout(out, opts=None, **kwargs):
     if 'output' in opts:
         # new --out option
         out = opts['output']
-        if out == 'text':
-            out = 'txt'
 
-    if out is None:
+    if out == 'text':
+        out = 'txt'
+    elif out is None:
         out = 'nested'
 
     opts.update(kwargs)

--- a/tests/integration/shell/matcher.py
+++ b/tests/integration/shell/matcher.py
@@ -215,23 +215,23 @@ class MatchTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
         '''
         Test to see if we're supporting --doc
         '''
-        data = self.run_salt(r'-d \* user')
-        self.assertIn('user.add:', data)
+        data = self.run_salt('-d "*" user')
+        self.assertIn("'user.add:'", data)
 
     def test_salt_documentation_arguments_not_assumed(self):
         '''
         Test to see if we're not auto-adding '*' and 'sys.doc' to the call
         '''
         data = self.run_salt('-d -t 20')
-        self.assertIn('user.add:', data)
-        data = self.run_salt('\'*\' -d -t 20')
-        self.assertIn('user.add:', data)
-        data = self.run_salt('\'*\' -d user -t 20')
-        self.assertIn('user.add:', data)
-        data = self.run_salt('\'*\' sys.doc -d user -t 20')
-        self.assertIn('user.add:', data)
-        data = self.run_salt('\'*\' sys.doc user -t 20')
-        self.assertIn('user.add:', data)
+        self.assertIn("'user.add:'", data)
+        data = self.run_salt('"*" -d -t 20')
+        self.assertIn("'user.add:'", data)
+        data = self.run_salt('"*" -d user -t 20')
+        self.assertIn("'user.add:'", data)
+        data = self.run_salt('"*" sys.doc -d user -t 20')
+        self.assertIn("'user.add:'", data)
+        data = self.run_salt('"*" sys.doc user -t 20')
+        self.assertIn("'user.add:'", data)
 
     def test_salt_documentation_too_many_arguments(self):
         '''

--- a/tests/integration/shell/runner.py
+++ b/tests/integration/shell/runner.py
@@ -80,7 +80,7 @@ class RunTest(integration.ShellCase, integration.ShellCaseCommonTestsMixIn):
             with_retcode=True
         )
         try:
-            self.assertIn('doc.runner:', ret[0])
+            self.assertIn("'doc.runner:'", ret[0])
             self.assertFalse(os.path.isdir(os.path.join(config_dir, 'file:')))
         except AssertionError:
             if os.path.exists('/dev/log') and ret[2] != 2:


### PR DESCRIPTION
Fixes #20612.  As to why the messages were going to the cli rather than
the log is an issue for someone more wise and wizardly.  I nominate
@cachedout.
