### PR TITLE
Moved ipcidr-doc to ipcidr() instead of compound()

### DIFF
--- a/salt/modules/match.py
+++ b/salt/modules/match.py
@@ -36,15 +36,6 @@ def compound(tgt, minion_id=None):
     .. code-block:: bash
 
         salt '*' match.compound 'L@cheese,foo and *'
-
-    delimiter
-    Pillar Example:
-
-    .. code-block:: yaml
-       '172.16.0.0/12':
-         - match: ipcidr
-         - nodeclass: internal
-
     '''
     opts = {'grains': __grains__}
     if minion_id is not None:
@@ -70,6 +61,15 @@ def ipcidr(tgt):
     .. code-block:: bash
 
         salt '*' match.ipcidr '192.168.44.0/24'
+
+    delimiter
+    Pillar Example:
+
+    .. code-block:: yaml
+       '172.16.0.0/12':
+         - match: ipcidr
+         - nodeclass: internal
+
     '''
     matcher = salt.minion.Matcher({'grains': __grains__}, __salt__)
     try:


### PR DESCRIPTION
When I originally did this pull request I accedentally put the pillar example for using the ipcidr-match under compound() instead of ipcidr(). So here's a fix for it.
