### PR TITLE
Change loglevel of virt-what message to debug

### DIFF
--- a/salt/grains/core.py
+++ b/salt/grains/core.py
@@ -477,7 +477,10 @@ def _virtual(osdata):
         if salt.utils.which('virt-what'):
             _cmds = (['virt-what'])
         else:
-            log.info('Please install "virt-what" to improve results of the "virtual" grain.')
+            log.debug(
+                'Please install \'virt-what\' to improve results of the '
+                '\'virtual\' grain.'
+            )
     # Check if enable_lspci is True or False
     elif __opts__.get('enable_lspci', True) is False:
         _cmds = (['dmidecode', 'dmesg'])


### PR DESCRIPTION
With this message at loglevel INFO, a user will see this message every time
they run a job using salt-call unless they have virt-what installed. This is
unnecessary and annoying.
