### PR TITLE
Fix second `unless` example

### DIFF
--- a/doc/ref/states/requisites.rst
+++ b/doc/ref/states/requisites.rst
@@ -451,9 +451,10 @@ For example:
 
     deploy_app:
       cmd.run:
-        - first_deploy_cmd
-        - second_deploy_cmd
-      - unless: some_check
+        - names:
+            - first_deploy_cmd
+            - second_deploy_cmd
+        - unless: some_check
 
 In the above case, ``some_check`` will be run prior to _each_ name -- once for
 ``first_deploy_cmd`` and a second time for ``second_deploy_cmd``.


### PR DESCRIPTION
I tried running [the second example for `unless`](http://docs.saltstack.com/en/latest/ref/states/requisites.html#unless):

``` yaml
deploy_app:
  cmd.run:
    - first_deploy_cmd
    - second_deploy_cmd
  - unless: some_check
```

... and got the following error:

```
local:
    Data failed to compile:
----------
    Rendering SLS flexlm_adapter failed, render error: while parsing a block mapping
  in "<unicode string>", line 26, column 3:
      cmd.run:
      ^
expected <block end>, but found '-'
  in "<unicode string>", line 29, column 3:
      - unless: some_check
      ^
```

This worked:

``` yaml
deploy_app:
  cmd.run:
    - names:
        - first_deploy_cmd
        - second_deploy_cmd
    - unless: some_check
```

... so this PR changes the example to the yaml above.
