### PR TITLE
Remove _locals from the final exec call in pyobjects

### DIFF
--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -319,7 +319,6 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
         load_states()
 
     # these hold the scope that our sls file will be executed with
-    _locals = {}
     _globals = {}
 
     # create our StateFactory objects
@@ -441,6 +440,6 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
     Registry.enabled = True
 
     # now exec our template using our created scopes
-    exec_(final_template, _globals, _locals)
+    exec_(final_template, _globals)
 
     return Registry.salt_data()

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -99,6 +99,12 @@ from salt://map.sls import Samba as Other
 Pkg.removed("samba-imported", names=[Other.server, Other.client])
 '''
 
+stdlib_template = '''#!pyobjects
+import random
+password = ''.join(random.SystemRandom().choice(
+        string.ascii_letters + string.digits) for _ in range(20))
+File.managed('/tmp/passwd', owner='root', group='root', mode='600', contents=password)
+'''
 
 class StateTests(TestCase):
     def setUp(self):
@@ -308,6 +314,10 @@ class RendererTests(RendererMixin, TestCase):
         render_and_assert(from_import_template)
         render_and_assert(import_as_template)
 
+    def test_stdlib_import(self):
+        '''Test for https://github.com/saltstack/salt/issues/21796'''
+
+        ret = self.render(stdlib_template)
 
 class MapTests(RendererMixin, TestCase):
     def test_map(self):

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -99,11 +99,14 @@ from salt://map.sls import Samba as Other
 Pkg.removed("samba-imported", names=[Other.server, Other.client])
 '''
 
-stdlib_template = '''#!pyobjects
-import random
+random_password_template = '''#!pyobjects
+import random, string
 password = ''.join(random.SystemRandom().choice(
         string.ascii_letters + string.digits) for _ in range(20))
-File.managed('/tmp/passwd', owner='root', group='root', mode='600', contents=password)
+'''
+
+random_password_import_template = '''#!pyobjecs
+from salt://password.sls import password
 '''
 
 class StateTests(TestCase):
@@ -314,10 +317,14 @@ class RendererTests(RendererMixin, TestCase):
         render_and_assert(from_import_template)
         render_and_assert(import_as_template)
 
-    def test_stdlib_import(self):
+    def test_random_password(self):
         '''Test for https://github.com/saltstack/salt/issues/21796'''
+        ret = self.render(random_password_template)
 
-        ret = self.render(stdlib_template)
+    def test_import_random_password(self):
+        '''Import test for https://github.com/saltstack/salt/issues/21796'''
+        self.write_template_file("password.sls", random_password_template)
+        ret = self.render(random_password_import_template)
 
 class MapTests(RendererMixin, TestCase):
     def test_map(self):


### PR DESCRIPTION
This PR fixes #21796

From the Python docs on the `exec` statement:

> Remember that at module level, globals and locals are the same dictionary. If two separate objects are given as globals and locals, the code will be executed as if it were embedded in a class definition.

We were providing a specific object for locals and in the specific case reported in #21796 this caused a very strange name error when used in a specific way.  By removing the explicit locals dictionary and just having the globals dictionary be shared fixes the issue, and we weren't using the specific locals anyway.
