### PR TITLE
fix #21971 - ssh_host_key.pub should return as key.pub not key.pub.pub

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -249,7 +249,7 @@ def host_keys(keydir=None):
     for fn_ in os.listdir(keydir):
         if fn_.startswith('ssh_host_'):
             top = fn_.split('.')
-            comps = fn_.split('_')
+            comps = top[0].split('_')
             kname = comps[2]
             if len(top) > 1:
                 kname += '.{0}'.format(top[1])


### PR DESCRIPTION
This will correct the output to simply be key.pub for the ssh_host_key.pub file.
