### PR TITLE
Additional logging for iptables module

### DIFF
--- a/salt/modules/iptables.py
+++ b/salt/modules/iptables.py
@@ -17,6 +17,9 @@ import salt.utils
 from salt.state import STATE_INTERNAL_KEYWORDS as _STATE_INTERNAL_KEYWORDS
 from salt.exceptions import SaltException
 
+import logging
+log = logging.getLogger(__name__)
+
 
 def __virtual__():
     '''
@@ -426,6 +429,8 @@ def save(filename=None, family='ipv4'):
     '''
     if _conf() and not filename:
         filename = _conf(family)
+
+    log.debug('Saving rules to {0}'.format(filename))
 
     parent_dir = os.path.dirname(filename)
     if not os.path.isdir(parent_dir):


### PR DESCRIPTION
Adding fix for iptables --check that is currently in 2015.2 into develop (#21321).  Adding a log entry for testing aggregating iptables rules, should show that the save function that writes to disk is only called once and only called when necessary. #20818 
