### PR TITLE
Multiaster no-block auth

### DIFF
--- a/salt/crypt.py
+++ b/salt/crypt.py
@@ -307,7 +307,7 @@ class SAuth(object):
 
         self.authenticate()
 
-    def authenticate(self):
+    def authenticate(self, timeout=None, safe=None):
         '''
         Authenticate with the master, this method breaks the functional
         paradigm, it will update the master information from a fresh sign
@@ -323,7 +323,7 @@ class SAuth(object):
             acceptance_wait_time_max = acceptance_wait_time
 
         while True:
-            creds = self.sign_in()
+            creds = self.sign_in(timeout, safe)
             if creds == 'retry':
                 if self.opts.get('caller'):
                     print('Minion failed to authenticate with the master, '

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -582,7 +582,10 @@ class MultiMinion(MinionBase):
             package = None
             for minion in minions.values():
                 if isinstance(minion, dict):
-                    minion = minion['minion']
+                    if 'minion' in minion:
+                        minion = minion['minion']
+                    else:
+                        continue
                 if not hasattr(minion, 'schedule'):
                     continue
                 loop_interval = self.process_schedule(minion, loop_interval)
@@ -1499,7 +1502,7 @@ class Minion(MinionBase):
             )
         )
         auth = salt.crypt.SAuth(self.opts)
-        auth.authenticate()
+        auth.authenticate(timeout=timeout, safe=safe)
         # TODO: remove these and just use a local reference to auth??
         self.tok = auth.gen_token('salt')
         self.crypticle = auth.crypticle


### PR DESCRIPTION
Restore ability from 2014.7 to auth without blocking on retries.

Also prevent exception being raised if minion is not fully intiialized.

Closes #21744 
