### PR TITLE
Fix invalid kwarg output

### DIFF
--- a/salt/minion.py
+++ b/salt/minion.py
@@ -195,7 +195,8 @@ def load_args_and_kwargs(func, args, data=None):
                     # **kwargs not in argspec and parsed argument name not in
                     # list of positional arguments. This keyword argument is
                     # invalid.
-                    invalid_kwargs.append('{0}'.format(arg))
+                    for key, val in string_kwarg.iteritems():
+                        invalid_kwargs.append('{0}={1}'.format(key, val))
                 continue
 
         # if the arg is a dict with __kwarg__ == True, then its a kwarg
@@ -209,7 +210,7 @@ def load_args_and_kwargs(func, args, data=None):
                     # **kwargs not in argspec and parsed argument name not in
                     # list of positional arguments. This keyword argument is
                     # invalid.
-                    invalid_kwargs.append('{0}'.format(arg))
+                    invalid_kwargs.append('{0}={1}'.format(key, val))
             continue
 
         else:


### PR DESCRIPTION
The str.format()'ed dictionary representation of the invalid kwargs dict. This
commit adds key=val pairs for each bad kwarg, making the output for the
exception that is raised look a lot nicer.
