### PR TITLE
add calculate_subnet to network module

### DIFF
--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -711,6 +711,7 @@ def ip_in_subnet(ip_addr, cidr):
     '''
     return salt.utils.network.ip_in_subnet(ip_addr, cidr)
 
+
 def calculate_subnet(ip_addr, netmask):
     '''
     Returns the CIDR of a subnet based on an IP address and network.
@@ -722,6 +723,7 @@ def calculate_subnet(ip_addr, netmask):
         salt '*' network.calculate_subnet 172.17.0.5 255.255.255.240
     '''
     return salt.utils.network.calculate_subnet(ip_addr, netmask)
+
 
 def ip_addrs(interface=None, include_loopback=False, cidr=None):
     '''

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -721,6 +721,8 @@ def calculate_subnet(ip_addr, netmask):
     .. code-block:: bash
 
         salt '*' network.calculate_subnet 172.17.0.5 255.255.255.240
+
+    .. versionadded:: Beryllium
     '''
     return salt.utils.network.calculate_subnet(ip_addr, netmask)
 

--- a/salt/modules/network.py
+++ b/salt/modules/network.py
@@ -711,6 +711,17 @@ def ip_in_subnet(ip_addr, cidr):
     '''
     return salt.utils.network.ip_in_subnet(ip_addr, cidr)
 
+def calculate_subnet(ip_addr, netmask):
+    '''
+    Returns the CIDR of a subnet based on an IP address and network.
+
+    CLI Example:
+
+    .. code-block:: bash
+
+        salt '*' network.calculate_subnet 172.17.0.5 255.255.255.240
+    '''
+    return salt.utils.network.calculate_subnet(ip_addr, netmask)
 
 def ip_addrs(interface=None, include_loopback=False, cidr=None):
     '''


### PR DESCRIPTION
I'm using jinja templating to create routes, exposing the calculate_subnet utility so that it can be called from jinja allows me to dynamically get a subnet from an ip address and netmask.
