### PR TITLE
convert datetime objects to strings

### DIFF
--- a/salt/modules/twilio_notify.py
+++ b/salt/modules/twilio_notify.py
@@ -82,7 +82,7 @@ def send_sms(profile, body, to, from_):
     ret['message']['status'] = message.status
     ret['message']['num_segments'] = message.num_segments
     ret['message']['body'] = message.body
-    ret['message']['date_sent'] = message.date_sent
-    ret['message']['date_created'] = message.date_created
+    ret['message']['date_sent'] = str(message.date_sent)
+    ret['message']['date_created'] = str(message.date_created)
     log.info(ret)
     return ret


### PR DESCRIPTION
so msgpack doesn't blow up
