### PR TITLE
Fixed dict unpacking in salt.utils.format_call

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -848,7 +848,9 @@ def format_call(fun,
 
     aspec = get_function_argspec(fun)
 
-    args, kwargs = arg_lookup(fun).itervalues()
+    arg_data = arg_lookup(fun)
+    args = arg_data['args']
+    kwargs = arg_data['kwargs']
 
     # Since we WILL be changing the data dictionary, let's change a copy of it
     data = data.copy()


### PR DESCRIPTION
When I imported salt in my project that was compiled with nuitka, the dict iteration order was random and as a result, sometimes args and kwargs were exchanged.

Note: originally the pull request was submitted against develop https://github.com/saltstack/salt/pull/20822
