### PR TITLE
git test=true fix

### DIFF
--- a/salt/states/git.py
+++ b/salt/states/git.py
@@ -212,7 +212,7 @@ def latest(name,
 
             # only do something, if the specified rev differs from the
             # current_rev and remote_rev
-            if current_rev in [rev, remote_rev]:
+            if current_rev in [rev, remote_rev] or remote_rev.startswith(current_rev):
                 new_rev = current_rev
             else:
 


### PR DESCRIPTION
ls_remote returns somthing like...
17a9759d9721381fdce9c1b69b4c09a54cac501e    refs/heads/master

so need to check if the string starts with the commit id.

https://github.com/saltstack/salt/issues/21333

i never tested this... but it looks logical.. perhaps tomorrow ill give the all good.
