### PR TITLE
fix wrong dict access in smtp returner in 2014.7

### DIFF
--- a/salt/returners/smtp_return.py
+++ b/salt/returners/smtp_return.py
@@ -97,7 +97,7 @@ def returner(ret):
         subject = cfg.get('smtp.subject', None)
         gpgowner = cfg.get('smtp.gpgowner', None)
         fields = cfg.get('smtp.fields', '').split(',')
-        smtp_tls = cfg('smtp.tls', False)
+        smtp_tls = cfg.get('smtp.tls', False)
 
     if not port:
         port = 25


### PR DESCRIPTION
```
2015-02-21 11:21:37,317 [salt.utils.schedule][ERROR   ] Unhandled exception running cmd.run
Traceback (most recent call last):
  File "/usr/lib/pymodules/python2.7/salt/utils/schedule.py", line 452, in handle_func
    self.returners[ret_str](ret)
  File "/usr/lib/pymodules/python2.7/salt/returners/smtp_return.py", line 100, in returner
    smtp_tls = cfg('smtp.tls', False)
TypeError: 'dict' object is not callable
```

this has been refactored in develop: https://github.com/saltstack/salt/commit/ba354624e94547ec8e4b8cf8e307c7332ec4816d#diff-678e07321e1c7f3d8a050fa298291eacR151
