### PR TITLE
Fix IOError when using check_cmd

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -1495,6 +1495,10 @@ def managed(name,
             if isinstance(cret, dict):
                 ret.update(cret)
                 return ret
+            # Since we generated a new tempfile and we are not returning here
+            # lets change the original sfn to the new tempfile or else we will
+            # get file not found
+            sfn = tmp_filename
         else:
             ret = {'changes': {},
                    'comment': '',


### PR DESCRIPTION
Before this change my specific combination of file.managed flags crashes with the following result:

```
Function: file.managed
  Result: False
 Comment: Unable to manage file: [Errno 2] No such file or directory: /tmp/tmp5lzqnn
```

With the traceback being:

```
  File "/usr/lib/python2.7/dist-packages/salt/states/file.py", line 1418, in managed
    follow_symlinks)
  File "/usr/lib/python2.7/dist-packages/salt/modules/file.py", line 3268, in manage_file
    __opts__['cachedir'])
  File "/usr/lib/python2.7/dist-packages/salt/utils/files.py", line 39, in copyfile
    '[Errno 2] No such file or directory: {0}'.format(source)
IOError: [Errno 2] No such file or directory: /tmp/tmp5lzqnn
```

The logic of this function was very hard to follow and I'm not sure if my fix is following the previous intent of the code but I can not produce any errors with using check_cmd or not after my change.
