### PR TITLE
Make systemd impl. of service.running aware of legacy service units

### DIFF
--- a/salt/modules/systemd.py
+++ b/salt/modules/systemd.py
@@ -130,9 +130,9 @@ def _get_all_legacy_init_scripts():
     '''
     ret = {}
     for fn in os.listdir(LEGACY_INIT_SCRIPT_PATH):
-        if not os.path.isfile(os.path.join(LEGACY_INIT_SCRIPT_PATH,fn)) or fn.startswith('rc'):
+        if not os.path.isfile(os.path.join(LEGACY_INIT_SCRIPT_PATH, fn)) or fn.startswith('rc'):
             continue
-        log.info('Legacy init script: "%s".'%fn)
+        log.info('Legacy init script: "%s".', fn)
         ret[fn] = 'inactive'
     return ret
 
@@ -216,7 +216,8 @@ def get_all():
 
         salt '*' service.get_all
     '''
-    return sorted(set(list(_get_all_units().keys()) + list(_get_all_unit_files().keys()) + list(_get_all_legacy_init_scripts().keys())))
+    return sorted(set(list(_get_all_units().keys()) + list(_get_all_unit_files().keys())
+                      + list(_get_all_legacy_init_scripts().keys())))
 
 
 def available(name):


### PR DESCRIPTION
While systemd is perfectly capable of using old-style SYSV-init scripts, they were not available in salt as services because they are not listed by systemd when asked for available units.
