### PR TITLE
add normpath

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -4294,6 +4294,27 @@ def pardir():
     return os.path.pardir
 
 
+def normpath(path):
+    '''
+    Returns Normalize path, eliminating double slashes, etc.
+
+    .. versionadded:: 2015.2
+
+    This can be useful at the CLI but is frequently useful when scripting.
+
+    .. code-block:: yaml
+
+        {%- from salt['file.normpath'](tpldir + '/../vars.jinja') import parent_vars %}
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' file.normpath 'a/b/c/..'
+    '''
+    return os.path.normpath(path)
+
+
 def basename(path):
     '''
     Returns the final component of a pathname


### PR DESCRIPTION
Returns Normalize path, eliminating double slashes, etc.
This can be useful at the CLI but is frequently useful when scripting.

Sorry I did say I was done adding to the 2015.2 release but I missed this one.
It fits in well with basename and dirname
