### PR TITLE
Fix #21304

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -221,7 +221,10 @@ def blkid(device=None):
         args = " " + device
 
     ret = {}
-    for line in __salt__['cmd.run_stdout']('blkid' + args, python_shell=False).split('\n'):
+    blkid_result = __salt__['cmd.run_stdout']('blkid' + args, python_shell=False).split('\n')
+    if not len(blkid_result) == 0:
+        return ret
+    for line in blkid_result:
         comps = line.split()
         device = comps[0][:-1]
         info = {}


### PR DESCRIPTION
blkid() was iterating over an empty list before checking it's length.
