### PR TITLE
Ensure nginx config check passes by checking the exit status

### DIFF
--- a/salt/modules/nginx.py
+++ b/salt/modules/nginx.py
@@ -55,11 +55,23 @@ def configtest():
 
         salt '*' nginx.configtest
     '''
+    ret = {}
 
     cmd = '{0} -t'.format(__detect_os())
-    out = __salt__['cmd.run'](cmd).splitlines()
-    ret = out[0].split(': ')
-    return ret[-1]
+    out = __salt__['cmd.run_all'](cmd)
+
+    if out['retcode'] != 0:
+        ret['comment'] = 'Syntax Error'
+        ret['stderr'] = out['stderr']
+        ret['result'] = False
+
+        return ret
+
+    ret['comment'] = 'Syntax OK'
+    ret['stdout'] = out['stderr']
+    ret['result'] = True
+
+    return ret
 
 
 def signal(signal=None):


### PR DESCRIPTION
Nginx writes to stderr even when the syntax is OK. 
# Syntax Error Example:-

``` bash
local:
    ----------
    comment:
        Syntax Error
    result:
        False
    stderr:
        nginx: [emerg] open() "/etc/nginx/conf.d/server.conf" failed (2: No such file or directory) in /etc/nginx/nginx.conf:34
        nginx: configuration file /etc/nginx/nginx.conf test failed
```
# Syntax OK

``` bash
al:
    ----------
    comment:
        Syntax OK
    result:
        True
    stdout:
        nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
        nginx: configuration file /etc/nginx/nginx.conf test is successful
```
