### PR TITLE
Gracefully handle race condition of 'makedirs'

### DIFF
--- a/salt/utils/verify.py
+++ b/salt/utils/verify.py
@@ -11,6 +11,7 @@ import os
 import re
 import sys
 import stat
+import errno
 import socket
 import logging
 
@@ -162,8 +163,11 @@ def verify_files(files, user):
     for fn_ in files:
         dirname = os.path.dirname(fn_)
         try:
-            if not os.path.isdir(dirname):
+            try:
                 os.makedirs(dirname)
+            except OSError as err:
+                if err.errno != errno.EEXIST:
+                    raise
             if not os.path.isfile(fn_):
                 with salt.utils.fopen(fn_, 'w+') as fp_:
                     fp_.write('')


### PR DESCRIPTION
## Problem

In the imperative sequence:

``` python
   if not os.path.isdir(folder_name):
       os.makedirs(folder_name)
```

There exists the possibility that another process may create `folder_name` between the system path test and the system folder construction.  This is especially true when launching both the salt-minion and salt-master simultaneously:

```
# systemctl status -l salt-minion salt-master
* salt-minion.service - The Salt Minion
   Loaded: loaded (/usr/lib/systemd/system/salt-minion.service; enabled)
   Active: inactive (dead) since Sat 2015-03-07 21:38:53 UTC; 7h ago
  Process: 1168 ExecStart=/usr/bin/salt-minion (code=exited, status=0/SUCCESS)
 Main PID: 1168 (code=exited, status=0/SUCCESS)

Mar 07 21:36:29 local.dev systemd[1]: Started The Salt Minion.
Mar 07 21:38:53 local.dev salt-minion[1168]: [ERROR   ] Attempt to authenticate with the salt master failed

* salt-master.service - The Salt Master Server
   Loaded: loaded (/usr/lib/systemd/system/salt-master.service; enabled)
   Active: failed (Result: exit-code) since Sat 2015-03-07 21:37:53 UTC; 7h ago
  Process: 1166 ExecStart=/usr/bin/salt-master (code=exited, status=17)
 Main PID: 1166 (code=exited, status=17)

Mar 07 21:37:52 local.dev salt-master[1166]: Failed to create path "/var/log/salt/master" - [Errno 17] File exists: '/var/log/salt'
Mar 07 21:37:53 local.dev systemd[1]: salt-master.service: main process exited, code=exited, status=17/n/a
Mar 07 21:37:53 local.dev systemd[1]: Failed to start The Salt Master Server.
Mar 07 21:37:53 local.dev systemd[1]: Unit salt-master.service entered failed state.
```

In such cases, the salt-minion tested for the non-existence (true), salt-master also tested (true), salt-minion created the folder, and then so salt-master failed with Errno 17: File exists.
## Solution

Do not test for path existence at all, always create, expecting `errno.EEXISTS` as an acceptable condition.  This delegates responsibility of handling such "race conditions" to the kernel where locks exist to prevent it.
