### PR TITLE
Don't use print statement without parenthesis (py3 compat)

### DIFF
--- a/tests/integration/modules/publish.py
+++ b/tests/integration/modules/publish.py
@@ -38,7 +38,7 @@ class PublishModuleTest(integration.ModuleCase,
         )
         for name in check_true:
             if name not in ret:
-                print name
+                print(name)
             self.assertTrue(name in ret)
 
         self.assertEqual(ret['cheese'], 'spam')


### PR DESCRIPTION
This backports a lint fix from #21158 into the tests for 2015.2.
