### PR TITLE
Add simple parser to return some activity numbers from our git log.

### DIFF
--- a/tests/committerparser.py
+++ b/tests/committerparser.py
@@ -1,0 +1,104 @@
+#!/usr/bin/python
+import sys
+import getopt
+import re
+import email.utils
+import datetime
+
+class Usage(Exception):
+    def __init__(self, msg):
+        self.msg = msg
+
+def parse_date(datestr):
+    d = email.utils.parsedate(datestr)
+
+    return datetime.datetime(d[0],d[1],d[2],d[3],d[4],d[5],d[6])
+
+def parse_gitlog(filename=None):
+
+    results = {}
+    commits = {}
+
+    if not filename or filename == '-':
+        fh = sys.stdin
+    else:
+        fh = open(filename, 'r+')
+
+    commitcount = 0
+    for line in fh.readlines():
+        line = line.rstrip()
+        if line.startswith('commit '):
+            new_commit = True
+            commitcount += 1
+            continue
+
+        if line.startswith('Author:'):
+            author = re.match('Author:\s+(.*)\s+<(.*)>', line)
+            if author:
+                email = author.group(2)
+            continue
+
+        if line.startswith('Date:'):
+
+            isodate = re.match('Date:\s+(.*)', line)
+            d = parse_date(isodate.group(1))
+            continue
+
+        if len(line) < 2 and new_commit:
+            new_commit = False
+            key = '{0}-{1}'.format(d.year, str(d.month).zfill(2))
+
+            if key not in results:
+                results[key] = []
+
+            if key not in commits:
+                commits[key] = 0
+
+            if email not in results[key]:
+                results[key].append(email)
+
+            commits[key] += commitcount
+            commitcount = 0
+
+    fh.close()
+
+    return (results, commits)
+
+
+def count_results(results, commits):
+
+    result_str = ''
+    print('Date\tContributors\tCommits')
+    for k in sorted(results.iterkeys()):
+        result_str += '{0}\t{1}\t{2}'.format(k, len(results[k]), commits[k])
+        result_str += '\n'
+
+    return result_str
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv
+    try:
+        try:
+            opts, args = getopt.getopt(argv[1:], "h", ["help"])
+        except getopt.error, msg:
+             raise Usage(msg)
+    except Usage, err:
+        print >>sys.stderr, err.msg
+        print >>sys.stderr, "for help use --help"
+        return 2
+
+    if len(opts) > 0:
+        if '-h' in opts[0] or '--help' in opts[0]:
+            print('committerparser.py [- | logfilename]')
+            print('   : Parse commit log from git and print number of commits and unique committers')
+            print('   : by month.  Accepts a filename or reads from stdin.')
+            return 0
+
+    data, counts = parse_gitlog(filename=args[0])
+
+    print count_results(data, counts)
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This python script parses the git log and returns numbers of commits and unique contributors.
