### PR TITLE
Added function create rds read replica

### DIFF
--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -273,13 +273,12 @@ def create_read_replica(name, source_name, db_instance_class=None, port=None,
                                                            option_group_name,
                                                            publicly_accessible,
                                                            tags)
-        if rds_replica:
-            log.info('Created replica {0} from {1}'.format(name, source_name))
-            return True
         if not rds_replica:
             msg = 'Failed to create RDS replica {0}'.format(name)
             log.error(msg)
             return False
+        log.info('Created replica {0} from {1}'.format(name, source_name))
+        return True
     except boto.exception.BotoServerError as e:
         log.debug(e)
         msg = 'Failed to create RDS replica {0}'.format(name)

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -245,6 +245,48 @@ def create(name, allocated_storage, db_instance_class, engine,
         return False
 
 
+def create_read_replica(name, source_name, db_instance_class=None, port=None,
+                        availability_zone=None, auto_minor_version_upgrade=None,
+                        option_group_name=None, publicly_accessible = None,
+                        tags = None,
+                        region=None, key=None, keyid=None, profile=None):
+    '''
+    Create an RDS read replica
+
+    CLI example to create an RDS  read replica::
+
+        salt myminion boto_rds.create_read_replica replicaname source_name
+    '''
+    conn = _get_conn(region, key, keyid, profile)
+    if not conn:
+        return False
+    if not __salt__['boto_rds.exists'](source_name, region, key, keyid, profile):
+        return False
+    if __salt__['boto_rds.exists'](name, region, key, keyid, profile):
+        return True
+    try:
+        rds_replica = conn.create_db_instance_read_replica(name, source_name,
+                                                           db_instance_class,
+                                                           availability_zone,
+                                                           port,
+                                                           auto_minor_version_upgrade,
+                                                           option_group_name,
+                                                           publicly_accessible,
+                                                           tags)
+        if rds_replica:
+            log.info('Created replica {0} from {1}'.format(name, source_name))
+            return True
+        else:
+            'Failed to create RDS replica {0}'.format(name)
+            log.error(msg)
+            return False
+    except boto.exception.BotoServerError as e:
+        log.debug(e)
+        msg = 'Failed to create RDS replica {0}'.format(name)
+        log.error(msg)
+        return False
+
+
 def create_option_group(name, engine_name, major_engine_version,
                         option_group_description, tags=None, region=None,
                         key=None, keyid=None, profile=None):

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -273,10 +273,10 @@ def create_read_replica(name, source_name, db_instance_class=None, port=None,
                                                            option_group_name,
                                                            publicly_accessible,
                                                            tags)
-        if not rds_replica:
+        if rds_replica:
             log.info('Created replica {0} from {1}'.format(name, source_name))
             return True
-        else:
+        if not rds_replica:
             msg = 'Failed to create RDS replica {0}'.format(name)
             log.error(msg)
             return False

--- a/salt/modules/boto_rds.py
+++ b/salt/modules/boto_rds.py
@@ -247,8 +247,8 @@ def create(name, allocated_storage, db_instance_class, engine,
 
 def create_read_replica(name, source_name, db_instance_class=None, port=None,
                         availability_zone=None, auto_minor_version_upgrade=None,
-                        option_group_name=None, publicly_accessible = None,
-                        tags = None,
+                        option_group_name=None, publicly_accessible=None,
+                        tags=None,
                         region=None, key=None, keyid=None, profile=None):
     '''
     Create an RDS read replica
@@ -273,11 +273,11 @@ def create_read_replica(name, source_name, db_instance_class=None, port=None,
                                                            option_group_name,
                                                            publicly_accessible,
                                                            tags)
-        if rds_replica:
+        if not rds_replica:
             log.info('Created replica {0} from {1}'.format(name, source_name))
             return True
         else:
-            'Failed to create RDS replica {0}'.format(name)
+            msg = 'Failed to create RDS replica {0}'.format(name)
             log.error(msg)
             return False
     except boto.exception.BotoServerError as e:

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -263,7 +263,6 @@ def create_replica(name, source, db_instance_class=None, port=None,
                    profile=None):
     '''
     Create RDS replica
-    
     .. code-block:: yaml
 
     Ensure myrds replica RDS exists:

--- a/salt/states/boto_rds.py
+++ b/salt/states/boto_rds.py
@@ -254,6 +254,57 @@ def _rds_present(name, allocated_storage, db_instance_class, engine,
     return ret
 
 
+def create_replica(name, source, db_instance_class=None, port=None,
+                   availability_zone=None,
+                   auto_minor_version_upgrade=None,
+                   option_group_name=None,
+                   publicly_accessible=None,
+                   tags=None, region=None, key=None, keyid=None,
+                   profile=None):
+    '''
+    Create RDS replica
+    
+    .. code-block:: yaml
+
+    Ensure myrds replica RDS exists:
+        boto_rds.create_replica:
+            - name: myreplica
+            - source: mydb
+    '''
+    ret = {'name': name,
+           'result': None,
+           'comment': '',
+           'changes': {}
+           }
+    source_exists = __salt__['boto_rds.exists'](source, region, key, keyid, profile)
+    if not source_exists:
+        ret['result'] = False
+        ret['comment'] = 'RDS source {0} does not exist.'.format(source)
+    replica_exists = __salt__['boto_rds.exists'](name, region, key, keyid, profile)
+    if not replica_exists:
+        created = __salt__['boto_rds.create_read_replica'](name, source,
+                                                           availability_zone,
+                                                           auto_minor_version_upgrade,
+                                                           option_group_name,
+                                                           publicly_accessible,
+                                                           tags, region, key,
+                                                           profile)
+        if created:
+            config = __salt__['boto_rds.describe'](name, tags=None, region=None,
+                                                  key=None, keyid=None,
+                                                  profile=None)
+            ret['result'] = True
+            ret['comment'] = 'RDS replica {0} created.'.format(name)
+            ret['changes']['old'] = None
+            ret['changes']['new'] = config
+        else:
+            ret['result'] = False
+            ret['comment'] = 'Failed to create RDS replica {0}.'.format(name)
+    ret['result'] = True
+    ret['comment'] = 'RDS replica {0} exists.'.format(name)
+    return ret
+
+
 def absent(name, skip_final_snapshot=None, final_db_snapshot_identifier=None,
            tags=None, region=None, key=None, keyid=None, profile=None):
     ret = {'name': name,


### PR DESCRIPTION
Create an RDS read replica module

CLI example to create an RDS  read replica::

```
salt myminion boto_rds.create_read_replica replicaname source_name
```

Create an RDS read replica state 

```
Ensure myrds replica RDS exists:
  boto_rds.create_replica:
    - name: myreplica
    - source: mydb
```
