### PR TITLE
2015.2: Add raw bool support to decorators

### DIFF
--- a/doc/ref/modules/index.rst
+++ b/doc/ref/modules/index.rst
@@ -336,3 +336,20 @@ If a "fallback_function" is defined, it will replace the function instead of rem
         replaced with "_fallback"
         '''
         return True
+
+In addition to global dependancies the depends decorator also supports raw booleans.
+
+.. code-block:: python
+
+    from salt.utils.decorators import depends
+
+    HAS_DEP = False
+    try:
+        import dependency_that_sometimes_exists
+        HAS_DEP = True
+    except ImportError:
+        pass
+
+    @depends(HAS_DEP)
+    def foo():
+        return True

--- a/salt/utils/decorators/__init__.py
+++ b/salt/utils/decorators/__init__.py
@@ -80,6 +80,15 @@ class Depends(object):
             # check if dependency is loaded
             for module, func, fallback_function in dependent_set:
                 # check if you have the dependency
+                if dependency is True:
+                    log.trace(
+                        'Dependency for {0}.{1} exists, not unloading'.format(
+                            module.__name__.split('.')[-1],
+                            func.__name__,
+                        )
+                    )
+                    continue
+
                 if dependency in dir(module):
                     log.trace(
                         'Dependency ({0}) already loaded inside {1}, '

--- a/tests/integration/files/file/base/_modules/runtests_decorators.py
+++ b/tests/integration/files/file/base/_modules/runtests_decorators.py
@@ -16,6 +16,13 @@ def working_function():
     '''
     return True
 
+@salt.utils.decorators.depends(True)
+def booldependsTrue():
+    return True
+
+@salt.utils.decorators.depends(False)
+def booldependsFalse():
+    return True
 
 @salt.utils.decorators.depends('time')
 def depends():

--- a/tests/integration/files/file/base/_modules/runtests_decorators.py
+++ b/tests/integration/files/file/base/_modules/runtests_decorators.py
@@ -18,6 +18,11 @@ def working_function():
 
 @salt.utils.decorators.depends(True)
 def booldependsTrue():
+    '''
+    CLI Example:
+
+    .. code-block:: bash
+    '''
     return True
 
 @salt.utils.decorators.depends(False)

--- a/tests/integration/modules/decorators.py
+++ b/tests/integration/modules/decorators.py
@@ -28,6 +28,21 @@ class DecoratorTest(integration.ModuleCase):
                     )
                 )
 
+    def test_bool_depends(self):
+        # test True
+        self.assertTrue(
+                self.run_function(
+                    'runtests_decorators.booldependsTrue'
+                    )
+                )
+
+        # test False
+        self.assertIn(
+                'is not available',
+                self.run_function('runtests_decorators.booldependsFalse'
+                    )
+                )
+
     def not_test_depends_will_fallback(self):
         ret = self.run_function('runtests_decorators.depends_will_fallback')
         self.assertTrue(ret['ret'])


### PR DESCRIPTION
Not sure why I didn't do this originally, its _much_ easier to implement-- and much cleaner. We may even want to consider deprecating the old mechanism (of a global name) since you can do the same with just booleans.
