### PR TITLE
fixing the doc for get_master_status return

### DIFF
--- a/salt/modules/mysql.py
+++ b/salt/modules/mysql.py
@@ -1853,7 +1853,8 @@ def get_master_status(**connection_args):
     '''
     Retrieves the master status from the minion.
 
-    Returns:
+    Returns::
+
         {'host.domain.com': {'Binlog_Do_DB': '',
                          'Binlog_Ignore_DB': '',
                          'File': 'mysql-bin.000021',


### PR DESCRIPTION
There was a slight formatting error

It looks like this currently

![screen shot 2015-02-18 at 8 07 31 pm](https://cloud.githubusercontent.com/assets/205373/6261768/dd7279f8-b7a9-11e4-920c-a08ddb5126ec.png)

I built the docs against my change and it looks better now
