### PR TITLE
Workaround for #21651

### DIFF
--- a/salt/utils/reactor.py
+++ b/salt/utils/reactor.py
@@ -168,9 +168,11 @@ class ReactWrap(object):
             f_call = salt.utils.format_call(l_fun, low)
             kwargs = f_call.get('kwargs', {})
 
-            # TODO: pick one...
-            kwargs['__user__'] = self.event_user
-            kwargs['user'] = self.event_user
+            # TODO: Setting the user doesn't seem to work for actual remote publishes
+            if low['state'] in ('runner', 'wheel'):
+                # TODO: pick one...
+                kwargs['__user__'] = self.event_user
+                kwargs['user'] = self.event_user
 
             l_fun(*f_call.get('args', ()), **kwargs)
         except Exception:


### PR DESCRIPTION
It seems that the runner and wheel systems are completely fine setting arbitrary users. When we go through the publish system we run into access issues.

Since this does solve the recursion problem partially I'll leave it in for now, but scope it to just runner and wheel. This should unblock our RC.

Workaround for #21651
