### PR TITLE
More correct fix for runner output issue

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -5,7 +5,6 @@ A collection of mixins useful for the various *Client interfaces
 from __future__ import print_function
 from __future__ import absolute_import
 import collections
-import copy
 import logging
 import traceback
 import multiprocessing
@@ -248,16 +247,6 @@ class SyncClientMixin(object):
                 'user': low.get('__user__', 'UNKNOWN'),
                 }
 
-        # Append kwargs to the data map. This is particularly important
-        # so as to include 'outputter' in the map.
-        # TODO: should this be done here or just before 'ret' event is fired?
-        if 'kwargs' in low:
-            kwargs = copy.deepcopy(low['kwargs'])
-            for kwargs_key, kwargs_value in kwargs.items():
-                # Do not overwrite fun, jid, or user.
-                if kwargs_key not in ('fun', 'jid', 'user'):
-                    data[kwargs_key] = kwargs[kwargs_key]
-
         event = salt.utils.event.get_event(
                 'master',
                 self.opts['sock_dir'],
@@ -450,33 +439,17 @@ class AsyncClientMixin(object):
             return
 
         # some suffixes we don't want to print
-        if suffix in ('new', ):
+        if suffix in ('new',):
             return
 
-        # --out/output and outtputer= are synonyms.
-        # --out/output wins if both are defined
-        # Default to the outputter in the event
-        outputter = event.get('outputter', None)
-        # --out and --output are gracked internally with 'output'
-        # self.opts.get('out') will resolve to None
-        opts_outputter = self.opts.get('output', None)
-
-        # Override with opts_outputter?
-        if opts_outputter is not None:
-            # Emit a warning if both are defined and the outputter is changing
-            if outputter is not None and outputter != opts_outputter:
-                warning = "Both outputter={0} and --out/output={1} are defined. {1} will be used.".format(outputter, opts_outputter)
-                log.warn(warning)
-            outputter = opts_outputter
-
-        # TODO: clean up this event print out. We probably want something
-        # more general, since this will get *really* messy as
-        # people use more events that don't quite fit into this mold
-        if suffix == 'ret':  # for "ret" just print out return
-            salt.output.display_output(event['return'], outputter, self.opts)
-        elif isinstance(event, dict) and outputter is not None:
-            print(self.outputters[outputter](event['data']))
-        # otherwise fall back on basic printing
+        # Check if ouputter was passed in the return data. If this is the case,
+        # then the return data will be a dict two keys: 'data' and 'outputter'
+        if isinstance(event['return'], dict) \
+                and set(event['return']) == set(('data', 'outputter')):
+            event_data = event['return']['data']
+            outputter = event['return']['outputter']
         else:
-            print('{tag}: {event}'.format(tag=suffix,
-                                          event=event))
+            event_data = event['return']
+            outputter = None
+
+        salt.output.display_output(event_data, outputter, self.opts)

--- a/salt/runners/cache.py
+++ b/salt/runners/cache.py
@@ -8,14 +8,12 @@ import logging
 
 # Import salt libs
 import salt.log
+import salt.utils
 import salt.utils.master
 import salt.payload
 from salt.ext.six import string_types
 
 log = logging.getLogger(__name__)
-
-DEPRECATION_WARNING = ("The 'minion' arg will be removed from "
-                       "cache.py runner. Specify minion with 'tgt' arg!")
 
 
 def grains(tgt=None, expr_form='glob', outputter=None, **kwargs):
@@ -30,10 +28,14 @@ def grains(tgt=None, expr_form='glob', outputter=None, **kwargs):
     '''
     deprecated_minion = kwargs.get('minion', None)
     if tgt is None and deprecated_minion is None:
-        log.warn("DEPRECATION WARNING: {0}".format(DEPRECATION_WARNING))
         tgt = '*'  # targat all minions for backward compatibility
     elif tgt is None and isinstance(deprecated_minion, string_types):
-        log.warn("DEPRECATION WARNING: {0}".format(DEPRECATION_WARNING))
+        salt.utils.warn_until(
+            'Boron',
+            'The \'minion\' argument to the cache.grains runner is '
+            'deprecated. Please specify the minion using the \'tgt\' '
+            'argument.'
+        )
         tgt = deprecated_minion
     elif tgt is None:
         return {}
@@ -43,6 +45,12 @@ def grains(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      opts=__opts__)
     cached_grains = pillar_util.get_minion_grains()
     if outputter:
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the cache.grains runner has '
+            'been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
         return {'outputter': outputter, 'data': cached_grains}
     else:
         return cached_grains
@@ -60,10 +68,14 @@ def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
     '''
     deprecated_minion = kwargs.get('minion', None)
     if tgt is None and deprecated_minion is None:
-        log.warn("DEPRECATION WARNING: {0}".format(DEPRECATION_WARNING))
         tgt = '*'  # targat all minions for backward compatibility
     elif tgt is None and isinstance(deprecated_minion, string_types):
-        log.warn("DEPRECATION WARNING: {0}".format(DEPRECATION_WARNING))
+        salt.utils.warn_until(
+            'Boron',
+            'The \'minion\' argument to the cache.pillar runner is '
+            'deprecated. Please specify the minion using the \'tgt\' '
+            'argument.'
+        )
         tgt = deprecated_minion
     elif tgt is None:
         return {}
@@ -75,6 +87,12 @@ def pillar(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      opts=__opts__)
     cached_pillar = pillar_util.get_minion_pillar()
     if outputter:
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the cache.pillar runner has '
+            'been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
         return {'outputter': outputter, 'data': cached_pillar}
     else:
         return cached_pillar
@@ -92,10 +110,14 @@ def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
     '''
     deprecated_minion = kwargs.get('minion', None)
     if tgt is None and deprecated_minion is None:
-        log.warn("DEPRECATION WARNING: {0}".format(DEPRECATION_WARNING))
         tgt = '*'  # targat all minions for backward compatibility
     elif tgt is None and isinstance(deprecated_minion, string_types):
-        log.warn("DEPRECATION WARNING: {0}".format(DEPRECATION_WARNING))
+        salt.utils.warn_until(
+            'Boron',
+            'The \'minion\' argument to the cache.mine runner is '
+            'deprecated. Please specify the minion using the \'tgt\' '
+            'argument.'
+        )
         tgt = deprecated_minion
     elif tgt is None:
         return {}
@@ -107,6 +129,12 @@ def mine(tgt=None, expr_form='glob', outputter=None, **kwargs):
                                                      opts=__opts__)
     cached_mine = pillar_util.get_cached_mine_data()
     if outputter:
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the cache.mine runner has '
+            'been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
         return {'outputter': outputter, 'data': cached_mine}
     else:
         return cached_mine

--- a/salt/runners/fileserver.py
+++ b/salt/runners/fileserver.py
@@ -5,10 +5,11 @@ Directly manage the Salt fileserver plugins
 from __future__ import absolute_import
 
 # Import Salt libs
+import salt.utils
 import salt.fileserver
 
 
-def envs(backend=None, sources=False, outputter='nested'):
+def envs(backend=None, sources=False, outputter=None):
     '''
     Return the available fileserver environments. If no backend is provided,
     then the environments for all configured backends will be returned.
@@ -32,7 +33,6 @@ def envs(backend=None, sources=False, outputter='nested'):
     .. code-block:: bash
 
         salt-run fileserver.envs
-        salt-run fileserver.envs outputter=nested
         salt-run fileserver.envs backend=roots,git
         salt-run fileserver.envs git
     '''
@@ -40,12 +40,18 @@ def envs(backend=None, sources=False, outputter='nested'):
     output = fileserver.envs(back=backend, sources=sources)
 
     if outputter:
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the fileserver.envs runner has '
+            'been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
         return {'outputter': outputter, 'data': output}
     else:
         return output
 
 
-def file_list(saltenv='base', backend=None, outputter='nested'):
+def file_list(saltenv='base', backend=None, outputter=None):
     '''
     Return a list of files from the salt fileserver
 
@@ -77,11 +83,18 @@ def file_list(saltenv='base', backend=None, outputter='nested'):
     output = fileserver.file_list(load=load)
 
     if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the fileserver.file_list runner '
+            'has been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
-def symlink_list(saltenv='base', backend=None, outputter='nested'):
+def symlink_list(saltenv='base', backend=None, outputter=None):
     '''
     Return a list of symlinked files and dirs
 
@@ -113,12 +126,18 @@ def symlink_list(saltenv='base', backend=None, outputter='nested'):
     output = fileserver.symlink_list(load=load)
 
     if outputter:
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the fileserver.symlink_list '
+            'runner has been deprecated. Please specify an outputter using '
+            '--out. See the output of \'salt-run -h\' for more information.'
+        )
         return {'outputter': outputter, 'data': output}
     else:
         return output
 
 
-def dir_list(saltenv='base', backend=None, outputter='nested'):
+def dir_list(saltenv='base', backend=None, outputter=None):
     '''
     Return a list of directories in the given environment
 
@@ -150,11 +169,18 @@ def dir_list(saltenv='base', backend=None, outputter='nested'):
     output = fileserver.dir_list(load=load)
 
     if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the fileserver.dir_list runner '
+            'has been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
-def empty_dir_list(saltenv='base', backend=None, outputter='nested'):
+def empty_dir_list(saltenv='base', backend=None, outputter=None):
     '''
     .. versionadded:: 2015.2.0
 
@@ -191,8 +217,15 @@ def empty_dir_list(saltenv='base', backend=None, outputter='nested'):
     output = fileserver.file_list_emptydirs(load=load)
 
     if outputter:
-        salt.output.display_output(output, outputter, opts=__opts__)
-    return output
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the fileserver.empty_dir_list '
+            'runner has been deprecated. Please specify an outputter using '
+            '--out. See the output of \'salt-run -h\' for more information.'
+        )
+        return {'outputter': outputter, 'data': output}
+    else:
+        return output
 
 
 def update(backend=None):

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -111,6 +111,15 @@ def lookup_jid(jid,
         data = mminion.returners['{0}.get_jid'.format(returner)](jid)
     except TypeError:
         return 'Requested returner could not be loaded. No JIDs could be retrieved.'
+
+    if outputter is None:
+        try:
+            # Check if the return data has an 'out' key. We'll use that as the
+            # outputter in the absence of one being passed on the CLI.
+            outputter = data[next(iter(data))].get('out')
+        except (StopIteration, AttributeError):
+            outputter = None
+
     for minion in data:
         if display_progress:
             __jid_event__.fire_event({'message': minion}, 'progress')

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -90,11 +90,6 @@ def lookup_jid(jid,
         When set to `True`, adds the minions that did not return from the command.
         Default: `False`.
 
-    outputter
-        The outputter to use. Default: `None`.
-
-        .. versionadded:: 2015.2.0
-
     display_progress
         Displays progress events when set to `True`. Default: `False`.
 
@@ -118,14 +113,6 @@ def lookup_jid(jid,
     except TypeError:
         return 'Requested returner could not be loaded. No JIDs could be retrieved.'
 
-    if outputter is None:
-        try:
-            # Check if the return data has an 'out' key. We'll use that as the
-            # outputter in the absence of one being passed on the CLI.
-            outputter = data[next(iter(data))].get('out')
-        except (StopIteration, AttributeError):
-            outputter = None
-
     for minion in data:
         if display_progress:
             __jid_event__.fire_event({'message': minion}, 'progress')
@@ -139,6 +126,18 @@ def lookup_jid(jid,
         for minion_id in exp:
             if minion_id not in data:
                 ret[minion_id] = 'Minion did not return'
+
+    # Once we remove the outputter argument in a couple releases, we still
+    # need to check to see if the 'out' key is present and use it to specify
+    # the correct outputter, so we get highstate output for highstate runs.
+    if outputter is None:
+        try:
+            # Check if the return data has an 'out' key. We'll use that as the
+            # outputter in the absence of one being passed on the CLI.
+            outputter = data[next(iter(data))].get('out')
+        except (StopIteration, AttributeError):
+            outputter = None
+
     if outputter:
         return {'outputter': outputter, 'data': ret}
     else:

--- a/salt/runners/jobs.py
+++ b/salt/runners/jobs.py
@@ -61,6 +61,12 @@ def active(outputter=None, display_progress=False):
                 ret[jid]['Returned'].append(minion)
 
     if outputter:
+        salt.utils.warn_until(
+            'Boron',
+            'The \'outputter\' argument to the jobs.active runner '
+            'has been deprecated. Please specify an outputter using --out. '
+            'See the output of \'salt-run -h\' for more information.'
+        )
         return {'outputter': outputter, 'data': ret}
     else:
         return ret

--- a/tests/integration/runners/fileserver.py
+++ b/tests/integration/runners/fileserver.py
@@ -23,21 +23,65 @@ class ManageTest(integration.ShellCase):
         ret = self.run_run_plus(fun='fileserver.dir_list')
         self.assertIsInstance(ret['fun'], list)
 
+        # Backend submitted as a string
+        ret = self.run_run_plus(fun='fileserver.dir_list',
+                                args=['backend="roots"'])
+        self.assertIsInstance(ret['fun'], list)
+
+        # Backend submitted as a list
+        ret = self.run_run_plus(fun='fileserver.dir_list',
+                                args=['backend="[roots]"'])
+        self.assertIsInstance(ret['fun'], list)
+
+    def test_empty_dir_list(self):
+        '''
+        fileserver.empty_dir_list
+        '''
+        ret = self.run_run_plus(fun='fileserver.empty_dir_list')
+        self.assertIsInstance(ret['fun'], list)
+
+        # Backend submitted as a string
+        ret = self.run_run_plus(fun='fileserver.empty_dir_list',
+                                args=['backend="roots"'])
+        self.assertIsInstance(ret['fun'], list)
+
+        # Backend submitted as a list
+        ret = self.run_run_plus(fun='fileserver.empty_dir_list',
+                                args=['backend="[roots]"'])
+        self.assertIsInstance(ret['fun'], list)
+
     def test_envs(self):
         '''
         fileserver.envs
         '''
         ret = self.run_run_plus(fun='fileserver.envs')
-        self.assertIsInstance(ret['fun'], dict)
+        self.assertIsInstance(ret['fun'], list)
 
-        ret = self.run_run_plus(fun='fileserver.envs', args=['backend="{0}"'.format(['root'])])
-        self.assertIsInstance(ret['fun'], dict)
+        # Backend submitted as a string
+        ret = self.run_run_plus(fun='fileserver.envs',
+                                args=['backend="roots"'])
+        self.assertIsInstance(ret['fun'], list)
+
+        # Backend submitted as a list
+        ret = self.run_run_plus(fun='fileserver.envs',
+                                args=['backend="[roots]"'])
+        self.assertIsInstance(ret['fun'], list)
 
     def test_file_list(self):
         '''
         fileserver.file_list
         '''
         ret = self.run_run_plus(fun='fileserver.file_list')
+        self.assertIsInstance(ret['fun'], list)
+
+        # Backend submitted as a string
+        ret = self.run_run_plus(fun='fileserver.file_list',
+                                args=['backend="roots"'])
+        self.assertIsInstance(ret['fun'], list)
+
+        # Backend submitted as a list
+        ret = self.run_run_plus(fun='fileserver.file_list',
+                                args=['backend="[roots]"'])
         self.assertIsInstance(ret['fun'], list)
 
     def test_symlink_list(self):
@@ -47,11 +91,31 @@ class ManageTest(integration.ShellCase):
         ret = self.run_run_plus(fun='fileserver.symlink_list')
         self.assertIsInstance(ret['fun'], dict)
 
+        # Backend submitted as a string
+        ret = self.run_run_plus(fun='fileserver.symlink_list',
+                                args=['backend="roots"'])
+        self.assertIsInstance(ret['fun'], dict)
+
+        # Backend submitted as a list
+        ret = self.run_run_plus(fun='fileserver.symlink_list',
+                                args=['backend="[roots]"'])
+        self.assertIsInstance(ret['fun'], dict)
+
     def test_update(self):
         '''
         fileserver.update
         '''
         ret = self.run_run_plus(fun='fileserver.update')
+        self.assertTrue(ret['fun'])
+
+        # Backend submitted as a string
+        ret = self.run_run_plus(fun='fileserver.update',
+                                args=['backend="roots"'])
+        self.assertTrue(ret['fun'])
+
+        # Backend submitted as a list
+        ret = self.run_run_plus(fun='fileserver.update',
+                                args=['backend="[roots]"'])
         self.assertTrue(ret['fun'])
 
 if __name__ == '__main__':


### PR DESCRIPTION
In the process of testing my fix for #19099 (after having merged #21454), I found out that if `--out` was passed on the CLI, the outputter is passed in the event's return data. This means that there is no reason to pass the outputter separately in the event data, and it lets us do two things:
1. Simplify the `print_async_event()` function's logic considerably
2. Deprecate the use of an `outputter` argument in runner funcs.

The 4 commits I have added to this pull request do just that.
