### PR TITLE
Allow for indented/pretty-printed json output from jinja/simplejson

### DIFF
--- a/salt/utils/jinja.py
+++ b/salt/utils/jinja.py
@@ -365,8 +365,8 @@ class SerializerExtension(Extension, object):
             return data
         return explore(data)
 
-    def format_json(self, value, sort_keys=True):
-        return Markup(json.dumps(value, sort_keys=sort_keys).strip())
+    def format_json(self, value, sort_keys=True, indent=None):
+        return Markup(json.dumps(value, sort_keys=sort_keys, indent=indent).strip())
 
     def format_yaml(self, value, flow_style=True):
         return Markup(yaml.dump(value, default_flow_style=flow_style,


### PR DESCRIPTION
While constructing a json config file with a jinja template, I found that my only output option was a json blob. When indent is passed to format_json() (and then down to simplejson.dump), it pretty-prints.

Note that the arg for the indent option changed in simplejson 2.1.0, but according to https://github.com/simplejson/simplejson/blob/master/simplejson/__init__.py#L182 , either a string or integer input is accepted.
