### PR TITLE
IPV4 mode should accept all modes

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -420,7 +420,7 @@ IPV4_ATTR_MAP = {
     'server':  __ipv4_quad,
     'hwaddr':  __mac,
     # tunnel
-    'mode':  __within(['gre', 'GRE', 'ipip', 'IPIP'], dtype=str),
+    'mode':  __anything,
     'endpoint':  __ipv4_quad,
     'dstaddr':  __ipv4_quad,
     'local':  __ipv4_quad,


### PR DESCRIPTION
The debian_ip module should not limit the types of modes to just the 4 listed previously.  With the way it was set up previously, modes like 802.3ad for bonding would not be accepted.
