### PR TITLE
Feature update mongo future return and mongo return

### DIFF
--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -126,9 +126,14 @@ def returner(ret):
         back = _remove_dots(ret['return'])
     else:
         back = ret['return']
+        
+    if isinstance(ret, dict):
+        full_ret = _remove_dots(ret)
+    else:
+        full_ret = ret
 
     log.debug(back)
-    sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': ret}
+    sdata = {'minion': ret['id'], 'jid': ret['jid'], 'return': back, 'fun': ret['fun'], 'full_ret': full_ret}
     if 'out' in ret:
         sdata['out'] = ret['out']
     # save returns in the saltReturns collection in the json format:

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -126,7 +126,7 @@ def returner(ret):
         back = _remove_dots(ret['return'])
     else:
         back = ret['return']
-        
+
     if isinstance(ret, dict):
         full_ret = _remove_dots(ret)
     else:
@@ -137,7 +137,7 @@ def returner(ret):
     if 'out' in ret:
         sdata['out'] = ret['out']
     # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
     #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
     mdb.saltReturns.insert(sdata)
 

--- a/salt/returners/mongo_future_return.py
+++ b/salt/returners/mongo_future_return.py
@@ -137,7 +137,8 @@ def returner(ret):
     if 'out' in ret:
         sdata['out'] = ret['out']
     # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 'fun': <function>, 'full_ret': <unformatted return with dots removed>}
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 
+    #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
     mdb.saltReturns.insert(sdata)
 
 

--- a/salt/returners/mongo_return.py
+++ b/salt/returners/mongo_return.py
@@ -125,7 +125,7 @@ def returner(ret):
         back = _remove_dots(ret['return'])
     else:
         back = ret['return']
-        
+
     if isinstance(ret, dict):
         full_ret = _remove_dots(ret)
     else:
@@ -136,7 +136,7 @@ def returner(ret):
     if 'out' in ret:
         sdata['out'] = ret['out']
         # save returns in the saltReturns collection in the json format:
-    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>, 
+    # { 'minion': <minion_name>, 'jid': <job_id>, 'return': <return info with dots removed>,
     #   'fun': <function>, 'full_ret': <unformatted return with dots removed>}
     mdb.saltReturns.insert(sdata)
 


### PR DESCRIPTION
some formatting changes and updating older mongo returner to also use correct keys for keys instead of job ids and minion names so that you can query the database without scanning the entire collection.
