### PR TITLE
Fix multi comps and multi dist bugs

### DIFF
--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -1168,7 +1168,7 @@ def _consolidate_repo_sources(sources):
     for repo in repos:
         repo.uri = repo.uri.rstrip('/')
         key = str((getattr(repo, 'architectures', []),
-                   repo.disabled, repo.type, repo.uri))
+                   repo.disabled, repo.type, repo.uri, repo.dist))
         if key in consolidated:
             combined = consolidated[key]
             combined_comps = set(repo.comps).union(set(combined.comps))
@@ -1576,7 +1576,7 @@ def mod_repo(repo, saltenv='base', **kwargs):
 
     if 'comps' in kwargs:
         kwargs['comps'] = kwargs['comps'].split(',')
-        full_comp_list.union(set(kwargs['comps']))
+        full_comp_list |= set(kwargs['comps'])
     else:
         kwargs['comps'] = list(full_comp_list)
 


### PR DESCRIPTION
Fix line full_comp_list.union(set(kwargs['comps'])) which actually don't do anything, because union don't modify source set. Looks like typo...
It is possible to have multiple 'dist' in single repository, i.e. wheezy and wheezy-backports . So in consolidate repos, use dist also as a key.
