### PR TITLE
Syndic client

### DIFF
--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -793,23 +793,38 @@ class LocalClient(object):
             self,
             jid,
             event=None,
-            gather_errors=False):
+            gather_errors=False,
+           additional_tags=None
+           ):
         '''
         Raw function to just return events of jid excluding timeout logic
 
         Yield either the raw event data or None
+
+       Pass a list of additional tags as `additional_tags` to search the
+       event bus for non-return data, such as minion lists returned from
+       syndics.
         '''
         if event is None:
             event = self.event
+
         jid_tag = 'salt/job/{0}'.format(jid)
+
+        tag_search = []
+        tag_search.append(jid_tag)
+        if isinstance(additional_tags, str):
+            tag_search.append(additional_tags)
+        elif isinstance(additional_tags, list):
+            for tag in additional_tags:
+                tag_search.append(tag)
         while True:
             if self.opts.get('transport') == 'zeromq':
                 try:
                     raw = event.get_event_noblock()
                     if gather_errors:
-                        if (raw and
-                               (raw.get('tag', '').startswith('_salt_error') or
-                                raw.get('tag', '').startswith(jid_tag))):
+                         if (raw and
+                                (raw.get('tag', '').startswith('_salt_error') or
+                                [raw.get('tag', '').startswith(tag) for tag in tag_search])):
                             yield raw
                     else:
                         if raw and raw.get('tag', '').startswith(jid_tag):
@@ -870,10 +885,15 @@ class LocalClient(object):
         syndic_wait = 0
         last_time = False
         # iterator for this job's return
-        ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors)
+        if self.opts['order_masters']:
+           # If we are a MoM, we need to gather expected minions from downstreams masters.
+            ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors, additional_tags='syndic')
+        else:
+            ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors)
         # iterator for the info of this job
         jinfo_iter = []
         timeout_at = time.time() + timeout
+        gather_syndic_wait = time.time() + self.opts['syndic_wait']
         # are there still minions running the job out there
         # start as True so that we ping at least once
         minions_running = True
@@ -894,9 +914,6 @@ class LocalClient(object):
                         yield ret
                 if 'minions' in raw.get('data', {}):
                     minions.update(raw['data']['minions'])
-                    continue
-                if 'syndic' in raw:
-                    minions.update(raw['syndic'])
                     continue
                 if 'return' not in raw['data']:
                     continue
@@ -920,8 +937,19 @@ class LocalClient(object):
                 # All minions have returned, break out of the loop
                 log.debug('jid {0} found all minions {1}'.format(jid, found))
                 break
+            elif len(found.intersection(minions)) >= len(minions) and self.opts['order_masters']:
+               if len(found) >= len(minions) and len(minions) > 0 and time.time() > gather_syndic_wait:
+                   # There were some minions to find and we found them
+                   # However, this does not imply that *all* masters have yet responded with expected minion lists.
+                   # Therefore, continue to wait up to the syndic_wait period (calculated in gather_syndic_wait) to see
+                   # if additional lower-level masters deliver their lists of expected
+                   # minions.
+                   break
+           # If we get here we may not have gathered the minion list yet. Keep waiting
+           # for all lower-level masters to respond with their minion lists
 
             # let start the timeouts for all remaining minions
+
             for id_ in minions - found:
                 # if we have a new minion in the list, make sure it has a timeout
                 if id_ not in minion_timeouts:

--- a/salt/client/__init__.py
+++ b/salt/client/__init__.py
@@ -794,7 +794,7 @@ class LocalClient(object):
             jid,
             event=None,
             gather_errors=False,
-           additional_tags=None
+            additional_tags=None
            ):
         '''
         Raw function to just return events of jid excluding timeout logic
@@ -822,9 +822,9 @@ class LocalClient(object):
                 try:
                     raw = event.get_event_noblock()
                     if gather_errors:
-                         if (raw and
+                        if (raw and
                                 (raw.get('tag', '').startswith('_salt_error') or
-                                [raw.get('tag', '').startswith(tag) for tag in tag_search])):
+                                any([raw.get('tag', '').startswith(tag) for tag in tag_search]))):
                             yield raw
                     else:
                         if raw and raw.get('tag', '').startswith(jid_tag):
@@ -886,7 +886,7 @@ class LocalClient(object):
         last_time = False
         # iterator for this job's return
         if self.opts['order_masters']:
-           # If we are a MoM, we need to gather expected minions from downstreams masters.
+            # If we are a MoM, we need to gather expected minions from downstreams masters.
             ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors, additional_tags='syndic')
         else:
             ret_iter = self.get_returns_no_block(jid, gather_errors=gather_errors)
@@ -938,13 +938,13 @@ class LocalClient(object):
                 log.debug('jid {0} found all minions {1}'.format(jid, found))
                 break
             elif len(found.intersection(minions)) >= len(minions) and self.opts['order_masters']:
-               if len(found) >= len(minions) and len(minions) > 0 and time.time() > gather_syndic_wait:
-                   # There were some minions to find and we found them
-                   # However, this does not imply that *all* masters have yet responded with expected minion lists.
-                   # Therefore, continue to wait up to the syndic_wait period (calculated in gather_syndic_wait) to see
-                   # if additional lower-level masters deliver their lists of expected
-                   # minions.
-                   break
+                if len(found) >= len(minions) and len(minions) > 0 and time.time() > gather_syndic_wait:
+                    # There were some minions to find and we found them
+                    # However, this does not imply that *all* masters have yet responded with expected minion lists.
+                    # Therefore, continue to wait up to the syndic_wait period (calculated in gather_syndic_wait) to see
+                    # if additional lower-level masters deliver their lists of expected
+                    # minions.
+                    break
            # If we get here we may not have gathered the minion list yet. Keep waiting
            # for all lower-level masters to respond with their minion lists
 

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -715,10 +715,10 @@ class RemoteFuncs(object):
             for event in load['events']:
                 self.event.fire_event(event, event['tag'])  # old dup event
                 if load.get('pretag') is not None:
-                   if 'data' in event:
-                       self.event.fire_event(event['data'], tagify(event['tag'], base=load['pretag']))
-                   else:
-                       self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
+                    if 'data' in event:
+                        self.event.fire_event(event['data'], tagify(event['tag'], base=load['pretag']))
+                    else:
+                        self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
         else:
             tag = load['tag']
             self.event.fire_event(load, tag)

--- a/salt/daemons/masterapi.py
+++ b/salt/daemons/masterapi.py
@@ -715,7 +715,10 @@ class RemoteFuncs(object):
             for event in load['events']:
                 self.event.fire_event(event, event['tag'])  # old dup event
                 if load.get('pretag') is not None:
-                    self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
+                   if 'data' in event:
+                       self.event.fire_event(event['data'], tagify(event['tag'], base=load['pretag']))
+                   else:
+                       self.event.fire_event(event, tagify(event['tag'], base=load['pretag']))
         else:
             tag = load['tag']
             self.event.fire_event(load, tag)


### PR DESCRIPTION
This adjusts LocalClient and the MasterAPI..

First, it fixes an issue wherein minion events passed to the master had the `data` key embedded in a higher-level `data` key. This was a regression that appeared at some point and fixed at the request of @thatch45.

Secondly, this PR adjusts the logic in LocalClient so that a client on a top-level master will wait for at least one syndic to return their top-level list of minions and then wait the additional `syndic_wait` for additional syndics to reply. This closes #19864.

Finally, it removes a check for a `syndic` tag in `LocalClient`. This seems to be deprecated and @thatch45 agrees.
