### PR TITLE
Add support for 'virt-what' in the 'virtual' grain. Improve handling of ...

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -468,18 +468,27 @@ def _virtual(osdata):
     # detection.
     skip_cmds = ('AIX',)
 
+    # list of commands to be executed to determine the 'virtual' grain
+    _cmds = set()
+
+    # test first for virt-what, which covers most of the desired functionality
+    # on most platforms
+    if not salt.utils.is_windows() and osdata['kernel'] not in skip_cmds:
+        if salt.utils.which('virt-what'):
+            _cmds = (['virt-what'])
+        else:
+            log.info('Please install "virt-what" to improve results of the "virtual" grain.')
     # Check if enable_lspci is True or False
-    if __opts__.get('enable_lspci', True) is False:
-        _cmds = ('dmidecode', 'dmesg')
+    elif __opts__.get('enable_lspci', True) is False:
+        _cmds = (['dmidecode', 'dmesg'])
     elif osdata['kernel'] in skip_cmds:
         _cmds = ()
     else:
         # /proc/bus/pci does not exists, lspci will fail
         if not os.path.exists('/proc/bus/pci'):
-            _cmds = ('dmidecode', 'dmesg')
+            _cmds = (['dmidecode', 'dmesg'])
         else:
-            _cmds = ('dmidecode', 'lspci', 'dmesg')
-
+            _cmds = (['dmidecode', 'lspci', 'dmesg'])
     failed_commands = set()
     for command in _cmds:
         args = []
@@ -568,6 +577,13 @@ def _virtual(osdata):
             elif 'virtio' in model:
                 grains['virtual'] = 'kvm'
             # Break out of the loop so the next log message is not issued
+            break
+        elif command == 'virt-what':
+            # if 'virt-what' returns nothing, it's either an undetected platform
+            # so we default just as virt-what to 'physical', otherwise use the
+            # platform detected/returned by virt-what
+            if output:
+                grains['virtual'] = output.lower()
             break
     else:
         if osdata['kernel'] in skip_cmds:


### PR DESCRIPTION
As a follow-up to #21328 which was opened against the wrong branch.

This adds support for [`virt-what`](http://people.redhat.com/~rjones/virt-what/) to `salt/grains/core.py` to determine the `virtual` grain.
`virt-what` has become the defacto standard-tool to determine whether a system is running on bare-metal or in a virtualized environment.
It supports a wide range of OS' and is able to detect a big number of virtualization technologies.

I implemented the support for `virt-what` in a way which makes the result from `virt-what` the #1 prioritized result in case it was found as it covers way more platforms/technologies than the rest of the code for the `virtual` grain which should IMHO only serve as fallback in case `virt-what` is not available.

`virt-what` is (at least) on RHEL/CentOS 7 installed by default.
