### PR TITLE
Remove check for physical virt type for salt.modules.virt.is_kvm_hyper()

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1543,8 +1543,6 @@ def is_kvm_hyper():
 
         salt '*' virt.is_kvm_hyper
     '''
-    if __grains__['virtual'] != 'physical':
-        return False
     try:
         if 'kvm_' not in salt.utils.fopen('/proc/modules').read():
             return False


### PR DESCRIPTION
KVM can run in VMs when VT-x is passed through the VM, as can be done on VMWare Fusion, and Workstation, perhaps even KVM itself.

This change removes the physical type check but leaves other checks intact, which returns the desired 'True' result.
