### PR TITLE
Fix file.recurse on root of gitfs/hgfs/svnfs repo

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -1888,14 +1888,13 @@ def _dir_list_gitpython(repo, tgt_env):
             tree = tree / repo['root']
         except KeyError:
             return ret
+    relpath = lambda path: os.path.relpath(path, repo['root'])
+    add_mountpoint = lambda path: os.path.join(repo['mountpoint'], path)
     for blob in tree.traverse():
-        if not isinstance(blob, git.Tree):
-            continue
-        if repo['root']:
-            path = os.path.relpath(blob.path, repo['root'])
-        else:
-            path = blob.path
-        ret.add(os.path.join(repo['mountpoint'], path))
+        if isinstance(blob, git.Tree):
+            ret.add(add_mountpoint(relpath(blob.path)))
+    if repo['mountpoint']:
+        ret.add(repo['mountpoint'])
     return ret
 
 
@@ -1935,10 +1934,12 @@ def _dir_list_pygit2(repo, tgt_env):
     blobs = []
     if len(tree):
         _traverse(tree, repo['repo'], blobs, repo['root'])
+    relpath = lambda path: os.path.relpath(path, repo['root'])
+    add_mountpoint = lambda path: os.path.join(repo['mountpoint'], path)
     for blob in blobs:
-        if repo['root']:
-            blob = os.path.relpath(blob, repo['root'])
-        ret.add(os.path.join(repo['mountpoint'], blob))
+        ret.add(add_mountpoint(relpath(blob)))
+    if repo['mountpoint']:
+        ret.add(repo['mountpoint'])
     return ret
 
 
@@ -1971,10 +1972,12 @@ def _dir_list_dulwich(repo, tgt_env):
     blobs = []
     if len(tree):
         _traverse(tree, repo['repo'], blobs, repo['root'])
+    relpath = lambda path: os.path.relpath(path, repo['root'])
+    add_mountpoint = lambda path: os.path.join(repo['mountpoint'], path)
     for blob in blobs:
-        if repo['root']:
-            blob = os.path.relpath(blob, repo['root'])
-        ret.add(os.path.join(repo['mountpoint'], blob))
+        ret.add(add_mountpoint(relpath(blob)))
+    if repo['mountpoint']:
+        ret.add(repo['mountpoint'])
     return ret
 
 

--- a/salt/fileserver/hgfs.py
+++ b/salt/fileserver/hgfs.py
@@ -875,4 +875,6 @@ def _get_dir_list(load):
                             ret.add(os.path.join(repo['mountpoint'], relpath))
                     split = split[0].rsplit('/', 1)
         repo['repo'].close()
+    if repo['mountpoint']:
+        ret.add(repo['mountpoint'])
     return sorted(ret)

--- a/salt/fileserver/svnfs.py
+++ b/salt/fileserver/svnfs.py
@@ -732,6 +732,8 @@ def _file_lists(load, form):
                                 env_root
                             )
                     ret['files'].add(os.path.join(repo['mountpoint'], rel_fn))
+        if repo['mountpoint']:
+            ret['dirs'].add(repo['mountpoint'])
         # Convert all compiled sets to lists
         for key in ret:
             ret[key] = sorted(ret[key])


### PR DESCRIPTION
This fixes a condition where a file.recurse fails on the root of a remote for
one of the VCS fileserver backends when the repo has a mountpoint.

Fixes #20812.
