### PR TITLE
[2015.2] Fix syndic pushing load to master of masters

### DIFF
--- a/salt/config.py
+++ b/salt/config.py
@@ -1015,6 +1015,7 @@ def syndic_config(master_config_path,
         'sock_dir': os.path.join(
             opts['cachedir'], opts.get('syndic_sock_dir', opts['sock_dir'])
         ),
+        'cachedir': master_opts['cachedir'],
     }
     opts.update(syndic_opts)
     # Prepend root_dir to other paths

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -2222,7 +2222,7 @@ class Syndic(Minion):
                     jdict['__fun__'] = event['data'].get('fun')
                     jdict['__jid__'] = event['data']['jid']
                     jdict['__load__'] = {}
-                    fstr = '{0}.get_jid'.format(self.opts['master_job_cache'])
+                    fstr = '{0}.get_load'.format(self.opts['master_job_cache'])
                     jdict['__load__'].update(
                         self.mminion.returners[fstr](event['data']['jid'])
                         )

--- a/tests/unit/config_test.py
+++ b/tests/unit/config_test.py
@@ -355,7 +355,7 @@ class ConfigTestCase(TestCase, integration.AdaptedConfigurationTestCaseMixIn):
         self.assertEqual(syndic_opts['master_ip'], '127.0.0.1')
         self.assertEqual(syndic_opts['master'], 'localhost')
         self.assertEqual(syndic_opts['sock_dir'], os.path.join(root_dir, 'minion_sock'))
-        self.assertEqual(syndic_opts['cachedir'], os.path.join(root_dir, 'cachedir'))
+        self.assertEqual(syndic_opts['cachedir'], os.path.join(root_dir, 'cache'))
         self.assertEqual(syndic_opts['log_file'], os.path.join(root_dir, 'osyndic.log'))
         self.assertEqual(syndic_opts['pidfile'], os.path.join(root_dir, 'osyndic.pid'))
         # Show that the options of localclient that repub to local master


### PR DESCRIPTION
This means that jobs initiated on lower level masters will now properly appear in the master of masters job cache.

Fixes #21495
