### PR TITLE
Fix for Python without a signal.SIGKILL (Win32)

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -19,6 +19,12 @@ import sys
 import copy
 import threading
 
+# Fix a nasty bug with Win32 Python not supporting all of the standard signals
+try:
+    salt_SIGKILL = signal.SIGKILL
+except NameError:
+    salt_SIGKILL = signal.SIGTERM
+
 # Import salt libs
 import salt.payload
 import salt.state
@@ -579,7 +585,9 @@ def kill_job(jid):
 
         salt '*' saltutil.kill_job <job id>
     '''
-    return signal_job(jid, signal.SIGKILL)
+    # Some OS's (Win32) don't have SIGKILL, so use salt_SIGKILL which is set to
+    # an appropriate value for the operating system this is running on.
+    return signal_job(jid, salt_SIGKILL)
 
 
 def regen_keys():


### PR DESCRIPTION
I think this is correct, but I don't know how to make the Windows minion executable to test.  This may be able to be back-ported to an earlier version, but I figured 2014.1 is old enough.  Please forward patch all the way up through develop.  Please check functionality first, or I'd be happy to if someone can give me an updated minion exe to install, or give me simple instructions on how to build the Windows minion.

Referene issue #21057.

Thanks!
