### PR TITLE
Fixed wrong placement of speechmarks

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -136,7 +136,7 @@ def set_locale(locale):
         )
         if __salt__['cmd.retcode']('grep "^LANG=" /etc/default/locale') != 0:
             __salt__['file.append']('/etc/default/locale',
-                                    '"\nLANG={0}"'.format(locale))
+                                    '\nLANG="{0}"'.format(locale))
     elif 'Gentoo' in __grains__['os_family']:
         cmd = 'eselect --brief locale set {0}'.format(locale)
         return __salt__['cmd.retcode'](cmd, python_shell=False) == 0


### PR DESCRIPTION
This bug leads to `/etc/default/locale` files like

```
# this line has already been there"
LANG=en_us.UTF-8"
```

with the fix, it will read 

```
# this line has already been there
LANG="en_us.UTF-8"
```
