### PR TITLE
Note eAuth PAM requires root salt-master

### DIFF
--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -7,6 +7,11 @@ External Authentication System
 Salt's External Authentication System (eAuth) allows for Salt to  pass through
 command authorization to any external authentication system, such as PAM or LDAP.
 
+.. note::
+
+    eAuth using the PAM external auth system requires salt-master to be run as 
+    root as this system needs root access to check authentication.
+
 Access Control System
 ---------------------
 


### PR DESCRIPTION
Using eAuth with PAM external authentication module requires salt-master to be run as root
