### PR TITLE
add system info to versions report

### DIFF
--- a/doc/topics/releases/beryllium.rst
+++ b/doc/topics/releases/beryllium.rst
@@ -2,6 +2,13 @@
 Salt Release Notes - Codename Beryllium
 =======================================
 
+Core Changes
+=============
+
+- Add system version info to ``versions_report``, which appears in both ``salt
+  --versions-report`` and ``salt '*' test.versions_report``. Also added is an
+  alias ``test.versions`` to ``test.versions_report``. (:issue:`21906`)
+
 JBoss 7 State
 =============
 

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -134,6 +134,9 @@ def versions_report():
     return '\n'.join(salt.version.versions_report())
 
 
+versions = versions_report
+
+
 def conf_test():
     '''
     Return the value for test.foo in the minion configuration file, or return

--- a/salt/modules/test.py
+++ b/salt/modules/test.py
@@ -110,7 +110,7 @@ def version():
 
 def versions_information():
     '''
-    Returns versions of components used by salt as a dict
+    Report the versions of dependent and system software
 
     CLI Example:
 
@@ -118,7 +118,7 @@ def versions_information():
 
         salt '*' test.versions_information
     '''
-    return dict(salt.version.versions_information())
+    return salt.version.versions_information()
 
 
 def versions_report():

--- a/salt/version.py
+++ b/salt/version.py
@@ -9,6 +9,7 @@ Set up the version of Salt
 from __future__ import absolute_import, print_function
 import re
 import sys
+import platform
 
 # Don't rely on external packages in this module since it's used at install time
 # pylint: disable=invalid-name,redefined-builtin
@@ -524,13 +525,18 @@ __version__ = __saltstack_version__.string
 # <---- Common version related attributes - NO NEED TO CHANGE --------------------------------------------------------
 
 
-def versions_information(include_salt_cloud=False):
+def salt_information():
     '''
-    Report on all of the versions for dependent software
+    Report version of salt.
     '''
+    yield 'Salt', __version__
 
+
+def dependency_information(include_salt_cloud=False):
+    '''
+    Report versions of library dependencies.
+    '''
     libs = [
-        ('Salt', None, __version__),
         ('Python', None, sys.version.rsplit('\n')[0].strip()),
         ('Jinja2', 'jinja2', '__version__'),
         ('M2Crypto', 'M2Crypto', 'version'),
@@ -567,18 +573,76 @@ def versions_information(include_salt_cloud=False):
             yield name, None
 
 
+def system_information():
+    '''
+    Report system versions.
+    '''
+    def system_version():
+        '''
+        Return host system version.
+        '''
+        lin_ver = platform.linux_distribution()
+        mac_ver = platform.mac_ver()
+        win_ver = platform.win32_ver()
+
+        if lin_ver[0]:
+            return ' '.join(lin_ver)
+        elif mac_ver[0]:
+            return ' '.join([mac_ver[0], '-'.join(mac_ver[1]), mac_ver[2]])
+        elif win_ver[0]:
+            return ' '.join(win_ver)
+
+    system = [
+        ('dist', ' '.join(platform.dist())),
+        ('release', platform.release()),
+        ('machine', platform.machine()),
+    ]
+
+    sys_ver = system_version()
+    if sys_ver:
+        system.append(('system', sys_ver))
+
+    for name, attr in system:
+        yield name, attr
+        continue
+
+
+def versions_information(include_salt_cloud=False):
+    '''
+    Report the versions of dependent software.
+    '''
+    salt_info = list(salt_information())
+    lib_info = list(dependency_information(include_salt_cloud))
+    sys_info = list(system_information())
+
+    return {'Salt Version': dict(salt_info),
+            'Dependency Versions': dict(lib_info),
+            'System Versions': dict(sys_info)}
+
+
 def versions_report(include_salt_cloud=False):
     '''
-    Yield each library properly formatted for a console clean output.
+    Yield each version properly formatted for console output.
     '''
-    libs = list(versions_information(include_salt_cloud=include_salt_cloud))
+    ver_info = versions_information(include_salt_cloud)
 
-    padding = max(len(lib[0]) for lib in libs) + 1
+    lib_pad = max(len(name) for name in ver_info['Dependency Versions'])
+    sys_pad = max(len(name) for name in ver_info['System Versions'])
+    padding = max(lib_pad, sys_pad) + 1
 
     fmt = '{0:>{pad}}: {1}'
+    info = []
+    for ver_type in ('Salt Version', 'Dependency Versions', 'System Versions'):
+        info.append('{0}:'.format(ver_type))
+        for name in sorted(ver_info[ver_type]):
+            ver = fmt.format(name,
+                             ver_info[ver_type][name] or 'Not Installed',
+                             pad=padding)
+            info.append(ver)
+        info.append(' ')
 
-    for name, version in libs:
-        yield fmt.format(name, version or 'Not Installed', pad=padding)
+    for line in info:
+        yield line
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The versions report ought to provide all information necessary about the setup a user is running.  Often it is important to also know the platform to properly triage issues.
