### PR TITLE
Fix for issue #21491 (composer install should always run)

### DIFF
--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -129,7 +129,7 @@ def installed(name,
 
         if did_install is True:
             install_status = ""
-        else
+        else:
             install_status = "not "
 
         ret['comment'] = 'The state of "{0}" will be changed.'.format(name)

--- a/salt/states/composer.py
+++ b/salt/states/composer.py
@@ -61,10 +61,10 @@ def installed(name,
               optimize=None,
               no_dev=None,
               quiet=False,
-              composer_home='/root'):
+              composer_home='/root',
+              always_check=True):
     '''
-    Verify that composer has installed the latest packages give a
-    ``composer.json`` and ``composer.lock`` file in a directory.
+    Verify that the correct versions of composer dependencies are present.
 
     dir
         Directory location of the composer.json file.
@@ -106,12 +106,19 @@ def installed(name,
 
     composer_home
         $COMPOSER_HOME environment variable
+
+    always_check
+        If True, _always_ run `composer install` in the directory.  This is the
+        default behavior.  If False, only run `composer install` if there is no
+        vendor directory present.
     '''
     ret = {'name': name, 'result': None, 'comment': '', 'changes': {}}
 
+    did_install = __salt__['composer.did_composer_install'](name)
+
     # Check if composer.lock exists, if so we already ran `composer install`
     # and we don't need to do it again
-    if __salt__['composer.did_composer_install'](name):
+    if always_check is False and did_install:
         ret['result'] = True
         ret['comment'] = 'Composer already installed this directory'
         return ret
@@ -119,9 +126,15 @@ def installed(name,
     # The state of the system does need to be changed. Check if we're running
     # in ``test=true`` mode.
     if __opts__['test'] is True:
+
+        if did_install is True:
+            install_status = ""
+        else
+            install_status = "not "
+
         ret['comment'] = 'The state of "{0}" will be changed.'.format(name)
         ret['changes'] = {
-            'old': 'composer install has not yet been run in {0}'.format(name),
+            'old': 'composer install has {0}been run in {1}'.format(install_status, name),
             'new': 'composer install will be run in {0}'.format(name)
         }
         ret['result'] = None

--- a/tests/unit/modules/composer_test.py
+++ b/tests/unit/modules/composer_test.py
@@ -36,20 +36,25 @@ class ComposerTestCase(TestCase):
         '''
         Test for Install composer dependencies for a directory.
         '''
+
+        # Test _valid_composer=False throws exception
         mock = MagicMock(return_value=False)
         with patch.object(composer, '_valid_composer', mock):
             self.assertRaises(CommandNotFoundError, composer.install, 'd')
 
+        # Test no directory specified throws exception
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             self.assertRaises(SaltInvocationError, composer.install, None)
 
+        # Test `composer install` exit status != 0 throws exception
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value={'retcode': 1, 'stderr': 'A'})
             with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
                 self.assertRaises(CommandExecutionError, composer.install, 'd')
 
+        # Test success with quiet=True returns True
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value={'retcode': 0, 'stderr': 'A'})
@@ -58,6 +63,7 @@ class ComposerTestCase(TestCase):
                                                  None, None, None, None, None,
                                                  True))
 
+        # Test success with quiet=False returns object
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             rval = {'retcode': 0, 'stderr': 'A', 'stdout': 'B'}
@@ -65,14 +71,27 @@ class ComposerTestCase(TestCase):
             with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
                 self.assertEqual(composer.install('dir'), rval)
 
+        # Test success with existing vendor directory and always_check=False returns object
+        mock = MagicMock(return_value=True)
+        with patch.object(composer, '_valid_composer', mock):
+            mock = MagicMock(return_value=True)
+            with patch.object(composer, 'did_composer_install', mock):
+                rval = {'retcode': 0, 'stderr': 'A', 'stdout': 'B'}
+                mock = MagicMock(return_value=rval)
+                with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
+                    self.assertEqual(composer.install('dir', always_check=False), rval)
+
     def test_update(self):
         '''
         Test for Update composer dependencies for a directory.
         '''
+
+        # Test _valid_composer=False throws exception
         mock = MagicMock(return_value=False)
         with patch.object(composer, '_valid_composer', mock):
             self.assertRaises(CommandNotFoundError, composer.update, 'd')
 
+        # Test no directory specified throws exception
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value=True)
@@ -88,7 +107,7 @@ class ComposerTestCase(TestCase):
                 with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
                     self.assertRaises(CommandExecutionError, composer.update, 'd')
 
-        # Test update with existing composer.lock and quiet=True
+        # Test update with existing vendor directory and quiet=True
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value=True)
@@ -99,7 +118,7 @@ class ComposerTestCase(TestCase):
                                                     None, None, None, None, None,
                                                     True))
 
-        # Test update with no composer.lock and quiet=True
+        # Test update with no vendor directory and quiet=True
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value=False)
@@ -110,7 +129,7 @@ class ComposerTestCase(TestCase):
                                                     None, None, None, None, None,
                                                     True))
 
-        # Test update with existing composer.lock
+        # Test update with existing vendor directory
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value=True)
@@ -120,7 +139,7 @@ class ComposerTestCase(TestCase):
                 with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
                     self.assertEqual(composer.update('dir'), rval)
 
-        # Test update with no composer.lock
+        # Test update with no vendor directory
         mock = MagicMock(return_value=True)
         with patch.object(composer, '_valid_composer', mock):
             mock = MagicMock(return_value=False)
@@ -132,7 +151,7 @@ class ComposerTestCase(TestCase):
 
     def test_selfupdate(self):
         '''
-        Test for Install composer dependencies for a directory.
+        Test for Composer selfupdate
         '''
         mock = MagicMock(return_value=False)
         with patch.object(composer, '_valid_composer', mock):

--- a/tests/unit/modules/composer_test.py
+++ b/tests/unit/modules/composer_test.py
@@ -71,16 +71,6 @@ class ComposerTestCase(TestCase):
             with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
                 self.assertEqual(composer.install('dir'), rval)
 
-        # Test success with existing vendor directory and always_check=False returns object
-        mock = MagicMock(return_value=True)
-        with patch.object(composer, '_valid_composer', mock):
-            mock = MagicMock(return_value=True)
-            with patch.object(composer, 'did_composer_install', mock):
-                rval = {'retcode': 0, 'stderr': 'A', 'stdout': 'B'}
-                mock = MagicMock(return_value=rval)
-                with patch.dict(composer.__salt__, {'cmd.run_all': mock}):
-                    self.assertEqual(composer.install('dir', always_check=False), rval)
-
     def test_update(self):
         '''
         Test for Update composer dependencies for a directory.


### PR DESCRIPTION
The composer.installed state will now _always_ execute `composer install` by default.  This reinstates the previous 2014.7 default functionality.  (Fix issue #21491)

You can now pass an optional parameter always_check=False to make it only execute if/when the `vendor` sub-directory does not exist.

Changed the "did we run this before?" functionality to check for existence of the `vendor` directory rather than the `composer.lock` file since `composer.lock` is sometimes committed to the repository.

While I was in here, I modified the composer.update and composer.selfupdate modules to pass the `--no-progress` flag to `composer` which will remove the "Downloading ... X%" spam from stdout.

Also added more comments to tests to make it easier to see what they're actually trying to test.
