### PR TITLE
change to $HOME during startup (#21241)

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -356,6 +356,15 @@ class Master(SMaster):
         should not start up.
         '''
         errors = []
+
+        home = os.path.expanduser('~' + self.opts['user'])
+        try:
+            os.chdir(home)
+        except OSError as err:
+            errors.append(
+                'Cannot change to home directory {0} ({1})'.format(home, err)
+            )
+
         fileserver = salt.fileserver.Fileserver(self.opts)
         if not fileserver.servers:
             errors.append(


### PR DESCRIPTION
this (lightly tested) patch is supposed to make the salt-master daemon change
to its user's home directory during startup, and hopefully fix #21241.

i am too new to salt to know if it is doing anything meaningful
in its $HOME, in my installation it is empty so far :]

there are many deamons that run without a $HOME, and if
salt does not really need it (and is not confined to it),
a simple `os.chdir('/')` would be probably a better solution.
