### PR TITLE
Check response status when using fileclient.get_url.

### DIFF
--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -591,6 +591,7 @@ class Client(object):
             else:
                 get_kwargs['stream'] = True
             response = requests.get(fixed_url, **get_kwargs)
+            response.raise_for_status()
             with salt.utils.fopen(dest, 'wb') as destfp:
                 for chunk in response.iter_content(chunk_size=32*1024):
                     destfp.write(chunk)


### PR DESCRIPTION
Fix for 2014.7 for Issue #21625.

Only works for 2014.7; will follow up with more PRs for newer versions,
where there is no a strict dependency on requests and we need to
duplicate the functionality when using urllib2.
