### PR TITLE
Fix msgpack issue with very long Python longs (> 64 bits) used with job ...

### DIFF
--- a/salt/payload.py
+++ b/salt/payload.py
@@ -120,7 +120,7 @@ class Serial(object):
         try:
             return msgpack.dumps(msg)
         except OverflowError:
-            # msgpack can't handle the very log Python longs for jids
+            # msgpack can't handle the very long Python longs for jids
             # Convert any very long longs to strings
             # We borrow the technique used by TypeError below
             def verylong_encoder(obj):

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -119,6 +119,26 @@ class Serial(object):
         '''
         try:
             return msgpack.dumps(msg)
+        except OverflowError:
+            # msgpack can't handle the very log Python longs for jids
+            # Convert any very long longs to strings
+            # We borrow the technique used by TypeError below
+            def verylong_encoder(obj):
+                if isinstance(obj, dict):
+                    for key, value in six.iteritems(obj.copy()):
+                        obj[key] = verylong_encoder(value)
+                    return dict(obj)
+                elif isinstance(obj, (list, tuple)):
+                    obj = list(obj)
+                    for idx, entry in enumerate(obj):
+                        obj[idx] = verylong_encoder(entry)
+                    return obj
+                if isinstance(obj, long) and long > pow(2,64):
+                    return str(obj)
+                else:
+                    return obj
+            return msgpack.dumps(verylong_encoder(msg))
+            
         except TypeError:
             if msgpack.version >= (0, 2, 0):
                 # Should support OrderedDict serialization, so, let's

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -133,12 +133,11 @@ class Serial(object):
                     for idx, entry in enumerate(obj):
                         obj[idx] = verylong_encoder(entry)
                     return obj
-                if isinstance(obj, long) and long > pow(2,64):
+                if isinstance(obj, long) and long > pow(2, 64):
                     return str(obj)
                 else:
                     return obj
             return msgpack.dumps(verylong_encoder(msg))
-            
         except TypeError:
             if msgpack.version >= (0, 2, 0):
                 # Should support OrderedDict serialization, so, let's


### PR DESCRIPTION
...ids

Reference issue #21383.  I'm not sure why the jid is not always stored as a string, but this patch will allow msgpack to work correctly as it can't handle longs > 64 bits.
