### PR TITLE
tls module: missing subdir in path check for create_ca_signed_cert

### DIFF
--- a/salt/modules/tls.py
+++ b/salt/modules/tls.py
@@ -862,7 +862,7 @@ def create_ca_signed_cert(ca_name, CN, days=365, cacert_path=None, cert_filename
         cert_filename = CN
 
     if os.path.exists(
-            '{0}/{1}/{2}.crt'.format(cert_base_path(),
+            '{0}/{1}/certs/{2}.crt'.format(cert_base_path(),
                                      ca_name, cert_filename)
     ):
         return 'Certificate "{0}" already exists'.format(cert_filename)


### PR DESCRIPTION
This fixes an issue in my previous commit where the `certs` subdirectory was omitted from the path check for an existing cert.
