### PR TITLE
Better error message for first_auth

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -718,9 +718,10 @@ class SAuth(object):
                     log.error(
                         'The Salt Master has cached the public key for this '
                         'node. If this is the first time connecting to this master '
-                        'then this key may need to be accepted using \'salt-key\'. '
-                        'This salt minion will wait for {0} seconds '
-                        'before attempting to re-authenticate'.format(
+                        'then this key may need to be accepted using \'salt-key -a {0}\' on '
+                        'the salt master. This salt minion will wait for {1} seconds '
+                        'before attempting to re-authenticate.'.format(
+                            self.opts['id'],
                             self.opts['acceptance_wait_time']
                         )
                     )

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -717,7 +717,9 @@ class SAuth(object):
                 else:
                     log.error(
                         'The Salt Master has cached the public key for this '
-                        'node, this salt minion will wait for {0} seconds '
+                        'node. If this is the first time connecting to this master '
+                        'then this key may need to be accepted using \'salt-key\'. '
+                        'This salt minion will wait for {0} seconds '
                         'before attempting to re-authenticate'.format(
                             self.opts['acceptance_wait_time']
                         )


### PR DESCRIPTION
Provide a hint for new users on key acceptance when a minion first starts up.
