### PR TITLE
Adding DNS support to boto vpc creation

### DIFF
--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -219,8 +219,9 @@ def exists(vpc_id=None, name=None, cidr=None, tags=None, region=None, key=None, 
         return False
 
 
-def create(cidr_block, instance_tenancy=None, vpc_name=None, tags=None, region=None, key=None, keyid=None,
-           profile=None):
+def create(cidr_block, instance_tenancy=None, vpc_name=None, 
+           enable_dns_support=None, enable_dns_hostnames=None, tags=None,
+           region=None, key=None, keyid=None, profile=None):
     '''
     Given a valid CIDR block, create a VPC.
 
@@ -248,6 +249,7 @@ def create(cidr_block, instance_tenancy=None, vpc_name=None, tags=None, region=N
 
             _maybe_set_name_tag(vpc_name, vpc)
             _maybe_set_tags(tags, vpc)
+            _maybe_set_dns(conn, vpc.id, enable_dns_support, enable_dns_hostnames)
 
             return vpc.id
         else:
@@ -1326,3 +1328,12 @@ def _maybe_set_tags(tags, obj):
         obj.add_tags(tags)
 
         log.debug('The following tags: {0} were added to {1}'.format(', '.join(tags), obj))
+
+
+def _maybe_set_dns(conn, vpcid, dns_support, dns_hostnames):
+    if dns_support:
+        conn.modify_vpc_attribute(vpc_id=vpcid, enable_dns_support=dns_support)
+        log.debug('DNS spport was set to: {0} on vpc {1}'.format(dns_support, vpcid))
+    if dns_hostnames:
+        conn.modify_vpc_attribute(vpc_id=vpcid, enable_dns_hostnames=dns_hostnames)
+        log.debug('DNS hostnames was set to: {0} on vpc {1}'.format(dns_hostnames, vpcid))


### PR DESCRIPTION
By default DNS hostnames is set to false when creating a VPC from API and web interface.
I added this when creating the VPC, maybe it is a good idea to add this as a separate function so that one could edit this parameters after a VPC has been created.

Or maybe having it in both places, separate function and when creating the VPC.
