### PR TITLE
Raise KeyError for None key in lazy loader

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1030,7 +1030,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         Load a single item if you have it
         '''
         # if the key doesn't have a '.' then it isn't valid for this mod dict
-        if '.' not in key:
+        if key is None or '.' not in key:
             raise KeyError
         mod_name, _ = key.split('.', 1)
         if mod_name in self.missing_modules:


### PR DESCRIPTION
When it's checked for key containment with 'in', [] or get(), lazy loader shall always either return the result or raise the KeyError.
Fixed lazy loader behavior for key = None.
