### PR TITLE
Enable reporting changes in test mode for cmd states when using stateful output

### DIFF
--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -119,8 +119,8 @@ a simple protocol described below:
    This is used to specify a command to run in test mode.  This command should
    return stateful data for changes that would be made by the command in the
    name parameter.
-    
-   .. versionadded:: 2015.3.0
+
+   .. versionadded:: 2015.2.0
 
    .. code-block:: yaml
 

--- a/salt/states/cmd.py
+++ b/salt/states/cmd.py
@@ -114,6 +114,31 @@ a simple protocol described below:
    Note that if the ``cmd.wait`` state also specifies ``stateful: True`` it can
    then be watched by some other states as well.
 
+4. :strong:`The stateful argument can optionally include a test_name parameter.`
+
+   This is used to specify a command to run in test mode.  This command should
+   return stateful data for changes that would be made by the command in the
+   name parameter.
+    
+   .. versionadded:: 2015.3.0
+
+   .. code-block:: yaml
+
+       Run myscript:
+         cmd.run:
+           - name: /path/to/myscript
+           - cwd: /
+           - stateful:
+             - test_name: /path/to/myscript test
+
+       Run masterscript:
+         cmd.script:
+           - name: masterscript
+           - source: salt://path/to/masterscript
+           - cwd: /
+           - stateful:
+             - test_name: masterscript test
+
 ``cmd.wait`` is not restricted to watching only cmd states. For example
 it can also watch a git state for changes
 


### PR DESCRIPTION
With this commit the stateful argument for cmd states can optionally include a test_name parameter.

This is used to specify a command to run in test mode.  This command should return stateful data for changes that would be made by the command in the name parameter.

``` yaml
keyval1:
  cmd.script:
    - name: nochange.sh Apply
    - source: salt://nochange.sh
    - stateful:
      - test_name: nochange.sh Test

keyval2:
  cmd.script:
    - name: change.sh Apply
    - source: salt://change.sh
    - stateful:
      - test_name: change.sh Test

keyval3:
  cmd.script:
    - name: fail.sh Apply
    - source: salt://fail.sh
    - stateful:
      - test_name: fail.sh Test
```

Note that the Name line in the output is showing the command for the name argument even though I'm setting name in the return dict to the command for the test_name argument when test=True.  Is that preferred for consistency between runs with test=True and test=False?

``` yaml
local:
----------
          ID: keyval1
    Function: cmd.script
        Name: nochange.sh Apply
      Result: True
     Comment: keyval Test
     Started: 14:11:26.081569
    Duration: 10.413 ms
     Changes:
----------
          ID: keyval2
    Function: cmd.script
        Name: change.sh Apply
      Result: None
     Comment: keyval Test
     Started: 14:11:26.092526
    Duration: 8.991 ms
     Changes:
              ----------
              changed:
                  yes
              pid:
                  9881
              retcode:
                  0
              stderr:

              stdout:
                  Test changes ...
----------
          ID: keyval3
    Function: cmd.script
        Name: fail.sh Apply
      Result: False
     Comment: keyval Test
     Started: 14:11:26.101938
    Duration: 9.08 ms
     Changes:
              ----------
              changed:
                  yes
              pid:
                  9882
              retcode:
                  9
              stderr:

              stdout:
                  Test failed ...

Summary
------------
Succeeded: 2 (unchanged=1, changed=2)
Failed:    1
------------
Total states run:     3
```
