### PR TITLE
Force LC_ALL=C for chkconfig, since that's LANG dependant

### DIFF
--- a/salt/cloud/deploy/bootstrap-salt.sh
+++ b/salt/cloud/deploy/bootstrap-salt.sh
@@ -1533,7 +1533,7 @@ __check_services_sysvinit() {
     servicename=$1
     echodebug "Checking if service ${servicename} is enabled"
 
-    if [ "$(/sbin/chkconfig --list  | grep salt-"$fname" | grep '[2-5]:on')" != "" ]; then
+    if [ "$(LC_ALL=C /sbin/chkconfig --list  | grep salt-"$fname" | grep '[2-5]:on')" != "" ]; then
         echodebug "Service ${servicename} is enabled"
         return 0
     else


### PR DESCRIPTION
On EL 6 and with LANG=fr_FR.utf8 ( as transmitted by ssh ), the script
fail. It turn out that running salt-cloud remotely with ssh mean that
LANG is transmitted, and chkconfig output is translated. So the grep fail,
and so the deploy fail.
