### PR TITLE
enable eauth during cli batch operations (repetition of #21658 for 2015.2)

### DIFF
--- a/salt/cli/salt.py
+++ b/salt/cli/salt.py
@@ -78,7 +78,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
             if self.options.static:
 
-                batch = salt.cli.batch.Batch(self.config, quiet=True)
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth, quiet=True)
 
                 ret = {}
 
@@ -88,7 +88,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 self._output_ret(ret, '')
 
             else:
-                batch = salt.cli.batch.Batch(self.config)
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth)
                 # Printing the output is already taken care of in run() itself
                 for res in batch.run():
                     pass


### PR DESCRIPTION
This is a repetition of #21658 in where the Batch object gets its eauth param, so non privileged external auth use with batch jobs is possible
