### PR TITLE
Backport fix for #20494

### DIFF
--- a/salt/cli/caller.py
+++ b/salt/cli/caller.py
@@ -169,6 +169,8 @@ class ZeroMQCaller(object):
             ret['fun_args'] = self.opts['arg']
 
         for returner in returners:
+            if not returner:  # if we got an empty returner somehow, skip
+                continue
             try:
                 ret['success'] = True
                 self.minion.returners['{0}.returner'.format(returner)](ret)


### PR DESCRIPTION
Catch case where 'return' not in opts, or other ways to get an empty returner (as it will just fail anyways)

backport fix for #20494
