### PR TITLE
Fix composer, issue #21349

### DIFF
--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -39,8 +39,15 @@ def _valid_composer(composer):
 def did_composer_install(dir):
     '''
     Test to see if the composer.lock file exists in this directory
-    :param dir: Directory to check for composer.lock
-    :return: Bool True if composer.lock exists in dir
+
+    dir
+        Directory location of the composer.json file
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' composer.did_composer_install /var/www/application
     '''
     lockFile = "{0}/composer.lock".format(dir)
     if os.path.exists(lockFile):

--- a/salt/modules/composer.py
+++ b/salt/modules/composer.py
@@ -6,10 +6,11 @@ from __future__ import absolute_import
 
 # Import python libs
 import logging
+import os.path
 
 # Import salt libs
 import salt.utils
-from salt.exceptions import CommandExecutionError
+from salt.exceptions import CommandExecutionError, CommandNotFoundError, SaltInvocationError
 
 log = logging.getLogger(__name__)
 
@@ -33,6 +34,154 @@ def _valid_composer(composer):
     if salt.utils.which(composer):
         return True
     return False
+
+
+def did_composer_install(dir):
+    '''
+    Test to see if the composer.lock file exists in this directory
+    :param dir: Directory to check for composer.lock
+    :return: Bool True if composer.lock exists in dir
+    '''
+    lockFile = "{0}/composer.lock".format(dir)
+    if os.path.exists(lockFile):
+        return True
+    return False
+
+
+def _run_composer(action,
+            dir=None,
+            composer=None,
+            php=None,
+            runas=None,
+            prefer_source=None,
+            prefer_dist=None,
+            no_scripts=None,
+            no_plugins=None,
+            optimize=None,
+            no_dev=None,
+            quiet=False,
+            composer_home='/root'):
+    '''
+    Run PHP's composer with a specific action.
+
+    If composer has not been installed globally making it available in the
+    system PATH & making it executable, the ``composer`` and ``php`` parameters
+    will need to be set to the location of the executables.
+
+    action
+        The action to pass to composer ('install', 'update', 'selfupdate', etc).
+
+    dir
+        Directory location of the composer.json file.  Required except when
+        action='selfupdate'
+
+    composer
+        Location of the composer.phar file. If not set composer will
+        just execute "composer" as if it is installed globally.
+        (i.e. /path/to/composer.phar)
+
+    php
+        Location of the php executable to use with composer.
+        (i.e. /usr/bin/php)
+
+    runas
+        Which system user to run composer as.
+
+    prefer_source
+        --prefer-source option of composer.
+
+    prefer_dist
+        --prefer-dist option of composer.
+
+    no_scripts
+        --no-scripts option of composer.
+
+    no_plugins
+        --no-plugins option of composer.
+
+    optimize
+        --optimize-autoloader option of composer. Recommended for production.
+
+    no_dev
+        --no-dev option for composer. Recommended for production.
+
+    quiet
+        --quiet option for composer. Whether or not to return output from composer.
+
+    composer_home
+        $COMPOSER_HOME environment variable
+    '''
+    if composer is not None:
+        if php is None:
+            php = 'php'
+    else:
+        composer = 'composer'
+
+    # Validate Composer is there
+    if not _valid_composer(composer):
+        raise CommandNotFoundError('\'composer.{0}\' is not available. Couldn\'t find {1!r}.'
+                                   .format(action, composer))
+
+    # Don't need a dir for the 'selfupdate' action; all other actions do need a dir
+    if dir is None and action != 'selfupdate':
+        raise SaltInvocationError('{0!r} is required for \'composer.{1}\''
+                                  .format('dir', action))
+
+    if action is None:
+        raise SaltInvocationError('{0!r} is required for {1!r}'
+                                  .format('action', 'composer._run_composer'))
+
+    # If we're running an update, and if composer.lock does not exist, then
+    # we really need to run install instead.
+    if action == 'update':
+        if not did_composer_install(dir):
+            action = 'install'
+
+    # Base Settings
+    cmd = '{0} {1} {2}'.format(composer, action, '--no-interaction --no-ansi')
+
+    # If php is set, prepend it
+    if php is not None:
+        cmd = php + ' ' + cmd
+
+    # Add Working Dir
+    if dir is not None:
+        cmd += ' --working-dir=' + dir
+
+    # Other Settings
+    if quiet is True:
+        cmd += ' --quiet'
+
+    if no_dev is True:
+        cmd += ' --no-dev'
+
+    if prefer_source is True:
+        cmd += ' --prefer-source'
+
+    if prefer_dist is True:
+        cmd += ' --prefer-dist'
+
+    if no_scripts is True:
+        cmd += ' --no-scripts'
+
+    if no_plugins is True:
+        cmd += ' --no-plugins'
+
+    if optimize is True:
+        cmd += ' --optimize-autoloader'
+
+    result = __salt__['cmd.run_all'](cmd,
+                                     runas=runas,
+                                     env={'COMPOSER_HOME': composer_home},
+                                     python_shell=False)
+
+    if result['retcode'] != 0:
+        raise CommandExecutionError(result['stderr'])
+
+    if quiet is True:
+        return True
+
+    return result
 
 
 def install(dir,
@@ -102,60 +251,148 @@ def install(dir,
         salt '*' composer.install /var/www/application \
             no_dev=True optimize=True
     '''
-    if composer is not None:
-        if php is None:
-            php = 'php'
-    else:
-        composer = 'composer'
+    result = _run_composer('install',
+                           dir=dir,
+                           composer=composer,
+                           php=php,
+                           runas=runas,
+                           prefer_source=prefer_source,
+                           prefer_dist=prefer_dist,
+                           no_scripts=no_scripts,
+                           no_plugins=no_plugins,
+                           optimize=optimize,
+                           no_dev=no_dev,
+                           quiet=quiet,
+                           composer_home=composer_home)
+    return result
 
-    # Validate Composer is there
-    if not _valid_composer(composer):
-        return '{0!r} is not available. Couldn\'t find {1!r}.'.format('composer.install', composer)
 
-    if dir is None:
-        return '{0!r} is required for {1!r}'.format('dir', 'composer.install')
+def update(dir,
+            composer=None,
+            php=None,
+            runas=None,
+            prefer_source=None,
+            prefer_dist=None,
+            no_scripts=None,
+            no_plugins=None,
+            optimize=None,
+            no_dev=None,
+            quiet=False,
+            composer_home='/root'):
+    '''
+    Update composer dependencies for a directory.
 
-    # Base Settings
-    cmd = composer + ' install --no-interaction'
+    If `composer install` has not yet been run, this runs `composer install`
+    instead.
 
-    # If php is set, prepend it
-    if php is not None:
-        cmd = php + ' ' + cmd
+    If composer has not been installed globally making it available in the
+    system PATH & making it executable, the ``composer`` and ``php`` parameters
+    will need to be set to the location of the executables.
 
-    # Add Working Dir
-    cmd += ' --working-dir=' + dir
+    dir
+        Directory location of the composer.json file.
 
-    # Other Settings
-    if quiet is True:
-        cmd += ' --quiet'
+    composer
+        Location of the composer.phar file. If not set composer will
+        just execute "composer" as if it is installed globally.
+        (i.e. /path/to/composer.phar)
 
-    if no_dev is True:
-        cmd += ' --no-dev'
+    php
+        Location of the php executable to use with composer.
+        (i.e. /usr/bin/php)
 
-    if prefer_source is True:
-        cmd += ' --prefer-source'
+    runas
+        Which system user to run composer as.
 
-    if prefer_dist is True:
-        cmd += ' --prefer-dist'
+    prefer_source
+        --prefer-source option of composer.
 
-    if no_scripts is True:
-        cmd += ' --no-scripts'
+    prefer_dist
+        --prefer-dist option of composer.
 
-    if no_plugins is True:
-        cmd += ' --no-plugins'
+    no_scripts
+        --no-scripts option of composer.
 
-    if optimize is True:
-        cmd += ' --optimize-autoloader'
+    no_plugins
+        --no-plugins option of composer.
 
-    result = __salt__['cmd.run_all'](cmd,
-                                     runas=runas,
-                                     env={'COMPOSER_HOME': composer_home},
-                                     python_shell=False)
+    optimize
+        --optimize-autoloader option of composer. Recommended for production.
 
-    if result['retcode'] != 0:
-        raise CommandExecutionError(result['stderr'])
+    no_dev
+        --no-dev option for composer. Recommended for production.
 
-    if quiet is True:
-        return True
+    quiet
+        --quiet option for composer. Whether or not to return output from composer.
 
-    return result['stdout']
+    composer_home
+        $COMPOSER_HOME environment variable
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' composer.update /var/www/application
+
+        salt '*' composer.update /var/www/application \
+            no_dev=True optimize=True
+    '''
+    result = _run_composer('update',
+                           dir=dir,
+                           composer=composer,
+                           php=php,
+                           runas=runas,
+                           prefer_source=prefer_source,
+                           prefer_dist=prefer_dist,
+                           no_scripts=no_scripts,
+                           no_plugins=no_plugins,
+                           optimize=optimize,
+                           no_dev=no_dev,
+                           quiet=quiet,
+                           composer_home=composer_home)
+    return result
+
+
+def selfupdate(composer=None,
+            php=None,
+            runas=None,
+            quiet=False,
+            composer_home='/root'):
+    '''
+    Update composer itself.
+
+    If composer has not been installed globally making it available in the
+    system PATH & making it executable, the ``composer`` and ``php`` parameters
+    will need to be set to the location of the executables.
+
+    composer
+        Location of the composer.phar file. If not set composer will
+        just execute "composer" as if it is installed globally.
+        (i.e. /path/to/composer.phar)
+
+    php
+        Location of the php executable to use with composer.
+        (i.e. /usr/bin/php)
+
+    runas
+        Which system user to run composer as.
+
+    quiet
+        --quiet option for composer. Whether or not to return output from composer.
+
+    composer_home
+        $COMPOSER_HOME environment variable
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' composer.selfupdate
+    '''
+    result = _run_composer('selfupdate',
+                           composer=composer,
+                           php=php,
+                           runas=runas,
+                           quiet=quiet,
+                           composer_home=composer_home)
+    return result

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -118,7 +118,7 @@ def installed(name,
 
     # The state of the system does need to be changed. Check if we're running
     # in ``test=true`` mode.
-    if __opts__['test'] == True:
+    if __opts__['test'] is True:
         ret['comment'] = 'The state of "{0}" will be changed.'.format(name)
         ret['changes'] = {
             'old': 'composer install has not yet been run in {0}'.format(name),
@@ -232,7 +232,7 @@ def update(name,
 
     # The state of the system does need to be changed. Check if we're running
     # in ``test=true`` mode.
-    if __opts__['test'] == True:
+    if __opts__['test'] is True:
         ret['comment'] = 'The state of "{0}" will be changed.'.format(name)
         ret['changes'] = {
             'old': old_status,

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -40,7 +40,7 @@ the location of composer in the state.
 from __future__ import absolute_import
 
 # Import salt libs
-from salt.exceptions import CommandExecutionError, CommandNotFoundError
+from salt.exceptions import SaltException
 
 
 def __virtual__():
@@ -60,6 +60,7 @@ def installed(name,
               no_plugins=None,
               optimize=None,
               no_dev=None,
+              quiet=False,
               composer_home='/root'):
     '''
     Verify that composer has installed the latest packages give a
@@ -108,6 +109,24 @@ def installed(name,
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
+    # Check if composer.lock exists, if so we already ran `composer install`
+    # and we don't need to do it again
+    if __salt__['composer.did_composer_install'](name):
+        ret['result'] = True
+        ret['comment'] = 'Composer already installed this directory'
+        return ret
+
+    # The state of the system does need to be changed. Check if we're running
+    # in ``test=true`` mode.
+    if __opts__['test'] == True:
+        ret['comment'] = 'The state of "{0}" will be changed.'.format(name)
+        ret['changes'] = {
+            'old': 'composer install has not yet been run in {0}'.format(name),
+            'new': 'composer install will be run in {0}'.format(name)
+        }
+        ret['result'] = None
+        return ret
+
     try:
         call = __salt__['composer.install'](
             name,
@@ -120,22 +139,140 @@ def installed(name,
             no_plugins=no_plugins,
             optimize=optimize,
             no_dev=no_dev,
-            quiet=False,
+            quiet=quiet,
             composer_home=composer_home
         )
-    except (CommandNotFoundError, CommandExecutionError) as err:
+    except (SaltException) as err:
         ret['result'] = False
         ret['comment'] = 'Error executing composer in \'{0!r}\': {1!r}'.format(name, err)
         return ret
 
-    if call or isinstance(call, list) or isinstance(call, dict):
-        ret['result'] = True
-        if call.find('Nothing to install or update') < 0:
-            ret['changes']['stdout'] = call
+    # If composer retcode != 0 then an exception was thrown and we dealt with it.
+    # Any other case is success, regardless of what composer decides to output.
 
-        ret['comment'] = 'Composer ran, nothing changed in {0!r}'.format(name)
+    ret['result'] = True
+
+    if quiet is True:
+        ret['comment'] = 'Composer install completed successfully, output silenced by quiet flag'
     else:
+        ret['comment'] = 'Composer install completed successfully'
+        ret['changes'] = {
+            'stderr': call['stderr'],
+            'stdout': call['stdout']
+        }
+
+    return ret
+
+
+def update(name,
+           composer=None,
+           php=None,
+           user=None,
+           prefer_source=None,
+           prefer_dist=None,
+           no_scripts=None,
+           no_plugins=None,
+           optimize=None,
+           no_dev=None,
+           quiet=False,
+           composer_home='/root'):
+    '''
+    Composer update the directory to ensure we have the latest versions
+    of all project dependencies.
+
+    dir
+        Directory location of the composer.json file.
+
+    composer
+        Location of the composer.phar file. If not set composer will
+        just execute "composer" as if it is installed globally.
+        (i.e. /path/to/composer.phar)
+
+    php
+        Location of the php executable to use with composer.
+        (i.e. /usr/bin/php)
+
+    user
+        Which system user to run composer as.
+
+        .. versionadded:: 2014.1.4
+
+    prefer_source
+        --prefer-source option of composer.
+
+    prefer_dist
+        --prefer-dist option of composer.
+
+    no_scripts
+        --no-scripts option of composer.
+
+    no_plugins
+        --no-plugins option of composer.
+
+    optimize
+        --optimize-autoloader option of composer. Recommended for production.
+
+    no_dev
+        --no-dev option for composer. Recommended for production.
+
+    quiet
+        --quiet option for composer. Whether or not to return output from composer.
+
+    composer_home
+        $COMPOSER_HOME environment variable
+    '''
+    ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
+
+    # Check if composer.lock exists, if so we already ran `composer install`
+    is_installed = __salt__['composer.did_composer_install'](name)
+    if is_installed:
+        old_status = "composer install has not yet been run in {0}".format(name)
+    else
+        old_status = "composer install has been run in {0}".format(name)
+
+    # The state of the system does need to be changed. Check if we're running
+    # in ``test=true`` mode.
+    if __opts__['test'] == True:
+        ret['comment'] = 'The state of "{0}" will be changed.'.format(name)
+        ret['changes'] = {
+            'old': old_status,
+            'new': 'composer install/update will be run in {0}'.format(name)
+        }
+        ret['result'] = None
+        return ret
+
+    try:
+        call = __salt__['composer.update'](
+            name,
+            composer=composer,
+            php=php,
+            runas=user,
+            prefer_source=prefer_source,
+            prefer_dist=prefer_dist,
+            no_scripts=no_scripts,
+            no_plugins=no_plugins,
+            optimize=optimize,
+            no_dev=no_dev,
+            quiet=quiet,
+            composer_home=composer_home
+        )
+    except (SaltException) as err:
         ret['result'] = False
-        ret['comment'] = 'Could not run composer'
+        ret['comment'] = 'Error executing composer in \'{0!r}\': {1!r}'.format(name, err)
+        return ret
+
+    # If composer retcode != 0 then an exception was thrown and we dealt with it.
+    # Any other case is success, regardless of what composer decides to output.
+
+    ret['result'] = True
+
+    if quiet is True:
+        ret['comment'] = 'Composer update completed successfully, output silenced by quiet flag'
+    else:
+        ret['comment'] = 'Composer update completed successfully'
+        ret['changes'] = {
+            'stderr': call['stderr'],
+            'stdout': call['stdout']
+        }
 
     return ret

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -227,7 +227,7 @@ def update(name,
     is_installed = __salt__['composer.did_composer_install'](name)
     if is_installed:
         old_status = "composer install has not yet been run in {0}".format(name)
-    else
+    else:
         old_status = "composer install has been run in {0}".format(name)
 
     # The state of the system does need to be changed. Check if we're running


### PR DESCRIPTION
Composer recently updated such that it does not produce any output.  That completely breaks the previous composer.py module/state which inspect stdout to determine success.  (Issue #21349)

This PR fixes it so that we rely on the exit code 0 to indicate success, regardless of what the output says or doesn't say.

Additionally, I've added the new state composer.update which will run `composer update` in the directory.  Doing so was virtually the same as running `composer.install` and so I refactored the code so as not to cut/paste a huge amount.

I modified the composer module such that it follows documented best practices like throwing exceptions instead of returning a string that you have to interpret whether it worked or not, and supporting `__opts__['test']`, etc.
