### PR TITLE
check for check then check, not check twice

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -507,6 +507,9 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
     ipt_cmd = _iptables_cmd(family)
 
     if _has_option('--check', family):
+        cmd = '{0} -t {1} -C {2} {3}'.format(ipt_cmd, table, chain, rule)
+        out = __salt__['cmd.run'](cmd)
+    else:
         _chain_name = hex(uuid.getnode())
 
         # Create temporary table
@@ -525,9 +528,6 @@ def check(table='filter', chain=None, rule=None, family='ipv4'):
                     return True
 
         return False
-    else:
-        cmd = '{0} -t {1} -C {2} {3}'.format(ipt_cmd, table, chain, rule)
-        out = __salt__['cmd.run'](cmd)
 
     if not out:
         return True


### PR DESCRIPTION
fixes #20818; if --check is available, use it rather than use the more
elaborate logic in the check function to workaround older iptables that
don't have --check.
