### PR TITLE
Fix client-side cert handling in http.query

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -404,7 +404,7 @@ def query(url,
         else:
             text = True
 
-        if os.path.exists(decode_out):
+        if decode_out and os.path.exists(decode_out):
             with salt.utils.fopen(decode_out, 'w') as dof:
                 dof.write(result_text)
 

--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -232,12 +232,6 @@ def query(url,
             else:
                 req_kwargs['stream'] = True
 
-        result = sess.request(
-            method, url, params=params, data=data, **req_kwargs
-        )
-        if stream is True or handle is True:
-            return {'handle': result}
-
         # Client-side cert handling
         if cert is not None:
             if isinstance(cert, string_types):
@@ -249,6 +243,12 @@ def query(url,
             else:
                 log.error('The client-side certificate path that was passed is '
                           'not valid: {0}'.format(cert))
+
+        result = sess.request(
+            method, url, params=params, data=data, **req_kwargs
+        )
+        if stream is True or handle is True:
+            return {'handle': result}
 
         result_status_code = result.status_code
         result_headers = result.headers
@@ -310,10 +310,10 @@ def query(url,
                         cert_kwargs = {
                             'host': request.get_host(),
                             'port': port,
-                            'cert_file': cert[0]
+                            'cert_file': cert_chain[0]
                         }
-                        if len(cert) > 1:
-                            cert_kwargs['key_file'] = cert[1]
+                        if len(cert_chain) > 1:
+                            cert_kwargs['key_file'] = cert_chain[1]
                         handlers[0] = httplib.HTTPSConnection(**cert_kwargs)
 
         opener = urllib2.build_opener(*handlers)


### PR DESCRIPTION
Moved the client cert handling to the right place for requests, and fixed the variable name for urllib2.
