### PR TITLE
Fix #21304 (backport of #21431)

### DIFF
--- a/salt/modules/disk.py
+++ b/salt/modules/disk.py
@@ -221,7 +221,10 @@ def blkid(device=None):
         args = " " + device
 
     ret = {}
-    for line in __salt__['cmd.run_stdout']('blkid' + args, python_shell=False).split('\n'):
+    blkid_result = __salt__['cmd.run_all']('blkid' + args, python_shell=False)
+    if blkid_result['retcode'] > 0:
+        return ret
+    for line in blkid_result['stdout'].split('\n'):
         comps = line.split()
         device = comps[0][:-1]
         info = {}


### PR DESCRIPTION
blkid() was iterating over an empty list before checking it's length.
Prevent this by using 'cmd.run_all' instead and checking it's returncode
before using the results.
