### PR TITLE
Fix for comments containing whitespaces

### DIFF
--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -332,4 +332,3 @@ def absent(name,
         ret['changes'][name] = 'Removed'
 
     return ret
-    

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -200,7 +200,7 @@ def present(
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:
-            key_and_comment = name.split()
+            key_and_comment = name.split(None,1)
             name = key_and_comment[0]
             if len(key_and_comment) == 2:
                 comment = key_and_comment[1]
@@ -209,7 +209,7 @@ def present(
             if fullkey.group(1):
                 options = fullkey.group(1).split(',')
             # key is of format: {enc} {key} [comment]
-            comps = fullkey.group(2).split()
+            comps = fullkey.group(2).split(None,2)
             enc = comps[0]
             name = comps[1]
             if len(comps) == 3:

--- a/salt/states/ssh_auth.py
+++ b/salt/states/ssh_auth.py
@@ -200,7 +200,7 @@ def present(
         fullkey = sshre.search(name)
         # if it is {key} [comment]
         if not fullkey:
-            key_and_comment = name.split(None,1)
+            key_and_comment = name.split(None, 1)
             name = key_and_comment[0]
             if len(key_and_comment) == 2:
                 comment = key_and_comment[1]
@@ -209,7 +209,7 @@ def present(
             if fullkey.group(1):
                 options = fullkey.group(1).split(',')
             # key is of format: {enc} {key} [comment]
-            comps = fullkey.group(2).split(None,2)
+            comps = fullkey.group(2).split(None, 2)
             enc = comps[0]
             name = comps[1]
             if len(comps) == 3:
@@ -292,7 +292,7 @@ def absent(name,
     fullkey = sshre.search(name)
     # if it is {key} [comment]
     if not fullkey:
-        key_and_comment = name.split()
+        key_and_comment = name.split(None, 1)
         name = key_and_comment[0]
         if len(key_and_comment) == 2:
             comment = key_and_comment[1]
@@ -301,7 +301,7 @@ def absent(name,
         if fullkey.group(1):
             options = fullkey.group(1).split(',')
         # key is of format: {enc} {key} [comment]
-        comps = fullkey.group(2).split()
+        comps = fullkey.group(2).split(None, 2)
         enc = comps[0]
         name = comps[1]
         if len(comps) == 3:
@@ -332,3 +332,4 @@ def absent(name,
         ret['changes'][name] = 'Removed'
 
     return ret
+    


### PR DESCRIPTION
When comments contain whitespaces they won't be copied over currently.
This is because the split keeps splitting along the whitespaces.

Reproduce:

```
name = "ecdsa-sha2-nistp256 awesomlylongkey= The Loeki proposes a fix for this"
```
