### PR TITLE
Allow pagerduty module to work with config in pillar

### DIFF
--- a/salt/modules/pagerduty.py
+++ b/salt/modules/pagerduty.py
@@ -43,7 +43,11 @@ def list_services(profile=None, api_key=None):
         salt myminion pagerduty.list_services my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'services', 'name', profile, api_key, opts=__opts__
+        'services',
+        'name',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -56,7 +60,11 @@ def list_incidents(profile=None, api_key=None):
         salt myminion pagerduty.list_incidents my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'incidents', 'id', profile, api_key, opts=__opts__
+        'incidents',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -69,7 +77,11 @@ def list_users(profile=None, api_key=None):
         salt myminion pagerduty.list_users my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'users', 'id', profile, api_key, opts=__opts__
+        'users',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -82,7 +94,11 @@ def list_schedules(profile=None, api_key=None):
         salt myminion pagerduty.list_schedules my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'schedules', 'id', profile, api_key, opts=__opts__
+        'schedules',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -96,7 +112,11 @@ def list_windows(profile=None, api_key=None):
         salt myminion pagerduty.list_maintenance_windows my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'maintenance_windows', 'id', profile, api_key, opts=__opts__
+        'maintenance_windows',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -114,7 +134,11 @@ def list_policies(profile=None, api_key=None):
         salt myminion pagerduty.list_escalation_policies my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'escalation_policies', 'id', profile, api_key, opts=__opts__
+        'escalation_policies',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -158,7 +182,7 @@ def create_event(service_key=None, description=None, details=None,
 
     ret = json.loads(salt.utils.pagerduty.query(
         method='POST',
-        profile=profile,
+        profile_dict=__salt__['config.option'](profile),
         api_key=service_key,
         data={
             'service_key': service_key,

--- a/salt/runners/pagerduty.py
+++ b/salt/runners/pagerduty.py
@@ -42,7 +42,11 @@ def list_services(profile=None, api_key=None):
         salt-run pagerduty.list_services my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'services', 'name', profile, api_key, opts=__opts__
+        'services',
+        'name',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -55,7 +59,11 @@ def list_incidents(profile=None, api_key=None):
         salt-run pagerduty.list_incidents my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'incidents', 'id', profile, api_key, opts=__opts__
+        'incidents',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -68,7 +76,11 @@ def list_users(profile=None, api_key=None):
         salt-run pagerduty.list_users my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'users', 'id', profile, api_key, opts=__opts__
+        'users',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -81,7 +93,11 @@ def list_schedules(profile=None, api_key=None):
         salt-run pagerduty.list_schedules my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'schedules', 'id', profile, api_key, opts=__opts__
+        'schedules',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -95,7 +111,11 @@ def list_windows(profile=None, api_key=None):
         salt-run pagerduty.list_maintenance_windows my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'maintenance_windows', 'id', profile, api_key, opts=__opts__
+        'maintenance_windows',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -113,7 +133,11 @@ def list_policies(profile=None, api_key=None):
         salt-run pagerduty.list_escalation_policies my-pagerduty-account
     '''
     return salt.utils.pagerduty.list_items(
-        'escalation_policies', 'id', profile, api_key, opts=__opts__
+        'escalation_policies',
+        'id',
+        __salt__['config.option'](profile),
+        api_key,
+        opts=__opts__
     )
 
 
@@ -157,7 +181,7 @@ def create_event(service_key=None, description=None, details=None,
 
     ret = json.loads(salt.utils.pagerduty.query(
         method='POST',
-        profile=profile,
+        profile_dict=__salt__['config.option'](profile),
         api_key=service_key,
         data={
             'service_key': service_key,

--- a/salt/utils/pagerduty.py
+++ b/salt/utils/pagerduty.py
@@ -26,7 +26,7 @@ from salt.version import __version__
 log = logging.getLogger(__name__)
 
 
-def query(method='GET', profile=None, url=None, path='api/v1',
+def query(method='GET', profile_dict=None, url=None, path='api/v1',
           action=None, api_key=None, service=None, params=None,
           data=None, subdomain=None, client_url=None, description=None,
           opts=None, verify_ssl=True):
@@ -38,8 +38,8 @@ def query(method='GET', profile=None, url=None, path='api/v1',
     if opts is None:
         opts = {}
 
-    if profile is not None:
-        creds = opts.get(profile, {})
+    if isinstance(profile_dict, dict):
+        creds = profile_dict
     else:
         creds = {}
 
@@ -71,7 +71,11 @@ def query(method='GET', profile=None, url=None, path='api/v1',
         data = {}
 
     data['client'] = user_agent
-    data['service_key'] = creds['pagerduty.service']
+
+    # pagerduty.service is not documented.  While it makes sense to have in
+    # some cases, don't force it when it is not defined.
+    if 'pagerduty.service' in creds and creds['pagerduty.service'] is not None:
+        data['service_key'] = creds['pagerduty.service']
     data['client_url'] = client_url
     if 'event_type' not in data:
         data['event_type'] = 'trigger'
@@ -104,13 +108,13 @@ def query(method='GET', profile=None, url=None, path='api/v1',
     return result['text']
 
 
-def list_items(action, key, profile=None, api_key=None, opts=None):
+def list_items(action, key, profile_dict=None, api_key=None, opts=None):
     '''
     List items belonging to an API call. Used for list_services() and
     list_incidents()
     '''
     items = json.loads(query(
-        profile=profile,
+        profile_dict=profile_dict,
         api_key=api_key,
         action=action,
         opts=opts


### PR DESCRIPTION
Previously the pagerduty util was just accepting <code> **opts** </code> from the module as opts and then trying to parse the opts dict for its configuration options.  This worked great if you had these configs in your minion's config file, but would not work at all if the configuration was in the pillar (which should work according to the documentation).  <code> **salt**['config.option']() </code> was the obvious work around.

Additionally, there is a configuration option that the util was looking for called pagerduty.service which was overwriting the service_key passed from the module.  This option is completely undocumented.  I left the option there if it were defined so that it can still be utilized (should allow for backwards compatibility for anyone using this module/util), but bypassed it if it was not defined.  I am not sure how anyone was able to use this module before without spending considerable time in the source because of this.

Please let me know if you have any questions regarding this change or any changes that I need to make to accommodate salt best practices.
