### PR TITLE
Update salttesting pip requirement to develop branch.

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -1,5 +1,5 @@
 -r base.txt
--e git+https://github.com/saltstack/salt-testing.git#egg=SaltTesting
+-e git+https://github.com/saltstack/salt-testing.git@develop#egg=SaltTesting
 
 mock
 boto>=2.32.1


### PR DESCRIPTION
I was trying to get the tests to run and it couldn't find requires_sshd_server in salttesting. Changing the pip dependency on salttesting to the develop branch fixes this (master is apparently unused since since Jan. 2, 2014, over a year ago.)
