### PR TITLE
Remove _locals from the final exec call in pyobjects (2014.7)

### DIFF
--- a/salt/renderers/pyobjects.py
+++ b/salt/renderers/pyobjects.py
@@ -316,7 +316,6 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
         load_states()
 
     # these hold the scope that our sls file will be executed with
-    _locals = {}
     _globals = {}
 
     # create our StateFactory objects
@@ -444,9 +443,9 @@ def render(template, saltenv='base', sls='', salt_data=True, **kwargs):
     # now exec our template using our created scopes
     if sys.version_info[0] > 2:
         # in py3+ exec is a function
-        exec(final_template, _globals, _locals)
+        exec(final_template, _globals)
     else:
         # prior to that it is a statement
-        exec final_template in _globals, _locals
+        exec final_template in _globals
 
     return Registry.salt_data()

--- a/tests/unit/pyobjects_test.py
+++ b/tests/unit/pyobjects_test.py
@@ -90,6 +90,16 @@ from   salt://map.sls  import     Samba
 Pkg.removed("samba-imported", names=[Samba.server, Samba.client])
 '''
 
+random_password_template = '''#!pyobjects
+import random, string
+password = ''.join(random.SystemRandom().choice(
+        string.ascii_letters + string.digits) for _ in range(20))
+'''
+
+random_password_import_template = '''#!pyobjecs
+from salt://password.sls import password
+'''
+
 
 class StateTests(TestCase):
     def setUp(self):
@@ -325,6 +335,15 @@ class MapTests(RendererMixin, TestCase):
 
         ret = samba_with_grains({'os_family': 'RedHat', 'os': 'CentOS'})
         assert_ret(ret, 'samba', 'samba', 'smb')
+
+    def test_random_password(self):
+        '''Test for https://github.com/saltstack/salt/issues/21796'''
+        ret = self.render(random_password_template)
+
+    def test_import_random_password(self):
+        '''Import test for https://github.com/saltstack/salt/issues/21796'''
+        self.write_template_file("password.sls", random_password_template)
+        ret = self.render(random_password_import_template)
 
 
 class SaltObjectTests(TestCase):


### PR DESCRIPTION
From the Python docs on the exec statement:

> Remember that at module level, globals and locals are the same dictionary.
> If two separate objects are given as globals and locals, the code will be
> executed as if it were embedded in a class definition.

We were providing a specific object for locals and in the specific case
reported in #21796 this caused a very strange name error when used in a
specific way. By removing the explicit locals dictionary and just having the
globals dictionary be shared fixes the issue, and we weren't using the
specific locals anyway.
