### PR TITLE
Make the warnings standout

### DIFF
--- a/salt/output/highstate.py
+++ b/salt/output/highstate.py
@@ -260,7 +260,7 @@ def _format_host(host, data):
                     subsequent_indent=u' ' * 14
                 )
                 hstrs.append(
-                    u'   {colors[YELLOW]} Warnings: {0}{colors[ENDC]}'.format(
+                    u'   {colors[LIGHT_RED]} Warnings: {0}{colors[ENDC]}'.format(
                         wrapper.fill('\n'.join(ret['warnings'])).lstrip(),
                         colors=colors
                     )
@@ -335,7 +335,7 @@ def _format_host(host, data):
         if num_warnings:
             hstrs.append(
                 colorfmt.format(
-                    colors['YELLOW'],
+                    colors['LIGHT_RED'],
                     _counts(rlabel['warnings'], num_warnings),
                     colors
                 )


### PR DESCRIPTION
Since in yellow they can be confused with unchanged state returns
