### PR TITLE
RVM doesn't install as non-root, gems don't install for RVM

### DIFF
--- a/salt/modules/rvm.py
+++ b/salt/modules/rvm.py
@@ -52,8 +52,8 @@ def _rvm(command, arguments=None, runas=None, cwd=None):
 
 
 def _rvm_do(ruby, command, runas=None, cwd=None):
-    return _rvm('{ruby} do {command}'.
-                format(ruby=ruby or 'default', command=command),
+    return _rvm('{ruby}'.format(ruby=ruby or 'default'),
+                arguments='do {command}'.format(command=command),
                 runas=runas, cwd=cwd)
 
 
@@ -120,8 +120,8 @@ def install_ruby(ruby, runas=None):
     #   libsqlite3-dev sqlite3 libxml2-dev libxslt1-dev autoconf libc6-dev
     #   libncurses5-dev automake libtool bison subversion ruby
     if runas and runas != 'root':
-        _rvm('autolibs disable', ruby, runas=runas)
-        return _rvm('install --disable-binary', ruby, runas=runas)
+        _rvm('autolibs', 'disable {ruby}'.format(ruby=ruby), runas=runas)
+        return _rvm('install', '--disable-binary {ruby}'.format(ruby=ruby), runas=runas)
     else:
         return _rvm('install', ruby, runas=runas)
 

--- a/tests/unit/modules/rvm_test.py
+++ b/tests/unit/modules/rvm_test.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 # Import Salt Testing libs
 from salttesting import skipIf, TestCase
 from salttesting.helpers import ensure_in_syspath
-from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch
+from salttesting.mock import NO_MOCK, NO_MOCK_REASON, MagicMock, patch, call
 ensure_in_syspath('../../')
 
 
@@ -31,15 +31,25 @@ class TestRvmModule(TestCase):
             )
 
     def test__rvm_do(self):
-        mock = MagicMock(return_value=None)
-        with patch.object(rvm, '_rvm', new=mock):
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': 'stdout'})
+        with patch.dict(rvm.__salt__, {'cmd.run_all': mock}):
             rvm._rvm_do('1.9.3', 'gemset list')
-            mock.assert_called_once_with('1.9.3 do gemset list', runas=None, cwd=None)
+            mock.assert_called_once_with('/usr/local/rvm/bin/rvm 1.9.3 do gemset list', runas=None, cwd=None)
 
     def test_install(self):
         mock = MagicMock(return_value={'retcode': 0})
         with patch.dict(rvm.__salt__, {'cmd.run_all': mock}):
             rvm.install()
+            mock.assert_called_once_with('curl -Ls https://raw.githubusercontent.com/wayneeseguin/rvm/master/binscripts/rvm-installer | bash -s stable', runas=None, python_shell=True)
+
+    def test_install_ruby_nonroot(self):
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': 'stdout'})
+        expected = [
+            call('/usr/local/rvm/bin/rvm autolibs disable 2.0.0', runas='rvm', cwd=None),
+            call('/usr/local/rvm/bin/rvm install --disable-binary 2.0.0', runas='rvm', cwd=None)]
+        with patch.dict(rvm.__salt__, {'cmd.run_all': mock}):
+            rvm.install_ruby('2.0.0', runas='rvm')
+            self.assertEqual(mock.call_args_list, expected)
 
     def test_list(self):
         list_output = '''


### PR DESCRIPTION
I found that the `rvm.py` creates extra single quotes for the following cases: 
- you want to install RVM as a non-root user
- you want to install gems

One of the wrong command lines created due to this (see the single quote just after `rvm` and at the end)

```
/usr/local/rvm/bin/rvm '2.2.0 do gem install rails --no-rdoc --no-ri'
```

This can be fixed when you ensure that the first argument for `_rvm` only contains the command, and all arguments go to the arguments. 

This should fix  #6815 and  #20317 (cc: @joshdover / @sergvag)

I have a locally running setup like this and it worked for me:

``` yaml
ruby-2.0.0:
  rvm.installed:
    - default: True
    - user: rvm
    - require:
      - pkg: rvm-deps
      - pkg: mri-deps
      - user: rvm

riemann-dash:
  gem.installed:
    - user: rvm
    - require:
      - gem: riemann-client
      - gem: riemann-tools
      - gem: thin
```

Until this `rvm.py` is available in a release, you can use it as a workaround in the `_modules` folder of release 2014.7.1 like I did here https://github.com/ahus1/hystrix-examples/tree/master/tools/riemann/salt/roots/salt
