### PR TITLE
Add error messages when missing setting_name param.

### DIFF
--- a/salt/modules/git.py
+++ b/salt/modules/git.py
@@ -871,7 +871,7 @@ def config_set(cwd=None, setting_name=None, setting_value=None, user=None, is_gl
         salt '*' git.config_set /path/to/repo user.email me@example.com
     '''
     if setting_name is None or setting_value is None:
-        raise TypeError
+        raise TypeError('Missing required parameter setting_name for git.config_set')
     if cwd is None and not is_global:
         raise SaltInvocationError('Either `is_global` must be set to True or '
                                   'you must provide `cwd`')
@@ -910,7 +910,7 @@ def config_get(cwd=None, setting_name=None, user=None):
         salt '*' git.config_get /path/to/repo user.name arthur
     '''
     if setting_name is None:
-        raise TypeError
+        raise TypeError('Missing required parameter setting_name for git.config_get')
     _check_git()
 
     return _git_run('git config {0}'.format(setting_name), cwd=cwd, runas=user)


### PR DESCRIPTION
Prevent empty error message of 'Passed invalid arguments:' when running
git.config_get or git.config_set without passing the setting_name
parameter by including error message in TypeError - make it clear that
the parameter is not invalid but missing.

These should be the only two such 'raw' TypeErrors across all current salt modules.
