### PR TITLE
Private key fix

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -2064,6 +2064,8 @@ def create(vm_=None, call=None):
             )
         )
     vm_['key_filename'] = key_filename
+    # wait_for_instance requires private_key
+    vm_['private_key'] = key_filename
 
     # Get SSH Gateway config early to verify the private_key,
     # if used, exists or not. We don't want to deploy an instance

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -118,7 +118,7 @@ try:
     import Crypto
     # PKCS1_v1_5 was added in PyCrypto 2.5
     from Crypto.Cipher import PKCS1_v1_5  # pylint: disable=E0611
-    from Crypto.Cipher import SHA  # pylint: disable=E0611
+    from Crypto.Hash import SHA  # pylint: disable=E0611
     HAS_PYCRYPTO = True
 except ImportError:
     HAS_PYCRYPTO = False

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -118,6 +118,7 @@ try:
     import Crypto
     # PKCS1_v1_5 was added in PyCrypto 2.5
     from Crypto.Cipher import PKCS1_v1_5  # pylint: disable=E0611
+    from Crypto.Cipher import SHA  # pylint: disable=E0611
     HAS_PYCRYPTO = True
 except ImportError:
     HAS_PYCRYPTO = False

--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -118,7 +118,7 @@ try:
     import Crypto
     # PKCS1_v1_5 was added in PyCrypto 2.5
     from Crypto.Cipher import PKCS1_v1_5  # pylint: disable=E0611
-    from Crypto.Hash import SHA  # pylint: disable=E0611
+    from Crypto.Hash import SHA  # pylint: disable=E0611,W0611
     HAS_PYCRYPTO = True
 except ImportError:
     HAS_PYCRYPTO = False


### PR DESCRIPTION
This is required for Windows instances, as it uses the private_key in wait_for_instance to get the Administrator password from AWS.  I haven't gotten Windows salting to work yet, but at least it doesn't bomb out now...
