### PR TITLE
fix pkgrepo.absent with ppa

### DIFF
--- a/salt/states/pkgrepo.py
+++ b/salt/states/pkgrepo.py
@@ -387,7 +387,9 @@ def absent(name, **kwargs):
            'comment': ''}
     repo = {}
     if 'ppa' in kwargs and __grains__['os'] == 'Ubuntu':
-        kwargs['name'] = kwargs.pop('ppa')
+        name = kwargs.pop('ppa')
+        if not name.startswith('ppa:'):
+            name = 'ppa:' + name
 
     try:
         repo = __salt__['pkg.get_repo'](


### PR DESCRIPTION
`pkgrepo.absent` for ppa doesn't work. `pkg.get_repo` and `pkg.del_repo` expects ppa repo start with `ppa:` string.

I fixed it. The test state.

```
manage_git_repo:
  pkgrepo:
    - managed
    - ppa: git-core/ppa

remove_git_repo:
  pkgrepo:
    - absent
    - ppa: git-core/ppa
    - require:
      - pkgrepo: manage_git_repo

check_git_repo:
  cmd:
    - run
    - name: ls -la /etc/apt/sources.list.d/git-core-ppa-precise.list
    - require:
      - pkgrepo: remove_git_repo
```

The result.

```
local:
----------
          ID: manage_git_repo
    Function: pkgrepo.managed
      Result: True
     Comment: Package repo 'manage_git_repo' already configured
     Started: 13:31:49.217683
    Duration: 18.987 ms
     Changes:
----------
          ID: remove_git_repo
    Function: pkgrepo.absent
      Result: True
     Comment: Removed package repo ppa:git-core/ppa
     Started: 13:31:49.237229
    Duration: 59081.879 ms
     Changes:
              ----------
              repo:
                  ppa:git-core/ppa
----------
          ID: check_git_repo
    Function: cmd.run
        Name: ls -la /etc/apt/sources.list.d/git-core-ppa-precise.list
      Result: False
     Comment: Command "ls -la /etc/apt/sources.list.d/git-core-ppa-precise.list" run
     Started: 13:32:48.319972
    Duration: 5.786 ms
     Changes:
              ----------
              pid:
                  7745
              retcode:
                  2
              stderr:
                  ls: cannot access /etc/apt/sources.list.d/git-core-ppa-precise.list: No such file or directory
              stdout:

Summary
------------
Succeeded: 2 (changed=2)
Failed:    1
------------
Total states run:     3
```
