### PR TITLE
Added boto_elb.register_instances state function

### DIFF
--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -339,6 +339,63 @@ def present(
     return ret
 
 
+def register_instances(name, instances, region=None, key=None, keyid=None,
+                       profile=None):
+    '''
+    Add instance/s to load balancer
+
+    add-instances:
+      boto_elb.register_instances:
+        - name: myloadbalancer
+        - instances:
+          - instance1
+          - instance2
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+    ret['name'] = name
+    lb = __salt__['boto_elb.exists'](name, region, key, keyid, profile)
+    log.debug(lb)
+    if lb:
+        health = __salt__['boto_elb.get_instance_health'](name,
+                                                          region,
+                                                          key,
+                                                          keyid,
+                                                          profile)
+        nodes = []
+        new = []
+        for value in health:
+            nodes.append(value['instance_id'])
+        for value in instances:
+            if value not in nodes:
+                new.append(value)
+        if len(new) == 0:
+            ret['comment'] = 'Instance/s {0} already exist.' \
+                              ''.format(str(instances).strip('[]'))
+            ret['result'] = True
+        else:
+            state = __salt__['boto_elb.register_instances'](name,
+                                                            instances,
+                                                            region,
+                                                            key,
+                                                            keyid,
+                                                            profile)
+            if state:
+                ret['comment'] = 'Load Balancer {0} has been changed' \
+                                 ''.format(name)
+                ret['changes']['old'] = '\n'.join(nodes)
+                log.debug(nodes)
+                new = set().union(nodes,instances)
+                ret['changes']['new'] = '\n'.join(list(new))
+                ret['result'] = True
+            else:
+                ret['comment'] = 'Load balancer {0} failed to add instances' \
+                                 ''.format(name)
+                ret['result'] = False
+    else:
+        ret['comment'] = 'Could not find lb {0}'.format(name)
+    return ret
+
+
 def _elb_present(
         name,
         availability_zones,

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -354,7 +354,6 @@ def register_instances(name, instances, region=None, key=None, keyid=None,
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     ret['name'] = name
     lb = __salt__['boto_elb.exists'](name, region, key, keyid, profile)
-    log.debug(lb)
     if lb:
         health = __salt__['boto_elb.get_instance_health'](name,
                                                           region,
@@ -383,8 +382,7 @@ def register_instances(name, instances, region=None, key=None, keyid=None,
                 ret['comment'] = 'Load Balancer {0} has been changed' \
                                  ''.format(name)
                 ret['changes']['old'] = '\n'.join(nodes)
-                log.debug(nodes)
-                new = set().union(nodes,instances)
+                new = set().union(nodes, instances)
                 ret['changes']['new'] = '\n'.join(list(new))
                 ret['result'] = True
             else:

--- a/salt/states/boto_elb.py
+++ b/salt/states/boto_elb.py
@@ -344,12 +344,16 @@ def register_instances(name, instances, region=None, key=None, keyid=None,
     '''
     Add instance/s to load balancer
 
+    .. versionsadded:: Beryllium
+
+    .. code-block:: yaml
+
     add-instances:
       boto_elb.register_instances:
         - name: myloadbalancer
         - instances:
-          - instance1
-          - instance2
+          - instance-id1
+          - instance-id2
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
     ret['name'] = name


### PR DESCRIPTION
Added function register_instances to boto_elb.

The function is able to register multiple instances by providing a list. 
Example

```
add-instances:
  boto_elb.register_instances:
    - name: myloadbalancer
    - instances:
      - instance-id1
      - instance-id2
```
