### PR TITLE
Skip the ec2 nightly cloud tests for now

### DIFF
--- a/tests/integration/cloud/providers/ec2.py
+++ b/tests/integration/cloud/providers/ec2.py
@@ -13,6 +13,7 @@ import integration
 from salt.config import cloud_providers_config
 
 # Import Salt Testing Libs
+from salttesting import skipIf
 from salttesting.helpers import ensure_in_syspath, expensiveTest
 
 ensure_in_syspath('../../../')
@@ -31,6 +32,7 @@ def __random_name(size=6):
 INSTANCE_NAME = __random_name()
 
 
+@skipIf(True, 'Skipping until we can figure out why the testrunner bails.')
 class EC2Test(integration.ShellCase):
     '''
     Integration tests for the EC2 cloud provider in Salt-Cloud


### PR DESCRIPTION
Something fundamental has changed with the way ec2 interacts with
the test runner starting in 2015.2 (and consequentially develop).
Let's skip these tests for now until we can pin down why so we don't
muddy the cloud-testing waters.
