### PR TITLE
fixes states.network bonding for debian

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1207,8 +1207,9 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     elif iface_type == 'bond':
         bonding = _parse_settings_bond(opts, iface)
         if bonding:
+            opts.pop('mode', None)
             iface_data['inet']['bonding'] = bonding
-            iface_data['inet']['bonding']['slaves'] = opts['slaves']
+            iface_data['inet']['bonding']['slaves'] =  " ".join([interface['network'] for interface in opts['slaves']])
             iface_data['inet']['bonding_keys'] = sorted(bonding)
 
     elif iface_type == 'slave':

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1210,7 +1210,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
         if bonding:
             opts.pop('mode', None)
             iface_data['inet']['bonding'] = bonding
-            iface_data['inet']['bonding']['slaves'] =  opts['slaves']
+            iface_data['inet']['bonding']['slaves'] = opts['slaves']
             iface_data['inet']['bonding_keys'] = sorted(bonding)
 
     elif iface_type == 'slave':

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1201,6 +1201,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
     if iface_type == 'bridge':
         bridging = _parse_bridge_opts(opts, iface)
         if bridging:
+            opts.pop('mode', None)
             iface_data['inet']['bridging'] = bridging
             iface_data['inet']['bridging_keys'] = sorted(bridging)
 

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -1210,7 +1210,7 @@ def _parse_settings_eth(opts, iface_type, enabled, iface):
         if bonding:
             opts.pop('mode', None)
             iface_data['inet']['bonding'] = bonding
-            iface_data['inet']['bonding']['slaves'] =  " ".join([interface['network'] for interface in opts['slaves']])
+            iface_data['inet']['bonding']['slaves'] =  opts['slaves']
             iface_data['inet']['bonding_keys'] = sorted(bonding)
 
     elif iface_type == 'slave':
@@ -1442,9 +1442,9 @@ def _write_file_ifaces(iface, data, **settings):
     for adapter in adapters:
         if 'type' in adapters[adapter] and adapters[adapter]['type'] == 'slave':
             # Override values so the interfaces file is correct
-            adapters[adapter]['enabled'] = False
             adapters[adapter]['data']['inet']['addrfam'] = 'inet'
             adapters[adapter]['data']['inet']['proto'] = 'manual'
+            adapters[adapter]['data']['inet']['master'] = adapters[adapter]['master']
 
         if 'type' in adapters[adapter] and adapters[adapter]['type'] == 'source':
             tmp = source_template.render({'name': adapter, 'data': adapters[adapter]})

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -91,11 +91,13 @@ all interfaces are ignored unless specified.
 
     eth2:
       network.managed:
+        - enabled: True
         - type: slave
         - master: bond0
 
     eth3:
       network.managed:
+        - enabled: True
         - type: slave
         - master: bond0
 
@@ -111,17 +113,14 @@ all interfaces are ignored unless specified.
         - type: bond
         - ipaddr: 10.1.0.1
         - netmask: 255.255.255.0
-        - mode: 802.3ad
-        - addrfam: inet
-        - proto: static # or "dhcp"
+        - mode: active-backup
+        - proto: static
         - dns:
           - 8.8.8.8
           - 8.8.4.4
         - ipv6:
         - enabled: False
-        - slaves:
-          - network: eth2
-          - network: eth3
+        - slaves: eth2 eth3
         - require:
           - network: eth2
           - network: eth3

--- a/salt/states/network.py
+++ b/salt/states/network.py
@@ -111,18 +111,20 @@ all interfaces are ignored unless specified.
         - type: bond
         - ipaddr: 10.1.0.1
         - netmask: 255.255.255.0
+        - mode: 802.3ad
+        - addrfam: inet
+        - proto: static # or "dhcp"
         - dns:
           - 8.8.8.8
           - 8.8.4.4
         - ipv6:
         - enabled: False
-        - use_in:
+        - slaves:
           - network: eth2
           - network: eth3
         - require:
           - network: eth2
           - network: eth3
-        - mode: 802.3ad
         - miimon: 100
         - arp_interval: 250
         - downdelay: 200

--- a/salt/templates/debian_ip/debian_eth.jinja
+++ b/salt/templates/debian_ip/debian_eth.jinja
@@ -30,6 +30,7 @@
 {%endif%}{% if interface.provider %}    provider {{interface.provider}}
 {%endif%}{% if interface.unit %}    unit {{interface.unit}}
 {%endif%}{% if interface.options %}    options {{interface.options}}
+{%endif%}{% if interface.master %}    bond_master {{interface.master}}
 {%endif%}{% if interface.dns_nameservers %}    dns-nameservers {%for item in interface.dns_nameservers %}{{item}} {%endfor%}
 {%endif%}{% if interface.dns_search %}    dns-search {% for item in interface.dns_search %}{{item}} {%endfor%}
 {%endif%}{% if interface.ethtool %}{%for item in interface.ethtool_keys %}    {{item}} {{interface.ethtool[item]}}


### PR DESCRIPTION
Currently the network state to create a bond on Debian is seriously broken!
Not only the example pillar in `salt/states/network.py` is invalid, even with a pillar made alongside looking into the code in `salt/modules/debian_ip.py` generates a broken `/etc/network/interfaces`.

My changes basically change the output of said state:

```
changes:
              ----------
              interface:
                  ---
                  +++
                  @@ -1,12 +1,11 @@
                   auto bond0

                   iface bond0 inet static

                  -    mode 802.3ad

                       bond_ad_select 0

                       bond_downdelay 200

                       bond_lacp_rate 0

                       bond_miimon 100

                       bond_mode 4

                  -    bond_slaves [OrderedDict([('network', 'eth2')]), OrderedDict([('network', 'eth3')])]

                  +    bond_slaves eth2 eth3

                       bond_updelay 0

                       bond_use_carrier on
```

Although my changes are made and tested on an Ubuntu 14.04, I assume they are not wrong for other related OS.
