### PR TITLE
fix set_locale when no locale is defined initially in RedHat family

### DIFF
--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -132,11 +132,11 @@ def set_locale(locale):
             __salt__['file.append']('/etc/sysconfig/i18n',
                                     '"\nLANG={0}"'.format(locale))
         else:
-          __salt__['file.sed'](
+          __salt__['file.replace'](
               '/etc/sysconfig/i18n', '^LANG=.*', 'LANG="{0}"'.format(locale)
           )
     elif 'Debian' in __grains__['os_family']:
-        __salt__['file.sed'](
+        __salt__['file.replace'](
             '/etc/default/locale', '^LANG=.*', 'LANG="{0}"'.format(locale)
         )
         if __salt__['cmd.retcode']('grep "^LANG=" /etc/default/locale') != 0:

--- a/salt/modules/localemod.py
+++ b/salt/modules/localemod.py
@@ -126,12 +126,15 @@ def set_locale(locale):
     if 'Arch' in __grains__['os_family']:
         return _localectl_set(locale)
     elif 'RedHat' in __grains__['os_family']:
-        __salt__['file.sed'](
-            '/etc/sysconfig/i18n', '^LANG=.*', 'LANG="{0}"'.format(locale)
-        )
+        if not __salt__['file.file_exists']('/etc/sysconfig/i18n'):
+            __salt__['file.touch']('/etc/sysconfig/i18n')
         if __salt__['cmd.retcode']('grep "^LANG=" /etc/sysconfig/i18n') != 0:
             __salt__['file.append']('/etc/sysconfig/i18n',
                                     '"\nLANG={0}"'.format(locale))
+        else:
+          __salt__['file.sed'](
+              '/etc/sysconfig/i18n', '^LANG=.*', 'LANG="{0}"'.format(locale)
+          )
     elif 'Debian' in __grains__['os_family']:
         __salt__['file.sed'](
             '/etc/default/locale', '^LANG=.*', 'LANG="{0}"'.format(locale)


### PR DESCRIPTION
without this modification, I get: 

```
          ID: en_US.UTF-8
    Function: locale.system
      Result: False
     Comment: An exception occurred in this state: Traceback (most recent call last):
                File "/usr/lib/python2.6/site-packages/salt/state.py", line 1529, in call
                  **cdata['kwargs'])
                File "/usr/lib64/python2.6/contextlib.py", line 34, in __exit__
                  self.gen.throw(type, value, traceback)
                File "/usr/lib/python2.6/site-packages/salt/utils/context.py", line 41, in func_globals_inject
                  yield
                File "/usr/lib/python2.6/site-packages/salt/state.py", line 1529, in call
                  **cdata['kwargs'])
                File "/usr/lib/python2.6/site-packages/salt/states/locale.py", line 40, in system
                  if __salt__['locale.set_locale'](name):
                File "/usr/lib/python2.6/site-packages/salt/modules/localemod.py", line 130, in set_locale
                  '"\nLANG={0}"'.format(locale))
                File "/usr/lib/python2.6/site-packages/salt/modules/file.py", line 1641, in append
                  with salt.utils.fopen(path, "r+") as ofile:
                File "/usr/lib/python2.6/site-packages/salt/utils/__init__.py", line 1066, in fopen
                  fhandle = open(*args, **kwargs)
              IOError: [Errno 2] No such file or directory: '/etc/sysconfig/i18n'
     Started: 16:01:46.830689
    Duration: 180.809 ms
     Changes:   
```
