### PR TITLE
engine updates

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -146,14 +146,16 @@ def raw_mod(opts, _, functions, mod='modules'):
                       pack={'__salt__': functions})
 
 
-def engines(opts, functions):
+def engines(opts, functions, runners):
     '''
     Return the master services plugins
     '''
+    pack = {'__salt__': functions,
+            '__runners__': runners}
     return LazyLoader(_module_dirs(opts, 'engines', 'engines'),
                       opts,
                       tag='engines',
-                      pack={'__salt__': functions})
+                      pack=pack)
 
 
 def proxy(opts, functions, whitelist=None):


### PR DESCRIPTION
- pack `__runners__` for master side engines
- for the sqs_events engine, fire events that will actually reach the master when running on a minion

@thatch45 related to firing events, would it make sense to make `event.send` work master side? Then `__salt__['event.send'](..)` would work regardless of the `__role`.
