### PR TITLE
Fix function imported from other dependencies

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1066,11 +1066,14 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
                 # load deep dependency if a function is coming from another import
                 # and mod need to be reloaded to set correctly opts
-                func_ref = getattr(mod, func)
-                func_ref_module = getattr(func_ref, '__module__')
-                if func_ref_module != name and func_ref_module != mod.__name__:
-                    self._load_module(func_ref_module)
-                    self._load_module(name)
+                try:
+                    func_ref = getattr(mod, func)
+                    func_ref_module = getattr(func_ref, '__module__')
+                    if func_ref_module != name and func_ref_module != mod.__name__:
+                        self._load_module(func_ref_module)
+                        self._load_module(name)
+                except AttributeError:
+                    pass
 
                 # if we got what we wanted, we are done
                 if mod and key in self._dict:

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1041,7 +1041,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
         # enforce depends
         Depends.enforce_dependencies(self._dict, self.tag)
-        return True
+        return mod
 
     def _load(self, key):
         '''
@@ -1050,19 +1050,29 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # if the key doesn't have a '.' then it isn't valid for this mod dict
         if not isinstance(key, six.string_types) or '.' not in key:
             raise KeyError
-        mod_name, _ = key.split('.', 1)
+        mod_name, fun = key.split('.', 1)
         if mod_name in self.missing_modules:
             return True
         # if the modulename isn't in the whitelist, don't bother
         if self.whitelist and mod_name not in self.whitelist:
             raise KeyError
 
-        def _inner_load(mod_name):
+        def _inner_load(mod_name, fun):
             for name in self._iter_files(mod_name):
                 if name in self.loaded_files:
                     continue
+
+                mod = self._load_module(name)
+
+                # load deep dependency if a function is coming from another import
+                # and mod need to be reloaded to set correctly opts
+                fun_ref = getattr(mod, fun)
+                if getattr(fun_ref, '__module__') != name:
+                    self._load_module(getattr(fun_ref, '__module__'))
+                    self._load_module(name)
+
                 # if we got what we wanted, we are done
-                if self._load_module(name) and key in self._dict:
+                if mod and key in self._dict:
                     return True
             return False
 
@@ -1073,7 +1083,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # filesystem
         while True:
             try:
-                ret = _inner_load(mod_name)
+                ret = _inner_load(mod_name, fun)
                 if not reloaded and ret is not True:
                     self.refresh_file_mapping()
                     reloaded = True

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1057,7 +1057,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         if self.whitelist and mod_name not in self.whitelist:
             raise KeyError
 
-        def _inner_load(mod_name, fun):
+        def _inner_load(mod_name, func):
             for name in self._iter_files(mod_name):
                 if name in self.loaded_files:
                     continue
@@ -1066,7 +1066,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
                 # load deep dependency if a function is coming from another import
                 # and mod need to be reloaded to set correctly opts
-                func_ref = getattr(mod, fun)
+                func_ref = getattr(mod, func)
                 func_ref_module = getattr(func_ref, '__module__')
                 if func_ref_module != name and func_ref_module != mod.__name__:
                     self._load_module(func_ref_module)
@@ -1084,7 +1084,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # filesystem
         while True:
             try:
-                ret = _inner_load(mod_name, fun)
+                ret = _inner_load(mod_name, func)
                 if not reloaded and ret is not True:
                     self.refresh_file_mapping()
                     reloaded = True

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -1050,7 +1050,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # if the key doesn't have a '.' then it isn't valid for this mod dict
         if not isinstance(key, six.string_types) or '.' not in key:
             raise KeyError
-        mod_name, fun = key.split('.', 1)
+        mod_name, func = key.split('.', 1)
         if mod_name in self.missing_modules:
             return True
         # if the modulename isn't in the whitelist, don't bother
@@ -1066,9 +1066,10 @@ class LazyLoader(salt.utils.lazy.LazyDict):
 
                 # load deep dependency if a function is coming from another import
                 # and mod need to be reloaded to set correctly opts
-                fun_ref = getattr(mod, fun)
-                if getattr(fun_ref, '__module__') != name:
-                    self._load_module(getattr(fun_ref, '__module__'))
+                func_ref = getattr(mod, fun)
+                func_ref_module = getattr(func_ref, '__module__')
+                if func_ref_module != name and func_ref_module != mod.__name__:
+                    self._load_module(func_ref_module)
                     self._load_module(name)
 
                 # if we got what we wanted, we are done


### PR DESCRIPTION
In order to fix this import error:

```
Traceback (most recent call last):
      File "/usr/lib/python2.6/site-packages/salt/minion.py", line 1133, in _thread_return
        sys.modules[func.__module__].__context__['retcode'] = 0
    AttributeError: 'module' object has no attribute '__context__'
```
