### PR TITLE
Support Chocolatey 0.9.9+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -781,6 +781,7 @@ class SaltDistribution(distutils.dist.Distribution):
 
         if IS_WINDOWS_PLATFORM:
             freezer_includes.extend([
+                'imp',
                 'win32api',
                 'win32file',
                 'win32con',


### PR DESCRIPTION
The upcoming release will require "--yes" to execute commands that change
the machine's state (install/remove packages, etc). Also, our old version
determination code won't work with it. This PR fixes both issues.

It also attempts to fix an ImportError (would like input from @UtahDave on this)
