### PR TITLE
Fixed dict unpacking in salt.utils.format_call

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -787,7 +787,9 @@ def format_call(fun,
 
     aspec = salt.utils.args.get_function_argspec(fun)
 
-    args, kwargs = six.itervalues(arg_lookup(fun))
+    arg_data = arg_lookup(fun)
+    args = arg_data['args']
+    kwargs = arg_data['kwargs']
 
     # Since we WILL be changing the data dictionary, let's change a copy of it
     data = data.copy()


### PR DESCRIPTION
When I imported salt in my project that was compiled with nuitka, the dict iteration order was random and as a result, sometimes args and kwargs were exchanged.
