### PR TITLE
Fix expr_match usage in salt.utils.check_whitelist_blacklist

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -1098,7 +1098,7 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     if whitelist:
         try:
             for expr in whitelist:
-                if expr_match(expr, value):
+                if expr_match(value, expr):
                     in_whitelist = True
                     break
         except TypeError:
@@ -1110,7 +1110,7 @@ def check_whitelist_blacklist(value, whitelist=None, blacklist=None):
     if blacklist:
         try:
             for expr in blacklist:
-                if expr_match(expr, value):
+                if expr_match(value, expr):
                     in_blacklist = True
                     break
         except TypeError:


### PR DESCRIPTION
In ef5c648e6ff60b430f21ddd333ab6c10c9f57c4c the ordering of parameters in expr_match was switched around, but only one of the three usages was changed. This commit fixes the other two usages.

I spotted this since the gitfs whitelist pattern suddenly stopped working.
