### PR TITLE
Fix parsing of NTP servers on Windows.

### DIFF
--- a/salt/modules/win_ntp.py
+++ b/salt/modules/win_ntp.py
@@ -68,7 +68,7 @@ def get_servers():
     cmd = ['w32tm', '/query', '/configuration']
     lines = __salt__['cmd.run'](cmd, python_shell=False).splitlines()
     for line in lines:
-        if 'NtpServer' in line:
+        if line.startswith('NtpServer:'):
             _, ntpsvrs = line.rstrip(' (Local)').split(':', 1)
             return sorted(ntpsvrs.split())
     return False


### PR DESCRIPTION
The output of `w32tm /query /configuration` contains (amongst others)
those two lines:

```
NtpServer: 1.europe.pool.ntp.org 0.europe.pool.ntp.org 2.europe.pool.ntp.org (Local)
NtpServer (Local)
```

On a system, where no NTP was configured yet, only the 2nd line is
present.
The current code of `salt.modules.win_ntp` didn't take this into account
and the match for `NtpServer` wasn't strict enough to ensure only the
first line would be parsed, so it ended up attemtping to `.split()` the
2nd line.
This lead to this result:

```
Comment: An exception occurred in this state: Traceback (most recent call last):
           File "salt/state.py", line 1529, in call
           File "salt/states/ntp.py", line 71, in managed
           File "salt/states/ntp.py", line 50, in _get_servers
           File "salt/modules/win_ntp.py", line 72, in get_servers
         ValueError: need more than 1 value to unpack
```

This commit improves the matching by using `.startswith('NtpServer:')` instead.
