### PR TITLE
Fix traceback when runner function does not exist

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -20,6 +20,7 @@ import salt.transport
 from salt.utils.error import raise_error
 from salt.utils.event import tagify
 from salt.utils.doc import strip_rst as _strip_rst
+from salt.utils.lazy import verify_fun
 
 log = logging.getLogger(__name__)
 
@@ -101,17 +102,6 @@ class SyncClientMixin(object):
         is passed in as kwargs, will re-use the JID passed in
         '''
         return ClientFuncsDict(self)
-
-    def _verify_fun(self, fun):
-        '''
-        Check that the function passed really exists
-        '''
-        if not fun:
-            err = 'Must specify a function to run'
-            raise salt.exceptions.CommandExecutionError(err)
-        if fun not in self.functions:
-            err = 'Function {0!r} is unavailable'.format(fun)
-            raise salt.exceptions.CommandExecutionError(err)
 
     def master_call(self, **kwargs):
         '''
@@ -274,7 +264,7 @@ class SyncClientMixin(object):
         func_globals['__jid_event__'].fire_event(data, 'new')
 
         try:
-            self._verify_fun(fun)
+            verify_fun(self.functions, fun)
 
             # Inject some useful globals to *all* the funciton's global
             # namespace only once per module-- not per func

--- a/salt/runner.py
+++ b/salt/runner.py
@@ -16,6 +16,7 @@ import salt.utils.args
 import salt.utils.event
 from salt.client import mixins
 from salt.output import display_output
+from salt.utils.lazy import verify_fun
 
 log = logging.getLogger(__name__)
 
@@ -132,10 +133,9 @@ class Runner(RunnerClient):
         if self.opts.get('doc', False):
             self.print_docs()
         else:
+            low = {'fun': self.opts['fun']}
             try:
-                low = {'fun': self.opts['fun']}
-                if not low['fun']:
-                    raise salt.exceptions.SaltClientError('\nMust specify a runner to run!\nex: salt-run manage.up\n')
+                verify_fun(self.functions, low['fun'])
                 args, kwargs = salt.minion.load_args_and_kwargs(
                     self.functions[low['fun']],
                     salt.utils.args.parse_input(self.opts['arg']),
@@ -158,16 +158,15 @@ class Runner(RunnerClient):
                 # otherwise run it in the main process
                 async_pub = self._gen_async_pub()
                 ret = self._proc_function(self.opts['fun'],
-                                           low,
-                                           user,
-                                           async_pub['tag'],
-                                           async_pub['jid'],
-                                           False,  # Don't daemonize
-                                           )
+                                          low,
+                                          user,
+                                          async_pub['tag'],
+                                          async_pub['jid'],
+                                          False)  # Don't daemonize
             except salt.exceptions.SaltException as exc:
-                ret = str(exc)
+                ret = '{0}'.format(exc)
                 if not self.opts.get('quiet', False):
-                    print(ret)
+                    salt.output.display_output(ret, 'nested', self.opts)
                 return ret
             log.debug('Runner return: {0}'.format(ret))
             return ret

--- a/salt/utils/lazy.py
+++ b/salt/utils/lazy.py
@@ -1,8 +1,28 @@
 # -*- coding: utf-8 -*-
 import logging
 import collections
+import salt.exceptions
 
 log = logging.getLogger(__name__)
+
+
+def verify_fun(lazy_obj, fun):
+    '''
+    Check that the function passed really exists
+    '''
+    if not fun:
+        raise salt.exceptions.SaltInvocationError(
+            'Must specify a function to run!\n'
+            'ex: salt-run manage.up'
+        )
+    if fun not in lazy_obj:
+        try:
+            lazy_obj[fun]
+        except KeyError:
+            # Runner function not found in the LazyLoader object
+            raise salt.exceptions.CommandExecutionError(
+                '\'{0}\' is not available'.format(fun)
+            )
 
 
 class LazyDict(collections.MutableMapping):


### PR DESCRIPTION
Also use salt.output.display_output to display error output, to make the
error output adhere to the rest of Salt's output behavior.

Fixes #21460.
