### PR TITLE
Avoid TypeError if Tornado is not installed

### DIFF
--- a/salt/netapi/rest_tornado/__init__.py
+++ b/salt/netapi/rest_tornado/__init__.py
@@ -21,7 +21,7 @@ try:
         has_tornado = True
     else:
         logger.error('rest_tornado requires at least tornado {0}'.format(min_tornado_version))
-except ImportError as err:
+except (ImportError, TypeError) as err:
     has_tornado = False
     logger.error('ImportError! {0}'.format(str(err)))
 


### PR DESCRIPTION
``` python
Traceback (most recent call last):
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/cmdline.py", line 245, in main
     opts.warningiserror, opts.tags, opts.verbosity, opts.jobs)
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/application.py", line 181, in __init__
     self._init_builder(buildername)
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/application.py", line 243, in _init_builder
     self.emit('builder-inited')
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/application.py", line 504, in emit
     results.append(callback(self, *args))
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/__init__.py", line 551, in process_generate_options
     base_path=app.srcdir)
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/generate.py", line 111, in generate_autosummary_docs
     items = find_autosummary_in_files(sources)
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/generate.py", line 226, in find_autosummary_in_files
     documented.extend(find_autosummary_in_lines(lines, filename=filename))
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/generate.py", line 323, in find_autosummary_in_lines
     current_module, filename=filename))
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/generate.py", line 236, in find_autosummary_in_docstring
     real_name, obj, parent, modname = import_by_name(name)
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/__init__.py", line 460, in import_by_name
     obj, parent, modname = _import_by_name(prefixed_name)
   File "/Users/shouse/tmp/venvs/sphinx/lib/python2.7/site-packages/sphinx/ext/autosummary/__init__.py", line 475, in _import_by_name
     __import__(modname)
   File "/Users/shouse/src/salt/salt/salt/netapi/rest_tornado/__init__.py", line 19, in <module>
     if distutils.version.StrictVersion(tornado.version) >= \
   File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/version.py", line 40, in __init__
     self.parse(vstring)
   File "/usr/local/Cellar/python/2.7.9/Frameworks/Python.framework/Versions/2.7/lib/python2.7/distutils/version.py", line 105, in parse
     match = self.version_re.match(vstring)
 TypeError: expected string or buffer
```
