### PR TITLE
Add system encoding detection

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -194,7 +194,22 @@ dummy-variables-rgx=_|dummy
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__,__low__,__states__,__lowstate__,__running__,__active_provider_name__,__master_opts__,__jid_event__,__instance_id__
+additional-builtins=__opts__,
+  __salt__,
+  __pillar__,
+  __grains__,
+  __context__,
+  __ret__,
+  __env__,
+  __low__,
+  __states__,
+  __lowstate__,
+  __running__,
+  __active_provider_name__,
+  __master_opts__,
+  __jid_event__,
+  __instance_id__,
+  __salt_system_encoding__
 
 
 [SIMILARITIES]

--- a/.testing.pylintrc
+++ b/.testing.pylintrc
@@ -154,7 +154,22 @@ indent-string='    '
 
 # List of additional names supposed to be defined in builtins. Remember that
 # you should avoid to define new builtins when possible.
-additional-builtins=__opts__,__salt__,__pillar__,__grains__,__context__,__ret__,__env__,__low__,__states__,__lowstate__,__running__,__active_provider_name__,__master_opts__,__jid_event__,__instance_id__
+additional-builtins=__opts__,
+  __salt__,
+  __pillar__,
+  __grains__,
+  __context__,
+  __ret__,
+  __env__,
+  __low__,
+  __states__,
+  __lowstate__,
+  __running__,
+  __active_provider_name__,
+  __master_opts__,
+  __jid_event__,
+  __instance_id__,
+  __salt_system_encoding__
 
 
 [IMPORTS]

--- a/salt/__init__.py
+++ b/salt/__init__.py
@@ -24,3 +24,41 @@ warnings.filterwarnings(
  '^Module backports was already imported from (.*), but (.*) is being added to sys.path$',
  UserWarning
 )
+
+
+def __define_global_system_encoding_variable__():
+    import sys
+    # This is the most trustworthy source of the system encoding, though, if
+    # salt is being imported after being daemonized, this information is lost
+    # and reset to None
+    encoding = sys.stdin.encoding
+    if not encoding:
+        # If the system is properly codfigured this should return a valid
+        # encoding. MS Windows has problems with this and reports the wrong
+        # encoding
+        import locale
+        encoding = locale.getdefaultlocale()[-1]
+
+        # This is now garbage collectable
+        del locale
+        if not encoding:
+            # This is most likely asccii which is not the best but we were
+            # unable to find a better encoding
+            encoding = sys.getdefaultencoding()
+
+    # Import 3rd-party libs
+    import salt.ext.six.moves.builtins as builtins  # pylint: disable=import-error,no-name-in-module
+
+    # Define the detected encoding as a built-in variable for ease of use
+    setattr(builtins, '__salt_system_encoding__', encoding)
+
+    # This is now garbage collectable
+    del sys
+    del builtins
+    del encoding
+
+
+__define_global_system_encoding_variable__()
+
+# This is now garbage collectable
+del __define_global_system_encoding_variable__

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1252,6 +1252,7 @@ def locale_info():
         # might do, per #2205
         grains['locale_info']['defaultlanguage'] = 'unknown'
         grains['locale_info']['defaultencoding'] = 'unknown'
+    grains['locale_info']['detectedencoding'] = __salt_system_encoding__
     return grains
 
 


### PR DESCRIPTION
Try to detect the system encoding as soon as possible.
`sys.stdin.encoding` is the most reliable source but it's reset to
`None` once a process is daemonized. If it's none, follow additional
paths to retrieve this information.
