### PR TITLE
Backport #20655 to 2015.2

### DIFF
--- a/requirements/raet.txt
+++ b/requirements/raet.txt
@@ -1,0 +1,5 @@
+-r base.txt
+
+libnacl >= 1.0.0
+ioflo >= 1.1.7
+raet >= 0.6.0

--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -354,7 +354,7 @@ class RAETCaller(ZeroMQCaller):
                           lanename=lanename,
                           sockdirpath=sockdirpath)
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         stack.addRemote(RemoteYard(stack=stack,
                                    name='manor',
                                    lanename=lanename,

--- a/salt/client/raet/__init__.py
+++ b/salt/client/raet/__init__.py
@@ -73,7 +73,7 @@ class LocalClient(salt.client.LocalClient):
                 name=name,
                 lanename=lanename,
                 sockdirpath=sockdirpath)
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         manor_yard = RemoteYard(
                 stack=stack,
                 lanename=lanename,

--- a/salt/daemons/flo/core.py
+++ b/salt/daemons/flo/core.py
@@ -131,7 +131,7 @@ class SaltRaetRoadStackSetup(ioflo.base.deeding.Deed):
         '''
         Assign class defaults
         '''
-        RoadStack.Bk = raeting.bodyKinds.msgpack
+        RoadStack.Bk = raeting.BodyKind.msgpack.value
         RoadStack.JoinentTimeout = 0.0
 
     def action(self):
@@ -320,9 +320,9 @@ class SaltRaetRoadStackRejected(ioflo.base.deeding.Deed):
         rejected = False
         if stack and isinstance(stack, RoadStack):
             if stack.remotes:
-                for remote in stack.remotes.values():
-                    rejected = all([remote.acceptance == raeting.acceptances.rejected
-                                    for remote in stack.remotes.values()])
+                rejected = all([remote.acceptance == raeting.Acceptance.rejected.value
+                                for remote in stack.remotes.values()
+                                if remote.kind == kinds.applKinds.master])
             else:  # no remotes so assume rejected
                 rejected = True
         self.status.update(rejected=rejected)
@@ -696,7 +696,7 @@ class SaltRaetManorLaneSetup(ioflo.base.deeding.Deed):
                                     name=name,
                                     lanename=lanename,
                                     sockdirpath=self.opts.value['sock_dir'])
-        self.stack.value.Pk = raeting.packKinds.pack
+        self.stack.value.Pk = raeting.PackKind.pack.value
         self.event_yards.value = set()
         self.local_cmd.value = deque()
         self.remote_cmd.value = deque()
@@ -1409,7 +1409,7 @@ class SaltRaetNixJobber(ioflo.base.deeding.Deed):
                 lanename=lanename,
                 sockdirpath=sockdirpath)
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         # add remote for the manor yard
         stack.addRemote(RemoteYard(stack=stack,
                                    name='manor',

--- a/salt/daemons/flo/worker.py
+++ b/salt/daemons/flo/worker.py
@@ -138,7 +138,7 @@ class SaltRaetWorkerSetup(ioflo.base.deeding.Deed):
                                      name=name,
                                      lanename=lanename,
                                      sockdirpath=sockdirpath)
-        self.stack.value.Pk = raeting.packKinds.pack
+        self.stack.value.Pk = raeting.PackKind.pack.value
         manor_yard = RemoteYard(
                                  stack=self.stack.value,
                                  name='manor',

--- a/salt/daemons/salting.py
+++ b/salt/daemons/salting.py
@@ -47,7 +47,7 @@ class SaltKeep(Keep):
                     'role', 'acceptance', 'verhex', 'pubhex']
     RemoteDumpFields = ['name', 'uid', 'fuid', 'ha', 'iha', 'natted', 'fqdn', 'dyned',
                          'sid', 'main', 'kind', 'joined', 'role']
-    Auto = raeting.autoModes.never #auto accept
+    Auto = raeting.AutoMode.never.value #auto accept
 
     def __init__(self, opts, prefix='estate', basedirpath='',  auto=None, **kwa):
         '''
@@ -56,9 +56,9 @@ class SaltKeep(Keep):
         basedirpath = basedirpath or os.path.join(opts['cache_dir'], 'raet')
         super(SaltKeep, self).__init__(prefix=prefix, basedirpath=basedirpath, **kwa)
         self.auto = (auto if auto is not None else
-                            (raeting.autoModes.always if opts['open_mode'] else
-                                (raeting.autoModes.once if opts['auto_accept'] else
-                                 raeting.autoModes.never)))
+                            (raeting.AutoMode.always.value if opts['open_mode'] else
+                                (raeting.AutoMode.once.value if opts['auto_accept'] else
+                                 raeting.AutoMode.never.value)))
         self.saltRaetKey = RaetKey(opts)
 
     def clearAllDir(self):
@@ -118,7 +118,7 @@ class SaltKeep(Keep):
             return None
 
         mid = data['role']
-        for status in raeting.ACCEPTANCES:
+        for status in [acceptance.name for acceptance in Acceptance]:
             keydata = self.saltRaetKey.read_remote(mid, status)
             if keydata:
                 break
@@ -128,7 +128,7 @@ class SaltKeep(Keep):
                          ('verhex', None),
                          ('pubhex', None)])
         else:
-            data.update(acceptance=raeting.ACCEPTANCES[status],
+            data.update(acceptance=raeting.Acceptance[status].value,
                         verhex=keydata['verify'],
                         pubhex=keydata['pub'])
 
@@ -151,7 +151,7 @@ class SaltKeep(Keep):
                     for name, data in keeps.items():
                         if data['role'] == mid:
                             keeps[name].update(
-                                    [('acceptance', raeting.ACCEPTANCES[status]),
+                                    [('acceptance', raeting.Acceptance[status].value),
                                      ('verhex', keydata['verify']),
                                      ('pubhex', keydata['pub'])])
         return keeps
@@ -250,9 +250,9 @@ class SaltKeep(Keep):
         Where status is acceptance status of role and keys
         and has value from raeting.acceptances
         '''
-        status = raeting.ACCEPTANCES[self.saltRaetKey.status(role,
+        status = raeting.Acceptance[self.saltRaetKey.status(role,
                                                              pubhex,
-                                                             verhex)]
+                                                             verhex)].value
 
         return status
 
@@ -262,7 +262,7 @@ class SaltKeep(Keep):
         '''
         mid = remote.role
         self.saltRaetKey.reject(match=mid, include_accepted=True)
-        remote.acceptance = raeting.acceptances.rejected
+        remote.acceptance = raeting.Acceptance.rejected.value
 
     def pendRemote(self, remote):
         '''
@@ -276,4 +276,4 @@ class SaltKeep(Keep):
         '''
         mid = remote.role
         self.saltRaetKey.accept(match=mid, include_rejected=True)
-        remote.acceptance = raeting.acceptances.accepted
+        remote.acceptance = raeting.Acceptance.accepted.value

--- a/salt/daemons/test/plan/actors.py
+++ b/salt/daemons/test/plan/actors.py
@@ -1,0 +1,827 @@
+# -*- coding: utf-8 -*-
+'''
+Test behaviors used by test plans
+'''
+# pylint: skip-file
+# pylint: disable=C0103
+
+import os
+import stat
+import time
+from collections import deque
+
+# Import ioflo libs
+import ioflo.base.deeding
+from ioflo.base.odicting import odict
+
+from ioflo.base.consoling import getConsole
+console = getConsole()
+
+from raet import raeting, nacling
+from raet.lane.stacking import LaneStack
+from raet.lane.yarding import RemoteYard
+from raet.road.estating import RemoteEstate
+from raet.road.stacking import RoadStack
+from raet.stacking import Stack
+
+from salt.daemons import salting
+from salt.utils.event import tagify
+
+
+class DeedTestWrapper():
+    def assertTrue(self, condition):
+        if not condition:
+            self.failure.value = 'Fail'
+            raise Exception("Test Failed")
+
+
+def createStack(ip):
+    stack = Stack()
+    stack.ha = (ip, '1234')
+    return stack
+
+
+class TestOptsSetup(ioflo.base.deeding.Deed):
+    '''
+    Setup opts share
+    '''
+    Ioinits = {'opts': '.salt.opts'}
+
+    def action(self):
+        '''
+        Register presence requests
+        Iterate over the registered presence yards and fire!
+        '''
+        pkiDirpath = os.path.join('/tmp', 'raet', 'test', self.role, 'pki')
+        if not os.path.exists(pkiDirpath):
+            os.makedirs(pkiDirpath)
+
+        acceptedDirpath = os.path.join(pkiDirpath, 'accepted')
+        if not os.path.exists(acceptedDirpath):
+            os.makedirs(acceptedDirpath)
+
+        pendingDirpath = os.path.join(pkiDirpath, 'pending')
+        if not os.path.exists(pendingDirpath):
+            os.makedirs(pendingDirpath)
+
+        rejectedDirpath = os.path.join(pkiDirpath, 'rejected')
+        if not os.path.exists(rejectedDirpath):
+            os.makedirs(rejectedDirpath)
+
+        localFilepath = os.path.join(pkiDirpath, 'local.key')
+        if os.path.exists(localFilepath):
+            mode = os.stat(localFilepath).st_mode
+            print(mode)
+            os.chmod(localFilepath, mode | stat.S_IWUSR | stat.S_IRUSR)
+            mode = os.stat(localFilepath).st_mode
+            print(mode)
+
+        cacheDirpath = os.path.join('/tmp/raet', 'cache', self.role)
+        if not os.path.exists(cacheDirpath):
+            os.makedirs(cacheDirpath)
+
+        sockDirpath = os.path.join('/tmp/raet', 'sock', self.role)
+        if not os.path.exists(sockDirpath):
+            os.makedirs(sockDirpath)
+
+        self.opts.value = dict(
+            id=self.role,
+            __role=self.role,
+            ioflo_period=0.1,
+            ioflo_realtime=True,
+            ioflo_verbose=2,
+            interface="",
+            raet_port=self.raet_port,
+            transport='raet',
+            client_acl=dict(),
+            pki_dir=pkiDirpath,
+            sock_dir=sockDirpath,
+            cachedir=cacheDirpath,
+            open_mode=True,
+            auto_accept=True,
+            )
+
+        name = "{0}_{1}".format(self.role, self.role)
+        basedirpath = os.path.abspath(os.path.join(cacheDirpath, 'raet'))
+        keep = salting.SaltKeep(opts=self.opts.value,
+                                basedirpath=basedirpath,
+                                stackname=name)
+        keep.clearLocalData()
+        keep.clearLocalRoleData()
+        keep.clearAllRemoteData()
+        keep.clearAllRemoteRoleData()
+
+
+class TestOptsSetupMaster(TestOptsSetup):
+
+    def action(self):
+        self.role = 'master'
+        self.raet_port = raeting.RAET_PORT
+        super(TestOptsSetupMaster, self).action()
+
+
+class TestOptsSetupMinion(TestOptsSetup):
+
+    def action(self):
+        self.role = 'minion'
+        self.raet_port = raeting.RAET_TEST_PORT
+        super(TestOptsSetupMinion, self).action()
+
+
+def serviceRoads(stacks, duration=1.0):
+    '''
+    Utility method to service queues for list of stacks. Call from test method.
+    '''
+    start = time.time()
+    while start + duration > time.time():
+        for stack in stacks:
+            stack.serviceAll()
+        if all([not stack.transactions for stack in stacks]):
+            console.terse("Service stacks done normally\n")
+            break
+        time.sleep(0.05)
+    for stack in stacks:
+        console.terse("Stack {0} remotes: {1}\n".format(stack.name, stack.nameRemotes))
+    console.terse("Service stacks exit\n")
+
+
+def serviceLanes(stacks, duration=1.0):
+    '''
+    Utility method to service queues for list of stacks. Call from test method.
+    '''
+    start = time.time()
+    while start + duration > time.time():
+        for stack in stacks:
+            stack.serviceAll()
+        if all([not stack.txMsgs for stack in stacks]):
+            console.terse("Service stacks done normally\n")
+            break
+        time.sleep(0.05)
+    for stack in stacks:
+        console.terse("Stack {0} remotes: {1}\n".format(stack.name, stack.nameRemotes))
+    console.terse("Service stacks exit\n")
+
+
+class PresenterTestSetup(ioflo.base.deeding.Deed):
+    '''
+    Setup shares for presence tests
+    '''
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'lane_stack': '.salt.lane.manor.stack',
+               'event_stack': '.salt.test.lane.stack',
+               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+                            'ival': odict()},
+               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+                           'ival': odict()},
+               'reapeds': {'ipath': '.salt.var.presence.reapeds',
+                           'ival': odict()},
+               'availables': {'ipath': '.salt.var.presence.availables',
+                              'ival': set()}}
+
+    def action(self):
+
+        self.presence_req.value = deque()
+        self.availables.value = set()
+        self.alloweds.value = odict()
+        self.aliveds.value = odict()
+        self.reapeds.value = odict()
+
+        # Create event stack
+        name = 'event' + nacling.uuid(size=18)
+        lanename = self.lane_stack.value.local.lanename
+        sock_dir = self.lane_stack.value.local.dirpath
+        ryn = 'manor'
+        console.terse("Create stack: name = {0}, lanename = {1}, sock_dir = {2}\n".
+                      format(name, lanename, sock_dir))
+        stack = LaneStack(
+            name=name,
+            lanename=lanename,
+            sockdirpath=sock_dir)
+        stack.addRemote(RemoteYard(stack=stack,
+                                   lanename=lanename,
+                                   name=ryn,
+                                   dirpath=sock_dir))
+        self.event_stack.value = stack
+
+        route = {'dst': (None, ryn, 'presence_req'),
+                 'src': (None, stack.local.name, None)}
+        msg = {'route': route}
+        stack.transmit(msg, stack.nameRemotes[ryn].uid)
+        serviceLanes([stack, self.lane_stack.value])
+
+
+class PresenterTestCleanup(ioflo.base.deeding.Deed):
+    '''
+    Clean up after a test
+    '''
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+                            'ival': odict()},
+               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+                           'ival': odict()},
+               'reapeds': {'ipath': '.salt.var.presence.reapeds',
+                           'ival': odict()},
+               'availables': {'ipath': '.salt.var.presence.availables',
+                              'ival': set()}}
+
+    def action(self):
+
+        self.presence_req.value = deque()
+        self.availables.value = set()
+        self.alloweds.value = odict()
+        self.aliveds.value = odict()
+        self.reapeds.value = odict()
+
+
+class TestPresenceAvailable(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+                           'ival': odict()},
+               'availables': {'ipath': '.salt.var.presence.availables',
+                              'ival': set()}}
+
+    def action(self):
+        """
+        Test Presenter 'available' request (A1, B*)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add available minions
+        self.availables.value.add('alpha')
+        self.availables.value.add('beta')
+        self.aliveds.value['alpha'] = createStack('1.1.1.1')
+        self.aliveds.value['beta'] = createStack('1.2.3.4')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        # general available request format
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'available'}})
+        # missing 'data', fallback to available
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)}})
+        # missing 'state' in 'data', fallback to available
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {}})
+        # requested None state, fallback to available
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': None}})
+        # requested 'present' state that is alias for available
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'present'}})
+
+
+class TestPresenceAvailableCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 5)
+
+        tag = tagify('present', 'presence')
+        while testStack.rxMsgs:
+            msg, sender = testStack.rxMsgs.popleft()
+            self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                              'dst': [None, None, 'event_fire']},
+                                    'tag': tag,
+                                    'data': {'present': {'alpha': '1.1.1.1',
+                                                         'beta': '1.2.3.4'}}})
+
+
+class TestPresenceJoined(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+                            'ival': odict()}}
+
+    def action(self):
+        """
+        Test Presenter 'joined' request (A2)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add joined minions
+        self.alloweds.value['alpha'] = createStack('1.1.1.1')
+        self.alloweds.value['beta'] = createStack('1.2.3.4')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'joined'}})
+
+
+class TestPresenceJoinedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        msg, sender = testStack.rxMsgs.popleft()
+        self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                          'dst': [None, None, 'event_fire']},
+                                'tag': tag,
+                                'data': {'joined': {'alpha': '1.1.1.1',
+                                                    'beta': '1.2.3.4'}}})
+
+
+class TestPresenceAllowed(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+                            'ival': odict()}}
+
+    def action(self):
+        """
+        Test Presenter 'allowed' request (A3)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add allowed minions
+        self.alloweds.value['alpha'] = createStack('1.1.1.1')
+        self.alloweds.value['beta'] = createStack('1.2.3.4')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'allowed'}})
+
+
+class TestPresenceAllowedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        msg, sender = testStack.rxMsgs.popleft()
+        self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                          'dst': [None, None, 'event_fire']},
+                                'tag': tag,
+                                'data': {'allowed': {'alpha': '1.1.1.1',
+                                                     'beta': '1.2.3.4'}}})
+
+
+class TestPresenceAlived(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+                            'ival': odict()}}
+
+    def action(self):
+        """
+        Test Presenter 'alived' request (A4)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add alived minions
+        self.aliveds.value['alpha'] = createStack('1.1.1.1')
+        self.aliveds.value['beta'] = createStack('1.2.3.4')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'alived'}})
+
+
+class TestPresenceAlivedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        msg, sender = testStack.rxMsgs.popleft()
+        self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                          'dst': [None, None, 'event_fire']},
+                                'tag': tag,
+                                'data': {'alived': {'alpha': '1.1.1.1',
+                                                    'beta': '1.2.3.4'}}})
+
+
+class TestPresenceReaped(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'reapeds': {'ipath': '.salt.var.presence.reapeds',
+                           'ival': odict()}}
+
+    def action(self):
+        """
+        Test Presenter 'reaped' request (A5)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add reaped minions
+        self.reapeds.value['alpha'] = createStack('1.1.1.1')
+        self.reapeds.value['beta'] = createStack('1.2.3.4')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'reaped'}})
+
+
+class TestPresenceReapedCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        msg, sender = testStack.rxMsgs.popleft()
+        self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                          'dst': [None, None, 'event_fire']},
+                                'tag': tag,
+                                'data': {'reaped': {'alpha': '1.1.1.1',
+                                                    'beta': '1.2.3.4'}}})
+
+
+class TestPresenceNoRequest(ioflo.base.deeding.Deed):
+    Ioinits = {}
+
+    def action(self):
+        """
+        Test Presenter with no requests (C1)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        pass # do nothing
+
+
+class TestPresenceNoRequestCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+
+
+class TestPresenceUnknownSrc(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        """
+        Test Presenter handles request from unknown (disconnected) source (C2)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        name = 'unknown_name'
+        self.assertTrue(name != testStack.local.name)
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, name, None)}})
+
+
+class TestPresenceUnknownSrcCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+
+
+class TestPresenceAvailableNoMinions(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack'}
+
+    def action(self):
+        """
+        Test Presenter 'available' request with no minions in the state (D1)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'available'}})
+
+
+class TestPresenceAvailableNoMinionsCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        while testStack.rxMsgs:
+            msg, sender = testStack.rxMsgs.popleft()
+            self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                              'dst': [None, None, 'event_fire']},
+                                    'tag': tag,
+                                    'data': {'present': {}}})
+
+
+class TestPresenceAvailableOneMinion(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+                           'ival': odict()},
+               'availables': {'ipath': '.salt.var.presence.availables',
+                              'ival': set()}}
+
+    def action(self):
+        """
+        Test Presenter 'available' request with one minions in the state (D2)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add available minions
+        self.availables.value.add('alpha')
+        self.aliveds.value['alpha'] = createStack('1.1.1.1')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'available'}})
+
+
+class TestPresenceAvailableOneMinionCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        while testStack.rxMsgs:
+            msg, sender = testStack.rxMsgs.popleft()
+            self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                              'dst': [None, None, 'event_fire']},
+                                    'tag': tag,
+                                    'data': {'present': {'alpha': '1.1.1.1'}}})
+
+
+class TestPresenceAvailableUnknownIp(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'aliveds': {'ipath': '.salt.var.presence.aliveds',
+                           'ival': odict()},
+               'availables': {'ipath': '.salt.var.presence.availables',
+                              'ival': set()}}
+
+    def action(self):
+        """
+        Test Presenter 'available' request with one minions in the state (D3)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add available minions
+        self.availables.value.add('alpha')
+        self.availables.value.add('beta')
+        self.availables.value.add('gamma')
+        self.aliveds.value['alpha'] = createStack('1.1.1.1')
+        self.aliveds.value['delta'] = createStack('1.2.3.4')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'available'}})
+
+
+class TestPresenceAvailableUnknownIpCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        while testStack.rxMsgs:
+            msg, sender = testStack.rxMsgs.popleft()
+            self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                              'dst': [None, None, 'event_fire']},
+                                    'tag': tag,
+                                    'data': {'present': {'alpha': '1.1.1.1',
+                                                         'beta': None,
+                                                         'gamma': None}}})
+
+
+class TestPresenceAllowedNoMinions(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack'}
+
+    def action(self):
+        """
+        Test Presenter 'allowed' request with no minions in the state (D4)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'allowed'}})
+
+
+class TestPresenceAllowedNoMinionsCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        msg, sender = testStack.rxMsgs.popleft()
+        self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                          'dst': [None, None, 'event_fire']},
+                                'tag': tag,
+                                'data': {'allowed': {}}})
+
+
+class TestPresenceAllowedOneMinion(ioflo.base.deeding.Deed):
+    Ioinits = {'presence_req': '.salt.presence.event_req',
+               'event_stack': '.salt.test.lane.stack',
+               'alloweds': {'ipath': '.salt.var.presence.alloweds',
+                            'ival': odict()}}
+
+    def action(self):
+        """
+        Test Presenter 'allowed' request with one minion in the state (D5)
+        """
+        console.terse("{0}\n".format(self.action.__doc__))
+
+        # Prepare
+        # add allowed minion
+        self.alloweds.value['alpha'] = createStack('1.1.1.1')
+        # add presence request
+        testStack = self.event_stack.value
+        presenceReq = self.presence_req.value
+        ryn = 'manor'
+        presenceReq.append({'route': {'dst': (None, ryn, 'presence_req'),
+                                      'src': (None, testStack.local.name, None)},
+                            'data': {'state': 'allowed'}})
+
+
+class TestPresenceAllowedOneMinionCheck(ioflo.base.deeding.Deed, DeedTestWrapper):
+    Ioinits = {'event_stack': '.salt.test.lane.stack',
+               'failure': '.meta.failure'}
+
+    def action(self):
+        testStack = self.event_stack.value
+        self.assertTrue(len(testStack.rxMsgs) == 0)
+        testStack.serviceAll()
+        self.assertTrue(len(testStack.rxMsgs) == 1)
+
+        tag = tagify('present', 'presence')
+        msg, sender = testStack.rxMsgs.popleft()
+        self.assertTrue(msg == {'route': {'src': [None, 'manor', None],
+                                          'dst': [None, None, 'event_fire']},
+                                'tag': tag,
+                                'data': {'allowed': {'alpha':'1.1.1.1'}}})
+
+
+class StatsMasterTestSetup(ioflo.base.deeding.Deed):
+    '''
+    Setup shares for stats tests
+    '''
+    Ioinits = {'stats_req': '.salt.stats.event_req',
+               'lane_stack': '.salt.lane.manor.stack',
+               'road_stack': '.salt.road.manor.stack',
+               'event_stack': '.salt.test.lane.stack'}
+
+    def action(self):
+
+        self.stats_req.value = deque()
+
+        # Create event stack
+        name = 'event' + nacling.uuid(size=18)
+        lanename = self.lane_stack.value.local.lanename
+        sock_dir = self.lane_stack.value.local.dirpath
+        ryn = 'manor'
+        console.terse("Create stack: name = {0}, lanename = {1}, sock_dir = {2}\n".
+                      format(name, lanename, sock_dir))
+        stack = LaneStack(
+            name=name,
+            lanename=lanename,
+            sockdirpath=sock_dir)
+        stack.addRemote(RemoteYard(stack=stack,
+                                   lanename=lanename,
+                                   name=ryn,
+                                   dirpath=sock_dir))
+        self.event_stack.value = stack
+
+        route = {'dst': (None, ryn, 'stats_req'),
+                 'src': (None, stack.local.name, None)}
+        msg = {'route': route}
+        stack.transmit(msg, stack.nameRemotes[ryn].uid)
+        serviceLanes([stack, self.lane_stack.value])
+
+
+class StatsMinionTestSetup(ioflo.base.deeding.Deed):
+    '''
+    Setup shares for stats tests
+    '''
+    Ioinits = {'stats_req': '.salt.stats.event_req',
+               'lane_stack': '.salt.lane.manor.stack',
+               'road_stack': '.salt.road.manor.stack',
+               'event_stack': '.salt.test.road.stack'}
+
+    def action(self):
+
+        self.stats_req.value = deque()
+
+        minionStack = self.road_stack.value
+
+        # Create Master Stack
+        self.store.stamp = 0.0
+        masterStack = RoadStack(store=self.store,
+                                name='master',
+                                ha=('', raeting.RAET_PORT),
+                                role='master',
+                                main=True,
+                                cleanremote=True,
+                                period=3.0,
+                                offset=0.5)
+        self.event_stack.value = masterStack
+
+        minionRemoteMaster = RemoteEstate(stack=minionStack,
+                                          fuid=0,
+                                          sid=0,
+                                          ha=masterStack.local.ha)
+        minionStack.addRemote(minionRemoteMaster)
+
+        # Make life easier
+        masterStack.keep.auto = raeting.AutoMode.always.value
+        minionStack.keep.auto = raeting.AutoMode.always.value
+
+        minionStack.join(minionRemoteMaster.uid)
+        serviceRoads([minionStack, masterStack])
+        minionStack.allow(minionRemoteMaster.uid)
+        serviceRoads([minionStack, masterStack])

--- a/salt/daemons/test/test_saltkeep.py
+++ b/salt/daemons/test/test_saltkeep.py
@@ -236,7 +236,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertTrue(main.keep.dirpath.endswith(
                 os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {'name': mainData['name'],
                                                          'uid': 1,
                                                          'ha': ['127.0.0.1', 7530],
@@ -358,7 +358,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.never)
+        self.assertIs(other.keep.auto, raeting.AutoMode.never.value)
 
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
@@ -475,7 +475,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -596,7 +596,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto,raeting.autoModes.always)
+        self.assertIs(other.keep.auto,raeting.AutoMode.always.value)
 
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
@@ -713,7 +713,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto,  raeting.autoModes.once)
+        self.assertIs(main.keep.auto,  raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -836,7 +836,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.once)
+        self.assertIs(other.keep.auto, raeting.AutoMode.once.value)
 
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
@@ -954,7 +954,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {'name': mainData['name'],
                                                          'uid': 1,
                                                          'ha': ['127.0.0.1', 7530],
@@ -1057,7 +1057,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(main.local.uid, 1)
         self.assertEqual(main.main, True)
         self.assertEqual(main.local.role, mainData['role'])
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertEqual(main.local.priver.keyhex, mainData['prihex'])
         self.assertEqual(main.local.signer.keyhex, mainData['sighex'])
@@ -1102,7 +1102,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1200,7 +1200,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(main.local.uid, 1)
         self.assertEqual(main.main, True)
         self.assertEqual(main.local.role, mainData['role'])
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertEqual(main.local.priver.keyhex, mainData['prihex'])
         self.assertEqual(main.local.signer.keyhex, mainData['sighex'])
@@ -1246,7 +1246,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1351,7 +1351,7 @@ class BasicTestCase(unittest.TestCase):
         self.assertEqual(main.local.uid, 1)
         self.assertEqual(main.main, True)
         self.assertEqual(main.local.role, mainData['role'])
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
         self.assertEqual(main.local.priver.keyhex, mainData['prihex'])
         self.assertEqual(main.local.signer.keyhex, mainData['sighex'])
@@ -1398,7 +1398,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1439,7 +1439,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto,  raeting.autoModes.once)
+        self.assertIs(other.keep.auto,  raeting.AutoMode.once.value)
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
                                 'name': otherData['name'],
@@ -1524,7 +1524,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.always)
+        self.assertIs(main.keep.auto, raeting.AutoMode.always.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1565,7 +1565,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.once)
+        self.assertIs(other.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
                                 'name': otherData['name'],
@@ -1646,7 +1646,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertEqual(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1687,7 +1687,7 @@ class BasicTestCase(unittest.TestCase):
                 other.name, other.keep.dirpath))
         self.assertTrue(other.keep.dirpath.endswith(os.path.join('other', 'raet', 'other_minion')))
         self.assertEqual(other.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other.keep.auto, raeting.autoModes.once)
+        self.assertIs(other.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other.keep.loadLocalData(),
                             {
                                 'name': otherData['name'],
@@ -1768,7 +1768,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.never)
+        self.assertIs(main.keep.auto, raeting.AutoMode.never.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -1809,7 +1809,7 @@ class BasicTestCase(unittest.TestCase):
                 other1.name, other1.keep.dirpath))
         self.assertTrue(other1.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_minion')))
         self.assertEqual(other1.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other1.keep.auto, raeting.autoModes.once)
+        self.assertIs(other1.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other1.keep.loadLocalData(),
                             {
                                 'name': other1Data['name'],
@@ -1877,7 +1877,7 @@ class BasicTestCase(unittest.TestCase):
                 other2.name, other2.keep.dirpath))
         self.assertTrue(other2.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_caller')))
         self.assertEqual(other2.ha, ("0.0.0.0", 7532))
-        self.assertIs(other2.keep.auto, raeting.autoModes.once)
+        self.assertIs(other2.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other2.keep.loadLocalData(),
                             {
                                 'name': other2Data['name'],
@@ -1937,7 +1937,7 @@ class BasicTestCase(unittest.TestCase):
                 other2.name, other2.keep.dirpath))
         self.assertTrue(other2.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_caller')))
         self.assertEqual(other2.ha, ("0.0.0.0", 7532))
-        self.assertIs(other2.keep.auto, raeting.autoModes.once)
+        self.assertIs(other2.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other2.keep.loadLocalData(),
                             {
                                 'name': other2Data['name'],
@@ -2023,7 +2023,7 @@ class BasicTestCase(unittest.TestCase):
                 main.name, main.keep.dirpath))
         self.assertTrue(main.keep.dirpath.endswith(os.path.join('main', 'raet', 'main_master')))
         self.assertTrue(main.ha, ("0.0.0.0", raeting.RAET_PORT))
-        self.assertIs(main.keep.auto, raeting.autoModes.once)
+        self.assertIs(main.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(main.keep.loadLocalData(), {
                                                          'name': mainData['name'],
                                                          'uid': 1,
@@ -2064,7 +2064,7 @@ class BasicTestCase(unittest.TestCase):
                 other1.name, other1.keep.dirpath))
         self.assertTrue(other1.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_minion')))
         self.assertEqual(other1.ha, ("0.0.0.0", raeting.RAET_TEST_PORT))
-        self.assertIs(other1.keep.auto, raeting.autoModes.once)
+        self.assertIs(other1.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other1.keep.loadLocalData(),
                             {
                                 'name': other1Data['name'],
@@ -2131,7 +2131,7 @@ class BasicTestCase(unittest.TestCase):
                 other2.name, other2.keep.dirpath))
         self.assertTrue(other2.keep.dirpath.endswith(os.path.join('primary', 'raet', 'primary_caller')))
         self.assertEqual(other2.ha, ("0.0.0.0", 7532))
-        self.assertIs(other2.keep.auto, raeting.autoModes.once)
+        self.assertIs(other2.keep.auto, raeting.AutoMode.once.value)
         self.assertDictEqual(other2.keep.loadLocalData(),
                             {
                                 'name': other2Data['name'],

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -154,7 +154,7 @@ class RAETChannel(Channel):
                           lanename=lanename,
                           sockdirpath=self.opts['sock_dir'])
 
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         stack.addRemote(RemoteYard(stack=stack,
                                    name=ryn,
                                    lanename=lanename,

--- a/salt/utils/raetevent.py
+++ b/salt/utils/raetevent.py
@@ -98,7 +98,7 @@ class RAETEvent(object):
                 name=name,
                 lanename=lanename,
                 sockdirpath=self.sock_dir)
-        stack.Pk = raeting.packKinds.pack
+        stack.Pk = raeting.PackKind.pack.value
         stack.addRemote(RemoteYard(stack=stack,
                                    lanename=lanename,
                                    name=ryn,

--- a/salt/utils/raetlane.py
+++ b/salt/utils/raetlane.py
@@ -118,7 +118,7 @@ def _setup(opts, ryn='manor'):
                       lanename=lanename,
                       sockdirpath=opts['sock_dir'])
 
-    lane_stack.Pk = raeting.packKinds.pack
+    lane_stack.Pk = raeting.PackKind.pack.value
     log.debug("Created new LaneStack and local Yard named {0} at {1}\n"
               "".format(lane_stack.name, lane_stack.ha))
     remote_yard = RemoteYard(stack=lane_stack,


### PR DESCRIPTION
Backport #20655 to 2015.2

Conflicts:
- CONFLICT (modify/delete): salt/daemons/test/plan/actors.py deleted in HEAD and modified in Support for Raet 0.6.0 with enums. Version Support for Raet 0.6.0 with enums of salt/daemons/test/plan/actors.py left in tree.
- CONFLICT (content): Merge conflict in salt/daemons/flo/core.py
- CONFLICT (modify/delete): requirements/raet.txt deleted in HEAD and modified in Support for Raet 0.6.0 with enums. Version Support for Raet 0.6.0 with enums of requirements/raet.txt left in tree.
