### PR TITLE
fix wrong additional quote filename

### DIFF
--- a/salt/states/archive.py
+++ b/salt/states/archive.py
@@ -186,7 +186,7 @@ def extracted(name,
         else:
             log.debug('Untar {0} in {1}'.format(filename, name))
 
-            tar_cmd = ['tar', 'x{0}'.format(tar_options), '-f', repr(filename)]
+            tar_cmd = ['tar', 'x{0}'.format(tar_options), '-f', filename]
             results = __salt__['cmd.run_all'](tar_cmd, cwd=name, python_shell=False)
             if results['retcode'] != 0:
                 ret['result'] = False


### PR DESCRIPTION
@jfindlay introduced this usage of `repr(filename)` in commit 726eb220b2e60856fbf1522db943d8e7fb150e7c.

It's is wrong and cause those issues #20852, #20485, #20201.

The `archive.extracted` code is changed completely in develop branch so maybe this bug is only in 2014.7 branch.
