### PR TITLE
Update virt.freemem documentation to clarify units

### DIFF
--- a/salt/modules/virt.py
+++ b/salt/modules/virt.py
@@ -1021,8 +1021,8 @@ def setvcpus(vm_, vcpus, config=False):
 
 def freemem():
     '''
-    Return an int representing the amount of memory that has not been given
-    to virtual machines on this node
+    Return an int representing the amount of memory (in MB) that has not
+    been given to virtual machines on this node
 
     CLI Example:
 


### PR DESCRIPTION
The units of the returned integer were unclear to me before looking into the code. I hope this might clear up any similar confusion for others in the future.
