### PR TITLE
Add versionadded tag to new jobs.last_run function

### DIFF
--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -87,12 +87,12 @@ def lookup_jid(jid,
     outputter
         The outputter to use. Default: `None`.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     display_progress
         Displays progress events when set to `True`. Default: `False`.
 
-        .. versionadded:: Lithium
+        .. versionadded:: 2015.2.0
 
     CLI Example:
 
@@ -262,6 +262,8 @@ def last_run(ext_source=None,
              display_progress=False):
     '''
     List all detectable jobs and associated functions
+
+    .. versionadded:: Beryllium
 
     CLI Example:
 


### PR DESCRIPTION
And changes a few Lithium labels to 2015.2.0.
