### PR TITLE
refactor nested outputter for much better performance

### DIFF
--- a/salt/output/nested.py
+++ b/salt/output/nested.py
@@ -26,10 +26,9 @@ Example output::
 from __future__ import absolute_import
 # Import python libs
 from numbers import Number
-import re
 
 # Import salt libs
-import salt.utils
+from salt.utils import get_colors, sdecode
 import salt.output
 from salt.ext.six import string_types
 
@@ -39,9 +38,13 @@ class NestDisplay(object):
     Manage the nested display contents
     '''
     def __init__(self):
-        self.colors = salt.utils.get_colors(
+        self.__dict__.update(
+            get_colors(
                 __opts__.get('color'),
-                __opts__.get('color_theme'))
+                __opts__.get('color_theme')
+            )
+        )
+        self.strip_colors = __opts__.get('strip_colors', True)
 
     def ustring(self,
                 indent,
@@ -51,69 +54,88 @@ class NestDisplay(object):
                 suffix='',
                 endc=None):
         if endc is None:
-            endc = self.colors['ENDC']
+            endc = self.ENDC
+
+        indent *= ' '
+        fmt = u'{0}{1}{2}{3}{4}{5}'
+
         try:
-            return u'{0}{1}{2}{3}{4}{5}\n'.format(
-                indent, color, prefix, msg, endc, suffix)
+            return fmt.format(indent, color, prefix, msg, endc, suffix)
         except UnicodeDecodeError:
-            return u'{0}{1}{2}{3}{4}{5}\n'.format(
-                indent, color, prefix, salt.utils.sdecode(msg), endc, suffix)
+            return fmt.format(indent, color, prefix, sdecode(msg), endc, suffix)
 
     def display(self, ret, indent, prefix, out):
         '''
         Recursively iterate down through data structures to determine output
         '''
-        strip_colors = __opts__.get('strip_colors', True)
 
         if ret is None or ret is True or ret is False:
-            out += self.ustring(
-                ' ' * indent,
-                self.colors['LIGHT_YELLOW'],
-                ret,
-                prefix=prefix)
+            out.append(
+                self.ustring(
+                    indent,
+                    self.LIGHT_YELLOW,
+                    ret,
+                    prefix=prefix
+                )
+            )
         # Number includes all python numbers types
         #  (float, int, long, complex, ...)
         elif isinstance(ret, Number):
-            out += self.ustring(
-                ' ' * indent,
-                self.colors['LIGHT_YELLOW'],
-                ret,
-                prefix=prefix)
+            out.append(
+                self.ustring(
+                    indent,
+                    self.LIGHT_YELLOW,
+                    ret,
+                    prefix=prefix
+                )
+            )
         elif isinstance(ret, string_types):
-            lines = re.split(r'\r?\n', ret)
-            for line in lines:
-                if strip_colors:
+            for line in ret.splitlines():
+                if self.strip_colors:
                     line = salt.output.strip_esc_sequence(line)
-                out += self.ustring(
-                    ' ' * indent,
-                    self.colors['GREEN'],
-                    line,
-                    prefix=prefix)
-        elif isinstance(ret, list) or isinstance(ret, tuple):
+                out.append(
+                    self.ustring(
+                        indent,
+                        self.GREEN,
+                        line,
+                        prefix=prefix
+                    )
+                )
+        elif isinstance(ret, (list, tuple)):
             for ind in ret:
                 if isinstance(ind, (list, tuple, dict)):
-                    out += self.ustring(' ' * indent,
-                                        self.colors['GREEN'],
-                                        '|_')
+                    out.append(
+                        self.ustring(
+                            indent,
+                            self.GREEN,
+                            '|_'
+                        )
+                    )
                     prefix = '' if isinstance(ind, dict) else '- '
-                    out = self.display(ind, indent + 2, prefix, out)
+                    self.display(ind, indent + 2, prefix, out)
                 else:
-                    out = self.display(ind, indent, '- ', out)
+                    self.display(ind, indent, '- ', out)
         elif isinstance(ret, dict):
             if indent:
-                out += self.ustring(
-                    ' ' * indent,
-                    self.colors['CYAN'],
-                    '-' * 10)
+                out.append(
+                    self.ustring(
+                        indent,
+                        self.CYAN,
+                        '----------'
+                    )
+                )
             for key in sorted(ret):
                 val = ret[key]
-                out += self.ustring(
-                    ' ' * indent,
-                    self.colors['CYAN'],
-                    key,
-                    suffix=":",
-                    prefix=prefix)
-                out = self.display(val, indent + 4, '', out)
+                out.append(
+                    self.ustring(
+                        indent,
+                        self.CYAN,
+                        key,
+                        suffix=':',
+                        prefix=prefix
+                    )
+                )
+                self.display(val, indent + 4, '', out)
         return out
 
 
@@ -122,4 +144,6 @@ def output(ret):
     Display ret data
     '''
     nest = NestDisplay()
-    return nest.display(ret, __opts__.get('nested_indent', 0), '', '')
+    return '\n'.join(
+        nest.display(ret, __opts__.get('nested_indent', 0), '', [])
+    )


### PR DESCRIPTION
When using the default nested.output function with very large objects the function could take many minutes to complete. With a return from an action with ~1600 hosts we were seeing times to render the output in the range of 15+ minutes. This change allows that same return data to take less than 1 second to render.

To ensure the same output format this was tested against the sample data in at the top of the file, our huge sample, as well as several generated datasets at various nesting levels. I did not see any tests for this function, but I can add them if you would like.

The main performance improvement came from changing the building of the out string via string concatenation in a loop to appending to a list of strings and joining them at the end. This avoids the huge overhead required to build many intermediate, immutable strings.

Additional performance improvements were realized via the following:

Replacing re.split with str.splitlines - much faster with the same universal newline behavior the regex exhibited.

Reducing key lookups by making the colors attributes of NestDisplay thereby obviating the need to do the extra lookup to access dict keys.

Reduce redundant opts fetches by moving the strip_colors to a NestDisplay attribute.
