### PR TITLE
Add minimum version dependency for linode-python in docs

### DIFF
--- a/doc/topics/cloud/linode.rst
+++ b/doc/topics/cloud/linode.rst
@@ -6,7 +6,7 @@ Linode is a public cloud provider with a focus on Linux instances.
 
 Dependencies
 ============
-* linode-python >= 1.1
+* linode-python >= 1.1.1
 
 OR
 
@@ -21,12 +21,11 @@ Driver selection is automatic.  If linode-python is present it will be used.
 If it is absent, salt-cloud will fall back to Libcloud.  If neither are present
 salt-cloud will abort.
 
-NOTE: linode-python 1.1 or later is recommended.  As of this publication it is
-not yet on PyPi.  Earlier versions of linode-python should work but can leak
-sensitive information into the debug logs.
+NOTE: linode-python 1.1.1 or later is recommended. Earlier versions of linode-python
+should work but leak sensitive information into the debug logs.
 
 Linode-python can be downloaded from
-https://github.com/tjfontaine/linode-python.
+https://github.com/tjfontaine/linode-python or installed via pip.
 
 Configuration
 =============

--- a/salt/cloud/clouds/linode.py
+++ b/salt/cloud/clouds/linode.py
@@ -7,9 +7,15 @@ The Linode cloud module is used to control access to the Linode VPS system
 
 Use of this module only requires the ``apikey`` parameter.
 
-:depends: linode-python >= 1.0
+:depends: linode-python >= 1.1.1
 OR
 :depends: apache-libcloud >= 0.13.2
+
+.. note::
+
+    The linode-python driver will work with earlier versions of linode-python,
+    but it is highly recommended to use a minimum version of 1.1.1. Earlier
+    versions leak sensitive information into the debug logs.
 
 Set up the cloud configuration at ``/etc/salt/cloud.providers`` or
 ``/etc/salt/cloud.providers.d/linode.conf``:


### PR DESCRIPTION
And warn users of older versions leaking sensitive information into the debug logs.

ping @cro @techhat 
