### PR TITLE
Added plugin-sync capabilities to the puppet module.

### DIFF
--- a/salt/modules/puppet.py
+++ b/salt/modules/puppet.py
@@ -339,6 +339,23 @@ def summary():
 
     return result
 
+def plugin_sync():
+    '''
+    Runs a plugin synch between the puppet master and agent
+
+    CLI Example:
+    .. code-block:: bash
+
+        salt '*' puppet.plugin_sync
+    '''
+
+    _check_puppet()
+
+    ret = __salt__['cmd.run']('puppet plugin download')
+
+    if not ret:
+        return ''
+    return ret
 
 def facts(puppet=False):
     '''


### PR DESCRIPTION
Motivation:
To use puppet facts as grains, one would first want to sync the plugins. I could
have just decided to run a noop, which would do a plugin sync implicitly,  however
there would be a lot of chaff in the output, and depending on the amount of changes
that puppet would do, could take a significant amount of time.

Implementation considerations:
I looked at the current implementation of the run method, and decided that
to generalize that method to be able to handle any generic puppet command
would turn to spaghetti code real quick, so I just add a separate method.
