### PR TITLE
Detect if we're running FreeBSD under KVM even if dmidecode is not installed

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -660,7 +660,9 @@ def _virtual(osdata):
             product = __salt__['cmd.run'](
                 '{0} smbios.system.product'.format(kenv)
             )
-            maker = __salt__['cmd.run']('{0} smbios.system.maker'.format(kenv))
+            maker = __salt__['cmd.run'](
+                '{0} smbios.system.maker'.format(kenv)
+            )
             if product.startswith('VMware'):
                 grains['virtual'] = 'VMware'
             if maker.startswith('Xen'):
@@ -670,6 +672,8 @@ def _virtual(osdata):
                 grains['virtual'] = 'VirtualPC'
             if maker.startswith('OpenStack'):
                 grains['virtual'] = 'OpenStack'
+            if maker.startswith('Bochs'):
+                grains['virtual'] = 'kvm'
         if sysctl:
             model = __salt__['cmd.run']('{0} hw.model'.format(sysctl))
             jail = __salt__['cmd.run'](


### PR DESCRIPTION
Detect if we're running FreeBSD under KVM even if dmidecode is not installed.

FreeBSD's py27-salt package does not depend on dmidecode and by default if running under KVM the **virtual** grain is set to **physical**.
