### PR TITLE
make latest 2014.7.x releases visible in documentation

### DIFF
--- a/doc/topics/releases/2014.7.2.rst
+++ b/doc/topics/releases/2014.7.2.rst
@@ -2,7 +2,7 @@
 Salt 2014.7.2 Release Notes
 ===========================
 
-:release: TBA
+:release: 2015-02-09
 
 Version 2014.7.2 is a bugfix release for :doc:`2014.7.0
 </topics/releases/2014.7.0>`.  The changes include:

--- a/doc/topics/releases/index.rst
+++ b/doc/topics/releases/index.rst
@@ -11,7 +11,7 @@ Latest Stable Release
 .. releasestree::
     :maxdepth: 1
 
-    2014.7.0
+    {{ release }}
 
 Previous Releases
 =================
@@ -20,7 +20,7 @@ Previous Releases
     :maxdepth: 1
     :glob:
 
-    2014.7.0
+    2014.7.*
     2014.1.*
     0.*
 


### PR DESCRIPTION
This brings the release notes documentation up to date. I was unable to test locally if this renders ok. Please provide information on how to do this locally (or can I view this on the CI server?)

Br, Alexander.
