### PR TITLE
Update faq.rst

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -246,7 +246,7 @@ distro the minion is running, in case they differ from the example below.
         - name: atd
         - enable: True
 
-An alternatvie to using the :program:`atd` daemon is to fork and disown the
+An alternative to using the :program:`atd` daemon is to fork and disown the
 process.
 
 .. code-block:: yaml
@@ -254,7 +254,10 @@ process.
     restart_minion:
       cmd.run:
         - name: |
-            nohup /bin/sh -c 'sleep 10 && salt-call --local service.restart salt-minion'
+            exec 0>&- # close stdin
+            exec 1>&- # close stdout
+            exec 2>&- # close stderr
+            nohup /bin/sh -c 'sleep 10 && salt-call --local service.restart salt-minion' &
         - python_shell: True
         - order: last
 


### PR DESCRIPTION
Fixed misspelling on "alternative" and updated cmd.run procedure to disconnect all input and output for the thread before executing the NOHUP.
