### PR TITLE
yumpkg.py: sort updates for latest_package to always actually get latest...

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -341,9 +341,14 @@ def latest_version(*names, **kwargs):
         refresh_db(_get_branch_option(**kwargs), repo_arg, exclude_arg)
 
     # Get updates for specified package(s)
-    updates = _repoquery_pkginfo(
-        '{0} {1} --pkgnarrow=available {2}'
-        .format(repo_arg, exclude_arg, ' '.join(names))
+    # Sort by version number (highest to lowest) for loop below
+    updates = sorted(
+        _repoquery_pkginfo(
+            '{0} {1} --pkgnarrow=available {2}'
+            .format(repo_arg, exclude_arg, ' '.join(names))
+        ),
+        key=lambda pkginfo: _LooseVersion(pkginfo.version),
+        reverse=True
     )
 
     for name in names:


### PR DESCRIPTION
... available

This pull requests addresses the behavior outlined here https://bpaste.net/show/f911d1c1d8e3.

The issue addressed is when a package that is noarch on an older version but has an arch in a newer version is shown as having a latest_version of the older noarch package in some cases.  To address this issue, I sorted the returned list by version in reverse.

If you have any questions or require any additional changes by me, please let me know and I will do my best to address them quickly and concisely.
