### PR TITLE
Check response status in utils.http.query with requests.

### DIFF
--- a/salt/utils/http.py
+++ b/salt/utils/http.py
@@ -247,6 +247,7 @@ def query(url,
         result = sess.request(
             method, url, params=params, data=data, **req_kwargs
         )
+        result.raise_for_status()
         if stream is True or handle is True:
             return {'handle': result}
 


### PR DESCRIPTION
Fix for 2015.2 for Issue #21625.

The default urllib2 code path already appears to handle HTTP errors
correctly; this PR adds the same handling when requests is being used.
