### PR TITLE
Begin refactoring ClearFuncs

### DIFF
--- a/salt/acl/__init__.py
+++ b/salt/acl/__init__.py
@@ -20,7 +20,7 @@ class ClientACL(object):
         self.blacklist = blacklist
 
 
-    def user_is_blacklisted(user):
+    def user_is_blacklisted(self, user):
         '''
         Takes a username as a string and returns a boolean. True indicates that
         the provided user has been blacklisted
@@ -31,7 +31,7 @@ class ClientACL(object):
         return False
 
 
-    def cmd_is_blacklisted(cmd):
+    def cmd_is_blacklisted(self, cmd):
         for blacklisted_module in self.blacklist.get('modules', []):
             # If this is a regular command, it is a single function
             if isinstance(cmd, str):

--- a/salt/acl/__init__.py
+++ b/salt/acl/__init__.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+'''
+The acl module handles client_acl operations
+
+Additional information on client_acl can be
+found by reading the salt documention:
+
+    http://docs.saltstack.com/en/latest/ref/clientacl.html
+'''
+
+# Import python libraries
+import re
+
+class ClientACL(object):
+    '''
+    Represents the client ACL and provides methods
+    to query the ACL for given operations
+    '''
+    def __init__(self, blacklist):
+        self.blacklist = blacklist
+
+
+    def user_is_blacklisted(user):
+        '''
+        Takes a username as a string and returns a boolean. True indicates that
+        the provided user has been blacklisted
+        '''
+        for blacklisted_user in self.blacklist.get('users', []):
+            if re.match(blacklisted_user, user):
+                return True
+        return False
+
+
+    def cmd_is_blacklisted(cmd):
+        for blacklisted_module in self.blacklist.get('modules', []):
+            # If this is a regular command, it is a single function
+            if isinstance(cmd, str):
+                funs_to_check = [cmd]
+            # If this is a compound function
+            else:
+                funs_to_check = cmd
+            for fun in funs_to_check:
+                if re.match(cmd, fun):
+                    return True
+        return False
+

--- a/salt/acl/__init__.py
+++ b/salt/acl/__init__.py
@@ -9,7 +9,9 @@ found by reading the salt documention:
 '''
 
 # Import python libraries
+from __future__ import absolute_import
 import re
+
 
 class ClientACL(object):
     '''
@@ -18,7 +20,6 @@ class ClientACL(object):
     '''
     def __init__(self, blacklist):
         self.blacklist = blacklist
-
 
     def user_is_blacklisted(self, user):
         '''
@@ -29,7 +30,6 @@ class ClientACL(object):
             if re.match(blacklisted_user, user):
                 return True
         return False
-
 
     def cmd_is_blacklisted(self, cmd):
         for blacklisted_module in self.blacklist.get('modules', []):
@@ -43,4 +43,3 @@ class ClientACL(object):
                 if re.match(cmd, fun):
                     return True
         return False
-

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -443,3 +443,13 @@ class AuthUser(object):
         user is not running with sudo
         '''
         return self.user.startswith('sudo_')
+
+    def is_running_user(self):
+        '''
+        Determines if the user is the same user as the one running
+        this process
+
+        Returns True if the user is the same user as the one running
+        this process and False if not.
+        '''
+        return self.user == salt.utils.get_user() 

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -452,4 +452,4 @@ class AuthUser(object):
         Returns True if the user is the same user as the one running
         this process and False if not.
         '''
-        return self.user == salt.utils.get_user() 
+        return self.user == salt.utils.get_user()

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -420,3 +420,11 @@ class Resolver(object):
         load['cmd'] = 'get_token'
         tdata = self._send_token_request(load)
         return tdata
+
+class AuthUser(object):
+    '''
+    Represents a user requesting authentication to the salt master
+    '''
+
+    def __init__(self, user):
+

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -421,6 +421,7 @@ class Resolver(object):
         tdata = self._send_token_request(load)
         return tdata
 
+
 class AuthUser(object):
     '''
     Represents a user requesting authentication to the salt master

--- a/salt/auth/__init__.py
+++ b/salt/auth/__init__.py
@@ -427,4 +427,18 @@ class AuthUser(object):
     '''
 
     def __init__(self, user):
+        '''
+        Instantiate an AuthUser object.
 
+        Takes a user to reprsent, as a string.
+        '''
+        self.user = user
+
+    def is_sudo(self):
+        '''
+        Determines if the user is running with sudo
+
+        Returns True if the user is running with sudo and False if the
+        user is not running with sudo
+        '''
+        return self.user.startswith('sudo_')

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -36,6 +36,10 @@ class SaltMasterError(SaltException):
     Problem reading the master root key
     '''
 
+class SaltNoMinionsFound(SaltException):
+    '''
+    An attempt to retrieve a list of minions failed
+    '''
 
 class SaltSyndicMasterError(SaltException):
     '''

--- a/salt/exceptions.py
+++ b/salt/exceptions.py
@@ -36,10 +36,12 @@ class SaltMasterError(SaltException):
     Problem reading the master root key
     '''
 
+
 class SaltNoMinionsFound(SaltException):
     '''
     An attempt to retrieve a list of minions failed
     '''
+
 
 class SaltSyndicMasterError(SaltException):
     '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -2350,9 +2350,8 @@ class ClearFuncs(object):
             )
         pub_sock.connect(pull_uri)
 
-        pub_sock.send(self.serial.dumps(int_payload))
+        pub_sock.send(self.serial.dumps(load))
         # TODO Check return from send()?
-
 
     def _prep_pub(self, clear_load, extra):
         '''
@@ -2507,8 +2506,6 @@ class ClearFuncs(object):
         if load['tgt_type'] == 'list':
             int_payload['topic_lst'] = load['tgt']
         return (int_payload, clear_load['jid'], minions)
-
-        
 
 
 class FloMWorker(MWorker):

--- a/salt/master.py
+++ b/salt/master.py
@@ -2280,7 +2280,7 @@ class ClearFuncs(object):
                         'Authentication failure of type "user" occurred.'
                     )
                     return ''
-            elif clear_load['user'] == salt.utils.get_user():
+            elif auth_user.is_running_user():
                 if clear_load.pop('key') != self.key.get(clear_load['user']):
                     log.warning(
                         'Authentication failure of type "user" occurred.'

--- a/salt/master.py
+++ b/salt/master.py
@@ -2324,9 +2324,24 @@ class ClearFuncs(object):
                 )
                 return ''
 
-        # FIXME Very hacky
+        # FIXME Needs additional refactoring
         int_payload, clear_load['jid'], minions = self._prep_pub(clear_load, extra)
 
+        #Send it!
+        self._send_pub(int_payload)
+
+        return {
+            'enc': 'clear',
+            'load': {
+                'jid': clear_load['jid'],
+                'minions': minions
+            }
+        }
+
+    def _send_pub(self, load):
+        '''
+        Take a load and send it across the network to connected minions
+        '''
         # Send 0MQ to the publisher
         context = zmq.Context(1)
         pub_sock = context.socket(zmq.PUSH)
@@ -2336,13 +2351,8 @@ class ClearFuncs(object):
         pub_sock.connect(pull_uri)
 
         pub_sock.send(self.serial.dumps(int_payload))
-        return {
-            'enc': 'clear',
-            'load': {
-                'jid': clear_load['jid'],
-                'minions': minions
-            }
-        }
+        # TODO Check return from send()?
+
 
     def _prep_pub(self, clear_load, extra):
         '''

--- a/salt/master.py
+++ b/salt/master.py
@@ -2323,7 +2323,9 @@ class ClearFuncs(object):
                     'Authentication failure of type "other" occurred.'
                 )
                 return ''
-        int_payload = self._prep_pub(clear_load)
+
+        # FIXME Very hacky
+        int_payload, clear_load['jid'], minions = self._prep_pub(clear_load, extra)
 
         # Send 0MQ to the publisher
         context = zmq.Context(1)
@@ -2342,7 +2344,7 @@ class ClearFuncs(object):
             }
         }
 
-    def _prep_pub(self, clear_load):
+    def _prep_pub(self, clear_load, extra):
         '''
         Take a given load and perform the necessary steps
         to prepare a publication.
@@ -2494,7 +2496,7 @@ class ClearFuncs(object):
         # add some targeting stuff for lists only (for now)
         if load['tgt_type'] == 'list':
             int_payload['topic_lst'] = load['tgt']
-        return int_payload
+        return (int_payload, clear_load['jid'], minions)
 
         
 

--- a/salt/master.py
+++ b/salt/master.py
@@ -41,6 +41,7 @@ import salt.wheel
 import salt.minion
 import salt.search
 import salt.key
+import salt.acl
 import salt.engines
 import salt.fileserver
 import salt.daemons.masterapi

--- a/salt/master.py
+++ b/salt/master.py
@@ -2143,10 +2143,7 @@ class ClearFuncs(object):
                     )
                 )
                 return ''
-            if not token:
-                log.warning('Authentication failure of type "token" occurred.')
-                return ''
-            if token['eauth'] not in self.opts['external_auth']:
+            if not token or token['eauth'] not in self.opts['external_auth']:
                 log.warning('Authentication failure of type "token" occurred.')
                 return ''
             if not ((token['name'] in self.opts['external_auth'][token['eauth']]) |

--- a/salt/master.py
+++ b/salt/master.py
@@ -2117,7 +2117,7 @@ class ClearFuncs(object):
         '''
         extra = clear_load.get('kwargs', {})
 
-        client_acl = salt.acl.ClientAcl(self.opts['client_acl_blacklist'])
+        client_acl = salt.acl.ClientACL(self.opts['client_acl_blacklist'])
 
         if client_acl.user_is_blacklisted(clear_load['user']) or \
                 client_acl.cmd_is_blacklisted(clear_load['fun']):


### PR DESCRIPTION
Shaved `publish()` to about half its former size.

There is still much work to be done here and a few of those places are indicated with TODOs. The goal here is to have `publish()` stripped down to just a handful of calls to external methods to perform the needed authorization and publication.
