### PR TITLE
Remove singletons from LazyLoader

### DIFF
--- a/salt/utils/schedule.py
+++ b/salt/utils/schedule.py
@@ -587,6 +587,9 @@ class Schedule(object):
         for job, data in schedule.items():
             if job == 'enabled' or not data:
                 continue
+            if not isinstance(data, dict):
+                log.error('Scheduled job "{0}" should have a dict value, not {1}'.format(job, type(data)))
+                continue
             # Job is disabled, continue
             if 'enabled' in data and not data['enabled']:
                 continue


### PR DESCRIPTION
After having implemented all of this, it doesn't make sense to do singletons for the loader dicts themselves-- although it probably does for the modules under the hood. Since we can't use this code and I don't think it'll be useful going forward-- I'm just removing it.
