### PR TITLE
Update mongo_future_return.py

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -142,7 +142,8 @@ def save_load(jid, load):
     '''
     conn, mdb = _get_conn(ret=None)
     # save load in jobs collection in the json format: {'jid': <job_id>, 'load': <unformatted load data>}
-    mdb.jobs.insert('jid': jid, 'load': load)
+    sdata = {'jid': jid, 'load': load}
+    mdb.jobs.insert(sdata)
 
 
 def get_load(jid):

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -151,7 +151,7 @@ def get_load(jid):
     Return the load associated with a given job id
     '''
     conn, mdb = _get_conn(ret=None)
-    ret = mdb.jobs.find_one({'jid':jid})
+    ret = mdb.jobs.find_one({'jid': jid})
     return ret['load']
 
 


### PR DESCRIPTION
updating the mongo returner to use mongo correctly and instead of creating collections for every job and every minion putting the minion returns into the collection saltReturns and all jobs into the collection jobs. this will allow users to query the collections using mongo and will use proper keys and values so you no longer have to do full collection scans to get any information out of the database.
