### PR TITLE
Add note about ldap module requirement

### DIFF
--- a/doc/topics/eauth/index.rst
+++ b/doc/topics/eauth/index.rst
@@ -105,6 +105,9 @@ Token expiration time can be set in the Salt master config file.
 
 LDAP
 ----
+.. note::
+
+    LDAP usage requires that you have installed python-ldap.
 
 Salt supports both user and group authentication for LDAP.
 


### PR DESCRIPTION
Currently the only way you can figure out that you need the LDAP module is to read the source. I assumed it was installed as part of my OS package, but it is not. This documents it clearly that you need to install the module.
