### PR TITLE
cli/batch.py: re-enable pylint instead of disabling it twice

### DIFF
--- a/salt/cli/batch.py
+++ b/salt/cli/batch.py
@@ -19,7 +19,7 @@ from salt.utils import print_cli
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import range
-# pylint: disable=import-error,no-name-in-module,redefined-builtin
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 
 class Batch(object):


### PR DESCRIPTION
Fixes apparent erratum from fb056b41c80e9823189e5bd2ee9a823767f550f0.
