### PR TITLE
[2015.2] Catch TypeErrors from cmd.run jid_file functionality in salt-ssh

### DIFF
--- a/salt/modules/cmdmod.py
+++ b/salt/modules/cmdmod.py
@@ -652,7 +652,7 @@ def run(cmd,
                 # Rewrite file
                 with salt.utils.fopen(jid_file, 'w+b') as fn_:
                     fn_.write(serial.dumps(jid_dict))
-        except NameError:
+        except (NameError, TypeError):
             # Avoids errors from msgpack not being loaded in salt-ssh
             pass
 


### PR DESCRIPTION
Fixes #21657 
