### PR TITLE
Fill out the systemd-nspawn support

### DIFF
--- a/doc/ref/modules/all/salt.modules.lxc.rst
+++ b/doc/ref/modules/all/salt.modules.lxc.rst
@@ -4,4 +4,4 @@ salt.modules.lxc
 
 .. automodule:: salt.modules.lxc
     :members:
-    :exclude-members: set_pass
+    :exclude-members: set_pass, remove

--- a/doc/ref/modules/all/salt.modules.nspawn.rst
+++ b/doc/ref/modules/all/salt.modules.nspawn.rst
@@ -4,3 +4,4 @@ salt.modules.nspawn
 
 .. automodule:: salt.modules.nspawn
     :members:
+    :exclude-members: stop, restart, list_, pull_docker

--- a/doc/ref/modules/all/salt.modules.nspawn.rst
+++ b/doc/ref/modules/all/salt.modules.nspawn.rst
@@ -4,4 +4,4 @@ salt.modules.nspawn
 
 .. automodule:: salt.modules.nspawn
     :members:
-    :exclude-members: stop, restart, list_, pull_docker
+    :exclude-members: list_, stop, restart, destroy, pull_docker

--- a/salt/modules/config.py
+++ b/salt/modules/config.py
@@ -233,12 +233,19 @@ def get(key, default='', delimiter=':', merge=None):
         The ``delimiter`` argument was added, to allow delimiters other than
         ``:`` to be used.
 
-    This function traverses these data stores in this order:
+    This function traverses these data stores in this order, returning the
+    first match found:
 
     - Minion config file
     - Minion's grains
     - Minion's pillar data
     - Master config file
+
+    This means that if there is a value that is going to be the same for the
+    majority of minions, it can be configured in the Master config file, and
+    then overridden using the grains, pillar, or Minion config file.
+
+    **Arguments**
 
     delimiter
         .. versionadded:: 2015.2.0

--- a/salt/modules/linux_sysctl.py
+++ b/salt/modules/linux_sysctl.py
@@ -57,22 +57,9 @@ def default_config():
 
         salt -G 'kernel:Linux' sysctl.default_config
     '''
-    if salt.utils.systemd.booted(__context__):
-        for line in __salt__['cmd.run_stdout'](
-            'systemctl --version'
-        ).splitlines():
-            if line.startswith('systemd '):
-                version = line.split()[-1]
-                try:
-                    if int(version) >= 207:
-                        return _check_systemd_salt_config()
-                except ValueError:
-                    log.error(
-                        'Unexpected non-numeric systemd version {0!r} '
-                        'detected'.format(version)
-                    )
-                break
-
+    if salt.utils.systemd.booted(__context__) \
+            and salt.utils.systemd.version(__context__) >= 207:
+        return _check_systemd_salt_config()
     return '/etc/sysctl.conf'
 
 

--- a/salt/modules/lxc.py
+++ b/salt/modules/lxc.py
@@ -2162,6 +2162,9 @@ def destroy(name, stop=False):
         )
     return _change_state('lxc-destroy', name, None)
 
+# Compatibility between LXC and nspawn
+remove = destroy
+
 
 def exists(name):
     '''

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -4,6 +4,7 @@ Manage nspawn containers
 '''
 # Import python libs
 from __future__ import absolute_import
+import logging
 import os
 import shutil
 
@@ -11,6 +12,8 @@ import shutil
 # Import Salt libs
 import salt.defaults.exitcodes
 import salt.utils.systemd
+
+log = logging.getLogger(__name__)
 
 __virtualname__ = 'nspawn'
 WANT = '/etc/systemd/system/multi-user.target.wants/systemd-nspawn@{0}.service'
@@ -98,7 +101,11 @@ def bootstrap(name, dist=None, version=None):
     '''
     if not dist:
         dist = __grains__['os'].lower()
-    return locals['_{0}_bootstrap'.format(dist)](name, version=version)
+        log.debug(
+            'nspawn.bootstrap: no dist provided, defaulting to \'{0}\''
+            .format(dist)
+        )
+    return globals()['_{0}_bootstrap'.format(dist)](name, version=version)
 
 
 def enable(name):

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -22,7 +22,6 @@ Minions running systemd >= 219 will place new containers in
 '''
 # Import python libs
 import errno
-import fnmatch
 import logging
 import os
 import re
@@ -1065,7 +1064,7 @@ def _pull_image(pull_type, image, name, **kwargs):
             pull_opts.append('--verify=no')
         else:
             def _bad_verify():
-                raise SaltInvocationEror(
+                raise SaltInvocationError(
                     '\'verify\' must be one of the following: '
                     'signature, checksum'
                 )
@@ -1126,7 +1125,7 @@ def pull_raw(url, name, verify=False):
 
         salt myminion nspawn.pull_raw http://ftp.halifax.rwth-aachen.de/fedora/linux/releases/21/Cloud/Images/x86_64/Fedora-Cloud-Base-20141203-21.x86_64.raw.xz fedora21
     '''
-    return _pull_image('raw', url, name, verify)
+    return _pull_image('raw', url, name, verify=verify)
 
 
 def pull_tar(url, name, verify=False):
@@ -1158,7 +1157,7 @@ def pull_tar(url, name, verify=False):
 
         salt myminion nspawn.pull_tar http://foo.domain.tld/containers/archlinux-2015.02.01.tar.gz arch2
     '''
-    return _pull_image('tar', url, name, verify)
+    return _pull_image('tar', url, name, verify=verify)
 
 
 def pull_dkr(url, name, index=False):
@@ -1187,6 +1186,6 @@ def pull_dkr(url, name, index=False):
         salt myminion nspawn.pull_dkr
         salt myminion nspawn.pull_docker
     '''
-    return _pull_image('dkr', url, name, verify)
+    return _pull_image('dkr', url, name, index=index)
 
 pull_docker = pull_dkr

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -10,7 +10,9 @@ these containers.
 
 .. __: http://www.freedesktop.org/software/systemd/man/systemd-nspawn.html
 
-Container root directories will live under /var/lib/container.
+Minions running systemd >= 219 will place new containers in
+``/var/lib/machines``, while those running systemd < 219 will place them in
+``/var/lib/container``.
 
 .. note:
 

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -1,22 +1,44 @@
 # -*- coding: utf-8 -*-
 '''
 Manage nspawn containers
+
+.. versionadded:: Beryllium
+
+`systemd-nspawn(1)`__ is a tool used to manage lightweight namespace
+containers. This execution module provides several functions to help manage
+these containers.
+
+.. __: http://www.freedesktop.org/software/systemd/man/systemd-nspawn.html
+
+Container root directories will live under /var/lib/container.
+
+.. note:
+
+    ``nsenter(1)`` is required to run commands within containers. It should
+    already be present on any systemd host, as part of the **util-linux**
+    package.
 '''
 # Import python libs
-from __future__ import absolute_import
 import logging
 import os
+import re
 import shutil
-
 
 # Import Salt libs
 import salt.defaults.exitcodes
 import salt.utils.systemd
+from salt.exceptions import CommandExecutionError
+from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
 
+__func_alias__ = {
+    'list_': 'list'
+}
 __virtualname__ = 'nspawn'
 WANT = '/etc/systemd/system/multi-user.target.wants/systemd-nspawn@{0}.service'
+PATH = 'PATH=/bin:/usr/bin:/sbin:/usr/sbin:/opt/bin:' \
+       '/usr/local/bin:/usr/local/sbin'
 
 
 def __virtual__():
@@ -28,11 +50,19 @@ def __virtual__():
     return False
 
 
+def _root():
+    '''
+    Right now this is static, but if machinectl becomes configurable we will
+    put additional logic here.
+    '''
+    return '/var/lib/container'
+
+
 def _arch_bootstrap(name, **kwargs):
     '''
     Bootstrap an Arch Linux container
     '''
-    dst = os.path.join('/var/lib/container', name)
+    dst = os.path.join(_root(), name)
     if os.path.exists(dst):
         __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
         return {'err': 'Container {0} already exists'.format(name)}
@@ -50,7 +80,7 @@ def _debian_bootstrap(name, **kwargs):
     '''
     Bootstrap a Debian Linux container (only unstable is currently supported)
     '''
-    dst = os.path.join('/var/lib/container', name)
+    dst = os.path.join(_root(), name)
     if os.path.exists(dst):
         __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
         return {'err': 'Container {0} already exists'.format(name)}
@@ -68,7 +98,7 @@ def _fedora_bootstrap(name, **kwargs):
     '''
     Bootstrap a Fedora container
     '''
-    dst = os.path.join('/var/lib/container', name)
+    dst = os.path.join(_root(), name)
     if not kwargs.get('version', False):
         if __grains__['os'].lower() == 'fedora':
             version = __grains__['osrelease']
@@ -89,7 +119,417 @@ def _fedora_bootstrap(name, **kwargs):
     return ret
 
 
-def bootstrap(name, dist=None, version=None):
+def _ensure_exists(name):
+    '''
+    Raise an exception if the container does not exist
+    '''
+    if not exists(name):
+        raise CommandExecutionError(
+            'Container \'{0}\' does not exist'.format(name)
+        )
+
+
+def _machinectl(cmd):
+    '''
+    Interface to run machinectl with no header/footer and without a pager
+    '''
+    prefix = 'machinectl --no-legend --no-pager'
+    return __salt__['cmd.run_all']('{0} {1}'.format(prefix, cmd))
+
+
+def _pid(name):
+    '''
+    Return container pid
+    '''
+    try:
+        return info(name).get('Leader', '').split()[0]
+    except IndexError:
+        raise CommandExecutionError(
+            'Unable to get PID for container \'{0}\''.format(name)
+        )
+
+
+def _nsenter(name):
+    '''
+    Return the nsenter command to attach to the named container
+    '''
+    return (
+        'nsenter --target {0} --mount --uts --ipc --net --pid'
+        .format(_pid(name))
+    )
+
+
+def _run(name,
+         cmd,
+         output=None,
+         no_start=False,
+         stdin=None,
+         python_shell=True,
+         preserve_state=False,
+         output_loglevel='debug',
+         ignore_retcode=False,
+         use_vt=False,
+         keep_env=None):
+    '''
+    Common logic for nspawn.run functions
+    '''
+    # No need to call _ensure_exists(), it will be called via _nsenter()
+    full_cmd = _nsenter(name)
+    if keep_env is not True:
+        full_cmd += ' env -i'
+    if keep_env is None:
+        full_cmd += ' {0}'.format(PATH)
+    elif isinstance(keep_env, string_types):
+        for var in keep_env.split(','):
+            if var in os.environ:
+                full_cmd += ' {0}="{1}"'.format(var, os.environ[var])
+    full_cmd += ' {0}'.format(cmd)
+
+    orig_state = state(name)
+    exc = None
+    try:
+        ret = __salt__['container_resource.run'](
+            name,
+            full_cmd,
+            output=output,
+            no_start=no_start,
+            stdin=stdin,
+            python_shell=python_shell,
+            output_loglevel=output_loglevel,
+            ignore_retcode=ignore_retcode,
+            use_vt=use_vt)
+    except Exception as exc:
+        raise
+    finally:
+        # Make sure we stop the container if necessary, even if an exception
+        # was raised.
+        if preserve_state \
+                and orig_state == 'stopped' \
+                and state(name) != 'stopped':
+            stop(name)
+
+    if output in (None, 'all'):
+        return ret
+    else:
+        return ret[output]
+
+
+def run(name,
+        cmd,
+        no_start=False,
+        preserve_state=True,
+        stdin=None,
+        python_shell=True,
+        output_loglevel='debug',
+        use_vt=False,
+        ignore_retcode=False,
+        keep_env=None):
+    '''
+    Run :mod:`cmd.run <salt.modules.cmdmod.run>` within a container
+
+    name
+        Name of the container in which to run the command
+
+    cmd
+        Command to run
+
+    no_start : False
+        If the container is not running, don't start it
+
+    preserve_state : True
+        After running the command, return the container to its previous state
+
+    stdin : None
+        Standard input to be used for the command
+
+    output_loglevel : debug
+        Level at which to log the output from the command. Set to ``quiet`` to
+        suppress logging.
+
+    use_vt : False
+        Use SaltStack's utils.vt to stream output to console. Assumes
+        ``output=all``.
+
+    keep_env : None
+        If not passed, only a sane default PATH environment variable will be
+        set. If ``True``, all environment variables from the container's host
+        will be kept. Otherwise, a comma-separated list (or Python list) of
+        environment variable names can be passed, and those environment
+        variables will be kept.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.run mycontainer 'ifconfig -a'
+    '''
+    return _run(name,
+                cmd,
+                output=None,
+                no_start=no_start,
+                preserve_state=preserve_state,
+                stdin=stdin,
+                python_shell=python_shell,
+                output_loglevel=output_loglevel,
+                use_vt=use_vt,
+                ignore_retcode=ignore_retcode,
+                keep_env=keep_env)
+
+
+def run_stdout(name,
+               cmd,
+               no_start=False,
+               preserve_state=True,
+               stdin=None,
+               python_shell=True,
+               output_loglevel='debug',
+               use_vt=False,
+               ignore_retcode=False,
+               keep_env=None):
+    '''
+    Run :mod:`cmd.run_stdout <salt.modules.cmdmod.run_stdout>` within a container
+
+    name
+        Name of the container in which to run the command
+
+    cmd
+        Command to run
+
+    no_start : False
+        If the container is not running, don't start it
+
+    preserve_state : True
+        After running the command, return the container to its previous state
+
+    stdin : None
+        Standard input to be used for the command
+
+    output_loglevel : debug
+        Level at which to log the output from the command. Set to ``quiet`` to
+        suppress logging.
+
+    use_vt : False
+        Use SaltStack's utils.vt to stream output to console. Assumes
+        ``output=all``.
+
+    keep_env : None
+        If not passed, only a sane default PATH environment variable will be
+        set. If ``True``, all environment variables from the container's host
+        will be kept. Otherwise, a comma-separated list (or Python list) of
+        environment variable names can be passed, and those environment
+        variables will be kept.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.run_stdout mycontainer 'ifconfig -a'
+    '''
+    return _run(name,
+                cmd,
+                output='stdout',
+                no_start=no_start,
+                preserve_state=preserve_state,
+                stdin=stdin,
+                python_shell=python_shell,
+                output_loglevel=output_loglevel,
+                use_vt=use_vt,
+                ignore_retcode=ignore_retcode,
+                keep_env=keep_env)
+
+
+def run_stderr(name,
+               cmd,
+               no_start=False,
+               preserve_state=True,
+               stdin=None,
+               python_shell=True,
+               output_loglevel='debug',
+               use_vt=False,
+               ignore_retcode=False,
+               keep_env=None):
+    '''
+    Run :mod:`cmd.run_stderr <salt.modules.cmdmod.run_stderr>` within a container
+
+    name
+        Name of the container in which to run the command
+
+    cmd
+        Command to run
+
+    no_start : False
+        If the container is not running, don't start it
+
+    preserve_state : True
+        After running the command, return the container to its previous state
+
+    stdin : None
+        Standard input to be used for the command
+
+    output_loglevel : debug
+        Level at which to log the output from the command. Set to ``quiet`` to
+        suppress logging.
+
+    use_vt : False
+        Use SaltStack's utils.vt to stream output to console. Assumes
+        ``output=all``.
+
+    keep_env : None
+        If not passed, only a sane default PATH environment variable will be
+        set. If ``True``, all environment variables from the container's host
+        will be kept. Otherwise, a comma-separated list (or Python list) of
+        environment variable names can be passed, and those environment
+        variables will be kept.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.run_stderr mycontainer 'ip addr show'
+    '''
+    return _run(name,
+                cmd,
+                output='stderr',
+                no_start=no_start,
+                preserve_state=preserve_state,
+                stdin=stdin,
+                python_shell=python_shell,
+                output_loglevel=output_loglevel,
+                use_vt=use_vt,
+                ignore_retcode=ignore_retcode,
+                keep_env=keep_env)
+
+
+def retcode(name,
+            cmd,
+            no_start=False,
+            preserve_state=True,
+            stdin=None,
+            python_shell=True,
+            output_loglevel='debug',
+            use_vt=False,
+            ignore_retcode=False,
+            keep_env=None):
+    '''
+    Run :mod:`cmd.retcode <salt.modules.cmdmod.retcode>` within a container
+
+    name
+        Name of the container in which to run the command
+
+    cmd
+        Command to run
+
+    no_start : False
+        If the container is not running, don't start it
+
+    preserve_state : True
+        After running the command, return the container to its previous state
+
+    stdin : None
+        Standard input to be used for the command
+
+    output_loglevel : debug
+        Level at which to log the output from the command. Set to ``quiet`` to
+        suppress logging.
+
+    use_vt : False
+        Use SaltStack's utils.vt to stream output to console. Assumes
+        ``output=all``.
+
+    keep_env : None
+        If not passed, only a sane default PATH environment variable will be
+        set. If ``True``, all environment variables from the container's host
+        will be kept. Otherwise, a comma-separated list (or Python list) of
+        environment variable names can be passed, and those environment
+        variables will be kept.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.retcode mycontainer 'ip addr show'
+    '''
+    return _run(name,
+                cmd,
+                output='retcode',
+                no_start=no_start,
+                preserve_state=preserve_state,
+                stdin=stdin,
+                python_shell=python_shell,
+                output_loglevel=output_loglevel,
+                use_vt=use_vt,
+                ignore_retcode=ignore_retcode,
+                keep_env=keep_env)
+
+
+def run_all(name,
+            cmd,
+            no_start=False,
+            preserve_state=True,
+            stdin=None,
+            python_shell=True,
+            output_loglevel='debug',
+            use_vt=False,
+            ignore_retcode=False,
+            keep_env=None):
+    '''
+    Run :mod:`cmd.run_all <salt.modules.cmdmod.run_all>` within a container
+
+    name
+        Name of the container in which to run the command
+
+    cmd
+        Command to run
+
+    no_start : False
+        If the container is not running, don't start it
+
+    preserve_state : True
+        After running the command, return the container to its previous state
+
+    stdin : None
+        Standard input to be used for the command
+
+    output_loglevel : debug
+        Level at which to log the output from the command. Set to ``quiet`` to
+        suppress logging.
+
+    use_vt : False
+        Use SaltStack's utils.vt to stream output to console. Assumes
+        ``output=all``.
+
+    keep_env : None
+        If not passed, only a sane default PATH environment variable will be
+        set. If ``True``, all environment variables from the container's host
+        will be kept. Otherwise, a comma-separated list (or Python list) of
+        environment variable names can be passed, and those environment
+        variables will be kept.
+
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.run_all mycontainer 'ip addr show'
+    '''
+    return _run(name,
+                cmd,
+                output='all',
+                no_start=no_start,
+                preserve_state=preserve_state,
+                stdin=stdin,
+                python_shell=python_shell,
+                output_loglevel=output_loglevel,
+                use_vt=use_vt,
+                ignore_retcode=ignore_retcode,
+                keep_env=keep_env)
+
+
+def bootstrap_container(name, dist=None, version=None):
     '''
     Bootstrap a container from package servers, if dist is None the os the
     minion is running as will be created, otherwise the needed bootstrapping
@@ -97,7 +537,7 @@ def bootstrap(name, dist=None, version=None):
 
     CLI Example::
 
-        salt '*' nspawn.bootstrap arch1
+        salt '*' nspawn.bootstrap_container <name>
     '''
     if not dist:
         dist = __grains__['os'].lower()
@@ -108,18 +548,183 @@ def bootstrap(name, dist=None, version=None):
     return globals()['_{0}_bootstrap'.format(dist)](name, version=version)
 
 
+def list_all():
+    '''
+    Lists all nspawn containers
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nspawn.list_all
+    '''
+    rootdir = _root()
+    return sorted(
+        [x for x in os.listdir(rootdir)
+         if os.path.isdir(os.path.join(rootdir, x))]
+    )
+
+
+def list_running():
+    '''
+    Lists running nspawn containers
+
+    .. note::
+
+        ``nspawn.list`` also works to list running containers
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nspawn.list_running
+        salt '*' nspawn.list
+    '''
+    ret = []
+    for line in _machinectl('list')['stdout'].splitlines():
+        try:
+            ret.append(line.split()[0])
+        except IndexError:
+            pass
+    return sorted(ret)
+
+# 'machinectl list' shows only running containers, so allow this to work as an
+# alias to nspawn.list_running
+list_ = list_running
+
+
+def list_stopped():
+    '''
+    Lists stopped nspawn containers
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nspawn.list_stopped
+    '''
+    return sorted(set(list_all()) - set(list_running()))
+
+
+def exists(name):
+    '''
+    Returns true if the named container exists
+    '''
+    return name in list_all()
+
+
+def state(name):
+    '''
+    Return state of container
+    '''
+    _ensure_exists(name)
+    try:
+        cmd = 'show {0} --property=State'.format(name)
+        return _machinectl(cmd)['stdout'].split('=')[1]
+    except IndexError:
+        return 'stopped'
+
+
+def info(name, force_start=True):
+    '''
+    Return info about a container
+
+    .. note::
+
+        The container must be running for ``machinectl`` to gather information
+        about it. If the container is stopped, then this function will start
+        it.
+
+    force_start : True
+
+        If ``False``, then this function will result in an error if the
+        container is not already running.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nspawn.info arch1
+        salt '*' nspawn.info arch1 force_start=False
+    '''
+    _ensure_exists(name)
+    running_containers = list_running()
+    needs_stop = False
+    if name not in running_containers:
+        if start:
+            start(name)
+            needs_stop = True
+        else:
+            raise CommandExecutionError(
+                'Container \'{0}\' is not running'.format(name)
+            )
+    # Have to parse 'machinectl status' here since 'machinectl show' doesn't
+    # contain IP address info. *shakes fist angrily*
+    c_info = _machinectl('status {0}'.format(name))
+    if c_info['retcode'] != 0:
+        raise CommandExecutionError(
+            'Unable to get info for container \'{0}\''.format(name)
+        )
+    ret = {}
+    kv_pair = re.compile(r'^\s+([A-Za-z]+): (.+)$')
+    tree = re.compile(r'[|`]')
+    lines = c_info['stdout'].splitlines()
+    multiline = False
+    cur_key = None
+    for idx in range(len(lines)):
+        match = kv_pair.match(lines[idx])
+        if match:
+            key, val = match.groups()
+            cur_key = key
+            if multiline:
+                multiline = False
+            ret[key] = val
+        else:
+            if cur_key is None:
+                continue
+            if tree.search(lines[idx]):
+                # We've reached the process tree, bail out
+                break
+            if multiline:
+                ret[cur_key].append(lines[idx].strip())
+            else:
+                ret[cur_key] = [ret[key], lines[idx].strip()]
+                multiline = True
+    return ret
+
+
 def enable(name):
     '''
-    Enable a specific container
+    Set the named container to be launched at boot
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt '*' nspawn.enable <name>
     '''
+    _ensure_exists(name)
     cmd = 'systemctl enable systemd-nspawn@{0}'.format(name)
-    ret = __salt__['cmd.run_all'](cmd, python_shell=False)
-    if ret['retcode'] != 0:
-        __context__['retcode'] = salt.defaults.exitcode.EX_UNAVAILABLE
+    if __salt__['cmd.retcode'](cmd, python_shell=False) != 0:
+        __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
+        return False
+    return True
+
+
+def disable(name):
+    '''
+    Set the named container to *not* be launched at boot
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' nspawn.enable <name>
+    '''
+    _ensure_exists(name)
+    cmd = 'systemctl disable systemd-nspawn@{0}'.format(name)
+    if __salt__['cmd.retcode'](cmd, python_shell=False) != 0:
+        __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
         return False
     return True
 
@@ -132,10 +737,11 @@ def start(name):
 
         salt '*' nspawn.start <name>
     '''
+    _ensure_exists(name)
     cmd = 'systemctl start systemd-nspawn@{0}'.format(name)
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
-        __context__['retcode'] = salt.defaults.exitcode.EX_UNAVAILABLE
+        __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
         return False
     return True
 
@@ -148,9 +754,10 @@ def stop(name):
 
         salt '*' nspawn.stop <name>
     '''
+    _ensure_exists(name)
     cmd = 'systemctl stop systemd-nspawn@{0}'.format(name)
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
-        __context__['retcode'] = salt.defaults.exitcode.EX_UNAVAILABLE
+        __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
         return False
     return True

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -651,7 +651,9 @@ def bootstrap_container(name, dist=None, version=None):
     minion is running as will be created, otherwise the needed bootstrapping
     tools will need to be available on the host.
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt myminion nspawn.bootstrap_container <name>
     '''
@@ -736,6 +738,12 @@ def list_stopped():
 def exists(name):
     '''
     Returns true if the named container exists
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.exists <name>
     '''
     return name in list_all()
 
@@ -750,7 +758,13 @@ def _get_state(name):
 
 def state(name):
     '''
-    Return state of container
+    Return state of container (running or stopped)
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.state <name>
     '''
     _ensure_exists(name)
     return _get_state(name)
@@ -880,7 +894,9 @@ def start(name):
     '''
     Start the named container
 
-    CLI Example::
+    CLI Example:
+
+    .. code-block:: bash
 
         salt myminion nspawn.start <name>
     '''

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -19,6 +19,8 @@ Container root directories will live under /var/lib/container.
     package.
 '''
 # Import python libs
+import errno
+import fnmatch
 import logging
 import os
 import re
@@ -26,14 +28,15 @@ import shutil
 
 # Import Salt libs
 import salt.defaults.exitcodes
+import salt.ext.six as six
+import salt.utils
 import salt.utils.systemd
-from salt.exceptions import CommandExecutionError
-from salt.ext.six import string_types
+from salt.exceptions import CommandExecutionError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 
 __func_alias__ = {
-    'list_': 'list'
+    'list_': 'list',
 }
 __virtualname__ = 'nspawn'
 WANT = '/etc/systemd/system/multi-user.target.wants/systemd-nspawn@{0}.service'
@@ -45,60 +48,112 @@ def __virtual__():
     '''
     Only work on systems that have been booted with systemd
     '''
-    if __grains__['kernel'] == 'Linux' and salt.utils.systemd.booted(__context__):
-        return __virtualname__
+    if __grains__['kernel'] == 'Linux' \
+            and salt.utils.systemd.booted(__context__):
+        if salt.utils.systemd.version() is None:
+            log.error('nspawn: Unable to determine systemd version')
+        else:
+            return __virtualname__
     return False
 
 
-def _root():
+def _sd_version():
     '''
-    Right now this is static, but if machinectl becomes configurable we will
-    put additional logic here.
+    Returns __context__.get('systemd.version', 0), avoiding duplication of the
+    call to dict.get and making it easier to change how we handle this context
+    var in the future
     '''
-    return '/var/lib/container'
+    return salt.utils.systemd.version(__context__)
 
 
-def _arch_bootstrap(name, **kwargs):
+def _root(name='', all_roots=False):
+    '''
+    Return the container root directory. Starting with systemd 219, new
+    images go into /var/lib/machines.
+    '''
+    if _sd_version() >= 219:
+        if all_roots:
+            return [os.path.join(x, name)
+                    for x in ('/var/lib/machines', '/var/lib/container')]
+        else:
+            return os.path.join('/var/lib/machines', name)
+    else:
+        ret = os.path.join('/var/lib/container', name)
+        if all_roots:
+            return [ret]
+        else:
+            return ret
+
+
+def _make_container_root(name):
+    '''
+    Make the container root directory
+    '''
+    path = _root(name)
+    if os.path.exists(path):
+        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+        raise CommandExecutionError(
+            'Container {0} already exists'.format(name)
+        )
+    else:
+        try:
+            os.makedirs(path)
+            return path
+        except OSError as exc:
+            raise CommandExecutionError(
+                'Unable to make container root directory {0}: {1}'
+                .format(name, exc)
+            )
+
+
+def _build_failed(dst, name):
+    try:
+        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
+        shutil.rmtree(dst)
+    except OSError as exc:
+        if exc.errno != errno.ENOENT:
+            raise CommandExecutionError(
+                'Unable to cleanup container root dir {0}'.format(dst)
+            )
+    raise CommandExecutionError(
+        'Container {0} failed to build'.format(name)
+    )
+
+
+def _bootstrap_arch(name, **kwargs):
     '''
     Bootstrap an Arch Linux container
     '''
-    dst = os.path.join(_root(), name)
-    if os.path.exists(dst):
-        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
-        return {'err': 'Container {0} already exists'.format(name)}
+    if not salt.utils.which('pacstrap'):
+        raise CommandExecutionError(
+            'pacstrap not found, is the arch-install-scripts package '
+            'installed?'
+        )
+    dst = _make_container_root(name)
     cmd = 'pacstrap -c -d {0} base'.format(dst)
-    os.makedirs(dst)
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
-        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
-        shutil.rmtree(dst)
-        return {'err': 'Container {0} failed to build'.format(name)}
+        _build_failed(dst, name)
     return ret
 
 
-def _debian_bootstrap(name, **kwargs):
+def _bootstrap_debian(name, **kwargs):
     '''
     Bootstrap a Debian Linux container (only unstable is currently supported)
     '''
-    dst = os.path.join(_root(), name)
-    if os.path.exists(dst):
-        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
-        return {'err': 'Container {0} already exists'.format(name)}
+    dst = _make_container_root(name)
     cmd = 'debootstrap --arch=amd64 unstable {0}'.format(dst)
-    os.makedirs(dst)
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
-        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
-        shutil.rmtree(dst)
-        return {'err': 'Container {0} failed to build'.format(name)}
+        _build_failed(dst, name)
     return ret
 
 
-def _fedora_bootstrap(name, **kwargs):
+def _bootstrap_fedora(name, **kwargs):
     '''
     Bootstrap a Fedora container
     '''
-    dst = os.path.join(_root(), name)
+    dst = _make_container_root(name)
     if not kwargs.get('version', False):
         if __grains__['os'].lower() == 'fedora':
             version = __grains__['osrelease']
@@ -106,35 +161,84 @@ def _fedora_bootstrap(name, **kwargs):
             version = '21'
     else:
         version = '21'
-    if os.path.exists(dst):
-        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
-        return {'err': 'Container {0} already exists'.format(name)}
-    cmd = 'yum -y --releasever={0} --nogpg --installroot={1} --disablerepo="*" --enablerepo=fedora install systemd passwd yum fedora-release vim-minimal'.format(version, dst)
-    os.makedirs(dst)
+    cmd = ('yum -y --releasever={0} --nogpg --installroot={1} '
+           '--disablerepo="*" --enablerepo=fedora install systemd passwd yum '
+           'fedora-release vim-minimal'.format(version, dst))
     ret = __salt__['cmd.run_all'](cmd, python_shell=False)
     if ret['retcode'] != 0:
-        __context__['retcode'] = salt.defaults.exitcodes.SALT_BUILD_FAIL
-        shutil.rmtree(dst)
-        return {'err': 'Container {0} failed to build'.format(name)}
+        _build_failed(dst, name)
     return ret
+
+
+def _clear_context():
+    '''
+    Clear any lxc variables set in __context__
+    '''
+    for var in [x for x in __context__ if x.startswith('nspawn.')]:
+        log.trace('Clearing __context__[\'{0}\']'.format(var))
+        __context__.pop(var, None)
+
+
+def _ensure_running(name):
+    '''
+    Raise an exception if the container does not exist
+    '''
+    if state(name) != 'running':
+        raise CommandExecutionError(
+            'Container \'{0}\' is stopped'.format(name)
+        )
 
 
 def _ensure_exists(name):
     '''
     Raise an exception if the container does not exist
     '''
-    if not exists(name):
+    contextkey = 'nspawn.exists.{0}'.format(name)
+    if contextkey in __context__:
+        # No need to return a value, this function is only here to raise an
+        # exception if the container doesn't exist, and just dropping a key
+        # into __context__ and returning early here will keep us from checking
+        # if the container exists multiple times.
+        return
+    if exists(name):
+        __context__[contextkey] = True
+    else:
         raise CommandExecutionError(
             'Container \'{0}\' does not exist'.format(name)
         )
 
 
-def _machinectl(cmd):
+def _ensure_systemd(version):
     '''
-    Interface to run machinectl with no header/footer and without a pager
+    Raises an exception if the systemd version is not greater than the
+    passed version.
+    '''
+    try:
+        version = int(version)
+    except ValueError:
+        raise CommandExecutionError('Invalid version \'{0}\''.format(version))
+
+    try:
+        installed = _sd_version()
+        log.debug('nspawn: detected systemd {0}'.format(installed))
+    except (IndexError, ValueError):
+        raise CommandExecutionError('nspawn: Unable to get systemd version')
+
+    if installed < version:
+        raise CommandExecutionError(
+            'This function requires systemd >= {0} '
+            '(Detected version: {1}).'.format(version, installed)
+        )
+
+
+def _machinectl(cmd, output_loglevel='debug', use_vt=False):
+    '''
+    Helper function to run machinectl
     '''
     prefix = 'machinectl --no-legend --no-pager'
-    return __salt__['cmd.run_all']('{0} {1}'.format(prefix, cmd))
+    return __salt__['cmd.run_all']('{0} {1}'.format(prefix, cmd),
+                                   output_loglevel=output_loglevel,
+                                   use_vt=use_vt)
 
 
 def _pid(name):
@@ -142,10 +246,10 @@ def _pid(name):
     Return container pid
     '''
     try:
-        return info(name).get('Leader', '').split()[0]
-    except IndexError:
+        return int(info(name).get('PID'))
+    except (TypeError, ValueError) as exc:
         raise CommandExecutionError(
-            'Unable to get PID for container \'{0}\''.format(name)
+            'Unable to get PID for container \'{0}\': {1}'.format(name, exc)
         )
 
 
@@ -179,7 +283,7 @@ def _run(name,
         full_cmd += ' env -i'
     if keep_env is None:
         full_cmd += ' {0}'.format(PATH)
-    elif isinstance(keep_env, string_types):
+    elif isinstance(keep_env, six.string_types):
         for var in keep_env.split(','):
             if var in os.environ:
                 full_cmd += ' {0}="{1}"'.format(var, os.environ[var])
@@ -212,6 +316,17 @@ def _run(name,
         return ret
     else:
         return ret[output]
+
+
+def _invalid_kwargs(*args, **kwargs):
+    '''
+    Raise an exception on bad kwarg input
+    '''
+    raise SaltInvocationError(
+        'The following invalid keyword arguments were passed: {0}'
+        .format(', '.join(['{0}={1}'.format(x, kwargs[x])
+                            for x in args]))
+    )
 
 
 def run(name,
@@ -537,7 +652,7 @@ def bootstrap_container(name, dist=None, version=None):
 
     CLI Example::
 
-        salt '*' nspawn.bootstrap_container <name>
+        salt myminion nspawn.bootstrap_container <name>
     '''
     if not dist:
         dist = __grains__['os'].lower()
@@ -545,7 +660,7 @@ def bootstrap_container(name, dist=None, version=None):
             'nspawn.bootstrap: no dist provided, defaulting to \'{0}\''
             .format(dist)
         )
-    return globals()['_{0}_bootstrap'.format(dist)](name, version=version)
+    return globals()['_bootstrap_{0}'.format(dist)](name, version=version)
 
 
 def list_all():
@@ -556,13 +671,24 @@ def list_all():
 
     .. code-block:: bash
 
-        salt '*' nspawn.list_all
+        salt myminion nspawn.list_all
     '''
-    rootdir = _root()
-    return sorted(
-        [x for x in os.listdir(rootdir)
-         if os.path.isdir(os.path.join(rootdir, x))]
-    )
+    ret = []
+    if _sd_version() >= 219:
+        for line in _machinectl('list-images')['stdout'].splitlines():
+            try:
+                ret.append(line.split()[0])
+            except IndexError:
+                continue
+    else:
+        rootdir = _root()
+        try:
+            for dirname in os.listdir(rootdir):
+                if os.path.isdir(os.path.join(rootdir, dirname)):
+                    ret.append(dirname)
+        except OSError:
+            pass
+    return ret
 
 
 def list_running():
@@ -577,8 +703,8 @@ def list_running():
 
     .. code-block:: bash
 
-        salt '*' nspawn.list_running
-        salt '*' nspawn.list
+        salt myminion nspawn.list_running
+        salt myminion nspawn.list
     '''
     ret = []
     for line in _machinectl('list')['stdout'].splitlines():
@@ -601,7 +727,7 @@ def list_stopped():
 
     .. code-block:: bash
 
-        salt '*' nspawn.list_stopped
+        salt myminion nspawn.list_stopped
     '''
     return sorted(set(list_all()) - set(list_running()))
 
@@ -613,11 +739,7 @@ def exists(name):
     return name in list_all()
 
 
-def state(name):
-    '''
-    Return state of container
-    '''
-    _ensure_exists(name)
+def _get_state(name):
     try:
         cmd = 'show {0} --property=State'.format(name)
         return _machinectl(cmd)['stdout'].split('=')[1]
@@ -625,7 +747,15 @@ def state(name):
         return 'stopped'
 
 
-def info(name, force_start=True):
+def state(name):
+    '''
+    Return state of container
+    '''
+    _ensure_exists(name)
+    return _get_state(name)
+
+
+def info(name, **kwargs):
     '''
     Return info about a container
 
@@ -635,36 +765,43 @@ def info(name, force_start=True):
         about it. If the container is stopped, then this function will start
         it.
 
-    force_start : True
-
-        If ``False``, then this function will result in an error if the
-        container is not already running.
+    start : False
+        If ``True``, then the container will be started to retrieve the info. A
+        ``Started`` key will be in the return data if the container was
+        started.
 
     CLI Example:
 
     .. code-block:: bash
 
-        salt '*' nspawn.info arch1
-        salt '*' nspawn.info arch1 force_start=False
+        salt myminion nspawn.info arch1
+        salt myminion nspawn.info arch1 force_start=False
     '''
-    _ensure_exists(name)
-    running_containers = list_running()
-    needs_stop = False
-    if name not in running_containers:
-        if start:
-            start(name)
-            needs_stop = True
-        else:
-            raise CommandExecutionError(
-                'Container \'{0}\' is not running'.format(name)
-            )
+    # Use kwargs to
+    start_ = kwargs.pop('start', False)
+    bad_kwargs = [x for x in kwargs if not x.startswith('__')]
+    if bad_kwargs:
+        _invalid_kwargs(*bad_kwargs, **kwargs)
+
+    if not start_:
+        _ensure_running(name)
+    elif name not in list_running():
+        start(name)
+
     # Have to parse 'machinectl status' here since 'machinectl show' doesn't
-    # contain IP address info. *shakes fist angrily*
+    # contain IP address info or OS info. *shakes fist angrily*
     c_info = _machinectl('status {0}'.format(name))
     if c_info['retcode'] != 0:
         raise CommandExecutionError(
             'Unable to get info for container \'{0}\''.format(name)
         )
+    # Better human-readable names. False means key should be ignored.
+    key_name_map = {
+        'Iface': 'Network Interface',
+        'Leader': 'PID',
+        'Service': False,
+        'Since': 'Running Since',
+    }
     ret = {}
     kv_pair = re.compile(r'^\s+([A-Za-z]+): (.+)$')
     tree = re.compile(r'[|`]')
@@ -675,6 +812,15 @@ def info(name, force_start=True):
         match = kv_pair.match(lines[idx])
         if match:
             key, val = match.groups()
+            # Get a better key name if one exists
+            key = key_name_map.get(key, key)
+            if key is False:
+                continue
+            elif key == 'PID':
+                try:
+                    val = val.split()[0]
+                except IndexError:
+                    pass
             cur_key = key
             if multiline:
                 multiline = False
@@ -701,7 +847,7 @@ def enable(name):
 
     .. code-block:: bash
 
-        salt '*' nspawn.enable <name>
+        salt myminion nspawn.enable <name>
     '''
     _ensure_exists(name)
     cmd = 'systemctl enable systemd-nspawn@{0}'.format(name)
@@ -719,7 +865,7 @@ def disable(name):
 
     .. code-block:: bash
 
-        salt '*' nspawn.enable <name>
+        salt myminion nspawn.enable <name>
     '''
     _ensure_exists(name)
     cmd = 'systemctl disable systemd-nspawn@{0}'.format(name)
@@ -735,29 +881,310 @@ def start(name):
 
     CLI Example::
 
-        salt '*' nspawn.start <name>
+        salt myminion nspawn.start <name>
     '''
     _ensure_exists(name)
-    cmd = 'systemctl start systemd-nspawn@{0}'.format(name)
-    ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if _sd_version() >= 219:
+        ret = _machinectl('start {0}'.format(name))
+    else:
+        cmd = 'systemctl start systemd-nspawn@{0}'.format(name)
+        ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+
     if ret['retcode'] != 0:
         __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
         return False
     return True
 
 
-def stop(name):
+# This function is hidden from sphinx docs
+def stop(name, kill=False):
     '''
-    Start the named container
-
-    CLI Example::
-
-        salt '*' nspawn.stop <name>
+    This is a compatibility function which provides the logic for
+    nspawn.poweroff and nspawn.terminate.
     '''
     _ensure_exists(name)
-    cmd = 'systemctl stop systemd-nspawn@{0}'.format(name)
-    ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if _sd_version() >= 219:
+        if kill:
+            action = 'terminate'
+        else:
+            action = 'poweroff'
+        ret = _machinectl('{0} {1}'.format(action, name))
+    else:
+        cmd = 'systemctl stop systemd-nspawn@{0}'.format(name)
+        ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+
     if ret['retcode'] != 0:
         __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
         return False
     return True
+
+
+def poweroff(name):
+    '''
+    Issue a clean shutdown to the container.  Equivalent to running
+    ``machinectl poweroff`` on the named container.
+
+    For convenience, running ``nspawn.stop``(as shown in the CLI examples
+    below) is equivalent to running ``nspawn.poweroff``.
+
+    .. note::
+
+        ``machinectl poweroff`` is only supported in systemd >= 219. On earlier
+        systemd versions, running this function will simply issue a clean
+        shutdown via ``systemctl``.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.poweroff arch1
+        salt myminion nspawn.stop arch1
+    '''
+    return stop(name, kill=False)
+
+
+def terminate(name):
+    '''
+    Kill all processes in the container without issuing a clean shutdown.
+    Equivalent to running ``machinectl terminate`` on the named container.
+
+    For convenience, running ``nspawn.stop`` and passing ``kill=True`` (as
+    shown in the CLI examples below) is equivalent to running
+    ``nspawn.terminate``.
+
+    .. note::
+
+        ``machinectl terminate`` is only supported in systemd >= 219. On
+        earlier systemd versions, running this function will simply issue a
+        clean shutdown via ``systemctl``.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.terminate arch1
+        salt myminion nspawn.stop arch1 kill=True
+    '''
+    return stop(name, kill=True)
+
+
+# This function is hidden from sphinx docs
+def restart(name):
+    '''
+    This is a compatibility function which simply calls nspawn.reboot.
+    '''
+    return reboot(name)
+
+
+def reboot(name, kill=False):
+    '''
+    Reboot the container by sending a SIGINT to its init process. Equivalent
+    to running ``machinectl reboot`` on the named container.
+
+    For convenience, running ``nspawn.restart`` (as shown in the CLI examples
+    below) is equivalent to running ``nspawn.reboot``.
+
+    .. note::
+
+        ``machinectl reboot`` is only supported in systemd >= 219. On earlier
+        systemd versions, running this function will instead restart the
+        container via ``systemctl``.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.reboot arch1
+        salt myminion nspawn.restart arch1
+    '''
+    _ensure_exists(name)
+    if _sd_version() >= 219:
+        if state(name) == 'running':
+            ret = _machinectl('reboot {0}'.format(name))
+        else:
+            # 'machinectl reboot' will fail on a stopped container
+            return start(name)
+    else:
+        # 'systemctl restart' did not work, at least in my testing. Running
+        # 'uptime' in the container afterwards showed it had not rebooted. So,
+        # we need stop and start the container in separate actions.
+
+        # First stop the container
+        cmd = 'systemctl stop systemd-nspawn@{0}'.format(name)
+        ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+        # Now check if successful
+        if ret['retcode'] != 0:
+            __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
+            return False
+        # Finally, start the container back up. No need to check the retcode a
+        # second time, it'll be checked below once we exit the if/else block.
+        cmd = 'systemctl start systemd-nspawn@{0}'.format(name)
+        ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+
+    if ret['retcode'] != 0:
+        __context__['retcode'] = salt.defaults.exitcodes.EX_UNAVAILABLE
+        return False
+    return True
+
+
+# Everything below requres systemd >= 219
+# TODO: Write a decorator to keep these functions from being available to older
+#       systemd versions.
+def _pull_image(pull_type, image, name, **kwargs):
+    '''
+    Common logic for machinectl pull-* commands
+    '''
+    _ensure_systemd(219)
+    if exists(name):
+        raise SaltInvocationError(
+            'Container \'{0}\' already exists'.format(name)
+        )
+    if pull_type in ('raw', 'tar'):
+        valid_kwargs = ('verify',)
+    elif pull_type == 'dkr':
+        valid_kwargs = 'index'
+    else:
+        raise SaltInvocationError(
+            'Unsupported image type \'{0}\''.format(pull_type)
+        )
+
+    bad_kwargs = [x for x in kwargs
+                  if not x.startswith('__')
+                  or x not in valid_kwargs]
+
+    if bad_kwargs:
+        _invalid_kwargs(*bad_kwargs, **kwargs)
+
+    pull_opts = []
+
+    if pull_type in ('raw', 'tar'):
+        verify = kwargs.get('verify', False)
+        if not verify:
+            pull_opts.append('--verify=no')
+        else:
+            def _bad_verify():
+                raise SaltInvocationEror(
+                    '\'verify\' must be one of the following: '
+                    'signature, checksum'
+                )
+            try:
+                verify = verify.lower()
+            except AttributeError:
+                _bad_verify()
+            else:
+                if verify not in ('signature', 'checksum'):
+                    _bad_verify()
+                pull_opts.append('--verify={0}'.format(verify))
+
+    elif pull_type == 'dkr':
+        # No need to validate the index URL, machinectl will take care of this
+        # for us.
+        if 'index' in kwargs:
+            pull_opts.append('--dkr-index-url={0}'.format(kwargs['index']))
+
+    cmd = 'pull-{0} {1} {2} {3}'.format(
+        pull_type, ' '.join(pull_opts), image, name
+    )
+    result = _machinectl(cmd, use_vt=True)
+    if result['retcode'] != 0:
+        msg = 'Error occurred pulling image. Stderr from the pull command ' \
+              '(if any) follows: '
+        if result['stderr']:
+            msg += '\n\n{0}'.format(result['stderr'])
+        raise CommandExecutionError(msg)
+    return True
+
+
+def pull_raw(url, name, verify=False):
+    '''
+    Execute a ``machinectl pull-raw`` to download a .qcow2 or raw disk image,
+    and add it to /var/lib/machines as a new container.
+
+    .. note::
+
+        **Requires systemd >= 219**
+
+    url
+        URL from which to download the container
+
+    name
+        Name for the new container
+
+    verify : False
+        Perform signature or checksum verification on the container. See the
+        ``machinectl(1)`` man page (section titled "Image Transfer Commands")
+        for more information on requirements for image verification. To perform
+        signature verification, use ``verify=signature``. For checksum
+        verification, use ``verify=checksum``. By default, no verification will
+        be performed.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.pull_raw http://ftp.halifax.rwth-aachen.de/fedora/linux/releases/21/Cloud/Images/x86_64/Fedora-Cloud-Base-20141203-21.x86_64.raw.xz fedora21
+    '''
+    return _pull_image('raw', url, name, verify)
+
+
+def pull_tar(url, name, verify=False):
+    '''
+    Execute a ``machinectl pull-raw`` to download a .tar container image,
+    and add it to /var/lib/machines as a new container.
+
+    .. note::
+
+        **Requires systemd >= 219**
+
+    url
+        URL from which to download the container
+
+    name
+        Name for the new container
+
+    verify : False
+        Perform signature or checksum verification on the container. See the
+        ``machinectl(1)`` man page (section titled "Image Transfer Commands")
+        for more information on requirements for image verification. To perform
+        signature verification, use ``verify=signature``. For checksum
+        verification, use ``verify=checksum``. By default, no verification will
+        be performed.
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.pull_tar http://foo.domain.tld/containers/archlinux-2015.02.01.tar.gz arch2
+    '''
+    return _pull_image('tar', url, name, verify)
+
+
+def pull_dkr(url, name, index=False):
+    '''
+    Execute a ``machinectl pull-dkr`` to download a docker image and add it to
+    /var/lib/machines as a new container.
+
+    .. note::
+
+        **Requires systemd >= 219**
+
+    url
+        URL from which to download the container
+
+    name
+        Name for the new container
+
+    index : None
+        URL of the Docker index server from which to pull (must be an
+        ``http://`` or ``https://`` URL).
+
+    CLI Examples:
+
+    .. code-block:: bash
+
+        salt myminion nspawn.pull_dkr
+        salt myminion nspawn.pull_docker
+    '''
+    return _pull_image('dkr', url, name, verify)
+
+pull_docker = pull_dkr

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -1228,7 +1228,7 @@ def pull_tar(url, name, verify=False):
     return _pull_image('tar', url, name, verify=verify)
 
 
-def pull_dkr(url, name, index=False):
+def pull_dkr(url, name, index):
     '''
     Execute a ``machinectl pull-dkr`` to download a docker image and add it to
     /var/lib/machines as a new container.
@@ -1243,7 +1243,7 @@ def pull_dkr(url, name, index=False):
     name
         Name for the new container
 
-    index : None
+    index
         URL of the Docker index server from which to pull (must be an
         ``http://`` or ``https://`` URL).
 
@@ -1251,8 +1251,8 @@ def pull_dkr(url, name, index=False):
 
     .. code-block:: bash
 
-        salt myminion nspawn.pull_dkr
-        salt myminion nspawn.pull_docker
+        salt myminion nspawn.pull_dkr centos/centos6 cent6 index=https://get.docker.com
+        salt myminion nspawn.pull_docker centos/centos6 cent6 index=https://get.docker.com
     '''
     return _pull_image('dkr', url, name, index=index)
 

--- a/salt/modules/nspawn.py
+++ b/salt/modules/nspawn.py
@@ -138,3 +138,19 @@ def start(name):
         __context__['retcode'] = salt.defaults.exitcode.EX_UNAVAILABLE
         return False
     return True
+
+
+def stop(name):
+    '''
+    Start the named container
+
+    CLI Example::
+
+        salt '*' nspawn.stop <name>
+    '''
+    cmd = 'systemctl stop systemd-nspawn@{0}'.format(name)
+    ret = __salt__['cmd.run_all'](cmd, python_shell=False)
+    if ret['retcode'] != 0:
+        __context__['retcode'] = salt.defaults.exitcode.EX_UNAVAILABLE
+        return False
+    return True

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -5,6 +5,7 @@ Contains systemd related help files
 # import python libs
 from __future__ import absolute_import
 import os
+import subprocess
 
 
 def booted(context):
@@ -14,7 +15,7 @@ def booted(context):
     systemd.sd_booted key to represent if systemd is running
     '''
     # We can cache this for as long as the minion runs.
-    if "systemd.sd_booted" not in context:
+    if 'systemd.sd_booted' not in context:
         try:
             # This check does the same as sd_booted() from libsystemd-daemon:
             # http://www.freedesktop.org/software/systemd/man/sd_booted.html
@@ -22,5 +23,34 @@ def booted(context):
                 context['systemd.sd_booted'] = True
         except OSError:
             context['systemd.sd_booted'] = False
-
     return context['systemd.sd_booted']
+
+
+def version(context=None):
+    '''
+    Attempts to run systemctl --version. Returns None if unable to determine
+    version.
+    '''
+    if isinstance(context, dict):
+        if 'systemd.version' in context:
+            return context['systemd.version']
+    elif context is not None:
+        raise SaltInvocationError('context must be a dictionary or None')
+    stdout = subprocess.Popen(
+        ['systemctl', '--version'],
+        close_fds=True,
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT).communicate()[0]
+    try:
+        ret = int(stdout.splitlines()[0].split()[-1])
+    except (IndexError, ValueError):
+        log.error(
+            'Unable to determine systemd version from systemctl '
+            '--version, output follows:\n{0}'.format(stdout)
+        )
+        return None
+    else:
+        try:
+            context['systemd.version'] = ret
+        except TypeError:
+            pass
+        return ret

--- a/salt/utils/systemd.py
+++ b/salt/utils/systemd.py
@@ -4,8 +4,14 @@ Contains systemd related help files
 '''
 # import python libs
 from __future__ import absolute_import
+import logging
 import os
 import subprocess
+
+# Import Salt libs
+from salt.exceptions import SaltInvocationError
+
+log = logging.getLogger(__name__)
 
 
 def booted(context):

--- a/tests/integration/modules/sysmod.py
+++ b/tests/integration/modules/sysmod.py
@@ -69,6 +69,8 @@ class SysModuleTest(integration.ModuleCase):
                 'yumpkg.expand_repo_def',
                 'yumpkg5.expand_repo_def',
                 'container_resource.run',
+                'nspawn.stop',
+                'nspawn.restart',
         )
 
         for fun in docs:


### PR DESCRIPTION
So far I have added a couple additional functions to manage and get the
container state, as well as a set of functions to run commands within
containers, and interfaces to `machinectl pull-*`.

**Still to add (in a future PR):**
- Function to run salt-bootstrap in a container
- Function to clone a container.
- Functions for `machinectl copy-to` and `machinectl copy-from`
