### PR TITLE
Fix ordering of generated interfaces in the /etc/network/interface file

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1448,7 +1448,7 @@ def _write_file_ifaces(iface, data, **settings):
             tmp = source_template.render({'name': adapter, 'data': adapters[adapter]})
         else:
             tmp = eth_template.render({'name': adapter, 'data': adapters[adapter]})
-        ifcfg = tmp + ifcfg
+        ifcfg = ifcfg + tmp
         if adapter == iface:
             saved_ifcfg = tmp
 


### PR DESCRIPTION
Previously debian_ip would mess up the order of the generated interfaces in the /etc/network/interface file by dumping the older config on top of the existing config.  This is a problem for bonded interfaces because they need to be brought up after the physical interfaces they depend on otherwise it'll create a ~60s delay while the bonded interface waits for the physical interface to join it.  
