### PR TITLE
Elasticache get cache nodes

### DIFF
--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -33,10 +33,12 @@ Connection module for Amazon Elasticache
 
 :depends: boto
 '''
+from __future__ import absolute_import
 
 # Import Python libs
 import logging
 import time
+import salt.ext.six as six
 
 log = logging.getLogger(__name__)
 
@@ -50,7 +52,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-from salt._compat import string_types
+from salt.ext.six import string_types
 import salt.utils.odict as odict
 
 
@@ -112,7 +114,7 @@ def get_config(name, node_info=None, region=None, key=None, keyid=None,
              'cache_subnet_group_name', 'engine_version', 'cache_node_type',
              'notification_configuration', 'preferred_maintenance_window',
              'configuration_endpoint', 'cache_cluster_status', 'cache_nodes']
-    for key, val in cc.iteritems():
+    for key, val in six.iteritems(cc):
         _key = boto.utils.pythonize_name(key)
         if _key not in attrs:
             continue
@@ -174,7 +176,7 @@ def get_cache_subnet_group(name, region=None, key=None, keyid=None,
         log.error(msg)
         return False
     ret = {}
-    for key, val in csg.iteritems():
+    for key, val in six.iteritems(csg):
         if key == 'CacheSubnetGroupName':
             ret['cache_subnet_group_name'] = val
         elif key == 'CacheSubnetGroupDescription':

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -84,7 +84,7 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
         return False
 
 
-def get_config(name, region=None, key=None, keyid=None, profile=None):
+def get_config(name, node_info=True, region=None, key=None, keyid=None, profile=None):
     '''
     Get the configuration for a cache cluster.
 
@@ -97,7 +97,7 @@ def get_config(name, region=None, key=None, keyid=None, profile=None):
         return None
     try:
         cc = conn.describe_cache_clusters(cache_cluster_id=name, 
-                                          show_cache_node_info=True)
+                                          show_cache_node_info=node_info)
     except boto.exception.BotoServerError as e:
         msg = 'Failed to get config for cache cluster {0}.'.format(name)
         log.error(msg)
@@ -195,7 +195,7 @@ def get_cache_subnet_group(name, region=None, key=None, keyid=None,
     return ret
 
 
-def create(name, num_cache_nodes, engine, cache_node_type,
+def create(name, num_cache_nodes=None, engine=None, cache_node_type=None,
            replication_group_id=None, engine_version=None,
            cache_parameter_group_name=None, cache_subnet_group_name=None,
            cache_security_group_names=None, security_group_ids=None,

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -84,8 +84,7 @@ def exists(name, region=None, key=None, keyid=None, profile=None):
         return False
 
 
-def get_config(name, node_info=None, region=None, key=None, keyid=None,
-               profile=None):
+def get_config(name, region=None, key=None, keyid=None, profile=None):
     '''
     Get the configuration for a cache cluster.
 
@@ -98,7 +97,7 @@ def get_config(name, node_info=None, region=None, key=None, keyid=None,
         return None
     try:
         cc = conn.describe_cache_clusters(cache_cluster_id=name, 
-                                          show_cache_node_info=node_info)
+                                          show_cache_node_info=True)
     except boto.exception.BotoServerError as e:
         msg = 'Failed to get config for cache cluster {0}.'.format(name)
         log.error(msg)

--- a/salt/modules/boto_elasticache.py
+++ b/salt/modules/boto_elasticache.py
@@ -96,8 +96,7 @@ def get_config(name, node_info=True, region=None, key=None, keyid=None, profile=
     if not conn:
         return None
     try:
-        cc = conn.describe_cache_clusters(cache_cluster_id=name, 
-                                          show_cache_node_info=node_info)
+        cc = conn.describe_cache_clusters(name, show_cache_node_info=node_info)
     except boto.exception.BotoServerError as e:
         msg = 'Failed to get config for cache cluster {0}.'.format(name)
         log.error(msg)


### PR DESCRIPTION
Currently the module did not retrieve cache_nodes and their info.
With this new functionality now we are able to get 
- CacheNodeCreateTime
- CacheNodeId
- CacheNodeStatus
- Endpoint 
  - Address
  - Port
- ParameterGroupStatus
- SourceCacheNodeId
