### PR TITLE
Update the RHEL installation guide

### DIFF
--- a/doc/topics/installation/rhel.rst
+++ b/doc/topics/installation/rhel.rst
@@ -24,8 +24,24 @@ Installation from pip is easy:
     More information on this can be found :ref:`here
     <installing-for-development>`.
 
-Installation from EPEL
-======================
+Installation from Repository
+============================
+
+.. _installation-rhel-5:
+
+RHEL/CentOS 5
+-------------
+
+Due to the removal of some of Salt's dependencies from EPEL5, we have created a
+repository on `Fedora COPR`_. Moving forward, this will be the official means
+of installing Salt on RHEL5-based systems. Information on how to enable this
+repository can be found here__.
+
+.. _`Fedora COPR`: https://copr.fedoraproject.org/
+.. __: https://copr.fedoraproject.org/coprs/saltstack/salt-el5/
+
+RHEL/CentOS 6 and 7, Scientific Linux, etc.
+-------------------------------------------
 
 Beginning with version 0.9.4, Salt has been available in `EPEL`_. It is
 installable using yum. Salt should work properly with all mainstream
@@ -41,27 +57,25 @@ installing salt on RHEL6.
 .. _`EPEL`: http://fedoraproject.org/wiki/EPEL
 
 
-Enabling EPEL on RHEL
----------------------
+Enabling EPEL
+*************
 
-If EPEL is not enabled on your system, you can use the following commands to
-enable it.
-
-For RHEL 5:
-
-.. code-block:: bash
-
-    rpm -Uvh http://mirror.pnl.gov/epel/5/i386/epel-release-5-4.noarch.rpm
-
-For RHEL 6:
+If the EPEL repository is not installed on your system, you can download the
+RPM from here__ for RHEL/CentOS 6 (or here__ for RHEL/CentOS 7) and install it
+using the following command:
 
 .. code-block:: bash
 
-    rpm -Uvh http://ftp.linux.ncsu.edu/pub/epel/6/i386/epel-release-6-8.noarch.rpm
+    rpm -Uvh epel-release-X-Y.rpm
+
+Replace ``epel-release-X-Y.rpm`` with the appropriate filename.
+
+.. __: http://download.fedoraproject.org/pub/epel/6/i386/repoview/epel-release.html
+.. __: http://download.fedoraproject.org/pub/epel/7/x86_64/repoview/epel-release.html
 
 
 Installing Stable Release
--------------------------
+*************************
 
 Salt is packaged separately for the minion and the master. It is necessary only
 to install the appropriate package for the role the machine will play.
@@ -80,7 +94,7 @@ On each salt-minion, run this:
     yum install salt-minion
 
 Installing from ``epel-testing``
---------------------------------
+********************************
 
 When a new Salt release is packaged, it is first admitted into the
 ``epel-testing`` repository, before being moved to the stable repo.
@@ -98,14 +112,21 @@ ZeroMQ 4
 We recommend using ZeroMQ 4 where available. SaltStack provides ZeroMQ 4.0.4
 and pyzmq 14.3.1 in a COPR_ repository. Instructions for adding this repository
 (as well as for upgrading ZeroMQ and pyzmq on existing minions) can be found
-here_.
+here__.
 
 .. _COPR: http://copr.fedoraproject.org/
-.. _here: http://copr.fedoraproject.org/coprs/saltstack/zeromq4/
+.. __: http://copr.fedoraproject.org/coprs/saltstack/zeromq4/
 
 If this repo is added *before* Salt is installed, then installing either
 ``salt-master`` or ``salt-minion`` will automatically pull in ZeroMQ 4.0.4, and
 additional states to upgrade ZeroMQ and pyzmq are unnecessary.
+
+.. note::
+
+    For RHEL/CentOS 5 installations, if using the new repository to install
+    Salt (as detailed :ref:`above <installation-rhel-5>`), then it is not
+    necessary to enable the zeromq4 COPR, as the new EL5 repository includes
+    ZeroMQ 4.
 
 
 Package Management


### PR DESCRIPTION
This updates the RHEL install instructions to reflect the new COPR for 
installation on RHEL/CentOS 5.

Additionally, it provides better instructions on how to enable EPEL:
- We don't care about EPEL5, so this link has been removed.
- We needed a link for EPEL7, so this has been added.
- The old RPM installation example used hard-coded URLs to an arbitrary
  EPEL mirror. This is not a good idea since A) the mirror could go
  away, and B) we are unfairly sending people to a single mirror when
  the Fedora Project has a perfectly good link on their wiki to send
  people to a "random" mirror. The install example now uses these links.

Resolves #20742.
