### PR TITLE
Fix postgres_local_cache handling of abnormal return data

### DIFF
--- a/salt/returners/postgres_local_cache.py
+++ b/salt/returners/postgres_local_cache.py
@@ -194,6 +194,12 @@ def returner(load):
     '''
     Return data to a postgres server
     '''
+    # salt guarantees that there will be 'fun', 'jid', 'return' and 'id' but not
+    # 'success'
+    success = 'Unknown'
+    if 'success' in load:
+        success = load['success']
+
     conn = _get_conn()
     if conn is None:
         return None
@@ -205,9 +211,9 @@ def returner(load):
         sql, (
             load['fun'],
             load['jid'],
-            json.dumps(load['return']),
+            json.dumps(unicode(str(load['return']), 'utf-8', 'replace')),
             load['id'],
-            load['success']
+            success
         )
     )
     _close_conn(conn)


### PR DESCRIPTION
We've been using the postgres_local_cache feature for a while now and have found that the data returned by salt-minions aren't always perfect.

This patch should strengthen postgres_local_cache handling of bad return data.
