### PR TITLE
[2014.7] saltutil.runner fixes

### DIFF
--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -29,6 +29,7 @@ import salt
 import salt.payload
 import salt.state
 import salt.client
+import salt.config
 import salt.runner
 import salt.utils
 import salt.utils.process
@@ -752,7 +753,14 @@ def runner(fun, **kwargs):
     '''
     kwargs = salt.utils.clean_kwargs(**kwargs)
 
-    rclient = salt.runner.RunnerClient(__opts__)
+    if 'master_job_cache' not in __opts__:
+        master_config = os.path.join(os.path.dirname(__opts__['conf_file']),
+                                     'master')
+        master_opts = salt.config.master_config(master_config)
+        rclient = salt.runner.RunnerClient(master_opts)
+    else:
+        rclient = salt.runner.RunnerClient(__opts__)
+
     return rclient.cmd(fun, [], kwarg=kwargs)
 
 

--- a/salt/modules/saltutil.py
+++ b/salt/modules/saltutil.py
@@ -750,6 +750,8 @@ def runner(fun, **kwargs):
 
         salt '*' saltutil.runner jobs.list_jobs
     '''
+    kwargs = salt.utils.clean_kwargs(**kwargs)
+
     rclient = salt.runner.RunnerClient(__opts__)
     return rclient.cmd(fun, [], kwarg=kwargs)
 


### PR DESCRIPTION
Fixes a couple of issues with `saltutil.runner`:
- Strips the `__pub` kwargs
- Generates the master config if it's being run on the minion on the master

Fixes #21650 
