### PR TITLE
Add `fun` and `state` to the runtime internal keywords listing

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -64,6 +64,8 @@ STATE_REQUISITE_IN_KEYWORDS = frozenset([
     'listen_in',
     ])
 STATE_RUNTIME_KEYWORDS = frozenset([
+    'fun',
+    'state',
     'check_cmd',
     'fail_hard',
     'onlyif',


### PR DESCRIPTION
Fixes #21120
Refs #21133
Refs https://github.com/saltstack/salt/issues/18806#issuecomment-76532356
