### PR TITLE
enable eauth during cli batch operations

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -94,7 +94,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
             if self.options.static:
 
-                batch = salt.cli.batch.Batch(self.config, quiet=True)
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth, quiet=True)
 
                 ret = {}
 
@@ -104,7 +104,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 self._output_ret(ret, '')
 
             else:
-                batch = salt.cli.batch.Batch(self.config)
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth)
                 # Printing the output is already taken care of in run() itself
                 for res in batch.run():
                     pass


### PR DESCRIPTION
This feels to me like it is overlooked.

unpatched, using `salt -b 10% -a ldap -T '*' test.ping` will result into a `EauthAuthenticationError`

diving into the stacktrace it looked like the Batch object was not configured with eauth information at all. It was either overlooked or it was not implemented due to undesired side effects I cannot  see at the moment.

anyway, without the patch output looks like

```
$ salt -b 10% -a ldap -T '*' test.ping
username: ruben
password:
[ERROR   ] An un-handled exception was caught by salt's global exception handler:
EauthAuthenticationError: Failed to authenticate!  This is most likely because this user is not permitted to execute commands, but there is a small possibility that a disk error occurred (check disk/inode
 usage).
Traceback (most recent call last):
  File "/usr/local/bin/salt", line 9, in <module>
    load_entry_point('salt==2014.7.2', 'console_scripts', 'salt')()
  File "/usr/local/lib/python2.7/site-packages/salt/scripts.py", line 241, in salt_main
    client.run()
  File "/usr/local/lib/python2.7/site-packages/salt/cli/__init__.py", line 107, in run
    batch = salt.cli.batch.Batch(self.config)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/batch.py", line 27, in __init__
    self.minions = self.__gather_minions()
  File "/usr/local/lib/python2.7/site-packages/salt/cli/batch.py", line 46, in __gather_minions
    for ret in self.local.cmd_iter(*args, **self.eauth):
  File "/usr/local/lib/python2.7/site-packages/salt/client/__init__.py", line 633, in cmd_iter
    **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/client/__init__.py", line 286, in run_job
    return self._check_pub_data(pub_data)
  File "/usr/local/lib/python2.7/site-packages/salt/client/__init__.py", line 221, in _check_pub_data
    'Failed to authenticate!  This is most likely because this '
EauthAuthenticationError: Failed to authenticate!  This is most likely because this user is not permitted to execute commands, but there is a small possibility that a disk error occurred (check disk/inode
 usage).
Traceback (most recent call last):
  File "/usr/local/bin/salt", line 9, in <module>
    load_entry_point('salt==2014.7.2', 'console_scripts', 'salt')()
  File "/usr/local/lib/python2.7/site-packages/salt/scripts.py", line 241, in salt_main
    client.run()
  File "/usr/local/lib/python2.7/site-packages/salt/cli/__init__.py", line 107, in run
    batch = salt.cli.batch.Batch(self.config)
  File "/usr/local/lib/python2.7/site-packages/salt/cli/batch.py", line 27, in __init__
    self.minions = self.__gather_minions()
  File "/usr/local/lib/python2.7/site-packages/salt/cli/batch.py", line 46, in __gather_minions
    for ret in self.local.cmd_iter(*args, **self.eauth):
  File "/usr/local/lib/python2.7/site-packages/salt/client/__init__.py", line 633, in cmd_iter
    **kwargs)
  File "/usr/local/lib/python2.7/site-packages/salt/client/__init__.py", line 286, in run_job
    return self._check_pub_data(pub_data)
  File "/usr/local/lib/python2.7/site-packages/salt/client/__init__.py", line 221, in _check_pub_data
    'Failed to authenticate!  This is most likely because this '
salt.exceptions.EauthAuthenticationError: Failed to authenticate!  This is most likely because this user is not permitted to execute commands, but there is a small possibility that a disk error occurred (
check disk/inode usage).
```

patched, it looks like this:

```
$ salt -b 10% -a ldap -T '*' test.ping
username: ruben
password:
owncloud.niet.verweg.com Detected for this batch run
jboss.niet.verweg.com Detected for this batch run
helium.niet.verweg.com Detected for this batch run
vpn.niet.verweg.com Detected for this batch run
test.niet.verweg.com Detected for this batch run
log.niet.verweg.com Detected for this batch run
gitlab.niet.verweg.com Detected for this batch run
media.niet.verweg.com Detected for this batch run
mgt.niet.verweg.com Detected for this batch run
dns.niet.verweg.com Detected for this batch run
ldap.niet.verweg.com Detected for this batch run
monitor.niet.verweg.com Detected for this batch run
puppetdb.niet.verweg.com Detected for this batch run
erg.niet.verweg.com Detected for this batch run

Executing run on ['vpn.niet.verweg.com']

vpn.niet.verweg.com:
    True

Executing run on ['test.niet.verweg.com']

test.niet.verweg.com:
    True

Executing run on ['puppetdb.niet.verweg.com']

puppetdb.niet.verweg.com:
    True

Executing run on ['owncloud.niet.verweg.com']

owncloud.niet.verweg.com:
...
```

the fix is implemented for both the normal and the -s batched case
