### PR TITLE
Clarify how defaults are indicated in the config files.

### DIFF
--- a/conf/master
+++ b/conf/master
@@ -2,7 +2,7 @@
 ##########################################
 # This configuration file is used to manage the behavior of the Salt Master.
 # Values that are commented out but have an empty line after the comment are
-# defaults that need not be set in the config. If there is a blank line after the
+# defaults that need not be set in the config. If there is no blank line after the
 # comment that the value is presented as an example and is not the default.
 
 # Per default, the master will automatically include all config files

--- a/conf/master
+++ b/conf/master
@@ -1,8 +1,8 @@
 ##### Primary configuration settings #####
 ##########################################
 # This configuration file is used to manage the behavior of the Salt Master.
-# Values that are commented out but have no space after the comment are
-# defaults that need not be set in the config. If there is a space after the
+# Values that are commented out but have an empty line after the comment are
+# defaults that need not be set in the config. If there is a blank line after the
 # comment that the value is presented as an example and is not the default.
 
 # Per default, the master will automatically include all config files
@@ -211,7 +211,7 @@
 #  larry:
 #    - test.ping
 #    - network.*
-
+#
 # Blacklist any of the following users or modules
 #
 # This example would blacklist all non sudo users, including root from
@@ -231,7 +231,7 @@
 #  pam:
 #    fred:
 #      - test.*
-
+#
 # Time (in seconds) for a newly generated token to live. Default: 12 hours
 #token_expire: 43200
 
@@ -356,7 +356,7 @@
 #   prod:
 #     - /srv/salt/prod/services
 #     - /srv/salt/prod/states
-
+#
 #file_roots:
 #  base:
 #    - /srv/salt
@@ -461,8 +461,8 @@
 # within the repository. The path is defined relative to the root of the
 # repository and defaults to the repository root.
 #gitfs_root: somefolder/otherfolder
-
-
+#
+#
 #####         Pillar settings        #####
 ##########################################
 # Salt Pillars allow for the building of global data that can be made selectively
@@ -557,8 +557,8 @@
 #peer_run:
 #  foo.example.com:
 #    - manage.up
-
-
+#
+#
 #####         Mine settings     #####
 ##########################################
 # Restrict mine.get access from minions. By default any minion has a full access
@@ -643,10 +643,11 @@
 ##############################################
 # Location of the repo on the master:
 #win_repo: '/srv/salt/win/repo'
-
+#
 # Location of the master's repo cache file:
 #win_repo_mastercachefile: '/srv/salt/win/repo/winrepo.p'
-
+#
 # List of git repositories to include with the local repo:
 #win_gitrepos:
 #  - 'https://github.com/saltstack/salt-winrepo.git'
+#

--- a/conf/minion
+++ b/conf/minion
@@ -1,10 +1,10 @@
 ##### Primary configuration settings #####
-##########################################
+########################################## 
 # This configuration file is used to manage the behavior of the Salt Minion.
-# With the exception of the location of the Salt Master Server, values that
-# are commented out but have no space after the comment are defaults that need
-# not be set in the config. If there is a space after the comment that the value
-# is presented as an example and is not the default.
+# With the exception of the location of the Salt Master Server, values that are
+# commented out but have an empty line after the comment are defaults that need
+# not be set in the config. If there is no blank line after the comment, the
+# value is presented as an example and is not the default.
 
 # Per default the minion will automatically include all config files
 # from minion.d/*.conf (minion.d is a directory in the same directory
@@ -68,7 +68,7 @@
 #  deployment: datacenter4
 #  cabinet: 13
 #  cab_u: 14-15
-
+#
 # Where cache data goes.
 #cachedir: /var/cache/salt/minion
 
@@ -219,7 +219,8 @@
 # recon_default: 100
 # recon_max: 5000
 # recon_randomize: False
-
+#
+#
 # The loop_interval sets how long in seconds the minion will wait between
 # evaluating the scheduler and running cleanup tasks. This defaults to a
 # sane 60 seconds, but if the minion scheduler needs to be evaluated more
@@ -279,8 +280,9 @@
 #include:
 #  - /etc/salt/extra_config
 #  - /etc/roles/webserver
-
-
+#
+#
+#
 #####   Minion module management     #####
 ##########################################
 # Disable specific modules. This allows the admin to limit the level of
@@ -430,8 +432,8 @@
 #pillar_roots:
 #  base:
 #    - /srv/pillar
-
-
+#
+#
 ######        Security settings       #####
 ###########################################
 # Enable "open mode", this mode still maintains encryption, but turns off
@@ -539,8 +541,8 @@
 #
 # A dict for the test module:
 #test.baz: {spam: sausage, cheese: bread}
-
-
+#
+#
 ######      Update settings          ######
 ###########################################
 # Using the features in Esky, a salt minion can both run as a frozen app and
@@ -586,3 +588,5 @@
 ############################################
 # Location of the repository cache file on the master:
 #win_repo_cachefile: 'salt://win/repo/winrepo.p'
+#
+#


### PR DESCRIPTION
Just make sure that defaults are always followed by a blank, empty line, and clarify at the top of the sample config files that this is in general how they are specified.
