### PR TITLE
Cleanup of virtual_err

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -105,7 +105,7 @@ class ZeroMQCaller(object):
             ret['jid']
         )
         if fun not in self.minion.functions:
-            sys.stderr.write('Function {0} is not available.'.format(fun))
+            sys.stderr.write(self.minion.functions.missing_fun_string(fun))
             mod_name = fun.split('.')[0]
             if mod_name in self.minion.function_errors:
                 sys.stderr.write(' Possible reasons: {0}\n'.format(self.minion.function_errors[mod_name]))

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -730,7 +730,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         # names of modules that we don't have (errors, __virtual__, etc.)
         self.missing_modules = {}  # mapping of name -> error
         self.loaded_modules = set()  # list of all modules that we have loaded
-        self.loaded_files = []  # TODO: just remove them from file_mapping?
+        self.loaded_files = set()  # TODO: just remove them from file_mapping?
 
         self.disabled = set(self.opts.get('disable_{0}s'.format(self.tag), []))
 
@@ -833,7 +833,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         Clear the dict
         '''
         super(LazyLoader, self).clear()  # clear the lazy loader
-        self.loaded_files = []
+        self.loaded_files = set()
         self.missing_modules = {}
         self.loaded_modules = set()
         # if we have been loaded before, lets clear the file mapping since
@@ -920,7 +920,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
     def _load_module(self, name):
         mod = None
         fpath, suffix = self.file_mapping[name]
-        self.loaded_files.append(name)
+        self.loaded_files.add(name)
         try:
             sys.path.append(os.path.dirname(fpath))
             if suffix == '.pyx':

--- a/salt/loader.py
+++ b/salt/loader.py
@@ -728,7 +728,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         self.initial_load = True
 
         # names of modules that we don't have (errors, __virtual__, etc.)
-        self.missing_modules = []
+        self.missing_modules = {}  # mapping of name -> error
         self.loaded_files = []  # TODO: just remove them from file_mapping?
 
         self.disabled = set(self.opts.get('disable_{0}s'.format(self.tag), []))
@@ -740,6 +740,20 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         _generate_module('{0}.int.{1}'.format(self.loaded_base_name, tag))
         _generate_module('{0}.ext'.format(self.loaded_base_name))
         _generate_module('{0}.ext.{1}'.format(self.loaded_base_name, tag))
+
+    def missing_fun_string(self, function_name):
+        '''
+        Return the error string for a missing function.
+
+        This can range from "not available' to "__virtual__" returned False
+        '''
+        mod_name = function_name.split('.')[0]
+        if self.missing_modules[mod_name] is not None:
+            return '{0!r}\' __virtual__ returned False: {1}'.format(mod_name, self.missing_modules[mod_name])
+        elif self.missing_modules[mod_name] is None:
+            return '{0!r}\' __virtual__ returned False'.format(mod_name)
+        else:
+            return '{0!r} is not available.'.format(function_name)
 
     def refresh_file_mapping(self):
         '''
@@ -816,7 +830,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
         '''
         super(LazyLoader, self).clear()  # clear the lazy loader
         self.loaded_files = []
-        self.missing_modules = []
+        self.missing_modules = {}
         # if we have been loaded before, lets clear the file mapping since
         # we obviously want a re-do
         if hasattr(self, 'opts'):
@@ -989,7 +1003,7 @@ class LazyLoader(salt.utils.lazy.LazyDict):
                 module_name,
             )
             if virtual_err is not None:
-                log.error('Error loading {0}.{1}: {2}'.format(self.tag,
+                log.debug('Error loading {0}.{1}: {2}'.format(self.tag,
                                                               module_name,
                                                               virtual_err,
                                                               ))
@@ -997,9 +1011,9 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             # if process_virtual returned a non-True value then we are
             # supposed to not process this module
             if virtual_ret is not True:
-                self.missing_modules.append(module_name)
-                self.missing_modules.append(name)
                 # If a module has information about why it could not be loaded, record it
+                self.missing_modules[module_name] = virtual_err
+                self.missing_modules[name] = virtual_err
                 return False
 
         # If this is a proxy minion then MOST modules cannot work. Therefore, require that
@@ -1009,8 +1023,9 @@ class LazyLoader(salt.utils.lazy.LazyDict):
             if not hasattr(mod, '__proxyenabled__') or \
                     self.opts['proxy']['proxytype'] in mod.__proxyenabled__ or \
                     '*' in mod.__proxyenabled__:
-                self.missing_modules.append(module_name)
-                self.missing_modules.append(name)
+                err_string = 'not a proxy_minion enabled module'
+                self.missing_modules[module_name] = err_string
+                self.missing_modules[name] = err_string
                 return False
 
         if getattr(mod, '__load__', False) is not False:

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -1176,7 +1176,7 @@ class Minion(MinionBase):
                 ret['return'] = '{0}: {1}'.format(msg, traceback.format_exc())
                 ret['out'] = 'nested'
         else:
-            ret['return'] = '{0!r} is not available.'.format(function_name)
+            ret['return'] = minion_instance.functions.missing_fun_string(function_name)
             mod_name = function_name.split('.')[0]
             if mod_name in minion_instance.function_errors:
                 ret['return'] += ' Possible reasons: {0!r}'.format(minion_instance.function_errors[mod_name])


### PR DESCRIPTION
Since now logging this, we've noticed its a bit noisy. To cut down on that I've changed the log level to debug. In addition, I changed the loader to keep a dict of mod -> error so that the caller (if so interested) can look up the error later. I switched caller and minion to use this new API. Now if you send a job to a minion with a module that isn't loaded you get a return like:

```
'mod_name'' __virtual__ returned False: <error message here>

```

Fixes #21185 
Replaces #21246 (since we want this in 2015.2)
