### PR TITLE
Add Bower execution and state modules

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Developers
 Aaron Bull Schaefer <aaron@elasticdog.com>
 Aaron Toponce <aaron.toponce@gmail.com>
 Aditya Kulkarni <adi@saltstack.com>
+Alexander Pyatkin <asp@thexyz.net>
 Andre Sachs <andre@sachs.nom.za>
 Andrew Kuhnhausen <trane@errstr.com>
 Antti Kaihola <akaihol+github@ambitone.com>

--- a/doc/ref/modules/all/index.rst
+++ b/doc/ref/modules/all/index.rst
@@ -38,6 +38,7 @@ Full list of builtin execution modules
     boto_sns
     boto_sqs
     boto_vpc
+    bower
     brew
     bridge
     bsd_shadow

--- a/doc/ref/modules/all/salt.modules.bower.rst
+++ b/doc/ref/modules/all/salt.modules.bower.rst
@@ -1,0 +1,6 @@
+==================
+salt.modules.bower
+==================
+
+.. automodule:: salt.modules.bower
+    :members:

--- a/doc/ref/states/all/index.rst
+++ b/doc/ref/states/all/index.rst
@@ -31,6 +31,7 @@ Full list of builtin state modules
     boto_secgroup
     boto_sns
     boto_sqs
+    bower
     chef
     cloud
     cmd

--- a/doc/ref/states/all/salt.states.bower.rst
+++ b/doc/ref/states/all/salt.states.bower.rst
@@ -1,0 +1,6 @@
+===============
+salt.states.bower
+===============
+
+.. automodule:: salt.states.bower
+    :members:

--- a/salt/modules/bower.py
+++ b/salt/modules/bower.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+'''
+Manage and query Bower packages
+===============================
+
+This module manages the installed packages using Bower.
+Note that npm, git and bower must be installed for this module to be
+available.
+
+'''
+from __future__ import absolute_import
+
+# Import python libs
+import json
+import logging
+import distutils.version  # pylint: disable=import-error,no-name-in-module
+
+# Import salt libs
+import salt.utils
+from salt.exceptions import CommandExecutionError
+
+
+log = logging.getLogger(__name__)
+
+# Function alias to make sure not to shadow built-in's
+__func_alias__ = {
+    'list_': 'list'
+}
+
+
+def __virtual__():
+    '''
+    Only work when Bower is installed
+    '''
+    return salt.utils.which('bower') is not None
+
+
+def _check_valid_version():
+    '''
+    Check the version of Bower to ensure this module will work. Currently
+    bower must be at least version 1.3.
+    '''
+    # pylint: disable=no-member
+    bower_version = distutils.version.LooseVersion(
+        __salt__['cmd.run']('bower --version'))
+    valid_version = distutils.version.LooseVersion('1.3')
+    # pylint: enable=no-member
+    if bower_version < valid_version:
+        raise CommandExecutionError(
+            '\'bower\' is not recent enough({0} < {1}). '
+            'Please Upgrade.'.format(
+                bower_version, valid_version
+            )
+        )
+
+
+def install(pkg,
+            dir,
+            pkgs=None,
+            runas=None,
+            env=None):
+    '''
+    Install a Bower package.
+
+    If no package is specified, the dependencies (from bower.json) of the
+    package in the given directory will be installed.
+
+    pkg
+        A package name in any format accepted by Bower, including a version
+        identifier
+
+    dir
+        The target directory in which to install the package
+
+    pkgs
+        A list of package names in the same format as the ``pkg`` parameter
+
+    runas
+        The user to run Bower with
+
+    env
+        Environment variables to set when invoking Bower. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' bower.install underscore /path/to/project
+
+        salt '*' bower.install jquery#2.0 /path/to/project
+
+    '''
+    _check_valid_version()
+
+    cmd = 'bower install'
+    cmd += ' --config.analytics false'
+    cmd += ' --config.interactive false'
+    cmd += ' --allow-root'
+    cmd += ' --json'
+
+    if pkg:
+        cmd += ' "{0}"'.format(pkg)
+    elif pkgs:
+        cmd += ' "{0}"'.format('" "'.join(pkgs))
+
+    result = __salt__['cmd.run_all'](cmd,
+                                     cwd=dir,
+                                     runas=runas,
+                                     env=env,
+                                     python_shell=False)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    # If package is already installed, Bower will emit empty dict to STDOUT
+    stdout = json.loads(result['stdout'])
+    return stdout != {}
+
+
+def uninstall(pkg, dir, runas=None, env=None):
+    '''
+    Uninstall a Bower package.
+
+    pkg
+        A package name in any format accepted by Bower
+
+    dir
+        The target directory from which to uninstall the package
+
+    runas
+        The user to run Bower with
+
+    env
+        Environment variables to set when invoking Bower. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' bower.uninstall underscore /path/to/project
+
+    '''
+    _check_valid_version()
+
+    cmd = 'bower uninstall'
+    cmd += ' --config.analytics false'
+    cmd += ' --config.interactive false'
+    cmd += ' --allow-root'
+    cmd += ' --json'
+    cmd += ' "{0}"'.format(pkg)
+
+    result = __salt__['cmd.run_all'](cmd,
+                                     cwd=dir,
+                                     runas=runas,
+                                     env=env,
+                                     python_shell=False)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    # If package is not installed, Bower will emit empty dict to STDOUT
+    stdout = json.loads(result['stdout'])
+    return stdout != {}
+
+
+def list_(dir, runas=None, env=None):
+    '''
+    List installed Bower packages.
+
+    dir
+        The directory whose packages will be listed
+
+    runas
+        The user to run Bower with
+
+    env
+        Environment variables to set when invoking Bower. Uses the same ``env``
+        format as the :py:func:`cmd.run <salt.modules.cmdmod.run>` execution
+        function.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' bower.list /path/to/project
+
+    '''
+    _check_valid_version()
+
+    cmd = 'bower list --json'
+    cmd += ' --config.analytics false'
+    cmd += ' --config.interactive false'
+    cmd += ' --offline'
+    cmd += ' --allow-root'
+
+    result = __salt__['cmd.run_all'](cmd,
+                                     cwd=dir,
+                                     runas=runas,
+                                     env=env,
+                                     python_shell=False)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    return json.loads(result['stdout'])['dependencies']

--- a/salt/states/bower.py
+++ b/salt/states/bower.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+'''
+Installation of Bower Packages
+==============================
+
+These states manage the installed packages using Bower.
+Note that npm, git and bower must be installed for these states to be
+available, so bower states should include requisites to pkg.installed states
+for the packages which provide npm and git (simply ``npm`` and ``git`` in most
+cases), and npm.installed state for the package which provides bower.
+
+Example:
+
+.. code-block:: yaml
+
+    npm:
+      pkg.installed
+    git:
+      pkg.installed
+    bower:
+      npm.installed
+      require:
+        - pkg: npm
+        - pkg: git
+
+    underscore:
+      bower.installed:
+        - dir: /path/to/project
+        - require:
+          - npm: bower
+'''
+
+from __future__ import absolute_import
+
+# Import salt libs
+from salt.exceptions import CommandExecutionError, CommandNotFoundError
+
+# Import 3rd-party libs
+import salt.ext.six as six
+
+
+def __virtual__():
+    '''
+    Only load if the bower module is available in __salt__
+    '''
+    return 'bower' if 'bower.list' in __salt__ else False
+
+
+def installed(name,
+              dir,
+              pkgs=None,
+              user=None,
+              env=None):
+    '''
+    Verify that the given package is installed and is at the correct version
+    (if specified).
+
+    .. code-block:: yaml
+
+        underscore:
+          bower.installed:
+            - dir: /path/to/project
+            - user: someuser
+
+        jquery#2.0:
+          bower.installed:
+            - dir: /path/to/project
+
+    name
+        The package to install
+
+    dir
+        The target directory in which to install the package
+
+    pkgs
+        A list of packages to install with a single Bower invocation;
+        specifying this argument will ignore the ``name`` argument
+
+    user
+        The user to run Bower with
+
+    env
+        A list of environment variables to be set prior to execution. The
+        format is the same as the :py:func:`cmd.run <salt.states.cmd.run>`.
+        state function.
+
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    if pkgs is not None:
+        pkg_list = pkgs
+    else:
+        pkg_list = [name]
+
+    try:
+        installed_pkgs = __salt__['bower.list'](dir=dir, runas=user, env=env)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error looking up {0!r}: {1}'.format(name, err)
+        return ret
+    else:
+        installed_pkgs = dict((p, info) for p, info in
+                              six.iteritems(installed_pkgs))
+
+    pkgs_satisfied = []
+    pkgs_to_install = []
+    for pkg in pkg_list:
+        pkg_name, _, pkg_ver = pkg.partition('#')
+        pkg_name = pkg_name.strip()
+
+        if pkg_name not in installed_pkgs:
+            pkgs_to_install.append(pkg)
+            continue
+
+        if pkg_name in installed_pkgs:
+            installed_pkg = installed_pkgs[pkg_name]
+            installed_pkg_ver = installed_pkg.get('pkgMeta').get('version')
+            installed_name_ver = '{0}#{1}'.format(
+                pkg_name,
+                installed_pkg_ver)
+
+            # If given an explicit version check the installed version matches.
+            if pkg_ver:
+                if installed_pkg_ver != pkg_ver:
+                    pkgs_to_install.append(pkg)
+                else:
+                    pkgs_satisfied.append(installed_name_ver)
+
+                continue
+            else:
+                pkgs_satisfied.append(installed_name_ver)
+                continue
+
+    if __opts__['test']:
+        ret['result'] = None
+
+        comment_msg = []
+        if pkgs_to_install:
+            comment_msg.append(
+                'Bower package(s) {0!r} are set to be installed'.format(
+                    ', '.join(pkgs_to_install)))
+
+            ret['changes'] = {'old': [], 'new': pkgs_to_install}
+
+        if pkgs_satisfied:
+            comment_msg.append(
+                'Package(s) {0!r} satisfied by {1}'.format(
+                    ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
+
+        ret['comment'] = '. '.join(comment_msg)
+        return ret
+
+    if not pkgs_to_install:
+        ret['result'] = True
+        ret['comment'] = ('Package(s) {0!r} satisfied by {1}'.format(
+            ', '.join(pkg_list), ', '.join(pkgs_satisfied)))
+        return ret
+
+    try:
+        cmd_args = {
+            'pkg': None,
+            'dir': dir,
+            'pkgs': None,
+            'runas': user,
+            'env': env,
+        }
+
+        if pkgs is not None:
+            cmd_args['pkgs'] = pkgs
+        else:
+            cmd_args['pkg'] = pkg_name
+
+        call = __salt__['bower.install'](**cmd_args)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error installing {0!r}: {1}'.format(
+                ', '.join(pkg_list), err)
+        return ret
+
+    if call:
+        ret['result'] = True
+        ret['changes'] = {'old': [], 'new': pkgs_to_install}
+        ret['comment'] = 'Package(s) {0!r} successfully installed'.format(
+                ', '.join(pkgs_to_install))
+    else:
+        ret['result'] = False
+        ret['comment'] = 'Could not install package(s) {0!r}'.format(
+                ', '.join(pkg_list))
+
+    return ret
+
+
+def removed(name, dir, user=None):
+    '''
+    Verify that the given package is not installed.
+
+    dir
+        The target directory in which to install the package
+
+    user
+        The user to run Bower with
+
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    try:
+        installed_pkgs = __salt__['bower.list'](dir=dir, runas=user)
+    except (CommandExecutionError, CommandNotFoundError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error removing {0!r}: {1}'.format(name, err)
+        return ret
+
+    if name not in installed_pkgs:
+        ret['result'] = True
+        ret['comment'] = 'Package {0!r} is not installed'.format(name)
+        return ret
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Package {0!r} is set to be removed!'.format(name)
+        return ret
+
+    try:
+        if __salt__['bower.uninstall'](pkg=name, dir=dir, runas=user):
+            ret['result'] = True
+            ret['changes'] = {name: 'Removed'}
+            ret['comment'] = 'Package {0!r} was successfully removed'.format(
+                name)
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Error removing {0!r}'.format(name)
+    except (CommandExecutionError, CommandNotFoundError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error removing {0!r}: {1}'.format(name, err)
+
+    return ret
+
+
+def bootstrap(name, user=None):
+    '''
+    Bootstraps a frontend distribution.
+
+    Will execute 'bower install' on the specified directory.
+
+    user
+        The user to run Bower with
+
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    if __opts__['test']:
+        ret['result'] = None
+        ret['comment'] = 'Directory {0!r} is set to be bootstrapped'.format(
+            name)
+        return ret
+
+    try:
+        call = __salt__['bower.install'](pkg=None, dir=name, runas=user)
+    except (CommandNotFoundError, CommandExecutionError) as err:
+        ret['result'] = False
+        ret['comment'] = 'Error bootstrapping {0!r}: {1}'.format(name, err)
+        return ret
+
+    if not call:
+        ret['result'] = True
+        ret['comment'] = 'Directory is already bootstrapped'
+        return ret
+
+    ret['result'] = True
+    ret['changes'] = {name: 'Bootstrapped'}
+    ret['comment'] = 'Directory was successfully bootstrapped'
+
+    return ret

--- a/tests/integration/states/bower.py
+++ b/tests/integration/states/bower.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexander Pyatkin <asp@thexyz.net`
+'''
+# Import Python libs
+from __future__ import absolute_import
+import json
+
+# Import Salt Testing libs
+from salttesting import skipIf
+from salttesting.helpers import destructiveTest, ensure_in_syspath
+ensure_in_syspath('../../')
+
+# Import salt libs
+import integration
+import salt.utils
+
+
+@skipIf(salt.utils.which('bower') is None, 'bower not installed')
+class BowerStateTest(integration.ModuleCase,
+                     integration.SaltReturnAssertsMixIn):
+
+    @destructiveTest
+    def test_bower_installed_removed(self):
+        '''
+        Basic test to determine if Bower package was successfully installed and
+        removed.
+        '''
+        ret = self.run_state('file.directory', name='/salt_test_bower_1',
+                             makedirs=True)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('bower.installed', name='underscore',
+                             dir='/salt_test_bower_1')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('bower.removed', name='underscore',
+                             dir='/salt_test_bower_1')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('file.absent', name='/salt_test_bower_1')
+        self.assertSaltTrueReturn(ret)
+
+    @destructiveTest
+    def test_bower_installed_pkgs(self):
+        '''
+        Basic test to determine if Bower package successfully installs multiple
+        packages.
+        '''
+        ret = self.run_state('file.directory', name='/salt_test_bower_2',
+                             makedirs=True)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('bower.installed', name='test',
+                             dir='/salt_test_bower_2',
+                             pkgs=['numeral', 'underscore'])
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('file.absent', name='/salt_test_bower_2')
+        self.assertSaltTrueReturn(ret)
+
+    @destructiveTest
+    def test_bower_installed_from_file(self):
+        ret = self.run_state('file.directory', name='/salt_test_bower_3',
+                             makedirs=True)
+        self.assertSaltTrueReturn(ret)
+        bower_json = json.dumps({
+            'name': 'salt_test_bower_3',
+            'dependencies': {
+                'numeral': '~1.5.3',
+                'underscore': '~1.7.0'
+            }
+        })
+        ret = self.run_state('file.managed',
+                             name='/salt_test_bower_3/bower.json',
+                             contents=bower_json)
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('bower.bootstrap', name='/salt_test_bower_3')
+        self.assertSaltTrueReturn(ret)
+        ret = self.run_state('file.absent', name='/salt_test_bower_3')
+        self.assertSaltTrueReturn(ret)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(BowerStateTest)

--- a/tests/unit/modules/bower_test.py
+++ b/tests/unit/modules/bower_test.py
@@ -1,0 +1,136 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexander Pyatkin <asp@thexyz.net>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.modules import bower
+from salt.exceptions import CommandExecutionError
+
+# Globals
+bower.__salt__ = {}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BowerTestCase(TestCase):
+    '''
+    Test cases for salt.modules.bower
+    '''
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_install_with_error(self):
+        '''
+        Test if it raises an exception when install package fails
+        '''
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(
+                CommandExecutionError,
+                bower.install,
+                '/path/to/project',
+                'underscore')
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_install_new_package(self):
+        '''
+        Test if it returns True when install package succeeds
+        '''
+        mock = MagicMock(return_value={'retcode': 0,
+                                       'stdout': '{"underscore":{}}'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertTrue(bower.install('/path/to/project', 'underscore'))
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_install_existing_package(self):
+        '''
+        Test if it returns False when package already installed
+        '''
+        mock = MagicMock(return_value={'retcode': 0,
+                                       'stdout': '{}'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertFalse(bower.install('/path/to/project', 'underscore'))
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_uninstall_with_error(self):
+        '''
+        Test if it raises an exception when uninstall package fails
+        '''
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(
+                CommandExecutionError,
+                bower.uninstall,
+                '/path/to/project',
+                'underscore')
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_uninstall_existing_package(self):
+        '''
+        Test if it returns True when uninstall package succeeds
+        '''
+        mock = MagicMock(return_value={'retcode': 0,
+                                       'stdout': '{"underscore": {}}'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertTrue(bower.uninstall('/path/to/project', 'underscore'))
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_uninstall_missing_package(self):
+        '''
+        Test if it returns False when package is not installed
+        '''
+        mock = MagicMock(return_value={'retcode': 0,
+                                       'stdout': '{}'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertFalse(bower.uninstall('/path/to/project', 'underscore'))
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_list_packages_with_error(self):
+        '''
+        Test if it raises an exception when list installed packages fails
+        '''
+        mock = MagicMock(return_value={'retcode': 1, 'stderr': 'error'})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertRaises(
+                CommandExecutionError,
+                bower.list_,
+                '/path/to/project')
+
+    @patch('salt.modules.bower._check_valid_version',
+           MagicMock(return_value=True))
+    def test_list_packages_success(self):
+        '''
+        Test if it lists installed Bower packages
+        '''
+        output = '{"dependencies": {"underscore": {}, "jquery":{}}}'
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': output})
+        with patch.dict(bower.__salt__, {'cmd.run_all': mock}):
+            self.assertEqual(bower.list_('/path/to/project'),
+                             {'underscore': {}, 'jquery': {}})
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(BowerTestCase, needs_daemon=False)

--- a/tests/unit/states/bower_test.py
+++ b/tests/unit/states/bower_test.py
@@ -1,0 +1,246 @@
+# -*- coding: utf-8 -*-
+'''
+    :codeauthor: :email:`Alexander Pyatkin <asp@thexyz.net>`
+'''
+
+# Import Python Libs
+from __future__ import absolute_import
+
+# Import Salt Testing Libs
+from salttesting import TestCase, skipIf
+from salttesting.mock import (
+    MagicMock,
+    patch,
+    NO_MOCK,
+    NO_MOCK_REASON
+)
+
+from salttesting.helpers import ensure_in_syspath
+
+ensure_in_syspath('../../')
+
+# Import Salt Libs
+from salt.states import bower
+from salt.exceptions import CommandExecutionError
+
+# Globals
+bower.__salt__ = {}
+bower.__opts__ = {'test': False}
+
+
+@skipIf(NO_MOCK, NO_MOCK_REASON)
+class BowerTestCase(TestCase):
+    '''
+    Test cases for salt.states.bower
+    '''
+
+    def test_removed_not_installed(self):
+        '''
+        Test if it returns True when specified package is not installed
+        '''
+
+        mock = MagicMock(return_value={'underscore': {}})
+
+        with patch.dict(bower.__salt__, {'bower.list': mock}):
+            ret = bower.removed('jquery', '/path/to/project')
+            expected = {'name': 'jquery',
+                        'result': True,
+                        'comment': 'Package \'jquery\' is not installed',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_removed_with_error(self):
+        '''
+        Test if returns False when list packages fails
+        '''
+
+        mock = MagicMock(side_effect=CommandExecutionError)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock}):
+            ret = bower.removed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': False,
+                        'comment': 'Error removing \'underscore\': ',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_removed_existing(self):
+        '''
+        Test if it returns True when specified package is installed and
+        uninstall succeeds
+        '''
+
+        mock_list = MagicMock(return_value={'underscore': {}})
+        mock_uninstall = MagicMock(return_value=True)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock_list,
+                                         'bower.uninstall': mock_uninstall}):
+            ret = bower.removed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': True,
+                        'comment':
+                            'Package \'underscore\' was successfully removed',
+                        'changes': {'underscore': 'Removed'}}
+            self.assertEqual(ret, expected)
+
+    def test_removed_existing_with_error(self):
+        '''
+        Test if it returns False when specified package is installed and
+        uninstall fails
+        '''
+
+        mock_list = MagicMock(return_value={'underscore': {}})
+        mock_uninstall = MagicMock(side_effect=CommandExecutionError)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock_list,
+                                         'bower.uninstall': mock_uninstall}):
+            ret = bower.removed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': False,
+                        'comment':
+                            'Error removing \'underscore\': ',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_bootstrap_with_error(self):
+        '''
+        Test if it return False when install packages fails
+        '''
+
+        mock = MagicMock(side_effect=CommandExecutionError)
+
+        with patch.dict(bower.__salt__, {'bower.install': mock}):
+            ret = bower.bootstrap('/path/to/project')
+            expected = {'name': '/path/to/project',
+                        'result': False,
+                        'comment':
+                            'Error bootstrapping \'/path/to/project\': ',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_bootstrap_not_needed(self):
+        '''
+        Test if it returns True when there is nothing to install
+        '''
+
+        mock = MagicMock(return_value=False)
+
+        with patch.dict(bower.__salt__, {'bower.install': mock}):
+            ret = bower.bootstrap('/path/to/project')
+            expected = {'name': '/path/to/project',
+                        'result': True,
+                        'comment':
+                            'Directory is already bootstrapped',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_bootstrap_success(self):
+        '''
+        Test if it returns True when install packages succeeds
+        '''
+
+        mock = MagicMock(return_value=True)
+
+        with patch.dict(bower.__salt__, {'bower.install': mock}):
+            ret = bower.bootstrap('/path/to/project')
+            expected = {'name': '/path/to/project',
+                        'result': True,
+                        'comment':
+                            'Directory was successfully bootstrapped',
+                        'changes': {'/path/to/project': 'Bootstrapped'}}
+            self.assertEqual(ret, expected)
+
+    def test_installed_with_error(self):
+        '''
+        Test if it returns False when list packages fails
+        '''
+
+        mock = MagicMock(side_effect=CommandExecutionError)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock}):
+            ret = bower.installed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': False,
+                        'comment': 'Error looking up \'underscore\': ',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_installed_not_needed(self):
+        '''
+        Test if it returns True when there is nothing to install
+        '''
+
+        mock = MagicMock(return_value={
+            'underscore': {
+                'pkgMeta': {'version': '1.7.0'}},
+            'jquery': {
+                'pkgMeta': {'version': '2.0.0'}}})
+
+        with patch.dict(bower.__salt__, {'bower.list': mock}):
+            ret = bower.installed('test', '/path/to/project',
+                                  ['underscore', 'jquery#2.0.0'])
+            expected = {'name': 'test',
+                        'result': True,
+                        'comment':
+                            ('Package(s) \'underscore, jquery#2.0.0\''
+                             ' satisfied by underscore#1.7.0, jquery#2.0.0'),
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_installed_new_with_exc(self):
+        '''
+        Test if it returns False when install packages fails (exception)
+        '''
+
+        mock_list = MagicMock(return_value={})
+        mock_install = MagicMock(side_effect=CommandExecutionError)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock_list,
+                                         'bower.install': mock_install}):
+            ret = bower.installed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': False,
+                        'comment': 'Error installing \'underscore\': ',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_installed_new_with_error(self):
+        '''
+        Test if returns False when install packages fails (bower error)
+        '''
+
+        mock_list = MagicMock(return_value={})
+        mock_install = MagicMock(return_value=False)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock_list,
+                                         'bower.install': mock_install}):
+            ret = bower.installed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': False,
+                        'comment':
+                            'Could not install package(s) \'underscore\'',
+                        'changes': {}}
+            self.assertEqual(ret, expected)
+
+    def test_installed_success(self):
+        '''
+        Test if it returns True when install succeeds
+        '''
+
+        mock_list = MagicMock(return_value={})
+        mock_install = MagicMock(return_value=True)
+
+        with patch.dict(bower.__salt__, {'bower.list': mock_list,
+                                         'bower.install': mock_install}):
+            ret = bower.installed('underscore', '/path/to/project')
+            expected = {'name': 'underscore',
+                        'result': True,
+                        'comment':
+                            'Package(s) \'underscore\' successfully installed',
+                        'changes': {'new': ['underscore'], 'old': []}}
+            self.assertEqual(ret, expected)
+
+
+if __name__ == '__main__':
+    from integration import run_tests
+    run_tests(BowerTestCase, needs_daemon=False)


### PR DESCRIPTION
This pull request adds Bower execution and state module to SaltStack proposed by me. It was highly inspired by npm execution and state modules.

I managed to write a bunch of unit and integration tests. Documentation is also available. Resolves #20587.

**P.S.** That is the rebase of my previous pull request (https://github.com/saltstack/salt/pull/20875) which I had occasionally broken.
