### PR TITLE
try/except salt.utils.fopen chown of file

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1035,7 +1035,12 @@ def fopen(*args, **kwargs):
         # no changes at all
         if (d_stat.st_uid != uid or d_stat.st_gid != gid) and \
                 [i for i in (uid, gid) if i != -1]:
-            os.chown(path, uid, gid)
+            try:
+                os.chown(path, uid, gid)
+            except OSError:
+                # uid and gid != -1, but file attrs are still immutable, such
+                # as on a network filesystem
+                pass
 
     if mode is not None:
         if d_stat.st_mode | mode != d_stat.st_mode:


### PR DESCRIPTION
Fixes #20882.  If the file resides on a filesystem with immutable file
attributes, such as a network filesystem, then a chown operation will
fail.

@robin-wittler
