### PR TITLE
Just use nested with statements instead of \ continuation

### DIFF
--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -267,7 +267,6 @@ class IptablesTestCase(TestCase):
         mock_has = MagicMock(return_value=True)
         mock_not = MagicMock(return_value=False)
 
-        # pylint: disable=E0001
         with patch.object(iptables, '_has_option', mock_not):
             with patch.object(uuid, 'getnode', MagicMock(return_value=mock_uuid)):
                 with patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
@@ -296,7 +295,6 @@ class IptablesTestCase(TestCase):
                     self.assertTrue(iptables.check(table='filter',
                                                    chain='0x4d2',
                                                    rule=mock_rule, family='ipv4'))
-        # pylint: enable=E0001
 
     # 'check_chain' function tests: 1
 

--- a/tests/unit/modules/iptables_test.py
+++ b/tests/unit/modules/iptables_test.py
@@ -268,34 +268,34 @@ class IptablesTestCase(TestCase):
         mock_not = MagicMock(return_value=False)
 
         # pylint: disable=E0001
-        with patch.object(iptables, '_has_option', mock_not),\
-                patch.object(uuid, 'getnode', MagicMock(return_value=mock_uuid)),\
-                patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
-            self.assertTrue(iptables.check(table='filter', chain=mock_chain,
-                                           rule=mock_rule, family='ipv4'))
+        with patch.object(iptables, '_has_option', mock_not):
+            with patch.object(uuid, 'getnode', MagicMock(return_value=mock_uuid)):
+                with patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
+                    self.assertTrue(iptables.check(table='filter', chain=mock_chain,
+                                                   rule=mock_rule, family='ipv4'))
 
         mock_cmd = MagicMock(return_value='')
 
-        with patch.object(iptables, '_has_option', mock_not),\
-                patch.object(uuid, 'getnode', MagicMock(return_value=mock_uuid)),\
-                patch.dict(iptables.__salt__, {'cmd.run': MagicMock(return_value='')}):
-            self.assertFalse(iptables.check(table='filter', chain=mock_chain,
-                                            rule=mock_rule, family='ipv4'))
+        with patch.object(iptables, '_has_option', mock_not):
+            with patch.object(uuid, 'getnode', MagicMock(return_value=mock_uuid)):
+                with patch.dict(iptables.__salt__, {'cmd.run': MagicMock(return_value='')}):
+                    self.assertFalse(iptables.check(table='filter', chain=mock_chain,
+                                                    rule=mock_rule, family='ipv4'))
 
-        with patch.object(iptables, '_has_option', mock_has),\
-                patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
-            self.assertTrue(iptables.check(table='filter', chain='INPUT',
-                                           rule=mock_rule, family='ipv4'))
+        with patch.object(iptables, '_has_option', mock_has):
+            with patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
+                self.assertTrue(iptables.check(table='filter', chain='INPUT',
+                                               rule=mock_rule, family='ipv4'))
 
         mock_cmd = MagicMock(return_value='-A 0x4d2')
         mock_uuid = MagicMock(return_value=1234)
 
-        with patch.object(iptables, '_has_option', mock_has),\
-                patch.object(uuid, 'getnode', mock_uuid),\
-                patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
-            self.assertTrue(iptables.check(table='filter',
-                                           chain='0x4d2',
-                                           rule=mock_rule, family='ipv4'))
+        with patch.object(iptables, '_has_option', mock_has):
+            with patch.object(uuid, 'getnode', mock_uuid):
+                with patch.dict(iptables.__salt__, {'cmd.run': mock_cmd}):
+                    self.assertTrue(iptables.check(table='filter',
+                                                   chain='0x4d2',
+                                                   rule=mock_rule, family='ipv4'))
         # pylint: enable=E0001
 
     # 'check_chain' function tests: 1


### PR DESCRIPTION
Python 2.6 doesn't like that.

This should fix the test errors we are seeing on CentOS 6 and Ubuntu 10 in the test suite.
