### PR TITLE
Fix file.replace regressions, fixes saltstack#20970 and saltstack#20603

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1122,52 +1122,39 @@ def replace(path,
     repl = str(repl)
 
     found = False
-
-    # First check the whole file, whether the replacement has already been made
-    try:
-        # open the file read-only and inplace=False, otherwise the result
-        # will be an empty file after iterating over it just for searching
-        fi_file = fileinput.input(path,
-                        inplace=False,
-                        backup=False,
-                        bufsize=bufsize,
-                        mode='r')
-
-        for line in fi_file:
-
-            line = line.strip()
-
-            if (prepend_if_not_found or append_if_not_found) and not_found_content:
-                if line == not_found_content:
-                    if search_only:
-                        return True
-                    found = True
-                    break
-
-            else:
-                if line == repl:
-                    if search_only:
-                        return True
-                    found = True
-                    break
-
-    finally:
-        fi_file.close()
+    content = str(not_found_content) if not_found_content and \
+                                       (prepend_if_not_found or
+                                        append_if_not_found) \
+                                     else repl
 
     try:
         fi_file = fileinput.input(path,
                         inplace=not (dry_run or search_only),
-                        backup=False if (dry_run or search_only or found) else backup,
+                        backup=False if (dry_run or search_only) else backup,
                         bufsize=bufsize,
-                        mode='r' if (dry_run or search_only or found) else 'rb')
+                        mode='rb')
 
-        if not found:
-            for line in fi_file:
+        for line in fi_file:
+
+            if search_only:
+                # Just search; bail as early as a match is found
+                result = re.search(cpattern, line)
+
+                if result:
+                    return True  # `finally` block handles file closure
+            else:
                 result, nrepl = re.subn(cpattern, repl, line, count)
 
                 # found anything? (even if no change)
                 if nrepl > 0:
                     found = True
+
+                if prepend_if_not_found or append_if_not_found:
+                    # Search for content, so we don't continue pre/appending
+                    # the content if it's been pre/appended in a previous run.
+                    if re.search(content, line):
+                        # Content was found, so set found.
+                        found = True
 
                 # Identity check each potential change until one change is made
                 if has_changes is False and result != line:


### PR DESCRIPTION
This commit reverts to the `file.replace` code from 2014.7.0, which fixes
saltstack#20970 and saltstack#20603. It then introduces an alternative
patch that fixes saltstack#18612 and doesn't require passing through the
file twice.

There is a small regression in backup behavior... If dry run is `False`, and 
if `backup` is `False`, and if there's a pre-existing filename of `name`+`.bak`, 
then that backup file will be overwritten and deleted. This backup behavior is 
a result of how `fileinput` works. Fixing it requires either passing through the 
file twice (the first time only to search for content and set a flag), or rewriting 
`file.replace` so it doesn't use `fileinput`.
