### PR TITLE
correctly count active devices when creating a mdadm array with spares

### DIFF
--- a/salt/modules/mdadm.py
+++ b/salt/modules/mdadm.py
@@ -205,11 +205,15 @@ def create(name,
     For more info, read the ``mdadm(8)`` manpage
     '''
     opts = []
+    raid_devices = len(devices)
+
     for key in kwargs:
         if not key.startswith('__'):
             opts.append('--{0}'.format(key))
             if kwargs[key] is not True:
                 opts.append(str(kwargs[key]))
+        if key == 'spare-devices':
+            raid_devices -= int(kwargs[key])
 
     cmd = ['mdadm',
            '-C', name,
@@ -217,7 +221,7 @@ def create(name,
            '-v'] + opts + [
            '-l', str(level),
            '-e', metadata,
-           '-n', str(len(devices))] + devices
+           '-n', str(raid_devices)] + devices
 
     cmd_str = ' '.join(cmd)
 


### PR DESCRIPTION
The `create` function on the `mdadm` execution module does not account for spare devices if specified. This causes a problem when the function runs the `mdadm` binary; the binary expects separate counts of active and spare devices. This patch corrects the issue.
