### PR TITLE
Fix ldap group handling for 2014.7

### DIFF
--- a/salt/auth/ldap.py
+++ b/salt/auth/ldap.py
@@ -227,7 +227,7 @@ def groups(username, **kwargs):
     else:
         return False
     for _, entry in search_results:
-        if entry['memberUid'][0] == username:
+        if username in entry['memberUid']:
             group_list.append(entry['cn'][0])
     log.debug('User {0} is a member of groups: {1}'.format(username, group_list))
     return group_list


### PR DESCRIPTION
This fixes #21661 by checking for existence of the user in the array, instead of assuming it will always be the first item
