### PR TITLE
Increase the timeout of boto route53 module

### DIFF
--- a/salt/modules/boto_route53.py
+++ b/salt/modules/boto_route53.py
@@ -212,7 +212,7 @@ def delete_record(name, zone, record_type, identifier=None, all_records=False,
 
 
 def _wait_for_sync(status, conn):
-    retry = 10
+    retry = 30
     i = 0
     while i < retry:
         log.info('Getting route53 status (attempt {0})'.format(i + 1))


### PR DESCRIPTION
When using `wait_for_insync` the boto route53 module doesn't wait long
enough. The default timeout is 10 retries of 10 seconds, but in actual
use it takes 13 tries to wait for insync.

This change ups the default timeout to 300 seconds (30 retries at 10
second sleeps each) to wait for insync to happen.
