### PR TITLE
Use LooseVersion instead of StrictVersion to use an RC version of MongoDB

### DIFF
--- a/salt/modules/mongodb.py
+++ b/salt/modules/mongodb.py
@@ -16,7 +16,7 @@ Module to provide MongoDB functionality to Salt
 
 # Import python libs
 import logging
-from distutils.version import StrictVersion  # pylint: disable=import-error,no-name-in-module
+from distutils.version import LooseVersion  # pylint: disable=import-error,no-name-in-module
 
 # Import salt libs
 from salt._compat import string_types
@@ -156,7 +156,7 @@ def user_list(user=None, password=None, host=None, port=None, database='admin'):
         output = []
         mongodb_version = mdb.eval('db.version()')
 
-        if StrictVersion(mongodb_version) >= StrictVersion('2.6'):
+        if LooseVersion(mongodb_version) >= LooseVersion('2.6'):
             for user in mdb.eval('db.getUsers()'):
                 output.append([
                     ('user', user['user']),


### PR DESCRIPTION
Fixes #21012
