### PR TITLE
Fix #21755 for 2015.2

### DIFF
--- a/tests/integration/netapi/rest_tornado/test_app.py
+++ b/tests/integration/netapi/rest_tornado/test_app.py
@@ -539,10 +539,11 @@ class TestWebhookSaltAPIHandler(SaltnadoTestCase):
         return application
 
     def test_post(self):
-        def verify_event(event):
+        def verify_event(future):
             '''
             Verify that the event fired on the master matches what we sent
             '''
+            event = future.result()
             self.assertEqual(event['tag'], 'salt/netapi/hook')
             self.assertIn('headers', event['data'])
             self.assertEqual(event['data']['post'], {'foo': 'bar'})

--- a/tests/unit/netapi/rest_tornado/test_utils.py
+++ b/tests/unit/netapi/rest_tornado/test_utils.py
@@ -109,6 +109,23 @@ class TestEventListener(AsyncTestCase):
             self.assertEqual(event_future.result()['tag'], 'evt1')
             self.assertEqual(event_future.result()['data']['data'], 'foo1')
 
+    def test_timeout(self):
+        '''
+        Make sure timeouts work correctly
+        '''
+        with eventpublisher_process():
+            event_listener = saltnado.EventListener({},  # we don't use mod_opts, don't save?
+                                                    {'sock_dir': SOCK_DIR,
+                                                     'transport': 'zeromq'})
+            event_future = event_listener.get_event(1,
+                                                    tag='evt1',
+                                                    callback=self.stop,
+                                                    timeout=1,
+                                                    )  # get an event future
+            self.wait()
+            self.assertTrue(event_future.done())
+            with self.assertRaises(saltnado.TimeoutException):
+                event_future.result()
 
 if __name__ == '__main__':
     from integration import run_tests  # pylint: disable=import-error


### PR DESCRIPTION
Fixes #21707

The issue is basically that the master has seen N minions-- and not all N are currently connected. The publish job returns to the salt-api that N minions got the job-- and it dutifilly waits for all the returns. With this we use the same ping timeout that the CLI does while waiting for returns. So once all minions are no longer running the job we will return.
