### PR TITLE
Trim the env base off the dest file path in the s3fs fileserver

### DIFF
--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -228,7 +228,7 @@ def serve_file(load, fnd):
             load['saltenv'],
             fnd['path'])
 
-    ret['dest'] = fnd['path']
+    ret['dest'] = _trim_env_off_path( [fnd['path']], load['saltend'] )[0]
 
     with salt.utils.fopen(cached_file_path, 'rb') as fp_:
         fp_.seek(load['loc'])


### PR DESCRIPTION
Currently custom modules/grains are broken if using s3fs. This seems to be because the `s3fs` fileserver returns the `dest` in `serve_file()` includes the env base. This is then appended to the cache dir via `RemoteClient.get_file()` which is already set with the environment in mind. This causes a path like: '/var/cache/salt/minion/files/base/base/_modules' which in turn screws up the copying into the modules dir.

The attached patch removed the environment off the beginning off path if using the "environments in bucket" option.
