### PR TITLE
Fix logic conflict with `enabled` between service.running and service.dead

### DIFF
--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -75,16 +75,14 @@ def _enable(name, started, result=True, **kwargs):
         if started is True:
             ret['comment'] = ('Enable is not available on this minion,'
                               ' service {0} started').format(name)
-            return ret
         elif started is None:
             ret['comment'] = ('Enable is not available on this minion,'
                               ' service {0} is in the desired state'
                               ).format(name)
-            return ret
         else:
             ret['comment'] = ('Enable is not available on this minion,'
                               ' service {0} is dead').format(name)
-            return ret
+        return ret
 
     # Service can be enabled
     if __salt__['service.enabled'](name):
@@ -92,15 +90,13 @@ def _enable(name, started, result=True, **kwargs):
         if started is True:
             ret['comment'] = ('Service {0} is already enabled,'
                               ' and is running').format(name)
-            return ret
         elif started is None:
             ret['comment'] = ('Service {0} is already enabled,'
                               ' and is in the desired state').format(name)
-            return ret
         else:
             ret['comment'] = ('Service {0} is already enabled,'
                               ' and is dead').format(name)
-            return ret
+        return ret
 
     # Service needs to be enabled
     if __opts__['test']:
@@ -115,34 +111,28 @@ def _enable(name, started, result=True, **kwargs):
         if started is True:
             ret['comment'] = ('Service {0} has been enabled,'
                               ' and is running').format(name)
-            return ret
         elif started is None:
             ret['comment'] = ('Service {0} has been enabled,'
                               ' and is in the desired state').format(name)
-            return ret
         else:
             ret['comment'] = ('Service {0} has been enabled,'
                               ' and is dead').format(name)
-            return ret
+        return ret
 
     # Service failed to be enabled
     if started is True:
-        ret['changes'] = {}
-        ret['changes'][name] = True
         ret['result'] = False
         ret['comment'] = ('Failed when setting service {0} to start at boot,'
                           ' but the service is running').format(name)
-        return ret
     elif started is None:
         ret['result'] = False
         ret['comment'] = ('Failed when setting service {0} to start at boot,'
                           ' but the service was already running').format(name)
-        return ret
     else:
         ret['result'] = False
         ret['comment'] = ('Failed when setting service {0} to start at boot,'
                           ' and the service is dead').format(name)
-        return ret
+    return ret
 
 
 def _disable(name, started, result=True, **kwargs):
@@ -161,16 +151,14 @@ def _disable(name, started, result=True, **kwargs):
         if started is True:
             ret['comment'] = ('Disable is not available on this minion,'
                               ' service {0} started').format(name)
-            return ret
         elif started is None:
             ret['comment'] = ('Disable is not available on this minion,'
                               ' service {0} is in the desired state'
                               ).format(name)
-            return ret
         else:
             ret['comment'] = ('Disable is not available on this minion,'
                               ' service {0} is dead').format(name)
-            return ret
+        return ret
 
     # Service can be disabled
     if __salt__['service.disabled'](name):
@@ -178,15 +166,13 @@ def _disable(name, started, result=True, **kwargs):
         if started is True:
             ret['comment'] = ('Service {0} is already disabled,'
                               ' and is running').format(name)
-            return ret
         elif started is None:
             ret['comment'] = ('Service {0} is already disabled,'
                               ' and is in the desired state').format(name)
-            return ret
         else:
             ret['comment'] = ('Service {0} is already disabled,'
                               ' and is dead').format(name)
-            return ret
+        return ret
 
     # Service needs to be disabled
     if __opts__['test']:
@@ -196,44 +182,33 @@ def _disable(name, started, result=True, **kwargs):
 
     if __salt__['service.disable'](name, **kwargs):
         # Service has been disabled
+        ret['changes'] = {}
+        ret['changes'][name] = True
         if started is True:
-            ret['changes'] = {}
-            ret['changes'][name] = True
             ret['comment'] = ('Service {0} has been disabled,'
                               ' and is running').format(name)
-            return ret
         elif started is None:
-            ret['changes'] = {}
-            ret['changes'][name] = True
             ret['comment'] = ('Service {0} has been disabled,'
                               ' and is in the desired state').format(name)
-            return ret
         else:
-            ret['changes'] = {}
-            ret['changes'][name] = True
             ret['comment'] = ('Service {0} has been disabled,'
                               ' and is dead').format(name)
-            return ret
+        return ret
 
     # Service failed to be disabled
+    ret['result'] = False
     if started is True:
-        ret['result'] = False
         ret['comment'] = ('Failed when setting service {0} to not start'
                           ' at boot, and is running').format(name)
-        return ret
     elif started is None:
-        ret['result'] = False
         ret['comment'] = ('Failed when setting service {0} to not start'
                           ' at boot, but the service was already running'
                           ).format(name)
         return ret
     else:
-        ret['changes'] = {}
-        ret['changes'][name] = True
-        ret['result'] = False
         ret['comment'] = ('Failed when setting service {0} to not start'
                           ' at boot, and the service is dead').format(name)
-        return ret
+    return ret
 
 
 def _available(name, ret):
@@ -300,26 +275,19 @@ def running(name, enable=None, sig=None, **kwargs):
     ret['changes'] = {name: __salt__['service.start'](name)}
 
     if not ret['changes'][name]:
+        ret['result'] = False
+        ret['comment'] = 'Service {0} failed to start'.format(name)
         if enable is True:
             ret.update(_enable(name, False, result=False, **kwargs))
-            return ret
         elif enable is False:
             ret.update(_disable(name, False, result=False, **kwargs))
-            return ret
-        else:
-            ret['result'] = False
-            ret['comment'] = 'Service {0} failed to start'.format(name)
-            return ret
-
-    if enable is True:
-        ret.update(_enable(name, True, **kwargs))
-        return ret
-    elif enable is False:
-        ret.update(_disable(name, True, **kwargs))
-        return ret
     else:
         ret['comment'] = 'Started Service {0}'.format(name)
-        return ret
+        if enable is True:
+            ret.update(_enable(name, True, **kwargs))
+        elif enable is False:
+            ret.update(_disable(name, True, **kwargs))
+    return ret
 
 
 def dead(name, enable=None, sig=None, **kwargs):
@@ -355,12 +323,9 @@ def dead(name, enable=None, sig=None, **kwargs):
         ret['comment'] = 'The service {0} is already dead'.format(name)
         if enable is True:
             ret.update(_enable(name, None, **kwargs))
-            return ret
         elif enable is False:
             ret.update(_disable(name, None, **kwargs))
-            return ret
-        else:
-            return ret
+        return ret
 
     if __opts__['test']:
         ret['result'] = None
@@ -374,24 +339,15 @@ def dead(name, enable=None, sig=None, **kwargs):
         ret['comment'] = 'Service {0} failed to die'.format(name)
         if enable is True:
             ret.update(_enable(name, True, result=False, **kwargs))
-            return ret
         elif enable is False:
             ret.update(_disable(name, True, result=False, **kwargs))
-            return ret
-        else:
-            ret['result'] = False
-            ret['comment'] = 'Service {0} failed to die'.format(name)
-            return ret
     else:
+        ret['comment'] = 'Service {0} was killed'.format(name)
         if enable is True:
             ret.update(_enable(name, False, **kwargs))
-            return ret
         elif enable is False:
             ret.update(_disable(name, False, **kwargs))
-            return ret
-        else:
-            ret['comment'] = 'Service {0} was killed'.format(name)
-            return ret
+    return ret
 
 
 def enabled(name, **kwargs):

--- a/salt/states/service.py
+++ b/salt/states/service.py
@@ -404,7 +404,13 @@ def enabled(name, **kwargs):
     name
         The name of the init or rc script used to manage the service
     '''
-    return _enable(name, None, **kwargs)
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    ret.update(_enable(name, None, **kwargs))
+    return ret
 
 
 def disabled(name, **kwargs):
@@ -417,7 +423,13 @@ def disabled(name, **kwargs):
     name
         The name of the init or rc script used to manage the service
     '''
-    return _disable(name, None, **kwargs)
+    ret = {'name': name,
+           'changes': {},
+           'result': True,
+           'comment': ''}
+
+    ret.update(_disable(name, None, **kwargs))
+    return ret
 
 
 def mod_watch(name, sfun=None, sig=None, reload=False, full_restart=False):


### PR DESCRIPTION
Fixes saltstack#20915.
- Modifies `_enable()` and `_disable()` so they return a dict that only contains keys changed by the referenced function (rather than a full state dict).
- Modifies `service.running`, `service.dead`, `service.enabled`, and `service.disabled` to update the `ret` variable based on the return value of `_enable()` or `_disable()`. 
- Cleans up some dead code and streamlines other logic resulting from above changes.
