### PR TITLE
Use plist from pkg in launchd runner.

### DIFF
--- a/salt/runners/launchd.py
+++ b/salt/runners/launchd.py
@@ -23,19 +23,28 @@ def write_launchd_plist(program):
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict>
+  <dict>
     <key>Label</key>
     <string>org.saltstack.{program}</string>
-
-    <key>ProgramArguments</key>
-    <array>
-        <string>{python}</string>
-        <string>{script}</string>
-    </array>
-
     <key>RunAtLoad</key>
     <true/>
-</dict>
+    <key>KeepAlive</key>
+    <true/>
+    <key>ProgramArguments</key>
+    <array>
+        <string>{script}</string>
+    </array>
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>100000</integer>
+    </dict>
+    <key>HardResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>100000</integer>
+    </dict>
+  </dict>
 </plist>
     '''.strip()
 


### PR DESCRIPTION
The plist from the `pkg/` toplevel dir looked more correct than the one in the launchd runner, so I pretty much copied it over. My salt-{master,minion} binaries are bash scripts, so I don't think the first program argument should be python? 

Are there any plans for the homebrew saltstack to autoinstall plists or perhaps make it an installation argument/documented? That would be helpful.
