### PR TITLE
Add Joyent cloud provider tests

### DIFF
--- a/tests/integration/cloud/providers/joyent.py
+++ b/tests/integration/cloud/providers/joyent.py
@@ -17,6 +17,7 @@ ensure_in_syspath('../../../')
 import integration
 from salt.config import cloud_providers_config
 
+
 def __random_name(size=6):
     '''
     Generates a random cloud instance name

--- a/tests/integration/cloud/providers/joyent.py
+++ b/tests/integration/cloud/providers/joyent.py
@@ -17,7 +17,6 @@ ensure_in_syspath('../../../')
 import integration
 from salt.config import cloud_providers_config
 
-
 def __random_name(size=6):
     '''
     Generates a random cloud instance name
@@ -31,9 +30,9 @@ def __random_name(size=6):
 INSTANCE_NAME = __random_name()
 
 
-class DigitalOceanTest(integration.ShellCase):
+class JoyentTest(integration.ShellCase):
     '''
-    Integration tests for the DigitalOcean cloud provider in Salt-Cloud
+    Integration tests for the Joyent cloud provider in Salt-Cloud
     '''
 
     @expensiveTest
@@ -41,11 +40,11 @@ class DigitalOceanTest(integration.ShellCase):
         '''
         Sets up the test requirements
         '''
-        super(DigitalOceanTest, self).setUp()
+        super(JoyentTest, self).setUp()
 
         # check if appropriate cloud provider and profile files are present
-        profile_str = 'digitalocean-config:'
-        provider = 'digital_ocean'
+        profile_str = 'joyent-config:'
+        provider = 'joyent'
         providers = self.run_cloud('--list-providers')
         if profile_str not in providers:
             self.skipTest(
@@ -54,21 +53,21 @@ class DigitalOceanTest(integration.ShellCase):
                 .format(provider)
             )
 
-        # check if client_key, api_key, ssh_key_file, and ssh_key_name are present
+        # check if user, password, private_key, and keyname are present
         path = os.path.join(integration.FILES,
                             'conf',
                             'cloud.providers.d',
                             provider + '.conf')
         config = cloud_providers_config(path)
 
-        api = config['digitalocean-config']['digital_ocean']['api_key']
-        client = config['digitalocean-config']['digital_ocean']['client_key']
-        ssh_file = config['digitalocean-config']['digital_ocean']['ssh_key_file']
-        ssh_name = config['digitalocean-config']['digital_ocean']['ssh_key_name']
+        user = config['joyent-config'][provider]['user']
+        password = config['joyent-config'][provider]['password']
+        private_key = config['joyent-config'][provider]['private_key']
+        keyname = config['joyent-config'][provider]['keyname']
 
-        if api == '' or client == '' or ssh_file == '' or ssh_name == '':
+        if user == '' or password == '' or private_key == '' or keyname == '':
             self.skipTest(
-                'A client key, an api key, an ssh key file, and an ssh key name '
+                'A user name, password, private_key file path, and a key name '
                 'must be provided to run these tests. Check '
                 'tests/integration/files/conf/cloud.providers.d/{0}.conf'
                 .format(provider)
@@ -76,11 +75,11 @@ class DigitalOceanTest(integration.ShellCase):
 
     def test_instance(self):
         '''
-        Test creating an instance on DigitalOcean
+        Test creating and deleting instance on Joyent
         '''
 
         # create the instance
-        instance = self.run_cloud('-p digitalocean-test {0}'.format(INSTANCE_NAME))
+        instance = self.run_cloud('-p joyent-test {0}'.format(INSTANCE_NAME))
         ret_str = '        {0}'.format(INSTANCE_NAME)
 
         # check if instance with salt installed returned
@@ -92,7 +91,7 @@ class DigitalOceanTest(integration.ShellCase):
 
         # delete the instance
         delete = self.run_cloud('-d {0} --assume-yes'.format(INSTANCE_NAME))
-        ret_str = '                OK'
+        ret_str = '            True'
         try:
             self.assertIn(ret_str, delete)
         except AssertionError:
@@ -112,4 +111,4 @@ class DigitalOceanTest(integration.ShellCase):
 
 if __name__ == '__main__':
     from integration import run_tests
-    run_tests(DigitalOceanTest)
+    run_tests(JoyentTest)

--- a/tests/integration/files/conf/cloud.profiles.d/joyent.conf
+++ b/tests/integration/files/conf/cloud.profiles.d/joyent.conf
@@ -1,0 +1,5 @@
+joyent-test:
+  provider: joyent-config
+  size: Extra Small 512 MB
+  image: ubuntu-certified-14.04
+  location: us-east-1

--- a/tests/integration/files/conf/cloud.providers.d/joyent.conf
+++ b/tests/integration/files/conf/cloud.providers.d/joyent.conf
@@ -1,0 +1,6 @@
+joyent-config:
+  provider: joyent
+  user: ''
+  password: ''
+  private_key: ''
+  keyname: ''


### PR DESCRIPTION
I've added the joyent cloud driver to the nightly cloud-tests gamut. However, we can't merge this until I can get some more instance slots provisioned from joyent to be able to run the tests nightly. I just wanted to get this up here so I didn't lose it.

I'll update when I hear back from joyent.
