### PR TITLE
Suggest a separate repo for `top.sls`.

### DIFF
--- a/doc/topics/tutorials/gitfs.rst
+++ b/doc/topics/tutorials/gitfs.rst
@@ -444,8 +444,8 @@ be used:
 
 ``top.sls`` files from different branches will be merged into one at runtime.
 Since this can lead to overly complex configurations, the recommended setup is
-to have the ``top.sls`` file only in the master branch and use
-environment-specific branches for state definitions.
+to have a separate repository, containing only the ``top.sls`` file with just
+one single ``master`` branch.
 
 To map a branch other than ``master`` as the ``base`` environment, use the
 :conf_master:`gitfs_base` parameter.


### PR DESCRIPTION
This replaces the suggestion to keep `top.sls` out of other branches
which is rather unpractical, as it would require to manually delete
it from each new created branch and prevent deleting it when merging
the branch back into `master`.
