### PR TITLE
Add a seperate loader base name path to multimaster

### DIFF
--- a/salt/loader.py
+++ b/salt/loader.py
@@ -112,7 +112,7 @@ def _create_loader(
     )
 
 
-def minion_mods(opts, context=None, whitelist=None):
+def minion_mods(opts, context=None, whitelist=None, loaded_base_name=None):
     '''
     Load execution modules
 
@@ -130,7 +130,11 @@ def minion_mods(opts, context=None, whitelist=None):
         __salt__ = salt.loader.minion_mods(__opts__)
         __salt__['test.ping']()
     '''
-    load = _create_loader(opts, 'modules', 'module')
+    load = _create_loader(
+            opts,
+            'modules',
+            'module',
+            loaded_base_name=loaded_base_name)
     if context is None:
         context = {}
     pack = {'name': '__context__',

--- a/salt/minion.py
+++ b/salt/minion.py
@@ -468,7 +468,7 @@ class MultiMinion(MinionBase):
             s_opts['master'] = master
             s_opts['multimaster'] = True
             try:
-                minions.append(Minion(s_opts, 5, False))
+                minions.append(Minion(s_opts, 5, False, 'salt.loader.{0}'.format(master)))
             except SaltClientError as exc:
                 log.error('Error while bringing up minion for multi-master. Is master at {0} responding?'.format(master))
         if len(minions) == 0:
@@ -565,12 +565,13 @@ class Minion(MinionBase):
     and loads all of the functions into the minion
     '''
 
-    def __init__(self, opts, timeout=60, safe=True):  # pylint: disable=W0231
+    def __init__(self, opts, timeout=60, safe=True, loaded_base_name=None):  # pylint: disable=W0231
         '''
         Pass in the options dict
         '''
         self._running = None
         self.win_proc = []
+        self.loaded_base_name = loaded_base_name
 
         # Warn if ZMQ < 3.2
         if HAS_ZMQ:
@@ -821,7 +822,7 @@ class Minion(MinionBase):
         self.opts['grains'] = salt.loader.grains(self.opts, force_refresh)
         if self.opts.get('multimaster', False):
             s_opts = copy.deepcopy(self.opts)
-            functions = salt.loader.minion_mods(s_opts)
+            functions = salt.loader.minion_mods(s_opts, loaded_base_name=self.loaded_base_name)
         else:
             functions = salt.loader.minion_mods(self.opts)
         returners = salt.loader.returners(self.opts, functions)


### PR DESCRIPTION
This allows for the minion instances to be separated within the loader as well
Thanks to @s0undt3ch for adding a feature to make this possible almost 3 years ago :)
