### PR TITLE
Fix 21578

### DIFF
--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -424,6 +424,9 @@ class AsyncClientMixin(object):
         '''
         Print all of the events with the prefix 'tag'
         '''
+        if not isinstance(event, dict):
+            return
+
         # if we are "quiet", don't print
         if self.opts.get('quiet', False):
             return
@@ -432,9 +435,9 @@ class AsyncClientMixin(object):
         if suffix in ('new',):
             return
 
-        outputter = event.get('outputter', None)
+        outputter = event.get('outputter', self.opts.get('output', None))
         # if this is a ret, we have our own set of rules
-        if isinstance(event, dict) and suffix == 'ret':
+        if suffix == 'ret':
             # Check if ouputter was passed in the return data. If this is the case,
             # then the return data will be a dict two keys: 'data' and 'outputter'
             if isinstance(event.get('return'), dict) \

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -435,7 +435,7 @@ class AsyncClientMixin(object):
         # Check if ouputter was passed in the return data. If this is the case,
         # then the return data will be a dict two keys: 'data' and 'outputter'
         outputter = None
-        if 'return' in event:
+        if isinstance(event, dict) and 'return' in event:
             if isinstance(event.get('return'), dict) \
                     and set(event['return']) == set(('data', 'outputter')):
                 event_data = event['return']['data']
@@ -443,6 +443,6 @@ class AsyncClientMixin(object):
             else:
                 event_data = event['return']
         else:
-            event_data = event
+            event_data = {'suffix': suffix, 'event': event}
 
         salt.output.display_output(event_data, outputter, self.opts)

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -435,7 +435,7 @@ class AsyncClientMixin(object):
         if suffix in ('new',):
             return
 
-        outputter = event.get('outputter', self.opts.get('output', None))
+        outputter = self.opts.get('output', event.get('outputter', None))
         # if this is a ret, we have our own set of rules
         if suffix == 'ret':
             # Check if ouputter was passed in the return data. If this is the case,

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -432,7 +432,7 @@ class AsyncClientMixin(object):
         if suffix in ('new',):
             return
 
-        outputter = None
+        outputter = event.get('outputter', None)
         # if this is a ret, we have our own set of rules
         if isinstance(event, dict) and suffix == 'ret':
             # Check if ouputter was passed in the return data. If this is the case,

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -432,10 +432,11 @@ class AsyncClientMixin(object):
         if suffix in ('new',):
             return
 
-        # Check if ouputter was passed in the return data. If this is the case,
-        # then the return data will be a dict two keys: 'data' and 'outputter'
         outputter = None
-        if isinstance(event, dict) and 'return' in event:
+        # if this is a ret, we have our own set of rules
+        if isinstance(event, dict) and suffix == 'ret':
+            # Check if ouputter was passed in the return data. If this is the case,
+            # then the return data will be a dict two keys: 'data' and 'outputter'
             if isinstance(event.get('return'), dict) \
                     and set(event['return']) == set(('data', 'outputter')):
                 event_data = event['return']['data']

--- a/salt/client/mixins.py
+++ b/salt/client/mixins.py
@@ -434,12 +434,15 @@ class AsyncClientMixin(object):
 
         # Check if ouputter was passed in the return data. If this is the case,
         # then the return data will be a dict two keys: 'data' and 'outputter'
-        if isinstance(event['return'], dict) \
-                and set(event['return']) == set(('data', 'outputter')):
-            event_data = event['return']['data']
-            outputter = event['return']['outputter']
+        outputter = None
+        if 'return' in event:
+            if isinstance(event.get('return'), dict) \
+                    and set(event['return']) == set(('data', 'outputter')):
+                event_data = event['return']['data']
+                outputter = event['return']['outputter']
+            else:
+                event_data = event['return']
         else:
-            event_data = event['return']
-            outputter = None
+            event_data = event
 
         salt.output.display_output(event_data, outputter, self.opts)


### PR DESCRIPTION
Not all events are returns, so we should do a .get() instead of a direct access

This should fix this regression which was introduced in #21463

We are still changing the output to _always_ use an outputter, but thats probably okay since the async_event print stuff _is_ new

fix #21578
