### PR TITLE
remove 'master' reference in error message

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -2755,7 +2755,7 @@ class BaseHighState(object):
                     if state:
                         self.merge_included_states(highstate, state, errors)
                     for i, error in enumerate(errors[:]):
-                        if 'is not available on the salt master' in error:
+                        if 'is not available' in error:
                             # match SLS foobar in environment
                             this_sls = 'SLS {0} in saltenv'.format(
                                 sls_match)


### PR DESCRIPTION
Remove an erroneous reference to a 'master' in render_highstate as the
error can be triggered when salt is run masterless, #21301.
