### PR TITLE
Teach file.check_perms to handle uids and gids.

### DIFF
--- a/salt/modules/file.py
+++ b/salt/modules/file.py
@@ -2986,9 +2986,13 @@ def check_perms(name, ret, user, group, mode, follow_symlinks=False):
                         ret['changes']['mode'] = mode
     # user/group changes if needed, then check if it worked
     if user:
+        if isinstance(user, int):
+            user = uid_to_user(user)
         if user != perms['luser']:
             perms['cuser'] = user
     if group:
+        if isinstance(group, int):
+            group = gid_to_group(group)
         if group != perms['lgroup']:
             perms['cgroup'] = group
     if 'cuser' in perms or 'cgroup' in perms:


### PR DESCRIPTION
Fixes #21423. Allow passing in numeric values for user and group.

I'm currently not able to get the tests to run, so I haven't included test cases for this, but I imagine it wouldn't be too hard to add some unit tests for this. I did test a state similar to roflmao's, and the PR does seem to handle numeric uids and gids.
