### PR TITLE
Backport #21819 to 2015.2

### DIFF
--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -30,6 +30,7 @@ from salt.ext.six.moves import shlex_quote as _cmd_quote, range
 
 # Import salt libs
 import salt.utils
+import salt.utils.decorators as decorators
 from salt.exceptions import (
     CommandExecutionError, MinionError, SaltInvocationError
 )
@@ -1876,3 +1877,50 @@ def owner(*paths):
     if len(ret) == 1:
         return next(ret.itervalues())
     return ret
+
+
+@decorators.which('yumdownloader')
+def download(*packages):
+    '''
+    Download packages to the local disk.
+    It requires "yumdownloader" from "yum-utils" package.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.download httpd
+        salt '*' pkg.download httpd postfix
+    '''
+    if not packages:
+        raise CommandExecutionError("No packages has been specified.")
+
+    CACHE_DIR = "/var/cache/yum/packages"
+    if not os.path.exists(CACHE_DIR):
+        os.makedirs(CACHE_DIR)
+    for pkg in packages:
+        __salt__['cmd.run']("rm {0}/{1}*".format(CACHE_DIR, pkg))
+
+    __salt__['cmd.run'](('yumdownloader -q {0} --destdir={1}'.format(' '.join(packages), CACHE_DIR)),
+                        output_loglevel='trace')
+    pkg_ret = {}
+    for dld_result in os.listdir(CACHE_DIR):
+        if not dld_result.endswith(".rpm"):
+            continue
+        pkg_name = None
+        pkg_file = None
+        for query_pkg in packages:
+            if dld_result.startswith("{0}-".format(query_pkg)):
+                pkg_name = query_pkg
+                pkg_file = dld_result
+                break
+        pkg_info = {
+            'path': "{0}/{1}".format(CACHE_DIR, pkg_file),
+        }
+        pkg_ret[pkg_name] = pkg_info
+
+    if pkg_ret:
+        return pkg_ret
+
+    raise CommandExecutionError("Unable to download packages: {0}.".format(', '.join(packages)))
+

--- a/salt/modules/yumpkg.py
+++ b/salt/modules/yumpkg.py
@@ -1924,3 +1924,38 @@ def download(*packages):
 
     raise CommandExecutionError("Unable to download packages: {0}.".format(', '.join(packages)))
 
+
+def diff(*paths):
+    '''
+    Return a formatted diff between current files and original in a package.
+    NOTE: this function includes all files (configuration and not), but does
+    not work on binary content.
+
+    :param path: Full path to the installed file
+    :return: Difference string or raises and exception if examined file is binary.
+
+    CLI example:
+
+    .. code-block:: bash
+
+        salt '*' pkg.diff /etc/apache2/httpd.conf /etc/sudoers
+    '''
+    ret = {}
+
+    pkg_to_paths = {}
+    for pth in paths:
+        pth_pkg = __salt__['lowpkg.owner'](pth)
+        if not pth_pkg:
+            ret[pth] = os.path.exists(pth) and 'Not managed' or 'N/A'
+        else:
+            if pkg_to_paths.get(pth_pkg) is None:
+                pkg_to_paths[pth_pkg] = []
+            pkg_to_paths[pth_pkg].append(pth)
+
+    if pkg_to_paths:
+        local_pkgs = __salt__['pkg.download'](*pkg_to_paths.keys())
+        for pkg, files in pkg_to_paths.items():
+            for path in files:
+                ret[path] = __salt__['lowpkg.diff'](local_pkgs[pkg]['path'], path) or 'Unchanged'
+
+    return ret


### PR DESCRIPTION
See https://github.com/saltstack/salt/pull/21819
This did not went straght-forward, because modified RPMs feature was not backported yet (PR coming).
