### PR TITLE
re-enable pylint instead of disabling it twice

### DIFF
--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -48,7 +48,7 @@ try:
     HAS_HG = True
 except ImportError:
     HAS_HG = False
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 # Import salt libs
 import salt.utils

--- a/salt/fileserver/s3fs.py
+++ b/salt/fileserver/s3fs.py
@@ -82,7 +82,7 @@ import salt.utils.s3 as s3
 import salt.ext.six as six
 from salt.ext.six.moves import filter
 from salt.ext.six.moves.urllib.parse import quote as _quote
-# pylint: disable=import-error,no-name-in-module,redefined-builtin
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 
 log = logging.getLogger(__name__)
 

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -44,7 +44,7 @@ try:
     CLIENT = pysvn.Client()
 except ImportError:
     pass
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 # Import salt libs
 import salt.utils

--- a/salt/key.py
+++ b/salt/key.py
@@ -27,7 +27,7 @@ from salt.utils.event import tagify
 # pylint: disable=import-error,no-name-in-module,redefined-builtin
 import salt.ext.six as six
 from salt.ext.six.moves import input
-# pylint: disable=import-error,no-name-in-module,redefined-builtin
+# pylint: enable=import-error,no-name-in-module,redefined-builtin
 try:
     import msgpack
 except ImportError:

--- a/salt/modules/aptpkg.py
+++ b/salt/modules/aptpkg.py
@@ -54,7 +54,7 @@ try:
     HAS_SOFTWAREPROPERTIES = True
 except ImportError:
     HAS_SOFTWAREPROPERTIES = False
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 # Source format for urllib fallback on PPA handling
 LP_SRC_FORMAT = 'deb http://ppa.launchpad.net/{0}/{1}/ubuntu {2} main'

--- a/salt/modules/boto_vpc.py
+++ b/salt/modules/boto_vpc.py
@@ -57,7 +57,7 @@ try:
     HAS_BOTO = True
 except ImportError:
     HAS_BOTO = False
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 
 def __virtual__():

--- a/salt/modules/keystone.py
+++ b/salt/modules/keystone.py
@@ -62,7 +62,7 @@ try:
     HAS_KEYSTONE = True
 except ImportError:
     pass
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 
 def __virtual__():

--- a/salt/modules/win_update.py
+++ b/salt/modules/win_update.py
@@ -26,7 +26,7 @@ try:
     HAS_DEPENDENCIES = True
 except ImportError:
     HAS_DEPENDENCIES = False
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 # Import salt libs
 import salt.utils

--- a/salt/netapi/rest_cherrypy/app.py
+++ b/salt/netapi/rest_cherrypy/app.py
@@ -247,7 +247,7 @@ import cherrypy
 from cherrypy.lib import cpstats
 import yaml
 import salt.ext.six as six
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 
 # Import Salt libs

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -40,7 +40,7 @@ from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=no-name-
 from salt.ext.six.moves import range
 from salt.ext.six.moves import zip
 from salt.ext.six.moves import map
-# pylint: disable=import-error,redefined-builtin
+# pylint: enable=import-error,redefined-builtin
 
 # Try to load pwd, fallback to getpass if unsuccessful
 try:

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -46,7 +46,7 @@ import salt.ext.six as six
 # pylint: disable=import-error,no-name-in-module
 import salt.ext.six.moves.http_client
 import salt.ext.six.moves.http_cookiejar
-# pylint: disable=import-error,no-name-in-module
+# pylint: enable=import-error,no-name-in-module
 try:
     import requests
     HAS_REQUESTS = True

--- a/salt/utils/openstack/neutron.py
+++ b/salt/utils/openstack/neutron.py
@@ -19,7 +19,7 @@ try:
     HAS_NEUTRON = True
 except ImportError:
     pass
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 # Import salt libs
 from salt import exceptions

--- a/tests/unit/modules/boto_secgroup_test.py
+++ b/tests/unit/modules/boto_secgroup_test.py
@@ -39,7 +39,7 @@ except ImportError:
         def stub_function(self):
             pass
         return stub_function
-# pylint: disable=import-error
+# pylint: enable=import-error
 
 # Import Salt Libs
 from salt.utils.odict import OrderedDict

--- a/tests/unit/modules/ps_test.py
+++ b/tests/unit/modules/ps_test.py
@@ -65,7 +65,7 @@ try:
     HAS_UTMP = True
 except ImportError:
     HAS_UTMP = False
-# pylint: disable=import-error,unused-import
+# pylint: enable=import-error,unused-import
 
 
 def _get_proc_name(proc):


### PR DESCRIPTION
Looks like there are several typos/copypastas where instead of

``` py
# pylint: disable=...
# temporarily disable pylint due to spurious warnings
...gnarly code...
# pylint: enable=...
# pylint is now re-enabled / back to normal
```

there is

``` py
# pylint: disable=...
...gnarly code...
# pylint: disable=...
# oops, redundant `disable` instead of an `enable`.
# Sacré bleu! Those pylint checks will now stay disabled for the rest of the file...
```

FYI @s0undt3ch.
