### PR TITLE
Mannually Backport #21468 to 2014.7

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -1172,6 +1172,12 @@ class AESFuncs(object):
 
         # otherwise, write to the master cache
         fstr = '{0}.returner'.format(self.opts['master_job_cache'])
+        if 'fun' not in load and load.get('return', {}):
+            ret_ = load.get('return', {})
+            if 'fun' in ret_:
+                load.update({'fun': ret_['fun']})
+            if 'user' in ret_:
+                load.update({'user': ret_['user']})
         self.mminion.returners[fstr](load)
 
     def _syndic_return(self, load):


### PR DESCRIPTION
Since the code in master.py was refactored in 2015.2,
the fix from #21468 needed to be backported manually here
for the fix to apply to 2014.7.

Please do not merge until we can test this.

ping @pass-by-value 
