### PR TITLE
Option handling for archive.tar fails with more uncommon options

### DIFF
--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -102,10 +102,13 @@ def tar(options, tarfile, sources=None, dest=None,
         cmd.extend(['-C', '{0}'.format(dest)])
 
     if not options.startswith('-'):
-        options = '{0}'.format(options)
+        options = '-{0}'.format(options)
 
-    cmd.extend([options, '{0}'.format(tarfile)])
-    cmd.extend(sources)
+    cmd.extend(options.split(" "))
+    cmd.extend(['{0}'.format(tarfile)])
+
+    if sources is not None:
+        cmd.extend(sources)
 
     return __salt__['cmd.run'](cmd,
                                cwd=cwd,

--- a/salt/modules/archive.py
+++ b/salt/modules/archive.py
@@ -101,7 +101,10 @@ def tar(options, tarfile, sources=None, dest=None,
     if dest:
         cmd.extend(['-C', '{0}'.format(dest)])
 
-    cmd.extend(['-{0}'.format(options), '{0}'.format(tarfile)])
+    if not options.startswith('-'):
+        options = '{0}'.format(options)
+
+    cmd.extend([options, '{0}'.format(tarfile)])
     cmd.extend(sources)
 
     return __salt__['cmd.run'](cmd,


### PR DESCRIPTION
When using archive.tar with option starting with double dash it's not clear how to use it.

Example from a deploy module

```
__salt__['archive.tar']('-xform s/shopmanager-mv/shopmanager/ -xzf', shopmandest, dest=shopmanhome, cwd=shopmanhome)
```

We use just one dash (as a hack) that it works with version 2014.1.5.
A dash is always added, which is a bad idea.

This version handles option with or without dash, to make it more consistent. It should be backwards-compatible.

It also fixes some strange behaviour with recent debian linux and tar 1.27.1 (don't know if the problem exists elsewhere), when using a string with multiple dash-options.
Tar fails with 

```
   - tar: unrecognized option '--xform s/shopmanager-mv/shopmanager/ -xzf'
    - Try 'tar --help' or 'tar --usage' for more information.
```

using the options above.
This version splits all option and extends the command.
