### PR TITLE
Giving publish.publish more robust return handling

### DIFF
--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -111,8 +111,6 @@ def _publish(
                     return cret
                 else:
                     return ret
-            if (loop_interval * loop_counter) > timeout:
-                return {}
             loop_counter = loop_counter + 1
             time.sleep(loop_interval)
     else:

--- a/salt/modules/publish.py
+++ b/salt/modules/publish.py
@@ -83,17 +83,27 @@ def _publish(
     # CLI args are passed as strings, re-cast to keep time.sleep happy
     if wait:
         loop_interval = 0.3
-        matched_minions = peer_data['minions']
-        returned_minions = []
+        matched_minions = set(peer_data['minions'])
+        returned_minions = set()
         loop_counter = 0
-        while len(returned_minions) < len(matched_minions):
+        while len(returned_minions ^ matched_minions) > 0:
             load = {'cmd': 'pub_ret',
                     'id': __opts__['id'],
                     'tok': tok,
                     'jid': peer_data['jid']}
             ret = sreq.send(load)
-            returned_minions = ret.keys()
+            returned_minions = set(ret.keys())
+
+            end_loop = False
             if returned_minions >= matched_minions:
+                end_loop = True
+            elif (loop_interval * loop_counter) > timeout:
+                # This may be unnecessary, but I am paranoid
+                if len(returned_minions) < 1:
+                    return {}
+                end_loop = True
+
+            if end_loop:
                 if form == 'clean':
                     cret = {}
                     for host in ret:


### PR DESCRIPTION
This fixes the two separate issues identified in #16510 in connection to the fact that the master actually seems to duplicate events when they pass through.

The first issue was that there was only a comparison on length of lists, which when the events were duplicated turned out to result in the bug reported in #16510 . This is fixed by using sets instead and checking the length of the symmetric difference between matched minions and returned minions.

The second issue was that if there was a minion or two that are disconnected in the matching pool, there will never be a return. This was of course masked by the underlying issue of the master duplicating events. This resulted in a completely empty result set because of how the timeout was implemented. I have now changed the implementation to always return what it has received thus far when the timeout is reached.

I'm putting up the pull request against the 2014.7 branch since this is a pure bug fix and for us it is rather critical, but that may be wrong of course. :)
