### PR TITLE
Make loader's imported modules not part of python's sys.modules

### DIFF
--- a/doc/topics/releases/2015.2.0.rst
+++ b/doc/topics/releases/2015.2.0.rst
@@ -14,6 +14,15 @@ changes, creation, deletion etc.
 This allows for the changes to be sent up to the master where the
 reactor can respond to changes.
 
+Lazy Loader
+========
+
+The Lazy Loader is a significant overhaul of Salt's module loader system. The
+Lazy Loader will lazily load modules on access, instead of all on start. In
+addition to major performance improvement this "sandboxes" modules-- meaning a
+bad/broken import of a single module will only effect jobs that require accessing
+the broken module. (:pull: `20274`)
+
 Salt SSH
 ========
 
@@ -39,6 +48,9 @@ Misc Fixes/Additions
 - LocalClient may now optionally raise SaltClientError exceptions. If using
   this class directly, checking for and handling this exception is recommended.
   (:issue: `21501`)
+- The SAuth object is now a singleton, meaning authentication state is
+  global (per master) on each minion. This reduces sign-ins of minions from 3->1
+  per startup.
 
 Deprecations
 ============


### PR DESCRIPTION
*\* DO NOT MERGE YET **

This means if you have multiple loader classes you will now import "unique" module objects-- instead of both pointing to the same underlying object in memory. This means opts (and all other globals) don't get into the weird merging state we were before. This also means that when a loader object is deleted we can actually unload modules.

In addition this includes a deprecation warning for all mutation of the **opts** global-- as it shouldn't be mutated.

If we aren't comfortable with this on 2015.2 I can put this against develop and just separate out the opts deprecation stuff.
