### PR TITLE
utils.http.query(): use list instead of tuple since `handlers` gets mutated

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -258,10 +258,10 @@ def query(url,
         result_cookies = result.cookies
     else:
         request = urllib2.Request(url, data)
-        handlers = (
+        handlers = [
             urllib2.HTTPHandler,
             urllib2.HTTPCookieProcessor(sess_cookies)
-        )
+        ]
 
         if url.startswith('https') or port == 443:
             if not HAS_MATCHHOSTNAME:


### PR DESCRIPTION
```
************* Module salt.utils.http
/Users/chris/code/salt/salt/utils/http.py:309: [E1101(no-member), query] Instance of 'tuple' has no 'append' member
```

And also, on line 319 there's:

``` py
handlers[0] = salt.ext.six.moves.http_client.HTTPSConnection(**cert_kwargs)
```
