### PR TITLE
bugfix: fix test mode in ssh_known_hosts

### DIFF
--- a/salt/states/ssh_known_hosts.py
+++ b/salt/states/ssh_known_hosts.py
@@ -87,22 +87,16 @@ def present(
             comment = 'Specify either "key" or "fingerprint", not both.'
             ret['result'] = False
             return dict(ret, comment=comment)
-        elif key:
-            if not enc:
-                comment = 'Required argument "enc" if using "key" argument.'
-                ret['result'] = False
-                return dict(ret, comment=comment)
-            result = __salt__['ssh.check_known_host'](user, name,
-                                                      key=key,
-                                                      config=config)
-        elif fingerprint:
-            result = __salt__['ssh.check_known_host'](user, name,
-                                                      fingerprint=fingerprint,
-                                                      config=config)
-        else:
-            comment = 'Arguments key or fingerprint required.'
+        elif key and not enc:
+            comment = 'Required argument "enc" if using "key" argument.'
             ret['result'] = False
             return dict(ret, comment=comment)
+
+        result = __salt__['ssh.check_known_host'](user, name,
+                                                  key=key,
+                                                  fingerprint=fingerprint,
+                                                  config=config)
+
         if result == 'exists':
             comment = 'Host {0} is already in {1}'.format(name, config)
             ret['result'] = True
@@ -161,7 +155,7 @@ def absent(name, user=None, config=None):
     '''
     ret = {'name': name,
            'changes': {},
-           'result': None if __opts__['test'] else True,
+           'result': True,
            'comment': ''}
 
     if not user:
@@ -181,6 +175,7 @@ def absent(name, user=None, config=None):
     if __opts__['test']:
         comment = 'Key for {0} is set to be removed from {1}'.format(name,
                                                                      config)
+        ret['result'] = None
         return dict(ret, comment=comment)
 
     rm_result = __salt__['ssh.rm_known_host'](user=user, hostname=name, config=config)

--- a/tests/integration/states/ssh.py
+++ b/tests/integration/states/ssh.py
@@ -146,7 +146,7 @@ class SSHKnownHostsStateTest(integration.ModuleCase,
 
         # test again
         ret = self.run_state('ssh_known_hosts.absent', test=True, **kwargs)
-        self.assertSaltNoneReturn(ret)
+        self.assertSaltTrueReturn(ret)
 
 
 class SSHAuthStateTests(integration.ModuleCase,


### PR DESCRIPTION
- present func: should not require key/fingerprint.
  In normal mode, key AND fingerprint can be omitted but
  test mode requires them, so fix the test mode to behave same
  way.
- absent function: return correct ret when change suppose to be made.
- refactor a bit.
