### PR TITLE
Pin SaltTesting dependency down to a specific version.

### DIFF
--- a/requirements/dev_python27.txt
+++ b/requirements/dev_python27.txt
@@ -1,6 +1,6 @@
 -r base.txt
--e git+https://github.com/saltstack/salt-testing.git@develop#egg=SaltTesting
 
 mock
 boto>=2.32.1
 moto>=0.3.6
+SaltTesting==2015.2.16


### PR DESCRIPTION
This pins the SaltTesting dev dependency as discussed in #21617. I'd like to keep that issue open for now and rename it to expand its scope to pinning versions for all of dependencies.

We'll need to bump this dependency version as needed.
