### PR TITLE
Multi syndic: Multi-master support

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1255,6 +1255,8 @@ class AESFuncs(object):
             ret = {'jid': load['jid'],
                    'id': key,
                    'return': item}
+            if 'master_id' in load:
+                ret['master_id'] = load['master_id']
             if 'out' in load:
                 ret['out'] = load['out']
             self._return(ret)
@@ -2417,7 +2419,8 @@ class ClearFuncs(object):
         # if you specified a master id, lets put that in the load
         if 'master_id' in self.opts:
             load['master_id'] = self.opts['master_id']
-        elif 'master_id' in extra:
+        # if someone passed us one, use that
+        if 'master_id' in extra:
             load['master_id'] = extra['master_id']
         # Only add the delimiter to the pub data if it is non-default
         if delimiter != DEFAULT_TARGET_DELIM:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2287,8 +2287,11 @@ class MultiSyndic(MinionBase):
                                            'sign_in_thread': t,
                                            }
             t.start()
+
         log.info('Syndic waiting on any master to connect...')
-        self._has_master.wait()
+        # threading events are un-interruptible in python 2 :/
+        while not self._has_master.is_set():
+            self._has_master.wait(1)
 
     # TODO: move auth_wait etc up to here
     def _connect_to_master_thread(self, master):


### PR DESCRIPTION
**\* Don't merge immediately ***

This PR has a few cleanups to the MultiSyndic, primarily around the failure cases-- we now stall 15s instead of 180s. 

This also add support for Syndics to run on multi top level masters-- the config is a little magic, but it works. To explain:

Lets say we have 3 masters-- and we want minions to connect to one of them (using failover minion), but we only want to log onto one master to start the job. With the code here you can now configure a syndic on each box (configured to talk to the other 2) and it will forward only publishes and returns. This basically "clusters" masters-- since a publish anywhere ends up on all minions.

This new forwarding mode is controlled by an opt "syndic_mode" (sync or cluster).
