### PR TITLE
Import salt.utils.openstack.pyrax differently to avoid failed import by loader

### DIFF
--- a/salt/cloud/clouds/pyrax.py
+++ b/salt/cloud/clouds/pyrax.py
@@ -17,7 +17,10 @@ import salt.utils.cloud
 import salt.config as config
 
 # Import pyrax libraries
-import salt.utils.openstack.pyrax as suop
+# This is typically against SaltStack coding styles,
+# it should be 'import salt.utils.openstack.pyrax as suop'.  Something
+# in the loader is creating a name clash and making that form fail
+from salt.utils.openstack import pyrax as suop
 
 
 # Only load in this module is the OPENSTACK configurations are in place


### PR DESCRIPTION
Otherwise we see

```
[ERROR   ] Failed to import clouds pyrax, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/root/salt/salt/loader.py", line 931, in _load_module
    ), fn_, fpath, desc)
  File "/root/salt/salt/cloud/clouds/pyrax.py", line 20, in <module>
    import salt.utils.openstack.pyrax as suop
  File "/root/salt/salt/utils/openstack/pyrax/__init__.py", line 3, in <module>
    import pyrax
  File "/root/salt/salt/cloud/clouds/pyrax.py", line 20, in <module>
    import salt.utils.openstack.pyrax as suop
AttributeError: 'module' object has no attribute 'pyrax'
[ERROR   ] Failed to import clouds pyrax, this is due most likely to a syntax error:
Traceback (most recent call last):
  File "/root/salt/salt/loader.py", line 931, in _load_module
    ), fn_, fpath, desc)
  File "/root/salt/salt/cloud/clouds/pyrax.py", line 20, in <module>
    import salt.utils.openstack.pyrax as suop
  File "/root/salt/salt/utils/openstack/pyrax/__init__.py", line 3, in <module>
    import pyrax
  File "/root/salt/salt/cloud/clouds/pyrax.py", line 20, in <module>
    import salt.utils.openstack.pyrax as suop
```

Ping @UtahDave 

Fixes #21130 
