### PR TITLE
Fix error in state.request

### DIFF
--- a/salt/modules/state.py
+++ b/salt/modules/state.py
@@ -293,6 +293,7 @@ def request(mods=None,
         salt '*' state.request test
         salt '*' state.request test,pkgs
     '''
+    kwargs['test'] = True
     ret = apply_(mods, **kwargs)
     notify_path = os.path.join(__opts__['cachedir'], 'req_state.p')
     serial = salt.payload.Serial(__opts__)
@@ -400,6 +401,8 @@ def run_request(name='default', **kwargs):
     if 'mods' not in n_req or 'kwargs' not in n_req:
         return {}
     req[name]['kwargs'].update(kwargs)
+    if 'test' in n_req['kwargs']:
+        n_req['kwargs'].pop('test')
     if req:
         ret = apply_(n_req['mods'], **n_req['kwargs'])
         try:

--- a/tests/integration/modules/state.py
+++ b/tests/integration/modules/state.py
@@ -77,7 +77,8 @@ class StateModuleTest(integration.ModuleCase,
         self._remove_request_cache_file()
 
         ret = self.run_function('state.request', mods='modules.state.requested')
-        self.assertSaltTrueReturn(ret)
+        result = ret['cmd_|-count_root_dir_contents_|-ls -a / | wc -l_|-run']['result']
+        self.assertEqual(result, None)
 
     def test_check_request(self):
         '''
@@ -88,7 +89,7 @@ class StateModuleTest(integration.ModuleCase,
         self.run_function('state.request', mods='modules.state.requested')
         ret = self.run_function('state.check_request')
         result = ret['default']['test_run']['cmd_|-count_root_dir_contents_|-ls -a / | wc -l_|-run']['result']
-        self.assertTrue(result)
+        self.assertEqual(result, None)
 
     def test_clear_request(self):
         '''


### PR DESCRIPTION
We were not running the initial request in test=True.

This changes things so we now run the state in testing mode when it is requested and then actually apply it when it is run.

Partially reverts #20773
