### PR TITLE
updated s3.query function to return headers for successful requests

### DIFF
--- a/salt/utils/s3.py
+++ b/salt/utils/s3.py
@@ -218,7 +218,7 @@ def query(key, keyid, method='GET', params=None, headers=None,
         if return_url is True:
             return ret, requesturl
     else:
-        if method == 'GET' or method == 'HEAD':
+        if result.status_code != requests.codes.ok:
             return
         ret = {'headers': []}
         for header in result.headers:


### PR DESCRIPTION
updated s3.query function to return headers array for successful requests
fixes issue with s3.head returning None for files that exist

@wt - would you be able to confirm that this doesn't re-introduce any s3fs issues fixed by  dde993e14db53b2efd163ee252413d5cd725adbf
