### PR TITLE
which_bin requires an Iterable collection

### DIFF
--- a/salt/modules/sysrc.py
+++ b/salt/modules/sysrc.py
@@ -22,7 +22,7 @@ def __virtual__():
     '''
     Only runs if sysrc exists
     '''
-    if salt.utils.which_bin('sysrc') is not None:
+    if salt.utils.which('sysrc') is not None:
         return True
     return False
 


### PR DESCRIPTION
Since we only need to make sure that a single binary exists, we are able to use which() instead.

Fixes #21671
