### PR TITLE
Fixed wrong placement of speechmarks

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -138,7 +138,7 @@ def set_locale(locale):
         )
         if __salt__['cmd.retcode']('grep "^LANG=" /etc/default/locale') != 0:
             __salt__['file.append']('/etc/default/locale',
-                                    '"\nLANG={0}"'.format(locale))
+                                    '\nLANG="{0}"'.format(locale))
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'eselect --brief locale set {0}'.format(locale)
         return __salt__['cmd.retcode'](cmd, python_shell=False) == 0


### PR DESCRIPTION
No idea why this is in the codebase for so long. Maybe all systems tested on never reach that line of code because the LANG line is always existing while executing the mod.
