### PR TITLE
states.boto_vpc: remove partially implemented salt_id code

### DIFF
--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -126,6 +126,27 @@ def present(name, cidr_block, instance_tenancy=None, dns_support=None,
 
 
 def absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
+    '''
+    Ensure VPC with passed properties is absent.
+
+    name
+        Name of the VPC.
+    tags
+        A list of tags. All tags must match.
+    region
+        Region to connect to.
+
+    key
+        Secret key to be used.
+
+    keyid
+        Access key to be used.
+
+    profile
+        A dict with region, key and keyid, or a pillar key (string) that
+        contains a dict with region, key and keyid.
+    '''
+
     ret = {'name': name,
            'result': True,
            'comment': '',

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -100,13 +100,8 @@ def present(name, cidr_block, instance_tenancy=None, dns_support=None,
            'changes': {}
            }
 
-    _id = {'salt_id': name}
-    if tags:
-        _tags = tags.update(_id)
-    else:
-        _tags = _id
-    exists = __salt__['boto_vpc.exists'](tags=_id, region=region, key=key,
-                                         keyid=keyid, profile=profile)
+    exists = __salt__['boto_vpc.exists'](name=name, tags=tags, region=region,
+                                         key=key, keyid=keyid, profile=profile)
     if not exists:
         if __opts__['test']:
             ret['comment'] = 'VPC {0} is set to be created.'.format(name)
@@ -137,13 +132,8 @@ def absent(name, tags=None, region=None, key=None, keyid=None, profile=None):
            'changes': {}
            }
 
-    _id = {'salt_id': name}
-    if tags:
-        _tags = tags.update(_id)
-    else:
-        _tags = _id
-    exists = __salt__['boto_vpc.exists'](tags=_id, region=region, key=key,
-                                         keyid=keyid, profile=profile)
+    exists = __salt__['boto_vpc.exists'](name=name, tags=tags, region=region,
+                                         key=key, keyid=keyid, profile=profile)
     if not exists:
         ret['comment'] = '{0} VPC does not exist.'.format(name)
         return ret

--- a/salt/states/boto_vpc.py
+++ b/salt/states/boto_vpc.py
@@ -109,7 +109,7 @@ def present(name, cidr_block, instance_tenancy=None, dns_support=None,
             return ret
         created = __salt__['boto_vpc.create'](cidr_block, instance_tenancy,
                                               name, dns_support, dns_hostnames,
-                                              _tags, region, key, keyid,
+                                              tags, region, key, keyid,
                                               profile)
         if not created:
             ret['result'] = False


### PR DESCRIPTION
The original rational for using `salt_id` was to avoid collisions with other uses of the AWS `Name` tag. However, all the other boto modules do use the `Name` tag and, per discussion with @ryan-lane and @claudiupopescu, this needs to be done in a uniform and backwards compatible way -- if it's to be done at all. It should also be done on the execution module level, not the state level.
