### PR TITLE
21434: Support EC2 provider with non-standard ssh port

### DIFF
--- a/salt/cloud/clouds/ec2.py
+++ b/salt/cloud/clouds/ec2.py
@@ -1917,6 +1917,9 @@ def wait_for_instance(
     ssh_connect_timeout = config.get_cloud_config_value(
         'ssh_connect_timeout', vm_, __opts__, 900   # 15 minutes
     )
+    ssh_port = config.get_cloud_config_value(
+        'ssh_port', vm_, __opts__, 22
+    )
 
     if config.get_cloud_config_value('win_installer', vm_, __opts__):
         username = config.get_cloud_config_value(
@@ -1966,6 +1969,7 @@ def wait_for_instance(
                 'Failed to authenticate against remote windows host'
             )
     elif salt.utils.cloud.wait_for_port(ip_address,
+                                        port=ssh_port,
                                         timeout=ssh_connect_timeout,
                                         gateway=ssh_gateway_config
                                         ):
@@ -2006,6 +2010,7 @@ def wait_for_instance(
         for user in vm_['usernames']:
             if salt.utils.cloud.wait_for_passwd(
                 host=ip_address,
+                port=ssh_port,
                 username=user,
                 ssh_timeout=config.get_cloud_config_value(
                     'wait_for_passwd_timeout', vm_, __opts__, default=1 * 60

--- a/salt/cloud/clouds/libcloud_aws.py
+++ b/salt/cloud/clouds/libcloud_aws.py
@@ -432,6 +432,9 @@ def create(vm_):
     ssh_connect_timeout = config.get_cloud_config_value(
         'ssh_connect_timeout', vm_, __opts__, 900   # 15 minutes
     )
+    ssh_port = config.get_cloud_config_value(
+        'ssh_port', vm_, __opts__, 22
+    )
     if salt.utils.cloud.wait_for_port(ip_address, timeout=ssh_connect_timeout):
         for user in usernames:
             if salt.utils.cloud.wait_for_passwd(
@@ -460,6 +463,7 @@ def create(vm_):
         deploy_kwargs = {
             'opts': __opts__,
             'host': ip_address,
+            'port': ssh_port,
             'salt_host': salt_ip_address,
             'username': username,
             'key_filename': key_filename,

--- a/salt/utils/cloud.py
+++ b/salt/utils/cloud.py
@@ -338,6 +338,9 @@ def bootstrap(vm_, opts):
     deploy_kwargs = {
         'opts': opts,
         'host': vm_['ssh_host'],
+        'port': salt.config.get_cloud_config_value(
+            'ssh_port', vm_, opts, default=22
+        ),
         'salt_host': vm_.get('salt_host', vm_['ssh_host']),
         'username': ssh_username,
         'script': deploy_script_code,


### PR DESCRIPTION
This change resolves the issue in 21434 where users with an EC2 AMI which runs sshd on a non-standard port are unable to bootstrap the newly spawned instance.   Users can specify a ssh_port in the cloud config.  Note that this is different than having a gateway ssh port, as this is the actual port that sshd is listening to on the EC2 instance.  
