### PR TITLE
Enable IPv6 by default

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -11,11 +11,11 @@
 #default_include: master.d/*.conf
 
 # The address of the interface to bind to:
-#interface: 0.0.0.0
+interface: ::
 
 # Whether the master should listen for IPv6 connections. If this is set to True,
 # the interface option must be adjusted, too. (For example: "interface: '::'")
-#ipv6: False
+ipv6: True
 
 # The tcp port used by the publisher:
 #publish_port: 4505

--- a/conf/master
+++ b/conf/master
@@ -11,7 +11,7 @@
 #default_include: master.d/*.conf
 
 # The address of the interface to bind to:
-interface: ::
+interface: '::'
 
 # Whether the master should listen for IPv6 connections. If this is set to True,
 # the interface option must be adjusted, too. (For example: "interface: '::'")

--- a/conf/minion
+++ b/conf/minion
@@ -23,7 +23,7 @@
 #random_master: False
 
 # Set whether the minion should connect to the master via IPv6:
-#ipv6: False
+ipv6: True
 
 # Set the number of seconds to wait before attempting to resolve
 # the master hostname if name resolution fails. Defaults to 30 seconds.

--- a/doc/ref/configuration/master.rst
+++ b/doc/ref/configuration/master.rst
@@ -26,7 +26,7 @@ Primary Master Configuration
 ``interface``
 -------------
 
-Default: ``0.0.0.0`` (all interfaces)
+Default: ``::`` (all interfaces)
 
 The local interface to bind to.
 
@@ -39,7 +39,7 @@ The local interface to bind to.
 ``ipv6``
 --------
 
-Default: ``False``
+Default: ``True``
 
 Whether the master should listen for IPv6 connections. If this is set to True,
 the interface option must be adjusted too (for example: "interface: '::'")

--- a/salt/config.py
+++ b/salt/config.py
@@ -288,7 +288,7 @@ VALID_OPTS = {
 
 # default configurations
 DEFAULT_MINION_OPTS = {
-    'interface': '0.0.0.0',
+    'interface': '::',
     'master': 'salt',
     'master_type': 'str',
     'master_port': '4506',
@@ -366,7 +366,7 @@ DEFAULT_MINION_OPTS = {
     'multiprocessing': True,
     'mine_interval': 60,
     'ipc_mode': 'ipc',
-    'ipv6': False,
+    'ipv6': True,
     'file_buffer_size': 262144,
     'tcp_pub_port': 4510,
     'tcp_pull_port': 4511,
@@ -443,7 +443,7 @@ DEFAULT_MINION_OPTS = {
 }
 
 DEFAULT_MASTER_OPTS = {
-    'interface': '0.0.0.0',
+    'interface': '::',
     'publish_port': '4505',
     'pub_hwm': 1000,
     'rep_hwm': 50000,
@@ -541,7 +541,7 @@ DEFAULT_MASTER_OPTS = {
     'master_job_cache': 'local_cache',
     'minion_data_cache': True,
     'enforce_mine_cache': False,
-    'ipv6': False,
+    'ipv6': True,
     'log_file': os.path.join(salt.syspaths.LOGS_DIR, 'master'),
     'log_level': None,
     'log_level_logfile': None,


### PR DESCRIPTION
With IPv6 becoming more and more common it should be enabled by default in configurations.

Should users want to disable IPv6, they can, but with the depletion of IPv4 going faster
and faster we should encourage users to use IPv6 by enabling it by default.
