### PR TITLE
Factor out `uid`, `gid` and `mode` support from `fopen()` into `fpopen()`

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -4,10 +4,8 @@ The crypt module manages all of the cryptography functions for minions and
 masters, encrypting and decrypting payloads, preparing messages, and
 authenticating peers
 '''
-from __future__ import absolute_import
-from __future__ import print_function
-
 # Import python libs
+from __future__ import absolute_import, print_function
 import os
 import sys
 import time
@@ -16,7 +14,7 @@ import hashlib
 import logging
 import traceback
 import binascii
-from salt.ext.six.moves import zip
+from salt.ext.six.moves import zip  # pylint: disable=import-error,redefined-builtin
 
 # Import third party libs
 try:

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -497,7 +497,8 @@ class SAuth(object):
                          'from master {0}'.format(self.opts['master']))
                 m_pub_fn = os.path.join(self.opts['pki_dir'], self.mpub)
                 uid = salt.utils.get_uid(self.opts.get('user', None))
-                salt.utils.fopen(m_pub_fn, 'w+', uid=uid).write(payload['pub_key'])
+                with salt.utils.fpopen(m_pub_fn, 'w+', uid=uid) as wfh:
+                    wfh.write(payload['pub_key'])
                 return True
             else:
                 log.error('Received signed public-key from master {0} '

--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -984,28 +984,9 @@ def fopen(*args, **kwargs):
 
     NB! We still have small race condition between open and fcntl.
 
-    Supported optional Keyword Arguments:
-
-      lock: lock the file with fcntl
-
-      mode: explicit mode to set. Mode is anything os.chmod
-            would accept as input for mode. Works only on unix/unix
-            like systems.
-
-      uid: the uid to set, if not set, or it is None or -1 no changes are
-           made. Same applies if the path is already owned by this
-           uid. Must be int. Works only on unix/unix like systems.
-
-      gid: the gid to set, if not set, or it is None or -1 no changes are
-           made. Same applies if the path is already owned by this
-           gid. Must be int. Works only on unix/unix like systems.
-
     '''
     # Remove lock, uid, gid and mode from kwargs if present
     lock = kwargs.pop('lock', False)
-    uid = kwargs.pop('uid', -1)  # -1 means no change to current uid
-    gid = kwargs.pop('gid', -1)  # -1 means no change to current gid
-    mode = kwargs.pop('mode', None)
 
     if lock is True:
         warn_until(
@@ -1028,20 +1009,6 @@ def fopen(*args, **kwargs):
         old_flags = fcntl.fcntl(fhandle.fileno(), fcntl.F_GETFD)
         fcntl.fcntl(fhandle.fileno(), fcntl.F_SETFD, old_flags | FD_CLOEXEC)
 
-    path = args[0]
-    d_stat = os.stat(path)
-
-    if hasattr(os, 'chown'):
-        # if uid and gid are both -1 then go ahead with
-        # no changes at all
-        if (d_stat.st_uid != uid or d_stat.st_gid != gid) and \
-                [i for i in (uid, gid) if i != -1]:
-            os.chown(path, uid, gid)
-
-    if mode is not None:
-        if d_stat.st_mode | mode != d_stat.st_mode:
-            os.chmod(path, d_stat.st_mode | mode)
-
     return fhandle
 
 
@@ -1058,6 +1025,48 @@ def flopen(*args, **kwargs):
         finally:
             if is_fcntl_available(check_sunos=True):
                 fcntl.flock(fhandle.fileno(), fcntl.LOCK_UN)
+
+
+@contextlib.contextmanager
+def fpopen(*args, **kwargs):
+    '''
+    Shortcut for fopen with extra uid, gid and mode options.
+
+    Supported optional Keyword Arguments:
+
+      mode: explicit mode to set. Mode is anything os.chmod
+            would accept as input for mode. Works only on unix/unix
+            like systems.
+
+      uid: the uid to set, if not set, or it is None or -1 no changes are
+           made. Same applies if the path is already owned by this
+           uid. Must be int. Works only on unix/unix like systems.
+
+      gid: the gid to set, if not set, or it is None or -1 no changes are
+           made. Same applies if the path is already owned by this
+           gid. Must be int. Works only on unix/unix like systems.
+
+    '''
+    # Remove uid, gid and mode from kwargs if present
+    uid = kwargs.pop('uid', -1)  # -1 means no change to current uid
+    gid = kwargs.pop('gid', -1)  # -1 means no change to current gid
+    mode = kwargs.pop('mode', None)
+    with fopen(*args, **kwargs) as fhandle:
+        path = args[0]
+        d_stat = os.stat(path)
+
+        if hasattr(os, 'chown'):
+            # if uid and gid are both -1 then go ahead with
+            # no changes at all
+            if (d_stat.st_uid != uid or d_stat.st_gid != gid) and \
+                    [i for i in (uid, gid) if i != -1]:
+                os.chown(path, uid, gid)
+
+        if mode is not None:
+            if d_stat.st_mode | mode != d_stat.st_mode:
+                os.chmod(path, d_stat.st_mode | mode)
+
+        yield fhandle
 
 
 def expr_match(line, expr):


### PR DESCRIPTION
Factor out `uid`, `gid` and `mode` support from `fopen()` into `fpopen()`
