### PR TITLE
fix wrong mode handling in get_proc_dir and utils.fpopen

### DIFF
--- a/salt/utils/__init__.py
+++ b/salt/utils/__init__.py
@@ -40,6 +40,7 @@ from salt.ext.six.moves.urllib.parse import urlparse  # pylint: disable=no-name-
 from salt.ext.six.moves import range
 from salt.ext.six.moves import zip
 from salt.ext.six.moves import map
+from stat import S_IMODE
 # pylint: enable=import-error,redefined-builtin
 
 # Try to load pwd, fallback to getpass if unsuccessful
@@ -1098,8 +1099,9 @@ def fpopen(*args, **kwargs):
                 os.chown(path, uid, gid)
 
         if mode is not None:
-            if d_stat.st_mode | mode != d_stat.st_mode:
-                os.chmod(path, d_stat.st_mode | mode)
+            mode_part = S_IMODE(d_stat.st_mode)
+            if mode_part != mode:
+                os.chmod(path, (d_stat.st_mode ^ mode_part) | mode)
 
         yield fhandle
 


### PR DESCRIPTION
Greetings,

there is an error in my changes for #20715. It will only change permissions if the explicit given permissions are not included in the actual permissions.

Example:
The file has the mode 0700 and you give mode 0755 -> file gets new mode 0755
The file has the mode 0777 and you give mode 0755 -> will not work

Here is a patch for saltstack.utils.fpopen and salt.minion.get_proc_dir.

Sorry about that. ;)
