### PR TITLE
Attempt to return errors to minions from Master

### DIFF
--- a/salt/master.py
+++ b/salt/master.py
@@ -732,6 +732,13 @@ class MWorker(multiprocessing.Process):
                     raise
                 # catch all other exceptions, so we don't go defunct
                 except Exception as exc:
+                    # since we are in an exceptional state, lets attempt to tell
+                    # the minion we have a problem, otherwise the minion will get
+                    # no response and be forced to wait for their max timeout
+                    try:
+                        socket.send('Unexpected Error in Mworker')
+                    except:  # pylint: disable=W0702
+                        pass
                     # Properly handle EINTR from SIGUSR1
                     if isinstance(exc, zmq.ZMQError) and exc.errno == errno.EINTR:
                         continue


### PR DESCRIPTION
Right now for all exceptions on the master we handle the exception and reset the socket. This means the master doesn't die-- but we aren't being very nice to the minion, since we never sent a response. This means the minion has to wait until their max timeout. This way we will attempt to notify the minion so they can stop waiting.

I found this while doing my transport overhaul, but this accounts for all the weird minion stall things I could find ;)
