### PR TITLE
Check python major version, add shell code py3 compat.

### DIFF
--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -1,3 +1,4 @@
+# pylint: disable=W9903
 '''
 This is a shim that handles checking and updating salt thin and
 then invoking thin.

--- a/salt/client/ssh/ssh_py_shim.py
+++ b/salt/client/ssh/ssh_py_shim.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 '''
 This is a shim that handles checking and updating salt thin and
 then invoking thin.

--- a/salt/defaults/exitcodes.py
+++ b/salt/defaults/exitcodes.py
@@ -10,7 +10,7 @@ prefix or in `sysexits.h`).
 EX_GENERIC = 1
 
 # Salt SSH "Thin" deployment failures
-EX_THIN_PYTHON_OLD = 10
+EX_THIN_PYTHON_INVALID = 10
 EX_THIN_DEPLOY = 11
 EX_THIN_CHECKSUM = 12
 EX_MOD_DEPLOY = 13


### PR DESCRIPTION
Start to prepare salt-ssh for py3 compatibility (not complete).

Update the python code in the shell script to not choke on py3 when checking installed versions.

Current blocker on py3 compat is PyYAML: the origin host runs py2, so it will always send py2 modules versions to targets. However, the py2 PyYAML module uses old-style relative imports, which do not work in py3. I haven't gotten a chance to get past this yet, so there may be more blockers.

The workaround in this PR is to require a python major version match on the original host and the target; the last update to the py2 PyYAML module was in late Nov 2014, so I'll look into fixing this upstream. A full solution would probably involve checking the remote python version and sending the correct modules (or having all modules be fully cross py2/py3 compatible).
