### PR TITLE
Interactive test suite

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -237,7 +237,6 @@ class TestDaemon(object):
         master = salt.master.Master(self.master_opts)
         self.master_process = multiprocessing.Process(target=master.start)
         self.master_process.start()
-
         minion = salt.minion.Minion(self.minion_opts)
         self.minion_process = multiprocessing.Process(target=minion.tune_in)
         self.minion_process.start()
@@ -434,6 +433,24 @@ class TestDaemon(object):
         with salt.utils.fopen(os.path.join(TMP_CONF_DIR, 'roster'), 'a') as roster:
             roster.write('  user: {0}\n'.format(pwd.getpwuid(os.getuid()).pw_name))
             roster.write('  priv: {0}/{1}'.format(TMP_CONF_DIR, 'key_test'))
+
+    @classmethod
+    def config(cls, role):
+        '''
+        Return a configuration for a master/minion/syndic.
+
+        Currently these roles are:
+            * master
+            * minion
+            * syndic
+            * syndic_master
+            * sub_minion
+        '''
+        return RUNTIME_CONFIGS[role]
+
+    @classmethod
+    def config_location(cls):
+        return TMP_CONF_DIR
 
     @property
     def client(self):

--- a/tests/integration/files/conf/minion
+++ b/tests/integration/files/conf/minion
@@ -9,7 +9,7 @@ sock_dir: minion_sock
 #acceptance_wait_time: = 1
 open_mode: True
 log_file: minion
-loop_interval: 0.05
+#loop_interval: 0.05
 
 # module extension
 test.foo: baz

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -10,6 +10,7 @@ from __future__ import absolute_import, print_function
 import os
 import resource
 import tempfile
+import time
 
 # Import salt libs
 from integration import TestDaemon, TMP  # pylint: disable=W0403
@@ -57,7 +58,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             choices=('zeromq', 'raet'),
             help='Set to raet to run integration tests with raet transport. Default: %default')
         self.add_option(
-            '--no-test',
+            '--interactive',
             default=False,
             action='store_true',
             help='Do not run any tests. Simply start the daemons.'
@@ -242,6 +243,80 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
         path = os.path.join(TEST_DIR, 'integration', suite_folder)
         return self.run_suite(path, display_name)
 
+    def start_daemons_only(self):
+        self.prep_filehandles()
+        try:
+            print_header(
+                ' * Setting up Salt daemons for interactive use',
+                top=False, width=getattr(self.options, 'output_columns', PNUM)
+            )
+        except TypeError:
+            print_header(' * Setting up Salt daemons for interactive use', top=False)
+
+        with TestDaemon(self):
+            print_header(' * Salt daemons started')
+            master_conf = TestDaemon.config('master')
+            minion_conf = TestDaemon.config('minion')
+            syndic_conf = TestDaemon.config('syndic')
+            syndic_master_conf = TestDaemon.config('syndic_master')
+
+            print_header(' * Syndic master configuration values', top=False)
+            print('interface: {0}'.format(syndic_master_conf['interface']))
+            print('publish port: {0}'.format(syndic_master_conf['publish_port']))
+            print('return port: {0}'.format(syndic_master_conf['ret_port']))
+            print('\n')
+
+            print_header(' * Master configuration values', top=True)
+            print('interface: {0}'.format(master_conf['interface']))
+            print('publish port: {0}'.format(master_conf['publish_port']))
+            print('return port: {0}'.format(master_conf['ret_port']))
+            print('\n')
+
+            print_header(' * Minion configuration values', top=True)
+            print('interface: {0}'.format(minion_conf['interface']))
+            print('\n')
+
+            print_header(' * Syndic configuration values', top=True)
+            print('interface: {0}'.format(syndic_conf['interface']))
+            print('syndic master port: {0}'.format(syndic_conf['syndic_master']))
+            print('\n')
+
+            print_header(' Your client configuration is at {0}'.format(TestDaemon.config_location()))
+            print('To access the minion: `salt -c {0} minion test.ping'.format(TestDaemon.config_location()))
+
+            while True:
+                time.sleep(1)
+
+    def prep_filehandles(self):
+        smax_open_files, hmax_open_files = resource.getrlimit(
+            resource.RLIMIT_NOFILE
+        )
+        if smax_open_files < REQUIRED_OPEN_FILES:
+            print(
+                ' * Max open files setting is too low({0}) for running the '
+                'tests'.format(smax_open_files)
+            )
+            print(
+                ' * Trying to raise the limit to {0}'.format(REQUIRED_OPEN_FILES)
+            )
+            if hmax_open_files < 4096:
+                hmax_open_files = 4096  # Decent default?
+            try:
+                resource.setrlimit(
+                    resource.RLIMIT_NOFILE,
+                    (REQUIRED_OPEN_FILES, hmax_open_files)
+                )
+            except Exception as err:
+                print(
+                    'ERROR: Failed to raise the max open files setting -> '
+                    '{0}'.format(err)
+                )
+                print('Please issue the following command on your console:')
+                print('  ulimit -n {0}'.format(REQUIRED_OPEN_FILES))
+                self.exit()
+            finally:
+                print('~' * getattr(self.options, 'output_columns', PNUM))
+
     def run_integration_tests(self):
         '''
         Execute the integration tests suite
@@ -273,35 +348,7 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             # passing only `unit.<whatever>` to --name.
             # We don't need the tests daemon running
             return [True]
-
-        smax_open_files, hmax_open_files = resource.getrlimit(
-            resource.RLIMIT_NOFILE
-        )
-        if smax_open_files < REQUIRED_OPEN_FILES:
-            print(
-                ' * Max open files setting is too low({0}) for running the '
-                'tests'.format(smax_open_files)
-            )
-            print(
-                ' * Trying to raise the limit to {0}'.format(REQUIRED_OPEN_FILES)
-            )
-            if hmax_open_files < 4096:
-                hmax_open_files = 4096  # Decent default?
-            try:
-                resource.setrlimit(
-                    resource.RLIMIT_NOFILE,
-                    (REQUIRED_OPEN_FILES, hmax_open_files)
-                )
-            except Exception as err:
-                print(
-                    'ERROR: Failed to raise the max open files setting -> '
-                    '{0}'.format(err)
-                )
-                print('Please issue the following command on your console:')
-                print('  ulimit -n {0}'.format(REQUIRED_OPEN_FILES))
-                self.exit()
-            finally:
-                print('~' * getattr(self.options, 'output_columns', PNUM))
+        self.prep_filehandles()
 
         try:
             print_header(
@@ -399,6 +446,8 @@ def main():
         parser.parse_args()
 
         overall_status = []
+        if parser.options.interactive:
+            parser.start_daemons_only()
         status = parser.run_integration_tests()
         overall_status.extend(status)
         status = parser.run_unit_tests()

--- a/tests/runtests.py
+++ b/tests/runtests.py
@@ -56,6 +56,12 @@ class SaltTestsuiteParser(SaltCoverageTestingParser):
             default='zeromq',
             choices=('zeromq', 'raet'),
             help='Set to raet to run integration tests with raet transport. Default: %default')
+        self.add_option(
+            '--no-test',
+            default=False,
+            action='store_true',
+            help='Do not run any tests. Simply start the daemons.'
+        )
 
         self.test_selection_group.add_option(
             '-m',


### PR DESCRIPTION
Provide a way to run the test suite in "interactive" mode. This means it will start up the necessary deamons and then sleep, giving you information on how to interact with those daemons directly. So with a single command, you can now spin up a master, two minions, a syndic and a secondary master, perform all module/grain syncing and then interact with them easily.

Use `python ./runtests --interactive` for an example. A sample output is as follows:

``
mp@silver ...devel/salt/tests % sudo python2 ./runtests.py --interactive                                                                                                                               (git)-[daemons_only] 

```
 * Transplanting configuration files to '/tmp/salt-tests-tmpdir/config'
 * Current Directory: /home/mp/devel/salt/tests
 * Test suite is running under PID 15937
 * Logging tests on /tmp/salt-runtests.log
```
- Max open files setting is too low(1024) for running the tests
- Trying to raise the limit to 3072

```
 * Setting up Salt daemons for interactive use
```
- Waiting at most 0:02:00 for minions(minion, sub_minion) to connect back
  - minion connected.  
  - sub_minion connected.  
- Syncing minion's modules (saltutil.sync_modules)
#  \* Syncing minion's states (saltutil.sync_states)                                                                                                                                                                            

```
 * Salt daemons started
```
- Syndic master configuration values

```
interface: 0.0.0.0
publish port: 54505
return port: 54506


```
- Master configuration values

```
interface: 0.0.0.0
publish port: 64505
return port: 64506


```
- Minion configuration values

```
interface: 0.0.0.0


```
- Syndic configuration values

```
interface: 0.0.0.0
syndic master port: localhost


```

 Your client configuration is at /tmp/salt-tests-tmpdir/config

```
To access the minion: `salt -c /tmp/salt-tests-tmpdir/config minion test.ping

``
```
