### PR TITLE
`override_params` contains the real list of allowed parameters

### DIFF
--- a/salt/fileserver/gitfs.py
+++ b/salt/fileserver/gitfs.py
@@ -738,7 +738,7 @@ def init():
                         'information.'.format(
                             param,
                             repo_url,
-                            ', '.join(PER_REMOTE_PARAMS)
+                            ', '.join(override_params)
                         )
                     )
                 per_remote_errors = True


### PR DESCRIPTION
Ease debugging when using pygit2
