### PR TITLE
Fire event on event init

### DIFF
--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -241,6 +241,7 @@ class SaltEvent(object):
         self.sub.connect(self.puburi)
         self.poller.register(self.sub, zmq.POLLIN)
         self.sub.setsockopt(zmq.SUBSCRIBE, '')
+        self.sub.setsockopt(zmq.LINGER, 5000)
         self.cpub = True
 
     def connect_pull(self, timeout=1000):
@@ -258,6 +259,7 @@ class SaltEvent(object):
             # This is for ZMQ < 2.2 (Caught when ssh'ing into the Jenkins
             #                        CentOS5, which still uses 2.1.9)
             pass
+        self.push.setsockopt(zmq.LINGER, 5000)
         self.push.connect(self.pulluri)
         self.cpush = True
 
@@ -426,10 +428,8 @@ class SaltEvent(object):
             # Wait at most 2.5 secs to send any remaining messages in the
             # socket or the context.term() bellow will hang indefinitely.
             # See https://github.com/zeromq/pyzmq/issues/102
-            self.sub.setsockopt(zmq.LINGER, linger)
             self.sub.close()
         if self.cpush is True and self.push.closed is False:
-            self.push.setsockopt(zmq.LINGER, linger)
             self.push.close()
         # If sockets are not unregistered from a poller, nothing which touches
         # that poller gets garbage collected. The Poller itself, its

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -170,7 +170,7 @@ class SaltEvent(object):
         self.pending_events = []
         # since ZMQ connect()  has no guarantees about the socket actually being
         # connected this is a hack to attempt to do so.
-        self.fire_event({}, '_event_client_startup', 0)
+        self.fire_event({}, tagify('event/new_client'), 0)
         self.get_event(wait=1)
 
     def __load_uri(self, sock_dir, node):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -170,6 +170,7 @@ class SaltEvent(object):
         self.pending_events = []
         # since ZMQ connect()  has no guarantees about the socket actually being
         # connected this is a hack to attempt to do so.
+        self.fire_event({}, '_event_client_startup', 0)
         self.get_event(wait=1)
 
     def __load_uri(self, sock_dir, node):

--- a/salt/utils/event.py
+++ b/salt/utils/event.py
@@ -259,7 +259,7 @@ class SaltEvent(object):
             # This is for ZMQ < 2.2 (Caught when ssh'ing into the Jenkins
             #                        CentOS5, which still uses 2.1.9)
             pass
-        self.push.setsockopt(zmq.LINGER, 5000)
+        self.push.setsockopt(zmq.LINGER, timeout)
         self.push.connect(self.pulluri)
         self.cpush = True
 


### PR DESCRIPTION
This way once we connect there will be something for us to get to. Not a perfect fix since we are fixing a race condition by adding in another one, but in most cases it seems to finish in 0.0007s instead of 1s (on a quiet event bus)

Better workaround for #20950
