### PR TITLE
Do not parse state name with pip in editable mode

### DIFF
--- a/salt/states/pip_state.py
+++ b/salt/states/pip_state.py
@@ -519,9 +519,9 @@ def installed(name,
         name = repo
 
     # Get the packages parsed name and version from the pip library.
-    # This only is done when there is no requirements parameter.
+    # This only is done when there is no requirements or editable parameter.
     pkgs_details = []
-    if pkgs and not requirements:
+    if pkgs and not (requirements or editable):
         comments = []
         for pkg in iter(pkgs):
             out = _check_pkg_version_format(pkg)

--- a/tests/unit/states/pip_test.py
+++ b/tests/unit/states/pip_test.py
@@ -278,6 +278,31 @@ class PipStateTest(TestCase, integration.SaltReturnAssertsMixIn):
         if hasattr(pip, '__version__'):
             pip.__version__ = original_pip_version
 
+    def test_install_in_editable_mode(self):
+        '''
+        Check that `name` parameter containing bad characters is not parsed by
+        pip when package is being installed in editable mode.
+        For more information, see issue #21890.
+        '''
+        mock = MagicMock(return_value={'retcode': 0, 'stdout': ''})
+        pip_list = MagicMock(return_value={})
+        pip_install = MagicMock(return_value={
+            'retcode': 0,
+            'stderr': '',
+            'stdout': 'Cloned!'
+        })
+        with patch.dict(pip_state.__salt__, {'cmd.run_all': mock,
+                                             'pip.list': pip_list,
+                                             'pip.install': pip_install}):
+            ret = pip_state.installed('state@name',
+                                      cwd='/path/to/project',
+                                      editable=['.'])
+            self.assertSaltTrueReturn({'test': ret})
+            self.assertInSaltComment(
+                'successfully installed',
+                {'test': ret}
+            )
+
 
 if __name__ == '__main__':
     from integration import run_tests


### PR DESCRIPTION
Hello, this pull request adds additional check in `pip.installed` state.
When package is being installed in editable mode (e.g. from VCS checkout), the state name can be any string. Previous version used to check state name with pip, and that could make the state fail when state name contained "bad" characters for pip (e.g. @ or :). Extra test also added.

Fixes #21890.
