### PR TITLE
Update salt_token name

### DIFF
--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -94,7 +94,7 @@ adding a ``-T`` option when authenticating:
     $ salt -T -a pam web\* test.ping
 
 Now a token will be created that has a expiration of 12 hours (by default).
-This token is stored in a file named ``.salt_token`` in the active user's home
+This token is stored in a file named ``salt_token`` in the active user's home
 directory.
 
 Once the token is created, it is sent with all subsequent communications.


### PR DESCRIPTION
salt_token seems to be now saved as ~/salt_token by default (https://github.com/saltstack/salt/blob/a52ebdac3b2a97245cb88eab34af4f8c6ad9c445/salt/config.py#L2192), update the documentation about default salt-token save path
