### PR TITLE
Support for Raet 0.6.0 with enums

### DIFF
--- a/requirements/raet.txt
+++ b/requirements/raet.txt
@@ -1,5 +1,5 @@
 -r base.txt
 
-libnacl
-ioflo
-raet
+libnacl >= 1.0.0
+ioflo >= 1.1.7
+raet >= 0.6.0

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -369,7 +369,7 @@ class RAETCaller(BaseCaller):
                           lanename=lanename,
                           sockdirpath=sockdirpath)
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         stack.addRemote(RemoteYard(stack=stack,
                                    name='manor',
                                    lanename=lanename,

--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -73,7 +73,7 @@ class LocalClient(salt.client.LocalClient):
                 name=name,
                 lanename=lanename,
                 sockdirpath=sockdirpath)
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         manor_yard = RemoteYard(
                 stack=stack,
                 lanename=lanename,

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -239,7 +239,7 @@ class SaltRaetRoadStackSetup(ioflo.base.deeding.Deed):
         '''
         Assign class defaults
         '''
-        RoadStack.Bk = raeting.bodyKinds.msgpack
+        RoadStack.Bk = raeting.BodyKind.msgpack.value
         RoadStack.JoinentTimeout = 0.0
 
     def action(self):
@@ -440,7 +440,7 @@ class SaltRaetRoadStackRejected(ioflo.base.deeding.Deed):
         rejected = False
         if stack and isinstance(stack, RoadStack):
             if stack.remotes:
-                rejected = all([remote.acceptance == raeting.acceptances.rejected
+                rejected = all([remote.acceptance == raeting.Acceptance.rejected.value
                                 for remote in stack.remotes.values()
                                 if remote.kind == kinds.applKinds.master])
             else:  # no remotes so assume rejected
@@ -818,7 +818,7 @@ class SaltRaetManorLaneSetup(ioflo.base.deeding.Deed):
                                     name=name,
                                     lanename=lanename,
                                     sockdirpath=self.opts.value['sock_dir'])
-        self.stack.value.Pk = raeting.packKinds.pack
+        self.stack.value.Pk = raeting.PackKind.pack.value
         self.event_yards.value = set()
         self.local_cmd.value = deque()
         self.remote_cmd.value = deque()
@@ -1851,7 +1851,7 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
                 lanename=lanename,
                 sockdirpath=sockdirpath)
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         # add remote for the manor yard
         stack.addRemote(RemoteYard(stack=stack,
                                    name='manor',

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -144,7 +144,7 @@ class SaltRaetWorkerSetup(ioflo.base.deeding.Deed):
                                      name=name,
                                      lanename=lanename,
                                      sockdirpath=sockdirpath)
-        self.stack.value.Pk = raeting.packKinds.pack
+        self.stack.value.Pk = raeting.PackKind.pack.value
         manor_yard = RemoteYard(
                                  stack=self.stack.value,
                                  name='manor',

--- a/salt/daemons/salting.py
+++ b/salt/daemons/salting.py
@@ -47,7 +47,7 @@ class SaltKeep(Keep):
                     'role', 'acceptance', 'verhex', 'pubhex']
     RemoteDumpFields = ['name', 'uid', 'fuid', 'ha', 'iha', 'natted', 'fqdn', 'dyned',
                          'sid', 'main', 'kind', 'joined', 'role']
-    Auto = raeting.autoModes.never #auto accept
+    Auto = raeting.AutoMode.never.value #auto accept
 
     def __init__(self, opts, prefix='estate', basedirpath='',  auto=None, **kwa):
         '''
@@ -56,9 +56,9 @@ class SaltKeep(Keep):
         basedirpath = basedirpath or os.path.join(opts['cache_dir'], 'raet')
         super(SaltKeep, self).__init__(prefix=prefix, basedirpath=basedirpath, **kwa)
         self.auto = (auto if auto is not None else
-                            (raeting.autoModes.always if opts['open_mode'] else
-                                (raeting.autoModes.once if opts['auto_accept'] else
-                                 raeting.autoModes.never)))
+                            (raeting.AutoMode.always.value if opts['open_mode'] else
+                                (raeting.AutoMode.once.value if opts['auto_accept'] else
+                                 raeting.AutoMode.never.value)))
         self.saltRaetKey = RaetKey(opts)
 
     def clearAllDir(self):
@@ -118,7 +118,7 @@ class SaltKeep(Keep):
             return None
 
         mid = data['role']
-        for status in raeting.ACCEPTANCES:
+        for status in [acceptance.name for acceptance in Acceptance]:
             keydata = self.saltRaetKey.read_remote(mid, status)
             if keydata:
                 break
@@ -128,7 +128,7 @@ class SaltKeep(Keep):
                          ('verhex', None),
                          ('pubhex', None)])
         else:
-            data.update(acceptance=raeting.ACCEPTANCES[status],
+            data.update(acceptance=raeting.Acceptance[status].value,
                         verhex=keydata['verify'],
                         pubhex=keydata['pub'])
 
@@ -151,7 +151,7 @@ class SaltKeep(Keep):
                     for name, data in keeps.items():
                         if data['role'] == mid:
                             keeps[name].update(
-                                    [('acceptance', raeting.ACCEPTANCES[status]),
+                                    [('acceptance', raeting.Acceptance[status].value),
                                      ('verhex', keydata['verify']),
                                      ('pubhex', keydata['pub'])])
         return keeps
@@ -250,9 +250,9 @@ class SaltKeep(Keep):
         Where status is acceptance status of role and keys
         and has value from raeting.acceptances
         '''
-        status = raeting.ACCEPTANCES[self.saltRaetKey.status(role,
+        status = raeting.Acceptance[self.saltRaetKey.status(role,
                                                              pubhex,
-                                                             verhex)]
+                                                             verhex)].value
 
         return status
 
@@ -262,7 +262,7 @@ class SaltKeep(Keep):
         '''
         mid = remote.role
         self.saltRaetKey.reject(match=mid, include_accepted=True)
-        remote.acceptance = raeting.acceptances.rejected
+        remote.acceptance = raeting.Acceptance.rejected.value
 
     def pendRemote(self, remote):
         '''
@@ -276,4 +276,4 @@ class SaltKeep(Keep):
         '''
         mid = remote.role
         self.saltRaetKey.accept(match=mid, include_rejected=True)
-        remote.acceptance = raeting.acceptances.accepted
+        remote.acceptance = raeting.Acceptance.accepted.value

--- a/salt/daemons/test/plan/actors.py
+++ b/salt/daemons/test/plan/actors.py
@@ -818,8 +818,8 @@ class StatsMinionTestSetup(ioflo.base.deeding.Deed):
         minionStack.addRemote(minionRemoteMaster)
 
         # Make life easier
-        masterStack.keep.auto = raeting.autoModes.always
-        minionStack.keep.auto = raeting.autoModes.always
+        masterStack.keep.auto = raeting.AutoMode.always.value
+        minionStack.keep.auto = raeting.AutoMode.always.value
 
         minionStack.join(minionRemoteMaster.uid)
         serviceRoads([minionStack, masterStack])

--- a/salt/daemons/test/test_saltkeep.py
+++ b/salt/daemons/test/test_saltkeep.py
@@ -236,7 +236,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertTrue(main.keep.dirpath.endswith(
                 os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {'name': mainData['name'],
                                                          'uid': 1,
                                                          'ha': ['127.0.0.1', 7530],
@@ -358,7 +358,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.never)
+        self.assertIs(other.keep.auto, raeting.AutoMode.never.value)
 
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
@@ -475,7 +475,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -596,7 +596,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto,raeting.autoModes.always)
+        self.assertIs(other.keep.auto,raeting.AutoMode.always.value)
 
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
@@ -713,7 +713,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto,  raeting.autoModes.once)
+        self.assertIs(main.keep.auto,  raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -836,7 +836,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.once)
+        self.assertIs(other.keep.auto, raeting.AutoMode.once.value)
 
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
@@ -954,7 +954,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {'name': mainData['name'],
                                                          'uid': 1,
                                                          'ha': ['127.0.0.1', 7530],
@@ -1057,7 +1057,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(main.local.uid, 1)
         self.assertEqual(main.main, True)
         self.assertEqual(main.local.role, mainData['role'])
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertEqual(main.local.priver.keyhex, mainData['prihex'])
         self.assertEqual(main.local.signer.keyhex, mainData['sighex'])
@@ -1102,7 +1102,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1200,7 +1200,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(main.local.uid, 1)
         self.assertEqual(main.main, True)
         self.assertEqual(main.local.role, mainData['role'])
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertEqual(main.local.priver.keyhex, mainData['prihex'])
         self.assertEqual(main.local.signer.keyhex, mainData['sighex'])
@@ -1246,7 +1246,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1351,7 +1351,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(main.local.uid, 1)
         self.assertEqual(main.main, True)
         self.assertEqual(main.local.role, mainData['role'])
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertEqual(main.local.priver.keyhex, mainData['prihex'])
         self.assertEqual(main.local.signer.keyhex, mainData['sighex'])
@@ -1398,7 +1398,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1439,7 +1439,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto,  raeting.autoModes.once)
+        self.assertIs(other.keep.auto,  raeting.AutoMode.once.value)
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
                                 'name': otherData['name'],
@@ -1524,7 +1524,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1565,7 +1565,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.once)
+        self.assertIs(other.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
                                 'name': otherData['name'],
@@ -1646,7 +1646,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertEqual(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1687,7 +1687,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.once)
+        self.assertIs(other.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
                                 'name': otherData['name'],
@@ -1768,7 +1768,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1809,7 +1809,7 @@ class BasicTestCase(unittest.TestCase):
                 other1.name, other1.keep.dirpath))
         self.assertTrue(other1.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_minion')))
         self.assertEqual(other1.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other1.keep.auto, raeting.autoModes.once)
+        self.assertIs(other1.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other1.keep.loadLocalData(),
                             {
                                 'name': other1Data['name'],
@@ -1877,7 +1877,7 @@ class BasicTestCase(unittest.TestCase):
                 other2.name, other2.keep.dirpath))
         self.assertTrue(other2.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_caller')))
         self.assertEqual(other2.ha, ("0.0.0.0", 7532))
-        self.assertIs(other2.keep.auto, raeting.autoModes.once)
+        self.assertIs(other2.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other2.keep.loadLocalData(),
                             {
                                 'name': other2Data['name'],
@@ -1937,7 +1937,7 @@ class BasicTestCase(unittest.TestCase):
                 other2.name, other2.keep.dirpath))
         self.assertTrue(other2.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_caller')))
         self.assertEqual(other2.ha, ("0.0.0.0", 7532))
-        self.assertIs(other2.keep.auto, raeting.autoModes.once)
+        self.assertIs(other2.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other2.keep.loadLocalData(),
                             {
                                 'name': other2Data['name'],
@@ -2023,7 +2023,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -2064,7 +2064,7 @@ class BasicTestCase(unittest.TestCase):
                 other1.name, other1.keep.dirpath))
         self.assertTrue(other1.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_minion')))
         self.assertEqual(other1.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other1.keep.auto, raeting.autoModes.once)
+        self.assertIs(other1.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other1.keep.loadLocalData(),
                             {
                                 'name': other1Data['name'],
@@ -2131,7 +2131,7 @@ class BasicTestCase(unittest.TestCase):
                 other2.name, other2.keep.dirpath))
         self.assertTrue(other2.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_caller')))
         self.assertEqual(other2.ha, ("0.0.0.0", 7532))
-        self.assertIs(other2.keep.auto, raeting.autoModes.once)
+        self.assertIs(other2.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other2.keep.loadLocalData(),
                             {
                                 'name': other2Data['name'],

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -160,7 +160,7 @@ class RAETChannel(Channel):
                           lanename=lanename,
                           sockdirpath=self.opts['sock_dir'])
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         stack.addRemote(RemoteYard(stack=stack,
                                    name=ryn,
                                    lanename=lanename,

--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -101,7 +101,7 @@ class RAETEvent(object):
                 name=name,
                 lanename=lanename,
                 sockdirpath=self.sock_dir)
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         stack.addRemote(RemoteYard(stack=stack,
                                    lanename=lanename,
                                    name=ryn,

--- a/salt/utils/raetlane.py
+++ b/salt/utils/raetlane.py
@@ -118,7 +118,7 @@ def _setup(opts, ryn='manor'):
                       lanename=lanename,
                       sockdirpath=opts['sock_dir'])
 
-    lane_stack.Pk = raeting.packKinds.pack
+    lane_stack.Pk = raeting.PackKind.pack.value
     log.debug("Created new LaneStack and local Yard named {0} at {1}\n"
               "".format(lane_stack.name, lane_stack.ha))
     remote_yard = RemoteYard(stack=lane_stack,


### PR DESCRIPTION
This adds support for Raet 0.6.0. 
Raet 0.6.0 replaced namedtuples in raet.raeting with Enum from the enum34 module for python < 3.4
the enum module is included in python3.4. This means raet has a new dep of enum34 package

Updated requirements/raet.txt to reflect these new requirements
