### PR TITLE
add def to test module to catch exceptions

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -457,6 +457,30 @@ def tty(*args, **kwargs):  # pylint: disable=W0613
     return 'ERROR: This function has been moved to cmd.tty'
 
 
+def try_(module, return_try_exception=False, **kwargs):
+    '''
+    Try to run a module command. On an exception return None.
+    If `return_try_exception` is set True return the exception.
+    This can be helpfull in templates where running a module might fail as expected.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        <pre>
+        {% for i in range(0,230) %}
+            {{ salt['test.try'](module='ipmi.get_users', bmc_host='172.2.2.'+i)|yaml(False) }}
+        {% endfor %}
+        </pre>
+    '''
+    try:
+        return __salt__[module](**kwargs)
+    except Exception as e:
+        if return_try_exception:
+            return e
+    return None
+
+
 def assertion(assertion):
     '''
     Assert the given argument


### PR DESCRIPTION
i find this helpfull in templates where I want to ignore errors.
Like in the example im creating an html webpage that has info on ipmi interfaces.
