### PR TITLE
Mac grains

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1755,6 +1755,7 @@ def _hw_data(osdata):
             if result['retcode'] == 0:
                 grains[key] = result['stdout']
     elif osdata['kernel'] == 'Darwin':
+        grains['manufacturer'] = 'Apple Inc.'
         sysctl = salt.utils.which('sysctl')
         hwdata = {'productname': 'hw.model'}
         for key, oid in hwdata.items():

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1754,6 +1754,13 @@ def _hw_data(osdata):
             result = __salt__['cmd.run_all']('{0} -n {1}'.format(sysctl, oid))
             if result['retcode'] == 0:
                 grains[key] = result['stdout']
+    elif osdata['kernel'] == 'Darwin':
+        sysctl = salt.utils.which('sysctl')
+        hwdata = {'productname': 'hw.model'}
+        for key, oid in hwdata.items():
+            value = __salt__['cmd.run']('{0} -b {1}'.format(sysctl, oid))
+            if not value.endswith(' is invalid'):
+                grains[key] = value
 
     return grains
 

--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -1237,6 +1237,7 @@ def os_data():
         osrelease = __salt__['cmd.run']('sw_vers -productVersion')
         grains['os'] = 'MacOS'
         grains['osrelease'] = osrelease
+        grains['osmajorrelease'] = osrelease.rsplit('.', 1)[0]
         grains.update(_bsd_cpudata(grains))
         grains.update(_osx_gpudata())
     else:


### PR DESCRIPTION
Add productname, manufacturer and osmajorrelease grains on OSX

There may be a better way of figuring out the osmajorrelease. And I'm not sure always setting manufacturer to 'Apple Inc.' is right. But these would be very useful grains to have on OSX.
