### PR TITLE
Fixing examples to avoid problem where there is always a change

### DIFF
--- a/salt/modules/rabbitmq.py
+++ b/salt/modules/rabbitmq.py
@@ -588,7 +588,7 @@ def set_policy(vhost, name, pattern, definition, priority=None, runas=None):
 
     .. code-block:: bash
 
-        salt '*' rabbitmq.set_policy / HA '.*' '{"ha-mode": "all"}'
+        salt '*' rabbitmq.set_policy / HA '.*' '{"ha-mode":"all"}'
     '''
     if runas is None:
         runas = salt.utils.get_user()

--- a/salt/states/rabbitmq_policy.py
+++ b/salt/states/rabbitmq_policy.py
@@ -15,7 +15,7 @@ Example:
         rabbitmq_policy.present:
             - name: HA
             - pattern: '.*'
-            - definition: '{"ha-mode": "all"}'
+            - definition: '{"ha-mode":"all"}'
 '''
 from __future__ import absolute_import
 


### PR DESCRIPTION
I experienced an issue where when setting up rabbitmq for high availability it would always cause a change in salt. If you use my old sls you get a change. If you use my new sls you don't. The change is one space before the all in definition. The "rabbitmqctl list_policies" will take out the space on you for at least rabbitmq 3.3.5 and 3.4.4. So when you hit line 68 of states/rabbitmq_policy.py, "if policy.get('definition') != definition:", it compares {"ha-mode": "all"} to  {"ha-mode":"all"} and calls them different. I had the space there in the first place, because I followed the example in the online documentation. Since that is generated from the code, we should change the examples.

My old sls:
rabbit_policy_ha:
    rabbitmq_policy.present:
        - name: HA
        - pattern: '.*'
        - definition: '{"ha-mode": "all"}'
        - priority: 1

My new sls:
rabbit_policy_ha:
    rabbitmq_policy.present:
        - name: HA
        - pattern: '.*'
        - definition: '{"ha-mode":"all"}'
        - priority: 1
## salt output with old sls:

```
      ID: rabbit_policy_ha
Function: rabbitmq_policy.present
    Name: HA
  Result: True
 Comment: Setting policy "HA" for pattern ".*" to "{\"ha-mode\": \"all\"}" with priority "1" ...
 Started: 17:26:18.514559
Duration: 1254.361 ms
 Changes:   
          ----------
          new:
              - Definition
          old:
              ----------
              apply_to:
                  all
              definition:
                  {"ha-mode":"all"}
              pattern:
                  .*
              priority:
                  1
```
