### PR TITLE
fixed issue which causes mount.mounted to fail when superopts are not pa...

### DIFF
--- a/salt/states/mount.py
+++ b/salt/states/mount.py
@@ -152,6 +152,8 @@ def mounted(name,
 
     device_list = []
     if real_name in active:
+        if 'superopts' not in active[real_name]:
+            active[real_name]['superopts'] = []
         if mount:
             device_list.append(active[real_name]['device'])
             device_list.append(os.path.realpath(device_list[0]))


### PR DESCRIPTION
...rt of mount.active (extended=True), this fix will also fix potential problems with Solaris and FreeBSD

This fixes issue #21215 
