### PR TITLE
Unbreak test for loader

### DIFF
--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -368,8 +368,7 @@ def not_loaded():
     '''
     prov = providers()
     ret = set()
-    loader = salt.loader._create_loader(__opts__, 'modules', 'module')
-    for mod_dir in loader.module_dirs:
+    for mod_dir in salt.loader._module_dirs(__opts__, 'modules', 'module'):
         if not os.path.isabs(mod_dir):
             continue
         if not os.path.isdir(mod_dir):


### PR DESCRIPTION
Fix for #21402

This will fix the test to do what it did before, but we shoudl re-work this module-- since this doesn't take everything into account (such as **virtual**)
