### PR TITLE
Develop aws irole

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -51,6 +51,7 @@ Eric Poelke <epoelke@gmail.com>
 Erik Nolte <enolte@beyondoblivion.com>
 Evan Borgstrom <evan@fatbox.ca>
 Forrest Alvarez <forrest.alvarez@gmail.com>
+Fred Reimer <freimer@freimer.org>
 Henrik Holmboe <henrik@holmboe.se>
 Gareth J. Greenaway <gareth@wiked.org>
 Jacob Albretsen <jakea@xmission.com>

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -12,9 +12,13 @@ To use the EC2 cloud module, set up the cloud configuration at
 .. code-block:: yaml
 
     my-ec2-config:
-      # The EC2 API authentication id
+      # The EC2 API authentication id, set this and/or key to
+      # 'use-instance-role-credentials' to use the instance role credentials
+      # from the meta-data if running on an AWS instance
       id: GKTADJGHEIQSXMKKRBJ08H
-      # The EC2 API authentication key
+      # The EC2 API authentication key, set this and/or id to
+      # 'use-instance-role-credentials' to use the instance role credentials
+      # from the meta-data if running on an AWS instance
       key: askdjghsdfjkghWupUjasdflkdfklgjsdfjajkghs
       # The ssh keyname to use
       keyname: default

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -300,7 +300,7 @@ def query(params=None, setname=None, requesturl=None, location=None,
     service_url = provider.get('service_url', 'amazonaws.com')
 
     # Retrieve access credentials from meta-data, or use provided
-    access_key_id, secret_access_key, token = aws.creds(prov_dict)
+    access_key_id, secret_access_key, token = aws.creds(provider)
 
     attempts = 5
     while attempts > 0:

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -232,7 +232,7 @@ def sig4(method, endpoint, params, prov_dict, aws_api_version, location,
 
     # Add in security token if we have one
     if token != '':
-        header['X-Amz-Security-Token'] = token
+        headers['X-Amz-Security-Token'] = token
 
     requesturl = '{0}?{1}'.format(requesturl, querystring)
     return headers, requesturl

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -46,7 +46,7 @@ IROLE_CODE = 'use-instance-role-credentials'
 __AccessKeyId__ = ''
 __SecretAccessKey__ = ''
 __Token__ = ''
-__Expiration__ == ''
+__Expiration__ = ''
 
 def creds(provider):
     '''

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -97,9 +97,6 @@ def sig2(method, endpoint, params, provider, aws_api_version):
 
     http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html
     '''
-    # Declare globals
-    global __AccessKeyId__, __SecretAccessKey__, __Token__
-
     timenow = datetime.datetime.utcnow()
     timestamp = timenow.strftime('%Y-%m-%dT%H:%M:%SZ')
 
@@ -143,9 +140,6 @@ def sig4(method, endpoint, params, prov_dict, aws_api_version, location,
     http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
     http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     '''
-    # Declare globals
-    global __AccessKeyId__, __SecretAccessKey__, __Token__
-
     timenow = datetime.datetime.utcnow()
     timestamp = timenow.strftime('%Y-%m-%dT%H:%M:%SZ')
 

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -48,6 +48,7 @@ __SecretAccessKey__ = ''
 __Token__ = ''
 __Expiration__ = ''
 
+
 def creds(provider):
     '''
     Return the credentials for AWS signing.  This could be just the id and key
@@ -101,7 +102,7 @@ def sig2(method, endpoint, params, provider, aws_api_version):
     timestamp = timenow.strftime('%Y-%m-%dT%H:%M:%SZ')
 
     # Retrieve access credentials from meta-data, or use provided
-    access_key_id, secret_access_key, token = creds(prov_dict)
+    access_key_id, secret_access_key, token = creds(provider)
 
     params_with_headers = params.copy()
     params_with_headers['AWSAccessKeyId'] = access_key_id

--- a/salt/utils/aws.py
+++ b/salt/utils/aws.py
@@ -55,6 +55,9 @@ def creds(provider):
     literal string 'use-instance-role-credentials' creds will pull the instance
     role credentials from the meta data, cache them, and provide them instead.
     '''
+    # Declare globals
+    global __AccessKeyId__, __SecretAccessKey__, __Token__, __Expiration__
+
     # if id or key is 'use-instance-role-credentials', pull them from meta-data
     ## if needed
     if provider['id'] == IROLE_CODE or provider['key'] == IROLE_CODE:
@@ -94,6 +97,9 @@ def sig2(method, endpoint, params, provider, aws_api_version):
 
     http://docs.aws.amazon.com/general/latest/gr/signature-version-2.html
     '''
+    # Declare globals
+    global __AccessKeyId__, __SecretAccessKey__, __Token__
+
     timenow = datetime.datetime.utcnow()
     timestamp = timenow.strftime('%Y-%m-%dT%H:%M:%SZ')
 
@@ -137,6 +143,9 @@ def sig4(method, endpoint, params, prov_dict, aws_api_version, location,
     http://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
     http://docs.aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html
     '''
+    # Declare globals
+    global __AccessKeyId__, __SecretAccessKey__, __Token__
+
     timenow = datetime.datetime.utcnow()
     timestamp = timenow.strftime('%Y-%m-%dT%H:%M:%SZ')
 


### PR DESCRIPTION
This change allows for the use of AWS instance role credentials, instead of having to hard-code credentials in a cloud.providers.d file.
