### PR TITLE
update state dockerio.running docs to reflect reality

### DIFF
--- a/salt/states/dockerio.py
+++ b/salt/states/dockerio.py
@@ -69,7 +69,7 @@ Available Functions
       my_service:
         docker.running:
           - container: mysuperdocker
-          - port_bindings:
+          - ports:
               "5000/tcp":
                   HostIp: ""
                   HostPort: "5000"


### PR DESCRIPTION
Looks like the top docblock on states/dockerio.py didn't get updated, so this just fixes, since using port_bindings doesn't actually seem to do anything anymore :)

I'm not sure if this request should be against master or develop, since I really just want
http://docs.saltstack.com/en/latest/ref/states/all/salt.states.dockerio.html updated.

Let me know if I need to change this pull request in any way, thanks.
