### PR TITLE
Disable POSIX mode on Windows for cmd.run

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -359,7 +359,7 @@ def _run(cmd,
         )
 
     if python_shell is not True and not isinstance(cmd, list):
-        cmd = shlex.split(cmd)
+        cmd = shlex.split(cmd, posix=not salt.utils.is_windows())
     if not use_vt:
         # This is where the magic happens
         try:

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -38,8 +38,6 @@ def _get_pip_bin(bin_env):
         which_result = __salt__['cmd.which_bin'](['pip2', 'pip', 'pip-python'])
         if which_result is None:
             raise CommandNotFoundError('Could not find a `pip` binary')
-        if salt.utils.is_windows():
-            return which_result.encode('string-escape')
         return which_result
 
     # try to get pip bin from env
@@ -127,7 +125,8 @@ def _process_requirements(requirements, cmd, saltenv, user, no_chown):
                 )
                 __salt__['file.chown'](treq, user, None)
                 cleanup_requirements.append(treq)
-            cmd.append('--requirement={0!r}'.format(treq or requirement))
+
+            cmd.append('--requirement={0}'.format(treq or requirement))
     return cleanup_requirements, None
 
 

--- a/salt/modules/pip.py
+++ b/salt/modules/pip.py
@@ -125,8 +125,8 @@ def _process_requirements(requirements, cmd, saltenv, user, no_chown):
                 )
                 __salt__['file.chown'](treq, user, None)
                 cleanup_requirements.append(treq)
+            cmd.append('--requirement="{0}"'.format(treq or requirement))
 
-            cmd.append('--requirement={0}'.format(treq or requirement))
     return cleanup_requirements, None
 
 
@@ -567,7 +567,7 @@ def install(pkgs=None,  # pylint: disable=R0912,R0913,R0914
         cmd_kwargs = dict(cwd=cwd, saltenv=saltenv, use_vt=use_vt, runas=user)
         if bin_env and os.path.isdir(bin_env):
             cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
-        return __salt__['cmd.run_all'](' '.join(cmd), python_shell=False, **cmd_kwargs)
+        return __salt__['cmd.run_all'](' '.join(cmd), python_shell=True, **cmd_kwargs)
     finally:
         for requirement in cleanup_requirements:
             try:
@@ -689,7 +689,7 @@ def uninstall(pkgs=None,
                             pass
         cmd.extend(pkgs)
 
-    cmd_kwargs = dict(python_shell=False, runas=user, cwd=cwd, saltenv=saltenv, use_vt=use_vt)
+    cmd_kwargs = dict(python_shell=True, runas=user, cwd=cwd, saltenv=saltenv, use_vt=use_vt)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
 
@@ -729,7 +729,7 @@ def freeze(bin_env=None,
         salt '*' pip.freeze /home/code/path/to/virtualenv/
     '''
     cmd = [_get_pip_bin(bin_env), 'freeze']
-    cmd_kwargs = dict(runas=user, cwd=cwd, use_vt=use_vt, python_shell=False)
+    cmd_kwargs = dict(runas=user, cwd=cwd, use_vt=use_vt, python_shell=True)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
     result = __salt__['cmd.run_all'](' '.join(cmd), **cmd_kwargs)
@@ -760,7 +760,7 @@ def list_(prefix=None,
     pip_version_cmd = [pip_bin, '--version']
     cmd = [pip_bin, 'freeze']
 
-    cmd_kwargs = dict(runas=user, cwd=cwd, python_shell=False)
+    cmd_kwargs = dict(runas=user, cwd=cwd, python_shell=True)
     if bin_env and os.path.isdir(bin_env):
         cmd_kwargs['env'] = {'VIRTUAL_ENV': bin_env}
 

--- a/tests/unit/modules/pip_test.py
+++ b/tests/unit/modules/pip_test.py
@@ -23,14 +23,14 @@ class PipTestCase(TestCase):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(requirements='requirements.txt')
-            expected_cmd = 'pip install --requirement=\'requirements.txt\''
+            expected_cmd = 'pip install --requirement="requirements.txt"'
             mock.assert_called_once_with(
                 expected_cmd,
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_editable_withough_egg_fails(self):
@@ -61,7 +61,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing editables as a comma separated list
@@ -76,7 +76,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_multiple_pkgs_and_editables(self):
@@ -102,7 +102,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing editables as a comma separated list
@@ -117,7 +117,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # As a single string
@@ -131,7 +131,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_issue5940_install_multiple_pip_mirrors(self):
@@ -154,7 +154,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a comma separated list
@@ -170,7 +170,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # As a single string
@@ -184,7 +184,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_with_multiple_find_links(self):
@@ -207,7 +207,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a comma separated list
@@ -223,7 +223,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a single string entry
@@ -236,7 +236,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Invalid proto raises exception
@@ -268,7 +268,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_no_index_with_index_url_or_extra_index_url_raises(self):
@@ -301,14 +301,14 @@ class PipTestCase(TestCase):
         mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(requirements='salt://requirements.txt')
-            expected_cmd = 'pip install --requirement=\'my_cached_reqs\''
+            expected_cmd = 'pip install --requirement="my_cached_reqs"'
             mock.assert_called_once_with(
                 expected_cmd,
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     @patch('os.path')
@@ -330,7 +330,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     @patch('os.path')
@@ -344,7 +344,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Let's fake a non-writable log file
@@ -369,7 +369,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing an int as a string
@@ -382,7 +382,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing a non-int to timeout
@@ -405,7 +405,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_extra_index_url_argument_in_resulting_command(self):
@@ -418,7 +418,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_no_index_argument_in_resulting_command(self):
@@ -431,7 +431,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_build_argument_in_resulting_command(self):
@@ -444,7 +444,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_target_argument_in_resulting_command(self):
@@ -457,7 +457,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_download_argument_in_resulting_command(self):
@@ -470,7 +470,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_no_download_argument_in_resulting_command(self):
@@ -483,7 +483,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_download_cache_argument_in_resulting_command(self):
@@ -496,7 +496,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_source_argument_in_resulting_command(self):
@@ -509,7 +509,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_exists_action_argument_in_resulting_command(self):
@@ -523,7 +523,7 @@ class PipTestCase(TestCase):
                     runas=None,
                     cwd=None,
                     use_vt=False,
-                    python_shell=False,
+                    python_shell=True,
                 )
 
         # Test for invalid action
@@ -554,7 +554,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a comma separated list
@@ -569,7 +569,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a single string entry
@@ -583,7 +583,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_global_options_argument_in_resulting_command(self):
@@ -604,7 +604,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a comma separated list
@@ -619,7 +619,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing mirrors as a single string entry
@@ -632,7 +632,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_upgrade_argument_in_resulting_command(self):
@@ -645,7 +645,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_force_reinstall_argument_in_resulting_command(self):
@@ -658,7 +658,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_ignore_installed_argument_in_resulting_command(self):
@@ -671,7 +671,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_no_deps_argument_in_resulting_command(self):
@@ -684,7 +684,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_no_install_argument_in_resulting_command(self):
@@ -697,7 +697,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_install_proxy_argument_in_resulting_command(self):
@@ -711,7 +711,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     @patch('salt.modules.pip._get_cached_requirements')
@@ -729,13 +729,13 @@ class PipTestCase(TestCase):
             pip.install(requirements=requirements)
             mock.assert_called_once_with(
                 'pip install '
-                '--requirement=\'my_cached_reqs-1\' '
-                '--requirement=\'my_cached_reqs-2\'',
+                '--requirement="my_cached_reqs-1" '
+                '--requirement="my_cached_reqs-2"',
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing option as a comma separated list
@@ -747,13 +747,13 @@ class PipTestCase(TestCase):
             pip.install(requirements=','.join(requirements))
             mock.assert_called_once_with(
                 'pip install '
-                '--requirement=\'my_cached_reqs-1\' '
-                '--requirement=\'my_cached_reqs-2\'',
+                '--requirement="my_cached_reqs-1" '
+                '--requirement="my_cached_reqs-2"',
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing option as a single string entry
@@ -762,12 +762,12 @@ class PipTestCase(TestCase):
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.install(requirements=requirements[0])
             mock.assert_called_once_with(
-                'pip install --requirement=\'my_cached_reqs-1\'',
+                'pip install --requirement="my_cached_reqs-1"',
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     @patch('salt.modules.pip._get_cached_requirements')
@@ -785,13 +785,13 @@ class PipTestCase(TestCase):
             pip.uninstall(requirements=requirements)
             mock.assert_called_once_with(
                 'pip uninstall -y '
-                '--requirement=\'my_cached_reqs-1\' '
-                '--requirement=\'my_cached_reqs-2\'',
+                '--requirement="my_cached_reqs-1" '
+                '--requirement="my_cached_reqs-2"',
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing option as a comma separated list
@@ -803,13 +803,13 @@ class PipTestCase(TestCase):
             pip.uninstall(requirements=','.join(requirements))
             mock.assert_called_once_with(
                 'pip uninstall -y '
-                '--requirement=\'my_cached_reqs-1\' '
-                '--requirement=\'my_cached_reqs-2\'',
+                '--requirement="my_cached_reqs-1" '
+                '--requirement="my_cached_reqs-2"',
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing option as a single string entry
@@ -818,12 +818,12 @@ class PipTestCase(TestCase):
         with patch.dict(pip.__salt__, {'cmd.run_all': mock}):
             pip.uninstall(requirements=requirements[0])
             mock.assert_called_once_with(
-                'pip uninstall -y --requirement=\'my_cached_reqs-1\'',
+                'pip uninstall -y --requirement="my_cached_reqs-1"',
                 saltenv='base',
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     def test_uninstall_proxy_argument_in_resulting_command(self):
@@ -839,7 +839,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
     @patch('os.path')
@@ -853,7 +853,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Let's fake a non-writable log file
@@ -878,7 +878,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing an int as a string
@@ -891,7 +891,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         # Passing a non-int to timeout
@@ -925,7 +925,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
             self.assertEqual(ret, eggs)
 
@@ -957,7 +957,7 @@ class PipTestCase(TestCase):
                 'pip freeze',
                 runas=None,
                 cwd=None,
-                python_shell=False,
+                python_shell=True,
             )
             self.assertEqual(
                 ret, {
@@ -998,7 +998,7 @@ class PipTestCase(TestCase):
                 'pip freeze',
                 runas=None,
                 cwd=None,
-                python_shell=False,
+                python_shell=True,
             )
             self.assertEqual(
                 ret, {
@@ -1024,7 +1024,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
         mock = MagicMock(side_effect=[
@@ -1041,7 +1041,7 @@ class PipTestCase(TestCase):
                 runas=None,
                 cwd=None,
                 use_vt=False,
-                python_shell=False,
+                python_shell=True,
             )
 
 


### PR DESCRIPTION
There was talk about making the string-encode changes more generic and in a single location (#20619), here is my attempt at doing that. It seems we are running commands on windows as if it was POSIX compliant AFAIK it isn't. 

Note: This may break other commands that are trying to use POSIX compliancy on Windows, I have tested quite a few different states but not all :)
