### PR TITLE
Merge forward from 2014.7 to 2015.2

### DIFF
--- a/salt/cli/__init__.py
+++ b/salt/cli/__init__.py
@@ -94,7 +94,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
 
             if self.options.static:
 
-                batch = salt.cli.batch.Batch(self.config, quiet=True)
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth, quiet=True)
 
                 ret = {}
 
@@ -104,7 +104,7 @@ class SaltCMD(parsers.SaltCMDOptionParser):
                 self._output_ret(ret, '')
 
             else:
-                batch = salt.cli.batch.Batch(self.config)
+                batch = salt.cli.batch.Batch(self.config, eauth=eauth)
                 # Printing the output is already taken care of in run() itself
                 for res in batch.run():
                     pass

--- a/salt/fileclient.py
+++ b/salt/fileclient.py
@@ -591,6 +591,7 @@ class Client(object):
             else:
                 get_kwargs['stream'] = True
             response = requests.get(fixed_url, **get_kwargs)
+            response.raise_for_status()
             with salt.utils.fopen(dest, 'wb') as destfp:
                 for chunk in response.iter_content(chunk_size=32*1024):
                     destfp.write(chunk)


### PR DESCRIPTION
Merge forward from 2014.7 to 2015.2

Because `salt/cli/__init__.py` was refactored into a number of other files, I manually made the changes intended for that file in `salt/cli/salt.py`.

```
Conflicts:
    salt/cli/__init__.py
    salt/fileclient.py
```
