### PR TITLE
Bugfix: enable download-only for both downgrades and installations.

### DIFF
--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -62,7 +62,7 @@ def list_upgrades(refresh=True):
     if salt.utils.is_true(refresh):
         refresh_db()
     ret = {}
-    call = __salt__['cmd.run_stdout'](
+    call = __salt__['cmd.run_all'](
         'zypper list-updates', output_loglevel='trace'
     )
     if call['retcode'] != 0:

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -1080,15 +1080,15 @@ def list_products():
 
         salt '*' pkg.list_products
     '''
-    products = '/etc/products.d'
-    if not os.path.exists(products):
-        raise CommandExecutionError('Directory {0} does not exists.'.format(products))
+    products_dir = '/etc/products.d'
+    if not os.path.exists(products_dir):
+        raise CommandExecutionError('Directory {0} does not exists.'.format(products_dir))
 
-    products = {}
-    for fname in os.listdir('/etc/products.d'):
-        pth_name = os.path.join(products, fname)
+    p_data = {}
+    for fname in os.listdir(products_dir):
+        pth_name = os.path.join(products_dir, fname)
         r_pth_name = os.path.realpath(pth_name)
-        products[r_pth_name] = r_pth_name != pth_name and 'baseproduct' or None
+        p_data[r_pth_name] = r_pth_name != pth_name and 'baseproduct' or None
 
     info = ['vendor', 'name', 'version', 'baseversion', 'patchlevel',
             'predecessor', 'release', 'endoflife', 'arch', 'cpeid',
@@ -1096,7 +1096,7 @@ def list_products():
             'description']
 
     ret = {}
-    for prod_meta, is_base_product in six.iteritems(products):
+    for prod_meta, is_base_product in six.iteritems(p_data):
         product = _parse_suse_product(prod_meta, *info)
         product['baseproduct'] = is_base_product is not None
         ret[product.pop('name')] = product

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -796,18 +796,16 @@ def list_locks():
 
         salt '*' pkg.list_locks
     '''
-    if not os.path.exists(LOCKS):
-        return False
-
     locks = {}
-    with salt.utils.fopen(LOCKS) as fhr:
-        for meta in [item.split('\n') for item in fhr.read().split('\n\n')]:
-            lock = {}
-            for element in [el for el in meta if el]:
-                if ':' in element:
-                    lock.update(dict([tuple([i.strip() for i in element.split(':', 1)]), ]))
-            if lock.get('solvable_name'):
-                locks[lock.pop('solvable_name')] = lock
+    if os.path.exists(LOCKS):
+        with salt.utils.fopen(LOCKS) as fhr:
+            for meta in [item.split('\n') for item in fhr.read().split('\n\n')]:
+                lock = {}
+                for element in [el for el in meta if el]:
+                    if ':' in element:
+                        lock.update(dict([tuple([i.strip() for i in element.split(':', 1)]), ]))
+                if lock.get('solvable_name'):
+                    locks[lock.pop('solvable_name')] = lock
 
     return locks
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -102,7 +102,7 @@ def latest_version(*names, **kwargs):
     name/version pairs is returned.
 
     If the latest version of a given package is already installed, an empty
-    string will be returned for that package.
+    dict will be returned for that package.
 
     CLI example:
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -616,6 +616,9 @@ def install(name=None,
     while targets:
         cmd = ['zypper', '--non-interactive', 'install', '--name',
                '--auto-agree-with-licenses']
+        if downloadonly:
+            cmd.append('--download-only')
+
         if fromrepo:
             cmd.extend(fromrepoopt)
         cmd.extend(targets[:500])

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -104,7 +104,7 @@ def latest_version(*names, **kwargs):
     If the latest version of a given package is already installed, an empty
     string will be returned for that package.
 
-    CLI Example:
+    CLI example:
 
     .. code-block:: bash
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -439,7 +439,7 @@ def mod_repo(repo, **kwargs):
         raise CommandExecutionError(
                 'Modification of the repository \'{0}\' was not specified.'.format(repo))
 
-    return {}
+    return get_repo(repo)
 
 
 def refresh_db():

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -171,7 +171,7 @@ def upgrade_available(name):
 
         salt '*' pkg.upgrade_available <package name>
     '''
-    return latest_version(name) != ''
+    return latest_version(name).get(name) is not None
 
 
 def version(*names, **kwargs):

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -176,7 +176,7 @@ def upgrade_available(name):
 
 def version(*names, **kwargs):
     '''
-    Returns a string representing the package version or an empty string if not
+    Returns a string representing the package version or an empty dict if not
     installed. If more than one package name is specified, a dict of
     name/version pairs is returned.
 

--- a/salt/modules/zypper.py
+++ b/salt/modules/zypper.py
@@ -187,7 +187,7 @@ def version(*names, **kwargs):
         salt '*' pkg.version <package name>
         salt '*' pkg.version <package1> <package2> <package3> ...
     '''
-    return __salt__['pkg_resource.version'](*names, **kwargs)
+    return __salt__['pkg_resource.version'](*names, **kwargs) or {}
 
 
 def list_pkgs(versions_as_list=False, **kwargs):


### PR DESCRIPTION
I overlooked that the `cmd` variable is initialized twice because of splitting the packages batch (this part is still questionable and I might open another PR for this), and thus forgot to add `download-only` option also to the installations. Currently it is working only for downgrades.

Additionally, this PR fixes other _major_ bugs, where functions was simply broken.
