### PR TITLE
import salt.minion in client

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -33,6 +33,7 @@ import salt.config
 import salt.payload
 import salt.transport
 import salt.loader
+import salt.minion
 import salt.utils
 import salt.utils.args
 import salt.utils.event


### PR DESCRIPTION
fixes this:

``` pytb
>>> from salt.client import Caller
>>> Caller()
Traceback (most recent call last):
  File "<input>", line 1, in <module>
  File "salt/client/__init__.py", line 1549, in __init__
    self.sminion = salt.minion.SMinion(self.opts)
AttributeError: 'module' object has no attribute 'minion'
```
