### PR TITLE
TCP keepalives on the ret side

### DIFF
--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -340,7 +340,8 @@ class Resolver(object):
             sreq = salt.payload.SREQ(
                     'tcp://{0}:{1}'.format(
                         salt.utils.ip_bracket(self.opts['interface']),
-                        self.opts['ret_port'])
+                        self.opts['ret_port']),
+                        opts=self.opts
                 )
             tdata = sreq.send('clear', load)
             return tdata

--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -676,6 +676,7 @@ class SAuth(object):
 
         sreq = salt.payload.SREQ(
             self.opts['master_uri'],
+            opts=self.opts
         )
 
         try:

--- a/salt/payload.py
+++ b/salt/payload.py
@@ -179,13 +179,14 @@ class SREQ(object):
     '''
     Create a generic interface to wrap salt zeromq req calls.
     '''
-    def __init__(self, master, id_='', serial='msgpack', linger=0):
+    def __init__(self, master, id_='', serial='msgpack', linger=0, opts=None):
         self.master = master
         self.id_ = id_
         self.serial = Serial(serial)
         self.linger = linger
         self.context = zmq.Context()
         self.poller = zmq.Poller()
+        self.opts = opts
 
     @property
     def socket(self):
@@ -200,6 +201,7 @@ class SREQ(object):
                     zmq.RECONNECT_IVL_MAX, 5000
                 )
 
+            self._set_tcp_keepalive()
             if self.master.startswith('tcp://['):
                 # Hint PF type if bracket enclosed IPv6 address
                 if hasattr(zmq, 'IPV6'):
@@ -211,6 +213,25 @@ class SREQ(object):
                 self._socket.setsockopt(zmq.IDENTITY, self.id_)
             self._socket.connect(self.master)
         return self._socket
+
+    def _set_tcp_keepalive(self):
+        if hasattr(zmq, 'TCP_KEEPALIVE') and self.opts:
+            if 'tcp_keepalive' in self.opts:
+                self._socket.setsockopt(
+                    zmq.TCP_KEEPALIVE, self.opts['tcp_keepalive']
+                )
+            if 'tcp_keepalive_idle' in self.opts:
+                self._socket.setsockopt(
+                    zmq.TCP_KEEPALIVE_IDLE, self.opts['tcp_keepalive_idle']
+                )
+            if 'tcp_keepalive_cnt' in self.opts:
+                self._socket.setsockopt(
+                    zmq.TCP_KEEPALIVE_CNT, self.opts['tcp_keepalive_cnt']
+                )
+            if 'tcp_keepalive_intvl' in self.opts:
+                self._socket.setsockopt(
+                    zmq.TCP_KEEPALIVE_INTVL, self.opts['tcp_keepalive_intvl']
+                )
 
     def clear_socket(self):
         '''

--- a/salt/transport/__init__.py
+++ b/salt/transport/__init__.py
@@ -229,12 +229,12 @@ class ZeroMQChannel(Channel):
         # When using threading, like on Windows, don't cache.
         # The following block prevents thread leaks.
         if not self.opts.get('multiprocessing'):
-            return salt.payload.SREQ(self.master_uri)
+            return salt.payload.SREQ(self.master_uri, opts=self.opts)
 
         key = self.sreq_key
 
         if not self.opts['cache_sreqs']:
-            return salt.payload.SREQ(self.master_uri)
+            return salt.payload.SREQ(self.master_uri, opts=self.opts)
         else:
             if key not in ZeroMQChannel.sreq_cache:
                 master_type = self.opts.get('master_type', None)
@@ -247,7 +247,7 @@ class ZeroMQChannel(Channel):
                             log.debug('Removed obsolete sreq-object from '
                                       'sreq_cache for master {0}'.format(check_key[0]))
 
-                ZeroMQChannel.sreq_cache[key] = salt.payload.SREQ(self.master_uri)
+                ZeroMQChannel.sreq_cache[key] = salt.payload.SREQ(self.master_uri, opts=self.opts)
 
             return ZeroMQChannel.sreq_cache[key]
 


### PR DESCRIPTION
It turns out that we were not setting the same keepalive settings on the
connection back to the master on TCP4506 as we were on the inbound side on 4505.

In the past, this technique would have been problematic but now that we are caching
SREQs this is far more viable.

This is a backport into 2015.2 per @thatch45 

cc: @jacksontj (This might interest you as well.)
