### PR TITLE
[QUESTION] Rework `file.replace` to remove `fileinput`

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1065,11 +1065,20 @@ def _get_flags(flags):
 def _mkstemp_copy(path,
                   preserve_inode=True):
     '''
-    Create a temp file and copy the contents of `path` to the temp file.
+    Create a temp file and move/copy the contents of ``path`` to the temp file.
     Return the path to the temp file.
-    
-    >>> _mkstemp_copy('/root/foo')
-    /tmp/tmpF48QrH
+
+    path
+        The full path to the file whose contents will be moved/copied to a temp file.
+        Whether it's moved or copied depends on the value of ``preserve_inode``.
+    preserve_inode
+        Preserve the inode of the file, so that any hard links continue to share the
+        inode with the original filename. This works by *copying* the file, reading
+        from the copy, and writing to the file at the original inode. If ``False``, the
+        file will be *moved* rather than copied, and a new file will be written to a
+        new inode, but using the original filename. Hard links will then share an inode
+        with the backup, instead (if using ``backup`` to create a backup copy).
+        Default is ``True``.
     '''
     temp_file = None
     # Create the temp file
@@ -1080,11 +1089,11 @@ def _mkstemp_copy(path,
             "Unable to create temp file. "
             "Exception: {0}".format(exc)
             )
-    # use `copy` to preserve the original file's
-    # inode, and thus preserve hardlinks to the
-    # file. otherwise, use `move` to preserve
-    # prior behavior, which results in writing
-    # the file to a new inode.
+    # use `copy` to preserve the inode of the
+    # original file, and thus preserve hardlinks
+    # to the inode. otherwise, use `move` to
+    # preserve prior behavior, which results in
+    # writing the file to a new inode.
     if preserve_inode:
         try:
             shutil.copy2(path, temp_file)
@@ -1105,6 +1114,7 @@ def _mkstemp_copy(path,
                 )
 
     return temp_file
+
 
 def replace(path,
             pattern,
@@ -1280,7 +1290,7 @@ def replace(path,
                     if has_changes is False and result != line:
                         has_changes = True
 
-                    # Keep track of show_changes here, in case the file isn't 
+                    # Keep track of show_changes here, in case the file isn't
                     # modified
                     if show_changes:
                         orig_file.append(line)

--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -1090,8 +1090,8 @@ def _mkstemp_copy(path,
             shutil.copy2(path, temp_file)
         except (OSError, IOError) as exc:
             raise CommandExecutionError(
-                "Unable to copy file '{0}' to the"
-                "temp file '{1}'."
+                "Unable to copy file '{0}' to the "
+                "temp file '{1}'. "
                 "Exception: {2}".format(path, temp_file, exc)
                 )
     else:
@@ -1099,8 +1099,8 @@ def _mkstemp_copy(path,
             shutil.move(path, temp_file)
         except (OSError, IOError) as exc:
             raise CommandExecutionError(
-                "Unable to move file '{0}' to the"
-                "temp file '{1}'."
+                "Unable to move file '{0}' to the "
+                "temp file '{1}'. "
                 "Exception: {2}".format(path, temp_file, exc)
                 )
 
@@ -1367,8 +1367,8 @@ def replace(path,
             shutil.move(temp_file, backup_name)
         except (OSError, IOError) as exc:
             raise CommandExecutionError(
-                "Unable to move the temp file '{0}' to the"
-                "backup file '{1}'."
+                "Unable to move the temp file '{0}' to the "
+                "backup file '{1}'. "
                 "Exception: {2}".format(path, temp_file, exc)
                 )
         if symlink:
@@ -1383,8 +1383,8 @@ def replace(path,
                 os.symlink(target_backup, symlink_backup)
             except:
                 raise CommandExecutionError(
-                    "Unable create backup symlink '{0}'."
-                    "Target was '{1}'."
+                    "Unable create backup symlink '{0}'. "
+                    "Target was '{1}'. "
                     "Exception: {2}".format(symlink_backup, target_backup,
                                             exc)
                     )
@@ -1393,7 +1393,7 @@ def replace(path,
             os.remove(temp_file)
         except (OSError, IOError) as exc:
             raise CommandExecutionError(
-                "Unable to delete temp file '{0}'."
+                "Unable to delete temp file '{0}'. "
                 "Exception: {1}".format(temp_file, exc)
                 )
 


### PR DESCRIPTION
Fixes saltstack#21362.
- Eliminate `fileinput`; utilize `salt.utils.fopen` instead
- Utilize `with` for file-handles instead of `try-finally`
- Catch and raise IOError and OSError exceptions on potential file read/write errors
- Search first to avoid updating timestamps if no changes have been made
- When making changes to the file, create a temp file to read from; temp file becomes the backup
- Add function _mkstemp_copy() to handle creation of the temp copy
- More granular control over when to keep/delete the backup; don't clobber existing backup file unless changes are made
