### PR TITLE
File.replace handles missing files more gracefully

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1074,6 +1074,7 @@ def replace(path,
             dry_run=False,
             search_only=False,
             show_changes=True,
+            ignore_if_missing=False,
         ):
     '''
     .. versionadded:: 0.17.0
@@ -1140,6 +1141,13 @@ def replace(path,
             Using this option will store two copies of the file in-memory
             (the original version and the edited version) in order to generate the
             diff.
+    ignore_if_missing
+        .. versionadded:: 
+
+        When this parameter is ``True``, ``file.replace`` will return ``False`` if the 
+        file doesn't exist. When this parameter is ``False``, ``file.replace`` will 
+        throw an error if the file doesn't exist.
+        Default is ``False`` (to maintain compatibility with prior behavior).
 
     If an equal sign (``=``) appears in an argument to a Salt command it is
     interpreted as a keyword argument in the format ``key=val``. That
@@ -1161,7 +1169,10 @@ def replace(path,
     path = os.path.expanduser(path)
 
     if not os.path.exists(path):
-        raise SaltInvocationError('File not found: {0}'.format(path))
+        if ignore_if_missing:
+            return False
+        else:
+            raise SaltInvocationError('File not found: {0}'.format(path))
 
     if not salt.utils.istextfile(path):
         raise SaltInvocationError(
@@ -1493,6 +1504,7 @@ def search(path,
         pattern,
         flags=0,
         bufsize=1,
+        ignore_if_missing=False,
         ):
     '''
     .. versionadded:: 0.17.0
@@ -1517,7 +1529,8 @@ def search(path,
             bufsize=bufsize,
             dry_run=True,
             search_only=True,
-            show_changes=False)
+            show_changes=False,
+            ignore_if_missing=ignore_if_missing)
 
 
 def patch(originalfile, patchfile, options='', dry_run=False):

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1142,12 +1142,12 @@ def replace(path,
             (the original version and the edited version) in order to generate the
             diff.
     ignore_if_missing
-        .. versionadded::
+        .. versionadded:: Beryllium
 
         When this parameter is ``True``, ``file.replace`` will return ``False`` if the
         file doesn't exist. When this parameter is ``False``, ``file.replace`` will
         throw an error if the file doesn't exist.
-        Default is ``False`` (to maintain compatibility with prior behavior).
+        Default is ``False`` (to maintain compatibility with prior behaviour).
 
     If an equal sign (``=``) appears in an argument to a Salt command it is
     interpreted as a keyword argument in the format ``key=val``. That

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1142,10 +1142,10 @@ def replace(path,
             (the original version and the edited version) in order to generate the
             diff.
     ignore_if_missing
-        .. versionadded:: 
+        .. versionadded::
 
-        When this parameter is ``True``, ``file.replace`` will return ``False`` if the 
-        file doesn't exist. When this parameter is ``False``, ``file.replace`` will 
+        When this parameter is ``True``, ``file.replace`` will return ``False`` if the
+        file doesn't exist. When this parameter is ``False``, ``file.replace`` will
         throw an error if the file doesn't exist.
         Default is ``False`` (to maintain compatibility with prior behavior).
 


### PR DESCRIPTION
Fixes https://github.com/saltstack/salt/issues/20695.

Add boolean parameter `ignore_if_missing`. This parameter controls whether file.replace (and file.search) throws an exception when the file is missing (`ignore_if_missing=False`) or simply returns `False` (`ignore_if_missing=True`). Default is `False` to preserve compatibility with prior behavior.
