### PR TITLE
fixes #21952 - only read ssh host_key header for legacy binary format

### DIFF
--- a/salt/modules/ssh.py
+++ b/salt/modules/ssh.py
@@ -255,7 +255,11 @@ def host_keys(keydir=None):
                 kname += '.{0}'.format(top[1])
             try:
                 with salt.utils.fopen(os.path.join(keydir, fn_), 'r') as _fh:
-                    keys[kname] = _fh.readline().strip()
+                    keys[kname] = _fh.readline()
+                    # only read the whole file if it is not in the legacy 1.1 binary format
+                    if keys[kname] != "SSH PRIVATE KEY FILE FORMAT 1.1\n":
+                        keys[kname] += _fh.read()
+                    keys[kname] = keys[kname].strip()
             except (IOError, OSError):
                 keys[kname] = ''
     return keys


### PR DESCRIPTION
For #21952, legacy ssh private keys in 1.1 format, which are binary, only return the header so that folks know it's the old private key but they do not get binary output.  This PR is for the 2014.7 branch since it is different than 2015.2/develop.
