### PR TITLE
add cabal module and state

### DIFF
--- a/salt/modules/cabal.py
+++ b/salt/modules/cabal.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+'''
+Manage and query Cabal packages.
+'''
+from __future__ import absolute_import
+
+import logging
+
+import salt.utils
+from salt.exceptions import CommandExecutionError
+
+logger = logging.getLogger(__name__)
+
+# Function alias to make sure not to shadow built-in's
+__func_alias__ = {
+    'list_': 'list'
+}
+
+
+def __virtual__():
+    '''
+    Only work when cabal-install is installed.
+    '''
+    return (salt.utils.which('cabal') is not None) and \
+        (salt.utils.which('ghc-pkg') is not None)
+
+
+def update(user=None, env=None):
+    '''
+    Updates list of known packages.
+    '''
+    return __salt__['cmd.run_all']('cabal update', runas=user, env=env)
+
+
+def install(pkg=None,
+            pkgs=None,
+            user=None,
+            install_global=False,
+            env=None):
+    '''
+    Install a cabal package.
+
+    pkg
+        A package name in format accepted by cabal-install. See:
+        https://wiki.haskell.org/Cabal-Install
+
+    pkgs
+        A list of packages names in same format as ``pkg``
+
+    user
+        The user to run cabal install with
+
+    install_global
+        Install package globally instead of locally
+
+    env
+        Environment variables to set when invoking cabal. Uses the
+        same ``env`` format as the :py:func:`cmd.run
+        <salt.modules.cmdmod.run>` execution function
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' cabal.install shellcheck
+        salt '*' cabal.install shellcheck-0.3.5
+    '''
+
+    cmd = ['cabal install']
+
+    if install_global:
+        cmd.append('--global')
+
+    if pkg:
+        cmd.append('"{0}"'.format(pkg))
+    elif pkgs:
+        cmd.append('"{0}"'.format('" "'.join(pkgs)))
+
+    result = __salt__['cmd.run_all'](' '.join(cmd), runas=user, env=env)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    return result
+
+
+def list_(
+        pkg=None,
+        user=None,
+        installed=False,
+        env=None):
+    '''
+    List packages matching a search string.
+
+    pkg
+        Search string for matching package names
+    user
+        The user to run cabal list with
+    installed
+        If True, only return installed packages.
+    env
+        Environment variables to set when invoking cabal. Uses the
+        same ``env`` format as the :py:func:`cmd.run
+        <salt.modules.cmdmod.run>` execution function
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' cabal.list
+        salt '*' cabal.list ShellCheck
+    '''
+    cmd = ['cabal list --simple-output']
+
+    if installed:
+        cmd.append('--installed')
+
+    if pkg:
+        cmd.append('"{0}"'.format(pkg))
+
+    result = __salt__['cmd.run_all'](' '.join(cmd), runas=user, env=env)
+
+    packages = {}
+    for line in result['stdout'].splitlines():
+        data = line.split()
+        package_name = data[0]
+        package_version = data[1]
+        packages[package_name] = package_version
+
+    return packages
+
+
+def uninstall(pkg,
+              user=None,
+              env=None):
+    '''
+    Uninstall a cabal package.
+
+    pkg
+        The package to uninstall
+    user
+        The user to run ghc-pkg unregister with
+    env
+        Environment variables to set when invoking cabal. Uses the
+        same ``env`` format as the :py:func:`cmd.run
+        <salt.modules.cmdmod.run>` execution function
+    '''
+    cmd = ['ghc-pkg unregister']
+    cmd.append('"{0}"'.format(pkg))
+
+    result = __salt__['cmd.run_all'](' '.join(cmd), runas=user, env=env)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    return result

--- a/salt/states/cabal.py
+++ b/salt/states/cabal.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+'''
+Installation of Cabal Packages
+==============================
+
+These states manage the installed packages for Haskell using
+cabal. Note that cabal-install must be installed for these states to
+be available, so cabal states should include a requisite to a
+pkg.installed state for the package which provides cabal
+(``cabal-install`` in case of Debian based distributions). Example::
+
+.. code-block:: yaml
+
+   cabal-install:
+     pkg.installed
+
+   ShellCheck:
+     cabal.installed:
+       - require:
+         - pkg: cabal-install
+
+'''
+
+from __future__ import absolute_import
+from salt.exceptions import CommandExecutionError, CommandNotFoundError
+
+import salt.utils
+
+
+def __virtual__():
+    '''
+    Only work when cabal-install is installed.
+    '''
+    return (salt.utils.which('cabal') is not None) and \
+        (salt.utils.which('ghc-pkg') is not None)
+
+
+def _parse_pkg_string(pkg):
+    '''
+    Parse pkg string and return a tuple of packge name, separator, and
+    package version.
+
+    Cabal support install package with following format:
+
+    * foo-1.0
+    * foo < 1.2
+    * foo > 1.3
+
+    For the sake of simplicity only the first form is supported,
+    support for other forms can be added later.
+    '''
+    pkg_name, separator, pkg_ver = pkg.partition('-')
+    return (pkg_name.strip(), separator, pkg_ver.strip())
+
+
+def installed(name,
+              pkgs=None,
+              user=None,
+              install_global=False,
+              env=None):
+    '''
+    Verify that the given package is installed and is at the correct version
+    (if specified).
+
+    .. code-block:: yaml
+
+        ShellCheck-0.3.5:
+          cabal:
+            - installed:
+
+    name
+        The package to install
+    user
+        The user to run cabal install with
+    install_global
+        Install package globally instead of locally
+    env
+        A list of environment variables to be set prior to execution. The
+        format is the same as the :py:func:`cmd.run <salt.states.cmd.run>`.
+        state function.
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    try:
+        call = __salt__['cabal.update']()
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Could not run cabal update {0}'.format(err)
+
+    if pkgs is not None:
+        pkg_list = pkgs
+    else:
+        pkg_list = [name]
+
+    try:
+        installed_pkgs = __salt__['cabal.list'](
+            user=user, installed=True, env=env)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error looking up  {0!r}: {1}'.format(name, err)
+
+    pkgs_satisfied = []
+    pkgs_to_install = []
+
+    for pkg in pkg_list:
+        pkg_name, _, pkg_ver = _parse_pkg_string(pkg)
+
+        if pkg_name not in installed_pkgs:
+            pkgs_to_install.append(pkg)
+        else:
+            if pkg_ver:  # version is specified
+                if installed_pkgs[pkg_name] != pkg_ver:
+                    pkgs_to_install.append(pkg)
+                else:
+                    pkgs_satisfied.append(pkg)
+            else:
+                pkgs_satisfied.append(pkg)
+
+    if __opts__['test']:
+        ret['result'] = None
+
+        comment_msg = []
+
+        if pkgs_to_install:
+            comment_msg.append(
+                'Packages(s) {0!r} are set to be installed'.format(
+                    ', '.join(pkgs_to_install)))
+
+        if pkgs_satisfied:
+            comment_msg.append(
+                'Packages(s) {0!r} satisfied by {1}'.format(
+                    ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
+
+        ret['comment'] = '. '.join(comment_msg)
+        return ret
+
+    if not pkgs_to_install:
+        ret['result'] = True
+        ret['comment'] = ('Packages(s) {0!r} satisfied by {1}'.format(
+            ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
+
+        return ret
+
+    try:
+        call = __salt__['cabal.install'](pkgs=pkg_list,
+                                         user=user,
+                                         install_global=install_global,
+                                         env=env)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error installing {0!r}: {1}'.format(
+            ', '.join(pkg_list), err)
+        return ret
+
+    if call and isinstance(call, dict):
+        ret['result'] = True
+        ret['changes'] = {'old': [], 'new': pkgs_to_install}
+        ret['comment'] = 'Packages(s) {0!r} successfully installed'.format(
+            ', '.join(pkgs_to_install))
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Could not install packages(s) {0!r}'.format(
+            ', '.join(pkg_list))
+
+    return ret
+
+
+def removed(name,
+            user=None,
+            env=None):
+    '''
+    Verify that given package is not installed.
+    '''
+
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    try:
+        installed_pkgs = __salt__['cabal.list'](
+            user=user, installed=True, env=env)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error looking up  {0!r}: {1}'.format(name, err)
+
+    if name not in installed_pkgs:
+        ret['result'] = True
+        ret['comment'] = 'Package {0!r} is not installed'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Package {0!r} is set to be removed'.format(name)
+        return ret
+
+    if __salt__['cabal.uninstall'](pkg=name, user=user, env=env):
+        ret['result'] = True
+        ret['changes'][name] = 'Removed'
+        ret['comment'] = 'Package {0!r} was successfully removed'.format(name)
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Error removing package {0!r}'.format(name)
+
+    return ret


### PR DESCRIPTION
I wrote module/state for cabal.

> The cabal-install package provides the cabal command-line tool which simplifies the process of managing Haskell software by automating the fetching, configuration, compilation and installation of Haskell libraries and programs.
