### PR TITLE
Revert "fix mysql returner for syndic master job cache"

### DIFF
--- a/salt/returners/mysql.py
+++ b/salt/returners/mysql.py
@@ -191,16 +191,10 @@ def returner(ret):
                     (`fun`, `jid`, `return`, `id`, `success`, `full_ret` )
                     VALUES (%s, %s, %s, %s, %s, %s)'''
 
-            success = 'None'
-            if 'success' in ret:
-                success = ret['success']
-            fun = 'None'
-            if 'fun' in ret:
-                fun = ret['fun']
-            cur.execute(sql, (fun, ret['jid'],
+            cur.execute(sql, (ret['fun'], ret['jid'],
                               json.dumps(ret['return']),
                               ret['id'],
-                              success,
+                              ret['success'],
                               json.dumps(ret)))
     except salt.exceptions.SaltMasterError:
         log.critical('Could not store return with MySQL returner. MySQL server unavailable.')
@@ -228,11 +222,11 @@ def save_load(jid, load):
     '''
     with _get_serv(commit=True) as cur:
 
-        sql = '''INSERT INTO `jids` (`jid`, `load`)
-                SELECT %s, %s FROM DUAL
-                WHERE NOT EXISTS (SELECT `jid` FROM `jids` where `jid`=%s)'''
+        sql = '''INSERT INTO `jids`
+               (`jid`, `load`)
+                VALUES (%s, %s)'''
 
-        cur.execute(sql, (jid, json.dumps(load), jid))
+        cur.execute(sql, (jid, json.dumps(load)))
 
 
 def get_load(jid):


### PR DESCRIPTION
Reverts saltstack/salt#19933

This is causing deadlocks in the returner and crashing the master with master_job_cache. This was added to prevent collisions with syndics, but the real solution is to not enable a master job cache on multiple layers of masters.
