### PR TITLE
Feature "line edit"

### DIFF
--- a/salt/states/file.py
+++ b/salt/states/file.py
@@ -2363,6 +2363,48 @@ def recurse(name,
     return ret
 
 
+def line(name, content, match=None, mode=None, location=None,
+         before=None, after=None, show_changes=True, backup=False):
+    '''
+    Line-based editing of a file.
+
+    Params are identical to the remote execution function
+    :mod:`file.line <salt.modules.file.line>`.
+
+    .. code-block: yaml
+
+       /etc/myconfig.conf
+         file.line:
+           - mode: ensure
+           - content: my key = my value
+           - before: somekey.*?
+    '''
+    name = os.path.expanduser(name)
+    ret = {'name': name, 'changes': {}, 'result': True, 'comment': ''}
+    if not name:
+        return _error(ret, 'Must provide name to file.line')
+
+    check_res, check_msg = _check_file(name)
+    if not check_res:
+        return _error(ret, check_msg)
+
+    changes = __salt__['file.line'](name, content, match=match, mode=mode, location=location,
+                                    before=before, after=after, show_changes=show_changes, backup=backup)
+    if changes:
+        if __opts__['test']:
+            ret['result'] = None
+            ret['comment'] = 'Changes would have been made:\ndiff:\n{0}'.format(changes)
+        else:
+            ret['result'] = True
+            ret['comment'] = 'Changes were made'
+            ret['changes'] = {'diff': changes}
+    else:
+        ret['result'] = True
+        ret['comment'] = 'No changes needed to be made'
+
+    return ret
+
+
 def replace(name,
             pattern,
             repl,


### PR DESCRIPTION
Sometimes Salt should touch only one line or ensure required expression is there. Inspired by [CFEngine "edit_line" promise](https://docs.cfengine.com/docs/3.5/reference-promise-types-files-edit_line.html), now this feature is here. :-)

You can use it from CLI:

```
salt 'e162.suse.de' file.line /etc/foo.conf 'foo = spam' match='foo\s+=.*' mode=replace
```

Or from state:

``` yaml
/etc/foo.conf:
  file.line:
    - content: foo = salty
    - mode: replace
    - match: 'foo\s+=.*' 
```

An example result:

```
e166:/srv/salt # salt 'e162.suse.de' state.highstate
e162.suse.de:
----------
          ID: /etc/foo.conf
    Function: file.line
      Result: True
     Comment: Changes were made
     Started: 20:16:48.104384
    Duration: 3.303 ms
     Changes:   
              ----------
              diff:
                  --- 
                  +++ 
                  @@ -1,7 +1,7 @@
                  -# My config
                  -key = value
                  -
                  -# Another comment
                  -foo = spam
                  -
                  -# The end
                  +# My config+key = value++# Another comment+foo = salty++# The end

Summary
------------
Succeeded: 1 (changed=1)
Failed:    0
------------
Total states run:     1
```
