### PR TITLE
File.replace module gains symlink awareness

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1160,9 +1160,9 @@ def replace(path,
     '''
     symlink = False
     if is_link(path):
-      symlink = True
-      target_path = os.readlink(path)
-      given_path = os.path.expanduser(path)
+        symlink = True
+        target_path = os.readlink(path)
+        given_path = os.path.expanduser(path)
 
     path = os.path.realpath(os.path.expanduser(path))
 

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1158,7 +1158,13 @@ def replace(path,
         salt '*' file.replace /etc/httpd/httpd.conf pattern='LogLevel warn' repl='LogLevel info'
         salt '*' file.replace /some/file pattern='before' repl='after' flags='[MULTILINE, IGNORECASE]'
     '''
-    path = os.path.expanduser(path)
+    symlink = False
+    if is_link(path):
+      symlink = True
+      target_path = os.readlink(path)
+      given_path = os.path.expanduser(path)
+
+    path = os.path.realpath(os.path.expanduser(path))
 
     if not os.path.exists(path):
         raise SaltInvocationError('File not found: {0}'.format(path))
@@ -1231,6 +1237,14 @@ def replace(path,
                         backup=False if (dry_run or search_only or found) else backup,
                         bufsize=bufsize,
                         mode='r' if (dry_run or search_only or found) else 'rb')
+
+        if symlink and (backup and not (dry_run or search_only or found)):
+            symlink_backup = given_path + backup
+            # Always clobber any existing symlink backup
+            # to match the behavior of the 'backup' option
+            if os.path.exists(symlink_backup):
+                os.remove(symlink_backup)
+            os.symlink(target_path + backup, given_path + backup)
 
         if not found:
             for line in fi_file:


### PR DESCRIPTION
Fixes #20910.

Note: backup behavior with symlinks currently mirrors the regular option. For a symlink 'bar' pointing to a file 'foo', this entails creating a 'foo.bak' file to store the actual backup, and a 'bar.bar' symlink to it to maintain consistency to the user (mv bar.bar bar will do what the user wants, which is effectively undoing the change). I think this is the behavior we want, but I'm not sure.
