### PR TITLE
fix file permission errors

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -498,7 +498,8 @@ class SAuth(object):
                 log.info('Received signed and verified master pubkey '
                          'from master {0}'.format(self.opts['master']))
                 m_pub_fn = os.path.join(self.opts['pki_dir'], self.mpub)
-                salt.utils.fopen(m_pub_fn, 'w+').write(payload['pub_key'])
+                uid = salt.utils.get_uid(self.opts.get('user', None))
+                salt.utils.fopen(m_pub_fn, 'w+', uid=uid).write(payload['pub_key'])
                 return True
             else:
                 log.error('Received signed public-key from master {0} '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -149,15 +149,61 @@ def resolve_dns(opts):
     return ret
 
 
-def get_proc_dir(cachedir):
+def get_proc_dir(cachedir, **kwargs):
     '''
     Given the cache directory, return the directory that process data is
     stored in, creating it if it doesn't exist.
+    The following optional Keyword Arguments are handled:
+
+    mode: which is anything os.makedir would accept as mode.
+
+    uid: the uid to set, if not set, or it is None or -1 no changes are
+         made. Same applies if the directory is already owned by this
+         uid. Must be int. Works only on unix/unix like systems.
+
+    gid: the gid to set, if not set, or it is None or -1 no changes are
+         made. Same applies if the directory is already owned by this
+         gid. Must be int. Works only on unix/unix like systems.
     '''
     fn_ = os.path.join(cachedir, 'proc')
+    mode = kwargs.pop('mode', None)
+
+    if mode is None:
+        mode = {}
+    else:
+        mode = {'mode': mode}
+
     if not os.path.isdir(fn_):
-        # proc_dir is not present, create it
-        os.makedirs(fn_)
+        # proc_dir is not present, create it with mode settings
+        os.makedirs(fn_, **mode)
+        d_stat = os.stat(fn_)
+    else:
+        d_stat = os.stat(fn_)
+
+    # if mode is not an empty dict then we have an explicit
+    # dir mode. So lets check if mode needs to be changed.
+    if mode:
+        if d_stat.st_mode | mode['mode'] != d_stat.st_mode:
+            os.chmod(fn_, d_stat.st_mode | mode['mode'])
+
+    if hasattr(os, 'chown'):
+        # only on unix/unix like systems
+        uid = kwargs.pop('uid', None)
+        gid = kwargs.pop('gid', None)
+
+        if uid is None:
+            # -1 means no change to current uid
+            uid = -1
+        if gid is None:
+            # -1 means no change to current gid
+            gid = -1
+
+        # if uid and gid are both -1 then go ahead with
+        # no changes at all
+        if (d_stat.st_uid != uid or d_stat.st_gid != gid) and \
+                [i for i in (uid, gid) if i != -1]:
+            os.chown(fn_, uid, gid)
+
     return fn_
 
 
@@ -639,7 +685,8 @@ class Minion(MinionBase):
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)
-        self.proc_dir = get_proc_dir(opts['cachedir'])
+        uid = salt.utils.get_uid(user=opts.get('user', None))
+        self.proc_dir = get_proc_dir(opts['cachedir'], uid=uid)
         self.schedule = salt.utils.schedule.Schedule(
             self.opts,
             self.functions,
@@ -2704,7 +2751,8 @@ class ProxyMinion(Minion):
         self.serial = salt.payload.Serial(self.opts)
         self.mod_opts = self._prep_mod_opts()
         self.matcher = Matcher(self.opts, self.functions)
-        self.proc_dir = get_proc_dir(opts['cachedir'])
+        uid = salt.utils.get_uid(user=opts.get('user', None))
+        self.proc_dir = get_proc_dir(opts['cachedir'], uid=uid)
         self.schedule = salt.utils.schedule.Schedule(
             self.opts,
             self.functions,

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -266,11 +266,11 @@ def get_uid(user=None):
     it will return None.
     """
     if pwd is None:
-        result =  None
+        result = None
     elif user is None:
         try:
             result = os.geteuid()
-        except:
+        except AttributeError:
             result = None
     else:
         try:
@@ -291,11 +291,11 @@ def get_gid(group=None):
     it will return None.
     """
     if grp is None:
-        result =  None
+        result = None
     elif group is None:
         try:
             result = os.getegid()
-        except:
+        except AttributeError:
             result = None
     else:
         try:
@@ -1029,7 +1029,6 @@ def fopen(*args, **kwargs):
         if lock and is_fcntl_available(check_sunos=True):
             fcntl.flock(fhandle.fileno(), fcntl.LOCK_SH)
         fcntl.fcntl(fhandle.fileno(), fcntl.F_SETFD, old_flags | FD_CLOEXEC)
-
 
     path = args[0]
     d_stat = os.stat(path)


### PR DESCRIPTION
This fixes some file permission errors when running salt-minion as non-root
and/or with the config options below:

  verify_master_pubkey_sign: True
  always_verify_signature: True

Changes:
- add salt.utils.(get_uid/get_gid) functions
- extend salt.utils.fopen to make use of
  uid, gid and mode keyword arguments.
- extend SAuth.verify_signing_master method so it
  uses now salt.utils.get_uid and calls
  salt.utils.fopen with the uid keyword
- extend minion.get_proc_dir:
  - add kwargs to function signature
  - extend doc string
  - handle mode in os.makedirs
  - check if mode of existing dir needs to be changed
  - check if uid/gid needs to be changed (only if os.chmod is
  - available)
- extend minion.Minion.**init** to call minion.get_proc_dir with kwargs
- extend minion.Proxyminion.**init** to call minion.get_proc_dir with kwargs
