### PR TITLE
Fix #20787: YamlEx pillar merging fails when using gpg (even if pillar_source_merging_strategy is set to aggregate)

### DIFF
--- a/salt/renderers/gpg.py
+++ b/salt/renderers/gpg.py
@@ -142,7 +142,9 @@ def decrypt_object(obj, gpg):
             obj[key] = decrypt_object(val, gpg)
         return obj
     elif isinstance(obj, list):
-        return [decrypt_object(e, gpg) for e in obj]
+        for n, v in enumerate(obj):
+            obj[n] = decrypt_object(v, gpg)
+        return obj
     else:
         return obj
 


### PR DESCRIPTION
This fixes issue #20787 by avoiding use of list comprehensions while mutating elements inside gpg render, as to avoid breaking type inference for yamlex items.

It looks like using list comprehensions changes the underlaying list type, and thus, yamlex merge/recursion fails as list object is no longer of type 'Sequence'.
