### PR TITLE
Remove return_url from get_console_output

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -3862,7 +3862,6 @@ def get_console_output(
 
     ret = {}
     data = aws.query(params,
-                     return_url=True,
                      location=get_location(),
                      provider=get_provider(),
                      opts=__opts__,


### PR DESCRIPTION
Signature Version 4 changes the behavior for return_url, and here it breaks things.
