### PR TITLE
"fixes" bug when parsing interfaces

### DIFF
--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -615,7 +615,7 @@ def _parse_interfaces(interface_files=None):
     # Return a sorted list of the keys for bond, bridge and ethtool options to
     # ensure a consistent order
     for iface_name in adapters:
-        if not adapters[iface_name].has_key('data'):
+        if 'data' not in adapters[iface_name]:
             msg = 'Interface file malformed for interface: {0}.'.format(iface_name)
             log.error(msg)
             adapters.pop(iface_name)

--- a/salt/modules/debian_ip.py
+++ b/salt/modules/debian_ip.py
@@ -615,6 +615,11 @@ def _parse_interfaces(interface_files=None):
     # Return a sorted list of the keys for bond, bridge and ethtool options to
     # ensure a consistent order
     for iface_name in adapters:
+        if not adapters[iface_name].has_key('data'):
+            msg = 'Interface file malformed for interface: {0}.'.format(iface_name)
+            log.error(msg)
+            adapters.pop(iface_name)
+            continue
         for opt in ['ethtool', 'bonding', 'bridging']:
             if 'inet' in adapters[iface_name]['data']:
                 if opt in adapters[iface_name]['data']['inet']:


### PR DESCRIPTION
On even only somewhat invalid /etc/network/interfaces files the
function broke with an inconprehensible error message.
This MR enhances the error message and removes the invalid
interface from the result.

See github issue #19405
