### PR TITLE
[2014.7] Catch msgpack error in file.recurse in salt-ssh

### DIFF
--- a/salt/fileserver/roots.py
+++ b/salt/fileserver/roots.py
@@ -298,9 +298,13 @@ def _file_lists(load, form):
                             rel_fn = rel_fn.replace('\\', '/')
                         ret['files'].append(rel_fn)
         if save_cache:
-            salt.fileserver.write_file_list_cache(
-                __opts__, ret, list_cache, w_lock
-            )
+            try:
+                salt.fileserver.write_file_list_cache(
+                    __opts__, ret, list_cache, w_lock
+                )
+            except NameError:
+                # Catch msgpack error in salt-ssh
+                pass
         return ret.get(form, [])
     # Shouldn't get here, but if we do, this prevents a TypeError
     return []


### PR DESCRIPTION
Fixes #21922 
