### PR TITLE
VCS fileserver backend fixes/optimizations

### DIFF
--- a/doc/ref/file_server/backends.rst
+++ b/doc/ref/file_server/backends.rst
@@ -1,21 +1,43 @@
+.. _file-server-backends:
+
 ====================
 File Server Backends
 ====================
 
-Salt version 0.12.0 introduced the ability for the Salt Master to integrate
-different file server backends. File server backends allows the Salt file
-server to act as a transparent bridge to external resources. The primary
-example of this is the git backend which allows for all of the Salt formulas
-and files to be maintained in a remote git repository.
+In Salt 0.12.0, the modular fileserver was introduced. This feature added the
+ability for the Salt Master to integrate different file server backends. File
+server backends allow the Salt file server to act as a transparent bridge to
+external resources. A good example of this is the :mod:`git
+<salt.fileserver.git>` backend, which allows Salt to serve files sourced from
+one or more git repositories, but there are several others as well. Click
+:ref:`here <all-salt.fileserver>` for a full list of Salt's fileserver
+backends.
 
-The fileserver backend system can accept multiple backends as well. This makes
-it possible to have the environments listed in the :conf_master:`file_roots`
-configuration available in addition to other backends, or the ability to mix
-multiple backends.
+Enabling a Fileserver Backend
+-----------------------------
 
-This feature is managed by the :conf_master:`fileserver_backend` option in the
-master config. The desired backend systems are listed in order of search
-priority:
+Fileserver backends can be enabled with the :conf_master:`fileserver_backend`
+option.
+
+.. code-block:: yaml
+
+    fileserver_backend:
+      - git
+
+See the :ref:`documentation <all-salt.fileserver>` for each backend to find the
+correct value to add to :conf_master:`fileserver_backend` in order to enable
+them.
+
+Using Multiple Backends
+-----------------------
+
+If :conf_master:`fileserver_backend` is not defined in the Master config file,
+Salt will use the :mod:`roots <salt.fileserver.roots>` backend, but the
+:conf_master:`fileserver_backend` option supports multiple backends. When more
+than one backend is in use, the files from the enabled backends are merged into a
+single virtual filesystem. When a file is requested, the backends will be
+searched in order for that file, and the first backend to match will be the one
+which returns the file.
 
 .. code-block:: yaml
 
@@ -24,16 +46,56 @@ priority:
       - git
 
 With this configuration, the environments and files defined in the
-:conf_master:`file_roots` parameter will be searched first, if the referenced
-environment and file is not found then the :mod:`git <salt.fileserver.gitfs>`
-backend will be searched.
+:conf_master:`file_roots` parameter will be searched first, and if the file is
+not found then the git repositories defined in :conf_master:`gitfs_remotes`
+will be searched.
 
 Environments
 ------------
 
-The concept of environments is followed in all backend systems. The
-environments in the classic :mod:`roots <salt.fileserver.roots>` backend are
-defined in the :conf_master:`file_roots` option. Environments map differently
-based on the backend, for instance the git backend translated branches and tags
-in git to environments. This makes it easy to define environments in git by
-just setting a tag or forking a branch.
+Just as the order of the values in :conf_master:`fileserver_backend` matters,
+so too does the order in which different sources are defined within a
+fileserver environment. For example, given the below :conf_master:`file_roots`
+configuration, if both ``/srv/salt/dev/foo.txt`` and ``/srv/salt/prod/foo.txt``
+exist on the Master, then ``salt://foo.txt`` would point to
+``/srv/salt/dev/foo.txt`` in the ``dev`` environment, but it would point to
+``/srv/salt/prod/foo.txt`` in the ``base`` environment.
+
+.. code-block:: yaml
+
+    file_roots:
+      base:
+        - /srv/salt/prod
+      qa:
+        - /srv/salt/qa
+        - /srv/salt/prod
+      dev:
+        - /srv/salt/dev
+        - /srv/salt/qa
+        - /srv/salt/prod
+
+Similarly, when using the :mod:`git <salt.fileserver.gitfs>` backend, if both
+repositories defined below have a ``hotfix23`` branch/tag, and both of them
+also contain the file ``bar.txt`` in the root of the repository at that
+branch/tag, then ``salt://bar.txt`` in the ``hotfix23`` environment would be
+served from the ``first`` repository.
+
+.. code-block:: yaml
+
+    gitfs_remotes:
+      - https://mydomain.tld/repos/first.git
+      - https://mydomain.tld/repos/second.git
+
+.. note::
+
+    Environments map differently based on the fileserver backend. For instance,
+    the mappings are explicitly defined in :mod:`roots <salt.fileserver.roots>`
+    backend, while in the VCS backends (:mod:`git <salt.fileserver.gitfs>`,
+    :mod:`hg <salt.fileserver.hgfs>`, :mod:`svn <salt.fileserver.svnfs>`) the
+    environments are created from branches/tags/bookmarks/etc. For the
+    :mod:`minion <salt.fileserver.minionfs>` backend, the files are all in a
+    single environment, which is specified by the :conf_master:`minionfs_env`
+    option.
+
+    See the documentation for each backend for a more detailed explanation of
+    how environments are mapped.

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -134,6 +134,15 @@ For APT-based distros such as Ubuntu and Debian:
 
         salt-run fileserver.clear_cache backend=git
 
+    If the Master is running an earlier version, then the cache can be cleared
+    by removing the ``gitfs`` and ``file_lists/gitfs`` directories (both paths
+    relative to the master cache directory, usually
+    ``/var/cache/salt/master``).
+
+    .. code-block:: bash
+
+        rm -rf /var/cache/salt/master{,/file_lists}/gitfs
+
 Simple Configuration
 ====================
 

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -118,6 +118,21 @@ For APT-based distros such as Ubuntu and Debian:
 
     # apt-get install python-dulwich
 
+.. important::
+
+    If switching to Dulwich from GitPython/pygit2, or switching from
+    GitPython/pygit2 to Dulwich, it is necessary to clear the gitfs cache to
+    avoid unpredictable behavior. This is probably a good idea whenever
+    switching to a new :conf_master:`gitfs_provider`, but it is less important
+    when switching between GitPython and pygit2.
+
+    Beginning in version 2015.2.0, the gitfs cache can be easily cleared using
+    the :mod:`fileserver.clear_cache <salt.runners.fileserver.clear_cache>`
+    runner.
+
+    .. code-block:: bash
+
+        salt-run fileserver.clear_cache backend=git
 
 Simple Configuration
 ====================

--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -177,6 +177,14 @@ master:
    Information on how to authenticate to SSH remotes can be found :ref:`here
    <gitfs-authentication>`.
 
+   .. note::
+
+       Dulwich does not recognize ``ssh://`` URLs, ``git+ssh://`` must be used
+       instead. Salt version 2015.2.0 and later will automatically add the
+       ``git+`` to the beginning of these URLs before fetching, but earlier
+       Salt versions will fail to fetch unless the URL is specified using
+       ``git+ssh://``.
+
 3. Restart the master to load the new configuration.
    
 

--- a/doc/topics/tutorials/states_pt4.rst
+++ b/doc/topics/tutorials/states_pt4.rst
@@ -33,6 +33,18 @@ same relative path in more than one root, then the top-most match "wins". For
 example, if ``/srv/salt/foo.txt`` and ``/mnt/salt-nfs/base/foo.txt`` both
 exist, then ``salt://foo.txt`` will point to ``/srv/salt/foo.txt``.
 
+.. note::
+
+    When using multiple fileserver backends, the order in which they are listed
+    in the :conf_master:`fileserver_backend` parameter also matters. If both
+    ``roots`` and ``git`` backends contain a file with the same relative path,
+    and ``roots`` appears before ``git`` in the
+    :conf_master:`fileserver_backend` list, then the file in ``roots`` will
+    "win", and the file in gitfs will be ignored.
+
+    A more thorough explanation of how Salt's modular fileserver works can be
+    found :ref:`here <file-server-backends>`. We recommend reading this.
+
 Environment configuration
 =========================
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -228,8 +228,10 @@ def fileserver_update(fileserver):
     '''
     try:
         if not fileserver.servers:
-            log.error('No fileservers loaded, the master will not be'
-                      'able to serve files to minions')
+            log.error(
+                'No fileservers loaded, the master will not be able to '
+                'serve files to minions'
+            )
             raise SaltMasterError('No fileserver backends available')
         fileserver.update()
     except Exception as exc:

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -69,6 +69,12 @@ class MinionError(SaltException):
     '''
 
 
+class FileserverConfigError(SaltException):
+    '''
+    Used when invalid fileserver settings are detected
+    '''
+
+
 class SaltInvocationError(SaltException, TypeError):
     '''
     Used when the wrong number of arguments are sent to modules or invalid

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -317,6 +317,33 @@ class Fileserver(object):
                     )
         return cleared, errors
 
+    def clear_lock(self, back=None, remote=None):
+        '''
+        Clear the update lock for the enabled fileserver backends
+
+        back
+            Only clear the update lock for the specified backend(s). The
+            default is to clear the lock for all enabled backends
+
+        remote
+            If not None, then any remotes which contain the passed string will
+            have their lock cleared.
+        '''
+        back = self._gen_back(back)
+        cleared = []
+        errors = []
+        for fsb in back:
+            fstr = '{0}.clear_lock'.format(fsb)
+            if fstr in self.servers:
+                msg = 'Clearing update.lk for {0} remotes'.format(fsb)
+                if remote:
+                    msg += ' matching {0}'.format(remote)
+                log.debug(msg)
+                good, bad = self.servers[fstr](remote=remote)
+                cleared.extend(good)
+                errors.extend(bad)
+        return cleared, errors
+
     def update(self, back=None):
         '''
         Update all of the enabled fileserver backends which support the update

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -301,26 +301,26 @@ class Fileserver(object):
         clear_cache function or the named backend(s) only.
         '''
         back = self._gen_back(back)
-        ret = []
+        cleared = []
+        errors = []
         for fsb in back:
             fstr = '{0}.clear_cache'.format(fsb)
             if fstr in self.servers:
                 log.debug('Clearing {0} fileserver cache'.format(fsb))
-                try:
-                    self.servers[fstr]()
-                except Exception as exc:
-                    log.error('Error occurred clearing {0} fileserver cache: '
-                              '{1}'.format(fsb, exc))
+                failed = self.servers[fstr]()
+                if failed:
+                    errors.extend(failed)
                 else:
-                    ret.append(
-                        'The {0} fileserver cache was cleared'.format(fsb)
+                    cleared.append(
+                        'The {0} fileserver cache was successfully cleared'
+                        .format(fsb)
                     )
-        return ret
+        return cleared, errors
 
     def update(self, back=None):
         '''
-        Update all of the fileserver backends that support the update function
-        or the named backend(s) only.
+        Update all of the enabled fileserver backends which support the update
+        function, or
         '''
         back = self._gen_back(back)
         for fsb in back:

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -14,6 +14,7 @@ import time
 # Import salt libs
 import salt.loader
 import salt.utils
+from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
 
@@ -281,8 +282,8 @@ class Fileserver(object):
         ret = []
         if not back:
             back = self.opts['fileserver_backend']
-        if isinstance(back, str):
-            back = [back]
+        if isinstance(back, string_types):
+            back = back.split(',')
         for sub in back:
             if '{0}.envs'.format(sub) in self.servers:
                 ret.append(sub)
@@ -294,21 +295,43 @@ class Fileserver(object):
         '''
         return self.opts
 
+    def clear_cache(self, back=None):
+        '''
+        Clear the cache of all of the fileserver backends that support the
+        clear_cache function or the named backend(s) only.
+        '''
+        back = self._gen_back(back)
+        ret = []
+        for fsb in back:
+            fstr = '{0}.clear_cache'.format(fsb)
+            if fstr in self.servers:
+                log.debug('Clearing {0} fileserver cache'.format(fsb))
+                try:
+                    self.servers[fstr]()
+                except Exception as exc:
+                    log.error('Error occurred clearing {0} fileserver cache: '
+                              '{1}'.format(fsb, exc))
+                else:
+                    ret.append(
+                        'The {0} fileserver cache was cleared'.format(fsb)
+                    )
+        return ret
+
     def update(self, back=None):
         '''
-        Update all of the file-servers that support the update function or the
-        named fileserver only.
+        Update all of the fileserver backends that support the update function
+        or the named backend(s) only.
         '''
         back = self._gen_back(back)
         for fsb in back:
             fstr = '{0}.update'.format(fsb)
             if fstr in self.servers:
-                log.debug('Updating fileserver cache')
+                log.debug('Updating {0} fileserver cache'.format(fsb))
                 self.servers[fstr]()
 
     def envs(self, back=None, sources=False):
         '''
-        Return the environments for the named backend or all back-ends
+        Return the environments for the named backend or all backends
         '''
         back = self._gen_back(back)
         ret = set()

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -287,6 +287,8 @@ class Fileserver(object):
         for sub in back:
             if '{0}.envs'.format(sub) in self.servers:
                 ret.append(sub)
+            elif '{0}.envs'.format(sub[:-2]) in self.servers:
+                ret.append(sub[:-2])
         return ret
 
     def master_opts(self, load):

--- a/salt/fileserver/__init__.py
+++ b/salt/fileserver/__init__.py
@@ -328,6 +328,34 @@ class Fileserver(object):
                     )
         return cleared, errors
 
+    def lock(self, back=None, remote=None):
+        '''
+        ``remote`` can either be a dictionary containing repo configuration
+        information, or a pattern. If the latter, then remotes for which the URL
+        matches the pattern will be locked.
+        '''
+        back = self._gen_back(back)
+        locked = []
+        errors = []
+        for fsb in back:
+            fstr = '{0}.lock'.format(fsb)
+            if fstr in self.servers:
+                msg = 'Setting update lock for {0} remotes'.format(fsb)
+                if remote:
+                    if not isinstance(remote, string_types):
+                        errors.append(
+                            'Badly formatted remote pattern \'{0}\''
+                            .format(remote)
+                        )
+                        continue
+                    else:
+                        msg += ' matching {0}'.format(remote)
+                log.debug(msg)
+                good, bad = self.servers[fstr](remote=remote)
+                locked.extend(good)
+                errors.extend(bad)
+        return locked, errors
+
     def clear_lock(self, back=None, remote=None):
         '''
         Clear the update lock for the enabled fileserver backends
@@ -346,7 +374,7 @@ class Fileserver(object):
         for fsb in back:
             fstr = '{0}.clear_lock'.format(fsb)
             if fstr in self.servers:
-                msg = 'Clearing update.lk for {0} remotes'.format(fsb)
+                msg = 'Clearing update lock for {0} remotes'.format(fsb)
                 if remote:
                     msg += ' matching {0}'.format(remote)
                 log.debug(msg)

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -899,6 +899,9 @@ def _init_dulwich(rp_, repo_url, ssl_verify):
     successful, otherwise return None. Also return a boolean that will tell
     init() whether a new repo was initialized.
     '''
+    if repo_url.startswith('ssh://'):
+        # Dulwich will throw an error if 'ssh' is used.
+        repo_url = 'git+' + repo_url
     new = False
     if not os.listdir(rp_):
         # Repo cachedir is empty, initialize a new repo there

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -6,7 +6,12 @@ With this backend, branches and tags in a remote git repository are exposed to
 salt as different environments.
 
 To enable, add ``git`` to the :conf_master:`fileserver_backend` option in the
-master config file.
+Master config file.
+
+.. code-block:: yaml
+
+    fileserver_backend:
+      - git
 
 As of Salt 2014.7.0, the Git fileserver backend supports GitPython_, pygit2_,
 and dulwich_ to provide the Python interface to git. If more than one of these

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -48,9 +48,9 @@ Walkthrough <tutorial-gitfs>`.
 
 # Import python libs
 import copy
-import contextlib
 import distutils.version  # pylint: disable=E0611
 import errno
+import fnmatch
 import glob
 import hashlib
 import logging

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -950,6 +950,45 @@ def clear_cache():
     return errors
 
 
+def clear_lock(remote=None):
+    '''
+    Clear update.lk
+    '''
+    def _add_error(errlist, url, lk_fn, exc):
+        errlist.append('Unable to remove update lock for {0} ({1}): {2} '
+                       .format(url, lk_fn, exc))
+
+    cleared = []
+    errors = []
+    for repo in init():
+        if remote:
+            try:
+                if remote not in repo['url']:
+                    continue
+            except TypeError:
+                # remote was non-string, try again
+                if _text_type(remote) not in repo['url']:
+                    continue
+        lk_fn = _update_lockfile(repo)
+        if os.path.exists(lk_fn):
+            try:
+                os.remove(lk_fn)
+            except OSError as exc:
+                if exc.errno == errno.EISDIR:
+                    # Somehow this path is a directory. Should never happen
+                    # unless some wiseguy manually creates a directory at this
+                    # path, but just in case, handle it.
+                    try:
+                        shutil.rmtree(lk_fn)
+                    except OSError as exc:
+                        _add_error(errors, repo['url'], lk_fn, exc)
+                else:
+                    _add_error(errors, repo['url'], lk_fn, exc)
+            else:
+                cleared.append('Removed lock for {0}'.format(repo['url']))
+    return cleared, errors
+
+
 def _update_lockfile(repo):
     '''
     Return the filename of the update lock

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -928,9 +928,15 @@ def _clear_old_remotes():
                    if rdir not in ('hash', 'refs', 'envs.p', 'remote_map.txt')]
     if remove_dirs:
         for rdir in remove_dirs:
-            shutil.rmtree(rdir)
-            log.debug('gitfs removed old cachedir {0}'.format(rdir))
-    # If remove_dirs is not empty, than
+            try:
+                shutil.rmtree(rdir)
+            except OSError as exc:
+                log.error(
+                    'Unable to remove old gitfs remote cachedir {0}: {1}'
+                    .format(rdir, exc)
+                )
+            else:
+                log.debug('gitfs removed old cachedir {0}'.format(rdir))
     return bool(remove_dirs), repos
 
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -940,11 +940,14 @@ def clear_cache():
     '''
     fsb_cachedir = os.path.join(__opts__['cachedir'], 'gitfs')
     list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists/gitfs')
+    errors = []
     for rdir in (fsb_cachedir, list_cachedir):
-        try:
-            shutil.rmtree(rdir)
-        except OSError:
-            pass
+        if os.path.exists(rdir):
+            try:
+                shutil.rmtree(rdir)
+            except OSError as exc:
+                errors.append('Unable to delete {0}: {1}'.format(rdir, exc))
+    return errors
 
 
 @contextlib.contextmanager

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -915,19 +915,26 @@ def _clear_old_remotes():
     '''
     bp_ = os.path.join(__opts__['cachedir'], 'gitfs')
     try:
-        remove_dirs = os.listdir(bp_)
+        cachedir_ls = os.listdir(bp_)
     except OSError:
-        remove_dirs = []
+        cachedir_ls = []
     repos = init()
+    # Remove actively-used remotes from list
     for repo in repos:
         try:
-            remove_dirs.remove(repo['hash'])
+            cachedir_ls.remove(repo['hash'])
         except ValueError:
             pass
-    remove_dirs = [os.path.join(bp_, rdir) for rdir in remove_dirs
-                   if rdir not in ('hash', 'refs', 'envs.p', 'remote_map.txt')]
-    if remove_dirs:
-        for rdir in remove_dirs:
+    to_remove = []
+    for item in cachedir_ls:
+        if item in ('hash', 'refs'):
+            continue
+        path = os.path.join(bp_, item)
+        if os.path.isdir(path):
+            to_remove.append(path)
+    failed = []
+    if to_remove:
+        for rdir in to_remove:
             try:
                 shutil.rmtree(rdir)
             except OSError as exc:
@@ -935,9 +942,12 @@ def _clear_old_remotes():
                     'Unable to remove old gitfs remote cachedir {0}: {1}'
                     .format(rdir, exc)
                 )
+                failed.append(rdir)
             else:
                 log.debug('gitfs removed old cachedir {0}'.format(rdir))
-    return bool(remove_dirs), repos
+    for fdir in failed:
+        to_remove.remove(fdir)
+    return bool(to_remove), repos
 
 
 def clear_cache():

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -1027,9 +1027,8 @@ def update():
                 'Update lockfile is present for gitfs remote {0}, skipping. '
                 'If this warning persists, it is possible that the update '
                 'process was interrupted. Removing {1} or running '
-                '\'salt-run fileserver.clear_lock backend=git\' will allow '
-                'updates to continue for this remote.'
-                .format(repo['url'], lk_fn)
+                '\'salt-run fileserver.clear_lock gitfs\' will allow updates '
+                'to continue for this remote.'.format(repo['url'], lk_fn)
             )
             continue
         try:

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -985,8 +985,10 @@ def clear_lock(remote=None):
     '''
     def _do_clear_lock(repo):
         def _add_error(errlist, repo, exc):
-            errlist.append('Unable to remove update lock for {0} ({1}): {2} '
-                           .format(repo['url'], repo['lockfile'], exc))
+            msg = ('Unable to remove update lock for {0} ({1}): {2} '
+                   .format(repo['url'], repo['lockfile'], exc))
+            log.debug(msg)
+            errlist.append(msg)
         success = []
         failed = []
         if os.path.exists(repo['lockfile']):
@@ -1004,7 +1006,9 @@ def clear_lock(remote=None):
                 else:
                     _add_error(failed, repo, exc)
             else:
-                success.append('Removed lock for {0}'.format(repo['url']))
+                msg = 'Removed lock for {0}'.format(repo['url'])
+                log.debug(msg)
+                success.append(msg)
         return success, failed
 
     if isinstance(remote, dict):
@@ -1043,10 +1047,14 @@ def lock(remote=None):
                 with salt.utils.fopen(repo['lockfile'], 'w+') as fp_:
                     fp_.write('')
             except (IOError, OSError) as exc:
-                failed.append('Unable to set update lock for {0} ({1}): {2} '
-                              .format(repo['url'], repo['lockfile'], exc))
+                msg = ('Unable to set update lock for {0} ({1}): {2} '
+                       .format(repo['url'], repo['lockfile'], exc))
+                log.debug(msg)
+                failed.append(msg)
             else:
-                success.append('Set lock for {0}'.format(repo['url']))
+                msg = 'Set lock for {0}'.format(repo['url'])
+                log.debug(msg)
+                success.append(msg)
         return success, failed
 
     if isinstance(remote, dict):
@@ -1092,12 +1100,8 @@ def update():
                 .format(repo['url'], repo['lockfile'])
             )
             continue
-        locked, errors = lock(repo)
-        for msg in locked:
-            log.debug(msg)
+        _, errors = lock(repo)
         if errors:
-            for msg in errors:
-                log.error(errors)
             log.error('Unable to set update lock for gitfs remote {0}, '
                       'skipping.'.format(repo['url']))
             continue
@@ -1195,11 +1199,7 @@ def update():
                 exc_info_on_loglevel=logging.DEBUG
             )
         finally:
-            success, errors = clear_lock(repo)
-            for msg in success:
-                log.debug(msg)
-            for msg in errors:
-                log.error(msg)
+            clear_lock(repo)
 
     env_cache = os.path.join(__opts__['cachedir'], 'gitfs/envs.p')
     if data.get('changed', False) is True or not os.path.isfile(env_cache):

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -45,7 +45,7 @@ Walkthrough <tutorial-gitfs>`.
 import copy
 import contextlib
 import distutils.version  # pylint: disable=E0611
-import fcntl
+import errno
 import glob
 import hashlib
 import logging
@@ -918,10 +918,10 @@ def _clear_old_remotes():
         remove_dirs = os.listdir(bp_)
     except OSError:
         remove_dirs = []
-    for repo in init():
+    repos = init()
+    for repo in repos:
         try:
-            with _acquire_update_lock_for_repo(repo):
-                remove_dirs.remove(repo['hash'])
+            remove_dirs.remove(repo['hash'])
         except ValueError:
             pass
     remove_dirs = [os.path.join(bp_, rdir) for rdir in remove_dirs
@@ -930,8 +930,8 @@ def _clear_old_remotes():
         for rdir in remove_dirs:
             shutil.rmtree(rdir)
             log.debug('gitfs removed old cachedir {0}'.format(rdir))
-        return True
-    return False
+    # If remove_dirs is not empty, than
+    return bool(remove_dirs), repos
 
 
 def clear_cache():
@@ -950,35 +950,18 @@ def clear_cache():
     return errors
 
 
-@contextlib.contextmanager
-def _acquire_update_lock_for_repo(repo):
+def _update_lockfile(repo):
+    '''
+    Return the filename of the update lock
+    '''
     provider = _get_provider()
-
     if provider == 'gitpython':
         working_dir = repo['repo'].working_dir
     elif provider == 'pygit2':
         working_dir = repo['repo'].workdir
     elif provider == 'dulwich':
         working_dir = repo['repo'].path
-
-    with wait_for_write_lock(os.path.join(working_dir, 'update.lk')):
-        yield
-
-
-@contextlib.contextmanager
-def wait_for_write_lock(filename):
-    fhandle = open(filename, 'w')
-
-    if salt.utils.is_fcntl_available(check_sunos=True):
-        fcntl.flock(fhandle.fileno(), fcntl.LOCK_EX)
-    try:
-        yield
-    finally:
-        if salt.utils.is_fcntl_available(check_sunos=True):
-            fcntl.flock(fhandle.fileno(), fcntl.LOCK_UN)
-
-        fhandle.close()
-        os.remove(filename)
+    return os.path.join(working_dir, 'update.lk')
 
 
 def update():
@@ -990,109 +973,115 @@ def update():
             'backend': 'gitfs'}
     provider = _get_provider()
     pid = os.getpid()
-    data['changed'] = _clear_old_remotes()
-    for repo in init():
-        if provider == 'gitpython':
+    # _clear_old_remotes runs init(), so use the value from there to avoid a
+    # second init()
+    data['changed'], repos = _clear_old_remotes()
+    for repo in repos:
+        if provider in ('gitpython', 'pygit2'):
             origin = repo['repo'].remotes[0]
-            working_dir = repo['repo'].working_dir
-        elif provider == 'pygit2':
-            origin = repo['repo'].remotes[0]
-            working_dir = repo['repo'].workdir
         elif provider == 'dulwich':
             # origin is just a url here, there is no origin object
             origin = repo['url']
-            working_dir = repo['repo'].path
-
-        with _acquire_update_lock_for_repo(repo):
-            try:
-                log.debug('gitfs is fetching from {0}'.format(repo['url']))
-                if provider == 'gitpython':
-                    try:
-                        fetch_results = origin.fetch()
-                    except AssertionError:
-                        fetch_results = origin.fetch()
-                    cleaned = _clean_stale(repo['repo'])
-                    if fetch_results or cleaned:
-                        data['changed'] = True
-                elif provider == 'pygit2':
-                    refs_pre = repo['repo'].listall_references()
-                    try:
-                        origin.credentials = repo['credentials']
-                    except KeyError:
-                        # No credentials configured for this repo
-                        pass
-                    fetch = origin.fetch()
-                    try:
-                        # pygit2.Remote.fetch() returns a dict in pygit2 < 0.21.0
-                        received_objects = fetch['received_objects']
-                    except (AttributeError, TypeError):
-                        # pygit2.Remote.fetch() returns a class instance in
-                        # pygit2 >= 0.21.0
-                        received_objects = fetch.received_objects
-                    log.debug(
-                        'gitfs received {0} objects for remote {1}'
-                        .format(received_objects, repo['url'])
-                    )
-                    # Clean up any stale refs
-                    refs_post = repo['repo'].listall_references()
-                    cleaned = _clean_stale(repo['repo'], refs_post)
-                    if received_objects or refs_pre != refs_post or cleaned:
-                        data['changed'] = True
-                elif provider == 'dulwich':
-                    client, path = \
-                        dulwich.client.get_transport_and_path_from_url(
-                            origin, thin_packs=True
-                        )
-                    refs_pre = repo['repo'].get_refs()
-                    try:
-                        refs_post = client.fetch(path, repo['repo'])
-                    except dulwich.errors.NotGitRepository:
-                        log.critical(
-                            'Dulwich does not recognize remote {0} as a valid '
-                            'remote URL. Perhaps it is missing \'.git\' at the '
-                            'end.'.format(repo['url'])
-                        )
-                        continue
-                    except KeyError:
-                        log.critical(
-                            'Local repository cachedir {0!r} (corresponding '
-                            'remote: {1}) has been corrupted. Salt will now '
-                            'attempt to remove the local checkout to allow it to '
-                            'be re-initialized in the next fileserver cache '
-                            'update.'
-                            .format(repo['cachedir'], repo['url'])
-                        )
-                        try:
-                            salt.utils.rm_rf(repo['cachedir'])
-                        except OSError as exc:
-                            log.critical(
-                                'Unable to remove {0!r}: {1}'
-                                .format(repo['cachedir'], exc)
-                            )
-                        continue
-                    if refs_post is None:
-                        # Empty repository
-                        log.warning(
-                            'gitfs remote {0!r} is an empty repository and will '
-                            'be skipped.'.format(origin)
-                        )
-                        continue
-                    if refs_pre != refs_post:
-                        data['changed'] = True
-                        # Update local refs
-                        for ref in _dulwich_env_refs(refs_post):
-                            repo['repo'][ref] = refs_post[ref]
-                        # Prune stale refs
-                        for ref in repo['repo'].get_refs():
-                            if ref not in refs_post:
-                                del repo['repo'][ref]
-            except Exception as exc:
-                # Do not use {0!r} in the error message, as exc is not a string
-                log.error(
-                    'Exception \'{0}\' caught while fetching gitfs remote {1}'
-                    .format(exc, repo['url']),
-                    exc_info_on_loglevel=logging.DEBUG
+        lk_fn = _update_lockfile(repo)
+        if os.path.exists(lk_fn):
+            log.warning(
+                'Update lockfile is present for gitfs remote {0}, skipping. '
+                'If this warning persists, it is possible that the update '
+                'process was interrupted. Removing {1} or running '
+                '\'salt-run fileserver.clear_lock backend=git\' will allow '
+                'updates to continue for this remote.'
+                .format(repo['url'], lk_fn)
+            )
+            continue
+        try:
+            log.debug('gitfs is fetching from {0}'.format(repo['url']))
+            if provider == 'gitpython':
+                try:
+                    fetch_results = origin.fetch()
+                except AssertionError:
+                    fetch_results = origin.fetch()
+                cleaned = _clean_stale(repo['repo'])
+                if fetch_results or cleaned:
+                    data['changed'] = True
+            elif provider == 'pygit2':
+                refs_pre = repo['repo'].listall_references()
+                try:
+                    origin.credentials = repo['credentials']
+                except KeyError:
+                    # No credentials configured for this repo
+                    pass
+                fetch = origin.fetch()
+                try:
+                    # pygit2.Remote.fetch() returns a dict in pygit2 < 0.21.0
+                    received_objects = fetch['received_objects']
+                except (AttributeError, TypeError):
+                    # pygit2.Remote.fetch() returns a class instance in
+                    # pygit2 >= 0.21.0
+                    received_objects = fetch.received_objects
+                log.debug(
+                    'gitfs received {0} objects for remote {1}'
+                    .format(received_objects, repo['url'])
                 )
+                # Clean up any stale refs
+                refs_post = repo['repo'].listall_references()
+                cleaned = _clean_stale(repo['repo'], refs_post)
+                if received_objects or refs_pre != refs_post or cleaned:
+                    data['changed'] = True
+            elif provider == 'dulwich':
+                client, path = \
+                    dulwich.client.get_transport_and_path_from_url(
+                        origin, thin_packs=True
+                    )
+                refs_pre = repo['repo'].get_refs()
+                try:
+                    refs_post = client.fetch(path, repo['repo'])
+                except dulwich.errors.NotGitRepository:
+                    log.critical(
+                        'Dulwich does not recognize remote {0} as a valid '
+                        'remote URL. Perhaps it is missing \'.git\' at the '
+                        'end.'.format(repo['url'])
+                    )
+                    continue
+                except KeyError:
+                    log.critical(
+                        'Local repository cachedir {0!r} (corresponding '
+                        'remote: {1}) has been corrupted. Salt will now '
+                        'attempt to remove the local checkout to allow it to '
+                        'be re-initialized in the next fileserver cache '
+                        'update.'
+                        .format(repo['cachedir'], repo['url'])
+                    )
+                    try:
+                        salt.utils.rm_rf(repo['cachedir'])
+                    except OSError as exc:
+                        log.critical(
+                            'Unable to remove {0!r}: {1}'
+                            .format(repo['cachedir'], exc)
+                        )
+                    continue
+                if refs_post is None:
+                    # Empty repository
+                    log.warning(
+                        'gitfs remote {0!r} is an empty repository and will '
+                        'be skipped.'.format(origin)
+                    )
+                    continue
+                if refs_pre != refs_post:
+                    data['changed'] = True
+                    # Update local refs
+                    for ref in _dulwich_env_refs(refs_post):
+                        repo['repo'][ref] = refs_post[ref]
+                    # Prune stale refs
+                    for ref in repo['repo'].get_refs():
+                        if ref not in refs_post:
+                            del repo['repo'][ref]
+        except Exception as exc:
+            # Do not use {0!r} in the error message, as exc is not a string
+            log.error(
+                'Exception \'{0}\' caught while fetching gitfs remote {1}'
+                .format(exc, repo['url']),
+                exc_info_on_loglevel=logging.DEBUG
+            )
 
     env_cache = os.path.join(__opts__['cachedir'], 'gitfs/envs.p')
     if data.get('changed', False) is True or not os.path.isfile(env_cache):
@@ -1250,157 +1239,155 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
                          '{0}.lk'.format(path))
     destdir = os.path.dirname(dest)
     hashdir = os.path.dirname(blobshadest)
+    if not os.path.isdir(destdir):
+        try:
+            os.makedirs(destdir)
+        except OSError:
+            # Path exists and is a file, remove it and retry
+            os.remove(destdir)
+            os.makedirs(destdir)
+    if not os.path.isdir(hashdir):
+        try:
+            os.makedirs(hashdir)
+        except OSError:
+            # Path exists and is a file, remove it and retry
+            os.remove(hashdir)
+            os.makedirs(hashdir)
 
     for repo in init():
-        with _acquire_update_lock_for_repo(repo):
-            if not os.path.isdir(destdir):
-                try:
-                    os.makedirs(destdir)
-                except OSError:
-                    # Path exists and is a file, remove it and retry
-                    os.remove(destdir)
-                    os.makedirs(destdir)
-            if not os.path.isdir(hashdir):
-                try:
-                    os.makedirs(hashdir)
-                except OSError:
-                    # Path exists and is a file, remove it and retry
-                    os.remove(hashdir)
-                    os.makedirs(hashdir)
+        if repo['mountpoint'] \
+                and not path.startswith(repo['mountpoint'] + os.path.sep):
+            continue
+        repo_path = path[len(repo['mountpoint']):].lstrip(os.path.sep)
+        if repo['root']:
+            repo_path = os.path.join(repo['root'], repo_path)
 
-            if repo['mountpoint'] \
-                    and not path.startswith(repo['mountpoint'] + os.path.sep):
+        blob = None
+        depth = 0
+        if provider == 'gitpython':
+            tree = _get_tree_gitpython(repo, tgt_env)
+            if not tree:
+                # Branch/tag/SHA not found in repo, try the next
                 continue
-            repo_path = path[len(repo['mountpoint']):].lstrip(os.path.sep)
-            if repo['root']:
-                repo_path = os.path.join(repo['root'], repo_path)
-
-            blob = None
-            depth = 0
-            if provider == 'gitpython':
-                tree = _get_tree_gitpython(repo, tgt_env)
-                if not tree:
-                    # Branch/tag/SHA not found in repo, try the next
-                    continue
-                while True:
-                    depth += 1
-                    if depth > SYMLINK_RECURSE_DEPTH:
-                        break
-                    try:
-                        file_blob = tree / repo_path
-                        if stat.S_ISLNK(file_blob.mode):
-                            # Path is a symlink. The blob data corresponding to
-                            # this path's object ID will be the target of the
-                            # symlink. Follow the symlink and set repo_path to the
-                            # location indicated in the blob data.
-                            stream = StringIO()
-                            file_blob.stream_data(stream)
-                            stream.seek(0)
-                            link_tgt = stream.read()
-                            stream.close()
-                            repo_path = os.path.normpath(
-                                os.path.join(os.path.dirname(repo_path), link_tgt)
-                            )
-                        else:
-                            blob = file_blob
-                            break
-                    except KeyError:
-                        # File not found or repo_path points to a directory
-                        break
-                if blob is None:
-                    continue
-                blob_hexsha = blob.hexsha
-
-            elif provider == 'pygit2':
-                tree = _get_tree_pygit2(repo, tgt_env)
-                if not tree:
-                    # Branch/tag/SHA not found in repo, try the next
-                    continue
-                while True:
-                    depth += 1
-                    if depth > SYMLINK_RECURSE_DEPTH:
-                        break
-                    try:
-                        if stat.S_ISLNK(tree[repo_path].filemode):
-                            # Path is a symlink. The blob data corresponding to this
-                            # path's object ID will be the target of the symlink. Follow
-                            # the symlink and set repo_path to the location indicated
-                            # in the blob data.
-                            link_tgt = repo['repo'][tree[repo_path].oid].data
-                            repo_path = os.path.normpath(
-                                os.path.join(os.path.dirname(repo_path), link_tgt)
-                            )
-                        else:
-                            oid = tree[repo_path].oid
-                            blob = repo['repo'][oid]
-                    except KeyError:
-                        break
-                if blob is None:
-                    continue
-                blob_hexsha = blob.hex
-
-            elif provider == 'dulwich':
-                while True:
-                    depth += 1
-                    if depth > SYMLINK_RECURSE_DEPTH:
-                        break
-                    prefix_dirs, _, filename = repo_path.rpartition(os.path.sep)
-                    tree = _get_tree_dulwich(repo, tgt_env)
-                    tree = _dulwich_walk_tree(repo['repo'], tree, prefix_dirs)
-                    if not isinstance(tree, dulwich.objects.Tree):
-                        # Branch/tag/SHA not found in repo
-                        break
-                    try:
-                        mode, oid = tree[filename]
-                        if stat.S_ISLNK(mode):
-                            # Path is a symlink. The blob data corresponding to
-                            # this path's object ID will be the target of the
-                            # symlink. Follow the symlink and set repo_path to the
-                            # location indicated in the blob data.
-                            link_tgt = repo['repo'].get_object(oid).as_raw_string()
-                            repo_path = os.path.normpath(
-                                os.path.join(os.path.dirname(repo_path), link_tgt)
-                            )
-                        else:
-                            blob = repo['repo'].get_object(oid)
-                            break
-                    except KeyError:
-                        break
-                if blob is None:
-                    continue
-                blob_hexsha = blob.sha().hexdigest()
-
-            salt.fileserver.wait_lock(lk_fn, dest)
-            if os.path.isfile(blobshadest) and os.path.isfile(dest):
-                with salt.utils.fopen(blobshadest, 'r') as fp_:
-                    sha = fp_.read()
-                    if sha == blob_hexsha:
-                        fnd['rel'] = path
-                        fnd['path'] = dest
-                        return fnd
-            with salt.utils.fopen(lk_fn, 'w+') as fp_:
-                fp_.write('')
-            for filename in glob.glob(hashes_glob):
+            while True:
+                depth += 1
+                if depth > SYMLINK_RECURSE_DEPTH:
+                    break
                 try:
-                    os.remove(filename)
-                except Exception:
-                    pass
-            with salt.utils.fopen(dest, 'w+') as fp_:
-                if provider == 'gitpython':
-                    blob.stream_data(fp_)
-                elif provider == 'pygit2':
-                    fp_.write(blob.data)
-                elif provider == 'dulwich':
-                    fp_.write(blob.as_raw_string())
-            with salt.utils.fopen(blobshadest, 'w+') as fp_:
-                fp_.write(blob_hexsha)
+                    file_blob = tree / repo_path
+                    if stat.S_ISLNK(file_blob.mode):
+                        # Path is a symlink. The blob data corresponding to
+                        # this path's object ID will be the target of the
+                        # symlink. Follow the symlink and set repo_path to the
+                        # location indicated in the blob data.
+                        stream = StringIO()
+                        file_blob.stream_data(stream)
+                        stream.seek(0)
+                        link_tgt = stream.read()
+                        stream.close()
+                        repo_path = os.path.normpath(
+                            os.path.join(os.path.dirname(repo_path), link_tgt)
+                        )
+                    else:
+                        blob = file_blob
+                        break
+                except KeyError:
+                    # File not found or repo_path points to a directory
+                    break
+            if blob is None:
+                continue
+            blob_hexsha = blob.hexsha
+
+        elif provider == 'pygit2':
+            tree = _get_tree_pygit2(repo, tgt_env)
+            if not tree:
+                # Branch/tag/SHA not found in repo, try the next
+                continue
+            while True:
+                depth += 1
+                if depth > SYMLINK_RECURSE_DEPTH:
+                    break
+                try:
+                    if stat.S_ISLNK(tree[repo_path].filemode):
+                        # Path is a symlink. The blob data corresponding to this
+                        # path's object ID will be the target of the symlink. Follow
+                        # the symlink and set repo_path to the location indicated
+                        # in the blob data.
+                        link_tgt = repo['repo'][tree[repo_path].oid].data
+                        repo_path = os.path.normpath(
+                            os.path.join(os.path.dirname(repo_path), link_tgt)
+                        )
+                    else:
+                        oid = tree[repo_path].oid
+                        blob = repo['repo'][oid]
+                except KeyError:
+                    break
+            if blob is None:
+                continue
+            blob_hexsha = blob.hex
+
+        elif provider == 'dulwich':
+            while True:
+                depth += 1
+                if depth > SYMLINK_RECURSE_DEPTH:
+                    break
+                prefix_dirs, _, filename = repo_path.rpartition(os.path.sep)
+                tree = _get_tree_dulwich(repo, tgt_env)
+                tree = _dulwich_walk_tree(repo['repo'], tree, prefix_dirs)
+                if not isinstance(tree, dulwich.objects.Tree):
+                    # Branch/tag/SHA not found in repo
+                    break
+                try:
+                    mode, oid = tree[filename]
+                    if stat.S_ISLNK(mode):
+                        # Path is a symlink. The blob data corresponding to
+                        # this path's object ID will be the target of the
+                        # symlink. Follow the symlink and set repo_path to the
+                        # location indicated in the blob data.
+                        link_tgt = repo['repo'].get_object(oid).as_raw_string()
+                        repo_path = os.path.normpath(
+                            os.path.join(os.path.dirname(repo_path), link_tgt)
+                        )
+                    else:
+                        blob = repo['repo'].get_object(oid)
+                        break
+                except KeyError:
+                    break
+            if blob is None:
+                continue
+            blob_hexsha = blob.sha().hexdigest()
+
+        salt.fileserver.wait_lock(lk_fn, dest)
+        if os.path.isfile(blobshadest) and os.path.isfile(dest):
+            with salt.utils.fopen(blobshadest, 'r') as fp_:
+                sha = fp_.read()
+                if sha == blob_hexsha:
+                    fnd['rel'] = path
+                    fnd['path'] = dest
+                    return fnd
+        with salt.utils.fopen(lk_fn, 'w+') as fp_:
+            fp_.write('')
+        for filename in glob.glob(hashes_glob):
             try:
-                os.remove(lk_fn)
-            except (OSError, IOError):
+                os.remove(filename)
+            except Exception:
                 pass
-            fnd['rel'] = path
-            fnd['path'] = dest
-            return fnd
+        with salt.utils.fopen(dest, 'w+') as fp_:
+            if provider == 'gitpython':
+                blob.stream_data(fp_)
+            elif provider == 'pygit2':
+                fp_.write(blob.data)
+            elif provider == 'dulwich':
+                fp_.write(blob.as_raw_string())
+        with salt.utils.fopen(blobshadest, 'w+') as fp_:
+            fp_.write(blob_hexsha)
+        try:
+            os.remove(lk_fn)
+        except OSError:
+            pass
+        fnd['rel'] = path
+        fnd['path'] = dest
+        return fnd
     return fnd
 
 

--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -137,16 +137,21 @@ def _verify_gitpython(quiet=False):
     '''
     Check if GitPython is available and at a compatible version (>= 0.3.0)
     '''
-    if not HAS_GITPYTHON:
-        log.error(
-            'Git fileserver backend is enabled in master config file, but '
-            'could not be loaded, is GitPython installed?'
-        )
-        if HAS_PYGIT2 and not quiet:
+    def _recommend():
+        if HAS_PYGIT2:
             log.error(_RECOMMEND_PYGIT2)
-        if HAS_DULWICH and not quiet:
+        if HAS_DULWICH:
             log.error(_RECOMMEND_DULWICH)
+
+    if not HAS_GITPYTHON:
+        if not quiet:
+            log.error(
+                'Git fileserver backend is enabled in master config file, but '
+                'could not be loaded, is GitPython installed?'
+            )
+            _recommend()
         return False
+
     gitver = distutils.version.LooseVersion(git.__version__)
     minver_str = '0.3.0'
     minver = distutils.version.LooseVersion(minver_str)
@@ -162,15 +167,15 @@ def _verify_gitpython(quiet=False):
             'The git command line utility is required by the Git fileserver '
             'backend when using the \'gitpython\' provider.'
         )
+
     if errors:
-        if HAS_PYGIT2 and not quiet:
-            errors.append(_RECOMMEND_PYGIT2)
-        if HAS_DULWICH and not quiet:
-            errors.append(_RECOMMEND_DULWICH)
         for error in errors:
             log.error(error)
+        if not quiet:
+            _recommend()
         return False
-    log.info('gitpython gitfs_provider enabled')
+
+    log.debug('gitpython gitfs_provider enabled')
     __opts__['verified_gitfs_provider'] = 'gitpython'
     return True
 
@@ -180,15 +185,19 @@ def _verify_pygit2(quiet=False):
     Check if pygit2/libgit2 are available and at a compatible version. Pygit2
     must be at least 0.20.3 and libgit2 must be at least 0.20.0.
     '''
-    if not HAS_PYGIT2:
-        log.error(
-            'Git fileserver backend is enabled in master config file, but '
-            'could not be loaded, are pygit2 and libgit2 installed?'
-        )
-        if HAS_GITPYTHON and not quiet:
+    def _recommend():
+        if HAS_GITPYTHON:
             log.error(_RECOMMEND_GITPYTHON)
-        if HAS_DULWICH and not quiet:
+        if HAS_DULWICH:
             log.error(_RECOMMEND_DULWICH)
+
+    if not HAS_PYGIT2:
+        if not quiet:
+            log.error(
+                'Git fileserver backend is enabled in master config file, but '
+                'could not be loaded, are pygit2 and libgit2 installed?'
+            )
+            _recommend()
         return False
 
     pygit2ver = distutils.version.LooseVersion(pygit2.__version__)
@@ -217,15 +226,15 @@ def _verify_pygit2(quiet=False):
             'The git command line utility is required by the Git fileserver '
             'backend when using the \'pygit2\' provider.'
         )
+
     if errors:
-        if HAS_GITPYTHON and not quiet:
-            errors.append(_RECOMMEND_GITPYTHON)
-        if HAS_DULWICH and not quiet:
-            errors.append(_RECOMMEND_DULWICH)
         for error in errors:
             log.error(error)
+        if not quiet:
+            _recommend()
         return False
-    log.info('pygit2 gitfs_provider enabled')
+
+    log.debug('pygit2 gitfs_provider enabled')
     __opts__['verified_gitfs_provider'] = 'pygit2'
     return True
 
@@ -234,15 +243,19 @@ def _verify_dulwich(quiet=False):
     '''
     Check if dulwich is available.
     '''
-    if not HAS_DULWICH:
-        log.error(
-            'Git fileserver backend is enabled in the master config file, but '
-            'could not be loaded. Is Dulwich installed?'
-        )
-        if HAS_GITPYTHON and not quiet:
+    def _recommend():
+        if HAS_GITPYTHON:
             log.error(_RECOMMEND_GITPYTHON)
-        if HAS_PYGIT2 and not quiet:
+        if HAS_PYGIT2:
             log.error(_RECOMMEND_PYGIT2)
+
+    if not HAS_DULWICH:
+        if not quiet:
+            log.error(
+                'Git fileserver backend is enabled in the master config file, but '
+                'could not be loaded. Is Dulwich installed?'
+            )
+            _recommend()
         return False
 
     dulwich_version = dulwich.__version__
@@ -257,16 +270,14 @@ def _verify_dulwich(quiet=False):
             'detected.'.format(dulwich_min_version, dulwich_version)
         )
 
-        if HAS_PYGIT2 and not quiet:
-            errors.append(_RECOMMEND_PYGIT2)
-        if HAS_GITPYTHON and not quiet:
-            errors.append(_RECOMMEND_GITPYTHON)
-
+    if errors:
         for error in errors:
             log.error(error)
+        if not quiet:
+            _recommend()
         return False
 
-    log.info('dulwich gitfs_provider enabled')
+    log.debug('dulwich gitfs_provider enabled')
     __opts__['verified_gitfs_provider'] = 'dulwich'
     return True
 

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -388,9 +388,8 @@ def update():
                 'Update lockfile is present for hgfs remote {0}, skipping. '
                 'If this warning persists, it is possible that the update '
                 'process was interrupted. Removing {1} or running '
-                '\'salt-run fileserver.clear_lock backend=hg\' will allow '
-                'updates to continue for this remote.'
-                .format(repo['url'], lk_fn)
+                '\'salt-run fileserver.clear_lock hgfs\' will allow updates '
+                'to continue for this remote.'.format(repo['url'], lk_fn)
             )
             continue
         with salt.utils.fopen(lk_fn, 'w+') as fp_:

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -218,7 +218,7 @@ def init():
 
         if not isinstance(repo_url, string_types):
             log.error(
-                'Invalid gitfs remote {0}. Remotes must be strings, you may '
+                'Invalid hgfs remote {0}. Remotes must be strings, you may '
                 'need to enclose the URI in quotes'.format(repo_url)
             )
             continue
@@ -285,9 +285,9 @@ def init():
     return repos
 
 
-def purge_cache():
+def _clear_old_remotes():
     '''
-    Purge the fileserver cache
+    Remove cache directories for remotes no longer configured
     '''
     bp_ = os.path.join(__opts__['cachedir'], 'hgfs')
     try:
@@ -304,8 +304,22 @@ def purge_cache():
     if remove_dirs:
         for rdir in remove_dirs:
             shutil.rmtree(rdir)
+            log.debug('hgfs removed old cachedir {0}'.format(rdir))
         return True
     return False
+
+
+def clear_cache():
+    '''
+    Completely clear hgfs cache
+    '''
+    fsb_cachedir = os.path.join(__opts__['cachedir'], 'hgfs')
+    list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists/hgfs')
+    for rdir in (fsb_cachedir, list_cachedir):
+        try:
+            shutil.rmtree(rdir)
+        except OSError:
+            pass
 
 
 def update():
@@ -316,7 +330,7 @@ def update():
     data = {'changed': False,
             'backend': 'hgfs'}
     pid = os.getpid()
-    data['changed'] = purge_cache()
+    data['changed'] = _clear_old_remotes()
     for repo in init():
         repo['repo'].open()
         lk_fn = os.path.join(repo['repo'].root(), 'update.lk')

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -438,10 +438,7 @@ def update():
             if curtip[1] != newtip[1]:
                 data['changed'] = True
         repo['repo'].close()
-        try:
-            os.remove(lk_fn)
-        except (IOError, OSError):
-            pass
+        clear_lock(repo)
 
     env_cache = os.path.join(__opts__['cachedir'], 'hgfs/envs.p')
     if data.get('changed', False) is True or not os.path.isfile(env_cache):

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -301,8 +301,9 @@ def _clear_old_remotes():
         cachedir_ls = os.listdir(bp_)
     except OSError:
         cachedir_ls = []
+    repos = init()
     # Remove actively-used remotes from list
-    for repo in init():
+    for repo in repos:
         try:
             cachedir_ls.remove(repo['hash'])
         except ValueError:
@@ -329,7 +330,7 @@ def _clear_old_remotes():
                 log.debug('hgfs removed old cachedir {0}'.format(rdir))
     for fdir in failed:
         to_remove.remove(fdir)
-    return bool(to_remove)
+    return bool(to_remove), repos
 
 
 def clear_cache():
@@ -405,8 +406,10 @@ def update():
     data = {'changed': False,
             'backend': 'hgfs'}
     pid = os.getpid()
-    data['changed'] = _clear_old_remotes()
-    for repo in init():
+    # _clear_old_remotes runs init(), so use the value from there to avoid a
+    # second init()
+    data['changed'], repos = _clear_old_remotes()
+    for repo in repos:
         repo['repo'].open()
         lk_fn = _update_lockfile(repo)
         if os.path.exists(lk_fn):

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -311,8 +311,15 @@ def _clear_old_remotes():
                    and not rdir.endswith('.update.lk')]
     if remove_dirs:
         for rdir in remove_dirs:
-            shutil.rmtree(rdir)
-            log.debug('hgfs removed old cachedir {0}'.format(rdir))
+            try:
+                shutil.rmtree(rdir)
+            except OSError as exc:
+                log.error(
+                    'Unable to remove old gitfs remote cachedir {0}: {1}'
+                    .format(rdir, exc)
+                )
+            else:
+                log.debug('hgfs removed old cachedir {0}'.format(rdir))
         return True
     return False
 

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -252,7 +252,14 @@ def init():
             )
             continue
 
-        refs = repo.config(names='paths')
+        try:
+            refs = repo.config(names='paths')
+        except hglib.error.CommandError:
+            refs = None
+
+        # Do NOT put this if statement inside the except block above. Earlier
+        # versions of hglib did not raise an exception, so we need to do it
+        # this way to support both older and newer hglib.
         if not refs:
             # Write an hgrc defining the remote URI
             hgconfpath = os.path.join(rp_, '.hg', 'hgrc')

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -3,7 +3,12 @@
 Mercurial Fileserver Backend
 
 To enable, add ``hg`` to the :conf_master:`fileserver_backend` option in the
-master config file.
+Master config file.
+
+.. code-block:: yaml
+
+    fileserver_backend:
+      - hg
 
 After enabling this backend, branches, bookmarks, and tags in a remote
 mercurial repository are exposed to salt as different environments. This

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -307,7 +307,8 @@ def _clear_old_remotes():
         except ValueError:
             pass
     remove_dirs = [os.path.join(bp_, rdir) for rdir in remove_dirs
-                   if rdir not in ('hash', 'refs', 'envs.p', 'remote_map.txt')]
+                   if rdir not in ('hash', 'refs', 'envs.p', 'remote_map.txt')
+                   and not rdir.endswith('.update.lk')]
     if remove_dirs:
         for rdir in remove_dirs:
             shutil.rmtree(rdir)
@@ -375,7 +376,10 @@ def _update_lockfile(repo):
     '''
     Return the filename of the update lock
     '''
-    return os.path.join(repo['repo'].root(), 'update.lk')
+    #return os.path.join(repo['repo'].root(), 'update.lk')
+    return os.path.join(__opts__['cachedir'],
+                        'hgfs',
+                        '{0}.update.lk'.format(repo['hash']))
 
 
 def update():

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -43,6 +43,7 @@ import os
 import shutil
 from datetime import datetime
 from salt._compat import text_type as _text_type
+from salt.exceptions import FileserverConfigError
 
 VALID_BRANCH_METHODS = ('branches', 'bookmarks', 'mixed')
 PER_REMOTE_PARAMS = ('base', 'branch_method', 'mountpoint', 'root')
@@ -168,6 +169,15 @@ def _get_ref(repo, name):
     return False
 
 
+def _failhard():
+    '''
+    Fatal fileserver configuration issue, raise an exception
+    '''
+    raise FileserverConfigError(
+        'Failed to load hg fileserver backend'
+    )
+
+
 def init():
     '''
     Return a list of hglib objects for the various hgfs remotes
@@ -191,11 +201,13 @@ def init():
             )
             if not per_remote_conf:
                 log.error(
-                    'Invalid per-remote configuration for remote {0}. If no '
-                    'per-remote parameters are being specified, there may be '
-                    'a trailing colon after the URI, which should be removed. '
-                    'Check the master configuration file.'.format(repo_url)
+                    'Invalid per-remote configuration for hgfs remote {0}. If '
+                    'no per-remote parameters are being specified, there may '
+                    'be a trailing colon after the URL, which should be '
+                    'removed. Check the master configuration file.'
+                    .format(repo_url)
                 )
+                _failhard()
 
             branch_method = \
                 per_remote_conf.get('branch_method',
@@ -207,8 +219,9 @@ def init():
                     .format(branch_method, repo_url,
                             ', '.join(VALID_BRANCH_METHODS))
                 )
-                continue
+                _failhard()
 
+            per_remote_errors = False
             for param in (x for x in per_remote_conf
                           if x not in PER_REMOTE_PARAMS):
                 log.error(
@@ -218,7 +231,10 @@ def init():
                         param, repo_url, ', '.join(PER_REMOTE_PARAMS)
                     )
                 )
-                per_remote_conf.pop(param)
+                per_remote_errors = True
+            if per_remote_errors:
+                _failhard()
+
             repo_conf.update(per_remote_conf)
         else:
             repo_url = remote
@@ -226,9 +242,9 @@ def init():
         if not isinstance(repo_url, string_types):
             log.error(
                 'Invalid hgfs remote {0}. Remotes must be strings, you may '
-                'need to enclose the URI in quotes'.format(repo_url)
+                'need to enclose the URL in quotes'.format(repo_url)
             )
-            continue
+            _failhard()
 
         try:
             repo_conf['mountpoint'] = salt.utils.strip_proto(
@@ -257,7 +273,13 @@ def init():
                 'delete this directory on the master to continue to use this '
                 'hgfs remote.'.format(rp_, repo_url)
             )
-            continue
+            _failhard()
+        except Exception as exc:
+            log.error(
+                'Exception \'{0}\' encountered while initializing hgfs remote '
+                '{1}'.format(exc, repo_url)
+            )
+            _failhard()
 
         try:
             refs = repo.config(names='paths')
@@ -268,7 +290,7 @@ def init():
         # versions of hglib did not raise an exception, so we need to do it
         # this way to support both older and newer hglib.
         if not refs:
-            # Write an hgrc defining the remote URI
+            # Write an hgrc defining the remote URL
             hgconfpath = os.path.join(rp_, '.hg', 'hgrc')
             with salt.utils.fopen(hgconfpath, 'w+') as hgconfig:
                 hgconfig.write('[paths]\n')

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -392,6 +392,7 @@ def update():
                 'to continue for this remote.'.format(repo['url'], lk_fn)
             )
             continue
+        log.debug('hgfs is fetching from {0}'.format(repo['url']))
         with salt.utils.fopen(lk_fn, 'w+') as fp_:
             fp_.write(str(pid))
         curtip = repo['repo'].tip()

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -315,11 +315,14 @@ def clear_cache():
     '''
     fsb_cachedir = os.path.join(__opts__['cachedir'], 'hgfs')
     list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists/hgfs')
+    errors = []
     for rdir in (fsb_cachedir, list_cachedir):
-        try:
-            shutil.rmtree(rdir)
-        except OSError:
-            pass
+        if os.path.exists(rdir):
+            try:
+                shutil.rmtree(rdir)
+            except OSError as exc:
+                errors.append('Unable to delete {0}: {1}'.format(rdir, exc))
+    return errors
 
 
 def update():

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -29,6 +29,7 @@ will set the desired branch method. Possible values are: ``branches``,
 
 # Import python libs
 import copy
+import fnmatch
 import glob
 import hashlib
 import logging
@@ -271,7 +272,10 @@ def init():
             'repo': repo,
             'url': repo_url,
             'hash': repo_hash,
-            'cachedir': rp_
+            'cachedir': rp_,
+            'lockfile': os.path.join(__opts__['cachedir'],
+                                     'hgfs',
+                                     '{0}.update.lk'.format(repo_hash))
         })
         repos.append(repo_conf)
         repo.close()
@@ -352,50 +356,96 @@ def clear_cache():
 def clear_lock(remote=None):
     '''
     Clear update.lk
-    '''
-    def _add_error(errlist, url, lk_fn, exc):
-        errlist.append('Unable to remove update lock for {0} ({1}): {2} '
-                       .format(url, lk_fn, exc))
 
-    cleared = []
-    errors = []
-    for repo in init():
-        if remote:
+    ``remote`` can either be a dictionary containing repo configuration
+    information, or a pattern. If the latter, then remotes for which the URL
+    matches the pattern will be locked.
+    '''
+    def _do_clear_lock(repo):
+        def _add_error(errlist, repo, exc):
+            errlist.append('Unable to remove update lock for {0} ({1}): {2} '
+                           .format(repo['url'], repo['lockfile'], exc))
+        success = []
+        failed = []
+        if os.path.exists(repo['lockfile']):
             try:
-                if remote not in repo['url']:
-                    continue
-            except TypeError:
-                # remote was non-string, try again
-                if _text_type(remote) not in repo['url']:
-                    continue
-        lk_fn = _update_lockfile(repo)
-        if os.path.exists(lk_fn):
-            try:
-                os.remove(lk_fn)
+                os.remove(repo['lockfile'])
             except OSError as exc:
                 if exc.errno == errno.EISDIR:
                     # Somehow this path is a directory. Should never happen
                     # unless some wiseguy manually creates a directory at this
                     # path, but just in case, handle it.
                     try:
-                        shutil.rmtree(lk_fn)
+                        shutil.rmtree(repo['lockfile'])
                     except OSError as exc:
-                        _add_error(errors, repo['url'], lk_fn, exc)
+                        _add_error(failed, repo, exc)
                 else:
-                    _add_error(errors, repo['url'], lk_fn, exc)
+                    _add_error(failed, repo, exc)
             else:
-                cleared.append('Removed lock for {0}'.format(repo['url']))
+                success.append('Removed lock for {0}'.format(repo['url']))
+        return success, failed
+
+    if isinstance(remote, dict):
+        return _do_clear_lock(remote)
+
+    cleared = []
+    errors = []
+    for repo in init():
+        if remote:
+            try:
+                if not fnmatch.fnmatch(repo['url'], remote):
+                    continue
+            except TypeError:
+                # remote was non-string, try again
+                if not fnmatch.fnmatch(repo['url'], _text_type(remote)):
+                    continue
+        success, failed = _do_clear_lock(repo)
+        cleared.extend(success)
+        errors.extend(failed)
     return cleared, errors
 
 
-def _update_lockfile(repo):
+def lock(remote=None):
     '''
-    Return the filename of the update lock
+    Place an update.lk
+
+    ``remote`` can either be a dictionary containing repo configuration
+    information, or a pattern. If the latter, then remotes for which the URL
+    matches the pattern will be locked.
     '''
-    #return os.path.join(repo['repo'].root(), 'update.lk')
-    return os.path.join(__opts__['cachedir'],
-                        'hgfs',
-                        '{0}.update.lk'.format(repo['hash']))
+    def _do_lock(repo):
+        success = []
+        failed = []
+        if not os.path.exists(repo['lockfile']):
+            try:
+                with salt.utils.fopen(repo['lockfile'], 'w+') as fp_:
+                    fp_.write('')
+            except (IOError, OSError) as exc:
+                failed.append('Unable to set update lock for {0} ({1}): {2} '
+                              .format(repo['url'], repo['lockfile'], exc))
+            else:
+                success.append('Set lock for {0}'.format(repo['url']))
+        return success, failed
+
+    if isinstance(remote, dict):
+        return _do_lock(remote)
+
+    locked = []
+    errors = []
+    for repo in init():
+        if remote:
+            try:
+                if not fnmatch.fnmatch(repo['url'], remote):
+                    continue
+            except TypeError:
+                # remote was non-string, try again
+                if not fnmatch.fnmatch(repo['url'], _text_type(remote)):
+                    continue
+        success, failed = _do_lock(repo)
+        locked.extend(success)
+        errors.extend(failed)
+
+    return locked, errors
 
 
 def update():
@@ -405,25 +455,31 @@ def update():
     # data for the fileserver event
     data = {'changed': False,
             'backend': 'hgfs'}
-    pid = os.getpid()
     # _clear_old_remotes runs init(), so use the value from there to avoid a
     # second init()
     data['changed'], repos = _clear_old_remotes()
     for repo in repos:
-        repo['repo'].open()
-        lk_fn = _update_lockfile(repo)
-        if os.path.exists(lk_fn):
+        if os.path.exists(repo['lockfile']):
             log.warning(
                 'Update lockfile is present for hgfs remote {0}, skipping. '
                 'If this warning persists, it is possible that the update '
                 'process was interrupted. Removing {1} or running '
                 '\'salt-run fileserver.clear_lock hgfs\' will allow updates '
-                'to continue for this remote.'.format(repo['url'], lk_fn)
+                'to continue for this remote.'
+                .format(repo['url'], repo['lockfile'])
             )
             continue
+        locked, errors = lock(repo)
+        for msg in locked:
+            log.debug(msg)
+        if errors:
+            for msg in errors:
+                log.error(errors)
+            log.error('Unable to set update lock for hgfs remote {0}, '
+                      'skipping.'.format(repo['url']))
+            continue
         log.debug('hgfs is fetching from {0}'.format(repo['url']))
-        with salt.utils.fopen(lk_fn, 'w+') as fp_:
-            fp_.write(str(pid))
+        repo['repo'].open()
         curtip = repo['repo'].tip()
         try:
             repo['repo'].pull()
@@ -438,7 +494,11 @@ def update():
             if curtip[1] != newtip[1]:
                 data['changed'] = True
         repo['repo'].close()
-        clear_lock(repo)
+        success, errors = clear_lock(repo)
+        for msg in success:
+            log.debug(msg)
+        for msg in errors:
+            log.error(msg)
 
     env_cache = os.path.join(__opts__['cachedir'], 'hgfs/envs.p')
     if data.get('changed', False) is True or not os.path.isfile(env_cache):

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -325,6 +325,52 @@ def clear_cache():
     return errors
 
 
+def clear_lock(remote=None):
+    '''
+    Clear update.lk
+    '''
+    def _add_error(errlist, url, lk_fn, exc):
+        errlist.append('Unable to remove update lock for {0} ({1}): {2} '
+                       .format(url, lk_fn, exc))
+
+    cleared = []
+    errors = []
+    for repo in init():
+        if remote:
+            try:
+                if remote not in repo['url']:
+                    continue
+            except TypeError:
+                # remote was non-string, try again
+                if _text_type(remote) not in repo['url']:
+                    continue
+        lk_fn = _update_lockfile(repo)
+        if os.path.exists(lk_fn):
+            try:
+                os.remove(lk_fn)
+            except OSError as exc:
+                if exc.errno == errno.EISDIR:
+                    # Somehow this path is a directory. Should never happen
+                    # unless some wiseguy manually creates a directory at this
+                    # path, but just in case, handle it.
+                    try:
+                        shutil.rmtree(lk_fn)
+                    except OSError as exc:
+                        _add_error(errors, repo['url'], lk_fn, exc)
+                else:
+                    _add_error(errors, repo['url'], lk_fn, exc)
+            else:
+                cleared.append('Removed lock for {0}'.format(repo['url']))
+    return cleared, errors
+
+
+def _update_lockfile(repo):
+    '''
+    Return the filename of the update lock
+    '''
+    return os.path.join(repo['repo'].root(), 'update.lk')
+
+
 def update():
     '''
     Execute an hg pull on all of the repos
@@ -336,7 +382,17 @@ def update():
     data['changed'] = _clear_old_remotes()
     for repo in init():
         repo['repo'].open()
-        lk_fn = os.path.join(repo['repo'].root(), 'update.lk')
+        lk_fn = _update_lockfile(repo)
+        if os.path.exists(lk_fn):
+            log.warning(
+                'Update lockfile is present for hgfs remote {0}, skipping. '
+                'If this warning persists, it is possible that the update '
+                'process was interrupted. Removing {1} or running '
+                '\'salt-run fileserver.clear_lock backend=hg\' will allow '
+                'updates to continue for this remote.'
+                .format(repo['url'], lk_fn)
+            )
+            continue
         with salt.utils.fopen(lk_fn, 'w+') as fp_:
             fp_.write(str(pid))
         curtip = repo['repo'].tip()

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -34,6 +34,7 @@ will set the desired branch method. Possible values are: ``branches``,
 
 # Import python libs
 import copy
+import errno
 import fnmatch
 import glob
 import hashlib

--- a/salt/fileserver/minionfs.py
+++ b/salt/fileserver/minionfs.py
@@ -1,11 +1,20 @@
 # -*- coding: utf-8 -*-
 '''
-Fileserver backend  which serves files pushed to master by :mod:`cp.push
-<salt.modules.cp.push>`
+Fileserver backend which serves files pushed to the Master
 
-:conf_master:`file_recv` needs to be enabled in the master config file in order
-to use this backend, and ``minion`` must also be present in the
-:conf_master:`fileserver_backends` list.
+The :mod:`cp.push <salt.modules.cp.push>` function allows Minions to push files
+up to the Master. Using this backend, these pushed files are exposed to other
+Minions via the Salt fileserver.
+
+To enable minionfs, :conf_master:`file_recv` needs to be set to ``True`` in
+the master config file (otherwise :mod:`cp.push <salt.modules.cp.push>` will
+not be allowed to push files to the Master), and ``minion`` must be added to
+the :conf_master:`fileserver_backends` list.
+
+.. code-block:: yaml
+
+    fileserver_backend:
+      - minion
 
 Other minionfs settings include: :conf_master:`minionfs_whitelist`,
 :conf_master:`minionfs_blacklist`, :conf_master:`minionfs_mountpoint`, and

--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -2,8 +2,18 @@
 '''
 The default file server backend
 
-Based on the environments in the :conf_master:`file_roots` configuration
-option.
+This fileserver backend serves files from the Master's local filesystem. If
+:conf_master:`fileserver_backend` is not defined in the Master config file,
+then this backend is enabled by default. If it *is* defined then ``roots`` must
+be in the :conf_master:`fileserver_backend` list to enable this backend.
+
+.. code-block:: yaml
+
+    fileserver_backend:
+      - roots
+
+Fileserver environments are defined using the :conf_master:`file_roots`
+configuration option.
 '''
 
 # Import python libs

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -1,15 +1,17 @@
 # -*- coding: utf-8 -*-
 '''
-The backend for a fileserver based on Amazon S3
+Amazon S3 Fileserver Backend
 
-.. seealso:: :doc:`/ref/file_server/index`
+This backend exposes directories in S3 buckets as Salt environments. To enable
+this backend, add ``s3`` to the :conf_master:`fileserver_backend` option in the
+Master config file.
 
-This backend exposes directories in S3 buckets as Salt environments.  This
-feature is managed by the :conf_master:`fileserver_backend` option in the Salt
-Master config.
+.. code-block:: yaml
 
+    fileserver_backend:
+      - s3
 
-S3 credentials can be set in the master config file like so:
+S3 credentials must also be set in the master config file:
 
 .. code-block:: yaml
 
@@ -18,14 +20,6 @@ S3 credentials can be set in the master config file like so:
 
 Alternatively, if on EC2 these credentials can be automatically loaded from
 instance metadata.
-
-Additionally, ``s3fs`` must be included in the
-:conf_master:`fileserver_backend` config parameter in the master config file:
-
-.. code-block:: yaml
-
-    fileserver_backend:
-      - s3fs
 
 This fileserver supports two modes of operation for the buckets:
 

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -143,7 +143,7 @@ def init():
 
         if not isinstance(repo_url, string_types):
             log.error(
-                'Invalid gitfs remote {0}. Remotes must be strings, you may '
+                'Invalid svnfs remote {0}. Remotes must be strings, you may '
                 'need to enclose the URI in quotes'.format(repo_url)
             )
             continue
@@ -216,9 +216,9 @@ def init():
     return repos
 
 
-def purge_cache():
+def _clear_old_remotes():
     '''
-    Purge the fileserver cache
+    Remove cache directories for remotes no longer configured
     '''
     bp_ = os.path.join(__opts__['cachedir'], 'svnfs')
     try:
@@ -235,8 +235,22 @@ def purge_cache():
     if remove_dirs:
         for rdir in remove_dirs:
             shutil.rmtree(rdir)
+            log.debug('svnfs removed old cachedir {0}'.format(rdir))
         return True
     return False
+
+
+def clear_cache():
+    '''
+    Completely clear svnfs cache
+    '''
+    fsb_cachedir = os.path.join(__opts__['cachedir'], 'svnfs')
+    list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists/svnfs')
+    for rdir in (fsb_cachedir, list_cachedir):
+        try:
+            shutil.rmtree(rdir)
+        except OSError:
+            pass
 
 
 def update():
@@ -247,7 +261,7 @@ def update():
     data = {'changed': False,
             'backend': 'svnfs'}
     pid = os.getpid()
-    data['changed'] = purge_cache()
+    data['changed'] = _clear_old_remotes()
     for repo in init():
         lk_fn = os.path.join(repo['repo'], 'update.lk')
         with salt.utils.fopen(lk_fn, 'w+') as fp_:

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -246,11 +246,14 @@ def clear_cache():
     '''
     fsb_cachedir = os.path.join(__opts__['cachedir'], 'svnfs')
     list_cachedir = os.path.join(__opts__['cachedir'], 'file_lists/svnfs')
+    errors = []
     for rdir in (fsb_cachedir, list_cachedir):
-        try:
-            shutil.rmtree(rdir)
-        except OSError:
-            pass
+        if os.path.exists(rdir):
+            try:
+                shutil.rmtree(rdir)
+            except OSError as exc:
+                errors.append('Unable to delete {0}: {1}'.format(rdir, exc))
+    return errors
 
 
 def update():

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -225,7 +225,9 @@ def _clear_old_remotes():
         cachedir_ls = os.listdir(bp_)
     except OSError:
         cachedir_ls = []
-    for repo in init():
+    repos = init()
+    # Remove actively-used remotes from list
+    for repo in repos:
         try:
             cachedir_ls.remove(repo['hash'])
         except ValueError:
@@ -244,7 +246,7 @@ def _clear_old_remotes():
                 shutil.rmtree(rdir)
             except OSError as exc:
                 log.error(
-k                   'Unable to remove old svnfs remote cachedir {0}: {1}'
+                    'Unable to remove old svnfs remote cachedir {0}: {1}'
                     .format(rdir, exc)
                 )
                 failed.append(rdir)
@@ -252,7 +254,7 @@ k                   'Unable to remove old svnfs remote cachedir {0}: {1}'
                 log.debug('svnfs removed old cachedir {0}'.format(rdir))
     for fdir in failed:
         to_remove.remove(fdir)
-    return bool(to_remove)
+    return bool(to_remove), repos
 
 
 def clear_cache():
@@ -325,8 +327,10 @@ def update():
     data = {'changed': False,
             'backend': 'svnfs'}
     pid = os.getpid()
-    data['changed'] = _clear_old_remotes()
-    for repo in init():
+    # _clear_old_remotes runs init(), so use the value from there to avoid a
+    # second init()
+    data['changed'], repos = _clear_old_remotes()
+    for repo in repos:
         lk_fn = _update_lockfile(repo)
         if os.path.exists(lk_fn):
             log.warning(

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -196,7 +196,8 @@ def init():
             'repo': rp_,
             'url': repo_url,
             'hash': repo_hash,
-            'cachedir': rp_
+            'cachedir': rp_,
+            'lockfile': os.path.join(rp_, 'update.lk')
         })
         repos.append(repo_conf)
 
@@ -280,10 +281,38 @@ def clear_cache():
 def clear_lock(remote=None):
     '''
     Clear update.lk
+
+    ``remote`` can either be a dictionary containing repo configuration
+    information, or a pattern. If the latter, then remotes for which the URL
+    matches the pattern will be locked.
     '''
-    def _add_error(errlist, url, lk_fn, exc):
-        errlist.append('Unable to remove update lock for {0} ({1}): {2} '
-                       .format(url, lk_fn, exc))
+    def _do_clear_lock(repo):
+        def _add_error(errlist, repo, exc):
+            errlist.append('Unable to remove update lock for {0} ({1}): {2} '
+                           .format(repo['url'], repo['lockfile'], exc))
+        success = []
+        failed = []
+        if os.path.exists(repo['lockfile']):
+            try:
+                os.remove(repo['lockfile'])
+            except OSError as exc:
+                if exc.errno == errno.EISDIR:
+                    # Somehow this path is a directory. Should never happen
+                    # unless some wiseguy manually creates a directory at this
+                    # path, but just in case, handle it.
+                    try:
+                        shutil.rmtree(repo['lockfile'])
+                    except OSError as exc:
+                        _add_error(failed, repo, exc)
+                else:
+                    _add_error(failed, repo, exc)
+            else:
+                success.append('Removed lock for {0}'.format(repo['url']))
+        return success, failed
+
+    if isinstance(remote, dict):
+        return _do_clear_lock(remote)
+
 
     cleared = []
     errors = []
@@ -296,31 +325,53 @@ def clear_lock(remote=None):
                 # remote was non-string, try again
                 if _text_type(remote) not in repo['url']:
                     continue
-        lk_fn = _update_lockfile(repo)
-        if os.path.exists(lk_fn):
-            try:
-                os.remove(lk_fn)
-            except OSError as exc:
-                if exc.errno == errno.EISDIR:
-                    # Somehow this path is a directory. Should never happen
-                    # unless some wiseguy manually creates a directory at this
-                    # path, but just in case, handle it.
-                    try:
-                        shutil.rmtree(lk_fn)
-                    except OSError as exc:
-                        _add_error(errors, repo['url'], lk_fn, exc)
-                else:
-                    _add_error(errors, repo['url'], lk_fn, exc)
-            else:
-                cleared.append('Removed lock for {0}'.format(repo['url']))
+        success, failed = _do_clear_lock(repo)
+        cleared.extend(success)
+        errors.extend(failed)
     return cleared, errors
 
 
-def _update_lockfile(repo):
+def lock(remote=None):
     '''
-    Return the filename of the update lock
+    Place an update.lk
+
+    ``remote`` can either be a dictionary containing repo configuration
+    information, or a pattern. If the latter, then remotes for which the URL
+    matches the pattern will be locked.
     '''
-    return os.path.join(repo['repo'], 'update.lk')
+    def _do_lock(repo):
+        success = []
+        failed = []
+        if not os.path.exists(repo['lockfile']):
+            try:
+                with salt.utils.fopen(repo['lockfile'], 'w+') as fp_:
+                    fp_.write('')
+            except (IOError, OSError) as exc:
+                failed.append('Unable to set update lock for {0} ({1}): {2} '
+                              .format(repo['url'], repo['lockfile'], exc))
+            else:
+                success.append('Set lock for {0}'.format(repo['url']))
+        return success, failed
+
+    if isinstance(remote, dict):
+        return _do_lock(remote)
+
+    locked = []
+    errors = []
+    for repo in init():
+        if remote:
+            try:
+                if not fnmatch.fnmatch(repo['url'], remote):
+                    continue
+            except TypeError:
+                # remote was non-string, try again
+                if not fnmatch.fnmatch(repo['url'], _text_type(remote)):
+                    continue
+        success, failed = _do_lock(repo)
+        locked.extend(success)
+        errors.extend(failed)
+
+    return locked, errors
 
 
 def update():
@@ -330,24 +381,30 @@ def update():
     # data for the fileserver event
     data = {'changed': False,
             'backend': 'svnfs'}
-    pid = os.getpid()
     # _clear_old_remotes runs init(), so use the value from there to avoid a
     # second init()
     data['changed'], repos = _clear_old_remotes()
     for repo in repos:
-        lk_fn = _update_lockfile(repo)
-        if os.path.exists(lk_fn):
+        if os.path.exists(repo['lockfile']):
             log.warning(
                 'Update lockfile is present for svn remote {0}, skipping. '
                 'If this warning persists, it is possible that the update '
                 'process was interrupted. Removing {1} or running '
                 '\'salt-run fileserver.clear_lock svnfs\' will allow updates '
-                'to continue for this remote.'.format(repo['url'], lk_fn)
+                'to continue for this remote.'
+                .format(repo['url'], repo['lockfile'])
             )
             continue
+        locked, errors = lock(repo)
+        for msg in locked:
+            log.debug(msg)
+        if errors:
+            for msg in errors:
+                log.error(errors)
+            log.error('Unable to set update lock for svnfs remote {0}, '
+                      'skipping.'.format(repo['url']))
+            continue
         log.debug('svnfs is fetching from {0}'.format(repo['url']))
-        with salt.utils.fopen(lk_fn, 'w+') as fp_:
-            fp_.write(str(pid))
         old_rev = _rev(repo)
         try:
             CLIENT.update(repo['repo'])
@@ -356,7 +413,6 @@ def update():
                 'Error updating svnfs remote {0} (cachedir: {1}): {2}'
                 .format(repo['url'], repo['cachedir'], exc)
             )
-        clear_lock(repo)
 
         new_rev = _rev(repo)
         if any((x is None for x in (old_rev, new_rev))):
@@ -364,6 +420,12 @@ def update():
             continue
         if new_rev != old_rev:
             data['changed'] = True
+
+        success, errors = clear_lock(repo)
+        for msg in success:
+            log.debug(msg)
+        for msg in errors:
+            log.error(msg)
 
     env_cache = os.path.join(__opts__['cachedir'], 'svnfs/envs.p')
     if data.get('changed', False) is True or not os.path.isfile(env_cache):

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -352,10 +352,7 @@ def update():
                 'Error updating svnfs remote {0} (cachedir: {1}): {2}'
                 .format(repo['url'], repo['cachedir'], exc)
             )
-        try:
-            os.remove(lk_fn)
-        except (OSError, IOError):
-            pass
+        clear_lock(repo)
 
         new_rev = _rev(repo)
         if any((x is None for x in (old_rev, new_rev))):

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -29,6 +29,7 @@ This backend assumes a standard svn layout with directories for ``branches``,
 
 # Import python libs
 import copy
+import errno
 import fnmatch
 import hashlib
 import logging

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -322,6 +322,7 @@ def update():
                 'to continue for this remote.'.format(repo['url'], lk_fn)
             )
             continue
+        log.debug('svnfs is fetching from {0}'.format(repo['url']))
         with salt.utils.fopen(lk_fn, 'w+') as fp_:
             fp_.write(str(pid))
         old_rev = _rev(repo)

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -3,16 +3,20 @@
 Subversion Fileserver Backend
 
 After enabling this backend, branches, and tags in a remote subversion
-repository are exposed to salt as different environments. This feature is
-managed by the :conf_master:`fileserver_backend` option in the salt master
-config.
+repository are exposed to salt as different environments. To enable this
+backend, add ``svn`` to the :conf_master:`fileserver_backend` option in the
+Master config file.
+
+.. code-block:: yaml
+
+    fileserver_backend:
+      - svn
 
 This backend assumes a standard svn layout with directories for ``branches``,
 ``tags``, and ``trunk``, at the repository root.
 
 :depends:   - subversion
             - pysvn
-
 
 .. versionchanged:: 2014.7.0
     The paths to the trunk, branches, and tags have been made configurable, via

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -318,9 +318,8 @@ def update():
                 'Update lockfile is present for svn remote {0}, skipping. '
                 'If this warning persists, it is possible that the update '
                 'process was interrupted. Removing {1} or running '
-                '\'salt-run fileserver.clear_lock backend=svn\' will allow '
-                'updates to continue for this remote.'
-                .format(repo['url'], lk_fn)
+                '\'salt-run fileserver.clear_lock svnfs\' will allow updates '
+                'to continue for this remote.'.format(repo['url'], lk_fn)
             )
             continue
         with salt.utils.fopen(lk_fn, 'w+') as fp_:

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -29,6 +29,7 @@ This backend assumes a standard svn layout with directories for ``branches``,
 
 # Import python libs
 import copy
+import fnmatch
 import hashlib
 import logging
 import os

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -288,8 +288,10 @@ def clear_lock(remote=None):
     '''
     def _do_clear_lock(repo):
         def _add_error(errlist, repo, exc):
-            errlist.append('Unable to remove update lock for {0} ({1}): {2} '
-                           .format(repo['url'], repo['lockfile'], exc))
+            msg = ('Unable to remove update lock for {0} ({1}): {2} '
+                   .format(repo['url'], repo['lockfile'], exc))
+            log.debug(msg)
+            errlist.append(msg)
         success = []
         failed = []
         if os.path.exists(repo['lockfile']):
@@ -307,12 +309,13 @@ def clear_lock(remote=None):
                 else:
                     _add_error(failed, repo, exc)
             else:
-                success.append('Removed lock for {0}'.format(repo['url']))
+                msg = 'Removed lock for {0}'.format(repo['url'])
+                log.debug(msg)
+                success.append(msg)
         return success, failed
 
     if isinstance(remote, dict):
         return _do_clear_lock(remote)
-
 
     cleared = []
     errors = []
@@ -347,10 +350,14 @@ def lock(remote=None):
                 with salt.utils.fopen(repo['lockfile'], 'w+') as fp_:
                     fp_.write('')
             except (IOError, OSError) as exc:
-                failed.append('Unable to set update lock for {0} ({1}): {2} '
-                              .format(repo['url'], repo['lockfile'], exc))
+                msg = ('Unable to set update lock for {0} ({1}): {2} '
+                       .format(repo['url'], repo['lockfile'], exc))
+                log.debug(msg)
+                failed.append(msg)
             else:
-                success.append('Set lock for {0}'.format(repo['url']))
+                msg = 'Set lock for {0}'.format(repo['url'])
+                log.debug(msg)
+                success.append(msg)
         return success, failed
 
     if isinstance(remote, dict):
@@ -387,7 +394,7 @@ def update():
     for repo in repos:
         if os.path.exists(repo['lockfile']):
             log.warning(
-                'Update lockfile is present for svn remote {0}, skipping. '
+                'Update lockfile is present for svnfs remote {0}, skipping. '
                 'If this warning persists, it is possible that the update '
                 'process was interrupted. Removing {1} or running '
                 '\'salt-run fileserver.clear_lock svnfs\' will allow updates '
@@ -395,12 +402,8 @@ def update():
                 .format(repo['url'], repo['lockfile'])
             )
             continue
-        locked, errors = lock(repo)
-        for msg in locked:
-            log.debug(msg)
+        _, errors = lock(repo)
         if errors:
-            for msg in errors:
-                log.error(errors)
             log.error('Unable to set update lock for svnfs remote {0}, '
                       'skipping.'.format(repo['url']))
             continue
@@ -421,11 +424,7 @@ def update():
         if new_rev != old_rev:
             data['changed'] = True
 
-        success, errors = clear_lock(repo)
-        for msg in success:
-            log.debug(msg)
-        for msg in errors:
-            log.error(msg)
+        clear_lock(repo)
 
     env_cache = os.path.join(__opts__['cachedir'], 'svnfs/envs.p')
     if data.get('changed', False) is True or not os.path.isfile(env_cache):
@@ -541,7 +540,7 @@ def find_file(path, tgt_env='base', **kwargs):  # pylint: disable=W0613
     '''
     Find the first file to match the path and ref. This operates similarly to
     the roots file sever but with assumptions of the directory structure
-    based of svn standard practices.
+    based on svn standard practices.
     '''
     fnd = {'path': '',
            'rel': ''}

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -222,29 +222,37 @@ def _clear_old_remotes():
     '''
     bp_ = os.path.join(__opts__['cachedir'], 'svnfs')
     try:
-        remove_dirs = os.listdir(bp_)
+        cachedir_ls = os.listdir(bp_)
     except OSError:
-        remove_dirs = []
+        cachedir_ls = []
     for repo in init():
         try:
-            remove_dirs.remove(repo['hash'])
+            cachedir_ls.remove(repo['hash'])
         except ValueError:
             pass
-    remove_dirs = [os.path.join(bp_, rdir) for rdir in remove_dirs
-                   if rdir not in ('hash', 'refs', 'envs.p', 'remote_map.txt')]
-    if remove_dirs:
-        for rdir in remove_dirs:
+    to_remove = []
+    for item in cachedir_ls:
+        if item in ('hash', 'refs'):
+            continue
+        path = os.path.join(bp_, item)
+        if os.path.isdir(path):
+            to_remove.append(path)
+    failed = []
+    if to_remove:
+        for rdir in to_remove:
             try:
                 shutil.rmtree(rdir)
             except OSError as exc:
                 log.error(
-                    'Unable to remove old gitfs remote cachedir {0}: {1}'
+k                   'Unable to remove old svnfs remote cachedir {0}: {1}'
                     .format(rdir, exc)
                 )
+                failed.append(rdir)
             else:
                 log.debug('svnfs removed old cachedir {0}'.format(rdir))
-        return True
-    return False
+    for fdir in failed:
+        to_remove.remove(fdir)
+    return bool(to_remove)
 
 
 def clear_cache():

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -234,8 +234,15 @@ def _clear_old_remotes():
                    if rdir not in ('hash', 'refs', 'envs.p', 'remote_map.txt')]
     if remove_dirs:
         for rdir in remove_dirs:
-            shutil.rmtree(rdir)
-            log.debug('svnfs removed old cachedir {0}'.format(rdir))
+            try:
+                shutil.rmtree(rdir)
+            except OSError as exc:
+                log.error(
+                    'Unable to remove old gitfs remote cachedir {0}: {1}'
+                    .format(rdir, exc)
+                )
+            else:
+                log.debug('svnfs removed old cachedir {0}'.format(rdir))
         return True
     return False
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -43,6 +43,7 @@ import salt.utils.verify
 import salt.utils.minions
 import salt.utils.gzip_util
 import salt.utils.process
+from salt.exceptions import FileserverConfigError
 from salt.utils.debug import enable_sigusr1_handler, enable_sigusr2_handler, inspect_stack
 from salt.utils.event import tagify
 import binascii
@@ -267,6 +268,13 @@ class Master(SMaster):
                 'Failed to load fileserver backends, the configured backends '
                 'are: {0}'.format(', '.join(self.opts['fileserver_backend']))
             )
+        else:
+            # Run init() for all backends which support the function, to
+            # double-check configuration
+            try:
+                fileserver.init()
+            except FileserverConfigError as exc:
+                errors.append('{0}'.format(exc))
         if not self.opts['fileserver_backend']:
             errors.append('No fileserver backends are configured')
         if errors:

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -135,6 +135,83 @@ def symlink_list(saltenv='base', backend=None, outputter='nested'):
     return output
 
 
+def dir_list(saltenv='base', backend=None, outputter='nested'):
+    '''
+    .. versionadded:: 2015.2.0
+
+    Return a list of directories in the given environment
+
+    saltenv : base
+        The salt fileserver environment to be listed
+
+    backend
+        Narrow fileserver backends to a subset of the enabled ones. If all
+        passed backends start with a minus sign (``-``), then these backends
+        will be excluded from the enabled backends. However, if there is a mix
+        of backends with and without a minus sign (ex:
+        ``backend=-roots,git``) then the ones starting with a minus sign will
+        be disregarded.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run fileserver.dir_list
+        salt-run fileserver.dir_list saltenv=prod
+        salt-run fileserver.dir_list saltenv=dev backend=git
+        salt-run fileserver.dir_list base hg,roots
+        salt-run fileserver.dir_list -git
+    '''
+    fileserver = salt.fileserver.Fileserver(__opts__)
+    load = {'saltenv': saltenv, 'fsbackend': backend}
+    output = fileserver.dir_list(load=load)
+
+    if outputter:
+        salt.output.display_output(output, outputter, opts=__opts__)
+    return output
+
+
+def empty_dir_list(saltenv='base', backend=None, outputter='nested'):
+    '''
+    .. versionadded:: 2015.2.0
+
+    Return a list of empty directories in the given environment
+
+    saltenv : base
+        The salt fileserver environment to be listed
+
+    backend
+        Narrow fileserver backends to a subset of the enabled ones. If all
+        passed backends start with a minus sign (``-``), then these backends
+        will be excluded from the enabled backends. However, if there is a mix
+        of backends with and without a minus sign (ex:
+        ``backend=-roots,git``) then the ones starting with a minus sign will
+        be disregarded.
+
+        .. note::
+
+            Some backends (such as :mod:`git <salt.fileserver.gitfs>` and
+            :mod:`hg <salt.fileserver.hgfs>`) do not support empty directories.
+            So, passing ``backend=git`` or ``backend=hg`` will result in an
+            empty list being returned.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run fileserver.empty_dir_list
+        salt-run fileserver.empty_dir_list saltenv=prod
+        salt-run fileserver.empty_dir_list backend=roots
+    '''
+    fileserver = salt.fileserver.Fileserver(__opts__)
+    load = {'saltenv': saltenv, 'fsbackend': backend}
+    output = fileserver.file_list_emptydirs(load=load)
+
+    if outputter:
+        salt.output.display_output(output, outputter, opts=__opts__)
+    return output
+
+
 def update(backend=None):
     '''
     Update the fileserver cache. If no backend is provided, then the cache for

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -110,19 +110,30 @@ def clear_cache(backend=None):
     '''
     .. versionadded:: 2015.2.0
 
-    Clear the fileserver cache. If no backend is provided, then the cache for
-    all configured backends will be cleared, provided the backend has a
-    ``clear_cache()`` function. This currently only includes the VCS backends
-    (:mod:`git <salt.fileserver.gitfs>`, :mod:`hg <salt.fileserver.hgfs>`,
-    :mod:`svn <salt.fileserver.svnfs>`).
+    Clear the fileserver cache from VCS fileserver backends (:mod:`git
+    <salt.fileserver.gitfs>`, :mod:`hg <salt.fileserver.hgfs>`, :mod:`svn
+    <salt.fileserver.svnfs>`). Executing this runner with no arguments will
+    clear the cache for all enabled VCS fileserver backends, but this
+    can be narrowed using the ``backend`` argument.
+
+    backend
+        Only clear the update lock for the specified backend(s).
 
     CLI Example:
 
     .. code-block:: bash
 
         salt-run fileserver.update
-        salt-run fileserver.update backend=git
+        salt-run fileserver.update backend=git,hg
+        salt-run fileserver.update backend=hg
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
-    ret = fileserver.clear_cache(back=backend)
+    cleared, errors = fileserver.clear_cache(back=backend)
+    ret = {}
+    if cleared:
+        ret['cleared'] = cleared
+    if errors:
+        ret['errors'] = errors
+    if not ret:
+        ret = 'No cache was cleared'
     salt.output.display_output(ret, 'nested', opts=__opts__)

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -7,26 +7,6 @@ Directly manage the Salt fileserver plugins
 import salt.fileserver
 
 
-def dir_list(saltenv='base', outputter='nested'):
-    '''
-    List all directories in the given environment
-
-    CLI Example:
-
-    .. code-block:: bash
-
-        salt-run fileserver.dir_list
-        salt-run fileserver.dir_list saltenv=prod
-    '''
-    fileserver = salt.fileserver.Fileserver(__opts__)
-    load = {'saltenv': saltenv}
-    output = fileserver.dir_list(load=load)
-
-    if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
-
-
 def envs(backend=None, sources=False, outputter='nested'):
     '''
     Return the available fileserver environments. If no backend is provided,
@@ -137,8 +117,6 @@ def symlink_list(saltenv='base', backend=None, outputter='nested'):
 
 def dir_list(saltenv='base', backend=None, outputter='nested'):
     '''
-    .. versionadded:: 2015.2.0
-
     Return a list of directories in the given environment
 
     saltenv : base
@@ -151,6 +129,8 @@ def dir_list(saltenv='base', backend=None, outputter='nested'):
         of backends with and without a minus sign (ex:
         ``backend=-roots,git``) then the ones starting with a minus sign will
         be disregarded.
+
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
@@ -362,4 +342,3 @@ def lock(backend=None, remote=None):
     if not ret:
         ret = 'No locks were set'
     salt.output.display_output(ret, 'nested', opts=__opts__)
-

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -29,7 +29,8 @@ def dir_list(saltenv='base', outputter='nested'):
 
 def envs(backend=None, sources=False, outputter='nested'):
     '''
-    Return the environments for the named backend or all back-ends
+    Return the available fileserver environments. If no backend is provided,
+    then the environments for all configured backends will be returned.
 
     CLI Example:
 
@@ -37,7 +38,7 @@ def envs(backend=None, sources=False, outputter='nested'):
 
         salt-run fileserver.envs
         salt-run fileserver.envs outputter=nested
-        salt-run fileserver.envs backend='["root", "git"]'
+        salt-run fileserver.envs backend=roots,git
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
     output = fileserver.envs(back=backend, sources=sources)
@@ -89,17 +90,39 @@ def symlink_list(saltenv='base', outputter='nested'):
 
 def update(backend=None):
     '''
-    Update all of the file-servers that support the update function or the
-    named fileserver only.
+    Update the fileserver cache. If no backend is provided, then the cache for
+    all configured backends will be updated.
 
     CLI Example:
 
     .. code-block:: bash
 
         salt-run fileserver.update
-        salt-run fileserver.update backend='["root", "git"]'
+        salt-run fileserver.update backend=roots,git
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
     fileserver.update(back=backend)
 
     return True
+
+
+def clear_cache(backend=None):
+    '''
+    .. versionadded:: 2015.2.0
+
+    Clear the fileserver cache. If no backend is provided, then the cache for
+    all configured backends will be cleared, provided the backend has a
+    ``clear_cache()`` function. This currently only includes the VCS backends
+    (:mod:`git <salt.fileserver.gitfs>`, :mod:`hg <salt.fileserver.hgfs>`,
+    :mod:`svn <salt.fileserver.svnfs>`).
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run fileserver.update
+        salt-run fileserver.update backend=git
+    '''
+    fileserver = salt.fileserver.Fileserver(__opts__)
+    ret = fileserver.clear_cache(back=backend)
+    salt.output.display_output(ret, 'nested', opts=__opts__)

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -32,6 +32,20 @@ def envs(backend=None, sources=False, outputter='nested'):
     Return the available fileserver environments. If no backend is provided,
     then the environments for all configured backends will be returned.
 
+    backend
+        Narrow fileserver backends to a subset of the enabled ones.
+
+        .. versionchanged:: 2015.2.0::
+            If all passed backends start with a minus sign (``-``), then these
+            backends will be excluded from the enabled backends. However, if
+            there is a mix of backends with and without a minus sign (ex:
+            ``backend=-roots,git``) then the ones starting with a minus
+            sign will be disregarded.
+
+            Additionally, fileserver backends can now be passed as a
+            comma-separated list. In earlier versions, they needed to be passed
+            as a python list (ex: ``backend="['roots', 'git']"``)
+
     CLI Example:
 
     .. code-block:: bash
@@ -39,6 +53,7 @@ def envs(backend=None, sources=False, outputter='nested'):
         salt-run fileserver.envs
         salt-run fileserver.envs outputter=nested
         salt-run fileserver.envs backend=roots,git
+        salt-run fileserver.envs git
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
     output = fileserver.envs(back=backend, sources=sources)
@@ -48,19 +63,35 @@ def envs(backend=None, sources=False, outputter='nested'):
     return output
 
 
-def file_list(saltenv='base', outputter='nested'):
+def file_list(saltenv='base', backend=None, outputter='nested'):
     '''
-    Return a list of files from the dominant environment
+    Return a list of files from the salt fileserver
 
-    CLI Example:
+    saltenv : base
+        The salt fileserver environment to be listed
+
+    backend
+        Narrow fileserver backends to a subset of the enabled ones. If all
+        passed backends start with a minus sign (``-``), then these backends
+        will be excluded from the enabled backends. However, if there is a mix
+        of backends with and without a minus sign (ex:
+        ``backend=-roots,git``) then the ones starting with a minus sign will
+        be disregarded.
+
+        .. versionadded:: 2015.2.0
+
+    CLI Examples:
 
     .. code-block:: bash
 
         salt-run fileserver.file_list
         salt-run fileserver.file_list saltenv=prod
+        salt-run fileserver.file_list saltenv=dev backend=git
+        salt-run fileserver.file_list base hg,roots
+        salt-run fileserver.file_list -git
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
-    load = {'saltenv': saltenv}
+    load = {'saltenv': saltenv, 'fsbackend': backend}
     output = fileserver.file_list(load=load)
 
     if outputter:
@@ -68,9 +99,22 @@ def file_list(saltenv='base', outputter='nested'):
     return output
 
 
-def symlink_list(saltenv='base', outputter='nested'):
+def symlink_list(saltenv='base', backend=None, outputter='nested'):
     '''
     Return a list of symlinked files and dirs
+
+    saltenv : base
+        The salt fileserver environment to be listed
+
+    backend
+        Narrow fileserver backends to a subset of the enabled ones. If all
+        passed backends start with a minus sign (``-``), then these backends
+        will be excluded from the enabled backends. However, if there is a mix
+        of backends with and without a minus sign (ex:
+        ``backend=-roots,git``) then the ones starting with a minus sign will
+        be disregarded.
+
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
@@ -78,9 +122,12 @@ def symlink_list(saltenv='base', outputter='nested'):
 
         salt-run fileserver.symlink_list
         salt-run fileserver.symlink_list saltenv=prod
+        salt-run fileserver.symlink_list saltenv=dev backend=git
+        salt-run fileserver.symlink_list base hg,roots
+        salt-run fileserver.symlink_list -git
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
-    load = {'saltenv': saltenv}
+    load = {'saltenv': saltenv, 'fsbackend': backend}
     output = fileserver.symlink_list(load=load)
 
     if outputter:
@@ -93,6 +140,20 @@ def update(backend=None):
     Update the fileserver cache. If no backend is provided, then the cache for
     all configured backends will be updated.
 
+    backend
+        Narrow fileserver backends to a subset of the enabled ones.
+
+        .. versionchanged:: 2015.2.0
+            If all passed backends start with a minus sign (``-``), then these
+            backends will be excluded from the enabled backends. However, if
+            there is a mix of backends with and without a minus sign (ex:
+            ``backend=-roots,git``) then the ones starting with a minus
+            sign will be disregarded.
+
+            Additionally, fileserver backends can now be passed as a
+            comma-separated list. In earlier versions, they needed to be passed
+            as a python list (ex: ``backend="['roots', 'git']"``)
+
     CLI Example:
 
     .. code-block:: bash
@@ -102,7 +163,6 @@ def update(backend=None):
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
     fileserver.update(back=backend)
-
     return True
 
 
@@ -117,7 +177,11 @@ def clear_cache(backend=None):
     can be narrowed using the ``backend`` argument.
 
     backend
-        Only clear the update lock for the specified backend(s).
+        Only clear the update lock for the specified backend(s). If all passed
+        backends start with a minus sign (``-``), then these backends will be
+        excluded from the enabled backends. However, if there is a mix of
+        backends with and without a minus sign (ex: ``backend=-roots,git``)
+        then the ones starting with a minus sign will be disregarded.
 
     CLI Example:
 
@@ -125,7 +189,8 @@ def clear_cache(backend=None):
 
         salt-run fileserver.update
         salt-run fileserver.update backend=git,hg
-        salt-run fileserver.update backend=hg
+        salt-run fileserver.update hg
+        salt-run fileserver.update -roots
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
     cleared, errors = fileserver.clear_cache(back=backend)
@@ -178,3 +243,4 @@ def clear_lock(backend=None, remote=None):
     if not ret:
         ret = 'No locks were removed'
     salt.output.display_output(ret, 'nested', opts=__opts__)
+

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -137,3 +137,44 @@ def clear_cache(backend=None):
     if not ret:
         ret = 'No cache was cleared'
     salt.output.display_output(ret, 'nested', opts=__opts__)
+
+
+def clear_lock(backend=None, remote=None):
+    '''
+    .. versionadded:: 2015.2.0
+
+    Clear the fileserver update lock from VCS fileserver backends (:mod:`git
+    <salt.fileserver.gitfs>`, :mod:`hg <salt.fileserver.hgfs>`, :mod:`svn
+    <salt.fileserver.svnfs>`). This should only need to be done if a fileserver
+    update was interrupted and a remote is not updating (generating a warning
+    in the Master's log file). Executing this runner with no arguments will
+    remove all update locks from all enabled VCS fileserver backends, but this
+    can be narrowed by using the following arguments:
+
+    backend
+        Only clear the update lock for the specified backend(s).
+
+    remote
+        If not None, then any remotes which contain the passed string will have
+        their lock cleared. For example, a ``remote`` value of **github** will
+        remove the lock from all github.com remotes.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run fileserver.clear_lock
+        salt-run fileserver.clear_lock backend=git,hg
+        salt-run fileserver.clear_lock backend=git remote=github
+        salt-run fileserver.clear_lock remote=bitbucket
+    '''
+    fileserver = salt.fileserver.Fileserver(__opts__)
+    cleared, errors = fileserver.clear_lock(back=backend, remote=remote)
+    ret = {}
+    if cleared:
+        ret['cleared'] = cleared
+    if errors:
+        ret['errors'] = errors
+    if not ret:
+        ret = 'No locks were removed'
+    salt.output.display_output(ret, 'nested', opts=__opts__)

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -244,10 +244,10 @@ def clear_cache(backend=None):
 
     .. code-block:: bash
 
-        salt-run fileserver.update
-        salt-run fileserver.update backend=git,hg
-        salt-run fileserver.update hg
-        salt-run fileserver.update -roots
+        salt-run fileserver.clear_cache
+        salt-run fileserver.clear_cache backend=git,hg
+        salt-run fileserver.clear_cache hg
+        salt-run fileserver.clear_cache -roots
     '''
     fileserver = salt.fileserver.Fileserver(__opts__)
     cleared, errors = fileserver.clear_cache(back=backend)

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -321,3 +321,45 @@ def clear_lock(backend=None, remote=None):
         ret = 'No locks were removed'
     salt.output.display_output(ret, 'nested', opts=__opts__)
 
+
+def lock(backend=None, remote=None):
+    '''
+    .. versionadded:: 2015.2.0
+
+    Set a fileserver update lock for VCS fileserver backends (:mod:`git
+    <salt.fileserver.gitfs>`, :mod:`hg <salt.fileserver.hgfs>`, :mod:`svn
+    <salt.fileserver.svnfs>`).
+
+    .. note::
+
+        This will only operate on enabled backends (those configured in
+        :master_conf:`fileserver_backend`).
+
+    backend
+        Only set the update lock for the specified backend(s).
+
+    remote
+        If not None, then any remotes which contain the passed string will have
+        their lock cleared. For example, a ``remote`` value of ``*github.com*``
+        will remove the lock from all github.com remotes.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt-run fileserver.lock
+        salt-run fileserver.lock backend=git,hg
+        salt-run fileserver.lock backend=git remote='*github.com*'
+        salt-run fileserver.lock remote=bitbucket
+    '''
+    fileserver = salt.fileserver.Fileserver(__opts__)
+    locked, errors = fileserver.lock(back=backend, remote=remote)
+    ret = {}
+    if locked:
+        ret['locked'] = locked
+    if errors:
+        ret['errors'] = errors
+    if not ret:
+        ret = 'No locks were set'
+    salt.output.display_output(ret, 'nested', opts=__opts__)
+

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1393,13 +1393,10 @@ def is_fcntl_available(check_sunos=False):
     Simple function to check if the `fcntl` module is available or not.
 
     If `check_sunos` is passed as `True` an additional check to see if host is
-    SunOS is also made. For additional information check commit:
-        http://goo.gl/159FF8
+    SunOS is also made. For additional information see: http://goo.gl/159FF8
     '''
-    if HAS_FCNTL is False:
+    if check_sunos and is_sunos():
         return False
-    if check_sunos is True:
-        return HAS_FCNTL and is_sunos()
     return HAS_FCNTL
 
 


### PR DESCRIPTION
This pull request does the following:
1. Resolves #20785, #17945, #20896, #20993, #21021.
2. Adds the following new fileserver runners: **clear_cache**, **lock**, **clear_lock**, **empty_dir_list**.

In the process of troubleshooting I noticed that dulwich has its own way of handling refs which, when switching back and forth between GitPython/pygit2 and Dulwich can cause additional environments to appear to be available when they are not, particularly (but perhaps not limited to) branches/tags with slashes in their names. It is for this reason that I added the new `fileserver.clear_cache` runner, to make the process of clearing the cache easier.

**EDIT:** In the process of investigating a traceback, I discovered a couple hgfs bugs which affect newer versions of hglib, effectively breaking hgfs. I have fixed these here. In addition, I took the opportunity to add several more fileserver runners.

I was forced to revert the changes from #20141 as they were causing stability issues. I will reopen the original issue (#18839) once this is merged and we will re-investigate.

I also discovered that, while we were laying down a lock file for each repo as we updated it, we were not checking that lockfile before we attempted to fetch those repos again. This could cause unexpected issues if one runs the `fileserver.update` runner during an automated fileserver update. The VCS backends now check for this lockfile before attempting to update a remote.

Finally, I added fixes for minor bugs #17945 and #20993.

Pending test failures and results of code review, this should be ready to merge.
