### PR TITLE
Add return code for status=2, hard-quote password

### DIFF
--- a/salt/modules/win_system.py
+++ b/salt/modules/win_system.py
@@ -294,12 +294,12 @@ def join_domain(
         join_options = 1
     cmd = ('wmic /interactive:off ComputerSystem Where '
            'name="%computername%" call JoinDomainOrWorkgroup FJoinOptions={0} '
-           'Name={1} UserName={2} Password={3}'
+           'Name={1} UserName={2} Password="{3}"'
            ).format(
                join_options,
                _cmd_quote(domain),
                _cmd_quote(username),
-               _cmd_quote(password))
+               password)
     if account_ou:
         # contrary to RFC#2253, 2.1, 'wmic' requires a ; as a RDN separator
         # for the DN
@@ -311,6 +311,7 @@ def join_domain(
     if 'ReturnValue = 0;' in ret:
         return {'Domain': domain}
     return_values = {
+        2:    'Invalid OU or specifying OU is not supported',
         5:    'Access is denied',
         87:   'The parameter is incorrect',
         110:  'The system cannot open the specified object',


### PR DESCRIPTION
At least on my Windows 2012 R2 systems, the quoting is not working correctly.  The command run includes \' around the password, which results in a bad user/password error.  Changing it to hard quoting with " appears to work, at least for my password.  This is not "correct," as the password could contain a ", which would cause this hard-quoting to fail.  I'm open to suggestions on how to do this better, but for now this works for me.

There is also an undocumented return code of 2, which Google find some references that appear to indicate this means an invalid OU specified, or specifying the OU is not supported.  I added an error message for this also.
