### PR TITLE
Better fix for #20998

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1101,7 +1101,7 @@ class Minion(MinionBase):
                     func,
                     data['arg'],
                     data)
-                sys.modules[func.__module__].__context__['retcode'] = 0
+                minion_instance.functions.pack['__context__']['retcode'] = 0
                 if opts.get('sudo_user', ''):
                     sudo_runas = opts.get('sudo_user')
                     if 'sudo.salt_call' in minion_instance.functions:
@@ -1129,7 +1129,7 @@ class Minion(MinionBase):
                     ret['return'] = iret
                 else:
                     ret['return'] = return_data
-                ret['retcode'] = sys.modules[func.__module__].__context__.get(
+                ret['retcode'] = minion_instance.functions.pack['__context__'].get(
                     'retcode',
                     0
                 )


### PR DESCRIPTION
since **context** is actually a shared global (among everything within the same loader response dict) we only need to set it once

Replaces #20998 
